### PR TITLE
[fix] Assign CUDAEvent external member properly

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -60,8 +60,6 @@ code = 'CLANGFORMAT'
 include_patterns = [
     'aten/src/ATen/*.h',
     'aten/src/ATen/cpu/vec/**/*.h',
-    'aten/src/ATen/cuda/**/*.h',
-    'aten/src/ATen/cuda/**/*.cpp',
     'aten/src/ATen/mps/**/*.mm',
     'aten/src/ATen/mps/**/*.h',
     'aten/src/ATen/xpu/**/*.h',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -60,6 +60,8 @@ code = 'CLANGFORMAT'
 include_patterns = [
     'aten/src/ATen/*.h',
     'aten/src/ATen/cpu/vec/**/*.h',
+    'aten/src/ATen/cuda/**/*.h',
+    'aten/src/ATen/cuda/**/*.cpp',
     'aten/src/ATen/mps/**/*.mm',
     'aten/src/ATen/mps/**/*.h',
     'aten/src/ATen/xpu/**/*.h',

--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -238,11 +238,18 @@ private:
   }
 
   void moveHelper(CUDAEvent&& other) {
-    std::swap(flags_, other.flags_);
-    std::swap(is_created_, other.is_created_);
-    std::swap(was_recorded_, other.was_recorded_);
-    std::swap(device_index_, other.device_index_);
-    std::swap(event_, other.event_);
+    // Transfer ownership of all state from other to this
+    flags_ = other.flags_;
+    is_created_ = other.is_created_;
+    was_recorded_ = other.was_recorded_;
+    external_ = other.external_;
+    device_index_ = other.device_index_;
+    event_ = other.event_;
+
+    // Reset other to a valid empty state to prevent double-free
+    // The moved-from object must not attempt to destroy the event
+    other.is_created_ = false;
+    other.event_ = cudaEvent_t{};
   }
 };
 

--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -14,40 +14,40 @@
 #include <utility>
 
 /*
- * `cudaEventExternal` is a torch-specific flag that is used to
- * indicate that the CUDAEvent will be used only for synchronization
- * with work outside of the cuda graph, rather than creation of
- * cross-stream dependencies within a cuda graph. Resources:
- * https://docs.nvidia.com/cuda/archive/12.9.0/cuda-c-programming-guide/index.html#cross-stream-dependencies-and-events
- * https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3457b81d1d32c6a00f6132fbc2693d47
- * https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g0c23426b7252eaa9cef695859991304e
- */
+* `cudaEventExternal` is a torch-specific flag that is used to
+* indicate that the CUDAEvent will be used only for synchronization
+* with work outside of the cuda graph, rather than creation of
+* cross-stream dependencies within a cuda graph. Resources:
+* https://docs.nvidia.com/cuda/archive/12.9.0/cuda-c-programming-guide/index.html#cross-stream-dependencies-and-events
+* https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3457b81d1d32c6a00f6132fbc2693d47
+* https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g0c23426b7252eaa9cef695859991304e
+*/
 #define cudaEventExternal 0x08
 
 namespace at::cuda {
 
 /*
- * CUDAEvents are movable not copyable wrappers around CUDA's events.
- *
- * CUDAEvents are constructed lazily when first recorded unless it is
- * reconstructed from a cudaIpcEventHandle_t. The event has a device, and this
- * device is acquired from the first recording stream. However, if reconstructed
- * from a handle, the device should be explicitly specified; or if ipc_handle()
- * is called before the event is ever recorded, it will use the current device.
- * Later streams that record the event must match this device.
- */
+* CUDAEvents are movable not copyable wrappers around CUDA's events.
+*
+* CUDAEvents are constructed lazily when first recorded unless it is
+* reconstructed from a cudaIpcEventHandle_t. The event has a device, and this
+* device is acquired from the first recording stream. However, if reconstructed
+* from a handle, the device should be explicitly specified; or if ipc_handle() is
+* called before the event is ever recorded, it will use the current device.
+* Later streams that record the event must match this device.
+*/
 struct TORCH_CUDA_CPP_API CUDAEvent {
   // Constructors
   // Default value for `flags` is specified below - it's cudaEventDisableTiming
   CUDAEvent() noexcept = default;
   CUDAEvent(unsigned int flags) noexcept : flags_{flags} {}
 
-  CUDAEvent(DeviceIndex device_index, const cudaIpcEventHandle_t* handle)
-      : device_index_(device_index) {
-    CUDAGuard guard(device_index_);
+  CUDAEvent(
+      DeviceIndex device_index, const cudaIpcEventHandle_t* handle) : device_index_(device_index) {
+      CUDAGuard guard(device_index_);
 
-    AT_CUDA_CHECK(cudaIpcOpenEventHandle(&event_, *handle));
-    is_created_ = true;
+      AT_CUDA_CHECK(cudaIpcOpenEventHandle(&event_, *handle));
+      is_created_ = true;
   }
 
   // Note: event destruction done on creating device to avoid creating a
@@ -56,24 +56,19 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     try {
       if (is_created_) {
         CUDAGuard guard(device_index_);
-        const c10::impl::PyInterpreter* interp =
-            c10::impl::GPUTrace::get_trace();
+        const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
         if (C10_UNLIKELY(interp)) {
-          (*interp)->trace_gpu_event_deletion(
-              at::kCUDA, reinterpret_cast<uintptr_t>(event_));
+          (*interp)->trace_gpu_event_deletion(at::kCUDA, reinterpret_cast<uintptr_t>(event_));
         }
         AT_CUDA_CHECK(cudaEventDestroy(event_));
       }
-    } catch (...) { /* No throw */
-    }
+    } catch (...) { /* No throw */ }
   }
 
   CUDAEvent(const CUDAEvent&) = delete;
   CUDAEvent& operator=(const CUDAEvent&) = delete;
 
-  CUDAEvent(CUDAEvent&& other) noexcept {
-    moveHelper(std::move(other));
-  }
+  CUDAEvent(CUDAEvent&& other) noexcept { moveHelper(std::move(other)); }
   CUDAEvent& operator=(CUDAEvent&& other) noexcept {
     if (this != &other) {
       moveHelper(std::move(other));
@@ -81,9 +76,7 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     return *this;
   }
 
-  operator cudaEvent_t() const {
-    return event();
-  }
+  operator cudaEvent_t() const { return event(); }
 
   // Less than operator (to allow use in sets)
   friend bool operator<(const CUDAEvent& left, const CUDAEvent& right) {
@@ -98,15 +91,9 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     }
   }
 
-  bool isCreated() const {
-    return is_created_;
-  }
-  DeviceIndex device_index() const {
-    return device_index_;
-  }
-  cudaEvent_t event() const {
-    return event_;
-  }
+  bool isCreated() const { return is_created_; }
+  DeviceIndex device_index() const {return device_index_;}
+  cudaEvent_t event() const { return event_; }
 
   // Note: cudaEventQuery can be safely called from any device
   bool query() const {
@@ -127,13 +114,10 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     return false;
   }
 
-  void record() {
-    record(getCurrentCUDAStream());
-  }
+  void record() { record(getCurrentCUDAStream()); }
 
   void recordOnce(const CUDAStream& stream) {
-    if (!was_recorded_)
-      record(stream);
+    if (!was_recorded_) record(stream);
   }
 
   // Note: cudaEventRecord must be called on the same device as the event.
@@ -142,33 +126,23 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
       createEvent(stream.device_index());
     }
 
-    TORCH_CHECK(
-        device_index_ == stream.device_index(),
-        "Event device ",
-        device_index_,
-        " does not match recording stream's device ",
-        stream.device_index(),
-        ".");
+    TORCH_CHECK(device_index_ == stream.device_index(), "Event device ", device_index_,
+      " does not match recording stream's device ", stream.device_index(), ".");
     CUDAGuard guard(device_index_);
 
 #ifndef USE_ROCM
-    // it is an error to use cudaEventRecordExternal when not doing stream
-    // capture
-    unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
-                              c10::cuda::CaptureStatus::None &&
-                          external_)
-        ? cudaEventRecordExternal
-        : cudaEventRecordDefault;
+    // it is an error to use cudaEventRecordExternal when not doing stream capture
+    unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() != c10::cuda::CaptureStatus::None && external_) ? cudaEventRecordExternal : cudaEventRecordDefault;
     AT_CUDA_CHECK(cudaEventRecordWithFlags(event_, stream, flags));
 #else
     AT_CUDA_CHECK(cudaEventRecord(event_, stream));
 #endif
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
     if (C10_UNLIKELY(interp)) {
-      (*interp)->trace_gpu_event_record(
-          at::kCUDA,
+      (*interp)->trace_gpu_event_record(at::kCUDA,
           reinterpret_cast<uintptr_t>(event_),
-          reinterpret_cast<uintptr_t>(stream.stream()));
+          reinterpret_cast<uintptr_t>(stream.stream())
+      );
     }
     was_recorded_ = true;
   }
@@ -179,23 +153,18 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     if (is_created_) {
       CUDAGuard guard(stream.device_index());
 #ifndef USE_ROCM
-      // it is an error to use cudaEventWaitExternal when not doing stream
-      // capture
-      unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
-                                c10::cuda::CaptureStatus::None &&
-                            external_)
-          ? cudaEventWaitExternal
-          : cudaEventWaitDefault;
+      // it is an error to use cudaEventWaitExternal when not doing stream capture
+      unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() != c10::cuda::CaptureStatus::None && external_) ? cudaEventWaitExternal : cudaEventWaitDefault;
       AT_CUDA_CHECK(cudaStreamWaitEvent(stream, event_, flags));
 #else
       AT_CUDA_CHECK(cudaStreamWaitEvent(stream, event_));
 #endif
       const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
       if (C10_UNLIKELY(interp)) {
-        (*interp)->trace_gpu_event_wait(
-            at::kCUDA,
+        (*interp)->trace_gpu_event_wait(at::kCUDA,
             reinterpret_cast<uintptr_t>(event_),
-            reinterpret_cast<uintptr_t>(stream.stream()));
+            reinterpret_cast<uintptr_t>(stream.stream())
+        );
       }
     }
   }
@@ -203,8 +172,7 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
   // Note: cudaEventElapsedTime can be safely called from any device
   float elapsed_time(const CUDAEvent& other) const {
     TORCH_CHECK_VALUE(
-        !(flags_ & cudaEventDisableTiming) &&
-            !(other.flags_ & cudaEventDisableTiming),
+        !(flags_ & cudaEventDisableTiming) && !(other.flags_ & cudaEventDisableTiming),
         "Both events must be created with argument 'enable_timing=True'.");
     TORCH_CHECK_VALUE(
         is_created_ && other.isCreated(),
@@ -228,25 +196,24 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     if (is_created_) {
       const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
       if (C10_UNLIKELY(interp)) {
-        (*interp)->trace_gpu_event_synchronization(
-            at::kCUDA, reinterpret_cast<uintptr_t>(event_));
+          (*interp)->trace_gpu_event_synchronization(at::kCUDA, reinterpret_cast<uintptr_t>(event_));
       }
       AT_CUDA_CHECK(cudaEventSynchronize(event_));
     }
   }
 
   // Note: cudaIpcGetEventHandle must be called on the same device as the event
-  void ipc_handle(cudaIpcEventHandle_t* handle) {
-    if (!is_created_) {
-      // this CUDAEvent object was initially constructed from flags but event_
-      // is not created yet.
-      createEvent(getCurrentCUDAStream().device_index());
-    }
-    CUDAGuard guard(device_index_);
-    AT_CUDA_CHECK(cudaIpcGetEventHandle(handle, event_));
+  void ipc_handle(cudaIpcEventHandle_t * handle) {
+      if (!is_created_) {
+        // this CUDAEvent object was initially constructed from flags but event_
+        // is not created yet.
+        createEvent(getCurrentCUDAStream().device_index());
+      }
+      CUDAGuard guard(device_index_);
+      AT_CUDA_CHECK(cudaIpcGetEventHandle(handle, event_));
   }
 
- private:
+private:
   unsigned int flags_ = cudaEventDisableTiming;
   bool is_created_ = false;
   bool was_recorded_ = false;
@@ -265,8 +232,7 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     AT_CUDA_CHECK(cudaEventCreateWithFlags(&event_, flags_));
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
     if (C10_UNLIKELY(interp)) {
-      (*interp)->trace_gpu_event_creation(
-          at::kCUDA, reinterpret_cast<uintptr_t>(event_));
+      (*interp)->trace_gpu_event_creation(at::kCUDA, reinterpret_cast<uintptr_t>(event_));
     }
     is_created_ = true;
   }
@@ -287,10 +253,9 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
   }
 };
 
-// EventPool - Thread-safe pool of CUDA events to avoid expensive
-// cudaEventCreate calls. cudaEventCreate when concurrently invoked from
-// multiple threads can be very expensive (especially on certain device/driver
-// combinations).
+// EventPool - Thread-safe pool of CUDA events to avoid expensive cudaEventCreate
+// calls. cudaEventCreate when concurrently invoked from multiple threads can be
+// very expensive (especially on certain device/driver combinations).
 using CUDAEventPtr =
     std::unique_ptr<CUDAEvent, std::function<void(CUDAEvent*)>>;
 
@@ -301,10 +266,11 @@ class EventPool {
   CUDAEventPtr get(const DeviceIndex device) {
     // If the device is invalid, return a default event and no pooling
     if (device < 0 || device >= (DeviceIndex)pools_.size()) {
-      auto deleter = [](CUDAEvent* event) { delete event; };
+      auto deleter = [](CUDAEvent* event) {
+        delete event;
+      };
       return CUDAEventPtr(
-          std::make_unique<CUDAEvent>(cudaEventDisableTiming).release(),
-          deleter);
+        std::make_unique<CUDAEvent>(cudaEventDisableTiming).release(), deleter);
     }
 
     auto& pool = pools_[device];
@@ -339,18 +305,17 @@ class EventPool {
   }
 
   void init_num_events(const size_t num_events) {
-    for (DeviceIndex device_idx = 0; device_idx < at::cuda::device_count();
-         ++device_idx) {
-      CUDAGuard device_guard(device_idx);
-      std::vector<CUDAEventPtr> temp_events;
-      temp_events.reserve(num_events);
-      for (size_t i = 0; i < num_events; ++i) {
-        auto event = get(device_idx);
-        // Record the event to ensure it's properly initialized
-        event->record();
-        temp_events.emplace_back(std::move(event));
-      }
-      // Events will be returned to pool when temp_events is destroyed
+    for (DeviceIndex device_idx = 0; device_idx < at::cuda::device_count(); ++device_idx) {
+        CUDAGuard device_guard(device_idx);
+        std::vector<CUDAEventPtr> temp_events;
+        temp_events.reserve(num_events);
+        for (size_t i = 0; i < num_events; ++i) {
+          auto event = get(device_idx);
+          // Record the event to ensure it's properly initialized
+          event->record();
+          temp_events.emplace_back(std::move(event));
+        }
+        // Events will be returned to pool when temp_events is destroyed
     }
   }
 

--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -14,40 +14,40 @@
 #include <utility>
 
 /*
-* `cudaEventExternal` is a torch-specific flag that is used to
-* indicate that the CUDAEvent will be used only for synchronization
-* with work outside of the cuda graph, rather than creation of
-* cross-stream dependencies within a cuda graph. Resources:
-* https://docs.nvidia.com/cuda/archive/12.9.0/cuda-c-programming-guide/index.html#cross-stream-dependencies-and-events
-* https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3457b81d1d32c6a00f6132fbc2693d47
-* https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g0c23426b7252eaa9cef695859991304e
-*/
+ * `cudaEventExternal` is a torch-specific flag that is used to
+ * indicate that the CUDAEvent will be used only for synchronization
+ * with work outside of the cuda graph, rather than creation of
+ * cross-stream dependencies within a cuda graph. Resources:
+ * https://docs.nvidia.com/cuda/archive/12.9.0/cuda-c-programming-guide/index.html#cross-stream-dependencies-and-events
+ * https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3457b81d1d32c6a00f6132fbc2693d47
+ * https://docs.nvidia.com/cuda/archive/12.9.0/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g0c23426b7252eaa9cef695859991304e
+ */
 #define cudaEventExternal 0x08
 
 namespace at::cuda {
 
 /*
-* CUDAEvents are movable not copyable wrappers around CUDA's events.
-*
-* CUDAEvents are constructed lazily when first recorded unless it is
-* reconstructed from a cudaIpcEventHandle_t. The event has a device, and this
-* device is acquired from the first recording stream. However, if reconstructed
-* from a handle, the device should be explicitly specified; or if ipc_handle() is
-* called before the event is ever recorded, it will use the current device.
-* Later streams that record the event must match this device.
-*/
+ * CUDAEvents are movable not copyable wrappers around CUDA's events.
+ *
+ * CUDAEvents are constructed lazily when first recorded unless it is
+ * reconstructed from a cudaIpcEventHandle_t. The event has a device, and this
+ * device is acquired from the first recording stream. However, if reconstructed
+ * from a handle, the device should be explicitly specified; or if ipc_handle()
+ * is called before the event is ever recorded, it will use the current device.
+ * Later streams that record the event must match this device.
+ */
 struct TORCH_CUDA_CPP_API CUDAEvent {
   // Constructors
   // Default value for `flags` is specified below - it's cudaEventDisableTiming
   CUDAEvent() noexcept = default;
   CUDAEvent(unsigned int flags) noexcept : flags_{flags} {}
 
-  CUDAEvent(
-      DeviceIndex device_index, const cudaIpcEventHandle_t* handle) : device_index_(device_index) {
-      CUDAGuard guard(device_index_);
+  CUDAEvent(DeviceIndex device_index, const cudaIpcEventHandle_t* handle)
+      : device_index_(device_index) {
+    CUDAGuard guard(device_index_);
 
-      AT_CUDA_CHECK(cudaIpcOpenEventHandle(&event_, *handle));
-      is_created_ = true;
+    AT_CUDA_CHECK(cudaIpcOpenEventHandle(&event_, *handle));
+    is_created_ = true;
   }
 
   // Note: event destruction done on creating device to avoid creating a
@@ -56,19 +56,24 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     try {
       if (is_created_) {
         CUDAGuard guard(device_index_);
-        const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+        const c10::impl::PyInterpreter* interp =
+            c10::impl::GPUTrace::get_trace();
         if (C10_UNLIKELY(interp)) {
-          (*interp)->trace_gpu_event_deletion(at::kCUDA, reinterpret_cast<uintptr_t>(event_));
+          (*interp)->trace_gpu_event_deletion(
+              at::kCUDA, reinterpret_cast<uintptr_t>(event_));
         }
         AT_CUDA_CHECK(cudaEventDestroy(event_));
       }
-    } catch (...) { /* No throw */ }
+    } catch (...) { /* No throw */
+    }
   }
 
   CUDAEvent(const CUDAEvent&) = delete;
   CUDAEvent& operator=(const CUDAEvent&) = delete;
 
-  CUDAEvent(CUDAEvent&& other) noexcept { moveHelper(std::move(other)); }
+  CUDAEvent(CUDAEvent&& other) noexcept {
+    moveHelper(std::move(other));
+  }
   CUDAEvent& operator=(CUDAEvent&& other) noexcept {
     if (this != &other) {
       moveHelper(std::move(other));
@@ -76,7 +81,9 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     return *this;
   }
 
-  operator cudaEvent_t() const { return event(); }
+  operator cudaEvent_t() const {
+    return event();
+  }
 
   // Less than operator (to allow use in sets)
   friend bool operator<(const CUDAEvent& left, const CUDAEvent& right) {
@@ -91,9 +98,15 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     }
   }
 
-  bool isCreated() const { return is_created_; }
-  DeviceIndex device_index() const {return device_index_;}
-  cudaEvent_t event() const { return event_; }
+  bool isCreated() const {
+    return is_created_;
+  }
+  DeviceIndex device_index() const {
+    return device_index_;
+  }
+  cudaEvent_t event() const {
+    return event_;
+  }
 
   // Note: cudaEventQuery can be safely called from any device
   bool query() const {
@@ -114,10 +127,13 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     return false;
   }
 
-  void record() { record(getCurrentCUDAStream()); }
+  void record() {
+    record(getCurrentCUDAStream());
+  }
 
   void recordOnce(const CUDAStream& stream) {
-    if (!was_recorded_) record(stream);
+    if (!was_recorded_)
+      record(stream);
   }
 
   // Note: cudaEventRecord must be called on the same device as the event.
@@ -126,23 +142,33 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
       createEvent(stream.device_index());
     }
 
-    TORCH_CHECK(device_index_ == stream.device_index(), "Event device ", device_index_,
-      " does not match recording stream's device ", stream.device_index(), ".");
+    TORCH_CHECK(
+        device_index_ == stream.device_index(),
+        "Event device ",
+        device_index_,
+        " does not match recording stream's device ",
+        stream.device_index(),
+        ".");
     CUDAGuard guard(device_index_);
 
 #ifndef USE_ROCM
-    // it is an error to use cudaEventRecordExternal when not doing stream capture
-    unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() != c10::cuda::CaptureStatus::None && external_) ? cudaEventRecordExternal : cudaEventRecordDefault;
+    // it is an error to use cudaEventRecordExternal when not doing stream
+    // capture
+    unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+                              c10::cuda::CaptureStatus::None &&
+                          external_)
+        ? cudaEventRecordExternal
+        : cudaEventRecordDefault;
     AT_CUDA_CHECK(cudaEventRecordWithFlags(event_, stream, flags));
 #else
     AT_CUDA_CHECK(cudaEventRecord(event_, stream));
 #endif
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
     if (C10_UNLIKELY(interp)) {
-      (*interp)->trace_gpu_event_record(at::kCUDA,
+      (*interp)->trace_gpu_event_record(
+          at::kCUDA,
           reinterpret_cast<uintptr_t>(event_),
-          reinterpret_cast<uintptr_t>(stream.stream())
-      );
+          reinterpret_cast<uintptr_t>(stream.stream()));
     }
     was_recorded_ = true;
   }
@@ -153,18 +179,23 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     if (is_created_) {
       CUDAGuard guard(stream.device_index());
 #ifndef USE_ROCM
-      // it is an error to use cudaEventWaitExternal when not doing stream capture
-      unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() != c10::cuda::CaptureStatus::None && external_) ? cudaEventWaitExternal : cudaEventWaitDefault;
+      // it is an error to use cudaEventWaitExternal when not doing stream
+      // capture
+      unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
+                                c10::cuda::CaptureStatus::None &&
+                            external_)
+          ? cudaEventWaitExternal
+          : cudaEventWaitDefault;
       AT_CUDA_CHECK(cudaStreamWaitEvent(stream, event_, flags));
 #else
       AT_CUDA_CHECK(cudaStreamWaitEvent(stream, event_));
 #endif
       const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
       if (C10_UNLIKELY(interp)) {
-        (*interp)->trace_gpu_event_wait(at::kCUDA,
+        (*interp)->trace_gpu_event_wait(
+            at::kCUDA,
             reinterpret_cast<uintptr_t>(event_),
-            reinterpret_cast<uintptr_t>(stream.stream())
-        );
+            reinterpret_cast<uintptr_t>(stream.stream()));
       }
     }
   }
@@ -172,7 +203,8 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
   // Note: cudaEventElapsedTime can be safely called from any device
   float elapsed_time(const CUDAEvent& other) const {
     TORCH_CHECK_VALUE(
-        !(flags_ & cudaEventDisableTiming) && !(other.flags_ & cudaEventDisableTiming),
+        !(flags_ & cudaEventDisableTiming) &&
+            !(other.flags_ & cudaEventDisableTiming),
         "Both events must be created with argument 'enable_timing=True'.");
     TORCH_CHECK_VALUE(
         is_created_ && other.isCreated(),
@@ -196,24 +228,25 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
     if (is_created_) {
       const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
       if (C10_UNLIKELY(interp)) {
-          (*interp)->trace_gpu_event_synchronization(at::kCUDA, reinterpret_cast<uintptr_t>(event_));
+        (*interp)->trace_gpu_event_synchronization(
+            at::kCUDA, reinterpret_cast<uintptr_t>(event_));
       }
       AT_CUDA_CHECK(cudaEventSynchronize(event_));
     }
   }
 
   // Note: cudaIpcGetEventHandle must be called on the same device as the event
-  void ipc_handle(cudaIpcEventHandle_t * handle) {
-      if (!is_created_) {
-        // this CUDAEvent object was initially constructed from flags but event_
-        // is not created yet.
-        createEvent(getCurrentCUDAStream().device_index());
-      }
-      CUDAGuard guard(device_index_);
-      AT_CUDA_CHECK(cudaIpcGetEventHandle(handle, event_));
+  void ipc_handle(cudaIpcEventHandle_t* handle) {
+    if (!is_created_) {
+      // this CUDAEvent object was initially constructed from flags but event_
+      // is not created yet.
+      createEvent(getCurrentCUDAStream().device_index());
+    }
+    CUDAGuard guard(device_index_);
+    AT_CUDA_CHECK(cudaIpcGetEventHandle(handle, event_));
   }
 
-private:
+ private:
   unsigned int flags_ = cudaEventDisableTiming;
   bool is_created_ = false;
   bool was_recorded_ = false;
@@ -232,7 +265,8 @@ private:
     AT_CUDA_CHECK(cudaEventCreateWithFlags(&event_, flags_));
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
     if (C10_UNLIKELY(interp)) {
-      (*interp)->trace_gpu_event_creation(at::kCUDA, reinterpret_cast<uintptr_t>(event_));
+      (*interp)->trace_gpu_event_creation(
+          at::kCUDA, reinterpret_cast<uintptr_t>(event_));
     }
     is_created_ = true;
   }
@@ -253,9 +287,10 @@ private:
   }
 };
 
-// EventPool - Thread-safe pool of CUDA events to avoid expensive cudaEventCreate
-// calls. cudaEventCreate when concurrently invoked from multiple threads can be
-// very expensive (especially on certain device/driver combinations).
+// EventPool - Thread-safe pool of CUDA events to avoid expensive
+// cudaEventCreate calls. cudaEventCreate when concurrently invoked from
+// multiple threads can be very expensive (especially on certain device/driver
+// combinations).
 using CUDAEventPtr =
     std::unique_ptr<CUDAEvent, std::function<void(CUDAEvent*)>>;
 
@@ -266,11 +301,10 @@ class EventPool {
   CUDAEventPtr get(const DeviceIndex device) {
     // If the device is invalid, return a default event and no pooling
     if (device < 0 || device >= (DeviceIndex)pools_.size()) {
-      auto deleter = [](CUDAEvent* event) {
-        delete event;
-      };
+      auto deleter = [](CUDAEvent* event) { delete event; };
       return CUDAEventPtr(
-        std::make_unique<CUDAEvent>(cudaEventDisableTiming).release(), deleter);
+          std::make_unique<CUDAEvent>(cudaEventDisableTiming).release(),
+          deleter);
     }
 
     auto& pool = pools_[device];
@@ -305,17 +339,18 @@ class EventPool {
   }
 
   void init_num_events(const size_t num_events) {
-    for (DeviceIndex device_idx = 0; device_idx < at::cuda::device_count(); ++device_idx) {
-        CUDAGuard device_guard(device_idx);
-        std::vector<CUDAEventPtr> temp_events;
-        temp_events.reserve(num_events);
-        for (size_t i = 0; i < num_events; ++i) {
-          auto event = get(device_idx);
-          // Record the event to ensure it's properly initialized
-          event->record();
-          temp_events.emplace_back(std::move(event));
-        }
-        // Events will be returned to pool when temp_events is destroyed
+    for (DeviceIndex device_idx = 0; device_idx < at::cuda::device_count();
+         ++device_idx) {
+      CUDAGuard device_guard(device_idx);
+      std::vector<CUDAEventPtr> temp_events;
+      temp_events.reserve(num_events);
+      for (size_t i = 0; i < num_events; ++i) {
+        auto event = get(device_idx);
+        // Record the event to ensure it's properly initialized
+        event->record();
+        temp_events.emplace_back(std::move(event));
+      }
+      // Events will be returned to pool when temp_events is destroyed
     }
   }
 

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -64,6 +64,7 @@ list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_device_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_distributions_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_dlconvertor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_event_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_exchange_device_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_generator_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_half_test.cu

--- a/aten/src/ATen/test/cuda_event_test.cpp
+++ b/aten/src/ATen/test/cuda_event_test.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include <ATen/cuda/CUDAEvent.h>
+#include <ATen/cuda/CUDAGraph.h>
+#include <ATen/cuda/Sleep.h>
+
+TEST(CUDAEventTest, testCUDAExternalEvent) {
+  if (!at::cuda::is_available()) {
+    return;
+  }
+
+  // Create two external CUDA events
+  unsigned int flags = cudaEventDefault | cudaEventExternal;
+  auto event1 = at::cuda::CUDAEvent(flags);
+  auto event2 = at::cuda::CUDAEvent(flags);
+  // Ensure external CUDAEvent remain valid and functional after being moved.
+  auto start_event = std::move(event1);
+  auto end_event = std::move(event2);
+
+  auto stream = at::cuda::getStreamFromPool();
+  at::cuda::setCurrentCUDAStream(stream);
+
+  auto graph = at::cuda::CUDAGraph();
+  graph.capture_begin();
+  start_event.record();
+  at::cuda::sleep(100000);
+  end_event.record();
+  graph.capture_end();
+
+  // External events should correctly record timestamps even when used inside
+  // CUDA graphs, and elapsed_time() between them should be positive.
+  stream.synchronize();
+  graph.replay();
+  at::cuda::device_synchronize();
+  EXPECT_TRUE(start_event.elapsed_time(end_event) > 0);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167711

# Motivation
This PR aims to fix the bug that the moved-to object's `external_` member is not assigned correctly.

# Additional Context
It's not fine to swap the valid value and the invalid value. We'd just need to prevent double-free.
