### PR TITLE
[doc] README add cmake prefix for non-conda env

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ export CMAKE_PREFIX_PATH="${CONDA_PREFIX:-'$(dirname $(which conda))/../'}:${CMA
 python -m pip install --no-build-isolation -v -e .
 
 # the CMake prefix for non-conda environment, e.g. Python venv
-# after activating the venv
+# call following after activating the venv
 export CMAKE_PREFIX_PATH="${VIRTUAL_ENV}:${CMAKE_PREFIX_PATH}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -292,8 +292,13 @@ python tools/amd_build/build_amd.py
 Install PyTorch
 
 ```bash
+# the CMake prefix for conda environment
 export CMAKE_PREFIX_PATH="${CONDA_PREFIX:-'$(dirname $(which conda))/../'}:${CMAKE_PREFIX_PATH}"
 python -m pip install --no-build-isolation -v -e .
+
+# the CMake prefix for non-conda environment, e.g. Python venv
+# after activating the venv
+export CMAKE_PREFIX_PATH="${VIRTUAL_ENV}:${CMAKE_PREFIX_PATH}"
 ```
 
 **On macOS**


### PR DESCRIPTION
Add the CMAKE_PREFIX_PATH for non-conda Python env
