### PR TITLE
[AArch64][Build] allow missing cutlass file if CUDA disabled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -634,14 +634,16 @@ def mirror_inductor_external_kernels() -> None:
     """
     Copy external kernels into Inductor so they are importable.
     """
+    cuda_is_disabled = not str2bool(os.getenv("USE_CUDA"))
     paths = [
         (
             CWD / "torch/_inductor/kernel/vendored_templates/cutedsl_grouped_gemm.py",
             CWD
             / "third_party/cutlass/examples/python/CuTeDSL/blackwell/grouped_gemm.py",
+            True,
         ),
     ]
-    for new_path, orig_path in paths:
+    for new_path, orig_path, allow_missing_if_cuda_is_disabled in paths:
         # Create the dirs involved in new_path if they don't exist
         if not new_path.exists():
             new_path.parent.mkdir(parents=True, exist_ok=True)
@@ -655,6 +657,12 @@ def mirror_inductor_external_kernels() -> None:
                 # copytree fails if the tree exists already, so remove it.
                 shutil.rmtree(new_path)
             shutil.copytree(orig_path, new_path)
+            continue
+        if (
+            not orig_path.exists()
+            and allow_missing_if_cuda_is_disabled
+            and cuda_is_disabled
+        ):
             continue
         raise RuntimeError(
             "Check the file paths in `mirror_inductor_external_kernels()`"


### PR DESCRIPTION
In a CUDA-disabled build of PyTorch, you may well want to wipe the `third_party/cutlass` directory. However, this can produce an error in `setup.py:mirror_inductor_external_kernels()`. This patch ignores the missing file if `USE_CUDA=0` is set before calling `setup.py`.