### PR TITLE
[xpu][test]port modules and view_ops test files for Intel GPU

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -11,7 +11,7 @@ import torch
 from torch._subclasses.meta_utils import assert_metadata_eq
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests, onlyCPU, onlyCUDA, toleranceOverride, tol, skipMeta)
+    instantiate_device_type_tests, onlyCPU, onlyOn, toleranceOverride, tol, skipMeta)
 from torch.testing._internal.common_modules import module_db, modules, ModuleErrorEnum, TrainEvalMode
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, freeze_rng_state, mock_wrapper, get_tensors_from, gradcheck,
@@ -23,6 +23,10 @@ if TEST_WITH_ROCM:
     import os
     os.environ["PYTORCH_MIOPEN_SUGGEST_NHWC"] = "1"
     os.environ["PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM"] = "1"
+
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
 
 
 class TestModule(TestCase):
@@ -145,7 +149,7 @@ class TestModule(TestCase):
                 m.train(training)
                 self._assert_module_parameters_and_buffer_are(m, device, dtype)
 
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @modules(module_db)
     def test_multiple_device_transfer(self, device, dtype, module_info, training):
         module_cls = module_info.module_cls
@@ -178,11 +182,11 @@ class TestModule(TestCase):
                 self._assert_module_parameters_and_buffer_are(m, "cpu", dtype)
 
                 # === Move back to GPU and forward pass ===
-                m.cuda()
+                m.to(device_type)
                 m(*input_device_args, **input_device_kwargs)
                 self._assert_module_parameters_and_buffer_are(m, device, dtype)
 
-                if torch.cuda.device_count() >= 2:
+                if torch.accelerator.device_count() >= 2:
                     # === test cross-GPU transfer works
                     def _to_device1(objs):
                         if isinstance(objs, (tuple, list)):
@@ -190,16 +194,16 @@ class TestModule(TestCase):
                         elif isinstance(objs, dict):
                             return {name: _to_device1(item) for name, item in objs.items()}
                         elif isinstance(objs, torch.Tensor):
-                            return objs.cuda(1)
+                            return objs.to(f"{device_type}:1")
                         else:
                             return objs
                     input_device_1_args = _to_device1(input_device_args)
                     input_device_1_kwargs = _to_device1(input_device_kwargs)
 
-                    m.cuda(1)
-                    with torch.cuda.device(1):
+                    m.to(f"{device_type}:1")
+                    with torch.device(f"{device_type}:1"):
                         m(*input_device_1_args, **input_device_1_kwargs)
-                    self._assert_module_parameters_and_buffer_are(m, torch.device("cuda:1"), dtype)
+                    self._assert_module_parameters_and_buffer_are(m, torch.device(f"{device_type}:1"), dtype)
 
     @modules(module_db)
     def test_repr(self, device, dtype, module_info, training):
@@ -534,7 +538,7 @@ class TestModule(TestCase):
     def test_gradgrad(self, device, dtype, module_info, training):
         self._test_gradients_helper(device, dtype, module_info, training, gradgradcheck)
 
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @with_tf32_off  # Turn off TF32 to compute at full precision https://github.com/pytorch/pytorch/issues/86798
     @toleranceOverride({torch.float32: tol(5e-2, 0),
                         torch.float64: tol(4e-4, 0)})
@@ -884,8 +888,8 @@ class TestModule(TestCase):
     def test_to(self, device, dtype, module_info, training, swap, set_grad):
         module_cls = module_info.module_cls
         devices = ['cpu']
-        if torch.cuda.is_available():
-            devices += ['cuda']
+        if device_type != "cpu":
+            devices += [device_type]
         dtypes = module_info.dtypes
         module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
                                                        requires_grad=False, training=training)
@@ -1007,7 +1011,7 @@ class TestModule(TestCase):
                 self.assertTrue(all(a != b for a, b in zip(p_cdatas_before, p_cdatas_after)))
 
 
-instantiate_device_type_tests(TestModule, globals(), allow_mps=True)
+instantiate_device_type_tests(TestModule, globals(), allow_mps=True, allow_xpu=True)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -194,13 +194,13 @@ class TestModule(TestCase):
                         elif isinstance(objs, dict):
                             return {name: _to_device1(item) for name, item in objs.items()}
                         elif isinstance(objs, torch.Tensor):
-                            return objs.to(f"{device_type}:1")
+                            return objs.to(1)
                         else:
                             return objs
                     input_device_1_args = _to_device1(input_device_args)
                     input_device_1_kwargs = _to_device1(input_device_kwargs)
 
-                    m.to(f"{device_type}:1")
+                    m.to(1)
                     with torch.device(f"{device_type}:1"):
                         m(*input_device_1_args, **input_device_1_kwargs)
                     self._assert_module_parameters_and_buffer_are(m, torch.device(f"{device_type}:1"), dtype)
@@ -450,7 +450,7 @@ class TestModule(TestCase):
         module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
                                                        requires_grad=True, training=training)
         if "xpu" in device and module_info.name == "nn.MultiheadAttention":
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2356")
+            self.skipTest("GradcheckError issue in MultiheadAttention, https://github.com/intel/torch-xpu-ops/issues/2356")
         # === Set nondet tol for gradcheck to user-defined value if on CUDA and cudNN is enabled
         gradcheck_nondet_tol = 0.0
         if (torch.device(device).type == 'cuda' and torch.backends.cudnn.enabled) or device_type == "xpu":

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -555,10 +555,7 @@ class TestModule(TestCase):
                 and 'cuda' in device
                 and torch.backends.cudnn.enabled):
             return
-        if "xpu" in device and module_info.name == "nn.ConvTranspose3d" and dtype is torch.complex32:
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2354")
-        if "xpu" in device and module_info.name == "nn.CrossEntropyLoss" and dtype is torch.float16:
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2354")
+
         # Test cpu and gpu results are the same
         module_cls = module_info.module_cls
         module_inputs_cpu = module_info.module_inputs_func(module_info, device="cpu", dtype=dtype,
@@ -640,17 +637,6 @@ class TestModule(TestCase):
     @with_tf32_off
     @modules(module_db)
     def test_memory_format(self, device, dtype, module_info, training):
-        if (
-            "xpu" in device
-            and module_info.name in [
-                "nn.GroupNorm",
-                "nn.ReflectionPad2d",
-                "nn.ReflectionPad3d",
-                "nn.ReplicationPad2d",
-                "nn.ReplicationPad3d"
-            ]
-        ):
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2357")
         is_sm86or80 = device.startswith("cuda") and (torch.cuda.get_device_capability(0) == (8, 6)
                                                      or torch.cuda.get_device_capability(0) == (8, 0))
         # TODO tighten it to a specific module

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -555,7 +555,10 @@ class TestModule(TestCase):
                 and 'cuda' in device
                 and torch.backends.cudnn.enabled):
             return
-
+        if "xpu" in device and module_info.name == "nn.ConvTranspose3d" and dtype is torch.complex32:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2354")
+        if "xpu" in device and module_info.name == "nn.CrossEntropyLoss" and dtype is torch.float16:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2354")
         # Test cpu and gpu results are the same
         module_cls = module_info.module_cls
         module_inputs_cpu = module_info.module_inputs_func(module_info, device="cpu", dtype=dtype,
@@ -637,6 +640,17 @@ class TestModule(TestCase):
     @with_tf32_off
     @modules(module_db)
     def test_memory_format(self, device, dtype, module_info, training):
+        if (
+            "xpu" in device
+            and module_info.name in [
+                "nn.GroupNorm",
+                "nn.ReflectionPad2d",
+                "nn.ReflectionPad3d",
+                "nn.ReplicationPad2d",
+                "nn.ReplicationPad3d"
+            ]
+        ):
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2357")
         is_sm86or80 = device.startswith("cuda") and (torch.cuda.get_device_capability(0) == (8, 6)
                                                      or torch.cuda.get_device_capability(0) == (8, 0))
         # TODO tighten it to a specific module

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -201,7 +201,7 @@ class TestModule(TestCase):
                     input_device_1_kwargs = _to_device1(input_device_kwargs)
 
                     m.to(1)
-                    with torch.device(f"{device_type}:1"):
+                    with torch.accelerator.device_index(1):
                         m(*input_device_1_args, **input_device_1_kwargs)
                     self._assert_module_parameters_and_buffer_are(m, torch.device(f"{device_type}:1"), dtype)
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -889,7 +889,7 @@ class TestModule(TestCase):
     def test_to(self, device, dtype, module_info, training, swap, set_grad):
         module_cls = module_info.module_cls
         devices = ['cpu']
-        if torch.cuda.is_available or torch.xpu.is_available:
+        if torch.cuda.is_available() or torch.xpu.is_available():
             devices += [device_type]
         dtypes = module_info.dtypes
         module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -28,7 +28,6 @@ device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )
 
-
 class TestModule(TestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -890,7 +889,7 @@ class TestModule(TestCase):
     def test_to(self, device, dtype, module_info, training, swap, set_grad):
         module_cls = module_info.module_cls
         devices = ['cpu']
-        if torch.accelerator.is_available:
+        if torch.cuda.is_available or torch.xpu.is_available:
             devices += [device_type]
         dtypes = module_info.dtypes
         module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -130,7 +130,11 @@ class TestViewOps(TestCase):
             return False
         # Note: only validates storage on native device types
         # because some accelerators, like XLA, do not expose storage
-        if base.device.type == "cpu" or base.device.type == "cuda":
+        if (
+            base.device.type == "cpu"
+            or base.device.type == "cuda"
+            or base.device.type == "xpu"
+        ):
             if base.untyped_storage().data_ptr() != other.untyped_storage().data_ptr():
                 return False
 
@@ -1109,6 +1113,9 @@ class TestViewOps(TestCase):
 
 class TestOldViewOps(TestCase):
     def test_ravel(self, device):
+        if "xpu" in device:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
+
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
                 # Continuous Tensor -> View
@@ -1270,6 +1277,8 @@ class TestOldViewOps(TestCase):
 
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
+        if "xpu" in device:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
         zero_dim_tensor = torch.tensor(123, device=device)
         flat0 = zero_dim_tensor.flatten()
         one_dim_tensor = torch.tensor([123], device=device)
@@ -2130,8 +2139,10 @@ class TestOldViewOps(TestCase):
         t.col_indices()
 
 
-instantiate_device_type_tests(TestViewOps, globals(), include_lazy=True, allow_mps=True)
-instantiate_device_type_tests(TestOldViewOps, globals())
+instantiate_device_type_tests(
+    TestViewOps, globals(), include_lazy=True, allow_mps=True, allow_xpu=True
+)
+instantiate_device_type_tests(TestOldViewOps, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1111,6 +1111,9 @@ class TestViewOps(TestCase):
 class TestOldViewOps(TestCase):
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_ravel(self, device):
+        if "xpu" in device:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
+
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
                 # Continuous Tensor -> View
@@ -1273,6 +1276,8 @@ class TestOldViewOps(TestCase):
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
+        if "xpu" in device:
+            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
         zero_dim_tensor = torch.tensor(123, device=device)
         flat0 = zero_dim_tensor.flatten()
         one_dim_tensor = torch.tensor([123], device=device)

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1109,7 +1109,10 @@ class TestViewOps(TestCase):
 
 
 class TestOldViewOps(TestCase):
-    @skipXPUIf(True, "NotImplementedError with test_ravel, https://github.com/intel/torch-xpu-ops/issues/2358")
+    @skipXPUIf(
+        True,
+        "NotImplementedError with test_ravel, https://github.com/intel/torch-xpu-ops/issues/2358",
+    )
     def test_ravel(self, device):
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
@@ -1270,7 +1273,10 @@ class TestOldViewOps(TestCase):
             RuntimeError, lambda: x.reshape_as(torch.rand(10, device=device))
         )
 
-    @skipXPUIf(True, "NotImplementedError with test_flatten,https://github.com/intel/torch-xpu-ops/issues/2358")
+    @skipXPUIf(
+        True,
+        "NotImplementedError with test_flatten,https://github.com/intel/torch-xpu-ops/issues/2358",
+    )
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
         zero_dim_tensor = torch.tensor(123, device=device)

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1111,9 +1111,6 @@ class TestViewOps(TestCase):
 class TestOldViewOps(TestCase):
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_ravel(self, device):
-        if "xpu" in device:
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
-
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
                 # Continuous Tensor -> View
@@ -1276,8 +1273,6 @@ class TestOldViewOps(TestCase):
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
-        if "xpu" in device:
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
         zero_dim_tensor = torch.tensor(123, device=device)
         flat0 = zero_dim_tensor.flatten()
         one_dim_tensor = torch.tensor([123], device=device)

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_device_type import (
     skipLazy,
     skipMeta,
     skipXLA,
+    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -130,11 +131,7 @@ class TestViewOps(TestCase):
             return False
         # Note: only validates storage on native device types
         # because some accelerators, like XLA, do not expose storage
-        if (
-            base.device.type == "cpu"
-            or base.device.type == "cuda"
-            or base.device.type == "xpu"
-        ):
+        if base.device.type in ["cpu", "cuda", "xpu"]:
             if base.untyped_storage().data_ptr() != other.untyped_storage().data_ptr():
                 return False
 
@@ -1112,10 +1109,8 @@ class TestViewOps(TestCase):
 
 
 class TestOldViewOps(TestCase):
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_ravel(self, device):
-        if "xpu" in device:
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
-
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
                 # Continuous Tensor -> View
@@ -1275,10 +1270,9 @@ class TestOldViewOps(TestCase):
             RuntimeError, lambda: x.reshape_as(torch.rand(10, device=device))
         )
 
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
-        if "xpu" in device:
-            self.skipTest("https://github.com/intel/torch-xpu-ops/issues/2358")
         zero_dim_tensor = torch.tensor(123, device=device)
         flat0 = zero_dim_tensor.flatten()
         one_dim_tensor = torch.tensor([123], device=device)

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1109,7 +1109,7 @@ class TestViewOps(TestCase):
 
 
 class TestOldViewOps(TestCase):
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
+    @skipXPUIf(True, "NotImplementedError with test_ravel, https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_ravel(self, device):
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
@@ -1270,7 +1270,7 @@ class TestOldViewOps(TestCase):
             RuntimeError, lambda: x.reshape_as(torch.rand(10, device=device))
         )
 
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2358")
+    @skipXPUIf(True, "NotImplementedError with test_flatten,https://github.com/intel/torch-xpu-ops/issues/2358")
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
         zero_dim_tensor = torch.tensor(123, device=device)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3688,6 +3688,8 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
+                                dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),
@@ -4028,7 +4030,9 @@ module_db: list[ModuleInfo] = [
                    DecorateInfo(toleranceOverride({torch.float16: tol(atol=3e-2, rtol=1e-3)}), "TestModule",
                                 "test_forward", dtypes=[torch.float16], device_type='cpu'),
                    DecorateInfo(unittest.expectedFailure, "TestModule", "test_cpu_gpu_parity", dtypes=[torch.float16],
-                                device_type='cuda'),),
+                                device_type='cuda'),
+                   DecorateInfo(unittest.expectedFailure, "TestModule", "test_cpu_gpu_parity", dtypes=[torch.float16],
+                                device_type='xpu'),),
                ),
     ModuleInfo(torch.nn.CTCLoss,
                module_inputs_func=module_inputs_torch_nn_CTCLoss,
@@ -4065,6 +4069,7 @@ module_db: list[ModuleInfo] = [
                    # No channels_last support for GroupNorm currently.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format', device_type='cuda'),
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format', device_type='mps'),
+                   DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format', device_type='xpu'),
                    DecorateInfo(unittest.skip("Skipped!"), "TestModule", "test_grad",
                                 active_if=TEST_WITH_ROCM, device_type='cuda'),)
                ),
@@ -4364,7 +4369,9 @@ module_db: list[ModuleInfo] = [
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
                                 device_type='cuda'),
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
-                                device_type='mps'),)
+                                device_type='mps'),
+                   DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
+                                device_type='xpu'),)
                ),
     ModuleInfo(torch.nn.ReflectionPad3d,
                module_inputs_func=module_inputs_torch_nn_ReflectionPad3d,
@@ -4373,7 +4380,9 @@ module_db: list[ModuleInfo] = [
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
                                 device_type='cuda'),
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
-                                device_type='mps'),)
+                                device_type='mps'),
+                   DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
+                                device_type='xpu'),)
                ),
     ModuleInfo(torch.nn.ReplicationPad1d,
                module_inputs_func=module_inputs_torch_nn_ReplicationPad1d,
@@ -4385,7 +4394,9 @@ module_db: list[ModuleInfo] = [
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
                                 device_type='cuda'),
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
-                                device_type='mps'),)
+                                device_type='mps'),
+                   DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
+                                device_type='xpu'),)
                ),
     ModuleInfo(torch.nn.ReplicationPad3d,
                module_inputs_func=module_inputs_torch_nn_ReplicationPad3d,
@@ -4394,7 +4405,9 @@ module_db: list[ModuleInfo] = [
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
                                 device_type='cuda'),
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
-                                device_type='mps'),)
+                                device_type='mps'),
+                   DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format',
+                                device_type='xpu'),)
                ),
     ModuleInfo(torch.nn.SELU,
                module_inputs_func=module_inputs_torch_nn_SELU,

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3709,6 +3709,8 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
+                                dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3688,8 +3688,6 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
-                                dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),


### PR DESCRIPTION
we port test_modules, and test_view_ops for Intel GPU in this pr.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

Use torch.accelerator for general gpu
Skip the case if running on xpu which has known issues
extend case that running on cuda to cuda and xpu.
