### PR TITLE
Use treeless checkout to speedup some workflows

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: Works as stated in actions/checkout, but the default value is 0
     required: false
     default: "0"
+  checkout-mode:
+    description: 'Mode of checkout; one of "normal", "blobless", "treeless".'
+    default: "normal"
 
 runs:
   using: composite
@@ -35,6 +38,7 @@ runs:
         cd "${GITHUB_WORKSPACE}"
         git config --global fetch.parallel 0
         git config --global submodule.fetchJobs 0
+        git config --global clone.filterSubmodules true
 
         # Clean workspace. The default checkout action should also do this, but
         # do it here as well just in case
@@ -49,13 +53,18 @@ runs:
     - name: Checkout PyTorch
       id: first-checkout-attempt
       continue-on-error: true
-      uses: actions/checkout@v4
+      uses: pytorch/test-infra/.github/actions/checkout@main
+      env:
+        filter: ${{ inputs.checkout-mode == 'blobless' && 'blob:none' || inputs.checkout-mode == 'treeless' && 'tree:0' || null }}
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         # --depth=1 for speed, manually fetch history and other refs as necessary
         fetch-depth: ${{ inputs.fetch-depth }}
+        single-branch: true
         submodules: ${{ inputs.submodules }}
         show-progress: false
+        filter: ${{ env.filter }}
+        submodules-filter: ${{ env.filter }}
 
     - name: Clean submodules post checkout
       id: clean-submodules
@@ -91,10 +100,15 @@ runs:
         mkdir "${GITHUB_WORKSPACE}"
 
     - name: Checkout PyTorch (try again)
-      uses: actions/checkout@v4
+      uses: pytorch/test-infra/.github/actions/checkout@main
+      env:
+        filter: ${{ inputs.checkout-mode == 'blobless' && 'blob:none' || inputs.checkout-mode == 'treeless' && 'tree:0' || null }}
       if: ${{ steps.first-clean.outcome != 'success' || steps.first-checkout-attempt.outcome != 'success' }}
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: ${{ inputs.fetch-depth }}
+        single-branch: true
         submodules: ${{ inputs.submodules }}
         show-progress: false
+        filter: ${{ env.filter }}
+        submodules-filter: ${{ env.filter }}

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -151,9 +151,11 @@ jobs:
       # checkout because when we run this action we don't *have* a local
       # checkout. In other cases you should prefer a local checkout.
       - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        # uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        uses: zklaus/pytorch/.github/actions/checkout-pytorch@test-treeless-checkout
         with:
           no-sudo: true
+          checkout-mode: treeless
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,7 +103,7 @@ jobs:
         ADDITIONAL_LINTRUNNER_ARGS="--take PYREFLY --all-files" .github/scripts/lintrunner.sh
 
   lintrunner-noclang:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: zklaus/test-infra/.github/workflows/linux_job_v2.yml@filtered-checkout
     name: lintrunner-noclang-${{ needs.get-changed-files.outputs.changed-files == '*' && 'all' || 'partial' }}
     needs: [get-label-type, get-changed-files]
     with:
@@ -113,6 +113,7 @@ jobs:
       # NB: A shallow checkout won't work here because calculate-docker-image requires a full checkout
       # to run git rev-parse HEAD~:.ci/docker when a new image is needed
       fetch-depth: 0
+      checkout-mode: treeless
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |


### PR DESCRIPTION
This PR is a test/demonstration of the treeless checkout technique described in https://github.com/pytorch/pytorch/issues/169184 and implemented in https://github.com/pytorch/test-infra/pull/7597.

It applies it to selected workflows and shows the reduction in time needed for the checkout step:

|Workflow|Time on `viable/strict`|Time here|Time Saving|
|-|-|-|-|
|Lint/lintrunner-noclang| 2m42s | 55s | 1m47s |
| linux-jammy-py3.14-clang12/build (via _linux-build)| 2m30s | 1m29s| 61s|
| linux-jammy-cuda12.8-cudnn9-py3.10-clang12 / build (via _linux-build) | 2m31s | 1m33s| 59s|