### PR TITLE
Removed deprecated `split_cat_fx_passes`

### DIFF
--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -278,7 +278,6 @@ class NumBytesMetricTests(TestCase):
         inp = (T(10, 10), T(10, 10))
         self.assertExpectedInline(count_numel(f, *inp), """680""")
 
-    @patch.object(config, "split_cat_fx_passes", False)
     @patch.object(
         config,
         "pre_grad_fusion_options",
@@ -300,7 +299,6 @@ class NumBytesMetricTests(TestCase):
         inp = (T(10, 10) for _ in range(16))
         self.assertExpectedInline(count_numel(f, *inp), """6400""")
 
-    @patch.object(config, "split_cat_fx_passes", False)
     @patch.object(
         config,
         "pre_grad_fusion_options",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -306,9 +306,6 @@ _post_fusion_custom_pass: Optional[
     ]
 ] = None
 
-# Deprecated
-split_cat_fx_passes = True
-
 # Optimize conv-batchnorm if batchnorm is in eval mode. Slightly reduces numerical stability.
 efficient_conv_bn_eval_fx_passes = False
 


### PR DESCRIPTION
  ## Remove deprecated `split_cat_fx_passes`

First of a couple of small PRs that remove deprecated and unused code.

Remove the deprecated `split_cat_fx_passes` configuration variable from inductor config and clean up associated test patches.

  ### Changes
  - Remove `split_cat_fx_passes` from `torch/_inductor/config.py`
  - Remove `@patch.object(config, "split_cat_fx_passes", False)` decorators from tests in `test/inductor/test_perf.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben