### PR TITLE
[dynamo, nested graph breaks] Fix-nested-graph-break-suppression

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1855,7 +1855,7 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
 User code traceback:
-  File "test_error_messages.py", line N, in test_try_block_causes_multiple_graph_breaks
+  File "test_error_messages.py", line N, in test_try_block_causes_graph_breaks
     torch.compile(outer, backend="eager")(torch.ones(3))
   File "test_error_messages.py", line N, in outer
     return middle_with_try(x)
@@ -1878,7 +1878,7 @@ Graph Break Reason: Call to `torch._dynamo.graph_break()`
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
 User code traceback:
-  File "test_error_messages.py", line N, in test_try_block_causes_multiple_graph_breaks
+  File "test_error_messages.py", line N, in test_try_block_causes_graph_breaks
     torch.compile(outer, backend="eager")(torch.ones(3))
   File "test_error_messages.py", line N, in outer
     return middle_with_try(x)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1811,6 +1811,101 @@ User code traceback:
 """,
         )
 
+    @make_logging_test(graph_breaks=True)
+    def test_frame_loc_chain_with_deep_nesting(self, records):
+        global f1, f2, f3, f4, f5
+
+        def f1(x):
+            torch._dynamo.graph_break()
+            return x + 1
+
+        def f2(x):
+            return f1(x + 2)
+
+        def f3(x):
+            return f2(x + 3)
+
+        def f4(x):
+            return f3(x + 4)
+
+        def f5(x):
+            return f4(x + 5)
+
+        torch.compile(f5, backend="eager")(torch.randn(3))
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Call to `torch._dynamo.graph_break()`
+  Explanation: User-inserted graph break. Message: None
+  Hint: Remove the `torch._dynamo.graph_break()` call.
+
+  Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
+User code traceback:
+  File "test_error_messages.py", line N, in test_frame_loc_chain_with_deep_nesting
+    torch.compile(f5, backend="eager")(torch.randn(3))
+  File "test_error_messages.py", line N, in f5
+    return f4(x + 5)
+  File "test_error_messages.py", line N, in f4
+    return f3(x + 4)
+  File "test_error_messages.py", line N, in f3
+    return f2(x + 3)
+  File "test_error_messages.py", line N, in f2
+    return f1(x + 2)
+  File "test_error_messages.py", line N, in f1
+    torch._dynamo.graph_break()
+""",
+        )
+
+    @make_logging_test(graph_breaks=True)
+    def test_frame_loc_chain_with_class_methods(self, records):
+        global MyClass
+
+        class MyClass:
+            def method_a(self, x):
+                return self.method_b(x + 1)
+
+            def method_b(self, x):
+                return self.method_c(x + 2)
+
+            def method_c(self, x):
+                torch._dynamo.graph_break()
+                return x + 3
+
+        def wrapper(x):
+            obj = MyClass()
+            return obj.method_a(x)
+
+        torch.compile(wrapper, backend="eager")(torch.randn(3))
+        self.assertEqual(len(records), 1)
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Call to `torch._dynamo.graph_break()`
+  Explanation: User-inserted graph break. Message: None
+  Hint: Remove the `torch._dynamo.graph_break()` call.
+
+  Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
+User code traceback:
+  File "test_error_messages.py", line N, in test_frame_loc_chain_with_class_methods
+    torch.compile(wrapper, backend="eager")(torch.randn(3))
+  File "test_error_messages.py", line N, in wrapper
+    return obj.method_a(x)
+  File "test_error_messages.py", line N, in method_a
+    return self.method_b(x + 1)
+  File "test_error_messages.py", line N, in method_b
+    return self.method_c(x + 2)
+  File "test_error_messages.py", line N, in method_c
+    torch._dynamo.graph_break()
+""",
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4203,18 +4203,11 @@ class InstructionTranslatorBase(
             user_stack = torch._guards.TracingContext.extract_stack()
 
         try:
-            if config.nested_graph_breaks and self.parent is not None:
-                frame_loc = self._make_frame_loc(
-                    self.f_code.co_filename,
-                    self.lineno,
-                    self.f_code.co_firstlineno,
-                )
-            else:
-                frame_loc = self._make_frame_loc(
-                    user_stack[-1].filename,
-                    user_stack[-1].lineno,
-                    0,
-                )
+            frame_loc = self._make_frame_loc(
+                self.f_code.co_filename,
+                self.lineno,
+                self.f_code.co_firstlineno,
+            )
         except IndexError:
             # first instruction
             frame_loc = (

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4203,11 +4203,18 @@ class InstructionTranslatorBase(
             user_stack = torch._guards.TracingContext.extract_stack()
 
         try:
-            frame_loc = self._make_frame_loc(
-                self.f_code.co_filename,
-                self.lineno,
-                self.f_code.co_firstlineno,
-            )
+            if config.nested_graph_breaks and self.parent is not None:
+                frame_loc = self._make_frame_loc(
+                    self.f_code.co_filename,
+                    self.lineno,
+                    self.f_code.co_firstlineno,
+                )
+            else:
+                frame_loc = self._make_frame_loc(
+                    user_stack[-1].filename,
+                    user_stack[-1].lineno,
+                    0,
+                )
         except IndexError:
             # first instruction
             frame_loc = (

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4203,11 +4203,18 @@ class InstructionTranslatorBase(
             user_stack = torch._guards.TracingContext.extract_stack()
 
         try:
-            frame_loc = self._make_frame_loc(
-                user_stack[-1].filename,
-                user_stack[-1].lineno,
-                0,
-            )
+            if config.nested_graph_breaks and self.parent is not None:
+                frame_loc = self._make_frame_loc(
+                    self.f_code.co_filename,
+                    self.lineno,
+                    self.f_code.co_firstlineno,
+                )
+            else:
+                frame_loc = self._make_frame_loc(
+                    user_stack[-1].filename,
+                    user_stack[-1].lineno,
+                    0,
+                )
         except IndexError:
             # first instruction
             frame_loc = (


### PR DESCRIPTION
Fixes #167393 


### Summary:

- Modified graph break deduplication to use the full chain of frame locations when nested_graph_breaks=True. 

### Impact:

- module: dynamo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela