### PR TITLE
Add aot_inductor.link_openmp config

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7520,7 +7520,7 @@ class AOTInductorTestsTemplate:
             "libomp",
             "libgomp",
             "libiomp",
-            'libiomp5',
+            "libiomp5",
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1780,6 +1780,9 @@ class aot_inductor:
     # Whether the compiled .so should link to libtorch
     link_libtorch: bool = True
 
+    # Whether the compiled .so should link to OpenMP
+    link_openmp: bool = True
+
     # Currently the only valid option is "windows".
     # We'll use x86_64-w64-mingw32-gcc to cross-compile a .dll file
     # If using cuda, you also need to set WINDOWS_CUDA_HOME env var

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1310,7 +1310,10 @@ def _get_openmp_args(
     libs: list[str] = []
     passthrough_args: list[str] = []
 
-    if (config.aot_inductor.cross_target_platform == "windows" or not config.aot_inductor.link_openmp):
+    if (
+        config.aot_inductor.cross_target_platform == "windows"
+        or not config.aot_inductor.link_openmp
+    ):
         return cflags, ldflags, include_dir_paths, lib_dir_paths, libs, passthrough_args
     if _IS_MACOS:
         # Per https://mac.r-project.org/openmp/ right way to pass `openmp` flags to MacOS is via `-Xclang`

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1310,7 +1310,7 @@ def _get_openmp_args(
     libs: list[str] = []
     passthrough_args: list[str] = []
 
-    if config.aot_inductor.cross_target_platform == "windows":
+    if (config.aot_inductor.cross_target_platform == "windows" or not config.aot_inductor.link_openmp):
         return cflags, ldflags, include_dir_paths, lib_dir_paths, libs, passthrough_args
     if _IS_MACOS:
         # Per https://mac.r-project.org/openmp/ right way to pass `openmp` flags to MacOS is via `-Xclang`


### PR DESCRIPTION
This pull request adds support for optionally linking OpenMP when compiling with AOTInductor. The main change is the introduction of a new configuration option to control whether the compiled shared object (`.so`) should link to OpenMP, and the build logic is updated to respect this option.

AOTInductor configuration:

* Added a new `link_openmp` boolean option to the `aot_inductor` class in `torch/_inductor/config.py`, allowing users to control whether the compiled `.so` links to OpenMP. This defaults to `True`

Build logic update:

* Modified `_get_openmp_args` in `torch/_inductor/cpp_builder.py` to skip OpenMP linking arguments if `link_openmp` is set to `False`, in addition to the existing Windows platform check.


cc @mlazos @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben