### PR TITLE
Fix batch_norm dtype mismatch on MPS (fixes #154887)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -273,11 +273,23 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
       }
 
       // Compute output of batch norm
+      auto castTensorIfNeeded = [&](MPSGraphTensor* tensor, NSString* name) -> MPSGraphTensor* {
+        if (tensor && tensor.dataType != input_mps_dtype) {
+          return [mpsGraph castTensor:tensor toType:input_mps_dtype name:name];
+        }
+        return tensor;
+      };
+
+      MPSGraphTensor* normMeanTensor = castTensorIfNeeded(saveMeanTensor, @"bn_norm_mean_cast");
+      MPSGraphTensor* normVarTensor = castTensorIfNeeded(varTensor, @"bn_norm_var_cast");
+      MPSGraphTensor* normWeightTensor = castTensorIfNeeded(weightTensor, @"bn_norm_weight_cast");
+      MPSGraphTensor* normBiasTensor = castTensorIfNeeded(biasTensor, @"bn_norm_bias_cast");
+
       MPSGraphTensor* outputTensor = [mpsGraph normalizationWithTensor:inputTensor
-                                                            meanTensor:saveMeanTensor
-                                                        varianceTensor:varTensor
-                                                           gammaTensor:weightTensor
-                                                            betaTensor:biasTensor
+                                                            meanTensor:normMeanTensor
+                                                        varianceTensor:normVarTensor
+                                                           gammaTensor:normWeightTensor
+                                                            betaTensor:normBiasTensor
                                                                epsilon:(float)epsilon
                                                                   name:nil];
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1902,6 +1902,28 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(bn_cpu.weight.grad, bn_mps.weight.grad, atol=1e-5, rtol=1e-5)
         self.assertEqual(bn_cpu.bias.grad, bn_mps.bias.grad, atol=1e-5, rtol=1e-5)
 
+    def test_batch_norm_mixed_dtypes(self):
+        # See issue: https://github.com/pytorch/pytorch/issues/154887#issue-3111485538
+        input_mps = torch.rand((2, 3, 4), dtype=torch.float16, device="mps")
+        input_cpu = input_mps.clone().cpu()
+        mean_mps = torch.rand((3,), dtype=torch.float32, device="mps")
+        mean_cpu = mean_mps.clone().cpu()
+        var_mps = torch.rand((3,), dtype=torch.float32, device="mps")
+        var_cpu = var_mps.clone().cpu()
+
+        cases = [
+            ("functional", lambda inp, mean, var: torch.nn.functional.batch_norm(
+                inp, mean, var, training=False, eps=1e-5)),
+            ("native_legit_no_training", lambda inp, mean, var: torch.ops.aten._native_batch_norm_legit_no_training.default(
+                inp, None, None, mean, var, 0.1, 1e-5)[0]),
+        ]
+
+        for name, fn in cases:
+            mps_out = fn(input_mps, mean_mps, var_mps)
+            cpu_out = fn(input_cpu, mean_cpu, var_cpu)
+            self.assertEqual(mps_out, cpu_out, atol=1e-2, rtol=1e-2, msg=f"{name} mismatch")
+
+
     def test_layer_norm_backward(self):
         inputs = torch.rand(4, 4, device="mps", requires_grad=True)
         x = torch.nn.LayerNorm(4).to("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1902,26 +1902,38 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(bn_cpu.weight.grad, bn_mps.weight.grad, atol=1e-5, rtol=1e-5)
         self.assertEqual(bn_cpu.bias.grad, bn_mps.bias.grad, atol=1e-5, rtol=1e-5)
 
-    def test_batch_norm_mixed_dtypes(self):
-        # See issue: https://github.com/pytorch/pytorch/issues/154887#issue-3111485538
-        input_mps = torch.rand((2, 3, 4), dtype=torch.float16, device="mps")
-        input_cpu = input_mps.clone().cpu()
-        mean_mps = torch.rand((3,), dtype=torch.float32, device="mps")
-        mean_cpu = mean_mps.clone().cpu()
-        var_mps = torch.rand((3,), dtype=torch.float32, device="mps")
-        var_cpu = var_mps.clone().cpu()
+    @parametrize("case_name,fn", [
+        ("functional", lambda inp, mean, var: torch.nn.functional.batch_norm(
+            inp, mean, var, training=False, eps=1e-5)),
+        ("native_legit_no_training", lambda inp, mean, var: torch.ops.aten._native_batch_norm_legit_no_training.default(
+            inp, None, None, mean, var, 0.1, 1e-5)[0]),
+    ])
+    @parametrize("input_dtype,param_dtype,expect_error", [
+        (torch.float16, torch.float32, False),   # allowed mixed dtype
+        (torch.bfloat16, torch.float32, False),  # allowed mixed dtype
+        (torch.float32, torch.float16, True),    # disallowed: input not reduced float, params not float
+        (torch.float16, torch.bfloat16, True),   # disallowed: params not float
+        (torch.bfloat16, torch.float16, True),   # disallowed: params not float
+    ])
+    def test_batch_norm_mixed_dtypes(self, case_name, fn, input_dtype, param_dtype, expect_error):
+        # See issue: https://github.com/pytorch/pytorch/issues/154887
+        input_mps = torch.rand((2, 3, 4), dtype=input_dtype, device="mps")
+        input_cpu = input_mps.cpu()
+        mean_mps = torch.rand((3,), dtype=param_dtype, device="mps")
+        mean_cpu = mean_mps.cpu()
+        var_mps = torch.rand((3,), dtype=param_dtype, device="mps")
+        var_cpu = var_mps.cpu()
 
-        cases = [
-            ("functional", lambda inp, mean, var: torch.nn.functional.batch_norm(
-                inp, mean, var, training=False, eps=1e-5)),
-            ("native_legit_no_training", lambda inp, mean, var: torch.ops.aten._native_batch_norm_legit_no_training.default(
-                inp, None, None, mean, var, 0.1, 1e-5)[0]),
-        ]
+        if expect_error:
+            with self.assertRaises(Exception):
+                fn(input_mps, mean_mps, var_mps)
+            with self.assertRaises(Exception):
+                fn(input_cpu, mean_cpu, var_cpu)
+            return
 
-        for name, fn in cases:
-            mps_out = fn(input_mps, mean_mps, var_mps)
-            cpu_out = fn(input_cpu, mean_cpu, var_cpu)
-            self.assertEqual(mps_out, cpu_out, atol=1e-2, rtol=1e-2, msg=f"{name} mismatch")
+        mps_out = fn(input_mps, mean_mps, var_mps)
+        cpu_out = fn(input_cpu, mean_cpu, var_cpu)
+        self.assertEqual(mps_out, cpu_out, atol=1e-2, rtol=1e-2, msg=f"{case_name} mismatch")
 
 
     def test_layer_norm_backward(self):


### PR DESCRIPTION
This PR fixes a dtype mismatch in MPS batch_norm where float16 inputs and float32 running stats caused MPSGraph to fail during type inference.
The fix adds a small dtype alignment step (casting mean/var/weight/bias to the input dtype when needed).
No functional or numerical changes-only dtype consistency before calling normalizationWithTensor.

Fixes #154887