### PR TITLE
[Device Mesh] Enable id based DeviceMesh universe with flag decouple_backend_at_save

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -568,12 +568,21 @@ class DTensorTest(DTensorTestBase):
         buffer.seek(0)
         reloaded_st = torch.load(buffer, weights_only=False)
         self.assertFalse(hasattr(reloaded_st._spec.mesh, "_dim_group_names"))
+        self.assertNotEqual(sharded_tensor._spec.mesh, reloaded_st._spec.mesh)
+        self.assertEqual(
+            sharded_tensor.to_local().tolist(), reloaded_st.to_local().tolist()
+        )
+        self.assertEqual(sharded_tensor._spec.placements, reloaded_st._spec.placements)
         reloaded_st._spec.mesh = device_mesh
-        # We will change this to be not Equal in the following PR.
         self.assertEqual(sharded_tensor, reloaded_st)
         buffer.seek(0)
         reloaded_st = torch.load(buffer, weights_only=True)
         self.assertFalse(hasattr(reloaded_st._spec.mesh, "_dim_group_names"))
+        self.assertNotEqual(sharded_tensor._spec.mesh, reloaded_st._spec.mesh)
+        self.assertEqual(
+            sharded_tensor.to_local().tolist(), reloaded_st.to_local().tolist()
+        )
+        self.assertEqual(sharded_tensor._spec.placements, reloaded_st._spec.placements)
         reloaded_st._spec.mesh = device_mesh
         self.assertEqual(sharded_tensor, reloaded_st)
         DeviceMesh.decouple_backend_at_save = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #166010
* __->__ #167753
* #167590
* #167581

We always want to enable ID based rank_map to differentiate device mesh created within one universe or different universes. With the flag which decouples PG infos from device mesh save, we are now ready to enable this. (We tried to do this in https://github.com/pytorch/pytorch/pull/165680 and https://github.com/pytorch/pytorch/pull/166689/files but both seems to be BC breaking so we gate within this new flag added in #167590)

cc @H-Huang @awgu @wanchaol @fegin @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci