### PR TITLE
Shouldn't SymInt::is_symbolic() be defined as !maybe_as_int().has_value()?

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -155,8 +155,7 @@ class C10_API SymInt {
 
   // Distinguish actual symbolic values from constants stored on the heap
   bool is_symbolic() const {
-    return is_heap_allocated() &&
-        !toSymNodeImplUnowned()->constant_int().has_value();
+    return !maybe_as_int().has_value();
   }
 
   // N.B. It's important to keep this definition in the header

--- a/c10/test/core/SymInt_test.cpp
+++ b/c10/test/core/SymInt_test.cpp
@@ -10,6 +10,7 @@ using namespace c10;
 static void check(int64_t value) {
   const auto i = SymInt(value);
   EXPECT_EQ(i.maybe_as_int(), std::make_optional(value));
+  EXPECT_EQ(i.is_symbolic(), !i.maybe_as_int().has_value()) << value;
 }
 
 TEST(SymIntTest, ConcreteInts) {
@@ -138,7 +139,29 @@ void test_operator() {
     }
   }
 }
+
+// Here we have a SymNodeImpl for which constant_int() is nullopt, but
+// maybe_as_int().has_value() and therefore is not symbolic.
+class ConstantIntPretendingToBeNonConstantSymNodeImpl
+    : public ConstantSymNodeImpl<int64_t> {
+ public:
+  using ConstantSymNodeImpl<int64_t>::ConstantSymNodeImpl;
+  std::optional<int64_t> constant_int() override {
+    return std::nullopt;
+  }
+  std::optional<int64_t> maybe_as_int() override {
+    return ConstantSymNodeImpl<int64_t>::constant_int();
+  }
+};
 } // namespace
+
+TEST(SymIntTest, MaybeAsIntHasValueImpliesNonSymbolic) {
+  auto i = SymInt(
+      SymNode(c10::make_intrusive<ConstantIntPretendingToBeNonConstantSymNodeImpl>(
+          1234)));
+  ASSERT_TRUE(i.maybe_as_int().has_value());
+  EXPECT_FALSE(i.is_symbolic());
+}
 
 TEST(SymIntTest, BinaryPlus) {
   test_operator<std::plus>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #167759
* __->__ #167758

is_symbolic() appears to be inconsistent with the rest of the interface currently. This is a behavior change, but I believe the old behavior was a bug. Please review carefully.

Motivation: https://github.com/pytorch/pytorch/pull/161586#issuecomment-3246530671

Differential Revision: [D86982216](https://our.internmc.facebook.com/intern/diff/D86982216/)