### PR TITLE
add assume_32bit_indexing inductor config

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1161,6 +1161,12 @@ decompose_mem_bound_mm: bool = False
 # In the common case, most inputs will be aligned.
 assume_aligned_inputs: bool = False
 
+# assume_32bit_indexing means that we assume 32-bit indexing is always safe; we always
+# use 32-bit indices regardless of tensor sizes. If assume_32bit_indexing contradicts
+# with example inputs we throw. This is useful when all dynamic shapes are unbacked and
+# you know you only operate with 32-bit sizes.
+assume_32bit_indexing: bool = False
+
 # For the user-written Triton kernels compiled with the model, ignore the unsupported
 # arguments passed to the @triton.autotune in the user's code; this is unsafe, as
 # ignoring the unsupported args may lead to unexpected autotuning behavior: don't

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3275,6 +3275,10 @@ def expr_fits_within_32bit(e: sympy.Expr) -> bool:
     size_hint = V.graph.sizevars.size_hint
     has_hint = V.graph.sizevars.shape_env.has_hint
 
+    if config.assume_32bit_indexing:
+        V.graph.sizevars.check_leq(e, int_max)  # type: ignore
+        return True
+
     # Allow for unhinted e as long as we can still statically prove
     # (e.g., via ValueRanges) that it is still in bounds
     if V.graph.sizevars.statically_known_true(e <= int_max):
@@ -3290,7 +3294,7 @@ def expr_fits_within_32bit(e: sympy.Expr) -> bool:
     #       whether this fits in int32
     #   - If allowed range does have an upper bound, then obey the upper bound
     #       (check whether upper bound < int32_max) without checking the hint.
-
+    # Laith: I do not like this!
     if V.aot_compilation:
         # check whether value has an upper bound (1e20 is > INT64_MAX, assume
         # there is no upper bound if it can be larger than 1e20)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3294,7 +3294,7 @@ def expr_fits_within_32bit(e: sympy.Expr) -> bool:
     #       whether this fits in int32
     #   - If allowed range does have an upper bound, then obey the upper bound
     #       (check whether upper bound < int32_max) without checking the hint.
-    # Laith: I do not like this!
+
     if V.aot_compilation:
         # check whether value has an upper bound (1e20 is > INT64_MAX, assume
         # there is no upper bound if it can be larger than 1e20)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3276,7 +3276,7 @@ def expr_fits_within_32bit(e: sympy.Expr) -> bool:
     has_hint = V.graph.sizevars.shape_env.has_hint
 
     if config.assume_32bit_indexing:
-        V.graph.sizevars.check_leq(e, int_max)  # type: ignore
+        V.graph.sizevars.check_leq(e, int_max)  # type: ignore[arg-type]
         return True
 
     # Allow for unhinted e as long as we can still statically prove


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167784

when we know all tensor and intermediate tensors fit in 32 bit but use unbacked DS
we want a way to assume that we can use 32 bit indexing(we will runtime assert on it).

It is not practical to torch check every possible intermediate tensor size ahead of time.

This is needed to enhance vLLM perf with unbacked,  since in vLLM all tensors and 
intermediates assumed to fit in 32 bits.  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela