### PR TITLE
[xpu][test] reduce xpu disabled cases (1/N)

### DIFF
--- a/test/inductor/test_cooperative_reductions.py
+++ b/test/inductor/test_cooperative_reductions.py
@@ -223,8 +223,7 @@ class CooperativeReductionTests(TestCase):
 
         # With online softmax, the computation of max and sum are done
         # jointly and they share a single barrier call.
-        # XPU doesn't support online softmax yet.
-        expected_num_barrier = 8 if config.online_softmax and GPU_TYPE != "xpu" else 16
+        expected_num_barrier = 8 if config.online_softmax else 16
         self.assertEqual(
             source_code.count("triton_helpers.x_grid_barrier"), expected_num_barrier
         )

--- a/test/inductor/test_custom_lowering.py
+++ b/test/inductor/test_custom_lowering.py
@@ -209,7 +209,7 @@ class TestCustomLowering(InductorTestCase):
 
     @requires_gpu()
     @skipIfRocm
-    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/2328")
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
     @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
     def test_tanh_approx(self):
         def fn(inp):
@@ -224,7 +224,7 @@ class TestCustomLowering(InductorTestCase):
 
     @requires_gpu()
     @skipIfRocm
-    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/2328")
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
     @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
     def test_multi_inp_asm(self):
         def fn(a, b):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1911,6 +1911,7 @@ class TestMaxAutotune(TestCase):
 
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
     @unittest.skipIf(TEST_WITH_ROCM, "out_dtype override only available on NVIDIA")
+    @skipIfXpu(msg="out_dtype override only available on NVIDIA")
     def test_bmm_out_dtype(self):
         def f(a, b):
             return torch.bmm(a, b, out_dtype=torch.float32)

--- a/test/inductor/test_op_dtype_prop.py
+++ b/test/inductor/test_op_dtype_prop.py
@@ -204,11 +204,20 @@ class TestCase(InductorTestCase):
 
         # Edge case: torch.round maps to libdevice.nearbyint.
         triton_op_name_overrides = {
-            "round": "nearbyint",
-            # torch.sqrt lowers to tl.sqrt_rn after switching away from libdevice.sqrt
-            "sqrt": "sqrt_rn",
+            "default": {
+                "round": "nearbyint",
+                # torch.sqrt lowers to tl.sqrt_rn after switching away from libdevice.sqrt
+                "sqrt": "sqrt_rn",
+            },
+            "xpu": {
+                "round": "nearbyint",
+                "sqrt": "sqrt",
+            },
         }
-        override = triton_op_name_overrides.get(op_name)
+        if GPU_TYPE in triton_op_name_overrides:
+            override = triton_op_name_overrides[GPU_TYPE].get(op_name)
+        else:
+            override = triton_op_name_overrides["default"].get(op_name)
         triton_op_name = override if override is not None else torch_op_name
 
         # Get the number of args for the op.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -13728,6 +13728,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             self.assertFalse(".run(" in code[0])
 
     # skip cpu test since rms norm is always decomposed on cpu
+    @skipIfXpu(msg="_fused_rms_norm is not implemented on XPU yet")
     def test_lite_mode_not_decompose(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -905,10 +905,6 @@ class CommonTemplate:
         # Check for 2 reduction dimensions.
         self._assert_reduction_ndims(code, 2)
 
-    @skipIfXpu(
-        msg="AssertionError: Scalars are not equal!, "
-        "https://github.com/intel/torch-xpu-ops/issues/2332"
-    )
     @test_torchinductor.skip_if_triton_cpu  # Illegal instruction  File; cannot xfail because it crashes process
     def test_2d_reduction_multi_kernel(self):
         """

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2556,10 +2556,7 @@ def forward(self, arg0_1, arg1_1):
         self.assertEqual(actual, expected)
 
     @requires_gpu
-    @skipIfXpu(
-        msg="XPU Triton result in nan, "
-        "https://github.com/intel/torch-xpu-ops/issues/2330"
-    )
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
     @skipIfRocm
     @inductor_config.patch({"triton.autotune_at_compile_time": True})
     @parametrize("quotes", ["single", "double"])

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -357,10 +357,11 @@ def prepare_softmax_extra_check(match):
     """
     We only have triton online softmax kernels currently.
     """
+    device_type = match.kwargs["x"].meta["val"].device.type
     return (
         config.online_softmax
-        and match.kwargs["x"].meta["val"].device.type in ["cuda", "xpu"]
-        and getattr(config, f'{match.kwargs["x"].meta["val"].device.type}_backend') == 'triton'
+        and device_type in ["cuda", "xpu"]
+        and getattr(config, f"{device_type}_backend") == "triton"
     )
 
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -359,8 +359,8 @@ def prepare_softmax_extra_check(match):
     """
     return (
         config.online_softmax
-        and match.kwargs["x"].meta["val"].device.type == "cuda"
-        and config.cuda_backend == "triton"
+        and match.kwargs["x"].meta["val"].device.type in ["cuda", "xpu"]
+        and getattr(config, f'{match.kwargs["x"].meta["val"].device.type}_backend') == 'triton'
     )
 
 


### PR DESCRIPTION
Fixes #167418, Fixes #166710, Fixes #166709, Fixes #167810, Fixes #167808, Fixes #167809, Fixes #165858

* skip `test_bmm_out_dtype` because only cuda support out_dtype
* skip `test_tanh_approx`, `test_kernel_inline_asm` and `test_multi_inp_asm` because `inline_asm_elementwise` not yet supported on Intel GPU
* revert `test_chained_reductions` because add xpu support for `prepare_softmax_extra_check`
* enable `test_2d_reduction_multi_kernel` because add xpu support for `prepare_softmax_extra_check`
* skip `test_lite_mode_not_decompose` and its related UT because `_fused_rms_norm` is not supported on xpu
* add device specific op names for `test_dtype_aware_codegen`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78