### PR TITLE
[dynamo] Remove redundant _nonvar_fields assignments in UserDefinedObjectVariable subclasses

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2016,8 +2016,6 @@ class UserDefinedDictVariable(UserDefinedObjectVariable):
     UserDefinedObjectVariable.
     """
 
-    _nonvar_fields = UserDefinedObjectVariable._nonvar_fields
-
     def __init__(self, value, dict_vt=None, **kwargs):
         super().__init__(value, **kwargs)
         self._dict_vt = dict_vt
@@ -2089,8 +2087,6 @@ class UserDefinedSetVariable(UserDefinedObjectVariable):
     variable tracker. For everything else, it falls back to
     UserDefinedObjectVariable.
     """
-
-    _nonvar_fields = UserDefinedObjectVariable._nonvar_fields
 
     def __init__(self, value, set_vt=None, **kwargs):
         super().__init__(value, **kwargs)
@@ -2165,8 +2161,6 @@ class UserDefinedListVariable(UserDefinedObjectVariable):
     UserDefinedObjectVariable.
     """
 
-    _nonvar_fields = UserDefinedObjectVariable._nonvar_fields
-
     def __init__(self, value, list_vt=None, **kwargs):
         super().__init__(value, **kwargs)
         self._list_vt = list_vt
@@ -2208,8 +2202,6 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
     UserDefinedObjectVariable.
     """
 
-    _nonvar_fields = UserDefinedObjectVariable._nonvar_fields
-
     def __init__(self, value, tuple_vt=None, init_args=None, **kwargs):
         super().__init__(value, init_args=init_args, **kwargs)
         self._tuple_vt = tuple_vt
@@ -2250,8 +2242,6 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
 
 
 class MutableMappingVariable(UserDefinedObjectVariable):
-    _nonvar_fields = UserDefinedObjectVariable._nonvar_fields
-
     def __init__(self, value, **kwargs):
         super().__init__(value, **kwargs)
         self.generic_dict_vt = variables.ConstDictVariable({})


### PR DESCRIPTION
Removed redundant `_nonvar_fields` assignments from 5 UserDefinedObjectVariable subclasses. These explicit re-assignments are unnecessary because Python's class attribute inheritance automatically provides access to parent class attributes.

   **Classes cleaned up:**
   - UserDefinedDictVariable
   - UserDefinedSetVariable
   - UserDefinedListVariable
   - UserDefinedTupleVariable
   - MutableMappingVariable

   All 5 classes inherit from `UserDefinedObjectVariable`, which defines `_nonvar_fields`. The pattern `_nonvar_fields = UserDefinedObjectVariable._nonvar_fields` is pure redundancy - the child classes will automatically inherit this attribute from the parent.

   ## Changes
   - **Lines removed:** 10 (5 redundant assignments + 5 blank lines)
   - **File modified:** `torch/_dynamo/variables/user_defined.py`
   ## Impact
   - **Code reduction:** -10 lines
   - **Maintainability:** ↑ (less redundancy)
   - **Risk:** Zero (identical behavior via inheritance)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela