### PR TITLE
[torch.onnx.export] Fix onnx export on big endian machines

### DIFF
--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -2,6 +2,7 @@
 # flake8: noqa: B950 We do not need flake8 as it complains line length
 from __future__ import annotations
 
+import sys
 import ctypes
 import datetime
 import inspect
@@ -182,6 +183,9 @@ class TorchTensor(ir.Tensor):
         ).from_address(tensor.data_ptr())
 
     def tobytes(self) -> bytes:
+        # On big-endian machines, call the super's tobytes() which returns a little-endian result.
+        if sys.byteorder == "big":
+            return super().tobytes()
         # Implement tobytes to support native PyTorch types so we can use types like bloat16
         # Reading from memory directly is also more efficient because
         # it avoids copying to a NumPy array
@@ -189,6 +193,9 @@ class TorchTensor(ir.Tensor):
         return bytes(data)
 
     def tofile(self, file) -> None:
+        # On big-endian machines, call the super's tofile() which returns a little-endian result.
+        if sys.byteorder == "big":
+            return super().tofile(file)
         _, data = self._get_cbytes()
         return file.write(data)
 

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -2,7 +2,6 @@
 # flake8: noqa: B950 We do not need flake8 as it complains line length
 from __future__ import annotations
 
-import sys
 import ctypes
 import datetime
 import inspect
@@ -10,6 +9,7 @@ import itertools
 import logging
 import operator
 import pathlib
+import sys
 import textwrap
 import traceback
 import typing


### PR DESCRIPTION
On big endian machines, constant values in the exported onnx model are still in big endian, they need to be converted to little endian to comply with the onnx specification.

This fixes that issue by calling super's methods of `ir.Tensor` that already handles endianness well.
