### PR TITLE
Fix: Dynamo log always emits ANSI color codes into torch_compile_debug/torchdynamo/debug.log due to colored=True in lazy_format_graph_code

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -903,11 +903,32 @@ def reset_graph_break_dup_checker() -> None:
     graph_break_dup_warning_checker.reset()
 
 
+# Matches ANSI escape sequences (CSI)
+ANSI_ESCAPE_RE = re.compile(
+    r'''
+    \x1B            # ESC
+    \[              # [
+    [0-?]*          # Parameter bytes
+    [ -/]*          # Intermediate bytes
+    [@-~]           # Final byte
+    ''',
+    re.VERBOSE
+)
+
+
+class StripAnsiFormatter(logging.Formatter):
+    """Logging formatter that strips ANSI escape codes."""
+    def format(self, record):
+        msg = super().format(record)
+        return ANSI_ESCAPE_PATTERN.sub('', msg)
+
+
 def add_file_handler() -> contextlib.ExitStack:
     log_path = os.path.join(get_debug_dir(), "torchdynamo")
     os.makedirs(log_path, exist_ok=True)
 
     log_file_handler = logging.FileHandler(os.path.join(log_path, "debug.log"))
+    log_file_handler.setFormatter(StripAnsiFormatter("%(message)s"))
     logger = logging.getLogger("torch._dynamo")
     logger.addHandler(log_file_handler)
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -904,23 +904,24 @@ def reset_graph_break_dup_checker() -> None:
 
 
 # Matches ANSI escape sequences (CSI)
-ANSI_ESCAPE_RE = re.compile(
-    r'''
+ANSI_ESCAPE_PATTERN = re.compile(
+    r"""
     \x1B            # ESC
     \[              # [
     [0-?]*          # Parameter bytes
     [ -/]*          # Intermediate bytes
     [@-~]           # Final byte
-    ''',
-    re.VERBOSE
+    """,
+    re.VERBOSE,
 )
 
 
 class StripAnsiFormatter(logging.Formatter):
     """Logging formatter that strips ANSI escape codes."""
+
     def format(self, record):
         msg = super().format(record)
-        return ANSI_ESCAPE_PATTERN.sub('', msg)
+        return ANSI_ESCAPE_PATTERN.sub("", msg)
 
 
 def add_file_handler() -> contextlib.ExitStack:


### PR DESCRIPTION
Added ANSI escape sequence handling and a custom logging formatter.

Please refer to https://github.com/pytorch/pytorch/issues/167812 for detailed background explanation.

This PR adds a format for log_file_handler in dynamo logger to filter ANSI codes.

Before this change, log in debug.log:

```
  def forward(self, L_x_: "[31mi64[0m[34m[][0m[2m[34m[][0m[2m[32mcpu[0m"):
      l_x_ = L_x_
      
      [2m# File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:11 in forward, code: a = torch.ones(2, x.item())[0m
      item: "Sym(s20 + 5)" = l_x_.item();  [2ml_x_ = None[0m
      a: "[31mf32[0m[34m[2, s20 + 5][0m[2m[34m[Max(1, s20 + 5), 1][0m[2m[32mcpu[0m" = torch.ones([34m2[0m, item)
      
      [2m# File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:12 in forward, code: b = torch.ones(3, y.item() + 5)[0m
      b: "[31mf32[0m[34m[3, s20 + 5][0m[2m[34m[Max(1, s20 + 5), 1][0m[2m[32mcpu[0m" = torch.ones([34m3[0m, item);  [2mitem = None[0m
      
      [2m# File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:13 in forward, code: res = torch.cat([a, b], dim=0)[0m
      res: "[31mf32[0m[34m[5, s20 + 5][0m[2m[34m[Max(1, s20 + 5), 1][0m[2m[32mcpu[0m" = torch.cat([a, b], dim = [34m0[0m);  [2ma = b = None[0m
      
      [2m# File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:14 in forward, code: return res.sum()[0m
      sum_1: "[31mf32[0m[34m[][0m[2m[34m[][0m[2m[32mcpu[0m" = res.sum();  [2mres = None[0m
      return (sum_1,)
```


After this change, log in debug.log:
```
  def forward(self, L_x_: "i64[][]cpu"):
      l_x_ = L_x_
      
      # File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:11 in forward, code: a = torch.ones(2, x.item())
      item: "Sym(s20 + 5)" = l_x_.item();  l_x_ = None
      a: "f32[2, s20 + 5][Max(1, s20 + 5), 1]cpu" = torch.ones(2, item)
      
      # File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:12 in forward, code: b = torch.ones(3, y.item() + 5)
      b: "f32[3, s20 + 5][Max(1, s20 + 5), 1]cpu" = torch.ones(3, item);  item = None
      
      # File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:13 in forward, code: res = torch.cat([a, b], dim=0)
      res: "f32[5, s20 + 5][Max(1, s20 + 5), 1]cpu" = torch.cat([a, b], dim = 0);  a = b = None
      
      # File: /Users/bytedance/Downloads/Repo/pytorch/mydebug1.py:14 in forward, code: return res.sum()
      sum_1: "f32[][]cpu" = res.sum();  res = None
      return (sum_1,)
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @yanboliang 
