### PR TITLE
skip format_import_statement and no mod by type_repr on str annotations

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1709,6 +1709,20 @@ class TestFX(JitTestCase):
         offsets = torch.LongTensor([0, 4])
         self.assertEqual(loaded(input, offsets), traced(input, offsets))
 
+    def test_pickle_string_type_annotation(self):
+        def f(x: "torch.Tensor") -> "torch.Tensor":
+            return x + 1
+
+        traced = symbolic_trace(f)
+        traced.graph.lint()
+
+        pickled = pickle.dumps(traced)
+        loaded = pickle.loads(pickled)
+        loaded.graph.lint()
+
+        x = torch.tensor([1.0, 2.0, 3.0])
+        self.assertEqual(loaded(x), traced(x))
+
     def test_return_tuple(self):
         class M(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -133,9 +133,14 @@ def _format_import_statement(name: str, obj: Any, importer: Importer) -> str:
 
 
 def _format_import_block(globals: dict[str, Any], importer: Importer):
-    import_strs: set[str] = {
-        _format_import_statement(name, obj, importer) for name, obj in globals.items()
-    }
+    import_strs: set[str] = set()
+    for name, obj in globals.items():
+        if isinstance(obj, str):
+            # Generate a definition for string type annotations
+            import_strs.add(f"{name} = {repr(obj)}")
+        else:
+            import_strs.add(_format_import_statement(name, obj, importer))
+
     # Sort the imports so we have a stable import block that allows us to
     # hash the graph module and get a consistent key for use in a cache.
     return "\n".join(sorted(import_strs))


### PR DESCRIPTION
Fixes #167117 

When torch.save() is called to serialize fx graph, it triggers the __reduce__methods of GraphModule. This method calls _format_import_block() to generate import statements for the serialized code. This then calls _format_import_statement() by iterating over global dictionary and assumes that all in dictionary are python objects however here string does not have __name__ hence the failure happens.

 String type annotations does not need imports hence should be skipped.  

After above fix another issue of type_repr where the annotation is added to global and created as an identifier where it should have been just a quoted literal was seen  and fix is to return this literal and not transforming it.
  


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv