### PR TITLE
Introduce HOP for inductor compiled regions to allow torch dispatch (inductor_compiled_code)

### DIFF
--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -1,0 +1,298 @@
+# Owner(s): ["module: dynamo"]
+import unittest
+
+import torch
+import torch._dynamo.test_case
+from torch._dynamo.utils import counters
+from torch._functorch import config as functorch_config
+from torch._inductor import config as inductor_config
+from torch.testing._internal.common_utils import TEST_WITH_TORCHDYNAMO
+from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.utils._debug_mode import DebugMode
+
+
+class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
+    """Tests for wrap_inductor_compiled_regions option"""
+
+    @requires_cuda_and_triton
+    def test_wrap_enabled_visible_in_debug_mode(self):
+        """Test that compiled regions are wrapped when option is enabled"""
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": True},
+            fullgraph=True,
+        )
+        def fn(x, y):
+            return torch.matmul(x, y)
+
+        x = torch.randn(4, 4, device="cuda")
+        y = torch.randn(4, 4, device="cuda")
+
+        with DebugMode() as debug_mode:
+            result = fn(x, y)
+
+        debug_string = debug_mode.debug_string()
+
+        # inductor_compiled_code HOP should be visible in DebugMode
+        self.assertIn("inductor_compiled_code", debug_string)
+
+        # Result should be correct
+        expected = torch.matmul(x, y)
+        self.assertEqual(result, expected)
+
+    @requires_cuda_and_triton
+    def test_wrap_disabled_not_visible_in_debug_mode(self):
+        """Test that compiled regions are not wrapped when option is disabled"""
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": False},
+            fullgraph=True,
+        )
+        def fn(x, y):
+            return torch.matmul(x, y)
+
+        x = torch.randn(4, 4, device="cuda")
+        y = torch.randn(4, 4, device="cuda")
+
+        with DebugMode() as debug_mode:
+            result = fn(x, y)
+
+        debug_string = debug_mode.debug_string()
+
+        # inductor_compiled_code HOP should NOT be visible
+        self.assertNotIn("inductor_compiled_code", debug_string)
+
+        # Result should still be correct
+        expected = torch.matmul(x, y)
+        self.assertEqual(result, expected)
+
+    @requires_cuda_and_triton
+    def test_wrap_default_disabled(self):
+        """Test that wrapping is disabled by default"""
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def fn(x, y):
+            return torch.matmul(x, y)
+
+        x = torch.randn(4, 4, device="cuda")
+        y = torch.randn(4, 4, device="cuda")
+
+        with DebugMode() as debug_mode:
+            result = fn(x, y)
+
+        debug_string = debug_mode.debug_string()
+
+        # inductor_compiled_code HOP should NOT be visible by default
+        self.assertNotIn("inductor_compiled_code", debug_string)
+
+        # Result should be correct
+        expected = torch.matmul(x, y)
+        self.assertEqual(result, expected)
+
+    @requires_cuda_and_triton
+    def test_wrap_with_backward(self):
+        """Test that wrapping works correctly with backward pass"""
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": True},
+            fullgraph=True,
+        )
+        def fn(x, y):
+            return torch.matmul(x, y)
+
+        x = torch.randn(4, 4, device="cuda", requires_grad=True)
+        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+
+        # Clone for eager comparison
+        x_eager = x.detach().clone().requires_grad_(True)
+        y_eager = y.detach().clone().requires_grad_(True)
+
+        # Compiled forward and backward
+        with DebugMode() as debug_mode:
+            result = fn(x, y)
+            loss = result.sum()
+            loss.backward()
+
+        debug_string = debug_mode.debug_string()
+
+        # inductor_compiled_code HOP should be visible in forward
+        self.assertIn("inductor_compiled_code", debug_string)
+
+        # Eager forward and backward
+        expected = torch.matmul(x_eager, y_eager)
+        expected_loss = expected.sum()
+        expected_loss.backward()
+
+        # Check correctness
+        self.assertEqual(result, expected)
+        self.assertEqual(x.grad, x_eager.grad)
+        self.assertEqual(y.grad, y_eager.grad)
+
+    @requires_cuda_and_triton
+    def test_wrap_with_multiple_ops(self):
+        """Test wrapping with a function that has multiple operations"""
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": True},
+            fullgraph=True,
+        )
+        def fn(x, y):
+            a = torch.matmul(x, y)
+            b = torch.relu(a)
+            c = b + x
+            return c
+
+        x = torch.randn(4, 4, device="cuda")
+        y = torch.randn(4, 4, device="cuda")
+
+        with DebugMode() as debug_mode:
+            result = fn(x, y)
+
+        debug_string = debug_mode.debug_string()
+
+        # inductor_compiled_code HOP should be visible
+        self.assertIn("inductor_compiled_code", debug_string)
+
+        # Result should be correct
+        a = torch.matmul(x, y)
+        b = torch.relu(a)
+        expected = b + x
+        self.assertEqual(result, expected)
+
+    @requires_cuda_and_triton
+    def test_wrap_option_type_validation(self):
+        """Test that wrap_inductor_compiled_regions validates type correctly"""
+
+        # Should accept bool
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": True},
+        )
+        def fn_true(x):
+            return x + 1
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": False},
+        )
+        def fn_false(x):
+            return x + 1
+
+        x = torch.randn(4, device="cuda")
+        _ = fn_true(x)
+        _ = fn_false(x)
+
+        # Should reject non-bool
+        with self.assertRaises(RuntimeError) as cm:
+
+            @torch.compile(
+                backend="inductor",
+                options={"wrap_inductor_compiled_regions": "true"},
+            )
+            def fn_invalid(x):
+                return x + 1
+
+        self.assertIn("Unexpected type", str(cm.exception))
+
+    @requires_cuda_and_triton
+    def test_wrap_per_compilation(self):
+        """Test that wrap option is per-compilation, not global"""
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": True},
+            fullgraph=True,
+        )
+        def fn_wrapped(x, y):
+            return torch.matmul(x, y)
+
+        @torch.compile(
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": False},
+            fullgraph=True,
+        )
+        def fn_not_wrapped(x, y):
+            return torch.matmul(x, y)
+
+        x = torch.randn(4, 4, device="cuda")
+        y = torch.randn(4, 4, device="cuda")
+
+        # First function should be wrapped
+        with DebugMode() as debug_mode1:
+            _ = fn_wrapped(x, y)
+        self.assertIn("inductor_compiled_code", debug_mode1.debug_string())
+
+        # Second function should not be wrapped
+        with DebugMode() as debug_mode2:
+            _ = fn_not_wrapped(x, y)
+        self.assertNotIn("inductor_compiled_code", debug_mode2.debug_string())
+
+    @requires_cuda_and_triton
+    @inductor_config.patch("fx_graph_cache", True)
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_wrap_with_cache(self):
+        """
+        Test that wrap_inductor_compiled_regions works correctly with caching.
+        Verify that the wrapper is applied even when loading from cache.
+        """
+        from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
+
+        def fn(x, y):
+            return torch.matmul(x, y)
+
+        x = torch.randn(4, 4, device="cuda")
+        y = torch.randn(4, 4, device="cuda")
+
+        # Clear all caches and counters
+        counters.clear()
+        torch._inductor.codecache.FxGraphCache.clear()
+        AOTAutogradCache.clear()
+        torch._dynamo.reset()
+        torch._inductor.codecache.PyCodeCache.cache_clear(purge=True)
+
+        compiled_fn = torch.compile(
+            fn,
+            backend="inductor",
+            options={"wrap_inductor_compiled_regions": True},
+            fullgraph=True,
+        )
+
+        # First call should miss the cache
+        with DebugMode() as debug_mode1:
+            result1 = compiled_fn(x, y)
+
+        # Verify wrapper is applied
+        self.assertIn("inductor_compiled_code", debug_mode1.debug_string())
+        # Verify cache miss
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        # Clear dynamo and codecache (but not FX or AOT autograd cache)
+        torch._dynamo.reset()
+        torch._inductor.codecache.PyCodeCache.cache_clear(purge=True)
+
+        # Second call should hit the cache
+        with DebugMode() as debug_mode2:
+            result2 = compiled_fn(x, y)
+
+        # Verify wrapper is still applied after loading from cache
+        self.assertIn("inductor_compiled_code", debug_mode2.debug_string())
+        # Verify cache hit
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+        # Results should be correct and identical
+        expected = torch.matmul(x, y)
+        self.assertEqual(result1, expected)
+        self.assertEqual(result2, expected)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -78,5 +78,5 @@ __all__ = [
     "while_loop_stack_output",
     "local_map_hop",
     "print",
-    "inductor_compiled_code"
+    "inductor_compiled_code",
 ]

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -35,6 +35,7 @@ from torch._higher_order_ops.while_loop import (
 )
 from torch._higher_order_ops.wrap import (
     dynamo_bypassing_wrapper,
+    inductor_compiled_code,
     tag_activation_checkpoint,
     wrap_activation_checkpoint,
     wrap_with_autocast,
@@ -77,4 +78,5 @@ __all__ = [
     "while_loop_stack_output",
     "local_map_hop",
     "print",
+    "inductor_compiled_code"
 ]

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -4,14 +4,17 @@ import itertools
 import logging
 from typing import Any, Optional
 
+from torch._C import DispatchKey
 import torch
 import torch.utils._pytree as pytree
-from torch._higher_order_ops.utils import reenter_make_fx
+from torch._higher_order_ops.utils import reenter_make_fx, redirect_to_mode
 from torch._logging import warning_once
 from torch._ops import HigherOrderOperator
 from torch.fx import GraphModule
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
 from torch.types import _dtype
+from torch.utils._debug_mode import DebugMode
+from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
 
 
 log = logging.getLogger(__name__)
@@ -39,6 +42,30 @@ class Wrap(HigherOrderOperator):
 
 
 wrap = Wrap()
+
+
+class InductorCompiledCode(HigherOrderOperator):
+    """
+    Defines a HOP for wrapping inductor compiled functions as a callable.
+    """
+    def __init__(self) -> None:
+        super().__init__("inductor_compiled_code")
+
+    def __call__(self, func, *args, **kwargs):
+        return super().__call__(func, *args, **kwargs)
+
+
+inductor_compiled_code = InductorCompiledCode()
+inductor_compiled_code.fallthrough(DispatchKey.AutogradCPU)
+inductor_compiled_code.fallthrough(DispatchKey.AutogradCUDA)
+
+@inductor_compiled_code.py_impl(DispatchKey.CompositeExplicitAutograd)
+def inductor_compiled_code_impl(func, inputs):
+    return func(inputs)
+
+redirect_to_mode(inductor_compiled_code, DebugMode)
+redirect_to_mode(inductor_compiled_code, _CachingTorchDispatchMode)
+redirect_to_mode(inductor_compiled_code, _CachedTorchDispatchMode)
 
 
 class WrapWithSetGradEnabled(HigherOrderOperator):

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -47,6 +47,8 @@ wrap = Wrap()
 class InductorCompiledCode(HigherOrderOperator):
     """
     Defines a HOP for wrapping inductor compiled functions as a callable.
+    When used with torch.compile via "wrap_inductor_compiled_regions",
+    this HOP will automatically be wrapped and redirect various torch dispatch modes.
     """
 
     def __init__(self) -> None:

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -4,10 +4,10 @@ import itertools
 import logging
 from typing import Any, Optional
 
-from torch._C import DispatchKey
 import torch
 import torch.utils._pytree as pytree
-from torch._higher_order_ops.utils import reenter_make_fx, redirect_to_mode
+from torch._C import DispatchKey
+from torch._higher_order_ops.utils import redirect_to_mode, reenter_make_fx
 from torch._logging import warning_once
 from torch._ops import HigherOrderOperator
 from torch.fx import GraphModule
@@ -48,6 +48,7 @@ class InductorCompiledCode(HigherOrderOperator):
     """
     Defines a HOP for wrapping inductor compiled functions as a callable.
     """
+
     def __init__(self) -> None:
         super().__init__("inductor_compiled_code")
 
@@ -59,9 +60,11 @@ inductor_compiled_code = InductorCompiledCode()
 inductor_compiled_code.fallthrough(DispatchKey.AutogradCPU)
 inductor_compiled_code.fallthrough(DispatchKey.AutogradCUDA)
 
+
 @inductor_compiled_code.py_impl(DispatchKey.CompositeExplicitAutograd)
 def inductor_compiled_code_impl(func, inputs):
     return func(inputs)
+
 
 redirect_to_mode(inductor_compiled_code, DebugMode)
 redirect_to_mode(inductor_compiled_code, _CachingTorchDispatchMode)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1155,7 +1155,6 @@ decompose_mem_bound_mm: bool = False
 
 # Wrap compiled regions in inductor_compiled_code HOP to make them visible to
 # TorchDispatchModes like DebugMode and Selective Activation Checkpointing.
-# This avoids runtime overhead of checking dispatch modes at every call.
 wrap_inductor_compiled_regions: bool = False
 
 # assume_aligned_inputs means that we assume that inputs will be aligned; we generate

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1153,6 +1153,11 @@ freezing_discard_parameters: bool = False
 # decompose some memory bound matmul/bmm to mul
 decompose_mem_bound_mm: bool = False
 
+# Wrap compiled regions in inductor_compiled_code HOP to make them visible to
+# TorchDispatchModes like DebugMode and Selective Activation Checkpointing.
+# This avoids runtime overhead of checking dispatch modes at every call.
+wrap_inductor_compiled_regions: bool = False
+
 # assume_aligned_inputs means that we assume that inputs will be aligned; we generate
 # code using this assumption, and clone tensors before use if they aren't aligned.
 # In the common case, most inputs will be aligned.

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -51,8 +51,6 @@ from torch._inductor.utils import (
 )
 from torch.autograd.profiler import record_function
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._python_dispatch import is_in_torch_dispatch_mode
-from torch._higher_order_ops.wrap import inductor_compiled_code
 
 from . import config
 from .runtime.autotune_cache import AutotuneCacheBundler

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -51,6 +51,8 @@ from torch._inductor.utils import (
 )
 from torch.autograd.profiler import record_function
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._python_dispatch import is_in_torch_dispatch_mode
+from torch._higher_order_ops.wrap import inductor_compiled_code
 
 from . import config
 from .runtime.autotune_cache import AutotuneCacheBundler
@@ -437,6 +439,7 @@ class CompiledFxGraph(OutputCode):
 
     _boxed_call: Optional[bool] = None
     _triton_bundle: Optional[TritonBundle] = None
+    _wrap_compiled_regions: bool = False
 
     def __init__(
         self,
@@ -581,6 +584,10 @@ class CompiledFxGraph(OutputCode):
         # aot autograd needs to know to pass in inputs as a list
         self._boxed_call = True
 
+        # Store whether to wrap compiled regions in inductor_compiled_code HOP
+        # This is set at compile time to avoid runtime overhead
+        self._wrap_compiled_regions = config.wrap_inductor_compiled_regions
+
     def __del__(self) -> None:
         if self.compiled_fn_runner is not None:
             # For torch._inductor.config.graph_partition = True,
@@ -711,6 +718,18 @@ class CompiledFxGraph(OutputCode):
             inputs_to_check,
             self.mutated_input_idxs,
         )
+
+        # Apply inductor_compiled_code HOP wrapper if configured
+        # This is done in post_compile to ensure it works with cached artifacts
+        if self._wrap_compiled_regions and self.current_callable is not None:
+            from torch._higher_order_ops.wrap import inductor_compiled_code
+
+            original_callable = self.current_callable
+
+            def wrapped_callable(inputs):
+                return inductor_compiled_code(original_callable, inputs)
+
+            self.current_callable = wrapped_callable
 
     def set_triton_bundle(self, triton_bundle: Any) -> None:
         self._triton_bundle = triton_bundle

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -104,6 +104,7 @@ FIXME_hop_that_doesnt_have_opinfo_test_allowlist = [
     "foreach_map",
     "aoti_call_delegate",
     "print",
+    "inductor_compiled_code",  # Tested separately in test_inductor_wrap_inductor_compile_regions
 ]
 
 torch.library.define(

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1313,6 +1313,10 @@ SAC_IGNORED_OPS = {
 
 
 class _CachingTorchDispatchMode(TorchDispatchMode):
+    @classmethod
+    def ignore_compile_internals(cls):
+        return True
+
     # Used together with _CachedTorchDispatchMode to implement SAC.
     def __init__(self, policy_fn, storage) -> None:
         self.policy_fn = policy_fn
@@ -1349,6 +1353,10 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):
+    @classmethod
+    def ignore_compile_internals(cls):
+        return True
+
     # Used together with _CachedTorchDispatchMode to implement SAC.
     def __init__(self, policy_fn, storage, allow_cache_entry_mutation) -> None:
         self.policy_fn = policy_fn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #167844

This is a cleaned up version of the POC at https://github.com/pytorch/pytorch/pull/167752/files


This PR adds a inductor option which you can pass into torch.compile that wraps all inductor generated code in a HOP, allowing it to be read by torch dispatches. 

This hop is created in output_code.post_compile, so it's cache safe. The configuration to turn it on is part of `inductor_config`, and therefore already part of the cache key. I've added a test that shows this HOP is cache safe. 

Because this wrapper occurs at compile time, there should be little to no cpu overhead from creating it, besides that of actually processing the torch_dispatches themselves. 

The context here is we want to be able to support compiled regions such as flex attention in eager mode, while working with other torch dispatch tracers like SAC. Will add more tests for SAC/flex attention specific things next. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela