### PR TITLE
[precompile] Support captured global tensors.

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -24,6 +24,8 @@ from torch.testing._internal.common_utils import instantiate_parametrized_tests
 
 MY_LAMBDA = lambda x: x + 1  # noqa: E731
 
+EPS = torch.tensor(1e-7)
+
 
 class CustomCompiledFunction(torch._dynamo.aot_compile.SerializableCallable):
     def __init__(self, gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]):
@@ -581,6 +583,18 @@ from user code:
             compiled_fn = torch.compiler.load_compiled_function(f)
         actual = compiled_fn(fn, *inputs)
         self.assertEqual(expected, actual)
+
+    def test_aot_compile_with_global_tensor(self):
+        def fn(x, y):
+            return x + y + EPS
+
+        def make_inputs():
+            return (torch.randn(3, 4), torch.randn(3, 4))
+
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile((make_inputs(), {}))
+
+        test_inputs = make_inputs()
+        self.assertEqual(compiled_fn(*test_inputs), fn(*test_inputs))
 
     def test_aot_compile_with_default_args(self):
         def fn(x, y=1):

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -1,5 +1,4 @@
 import dataclasses
-import importlib
 import inspect
 import io
 import logging
@@ -12,6 +11,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 import torch
 import torch.fx
+from torch._dynamo.convert_frame import GraphRuntimeEnv
 from torch._dynamo.graph_utils import _graph_device_type
 from torch._dynamo.package import SystemInfo
 
@@ -42,15 +42,12 @@ def bind_locals(
 @dataclass
 class CompileArtifacts:
     signature: inspect.Signature
-    bytecode: types.CodeType
     guard_manager: Optional["GuardManagerWrapper"]
     guards_state: bytes
-    import_sources: dict[str, str]
     backend_id: str
     compiled_fn: SerializableCallable
     original_code: types.CodeType
-    closure: Optional[tuple[Any, ...]]
-    argdefs: Optional[tuple[Any, ...]]
+    runtime_env: GraphRuntimeEnv
     source_info: "SourceInfo"
     device_type: str
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
@@ -83,15 +80,14 @@ class AOTCompiledFunction:
 
     def guard_check(self, *args: Any, **kwargs: Any) -> bool:
         f_locals: dict[str, Any] = {}
-        if self._artifacts.closure:
-            assert self._artifacts.bytecode.co_freevars and len(
-                self._artifacts.closure
-            ) == len(self._artifacts.bytecode.co_freevars)
+        env = self._artifacts.runtime_env
+        if env.closure:
+            assert env.bytecode.co_freevars and len(env.closure) == len(
+                env.bytecode.co_freevars
+            )
             f_locals = {
                 name: cell.cell_contents
-                for name, cell in zip(
-                    self._artifacts.bytecode.co_freevars, self._artifacts.closure
-                )
+                for name, cell in zip(env.bytecode.co_freevars, env.closure)
             }
         f_locals.update(bind_locals(self._artifacts.signature, *args, **kwargs))
         assert self._artifacts.guard_manager is not None
@@ -102,20 +98,9 @@ class AOTCompiledFunction:
 
         self._artifacts.check_compatibility()
 
-        import_sources = {
-            alias: importlib.import_module(module_name)
-            for alias, module_name in self._artifacts.import_sources.items()
-        }
-        f_globals = {
-            **import_sources,
-            self._artifacts.backend_id: self._artifacts.compiled_fn,
-        }
         # pyrefly: ignore [read-only]
-        self.fn = types.FunctionType(
-            self._artifacts.bytecode,
-            f_globals,
-            closure=self._artifacts.closure,
-            argdefs=self._artifacts.argdefs,
+        self.fn = self._artifacts.runtime_env.forward_callable(
+            self._artifacts.backend_id, self._artifacts.compiled_fn
         )
 
         if self._artifacts.guard_manager is None:
@@ -123,7 +108,7 @@ class AOTCompiledFunction:
             self._artifacts.guard_manager = load_guard_manager(
                 guards_state,
                 self._artifacts.original_code,
-                f_globals,
+                self.fn.__globals__,
             )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
@@ -147,7 +132,10 @@ class AOTCompiledFunction:
 
         state = fn._artifacts.__dict__.copy()
         state["guard_manager"] = None
-        state["bytecode"] = SerializedCode.from_code_object(state["bytecode"])
+        state["runtime_env"] = dataclasses.replace(
+            state["runtime_env"],
+            bytecode=SerializedCode.from_code_object(state["runtime_env"].bytecode),
+        )
         compiled_fn = state["compiled_fn"]
         state["compiled_fn"] = (
             type(compiled_fn).deserialize_compile_artifacts,
@@ -164,7 +152,10 @@ class AOTCompiledFunction:
         from torch._dynamo.package import SerializedCode
 
         state = pickle.loads(data)
-        state["bytecode"] = SerializedCode.to_code_object(state["bytecode"])
+        state["runtime_env"] = dataclasses.replace(
+            state["runtime_env"],
+            bytecode=SerializedCode.to_code_object(state["runtime_env"].bytecode),
+        )
         deserializer, compiled_fn_state = state["compiled_fn"]
         state["compiled_fn"] = deserializer(compiled_fn_state)
         state["original_code"] = SerializedCode.to_code_object(state["original_code"])
@@ -262,15 +253,12 @@ def aot_compile_fullgraph(
 
         artifacts = CompileArtifacts(
             signature=convert_frame._get_signature(fn),
-            bytecode=graph_capture_output.bytecode,
             guard_manager=check_fn.guard_manager,
             guards_state=check_fn.guards_state,
-            import_sources=graph_capture_output.import_sources,
             backend_id=backend_input.backend_id,
             compiled_fn=compiled_fn,
             original_code=fn.__code__,
-            closure=fn.__closure__,
-            argdefs=fn.__defaults__,
+            runtime_env=graph_capture_output.get_runtime_env(),
             source_info=source_info,
             device_type=device_type,
         )

--- a/torch/_dynamo/aot_compile_types.py
+++ b/torch/_dynamo/aot_compile_types.py
@@ -16,6 +16,10 @@ class SerializableCallable(abc.ABC):
     def deserialize_compile_artifacts(cls, data: bytes) -> Any:
         pass
 
+    @abc.abstractmethod
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
 
 class BundledAOTAutogradSerializableCallable(SerializableCallable):
     """

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -29,6 +29,7 @@ import cProfile
 import dis
 import functools
 import gc
+import importlib
 import inspect
 import itertools
 import logging
@@ -901,6 +902,7 @@ class DynamoOutput:
             self.bytecode,
             self.tracer_output.closure,
             argdefs,
+            self.tracer_output.f_globals,
         )
 
 
@@ -922,6 +924,34 @@ class BackendInput:
     tensor_to_context: WeakIdKeyDictionary
 
 
+@dataclass(frozen=True)
+class GraphRuntimeEnv:
+    bytecode: types.CodeType
+    import_sources: dict[str, str]
+    used_globals: dict[str, Any]
+    closure: Optional[tuple[Any, ...]]
+    argdefs: Optional[tuple[Any, ...]]
+
+    def forward_callable(
+        self, backend_id: str, compiled_fn: Callable[..., Any]
+    ) -> Callable[..., Any]:
+        import_sources = {
+            alias: importlib.import_module(module_name)
+            for alias, module_name in self.import_sources.items()
+        }
+        f_globals = {
+            **import_sources,
+            **self.used_globals,
+            backend_id: compiled_fn,
+        }
+        return types.FunctionType(
+            self.bytecode,
+            f_globals,
+            closure=self.closure,
+            argdefs=self.argdefs,
+        )
+
+
 @dataclass
 class GraphCaptureOutput:
     """
@@ -934,6 +964,7 @@ class GraphCaptureOutput:
     bytecode: CodeType
     closure: Optional[tuple[Any, ...]]
     argdefs: Optional[tuple[Any, ...]]
+    f_globals: dict[str, Any]
 
     def build_guards(
         self,
@@ -953,6 +984,27 @@ class GraphCaptureOutput:
             strict_error=strict_error,
         )
 
+    def get_runtime_env(self) -> GraphRuntimeEnv:
+        from torch._dynamo.source import get_global_source_name
+
+        used_globals = {}
+        for (
+            source
+        ) in self.output_graph.export_metadata.graph_input_idx_to_local_source.values():
+            global_name = get_global_source_name(source)
+            if global_name is None:
+                continue
+            if global_name in self.f_globals:
+                used_globals[global_name] = self.f_globals[global_name]
+
+        return GraphRuntimeEnv(
+            bytecode=self.bytecode,
+            import_sources=self.import_sources,
+            used_globals=used_globals,
+            closure=self.closure,
+            argdefs=self.argdefs,
+        )
+
 
 @dataclass
 class CaptureOutput:
@@ -970,27 +1022,17 @@ class CaptureOutput:
     # BackendInput can be None when dynamo didn't compile any graph (no tensor op)
     backend_input: Optional[BackendInput]
 
-    def forward_callable(self) -> Callable[..., Any]:
-        import importlib
-
-        # TODO code sharing
-        import_sources = self.graph_capture_output.output_graph.import_sources
+    def forward_callable(
+        self,
+        *,
+        compiled_fn: Optional[Callable[..., Any]] = None,
+    ) -> Callable[..., Any]:
+        runtime_env = self.graph_capture_output.get_runtime_env()
         assert self.backend_input is not None
         backend_id = self.backend_input.backend_id
-        import_sources = {
-            alias: importlib.import_module(module_name)
-            for alias, module_name in import_sources.items()
-        }
-        f_globals = {
-            **import_sources,
-            backend_id: self.backend_input.graph_module,
-        }
-        return types.FunctionType(
-            self.graph_capture_output.bytecode,
-            f_globals,
-            closure=self.graph_capture_output.closure,
-            argdefs=self.graph_capture_output.argdefs,
-        )
+        # pyrefly: ignore [not-callable]
+        compiled_fn = compiled_fn or self.backend_input.graph_module
+        return runtime_env.forward_callable(backend_id, compiled_fn)
 
 
 def get_traced_fn(mod: Any) -> tuple[FunctionType, Optional[object]]:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2781,6 +2781,7 @@ class DynamoTracerOutput:
     is_tracing_resume_prologue: bool
     output_graph: Optional[OutputGraph]
     closure: Optional[tuple[Any, ...]]
+    f_globals: dict[str, Any]
 
     def __init__(
         self, tracer: "InstructionTranslatorBase", error: Optional[Any] = None
@@ -2788,6 +2789,7 @@ class DynamoTracerOutput:
         self.error_on_graph_break = tracer.error_on_graph_break
         self.is_tracing_resume_prologue = tracer.is_tracing_resume_prologue
         self.closure = tracer.closure
+        self.f_globals = tracer.f_globals
         if error:
             self.output_graph = None
         else:


### PR DESCRIPTION
Summary:
In vllm we saw cases where user intialize a tensor in the global scope and reference it in the forward body. This should be supported by pruning the used globals in the scope and serialize them along the artifacts similar to how we handle closure.

Use case example: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gemma3n.py#L65

Test Plan:
test_aot_compile.py

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela