### PR TITLE
Add unit test for nccl x cg compatibility

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -467,13 +467,15 @@ class TestWithNCCL(MultiProcessTestCase):
     def test_cudagraph_all_gather(self) -> None:
         self._init_process_group()
 
-
         input = torch.full((10, 10), float(self.rank), device=self.device)
 
         g = torch.cuda.CUDAGraph()
 
         # ncclUnhandledCudaError: Call to CUDA function failed.
-        with self.assertRaisesRegex(RuntimeError, "CUDA error: operation failed due to a previous error during capture"):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "CUDA error: operation failed due to a previous error during capture",
+        ):
             with torch.cuda.graph(g):
                 output = torch.ops._c10d_functional.all_gather_into_tensor(
                     input,
@@ -493,7 +495,6 @@ class TestWithNCCL(MultiProcessTestCase):
             # )
             # assert torch.allclose(output, expect)
             # assert output.eq(expect).all()
-
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -482,11 +482,12 @@ class TestWithNCCL(MultiProcessTestCase):
                     self.world_size,
                     "default",
                 )
-                output = torch.ops._c10d_functional.wait_tensor(output)
-
-            g.replay()
 
             # Uncomment when all_gather_into_tensor is compatible with cudagraph.
+            #     output = torch.ops._c10d_functional.wait_tensor(output)
+
+            # g.replay()
+
             # expect = torch.cat(
             #     [
             #         torch.full((10, 10), float(rank), device=self.device)


### PR DESCRIPTION
This PR adds unit tests for functional nccl op and cudagraph compatibility. Currently it covers `torch.ops._c10d_functional.all_gather_into_tensor`. Will examine more ops.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci