### PR TITLE
[Inductor] Propagate benchmarking env variables for all Autotuning Types

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -578,7 +578,7 @@ class GPUDeviceBenchmarkMixin:
         else:
             device_idx = device_interface.current_device()
         with device_interface.device(device_idx):  # type: ignore[attr-defined]
-            res = benchmarker.benchmark_gpu(fn)
+            res = benchmarker.benchmark(fn, device=device_type)
             device_interface.synchronize()  # shake out any CUDA errors
 
         return res

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -85,7 +85,6 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
         TODO: Add precompile() method to enable parallel compilation of all choices
         before benchmarking.
         """
-        import torch._inductor.config as inductor_config
         from torch._inductor.graph import GraphLowering
 
         safe_name = self.name.replace("::", "_").replace(".", "_")
@@ -125,7 +124,7 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
 
         with V.set_graph_handler(bm_graph_lowering):
             # Don't bother autotuning on Triton here
-            with inductor_config.patch(
+            with config.patch(
                 max_autotune=False,
                 max_autotune_gemm=False,
                 max_autotune_gemm_backends="ATEN",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -475,6 +475,13 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
+inductor_default_autotune_warmup = int(
+    os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
+)
+inductor_default_autotune_rep = int(
+    os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_REP", 100)
+)
+
 # Modifies the number of autotuning choices displayed, set to None for all
 autotune_num_choices_displayed: Optional[int] = 10
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6,7 +6,6 @@ import functools
 import itertools
 import logging
 import operator
-import os
 import textwrap
 import traceback
 from collections.abc import Callable, Container, Generator, Iterable, Iterator, Sequence
@@ -150,9 +149,6 @@ _OpOverloads: TypeAlias = Union[torch._ops.OpOverload, torch._ops.HigherOrderOpe
 log = logging.getLogger(__name__)
 indent = functools.partial(textwrap.indent, prefix="  ")
 aten = torch.ops.aten
-
-autotune_warmup = int(os.getenv("TORCH_AUTOTUNE_WARMUP", 25))
-autotune_rep = int(os.getenv("TORCH_AUTOTUNE_REP", 100))
 
 """ [Note: Inductor IR]
 
@@ -5225,15 +5221,9 @@ class ChoiceCaller:
 
     def benchmark(self, *args: Any, out: torch.Tensor) -> float:
         algo = self.to_callable()
-        benchmark_configs = {
-            "warmup": autotune_warmup,
-            "rep": autotune_rep,
-        }
         if config.profile_bandwidth_with_do_bench_using_profiling:
-            return do_bench_using_profiling(lambda: algo(*args), **benchmark_configs)  # type: ignore[arg-type]
-        return benchmarker.benchmark(
-            algo, args, {"out": out}, device=None, **benchmark_configs
-        )
+            return do_bench_using_profiling(lambda: algo(*args))  # type: ignore[arg-type]
+        return benchmarker.benchmark(algo, args, {"out": out}, device=None)
 
     def call_name(self) -> str:
         raise NotImplementedError

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -11,7 +11,11 @@ from typing_extensions import ParamSpec, Self, TypeVar
 import torch
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import counters, dynamo_timed
-from torch._inductor.config import use_experimental_benchmarker
+from torch._inductor.config import (
+    inductor_default_autotune_rep,
+    inductor_default_autotune_warmup,
+    use_experimental_benchmarker,
+)
 from torch.utils._debug_mode import DebugMode
 
 
@@ -190,14 +194,17 @@ class Benchmarker:
         else:
             _callable = lambda: fn(*fn_args, **fn_kwargs)  # noqa: E731
 
+        warmup = kwargs.pop("warmup", inductor_default_autotune_warmup)
+        rep = kwargs.pop("rep", inductor_default_autotune_rep)
+
         # Surfacing all kernels during autotuning is super noisy; filtering these out.
         with DebugMode._benchmarking_inductor():
             if inferred_device == torch.device("cpu"):
-                return self.benchmark_cpu(_callable, **kwargs)
+                return self.benchmark_cpu(_callable, warmup=warmup, rep=rep, **kwargs)
             # TODO(nmacchioni): For non-CPU functions we default to using the GPU-specific benchmarking
             # implementation which was written specifically with CUDA devices in mind, we may want to
             # explore alternate implementations for other device types.
-            return self.benchmark_gpu(_callable, **kwargs)
+            return self.benchmark_gpu(_callable, warmup=warmup, rep=rep, **kwargs)
 
     @time_and_count
     def benchmark_cpu(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3601,7 +3601,7 @@ class AlgorithmSelectorCache(PersistentCache):
         timeout_seconds = config.collective_benchmark_timeout
 
         nruns = config.collective_benchmark_nruns
-        nwarmup = ir.autotune_warmup
+        nwarmup = config.inductor_default_autotune_warmup
 
         # Use default process group (None = all ranks)
         process_group = None


### PR DESCRIPTION
Summary:
Takes the `TORCH_AUTOTUNE_WARMUP` and `TORCH_AUTOTUNE_REP` environment variables, which were previously only being applied to ATEN operators and applies them to Triton, subgraph and external templates. This should help ensure stable results on B200.

co authored with: PaulZhang12

Test Plan: Test on a model Max Autotune run to stablize results.

Differential Revision: D87099442




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78