### PR TITLE
control_plane: add handler for WaitCounters

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -521,6 +521,7 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/comm.cpp",
     "torch/csrc/distributed/c10d/control_collectives/StoreCollectives.cpp",
     "torch/csrc/distributed/c10d/control_plane/Handlers.cpp",
+    "torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.cpp",
     "torch/csrc/distributed/c10d/control_plane/WorkerServer.cpp",
     "torch/csrc/distributed/c10d/cuda/StreamBlock.cpp",
     "torch/csrc/distributed/c10d/debug.cpp",

--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -6,6 +6,7 @@ import os
 import pickle
 import socket
 import tempfile
+import unittest
 from contextlib import contextmanager
 
 from urllib3.connection import HTTPConnection
@@ -15,7 +16,13 @@ from torch.distributed.elastic.control_plane import (
     TORCH_WORKER_SERVER_SOCKET,
     worker_main,
 )
-from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+from torch.monitor import _WaitCounter
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    requires_cuda,
+    run_tests,
+    TestCase,
+)
 
 
 class UnixHTTPConnection(HTTPConnection):
@@ -215,6 +222,68 @@ class WorkerServerTest(TestCase):
 
         names = _get_handler_names()
         self.assertIn("ping", names)
+
+    @unittest.skipIf(IS_FBCODE, "disabled in FBCODE")
+    def test_wait_counter_values(self) -> None:
+        """
+        Test that WaitCounter values are properly tracked and returned by the handler.
+
+        Note: This test may trigger an ASAN heap-use-after-free error during process
+        shutdown due to static destruction order issues with boost regex in the logging
+        framework. The test assertions pass successfully before this shutdown error occurs.
+        """
+        with local_worker_server() as pool:
+            # Create and use a WaitCounter with a specific name
+            counter_name = "test_counter"
+            counter = _WaitCounter(counter_name)
+
+            # Use the counter multiple times to generate metrics
+            # Note: Using minimal/no sleep to avoid timing issues
+            for i in range(3):
+                with counter.guard():
+                    pass  # Minimal work
+
+            # Query the wait counter values
+            resp = pool.request("POST", "/handler/wait_counter_values")
+            self.assertEqual(resp.status, 200)
+
+            # Parse the JSON response
+            data = json.loads(resp.data)
+            # Should be a dictionary
+            self.assertIsInstance(data, dict)
+
+            # Verify our test counter appears in the response
+            self.assertIn(
+                counter_name,
+                data,
+                f"Counter '{counter_name}' not found in response. Available counters: {list(data.keys())}",
+            )
+
+            # Verify the counter has expected metrics
+            counter_data = data[counter_name]
+            self.assertIn("active_count", counter_data)
+            self.assertIn("total_calls", counter_data)
+            self.assertIn("total_time_us", counter_data)
+            self.assertIn("max_time_us", counter_data)
+
+            # Verify the counter was called 3 times
+            self.assertEqual(
+                counter_data["total_calls"],
+                3,
+                f"Expected 3 calls, got {counter_data['total_calls']}",
+            )
+
+            # Verify active_count is 0 (no active waiters)
+            self.assertEqual(
+                counter_data["active_count"],
+                0,
+                f"Expected 0 active, got {counter_data['active_count']}",
+            )
+
+            # total_time_us and max_time_us may be 0 or very small for fast operations
+            # Just verify they exist and are non-negative
+            self.assertGreaterEqual(counter_data["total_time_us"], 0)
+            self.assertGreaterEqual(counter_data["max_time_us"], 0)
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_debug.py
+++ b/test/distributed/test_debug.py
@@ -40,6 +40,7 @@ class TestDebug(TestCase):
         self.assertIn("View 0", fetch("/profile?duration=0.01"))
         self.assertIn("test_basics", fetch("/stacks"))
         self.assertIn("pg_status", fetch("/fr_trace"))
+        self.assertIn("Rank 0", fetch("/wait_counters"))
 
         if torch.cuda.is_available():
             self.assertIn("pg_status", fetch("/fr_trace_nccl"))

--- a/torch/csrc/distributed/c10d/control_plane/Handlers.cpp
+++ b/torch/csrc/distributed/c10d/control_plane/Handlers.cpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include <torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.hpp>
+
 namespace c10d::control_plane {
 
 namespace {
@@ -72,6 +74,22 @@ RegisterHandler frTracehandler(
       res.setContent(std::move(trace), "application/json");
       res.setStatus(200);
     });
+
+RegisterHandler waitCounterHandler{
+    "wait_counter_values",
+    [](const Request&, Response& res) {
+      // Get all wait counter values from our tracking backend
+      res.setContent(getWaitCounterValuesJson(), "application/json");
+      res.setStatus(200);
+    }};
+
+#if !defined(FBCODE_CAFFE2)
+// Initialize the wait counter backend
+[[maybe_unused]] static bool init_backend = []() {
+  ensureWaitCounterBackendRegistered();
+  return true;
+}();
+#endif
 
 } // namespace
 

--- a/torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.cpp
+++ b/torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.cpp
@@ -1,0 +1,138 @@
+#include <torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <c10/util/CallOnce.h>
+#include <c10/util/Synchronized.h>
+#include <c10/util/WaitCounter.h>
+
+#include <nlohmann/json.hpp>
+
+namespace c10d::control_plane {
+
+namespace {
+
+// Data structure to hold counter metrics
+struct CounterData {
+  std::atomic<int64_t> active_count{0};
+  std::atomic<int64_t> total_calls{0};
+  std::atomic<int64_t> total_time_us{0};
+  std::atomic<int64_t> max_time_us{0};
+};
+
+// Holder struct for the counter data map
+struct CounterDataMapHolder {
+  c10::Synchronized<
+      std::unordered_map<std::string, std::shared_ptr<CounterData>>>
+      map;
+};
+
+// Leaky singleton to avoid static destruction order issues
+CounterDataMapHolder* getCounterDataMapHolder() {
+  static CounterDataMapHolder* holder = new CounterDataMapHolder();
+  return holder;
+}
+
+// Backend implementation that tracks counter metrics
+class TrackingBackend : public c10::monitor::detail::WaitCounterBackendIf {
+ public:
+  explicit TrackingBackend(std::string key) : key_(std::move(key)) {
+    // Get or create counter data for this key
+    getCounterDataMapHolder()->map.withLock([&](auto& map) {
+      auto it = map.find(key_);
+      if (it == map.end()) {
+        data_ = std::make_shared<CounterData>();
+        map[key_] = data_;
+      } else {
+        data_ = it->second;
+      }
+    });
+  }
+
+  intptr_t start(std::chrono::steady_clock::time_point now) noexcept override {
+    data_->active_count.fetch_add(1, std::memory_order_relaxed);
+    data_->total_calls.fetch_add(1, std::memory_order_relaxed);
+    // Return the start time as the context
+    return static_cast<intptr_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now.time_since_epoch())
+            .count());
+  }
+
+  void stop(std::chrono::steady_clock::time_point now, intptr_t ctx) noexcept
+      override {
+    // Calculate duration from the stored start time
+    auto start_ns = std::chrono::nanoseconds(ctx);
+    auto start_time = std::chrono::steady_clock::time_point(start_ns);
+    auto duration_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(now - start_time)
+            .count();
+
+    data_->active_count.fetch_sub(1, std::memory_order_relaxed);
+    data_->total_time_us.fetch_add(duration_us, std::memory_order_relaxed);
+
+    // Update max_time_us using compare-and-swap
+    int64_t current_max = data_->max_time_us.load(std::memory_order_relaxed);
+    while (duration_us > current_max) {
+      if (data_->max_time_us.compare_exchange_weak(
+              current_max, duration_us, std::memory_order_relaxed)) {
+        break;
+      }
+    }
+  }
+
+ private:
+  std::string key_;
+  std::shared_ptr<CounterData> data_;
+};
+
+// Factory for creating tracking backends
+class TrackingBackendFactory
+    : public c10::monitor::detail::WaitCounterBackendFactoryIf {
+ public:
+  std::unique_ptr<c10::monitor::detail::WaitCounterBackendIf> create(
+      std::string_view key) noexcept override {
+    return std::make_unique<TrackingBackend>(std::string(key));
+  }
+};
+
+} // namespace
+
+// Ensures the wait counter backend is registered
+// NOTE: This function is in the c10d::control_plane namespace, NOT anonymous
+void ensureWaitCounterBackendRegistered() {
+  static c10::once_flag once;
+  c10::call_once(once, []() {
+    c10::monitor::detail::registerWaitCounterBackend(
+        std::make_unique<TrackingBackendFactory>());
+  });
+}
+
+// Returns all wait counter values as a JSON string
+// NOTE: This function is in the c10d::control_plane namespace, NOT anonymous
+std::string getWaitCounterValuesJson() {
+  nlohmann::json j = nlohmann::json::object();
+
+  getCounterDataMapHolder()->map.withLock([&](const auto& map) {
+    for (const auto& [name, data] : map) {
+      nlohmann::json counter_obj = nlohmann::json::object();
+      counter_obj["active_count"] =
+          data->active_count.load(std::memory_order_relaxed);
+      counter_obj["total_calls"] =
+          data->total_calls.load(std::memory_order_relaxed);
+      counter_obj["total_time_us"] =
+          data->total_time_us.load(std::memory_order_relaxed);
+      counter_obj["max_time_us"] =
+          data->max_time_us.load(std::memory_order_relaxed);
+      j[name] = std::move(counter_obj);
+    }
+  });
+
+  return j.dump();
+}
+
+} // namespace c10d::control_plane

--- a/torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.hpp
+++ b/torch/csrc/distributed/c10d/control_plane/WaitCounterHandler.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace c10d {
+namespace control_plane {
+
+// Returns all wait counter values as a JSON string
+std::string getWaitCounterValuesJson();
+
+// Ensures the wait counter backend is registered
+void ensureWaitCounterBackendRegistered();
+
+} // namespace control_plane
+} // namespace c10d

--- a/torch/distributed/debug/_frontend.py
+++ b/torch/distributed/debug/_frontend.py
@@ -96,6 +96,7 @@ templates = {
     <a href="/fr_trace">FlightRecorder</a> <!--@lint-ignore-->
     <a href="/fr_trace_nccl">FlightRecorder NCCL</a> <!--@lint-ignore-->
     <a href="/profile">torch profiler</a> <!--@lint-ignore-->
+    <a href="/wait_counters">Wait Counters</a> <!--@lint-ignore-->
 </nav>
 
 <section class="content">
@@ -257,6 +258,7 @@ class FrontendServer:
             "/fr_trace": self._handle_fr_trace,
             "/fr_trace_nccl": self._handle_fr_trace_nccl,
             "/profile": self._handle_profiler,
+            "/wait_counters": self._handle_wait_counters,
         }
 
         # Create HTTP server
@@ -345,6 +347,12 @@ class FrontendServer:
         addrs, resps = fetch_all("torch_profile", f"duration={duration}")
 
         return self._render_template("profile.html", addrs=addrs, resps=resps)
+
+    def _handle_wait_counters(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("wait_counter_values")
+        return self._render_template(
+            "json_resp.html", title="Wait Counters", addrs=addrs, resps=resps
+        )
 
 
 def main(port: int) -> None:


### PR DESCRIPTION
Summary:
This adds a DebugServer handler for WaitCounters such that we can access all wait counters live via HTTP.

To do so we register a wait counter backend that tracks all counter values in a shared synchronized map. When creating a counter this will acquire the lock to add it to the global map but during runtime it only uses atomic operation.

Test Plan:
```
//caffe2/test/distributed/elastic:test_control_plane
```

Differential Revision: D87095718




cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @pragupta @msaroufim @dcci