### PR TITLE
[inductor][pattern_matcher] Have check_fn just check matches with tensors

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1428,7 +1428,7 @@ class TestPatternMatcher(TestCase):
         torch.manual_seed(40)
         result_compiled = cm(x)
         torch.testing.assert_close(result, result_compiled)
-        assert counters["inductor"]["pattern_matcher_count"] == 1
+        assert counters["inductor"]["pattern_matcher_count"] > 0
 
     @inductor_config.patch(fx_graph_remote_cache=False)
     def test_match_equivalent_function_invocations2(self):

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1418,18 +1418,17 @@ class TestPatternMatcher(TestCase):
         x = torch.randn(3, device=GPU_TYPE)
 
         def func(x):
-            twos = torch.ones(3, device=x.device) * 2
-            x = twos * x
-            x = x + 1
             perm = torch.randperm(x.numel(), device=x.device)
             return x.view(-1)[perm].view_as(x)
 
+        counters.clear()
         torch.manual_seed(40)
         result = func(x)
         cm = torch.compile(func)
         torch.manual_seed(40)
         result_compiled = cm(x)
         torch.testing.assert_close(result, result_compiled)
+        assert counters["inductor"]["pattern_matcher_count"] == 1
 
     @inductor_config.patch(fx_graph_remote_cache=False)
     def test_match_equivalent_function_invocations2(self):

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1413,10 +1413,10 @@ class TestPatternMatcher(TestCase):
         out, code = run_and_get_code(test_c, x, y)
         FileCheck().check_not(".run").run(code[0])
         self.assertEqual(out, test(x, y))
-    
+
     def test_randperm_index_scalar_workaround(self):
         x = torch.randn(3, device=GPU_TYPE)
-        
+
         def func(x):
             twos = torch.ones(3, device=x.device) * 2
             x = twos * x

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1447,7 +1447,9 @@ def register_replacement(
         extra_check: additional check to run on match(using real shapes)
     """
     argnames_static = [*inspect.signature(search_fn).parameters.keys()]
-    scalar_workaround_keys = set(scalar_workaround.keys() if scalar_workaround else [])
+    scalar_workaround_keys = (
+        OrderedSet(scalar_workaround.keys()) if scalar_workaround else OrderedSet()
+    )
     argnames_from_example_inputs = [
         name for name in argnames_static if name not in scalar_workaround_keys
     ]


### PR DESCRIPTION
Fixes #166604

The issue was that args in check_fn included scalar_workraounds and tensors. I had it just use the tensors instead. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78