### PR TITLE
Back out "MatMal - fix folding logic"

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4535,7 +4535,7 @@ def should_fold(tensor1: torch.Tensor, tensor2: torch.Tensor, is_out: bool) -> b
 
     if not (t1.ndim >= 3 and t2.ndim <= 2):
         return False
-    if (t1.requires_grad or t2.requires_grad) and not is_out:
+    if t2.requires_grad and not is_out:
         return True
     if tensor1.ndim == 2:
         return False


### PR DESCRIPTION
Summary:
For sepcific hardware (A100), Autocast will generate a relatively large error on Transformer (torch.nn.TransformerEncoder) when using no_grad decorator on dim=256 (and larger presuably).

H100 seems fine, as does A100 with mig (so less than full SMs).

For now backing out, and revisting next week.

Test Plan:
failed jobs:
https://fburl.com/scuba/remote_execution_action/jzcmujgk

 {F1983543613}

Reviewed By: t-ivan-gr

Differential Revision: D87111518


