### PR TITLE
Add sinusoidal_ initialization method to torch.nn.init

### DIFF
--- a/test/nn/test_init.py
+++ b/test/nn/test_init.py
@@ -514,6 +514,20 @@ class TestNNInit(TestCase):
                         rtol=0,
                     )
 
+    def test_sinusoidal(self):
+        # Linear-like
+        t = torch.empty(64, 128)
+        init.sinusoidal_(t)
+        assert torch.isfinite(t).all()
+        assert abs(t.mean()) < 1e-2
+        assert abs(t.std() - math.sqrt(2.0 / (64 + 128))) < 0.1
+
+        # Conv-like
+        t2 = torch.empty(32, 3, 3, 3)
+        init.sinusoidal_(t2)
+        assert torch.isfinite(t2).all()
+        assert t2.shape == (32, 3, 3, 3)
+
     def test_deprecation(self):
         x = torch.randn(3, 3)
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -25,6 +25,7 @@ __all__ = [
     "kaiming_uniform_",
     "kaiming_normal_",
     "orthogonal_",
+    "sinusoidal_",
     "sparse_",
     # Deprecated aliases (for backward compatibility)
     "uniform",
@@ -37,6 +38,7 @@ __all__ = [
     "kaiming_uniform",
     "kaiming_normal",
     "orthogonal",
+    "sinusoidal",
     "sparse",
 ]
 
@@ -678,6 +680,73 @@ def orthogonal_(
         tensor.mul_(gain)
     return tensor
 
+def sinusoidal_(
+    tensor: Tensor,
+    generator: _Optional[torch.Generator] = None,
+) -> Tensor:
+    r"""Fill the input `Tensor` with sinusoidal patterns for structured initialization.
+
+    The method is described in `Sinusoidal Initialization, Time for a New Start` - 
+    Fernandez-Hernandez, A. et al. (2025).
+
+    This initialization assigns each output channel (or neuron) a sinusoidal
+    weight pattern with varying frequency and phase, scaled to preserve
+    variance similar to Kaiming/Xavier methods.
+
+    The sinusoidal initialization encourages smooth and diverse feature
+    selectivity at initialization, potentially aiding convergence and
+    interpretability in early training stages.
+
+    Args:
+        tensor: an n-dimensional `torch.Tensor`
+            - For Linear layers: shape ``(out_features, in_features)``
+            - For Conv layers: shape ``(out_channels, in_channels, kernel_height, kernel_width)``
+        generator: the torch Generator to sample from (default: None)
+
+    Examples:
+        >>> w = torch.empty(3, 5)
+        >>> nn.init.sinusoidal_(w)
+        >>> conv_w = torch.empty(16, 3, 3, 3)
+        >>> nn.init.sinusoidal_(conv_w)
+    """
+    if torch.overrides.has_torch_function_variadic(tensor):
+        return torch.overrides.handle_torch_function(
+            sinusoidal_, (tensor,), tensor=tensor, generator=generator
+        )
+
+    with torch.no_grad():
+        # Flatten input channels for unified handling
+        shape = tensor.shape
+        if tensor.ndimension() == 2:
+            n_out, n_in = shape
+            n_flat = n_in
+        elif tensor.ndimension() >= 3:
+            n_out, n_in = shape[0], shape[1] * math.prod(shape[2:])
+            n_flat = n_in
+        else:
+            raise ValueError("Tensor must have at least 2 dimensions")
+
+        # Create sinusoidal pattern
+        phase = (2 * math.pi / n_out)
+        freq = (2 * math.pi / n_flat)
+        position = torch.arange(n_flat, dtype=torch.float32) * freq + phase
+
+        # Give each neuron a different wave
+        neuron = torch.arange(n_out, dtype=torch.float32) + 1
+        weights = torch.sin(position.unsqueeze(0) * neuron.unsqueeze(1))
+
+        # Normalize amplitude
+        var = torch.var(weights, unbiased=True)
+        amplitude = math.sqrt(2.0 / (var.item() * (n_in + n_out)))
+        weights = weights * amplitude
+
+        # Reshape for conv layers if needed
+        if tensor.ndimension() >= 3:
+            weights = weights.view(shape[0], shape[1], *shape[2:])
+
+        tensor.copy_(weights)
+        return tensor
+
 
 def sparse_(
     tensor: Tensor,
@@ -751,4 +820,5 @@ xavier_normal = _make_deprecate(xavier_normal_)
 kaiming_uniform = _make_deprecate(kaiming_uniform_)
 kaiming_normal = _make_deprecate(kaiming_normal_)
 orthogonal = _make_deprecate(orthogonal_)
+sinusoidal = _make_deprecate(sinusoidal_)
 sparse = _make_deprecate(sparse_)


### PR DESCRIPTION
This PR adds a new initialization described in `Sinusoidal Initialization, Time for a New Start` - Fernandez-Hernandez, A. et al. (NeurIPS 2025).

A new deterministic structured initialization, `sinusoidal_`, which fills weights with scaled sinusoidal patterns. The method unifies linear and convolutional layer initialization, preserving variance while introducing frequency-phase diversity across output channels.

