### PR TITLE
[MPS] remove expected failure for a test

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -3918,6 +3918,7 @@ class TestSparse(TestSparseBase):
             self.skipTest(f"Test with dtype={dtype}, device={device} runs only with coalesced inputs")
 
     @coalescedonoff
+    @expectedFailureMPS
     # NOTE: addcmul_out is not implemented for bool.
     @dtypes(*all_types_and_complex_and(torch.bfloat16, torch.float16))
     @dtypesIfMPS(*all_mps_types())

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -646,7 +646,8 @@ class TestSparse(TestSparseBase):
             def fn(x):
                 return x.to_dense(masked_grad=gradcheck.masked)
             x.requires_grad_(True)
-            gradcheck(fn, (x,), eps=1e-4)
+            eps = 1e-4 if device == "mps:0" else 1e-5
+            gradcheck(fn, (x,), eps=eps)
 
         i = self.index_tensor([
             [0, 1, 2, 2],
@@ -3917,7 +3918,6 @@ class TestSparse(TestSparseBase):
             self.skipTest(f"Test with dtype={dtype}, device={device} runs only with coalesced inputs")
 
     @coalescedonoff
-    @expectedFailureMPS
     # NOTE: addcmul_out is not implemented for bool.
     @dtypes(*all_types_and_complex_and(torch.bfloat16, torch.float16))
     @dtypesIfMPS(*all_mps_types())

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -646,7 +646,7 @@ class TestSparse(TestSparseBase):
             def fn(x):
                 return x.to_dense(masked_grad=gradcheck.masked)
             x.requires_grad_(True)
-            kawrgs = {"eps": 1e-4} if device == "mps:0" else {}
+            kwargs = {"eps": 1e-4} if device == "mps:0" else {}
             gradcheck(fn, (x,), **kwargs)
 
         i = self.index_tensor([

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -630,7 +630,6 @@ class TestSparse(TestSparseBase):
         i[0][0] = 0
         self.assertEqual(torch.empty((3, 0), dtype=dtype, device=device), self.safeToDense(x))
 
-    @expectedFailureMPS
     @dtypes(torch.double, torch.cdouble)
     @dtypesIfMPS(torch.float32, torch.complex64)
     @unittest.skipIf(TEST_WITH_CROSSREF, "generator unsupported triggers assertion error")
@@ -647,7 +646,7 @@ class TestSparse(TestSparseBase):
             def fn(x):
                 return x.to_dense(masked_grad=gradcheck.masked)
             x.requires_grad_(True)
-            gradcheck(fn, (x,))
+            gradcheck(fn, (x,), eps=1e-4)
 
         i = self.index_tensor([
             [0, 1, 2, 2],

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -646,8 +646,8 @@ class TestSparse(TestSparseBase):
             def fn(x):
                 return x.to_dense(masked_grad=gradcheck.masked)
             x.requires_grad_(True)
-            eps = 1e-4 if device == "mps:0" else 1e-5
-            gradcheck(fn, (x,), eps=eps)
+            kawrgs = {"eps": 1e-4} if device == "mps:0" else {}
+            gradcheck(fn, (x,), **kwargs)
 
         i = self.index_tensor([
             [0, 1, 2, 2],


### PR DESCRIPTION
remove expected failure for a test for MPS backend, but lower the precision to `1e-4` 