### PR TITLE
Add comprehensive test coverage for openreg backend

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autocast.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autocast.py
@@ -6,6 +6,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestAutocast(TestCase):
     def test_autocast_with_unsupported_type(self):
+        """Test autocast with unsupported dtype (float32)"""
         with self.assertWarnsRegex(
             UserWarning,
             "In openreg autocast, but the target dtype is not supported. Disabling autocast.\n"
@@ -15,6 +16,7 @@ class TestAutocast(TestCase):
                 _ = torch.ones(10)
 
     def test_autocast_operator_not_supported(self):
+        """Test that binary_cross_entropy is not supported in autocast"""
         with self.assertRaisesRegex(
             RuntimeError,
             "torch.nn.functional.binary_cross_entropy and torch.nn.BCELoss are unsafe to autocast.",
@@ -25,6 +27,7 @@ class TestAutocast(TestCase):
                 _ = torch.nn.functional.binary_cross_entropy(x, y)
 
     def test_autocast_low_precision(self):
+        """Test low precision operations (mm) in autocast"""
         with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
             x = torch.randn(2, 3, device="openreg")
             y = torch.randn(3, 3, device="openreg")
@@ -32,19 +35,157 @@ class TestAutocast(TestCase):
             self.assertEqual(result.dtype, torch.float16)
 
     def test_autocast_fp32(self):
+        """Test fp32 operations (asin) in autocast"""
         with torch.amp.autocast(device_type="openreg"):
             x = torch.randn(2, device="openreg", dtype=torch.float16)
             result = torch.asin(x)
             self.assertEqual(result.dtype, torch.float32)
 
     def test_autocast_default_dtype(self):
+        """Test default autocast dtype"""
         openreg_fast_dtype = torch.get_autocast_dtype(device_type="openreg")
         self.assertEqual(openreg_fast_dtype, torch.half)
 
     def test_autocast_set_dtype(self):
+        """Test setting autocast dtype"""
         for dtype in [torch.float16, torch.bfloat16]:
             torch.set_autocast_dtype("openreg", dtype)
             self.assertEqual(torch.get_autocast_dtype("openreg"), dtype)
+
+    def test_autocast_bfloat16(self):
+        """Test autocast with bfloat16 dtype"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.bfloat16):
+            x = torch.randn(2, 3, device="openreg", dtype=torch.float32)
+            y = torch.randn(3, 3, device="openreg", dtype=torch.float32)
+            result = torch.mm(x, y)
+            self.assertEqual(result.dtype, torch.bfloat16)
+
+    def test_autocast_low_precision_bfloat16(self):
+        """Test low precision operations with bfloat16"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.bfloat16):
+            x = torch.randn(2, 3, device="openreg")
+            y = torch.randn(3, 3, device="openreg")
+            result = torch.mm(x, y)
+            self.assertEqual(result.dtype, torch.bfloat16)
+
+    def test_autocast_fp32_with_bfloat16(self):
+        """Test fp32 operations with bfloat16 autocast"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.bfloat16):
+            x = torch.randn(2, device="openreg", dtype=torch.bfloat16)
+            result = torch.asin(x)
+            self.assertEqual(result.dtype, torch.float32)
+
+    def test_autocast_nested_context(self):
+        """Test nested autocast contexts"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, 3, device="openreg")
+            y = torch.randn(3, 3, device="openreg")
+            result1 = torch.mm(x, y)
+            self.assertEqual(result1.dtype, torch.float16)
+            
+            # Nested autocast context with bfloat16
+            with torch.amp.autocast(device_type="openreg", dtype=torch.bfloat16):
+                result2 = torch.mm(x, y)
+                self.assertEqual(result2.dtype, torch.bfloat16)
+            
+            # After exiting nested context, should restore to float16
+            result3 = torch.mm(x, y)
+            self.assertEqual(result3.dtype, torch.float16)
+
+    def test_autocast_fallthrough_operation(self):
+        """Test fallthrough operations (operations not specially registered)"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, 3, device="openreg", dtype=torch.float32)
+            # add operation is not specially registered, should fallthrough
+            result = torch.add(x, x)
+            # fallthrough operations should preserve input type or use default behavior
+            self.assertIn(result.dtype, [torch.float32, torch.float16])
+
+    def test_autocast_with_requires_grad(self):
+        """Test autocast interaction with requires_grad"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, 3, device="openreg", requires_grad=True)
+            y = torch.randn(3, 3, device="openreg", requires_grad=True)
+            result = torch.mm(x, y)
+            self.assertEqual(result.dtype, torch.float16)
+            self.assertTrue(result.requires_grad)
+            
+            # Test backward propagation
+            loss = result.sum()
+            loss.backward()
+            self.assertIsNotNone(x.grad)
+            self.assertIsNotNone(y.grad)
+
+    def test_autocast_mixed_input_dtypes(self):
+        """Test combinations of different input dtypes"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, 3, device="openreg", dtype=torch.float32)
+            y = torch.randn(3, 3, device="openreg", dtype=torch.float16)
+            # mm operation should convert inputs to low precision
+            result = torch.mm(x, y)
+            self.assertEqual(result.dtype, torch.float16)
+
+    def test_autocast_already_target_dtype(self):
+        """Test when inputs are already in target dtype"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, 3, device="openreg", dtype=torch.float16)
+            y = torch.randn(3, 3, device="openreg", dtype=torch.float16)
+            result = torch.mm(x, y)
+            self.assertEqual(result.dtype, torch.float16)
+
+    def test_autocast_combination_operations(self):
+        """Test multiple operations combination under autocast"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, 3, device="openreg")
+            y = torch.randn(3, 3, device="openreg")
+            z = torch.randn(2, device="openreg")
+            
+            # Low precision operation
+            result1 = torch.mm(x, y)
+            self.assertEqual(result1.dtype, torch.float16)
+            
+            # fp32 operation
+            result2 = torch.asin(z)
+            self.assertEqual(result2.dtype, torch.float32)
+            
+            # Combined operations
+            result3 = torch.mm(result1, y)
+            self.assertEqual(result3.dtype, torch.float16)
+
+    def test_autocast_disable(self):
+        """Test disabling autocast"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16, enabled=False):
+            x = torch.randn(2, 3, device="openreg", dtype=torch.float32)
+            y = torch.randn(3, 3, device="openreg", dtype=torch.float32)
+            result = torch.mm(x, y)
+            # When autocast is disabled, should preserve original dtype
+            self.assertEqual(result.dtype, torch.float32)
+
+    def test_autocast_cache_enabled(self):
+        """Test autocast caching"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16, cache_enabled=True):
+            x = torch.randn(2, 3, device="openreg")
+            y = torch.randn(3, 3, device="openreg")
+            result1 = torch.mm(x, y)
+            result2 = torch.mm(x, y)
+            self.assertEqual(result1.dtype, torch.float16)
+            self.assertEqual(result2.dtype, torch.float16)
+
+    def test_autocast_fp32_operation_with_float16_input(self):
+        """Test fp32 operations receiving float16 input"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, device="openreg", dtype=torch.float16)
+            result = torch.asin(x)
+            # asin should output float32
+            self.assertEqual(result.dtype, torch.float32)
+
+    def test_autocast_fp32_operation_with_float32_input(self):
+        """Test fp32 operations receiving float32 input"""
+        with torch.amp.autocast(device_type="openreg", dtype=torch.float16):
+            x = torch.randn(2, device="openreg", dtype=torch.float32)
+            result = torch.asin(x)
+            # asin should output float32
+            self.assertEqual(result.dtype, torch.float32)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autograd.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autograd.py
@@ -20,6 +20,7 @@ class TestAutograd(TestCase):
     @skipIfWindows()
     @skipIfTorchDynamo()
     def test_autograd_init(self):
+        """Test autograd initialization and thread creation"""
         # Make sure autograd is initialized
         torch.ones(2, requires_grad=True, device="openreg").sum().backward()
 
@@ -36,6 +37,90 @@ class TestAutograd(TestCase):
 
         for i in range(torch.accelerator.device_count()):
             self.assertIn(f"pt_autograd_{i}", all_thread_names)
+
+    def test_autograd_backward(self):
+        """Test backward propagation on openreg device"""
+        x = torch.randn(2, 3, device="openreg", requires_grad=True)
+        y = torch.randn(3, 2, device="openreg", requires_grad=True)
+        z = torch.mm(x, y)
+        loss = z.sum()
+        loss.backward()
+        
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(y.grad)
+        self.assertEqual(x.grad.shape, x.shape)
+        self.assertEqual(y.grad.shape, y.shape)
+
+    def test_autograd_grad_fn(self):
+        """Test gradient function tracking"""
+        x = torch.randn(2, 3, device="openreg", requires_grad=True)
+        y = x * 2
+        z = y.sum()
+        
+        self.assertIsNotNone(y.grad_fn)
+        self.assertIsNone(x.grad)
+        
+        z.backward()
+        self.assertIsNotNone(x.grad)
+
+    def test_autograd_no_grad(self):
+        """Test no_grad context manager"""
+        x = torch.randn(2, 3, device="openreg", requires_grad=True)
+        
+        with torch.no_grad():
+            y = x * 2
+            self.assertIsNone(y.grad_fn)
+            self.assertFalse(y.requires_grad)
+        
+        z = x * 2
+        self.assertIsNotNone(z.grad_fn)
+        self.assertTrue(z.requires_grad)
+
+    def test_autograd_detach(self):
+        """Test tensor detach"""
+        x = torch.randn(2, 3, device="openreg", requires_grad=True)
+        y = x.detach()
+        
+        self.assertFalse(y.requires_grad)
+        self.assertIsNone(y.grad_fn)
+        
+        z = y * 2
+        self.assertIsNone(z.grad_fn)
+
+    def test_autograd_retain_grad(self):
+        """Test retain_grad for intermediate tensors"""
+        x = torch.randn(2, 3, device="openreg", requires_grad=True)
+        y = x * 2
+        y.retain_grad()
+        z = y.sum()
+        z.backward()
+        
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(y.grad)
+
+    def test_autograd_multiple_backward(self):
+        """Test multiple backward passes"""
+        x = torch.randn(2, 3, device="openreg", requires_grad=True)
+        y = x.sum()
+        
+        y.backward(retain_graph=True)
+        grad1 = x.grad.clone()
+        
+        y.backward()
+        grad2 = x.grad
+        
+        # Second backward should accumulate gradients
+        self.assertEqual(grad2, grad1 * 2)
+
+    def test_autograd_cross_device(self):
+        """Test autograd with cross-device operations"""
+        x = torch.randn(2, 3, requires_grad=True)
+        y = x.to("openreg")
+        z = y.sum()
+        z.backward()
+        
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(x.grad.is_cpu)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_device.py
@@ -7,10 +7,12 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestDevice(TestCase):
     def test_device_count(self):
+        """Test device count query"""
         count = torch.accelerator.device_count()
         self.assertEqual(count, 2)
 
     def test_device_switch(self):
+        """Test switching between devices"""
         torch.accelerator.set_device_index(1)
         self.assertEqual(torch.accelerator.current_device_index(), 1)
 
@@ -18,6 +20,7 @@ class TestDevice(TestCase):
         self.assertEqual(torch.accelerator.current_device_index(), 0)
 
     def test_device_context(self):
+        """Test device context manager"""
         device = torch.accelerator.current_device_index()
         with torch.accelerator.device_index(None):
             self.assertEqual(torch.accelerator.current_device_index(), device)
@@ -28,8 +31,57 @@ class TestDevice(TestCase):
         self.assertEqual(torch.accelerator.current_device_index(), device)
 
     def test_invalid_device_index(self):
+        """Test error handling for invalid device index"""
         with self.assertRaisesRegex(RuntimeError, "The device index is out of range"):
             torch.accelerator.set_device_index(2)
+
+    def test_device_properties(self):
+        """Test device properties"""
+        device = torch.device("openreg:0")
+        self.assertEqual(device.type, "openreg")
+        self.assertEqual(device.index, 0)
+        
+        device = torch.device("openreg")
+        self.assertEqual(device.type, "openreg")
+        self.assertIsNone(device.index)
+
+    def test_tensor_device(self):
+        """Test tensor device assignment"""
+        x = torch.randn(2, 3, device="openreg")
+        self.assertEqual(x.device.type, "openreg")
+        
+        x = torch.randn(2, 3, device="openreg:1")
+        self.assertEqual(x.device.type, "openreg")
+        self.assertEqual(x.device.index, 1)
+
+    def test_device_guard(self):
+        """Test device guard context manager"""
+        original_device = torch.accelerator.current_device_index()
+        
+        with torch.accelerator.device_index(1):
+            self.assertEqual(torch.accelerator.current_device_index(), 1)
+        
+        self.assertEqual(torch.accelerator.current_device_index(), original_device)
+
+    def test_device_switch_persistence(self):
+        """Test that device switch persists across operations"""
+        torch.accelerator.set_device_index(1)
+        x = torch.randn(2, 3, device="openreg")
+        self.assertEqual(x.device.index, 1)
+        
+        y = torch.randn(3, 3, device="openreg")
+        self.assertEqual(y.device.index, 1)
+
+    def test_device_count_consistency(self):
+        """Test device count consistency"""
+        count = torch.accelerator.device_count()
+        self.assertGreater(count, 0)
+        self.assertLess(count, 10)  # Reasonable upper bound
+        
+        # Test that we can access all devices
+        for i in range(count):
+            torch.accelerator.set_device_index(i)
+            self.assertEqual(torch.accelerator.current_device_index(), i)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_event.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_event.py
@@ -7,6 +7,7 @@ from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, T
 class TestEvent(TestCase):
     @skipIfTorchDynamo()
     def test_event_create(self):
+        """Test event creation with different methods"""
         event = torch.Event(device="openreg")
         self.assertEqual(event.device.type, "openreg")
         self.assertEqual(event.device.index, None)
@@ -30,6 +31,7 @@ class TestEvent(TestCase):
 
     @skipIfTorchDynamo()
     def test_event_query(self):
+        """Test event query operation"""
         event = torch.Event()
         self.assertTrue(event.query())
 
@@ -40,6 +42,7 @@ class TestEvent(TestCase):
 
     @skipIfTorchDynamo()
     def test_event_record(self):
+        """Test recording events on streams"""
         stream = torch.Stream(device="openreg:1")
         event1 = stream.record_event()
         self.assertNotEqual(0, event1.event_id)
@@ -51,6 +54,7 @@ class TestEvent(TestCase):
 
     @skipIfTorchDynamo()
     def test_event_elapsed_time(self):
+        """Test elapsed time calculation between events"""
         stream = torch.Stream(device="openreg:1")
 
         event1 = torch.Event(device="openreg:1", enable_timing=True)
@@ -67,11 +71,80 @@ class TestEvent(TestCase):
 
     @skipIfTorchDynamo()
     def test_event_wait_stream(self):
+        """Test stream waiting on event"""
         stream1 = torch.Stream(device="openreg")
         stream2 = torch.Stream(device="openreg")
 
         event = stream1.record_event()
         stream2.wait_event(event)
+
+    @skipIfTorchDynamo()
+    def test_event_synchronize(self):
+        """Test event synchronization"""
+        event = torch.Event(device="openreg")
+        self.assertTrue(event.query())
+        
+        stream = torch.Stream(device="openreg")
+        event.record(stream)
+        event.synchronize()
+        self.assertTrue(event.query())
+
+    @skipIfTorchDynamo()
+    def test_event_multiple_record(self):
+        """Test recording event multiple times"""
+        stream = torch.Stream(device="openreg:1")
+        event = torch.Event(device="openreg:1")
+        
+        event.record(stream)
+        event_id1 = event.event_id
+        
+        event.record(stream)
+        event_id2 = event.event_id
+        
+        # Event ID should remain the same
+        self.assertEqual(event_id1, event_id2)
+
+    @skipIfTorchDynamo()
+    def test_event_different_devices(self):
+        """Test events on different devices"""
+        event0 = torch.Event(device="openreg:0")
+        event1 = torch.Event(device="openreg:1")
+        
+        stream0 = torch.Stream(device="openreg:0")
+        stream1 = torch.Stream(device="openreg:1")
+        
+        event0.record(stream0)
+        event1.record(stream1)
+        
+        self.assertEqual(event0.device.index, 0)
+        self.assertEqual(event1.device.index, 1)
+
+    @skipIfTorchDynamo()
+    def test_event_timing_disabled(self):
+        """Test event with timing disabled"""
+        event1 = torch.Event(device="openreg:1", enable_timing=False)
+        event2 = torch.Event(device="openreg:1", enable_timing=False)
+        
+        stream = torch.Stream(device="openreg:1")
+        event1.record(stream)
+        event2.record(stream)
+        stream.synchronize()
+        
+        # Should not be able to calculate elapsed time
+        with self.assertRaises(RuntimeError):
+            _ = event1.elapsed_time(event2)
+
+    @skipIfTorchDynamo()
+    def test_event_wait_event(self):
+        """Test stream waiting on event"""
+        stream1 = torch.Stream(device="openreg")
+        stream2 = torch.Stream(device="openreg")
+        
+        event = stream1.record_event()
+        stream2.wait_event(event)
+        stream2.synchronize()
+        
+        self.assertTrue(event.query())
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
@@ -7,6 +7,7 @@ from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, T
 class TestPinMemory(TestCase):
     @skipIfTorchDynamo("unsupported aten.is_pinned.default")
     def test_pin_memory(self):
+        """Test pin memory for tensors, storage, and untyped storage"""
         tensor = torch.randn(10)
         self.assertFalse(tensor.is_pinned())
         pinned_tensor = tensor.pin_memory()
@@ -25,6 +26,45 @@ class TestPinMemory(TestCase):
         self.assertFalse(untyped_storage.is_pinned("openreg"))
         pinned_untyped_storage = untyped_storage.pin_memory("openreg")
         self.assertTrue(pinned_untyped_storage.is_pinned("openreg"))
+
+    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    def test_pin_memory_different_devices(self):
+        """Test pin memory on different devices"""
+        tensor = torch.randn(10)
+        pinned_tensor = tensor.pin_memory()
+        self.assertTrue(pinned_tensor.is_pinned())
+        
+        # Test pinning to specific device
+        pinned_tensor_openreg = tensor.pin_memory("openreg")
+        self.assertTrue(pinned_tensor_openreg.is_pinned("openreg"))
+
+    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    def test_pin_memory_view(self):
+        """Test pin memory with tensor views"""
+        tensor = torch.randn(20)
+        pinned_tensor = tensor.pin_memory()
+        
+        # Test various views
+        view1 = pinned_tensor[2:5]
+        self.assertTrue(view1.is_pinned())
+        
+        view2 = pinned_tensor[::2]
+        self.assertTrue(view2.is_pinned())
+        
+        view3 = pinned_tensor.view(4, 5)
+        self.assertTrue(view3.is_pinned())
+
+    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    def test_pin_memory_storage_sharing(self):
+        """Test pin memory with shared storage"""
+        tensor = torch.randn(10)
+        pinned_tensor = tensor.pin_memory()
+        
+        # Create another tensor sharing the same storage
+        shared_tensor = torch.tensor((), dtype=torch.float32).set_(
+            pinned_tensor.storage()
+        )
+        self.assertTrue(shared_tensor.is_pinned())
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_ops.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_ops.py
@@ -16,6 +16,7 @@ SDPAShape = collections.namedtuple(
 
 class TestFactory(TestCase):
     def test_empty(self):
+        """Test empty tensor creation"""
         x = torch.empty(3, device="openreg")
         self.assertEqual(x.device.type, "openreg")
         self.assertEqual(x.shape, torch.Size([3]))
@@ -32,11 +33,13 @@ class TestFactory(TestCase):
             self.assertEqual(z.shape, torch.Size([3, 3]))
 
     def test_zeros(self):
+        """Test zeros tensor creation"""
         y = torch.zeros(3, device="openreg")
         self.assertEqual(y.device.type, "openreg")
         self.assertEqual(y.shape, torch.Size([3]))
 
     def test_tensor(self):
+        """Test tensor creation from empty tuple"""
         z = torch.tensor((), device="openreg")
         self.assertEqual(z.device.type, "openreg")
         self.assertEqual(z.shape, torch.Size([0]))
@@ -44,21 +47,25 @@ class TestFactory(TestCase):
 
 class TestCopy(TestCase):
     def test_copy_same_device(self):
+        """Test copy operation on same device"""
         a = torch.ones(10, device="openreg").clone()
         self.assertEqual(a, torch.ones(10, device="openreg"))
 
     def test_cross_device_copy(self):
+        """Test copy operation across CPU and openreg"""
         a = torch.rand(10)
         b = a.to(device="openreg").add(2).to(device="cpu")
         self.assertEqual(b, a + 2)
 
     def test_cross_diff_devices_copy(self):
+        """Test copy operation across different openreg devices"""
         a = torch.ones(10, device="openreg:0").to(device="openreg:1").to(device="cpu")
         self.assertEqual(a, torch.ones(10))
 
 
 class TestOps(TestCase):
     def test_masked_select(self):
+        """Test masked_select operation"""
         tensor_cpu = torch.randn(10)
         tensor_openreg = tensor_cpu.to(device="openreg")
         mask = tensor_openreg.gt(0)
@@ -67,12 +74,14 @@ class TestOps(TestCase):
         self.assertEqual(out, tensor_cpu.masked_select(tensor_cpu.gt(0)))
 
     def test_expand(self):
+        """Test tensor expand operation"""
         x = torch.tensor([[1], [2], [3]], device="openreg")
         y = x.expand(3, 2)
         self.assertEqual(y.to(device="cpu"), torch.tensor([[1, 1], [2, 2], [3, 3]]))
         self.assertEqual(x.data_ptr(), y.data_ptr())
 
     def test_resize(self):
+        """Test tensor resize operation"""
         tensor_cpu = torch.randn([4, 4])
 
         tensor_openreg = tensor_cpu.openreg()
@@ -88,12 +97,14 @@ class TestOps(TestCase):
         self.assertTrue(storage_openreg.size() == 16)
 
     def test_printing(self):
+        """Test tensor printing"""
         a = torch.ones(20, device="openreg")
         print(a)
 
 
 class TestSTUB(TestCase):
     def test_backend_dispatchstub(self):
+        """Test backend dispatch stub for abs operation"""
         x_cpu = torch.randn(2, 2, 3, dtype=torch.float32, device="cpu")
         x_openreg = x_cpu.to("openreg")
 
@@ -117,6 +128,7 @@ class TestSTUB(TestCase):
 
 class TestQuantization(TestCase):
     def test_quantize(self):
+        """Test quantization per tensor"""
         x = torch.randn(3, 4, 5, dtype=torch.float32, device="openreg")
         quantized_tensor = torch.quantize_per_tensor(x, 0.1, 10, torch.qint8)
         self.assertEqual(quantized_tensor.device, torch.device("openreg:0"))
@@ -125,6 +137,7 @@ class TestQuantization(TestCase):
 
 class TestAutogradFunction(TestCase):
     def test_compile_autograd_function_returns_self(self):
+        """Test compiled autograd function that returns self"""
         in_ref = torch.randn(4, device="openreg", requires_grad=True)
         out_ref = torch.ops.openreg.custom_autograd_fn_returns_self(in_ref)
         out_ref.sum().backward()
@@ -141,6 +154,7 @@ class TestAutogradFunction(TestCase):
 
     @skipIfTorchDynamo("Temporary disabled due to torch._ops.OpOverloadPacket")
     def test_compile_autograd_function_aliasing(self):
+        """Test compiled autograd function with aliasing"""
         in_ref = torch.randn(4, device="openreg", requires_grad=True)
         out_ref = torch.ops.openreg.custom_autograd_fn_aliasing(in_ref)
         out_ref.sum().backward()
@@ -158,11 +172,13 @@ class TestAutogradFunction(TestCase):
 
 class TestFallback(TestCase):
     def test_scalar_type_fallback(self):
+        """Test scalar type fallback to CPU"""
         x_cpu = torch.Tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]).to(torch.int64)
         x = torch.triu_indices(3, 3, device="openreg")
         self.assertEqual(x_cpu, x)
 
     def test_tensor_type_fallback(self):
+        """Test tensor type fallback to CPU"""
         x = torch.Tensor([[1, 2, 3], [2, 3, 4]]).to("openreg")
         y = torch.Tensor([1, 0, 2]).to("openreg")
         self.assertTrue(x.device.type, "openreg")
@@ -180,6 +196,7 @@ class TestFallback(TestCase):
         self.assertEqual(z_cpu, z)
 
     def test_tensorlist_type_fallback(self):
+        """Test tensor list type fallback to CPU"""
         # create tensors located in custom device
         v_openreg = torch.Tensor([1, 2, 3]).to("openreg")
         # create result tensor located in cpu
@@ -201,6 +218,7 @@ class TestFallback(TestCase):
 class TestSDPA(NNTestCase):
     @skipIfTorchDynamo()
     def test_fused_sdp_choice_privateuseone(self):
+        """Test fused SDP choice for privateuse1 backend"""
         batch_size, seq_len, num_heads, head_dim = 4, 256, 2, 128
         make_tensor = functools.partial(torch.rand, device="cpu", dtype=torch.float16)
         shape = SDPAShape(batch_size, num_heads, seq_len, head_dim)
@@ -214,6 +232,7 @@ class TestSDPA(NNTestCase):
         )
 
     def test_scaled_dot_product_fused_attention_overrideable(self):
+        """Test scaled dot product fused attention overrideable forward"""
         batch_size, seq_len, num_heads, head_dim = 4, 256, 2, 128
         make_tensor = functools.partial(torch.rand, device="cpu", dtype=torch.float16)
         shape = SDPAShape(batch_size, num_heads, seq_len, head_dim)
@@ -226,6 +245,7 @@ class TestSDPA(NNTestCase):
         )
 
     def test_scaled_dot_product_fused_attention_overrideable_backward(self):
+        """Test scaled dot product fused attention overrideable backward"""
         batch_size, seq_len, num_heads, head_dim = 4, 256, 2, 128
         make_tensor = functools.partial(
             torch.rand, device="cpu", dtype=torch.float16, requires_grad=True
@@ -276,6 +296,399 @@ class TestSDPA(NNTestCase):
                 philox_offset=philox_offset,
             )
         )
+
+
+class TestFactoryExtended(TestCase):
+    def test_empty_with_memory_format(self):
+        """Test empty tensor creation with memory format"""
+        x = torch.empty(2, 3, 4, device="openreg", memory_format=torch.channels_last)
+        self.assertEqual(x.device.type, "openreg")
+        self.assertEqual(x.shape, torch.Size([2, 3, 4]))
+        
+        x = torch.empty(2, 3, 4, device="openreg", memory_format=torch.contiguous_format)
+        self.assertEqual(x.device.type, "openreg")
+        self.assertTrue(x.is_contiguous())
+
+    def test_empty_strided(self):
+        """Test empty_strided tensor creation"""
+        size = (3, 4)
+        stride = (4, 1)
+        x = torch.empty_strided(size, stride, device="openreg")
+        self.assertEqual(x.device.type, "openreg")
+        self.assertEqual(x.shape, torch.Size(size))
+        self.assertEqual(x.stride(), stride)
+
+    def test_ones(self):
+        """Test ones tensor creation"""
+        x = torch.ones(3, 4, device="openreg")
+        self.assertEqual(x.device.type, "openreg")
+        self.assertEqual(x.shape, torch.Size([3, 4]))
+        self.assertTrue(torch.all(x == 1))
+
+    def test_ones_like(self):
+        """Test ones_like tensor creation"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.ones_like(x)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(torch.all(y == 1))
+
+    def test_randn(self):
+        """Test randn tensor creation"""
+        x = torch.randn(3, 4, device="openreg")
+        self.assertEqual(x.device.type, "openreg")
+        self.assertEqual(x.shape, torch.Size([3, 4]))
+
+    def test_full(self):
+        """Test full tensor creation"""
+        x = torch.full((3, 4), 5.0, device="openreg")
+        self.assertEqual(x.device.type, "openreg")
+        self.assertEqual(x.shape, torch.Size([3, 4]))
+        self.assertTrue(torch.all(x == 5.0))
+
+
+class TestCopyExtended(TestCase):
+    def test_copy_different_dtypes(self):
+        """Test copy with different dtypes"""
+        x = torch.randn(3, 4, dtype=torch.float32, device="openreg")
+        y = torch.empty(3, 4, dtype=torch.float64, device="openreg")
+        y.copy_(x)
+        self.assertEqual(y.dtype, torch.float64)
+        self.assertEqual(y.cpu(), x.cpu().double())
+
+    def test_clone(self):
+        """Test tensor clone"""
+        x = torch.randn(3, 4, device="openreg")
+        y = x.clone()
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(y, x)
+        self.assertNotEqual(y.data_ptr(), x.data_ptr())
+
+    def test_copy_non_blocking(self):
+        """Test non-blocking copy"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.empty(3, 4, device="openreg")
+        y.copy_(x, non_blocking=True)
+        self.assertEqual(y, x)
+
+
+class TestOpsExtended(TestCase):
+    def test_view(self):
+        """Test tensor view operation"""
+        x = torch.randn(2, 3, 4, device="openreg")
+        y = x.view(6, 4)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(y.shape, torch.Size([6, 4]))
+        self.assertEqual(x.data_ptr(), y.data_ptr())
+
+    def test_reshape(self):
+        """Test tensor reshape operation"""
+        x = torch.randn(2, 3, 4, device="openreg")
+        y = x.reshape(6, 4)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(y.shape, torch.Size([6, 4]))
+
+    def test_as_strided(self):
+        """Test as_strided operation"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.as_strided(x, (2, 2), (4, 1), 1)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(y.shape, torch.Size([2, 2]))
+
+    def test_local_scalar_dense(self):
+        """Test local scalar dense extraction"""
+        x = torch.tensor([5.0], device="openreg")
+        scalar = x.item()
+        self.assertEqual(scalar, 5.0)
+
+    def test_set_tensor(self):
+        """Test set_ operation with tensor source"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.empty(3, 4, device="openreg")
+        y.set_(x)
+        self.assertEqual(y, x)
+
+    def test_set_storage(self):
+        """Test set_ operation with storage source"""
+        x = torch.randn(3, 4, device="openreg")
+        storage = x.storage()
+        y = torch.empty(3, 4, device="openreg")
+        y.set_(storage)
+        self.assertEqual(y, x)
+
+
+class TestSTUBExtended(TestCase):
+    def test_abs_contiguous(self):
+        """Test abs operation with contiguous tensor"""
+        x = torch.randn(2, 3, dtype=torch.float32, device="openreg")
+        y = torch.abs(x)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertTrue(torch.all(y >= 0))
+        self.assertEqual(y.shape, x.shape)
+
+    def test_abs_non_contiguous(self):
+        """Test abs operation with non-contiguous tensor"""
+        x = torch.randn(2, 3, dtype=torch.float32, device="openreg")
+        x_t = x.t()  # Transpose makes it non-contiguous
+        y = torch.abs(x_t)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertTrue(torch.all(y >= 0))
+
+    def test_custom_abs(self):
+        """Test custom abs operation"""
+        x = torch.randn(2, 3, dtype=torch.float32, device="openreg")
+        y = torch.ops.openreg.custom_abs(x)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertTrue(torch.all(y >= 0))
+        self.assertEqual(y.shape, x.shape)
+
+    def test_abs_out(self):
+        """Test abs with output tensor"""
+        x = torch.randn(2, 3, dtype=torch.float32, device="openreg")
+        out = torch.empty_like(x)
+        torch.abs(x, out=out)
+        self.assertEqual(out.device.type, "openreg")
+        self.assertTrue(torch.all(out >= 0))
+        self.assertEqual(out, torch.abs(x))
+
+
+class TestQuantizationExtended(TestCase):
+    def test_quantize_per_tensor_different_scales(self):
+        """Test quantization with different scales"""
+        x = torch.randn(3, 4, 5, dtype=torch.float32, device="openreg")
+        
+        scale = 0.1
+        zero_point = 10
+        quantized = torch.quantize_per_tensor(x, scale, zero_point, torch.qint8)
+        self.assertEqual(quantized.device.type, "openreg")
+        self.assertEqual(quantized.dtype, torch.qint8)
+        self.assertEqual(quantized.q_scale(), scale)
+        self.assertEqual(quantized.q_zero_point(), zero_point)
+
+    def test_quantize_per_tensor_quint8(self):
+        """Test quantization with quint8 dtype"""
+        x = torch.randn(3, 4, dtype=torch.float32, device="openreg")
+        quantized = torch.quantize_per_tensor(x, 0.1, 128, torch.quint8)
+        self.assertEqual(quantized.device.type, "openreg")
+        self.assertEqual(quantized.dtype, torch.quint8)
+
+    def test_dequantize(self):
+        """Test dequantization"""
+        x = torch.randn(3, 4, dtype=torch.float32, device="openreg")
+        quantized = torch.quantize_per_tensor(x, 0.1, 10, torch.qint8)
+        dequantized = quantized.dequantize()
+        self.assertEqual(dequantized.device.type, "openreg")
+        self.assertEqual(dequantized.dtype, torch.float32)
+
+
+class TestFallbackExtended(TestCase):
+    def test_cpu_fallback_blocklist(self):
+        """Test that abs is blocked from CPU fallback"""
+        x = torch.randn(2, 3, dtype=torch.float32, device="openreg")
+        # abs should work (it's implemented)
+        y = torch.abs(x)
+        self.assertEqual(y.device.type, "openreg")
+        
+        # But abs.out should also work
+        out = torch.empty_like(x)
+        torch.abs(x, out=out)
+        self.assertEqual(out.device.type, "openreg")
+
+    def test_fallback_operations(self):
+        """Test various fallback operations"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.randn(3, 4, device="openreg")
+        
+        # Operations that should fallback to CPU
+        z = torch.add(x, y)
+        self.assertEqual(z.device.type, "openreg")
+        
+        z = torch.mul(x, y)
+        self.assertEqual(z.device.type, "openreg")
+
+    def test_fallback_with_scalars(self):
+        """Test fallback with scalar operations"""
+        x = torch.randn(3, 4, device="openreg")
+        y = x + 1.0
+        self.assertEqual(y.device.type, "openreg")
+        
+        y = x * 2.0
+        self.assertEqual(y.device.type, "openreg")
+
+
+class TestSDPAExtended(NNTestCase):
+    @skipIfTorchDynamo()
+    def test_fused_sdp_choice_with_mask(self):
+        """Test fused SDP choice with attention mask"""
+        batch_size, seq_len, num_heads, head_dim = 4, 256, 2, 128
+        make_tensor = functools.partial(torch.rand, device="cpu", dtype=torch.float16)
+        shape = SDPAShape(batch_size, num_heads, seq_len, head_dim)
+        q_cpu, k_cpu, v_cpu = make_tensor(shape), make_tensor(shape), make_tensor(shape)
+        attn_mask = make_tensor((batch_size, num_heads, seq_len, seq_len))
+        
+        q_privateuse1 = q_cpu.to("openreg")
+        k_privateuse1 = k_cpu.to("openreg")
+        v_privateuse1 = v_cpu.to("openreg")
+        attn_mask_privateuse1 = attn_mask.to("openreg")
+        
+        backend = torch._fused_sdp_choice(
+            q_privateuse1, k_privateuse1, v_privateuse1, attn_mask_privateuse1
+        )
+        self.assertEqual(backend, SDPBackend.OVERRIDEABLE.value)
+
+    @skipIfTorchDynamo()
+    def test_scaled_dot_product_attention_with_dropout(self):
+        """Test scaled dot product attention with dropout"""
+        batch_size, seq_len, num_heads, head_dim = 4, 256, 2, 128
+        make_tensor = functools.partial(torch.rand, device="cpu", dtype=torch.float16)
+        shape = SDPAShape(batch_size, num_heads, seq_len, head_dim)
+        q_cpu, k_cpu, v_cpu = make_tensor(shape), make_tensor(shape), make_tensor(shape)
+        
+        q_privateuse1 = q_cpu.to("openreg")
+        k_privateuse1 = k_cpu.to("openreg")
+        v_privateuse1 = v_cpu.to("openreg")
+        
+        output = torch.nn.functional.scaled_dot_product_attention(
+            q_privateuse1, k_privateuse1, v_privateuse1,
+            attn_mask=None, dropout_p=0.1, is_causal=False
+        )
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(output.shape, shape)
+
+    @skipIfTorchDynamo()
+    def test_scaled_dot_product_attention_is_causal(self):
+        """Test scaled dot product attention with causal mask"""
+        batch_size, seq_len, num_heads, head_dim = 4, 256, 2, 128
+        make_tensor = functools.partial(torch.rand, device="cpu", dtype=torch.float16)
+        shape = SDPAShape(batch_size, num_heads, seq_len, head_dim)
+        q_cpu, k_cpu, v_cpu = make_tensor(shape), make_tensor(shape), make_tensor(shape)
+        
+        q_privateuse1 = q_cpu.to("openreg")
+        k_privateuse1 = k_cpu.to("openreg")
+        v_privateuse1 = v_cpu.to("openreg")
+        
+        output = torch.nn.functional.scaled_dot_product_attention(
+            q_privateuse1, k_privateuse1, v_privateuse1,
+            attn_mask=None, dropout_p=0.0, is_causal=True
+        )
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(output.shape, shape)
+
+
+class TestCopyFromAndResize(TestCase):
+    def test_copy_from_and_resize(self):
+        """Test _copy_from_and_resize operation"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.empty(2, 2, device="openreg")
+        result = torch.ops.aten._copy_from_and_resize(x, y)
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.shape, x.shape)
+
+    def test_copy_from_same_device(self):
+        """Test _copy_from operation on same device"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.empty(3, 4, device="openreg")
+        result = torch.ops.aten._copy_from(x, y, non_blocking=False)
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.shape, x.shape)
+        self.assertEqual(result.cpu(), x.cpu())
+
+    def test_copy_from_cross_device(self):
+        """Test _copy_from operation across devices"""
+        x = torch.randn(3, 4, device="cpu")
+        y = torch.empty(3, 4, device="openreg")
+        result = torch.ops.aten._copy_from(x, y, non_blocking=False)
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.cpu(), x)
+
+    def test_copy_from_non_blocking(self):
+        """Test _copy_from with non_blocking=True"""
+        x = torch.randn(3, 4, device="openreg")
+        y = torch.empty(3, 4, device="openreg")
+        result = torch.ops.aten._copy_from(x, y, non_blocking=True)
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.cpu(), x.cpu())
+
+    def test_reshape_alias(self):
+        """Test _reshape_alias operation"""
+        x = torch.randn(2, 3, 4, device="openreg")
+        new_size = (6, 4)
+        new_stride = (4, 1)
+        y = torch.ops.aten._reshape_alias(x, new_size, new_stride)
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(y.shape, torch.Size(new_size))
+        self.assertEqual(y.stride(), new_stride)
+
+    def test_set_storage_storage_offset(self):
+        """Test set_ operation with storage and storage offset"""
+        x = torch.randn(3, 4, device="openreg")
+        storage = x.storage()
+        y = torch.empty(2, 2, device="openreg")
+        result = torch.ops.aten.set_.source_Storage_storage_offset(
+            y, storage, 0, (2, 2), (2, 1)
+        )
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.shape, torch.Size([2, 2]))
+
+    def test_set_storage_storage_offset_with_offset(self):
+        """Test set_ operation with non-zero storage offset"""
+        x = torch.randn(4, 4, device="openreg")
+        storage = x.storage()
+        y = torch.empty(2, 2, device="openreg")
+        # Use storage offset to skip first 4 elements
+        result = torch.ops.aten.set_.source_Storage_storage_offset(
+            y, storage, 4, (2, 2), (2, 1)
+        )
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.shape, torch.Size([2, 2]))
+
+
+class TestCustomAutogradFunctions(TestCase):
+    def test_custom_autograd_fn_returns_self_basic(self):
+        """Test basic usage of custom_autograd_fn_returns_self"""
+        x = torch.randn(4, device="openreg", requires_grad=True)
+        y = torch.ops.openreg.custom_autograd_fn_returns_self(x)
+        
+        # Should return the same tensor
+        self.assertEqual(x, y)
+        self.assertTrue(y.requires_grad)
+        
+        # Test backward
+        loss = y.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        # Gradient should be 0.5 * 1.0 = 0.5
+        self.assertTrue(torch.allclose(x.grad, torch.ones_like(x) * 0.5))
+
+    def test_custom_autograd_fn_aliasing_basic(self):
+        """Test basic usage of custom_autograd_fn_aliasing"""
+        x = torch.randn(4, device="openreg", requires_grad=True)
+        y = torch.ops.openreg.custom_autograd_fn_aliasing(x)
+        
+        # Should return a view of the same tensor
+        self.assertEqual(x.shape, y.shape)
+        self.assertTrue(y.requires_grad)
+        
+        # Test backward
+        loss = y.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        # Gradient should be 0.5 * 1.0 = 0.5
+        self.assertTrue(torch.allclose(x.grad, torch.ones_like(x) * 0.5))
+
+    def test_custom_autograd_fn_returns_self_no_grad(self):
+        """Test custom_autograd_fn_returns_self without requires_grad"""
+        x = torch.randn(4, device="openreg", requires_grad=False)
+        y = torch.ops.openreg.custom_autograd_fn_returns_self(x)
+        self.assertEqual(x, y)
+        self.assertFalse(y.requires_grad)
+
+    def test_custom_autograd_fn_aliasing_no_grad(self):
+        """Test custom_autograd_fn_aliasing without requires_grad"""
+        x = torch.randn(4, device="openreg", requires_grad=False)
+        y = torch.ops.openreg.custom_autograd_fn_aliasing(x)
+        self.assertEqual(x.shape, y.shape)
+        self.assertFalse(y.requires_grad)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
@@ -6,17 +6,85 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestRNG(TestCase):
     def test_generator(self):
+        """Test generator creation on openreg device"""
         generator = torch.Generator(device="openreg:1")
         self.assertEqual(generator.device.type, "openreg")
         self.assertEqual(generator.device.index, 1)
 
     def test_rng_state(self):
+        """Test RNG state get and set"""
         state = torch.openreg.get_rng_state(0)
         torch.openreg.set_rng_state(state, 0)
 
     def test_manual_seed(self):
+        """Test manual seed setting"""
         torch.openreg.manual_seed_all(2024)
         self.assertEqual(torch.openreg.initial_seed(), 2024)
+
+    def test_generator_seed(self):
+        """Test generator seed setting"""
+        generator = torch.Generator(device="openreg:0")
+        generator.manual_seed(42)
+        self.assertEqual(generator.initial_seed(), 42)
+        
+        generator = torch.Generator(device="openreg:1")
+        generator.manual_seed(100)
+        self.assertEqual(generator.initial_seed(), 100)
+
+    def test_generator_state(self):
+        """Test generator state get/set"""
+        generator = torch.Generator(device="openreg:0")
+        state = generator.get_state()
+        
+        # Generate some random numbers
+        x1 = torch.randn(10, device="openreg:0", generator=generator)
+        
+        # Set state back
+        generator.set_state(state)
+        x2 = torch.randn(10, device="openreg:0", generator=generator)
+        
+        # Should produce same sequence
+        self.assertEqual(x1, x2)
+
+    def test_rng_state_consistency(self):
+        """Test RNG state consistency across devices"""
+        state0 = torch.openreg.get_rng_state(0)
+        state1 = torch.openreg.get_rng_state(1)
+        
+        # States should be different for different devices
+        self.assertNotEqual(state0, state1)
+        
+        # Setting state should work
+        torch.openreg.set_rng_state(state0, 0)
+        restored_state = torch.openreg.get_rng_state(0)
+        self.assertEqual(state0, restored_state)
+
+    def test_manual_seed_all(self):
+        """Test manual_seed_all sets seed for all devices"""
+        torch.openreg.manual_seed_all(1234)
+        
+        # Check that seed is set
+        seed = torch.openreg.initial_seed()
+        self.assertEqual(seed, 1234)
+        
+        # Test with different seed
+        torch.openreg.manual_seed_all(5678)
+        seed = torch.openreg.initial_seed()
+        self.assertEqual(seed, 5678)
+
+    def test_generator_different_devices(self):
+        """Test generators on different devices"""
+        gen0 = torch.Generator(device="openreg:0")
+        gen1 = torch.Generator(device="openreg:1")
+        
+        gen0.manual_seed(1)
+        gen1.manual_seed(1)
+        
+        x0 = torch.randn(10, device="openreg:0", generator=gen0)
+        x1 = torch.randn(10, device="openreg:1", generator=gen1)
+        
+        # Should produce same sequence with same seed
+        self.assertEqual(x0.cpu(), x1.cpu())
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
 class TestStorage(TestCase):
     @skipIfTorchDynamo("unsupported aten.is_pinned.default")
     def test_rewrapped_storage(self):
+        """Test rewrapping pinned storage"""
         pinned_a = torch.randn(10).pin_memory()
         rewrapped_a = torch.tensor((), dtype=torch.float32).set_(
             pinned_a.untyped_storage()[2:],
@@ -34,6 +35,7 @@ class TestStorage(TestCase):
 
 class TestSerialization(TestCase):
     def test_serialization(self):
+        """Test basic serialization and deserialization"""
         storage = torch.UntypedStorage(4, device=torch.device("openreg"))
         self.assertEqual(torch.serialization.location_tag(storage), "openreg:0")
 
@@ -168,6 +170,65 @@ class TestSerialization(TestCase):
                 ):
                     with torch.serialization.skip_data():
                         torch.save(sd, f)
+
+    def test_serialization_metadata_preservation(self):
+        """Test that metadata is preserved during serialization"""
+        tensor = torch.empty(3, 3, device="openreg")
+        metadata = {"version_number": True, "format_number": True}
+        torch._utils.set_tensor_metadata(tensor, metadata)
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "data.pt")
+            torch.save(tensor, path)
+            
+            loaded_tensor = torch.load(path)
+            self.assertEqual(torch._utils.get_tensor_metadata(loaded_tensor), metadata)
+
+    def test_serialization_map_location_cpu(self):
+        """Test serialization with map_location to CPU"""
+        tensor = torch.randn(3, 3, device="openreg")
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "data.pt")
+            torch.save(tensor, path)
+            
+            loaded_cpu = torch.load(path, map_location="cpu")
+            self.assertTrue(loaded_cpu.is_cpu)
+            self.assertEqual(loaded_cpu, tensor.cpu())
+
+    def test_serialization_map_location_device(self):
+        """Test serialization with map_location to specific device"""
+        tensor = torch.randn(3, 3, device="openreg:0")
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "data.pt")
+            torch.save(tensor, path)
+            
+            loaded_device = torch.load(path, map_location="openreg:1")
+            self.assertEqual(loaded_device.device.index, 1)
+            self.assertEqual(loaded_device.cpu(), tensor.cpu())
+
+    def test_serialization_storage_location_tag(self):
+        """Test storage location tag"""
+        storage = torch.UntypedStorage(4, device=torch.device("openreg:1"))
+        self.assertEqual(torch.serialization.location_tag(storage), "openreg:1")
+        
+        storage = torch.UntypedStorage(4, device=torch.device("openreg"))
+        self.assertEqual(torch.serialization.location_tag(storage), "openreg:0")
+
+    def test_serialization_default_restore_location(self):
+        """Test default restore location"""
+        storage_cpu = torch.empty(4, 4).storage()
+        
+        storage_openreg0 = torch.serialization.default_restore_location(
+            storage_cpu, "openreg:0"
+        )
+        self.assertTrue(storage_openreg0.is_openreg)
+        
+        storage_openreg1 = torch.serialization.default_restore_location(
+            storage_cpu, "openreg:1"
+        )
+        self.assertTrue(storage_openreg1.is_openreg)
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_streams.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_streams.py
@@ -7,6 +7,7 @@ from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, T
 class TestStream(TestCase):
     @skipIfTorchDynamo()
     def test_stream_create(self):
+        """Test stream creation with different methods"""
         stream = torch.Stream(device="openreg")
         self.assertEqual(stream.device_index, torch.openreg.current_device())
 
@@ -27,11 +28,13 @@ class TestStream(TestCase):
 
     @skipIfTorchDynamo()
     def test_stream_context(self):
+        """Test stream context manager"""
         with torch.Stream(device="openreg:1") as stream:
             self.assertEqual(torch.accelerator.current_stream(), stream)
 
     @skipIfTorchDynamo()
     def test_stream_switch(self):
+        """Test switching between streams"""
         stream1 = torch.Stream(device="openreg:0")
         torch.accelerator.set_stream(stream1)
         current_stream = torch.accelerator.current_stream()
@@ -44,6 +47,7 @@ class TestStream(TestCase):
 
     @skipIfTorchDynamo()
     def test_stream_synchronize(self):
+        """Test stream synchronization"""
         stream = torch.Stream(device="openreg:1")
         self.assertEqual(True, stream.query())
 
@@ -54,6 +58,7 @@ class TestStream(TestCase):
 
     @skipIfTorchDynamo()
     def test_stream_repr(self):
+        """Test stream string representation"""
         stream = torch.Stream(device="openreg:1")
         self.assertTrue(
             "torch.Stream device_type=openreg, device_index=1" in repr(stream)
@@ -61,16 +66,97 @@ class TestStream(TestCase):
 
     @skipIfTorchDynamo()
     def test_stream_wait_stream(self):
+        """Test stream waiting on another stream"""
         stream_1 = torch.Stream(device="openreg:0")
         stream_2 = torch.Stream(device="openreg:1")
         stream_2.wait_stream(stream_1)
 
     @skipIfTorchDynamo()
     def test_stream_wait_event(self):
+        """Test stream waiting on event"""
         s1 = torch.Stream(device="openreg")
         s2 = torch.Stream(device="openreg")
         e = s1.record_event()
         s2.wait_event(e)
+
+    @skipIfTorchDynamo()
+    def test_stream_equality(self):
+        """Test stream equality comparison"""
+        stream1 = torch.Stream(device="openreg:0")
+        stream2 = torch.Stream(device="openreg:0")
+        
+        # Different streams should not be equal
+        self.assertNotEqual(stream1, stream2)
+        
+        # Same stream should be equal to itself
+        self.assertEqual(stream1, stream1)
+        
+        # Stream created with same parameters should be equal
+        stream3 = torch.Stream(
+            stream_id=stream1.stream_id,
+            device_type=stream1.device_type,
+            device_index=stream1.device_index,
+        )
+        self.assertEqual(stream1, stream3)
+
+    @skipIfTorchDynamo()
+    def test_stream_default(self):
+        """Test default stream"""
+        default_stream = torch.accelerator.default_stream()
+        self.assertEqual(default_stream.device_type, "openreg")
+        
+        current_stream = torch.accelerator.current_stream()
+        # Default stream should be current stream initially
+        self.assertEqual(default_stream, current_stream)
+
+    @skipIfTorchDynamo()
+    def test_stream_priority(self):
+        """Test stream priority"""
+        stream = torch.Stream(device="openreg")
+        # Stream should have a priority attribute
+        self.assertTrue(hasattr(stream, "priority"))
+
+    @skipIfTorchDynamo()
+    def test_stream_multiple_devices(self):
+        """Test streams on multiple devices"""
+        stream0 = torch.Stream(device="openreg:0")
+        stream1 = torch.Stream(device="openreg:1")
+        
+        self.assertEqual(stream0.device_index, 0)
+        self.assertEqual(stream1.device_index, 1)
+        
+        # Set current stream for each device
+        torch.accelerator.set_device_index(0)
+        torch.accelerator.set_stream(stream0)
+        self.assertEqual(torch.accelerator.current_stream(), stream0)
+        
+        torch.accelerator.set_device_index(1)
+        torch.accelerator.set_stream(stream1)
+        self.assertEqual(torch.accelerator.current_stream(), stream1)
+
+    @skipIfTorchDynamo()
+    def test_stream_context_nested(self):
+        """Test nested stream contexts"""
+        stream1 = torch.Stream(device="openreg:0")
+        stream2 = torch.Stream(device="openreg:0")
+        
+        with stream1:
+            self.assertEqual(torch.accelerator.current_stream(), stream1)
+            with stream2:
+                self.assertEqual(torch.accelerator.current_stream(), stream2)
+            # Should restore to stream1
+            self.assertEqual(torch.accelerator.current_stream(), stream1)
+
+    @skipIfTorchDynamo()
+    def test_stream_record_event(self):
+        """Test recording events on streams"""
+        stream = torch.Stream(device="openreg")
+        event = stream.record_event()
+        
+        self.assertIsNotNone(event)
+        self.assertEqual(event.device.type, "openreg")
+        stream.synchronize()
+        self.assertTrue(event.query())
 
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_utils.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_utils.py
@@ -6,6 +6,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestDLPack(TestCase):
     def test_open_device_dlpack(self):
+        """Test DLPack conversion for openreg device"""
         x_in = torch.randn(2, 3).to("openreg")
         capsule = torch.utils.dlpack.to_dlpack(x_in)
         x_out = torch.from_dlpack(capsule)
@@ -14,6 +15,61 @@ class TestDLPack(TestCase):
         x_in = x_in.to("cpu")
         x_out = x_out.to("cpu")
         self.assertEqual(x_in, x_out)
+
+    def test_dlpack_roundtrip(self):
+        """Test DLPack roundtrip conversion"""
+        x = torch.randn(2, 3, device="openreg")
+        capsule = torch.utils.dlpack.to_dlpack(x)
+        y = torch.from_dlpack(capsule)
+        
+        self.assertEqual(x.device, y.device)
+        self.assertEqual(x, y)
+
+    def test_dlpack_different_shapes(self):
+        """Test DLPack with different tensor shapes"""
+        shapes = [(1,), (2, 3), (4, 5, 6), (1, 2, 3, 4)]
+        
+        for shape in shapes:
+            x = torch.randn(*shape, device="openreg")
+            capsule = torch.utils.dlpack.to_dlpack(x)
+            y = torch.from_dlpack(capsule)
+            
+            self.assertEqual(x.shape, y.shape)
+            self.assertEqual(x, y)
+
+    def test_dlpack_different_dtypes(self):
+        """Test DLPack with different dtypes"""
+        dtypes = [torch.float32, torch.float16, torch.int32, torch.int64]
+        
+        for dtype in dtypes:
+            x = torch.randn(2, 3, device="openreg", dtype=dtype)
+            capsule = torch.utils.dlpack.to_dlpack(x)
+            y = torch.from_dlpack(capsule)
+            
+            self.assertEqual(x.dtype, y.dtype)
+            self.assertEqual(x, y)
+
+    def test_dlpack_cross_device(self):
+        """Test DLPack conversion across devices"""
+        x_cpu = torch.randn(2, 3)
+        x_openreg = x_cpu.to("openreg")
+        
+        capsule = torch.utils.dlpack.to_dlpack(x_openreg)
+        y = torch.from_dlpack(capsule)
+        
+        self.assertEqual(y.device.type, "openreg")
+        self.assertEqual(x_cpu, y.cpu())
+
+    def test_dlpack_non_contiguous(self):
+        """Test DLPack with non-contiguous tensors"""
+        x = torch.randn(3, 4, device="openreg")
+        x_t = x.t()  # Transpose creates non-contiguous tensor
+        
+        capsule = torch.utils.dlpack.to_dlpack(x_t)
+        y = torch.from_dlpack(capsule)
+        
+        self.assertEqual(x_t.shape, y.shape)
+        self.assertEqual(x_t, y)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Complete test cases for all 11 test files in torch_openreg/tests/
- Add docstrings for all test methods
- Expand coverage for autocast, autograd, device, event, memory, RNG, storage, streams, utils, ops, and misc functionality
- Add tests for internal operations and custom autograd functions
- All tests use PyTorch Python interface

Fixes #ISSUE_NUMBER
