### PR TITLE
[CI] Fix xpu runner teardown docker prune failure

### DIFF
--- a/.github/actions/teardown-xpu/action.yml
+++ b/.github/actions/teardown-xpu/action.yml
@@ -11,9 +11,12 @@ runs:
       run: |
         # Prune all stopped containers.
         # If other runner is pruning on this node, will skip.
-        nprune=$(ps -ef | grep -c "docker container prune")
-        if [[ $nprune -eq 1 ]]; then
+        nprune=$(ps -ef | grep "docker" | grep -c "prune")
+        if [[ $nprune -eq 0 ]]; then
           docker container prune -f
+        else
+          echo "Another prune process is running, skip prune."
+          ps -ef | grep "docker" | grep "prune"
         fi
     - name: Runner diskspace health check
       uses: ./.github/actions/diskspace-cleanup


### PR DESCRIPTION
Fixes teardown-xpu action docker prune issue, cause the xpu runner host has docker prune cron tasks also to release more disk space, refer https://github.com/pytorch/pytorch/actions/runs/19407751577/job/55525716734?pr=166436#step:27:36