### PR TITLE
Fix special gpu_num cases for test_parallelize_api

### DIFF
--- a/test/distributed/tensor/parallel/test_parallelize_api.py
+++ b/test/distributed/tensor/parallel/test_parallelize_api.py
@@ -34,7 +34,7 @@ class TensorParallelAPITests(DTensorTestBase):
     @property
     def world_size(self):
         gpu_num = torch.accelerator.device_count()
-        return gpu_num if gpu_num % 2 == 0 and gpu_num > 4 else 4
+        return gpu_num if gpu_num % 2 == 0 and gpu_num > 4 and 16 % gpu_num == 0 else 4
 
     def _compare_params(
         self,


### PR DESCRIPTION
The UT TensorParallelAPITests.test_linear_row_wise_parallel requires the number of gpus to be power of two for row-wise partition to work. A world size of 6 or 12 is actually expected to fail. https://github.com/pytorch/pytorch/blob/d8ce6f8df991e083ad3b8fcb9d54550df4b5f2a1/test/distributed/tensor/parallel/test_parallelize_api.py#L150
The PR fixes these corner cases when setting the world size.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci