### PR TITLE
[XPU] fix SYCL_KERNEL_ASSERT on Windows.

### DIFF
--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -431,6 +431,7 @@ __host__ __device__
            0);                                                        \
   }
 #ifdef __SYCL_DEVICE_ONLY__
+#include <CL/__spirv/spirv_vars.hpp>
 // SYCL Device assertions on Windows do not work properly so we define these
 // wrappers around the STL assertion headers cassert and assert.h where we
 // redefine the assert macro to call __devicelib_assert_fail directly and

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -431,7 +431,7 @@ __host__ __device__
            0);                                                        \
   }
 #ifdef __SYCL_DEVICE_ONLY__
-#include <CL/__spirv/spirv_vars.hpp>
+// #include <CL/__spirv/spirv_vars.hpp>
 // SYCL Device assertions on Windows do not work properly so we define these
 // wrappers around the STL assertion headers cassert and assert.h where we
 // redefine the assert macro to call __devicelib_assert_fail directly and

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -431,7 +431,6 @@ __host__ __device__
            0);                                                        \
   }
 #ifdef __SYCL_DEVICE_ONLY__
-// #include <CL/__spirv/spirv_vars.hpp>
 // SYCL Device assertions on Windows do not work properly so we define these
 // wrappers around the STL assertion headers cassert and assert.h where we
 // redefine the assert macro to call __devicelib_assert_fail directly and

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -431,9 +431,8 @@ __host__ __device__
            0);                                                        \
   }
 #ifdef __SYCL_DEVICE_ONLY__
-// SYCL Device assertions on Windows do not work properly so we define these
-// wrappers around the STL assertion headers cassert and assert.h where we
-// redefine the assert macro to call __devicelib_assert_fail directly and
+// SYCL Device assertions on Windows do not work properly so we define
+// SYCL_KERNEL_ASSERT macro to call __devicelib_assert_fail directly and
 // bypass _wassert.
 #define SYCL_KERNEL_ASSERT(cond)        \
   if (C10_UNLIKELY(!(cond))) {          \

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -431,9 +431,9 @@ __host__ __device__
            0);                                                        \
   }
 #ifdef __SYCL_DEVICE_ONLY__
-// SYCL Device assertions on Windows do not work properly so we define
-// SYCL_KERNEL_ASSERT macro to call __devicelib_assert_fail directly and
-// bypass _wassert.
+// SYCL Device assertions on Windows do not work properly with MSVC _wassert.
+// So we define SYCL_KERNEL_ASSERT macro to call __devicelib_assert_fail directly
+// and bypass _wassert.
 #define SYCL_KERNEL_ASSERT(cond)        \
   if (C10_UNLIKELY(!(cond))) {          \
     (void)__devicelib_assert_fail(      \

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -432,8 +432,8 @@ __host__ __device__
   }
 #ifdef __SYCL_DEVICE_ONLY__
 // SYCL Device assertions on Windows do not work properly with MSVC _wassert.
-// So we define SYCL_KERNEL_ASSERT macro to call __devicelib_assert_fail directly
-// and bypass _wassert.
+// So we define SYCL_KERNEL_ASSERT macro to call __devicelib_assert_fail
+// directly and bypass _wassert.
 #define SYCL_KERNEL_ASSERT(cond)        \
   if (C10_UNLIKELY(!(cond))) {          \
     (void)__devicelib_assert_fail(      \


### PR DESCRIPTION
Original issue is https://github.com/intel/torch-xpu-ops/issues/1171

@chunhuanMeng discussed with Intel compiler team, and got these:
1. Intel compiler Windows version is not support `_wassert`.
2. They suggest to use Intel provided `__devicelib_assert_fail` to instead of `_wassert`. Reference to https://intel.github.io/llvm/design/Assert.html#online-linking-fallback-devicelib-assert-fail 

Before fix:
<img width="2195" height="174" alt="image" src="https://github.com/user-attachments/assets/50c6bc3a-9472-4ca6-904c-bec48f87ed4f" />

After this fix:
<img width="1664" height="373" alt="image" src="https://github.com/user-attachments/assets/932bc17f-54d0-49ca-909f-ca3313dde92c" />


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey