### PR TITLE
[dataloader] Fix UserWarning for non-writeable numpy arrays in defaul…

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3053,8 +3053,6 @@ except RuntimeError as e:
 
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_default_collate_non_writeable_numpy(self):
-        import warnings
-
         import numpy as np
 
         arr = np.arange(5.0)
@@ -3062,13 +3060,64 @@ except RuntimeError as e:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            dataloader.default_collate([arr])
+            result = dataloader.default_collate([arr])
 
             # check that no warning about non-writeable numpy arrays was raised
             numpy_writable_warnings = [
                 warning for warning in w if "given NumPy array" in str(warning.message)
             ]
             self.assertEqual(len(numpy_writable_warnings), 0)
+
+        # Verify the data is copied, not shared
+        result[0][0] = 99.0
+        self.assertEqual(arr[0], 0.0)  # Original array unchanged
+        self.assertEqual(result[0][0].item(), 99.0)  # Tensor was modified
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_non_writeable_numpy_with_custom_collate_fn_map(self):
+        import numpy as np
+
+        from torch.utils.data._utils.collate import (
+            collate,
+            collate_tensor_fn,
+            default_collate_fn_map,
+        )
+
+        arr = np.arange(5.0)
+        arr.flags.writeable = False
+
+        # Test 1: Using default collate_fn_map (should suppress warning)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result1 = dataloader.default_collate([arr])
+            numpy_writable_warnings = [
+                warning for warning in w if "not writable" in str(warning.message)
+            ]
+            self.assertEqual(
+                len(numpy_writable_warnings),
+                0,
+                "Default collate should suppress warning",
+            )
+
+        # Test 2: Custom map that still uses collate_tensor_fn (should suppress)
+        custom_map_with_default = default_collate_fn_map.copy()
+        custom_map_with_default[torch.Tensor] = collate_tensor_fn
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result2 = collate([arr], collate_fn_map=custom_map_with_default)
+            numpy_writable_warnings = [
+                warning for warning in w if "not writable" in str(warning.message)
+            ]
+            self.assertEqual(
+                len(numpy_writable_warnings),
+                0,
+                "Custom map with collate_tensor_fn should suppress",
+            )
+
+        # Test 3: Verify both results are equivalent and copied data
+        self.assertEqual(result1.tolist(), result2.tolist())
+        result1[0][0] = 99.0
+        self.assertEqual(arr[0], 0.0, "Original array should remain unchanged")
 
     def test_excessive_thread_creation_warning(self):
         with self.assertWarnsRegex(

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3051,6 +3051,31 @@ except RuntimeError as e:
         finally:
             _utils.worker._worker_info = old
 
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_non_writeable_numpy(self):
+        import warnings
+
+        import numpy as np
+
+        # test that non-writeable numpy arrays don't raise warnings
+        # since default_collate creates a copy
+        arr = np.arange(5.0)
+        arr.flags.writeable = False
+
+        # this should not raise a UserWarning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = dataloader.default_collate([arr])
+
+        # verify the result is correct
+        self.assertEqual(
+            result, torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0]], dtype=torch.float64)
+        )
+
+        # verify that modifying the result doesn't affect the original
+        result[0][0] = 99
+        self.assertEqual(arr[0], 0.0)
+
     def test_excessive_thread_creation_warning(self):
         with self.assertWarnsRegex(
             UserWarning,

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3073,52 +3073,6 @@ except RuntimeError as e:
         self.assertEqual(arr[0], 0.0)  # Original array unchanged
         self.assertEqual(result[0][0].item(), 99.0)  # Tensor was modified
 
-    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
-    def test_default_collate_non_writeable_numpy_with_custom_collate_fn_map(self):
-        import numpy as np
-
-        from torch.utils.data._utils.collate import (
-            collate,
-            collate_tensor_fn,
-            default_collate_fn_map,
-        )
-
-        arr = np.arange(5.0)
-        arr.flags.writeable = False
-
-        # Test 1: Using default collate_fn_map (should suppress warning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result1 = dataloader.default_collate([arr])
-            numpy_writable_warnings = [
-                warning for warning in w if "not writable" in str(warning.message)
-            ]
-            self.assertEqual(
-                len(numpy_writable_warnings),
-                0,
-                "Default collate should suppress warning",
-            )
-
-        # Test 2: Custom map that still uses collate_tensor_fn (should suppress)
-        custom_map_with_default = default_collate_fn_map.copy()
-        custom_map_with_default[torch.Tensor] = collate_tensor_fn
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result2 = collate([arr], collate_fn_map=custom_map_with_default)
-            numpy_writable_warnings = [
-                warning for warning in w if "not writable" in str(warning.message)
-            ]
-            self.assertEqual(
-                len(numpy_writable_warnings),
-                0,
-                "Custom map with collate_tensor_fn should suppress",
-            )
-
-        # Test 3: Verify both results are equivalent and copied data
-        self.assertEqual(result1.tolist(), result2.tolist())
-        result1[0][0] = 99.0
-        self.assertEqual(arr[0], 0.0, "Original array should remain unchanged")
-
     def test_excessive_thread_creation_warning(self):
         with self.assertWarnsRegex(
             UserWarning,

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3057,24 +3057,21 @@ except RuntimeError as e:
 
         import numpy as np
 
-        # test that non-writeable numpy arrays don't raise warnings
-        # since default_collate creates a copy
         arr = np.arange(5.0)
         arr.flags.writeable = False
 
-        # this should not raise a UserWarning
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            result = dataloader.default_collate([arr])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            dataloader.default_collate([arr])
 
-        # verify the result is correct
-        self.assertEqual(
-            result, torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0]], dtype=torch.float64)
-        )
-
-        # verify that modifying the result doesn't affect the original
-        result[0][0] = 99
-        self.assertEqual(arr[0], 0.0)
+            # check that no warning about non-writable/writeable numpy arrays was raised
+            numpy_writable_warnings = [
+                warning
+                for warning in w
+                if "not writable" in str(warning.message).lower()
+                or "not writeable" in str(warning.message).lower()
+            ]
+            self.assertEqual(len(numpy_writable_warnings), 0)
 
     def test_excessive_thread_creation_warning(self):
         with self.assertWarnsRegex(

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3064,12 +3064,9 @@ except RuntimeError as e:
             warnings.simplefilter("always")
             dataloader.default_collate([arr])
 
-            # check that no warning about non-writable/writeable numpy arrays was raised
+            # check that no warning about non-writeable numpy arrays was raised
             numpy_writable_warnings = [
-                warning
-                for warning in w
-                if "not writable" in str(warning.message).lower()
-                or "not writeable" in str(warning.message).lower()
+                warning for warning in w if "given NumPy array" in str(warning.message)
             ]
             self.assertEqual(len(numpy_writable_warnings), 0)
 

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -285,7 +285,10 @@ def collate_numpy_array_fn(
     if np_str_obj_array_pattern.search(elem.dtype.str) is not None:
         raise TypeError(default_collate_err_msg_format.format(elem.dtype))
 
-    return collate([torch.as_tensor(b) for b in batch], collate_fn_map=collate_fn_map)
+    return collate(
+        [torch.as_tensor(b.copy() if not b.flags.writeable else b) for b in batch],
+        collate_fn_map=collate_fn_map,
+    )
 
 
 def collate_numpy_scalar_fn(

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -12,7 +12,6 @@ import collections
 import contextlib
 import copy
 import re
-import warnings
 from collections.abc import Callable
 
 import torch
@@ -286,15 +285,19 @@ def collate_numpy_array_fn(
     if np_str_obj_array_pattern.search(elem.dtype.str) is not None:
         raise TypeError(default_collate_err_msg_format.format(elem.dtype))
 
-    # Suppress the non-writable warning because the data will be copied
-    # during collation (e.g., by torch.stack in collate_tensor_fn).
-    # The final batched tensor does not alias the original numpy arrays.
+    # Convert numpy arrays to tensors. For non-writeable arrays, use torch.tensor()
+    # to copy and avoid the warning. For writeable arrays, use torch.as_tensor() to alias.
+    tensors = []
+    for b in batch:
+        if not b.flags.writeable:
+            tensors.append(torch.tensor(b))
+        else:
+            tensors.append(torch.as_tensor(b))
+
     actual_map = (
         collate_fn_map if collate_fn_map is not None else default_collate_fn_map
     )
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message=".*not writable.*")
-        return collate([torch.as_tensor(b) for b in batch], collate_fn_map=actual_map)
+    return collate(tensors, collate_fn_map=actual_map)
 
 
 def collate_numpy_scalar_fn(


### PR DESCRIPTION
…t_collate

Fix unnecessary UserWarning when collating non-writeable numpy arrays by explicitly copying them before tensor conversion. Only copies when necessary to maintain performance for normal writeable arrays.

Added test_default_collate_non_writeable_numpy to verify the fix.

Fixes #153536
