### PR TITLE
Typecast features to int in lazy modules to run modules in compile mode

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -260,7 +260,7 @@ class _LazyNormBase(LazyModuleMixin, _NormBase):
     def initialize_parameters(self, input) -> None:  # type: ignore[override]
         # pyrefly: ignore [bad-argument-type]
         if self.has_uninitialized_params():
-            self.num_features = input.shape[1]
+            self.num_features = int(input.shape[1]) if isinstance(input.shape[1], torch.SymInt) else input.shape[1]
             if self.affine:
                 assert isinstance(self.weight, UninitializedParameter)
                 assert isinstance(self.bias, UninitializedParameter)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1463,7 +1463,11 @@ class _LazyConvXdMixin(LazyModuleMixin):
                 f"to {self.__class__.__name__}, but "
                 f"got input of size: {input.shape}"
             )
-        return input.shape[1] if input.dim() == num_dims_batch else input.shape[0]
+        in_channels = (
+            input.shape[1] if input.dim() == num_dims_batch else input.shape[0]
+        )
+        in_channels = int(in_channels) if isinstance(in_channels, torch.SymInt) else in_channels
+        return in_channels
 
     # Function to return the number of spatial dims expected for inputs to the module.
     # This is expected to be implemented by subclasses.

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -320,7 +320,7 @@ class LazyLinear(LazyModuleMixin, Linear):
         # pyrefly: ignore [bad-argument-type]
         if self.has_uninitialized_params():
             with torch.no_grad():
-                self.in_features = input.shape[-1]
+                self.in_features = int(input.shape[-1]) if isinstance(input.shape[-1], torch.SymInt) else input.shape[-1]
                 self.weight.materialize((self.out_features, self.in_features))
                 if self.bias is not None:
                     self.bias.materialize((self.out_features,))
@@ -331,7 +331,7 @@ class LazyLinear(LazyModuleMixin, Linear):
                 f"is not equal to in_features from self.weight: "
                 f"{self.weight.shape[-1]}"
             )
-            self.in_features = input.shape[-1]
+            self.in_features = int(input.shape[-1]) if isinstance(input.shape[-1], torch.SymInt) else input.shape[-1]
 
 
 # TODO: PartialLinear - maybe in sparse?


### PR DESCRIPTION
Fixes #167191
When using torch.compile(dynamic=True), tensor shapes become symbolic (like variables) to support varying sizes. However, lazy modules must create actual parameters with fixed sizes in memory during initialization. This requires converting symbolic shapes to concrete integers - you can't allocate memory with a variable-sized shape.