### PR TITLE
[ATen][CUDA][CCCL] Migrate tuple and pair from thrust to cuda::std

### DIFF
--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -16,7 +16,7 @@
 #include <ATen/native/hip/DeviceSqrt.cuh>
 #endif
 #if defined(__CUDACC__) || defined(__HIPCC__)
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 #else
 #include <cmath>
 #define device_sqrt std::sqrt
@@ -68,7 +68,7 @@ namespace at::native {
 namespace detail {
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
-template <typename T1, typename T2> using pair = thrust::pair<T1, T2>;
+template <typename T1, typename T2> using pair = ::cuda::std::pair<T1, T2>;
 #else
 template <typename T1, typename T2> using pair = std::pair<T1, T2>;
 #endif

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -9,9 +9,11 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/OpMathType.h>
 #if defined(__CUDACC__)
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
 #elif defined(__HIPCC__)
+#include <ATen/hip/cub.cuh>
 #include <ATen/hip/DeviceUtils.cuh>
 #include <ATen/native/hip/DeviceSqrt.cuh>
 #endif

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -15,7 +15,7 @@
 #include <ATen/hip/DeviceUtils.cuh>
 #include <ATen/native/hip/DeviceSqrt.cuh>
 #endif
-#if defined(__CUDACC__) || defined(__HIPCC__)
+#if defined(__CUDACC__)
 #include <cuda/std/utility>
 #else
 #include <cmath>
@@ -68,7 +68,7 @@ namespace at::native {
 namespace detail {
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
-template <typename T1, typename T2> using pair = ::cuda::std::pair<T1, T2>;
+template <typename T1, typename T2> using pair = NO_ROCM(::cuda)::std::pair<T1, T2>;
 #else
 template <typename T1, typename T2> using pair = std::pair<T1, T2>;
 #endif

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -326,7 +326,7 @@ void cpu_kernel(TensorIteratorBase& iter, func_t&& op, int64_t grain_size = at::
 // of `multiple_outputs_loop` returns `std::tuple` instead of `scalar_t`.
 // The `gpu_kernel_multiple_outputs` is also implemented without this check,
 // We could extend `needs_dynamic_casting` to support both `std::tuple` and
-// `thrust::tuple` in the future.
+// `cuda::std::tuple` in the future.
 template <typename func_t>
 void cpu_kernel_multiple_outputs(TensorIteratorBase& iter, func_t&& op, int64_t grain_size = at::internal::GRAIN_SIZE) {
   using traits = function_traits<func_t>;

--- a/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
@@ -5,7 +5,6 @@
 
 #include <cmath>
 
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -5,7 +5,7 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -33,7 +33,7 @@ void prelu_kernel(TensorIterator &iter) {
 void prelu_backward_kernel(TensorIterator &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "prelu_backward_cuda", [&] {
     gpu_kernel_multiple_outputs(iter,
-      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> thrust::tuple<scalar_t, scalar_t> {
+      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> ::cuda::std::tuple<scalar_t, scalar_t> {
         auto mask = input > 0;
         auto grad_input = mask ? grad : weight * grad;
         auto grad_weight = mask ? scalar_t{0} : input * grad;

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -5,7 +5,9 @@
 
 #include <cmath>
 
+#ifndef USE_ROCM
 #include <cuda/std/tuple>
+#endif
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -33,7 +35,7 @@ void prelu_kernel(TensorIterator &iter) {
 void prelu_backward_kernel(TensorIterator &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "prelu_backward_cuda", [&] {
     gpu_kernel_multiple_outputs(iter,
-      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> ::cuda::std::tuple<scalar_t, scalar_t> {
+      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> NO_ROCM(::cuda)::std::tuple<scalar_t, scalar_t> {
         auto mask = input > 0;
         auto grad_input = mask ? grad : weight * grad;
         auto grad_weight = mask ? scalar_t{0} : input * grad;

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -7,6 +7,10 @@
 
 #ifndef USE_ROCM
 #include <cuda/std/tuple>
+#define TUPLE_NAMESPACE ::cuda::std
+#else
+#include <thrust/tuple.h>
+#define TUPLE_NAMESPACE thrust
 #endif
 
 #include <ATen/AccumulateType.h>
@@ -35,7 +39,7 @@ void prelu_kernel(TensorIterator &iter) {
 void prelu_backward_kernel(TensorIterator &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "prelu_backward_cuda", [&] {
     gpu_kernel_multiple_outputs(iter,
-      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> NO_ROCM(::cuda)::std::tuple<scalar_t, scalar_t> {
+      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> TUPLE_NAMESPACE::tuple<scalar_t, scalar_t> {
         auto mask = input > 0;
         auto grad_input = mask ? grad : weight * grad;
         auto grad_weight = mask ? scalar_t{0} : input * grad;

--- a/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
+++ b/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <ATen/native/CompositeRandomAccessorCommon.h>
-#include <thrust/swap.h>
 #include <cuda/std/tuple>
+#include <cuda/std/utility>
 
 namespace at { namespace native {
 
@@ -12,7 +12,7 @@ struct TupleInfoCPU {
 
   template <typename ...Types>
   static constexpr auto tie(Types&... args) noexcept {
-    return thrust::tie(args...);
+    return ::cuda::std::tie(args...);
   }
 };
 
@@ -25,12 +25,12 @@ void swap(
   references_holder<Values, References> rh1,
   references_holder<Values, References> rh2
 ) {
-  return thrust::swap(rh1.data(), rh2.data());
+  return ::cuda::std::swap(rh1.data(), rh2.data());
 }
 
 template <int N, typename Values, typename References>
-auto get(references_holder<Values, References> rh) -> decltype(thrust::get<N>(rh.data())) {
-  return thrust::get<N>(rh.data());
+auto get(references_holder<Values, References> rh) -> decltype(::cuda::std::get<N>(rh.data())) {
+  return ::cuda::std::get<N>(rh.data());
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
+++ b/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
@@ -2,13 +2,13 @@
 
 #include <ATen/native/CompositeRandomAccessorCommon.h>
 #include <thrust/swap.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace at { namespace native {
 
 struct TupleInfoCPU {
   template <typename ...Types>
-  using tuple = thrust::tuple<Types...>;
+  using tuple = ::cuda::std::tuple<Types...>;
 
   template <typename ...Types>
   static constexpr auto tie(Types&... args) noexcept {

--- a/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
+++ b/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
@@ -1,18 +1,21 @@
 #pragma once
 
 #include <ATen/native/CompositeRandomAccessorCommon.h>
+
+#ifndef USE_ROCM
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
+#endif
 
 namespace at { namespace native {
 
 struct TupleInfoCPU {
   template <typename ...Types>
-  using tuple = ::cuda::std::tuple<Types...>;
+  using tuple = NO_ROCM(::cuda)::std::tuple<Types...>;
 
   template <typename ...Types>
   static constexpr auto tie(Types&... args) noexcept {
-    return ::cuda::std::tie(args...);
+    return NO_ROCM(::cuda)::std::tie(args...);
   }
 };
 
@@ -25,12 +28,12 @@ void swap(
   references_holder<Values, References> rh1,
   references_holder<Values, References> rh2
 ) {
-  return ::cuda::std::swap(rh1.data(), rh2.data());
+  return NO_ROCM(::cuda)::std::swap(rh1.data(), rh2.data());
 }
 
 template <int N, typename Values, typename References>
-auto get(references_holder<Values, References> rh) -> decltype(::cuda::std::get<N>(rh.data())) {
-  return ::cuda::std::get<N>(rh.data());
+auto get(references_holder<Values, References> rh) -> decltype(NO_ROCM(::cuda)::std::get<N>(rh.data())) {
+  return NO_ROCM(::cuda)::std::get<N>(rh.data());
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
+++ b/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/cuda/cub.cuh>
 #include <ATen/native/CompositeRandomAccessorCommon.h>
 
 #ifndef USE_ROCM

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -67,7 +67,11 @@ __device__ inline void elementwise_kernel_helper(func_t f, policy_t policy) {
   #pragma unroll
   for (int i = 0; i < elems_per_thread; i++) {
     if (policy.check_inbounds(i)) {
+#if defined(__HIP__)
+      results[i] = c10::guts::apply(f, args[i]);
+#else
       results[i] = std::apply(f, args[i]);
+#endif
     }
   }
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -8,6 +8,8 @@
 #include <ATen/native/cuda/thread_constants.h>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 
+#include <cuda/std/tuple>
+#include <cuda/std/utility>
 #include <tuple>
 
 
@@ -256,10 +258,10 @@ void gpu_kernel_with_scalars(TensorIteratorBase& iter, const func_t& f) {
 
 namespace { // functions for `gpu_kernel_multiple_outputs`.
 
-// check the return type is `thrust::tuple`, not `std::tuple`.
+// check the return type is `cuda::std::tuple`, not `std::tuple`.
 template <typename T> struct is_tuple: std::false_type {};
 
-template <typename ...T> struct is_tuple<thrust::tuple<T...>>: std::true_type {};
+template <typename ...T> struct is_tuple<::cuda::std::tuple<T...>>: std::true_type {};
 
 template <int num_outputs, typename func_t, typename array_t, typename inp_calc_t, typename out_calc_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
@@ -281,8 +283,8 @@ template <typename func_t>
 void gpu_kernel_multiple_outputs_impl(TensorIteratorBase& iter, const func_t& f) {
   using traits = function_traits<func_t>;
   using output_t = typename traits::result_type;
-  static_assert(is_tuple<output_t>::value, "f's return type must be `thrust::tuple`");
-  constexpr int num_outputs = std::tuple_size<output_t>::value;
+  static_assert(is_tuple<output_t>::value, "f's return type must be `cuda::std::tuple`");
+  constexpr int num_outputs = ::cuda::std::tuple_size_v<output_t>;
   constexpr int num_inputs = traits::arity;
   constexpr int ntensors = num_outputs + num_inputs;
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -8,8 +8,11 @@
 #include <ATen/native/cuda/thread_constants.h>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 
+#ifndef USE_ROCM
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
+#endif
+
 #include <tuple>
 
 
@@ -261,7 +264,7 @@ namespace { // functions for `gpu_kernel_multiple_outputs`.
 // check the return type is `cuda::std::tuple`, not `std::tuple`.
 template <typename T> struct is_tuple: std::false_type {};
 
-template <typename ...T> struct is_tuple<::cuda::std::tuple<T...>>: std::true_type {};
+template <typename ...T> struct is_tuple<NO_ROCM(::cuda)::std::tuple<T...>>: std::true_type {};
 
 template <int num_outputs, typename func_t, typename array_t, typename inp_calc_t, typename out_calc_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
@@ -284,7 +287,7 @@ void gpu_kernel_multiple_outputs_impl(TensorIteratorBase& iter, const func_t& f)
   using traits = function_traits<func_t>;
   using output_t = typename traits::result_type;
   static_assert(is_tuple<output_t>::value, "f's return type must be `cuda::std::tuple`");
-  constexpr int num_outputs = ::cuda::std::tuple_size_v<output_t>;
+  constexpr int num_outputs = NO_ROCM(::cuda)::std::tuple_size_v<output_t>;
   constexpr int num_inputs = traits::arity;
   constexpr int ntensors = num_outputs + num_inputs;
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/OpMathType.h>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -67,11 +67,7 @@ __device__ inline void elementwise_kernel_helper(func_t f, policy_t policy) {
   #pragma unroll
   for (int i = 0; i < elems_per_thread; i++) {
     if (policy.check_inbounds(i)) {
-#if defined(__HIP__)
-      results[i] = c10::guts::apply(f, args[i]);
-#else
       results[i] = std::apply(f, args[i]);
-#endif
     }
   }
 

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -109,7 +109,7 @@ struct multi_outputs_store_helper {
       ::cuda::std::tuple<Args...> ret) {
     using T = typename ::cuda::std::tuple_element_t<current, ::cuda::std::tuple<Args...>>;
     T *to = reinterpret_cast<T *>(data[current]) + offsets[current];
-    *to = thrust::get<current>(ret);
+    *to = ::cuda::std::get<current>(ret);
   }
 };
 

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -11,7 +11,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/thread_constants.h>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 // References:
 // https://devblogs.nvidia.com/cuda-pro-tip-increase-performance-with-vectorized-memory-access/
@@ -106,8 +106,8 @@ struct multi_outputs_store_helper {
   C10_HOST_DEVICE static void apply(
       const data_t& data,
       const offsets_t& offsets,
-      thrust::tuple<Args...> ret) {
-    using T = typename thrust::tuple_element<current, thrust::tuple<Args...>>::type;
+      ::cuda::std::tuple<Args...> ret) {
+    using T = typename ::cuda::std::tuple_element_t<current, ::cuda::std::tuple<Args...>>;
     T *to = reinterpret_cast<T *>(data[current]) + offsets[current];
     *to = thrust::get<current>(ret);
   }

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -8,6 +8,7 @@
 #include <c10/util/TypeCast.h>
 #include <c10/macros/Macros.h>
 #include <ATen/detail/FunctionTraits.h>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/thread_constants.h>
 

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -11,7 +11,9 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/thread_constants.h>
 
+#ifndef USE_ROCM
 #include <cuda/std/tuple>
+#endif
 
 // References:
 // https://devblogs.nvidia.com/cuda-pro-tip-increase-performance-with-vectorized-memory-access/
@@ -106,10 +108,10 @@ struct multi_outputs_store_helper {
   C10_HOST_DEVICE static void apply(
       const data_t& data,
       const offsets_t& offsets,
-      ::cuda::std::tuple<Args...> ret) {
-    using T = typename ::cuda::std::tuple_element_t<current, ::cuda::std::tuple<Args...>>;
+      NO_ROCM(::cuda)::std::tuple<Args...> ret) {
+    using T = typename NO_ROCM(::cuda)::std::tuple_element_t<current, NO_ROCM(::cuda)::std::tuple<Args...>>;
     T *to = reinterpret_cast<T *>(data[current]) + offsets[current];
-    *to = ::cuda::std::get<current>(ret);
+    *to = NO_ROCM(::cuda)::std::get<current>(ret);
   }
 };
 

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -367,9 +367,9 @@ void batch_norm_update_stats(
       const auto momentum = static_cast<acc_t>(momentum_);
       gpu_kernel_multiple_outputs(
           iter, [=] GPU_LAMBDA (acc_t mean, acc_t var, scalar_t running_mean, scalar_t running_var)
-               -> thrust::tuple<scalar_t, scalar_t> {
+               -> ::cuda::std::tuple<scalar_t, scalar_t> {
         const auto unbiased_var = var * bessel_correction_factor;
-        return thrust::tuple<scalar_t, scalar_t>{
+        return ::cuda::std::tuple<scalar_t, scalar_t>{
           mean * momentum + (1 - momentum) * running_mean,
           unbiased_var * momentum + (1 - momentum) * running_var,
         };
@@ -403,9 +403,9 @@ void batch_norm_update_stats_and_invert(
       const auto momentum = static_cast<acc_t>(momentum_);
       gpu_kernel_multiple_outputs(
           iter, [=] GPU_LAMBDA (acc_t mean, acc_t var, scalar_t running_mean, scalar_t running_var)
-               -> thrust::tuple<scalar_t, scalar_t, acc_t> {
+               -> ::cuda::std::tuple<scalar_t, scalar_t, acc_t> {
         const auto unbiased_var = var * bessel_correction_factor;
-        return thrust::tuple<scalar_t, scalar_t, acc_t>{
+        return ::cuda::std::tuple<scalar_t, scalar_t, acc_t>{
           mean * momentum + (1 - momentum) * running_mean,
           unbiased_var * momentum + (1 - momentum) * running_var,
           c10::cuda::compat::rsqrt(var + eps)

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -1,4 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/native/Normalization.h>

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -368,9 +368,9 @@ void batch_norm_update_stats(
       const auto momentum = static_cast<acc_t>(momentum_);
       gpu_kernel_multiple_outputs(
           iter, [=] GPU_LAMBDA (acc_t mean, acc_t var, scalar_t running_mean, scalar_t running_var)
-               -> ::cuda::std::tuple<scalar_t, scalar_t> {
+               -> NO_ROCM(::cuda)::std::tuple<scalar_t, scalar_t> {
         const auto unbiased_var = var * bessel_correction_factor;
-        return ::cuda::std::tuple<scalar_t, scalar_t>{
+        return NO_ROCM(::cuda)::std::tuple<scalar_t, scalar_t>{
           mean * momentum + (1 - momentum) * running_mean,
           unbiased_var * momentum + (1 - momentum) * running_var,
         };
@@ -404,9 +404,9 @@ void batch_norm_update_stats_and_invert(
       const auto momentum = static_cast<acc_t>(momentum_);
       gpu_kernel_multiple_outputs(
           iter, [=] GPU_LAMBDA (acc_t mean, acc_t var, scalar_t running_mean, scalar_t running_var)
-               -> ::cuda::std::tuple<scalar_t, scalar_t, acc_t> {
+               -> NO_ROCM(::cuda)::std::tuple<scalar_t, scalar_t, acc_t> {
         const auto unbiased_var = var * bessel_correction_factor;
-        return ::cuda::std::tuple<scalar_t, scalar_t, acc_t>{
+        return NO_ROCM(::cuda)::std::tuple<scalar_t, scalar_t, acc_t>{
           mean * momentum + (1 - momentum) * running_mean,
           unbiased_var * momentum + (1 - momentum) * running_var,
           c10::cuda::compat::rsqrt(var + eps)

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -15,7 +15,7 @@
 #include <iosfwd>
 #include <type_traits>
 #include <utility>
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 
 #include <ATen/native/cuda/jit_utils.h>
 #include <ATen/native/cuda/KernelUtils.cuh>
@@ -760,7 +760,7 @@ struct ReduceOp {
 
   //Currently implemented for max of two outputs
   template<class T1, class T2>
-  C10_DEVICE void set_results(const thrust::pair<T1, T2> x, const index_t base_offset) const {
+  C10_DEVICE void set_results(const ::cuda::std::pair<T1, T2> x, const index_t base_offset) const {
     if (noutputs >= 1) {
       auto res0 = (T1*)((char*)dst[0] + base_offset);
       *res0 = x.first;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -15,7 +15,10 @@
 #include <iosfwd>
 #include <type_traits>
 #include <utility>
+
+#ifndef USE_ROCM
 #include <cuda/std/utility>
+#endif
 
 #include <ATen/native/cuda/jit_utils.h>
 #include <ATen/native/cuda/KernelUtils.cuh>
@@ -760,7 +763,7 @@ struct ReduceOp {
 
   //Currently implemented for max of two outputs
   template<class T1, class T2>
-  C10_DEVICE void set_results(const ::cuda::std::pair<T1, T2> x, const index_t base_offset) const {
+  C10_DEVICE void set_results(const NO_ROCM(::cuda)::std::pair<T1, T2> x, const index_t base_offset) const {
     if (noutputs >= 1) {
       auto res0 = (T1*)((char*)dst[0] + base_offset);
       *res0 = x.first;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>

--- a/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
@@ -22,7 +22,7 @@ void _min_max_values_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinMaxOps<scalar_t, scalar_t, int32_t>{},
-      thrust::pair<scalar_t, scalar_t>(
+      ::cuda::std::pair<scalar_t, scalar_t>(
           at::numeric_limits<scalar_t>::upper_bound(),
           at::numeric_limits<scalar_t>::lower_bound()));
 }
@@ -40,7 +40,7 @@ void aminmax_launch_kernel(TensorIterator& iter) {
         gpu_reduce_kernel<scalar_t, scalar_t>(
             iter,
             MinMaxOps<scalar_t, scalar_t, int32_t>{},
-            thrust::pair<scalar_t, scalar_t>(
+            ::cuda::std::pair<scalar_t, scalar_t>(
                 at::numeric_limits<scalar_t>::upper_bound(),
                 at::numeric_limits<scalar_t>::lower_bound()));
       });

--- a/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
@@ -22,7 +22,7 @@ void _min_max_values_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinMaxOps<scalar_t, scalar_t, int32_t>{},
-      ::cuda::std::pair<scalar_t, scalar_t>(
+      NO_ROCM(::cuda)::std::pair<scalar_t, scalar_t>(
           at::numeric_limits<scalar_t>::upper_bound(),
           at::numeric_limits<scalar_t>::lower_bound()));
 }
@@ -40,7 +40,7 @@ void aminmax_launch_kernel(TensorIterator& iter) {
         gpu_reduce_kernel<scalar_t, scalar_t>(
             iter,
             MinMaxOps<scalar_t, scalar_t, int32_t>{},
-            ::cuda::std::pair<scalar_t, scalar_t>(
+            NO_ROCM(::cuda)::std::pair<scalar_t, scalar_t>(
                 at::numeric_limits<scalar_t>::upper_bound(),
                 at::numeric_limits<scalar_t>::lower_bound()));
       });

--- a/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
@@ -22,7 +22,7 @@ void argmax_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMaxOps<acc_t>{},
-      thrust::pair<acc_t, int64_t>(
+      ::cuda::std::pair<acc_t, int64_t>(
           at::numeric_limits<acc_t>::lower_bound(), 0));
 };
 

--- a/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
@@ -22,7 +22,7 @@ void argmax_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMaxOps<acc_t>{},
-      ::cuda::std::pair<acc_t, int64_t>(
+      NO_ROCM(::cuda)::std::pair<acc_t, int64_t>(
           at::numeric_limits<acc_t>::lower_bound(), 0));
 };
 

--- a/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
@@ -22,7 +22,7 @@ void argmin_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMinOps<acc_t>{},
-      thrust::pair<acc_t, int64_t>(
+      ::cuda::std::pair<acc_t, int64_t>(
           at::numeric_limits<acc_t>::upper_bound(), 0));
 };
 

--- a/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
@@ -22,7 +22,7 @@ void argmin_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMinOps<acc_t>{},
-      ::cuda::std::pair<acc_t, int64_t>(
+      NO_ROCM(::cuda)::std::pair<acc_t, int64_t>(
           at::numeric_limits<acc_t>::upper_bound(), 0));
 };
 

--- a/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
@@ -45,7 +45,7 @@ void max_launch_kernel(TensorIterator& iter) {
         gpu_reduce_kernel<scalar_t, scalar_t>(
             iter,
             MaxOps<scalar_t>{},
-            thrust::pair<scalar_t, int64_t>(
+            ::cuda::std::pair<scalar_t, int64_t>(
                 at::numeric_limits<scalar_t>::lower_bound(), 0));
       });
 }

--- a/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
@@ -45,7 +45,7 @@ void max_launch_kernel(TensorIterator& iter) {
         gpu_reduce_kernel<scalar_t, scalar_t>(
             iter,
             MaxOps<scalar_t>{},
-            ::cuda::std::pair<scalar_t, int64_t>(
+            NO_ROCM(::cuda)::std::pair<scalar_t, int64_t>(
                 at::numeric_limits<scalar_t>::lower_bound(), 0));
       });
 }

--- a/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
@@ -43,7 +43,7 @@ void min_launch_kernel(TensorIterator &iter) {
     gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinOps<scalar_t>{},
-      thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
+      ::cuda::std::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
   });
 }
 

--- a/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
@@ -43,7 +43,7 @@ void min_launch_kernel(TensorIterator &iter) {
     gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinOps<scalar_t>{},
-      ::cuda::std::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
+      NO_ROCM(::cuda)::std::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
   });
 }
 

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -15,7 +15,7 @@ void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt
   // reducing unrolling factor to 2 for welford kernel
   // This is necessary to lower register usage that leads to register spills.
   using accscalar_t = at::acc_type<scalar_t, true>;
-  using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, thrust::pair<out_t, out_t>>;
+  using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, ::cuda::std::pair<out_t, out_t>>;
   ops_t ops(static_cast<accscalar_t>(correction), take_sqrt);
   gpu_reduce_kernel<scalar_t, out_t, 2>(iter, ops, typename ops_t::acc_t{});
 }

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -15,7 +15,7 @@ void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt
   // reducing unrolling factor to 2 for welford kernel
   // This is necessary to lower register usage that leads to register spills.
   using accscalar_t = at::acc_type<scalar_t, true>;
-  using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, ::cuda::std::pair<out_t, out_t>>;
+  using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, NO_ROCM(::cuda)::std::pair<out_t, out_t>>;
   ops_t ops(static_cast<accscalar_t>(correction), take_sqrt);
   gpu_reduce_kernel<scalar_t, out_t, 2>(iter, ops, typename ops_t::acc_t{});
 }

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -23,7 +23,7 @@
 #include <ATen/ops/reflection_pad3d_backward_native.h>
 #endif
 
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 
 namespace at::native {
 namespace {
@@ -31,7 +31,7 @@ namespace {
 using at::cuda::detail::canUse32BitIndexMath;
 
 __device__
-inline thrust::pair<int64_t, int64_t> get_index_mapping1d(
+inline ::cuda::std::pair<int64_t, int64_t> get_index_mapping1d(
     int64_t input_w, int64_t output_w,
     int64_t output_x,
     int64_t pad_l) {
@@ -50,13 +50,13 @@ inline thrust::pair<int64_t, int64_t> get_index_mapping1d(
                     + 2 * pad_l + input_w - 1
                     - o_start_x + i_start_x;
 
-  return thrust::make_pair<int64_t, int64_t>(
+  return ::cuda::std::make_pair<int64_t, int64_t>(
     input_offset + input_x, output_offset + output_x);
 }
 
 
 __device__
-inline thrust::pair<int64_t, int64_t>  get_index_mapping2d(
+inline ::cuda::std::pair<int64_t, int64_t>  get_index_mapping2d(
     int64_t input_dim_x, int64_t input_dim_y,
     int64_t output_dim_x, int64_t output_dim_y,
     int64_t pad_l, int64_t pad_t,
@@ -87,7 +87,7 @@ inline thrust::pair<int64_t, int64_t>  get_index_mapping2d(
                  + 2 * pad_t + input_dim_y - 1
                  - o_start_y + i_start_y;
 
-  return thrust::make_pair<int64_t, int64_t>(
+  return ::cuda::std::make_pair<int64_t, int64_t>(
     input_offset + input_y * input_dim_x + input_x,
     output_offset + output_y * output_dim_x + output_x);
 }

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -3,6 +3,7 @@
 #include <ATen/ceil_div.h>
 #include <ATen/Dispatch.h>
 #include <ATen/cuda/Atomic.cuh>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/TensorUtils.h>

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -23,7 +23,9 @@
 #include <ATen/ops/reflection_pad3d_backward_native.h>
 #endif
 
+#ifndef USE_ROCM
 #include <cuda/std/utility>
+#endif
 
 namespace at::native {
 namespace {
@@ -31,7 +33,7 @@ namespace {
 using at::cuda::detail::canUse32BitIndexMath;
 
 __device__
-inline ::cuda::std::pair<int64_t, int64_t> get_index_mapping1d(
+inline NO_ROCM(::cuda)::std::pair<int64_t, int64_t> get_index_mapping1d(
     int64_t input_w, int64_t output_w,
     int64_t output_x,
     int64_t pad_l) {
@@ -50,13 +52,13 @@ inline ::cuda::std::pair<int64_t, int64_t> get_index_mapping1d(
                     + 2 * pad_l + input_w - 1
                     - o_start_x + i_start_x;
 
-  return ::cuda::std::make_pair<int64_t, int64_t>(
+  return NO_ROCM(::cuda)::std::make_pair<int64_t, int64_t>(
     input_offset + input_x, output_offset + output_x);
 }
 
 
 __device__
-inline ::cuda::std::pair<int64_t, int64_t>  get_index_mapping2d(
+inline NO_ROCM(::cuda)::std::pair<int64_t, int64_t>  get_index_mapping2d(
     int64_t input_dim_x, int64_t input_dim_y,
     int64_t output_dim_x, int64_t output_dim_y,
     int64_t pad_l, int64_t pad_t,
@@ -87,7 +89,7 @@ inline ::cuda::std::pair<int64_t, int64_t>  get_index_mapping2d(
                  + 2 * pad_t + input_dim_y - 1
                  - o_start_y + i_start_y;
 
-  return ::cuda::std::make_pair<int64_t, int64_t>(
+  return NO_ROCM(::cuda)::std::make_pair<int64_t, int64_t>(
     input_offset + input_y * input_dim_x + input_x,
     output_offset + output_y * output_dim_x + output_x);
 }

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -267,7 +267,7 @@ void frexp_kernel_cuda(TensorIteratorBase& iter) {
     // It's a floating point type and must be the same as the input's dtype.
     iter.dtype(),
     "frexp_cuda", [&]() {
-      gpu_kernel_multiple_outputs(iter, [=] GPU_LAMBDA (scalar_t a) -> thrust::tuple<scalar_t, int32_t> {
+      gpu_kernel_multiple_outputs(iter, [=] GPU_LAMBDA (scalar_t a) -> ::cuda::std::tuple<scalar_t, int32_t> {
         int32_t exponent;
         scalar_t mantissa = std::frexp(a, &exponent);
         return {mantissa, exponent};

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -267,7 +267,7 @@ void frexp_kernel_cuda(TensorIteratorBase& iter) {
     // It's a floating point type and must be the same as the input's dtype.
     iter.dtype(),
     "frexp_cuda", [&]() {
-      gpu_kernel_multiple_outputs(iter, [=] GPU_LAMBDA (scalar_t a) -> ::cuda::std::tuple<scalar_t, int32_t> {
+      gpu_kernel_multiple_outputs(iter, [=] GPU_LAMBDA (scalar_t a) -> NO_ROCM(::cuda)::std::tuple<scalar_t, int32_t> {
         int32_t exponent;
         scalar_t mantissa = std::frexp(a, &exponent);
         return {mantissa, exponent};

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -3,6 +3,10 @@
 
 #include <type_traits>
 
+#ifndef USE_ROCM
+#include <cuda/std/utility>
+#endif
+
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -36,7 +40,7 @@ __global__ void RowwiseMomentsCUDAKernel(
   using T_ACC = acc_type<T, true>;
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp =
-      WelfordOps<T_ACC, T_ACC, int64_t, ::cuda::std::pair<T_ACC, T_ACC>>;
+      WelfordOps<T_ACC, T_ACC, int64_t, NO_ROCM(::cuda)::std::pair<T_ACC, T_ACC>>;
 
   const int64_t i = blockIdx.x;
   WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -3,7 +3,6 @@
 
 #include <type_traits>
 
-
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -37,7 +36,7 @@ __global__ void RowwiseMomentsCUDAKernel(
   using T_ACC = acc_type<T, true>;
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp =
-      WelfordOps<T_ACC, T_ACC, int64_t, thrust::pair<T_ACC, T_ACC>>;
+      WelfordOps<T_ACC, T_ACC, int64_t, ::cuda::std::pair<T_ACC, T_ACC>>;
 
   const int64_t i = blockIdx.x;
   WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -11,6 +11,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -4,6 +4,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include <cuda/std/utility>
+
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -63,7 +65,7 @@ __global__ void RowwiseMomentsCUDAKernel(
     T_ACC* rstd) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp =
-      WelfordOps<T_ACC, T_ACC, int64_t, thrust::pair<T_ACC, T_ACC>>;
+      WelfordOps<T_ACC, T_ACC, int64_t, ::cuda::std::pair<T_ACC, T_ACC>>;
 
   __shared__
       typename std::aligned_storage<sizeof(WelfordType), alignof(WelfordType)>::

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -4,7 +4,9 @@
 #include <tuple>
 #include <type_traits>
 
+#ifndef USE_ROCM
 #include <cuda/std/utility>
+#endif
 
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
@@ -65,7 +67,7 @@ __global__ void RowwiseMomentsCUDAKernel(
     T_ACC* rstd) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp =
-      WelfordOps<T_ACC, T_ACC, int64_t, ::cuda::std::pair<T_ACC, T_ACC>>;
+      WelfordOps<T_ACC, T_ACC, int64_t, NO_ROCM(::cuda)::std::pair<T_ACC, T_ACC>>;
 
   __shared__
       typename std::aligned_storage<sizeof(WelfordType), alignof(WelfordType)>::

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -544,11 +544,11 @@ struct ReduceJitOp {
     *res = x;
   }
 
-//TODO - multi-output reduction - we won't be able to use thrust::pair
+//TODO - multi-output reduction - we won't be able to use cuda::std::pair
 //just explicitly specify typed output reads/writes
 //Currently implemented for max of two outputs
 //   template<class T1, class T2>
-//   C10_DEVICE void set_results(const thrust::pair<T1, T2> x, const index_t base_offset) const {
+//   C10_DEVICE void set_results(const cuda::std::pair<T1, T2> x, const index_t base_offset) const {
 //     if (noutputs >= 1) {
 //       auto res0 = (T1*)((char*)dst[0] + base_offset);
 //       *res0 = x.first;

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -3,7 +3,7 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/native/quantized/FakeQuantAffine.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 #include <cmath>
 
 /* Fake quantize a tensor
@@ -39,7 +39,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
           const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
           return {
             // fake_quantized value
@@ -54,7 +54,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
           const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
           return {
             // fake_quantized value
@@ -91,7 +91,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
           if (*fake_quant_on == 0) {
             return {input_val, 1};
           }
@@ -110,7 +110,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
           if (*fake_quant_on == 0) {
             return {input_val, 1};
           }
@@ -139,7 +139,7 @@ void _fake_quantize_grad_learnable_tensor_kernel_cuda(
   float dscale_small = quant_min - zero_point;
   float dscale_big = quant_max - zero_point;
   gpu_kernel_multiple_outputs(
-    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> thrust::tuple<float, float, float> {
+    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> ::cuda::std::tuple<float, float, float> {
       float dXOutput, dZeroPointOutput, dScaleOutput;
       int64_t xq = std::nearbyint(XInput * inv_scale) + zero_point;
       dXOutput = dYInput * (xq >= quant_min && xq <= quant_max);
@@ -234,7 +234,7 @@ void fake_quant_per_channel_cachemask_cuda(
 
 void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max, float grad_factor) {
   gpu_kernel_multiple_outputs(iter,
-    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> thrust::tuple<float, float, float> {
+    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> ::cuda::std::tuple<float, float, float> {
       float dx_output, dscale_output, dzero_point_output;
       float inv_scale = 1.0f / scale_input;
       float dscale_small = quant_min - zero_point_input;

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -3,7 +3,11 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/native/quantized/FakeQuantAffine.h>
 #include <ATen/native/cuda/Loops.cuh>
+
+#ifndef USE_ROCM
 #include <cuda/std/tuple>
+#endif
+
 #include <cmath>
 
 /* Fake quantize a tensor
@@ -39,7 +43,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> NO_ROCM(::cuda)::std::tuple<scalar_t, bool> {
           const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
           return {
             // fake_quantized value
@@ -54,7 +58,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> NO_ROCM(::cuda)::std::tuple<scalar_t, bool> {
           const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
           return {
             // fake_quantized value
@@ -91,7 +95,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> NO_ROCM(::cuda)::std::tuple<scalar_t, bool> {
           if (*fake_quant_on == 0) {
             return {input_val, 1};
           }
@@ -110,7 +114,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> ::cuda::std::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> NO_ROCM(::cuda)::std::tuple<scalar_t, bool> {
           if (*fake_quant_on == 0) {
             return {input_val, 1};
           }
@@ -139,7 +143,7 @@ void _fake_quantize_grad_learnable_tensor_kernel_cuda(
   float dscale_small = quant_min - zero_point;
   float dscale_big = quant_max - zero_point;
   gpu_kernel_multiple_outputs(
-    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> ::cuda::std::tuple<float, float, float> {
+    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> NO_ROCM(::cuda)::std::tuple<float, float, float> {
       float dXOutput, dZeroPointOutput, dScaleOutput;
       int64_t xq = std::nearbyint(XInput * inv_scale) + zero_point;
       dXOutput = dYInput * (xq >= quant_min && xq <= quant_max);
@@ -234,7 +238,7 @@ void fake_quant_per_channel_cachemask_cuda(
 
 void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max, float grad_factor) {
   gpu_kernel_multiple_outputs(iter,
-    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> ::cuda::std::tuple<float, float, float> {
+    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> NO_ROCM(::cuda)::std::tuple<float, float, float> {
       float dx_output, dscale_output, dzero_point_output;
       float inv_scale = 1.0f / scale_input;
       float dscale_small = quant_min - zero_point_input;

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -3,6 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/ceil_div.h>
 #include <ATen/Dispatch.h>
+#include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/ThrustAllocator.h>
 #include <ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh>

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -22,7 +22,10 @@
 #include <ATen/ops/zeros.h>
 #endif
 
+#ifndef USE_ROCM
 #include <cuda/std/utility>
+#endif
+
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
@@ -89,7 +92,7 @@ SparseTensor _coalesce_sparse_cuda(const SparseTensor& self) {
   );
 
   // this forces device-host synchronization!
-  ::cuda::std::pair<thrust_ptr, thrust_ptr> newEnd = thrust::unique_by_key(policy,
+  NO_ROCM(::cuda)::std::pair<thrust_ptr, thrust_ptr> newEnd = thrust::unique_by_key(policy,
     indicesIter, indicesIter + nnz,
     uniqueOffsetsIter
   );

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -22,6 +22,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
+#include <cuda/std/utility>
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
@@ -88,7 +89,7 @@ SparseTensor _coalesce_sparse_cuda(const SparseTensor& self) {
   );
 
   // this forces device-host synchronization!
-  thrust::pair<thrust_ptr, thrust_ptr> newEnd = thrust::unique_by_key(policy,
+  ::cuda::std::pair<thrust_ptr, thrust_ptr> newEnd = thrust::unique_by_key(policy,
     indicesIter, indicesIter + nnz,
     uniqueOffsetsIter
   );


### PR DESCRIPTION
According to the https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html :

> `thrust::tuple`: Is now an alias to `cuda::std::tuple` and no longer a distinct type
> `thrust::pair`: Is now an alias to `cuda::std::pair` and no longer a distinct type

The old types `thrust::tuple` and `thrust::pair` are now getting removed: https://github.com/NVIDIA/cccl/pull/6616

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01