### PR TITLE
[FP8] Additional fp8 rowwise-scaling testing

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1213,7 +1213,7 @@ class TestFP8Matmul(TestCase):
         out_dq = x_dq @ y_dq.t()
 
         if bias is not None:
-            out_dq += bias.float()
+            out_dq += bias.to(base_dtype).float()
 
         out_dq = out_dq.to(base_dtype)
 

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1178,7 +1178,6 @@ class TestFP8Matmul(TestCase):
             bias_dtype_ = y.dtype if bias_dtype == "same" else torch.float32
             bias = torch.randn((N,), device=device, dtype=bias_dtype_)
 
-        e4m3_type = torch.float8_e4m3fn
         x_scales = tensor_to_scale(x, e4m3_type, dim=1).float()
         y_scales = tensor_to_scale(y, e4m3_type, dim=1).float()
 
@@ -1636,8 +1635,6 @@ class TestFP8Matmul(TestCase):
                 return hp_to_1x128(t, scale)
             else:
                 return hp_to_128x128(t, scale)
-
-        e4m3_type = torch.float8_e4m3fn
 
         if test_case == "x_eye_b_eye":
             if M != K or M != N:

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_device_type import (
     e5m2_type,
     E4M3_MAX_POS,
     E5M2_MAX_POS,
+    largeTensorTest,
 )
 
 from torch.testing._internal.common_utils import (
@@ -1143,6 +1144,7 @@ class TestFP8Matmul(TestCase):
     @parametrize("use_fast_accum", [True, False])
     @parametrize("bias_dtype", [None, "same", torch.float32], name_fn=lambda t: f"{t}")
     @with_tf32_off
+    @largeTensorTest("20GB", "cuda")
     def test_float8_rowwise_scaling_numerics(
         self,
         device,

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1153,6 +1153,7 @@ class TestFP8Matmul(TestCase):
         use_fast_accum: bool,
         bias_dtype: torch.dtype | None
     ) -> None:
+        torch.manual_seed(42)
         # Fp32 out_dtype is only supported by cuBLAS, which however only started
         # shipping row-wise kernels in CUDA 12.9, and only for sm90+.
         if base_dtype is torch.float32:
@@ -1394,6 +1395,7 @@ class TestFP8Matmul(TestCase):
     ])
     @with_tf32_off
     def test_scaled_mm_vs_emulated_row_wise(self, base_dtype, shapes):
+        torch.manual_seed(42)
         M, K, N = shapes
         # Fp32 out_dtype is only supported by cuBLAS, which however only started
         # shipping row-wise kernels in CUDA 12.9, and only for sm90+.

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1245,7 +1245,7 @@ class TestFP8Matmul(TestCase):
         # - fp8 vs. dq and fp8 vs. emulated should be high
         # - fp8 vs. hp should be lower (due to capturing quant error as well)
         snr_limit_hp = 25.
-        snr_limit_dq_emulated = 60
+        snr_limit_dq_emulated = 55
 
         def check_snr(Ps, Pq, limit):
             snr = compute_error(Ps, Pq)

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1179,8 +1179,8 @@ class TestFP8Matmul(TestCase):
             bias = torch.randn((N,), device=device, dtype=bias_dtype_)
 
         e4m3_type = torch.float8_e4m3fn
-        x_scales = tensor_to_scale(x, torch.float8_e4m3fn, dim=1).float()
-        y_scales = tensor_to_scale(y, torch.float8_e4m3fn, dim=1).float()
+        x_scales = tensor_to_scale(x, e4m3_type, dim=1).float()
+        y_scales = tensor_to_scale(y, e4m3_type, dim=1).float()
 
         x_fp8 = to_fp8_saturated(x * x_scales, e4m3_type)
         y_fp8 = to_fp8_saturated(y * y_scales, e4m3_type)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168004

Summary:

During working on a nasty numerics bug involving rowwise scaled mm
calls, I wrote a bunch of testing to convince myself that everything was
ok. That testing is useful to OSS, so here it is.

Note: For main rowwise numerics testing, don't use fp16 as an output
type - it overflows too easily, and pretty easily just infs-out the
tests.

Test Plan:

```
pytest -sv -k "test_float8_rowwise_scaling_numerics" test/test_scaled_matmul_cuda.py
```

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Simon Layton <simonlayton@meta.com>