### PR TITLE
Follow up for D86436435

### DIFF
--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -15,21 +15,40 @@
 
 namespace c10 {
 
-C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
+template <typename T>
+C10_ALWAYS_INLINE bool add_overflows(T a, T b, T* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_add_overflow(a, b, out);
 #else
-  unsigned long long tmp;
-#if defined(_M_IX86) || defined(_M_X64)
-  auto carry = _addcarry_u64(0, a, b, &tmp);
-#else
-  tmp = a + b;
-  unsigned long long vector = (a & b) ^ ((a ^ b) & ~tmp);
-  auto carry = vector >> 63;
+  static_assert(
+      std::is_integral_v<T>, "add_overflows only supports integral types");
+
+  if constexpr (std::is_signed_v<T>) {
+    // For signed types, detect overflow by checking sign changes
+    volatile T tmp = a + b;
+    *out = tmp;
+
+    // If both operands have the same sign, check if result changed sign unexpectedly
+    if ((a > 0) == (b > 0)) {
+      if ((a > 0) && (tmp <= 0)) {
+        return true;  // Positive overflow
+      }
+      if ((a < 0) && (tmp >= 0)) {
+        return true;  // Negative overflow
+      }
+    }
+    return false;
+  } else {
+    // For unsigned types, overflow causes wrap-around
+    volatile T tmp = a + b;
+    *out = tmp;
+    return (tmp < a || tmp < b);
+  }
 #endif
-  *out = tmp;
-  return carry;
-#endif
+}
+
+C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
+  return add_overflows<uint64_t>(a, b, out);
 }
 
 template <typename T>


### PR DESCRIPTION
Summary: D86436435 is the patch for T235095990, but it is insufficient when overflow happenes.

Test Plan:
Please check T235095990.md in D87113673

```
PYTHONPATH=/data/users/soyeon/fbsource/fbcode:/data/users/soyeon/fbsource/third-party/pypi/flatbuffers/24.3.25:$PYTHONPATH python3 gen_6_for_hyp_2.py
ET_LIONHEAD_PTE_PATH=[fbsource_path]/fbcode/security/prodsec_native/executorch_pocs/out.pte arc lionhead crash reproduce [any_existing_file] --harness-name fbcode//executorch/runtime/executor/test/fb:FuzzLoadAndExecuteModuleAdd
```

Differential Revision: D87115901


