### PR TITLE
Fix memory leak test for SDPA op call

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9667,10 +9667,12 @@ class TestSDPA(TestCaseMPS):
         memory_footprints = []
         for _ in range(100):
             output = F.scaled_dot_product_attention(query, key, value)
+            # syncronize to wait for the GPU computation to return
+            torch.mps.synchronize()
             current_mem, driver_mem = get_mps_memory_usage()
             memory_footprints.append((current_mem, driver_mem))
-        # 5 MB different maximum allowed value(could be decreased even more)
-        torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=5, rtol=1)
+        # 1 kB different maximum allowed value
+        torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=1e-3, rtol=1e-3)
 
     def generate_qkv(self, batch: int, NH: int, q_len: int, s_len: int, head_dim: int, layout: str, dtype: torch.dtype):
         if layout == "contiguous":


### PR DESCRIPTION
Fixes #158330

Currently the test fails in the nightly because it keeps committing more work without waiting for previous work to finish and clean-up. So it is not testing the correct thing. Each iteration adds 2MB to the driver allocated memory as it holds on to the needed inputs, outputs and graph definition while the computation is in-flight.

Either waiting for about ~0.2s after each op call or calling device to synchronize allows the computation to wrap-up and the underlying memory to get released, displaying the expected result that the memory before and after the op call is the same.