### PR TITLE
[DTensor][ops] adding aten.std.correction propagation rule

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -436,8 +436,6 @@ dtensor_fails = {
     xfail("signal.windows.nuttall"),
     xfail("signal.windows.kaiser"),
     xfail("stack"),
-    xfail("std"),
-    xfail("std", "unbiased"),
     xfail("std_mean"),
     xfail("std_mean", "unbiased"),
     xfail("stft"),

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1037,6 +1037,30 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(out_with_redistribute.placements[0].is_replicate())
         self.assertEqual(out_without_redistribute, out_with_redistribute)
 
+    @with_comms
+    def test_std(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(4).reshape(2, 2))
+        rank = self.rank
+        comm_mode = CommDebugMode()
+
+        global_tensor = map_local_for_rank(
+            rank,
+            lambda rank: torch.tensor(
+                [[-20.0, -18.0, -12.0, 0.0], [-20.0, -18.0, -8.0, 4.0]]
+            ),
+        )
+
+        dt = distribute_tensor(global_tensor, mesh, [Shard(0), Shard(1)])
+
+        with comm_mode:
+            res = dt.std(dim=1)
+        expected_answer = torch.tensor([9.0, 11.0])
+
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+        self.assertEqual(comm_mode.get_comm_counts()[funcol.all_gather_into_tensor], 1)
+        self.assertEqual(res.placements, [Shard(0), Replicate()])
+        self.assertEqual(res.full_tensor(), expected_answer)
+
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistMathOpsTest,

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -406,14 +406,14 @@ def cumsum_strategy(op_schema: OpSchema) -> OpStrategy:
 
 @register_op_strategy(
     [
-        aten.var.correction,
-        aten.var.correction_out,
         aten.std.correction,
         aten.std.correction_out,
+        aten.var.correction,
+        aten.var.correction_out,
     ],
     schema_info=RuntimeSchemaInfo(1, ["keepdim"]),
 )
-def var_reduction_strategy(op_schema: OpSchema) -> OpStrategy:
+def std_var_reduction_strategy(op_schema: OpSchema) -> OpStrategy:
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
     if not isinstance(input_strategy, OpStrategy):

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -405,7 +405,12 @@ def cumsum_strategy(op_schema: OpSchema) -> OpStrategy:
 
 
 @register_op_strategy(
-    [aten.var.correction, aten.var.correction_out],
+    [
+        aten.var.correction,
+        aten.var.correction_out,
+        aten.std.correction,
+        aten.std.correction_out,
+    ],
     schema_info=RuntimeSchemaInfo(1, ["keepdim"]),
 )
 def var_reduction_strategy(op_schema: OpSchema) -> OpStrategy:


### PR DESCRIPTION
**Summary:** I added a new sharding propagation rule for aten.std.correction so that users can call .std() on DTensors. Since aten.var.correction already has a sharding propagation rule, and aten.std.correction should just take the square root, I added it to std_var_reduction_strategy's register op strategy list. Also removed std from list of ops that should fail on dtensors.

**Test Case**
1. pytest test/distributed/tensor/test_math_ops.py -k test_std

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168057



cc @wanchaol @tianyu-l @wz337 @XilunWu @d4l3k @pragupta @SherlockNoMad @H-Huang @awgu @fegin @fduwjj @wconstab @msaroufim @dcci