### PR TITLE
Fix misleading device mismatch error message in conv2d

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -775,6 +775,12 @@ static void check_input_same_type_as_parameters(
     const Tensor& input,
     const Tensor& weight,
     const Tensor& bias) {
+  TORCH_CHECK(input.device() == weight.device(),
+      "Expected input and weight to be on the same device (got ",
+      input.device(), " and ", weight.device(), ")");
+  TORCH_CHECK(!bias.defined() || input.device() == bias.device(), 
+      "Expected input and bias to be on the saem device (got ",
+      input.device(), " and ", bias.device(), ")");
   TORCH_CHECK(input.options().type_equal(weight.options()),
       "Input type (", input.toString(), ") and weight type (", weight.toString(),
       ") should be the same");

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -188,6 +188,17 @@ class TestConvolutionNN(NNTestCase):
                 + r"input of size: \[1, 10, 1, 28, 28\]",
             ):
                 F.conv2d(x, w)
+    
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_conv2d_device_mismatch_error(self):
+        x = torch.randn(1, 3, 32, 32, device="cuda")
+        w = torch.randn(3, 3, 3, 3, device="cpu")
+        
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected input and weight to be on the same device"
+            ):
+                F.conv2d(x, w)
 
     def test_conv2d_discontiguous_weight(self):
         for dtype in (torch.float, torch.cfloat):


### PR DESCRIPTION
Fixes #168010

Updates the precondition checks in the convolution implementation
so that `torch.nn.functional.conv2d` reports a device mismatch error
when the input and weight tensors are on different devices.

Previously, calling `F.conv2d` with input on CUDA and weight on CPU produced
a misleading error:
`RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same`

This change adds an explicit device check:
- If devices differ, raise:
  `RuntimeError: Expected input and weight to be on the same device (got cuda:0 and cpu)`

- If devices match but dtypes differ, the existing type mismatch error is preserved.
A regression test `test_conv2d_device_mismatch_error` is added to `test/test_nn.py`
to verify the new behavior.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01