### PR TITLE
[DTensor] Fix deadlock after fast cache clear

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -388,10 +388,10 @@ class TestCostModel(DTensorOpTestBase):
 # reference: https://docs.pytorch.org/docs/stable/library.html#torch.library.register_autograd
 @torch.library.custom_op("mylib::numpy_sin", mutates_args=())
 def numpy_sin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-    x_np = x.cpu()
-    y_np = y.cpu()
-    out_np = torch.sin(x_np) + torch.sin(y_np)
-    return out_np
+    x_np = x.cpu().numpy()
+    y_np = y.cpu().numpy()
+    out_np = np.sin(x_np) + np.sin(y_np)
+    return torch.from_numpy(out_np).to(device=x.device)
 
 
 def setup_context(ctx, inputs, output):

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -34,7 +34,11 @@ from torch.distributed.tensor._ops.utils import (
     register_op_strategy,
     replicate_op_strategy,
 )
-from torch.distributed.tensor.debug import CommDebugMode
+from torch.distributed.tensor.debug import (
+    _clear_fast_path_sharding_prop_cache,
+    _clear_python_sharding_prop_cache,
+    CommDebugMode,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -384,10 +388,10 @@ class TestCostModel(DTensorOpTestBase):
 # reference: https://docs.pytorch.org/docs/stable/library.html#torch.library.register_autograd
 @torch.library.custom_op("mylib::numpy_sin", mutates_args=())
 def numpy_sin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-    x_np = x.cpu().numpy()
-    y_np = y.cpu().numpy()
-    out_np = np.sin(x_np) + np.sin(y_np)
-    return torch.from_numpy(out_np).to(device=x.device)
+    x_np = x.cpu()
+    y_np = y.cpu()
+    out_np = torch.sin(x_np) + torch.sin(y_np)
+    return out_np
 
 
 def setup_context(ctx, inputs, output):
@@ -479,7 +483,8 @@ def op_strategy_context(op_overload, strategy_func, schema_info=None):
                 del propagator.op_to_schema_info[op_overload]
         else:
             propagator.op_to_schema_info[op_overload] = _origin_op_strategy_schema
-        propagator.propagate_op_sharding.cache.cache_clear()
+        _clear_fast_path_sharding_prop_cache()
+        _clear_python_sharding_prop_cache()
 
 
 def detect_exists_identical_opspec(*args, op, mesh, strategy_function) -> bool:
@@ -643,6 +648,28 @@ class TestStrategyHashing(DTensorTestBase):
         with op_strategy_context(torch.ops.aten.sort.default, replicate_op_strategy):
             out2, _ = torch.sort(sharded_dtensor, dim=1)
         self.assertEqual(out1.full_tensor(), out2.full_tensor())
+
+
+class TestStrategyOperation(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 2
+
+    @with_comms
+    def test_cache_clean(self):
+        mesh = self.build_device_mesh()
+        test_op = torch.ops.mylib.numpy_sin
+        x = torch.randn(2, device=self.device_type)
+        y = torch.randn(2, device=self.device_type)
+        x_dt = distribute_tensor(x, mesh, [Shard(0)])
+        y_dt = distribute_tensor(y, mesh, [Shard(0)])
+        with op_strategy_context(test_op.default, replicate_op_strategy):
+            self._test_op_on_dtensor(test_op, x_dt, y_dt)
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            f"Operator {test_op.default} does not have a sharding strategy registered",
+        ):
+            self._test_op_on_dtensor(test_op, x_dt, y_dt)
 
 
 DistTensorReplicateStrategyRegistrationTestWithLocalTensor = (

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -46,7 +46,6 @@
 #include <ATen/ATen.h>
 
 #include <structmember.h>
-#include <csignal>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -1278,7 +1277,7 @@ get_thread_local_native_sharding_propagator_cache() {
     py::dict thread_dict =
         py::reinterpret_borrow<py::dict>(PyThreadState_GetDict());
     // We need to clean up before Python detaches from the thread if
-    // the thread is being destroyed. There is a chance that
+    // the thread is being destroyed.
     if (!thread_dict.contains("__DTensor_fastpath_thread_cache_cleanup")) {
       thread_dict["__DTensor_fastpath_thread_cache_cleanup"] =
           py::capsule(new std::thread::id(this_thread_id), [](void* p) {


### PR DESCRIPTION
This is the necessary fix for https://github.com/meta-pytorch/autoparallel/issues/256.

### Issue: 
when we call `_clear_fast_path_sharding_prop_cache()`, and then `get_thread_local_native_sharding_propagator_cache()`, the code will stuck due to deadlock.

### Cause: 
When you assign to a Python dict key that already exists:
```C++
thread_dict["__DTensor_fastpath_thread_cache_cleanup"] = old_capsule  // capsule #1 stored
...
clear_DTensor_sharding_propagator_cache() // call to clean up the cache
...
get_thread_local_native_sharding_propagator_cache() {
  std::lock_guard<std::mutex> lock(
        native_sharding_propagator_cache_cleanup_mutex);  // FIRST claims the lock!
  if (!native_sharding_propagator_cache_DO_NOT_USE.has_value()) { // enter this again because we have cleared the cache.
    ...
    // Destroys old_capsule FIRST then stores new_capsule. However, where we destroy the old_capsule, 
    // it will trigger the destructor to claim `native_sharding_propagator_cache_cleanup_mutex` again!
    thread_dict["__DTensor_fastpath_thread_cache_cleanup"] = new_capsule  // SECOND claims the lock before FIRST releases
  }
}
```



cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci