### PR TITLE
Replace uses of `thrust::pair` and `thrust::tuple` with `cuda::std::` ones

### DIFF
--- a/.claude/skills/at-dispatch-v2/SKILL.md
+++ b/.claude/skills/at-dispatch-v2/SKILL.md
@@ -141,7 +141,7 @@ AT_DISPATCH_V2(
       gpu_reduce_kernel<scalar_t, scalar_t>(
         iter,
         MinOps<scalar_t>{},
-        thrust::pair<scalar_t, int64_t>(upper_bound(), 0)  // Commas inside!
+        cuda::std::pair<scalar_t, int64_t>(upper_bound(), 0)  // Commas inside!
       );
     }),
     AT_EXPAND(AT_ALL_TYPES)

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -16,7 +16,7 @@
 #include <ATen/native/hip/DeviceSqrt.cuh>
 #endif
 #if defined(__CUDACC__) || defined(__HIPCC__)
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 #else
 #include <cmath>
 #define device_sqrt std::sqrt
@@ -68,7 +68,7 @@ namespace at::native {
 namespace detail {
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
-template <typename T1, typename T2> using pair = thrust::pair<T1, T2>;
+template <typename T1, typename T2> using pair = cuda::std::pair<T1, T2>;
 #else
 template <typename T1, typename T2> using pair = std::pair<T1, T2>;
 #endif

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -326,7 +326,7 @@ void cpu_kernel(TensorIteratorBase& iter, func_t&& op, int64_t grain_size = at::
 // of `multiple_outputs_loop` returns `std::tuple` instead of `scalar_t`.
 // The `gpu_kernel_multiple_outputs` is also implemented without this check,
 // We could extend `needs_dynamic_casting` to support both `std::tuple` and
-// `thrust::tuple` in the future.
+// `cuda::std::tuple` in the future.
 template <typename func_t>
 void cpu_kernel_multiple_outputs(TensorIteratorBase& iter, func_t&& op, int64_t grain_size = at::internal::GRAIN_SIZE) {
   using traits = function_traits<func_t>;

--- a/aten/src/ATen/native/cuda/ActivationEluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationEluKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationGluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGluKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationMishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationMishKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -5,7 +5,7 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -33,7 +33,7 @@ void prelu_kernel(TensorIterator &iter) {
 void prelu_backward_kernel(TensorIterator &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "prelu_backward_cuda", [&] {
     gpu_kernel_multiple_outputs(iter,
-      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> thrust::tuple<scalar_t, scalar_t> {
+      [] GPU_LAMBDA (scalar_t input, scalar_t weight, scalar_t grad) -> cuda::std::tuple<scalar_t, scalar_t> {
         auto mask = input > 0;
         auto grad_input = mask ? grad : weight * grad;
         auto grad_weight = mask ? scalar_t{0} : input * grad;

--- a/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
@@ -5,8 +5,6 @@
 
 #include <cmath>
 
-#include <thrust/tuple.h>
-
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/TensorBase.h>

--- a/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
+++ b/aten/src/ATen/native/cuda/CompositeRandomAccessor.h
@@ -2,17 +2,17 @@
 
 #include <ATen/native/CompositeRandomAccessorCommon.h>
 #include <thrust/swap.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace at { namespace native {
 
 struct TupleInfoCPU {
   template <typename ...Types>
-  using tuple = thrust::tuple<Types...>;
+  using tuple = cuda::std::tuple<Types...>;
 
   template <typename ...Types>
   static constexpr auto tie(Types&... args) noexcept {
-    return thrust::tie(args...);
+    return cuda::std::tie(args...);
   }
 };
 
@@ -29,8 +29,8 @@ void swap(
 }
 
 template <int N, typename Values, typename References>
-auto get(references_holder<Values, References> rh) -> decltype(thrust::get<N>(rh.data())) {
-  return thrust::get<N>(rh.data());
+auto get(references_holder<Values, References> rh) -> decltype(cuda::std::get<N>(rh.data())) {
+  return cuda::std::get<N>(rh.data());
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/MemoryAccess.cuh>
 
 #include <tuple>
-
-
+#include <cuda/std/tuple>
 
 namespace at::native {
 
@@ -256,10 +255,10 @@ void gpu_kernel_with_scalars(TensorIteratorBase& iter, const func_t& f) {
 
 namespace { // functions for `gpu_kernel_multiple_outputs`.
 
-// check the return type is `thrust::tuple`, not `std::tuple`.
+// check the return type is `cuda::std::tuple`, not `std::tuple`.
 template <typename T> struct is_tuple: std::false_type {};
 
-template <typename ...T> struct is_tuple<thrust::tuple<T...>>: std::true_type {};
+template <typename ...T> struct is_tuple<cuda::std::tuple<T...>>: std::true_type {};
 
 template <int num_outputs, typename func_t, typename array_t, typename inp_calc_t, typename out_calc_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
@@ -281,8 +280,8 @@ template <typename func_t>
 void gpu_kernel_multiple_outputs_impl(TensorIteratorBase& iter, const func_t& f) {
   using traits = function_traits<func_t>;
   using output_t = typename traits::result_type;
-  static_assert(is_tuple<output_t>::value, "f's return type must be `thrust::tuple`");
-  constexpr int num_outputs = thrust::tuple_size<output_t>::value;
+  static_assert(is_tuple<output_t>::value, "f's return type must be `cuda::std::tuple`");
+  constexpr int num_outputs = cuda::std::tuple_size<output_t>::value;
   constexpr int num_inputs = traits::arity;
   constexpr int ntensors = num_outputs + num_inputs;
 

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -11,7 +11,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/thread_constants.h>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 // References:
 // https://devblogs.nvidia.com/cuda-pro-tip-increase-performance-with-vectorized-memory-access/
@@ -106,10 +106,10 @@ struct multi_outputs_store_helper {
   C10_HOST_DEVICE static void apply(
       const data_t& data,
       const offsets_t& offsets,
-      thrust::tuple<Args...> ret) {
-    using T = typename thrust::tuple_element<current, thrust::tuple<Args...>>::type;
+      cuda::std::tuple<Args...> ret) {
+    using T = typename cuda::std::tuple_element<current, cuda::std::tuple<Args...>>::type;
     T *to = reinterpret_cast<T *>(data[current]) + offsets[current];
-    *to = thrust::get<current>(ret);
+    *to = cuda::std::get<current>(ret);
   }
 };
 

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -34,6 +34,8 @@
 #include <ATen/ops/scalar_tensor.h>
 #endif
 
+#include <cuda/std/tuple>
+
 namespace at::native {
 
 namespace {
@@ -367,9 +369,9 @@ void batch_norm_update_stats(
       const auto momentum = static_cast<acc_t>(momentum_);
       gpu_kernel_multiple_outputs(
           iter, [=] GPU_LAMBDA (acc_t mean, acc_t var, scalar_t running_mean, scalar_t running_var)
-               -> thrust::tuple<scalar_t, scalar_t> {
+               -> cuda::std::tuple<scalar_t, scalar_t> {
         const auto unbiased_var = var * bessel_correction_factor;
-        return thrust::tuple<scalar_t, scalar_t>{
+        return cuda::std::tuple<scalar_t, scalar_t>{
           mean * momentum + (1 - momentum) * running_mean,
           unbiased_var * momentum + (1 - momentum) * running_var,
         };
@@ -403,9 +405,9 @@ void batch_norm_update_stats_and_invert(
       const auto momentum = static_cast<acc_t>(momentum_);
       gpu_kernel_multiple_outputs(
           iter, [=] GPU_LAMBDA (acc_t mean, acc_t var, scalar_t running_mean, scalar_t running_var)
-               -> thrust::tuple<scalar_t, scalar_t, acc_t> {
+               -> cuda::std::tuple<scalar_t, scalar_t, acc_t> {
         const auto unbiased_var = var * bessel_correction_factor;
-        return thrust::tuple<scalar_t, scalar_t, acc_t>{
+        return cuda::std::tuple<scalar_t, scalar_t, acc_t>{
           mean * momentum + (1 - momentum) * running_mean,
           unbiased_var * momentum + (1 - momentum) * running_var,
           c10::cuda::compat::rsqrt(var + eps)

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -15,7 +15,7 @@
 #include <iosfwd>
 #include <type_traits>
 #include <utility>
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 
 #include <ATen/native/cuda/jit_utils.h>
 #include <ATen/native/cuda/KernelUtils.cuh>
@@ -760,7 +760,7 @@ struct ReduceOp {
 
   //Currently implemented for max of two outputs
   template<class T1, class T2>
-  C10_DEVICE void set_results(const thrust::pair<T1, T2> x, const index_t base_offset) const {
+  C10_DEVICE void set_results(const cuda::std::pair<T1, T2> x, const index_t base_offset) const {
     if (noutputs >= 1) {
       auto res0 = (T1*)((char*)dst[0] + base_offset);
       *res0 = x.first;

--- a/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
@@ -22,7 +22,7 @@ void _min_max_values_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinMaxOps<scalar_t, scalar_t, int32_t>{},
-      thrust::pair<scalar_t, scalar_t>(
+      cuda::std::pair<scalar_t, scalar_t>(
           at::numeric_limits<scalar_t>::upper_bound(),
           at::numeric_limits<scalar_t>::lower_bound()));
 }
@@ -40,7 +40,7 @@ void aminmax_launch_kernel(TensorIterator& iter) {
         gpu_reduce_kernel<scalar_t, scalar_t>(
             iter,
             MinMaxOps<scalar_t, scalar_t, int32_t>{},
-            thrust::pair<scalar_t, scalar_t>(
+            cuda::std::pair<scalar_t, scalar_t>(
                 at::numeric_limits<scalar_t>::upper_bound(),
                 at::numeric_limits<scalar_t>::lower_bound()));
       });

--- a/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <cuda/std/utility>
+
 namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>
@@ -22,7 +24,7 @@ void argmax_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMaxOps<acc_t>{},
-      thrust::pair<acc_t, int64_t>(
+      cuda::std::pair<acc_t, int64_t>(
           at::numeric_limits<acc_t>::lower_bound(), 0));
 };
 

--- a/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <cuda/std/utility>
+
 namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>
@@ -22,7 +24,7 @@ void argmin_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMinOps<acc_t>{},
-      thrust::pair<acc_t, int64_t>(
+      cuda::std::pair<acc_t, int64_t>(
           at::numeric_limits<acc_t>::upper_bound(), 0));
 };
 

--- a/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <cuda/std/utility>
+
 namespace at::native {
 
 template <typename acc_t>
@@ -45,7 +47,7 @@ void max_launch_kernel(TensorIterator& iter) {
         gpu_reduce_kernel<scalar_t, scalar_t>(
             iter,
             MaxOps<scalar_t>{},
-            thrust::pair<scalar_t, int64_t>(
+            cuda::std::pair<scalar_t, int64_t>(
                 at::numeric_limits<scalar_t>::lower_bound(), 0));
       });
 }

--- a/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
@@ -15,6 +15,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <cuda/std/utility>
 
 namespace at::native {
 
@@ -43,7 +44,7 @@ void min_launch_kernel(TensorIterator &iter) {
     gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinOps<scalar_t>{},
-      thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
+      cuda::std::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
   });
 }
 

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -8,6 +8,8 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/ReduceOps.h>
 
+#include <cuda/std/utility>
+
 namespace at::native {
 
 template <typename scalar_t, typename out_t=scalar_t>
@@ -15,7 +17,7 @@ void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt
   // reducing unrolling factor to 2 for welford kernel
   // This is necessary to lower register usage that leads to register spills.
   using accscalar_t = at::acc_type<scalar_t, true>;
-  using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, thrust::pair<out_t, out_t>>;
+  using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, cuda::std::pair<out_t, out_t>>;
   ops_t ops(static_cast<accscalar_t>(correction), take_sqrt);
   gpu_reduce_kernel<scalar_t, out_t, 2>(iter, ops, typename ops_t::acc_t{});
 }

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -23,7 +23,7 @@
 #include <ATen/ops/reflection_pad3d_backward_native.h>
 #endif
 
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 
 namespace at::native {
 namespace {
@@ -31,7 +31,7 @@ namespace {
 using at::cuda::detail::canUse32BitIndexMath;
 
 __device__
-inline thrust::pair<int64_t, int64_t> get_index_mapping1d(
+inline cuda::std::pair<int64_t, int64_t> get_index_mapping1d(
     int64_t input_w, int64_t output_w,
     int64_t output_x,
     int64_t pad_l) {
@@ -50,13 +50,13 @@ inline thrust::pair<int64_t, int64_t> get_index_mapping1d(
                     + 2 * pad_l + input_w - 1
                     - o_start_x + i_start_x;
 
-  return thrust::make_pair<int64_t, int64_t>(
+  return cuda::std::make_pair<int64_t, int64_t>(
     input_offset + input_x, output_offset + output_x);
 }
 
 
 __device__
-inline thrust::pair<int64_t, int64_t>  get_index_mapping2d(
+inline cuda::std::pair<int64_t, int64_t>  get_index_mapping2d(
     int64_t input_dim_x, int64_t input_dim_y,
     int64_t output_dim_x, int64_t output_dim_y,
     int64_t pad_l, int64_t pad_t,
@@ -87,7 +87,7 @@ inline thrust::pair<int64_t, int64_t>  get_index_mapping2d(
                  + 2 * pad_t + input_dim_y - 1
                  - o_start_y + i_start_y;
 
-  return thrust::make_pair<int64_t, int64_t>(
+  return cuda::std::make_pair<int64_t, int64_t>(
     input_offset + input_y * input_dim_x + input_x,
     output_offset + output_y * output_dim_x + output_x);
 }

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -18,6 +18,8 @@
 #include <c10/core/Scalar.h>
 #include <c10/util/complex.h>
 
+#include <cuda/std/utility>
+
 namespace at::native {
 
 void bitwise_not_kernel_cuda(TensorIteratorBase& iter) {
@@ -267,7 +269,7 @@ void frexp_kernel_cuda(TensorIteratorBase& iter) {
     // It's a floating point type and must be the same as the input's dtype.
     iter.dtype(),
     "frexp_cuda", [&]() {
-      gpu_kernel_multiple_outputs(iter, [=] GPU_LAMBDA (scalar_t a) -> thrust::tuple<scalar_t, int32_t> {
+      gpu_kernel_multiple_outputs(iter, [=] GPU_LAMBDA (scalar_t a) -> cuda::std::tuple<scalar_t, int32_t> {
         int32_t exponent;
         scalar_t mantissa = std::frexp(a, &exponent);
         return {mantissa, exponent};

--- a/aten/src/ATen/native/cuda/block_reduce.cuh
+++ b/aten/src/ATen/native/cuda/block_reduce.cuh
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <thrust/tuple.h>
-
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/cuda/DeviceUtils.cuh>
 

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -3,7 +3,7 @@
 
 #include <type_traits>
 
-#include <thrust/tuple.h>
+#include <cuda/std/pair>
 
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
@@ -38,7 +38,7 @@ __global__ void RowwiseMomentsCUDAKernel(
   using T_ACC = acc_type<T, true>;
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp =
-      WelfordOps<T_ACC, T_ACC, int64_t, thrust::pair<T_ACC, T_ACC>>;
+      WelfordOps<T_ACC, T_ACC, int64_t, cuda::std::pair<T_ACC, T_ACC>>;
 
   const int64_t i = blockIdx.x;
   WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false};
@@ -65,7 +65,7 @@ __global__ void RowwiseMomentsCUDAKernel(
   if (threadIdx.x == 0) {
     T_ACC m1;
     T_ACC m2;
-    thrust::tie(m2, m1) = welford_op.project(val);
+    cuda::std::tie(m2, m1) = welford_op.project(val);
     mean[i] = m1;
     rstd[i] = c10::cuda::compat::rsqrt(m2 + static_cast<T_ACC>(eps));
   }

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -3,7 +3,7 @@
 
 #include <type_traits>
 
-#include <thrust/tuple.h>
+#include <cuda/std/utility>
 
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
@@ -64,7 +64,7 @@ __global__ void RowwiseMomentsCUDAKernel(
     T_ACC* rstd) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
   using WelfordOp =
-      WelfordOps<T_ACC, T_ACC, int64_t, thrust::pair<T_ACC, T_ACC>>;
+      WelfordOps<T_ACC, T_ACC, int64_t, cuda::std::pair<T_ACC, T_ACC>>;
 
   __shared__
       typename std::aligned_storage<sizeof(WelfordType), alignof(WelfordType)>::
@@ -88,7 +88,7 @@ __global__ void RowwiseMomentsCUDAKernel(
   if (threadIdx.x == 0) {
     T_ACC m1;
     T_ACC m2;
-    thrust::tie(m2, m1) = welford_op.project(val);
+    cuda::std::tie(m2, m1) = welford_op.project(val);
     if constexpr (!rms_norm){
       mean[i] = m1;
       rstd[i] = c10::cuda::compat::rsqrt(m2 + eps);

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -544,11 +544,11 @@ struct ReduceJitOp {
     *res = x;
   }
 
-//TODO - multi-output reduction - we won't be able to use thrust::pair
+//TODO - multi-output reduction - we won't be able to use cuda::std::pair
 //just explicitly specify typed output reads/writes
 //Currently implemented for max of two outputs
 //   template<class T1, class T2>
-//   C10_DEVICE void set_results(const thrust::pair<T1, T2> x, const index_t base_offset) const {
+//   C10_DEVICE void set_results(const cuda::std::pair<T1, T2> x, const index_t base_offset) const {
 //     if (noutputs >= 1) {
 //       auto res0 = (T1*)((char*)dst[0] + base_offset);
 //       *res0 = x.first;

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -3,7 +3,7 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/native/quantized/FakeQuantAffine.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 #include <cmath>
 
 /* Fake quantize a tensor
@@ -39,7 +39,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> cuda::std::tuple<scalar_t, bool> {
           const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
           return {
             // fake_quantized value
@@ -54,7 +54,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> cuda::std::tuple<scalar_t, bool> {
           const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
           return {
             // fake_quantized value
@@ -91,7 +91,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> cuda::std::tuple<scalar_t, bool> {
           if (*fake_quant_on == 0) {
             return {input_val, 1};
           }
@@ -110,7 +110,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
       gpu_kernel_multiple_outputs(
         iter,
-        [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        [=] GPU_LAMBDA (scalar_t input_val) -> cuda::std::tuple<scalar_t, bool> {
           if (*fake_quant_on == 0) {
             return {input_val, 1};
           }
@@ -139,7 +139,7 @@ void _fake_quantize_grad_learnable_tensor_kernel_cuda(
   float dscale_small = quant_min - zero_point;
   float dscale_big = quant_max - zero_point;
   gpu_kernel_multiple_outputs(
-    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> thrust::tuple<float, float, float> {
+    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> cuda::std::tuple<float, float, float> {
       float dXOutput, dZeroPointOutput, dScaleOutput;
       int64_t xq = std::nearbyint(XInput * inv_scale) + zero_point;
       dXOutput = dYInput * (xq >= quant_min && xq <= quant_max);
@@ -234,7 +234,7 @@ void fake_quant_per_channel_cachemask_cuda(
 
 void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max, float grad_factor) {
   gpu_kernel_multiple_outputs(iter,
-    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> thrust::tuple<float, float, float> {
+    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> cuda::std::tuple<float, float, float> {
       float dx_output, dscale_output, dzero_point_output;
       float inv_scale = 1.0f / scale_input;
       float dscale_small = quant_min - zero_point_input;

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -36,6 +36,8 @@
 #include <thrust/binary_search.h>
 #include <c10/macros/Macros.h>
 
+#include <cuda/std/utility>
+
 namespace at::native {
 
 using namespace at::sparse;
@@ -89,7 +91,7 @@ SparseTensor _coalesce_sparse_cuda(const SparseTensor& self) {
   );
 
   // this forces device-host synchronization!
-  thrust::pair<thrust_ptr, thrust_ptr> newEnd = thrust::unique_by_key(policy,
+  cuda::std::pair<thrust_ptr, thrust_ptr> newEnd = thrust::unique_by_key(policy,
     indicesIter, indicesIter + nnz,
     uniqueOffsetsIter
   );


### PR DESCRIPTION
Both `thrust::pair` and `thrust::tuple` are aliases for `cuda::std::pair` and `cuda::std::tuple`

They will be removed in a future version of CCCL, so move to the proper standard conforming ones

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01