### PR TITLE
Do not autolabel PRs with `oncall:distributed`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -91,13 +91,6 @@
 "ciflow/trunk":
 - .ci/docker/ci_commit_pins/triton.txt
 
-"oncall: distributed":
-- torch/csrc/distributed/**
-- torch/distributed/**
-- torch/nn/parallel/**
-- test/distributed/**
-- torch/testing/_internal/distributed/**
-
 "release notes: distributed (checkpoint)":
 - torch/distributed/checkpoint/**
 - test/distributed/checkpoint/**


### PR DESCRIPTION
Removed distributed related paths from labeler configuration.
