### PR TITLE
Improve error message for unsupported old_arg type in export

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -610,7 +610,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
             return SymFloatArgument(name=new_ph.name)
         elif isinstance(old_arg, SymBoolArgument):
             return SymBoolArgument(name=new_ph.name)
-        raise RuntimeError(f"Type of old_arg not supported: {type(old_arg)}")
+        raise RuntimeError(f"Type of old_arg not supported: {type(old_arg).__name__} (got {old_arg})")
 
     new_placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]
     new_outputs: tuple[torch.fx.Node, ...] = tuple(gm.graph.output_node().args[0])  # type: ignore[arg-type]


### PR DESCRIPTION
# Improve error message in ExportedProgram for unsupported argument types

## Summary

This PR improves the error message when an unsupported argument type is encountered in `ExportedProgram._decompose_and_get_gm_with_new_signature_constants`. The error message now includes both the type name and the actual value, making debugging easier.

## Changes

**File Modified**: `torch/export/exported_program.py` (line 613)

**Change**: Updated error message to include type name and actual value

**Before**:
```python
raise RuntimeError(f"Type of old_arg not supported: {type(old_arg)}")
```

**After**:
```python
raise RuntimeError(
    f"Type of old_arg not supported: {type(old_arg).__name__} (got {old_arg})"
)
```

## Motivation

When this error occurs, the current message shows `<class 'SomeType'>` which is less readable. The improved message:
- Shows a cleaner type name using `type(old_arg).__name__` instead of the full `<class '...'>` representation
- Includes the actual value that caused the error, which helps with debugging


