### PR TITLE
Use c7i.2xlarge for RISC64 build

### DIFF
--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -20,5 +20,5 @@ jobs:
     with:
       build-environment: linux-noble-riscv64-py3.12-gcc14
       docker-image-name: pytorch-linux-noble-riscv64-py3.12-gcc14
-      runner: linux.2xlarge
+      runner: linux.c7i.2xlarge
     secrets: inherit


### PR DESCRIPTION
The newer generation hardware should run the build faster helping with some cost reduction.

Relates to pytorch/test-infra#7175.
