### PR TITLE
[inductor][heuristics] make exhaustive config pruning optional

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -544,6 +544,13 @@ max_autotune_gemm_search_space: Literal["DEFAULT", "EXHAUSTIVE"] = os.environ.ge
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_SEARCH_SPACE", "DEFAULT"
 ).upper()  # type: ignore[assignment]
 
+
+# Specify whether to prune the search space for GEMM autotuning in Exhaustive based
+# on a heuristic about shared memory usage.
+max_autotune_gemm_prune_exhaustive_configs: bool = (
+    os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_PRUNE_EXHAUSTIVE_CONFIGS", "1")
+) == "1"
+
 # Specify the size of the search space for flex attention autotuning.
 # DEFAULT     - balance between compile time overhead and performance
 # EXHAUSTIVE  - maximize performance

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -739,7 +739,10 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
                 scaled_configs, dtype_size
             )
 
-        if config.max_autotune_gemm_search_space == "EXHAUSTIVE":
+        if (
+            config.max_autotune_gemm_prune_exhaustive_configs
+            and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
+        ):
             assert dtype_size > 0, "dtype_size must be provided for exhaustive search"
             scaled_configs = self._prune_exhaustive_configs(scaled_configs, dtype_size)
         return self._finalize_mm_configs(scaled_configs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168100

# why

- make it possible for workflows to explore the full search space

# what

- make exhaustive config pruning logic conditional on env var/flag
- turn that flag on by default

# testing

```
python3 -bb -m pytest test/inductor/test_max_autotune.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @jataylo @chenyang78

Differential Revision: [D87362465](https://our.internmc.facebook.com/intern/diff/D87362465)