### PR TITLE
[export] Enable context manager returns for dynamo graph capture.

### DIFF
--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -501,6 +501,7 @@ def pytreeify(
     torch._dynamo.eval_frame.check_user_input_output(
         flat_real_args[1 if root else 0 :], UserErrorType.INVALID_INPUT
     )
+    f_globals = out.graph_capture_output.f_globals
 
     class Yield(Exception):
         pass
@@ -522,7 +523,9 @@ def pytreeify(
                 raise Yield
 
             try:
-                out.forward_callable(compiled_fn=backend_dummy)(*args, **kwargs)
+                out.forward_callable(
+                    compiled_fn=backend_dummy, extra_globals=f_globals
+                )(*args, **kwargs)
             except Yield:
                 assert self.gm_inputs is not None
                 return self.gm_inputs
@@ -557,7 +560,9 @@ def pytreeify(
                     for i in range(self.num_outputs)
                 ]
 
-            results = out.forward_callable(compiled_fn=backend_dummy)(*args, **kwargs)
+            results = out.forward_callable(
+                compiled_fn=backend_dummy, extra_globals=f_globals
+            )(*args, **kwargs)
             ret, self.out_spec = pytree.tree_flatten(results)
             return ret
 
@@ -606,7 +611,6 @@ def dynamo_graph_capture_for_export(
     def inner(*args: Any, **kwargs: Any) -> Any:
         assert not torch._dynamo.config.install_free_tensors
         with (
-            torch._dynamo.config.patch(replay_side_effects=False),
             torch._dynamo.config.patch(side_effect_replay_policy="warn"),
             get_metrics_context(),
             dynamo_timed("fullgraph_capture"),

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -851,7 +851,9 @@ def _export_to_torch_ir(
                             f, constraints=constraints, dynamic_shapes=dynamic_shapes
                         )
                     else:
-                        dynamo_graph_capture = dynamo_graph_capture_for_export(f)
+                        dynamo_graph_capture = torch._dynamo.config.patch(
+                            replay_side_effects=False
+                        )(dynamo_graph_capture_for_export(f))
                     # We can't serialize entire fake mode yet, so this is to make sure
                     # things like copy.deepcopy(ep.graph_module) not crash.
                     # see test_export.py::test_custom_tag_metadata_re_export


### PR DESCRIPTION
Summary:
This adds the ability to trace through the code which has context manager enabled
and returned in a user callable.

Since we rely on side effects to return user defined variables, we cannot disable
side effects by default anymore in the short term. So we decide to leave
side effect config up to the caller side of dynamo_graph_capture_for_export,
and still disable it for torch.export by default. In the short term we will
just assume dynamo_graph_capture_for_export is a low level API and it's user
responsibility to control side effect options.

Test Plan:
CI
Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela