### PR TITLE
Fix Inductor Stride Mismatch for torch.fft.ifft 

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4508,6 +4508,7 @@ def inplace_constant_pad_nd(
 @register_lowering(aten.constant_pad_nd, type_promotion_kind=None)
 def constant_pad_nd(x, padding, fill_value=0):
     assert (len(padding) % 2) == 0
+    x = ir.ExternKernel.require_contiguous(x)
     if all(p == 0 for p in padding):
         return clone(x)
 


### PR DESCRIPTION
Fixes #166514

**Problem**

When FFT operations follow convolution layers in a compiled model, the inductor backend may optimize conv2d outputs to non-contiguous layouts. FFT operations decompose into ```constant_pad_nd``` for input resizing, which then receives non-contiguous tensors, causing stride validation errors like:
```expected size 64==64, stride 256==8192 at dim=1```
```Error in op: torch.ops.aten._fft_r2c.default```

**Solution**

Added ```ir.ExternKernel.require_contiguous(x)``` at the beginning of the ```constant_pad_nd``` lowering function. This ensures padding operations receive contiguous inputs, preventing stride mismatches when tensors flow through FFT decompositions. 
Test case added to verify correct behavior with conv2d → FFT patterns.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78

@vishalgoyal316 @cleonard530 @abhitorch81 @gaurav-redhat @morrison-turnansky @skpark-rh 