### PR TITLE
[inductor] make mix order reduction work with dynamic shapes

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -408,7 +408,7 @@ class MixOrderReductionTest(TestBase):
             out.backward(dy)
             return x.grad, w.grad
 
-        M0, M1, N = 1151, 1023, 256
+        M0, M1, N = 251, 223, 128
         wbdtype = torch.float
         xdtype = torch.float
         x = torch.randn(M0, M1, N, dtype=xdtype, device=GPU_TYPE, requires_grad=True)

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -397,6 +397,37 @@ class MixOrderReductionTest(TestBase):
             metrics.codegen_mix_order_reduction,
         )
 
+    def test_layer_norm_bwd_with_dynamic_shape(self):
+        def f(x, w, eps):
+            return F.layer_norm(x, x.shape[-1:], weight=w, bias=None, eps=eps)
+
+        def fwd_bwd(f):
+            x.grad = None
+            w.grad = None
+            out = f(x, w, eps)
+            out.backward(dy)
+            return x.grad, w.grad
+
+        M0, M1, N = 1152, 1024, 256
+        wbdtype = torch.float
+        xdtype = torch.float
+        x = torch.randn(M0, M1, N, dtype=xdtype, device=GPU_TYPE, requires_grad=True)
+        torch._dynamo.mark_dynamic(x, 0)
+        w = torch.randn(N, dtype=wbdtype, device=GPU_TYPE, requires_grad=True)
+        dy = torch.randn_like(x)
+        eps = 1e-5
+
+        opt_f = torch.compile(f)
+
+        ref = fwd_bwd(f)
+        act, (_, bwd_wrapper) = utils.run_and_get_code(fwd_bwd, opt_f)
+
+        self.assertTrue(same(ref, act, tol=1e-2), f"ref:\n{ref}\nact:\n{act}")
+        self.assertEqual(
+            inductor_config.triton.mix_order_reduction,
+            metrics.codegen_mix_order_reduction,
+        )
+
     @parametrize("split_reductions", (False, True))
     @parametrize("shape", ((32768, 768), (32769, 768)))
     def test_layer_norm_bwd_no_bias(self, split_reductions, shape):

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -408,7 +408,7 @@ class MixOrderReductionTest(TestBase):
             out.backward(dy)
             return x.grad, w.grad
 
-        M0, M1, N = 1152, 1024, 256
+        M0, M1, N = 1151, 1023, 256
         wbdtype = torch.float
         xdtype = torch.float
         x = torch.randn(M0, M1, N, dtype=xdtype, device=GPU_TYPE, requires_grad=True)

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -565,9 +565,7 @@ class InductorChoices:
             # For mix order reduction, we disregard shared data or
             # distance.
             return True
-        if (
-            shared_data_score < config.score_fusion_memory_threshold
-        ):
+        if shared_data_score < config.score_fusion_memory_threshold:
             WhyNoFuse(node1, node2)("score_fusion_memory_threshold")
             return False
         if scheduler.are_long_distant_nodes(node1, node2):
@@ -610,7 +608,7 @@ class InductorChoices:
 
         # pyrefly: ignore [bad-return]
         return (
-            # MixOrderReduction.can_fuse(node1, node2),
+            MixOrderReduction.can_fuse(node1, node2),
             template_score,
             node1.is_reduction() == node2.is_reduction() and memory_score > 0,
             memory_score,

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -561,9 +561,13 @@ class InductorChoices:
         shared_data_score: int,
     ) -> bool:
         """Hook for heuristics to prevent horizontal (consumer/consumer) fusions"""
+        if MixOrderReduction.can_fuse(node1, node2):
+            # For mix order reduction, we disregard shared data or
+            # distance.
+            return True
         if (
             shared_data_score < config.score_fusion_memory_threshold
-        ) and not MixOrderReduction.can_fuse(node1, node2):
+        ):
             WhyNoFuse(node1, node2)("score_fusion_memory_threshold")
             return False
         if scheduler.are_long_distant_nodes(node1, node2):
@@ -606,6 +610,7 @@ class InductorChoices:
 
         # pyrefly: ignore [bad-return]
         return (
+            # MixOrderReduction.can_fuse(node1, node2),
             template_score,
             node1.is_reduction() == node2.is_reduction() and memory_score > 0,
             memory_score,

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -608,7 +608,6 @@ class InductorChoices:
 
         # pyrefly: ignore [bad-return]
         return (
-            MixOrderReduction.can_fuse(node1, node2),
             template_score,
             node1.is_reduction() == node2.is_reduction() and memory_score > 0,
             memory_score,

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1739,7 +1739,7 @@ class SIMDScheduling(BaseScheduling):
 
         # a extra round of reduction
         assert len(converted_nodes) == len(kernel.saved_partial_accumulate)
-        nsplit = (numel + split_size - 1) // split_size
+        nsplit = V.graph.wrapper_code.codegen_python_sizevar((numel + split_size - 1) // split_size)
         for idx, partial_accum in enumerate(kernel.saved_partial_accumulate):
             buffer_name = partial_accum.buffer_name
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1732,6 +1732,7 @@ class SIMDScheduling(BaseScheduling):
                 if node.get_outputs()[0].node.get_name() not in rename:
                     node.mark_run()
 
+        self.codegen_comment(node_schedule, None)
         # workspace args is still needed after the call
         kernel.call_kernel(kernel.kernel_name, deallocate_ws=False)
         V.graph.removed_buffers |= kernel.removed_buffers

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1610,13 +1610,7 @@ class SIMDScheduling(BaseScheduling):
     def _codegen_mix_order_reduction(self, node1, node2):
         numel, rnumel = scheduler.MixOrderReduction.get_numel_rnumel(node1)
 
-        # the statically_known_gt works as expected for dynamic shapes
-        # since we already add guards in MixOrderReduction.can_fuse
-        # for dynamic shapes.
-        if not V.graph.sizevars.statically_known_gt(
-            numel,
-            rnumel,
-        ):
+        if not V.graph.sizevars.evaluate_expr(sympy.Gt(numel, rnumel)):
             return self._codegen_mix_order_reduction(node2, node1)
 
         def _pick_split_size():
@@ -1640,10 +1634,7 @@ class SIMDScheduling(BaseScheduling):
         # pyrefly: ignore [bad-assignment]
         metrics.codegen_mix_order_reduction += 1
 
-        assert V.graph.sizevars.statically_known_gt(
-            numel,
-            rnumel,
-        )
+        assert V.graph.sizevars.evaluate_expr(sympy.Gt(numel, rnumel))
 
         # split epilogue out of node2
         node2_reductions, node2_epilogue = self._split_mix_order_reduction_epilogue(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1732,6 +1732,7 @@ class SIMDScheduling(BaseScheduling):
                 if node.get_outputs()[0].node.get_name() not in rename:
                     node.mark_run()
 
+        V.graph.wrapper_code.make_comment("# Call mix order reduction kernel")
         self.codegen_comment(node_schedule, None)
         # workspace args is still needed after the call
         kernel.call_kernel(kernel.kernel_name, deallocate_ws=False)
@@ -1740,7 +1741,9 @@ class SIMDScheduling(BaseScheduling):
 
         # a extra round of reduction
         assert len(converted_nodes) == len(kernel.saved_partial_accumulate)
-        nsplit = V.graph.wrapper_code.codegen_python_sizevar((numel + split_size - 1) // split_size)
+        nsplit = V.graph.wrapper_code.codegen_python_sizevar(
+            (numel + split_size - 1) // split_size
+        )
         for idx, partial_accum in enumerate(kernel.saved_partial_accumulate):
             buffer_name = partial_accum.buffer_name
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -699,7 +699,7 @@ aggressive_fusion = False
 
 # For each fused kernel in the wrapper, comment with the nodes that get fused.
 # Useful for debugging fusion.
-debug_fusion: bool = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION") == "1"
+debug_fusion: bool = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION", "1") == "1"
 benchmark_fusion: bool = os.environ.get("TORCHINDUCTOR_BENCHMARK_FUSION") == "1"
 enabled_metric_tables = os.environ.get("TORCHINDUCTOR_ENABLED_METRIC_TABLES", "")
 loop_ordering_after_fusion: bool = (

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -699,7 +699,7 @@ aggressive_fusion = False
 
 # For each fused kernel in the wrapper, comment with the nodes that get fused.
 # Useful for debugging fusion.
-debug_fusion: bool = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION", "1") == "1"
+debug_fusion: bool = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION") == "1"
 benchmark_fusion: bool = os.environ.get("TORCHINDUCTOR_BENCHMARK_FUSION") == "1"
 enabled_metric_tables = os.environ.get("TORCHINDUCTOR_ENABLED_METRIC_TABLES", "")
 loop_ordering_after_fusion: bool = (

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -254,7 +254,7 @@ class MixOrderReduction:
         # fully cached by L2
         size_thres = 5 * 2**20
 
-        # Call evaluate_expr ratehr than statically_known_geq since nrow can
+        # Call evaluate_expr rather than statically_known_geq since nrow can
         # have dynamic shape in real models.
         # Don't use hint directly since hint can be non-representative.
         if not V.graph.sizevars.evaluate_expr(sympy.Ge(nrow * ncol, size_thres)):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -253,19 +253,23 @@ class MixOrderReduction:
         # small workload. When a workload is small enough, data can be
         # fully cached by L2
         size_thres = 5 * 2**20
-        if not V.graph.sizevars.statically_known_geq(nrow * ncol, size_thres):
+
+        # Call evaluate_expr ratehr than statically_known_geq since nrow can
+        # have dynamic shape in real models.
+        # Don't use hint directly since hint can be non-representative.
+        if not V.graph.sizevars.evaluate_expr(sympy.Ge(nrow * ncol, size_thres)):
             return False
 
         # We require more more row than columns since
         # 1, we prefer doing persistent reduction for each row
         # 2, we will split the reduction across the rows
-        if not V.graph.sizevars.statically_known_geq(nrow, ncol * 2):
+        if not V.graph.sizevars.evaluate_expr(sympy.Ge(nrow, ncol * 2)):
             return False
 
         # When nrow is small, ncol should also be small (due to the check
         # above). Thus the entire tensor should be well cached in L2.
         # Mix order reduction is less beneficial.
-        if not V.graph.sizevars.statically_known_geq(nrow, 4096):
+        if not V.graph.sizevars.evaluate_expr(sympy.Ge(nrow, 4096)):
             return False
 
         contiguous_node, other_node = (
@@ -301,6 +305,8 @@ class MixOrderReduction:
             return False
 
         # rnumel so large that we will not generated persistent reduction
+        # We don't see real use cases with dynamic ncol. But if we do,
+        # we should call evaluete_expr here which adds guards.
         if not V.graph.sizevars.statically_known_leq(ncol, 1024 * 16):
             return False
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2681,9 +2681,6 @@ class Scheduler:
             self.compute_ancestors()
 
         self.nodes = self.fuse_nodes(self.nodes)
-        # n551 = self.name_to_fused_node["op551"]
-        # n552 = self.name_to_fused_node["op552"]
-        # breakpoint()
         if config._post_fusion_custom_pass is not None:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2681,6 +2681,9 @@ class Scheduler:
             self.compute_ancestors()
 
         self.nodes = self.fuse_nodes(self.nodes)
+        # n551 = self.name_to_fused_node["op551"]
+        # n552 = self.name_to_fused_node["op552"]
+        # breakpoint()
         if config._post_fusion_custom_pass is not None:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #168209
* __->__ #168117


Internal models have dynamic shapes for rms/layer norm. Mix order reduction would be by-passed without this PR.

co-author this PR with Paul Zhang.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

Differential Revision: [D87378475](https://our.internmc.facebook.com/intern/diff/D87378475)