### PR TITLE
The Nested Pools and Untangling Graph Capture from User Memory Pools 

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -98,7 +98,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
   // Addendum: beginAllocateStreamToPool is now called before cudaStreamBeginCapture to prevent an
   // autograd thread's free() call triggering an invalid cudaEventRecord in the caching allocator
   // due to the capture status being updated _after_ a capture had already started.
-  c10::cuda::CUDACachingAllocator::beginAllocateToPool(capture_dev_, mempool_id_, [this](cudaStream_t stream) {
+  c10::cuda::CUDACachingAllocator::beginAllocateToGraphPool(capture_dev_, mempool_id_, [this](cudaStream_t stream) {
       cudaStreamCaptureStatus status{};
       CaptureId_t stream_capture_id = 0;
       AT_CUDA_CHECK(cudaStreamGetCaptureInfo(stream, &status, &stream_capture_id));
@@ -124,7 +124,7 @@ void CUDAGraph::capture_end() {
 
   AT_CUDA_CHECK(cudaStreamEndCapture(capture_stream_, &graph_));
 
-  c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
+  c10::cuda::CUDACachingAllocator::endAllocateToGraphPool(capture_dev_, mempool_id_);
 
   TORCH_CHECK(graph_ != nullptr, "Invalid capture.");
 

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -243,6 +243,13 @@ class CUDAAllocator : public DeviceAllocator {
   virtual void endAllocateToPool(
       c10::DeviceIndex device,
       MempoolId_t mempool_id) = 0;
+  virtual void beginAllocateToGraphPool(
+      c10::DeviceIndex device,
+      MempoolId_t mempool_id,
+      std::function<bool(cudaStream_t)> filter) = 0;
+  virtual void endAllocateToGraphPool(
+      c10::DeviceIndex device,
+      MempoolId_t mempool_id) = 0;
   virtual void releasePool(c10::DeviceIndex device, MempoolId_t mempool_id) = 0;
   virtual int getPoolUseCount(
       c10::DeviceIndex /*device*/,
@@ -458,6 +465,19 @@ inline void beginAllocateToPool(
 
 inline void endAllocateToPool(c10::DeviceIndex device, MempoolId_t mempool_id) {
   get()->endAllocateToPool(device, mempool_id);
+}
+
+inline void beginAllocateToGraphPool(
+    c10::DeviceIndex device,
+    MempoolId_t mempool_id,
+    std::function<bool(cudaStream_t)> filter) {
+  get()->beginAllocateToGraphPool(device, mempool_id, std::move(filter));
+}
+
+inline void endAllocateToGraphPool(
+    c10::DeviceIndex device,
+    MempoolId_t mempool_id) {
+  get()->endAllocateToGraphPool(device, mempool_id);
 }
 
 inline void recordHistory(

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -793,15 +793,19 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     return {};
   }
 
+  // When using user pools under cudaMallocAsync, we do nothing,
+  // as all memory is redirected to a single cudaMallocAsync backend pool.
   void beginAllocateToPool(
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
       std::function<bool(cudaStream_t)> /*filter*/) override {
-    // We direct all allocations to the cudaMallocAsync mempool.
+    // No operation required.
   }
 
   void endAllocateToPool(c10::DeviceIndex device, MempoolId_t mempool_id)
-      override {}
+      override {
+    // No operation required.
+  }
 
   // CUDAGraph interactions
   void beginAllocateToGraphPool(

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -793,8 +793,18 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     return {};
   }
 
-  // CUDAGraph interactions
   void beginAllocateToPool(
+      c10::DeviceIndex device,
+      MempoolId_t mempool_id,
+      std::function<bool(cudaStream_t)> /*filter*/) override {
+    // We direct all allocations to the cudaMallocAsync mempool.
+  }
+
+  void endAllocateToPool(c10::DeviceIndex device, MempoolId_t mempool_id)
+      override {}
+
+  // CUDAGraph interactions
+  void beginAllocateToGraphPool(
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
       std::function<bool(cudaStream_t)> /*filter*/) override {
@@ -807,7 +817,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     capture_underway = true;
   }
 
-  void endAllocateToPool(c10::DeviceIndex device, MempoolId_t mempool_id)
+  void endAllocateToGraphPool(c10::DeviceIndex device, MempoolId_t mempool_id)
       override {
     assertValidDevice(device);
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -100,13 +100,14 @@ requiresCppContext = unittest.skipUnless(
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests  # noqa: PLW0127
 
-try:
-    import torchvision.models  # noqa: F401
-    from torchvision.models import resnet18  # noqa: F401
-
-    HAS_TORCHVISION = True
-except ImportError:
-    HAS_TORCHVISION = False
+#try:
+#    import torchvision.models  # noqa: F401
+#    from torchvision.models import resnet18  # noqa: F401
+#
+#    HAS_TORCHVISION = True
+#except ImportError:
+#    HAS_TORCHVISION = False
+HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 TEST_CUDAMALLOCASYNC = TEST_CUDA and (
@@ -5709,6 +5710,38 @@ class TestMemPool(TestCase):
         for p in pools:
             s = p.snapshot()
             self.assertEqual(len(s), 1, "Expected to have a single segment")
+
+    def test_nested_mempool(self):
+        torch.cuda.empty_cache()
+        pool1 = torch.cuda.MemPool()
+        pool2 = torch.cuda.MemPool()
+        pool3 = torch.cuda.MemPool()
+
+        nelem = 1024 * 1024 * 20
+
+        data = []
+        data_ptrs = []
+        def allocate_data():
+            x = torch.empty(nelem, device="cuda")
+            data.append(x)
+            data_ptrs.append(x.data_ptr())
+
+        with torch.cuda.use_mem_pool(pool1):
+            allocate_data()
+            with torch.cuda.use_mem_pool(pool2):
+                allocate_data()
+                with torch.cuda.use_mem_pool(pool3):
+                    allocate_data()
+                allocate_data()
+            allocate_data()
+
+        pool1_segments = torch.cuda.memory.memory_snapshot(pool1.id)
+        pool2_segments = torch.cuda.memory.memory_snapshot(pool2.id)
+        pool3_segments = torch.cuda.memory.memory_snapshot(pool3.id)
+
+        self.assertEqual(len(pool1_segments), 2)
+        self.assertEqual(len(pool2_segments), 2)
+        self.assertEqual(len(pool3_segments), 1)
 
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -101,12 +101,12 @@ requiresCppContext = unittest.skipUnless(
 load_tests = load_tests  # noqa: PLW0127
 
 try:
-   import torchvision.models  # noqa: F401
-   from torchvision.models import resnet18  # noqa: F401
+    import torchvision.models  # noqa: F401
+    from torchvision.models import resnet18  # noqa: F401
 
-   HAS_TORCHVISION = True
+    HAS_TORCHVISION = True
 except ImportError:
-   HAS_TORCHVISION = False
+    HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 TEST_CUDAMALLOCASYNC = TEST_CUDA and (

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -100,14 +100,13 @@ requiresCppContext = unittest.skipUnless(
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests  # noqa: PLW0127
 
-#try:
-#    import torchvision.models  # noqa: F401
-#    from torchvision.models import resnet18  # noqa: F401
-#
-#    HAS_TORCHVISION = True
-#except ImportError:
-#    HAS_TORCHVISION = False
-HAS_TORCHVISION = False
+try:
+   import torchvision.models  # noqa: F401
+   from torchvision.models import resnet18  # noqa: F401
+
+   HAS_TORCHVISION = True
+except ImportError:
+   HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 TEST_CUDAMALLOCASYNC = TEST_CUDA and (

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -267,6 +267,23 @@ void CUDAPluggableAllocator::endAllocateToPool(
   }
 }
 
+void CUDAPluggableAllocator::beginAllocateToGraphPool(
+    c10::DeviceIndex device,
+    c10::cuda::MempoolId_t mempool_id,
+    std::function<bool(cudaStream_t)> filter) {
+  if (begin_allocate_to_pool_fn_) {
+    begin_allocate_to_pool_fn_(device, mempool_id, std::move(filter));
+  }
+}
+
+void CUDAPluggableAllocator::endAllocateToGraphPool(
+    c10::DeviceIndex device,
+    c10::cuda::MempoolId_t mempool_id) {
+  if (end_allocate_to_pool_fn_) {
+    end_allocate_to_pool_fn_(device, mempool_id);
+  }
+}
+
 void CUDAPluggableAllocator::releasePool(
     c10::DeviceIndex device,
     c10::cuda::MempoolId_t mempool_id) {

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -113,6 +113,13 @@ struct TORCH_CUDA_CPP_API CUDAPluggableAllocator
   void endAllocateToPool(
       c10::DeviceIndex device,
       c10::cuda::MempoolId_t mempool_id) override;
+  void beginAllocateToGraphPool(
+      c10::DeviceIndex device,
+      c10::cuda::MempoolId_t mempool_id,
+      std::function<bool(cudaStream_t)> filter) override;
+  void endAllocateToGraphPool(
+      c10::DeviceIndex device,
+      c10::cuda::MempoolId_t mempool_id) override;
   void releasePool(c10::DeviceIndex device, c10::cuda::MempoolId_t mempool_id)
       override;
   std::shared_ptr<void> getIpcDevPtr(std::string handle) override;


### PR DESCRIPTION
This PR fixes issue #161193 by separating two concepts that were previously conflated inside captures_underway:
(1) the single CUDA graph–capture private pool, and
(2) nested eager-mode torch.cuda.use_mem_pool() pools.

As @ngimel pointed out at https://github.com/pytorch/pytorch/issues/167745#issuecomment-3529794532, graph capture can only have one active pool, while user mempools must support stacked nesting. The old shared mechanism could not correctly represent both, and caused nested mempools to mis-route allocations.

This PR introduces an explicit `capturing_graph_pool` for CUDA graph capture, and a separate `pool_stack` for eager-mode mempools. Graph capture now exclusively owns one pool, while eager mempools behave like a proper stack, enabling correct nested semantics. Fast-path behavior for non-capturing allocations is restored, since eager mempools no longer trigger “capture-like” slow paths.

Correctness invariants are now explicit: a graph capture cannot be nested inside a user mempool, and a user mempool cannot be entered during graph capture. These situations previously produced silent misbehavior; they now produce a clear error.

Multi-threaded behavior is safe and well-defined. Each mempool context installs a thread-id–based filter, ensuring that pool redirects remain thread-local. All modifications to capture state and pool stacks remain protected by the allocator’s global mutex, matching the allocator’s existing synchronization model.

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @ngimel @galv 