### PR TITLE
Fix torch.tensor() not creating FakeTensor under FakeTensorMode

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -360,6 +360,33 @@ class FakeTensorTest(TestCase):
         with torch._subclasses.CrossRefFakeMode():
             y = torch.full((4, 4), 1)
 
+    def test_tensor_with_meta_device(self):
+        """Test that torch.tensor() creates FakeTensor when used with device('meta') context manager.
+        
+        This test verifies the fix for issue #139092.
+        """
+        from torch._subclasses.fake_tensor import FakeTensor
+        
+        with FakeTensorMode(), torch.device("meta"):
+            # Test scalar tensor
+            a = torch.tensor(3.0)
+            self.assertTrue(isinstance(a, FakeTensor), 
+                           f"Expected FakeTensor, got {type(a)}")
+            self.assertEqual(a.device.type, "meta")
+            self.assertEqual(a.shape, ())
+            
+            # Test list tensor
+            b = torch.tensor([1.0, 2.0, 3.0])
+            self.assertTrue(isinstance(b, FakeTensor))
+            self.assertEqual(b.device.type, "meta")
+            self.assertEqual(b.shape, (3,))
+            
+            # Test explicit device='meta' (should also work)
+            c = torch.tensor(5.0, device="meta")
+            self.assertTrue(isinstance(c, FakeTensor))
+            self.assertEqual(c.device.type, "meta")
+            self.assertEqual(c.shape, ())
+
     def check_function_with_fake(self, fn):
         out = fn()
         with torch._subclasses.FakeTensorMode():

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -362,25 +362,27 @@ class FakeTensorTest(TestCase):
 
     def test_tensor_with_meta_device(self):
         """Test that torch.tensor() creates FakeTensor when used with device('meta') context manager.
-        
+
         This test verifies the fix for issue #139092.
         """
         from torch._subclasses.fake_tensor import FakeTensor
-        
+
         with FakeTensorMode(), torch.device("meta"):
             # Test scalar tensor
             a = torch.tensor(3.0)
-            self.assertTrue(isinstance(a, FakeTensor), 
-                           f"Expected FakeTensor, got {type(a)}")
+            self.assertTrue(
+                isinstance(a, FakeTensor),
+                f"Expected FakeTensor, got {type(a)}",
+            )
             self.assertEqual(a.device.type, "meta")
             self.assertEqual(a.shape, ())
-            
+
             # Test list tensor
             b = torch.tensor([1.0, 2.0, 3.0])
             self.assertTrue(isinstance(b, FakeTensor))
             self.assertEqual(b.device.type, "meta")
             self.assertEqual(b.shape, (3,))
-            
+
             # Test explicit device='meta' (should also work)
             c = torch.tensor(5.0, device="meta")
             self.assertTrue(isinstance(c, FakeTensor))

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6811,22 +6811,13 @@ def _internal_new_from_data(
         return NotImplemented
     else:
         if torch.device(device).type == "meta":
-            # Check if FakeTensorMode is active. If so, we need to handle meta device
-            # using the Python path so that FakeTensorMode can wrap the result.
-            # Otherwise, fall back to C++ implementation.
             from torch._guards import active_fake_mode
-            
-            fake_mode = active_fake_mode()
-            if fake_mode is None:
+
+            # If FakeTensorMode is *not* active, keep old behavior: delegate to C++.
+            if active_fake_mode() is None:
                 return NotImplemented
-            
-            # FakeTensorMode is active, so create tensor on meta device using Python path
-            # This allows FakeTensorMode to intercept and wrap it as a FakeTensor
-            tensor = _recursive_build(inferred_scalar_type, data)
-            tensor = tensor.to(device, inferred_scalar_type, non_blocking=False, copy=False)
-            # FakeTensorMode will automatically wrap meta tensors when they're returned
-            # from operations, so we don't need to manually wrap here
-            return tensor
+            # If FakeTensorMode *is* active, just fall through to the normal Python path
+            # below so it can intercept the ops.
 
         # In the C implementation, we would directly start poking the memory
         # of a freshly allocated CPU tensor.  Here, we're going to do an

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6802,7 +6802,15 @@ def _internal_new_from_data(
 
     # TODO: test for numpy input with PyArray_Check
 
-    device = device_opt if device_opt is not None else options["device"]
+    # Resolve device: check explicit device_opt, then default device from context manager,
+    # then fall back to options["device"]
+    if device_opt is not None:
+        device = device_opt
+    else:
+        # Check for default device from torch.device() context manager
+        # This handles the case: with torch.device("meta"): torch.tensor(3.0)
+        default_device = torch.get_default_device()
+        device = default_device if default_device.type != "cpu" else options["device"]
     inferred_scalar_type = _infer_scalar_type(data) if type_inference else scalar_type
 
     # NB: Don't need to avoid tracing, as we aren't going to do any manual

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6811,6 +6811,9 @@ def _internal_new_from_data(
         # This handles the case: with torch.device("meta"): torch.tensor(3.0)
         default_device = torch.get_default_device()
         device = default_device if default_device.type != "cpu" else options["device"]
+
+    # Normalize device to ensure it's always a device object
+    device = torch.device(device)
     inferred_scalar_type = _infer_scalar_type(data) if type_inference else scalar_type
 
     # NB: Don't need to avoid tracing, as we aren't going to do any manual
@@ -6818,7 +6821,7 @@ def _internal_new_from_data(
     if _isStorage(data):
         return NotImplemented
     else:
-        if torch.device(device).type == "meta":
+        if device.type == "meta":
             from torch._guards import active_fake_mode
 
             # If FakeTensorMode is *not* active, keep old behavior: delegate to C++.


### PR DESCRIPTION
## Summary

Fixes #139092

When `torch.tensor()` is called with `device='meta'` under `FakeTensorMode`, it doesn't create a `FakeTensor`. The function returns `NotImplemented` for meta devices, causing a fallback to C++ that bypasses `FakeTensorMode`.

## Problem

The issue occurs in `_internal_new_from_data()` in `torch/_refs/__init__.py`. When `device.type == "meta"`, the function returns `NotImplemented`, which causes Python to fall back to the C++ implementation. This bypasses `FakeTensorMode`, resulting in a regular tensor instead of a `FakeTensor`.

**Reproduction:**
```python
from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensor

with FakeTensorMode(), torch.device("meta"):
    a = torch.tensor(3.0)  # Returns regular tensor, not FakeTensor
    print(isinstance(a, FakeTensor))  # False (should be True)
```

## Solution

Modified `_internal_new_from_data()` to check if `FakeTensorMode` is active when `device="meta"`. If active, we use the Python path (via `_recursive_build`) instead of returning `NotImplemented`, allowing `FakeTensorMode` to intercept and wrap the result as a `FakeTensor`.

## Changes

- **File**: `torch/_refs/__init__.py` (lines 6813-6829)
  - Added check for active `FakeTensorMode` when `device.type == "meta"`
  - Use Python path when `FakeTensorMode` is active, fall back to C++ otherwise

- **File**: `test/test_fake_tensor.py` (lines 363-388)
  - Added `test_tensor_with_meta_device()` test case to verify the fix

## Testing

- Added comprehensive test case covering:
  - Scalar tensor with `device('meta')` context manager
  - List tensor with `device('meta')` context manager  
  - Explicit `device='meta'` parameter
- Verified backward compatibility (works without `FakeTensorMode`)
- Python syntax verified
- (Still not certain if i put the test case in proper place,please guide if needed a change)

