### PR TITLE
[3.14] Fix module 'torch' has no attribute 'f'

### DIFF
--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -70,6 +70,8 @@ class PackagePickler(_PyTorchLegacyPickler):
             # to take iterable and return just the object (not tuple)
             # We need to get the parent object that contains the attribute
             name_parts = name.split(".")
+            if "<locals>" in name_parts:
+                raise PicklingError(f"Can't pickle local object {obj!r}")
             if len(name_parts) == 1:
                 parent = module
             else:

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -67,8 +67,13 @@ class PackagePickler(_PyTorchLegacyPickler):
         module = self.importer.import_module(module_name)
         if sys.version_info >= (3, 14):
             # pickle._getattribute signature changes in 3.14
-            # to take iterable and return just one object
-            parent = _getattribute(module, name.split("."))
+            # to take iterable and return just the object (not tuple)
+            # We need to get the parent object that contains the attribute
+            name_parts = name.split(".")
+            if len(name_parts) == 1:
+                parent = module
+            else:
+                parent = _getattribute(module, name_parts[:-1])
         else:
             _, parent = _getattribute(module, name)
         # END CHANGED

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 # pyrefly: ignore [missing-module-attribute]
+import sys
 from pickle import (  # type: ignore[attr-defined]
     _compat_pickle,
     _extension_registry,
@@ -64,7 +65,12 @@ class PackagePickler(_PyTorchLegacyPickler):
             raise PicklingError(f"Can't pickle {obj}: {str(err)}") from err
 
         module = self.importer.import_module(module_name)
-        _, parent = _getattribute(module, name)
+        if sys.version_info >= (3, 14):
+            # pickle._getattribute signature changes in 3.14
+            # to take iterable and return just one object
+            parent = _getattribute(module, name.split("."))
+        else:
+            _, parent = _getattribute(module, name)
         # END CHANGED
 
         if self.proto >= 2:  # type: ignore[attr-defined]


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/commit/4316df857c9e7f301142eb54d06a85a43f8d617b, the pickle `_getattribute` signature changed, but not all uses were caught. This PR applies a similar fix to the mentioned commit, but since we require `parent` instead of `obj` here there is some additional logic for getting the parent.

**Test Plan:** Manually ran the following tests with 3.14
```
'test/test_package.py::TestImporter::test_package_importer_whichmodule_no_dunder_module',
'test/test_package.py::TestPackageScript::test_load_shared_tensors_repackaged',
'test/test_package.py::TestPackageScript::test_saving_and_scripting_packaged_mod',
'test/test_package.py::TestRepackage::test_repackage_import_indirectly_via_parent_module',
'test/test_package.py::TestSaveLoad::test_exporting_mismatched_code'
```

