### PR TITLE
Fix EmbeddingBag when input is 2D and include_last_offset is True

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -287,7 +287,9 @@ class TestEmbeddingNN(NNTestCase):
 
     def test_embeddingbag_2d_include_last_offset(self):
         # Test case from https://https://github.com/pytorch/pytorch/issues/167974
-        embedding_sum = torch.nn.EmbeddingBag(10, 3, mode='sum', include_last_offset=True)
+        embedding_sum = torch.nn.EmbeddingBag(
+            10, 3, mode='sum', include_last_offset=True
+        )
         input = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]], dtype=torch.long)
         res = embedding_sum(input)
         # Check if number of bags matches

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -286,10 +286,8 @@ class TestEmbeddingNN(NNTestCase):
         self.assertEqual(ref_out, out2)
 
     def test_embeddingbag_2d_include_last_offset(self):
-        # Test case from https://https://github.com/pytorch/pytorch/issues/167974
-        embedding_sum = torch.nn.EmbeddingBag(
-            10, 3, mode='sum', include_last_offset=True
-        )
+        # Test case from https://github.com/pytorch/pytorch/issues/167974
+        embedding_sum = torch.nn.EmbeddingBag(10, 3, include_last_offset=True)
         input = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]], dtype=torch.long)
         res = embedding_sum(input)
         # Check if number of bags matches

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -285,6 +285,14 @@ class TestEmbeddingNN(NNTestCase):
         self.assertEqual(ref_out, out)
         self.assertEqual(ref_out, out2)
 
+    def test_embeddingbag_2d_include_last_offset(self):
+        # Test case from https://https://github.com/pytorch/pytorch/issues/167974
+        embedding_sum = torch.nn.EmbeddingBag(10, 3, mode='sum', include_last_offset=True)
+        input = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]], dtype=torch.long)
+        res = embedding_sum(input)
+        # Check if number of bags matches
+        self.assertTrue(res.shape[0] == input.shape[0])
+
 
 class TestEmbeddingNNDeviceType(NNTestCase):
     def test_embedding_dense_grad(self, device):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2613,7 +2613,9 @@ def embedding_bag(
             :attr:`offsets`, if those are not None.
 
         include_last_offset (bool, optional): if ``True``, the size of offsets is equal to the number of bags + 1.
-            The last element is the size of the input, or the ending index position of the last bag (sequence).
+                                              The last element is the size of the input, or the ending index position
+                                              of the last bag (sequence). This matches the CSR format. Ignored when
+                                              input is 2D. Default ``False``.
 
         padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the
                                      gradient; therefore, the embedding vector at :attr:`padding_idx` is not updated
@@ -2724,7 +2726,7 @@ def embedding_bag(
         offsets = torch.arange(
             0, input.numel(), input.size(1), dtype=input.dtype, device=input.device
         )
-
+        include_last_offset = False
         input = input.reshape(-1)
         if per_sample_weights is not None:
             per_sample_weights = per_sample_weights.reshape(-1)

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -304,8 +304,10 @@ class EmbeddingBag(Module):
         sparse (bool, optional): if ``True``, gradient w.r.t. :attr:`weight` matrix will be a sparse tensor. See
                                  Notes for more details regarding sparse gradients. Note: this option is not
                                  supported when ``mode="max"``.
-        include_last_offset (bool, optional): if ``True``, :attr:`offsets` has one additional element, where the last element
-                                      is equivalent to the size of `indices`. This matches the CSR format.
+        include_last_offset (bool, optional): if ``True``, the size of offsets is equal to the number of bags + 1.
+                                              The last element is the size of the input, or the ending index position
+                                              of the last bag (sequence). This matches the CSR format. Ignored when
+                                              input is 2D. Default ``False``.
         padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the
                                      gradient; therefore, the embedding vector at :attr:`padding_idx` is not updated
                                      during training, i.e. it remains as a fixed "pad". For a newly constructed


### PR DESCRIPTION
Before this change, EmbeddingBag generated incorrect offsets when the input indices were 2D and include_last_offset was set to True, resulting in one fewer bag than expected. 
This PR also aligns the documentation for the include_last_offset parameter between nn.EmbeddingBag and nn.functional.embedding_bag.

Fixes #167974

cc @ezyang @gchanan