### PR TITLE
FindMKL: Honor the compiler library path when testing MKL usability

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -281,6 +281,10 @@ MACRO(CHECK_ALL_LIBRARIES LIBRARIES OPENMP_TYPE OPENMP_LIBRARY _name _list _flag
       ELSEIF(${_library} STREQUAL "tbb")
         # Separately handling compiled TBB
         SET(_found_tbb TRUE)
+      ELSEIF(${_library} MATCHES "^(pthread|m|dl)$")
+        # Use -l to find these system libraries so that we honor the
+	# compiler library path when searching for them
+        SET(${_prefix}_${_library}_LIBRARY "-l${_library}")
       ELSE()
         IF(MSVC)
           SET(lib_names ${_library}_dll)


### PR DESCRIPTION
We build manylinux wheels against an ABI-appropriate GLIBC installed in an alternate path by overriding our compiler search paths. This build environment also includes our rolling GLIBC under /usr/lib, which is used by our rolling distro binaries at build-time.

The `cblas_sgemm` CMake test fails in this configuration. It currently ignores our compiler library search path, and tries to link the GLIBC .a's in /usr/lib. In newer GLIBCs, libm, libpthread and libdl have all been merged into libc itself - their .a's are now empty stubs provided for backwards compat. I can demonstrate the issue with the following:

```
$ bash-5.3# gcc-13 /tmp/test_mkl.c -o /tmp/test_mkl_gcc13   /opt/intel/oneapi/mkl/latest/lib/libmkl_intel_lp64.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_gnu_thread.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_gnu_thread.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a   -fopenmp /usr/lib/libpthread.a /usr/lib/libm.so /usr/lib/libdl.a  /opt/intel/oneapi/mkl/latest/lib/libmkl_intel_lp64.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_gnu_thread.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_gnu_thread.a   /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a   -fopenmp /usr/lib/libpthread.a /usr/lib/libm.so /usr/lib/libdl.a
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a(load_dll_static_patched.o): in function `_Init_MKL_Loader':
load_dll.c:(.text+0x1f): undefined reference to `dladdr'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a(mkl_memory_patched.o): in function `_Init_MKL_Loader':
mkl_memory.c:(.text+0x2f): undefined reference to `dladdr'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a(mkl_memory_patched.o): in function `mm_init':
mkl_memory.c:(.text+0x1a5a): undefined reference to `dlerror'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: mkl_memory.c:(.text+0x1adb): undefined reference to `dlopen'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: mkl_memory.c:(.text+0x1af2): undefined reference to `dlsym'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: mkl_memory.c:(.text+0x1b37): undefined reference to `dlclose'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: mkl_memory.c:(.text+0x1c05): undefined reference to `dlsym'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: mkl_memory.c:(.text+0x1c1b): undefined reference to `dlsym'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a(mkl_memory_patched.o): in function `MKLLoadLibrary':
mkl_memory.c:(.text+0x20c6): undefined reference to `dlopen'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /opt/intel/oneapi/mkl/latest/lib/libmkl_core.a(libc_is_static_interface.o): in function `mkl_serv_libc_is_static':
libc_is_static_interface.c:(.text+0x15): undefined reference to `dladdr'
collect2: error: ld returned 1 exit status
```

Change this test to dynamically link these GLIBC libraries, using the compiler library path. This will find our older GLIBC install where those .a's contain the expected symbols.

Fixes #ISSUE_NUMBER


cc @malfet @seemethere