### PR TITLE
[BE] Remove erroneous `const_cast`

### DIFF
--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -212,7 +212,7 @@ void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
       std::nullopt /* memory format */
   );
   at::cuda::memcpy_and_sync(
-      (void*)pinned_num_nonzeros_h.const_data_ptr<int>(),
+      pinned_num_nonzeros_h.data_ptr<int>(),
       num_nonzeros.get(),
       sizeof(int) * num_chunks,
       cudaMemcpyDeviceToHost,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #167929
* #168132
* __->__ #168165

Not sure what was the purpose of using `TensorBase::const_data_ptr` template, but 1st argument of `memcpy` should be a mutable pointer, therefore replacing it with `TensorBase::data_ptr`

Introduced in https://github.com/pytorch/pytorch/pull/134712