### PR TITLE
Replace certain Dynamo/Inductor global state with thread local

### DIFF
--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -255,7 +255,12 @@ def setup_compilation_env():
 
 @contextmanager
 def _set_compilation_env():
-    _old_is_tracing = torch.fx._symbolic_trace._is_fx_tracing_flag
+    _symbolic_trace_tls = getattr(torch.fx._symbolic_trace, "_is_fx_tracing_tls", None)
+    _old_is_tracing = (
+        getattr(_symbolic_trace_tls, "flag", False)
+        if _symbolic_trace_tls is not None
+        else False
+    )
     _old_allow_empty_graphs = torch._dynamo.config.allow_empty_graphs
     _old_capture_scalar_outputs = torch._dynamo.config.capture_scalar_outputs
     # The issue is tracked in https://github.com/pytorch/pytorch/issues/144360: when dynamo finds
@@ -269,13 +274,13 @@ def _set_compilation_env():
     try:
         # We need to turn off the is_fx_tracing_flag. Remove this flag check from dyanmo
         # once we are confident fx tracing works with dynamo.
-        torch.fx._symbolic_trace._is_fx_tracing_flag = False
+        torch.fx._symbolic_trace._set_is_fx_tracing(False)
         # pyrefly: ignore [bad-assignment]
         torch._dynamo.config.allow_empty_graphs = True
         torch._dynamo.config.capture_scalar_outputs = True
         yield
     finally:
-        torch.fx._symbolic_trace._is_fx_tracing_flag = _old_is_tracing
+        torch.fx._symbolic_trace._set_is_fx_tracing(_old_is_tracing)
         torch._dynamo.config.allow_empty_graphs = _old_allow_empty_graphs
         torch._dynamo.config.capture_scalar_outputs = _old_capture_scalar_outputs
 


### PR DESCRIPTION
Fixes [#126024](https://github.com/pytorch/pytorch/issues/126024 )
Fixes issues 1-4 in [#168042](https://github.com/pytorch/pytorch/issues/168042) 

Summary: Currently, Dynamo/inductor configurations are reliant on global variables. This has led to many race conditions in workflows which call torch.compile (more specifically compile_fx) from multiple threads simultaneously. To resolve this, I propose replacing parts of this global state with thread local state.

Note: these changes are only made in places where I have encountered errors in my own work. Since the entire config is global, I’m sure there are many similar issues not addressed in this PR. Perhaps these changes could be expanded into the full solution described in https://github.com/pytorch/pytorch/issues/118387, and I would be happy to discuss more about this.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78