### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from caffe2/torch/csrc/Storage.cpp

### DIFF
--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -245,7 +245,7 @@ static PyObject* THPStorage_pynew(
           storage_set(storage, i, value);
         }
       }
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       TORCH_CHECK(
           THPStorageStr "(): tried to construct a storage from a sequence (",
           THPUtils_typename(sequence),

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -448,7 +448,7 @@ c10::intrusive_ptr<c10::ivalue::Future> DistEngine::
       const variable_list& grads = futureGrads.constValue().toTensorVector();
       TORCH_INTERNAL_ASSERT(grads.size() == outputEdges.size());
       accumulateGradFuture->markCompleted(c10::IValue());
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       accumulateGradFuture->setErrorIfNeeded(std::current_exception());
     }
   });
@@ -527,7 +527,7 @@ c10::intrusive_ptr<c10::ivalue::Future> DistEngine::executeSendFunctionAsync(
                 // Perform cleanup at the end of the backward pass (before
                 // we mark the future as completed).
                 DistEngine::getInstance().cleanupBackwardPass(autogradContext);
-              } catch (std::exception& e) {
+              } catch (std::exception&) {
                 callbackFuture->setErrorIfNeeded(std::current_exception());
                 return;
               }
@@ -539,7 +539,7 @@ c10::intrusive_ptr<c10::ivalue::Future> DistEngine::executeSendFunctionAsync(
                 callbackFuture->setError(rpcFuture.exception_ptr());
               }
             });
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             callbackFuture->setErrorIfNeeded(std::current_exception());
           }
         });

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -339,7 +339,7 @@ class TORCH_PYTHON_API PythonOnCompletionHook {
         eptr = std::make_exception_ptr(std::runtime_error(e.what()));
         e.restore();
         PyErr_Clear();
-      } catch (std::exception& e) {
+      } catch (std::exception&) {
         eptr = std::current_exception();
       }
     }

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -270,7 +270,7 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
       // server successfully started
       C10D_DEBUG("The server has started on port = {}.", server_->port());
       addr_.port = server_->port();
-    } catch (const SocketError& e) {
+    } catch (const SocketError&) {
       bool useAgentStore = getCvarBool({"TORCHELASTIC_USE_AGENT_STORE"}, false);
       int masterPort = getCvarInt({"MASTER_PORT"}, 0);
       if (useAgentStore && masterPort == opts.port) {

--- a/torch/csrc/distributed/c10d/python_callback_work.cpp
+++ b/torch/csrc/distributed/c10d/python_callback_work.cpp
@@ -40,14 +40,14 @@ bool PythonCallbackWork::wait(std::chrono::milliseconds timeout) {
     }
 
     return success;
-  } catch (py::error_already_set& e) {
+  } catch (py::error_already_set&) {
     // Capture the Python exception and store it
     finish(std::current_exception());
     if (!future_->completed()) {
       future_->setErrorIfNeeded(std::current_exception());
     }
     throw;
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     // Capture any C++ exception and store it
     finish(std::current_exception());
     if (!future_->completed()) {


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Differential Revision: D87467930


