### PR TITLE
[CUDA] Update minimum NVIDIA driver version requirement in Green Context test

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -89,7 +89,7 @@ def evaluate_platform_supports_green_context():
     driver_version = torch.utils.collect_env.get_nvidia_driver_version(torch.utils.collect_env.run)
     if driver_version is None:
         return False
-    return int(driver_version.split('.')[0]) >= 550
+    return int(driver_version.split('.')[0]) >= 570
 
 PLATFORM_SUPPORTS_FLASH_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
 PLATFORM_SUPPORTS_MEM_EFF_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_efficient_attention())


### PR DESCRIPTION
We seem to have runners that have a system toolkit version of 12.4 + driver version 550 which is causing the test to fail?

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia