### PR TITLE
[3.14] Add check for __module__ to _SysImporter.whichmodule

### DIFF
--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -181,6 +181,12 @@ class _SysImporter(Importer):
         return importlib.import_module(module_name)
 
     def whichmodule(self, obj: Any, name: str) -> str:
+        # In Python 3.14+, pickle.whichmodule tries to import the module,
+        # which fails for mangled package names like '<torch_package_0>'.
+        # Check __module__ first before calling pickle.whichmodule.
+        module_name = getattr(obj, "__module__", None)
+        if module_name is not None:
+            return module_name
         return _pickle_whichmodule(obj, name)
 
 


### PR DESCRIPTION
To be merged after https://github.com/pytorch/pytorch/pull/168152 (sorry, I should've made this a stack before)

This fixes an issue with Python 3.14 where pickle.whichmodule fails to import package names like <torch_package_0>. To avoid this, I added a check for `__module__` first.

**Test Plan:** Locally ran with Python 3.14
```
python3  test/test_package.py TestPackageFX.test_package_fx_package
```