### PR TITLE
[3.14] Add python version adjustment for frame count changes

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -302,7 +302,7 @@ class TestPythonRegistration(TestCase):
         # 1 for `lib`, 1 for sys.getrefcount' for previous python version (<=3.12)
         # In Python 3.13+, sys.getrefcount() was optimized to not create
         # a temporary reference, so expected counts are 1 less than before
-        expected_refcount = 1 if sys.version_info >= (3, 13) else 2
+        expected_refcount = 1 if sys.version_info >= (3, 14) else 2
         self.assertEqual(sys.getrefcount(lib), expected_refcount)
 
         # We gained an additional reference that gets cleared when the finalizer runs

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -299,8 +299,12 @@ class TestPythonRegistration(TestCase):
         lib = Library(self.test_ns, "FRAGMENT")  # noqa: TOR901
         lib.define("foo123(Tensor x) -> Tensor")
 
-        # 1 for `lib`, 1 for sys.getrefcount
-        self.assertEqual(sys.getrefcount(lib), 2)
+        # 1 for `lib`, 1 for sys.getrefcount' for previous python version (<=3.12)
+        # In Python 3.13+, sys.getrefcount() was optimized to not create
+        # a temporary reference, so expected counts are 1 less than before
+        expected_refcount = 1 if sys.version_info >= (3, 13) else 2
+        self.assertEqual(sys.getrefcount(lib), expected_refcount)
+
         # We gained an additional reference that gets cleared when the finalizer runs
         self.assertEqual(sys.getrefcount(torch.library._impls), impls_refcnt + 1)
         # 1 for `lib`
@@ -318,7 +322,7 @@ class TestPythonRegistration(TestCase):
         saved_op_impls = lib._op_impls
 
         # del will definitely work if the following passes
-        self.assertEqual(sys.getrefcount(lib), 2)
+        self.assertEqual(sys.getrefcount(lib), expected_refcount)
         del lib
 
         # 1 for saved_op_impls
@@ -326,7 +330,7 @@ class TestPythonRegistration(TestCase):
         # This function should be the last user of lib._op_impls:
         # - lib should not have a reference anymore (it was del'ed)
         # - lib's finalizer should not have a reference anymore
-        self.assertEqual(sys.getrefcount(saved_op_impls), 2)
+        self.assertEqual(sys.getrefcount(saved_op_impls), expected_refcount)
 
         self.assertTrue(key not in torch.library._impls)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168190

``sys.getrefcount(lib)`` got impacted due to python3.13 optimization. ``sys.getrefcount(lib._op_impls)`` and others remain the same.

Test plan:
``python test/test_python_dispatch.py TestPythonRegistration.test_finalizer`` in local ``python=3.14`` env

