### PR TITLE
[3.14] Use refcount difference for TestNumPyInterop.test_from_numpy_no_leak_on_invalid_dtype

### DIFF
--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -301,12 +301,15 @@ class TestNumPyInterop(TestCase):
         # This used to leak memory as the `from_numpy` call raised an exception and didn't decref the temporary
         # object. See https://github.com/pytorch/pytorch/issues/121138
         x = np.array(b"value")
+        initial_refcount = sys.getrefcount(x)
         for _ in range(1000):
             try:
                 torch.from_numpy(x)
             except TypeError:
                 pass
-        self.assertTrue(sys.getrefcount(x) == 2)
+        final_refcount = sys.getrefcount(x)
+        self.assertEqual(final_refcount, initial_refcount,
+                         f"Memory leak detected: refcount increased from {initial_refcount} to {final_refcount}")
 
     @skipIfTorchDynamo("No need to test invalid dtypes that should fail by design.")
     @onlyCPU

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -308,8 +308,11 @@ class TestNumPyInterop(TestCase):
             except TypeError:
                 pass
         final_refcount = sys.getrefcount(x)
-        self.assertEqual(final_refcount, initial_refcount,
-                         f"Memory leak detected: refcount increased from {initial_refcount} to {final_refcount}")
+        self.assertEqual(
+            final_refcount,
+            initial_refcount,
+            f"Memory leak detected: refcount increased from {initial_refcount} to {final_refcount}",
+        )
 
     @skipIfTorchDynamo("No need to test invalid dtypes that should fail by design.")
     @onlyCPU


### PR DESCRIPTION
Updates TestNumPyInterop.test_from_numpy_no_leak_on_invalid_dtype to use difference in refcount instead of a hardcoded value. This is needed because Python 3.14 changed sys.getrefcount behavior with optimizations that returns a lower number of refcounts for inside functions/methods vs module-level. Instead, this PR updates the test to check if there is any change to the number of recounts.

**Test Plan:** Ran locally with Python 3.14
```
python3 test/test_numpy_interop.py TestNumPyInteropCPU.test_from_numpy_no_leak_on_invalid_dtype_cpu
```