### PR TITLE
[DTensor] Clean up ShardingProp LRUCache

### DIFF
--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
+from torch.distributed.tensor._tp_conv import cached_dtensor_propagate_sharding
 from torch.distributed.tensor.parallel import ParallelStyle
 from torch.nn.attention.flex_attention import (
     _mask_mod_signature,
@@ -898,7 +899,7 @@ def _sdpa_handler(
     # TODO: remove the context parallel strategy from the default propagation
     # rule. Either figure out how to dynamically enable it or just don't call
     # propagate.
-    DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    cached_dtensor_propagate_sharding(op_info)
     output_sharding = op_info.output_sharding
     assert output_sharding is not None, "output sharding should not be None"
     assert not output_sharding.needs_redistribute, "inputs need to be redistributed"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168198
* #168192

Note: will not land for now.  we're going to be using the LRUCache a bit longer per https://github.com/pytorch/pytorch/pull/168269.


This is not a very good PR.  Maybe we shouldn't land it as-is.  The
version that might be better is to expose a c++ entrypoint to
'propagate' that uses the c++ cache.  (Currently, the c++ cache is only
accessible via the dispatchDTensorOp codepath).

At least in this PR it is clear to readers that there is no more python
DTensor ShardingProp cache, and it is also more clear to the tail users
(sdpa, tp_conv) that they are using a separate cache that won't be
populated by / shared with propagation that happens during normal
DTensor dispatch.

Does this even matter?  Maybe it is fine for sdpa/tp_conv to have their
own separate python cache, if we do not expect to get reuse between
dispatch prop and sdpa/tp_conv prop.