### PR TITLE
[ROCm][CI] Add ROCm noble image caching to docker-cache-rocm.yml

### DIFF
--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -6,9 +6,19 @@ on:
     branches: [main, release]
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      name: branch
+        type: string
+        description: Branch corresponding to the docker images being cached
+        required: true
+      name: run_id
+        type: string
+        description: Workflow run id to pull artifacts from
+        required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}
   cancel-in-progress: true
 
 permissions:
@@ -29,7 +39,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.7
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
           path: ./docker-builds-artifacts
           merge-multiple: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -90,7 +100,7 @@ jobs:
           docker_image_tag=${{ matrix.docker-image }}
           docker_image_tag="${docker_image_tag#*:}" # Remove everything before and including first ":"
           docker_image_tag="${docker_image_tag%-*}" # Remove everything after and including last "-"
-          ref_name=${{ github.event.workflow_run.head_branch }}
+          ref_name=${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}
           if [[ $ref_name =~ "release/" ]]; then
             ref_suffix="release"
           elif [[ $ref_name == "main" ]]; then

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -8,11 +8,11 @@ on:
       - completed
   workflow_dispatch:
     inputs:
-      name: branch
+      branch:
         type: string
         description: Branch corresponding to the docker images being cached
         required: true
-      name: run_id
+      run_id:
         type: string
         description: Workflow run id to pull artifacts from
         required: true

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -49,9 +49,8 @@ jobs:
       matrix:
         runner: [linux.rocm.gfx942.docker-cache]
         docker-image: [
-          "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}"
-          #"${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
-          #"${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}",
+          "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
+          "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"
           #"${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3-benchmarks }}"
         ]
     runs-on: "${{ matrix.runner }}"


### PR DESCRIPTION
Needed due to https://github.com/pytorch/pytorch/pull/168162, which means rocm-mi300.yml (uses noble images) and periodic-rocm-mi300.yml (uses jammy images) will both run on the new MI3xx capacity.

Also re-enable `workflow_dispatch` with inputs required to run successfully

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd