### PR TITLE
[Distributed] Enable support for reduce_scatter_base backward for XCCL backend

### DIFF
--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -341,7 +341,7 @@ class _AllGather(Function):
 
     @staticmethod
     def backward(ctx, *grad_outputs):
-        if dist.get_backend(group=ctx.group) is dist.Backend.NCCL:
+        if dist.get_backend(group=ctx.group) in (dist.Backend.NCCL, dist.Backend.XCCL):
             rank = dist.get_rank(group=ctx.group)
             gx = torch.empty_like(grad_outputs[rank])
             gx = _Reduce_Scatter.apply(ReduceOp.SUM, ctx.group, gx, *grad_outputs)

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -365,16 +365,21 @@ class _AllGatherBase(Function):
     @staticmethod
     # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
-        world_size = dist.get_world_size(group=ctx.group)
-        out_size = list(grad_output.size())
-        if out_size[0] % world_size != 0:
-            raise RuntimeError(
-                f"Tensor with dimensions: {out_size} does "
-                f"not have first dimension divisible by world_size: {world_size}"
+        if dist.get_backend(group=ctx.group) in (dist.Backend.NCCL, dist.Backend.XCCL):
+            world_size = dist.get_world_size(group=ctx.group)
+            out_size = list(grad_output.size())
+            if out_size[0] % world_size != 0:
+                raise RuntimeError(
+                    f"Tensor with dimensions: {out_size} does "
+                    f"not have first dimension divisible by world_size: {world_size}"
+                )
+            out_size[0] = out_size[0] // dist.get_world_size(group=ctx.group)
+            gx = torch.empty(
+                out_size, device=grad_output.device, dtype=grad_output.dtype
             )
-        out_size[0] = out_size[0] // dist.get_world_size(group=ctx.group)
-        gx = torch.empty(out_size, device=grad_output.device, dtype=grad_output.dtype)
-        dist._reduce_scatter_base(gx, grad_output, ReduceOp.SUM, ctx.group)
+            dist._reduce_scatter_base(gx, grad_output, ReduceOp.SUM, ctx.group)
+        else:
+            raise RuntimeError("Backend not supported!")
         return (None, gx, None)
 
 

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -373,9 +373,7 @@ class _AllGatherBase(Function):
                 f"not have first dimension divisible by world_size: {world_size}"
             )
         out_size[0] = out_size[0] // dist.get_world_size(group=ctx.group)
-        gx = torch.empty(
-            out_size, device=grad_output.device, dtype=grad_output.dtype
-        )
+        gx = torch.empty(out_size, device=grad_output.device, dtype=grad_output.dtype)
         dist._reduce_scatter_base(gx, grad_output, ReduceOp.SUM, ctx.group)
         return (None, gx, None)
 


### PR DESCRIPTION
Enable reduce_scatter_base backward support for XCCL  backends

With XPU it was resulting in below error

```
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/testing/_internal/common_distributed.py", line 816, in run_test
    getattr(self, test_name)()
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/testing/_internal/common_distributed.py", line 670, in wrapper
    fn()
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/ssamuel/workspace/pytorch/test/distributed/test_c10d_spawn_nccl.py", line 193, in test_all_gather_base
    z.backward()
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/_tensor.py", line 625, in backward
    torch.autograd.backward(
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/autograd/__init__.py", line 354, in backward
    _engine_run_backward(
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/autograd/graph.py", line 841, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/autograd/function.py", line 315, in apply
    return user_fn(self, *args)
  File "/home/ssamuel/miniforge3/envs/env_borealis_2025_1.24_py_3_10/lib/python3.10/site-packages/torch/distributed/nn/functional.py", line 366, in backward
    raise RuntimeError("Backend not supported!")
RuntimeError: Backend not supported!

```


Previously the backward path for reduce_scatter_base was supported only for NCCL which caused runtime errors on XPU. This change implements the missing backward handling and unifies the behavior for XCCL backends.

Verified with XCCL; reduce_scatter_base backward now completes without errors.

Fixes #[intel/torch-xpu-ops#2369](https://github.com/intel/torch-xpu-ops/issues/2369)
