### PR TITLE
Replace string with char for output

### DIFF
--- a/aten/src/ATen/code_template.h
+++ b/aten/src/ATen/code_template.h
@@ -232,7 +232,7 @@ struct CodeTemplate {
         emitIndent(out, indent);
       emitStringWithIndents(out, indent, strings[i]);
       if (i + 1 != strings.size())
-        out << "\n";
+        out << '\n';
     }
   }
   std::string template_text;

--- a/aten/src/ATen/miopen/Descriptors.cpp
+++ b/aten/src/ATen/miopen/Descriptors.cpp
@@ -114,8 +114,8 @@ void FilterDescriptor::set(const at::Tensor &t, const at::MemoryFormat memory_fo
   // that is the common case, so we can catch most client errors with this test.
   TORCH_CHECK(t.is_contiguous(memory_format),
     "MIOpen filters (a.k.a. weights) must be contiguous in desired memory_format\n",
-    "Weight sizes: ", t.sizes(), "\n",
-    "Weight strides: ", t.strides(), "\n",
+    "Weight sizes: ", t.sizes(), '\n',
+    "Weight strides: ", t.strides(), '\n',
     "cuDNN suggested memory_format: ", memory_format);
 
   int size[MIOPEN_DIM_MAX];

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -774,7 +774,7 @@ void raw_cudnn_convolution_forward_out_32bit(
             args,
             "Forward algorithm: ",
             static_cast<int>(fwdAlgPerf.algo),
-            "\n");
+            '\n');
       });
 }
 

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -843,22 +843,22 @@ public:
         std::stringstream stream;
         stream.precision(std::numeric_limits<UVT>::max_digits10);
         stream << "Failure Details:\n";
-        stream << additionalInfo << "\n";
+        stream << additionalInfo << '\n';
         if (hasSeed)
         {
-            stream << "Test Seed to reproduce: " << testSeed << "\n";
+            stream << "Test Seed to reproduce: " << testSeed << '\n';
         }
         if (argSize > 0)
         {
             stream << "Arguments:\n";
-            stream << "#\t " << arg0 << "\n";
+            stream << "#\t " << arg0 << '\n';
             if (argSize == 2)
             {
-                stream << "#\t " << arg1 << "\n";
+                stream << "#\t " << arg1 << '\n';
             }
             if (argSize == 3)
             {
-                stream << "#\t " << arg2 << "\n";
+                stream << "#\t " << arg2 << '\n';
             }
         }
         stream << "Expected:\n#\t" << exp << "\nActual:\n#\t" << act;
@@ -890,7 +890,7 @@ public:
         else if (checkWithTolerance)
         {
             for (const auto i : c10::irange(sizeX)) {
-                EXPECT_EQ(nearlyEqual<UVT>(expArr[i], actArr[i], absErr), true) << expArr[i] << "!=" << actArr[i] << "\n" << getDetail(i / unitStorageCount);
+                EXPECT_EQ(nearlyEqual<UVT>(expArr[i], actArr[i], absErr), true) << expArr[i] << "!=" << actArr[i] << '\n' << getDetail(i / unitStorageCount);
                 if (::testing::Test::HasFailure())
                     return true;
             }
@@ -1116,11 +1116,11 @@ void test_binary_fp8(
             if (is_bit_wise) {
                 EXPECT_EQ(static_cast<bool>(ref_res_scalar), static_cast<bool>(res_scalar))
                     << "Test failed for input0: " << c10::detail::fp8e4m3fn_to_fp32_value(f8_0.x)
-                    << " input1: " << c10::detail::fp8e4m3fn_to_fp32_value(f8_1.x) << "\n";
+                    << " input1: " << c10::detail::fp8e4m3fn_to_fp32_value(f8_1.x) << '\n';
             } else {
                 EXPECT_EQ(ref_res_scalar, res_scalar)
                     << "Test failed for input0: " << c10::detail::fp8e4m3fn_to_fp32_value(f8_0.x)
-                    << " input1: " << c10::detail::fp8e4m3fn_to_fp32_value(f8_1.x) << "\n";
+                    << " input1: " << c10::detail::fp8e4m3fn_to_fp32_value(f8_1.x) << '\n';
             }
         } else {
             at::vec::cvtfp8e5m2_fp32(_mm512_castsi512_si128(res), res_fp32_512);
@@ -1128,11 +1128,11 @@ void test_binary_fp8(
             if (is_bit_wise) {
                 EXPECT_EQ(static_cast<bool>(ref_res_scalar), static_cast<bool>(res_scalar))
                     << "Test failed for input0: " << c10::detail::fp8e5m2_to_fp32_value(f8_0.x)
-                    << " input1: " << c10::detail::fp8e5m2_to_fp32_value(f8_1.x) << "\n";
+                    << " input1: " << c10::detail::fp8e5m2_to_fp32_value(f8_1.x) << '\n';
             } else {
                 EXPECT_EQ(ref_res_scalar, res_scalar)
                     << "Test failed for input0: " << c10::detail::fp8e5m2_to_fp32_value(f8_0.x)
-                    << " input1: " << c10::detail::fp8e5m2_to_fp32_value(f8_1.x) << "\n";
+                    << " input1: " << c10::detail::fp8e5m2_to_fp32_value(f8_1.x) << '\n';
             }
         }
       }

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -341,7 +341,7 @@ void Reducer::check_grad_layout(
         grad.sizes(),
         ", strides() = ",
         grad.strides(),
-        "\n",
+        '\n',
         "bucket_view.sizes() = ",
         bucket_view.sizes(),
         ", strides() = ",

--- a/torch/csrc/jit/codegen/onednn/kernel.cpp
+++ b/torch/csrc/jit/codegen/onednn/kernel.cpp
@@ -28,7 +28,7 @@ LlgaKernel::LlgaKernel(const Node* fusionNode)
   partition_ = partitions[0];
   nPartitionInputs_ = partition_.get_input_ports().size();
 #ifdef GRAPH_DEBUG_ENABLED
-  GRAPH_DEBUG("Initialized ", debugName(), "\n", graph_->toString());
+  GRAPH_DEBUG("Initialized ", debugName(), '\n', graph_->toString());
 #endif
 }
 
@@ -243,7 +243,7 @@ compiled_partition LlgaKernel::compile(const partition& partition) {
 
 void LlgaKernel::run(Stack& stack) {
 #ifdef GRAPH_DEBUG_ENABLED
-  GRAPH_DEBUG("In ", debugName(), "\n");
+  GRAPH_DEBUG("In ", debugName(), '\n');
 #endif
 
   // Grab input values from stack

--- a/torch/csrc/jit/ir/subgraph_matcher.cpp
+++ b/torch/csrc/jit/ir/subgraph_matcher.cpp
@@ -272,8 +272,8 @@ bool SubgraphMatcher::matchNodes(const Node* n1, Node* n2) {
       if (!endsWith(real_typename, pattern_typename)) {
         GRAPH_DEBUG(
             "Nodes did not match because expected module type is different:\n");
-        GRAPH_DEBUG("  actualtype:    ", real_typename, "\n");
-        GRAPH_DEBUG("  expected type: ", pattern_typename, "\n");
+        GRAPH_DEBUG("  actualtype:    ", real_typename, '\n');
+        GRAPH_DEBUG("  expected type: ", pattern_typename, '\n');
         GRAPH_DEBUG("Nodes:", *n1, *n2);
         return false;
       }

--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -95,12 +95,12 @@ TORCH_API std::ostream& operator<<(
   JIT_LOG(                                        \
       ::torch::jit::JitLoggingLevels::GRAPH_DUMP, \
       MSG,                                        \
-      "\n",                                       \
+      '\n',                                       \
       ::torch::jit::log_function(G));
 // use GRAPH_DUMP for dumping graphs after optimization passes
 #define GRAPH_DUMP(MSG, G) \
   JIT_LOG(                 \
-      ::torch::jit::JitLoggingLevels::GRAPH_DUMP, MSG, "\n", (G)->toString());
+      ::torch::jit::JitLoggingLevels::GRAPH_DUMP, MSG, '\n', (G)->toString());
 // use GRAPH_UPDATE for reporting graph transformations (i.e. node deletion,
 // constant folding, CSE)
 #define GRAPH_UPDATE(...) \

--- a/torch/csrc/jit/tensorexpr/block_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/block_codegen.cpp
@@ -351,7 +351,7 @@ void BlockCodeGen::Initialize() {
 
   stmt_v->accept(printer_.get());
 
-  GRAPH_DEBUG("Generated Block code: ", oss_.str(), "\n");
+  GRAPH_DEBUG("Generated Block code: ", oss_.str(), '\n');
 }
 
 void BlockCodeGen::call(const std::vector<CallArg>& args) {

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -320,7 +320,7 @@ void CodeGen::allocIntermediateBufs() {
     set_stmt(stmt_new);
   }
 
-  GRAPH_DEBUG("\nMemory Allocation:\n\n", *stmt(), "\n");
+  GRAPH_DEBUG("\nMemory Allocation:\n\n", *stmt(), '\n');
 }
 
 } // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -795,7 +795,7 @@ static void parallelizeOuterLoops(LoopNest& l, const Bufs& bufs) {
 StmtPtr TensorExprKernel::transformLoops(BackendType backendType, StmtPtr st) {
   torch::jit::tensorexpr::LoopNest l(std::move(st), bufOutputs_);
   LoopNest::sanitizeNames(l.root_stmt());
-  GRAPH_DEBUG("Original Stmt:\n", std::to_string(l.root_stmt()), "\n");
+  GRAPH_DEBUG("Original Stmt:\n", std::to_string(l.root_stmt()), '\n');
   int64_t random_tr_seed = randomTransformsRequested();
   if (random_tr_seed) {
     if (random_tr_seed == -1)
@@ -939,7 +939,7 @@ StmtPtr TensorExprKernel::transformLoops(BackendType backendType, StmtPtr st) {
   StmtPtr stmt = l.root_stmt();
   // Arithmetic Simplification.
   stmt = IRSimplifier::simplify(stmt);
-  GRAPH_DEBUG("Final Stmt:\n", std::to_string(stmt), "\n");
+  GRAPH_DEBUG("Final Stmt:\n", std::to_string(stmt), '\n');
   return stmt;
 }
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -777,7 +777,7 @@ void LLVMCodeGenImpl::emitKernel(
   PM.run(*module_);
   asmCode_ = asmStream.str().str();
 
-  GRAPH_DEBUG("\nLLVM generated assembly code\n\n", asmCode_, "\n");
+  GRAPH_DEBUG("\nLLVM generated assembly code\n\n", asmCode_, '\n');
 }
 
 // TODO: The binary ops are copypaste.


### PR DESCRIPTION
This PR replaces `"\n"` with `'\n'` in assertion macros for constructing error messages. The possible violating instances were searched by 
```
grep '"[\]n"' -r aten c10 torch | grep -v py
```


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @mingfeima @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal