### PR TITLE
[ROCm][CI] Enable TD for all ROCm default and distributed config workflows

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -152,9 +152,12 @@ runs:
 
         echo
         echo "Is the current job unstable? ${{ steps.filter.outputs.is-unstable }}"
-
+        
         echo
         echo "Is keep-going label set? ${{ steps.filter.outputs.keep-going }}"
+        
+        echo
+        echo "Is ci-no-td label set? ${{ steps.filter.outputs.ci-no-td }}"
 
         echo
         echo "Reenabled issues? ${{ steps.filter.outputs.reenabled-issues }}"

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -152,10 +152,10 @@ runs:
 
         echo
         echo "Is the current job unstable? ${{ steps.filter.outputs.is-unstable }}"
-        
+
         echo
         echo "Is keep-going label set? ${{ steps.filter.outputs.keep-going }}"
-        
+
         echo
         echo "Is ci-no-td label set? ${{ steps.filter.outputs.ci-no-td }}"
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1487,8 +1487,10 @@ def parse_args():
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
-        and (GITHUB_WORKFLOW in ("trunk", "pull")
-        or GITHUB_WORKFLOW.startswith(("rocm-", "periodic-rocm-"))),
+        and (
+            GITHUB_WORKFLOW in ("trunk", "pull")
+            or GITHUB_WORKFLOW.startswith(("rocm-", "periodic-rocm-"))
+        ),
     )
     parser.add_argument(
         "--shard",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1495,7 +1495,7 @@ def parse_args():
         nargs=2,
         type=int,
         help="runs a shard of the tests (taking into account other selections), e.g., "
-        "--shard 2 3 will break upthee selected tests into 3 shards and run the tests "
+        "--shard 2 3 will break up the selected tests into 3 shards and run the tests "
         "in the 2nd shard (the first number should not exceed the second)",
     )
     parser.add_argument(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1476,6 +1476,7 @@ def parse_args():
         help="Set a timeout based on the test times json file.  Only works if there are test times available",
         default=IS_CI and not strtobool(os.environ.get("NO_TEST_TIMEOUT", "False")),
     )
+    GITHUB_WORKFLOW = os.environ.get("GITHUB_WORKFLOW", "slow")
     parser.add_argument(
         "--enable-td",
         action="store_true",
@@ -1486,15 +1487,15 @@ def parse_args():
         and not IS_MACOS
         and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
-        and os.environ.get("GITHUB_WORKFLOW", "slow")
-        in ("trunk", "pull", "rocm", "rocm-mi300"),
+        and (GITHUB_WORKFLOW in ("trunk", "pull")
+        or GITHUB_WORKFLOW.startswith(("rocm-", "periodic-rocm-"))),
     )
     parser.add_argument(
         "--shard",
         nargs=2,
         type=int,
         help="runs a shard of the tests (taking into account other selections), e.g., "
-        "--shard 2 3 will break up the selected tests into 3 shards and run the tests "
+        "--shard 2 3 will break upthee selected tests into 3 shards and run the tests "
         "in the 2nd shard (the first number should not exceed the second)",
     )
     parser.add_argument(


### PR DESCRIPTION
Ensures that Target Determination (TD) is enabled for all ROCm workflows that run default or distributed config tests on PRs.

NOTE: Excluding inductor-rocm workflows to keep parity with CUDA inductor workflows, which also do not seem to have TD enabled.

Example of TD not being enabled on some ROCm workflows (TD enabled will have "[Running 25% of tests based on TD](https://github.com/pytorch/pytorch/blob/6fa7791bab2785bdcae096bd2f80b2528112b859/test/run_test.py#L2104)" in the log; while TD disabled will have "[Running all tests](https://github.com/pytorch/pytorch/blob/6fa7791bab2785bdcae096bd2f80b2528112b859/test/run_test.py#L2106)" in the log):
periodic-rocm-mi300: https://hud.pytorch.org/pr/pytorch/pytorch/167548#periodic-rocm-mi300
periodic-rocm-mi200: https://hud.pytorch.org/pr/pytorch/pytorch/167548#periodic-rocm-mi200
rocm-mi200: https://hud.pytorch.org/pr/167183#rocm-mi200


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @dllehr-amd