### PR TITLE
[BE][BugFix] Fix incorrect usage of const_data_ptr in memcpy

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -29,7 +29,7 @@ Scalar _local_scalar_dense_cuda(const Tensor& self) {
             std::nullopt /* memory format */
           );
           cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-          at::cuda::memcpy_and_sync((void *)value.const_data_ptr<scalar_t>(), self.const_data_ptr<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream);
+          at::cuda::memcpy_and_sync(value.data_ptr<scalar_t>(), self.const_data_ptr<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream);
           r = Scalar(*value.const_data_ptr<scalar_t>());
         }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kHalf, kBool, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
   return r;


### PR DESCRIPTION
> Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
> 
> * [[CMake] Bump C++ version to 20 #167929](https://github.com/pytorch/pytorch/pull/167929)
> * [[BE] C++20 template instantiation adjustments #168132](https://github.com/pytorch/pytorch/pull/168132)
> * **->** [[BE][BugFix] Fix incorrect usage of const_data_ptr in memcpy #168227](https://github.com/pytorch/pytorch/pull/168227)
> 
> 1st argument of `memcpy` should be a mutable pointer, therefore replacing it with `TensorBase::data_ptr`
