### PR TITLE
Honor $XDG_CACHE_HOME in C++ code of DebugInfoWriter

### DIFF
--- a/torch/csrc/distributed/c10d/FlightRecorder.cpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.cpp
@@ -42,10 +42,20 @@ void DebugInfoWriter::write(const std::string& trace) {
 
 DebugInfoWriter& DebugInfoWriter::getWriter(int rank) {
   if (writer_ == nullptr) {
-    // Attempt to write to running user's HOME directory cache folder - if it
-    // exists.
-    auto homeDir = getCvarString({"HOME"}, "/tmp");
-    auto cacheDirPath = c10::filesystem::path(homeDir + "/.cache/torch");
+// Attempt to write to running user's HOME directory cache folder - if it
+// exists.
+#ifdef _WIN32
+    const char* cacheHome = nullptr;
+#else
+    // Uses XDG_CACHE_HOME if it's set
+    const char* cacheHome = std::getenv("XDG_CACHE_HOME");
+#endif
+    std::string cacheRoot;
+    if (cacheHome)
+      cacheRoot = cacheHome;
+    else
+      cacheRoot = getCvarString({"HOME"}, "/tmp") + "/.cache";
+    auto cacheDirPath = std::filesystem::path(cacheRoot + "/torch");
     // Create the .cache directory if it doesn't exist
     c10::filesystem::create_directories(cacheDirPath);
     auto defaultLocation = cacheDirPath / "comm_lib_trace_rank_";

--- a/torch/csrc/distributed/c10d/FlightRecorder.cpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.cpp
@@ -51,10 +51,11 @@ DebugInfoWriter& DebugInfoWriter::getWriter(int rank) {
     const char* cacheHome = std::getenv("XDG_CACHE_HOME");
 #endif
     std::string cacheRoot;
-    if (cacheHome)
+    if (cacheHome) {
       cacheRoot = cacheHome;
-    else
+    } else {
       cacheRoot = getCvarString({"HOME"}, "/tmp") + "/.cache";
+    }
     auto cacheDirPath = std::filesystem::path(cacheRoot + "/torch");
     // Create the .cache directory if it doesn't exist
     c10::filesystem::create_directories(cacheDirPath);


### PR DESCRIPTION
In other places, e.g. Python code, "~/.cache/torch" is only used as fallback of "$XDG_CACHE_HOME/torch".
So honor it here too.


This avoids issues where $HOME is not set or not writable.