### PR TITLE
[xpu] Enable TransformerEncoderLayer Fast Path for XPU Device

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -511,6 +511,7 @@ class TransformerEncoder(Module):
             _supported_device_type = [
                 "cpu",
                 "cuda",
+                "xpu",
                 torch.utils.backend_registration._privateuse1_backend_name,
             ]
             if torch.overrides.has_torch_function(tensor_args):
@@ -895,6 +896,7 @@ class TransformerEncoderLayer(Module):
             _supported_device_type = [
                 "cpu",
                 "cuda",
+                "xpu",
                 torch.utils.backend_registration._privateuse1_backend_name,
             ]
             if torch.overrides.has_torch_function(tensor_args):


### PR DESCRIPTION
This PR aims to fix the device compatibility check for the Fast Path (high-performance C++ fusion operation) within torch.nn.TransformerEncoderLayer.
In the forward method of TransformerEncoderLayer, the device whitelist for the Fast Path implementation by default only includes "cpu" and "cuda". This change explicitly adds the "xpu" device type to the supported list. 
This ensures that when XPU tensors are used as input, the code correctly selects and executes the highly optimized C++ fused kernel (torch._transformer_encoder_layer_fwd), instead of falling back to the slower, unoptimized Python implementation.
cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01