### PR TITLE
Adjust the `gradcheck` tests for `ComplexTensor`

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -32,10 +32,7 @@ from torch.testing._internal.common_device_type import (
     OpDTypes,
     ops,
 )
-from torch.testing._internal.common_utils import (
-    run_tests,
-    unMarkDynamoStrictTest,
-)
+from torch.testing._internal.common_utils import run_tests, unMarkDynamoStrictTest
 
 
 if TYPE_CHECKING:

--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -13,7 +13,6 @@ try:
         COMPLEX_DTYPES,
         Descriptor,
         force_test_op_db,
-        get_overload_packet_from_name,
         implemented_op_db,
         TestCase,
         Variant,
@@ -23,13 +22,11 @@ except ImportError:
         COMPLEX_DTYPES,
         Descriptor,
         force_test_op_db,
-        get_overload_packet_from_name,
         implemented_op_db,
         TestCase,
         Variant,
     )
 
-from torch._subclasses.complex_tensor._ops.common import ComplexTensorMode
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     OpDTypes,
@@ -50,47 +47,6 @@ aten = torch.ops.aten
 SKIPS = {
     Descriptor(op=aten.empty_like, variant=None): "Non-deterministic output",
     Descriptor(op=aten.randn_like, variant=None): "Non-deterministic output",
-    Descriptor(op=aten.angle, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.asinh, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.atanh, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(
-        op=aten.reciprocal, variant=Variant.GradCheck
-    ): "Numerical inconsistency",
-    Descriptor(op=aten.rsqrt, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.select, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.asin, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.log, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.sgn, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.cumprod, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.slice, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.sqrt, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.tan, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(
-        op=aten.true_divide, variant=Variant.GradCheck
-    ): "Numerical inconsistency",
-    Descriptor(op=aten.prod, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.div, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.expm1, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.var, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.bmm, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.diagonal, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.sinh, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.abs, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.sin, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.atan, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.acos, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.acosh, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.cos, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.cosh, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.addmm, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.pow, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.log1p, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.tanh, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.mm, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.dot, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.mul, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.exp, variant=Variant.GradCheck): "Numerical inconsistency",
-    Descriptor(op=aten.to, variant=Variant.GradCheck): "Numerical inconsistency",
     Descriptor(
         op=aten.any, variant=Variant.Distributed
     ): "does not have a sharding strategy registered",
@@ -192,7 +148,7 @@ class TestComplexTensor(TestCase):
 
 
 @unMarkDynamoStrictTest
-class TestComplexBwdGradients(TestGradients):
+class TestComplexBwdGradients(TestCase, TestGradients):
     _default_dtype_check_enabled = True
 
     @ops(
@@ -201,22 +157,7 @@ class TestComplexBwdGradients(TestGradients):
         allowed_dtypes=[torch.complex128],
     )
     def test_fn_grad(self, device: str, dtype: torch.dtype, op: OpInfo) -> None:
-        test_info = Descriptor(
-            op=get_overload_packet_from_name(op.name),
-            device_type=torch.device(device).type,
-            dtype=dtype,
-            variant=Variant.GradCheck,
-        )
-        for xfail_info, reason in SKIPS.items():
-            if xfail_info.matches(test_info):
-                self.skipTest(reason)
-
-        if dtype not in op.supported_backward_dtypes(torch.device(device).type):
-            self.skipTest(f"Skipped! {dtype=} is not in supported backward dtypes!")
-
-        with ComplexTensorMode():
-            op.gradcheck_fast_mode = False
-            self._grad_test_helper(device, dtype, op, op.get_op())
+        self.check_consistency(device, dtype, op, Variant.GradCheck)
 
 
 instantiate_device_type_tests(TestComplexTensor, globals())

--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -153,7 +153,7 @@ class TestComplexBwdGradients(TestCase):
         allowed_dtypes=[torch.complex128],
     )
     def test_fn_grad(self, device: str, dtype: torch.dtype, op: OpInfo) -> None:
-        self.check_consistency(device, dtype, op, Variant.GradCheck)
+        self.check_grad(device, dtype, op)
 
 
 instantiate_device_type_tests(TestComplexTensor, globals())

--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -34,7 +34,6 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import (
     run_tests,
-    TestGradients,
     unMarkDynamoStrictTest,
 )
 
@@ -148,7 +147,7 @@ class TestComplexTensor(TestCase):
 
 
 @unMarkDynamoStrictTest
-class TestComplexBwdGradients(TestCase, TestGradients):
+class TestComplexBwdGradients(TestCase):
     _default_dtype_check_enabled = True
 
     @ops(

--- a/test/complex_tensor/utils.py
+++ b/test/complex_tensor/utils.py
@@ -57,11 +57,9 @@ def _as_gradcheck_tensor(
     if not isinstance(arg, torch.Tensor):
         return arg
     arg = _as_complex_tensor(arg)
-    if not (arg.dtype.is_floating_point or arg.dtype.is_complex):
-        input_list.append(arg)
-        return arg
+    if arg.dtype.is_floating_point or arg.dtype.is_complex:
+        arg = arg.requires_grad_()
 
-    arg = arg.requires_grad_()
     input_list.append(arg)
     return arg
 

--- a/test/complex_tensor/utils.py
+++ b/test/complex_tensor/utils.py
@@ -211,12 +211,15 @@ class TestCase(PytorchTestCase):
                         )
 
                     # Do the actual gradcheck
-                    gradcheck(
-                        func,
-                        input_list,
-                        raise_exception=True,
-                        fast_mode=True,
-                        check_batched_grad=True,
+                    self.assertTrue(
+                        gradcheck(
+                            func,
+                            input_list,
+                            raise_exception=True,
+                            fast_mode=True,
+                            check_batched_grad=True,
+                            check_forward_ad=True,
+                        )
                     )
                 case _:
                     self.assertTrue(False, "Testcase not implemented for variant.")

--- a/test/complex_tensor/utils.py
+++ b/test/complex_tensor/utils.py
@@ -50,23 +50,9 @@ def _as_complex_dtensor(arg: torch.Tensor | Any) -> torch.Tensor | Any:
     return dist.tensor.DTensor.from_local(_as_complex_tensor(arg))
 
 
-def _as_gradcheck_tensor(
-    arg: torch.Tensor | Any, input_list: list[torch.Tensor]
-) -> torch.Tensor | Any:
-    if not isinstance(arg, torch.Tensor):
-        return arg
-    arg = _as_complex_tensor(arg)
-    if arg.dtype.is_floating_point or arg.dtype.is_complex:
-        arg = arg.requires_grad_()
-
-    input_list.append(arg)
-    return arg
-
-
 TRANSFORM_FUNCS = {
     Variant.Op: _as_complex_tensor,
     Variant.Distributed: _as_complex_dtensor,
-    Variant.GradCheck: _as_gradcheck_tensor,
 }
 
 

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -164,7 +164,7 @@ def div_impl(lhs: ComplexTensor, rhs: ComplexTensor, *, rounding_mode=None):
         raise NotImplementedError(
             "`rounding_mode` other than `None` not implemented for`ComplexTensor`."
         )
-    a_r, a_i = split_complex_tensor(lhs)
+    a_r, a_i = split_complex_arg(lhs)
     if not is_complex(rhs):
         return ComplexTensor(a_r / rhs, a_i / rhs)
     b_r, b_i = split_complex_arg(rhs)
@@ -699,7 +699,11 @@ def linalg_vector_norm_impl(self: ComplexTensor, *args, **kwargs) -> torch.Tenso
 
 @register_force_test(aten.copy_)
 def copy__impl(self: ComplexTensor, src, *args, **kwargs):
-    self_re, self_im = split_complex_tensor(self)
+    if not self.dtype.is_complex:
+        src_re, src_im = split_complex_arg(src)
+        return self.copy_(src_re)
+
+    self_re, self_im = split_complex_arg(self)
     src_re, src_im = split_complex_arg(src)
 
     ret_re = self_re.copy_(src_re, *args, **kwargs)

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -698,7 +698,12 @@ def linalg_vector_norm_impl(self: ComplexTensor, *args, **kwargs) -> torch.Tenso
 
 
 @register_force_test(aten.copy_)
-def copy__impl(self: ComplexTensor, src, *args, **kwargs):
+def copy__impl(
+    self: ComplexTensor | torch.Tensor,
+    src: ComplexTensor | torch.Tensor,
+    *args,
+    **kwargs,
+) -> ComplexTensor | torch.Tensor:
     if not self.dtype.is_complex:
         src_re, src_im = split_complex_arg(src)
         return self.copy_(src_re)

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import torch
@@ -705,6 +706,9 @@ def copy__impl(
     **kwargs,
 ) -> ComplexTensor | torch.Tensor:
     if not self.dtype.is_complex:
+        warnings.warn(
+            "Casting complex values to real discards the imaginary part", UserWarning
+        )
         src_re, src_im = split_complex_arg(src)
         return self.copy_(src_re)
 


### PR DESCRIPTION
The existing `gradcheck` tests appear to have some bugs when it comes to dealing with a `TorchDispatchMode`. In this PR, I've hand-rolled some tests that manually use `torch.autograd.gradcheck.gradcheck`; and all of these work as expected.
