### PR TITLE
Fix `hash(Size([SymInt, ...]))` on Python 3.14+

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -501,6 +501,7 @@ class TestPySymInt(TestCase):
         self.assertIsInstance(r.shape[0], SymInt)
 
     def test_hash_size(self):
+        # See issue #168254
         shape_env = ShapeEnv()
         a0 = create_symint(shape_env, 2)
         r = torch.empty(a0, device="meta")

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -500,6 +500,12 @@ class TestPySymInt(TestCase):
         r = torch.empty(a0, device="meta")
         self.assertIsInstance(r.shape[0], SymInt)
 
+    def test_hash_size(self):
+        shape_env = ShapeEnv()
+        a0 = create_symint(shape_env, 2)
+        r = torch.empty(a0, device="meta")
+        self.assertRaises(TypeError, lambda: hash(r.shape))
+
     def test_guard_int(self):
         shape_env = ShapeEnv()
         a0 = create_symint(shape_env, 2)

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -5,7 +5,6 @@
 
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_arg_parser.h>
-#include <torch/csrc/utils/python_compat.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_tuples.h>
@@ -220,7 +219,7 @@ static PySequenceMethods THPSize_as_sequence = {
     nullptr /* sq_contains */
 };
 
-#ifdef IS_PYTHON_3_14_PLUS
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 14
 static Py_hash_t THPSize_hash(PyObject* self) {
   /*
   Python 3.14 introduce a caching mechanism for tuple hashing which is stored
@@ -302,7 +301,7 @@ PyTypeObject THPSizeType = {
     &THPSize_as_number, /* tp_as_number */
     &THPSize_as_sequence, /* tp_as_sequence */
     &THPSize_as_mapping, /* tp_as_mapping */
-#ifdef IS_PYTHON_3_14_PLUS
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 14
     &THPSize_hash, /* tp_hash  */
 #else
     nullptr, /* tp_hash */
@@ -316,7 +315,7 @@ PyTypeObject THPSizeType = {
     nullptr, /* tp_doc */
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
-#ifdef IS_PYTHON_3_14_PLUS
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 14
     // if tp_hash is defined, one must also defines tp_richcompare
     PyTuple_Type.tp_richcompare, /* tp_richcompare */
 #else

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -225,10 +225,10 @@ static Py_hash_t THPSize_hash(PyObject* self) {
   Python 3.14 introduce a caching mechanism for tuple hashing which is stored
   in the `ob_hash` field. The caching mechanism relies on a sentinel value (-1)
   to indicate the hash has not yet been computed.
-  For some unknown reason, this field is initialized with 0 when Size is created,
-  which causes the caching logic to behave incorrectly.
+  For some unknown reason, this field is initialized with 0 when Size is
+  created, which causes the caching logic to behave incorrectly.
   */
-  PyTupleObject *v = _PyTuple_CAST(self);
+  PyTupleObject* v = _PyTuple_CAST(self);
   // reset ob_hash and force hash to be recomputed
   Py_hash_t sentinel = -1;
   v->ob_hash = sentinel;

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -219,6 +219,23 @@ static PySequenceMethods THPSize_as_sequence = {
     nullptr /* sq_contains */
 };
 
+#ifdef IS_PYTHON_3_14_PLUS
+static Py_hash_t THPSize_hash(PyObject* self) {
+  /*
+  Python 3.14 introduce a caching mechanism for tuple hashing which is stored
+  in the `ob_hash` field. The caching mechanism relies on a sentinel value (-1)
+  to indicate the hash has not yet been computed.
+  For some unknown reason, this field is initialized with 0 when Size is created,
+  which causes the caching logic to behave incorrectly.
+  */
+  PyTupleObject *v = _PyTuple_CAST(self);
+  // reset ob_hash and force hash to be recomputed
+  Py_hash_t sentinel = -1;
+  v->ob_hash = sentinel;
+  return PyTuple_Type.tp_hash(self);
+}
+#endif
+
 static PyMappingMethods THPSize_as_mapping = {
     nullptr, /* mp_length */
     wrap_tuple_fn<decltype(&mp_subscript), &mp_subscript>,
@@ -284,7 +301,11 @@ PyTypeObject THPSizeType = {
     &THPSize_as_number, /* tp_as_number */
     &THPSize_as_sequence, /* tp_as_sequence */
     &THPSize_as_mapping, /* tp_as_mapping */
-    nullptr, /* tp_hash  */
+#ifdef IS_PYTHON_3_14_PLUS
+    &THPSize_hash, /* tp_hash  */
+#else
+    nullptr, /* tp_hash */
+#endif
     nullptr, /* tp_call */
     nullptr, /* tp_str */
     nullptr, /* tp_getattro */
@@ -294,7 +315,12 @@ PyTypeObject THPSizeType = {
     nullptr, /* tp_doc */
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
+#ifdef IS_PYTHON_3_14_PLUS
+    // if tp_hash is defined, one must also defines tp_richcompare
+    PyTuple_Type.tp_richcompare, /* tp_richcompare */
+#else
     nullptr, /* tp_richcompare */
+#endif
     0, /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -5,6 +5,7 @@
 
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_arg_parser.h>
+#include <torch/csrc/utils/python_compat.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_tuples.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #168256

Fixes PyTorch issue #168254

Python 3.14 introduced an optimization to tuple hashing by adding hash caching in the tuple structure. In older versions, Python would recompute the hash on every call. Now, the computed hash is stored in the tuple's `ob_hash` field and reused on subsequent calls.

`torch.Size(...)` has this field set to `0` in some scenarios and causes the cache to behave incorrectly. To fix this, we reset the cache right before delegating the call to CPython `tuple_hash`.