### PR TITLE
Make TORCH_BOX support (const) ref arguments

### DIFF
--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -280,7 +280,7 @@ struct boxer {
       uint64_t num_outputs) {
     boxer_impl<
         typename FunctionTraits::return_type,
-        torch::headeronly::guts::typelist::map_t<std::remove_reference_t, typename FunctionTrait::parameter_types>,
+        torch::headeronly::guts::typelist::map_t<std::remove_reference_t, typename FunctionTraits::parameter_types>,
         FuncT,
         func>::boxed_fn(stack, num_args, num_outputs);
   }

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -280,7 +280,7 @@ struct boxer {
       uint64_t num_outputs) {
     boxer_impl<
         typename FunctionTraits::return_type,
-        typename FunctionTraits::parameter_types,
+        torch::headeronly::guts::typelist::map_t<std::remove_reference_t, typename FunctionTrait::parameter_types>,
         FuncT,
         func>::boxed_fn(stack, num_args, num_outputs);
   }


### PR DESCRIPTION
A bunch of operators in xFormers take `const Tensor&` arguments. We could change them to become by-value as part of the migration to stable ABI, but perhaps it's simpler to just fix TORCH_BOX to handle this?

The concrete errors I was seeing were that `to<T>(...)` and `from<T>(...)` have a static assert that the type is a plain data type, which fails for references. However, if we remove the reference only around `to` and `from`, we hit a second issue which is that the tuple returned by `unbox_to_tuple` is a tuple of _dangling_ references, since they refer to temporaries that have been deleted. The "standard" solution would be to use `std::reference_wrapper` or something, but I thought that it would just be easier to just change the signature of the function when we parse it to remove the references.