### PR TITLE
Skipping few distributed tests for 2 GPU setups

### DIFF
--- a/test/distributed/tensor/test_dtensor_dispatch_overhead.py
+++ b/test/distributed/tensor/test_dtensor_dispatch_overhead.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 import torch
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -65,6 +66,7 @@ class DistOpDispatchOverHead(DTensorTestBase):
     def world_size(self) -> int:
         return 4
 
+    @skip_if_lt_x_gpu(4)
     @with_comms
     def test_dtensor_add_op_dispatch_overhead(self):
         if torch.cuda.is_available():

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1037,6 +1037,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(out_with_redistribute.placements[0].is_replicate())
         self.assertEqual(out_without_redistribute, out_with_redistribute)
 
+    @skip_if_lt_x_gpu(4)
     @with_comms
     def test_std(self):
         mesh = DeviceMesh(self.device_type, torch.arange(4).reshape(2, 2))

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -23,6 +23,7 @@ from torch.distributed.tensor._collective_utils import shard_dim_alltoall
 from torch.distributed.tensor._dtensor_spec import ShardOrderEntry
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard, MaskPartial
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -507,6 +508,7 @@ class RedistributeTest(DTensorTestBase):
                 dt_full_tensor = dt.full_tensor()
                 self.assertEqual(dt_full_tensor, input_tensor)
 
+    @skip_if_lt_x_gpu(4)
     @with_comms
     @parametrize("dtype", [torch.float32, torch.cfloat])
     def test_redistribute_shard_dim_change(self, dtype):


### PR DESCRIPTION
Skipping test/distributed/tensor/test_math_ops.py::DistMathOpsTestWithLocalTensor::test_std and test/distributed/tensor/test_redistribute.py::RedistributeTest::test_redistribute_shard_dim_change_float32 if less than 4 gpus are present.