### PR TITLE
Add human-readable type name comment to TYPE_MATCH guards for debugging clarity

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1937,7 +1937,8 @@ class GuardBuilder(GuardBuilderBase):
             guard._unserializable = True
 
         obj_id = self.id_ref(t, f"type({guard.name})")
-        code = f"___check_type_id({self.arg_ref(guard)}, {obj_id})"
+        type_repr = repr(t)
+        code = f"___check_type_id({self.arg_ref(guard)}, {obj_id})  # {type_repr}"
         self._set_guard_export_info(guard, [code])
 
         self.get_guard_manager(guard).add_type_match_guard(


### PR DESCRIPTION
Fixes #168160

TYPE_MATCH guards currently generate code like:

    ___check_type_id(x, 94229757490048)

The numeric type-id provides no information about the type being checked.
This PR appends a human-readable `repr(type)` as a trailing comment:

    ___check_type_id(x, 94229757490048)  # <class 'torch.nn.modules.linear.Linear'>

### What This Change Does
- Adds `repr(t)` to improve readability of guard output.
- No behavior or semantics are changed — this is a debug-only improvement.

### Testing
Verified that `repr(type)` produces readable, accurate names for built-in,
user-defined, and torch.nn module types. Runtime behavior is unchanged; CI
will validate everything end-to-end.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @jataylo