### PR TITLE
[precompile] nicer error message when caches are disabled

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -787,6 +787,11 @@ class _TorchDynamoContext:
         def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
             from torch._dynamo.aot_compile import aot_compile_fullgraph
 
+            if torch._inductor.config.force_disable_caches:
+                raise RuntimeError(
+                    "Cannot precompile with torch._inductor.config.force_disable_caches=True; caching is required."
+                )
+
             if not self.fullgraph:
                 raise RuntimeError(
                     "Graph breaks are not supported with aot compile. Please use torch.compile(fullgraph=True)."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168274

I commonly use the following alias for generating tlparses

```
function tlp {
  setopt rm_star_silent
  rm -rf ~/tmp/trace_logs/*
  TORCH_TRACE=~/tmp/trace_logs TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 "$@"
  tlparse ~/tmp/trace_logs --slug "$USER/$(uuidgen)/custom" --overwrite-manifold
}
```

and was surprised to see the following failure

```
(/home/bobren/local/a/pytorch-env) [9:18] devgpu009:/home/bobren/local/a/pytorch [130]
❯ tlp python pc.py
/home/bobren/local/a/pytorch/torch/_dynamo/pgo.py:539: UserWarning: dynamo_pgo force disabled by torch.compiler.config.force_disable_caches
  warn_once(
Traceback (most recent call last):
  File "/home/bobren/local/a/pytorch/pc.py", line 24, in <module>
    compiled_fn.save_compiled_function(path)
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile.py", line 128, in save_compiled_function
    f.write(type(self).serialize(self))
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile.py", line 143, in serialize
    type(compiled_fn).serialize_compile_artifacts(compiled_fn),
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile_types.py", line 50, in serialize_compile_artifacts
    result = pickle.dumps(fn.compiled_fn.serialize())
TypeError: 'NoneType' object is not callable
```

which goes away if i remove TORCH_INDUCTOR_FORCE_DISABLE_CACHE=1

This PR adds a nicer error message

```
❯ tlp python pc.py
/home/bobren/local/a/pytorch/torch/_dynamo/pgo.py:539: UserWarning: dynamo_pgo force disabled by torch.compiler.config.force_disable_caches
  warn_once(
Traceback (most recent call last):
  File "/home/bobren/local/a/pytorch/pc.py", line 24, in <module>
    compiled_fn.save_compiled_function(path)
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile.py", line 128, in save_compiled_function
    raise RuntimeError(
RuntimeError: Cannot precompile with torch._inductor.config.force_disable_caches=True; caching is required.
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela