### PR TITLE
Eliminate GPU to CPU sync in linalg.eig for CUDA tensors

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.h
+++ b/aten/src/ATen/native/BatchLinearAlgebra.h
@@ -236,6 +236,17 @@ using linalg_eig_fn = void (*)(Tensor& /*eigenvalues*/, Tensor& /*eigenvectors*/
 
 DECLARE_DISPATCH(linalg_eig_fn, linalg_eig_stub)
 
+// Converts LAPACK's real-valued eigenvector encoding to complex eigenvectors
+TORCH_API void linalg_eig_make_complex_eigenvectors(
+    const Tensor& complex_vectors,
+    const Tensor& complex_values,
+    const Tensor& real_vectors);
+
+DECLARE_DISPATCH(
+    void(*)(const Tensor&, const Tensor&, const Tensor&),
+    linalg_eig_make_complex_eigenvectors_stub)
+
+
 using geqrf_fn = void (*)(const Tensor& /*input*/, const Tensor& /*tau*/);
 DECLARE_DISPATCH(geqrf_fn, geqrf_stub)
 

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/Config.h>
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/BatchLinearAlgebra.h>
 #include <ATen/native/LinearAlgebraUtils.h>
@@ -134,6 +135,59 @@ Tensor& cholesky_inverse_kernel_impl(Tensor& result, Tensor& infos, bool upper) 
     apply_cholesky_inverse<scalar_t>(result, infos, upper);
   });
   return result;
+}
+
+// This function returns complex-valued eigenvectors that is obtained from LAPACK GEEV's real-valued output
+// This function is also used for the MAGMA path because intermediate MAGMA's results live on CPU
+template <typename scalar_t>
+static void linalg_eig_make_complex_eigenvectors_cpu_impl(const Tensor& result, const Tensor& complex_values, const Tensor& real_vectors) {
+  // From GEEV documentation:
+  // Complex conjugate pairs of eigenvalues appear consecutively with the eigenvalue having the positive imaginary part first
+  // If the j-th eigenvalue is real, then v(j) = VR(:,j), the j-th column of VR.
+  // If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, then v(j) = VR(:,j) + i*VR(:,j+1) and v(j+1) = VR(:,j) - i*VR(:,j+1).
+
+  auto batch_size = batchCount(real_vectors);
+  auto n = real_vectors.size(-1);
+  auto matrix_stride = matrixStride(real_vectors);
+
+  auto result_data = result.data_ptr<c10::complex<scalar_t>>();
+  auto real_vectors_data = real_vectors.const_data_ptr<scalar_t>();
+  auto values_data = complex_values.const_data_ptr<c10::complex<scalar_t>>();
+
+  for (auto b = decltype(batch_size){0}; b < batch_size; b++) {
+    const scalar_t* vecs = &real_vectors_data[b * matrix_stride];
+    c10::complex<scalar_t>* res = &result_data[b * matrix_stride];
+    const c10::complex<scalar_t>* vals = &values_data[b * n];
+    for (auto j = decltype(n){0}; j < n; j++) {
+      if (vals[j].imag() == 0.0) {  // eigenvalue is real, then v(j) = VR(:,j)
+        for (auto i = decltype(n){0}; i < n; i++) {
+          res[j * n + i] = c10::complex<scalar_t>(vecs[j * n + i], 0);
+        }
+      } else {
+        for (auto i = decltype(n){0}; i < n; i++) {
+          res[j * n + i] = c10::complex<scalar_t>(vecs[j * n + i],  vecs[(j+1) * n + i]);      // v(j)   = VR(:,j) + i*VR(:,j+1)
+          res[(j+1) * n + i] = c10::complex<scalar_t>(vecs[j * n + i], -vecs[(j+1) * n + i]);  // v(j+1) = VR(:,j) - i*VR(:,j+1)
+        }
+        j++;
+      }
+    }
+  }
+}
+
+// CPU dispatch kernel
+void linalg_eig_make_complex_eigenvectors_cpu(const Tensor& complex_vectors, const Tensor& complex_values, const Tensor& real_vectors) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(complex_vectors.mT().is_contiguous());
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(complex_values.is_contiguous());
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(real_vectors.mT().is_contiguous());
+
+  AT_DISPATCH_V2(
+    real_vectors.scalar_type(),
+    "linalg_eig_make_complex_eigenvectors_cpu",
+    AT_WRAP([&] {
+      linalg_eig_make_complex_eigenvectors_cpu_impl<scalar_t>(
+        complex_vectors, complex_values, real_vectors);
+    }),
+    AT_EXPAND(AT_FLOATING_TYPES));
 }
 
 /*
@@ -1165,6 +1219,13 @@ REGISTER_AVX2_DISPATCH(cholesky_inverse_stub, &cholesky_inverse_kernel_impl)
 REGISTER_VSX_DISPATCH(cholesky_inverse_stub, &cholesky_inverse_kernel_impl)
 REGISTER_ZVECTOR_DISPATCH(cholesky_inverse_stub, &cholesky_inverse_kernel_impl)
 REGISTER_SVE256_DISPATCH(cholesky_inverse_stub, &cholesky_inverse_kernel_impl)
+
+REGISTER_ARCH_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, DEFAULT, &linalg_eig_make_complex_eigenvectors_cpu)
+REGISTER_AVX512_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, &linalg_eig_make_complex_eigenvectors_cpu)
+REGISTER_AVX2_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, &linalg_eig_make_complex_eigenvectors_cpu)
+REGISTER_VSX_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, &linalg_eig_make_complex_eigenvectors_cpu)
+REGISTER_ZVECTOR_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, &linalg_eig_make_complex_eigenvectors_cpu)
+REGISTER_SVE256_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, &linalg_eig_make_complex_eigenvectors_cpu)
 
 REGISTER_ARCH_DISPATCH(linalg_eig_stub, DEFAULT, &linalg_eig_kernel)
 REGISTER_AVX512_DISPATCH(linalg_eig_stub, &linalg_eig_kernel)

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebraEig.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebraEig.cu
@@ -1,0 +1,119 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/core/Tensor.h>
+#include <ATen/Dispatch_v2.h>
+#include <ATen/native/BatchLinearAlgebra.h>
+#include <ATen/native/LinearAlgebraUtils.h>
+#include <c10/cuda/CUDAGuard.h>
+
+namespace at::native {
+
+namespace {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ linalg_eig_make_complex_eigenvectors ~~~~~~~~~~~~~~~~~~~~~~~
+
+// Processes all columns in parallel. For complex conjugate pairs, each thread
+// reads from neighboring columns but writes only to its own column.
+template <typename scalar_t>
+__global__ void linalg_eig_make_complex_eigenvectors_kernel(
+    c10::complex<scalar_t>* __restrict__ result,
+    const c10::complex<scalar_t>* __restrict__ eigenvalues,
+    const scalar_t* __restrict__ vectors,
+    const int64_t batch_size,
+    const int64_t n,
+    const int64_t matrix_stride) {
+
+  const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t total_elements = batch_size * n * n;
+
+  if (idx >= total_elements) return;
+
+  const int64_t batch_idx = idx / (n * n);
+  const int64_t local_idx = idx % (n * n);
+  const int64_t col = local_idx / n;
+  const int64_t row = local_idx % n;
+
+  const auto* batch_eigenvalues = eigenvalues + batch_idx * n;
+  const auto* batch_vectors = vectors + batch_idx * matrix_stride;
+  auto* batch_result = result + batch_idx * matrix_stride;
+
+  const auto eigenvalue = batch_eigenvalues[col];
+
+  if (eigenvalue.imag() == scalar_t(0)) {
+    batch_result[col * n + row] = c10::complex<scalar_t>(
+        batch_vectors[col * n + row],
+        scalar_t(0));
+  } else if (eigenvalue.imag() > scalar_t(0)) {
+    batch_result[col * n + row] = c10::complex<scalar_t>(
+        batch_vectors[col * n + row],
+        batch_vectors[(col + 1) * n + row]);
+  } else {
+    batch_result[col * n + row] = c10::complex<scalar_t>(
+        batch_vectors[(col - 1) * n + row],
+        -batch_vectors[col * n + row]);
+  }
+}
+
+template <typename scalar_t>
+void linalg_eig_make_complex_eigenvectors_cuda_impl(
+    const Tensor& complex_vectors,
+    const Tensor& complex_values,
+    const Tensor& real_vectors) {
+
+  const auto n = real_vectors.size(-1);
+  const auto matrix_stride = matrixStride(real_vectors);
+  const auto batch_size = batchCount(real_vectors);
+
+  if (batch_size == 0 || n == 0) return;
+
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(complex_vectors.mT().is_contiguous());
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(complex_values.is_contiguous());
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(real_vectors.mT().is_contiguous());
+
+  const int64_t total_elements = batch_size * n * n;
+
+  const int threads = 256;
+  const int blocks = (total_elements + threads - 1) / threads;
+
+  auto* result_ptr = complex_vectors.data_ptr<c10::complex<scalar_t>>();
+  const auto* eigenvalues_ptr = complex_values.const_data_ptr<c10::complex<scalar_t>>();
+  const auto* vectors_ptr = real_vectors.const_data_ptr<scalar_t>();
+
+  linalg_eig_make_complex_eigenvectors_kernel<scalar_t>
+      <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+          result_ptr,
+          eigenvalues_ptr,
+          vectors_ptr,
+          batch_size,
+          n,
+          matrix_stride);
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void linalg_eig_make_complex_eigenvectors_cuda(
+    const Tensor& complex_vectors,
+    const Tensor& complex_values,
+    const Tensor& real_vectors) {
+
+  TORCH_INTERNAL_ASSERT(complex_vectors.is_cuda());
+  TORCH_INTERNAL_ASSERT(complex_values.is_cuda());
+  TORCH_INTERNAL_ASSERT(real_vectors.is_cuda());
+
+  c10::cuda::CUDAGuard device_guard(real_vectors.device());
+
+  AT_DISPATCH_V2(
+      real_vectors.scalar_type(),
+      "linalg_eig_make_complex_eigenvectors_cuda",
+      AT_WRAP([&] {
+        linalg_eig_make_complex_eigenvectors_cuda_impl<scalar_t>(
+            complex_vectors, complex_values, real_vectors);
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES));
+}
+
+} // anonymous namespace
+
+REGISTER_CUDA_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, &linalg_eig_make_complex_eigenvectors_cuda)
+
+} // namespace at::native


### PR DESCRIPTION
This PR adds a CUDA kernel for linalg_eig_make_complex_eigenvectors,
eliminating unnecessary GPU→CPU→GPU synchronization when computing
eigenvalues and eigenvectors of real-valued CUDA tensors with complex eigenvalues.

When torch.linalg.eig() is called on a real-valued CUDA tensor that produces
complex eigenvalues, the implementation previously transferred eigenvectors to
CPU for decoding, then transferred them back to GPU. This PR keeps all
operations on the GPU, improving performance by ~8-10%.

## PR Overview

This PR makes linalg_eig_make_complex_eigenvectors dispatchable and adds a
CUDA kernel implementation. The changes span 4 commits:

**Commit 1: Add dispatch infrastructure**
- Declares DECLARE_DISPATCH stub for linalg_eig_make_complex_eigenvectors
- File: aten/src/ATen/native/BatchLinearAlgebra.h

**Commit 2: Refactor for dispatch**
- Moves CPU implementation to dispatch system
- Removes GPU-to-CPU synchronization from call site
- Preserves existing CPU implementation exactly (rename only)
- Files: aten/src/ATen/native/BatchLinearAlgebra.cpp, BatchLinearAlgebraKernel.cpp

**Commit 3: Add CUDA kernel**
- Implements parallel CUDA kernel for eigenvector decoding
- Parallelizes across batch, eigenvectors, and elements
- Uses AT_DISPATCH_V2 for float32/float64 support
- File: aten/src/ATen/native/cuda/BatchLinearAlgebraEig.cu

**Commit 4: Add comprehensive test**
- Tests CUDA kernel with rotation matrices (known analytical eigenvalues)
- Validates fundamental identity: A@v = λv
- Covers complex eigenvalues, real eigenvalues, and batched operations
- File: test/test_linalg.py

Now, for CUDA tensors, the entire pipeline runs on GPU with no host synchronization.

## Performance Results

Benchmarked on NVIDIA H200 with CUDA 12.8 using block-diagonal rotation matrices
(which guarantee complex eigenvalues, triggering the eigenvector decoding path).

Timing method: Wall-clock with GPU synchronization, 20 iterations after 5 warmup runs.

Configuration: batch_size × matrix_rows × matrix_cols
(e.g., 1×100×100 = single 100×100 matrix, 10×100×100 = batch of 10 matrices of size 100×100)

| Configuration  | Before (ms) | After (ms) | Improvement | Speedup |
|----------------|-------------|------------|-------------|---------|
| 1×100×100      |      11.459 |     10.506 |    0.953 ms |   8.3%  |
| 1×500×500      |      58.677 |     52.918 |    5.759 ms |   9.8%  |
| 1×1000×1000    |     123.130 |    110.919 |   12.211 ms |   9.9%  |
| 10×100×100     |     112.885 |    103.173 |    9.712 ms |   8.6%  |
| 100×100×100    |    1109.828 |   1024.709 |   85.119 ms |   7.7%  |

**Average speedup: ~9% for the entire linalg.eig() operation**

Fixes #167105

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @jianyuh @nikitaved @mruberry @walterddr @xwang233 @Lezcano