### PR TITLE
[3.14] Clear tx lookup_tensor in VariableBuilder call

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1224,6 +1224,9 @@ class InstructionTranslatorBase(
             raise AssertionError(f"Attempt to trace forbidden callable {inner_fn}")
         self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
 
+        if not self.export and self.fake_mode is not None:
+            self.fake_mode.fake_tensor_converter.meta_converter.describer.lookup_tensor.clear()
+
     def inline_generator_function(
         self, fn: VariableTracker, args: Sequence[Any], kwargs: dict[str, Any]
     ) -> Any:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -495,7 +495,6 @@ class VariableBuilder:
             vt = self.tx.output.side_effects.track_object_existing(value, vt)
 
         self.tx.output.variable_tracker_cache.add(value, self.source, vt)
-
         return vt
 
     def _can_lift_attrs_to_inputs(self, vt):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -495,6 +495,8 @@ class VariableBuilder:
             vt = self.tx.output.side_effects.track_object_existing(value, vt)
 
         self.tx.output.variable_tracker_cache.add(value, self.source, vt)
+
+        self.tx.fake_mode.fake_tensor_converter.meta_converter.describer.lookup_tensor.clear()
         return vt
 
     def _can_lift_attrs_to_inputs(self, vt):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -496,7 +496,6 @@ class VariableBuilder:
 
         self.tx.output.variable_tracker_cache.add(value, self.source, vt)
 
-        self.tx.fake_mode.fake_tensor_converter.meta_converter.describer.lookup_tensor.clear()
         return vt
 
     def _can_lift_attrs_to_inputs(self, vt):


### PR DESCRIPTION
My debug process: https://gist.github.com/azahed98/efa1803c557678927e5e29d22c3f0087

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela