### PR TITLE
Fix unused gradient tracking to respect create_graph

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -404,8 +404,6 @@ class TestAutograd(TestCase):
         out.backward()
 
     def test_unused_grad_requires_grad_with_materialize(self):
-        """Test that unused gradients have requires_grad=False when create_graph=False"""
-
         x = torch.ones(10, requires_grad=True)
         y = torch.ones(10, requires_grad=True)
         z = (x**2).sum()

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -403,6 +403,20 @@ class TestAutograd(TestCase):
         out = Func.apply(a)[0]
         out.backward()
 
+    def test_unused_grad_requires_grad_with_materialize(self):
+        """Test that unused gradients have requires_grad=False when create_graph=False"""
+
+        x = torch.ones(10, requires_grad=True)
+        y = torch.ones(10, requires_grad=True)
+        z = (x**2).sum()
+
+        g = torch.autograd.grad(
+            z, (x, y), allow_unused=True, materialize_grads=True, create_graph=False
+        )
+
+        self.assertFalse(g[0].requires_grad)
+        self.assertFalse(g[1].requires_grad)
+
     def test_legacy_function_deprecation_exception(self):
         # Trigger exception
         class MyFunction(Function):

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -532,7 +532,7 @@ def grad(
         result = tuple(
             output
             if output is not None
-            else torch.zeros_like(input, requires_grad=True)
+            else torch.zeros_like(input, requires_grad=create_graph)
             for (output, input) in zip(result, inputs)
         )
     return result


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/168059

PyTorch was incorrectly setting requires_grad=True on unused gradients even when create_graph=False. This caused unnecessary autograd tracking and extra memory usage.

This PR updates the logic to set requires_grad based on the value of create_graph, ensuring that unused gradients are tracked only when explicitly requested. This aligns torch.autograd.grad( ) behavior with expectations.


Includes test coverage in test_unused_grad_requires_grad_with_materialize