### PR TITLE
[Kineto] Generate and Upload the protobuf trace along with chrome trace

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1207,8 +1207,8 @@ class TestProfiler(TestCase):
                     parts[-4].isdigit() and int(parts[-4]) > 0,
                     "Wrong tracing file name pattern",
                 )
-                self.assertEqual(parts[-3:], ["pt", "trace", "json"])
-                file_num += 1
+                if parts[-3:] == ["pt", "trace", "json"]:
+                    file_num += 1
             self.assertEqual(file_num, 3)
 
         # test case for gzip file format


### PR DESCRIPTION
Summary: The JSON format perfetto trace has render issue for overlapping events. The protobuf format could solve it

Test Plan:
https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html?url=https://interncache-all.fbcdn.net/manifold/mtia_traces/tree/traces/dynocli/0/1761149407/localhost/libkineto_activities_2074019.pb.gz


https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html?url=https://interncache-all.fbcdn.net/manifold/perfdoctor_gpu_traces_test/tree/traces/test/zzmeng/mtia_eager_bench/1761684945.pb.gz#!/viewer?url=https%3A%2F%2Finterncache-all.fbcdn.net%2Fmanifold%2Fperfdoctor_gpu_traces_test%2Ftree%2Ftraces%2Ftest%2Fzzmeng%2Fmtia_eager_bench%2F1761684945.pb.gz&local_cache_key

 {F1983072300}

Differential Revision: D85279977


