### PR TITLE
[Compile] Fix warning: `use of ‘std::hardware_destructive_interference_size’`

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -39,7 +39,7 @@ struct HostBlock {
 };
 
 template <typename B>
-struct alignas(hardware_destructive_interference_size) FreeBlockList {
+struct alignas(c10::hardware_destructive_interference_size) FreeBlockList {
   std::mutex mutex_;
   std::deque<B*> list_;
 };
@@ -122,7 +122,7 @@ struct TORCH_API HostStats {
 // Struct containing memory allocator summary statistics for host, as they
 // are staged for reporting. This is a temporary struct that is used to
 // avoid locking the allocator while collecting stats.
-struct alignas(hardware_destructive_interference_size) HostStatsStaged {
+struct alignas(c10::hardware_destructive_interference_size) HostStatsStaged {
   std::mutex timing_mutex_;
   // COUNT: total allocations (active + free)
   // LOCK: access to this stat is protected by the allocator's blocks_mutex_
@@ -670,7 +670,7 @@ struct CachingHostAllocatorImpl {
     TORCH_CHECK_NOT_IMPLEMENTED(false, "Not implemented for query_event");
   }
 
-  alignas(hardware_destructive_interference_size) std::mutex blocks_mutex_;
+  alignas(c10::hardware_destructive_interference_size) std::mutex blocks_mutex_;
   ska::flat_hash_set<B*> blocks_; // block list
   ska::flat_hash_map<void*, B*> ptr_to_block_;
 
@@ -678,17 +678,17 @@ struct CachingHostAllocatorImpl {
   // size. This allows us to quickly find a free block of the right size.
   // We use deque to store per size free list and guard the list with its own
   // mutex.
-  alignas(hardware_destructive_interference_size) std::vector<FreeBlockList<B>>
+  alignas(c10::hardware_destructive_interference_size) std::vector<FreeBlockList<B>>
       free_list_{MAX_SIZE_INDEX};
 
-  alignas(hardware_destructive_interference_size) std::mutex events_mutex_;
+  alignas(c10::hardware_destructive_interference_size) std::mutex events_mutex_;
   std::deque<std::pair<E, B*>> events_; // event queue paired with block
 
   // Indicates whether the event-processing thread pool is active.
   // Set to false in the destructor to signal background threads to stop.
   std::atomic<bool> active_{false};
 protected:
-  alignas(hardware_destructive_interference_size) HostStatsStaged stats_;
+  alignas(c10::hardware_destructive_interference_size) HostStatsStaged stats_;
 };
 
 struct TORCH_API HostAllocator : public at::Allocator {

--- a/c10/core/alignment.h
+++ b/c10/core/alignment.h
@@ -20,11 +20,6 @@ constexpr size_t gPagesize = 4096;
 // for buffers of size 2MB or larger to avoid memory bloating
 constexpr size_t gAlloc_threshold_thp = static_cast<size_t>(2) * 1024 * 1024;
 
-// Cache line size used to avoid false sharing between threads. Falls back to 64
-// bytes if C++17 feature is unavailable.
-#ifdef __cpp_lib_hardware_interference_size
-using std::hardware_destructive_interference_size;
-#else
+// Cache line size used to avoid false sharing between threads.
 constexpr std::size_t hardware_destructive_interference_size = 64;
-#endif
 } // namespace c10

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -15,17 +15,6 @@ set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
 # the rpath (per library?)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-# pin hardware_destructive_interference_size for ABI stability with GCC,
-# but only if the compiler actually supports the corresponding --param.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag("--param=hardware_destructive_interference_size=64"
-    CXX_SUPPORTS_HW_INTERFERENCE_PARAM)
-  if(CXX_SUPPORTS_HW_INTERFERENCE_PARAM)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:--param=hardware_destructive_interference_size=64>)
-  endif()
-endif()
-
 # UBSAN triggers when compiling protobuf, so we need to disable it.
 set(UBSAN_FLAG "-fsanitize=undefined")
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -15,9 +15,15 @@ set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
 # the rpath (per library?)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-# pin hardware_destructive_interference_size for ABI stability with GCC.
+# pin hardware_destructive_interference_size for ABI stability with GCC,
+# but only if the compiler actually supports the corresponding --param.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:--param=destructive-interference-size=64>)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("--param=hardware_destructive_interference_size=64"
+    CXX_SUPPORTS_HW_INTERFERENCE_PARAM)
+  if(CXX_SUPPORTS_HW_INTERFERENCE_PARAM)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:--param=hardware_destructive_interference_size=64>)
+  endif()
 endif()
 
 # UBSAN triggers when compiling protobuf, so we need to disable it.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -15,7 +15,12 @@ set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
 # the rpath (per library?)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
- # UBSAN triggers when compiling protobuf, so we need to disable it.
+# pin hardware_destructive_interference_size for ABI stability with GCC.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:--param=destructive-interference-size=64>)
+endif()
+
+# UBSAN triggers when compiling protobuf, so we need to disable it.
 set(UBSAN_FLAG "-fsanitize=undefined")
 
 macro(disable_ubsan)


### PR DESCRIPTION
```bash
DEBUG /data/vllm-community-homes/vllm-user-6/pytorch/aten/src/ATen/core/CachingHostAllocator.h:125:16: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
DEBUG   125 | struct alignas(hardware_destructive_interference_size) HostStatsStaged {
DEBUG       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG /data/vllm-community-homes/vllm-user-6/pytorch/aten/src/ATen/core/CachingHostAllocator.h:673:11: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
DEBUG   673 |   alignas(hardware_destructive_interference_size) std::mutex blocks_mutex_;
DEBUG       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG /data/vllm-community-homes/vllm-user-6/pytorch/aten/src/ATen/core/CachingHostAllocator.h:681:11: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
DEBUG   681 |   alignas(hardware_destructive_interference_size) std::vector<FreeBlockList<B>>
DEBUG       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG /data/vllm-community-homes/vllm-user-6/pytorch/aten/src/ATen/core/CachingHostAllocator.h:684:11: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
DEBUG   684 |   alignas(hardware_destructive_interference_size) std::mutex events_mutex_;
DEBUG       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG /data/vllm-community-homes/vllm-user-6/pytorch/aten/src/ATen/core/CachingHostAllocator.h:691:11: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
DEBUG   691 |   alignas(hardware_destructive_interference_size) HostStatsStaged stats_;
DEBUG       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes this issue.