### PR TITLE
Don't warn about `CMAKE_CUDA_ARCHITECTURES` when `TORCH_CUDA_ARCH_LIST` is set

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -328,7 +328,7 @@ endif()
 # setting nvcc arch flags
 torch_cuda_get_nvcc_gencode_flag(NVCC_FLAGS_EXTRA)
 # CMake 3.18 adds integrated support for architecture selection, but we can't rely on it
-if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+if(DEFINED CMAKE_CUDA_ARCHITECTURES AND NOT TORCH_CUDA_ARCH_LIST)
   message(WARNING
           "pytorch is not compatible with `CMAKE_CUDA_ARCHITECTURES` and will ignore its value. "
           "Please configure `TORCH_CUDA_ARCH_LIST` instead.")


### PR DESCRIPTION
Since user knows about it when they are setting `TORCH_CUDA_ARCH_LIST`

cc @janeyx99