### PR TITLE
[WIP] Fake Tensor use weakref for FakeTensorMode

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3682,11 +3682,15 @@ def wrap_to_fake_tensor_and_record(
         # we use enable_python_dispatcher mainly to tweak the DispatchKeyState so that subclass authors
         # can check it to know if they are running in an eager context or not
         with enable_python_dispatcher():
+            # FakeTensors made here can hold on to the FakeTensorMode longer than needed, so they will only hold a weak
+            # reference to the FakeTensorMode and use the TracingContext to keep it alive, except in Export where the
+            # FakeTensors keep the FakeTensorMode alive
             fake_e = wrap_fake_exception(
                 lambda: tx.fake_mode.from_tensor(
                     e,
                     source=source,
                     symbolic_context=symbolic_context,
+                    strong_fake_mode=tx.fake_mode.fake_tensor_converter.export,
                 )
             )
         if (


### PR DESCRIPTION
Fixes #169388

In Python 3.14, FakeTensors holding onto the `fake_mode` prevent garbage collection of the FakeTensorMode, which in turn holds onto weakrefs of real tensors in caches. These weakrefs may prevent swapping devices of the tensors down the line after compile. This change adds `_fake_mode`, `_fake_mode_ref` and `_strong_fake_mode` to replace `FakeTensor.fake_mode` with a property getter and setter instead, that allows holding onto a weakref of the fake mode if needed. This specifically is a weakref if the FakeTensor is made from `wrap_to_fake_tensor_and_record` during compile, but not during export (which needs the strong ref afterwards).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela