### PR TITLE
[MPS][BugFix] Fix MaxPool2d/MaxPool3d output size validation (Issue #168246)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -394,20 +394,28 @@ static PoolSizes process_pool_sizes(const Tensor& input,
       std::stringstream input_size_str, output_size_str;
       // Build input size string for pooling dimensions
       for (const auto d : c10::irange(pooling_dims)) {
-        if (d > 0) input_size_str << "x";
+        if (d > 0)
+          input_size_str << "x";
         input_size_str << input.size(leading_dims + d);
       }
       // Build output size string for pooling dimensions
       for (const auto d : c10::irange(pooling_dims)) {
-        if (d > 0) output_size_str << "x";
+        if (d > 0)
+          output_size_str << "x";
         output_size_str << output_pooling_size[d];
       }
       // Always throw error - no need for extra bool flag
       TORCH_CHECK(output_pooling_size[dim] >= 1,
                   "Given input size: (",
-                  input.size(leading_dims - 1), "x", input_size_str.str(), "). ",
+                  input.size(leading_dims - 1),
+                  "x",
+                  input_size_str.str(),
+                  "). ",
                   "Calculated output size: (",
-                  input.size(leading_dims - 1), "x", output_size_str.str(), "). ",
+                  input.size(leading_dims - 1),
+                  "x",
+                  output_size_str.str(),
+                  "). ",
                   "Output size is too small");
     }
   }

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -395,25 +395,25 @@ static PoolSizes process_pool_sizes(const Tensor& input,
       // Build input size string for pooling dimensions
       for (const auto d : c10::irange(pooling_dims)) {
         if (d > 0)
-          input_size_str << "x";
+          input_size_str << 'x';
         input_size_str << input.size(leading_dims + d);
       }
       // Build output size string for pooling dimensions
       for (const auto d : c10::irange(pooling_dims)) {
         if (d > 0)
-          output_size_str << "x";
+          output_size_str << 'x';
         output_size_str << output_pooling_size[d];
       }
       // Always throw error - no need for extra bool flag
       TORCH_CHECK(output_pooling_size[dim] >= 1,
                   "Given input size: (",
                   input.size(leading_dims - 1),
-                  "x",
+                  'x',
                   input_size_str.str(),
                   "). ",
                   "Calculated output size: (",
                   input.size(leading_dims - 1),
-                  "x",
+                  'x',
                   output_size_str.str(),
                   "). ",
                   "Output size is too small");

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -2045,7 +2045,6 @@ torch.cuda.synchronize()
         helper(nn.AdaptiveAvgPool2d((2**6, 2**6)))
 
     @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16))
-    @expectedFailureMPS
     @dtypes(torch.float)
     def test_pool_invalid_size(self, device, dtype):
         for op in ("max", "avg"):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -804,6 +804,56 @@ class TestAvgPool(TestCaseMPS):
             self.assertEqual(out_mps, out_cpu, msg=msg)
 
 
+class TestMaxPool(TestCaseMPS):
+    """Tests for MaxPool output size validation (Issue #168246)"""
+
+    def test_max_pool2d_output_size_validation(self):
+        """Test MaxPool2d output size validation with CPU and MPS"""
+        max_pool = torch.nn.MaxPool2d(kernel_size=2)
+        x = torch.randn(1, 1, 4)
+
+        # Test CPU
+        cpu_error = None
+        try:
+            cpu_result = max_pool(x)
+        except RuntimeError as e:
+            cpu_error = str(e)
+
+        # Test MPS
+        mps_error = None
+        try:
+            x_mps = x.to("mps")
+            mps_result = max_pool(x_mps)
+        except RuntimeError as e:
+            mps_error = str(e)
+        
+        self.assertEqual(cpu_error, mps_error)
+        self.assertEqual(cpu_result, mps_result)
+
+
+    def test_max_pool3d_output_size_validation(self):
+        """Test MaxPool3d output size validation with CPU and MPS"""
+        max_pool = torch.nn.MaxPool3d(kernel_size=2)
+        x = torch.randn(1, 1, 1, 4, 4)
+
+        # Test CPU
+        cpu_error = None
+        try:
+            cpu_result = max_pool(x)
+        except RuntimeError as e:
+            cpu_error = str(e)
+
+        # Test MPS
+        mps_error = None
+        try:
+            x_mps = x.to("mps")
+            mps_result = max_pool(x_mps)
+        except RuntimeError as e:
+            mps_error = str(e)
+
+        self.assertEqual(cpu_error, mps_error)
+        self.assertEqual(cpu_result, mps_result)
+        
 class TestMPS(TestCaseMPS):
     def test_exp(self, device="mps", dtype=torch.float):
         for v in (2, -2) + ((1j, 1 + 1j) if dtype.is_complex else ()):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -804,50 +804,6 @@ class TestAvgPool(TestCaseMPS):
             self.assertEqual(out_mps, out_cpu, msg=msg)
 
 
-class TestMaxPool(TestCaseMPS):
-    """Tests for MaxPool output size validation (Issue #168246)"""
-
-    def test_max_pool2d_output_size_validation(self):
-        """Test MaxPool2d output size validation with CPU and MPS"""
-        max_pool = torch.nn.MaxPool2d(kernel_size=2)
-        x = torch.randn(1, 1, 4)
-
-        # Test CPU
-        try:
-            cpu_result = max_pool(x)
-        except RuntimeError as e:
-            cpu_result = str(e)
-
-        # Test MPS
-        try:
-            x_mps = x.to("mps")
-            mps_result = max_pool(x_mps)
-        except RuntimeError as e:
-            mps_result = str(e)
-
-        self.assertEqual(cpu_result, mps_result)
-
-
-    def test_max_pool3d_output_size_validation(self):
-        """Test MaxPool3d output size validation with CPU and MPS"""
-        max_pool = torch.nn.MaxPool3d(kernel_size=2)
-        x = torch.randn(1, 1, 1, 4, 4)
-
-        # Test CPU
-        try:
-            cpu_result = max_pool(x)
-        except RuntimeError as e:
-            cpu_result = str(e)
-
-        # Test MPS
-        try:
-            x_mps = x.to("mps")
-            mps_result = max_pool(x_mps)
-        except RuntimeError as e:
-            mps_result = str(e)
-
-        self.assertEqual(cpu_result, mps_result)
-
 class TestMPS(TestCaseMPS):
     def test_exp(self, device="mps", dtype=torch.float):
         for v in (2, -2) + ((1j, 1 + 1j) if dtype.is_complex else ()):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -813,21 +813,18 @@ class TestMaxPool(TestCaseMPS):
         x = torch.randn(1, 1, 4)
 
         # Test CPU
-        cpu_error = None
         try:
             cpu_result = max_pool(x)
         except RuntimeError as e:
-            cpu_error = str(e)
+            cpu_result = str(e)
 
         # Test MPS
-        mps_error = None
         try:
             x_mps = x.to("mps")
             mps_result = max_pool(x_mps)
         except RuntimeError as e:
-            mps_error = str(e)
+            mps_result = str(e)
         
-        self.assertEqual(cpu_error, mps_error)
         self.assertEqual(cpu_result, mps_result)
 
 
@@ -837,23 +834,20 @@ class TestMaxPool(TestCaseMPS):
         x = torch.randn(1, 1, 1, 4, 4)
 
         # Test CPU
-        cpu_error = None
         try:
             cpu_result = max_pool(x)
         except RuntimeError as e:
-            cpu_error = str(e)
+            cpu_result = str(e)
 
         # Test MPS
-        mps_error = None
         try:
             x_mps = x.to("mps")
             mps_result = max_pool(x_mps)
         except RuntimeError as e:
-            mps_error = str(e)
-
-        self.assertEqual(cpu_error, mps_error)
-        self.assertEqual(cpu_result, mps_result)
+            mps_result = str(e)
         
+        self.assertEqual(cpu_result, mps_result)
+
 class TestMPS(TestCaseMPS):
     def test_exp(self, device="mps", dtype=torch.float):
         for v in (2, -2) + ((1j, 1 + 1j) if dtype.is_complex else ()):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -824,7 +824,7 @@ class TestMaxPool(TestCaseMPS):
             mps_result = max_pool(x_mps)
         except RuntimeError as e:
             mps_result = str(e)
-        
+
         self.assertEqual(cpu_result, mps_result)
 
 
@@ -845,7 +845,7 @@ class TestMaxPool(TestCaseMPS):
             mps_result = max_pool(x_mps)
         except RuntimeError as e:
             mps_result = str(e)
-        
+
         self.assertEqual(cpu_result, mps_result)
 
 class TestMPS(TestCaseMPS):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3801,6 +3801,11 @@ def error_inputs_max_pool2d(op_info, device, **kwargs):
                                  kwargs={'kernel_size': 1}),
                      error_regex=err_msg)
 
+    # error: inputs when kernel size too large for input
+    yield ErrorInput(SampleInput(make_arg((1, 1, 4)),
+                                 kwargs={'kernel_size': 2}),
+                     error_regex='output size is too small')
+
 
 def error_inputs_max_pool3d(op_info, device, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=torch.float, requires_grad=False)
@@ -3832,6 +3837,12 @@ def error_inputs_max_pool3d(op_info, device, **kwargs):
     yield ErrorInput(SampleInput(make_arg((2, 1, 0, 1, 2)),
                                  kwargs={'kernel_size': 1}),
                      error_regex=err_msg)
+
+    # error: inputs when kernel size too large for input
+    yield ErrorInput(SampleInput(make_arg((1, 1, 1, 4, 4)),
+                                 kwargs={'kernel_size': 2}),
+                     error_regex='output size is too small')
+
 
 
 def sample_inputs_normalize(self, device, dtype, requires_grad, **kwargs):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3804,7 +3804,7 @@ def error_inputs_max_pool2d(op_info, device, **kwargs):
     # error: inputs when kernel size too large for input
     yield ErrorInput(SampleInput(make_arg((1, 1, 4)),
                                  kwargs={'kernel_size': 2}),
-                     error_regex='output size is too small')
+                     error_regex='Output size is too small')
 
 
 def error_inputs_max_pool3d(op_info, device, **kwargs):
@@ -3841,7 +3841,7 @@ def error_inputs_max_pool3d(op_info, device, **kwargs):
     # error: inputs when kernel size too large for input
     yield ErrorInput(SampleInput(make_arg((1, 1, 1, 4, 4)),
                                  kwargs={'kernel_size': 2}),
-                     error_regex='output size is too small')
+                     error_regex='Output size is too small')
 
 
 


### PR DESCRIPTION
Fix MaxPool2d and MaxPool3d on Apple MPS backend to properly validate output dimensions and raise errors for invalid kernel sizes, matching CPU behavior.

Fixes #168246

cc @malfet