### PR TITLE
Fix quadratic complexity in _apply_to_modules

### DIFF
--- a/test/distributed/fsdp/test_fsdp_prefix_set.py
+++ b/test/distributed/fsdp/test_fsdp_prefix_set.py
@@ -1,0 +1,157 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp._common_utils import (
+    _apply_to_modules,
+    _build_prefix_set,
+    _get_param_to_fqns,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestPrefixSet(TestCase):
+    """Tests for the prefix set optimization in _common_utils."""
+
+    def test_build_prefix_set_simple(self):
+        """Test that _build_prefix_set correctly builds prefix sets from FQNs."""
+        fqns = ["layer1.weight", "layer1.bias", "layer2.weight"]
+        prefix_set = _build_prefix_set(fqns)
+
+        # Should contain all intermediate prefixes and the FQNs themselves
+        expected = {
+            "layer1.",
+            "layer1.weight",
+            "layer1.bias",
+            "layer2.",
+            "layer2.weight",
+        }
+        self.assertEqual(prefix_set, expected)
+
+    def test_build_prefix_set_nested(self):
+        """Test prefix set with deeply nested module hierarchy."""
+        fqns = ["model.encoder.layer1.weight", "model.decoder.layer2.bias"]
+        prefix_set = _build_prefix_set(fqns)
+
+        expected = {
+            "model.",
+            "model.encoder.",
+            "model.encoder.layer1.",
+            "model.encoder.layer1.weight",
+            "model.decoder.",
+            "model.decoder.layer2.",
+            "model.decoder.layer2.bias",
+        }
+        self.assertEqual(prefix_set, expected)
+
+    def test_build_prefix_set_empty(self):
+        """Test prefix set with empty FQN list."""
+        prefix_set = _build_prefix_set([])
+        self.assertEqual(prefix_set, set())
+
+    def test_build_prefix_set_single_level(self):
+        """Test prefix set with single-level names (no dots)."""
+        fqns = ["weight", "bias"]
+        prefix_set = _build_prefix_set(fqns)
+
+        # Single-level names should just be themselves (no trailing dot)
+        expected = {"weight", "bias"}
+        self.assertEqual(prefix_set, expected)
+
+    def test_apply_to_modules_with_prefix_set(self):
+        """Test that _apply_to_modules correctly uses prefix set for filtering."""
+        # Create a simple model
+        class SimpleModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer1 = nn.Linear(10, 10)
+                self.layer2 = nn.Linear(10, 10)
+                self.layer3 = nn.Linear(10, 10)
+
+        model = SimpleModel()
+
+        # Collect visited module prefixes
+        visited_prefixes = []
+
+        def module_fn(module, prefix, tree_level):
+            visited_prefixes.append(prefix)
+
+        def return_fn():
+            return visited_prefixes
+
+        # Call with filter_fqns - should use prefix set internally
+        param_fqns = [name for name, _ in model.named_parameters()]
+        result = _apply_to_modules(
+            model,
+            module_fn,
+            return_fn,
+            param_fqns,
+        )
+
+        # Should visit the root and all layers
+        self.assertIn("", result)  # root
+        self.assertIn("layer1.", result)
+        self.assertIn("layer2.", result)
+        self.assertIn("layer3.", result)
+
+    def test_get_param_to_fqns_consistency(self):
+        """Test that _get_param_to_fqns produces correct mappings."""
+        class NestedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer1 = nn.Sequential(
+                    nn.Linear(10, 10),
+                    nn.ReLU(),
+                    nn.Linear(10, 10),
+                )
+                self.layer2 = nn.Linear(10, 5)
+
+        model = NestedModel()
+        param_to_fqns = _get_param_to_fqns(model)
+
+        # Each parameter should map to exactly one FQN (singleton list)
+        for param, fqns in param_to_fqns.items():
+            self.assertIsInstance(fqns, list)
+            self.assertGreaterEqual(len(fqns), 1)
+            for fqn in fqns:
+                self.assertIsInstance(fqn, str)
+
+        # Count should match the total number of parameters
+        self.assertEqual(len(param_to_fqns), len(list(model.parameters())))
+
+    def test_get_param_to_fqns_shared_params(self):
+        """Test _get_param_to_fqns with shared parameters."""
+        class SharedParamModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer1 = nn.Linear(10, 10)
+                # Share the weight with layer1
+                self.layer2 = nn.Linear(10, 10)
+                self.layer2.weight = self.layer1.weight
+
+        model = SharedParamModel()
+
+        # With dedup_shared_params=True (default)
+        param_to_fqns = _get_param_to_fqns(model, dedup_shared_params=True)
+        shared_weight = model.layer1.weight
+        # Should only have the first FQN
+        self.assertIn(shared_weight, param_to_fqns)
+        fqns = param_to_fqns[shared_weight]
+        self.assertEqual(len(fqns), 1)
+        self.assertTrue(fqns[0] in ["layer1.weight", "layer2.weight"])
+
+        # With dedup_shared_params=False
+        param_to_fqns = _get_param_to_fqns(model, dedup_shared_params=False)
+        shared_weight = model.layer1.weight
+        self.assertIn(shared_weight, param_to_fqns)
+        fqns = param_to_fqns[shared_weight]
+        # Should have both FQNs
+        self.assertEqual(len(fqns), 2)
+        self.assertIn("layer1.weight", fqns)
+        self.assertIn("layer2.weight", fqns)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_fsdp_prefix_set.py
+++ b/test/distributed/fsdp/test_fsdp_prefix_set.py
@@ -1,8 +1,5 @@
 # Owner(s): ["oncall: distributed"]
 
-import sys
-
-import torch
 import torch.nn as nn
 from torch.distributed.fsdp._common_utils import (
     _apply_to_modules,
@@ -62,6 +59,7 @@ class TestPrefixSet(TestCase):
 
     def test_apply_to_modules_with_prefix_set(self):
         """Test that _apply_to_modules correctly uses prefix set for filtering."""
+
         # Create a simple model
         class SimpleModel(nn.Module):
             def __init__(self):
@@ -98,6 +96,7 @@ class TestPrefixSet(TestCase):
 
     def test_get_param_to_fqns_consistency(self):
         """Test that _get_param_to_fqns produces correct mappings."""
+
         class NestedModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -112,7 +111,7 @@ class TestPrefixSet(TestCase):
         param_to_fqns = _get_param_to_fqns(model)
 
         # Each parameter should map to exactly one FQN (singleton list)
-        for param, fqns in param_to_fqns.items():
+        for fqns in param_to_fqns.values():
             self.assertIsInstance(fqns, list)
             self.assertGreaterEqual(len(fqns), 1)
             for fqn in fqns:
@@ -123,6 +122,7 @@ class TestPrefixSet(TestCase):
 
     def test_get_param_to_fqns_shared_params(self):
         """Test _get_param_to_fqns with shared parameters."""
+
         class SharedParamModel(nn.Module):
             def __init__(self):
                 super().__init__()

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -393,15 +393,14 @@ def _build_prefix_set(fqns: list[str]) -> set[str]:
     Returns:
         Set of all prefixes including the full FQNs themselves.
     """
-    prefix_set = set()
+    prefix_set: set[str] = set()
     for fqn in fqns:
-        # Add all intermediate prefixes
         parts = fqn.split(".")
-        for i in range(1, len(parts) + 1):
-            prefix = ".".join(parts[:i])
-            if i < len(parts):
-                prefix += "."
-            prefix_set.add(prefix)
+        for i in range(1, len(parts)):
+            # add prefixes ending with '.'
+            prefix_set.add(".".join(parts[:i]) + ".")
+        # add the full name without trailing '.'
+        prefix_set.add(fqn)
     return prefix_set
 
 

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -380,6 +380,31 @@ def _get_handle_fqns_from_root(
     return param_fqns
 
 
+def _build_prefix_set(fqns: list[str]) -> set[str]:
+    """
+    Builds a set of all prefixes from a list of fully-qualified names.
+
+    For example, given ["a.b.c", "a.b.d"], returns {"a.", "a.b.", "a.b.c", "a.b.d"}.
+    This enables O(1) prefix existence checks instead of O(P) startswith scans.
+
+    Args:
+        fqns: List of fully-qualified names (e.g., parameter names).
+
+    Returns:
+        Set of all prefixes including the full FQNs themselves.
+    """
+    prefix_set = set()
+    for fqn in fqns:
+        # Add all intermediate prefixes
+        parts = fqn.split(".")
+        for i in range(1, len(parts) + 1):
+            prefix = ".".join(parts[:i])
+            if i < len(parts):
+                prefix += "."
+            prefix_set.add(prefix)
+    return prefix_set
+
+
 def _apply_to_modules(
     root_module: torch.nn.Module,
     module_fn: Callable,
@@ -399,6 +424,8 @@ def _apply_to_modules(
     to ``FullyShardedDataParallel`` and the ``named_parameters()`` is overwritten
     to remove the prefix.
     """
+    # Pre-compute prefix set for O(1) lookups instead of O(P) per module
+    prefix_set = _build_prefix_set(filter_fqns) if filter_fqns is not None else None
 
     def f(module: torch.nn.Module, prefix: str, tree_level: int, *args, **kwargs):
         # Call the module function before recursing over children (pre-order)
@@ -408,11 +435,9 @@ def _apply_to_modules(
                 continue
             new_prefix = prefix + submodule_name + "."
             new_tree_level = tree_level + 1
-            if filter_fqns is not None:
-                for fqn in filter_fqns:
-                    if fqn.startswith(new_prefix):
-                        break
-                else:
+            if prefix_set is not None:
+                # O(1) lookup instead of O(P) scan through all FQNs
+                if new_prefix not in prefix_set:
                     # DMP's named_parameter() will mess up the traversal with
                     # ``named_children`` + `named_parameter(recurse=False)``.
                     # This hack is a must to make the traversal work.

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -395,10 +395,10 @@ def _build_prefix_set(fqns: list[str]) -> set[str]:
     """
     prefix_set: set[str] = set()
     for fqn in fqns:
-        parts = fqn.split(".")
-        for i in range(1, len(parts)):
-            # add prefixes ending with '.'
-            prefix_set.add(".".join(parts[:i]) + ".")
+        # add prefixes ending with '.'
+        for i, ch in enumerate(fqn):
+            if ch == '.':
+                prefix_set.add(fqn[:i+1])
         # add the full name without trailing '.'
         prefix_set.add(fqn)
     return prefix_set

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -397,8 +397,8 @@ def _build_prefix_set(fqns: list[str]) -> set[str]:
     for fqn in fqns:
         # add prefixes ending with '.'
         for i, ch in enumerate(fqn):
-            if ch == '.':
-                prefix_set.add(fqn[:i+1])
+            if ch == ".":
+                prefix_set.add(fqn[: i + 1])
         # add the full name without trailing '.'
         prefix_set.add(fqn)
     return prefix_set


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/168329

Before this change, the first forward pass with Qwen-30B-A3B + LoRA looks like:
<img width="3482" height="307" alt="image" src="https://github.com/user-attachments/assets/e2a5dfd0-fbaf-4edb-a64b-0df0c621b1b1" />

8.5 minutes for a forward pass over a couple of tokens!

After this change, the first forward pass looks like this:
<img width="2501" height="573" alt="image" src="https://github.com/user-attachments/assets/b3588695-7232-4ef4-b436-f9fdf65c58ce" />

Down to 42s :)