### PR TITLE
Refactor: Remove unnecessary ConstantVariable wrapping in raise_observed_exception

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -200,11 +200,7 @@ def bind_args_cached(
             raise_observed_exception(
                 TypeError,
                 tx,
-                args=[
-                    ConstantVariable.create(
-                        f"Missing required positional argument: {name}"
-                    )
-                ],
+                args=[f"Missing required positional argument: {name}"],
             )
 
     # 2) *args
@@ -216,9 +212,7 @@ def bind_args_cached(
             TypeError,
             tx,
             args=[
-                ConstantVariable.create(
-                    f"Too many positional arguments: got {len(args)}, expected {len(spec.all_pos_names)}"
-                )
+                f"Too many positional arguments: got {len(args)}, expected {len(spec.all_pos_names)}"
             ],
         )
 
@@ -235,11 +229,7 @@ def bind_args_cached(
             raise_observed_exception(
                 TypeError,
                 tx,
-                args=[
-                    ConstantVariable.create(
-                        f"Missing required keyword-only argument: {name}"
-                    )
-                ],
+                args=[f"Missing required keyword-only argument: {name}"],
             )
 
     # 4) **kwargs
@@ -249,9 +239,7 @@ def bind_args_cached(
         raise_observed_exception(
             TypeError,
             tx,
-            args=[
-                ConstantVariable.create(f"Unexpected keyword arguments: {list(rem_kw)}")
-            ],
+            args=[f"Unexpected keyword arguments: {list(rem_kw)}"],
         )
 
     return ba
@@ -2747,7 +2735,7 @@ class PyTreeGetNodeTypeFunctionVariable(UserFunctionVariable):
         if len(args) != 1:
             raise_type_error_exc(
                 tx,
-                f"pytree_get_node_type requires exactly 1 argument, got {len(args)}",
+                f"_get_node_type() takes 1 positional argument but {len(args)} were given",
             )
         type_source = None
         if args[0].source:


### PR DESCRIPTION
Fixes #168291

# Summary
Removes `ConstantVariable.create` wrapping in `raise_observed_exception` calls within `torch/_dynamo/variables/functions.py`.

# Context
The `raise_observed_exception` function handles the exception creation internally. Wrapping the error strings in `ConstantVariable` is unnecessary and can be simplified to passing raw strings.

# Test Plan
- [x] Verified syntax validity via `python3 -m py_compile torch/_dynamo/variables/functions.py`
- [ ] CI/CD (Existing tests should pass as this is a refactor of error reporting paths)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78