### PR TITLE
[Inductor] Add mutation dependency detection API

### DIFF
--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -477,6 +477,29 @@ def get_mutable_args_from_schema(
     return mutable_args_names, mutable_args_types  # type: ignore[return-value]
 
 
+def normalize_args_kwargs_by_schema(
+    schema: torch._C.FunctionSchema,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Normalize args and kwargs into a dict by arg names from the schema.
+    """
+    normalized_kwargs = {}
+    for idx, arg in enumerate(schema.arguments):
+        # NB: torch_dispatch kwargs are the args defined as kwarg-only in the schema
+        if arg.name in kwargs:
+            normalized_kwargs[arg.name] = kwargs[arg.name]
+        elif idx < len(args):
+            # if its out of bounds we don't need to do anything
+            # as it means the optional arg was passed with its default
+            # value
+            normalized_kwargs[arg.name] = args[idx]
+        else:
+            normalized_kwargs[arg.name] = arg.default_value
+    return normalized_kwargs
+
+
 def get_mutable_args(op: OpOverload) -> tuple[list[str], list[torch.Type]]:
     return get_mutable_args_from_schema(op._schema)
 
@@ -500,19 +523,7 @@ def do_auto_functionalize(
 
     # All of the (args, kwargs), but all as kwargs. The names for the
     # args come from the schema. This makes it easier for us to work with them.
-    normalized_kwargs = {}
-    schema = op._schema
-    for idx, arg in enumerate(schema.arguments):
-        # NB: torch_dispatch kwargs are the args defined as kwarg-only in the schema
-        if arg.name in kwargs:
-            normalized_kwargs[arg.name] = kwargs[arg.name]
-        elif idx < len(args):
-            # if its out of bounds we don't need to do anything
-            # as it means the optional arg was passed with its default
-            # value
-            normalized_kwargs[arg.name] = args[idx]
-        else:
-            normalized_kwargs[arg.name] = arg.default_value
+    normalized_kwargs = normalize_args_kwargs_by_schema(op._schema, args, kwargs)
 
     unwrapped_kwargs = ctx.unwrap_tensors(normalized_kwargs)  # type: ignore[arg-type]
     if "self" in unwrapped_kwargs or "self_" in unwrapped_kwargs:
@@ -605,10 +616,6 @@ def do_auto_functionalize_v2(
 
     ctx = PythonFunctionalizeAPI(mode=mode)
 
-    # All of the (args, kwargs), but all as kwargs. The names for the
-    # args come from the schema. This makes it easier for us to work with them.
-    normalized_kwargs = {}
-
     schema = op._schema
     # pyrefly: ignore [bad-assignment]
     op = op._op if isinstance(op, HopInstance) else op
@@ -621,17 +628,9 @@ def do_auto_functionalize_v2(
 
     args, kwargs = pytree.tree_map(_functionalize_callable, (args, kwargs))
 
-    for idx, arg in enumerate(schema.arguments):
-        # NB: torch_dispatch kwargs are the args defined as kwarg-only in the schema
-        if arg.name in kwargs:
-            normalized_kwargs[arg.name] = kwargs[arg.name]
-        elif idx < len(args):
-            # if its out of bounds we don't need to do anything
-            # as it means the optional arg was passed with its default
-            # value
-            normalized_kwargs[arg.name] = args[idx]
-        else:
-            normalized_kwargs[arg.name] = arg.default_value
+    # All of the (args, kwargs), but all as kwargs. The names for the
+    # args come from the schema. This makes it easier for us to work with them.
+    normalized_kwargs = normalize_args_kwargs_by_schema(op._schema, args, kwargs)
 
     # List of the name of args that get mutated (according to the schema)
     mutable_args_names, mutable_args_types = get_mutable_args_from_schema(schema)

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -630,7 +630,7 @@ def do_auto_functionalize_v2(
 
     # All of the (args, kwargs), but all as kwargs. The names for the
     # args come from the schema. This makes it easier for us to work with them.
-    normalized_kwargs = normalize_args_kwargs_by_schema(op._schema, args, kwargs)
+    normalized_kwargs = normalize_args_kwargs_by_schema(schema, args, kwargs)
 
     # List of the name of args that get mutated (according to the schema)
     mutable_args_names, mutable_args_types = get_mutable_args_from_schema(schema)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168347

This PR adds `get_additional_mutation_deps()` to identify nodes that must execute after mutations due to storage aliasing and Extracted `normalize_args_kwargs_by_schema()` to remove code duplication btw `do_auto_functionalize` and `do_auto_functionalize_v2`.

The algorithm works in two phases:
1. Build a mapping from storage to all mutations affecting it
2. For each node, check if it reads from mutated storage and add dependencies on mutations that occurred before it

for example:

```python
def fn(x, y):
    vx = x.view(-1)
    vy = y.view(-1)

    a = x + 1  # before mutation: no deps
    vx.add_(10)  # mut1 on x
    b = x + 2  # depends on add_
    vx.mul_(5)  # mut2 on x, depends on add_
    c = x + 3  # depends on add_ and mul_
    d = y + 4  # no deps
    vy.sub_(7)  # mut3 on y
    e = x + y  # depends on add_, mul_, sub_
    f = y + 5  # depends on sub_

    return a, b, c, d, e, f
```

Fx graph input to the `get_additional_mutation_deps(graph)`
```
graph():
    %x_1 : [num_users=5] = placeholder[target=x_1]
    %y_1 : [num_users=4] = placeholder[target=y_1]
    %view : [num_users=1] = call_function[target=torch.ops.aten.view.default](args = (%x_1, [-1]), kwargs = {})
    %view_1 : [num_users=1] = call_function[target=torch.ops.aten.view.default](args = (%y_1, [-1]), kwargs = {})
    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x_1, 1), kwargs = {})
    %add_ : [num_users=1] = call_function[target=torch.ops.aten.add_.Tensor](args = (%view, 10), kwargs = {})
    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x_1, 2), kwargs = {})
    %mul_ : [num_users=0] = call_function[target=torch.ops.aten.mul_.Tensor](args = (%add_, 5), kwargs = {})
    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x_1, 3), kwargs = {})
    %add_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%y_1, 4), kwargs = {})
    %sub_ : [num_users=0] = call_function[target=torch.ops.aten.sub_.Tensor](args = (%view_1, 7), kwargs = {})
    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x_1, %y_1), kwargs = {})
    %add_5 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%y_1, 5), kwargs = {})
    return (add, add_1, add_2, add_3, add_4, add_5)
```

returns:
```
{
    "add_1": ["add_"],  # b depends on mut1
    "mul_": ["add_"],  # mut2 depends on mut1 (reads mutated value!)
    "add_2": ["add_", "mul_"],  # c depends on mut1, mut2 (ordered)
    "add_4": ["add_", "mul_", "sub_"],  # e depends on all mutations
    "add_5": ["sub_"],  # f depends on mut3
}
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @chenyang78