### PR TITLE
Remove useless parent method delegation

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1289,11 +1289,6 @@ class SetVariable(ConstDictVariable):
         # Already EQUALS_MATCH guarded
         pass
 
-    def install_dict_contains_guard(
-        self, tx: "InstructionTranslator", args: list[VariableTracker]
-    ) -> None:
-        super().install_dict_contains_guard(tx, args)
-
 
 class FrozensetVariable(SetVariable):
     def debug_repr(self) -> str:

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1109,15 +1109,6 @@ class TupleVariable(BaseListVariable):
         codegen.foreach(self.items)
         codegen.append_output(create_build_tuple(len(self.items)))
 
-    def call_method(
-        self,
-        tx: "InstructionTranslator",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        return super().call_method(tx, name, args, kwargs)
-
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name == "__class__":
             source = AttrSource(self.source, name) if self.source else None

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -948,9 +948,6 @@ class Loops(IRNode):
             + [f"origin_node={self.origin_node!r}"]
         )
 
-    def __post_init__(self) -> None:
-        super().__post_init__()
-
     def __str__(self) -> str:
         return self._to_str(("ranges",))
 
@@ -8217,9 +8214,6 @@ class FallbackKernel(ExternKernelAlloc):
             packed.outputs = [outputs]
         # pyrefly: ignore [bad-return]
         return outputs
-
-    def apply_constraint(self) -> None:
-        return super().apply_constraint()
 
 
 @ir_dataclass(frozen=False)

--- a/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
@@ -261,10 +261,6 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
 
         return conv_bn
 
-    def extra_repr(self):
-        # TODO(jerryzh): extend
-        return super().extra_repr()
-
     def forward(self, input):
         return self._forward(input)
 

--- a/torch/fx/experimental/migrate_gradual_types/constraint.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint.py
@@ -138,9 +138,6 @@ class BinConstraintT(BinaryConstraint):
         )
         super().__init__(lhs, rhs, op)
 
-    def __eq__(self, other):
-        return super().__eq__(other)
-
 
 class BinConstraintD(BinaryConstraint):
     """
@@ -152,9 +149,6 @@ class BinConstraintD(BinaryConstraint):
         assert is_algebraic_expression(rhs) or is_dim(rhs) or is_bool_expr(rhs)
 
         super().__init__(lhs, rhs, op)
-
-    def __eq__(self, other):
-        return super().__eq__(other)
 
 
 class TGreatestUpperBound(Constraint):

--- a/torch/testing/_internal/common_subclass.py
+++ b/torch/testing/_internal/common_subclass.py
@@ -200,9 +200,6 @@ class SparseTensor(WrapperTensor):
         rs = tree_map(wrap, func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs or {})))
         return rs
 
-    # To show how things happen later
-    def __rmul__(self, other):
-        return super().__rmul__(other)
 
     _SPECIAL_IMPLS = {}
 


### PR DESCRIPTION
Remove redundant parent method delegations in Python code.


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela