### PR TITLE
[1/N][SymmMem] Reuse handle when ptr falls in allocation range

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -113,6 +113,7 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
  private:
   c10::intrusive_ptr<Block> find_block(void* ptr);
+  c10::intrusive_ptr<Block> find_block_covering(void* ptr);
 
   std::shared_mutex mutex_;
   std::unordered_map<void*, c10::intrusive_ptr<Block>> ptr_to_block_;


### PR DESCRIPTION
Reuse rendezvous as long as tensor storage pointer falls within an allocation range. 

Resolves #167765