### PR TITLE
Ldexp out of range

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -442,6 +442,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(gcd);
   BINARY_POINTWISE(igamma);
   BINARY_POINTWISE(igammac);
+  BINARY_POINTWISE2(ldexp, Tensor);
   BINARY_POINTWISE(logaddexp);
   BINARY_POINTWISE(logaddexp2);
   POINTWISE_BOXED(lerp.Scalar);

--- a/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
@@ -159,7 +159,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatchedDecomposition, m) {
   OP_DECOMPOSE(l1_loss);
   m.impl("layer_norm", native::layer_norm_symint);
   m.impl("_fused_rms_norm", native::rms_norm_composite);
-  OP_DECOMPOSE2(ldexp, Tensor);
   OP_DECOMPOSE2(less_equal, Tensor );
   OP_DECOMPOSE2(less, Tensor );
   OP_DECOMPOSE(linear);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1569,7 +1569,9 @@ static inline Tensor _pow2(const Tensor& self, const Tensor& other) {
   return at::full({}, 2.0, self.options()).pow(other);
 }
 
-Tensor& _ldexp_int_exponent(const Tensor& self, const Tensor& other, Tensor& result) {
+// This function is used to dispatch to kernels that use std::ldexp on CPU and the global namespaces ::ldexp on CUDA
+// Both of these require floating types for 'self' and integer types for 'other'.
+static inline Tensor& _ldexp_int_exponent(const Tensor& self, const Tensor& other, Tensor& result) {
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(result)

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1588,8 +1588,7 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
               "ldexp can't be cast to the desired output type ", result.scalar_type());
 
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
-      isFloatingType(self.scalar_type()) &&
-      !self.is_meta()) {
+      isFloatingType(self.scalar_type())) {
     return _ldexp_int_exponent(self, other, result);
   }
 
@@ -1598,8 +1597,7 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
 
 Tensor ldexp(const Tensor& self, const Tensor& other) {
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
-      isFloatingType(self.scalar_type()) &&
-      !self.is_meta()) {
+      isFloatingType(self.scalar_type())) {
     Tensor result = at::empty_like(self);
     return _ldexp_int_exponent(self, other, result);
   }

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1588,7 +1588,8 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
               "ldexp can't be cast to the desired output type ", result.scalar_type());
 
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
-      isFloatingType(self.scalar_type())) {
+      isFloatingType(self.scalar_type()) &&
+      !self.is_meta()) {
     return _ldexp_int_exponent(self, other, result);
   }
 
@@ -1597,7 +1598,8 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
 
 Tensor ldexp(const Tensor& self, const Tensor& other) {
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
-      isFloatingType(self.scalar_type())) {
+      isFloatingType(self.scalar_type()) &&
+      !self.is_meta()) {
     Tensor result = at::empty_like(self);
     return _ldexp_int_exponent(self, other, result);
   }

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -36,7 +36,6 @@
 #include <ATen/ops/bitwise_right_shift_native.h>
 #include <ATen/ops/bitwise_xor.h>
 #include <ATen/ops/bitwise_xor_native.h>
-#include <ATen/ops/complex.h>
 #include <ATen/ops/copysign.h>
 #include <ATen/ops/copysign_native.h>
 #include <ATen/ops/div.h>
@@ -65,7 +64,6 @@
 #include <ATen/ops/igamma_native.h>
 #include <ATen/ops/igammac.h>
 #include <ATen/ops/igammac_native.h>
-#include <ATen/ops/imag.h>
 #include <ATen/ops/lcm_native.h>
 #include <ATen/ops/ldexp.h>
 #include <ATen/ops/ldexp_native.h>
@@ -104,7 +102,6 @@
 #include <ATen/ops/not_equal_native.h>
 #include <ATen/ops/or_native.h>
 #include <ATen/ops/pow.h>
-#include <ATen/ops/real.h>
 #include <ATen/ops/remainder.h>
 #include <ATen/ops/remainder_native.h>
 #include <ATen/ops/rshift_native.h>

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1596,7 +1596,7 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
 Tensor ldexp(const Tensor& self, const Tensor& other) {
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
       isFloatingType(self.scalar_type())) {
-    Tensor result = at::empty(self.sizes(), self.options().dtype(self.scalar_type()));
+    Tensor result = at::empty_like(self);
     return _ldexp_int_exponent(self, other, result);
   }
 

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -18,7 +18,6 @@
 #include <ATen/ops/_efficientzerotensor.h>
 #include <ATen/ops/_test_serialization_subcmul_native.h>
 #include <ATen/ops/_to_copy.h>
-#include <ATen/ops/abs.h>
 #include <ATen/ops/add.h>
 #include <ATen/ops/add_native.h>
 #include <ATen/ops/add_ops.h>
@@ -73,7 +72,6 @@
 #include <ATen/ops/less_native.h>
 #include <ATen/ops/linalg_cross_native.h>
 #include <ATen/ops/linalg_cross_ops.h>
-#include <ATen/ops/log2.h>
 #include <ATen/ops/logaddexp2_native.h>
 #include <ATen/ops/logaddexp_native.h>
 #include <ATen/ops/logical_and.h>
@@ -107,7 +105,6 @@
 #include <ATen/ops/rshift_native.h>
 #include <ATen/ops/rsub_native.h>
 #include <ATen/ops/sigmoid_backward_native.h>
-#include <ATen/ops/sign.h>
 #include <ATen/ops/special_chebyshev_polynomial_t.h>
 #include <ATen/ops/special_chebyshev_polynomial_t_native.h>
 #include <ATen/ops/special_chebyshev_polynomial_u.h>

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -4,6 +4,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <c10/core/Scalar.h>
 #include <c10/util/TypeSafeSignMath.h>
+#include <ATen/native/TensorIterator.h>
 
 
 namespace at {
@@ -51,6 +52,7 @@ using binary_fn_double = void(*)(TensorIterator&, double);
 using binary_fn = void(*)(TensorIterator&);
 using binary_clamp_fn_alpha =
     void(*)(TensorIterator&, const Scalar& alpha, const Scalar& min_val, const Scalar& max_val);
+using ldexp_fn = void(*)(TensorIteratorBase&);
 
 // NB: codegenned
 DECLARE_DISPATCH(structured_binary_fn_alpha, add_stub)
@@ -115,5 +117,6 @@ DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_t_stub)
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_u_stub)
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_v_stub)
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_w_stub)
+DECLARE_DISPATCH(ldexp_fn, ldexp_stub)
 
 } // namespace at::native

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1430,6 +1430,18 @@ void shifted_chebyshev_polynomial_w_kernel(TensorIteratorBase& iterator) {
       });
 } // shifted_chebyshev_polynomial_w_kernel(TensorIteratorBase& iterator)
 
+void ldexp_kernel(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.input_dtype(0), "ldexp_cpu", [&] {
+    using float_t = scalar_t;
+    AT_DISPATCH_INTEGRAL_TYPES(iter.input_dtype(1), "ldexp_cpu_exp", [&] {
+      using int_t = scalar_t;
+      cpu_kernel(iter, [](float_t x, int_t exp) -> float_t {
+        return static_cast<float_t>(std::ldexp(static_cast<double>(x), exp));
+      });
+    });
+  });
+}
+
 } // namespace
 
 REGISTER_DISPATCH(add_clamp_stub, &add_clamp_kernel)
@@ -1486,6 +1498,7 @@ REGISTER_DISPATCH(
 REGISTER_DISPATCH(chebyshev_polynomial_u_stub, &chebyshev_polynomial_u_kernel)
 REGISTER_DISPATCH(hermite_polynomial_h_stub, &hermite_polynomial_h_kernel)
 REGISTER_DISPATCH(hermite_polynomial_he_stub, &hermite_polynomial_he_kernel)
+REGISTER_DISPATCH(ldexp_stub, ldexp_kernel);
 
 ALSO_REGISTER_AVX512_DISPATCH(atan2_stub, &atan2_kernel)
 ALSO_REGISTER_AVX512_DISPATCH(smooth_l1_stub, &smooth_l1_kernel)

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1498,7 +1498,7 @@ REGISTER_DISPATCH(
 REGISTER_DISPATCH(chebyshev_polynomial_u_stub, &chebyshev_polynomial_u_kernel)
 REGISTER_DISPATCH(hermite_polynomial_h_stub, &hermite_polynomial_h_kernel)
 REGISTER_DISPATCH(hermite_polynomial_he_stub, &hermite_polynomial_he_kernel)
-REGISTER_DISPATCH(ldexp_stub, ldexp_kernel);
+REGISTER_DISPATCH(ldexp_stub, ldexp_kernel)
 
 ALSO_REGISTER_AVX512_DISPATCH(atan2_stub, &atan2_kernel)
 ALSO_REGISTER_AVX512_DISPATCH(smooth_l1_stub, &smooth_l1_kernel)

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -71,7 +71,7 @@ void xlog1py_kernel_cuda(TensorIteratorBase& iter) {
 
 void ldexp_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(0), "ldexp_cuda", [&] {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t x, int exp) -> scalar_t {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t x, int exp) -> scalar_t {
       return ::ldexp(x, exp);
     });
   });

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -69,11 +69,20 @@ void xlog1py_kernel_cuda(TensorIteratorBase& iter) {
   });
 }
 
+void ldexp_kernel_cuda(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(0), "ldexp_cuda", [&] {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t x, int exp) -> scalar_t {
+      return ::ldexp(x, exp);
+    });
+  });
+}
+
 REGISTER_DISPATCH(smooth_l1_stub, &smooth_l1_kernel_cuda)
 REGISTER_DISPATCH(huber_stub, &huber_kernel_cuda)
 REGISTER_DISPATCH(mse_stub, &mse_kernel_cuda)
 REGISTER_DISPATCH(xlogy_stub, &xlogy_kernel_cuda)
 REGISTER_DISPATCH(xlog1py_stub, &xlog1py_kernel_cuda)
+REGISTER_DISPATCH(ldexp_stub, &ldexp_kernel_cuda)
 
 // DO NOT ADD ANY NEW KERNELS HERE
 // CUDA compilation times grow quickly.  It's perfectly acceptable to have a file per kernel.

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3482,6 +3482,7 @@
 
 - func: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
   variants: function, method
+  tags: pointwise
 
 - func: ldexp_(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3483,13 +3483,19 @@
 - func: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
   variants: function, method
   tags: pointwise
+  dispatch:
+    CompositeExplicitAutograd: ldexp
 
 - func: ldexp_(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: function, method
   tags: pointwise
+  dispatch:
+    CompositeExplicitAutograd: ldexp_
 
 - func: ldexp.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   tags: pointwise
+  dispatch:
+    CompositeExplicitAutograd: ldexp_out
 
 - func: linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:

--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -298,6 +298,9 @@ aten::isnan.out
 aten::lcm
 aten::lcm.out
 aten::lcm_
+aten::ldexp.Tensor
+aten::ldexp.out
+aten::ldexp_
 aten::le.Scalar
 aten::le.Scalar_out
 aten::le.Tensor

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2401,7 +2401,7 @@ class TestOperators(TestCase):
         (
             tol1(
                 "ldexp",
-                {torch.float32: tol(atol=3e-04, rtol=1.6e-06)},
+                {torch.float32: tol(atol=6e-04, rtol=5e-06)},
                 device_type="cuda",
             ),
             tol1(

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3501,6 +3501,14 @@ class TestBinaryUfuncs(TestCase):
         exponents = torch.randint(-5, 5, (64,), device=device)
         self.assertEqual(torch.ldexp(mantissas, exponents).dtype, torch.half)
 
+        # test half dtype bound ends (very small and very large exponents)
+        mantissas = torch.tensor([-2, 2**-10], device=device, dtype=torch.half)
+        exponents = torch.tensor([-25, 20], device=device)
+        self.assertEqual(
+            torch.ldexp(mantissas, exponents),
+            torch.tensor([-(2**-24), 2**10], dtype=torch.half),
+        )
+
         # test float64 computation
         mantissas = torch.tensor([1], dtype=torch.float64, device=device)
         exponents = torch.tensor([128], dtype=torch.int64, device=device)

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -367,6 +367,7 @@ CHECK_STRIDES_SKIPS = {
     aten.div.Tensor_mode,
     aten.floor_divide.default,
     aten.heaviside.default,
+    aten.ldexp.Tensor,
     aten.lerp.Scalar,
     aten.lerp.Tensor,
     aten.logaddexp.default,
@@ -437,6 +438,8 @@ def assert_ref_meta_equal(test_case, func, meta_rs, rs, msg_callable):
             test_assert(same_strides, f"for element {i}, was {meta_r.stride()} but real stride was {r.stride()}")
         elif should_check_strides(func) == CheckStrides.SIGNIFICANT:
             same_strides, _ = torch._prims_common.check_significant_strides(meta_r, r)
+            if not same_strides:
+                print(same_strides)
             test_assert(same_strides, f"for element {i}, was {meta_r.stride()} but real stride was {r.stride()}")
         test_assert(
             meta_r.storage_offset() == r.storage_offset(),

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -438,8 +438,6 @@ def assert_ref_meta_equal(test_case, func, meta_rs, rs, msg_callable):
             test_assert(same_strides, f"for element {i}, was {meta_r.stride()} but real stride was {r.stride()}")
         elif should_check_strides(func) == CheckStrides.SIGNIFICANT:
             same_strides, _ = torch._prims_common.check_significant_strides(meta_r, r)
-            if not same_strides:
-                print(same_strides)
             test_assert(same_strides, f"for element {i}, was {meta_r.stride()} but real stride was {r.stride()}")
         test_assert(
             meta_r.storage_offset() == r.storage_offset(),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -920,9 +920,9 @@
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
 - name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
-  self: grad * at::pow(2, other)
-  other: grad * result * std::log(2.0)
-  result: self_t * at::pow(2, other_p) + other_t * result * std::log(2.0)
+  self: grad * at::pow(2, other).conj()
+  other: grad * result.conj() * M_LN2
+  result: self_t * at::pow(2, other_p) + other_t * result * M_LN2
 
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -919,6 +919,11 @@
   self: value_selecting_reduction_backward_symint(grad, dim, indices, self.sym_sizes(), keepdim)
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
+- name: ldexp.Tensor(Tensor self, Tensor other) -> Tensor
+  self: grad * at::pow(2, other)
+  other: grad * result * std::log(2.0)
+  result: self_t * at::pow(2, other_p) + other_t * result * std::log(2.0)
+
 - name: le_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)
   result: self_t.zero_()

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -261,6 +261,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     "diagonal",
     "alias",
     "atan",
+    "ldexp",
     "log",
     "log10",
     "log1p",

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -355,7 +355,12 @@ def log_sigmoid_backward(grad_output: Tensor, self: Tensor, buffer: Tensor) -> T
 @register_decomposition(aten.ldexp)
 @out_wrapper()
 def ldexp(self: Tensor, other: Tensor) -> Tensor:
-    two_tensor = torch.tensor(2.0, dtype=self.dtype, device=self.device)
+    two_dtype = (
+        torch.float32
+        if utils.is_integer_dtype(self.dtype) or utils.is_boolean_dtype(self.dtype)
+        else self.dtype
+    )
+    two_tensor = self.new_full((), 2.0, dtype=two_dtype)
     return self * torch.pow(two_tensor, other)
 
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -355,7 +355,8 @@ def log_sigmoid_backward(grad_output: Tensor, self: Tensor, buffer: Tensor) -> T
 @register_decomposition(aten.ldexp)
 @out_wrapper()
 def ldexp(self: Tensor, other: Tensor) -> Tensor:
-    return self * (2.0**other)
+    two_tensor = torch.tensor(2.0, dtype=self.dtype, device=self.device)
+    return self * torch.pow(two_tensor, other)
 
 
 def apply_loss_reduction(loss: Tensor, reduction: int):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -352,6 +352,12 @@ def log_sigmoid_backward(grad_output: Tensor, self: Tensor, buffer: Tensor) -> T
     # return (max_deriv - sign * (buffer / (1 + buffer))) * grad_output
 
 
+@register_decomposition(aten.ldexp)
+@out_wrapper()
+def ldexp(self: Tensor, other: Tensor) -> Tensor:
+    return self * (2.0**other)
+
+
 def apply_loss_reduction(loss: Tensor, reduction: int):
     if reduction == Reduction.MEAN.value:
         return torch.mean(loss)
@@ -5365,6 +5371,7 @@ register_inplace(aten.index_reduce_, aten.index_reduce)
 register_inplace(aten.__ior__, aten.__or__)
 register_inplace(aten.__irshift__, aten.__rshift__)
 register_inplace(aten.__ixor__, aten.__xor__)
+register_inplace(aten.ldexp_, aten.ldexp)
 register_inplace(aten.leaky_relu_, aten.leaky_relu)
 register_inplace(aten.logit_, aten.logit)
 register_inplace(aten.relu_, aten.relu)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -76,6 +76,7 @@ inductor_decompositions = get_decompositions(
         aten.gelu,
         aten.hardtanh,
         aten.lcm,
+        aten.ldexp,
         aten.leaky_relu,
         aten.linalg_vector_norm,
         aten._log_softmax,

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -242,7 +242,7 @@ pointwise_ops = [
     aten.isneginf.out,
     aten.isposinf.default,
     aten.isposinf.out,
-    aten.ldexp.default,
+    aten.ldexp.Tensor,
     aten.ldexp.out,
     aten.ldexp_.default,
     aten.lt.Tensor,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14293,6 +14293,15 @@ op_db: list[OpInfo] = [
                     promotes_int_to_float=True,
                     supports_out=True,
                     supports_rhs_python_scalar=False,
+                    skips=(
+                        # RuntimeError: mul(): functions with out=... arguments don't support
+                        # automatic differentiation, but one of the arguments requires grad
+                        # https://github.com/pytorch/pytorch/issues/68966
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_variant_consistency_eager'),
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_conj_view'),
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_neg_view'),
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_neg_conj_view'),
+                    ),
                     decorators=[
                         DecorateInfo(
                             toleranceOverride({

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14293,15 +14293,6 @@ op_db: list[OpInfo] = [
                     promotes_int_to_float=True,
                     supports_out=True,
                     supports_rhs_python_scalar=False,
-                    skips=(
-                        # RuntimeError: mul(): functions with out=... arguments don't support
-                        # automatic differentiation, but one of the arguments requires grad
-                        # https://github.com/pytorch/pytorch/issues/68966
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager'),
-                        DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
-                        DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
-                        DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
-                    ),
                     decorators=[
                         DecorateInfo(
                             toleranceOverride({

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14297,6 +14297,7 @@ op_db: list[OpInfo] = [
                         # RuntimeError: mul(): functions with out=... arguments don't support
                         # automatic differentiation, but one of the arguments requires grad
                         # https://github.com/pytorch/pytorch/issues/68966
+                        # Eager tests pass but there is an error in the inductor tests.
                         DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_variant_consistency_eager'),
                         DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_conj_view'),
                         DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_neg_view'),


### PR DESCRIPTION
Fixes #153069

Updated ldexp to calculate $a\cdot2^b$ as $2^{\log_2(a) + b}$. This helps fix the issue where $2^b$ is not in range for a specific data type (such as $2^{-25}$ or $2^{20}$ with torch.half) but $a\cdot2^b$ is (such as $2\cdot2^{-25}$ or $2^{-10}\cdot 2^{20}$). 

The issue was happening because $2^b$ was being calculated first, which would go out of range and mess up the rest of the calculation. Using $2^{\log_2(a) + b}$, we calculate ${\log_2(a) + b}$ first, thus the exponential will only go out of range if the whole expression is out of range. 

This also fixes the issue #133265, that was closed since it was a duplicate of the other.

@ngimel, @isuruf 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo