### PR TITLE
[AMD] Reduce Autotune Search Space for Pointwise Triton Kernels

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -457,6 +457,8 @@ distributed_max_autotune_gemm = (
     os.environ.get("TORCHINDUCTOR_DISTRIBUTED_MAX_AUTOTUNE_GEMM") == "1"
 )
 
+extend_amd_autotune_search_space = False
+
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -84,6 +84,7 @@ def inductor_meta_from_config() -> _InductorMetaTy:
         "backend_hash": backend_hash,
         "bundled_autotune_remote_cache": config.bundled_autotune_remote_cache,
         "coordinate_descent_tuning": config.coordinate_descent_tuning,
+        "extend_amd_autotune_search_space": config.extend_amd_autotune_search_space,
         "is_fbcode": config.is_fbcode(),
         "is_hip": is_hip,
     }

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -6,14 +6,13 @@ import functools
 import typing
 from enum import auto, Enum
 
-import torch
 from torch.utils._triton import has_triton_package
 
 
 # The following maximums only apply to runtime autotuning, when using FixedTritonConfig one may see larger values
 # NOTE: if these fail asserts submit a PR to increase them
 TRITON_MAX_BLOCK = {
-    "X": 8192 if torch.version.hip else 4096,
+    "X": 4096,
     "Y": 1024,
     "Z": 1024,
     "R0_": 4096 * 16,  # * 16 is multi-kernel only

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2650,24 +2650,25 @@ def pointwise(
             ]
             # Additional configs appended for ROCm builds
             if torch.version.hip:
-                configs.extend(
-                    [
-                        triton_config_with_settings(
-                            size_hints, TRITON_MAX_BLOCK["X"], waves_per_eu=2
-                        ),
-                        triton_config_with_settings(
-                            size_hints,
-                            4096,  # wrt: better than the max_block for some kernel
-                        ),
-                        triton_config_with_settings(
-                            size_hints,
-                            2048,
-                            num_warps=8,
-                            num_stages=2,
-                            waves_per_eu=1,  # 20% improvement
-                        ),
-                    ]
-                )
+                if inductor_meta.get("extend_amd_autotune_search_space", False):
+                    configs.extend(
+                        [
+                            triton_config_with_settings(
+                                size_hints, TRITON_MAX_BLOCK["X"], waves_per_eu=2
+                            ),
+                            triton_config_with_settings(
+                                size_hints,
+                                4096,  # wrt: better than the max_block for some kernel
+                            ),
+                            triton_config_with_settings(
+                                size_hints,
+                                2048,
+                                num_warps=8,
+                                num_stages=2,
+                                waves_per_eu=1,  # 20% improvement
+                            ),
+                        ]
+                    )
                 if inductor_meta.get("atomic_add_found"):
                     configs.extend(
                         [
@@ -2702,22 +2703,23 @@ def pointwise(
             ]
             # Additional configs appended for ROCm builds
             if torch.version.hip:
-                configs.extend(
-                    [
-                        triton_config_with_settings(
-                            size_hints, 64, 32
-                        ),  # better for some kernels
-                        triton_config_with_settings(
-                            size_hints, 128, 16
-                        ),  # +10% for some kernels
-                        triton_config_with_settings(
-                            size_hints, 128, 32
-                        ),  # additional 10% more
-                        triton_config_with_settings(
-                            size_hints, 32, 512
-                        ),  # +30% for some kernels
-                    ]
-                )
+                if inductor_meta.get("extend_amd_autotune_search_space", False):
+                    configs.extend(
+                        [
+                            triton_config_with_settings(
+                                size_hints, 64, 32
+                            ),  # better for some kernels
+                            triton_config_with_settings(
+                                size_hints, 128, 16
+                            ),  # +10% for some kernels
+                            triton_config_with_settings(
+                                size_hints, 128, 32
+                            ),  # additional 10% more
+                            triton_config_with_settings(
+                                size_hints, 32, 512
+                            ),  # +30% for some kernels
+                        ]
+                    )
     if len(size_hints) == 3:
         if not inductor_meta.get("autotune_pointwise", True):
             configs = [triton_config_with_settings(size_hints, 16, 16, 16)]
@@ -2999,12 +3001,13 @@ def _reduction_configs(
     ]
 
     if torch.version.hip:
-        result_configs.extend(
-            [
-                make_config(1024, 8, num_warps=4, num_stages=1, waves_per_eu=2),
-                make_config(512, 8, num_warps=4, num_stages=1, waves_per_eu=1),
-            ]
-        )
+        if inductor_meta.get("extend_amd_autotune_search_space", False):
+            result_configs.extend(
+                [
+                    make_config(1024, 8, num_warps=4, num_stages=1, waves_per_eu=2),
+                    make_config(512, 8, num_warps=4, num_stages=1, waves_per_eu=1),
+                ]
+            )
 
     return result_configs
 


### PR DESCRIPTION
Summary: This addresses the issue where AMD lowering times have greatly increased due to the additional configs used for AMD, which was introduced in D84996237

Test Plan:
We can run
```
buck2 run \
   @//mode/opt-amd-gpu \
   -c fbcode.split-dwarf=true \
   -c python.package_style=inplace \
   -c fbcode.platform=platform010 \
   -c fbcode.caffe2_gpu_type=amd \
   -c fbcode.enable_distributed_thinlto=true \
   -c fbcode.enable_gpu_sections=true \
   -c fbcode.use_link_groups=true \
//inference_enablement/model_processing/infra/components/lowering/re:re_cinder -- -r "$(cat <<'EOF'
{"aot_inductor":{"serialized_inference_model_input_path":"ads_storage_fblearner/tree/user/facebook/fblearner/predictor/828532939/13/lowering/.predictor.precompute.remote_request_only.merge/input_model","serialized_inference_model_output_path":"ads_storage_fblearner/tree/user/facebook/fblearner/predictor/828532939/13/lowering/.predictor.precompute.remote_request_only.merge/output.74af1f14fc5e43d0c0d522b0985fb2bc.user_merge_request_only.GFX942_X86.AOTINDUCTOR","submodule_names_to_lower":["user_merge_request_only"],"inductor_lowering_context":{"aot_inductor_lowering_settings":{"max_batch_size":64,"min_acc_module_size":10,"workdir":"","name":"","dll_name":"inductor_engine.so","use_scripting":true,"preset_lowerer":"disable_new_lowering_weights","precision":4,"output_precision":4,"remote_cache_file_path_folder":"ads_storage_fblearner/tree/user/facebook/fblearner/predictor/828532939/","save_remote_cache":true,"aot_inductor_config":"{'max_autotune': True, 'comprehensive_padding': False, 'aot_inductor.use_runtime_constant_folding': False, 'combo_kernels': True, 'benchmark_combo_kernel': True, 'combo_kernel_foreach_dynamic_shapes': True}","disable_dynamic_shapes":false,"remove_unexpected_type_cast":true,"disable_constraint_solver":false,"sample_input_tile_factor":1,"disable_acc_tracer":false,"generate_sample_inputs":true,"tile_sample_input_by_dynamic_shape":false,"node_replacement_dict":"","enable_fp8_in_pass":false,"auto_dynamic_shapes":false,"auto_dynamic_shapes_min_size":1,"auto_dynamic_shapes_max_size":1048576,"max_acc_splits":-1,"dynamic_size":-1,"pre_dispatch_export":true,"merge_split_optimization":false,"use_dynamic_dim_hints":false,"allow_refine_dynamic_shapes_on_constants":false,"use_sigmoid":false,"input_tiling_factor":1,"use_custom_tracer":false,"submodules_to_skip_quantization":[],"use_partial_lowering":false,"copy_placeholder_metadata":false,"validate_in_fp32":false,"allowed_percent_mismatch":0,"skip_output_dtype_conversion_lowering":false,"check_preset_change":false,"use_duck_shape":false,"sparsity_config":"","strip_inference_module_from_lowering_output_package":false,"remove_ancestors_of_removed_nodes":false,"weight_changing_transforms":"","per_hardware_xl_weights_location":"","env_vars":""}},"model_entity_id":828532939,"model_snapshot_id":13,"add_sample_inputs":true,"hardware_type":0,"platform_arch":200,"lowering_lib_pkg":"ien.lower.mi300x:180","dense_in_place_format":2,"dense_update_mode":0}}
EOF
)"
```
before and after the diff. Before, the lowering duration is ~45-50 minutes whereas it is ~20 minutes after.

Differential Revision: D87628831




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chenyang78


@diff-train-skip-merge