### PR TITLE
[cuDNN][conv][64-bit] Reenable cuDNN for 64-bit depthwise convs

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -456,7 +456,7 @@ struct ConvParams {
       static long cudnn_version = detail::getCUDAHooks().compiledWithCuDNN() ? detail::getCUDAHooks().versionRuntimeCuDNN() : -1;
       // TODO(eqy): remove this once cuDNN fixes 64-bit depthwise support, first broken in 9.11x
       if (cudnn_conv_suggest_memory_format(input, weight) != at::MemoryFormat::Contiguous) {
-        if (cudnn_version < 0 || cudnn_version > 91000) {
+        if (cudnn_version < 0 || (cudnn_version > 91000 && cudnn_version < 91500)) {
           return false;
         }
       }


### PR DESCRIPTION
Support for 64-bit depthwise convolution has been fixed as of cuDNN 9.15, so the heuristic and test that were disabled in #163171 can now be reenabled.

cc @csarofeen @ptrblck @xwang233 @eqy @nWEIdia @msaroufim @jerryzh168 @tinglvv @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 
