### PR TITLE
Forward fix numpy binary check after #168270

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -53,9 +53,9 @@ if [[ "$PACKAGE_TYPE" != libtorch ]]; then
     # numpy tests:
     # We test 1 version no numpy. 1 version with numpy 1.x and rest with numpy 2.x
     if [[ "\$python_nodot" = *311* ]]; then
-      retry pip install -q protobuf typing-extensions
+      retry pip install -q numpy==1.23.5 protobuf typing-extensions
     elif [[ "\$python_nodot" = *312* ]]; then
-      retry pip install -q numpy==1.21.2 protobuf typing-extensions
+      retry pip install -q protobuf typing-extensions
     else
       retry pip install -q numpy protobuf typing-extensions
     fi


### PR DESCRIPTION
Looks like https://pypi.org/project/numpy/1.23.5/#files is available for Python 3.11 hence use this version instead of 1.21.2