### PR TITLE
The Nested Pool

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1838,9 +1838,11 @@ class DeviceCachingAllocator {
     if (graph_reuse_context.find(info.capture_id) ==
         graph_reuse_context.end()) {
       bool found = false;
-      for (auto& entry : captures_underway) {
-        if (entry.second(stream)) {
-          auto graph_pool = graph_pools.find(entry.first);
+      // Use the reverse iterator to search captures_underway in LIFO order.
+      for (auto it = captures_underway.rbegin(); it != captures_underway.rend();
+           ++it) {
+        if (it->second(stream)) {
+          auto graph_pool = graph_pools.find(it->first);
           TORCH_INTERNAL_ASSERT(
               graph_pool != graph_pools.end(),
               "Could not find graph pool for capture.");
@@ -2530,10 +2532,10 @@ class DeviceCachingAllocator {
       std::function<bool(cudaStream_t)> filter) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     create_or_incref_pool(mempool_id);
-    for (auto it2 = captures_underway.begin(); it2 != captures_underway.end();
-         ++it2) {
+    for (auto it = captures_underway.begin(); it != captures_underway.end();
+         ++it) {
       TORCH_CHECK(
-          it2->first != mempool_id,
+          it->first != mempool_id,
           "beginAllocateToPool: already recording to mempool_id");
     }
     captures_underway.emplace_back(mempool_id, std::move(filter));
@@ -2962,9 +2964,11 @@ class DeviceCachingAllocator {
     // a capture, so it's usually 0, and we can short-circuit
     // cudaStreamCaptureStatus (which does a TLS lookup).
     if (C10_UNLIKELY(!captures_underway.empty())) {
-      for (auto& entry : captures_underway) {
-        if (entry.second(stream)) {
-          auto it1 = graph_pools.find(entry.first);
+      // Use the reverse iterator to search captures_underway in LIFO order.
+      for (auto it = captures_underway.rbegin(); it != captures_underway.rend();
+           ++it) {
+        if (it->second(stream)) {
+          auto it1 = graph_pools.find(it->first);
           TORCH_INTERNAL_ASSERT(it1 != graph_pools.end());
           if (size <= kSmallSize) {
             return it1->second->small_blocks;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5718,9 +5718,10 @@ class TestMemPool(TestCase):
         pool3 = torch.cuda.MemPool()
 
         data = []
+        nelem_1mb = 1024 * 1024 // 4
 
         def allocate_data():
-            x = torch.empty(1024, device="cuda")
+            x = torch.empty(nelem_1mb * 20, device="cuda")
             data.append(x)
 
         with torch.cuda.use_mem_pool(pool1):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5710,20 +5710,17 @@ class TestMemPool(TestCase):
             s = p.snapshot()
             self.assertEqual(len(s), 1, "Expected to have a single segment")
 
+    @serialTest()
     def test_nested_mempool(self):
         torch.cuda.empty_cache()
         pool1 = torch.cuda.MemPool()
         pool2 = torch.cuda.MemPool()
         pool3 = torch.cuda.MemPool()
 
-        nelem = 1024 * 1024 * 20
-
         data = []
-        data_ptrs = []
         def allocate_data():
-            x = torch.empty(nelem, device="cuda")
+            x = torch.empty(1024, device="cuda")
             data.append(x)
-            data_ptrs.append(x.data_ptr())
 
         with torch.cuda.use_mem_pool(pool1):
             allocate_data()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5718,6 +5718,7 @@ class TestMemPool(TestCase):
         pool3 = torch.cuda.MemPool()
 
         data = []
+
         def allocate_data():
             x = torch.empty(1024, device="cuda")
             data.append(x)


### PR DESCRIPTION
This PR fixes issue #161193 by simply reversing the iteration order over captures_underway.
After discussing with @galv, we decided to land this minimal fix first to unblock nested MemPool usage.

Long-term, the underlying infrastructure (e.g., captures_underway) still needs refactoring to clearly define the interaction between graph capture, MemPools, and threads. That broader cleanup will be addressed in #168137.

cc @eqy @syed-ahmed @ngimel @galv 