### PR TITLE
[DTensor] Fix gap in ExplicitRedistributeContext

### DIFF
--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -215,7 +215,11 @@ class _FromTorchTensor(torch.autograd.Function):
             )
             local_tensor = grad_output._local_tensor
             output = redistribute_local_tensor(
-                local_tensor, current_spec, target_spec, is_backward=True
+                local_tensor,
+                current_spec,
+                target_spec,
+                is_backward=True,
+                redistribute_tag="_FromTorchTensor.backward",
             )
             # TODO: return the redistributed local tensor directly without
             # differentiable backward. see if this make sense for all cases.

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -26,10 +26,7 @@ from torch.distributed.tensor._tp_conv import (
     convolution_backward_handler,
     convolution_handler,
 )
-from torch.distributed.tensor._utils import (
-    ExplicitRedistributionContext,
-    try_find_mesh_from_args,
-)
+from torch.distributed.tensor._utils import try_find_mesh_from_args
 from torch.distributed.tensor.placement_types import Partial, Placement, Replicate
 from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._python_dispatch import return_and_correct_aliasing
@@ -459,20 +456,13 @@ class OpDispatcher:
                         if debug_mode is not None
                         else contextlib.nullcontext()
                     )
-                    if not ExplicitRedistributionContext.is_redistribute_allowed(
-                        arg_spec,
-                        # pyrefly: ignore [bad-argument-type]
-                        reshard_arg_spec,
-                    ):
-                        raise RuntimeError(
-                            f"Implicit redistribution occurred for {op_info.schema} while ExplicitRedistributionContext was active"
-                        )
                     with redistribute_context:
                         resharded_local_tensor = redistribute_local_tensor(
                             local_tensor,
                             arg_spec,
                             # pyrefly: ignore [bad-argument-type]
                             reshard_arg_spec,
+                            redistribute_tag=str(op_info.schema),
                         )
                     new_local_args.append(resharded_local_tensor)
                 else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #168887

Previously, only redistribution called as a part of DTensor dispatch
would check the context.  There are several other call sites for
redistribute_local_tensor which were unguarded.  Rather than guarding
them all, this PR:

- moves the guard inside redistribute_local_tensor
- adds tags to the various callsites to identify them in the exception
  message