### PR TITLE
[DTensor] Sharding rule for aten.detach_.default

### DIFF
--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -85,6 +85,7 @@ register_op_strategy(
         aten.clone.default,
         aten.contiguous.default,
         aten.detach.default,
+        aten.detach_.default,
         aten.alias.default,
         aten.fill_.Scalar,
         aten.view.dtype,


### PR DESCRIPTION
Register aten.detach_.default with propagate_single_input_strategy

Testing: Adding unit tests: test_detach_, test_detach_in_custom_op

Fixes https://github.com/pytorch/pytorch/issues/167917
