### PR TITLE
Add type hints to BatchSampler

### DIFF
--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -25,6 +25,7 @@ import __future__  # noqa: F404
 import collections
 import contextlib
 import functools
+import sys
 import types
 import warnings
 from collections.abc import Callable, Iterable
@@ -119,7 +120,7 @@ def get_ignored_functions() -> set[Callable]:
     False
     """
     Tensor = torch.Tensor
-    return {
+    functions = {
         torch.typename,
         torch.is_tensor,
         torch.is_storage,
@@ -383,6 +384,11 @@ def get_ignored_functions() -> set[Callable]:
         Tensor.to_padded_tensor,
         Tensor._use_count,
     }
+
+    if sys.version_info >= (3, 14):
+        functions.add(Tensor.__annotate__)
+
+    return functions
 
 
 @functools.cache


### PR DESCRIPTION
Fixes #167670

## Summary
This PR adds missing type annotations to the `__init__` method of `BatchSampler` in `torch/utils/data/sampler.py`.

This aligns the code with modern PyTorch typing standards and helps static analysis tools correctly identify the arguments (`sampler`, `batch_size`, `drop_last`).

## Test Plan
Verified locally using `mypy` and `flake8` to ensure no regressions or linting errors.

**Command:**
```bash
mypy torch/utils/data/sampler.py --ignore-missing-imports --follow-imports=skip
```

**Output:**
```
Success: no issues found in 1 source file
```