### PR TITLE
Add read contributing.md to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 Fixes #ISSUE_NUMBER
 
-[ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md).
+[ ] I have read the relevant parts of [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Fixes #ISSUE_NUMBER
 
-[ ] I have read the relevant parts of [CONTRIBUTING.md](CONTRIBUTING.md).
-[ ] `make lint` is passing.
+[ ] I am aware of the existence of [CONTRIBUTING.md](CONTRIBUTING.md).
+[ ] `lintrunner -a` is passing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 Fixes #ISSUE_NUMBER
 
 [ ] I have read the relevant parts of [CONTRIBUTING.md](CONTRIBUTING.md).
+[ ] `make lint` is passing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,3 @@
 Fixes #ISSUE_NUMBER
+
+[ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Fixes #ISSUE_NUMBER
 
-[ ] I am aware of the existence of [CONTRIBUTING.md](CONTRIBUTING.md).
-[ ] `lintrunner -a` is passing.
+[ ] I am familiar with [CONTRIBUTING.md](CONTRIBUTING.md).
+[ ] I ran `lintrunner -a`, and fixed all errors relevant to this change.


### PR DESCRIPTION
Add to pr template:
```
[ ] I am aware of the existence of [CONTRIBUTING.md](CONTRIBUTING.md).
[ ] `lintrunner -a` is passing.
```