### PR TITLE
Add support for ignore_logging_functions in Dynamo to skip arbitrary logging callables during tracing

### DIFF
--- a/docs/source/user_guide/torch_compiler/compile/programming_model.common_graph_breaks.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.common_graph_breaks.md
@@ -131,9 +131,9 @@ However, the logged contents may differ if, for example, a mutation occurs.
 Note: `reorderable_logging_functions` has restrictions, these functions must return `None`, and their arguments must be limited to tensors, constants, or format strings.
 
 You can also use `torch._dynamo.config.ignore_logging_functions` to completely skip selected logging functions during tracing.
- 
-Ignored functions can take any arguments, but MUST return `None`. 
-Functions should either be module-level functions, `logging.Logger.<method>` (ignores that method for all `logging.Logger` instances) or `logger_obj.<method>` (ignores that method only for the specific `logger_obj` instance). 
+
+Ignored functions can take any arguments, but MUST return `None`.
+Functions should either be module-level functions, `logging.Logger.<method>` (ignores that method for all `logging.Logger` instances) or `logger_obj.<method>` (ignores that method only for the specific `logger_obj` instance).
 Other functions may or may not be ignored due to implementation details. If you want to ignore a function that `ignore_logging_functions` is failing to ignore, please submit an issue.
 
 

--- a/docs/source/user_guide/torch_compiler/compile/programming_model.common_graph_breaks.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.common_graph_breaks.md
@@ -131,6 +131,10 @@ However, the logged contents may differ if, for example, a mutation occurs.
 Note: `reorderable_logging_functions` has restrictions, these functions must return `None`, and their arguments must be limited to tensors, constants, or format strings.
 
 You can also use `torch._dynamo.config.ignore_logging_functions` to completely skip selected logging functions during tracing.
+ 
+Ignored functions can take any arguments, but MUST return `None`. 
+Functions should either be module-level functions, `logging.Logger.<method>` (ignores that method for all `logging.Logger` instances) or `logger_obj.<method>` (ignores that method only for the specific `logger_obj` instance). 
+Other functions may or may not be ignored due to implementation details. If you want to ignore a function that `ignore_logging_functions` is failing to ignore, please submit an issue.
 
 
 ```{code-cell}

--- a/docs/source/user_guide/torch_compiler/compile/programming_model.common_graph_breaks.md
+++ b/docs/source/user_guide/torch_compiler/compile/programming_model.common_graph_breaks.md
@@ -128,6 +128,10 @@ This config is used to reorder logging functions so that they are called at the 
 traced function, thus avoiding a graph break.
 However, the logged contents may differ if, for example, a mutation occurs.
 
+Note: `reorderable_logging_functions` has restrictions, these functions must return `None`, and their arguments must be limited to tensors, constants, or format strings.
+
+You can also use `torch._dynamo.config.ignore_logging_functions` to completely skip selected logging functions during tracing.
+
 
 ```{code-cell}
 torch._dynamo.config.reorderable_logging_functions.add(print)

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -68,7 +68,7 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
         else:
             self.assertIn("moo", printed_output)
             self.assertGreater(len(counters["graph_break"]), 0)
-    
+
 
     def test_ignore_arbitrary_function_noop(self):
         counters.clear()
@@ -76,7 +76,7 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
 
         def dbg_fn(x):
             calls.append("ran")
-        
+
         def f(x):
             dbg_fn(x)  # must be no-op inside Dynamo
             return x + 1
@@ -92,10 +92,10 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
 
         # output must match eager
         self.assertTrue(same(opt_out, x + 1))
-        
+
         # no graph breaks allowed
         self.assertEqual(len(counters["graph_break"]), 0)
-    
+
 
     def test_ignore_function_returns_none(self):
         counters.clear()
@@ -135,6 +135,7 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
 
         def ignored(x):
             log.append("ignored")
+
         def reordered(x):
             log.append("reordered")
 

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -54,7 +54,7 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
         counters.clear()
         x = torch.randn(3, 3)
         orig_out = fn(x)
-        with torch._dynamo.config.patch(ignore_logger_methods={ignore_method}):
+        with torch._dynamo.config.patch(ignore_logging_functions={ignore_method}):
             opt_f = torch.compile(backend="eager")(fn)
             with self.assertLogs(logger, level="INFO") as captured:
                 logger.info("call logger info to avoid error")
@@ -68,6 +68,97 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
         else:
             self.assertIn("moo", printed_output)
             self.assertGreater(len(counters["graph_break"]), 0)
+
+
+    def test_ignore_arbitrary_function_noop(self):
+        counters.clear()
+        calls = []
+
+        def dbg_fn(x):
+            calls.append("ran")
+
+        torch._dynamo.config.ignore_logging_functions.add(dbg_fn)
+
+        def f(x):
+            dbg_fn(x)  # must be no-op inside Dynamo
+            return x + 1
+
+        x = torch.randn(3, 3)
+        opt_f = torch.compile(backend="eager", fullgraph=True)(f)
+
+        opt_out = opt_f(x)
+
+        # function must never run
+        self.assertEqual(calls, [])
+
+        # output must match eager
+        self.assertTrue(same(opt_out, x + 1))
+
+        # no graph breaks allowed
+        self.assertEqual(len(counters["graph_break"]), 0)
+
+        torch._dynamo.config.ignore_logging_functions.clear()
+
+
+    def test_ignore_function_returns_none(self):
+        counters.clear()
+
+        def ignore_me(x):
+            return "should_not_run"
+
+        torch._dynamo.config.ignore_logging_functions.add(ignore_me)
+
+        def f(x):
+            y = ignore_me(x)  # Dynamo substitutes Constant(None)
+            return x * 2
+
+        x = torch.randn(3, 3)
+        opt_f = torch.compile(backend="eager", fullgraph=True)(f)
+
+        opt_out = opt_f(x)
+
+        # output correct
+        self.assertTrue(same(opt_out, x * 2))
+
+        # ensure no graph breaks
+        self.assertEqual(len(counters["graph_break"]), 0)
+
+        torch._dynamo.config.ignore_logging_functions.clear()
+
+
+    def test_ignore_function_does_not_conflict_with_reorderable(self):
+        counters.clear()
+        log = []
+
+        def ignored(x):
+            log.append("ignored")
+
+        def reordered(x):
+            log.append("reordered")
+
+        torch._dynamo.config.ignore_logging_functions.add(ignored)
+
+        with torch._dynamo.config.patch(reorderable_logging_functions={reordered}):
+
+            def f(x):
+                ignored(x)
+                reordered(x)
+                return x + 1
+
+            x = torch.ones(3, 3)
+            opt_f = torch.compile(backend="eager", fullgraph=True)(f)
+            opt_out = opt_f(x)
+
+        # ignored must NOT run
+        self.assertNotIn("ignored", log)
+
+        # reordered MUST run
+        self.assertIn("reordered", log)
+
+        # output is correct
+        self.assertTrue(same(opt_out, x + 1))
+
+        torch._dynamo.config.ignore_logging_functions.clear()
 
 
 class ReorderLogsTests(torch._dynamo.test_case.TestCase):

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -69,7 +69,6 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
             self.assertIn("moo", printed_output)
             self.assertGreater(len(counters["graph_break"]), 0)
 
-
     def test_ignore_arbitrary_function_noop(self):
         counters.clear()
         calls = []
@@ -95,7 +94,6 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
 
         # no graph breaks allowed
         self.assertEqual(len(counters["graph_break"]), 0)
-
 
     def test_ignore_function_returns_none(self):
         counters.clear()
@@ -126,8 +124,6 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
 
         # no graph breaks
         self.assertEqual(len(counters["graph_break"]), 0)
-
-
 
     def test_ignore_function_does_not_conflict_with_reorderable(self):
         counters.clear()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -586,11 +586,10 @@ log_compilation_metrics = True
 # mutated after the print statement.
 reorderable_logging_functions: set[Callable[[Any], None]] = set()
 
-# A set of methods that will be ignored while tracing,
-# to prevent graph breaks.
-# Add logging.Logger.<method> to ignore all calls for method,
-# or logger.<method> to ignore calls for method from this logger instance only.
-ignore_logger_methods: set[Callable[..., Any]] = set()
+# A set of callables that will be ignored during Dynamo tracing.
+# These functions will NOT run, will NOT be reordered, and will NOT
+# cause graph breaks. They act as full no-ops.
+ignore_logging_functions: set[Callable[..., Any]] = set()
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -590,7 +590,9 @@ reorderable_logging_functions: set[Callable[[Any], None]] = set()
 # These functions will NOT run, will NOT be reordered, and will NOT
 # cause graph breaks. They act as full no-ops.
 # Ignored functions can take any arguments, but MUST return None.
-# Functions should either be module-level functions, `logging.Logger.<method>` (ignores all method for all logging.Logger instances) or `logger_obj.<method>` (ignores method only for logger_obj logging.Logger instance).
+# Functions should either be module-level functions,
+# `logging.Logger.<method>` (ignores all method for all logging.Logger instances)
+# or `logger_obj.<method>` (ignores method only for logger_obj logging.Logger instance).
 # Other functions may or may not be ignored due to implementation details. If you want to ignore a function
 # that `ignore_logging_functions` is failing to ignore, please submit an issue.
 ignore_logging_functions: set[Callable[..., Any]] = set()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -597,7 +597,9 @@ ignore_logging_functions: set[Callable[..., Any]] = set()
 
 # Backwards compat: `ignore_logger_methods` now aliases `ignore_logging_functions`.
 # Existing code that used `ignore_logger_methods` will continue to work.
-ignore_logger_methods = ignore_logging_functions
+ignore_logger_methods: set[Callable[..., Any]] = Config(
+    alias="torch._dynamo.config.ignore_logging_functions"
+)
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -586,10 +586,18 @@ log_compilation_metrics = True
 # mutated after the print statement.
 reorderable_logging_functions: set[Callable[[Any], None]] = set()
 
-# A set of callables that will be ignored during Dynamo tracing.
+# A set of functions that will be ignored during Dynamo tracing.
 # These functions will NOT run, will NOT be reordered, and will NOT
 # cause graph breaks. They act as full no-ops.
+# Ignored functions can take any arguments, but MUST return None.
+# Functions should either be module-level functions, `logging.Logger.<method>` (ignores all method for all logging.Logger instances) or `logger_obj.<method>` (ignores method only for logger_obj logging.Logger instance).
+# Other functions may or may not be ignored due to implementation details. If you want to ignore a function
+# that `ignore_logging_functions` is failing to ignore, please submit an issue.
 ignore_logging_functions: set[Callable[..., Any]] = set()
+
+# Backwards compat: `ignore_logger_methods` now aliases `ignore_logging_functions`.
+# Existing code that used `ignore_logger_methods` will continue to work.
+ignore_logger_methods = ignore_logging_functions
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2978,6 +2978,14 @@
       "Context": "method: {self.value}.{name}, args: {args}, kwargs: {kwargs}",
       "Explanation": "logging.Logger methods are not supported for non-export cases.",
       "Hints": [
+        "Add the logging method to `torch._dynamo.config.ignore_logging_functions`."
+      ]
+    },
+    {
+      "Gb_type": "logging.Logger method not supported for non-export cases",
+      "Context": "method: {self.value}.{name}, args: {args}, kwargs: {kwargs}",
+      "Explanation": "logging.Logger methods are not supported for non-export cases.",
+      "Hints": [
         "Add the logging method to `torch._dynamo.config.ignore_logger_methods."
       ]
     }

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -878,7 +878,7 @@ class VariableBuilder:
             and value in torch._dynamo.config.ignore_logging_functions
         ):
             # Treat ignored functions as full no-ops
-            self.install_guards(GuardBuilder.BUILTIN_MATCH)
+            self.install_guards(GuardBuilder.ID_MATCH)
             return IgnoredFunctionVariable(value, source=self.source)
         elif isinstance(value, logging.Logger):
             self.install_guards(GuardBuilder.TYPE_MATCH)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -233,6 +233,7 @@ from .misc import (
     AutogradFunctionVariable,
     ComptimeVariable,
     DebuggingVariable,
+    IgnoredFunctionVariable,
     DelayGraphBreakVariable,
     GetAttrVariable,
     GetSetDescriptorVariable,
@@ -872,6 +873,13 @@ class VariableBuilder:
             # along with other builtin debugging functions
             self.install_guards(GuardBuilder.BUILTIN_MATCH)
             return DebuggingVariable(value, source=self.source)
+        elif (
+            callable(value)
+            and value in torch._dynamo.config.ignore_logging_functions
+        ):
+            # Treat ignored functions as full no-ops
+            self.install_guards(GuardBuilder.BUILTIN_MATCH)
+            return IgnoredFunctionVariable(value, source=self.source)
         elif isinstance(value, logging.Logger):
             self.install_guards(GuardBuilder.TYPE_MATCH)
             return LoggingLoggerVariable(value, source=self.source)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -873,7 +873,9 @@ class VariableBuilder:
             # along with other builtin debugging functions
             self.install_guards(GuardBuilder.BUILTIN_MATCH)
             return DebuggingVariable(value, source=self.source)
-        elif callable(value) and value in torch._dynamo.config.ignore_logging_functions:
+        elif callable(value) and any(
+            value is fn for fn in torch._dynamo.config.ignore_logging_functions
+        ):
             # Treat ignored functions as full no-ops
             self.install_guards(GuardBuilder.ID_MATCH)
             return IgnoredFunctionVariable(value, source=self.source)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -233,10 +233,10 @@ from .misc import (
     AutogradFunctionVariable,
     ComptimeVariable,
     DebuggingVariable,
-    IgnoredFunctionVariable,
     DelayGraphBreakVariable,
     GetAttrVariable,
     GetSetDescriptorVariable,
+    IgnoredFunctionVariable,
     LambdaVariable,
     LoggingLoggerVariable,
     MethodWrapperVariable,
@@ -873,10 +873,7 @@ class VariableBuilder:
             # along with other builtin debugging functions
             self.install_guards(GuardBuilder.BUILTIN_MATCH)
             return DebuggingVariable(value, source=self.source)
-        elif (
-            callable(value)
-            and value in torch._dynamo.config.ignore_logging_functions
-        ):
+        elif callable(value) and value in torch._dynamo.config.ignore_logging_functions:
             # Treat ignored functions as full no-ops
             self.install_guards(GuardBuilder.ID_MATCH)
             return IgnoredFunctionVariable(value, source=self.source)

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1785,6 +1785,7 @@ class IgnoredFunctionVariable(VariableTracker):
     """
     Represents a call to an arbitrary function that should be ignored.
     """
+
     def __init__(self, value, **kwargs):
         super().__init__(**kwargs)
         self.value = value
@@ -1809,7 +1810,6 @@ class LoggingLoggerVariable(VariableTracker):
         args: "list[VariableTracker]",
         kwargs: "dict[str, VariableTracker]",
     ) -> "VariableTracker":
-
         if tx.export:
             # For export cases, we can just make logging functions no-ops.
             return variables.ConstantVariable.create(None)

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1785,17 +1785,12 @@ class IgnoredFunctionVariable(VariableTracker):
     """
     Represents a call to an arbitrary function that should be ignored.
     """
-
-    _nonvar_fields = {"fn", *VariableTracker._nonvar_fields}
-
-    def __init__(self, fn, **kwargs):
+    def __init__(self, value, **kwargs):
         super().__init__(**kwargs)
-        self.fn = fn
+        self.value = value
 
     def call_function(self, tx, args, kwargs):
-        # Correct import
-        from torch._dynamo.variables import ConstantVariable
-        return ConstantVariable.create(None)
+        return variables.ConstantVariable.create(None)
 
 
 class LoggingLoggerVariable(VariableTracker):
@@ -1817,7 +1812,7 @@ class LoggingLoggerVariable(VariableTracker):
 
         if tx.export:
             # For export cases, we can just make logging functions no-ops.
-            return
+            return variables.ConstantVariable.create(None)
 
         method = getattr(self.value, name, None)
         function = getattr(method, "__func__", None)


### PR DESCRIPTION
Fixes #168317

Adds support for ignoring arbitrary Python callables during TorchDynamo tracing.
Introduces the new `ignore_logging_functions` config and updates DebuggingVariable
so functions in this set are treated as full no-ops without reordering, execution,
or graph breaks. The existing behavior for other logging configurations remains unchanged.

Tested locally by adding functions to `ignore_logging_functions` and verifying
that Dynamo skips them without graph breaks and produces the correct compiled output.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78