### PR TITLE
Add `symm_mem_sync` Triton kernel to `torch.ops.symm_mem`

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -6,6 +6,9 @@ import random
 from contextlib import nullcontext
 from unittest import skip, skipIf, skipUnless
 
+import triton
+import triton.language as tl
+
 import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
@@ -58,6 +61,17 @@ os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"
 # So that tests are written in device-agnostic way
 device_type = "cuda"
 device_module = torch.get_device_module(device_type)
+
+
+@triton.jit
+def barrier_test_kernel(
+    signal_pad_ptrs,
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    torch.ops.symm_mem.symm_mem_sync(
+        signal_pad_ptrs, rank, world_size, None, False, False
+    )
 
 
 @instantiate_parametrized_tests
@@ -1363,6 +1377,50 @@ class SymmMemSingleProcTest(TestCase):
 
         _SymmetricMemory.memset32(t, offset=0, val=1, count=64)
         _SymmetricMemory.memset32(t, offset=63, val=1, count=1)
+
+
+@requires_cuda_p2p_access()
+class SymmMemBarrierTest(MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self) -> int:
+        return torch.cuda.device_count()
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(f"cuda:{self.rank}")
+
+    def _init_process(self):
+        torch.cuda.set_device(self.device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.manual_seed(42 + self.rank)
+
+    @skip_if_lt_x_gpu(2)
+    def test_torch_ops_symm_mem_sync_within_triton_kernel(self):
+        """Test using torch.ops.symm_mem.symm_mem_sync within Triton kernel"""
+        self._init_process()
+        t = symm_mem.empty(4096, device=self.device)
+        symm_mem_hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        barrier_test_kernel[(32, 1, 1)](
+            symm_mem_hdl.signal_pad_ptrs_dev,
+            rank=symm_mem_hdl.rank,
+            world_size=symm_mem_hdl.world_size,
+        )
+
+        signal_pad = symm_mem_hdl.get_signal_pad(symm_mem_hdl.rank)
+        assert signal_pad.eq(0).all().item()
+
+        dist.destroy_process_group()
 
 
 @instantiate_parametrized_tests

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -17,6 +17,8 @@ import torch.distributed.distributed_c10d as c10d
 from torch._C._autograd import DeviceType
 from torch._C._distributed_c10d import _SymmetricMemory, Work as _Work
 
+from . import symm_mem_sync
+
 
 _group_name_to_store: dict[str, c10d.Store] = {}
 

--- a/torch/distributed/_symmetric_memory/symm_mem_sync.py
+++ b/torch/distributed/_symmetric_memory/symm_mem_sync.py
@@ -1,0 +1,174 @@
+import torch
+from torch.utils._triton import has_triton
+
+
+if has_triton():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _get_tid():
+        """Get thread ID within a block."""
+        return tl.inline_asm_elementwise(
+            """
+            mov.u32 $0, %tid.x;
+            mov.u32 $1, %tid.y;
+            mov.u32 $2, %tid.z;
+            """,
+            "=r,=r,=r",
+            [],
+            dtype=(tl.uint32, tl.uint32, tl.uint32),
+            is_pure=True,
+            pack=1,
+        )
+
+    @triton.jit
+    def _get_ntid():
+        """Get number of threads in a block."""
+        return tl.inline_asm_elementwise(
+            """
+            mov.u32 $0, %ntid.x;
+            mov.u32 $1, %ntid.y;
+            mov.u32 $2, %ntid.z;
+            """,
+            "=r,=r,=r",
+            [],
+            dtype=(tl.uint32, tl.uint32, tl.uint32),
+            is_pure=True,
+            pack=1,
+        )
+
+    @triton.jit
+    def _get_flat_tid():
+        """Get flattened thread ID within a block."""
+        tid_x, tid_y, tid_z = _get_tid()
+        ntid_x, ntid_y, _ = _get_ntid()
+        return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+    @triton.jit
+    def _get_flat_bid():
+        """Get flattened block ID."""
+        return (
+            tl.program_id(2) * tl.num_programs(1) * tl.num_programs(0)
+            + tl.program_id(1) * tl.num_programs(0)
+            + tl.program_id(0)
+        )
+
+    @triton.jit
+    def _send_signal(addrs, sem: tl.constexpr):
+        """Send signal to remote device using atomic operations."""
+        tl.inline_asm_elementwise(
+            f"""
+            {{
+                .reg .u32   %tmp32_<1>;
+                .reg .pred  %p<1>;
+
+                send_signal:
+                    atom.global.{sem}.sys.cas.b32 %tmp32_0, [$1], 0, 1;
+                    setp.eq.u32 %p0, %tmp32_0, 0;
+                    @!%p0 bra send_signal;
+            }}
+            """,
+            "=r, l",
+            [addrs],
+            dtype=addrs.dtype,
+            is_pure=False,
+            pack=1,
+        )
+
+    @triton.jit
+    def _wait_signal(addrs, sem: tl.constexpr):
+        """Wait for signal from remote device using atomic operations."""
+        tl.inline_asm_elementwise(
+            f"""
+            {{
+                .reg .u32   %tmp32_<1>;
+                .reg .pred  %p<1>;
+
+                wait_signal:
+                    atom.global.sys.{sem}.cas.b32 %tmp32_0, [$1], 1, 0;
+                    setp.eq.u32 %p0, %tmp32_0, 1;
+                    @!%p0 bra wait_signal;
+            }}
+            """,
+            "=r, l",
+            [addrs],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=1,
+        )
+
+    @triton.jit
+    def symm_mem_sync(
+        signal_pad_ptrs,
+        rank: tl.constexpr,
+        world_size: tl.constexpr,
+        block_id,
+        hasPreviousMemAccess: tl.constexpr = False,
+        hasSubsequentMemAccess: tl.constexpr = False,
+    ):
+        """
+        Synchronizes blocks with matching block_id across participating devices.
+
+        Note: the function itself is not a system level barrier/fence. It is a
+        building block for expressing different synchronization patterns.
+
+        Pattern 0: Ensures that all writes to symm_mem buffers from previous
+        kernels across all devices are visible to the current kernel:
+
+            symm_mem_sync(..., hasPreviousMemAccess=False, hasSubsequentMemAccess=True)
+
+        Pattern 1: Ensures that all writes to symm_mem buffers from the current
+        block are visible to all remote blocks with matching blockIdx:
+
+            symm_mem_sync(..., hasPreviousMemAccess=True, hasSubsequentMemAccess=True)
+
+        Pattern 2: Ensures that symm_mem buffers read by the current kernel are safe
+        for writing by subsequent kernels across all devices.
+
+            symm_mem_sync(..., hasPreviousMemAccess=True, hasSubsequentMemAccess=False)
+
+        CUDA graph friendliness:
+
+            This barrier operates through atomic operations on a zero-filled signal
+            pad, which resets to a zero-filled state after each successful
+            synchronization. This design eliminates the need for incrementing a
+            flag from host.
+        """
+        if block_id is None:
+            block_id = _get_flat_bid()
+        flat_tid = _get_flat_tid()
+
+        remote_ranks = tl.arange(0, world_size)
+        signal_pad_ptrs = signal_pad_ptrs.to(tl.pointer_type(tl.uint64))
+        remote_signal_pad_addrs = tl.load(signal_pad_ptrs + remote_ranks).to(
+            tl.pointer_type(tl.uint32)
+        )
+        send_addrs = remote_signal_pad_addrs + block_id * world_size + rank
+
+        local_signal_pad_addr = tl.load(signal_pad_ptrs + rank).to(
+            tl.pointer_type(tl.uint32)
+        )
+        wait_addrs = local_signal_pad_addr + block_id * world_size + remote_ranks
+
+        if hasPreviousMemAccess:
+            tl.debug_barrier()
+
+        if flat_tid < world_size:
+            _send_signal(send_addrs, "release" if hasPreviousMemAccess else "relaxed")
+            _wait_signal(wait_addrs, "acquire" if hasSubsequentMemAccess else "relaxed")
+
+        if hasSubsequentMemAccess:
+            tl.debug_barrier()
+
+    torch.ops.symm_mem.symm_mem_sync = symm_mem_sync  # type: ignore[attr-defined]
+
+else:
+
+    def symm_mem_sync(*args, **kwargs):  # type: ignore[no-redef]
+        raise RuntimeError(
+            "symm_mem_sync requires Triton to be installed. "
+            "Please install Triton to use this functionality."
+        )
+
+    torch.ops.symm_mem.symm_mem_sync = symm_mem_sync  # type: ignore[attr-defined]


### PR DESCRIPTION
`symm_mem_sync` is commonly used in symm-mem examples https://github.com/search?q=repo%3Ameta-pytorch%2Fkraken%20symm_mem_sync&type=code, and we would like to call the same API within Helion kernels as well.

cc. @kwen2501 