### PR TITLE
Remove cudaProfilerInitialize

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -309,11 +309,6 @@ if(USE_NCCL AND NOT WIN32)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NCCL)
 endif()
 
-if(NOT MSVC)
-  # cudaProfilerInitialize must go away
-  set_source_files_properties(${TORCH_SRC_DIR}/csrc/cuda/shared/cudart.cpp PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
-endif()
-
 # coreml
 if(USE_COREML_DELEGATE)
   list(APPEND TORCH_PYTHON_SRCS ${TORCH_SRC_DIR}/csrc/jit/backends/coreml/cpp/backend.cpp)

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -28,17 +28,6 @@ void initCudartBindings(PyObject* module) {
   // By splitting the names of these objects into two literals we prevent the
   // HIP rewrite rules from changing these names when building with HIP.
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION < 12000
-  // cudaOutputMode_t is used in cudaProfilerInitialize only. The latter is gone
-  // in CUDA 12.
-  py::enum_<cudaOutputMode_t>(
-      cudart,
-      "cuda"
-      "OutputMode")
-      .value("KeyValuePair", cudaKeyValuePair)
-      .value("CSV", cudaCSV);
-#endif
-
   py::enum_<cudaError_t>(
       cudart,
       "cuda"
@@ -100,15 +89,6 @@ void initCudartBindings(PyObject* module) {
         // NOLINTNEXTLINE(performance-no-int-to-ptr)
         return C10_CUDA_ERROR_HANDLED(cudaStreamDestroy((cudaStream_t)ptr));
       });
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION < 12000
-  // cudaProfilerInitialize is no longer needed after CUDA 12:
-  // https://forums.developer.nvidia.com/t/cudaprofilerinitialize-is-deprecated-alternative/200776/3
-  cudart.def(
-      "cuda"
-      "ProfilerInitialize",
-      cudaProfilerInitialize,
-      py::call_guard<py::gil_scoped_release>());
-#endif
   cudart.def(
       "cuda"
       "MemGetInfo",

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -5529,10 +5529,6 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             ),
         ),
         ("cudaDeviceGetLimit", ("hipDeviceGetLimit", CONV_DEVICE, API_RUNTIME)),
-        (
-            "cudaProfilerInitialize",
-            ("hipProfilerInitialize", CONV_OTHER, API_RUNTIME, HIP_UNSUPPORTED),
-        ),
         ("cudaProfilerStart", ("hipProfilerStart", CONV_OTHER, API_RUNTIME)),
         ("cudaProfilerStop", ("hipProfilerStop", CONV_OTHER, API_RUNTIME)),
         (


### PR DESCRIPTION
cudaProfilerInitialize is not required since CUDA 12+.
