### PR TITLE
Resolve collective autotuning test failure on arm

### DIFF
--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,7 +1,15 @@
 # Owner(s): ["module: inductor"]
 
+import sys
+
 import torch
 import torch.distributed as dist
+
+
+if not dist.is_available() or not dist.is_nccl_available():
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,15 +1,9 @@
 # Owner(s): ["module: inductor"]
 
-import sys
+import unittest
 
 import torch
 import torch.distributed as dist
-
-
-if not dist.is_available() or not dist.is_nccl_available():
-    print("c10d NCCL not available, skipping tests", file=sys.stderr)
-    sys.exit(0)
-
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
@@ -17,6 +11,10 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import run_tests
 
 
+@unittest.skipIf(
+    not dist.is_available() or not dist.is_nccl_available(),
+    "c10d NCCL not available, skipping tests",
+)
 class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
     """Test collective autotuning with 2 ranks"""
 
@@ -99,6 +97,10 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         dist.destroy_process_group()
 
 
+@unittest.skipIf(
+    not dist.is_available() or not dist.is_nccl_available(),
+    "c10d NCCL not available, skipping tests",
+)
 class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
     """Test collective autotuning with 4 ranks"""
 

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,9 +1,15 @@
 # Owner(s): ["module: inductor"]
 
-import unittest
+import sys
 
 import torch
 import torch.distributed as dist
+
+
+if not dist.is_available() or not dist.is_nccl_available():
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
@@ -11,10 +17,6 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import run_tests
 
 
-@unittest.skipIf(
-    not dist.is_available() or not dist.is_nccl_available(),
-    "c10d NCCL not available, skipping tests",
-)
 class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
     """Test collective autotuning with 2 ranks"""
 
@@ -97,10 +99,6 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         dist.destroy_process_group()
 
 
-@unittest.skipIf(
-    not dist.is_available() or not dist.is_nccl_available(),
-    "c10d NCCL not available, skipping tests",
-)
 class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
     """Test collective autotuning with 4 ranks"""
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3586,7 +3586,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
         try:
             # Do n warmups
-            total_time = cls._run_collective_benchmark(
+            cls._run_collective_benchmark(
                 choice, inputs, output, nwarmup, process_group, timeout
             )
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/pull/167294 collective autotuning test failure on ARM64

This PR resolves the earlier test failure on arm64 in main:
```ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package```
The failure occurred on ARM due to unsupported c10 imports and nccl for collective autotuning tests. This PR updates the test logic to skip on unsupported platforms, ensuring CI passes on ARM.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @mlazos @chenyang78