### PR TITLE
[Profiler] Add synchronization before starting trace in _KinetoProfile

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -208,6 +208,10 @@ class _KinetoProfile:
         self.profiler._prepare_trace()
 
     def start_trace(self) -> None:
+        if self.use_device and hasattr(torch, self.use_device):
+            device_module = getattr(torch, self.use_device)
+            if hasattr(device_module, "synchronize"):
+                device_module.synchronize()
         if self.execution_trace_observer:
             self.execution_trace_observer.start()
         if self.profiler is None:


### PR DESCRIPTION
## Context
Fixes #162481  

## Summary  
This PR introduces explicit device synchronization before calling `start_trace()` in the PyTorch profiler. This ensures that events from the previous round do not interfere with or carry over into the current profiling round.  

## Solution  
In issue #162481, it was observed that explicitly synchronizing before `profiler.step()` resolved the problem. Breaking it down further, when using a scheduler configuration such as `torch.profiler.schedule(wait=0, warmup=1, active=1, repeat=1)`, the `warmup` phase directly precedes the `active` phase (with no `wait` phase). This triggers profiler actions as outlined here:  
https://github.com/pytorch/pytorch/blob/4fd97b460cdf7aeebe9f886d1bb55486dfce5006/torch/profiler/profiler.py#L805  

The profiler does not process or filter events from the `warmup` phase. Consequently, some events from the `warmup` phase may unintentionally appear in the `active` phase. To prevent this, it is necessary to ensure that all events are synchronized before starting the trace.  

The proposed solution introduces synchronization at the beginning of the `start_trace()` method. Since `start_trace()` is not frequently called during profiling (compared to synchronizing directly within `step()`), this approach is unlikely to introduce significant overhead.  

## Results
### Given Example
I just copied the code from https://github.com/pytorch/pytorch/issues/162481 and named it `test_profiler.py` for testing.
The issue was reproduced in my workspace:  

**Versions:**  
torch: 2.10.0a0+git65b9892 
GPU: 3070 Laptop
CUDA: 12.9

**Before:**  
```
10
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                              Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
void at::native::vectorized_elementwise_kernel<...         0.00%       0.000us         0.00%       0.000us       0.000us     344.396ms        99.59%     344.396ms       4.592ms            75  
ampere_bf16_s16816gemm_bf16_256x128_ldg8_f2f_st...         0.00%       0.000us         0.00%       0.000us       0.000us       1.424ms         0.41%       1.424ms      74.931us            19  
                                  cudaLaunchKernel         0.22%     756.572us         0.22%     756.572us      15.131us       0.000us         0.00%       0.000us       0.000us            50  
     cudaOccupancyMaxActiveBlocksPerMultiprocessor         0.00%      14.005us         0.00%      14.005us       1.400us       0.000us         0.00%       0.000us       0.000us            10  
                             cudaDeviceSynchronize        99.78%     344.680ms        99.78%     344.680ms     344.680ms       0.000us         0.00%       0.000us       0.000us             1  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 345.451ms
Self CUDA time total: 345.820ms

10
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                              Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
void at::native::vectorized_elementwise_kernel<...         0.00%       0.000us         0.00%       0.000us       0.000us     358.152ms        99.59%     358.152ms       4.592ms            78  
ampere_bf16_s16816gemm_bf16_256x128_ldg8_f2f_st...         0.00%       0.000us         0.00%       0.000us       0.000us       1.492ms         0.41%       1.492ms      74.621us            20  
                                  cudaLaunchKernel         0.21%     739.018us         0.21%     739.018us      14.780us       0.000us         0.00%       0.000us       0.000us            50  
     cudaOccupancyMaxActiveBlocksPerMultiprocessor         0.00%      14.757us         0.00%      14.757us       1.476us       0.000us         0.00%       0.000us       0.000us            10  
                             cudaDeviceSynchronize        99.79%     358.271ms        99.79%     358.271ms     358.271ms       0.000us         0.00%       0.000us       0.000us             1  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 359.025ms
Self CUDA time total: 359.645ms
```

**After:**  
```
10
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                              Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
void at::native::vectorized_elementwise_kernel<...         0.00%       0.000us         0.00%       0.000us       0.000us     183.677ms        99.60%     183.677ms       4.592ms            40  
ampere_bf16_s16816gemm_bf16_256x128_ldg8_f2f_st...         0.00%       0.000us         0.00%       0.000us       0.000us     745.609us         0.40%     745.609us      74.561us            10  
                                  cudaLaunchKernel         0.41%     742.089us         0.41%     742.089us      14.842us       0.000us         0.00%       0.000us       0.000us            50  
     cudaOccupancyMaxActiveBlocksPerMultiprocessor         0.01%      16.640us         0.01%      16.640us       1.664us       0.000us         0.00%       0.000us       0.000us            10  
                             cudaDeviceSynchronize        99.58%     181.916ms        99.58%     181.916ms     181.916ms       0.000us         0.00%       0.000us       0.000us             1  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 182.674ms
Self CUDA time total: 184.423ms

10
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                              Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
void at::native::vectorized_elementwise_kernel<...         0.00%       0.000us         0.00%       0.000us       0.000us     183.671ms        99.60%     183.671ms       4.592ms            40  
ampere_bf16_s16816gemm_bf16_256x128_ldg8_f2f_st...         0.00%       0.000us         0.00%       0.000us       0.000us     745.265us         0.40%     745.265us      74.526us            10  
                                  cudaLaunchKernel         0.41%     739.636us         0.41%     739.636us      14.793us       0.000us         0.00%       0.000us       0.000us            50  
     cudaOccupancyMaxActiveBlocksPerMultiprocessor         0.01%      16.652us         0.01%      16.652us       1.665us       0.000us         0.00%       0.000us       0.000us            10  
                             cudaDeviceSynchronize        99.59%     181.844ms        99.59%     181.844ms     181.844ms       0.000us         0.00%       0.000us       0.000us             1  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 182.601ms
Self CUDA time total: 184.416ms
```
### New Test

I've also added a new regression test for this and here is the test results before and after the fix:

**Before:**
```
test_profiler_step_device_sync (__main__.TestProfiler.test_profiler_step_device_sync)
Test that device synchronization happens before profiler.step() to ensure ... FAIL

======================================================================
FAIL: test_profiler_step_device_sync (__main__.TestProfiler.test_profiler_step_device_sync)
Test that device synchronization happens before profiler.step() to ensure
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/codes/python/pytorch/torch/testing/_internal/common_utils.py", line 3334, in wrapper
    method(*args, **kwargs)
    ~~~~~~^^^^^^^^^^^^^^^^^
  File "/root/codes/python/pytorch/torch/testing/_internal/common_utils.py", line 1741, in wrapper
    fn(*args, **kwargs)
    ~~^^^^^^^^^^^^^^^^^
  File "/root/codes/python/pytorch/test/profiler/test_profiler.py", line 2310, in test_profiler_step_device_sync
    self.assertEqual(
    ~~~~~~~~~~~~~~~~^
        len(unique_counts),
        ^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        f"This indicates device synchronization is not happening before profiler phase transitions.",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/root/codes/python/pytorch/torch/testing/_internal/common_utils.py", line 4289, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
    ...<4 lines>...
    )
AssertionError: Scalars are not equal!

Expected 1 but got 2.
Absolute difference: 1
Relative difference: 1.0
Inconsistent GPU kernel counts across profiling cycles: [19, 15, 15]. Expected all cycles to report the same count, but got 2 different values. This indicates device synchronization is not happening before profiler phase transitions.

To execute this test, run the following from the base repo dir:
    python test/profiler/test_profiler.py TestProfiler.test_profiler_step_device_sync

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

----------------------------------------------------------------------
Ran 1 test in 0.307s

FAILED (failures=1)
```
**After:**
```
test_profiler_step_device_sync (__main__.TestProfiler.test_profiler_step_device_sync)
Test that device synchronization happens before profiler.step() to ensure ... ok

----------------------------------------------------------------------
Ran 1 test in 0.323s

OK
```