### PR TITLE
[xpu][test] Port distributed elastic test cases to Intel GPU

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -157,7 +157,7 @@ class CreateBackendTest(TestCase):
 
     def test_create_backend_returns_backend_if_is_host_is_false(self) -> None:
         if device_type == "xpu":
-            store = TCPStore(  # type: ignore[call-arg]
+            store = TCPStore(  # type: ignore[call-arg] # noqa: F841
                 self._expected_endpoint_host,
                 self._expected_endpoint_port,
                 is_master=True,

--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -16,7 +16,6 @@ from unittest import mock, TestCase
 
 from rendezvous_backend_test import RendezvousBackendTestMixin
 
-import torch
 from torch.distributed import FileStore, TCPStore
 from torch.distributed.elastic.rendezvous import (
     RendezvousConnectionError,
@@ -28,11 +27,6 @@ from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import (
     create_backend,
 )
 from torch.distributed.elastic.utils.distributed import get_free_port
-
-
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
 
 
 class TCPStoreBackendTest(TestCase, RendezvousBackendTestMixin):
@@ -156,18 +150,11 @@ class CreateBackendTest(TestCase):
                 )
 
     def test_create_backend_returns_backend_if_is_host_is_false(self) -> None:
-        if device_type == "xpu":
-            store = TCPStore(  # type: ignore[call-arg] # noqa: F841
-                self._expected_endpoint_host,
-                self._expected_endpoint_port,
-                is_master=True,
-            )
-        else:
-            TCPStore(  # type: ignore[call-arg]
-                self._expected_endpoint_host,
-                self._expected_endpoint_port,
-                is_master=True,
-            )
+        store = TCPStore(  # type: ignore[call-arg] # noqa: F841
+            self._expected_endpoint_host,
+            self._expected_endpoint_port,
+            is_master=True,
+        )
 
         self._params.config["is_host"] = "false"
 

--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -20,7 +20,6 @@ from typing import cast, Optional
 from unittest import TestCase
 from unittest.mock import call, MagicMock, Mock, patch, PropertyMock
 
-import torch
 import torch.distributed as dist
 from torch.distributed import HashStore, Store
 from torch.distributed.elastic.rendezvous import (
@@ -56,9 +55,6 @@ from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
 
 TEST_PORT = 54321
 TEST_ADDR = "host"
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
 
 
 class CustomAssertMixin:
@@ -257,9 +253,7 @@ class BackendRendezvousStateHolderTest(TestCase, CustomAssertMixin):
         )
 
         mock_datetime = self._datetime_patch.start()
-        mock_datetime.utcnow.return_value = self._now
-        if device_type == "xpu":
-            mock_datetime.now.return_value = self._now
+        mock_datetime.now.return_value = self._now
 
     def tearDown(self) -> None:
         self._datetime_patch.stop()
@@ -572,9 +566,7 @@ class DistributedRendezvousOpExecutorTest(TestCase, CustomAssertMixin):
         )
 
         mock_datetime = self._datetime_patch.start()
-        mock_datetime.utcnow.return_value = self._now
-        if device_type == "xpu":
-            mock_datetime.now.return_value = self._now
+        mock_datetime.now.return_value = self._now
 
     def tearDown(self) -> None:
         self._datetime_patch.stop()
@@ -887,9 +879,7 @@ class AbstractTestRendezvousOp(ABC):
         )
 
         mock_datetime = self._datetime_patch.start()
-        mock_datetime.utcnow.return_value = self._now
-        if device_type == "xpu":
-            mock_datetime.now.return_value = self._now
+        mock_datetime.now.return_value = self._now
 
         self._time_patch = patch(
             "torch.distributed.elastic.rendezvous.dynamic_rendezvous.time"
@@ -1422,9 +1412,7 @@ class DynamicRendezvousHandlerTest(TestCase):
     def test_keep_alive_updates_last_heartbeat(self, mock_datetime) -> None:
         now = datetime(2000, 1, 1, hour=0, minute=0)
 
-        mock_datetime.utcnow.return_value = now
-        if device_type == "xpu":
-            mock_datetime.now.return_value = now
+        mock_datetime.now.return_value = now
 
         self._state.last_heartbeats[self._node] = now - (self._keep_alive_interval * 2)
 
@@ -1773,7 +1761,7 @@ class IntegrationTest(TestCase):
         handler2 = self._create_handler(
             min_nodes=1,
             max_nodes=2,
-            keep_alive_interval=1 if device_type == "xpu" else timedelta(seconds=1),
+            keep_alive_interval=timedelta(seconds=1),
         )
         handler3 = self._create_handler(
             min_nodes=1,


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

- use "torch.accelerator.current_accelerator()" to determine the accelerator backend
- enabled XPU for some test path


cc @dzhulgakov @gujinghui @EikanWang @fengyuan14 @guangyey