### PR TITLE
[MTIA] Support bfloat16 in half_to_float

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12149,6 +12149,16 @@ class TestNNDeviceType(NNTestCase):
             # test softmax with large input value which causes exp() to overflow
             _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
 
+    def test_softmax_bfloat16_half_to_float(self):
+        # half_to_float is only supported on MTIA
+        # Test meta tensors - both dtypes work for meta regardless of target device
+        for dtype in [torch.half, torch.bfloat16]:
+            x_meta = torch.randn(8, 16, device='meta', dtype=dtype)
+            result_meta = torch._softmax(x_meta, dim=1, half_to_float=True)
+            # Meta tensor result should also be float32
+            self.assertEqual(result_meta.dtype, torch.float32)
+            self.assertEqual(result_meta.shape, (8, 16))
+
     def test_nll_loss_1d_input_1d_target_invalid_size(self, device):
         x = torch.randn(10, device=device)
         t = torch.randint(0, 10, (3,), dtype=torch.int64, device=device)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8103,7 +8103,8 @@ def meta_scaled_grouped_mm(
 @out_wrapper()
 def softmax(x: Tensor, dim: int, half_to_float: bool) -> Tensor:
     if half_to_float:
-        assert x.dtype == torch.half
+        assert x.dtype in [torch.half, torch.bfloat16]
+
     computation_dtype, result_dtype = utils.elementwise_dtypes(
         x, type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
     )


### PR DESCRIPTION
Summary: Support bfloat16 in half_to_float when tracing a softmax op that has half_to_float=True.

Test Plan: CI

Differential Revision: D87607452


