### PR TITLE
[CUDA][BugFix] fix truncated error messages

### DIFF
--- a/aten/src/ATen/cuda/PeerToPeerAccess.cpp
+++ b/aten/src/ATen/cuda/PeerToPeerAccess.cpp
@@ -42,10 +42,10 @@ void init_p2p_access_cache(int64_t num_devices) {
 bool get_p2p_access(c10::DeviceIndex dev, c10::DeviceIndex dev_to_access) {
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
 
-  TORCH_CHECK(dev >= 0 || dev < num_devices_, dev, " is not a device");
+  TORCH_CHECK(dev >= 0 || dev < num_devices_, static_cast<int>(dev), " is not a device");
   TORCH_CHECK(
       dev_to_access >= 0 || dev_to_access < num_devices_,
-      dev_to_access,
+      static_cast<int>(dev_to_access),
       " is not a device");
   TORCH_INTERNAL_ASSERT(num_devices_ >= 0, "p2p access cache not initialized");
 
@@ -147,7 +147,7 @@ bool get_fabric_access(c10::DeviceIndex dev) {
 #if !defined USE_ROCM && defined CUDA_VERSION && CUDA_VERSION >= 12040 && defined PYTORCH_C10_DRIVER_API_SUPPORTED
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
 
-  TORCH_CHECK(dev >= 0 || dev < num_devices_, dev, " is not a device");
+  TORCH_CHECK(dev >= 0 || dev < num_devices_, static_cast<int>(dev), " is not a device");
   auto& cache = fabricAccessEnabled_[dev];
   if (cache != -1) {
     return cache;

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -60,7 +60,7 @@ void set_magma_init_fn(void (*fn)()) {
 namespace {
 bool _hasPrimaryContext(DeviceIndex device_index) {
   TORCH_CHECK(device_index >= 0 && device_index < at::cuda::device_count(),
-              "hasPrimaryContext expects a valid device index, but got device_index=", device_index);
+              "hasPrimaryContext expects a valid device index, but got device_index=", static_cast<int>(device_index));
   unsigned int ctx_flags = 0;
   // In standalone tests of cuDevicePrimaryCtxGetState, I've seen the "active" argument end up with weird
   // (garbage-looking nonzero) values when the context is not active, unless I initialize it to zero.

--- a/c10/cuda/CUDAFunctions.cpp
+++ b/c10/cuda/CUDAFunctions.cpp
@@ -242,7 +242,8 @@ cudaError_t GetDevice(DeviceIndex* device) {
 }
 
 cudaError_t SetDevice(DeviceIndex device, const bool force) {
-  TORCH_CHECK(device >= 0, "device id must be non-negative!", device);
+  TORCH_CHECK(
+      device >= 0, "device id must be non-negative!", static_cast<int>(device));
   targetDeviceIndex = -1;
   if (force) {
     return cudaSetDevice(device);
@@ -323,7 +324,8 @@ cudaError_t GetDevice(DeviceIndex* device) {
 }
 
 cudaError_t SetDevice(DeviceIndex device, const bool force) {
-  TORCH_CHECK(device >= 0, "device id must be non-negative!", device);
+  TORCH_CHECK(
+      device >= 0, "device id must be non-negative!", static_cast<int>(device));
   if (force) {
     return cudaSetDevice(device);
   }


### PR DESCRIPTION
Inspired by #168369

I found https://github.com/pytorch/pytorch/blob/9a38bb8622e5427e28b655df89b81293f63ecaac/c10/core/Device.h#L19

When device indices (DeviceIndex) with value 0 are passed to TORCH_CHECK macros,they are interpreted as string terminators (\0), causing error messages to be truncated. 


For example:

```cpp
#include <iostream>
#include <sstream>
#include <cstring>
#include <cstdint>

int8_t device = 0;

int main() {
    std::cout << std::strlen((std::stringstream() << "Head" << device << "Tail").str().c_str()) << std::endl;
    std::cout << std::strlen((std::stringstream() << "Head" << static_cast<int>(device) << "Tail").str().c_str()) << std::endl;
    std::cout << std::strlen((std::stringstream() << "Head" << +device << "Tail").str().c_str()) << std::endl;
    return 0;

}

```

output

```bash
4
9
9
```

Maybe we can use `+` instead of `static_cast<int>`, but it needs discussion.

cc @galv @cyyever 
