### PR TITLE
Fix tracing infinite loop

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -1197,6 +1197,8 @@ class OpOverloadPacket(Generic[_P, _T]):
         # if there exists other attributes like `__name__` that only exist on self._op and not on the
         # opoverloadpacket.
         # This is ok since we are guaranteed that an overload name for an aten op can't start with '__'
+        if key in ["_qualified_op_name", "_op"]:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'")
         try:
             if key.startswith("__"):
                 return getattr(self._op, key)

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import itertools
 from collections.abc import Iterable, Iterator, Sequence, Sized
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 
 import torch
 
@@ -307,7 +307,7 @@ class BatchSampler(Sampler[list[int]]):
 
     def __init__(
         self,
-        sampler: Sampler[int] | Iterable[int],
+        sampler: Union[Sampler[int], Iterable[int]],
         batch_size: int,
         drop_last: bool,
     ) -> None:

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import itertools
 from collections.abc import Iterable, Iterator, Sequence, Sized
-from typing import Generic, TypeVar, Union
+from typing import Generic, TypeVar
 
 import torch
 
@@ -307,7 +307,7 @@ class BatchSampler(Sampler[list[int]]):
 
     def __init__(
         self,
-        sampler: Union[Sampler[int], Iterable[int]],
+        sampler: Sampler[int] | Iterable[int],
         batch_size: int,
         drop_last: bool,
     ) -> None:


### PR DESCRIPTION
Fixes #168136.
## Summary

When using tracing tools like `viztracer` or `sys.settrace`, `OpOverloadPacket.__getattr__` can be triggered before the object is fully initialized (specifically before `_qualified_op_name` or `_op` are set). This causes `__repr__` or other methods to fail, triggering `__getattr__` again recursively, leading to a `RecursionError`.

This PR adds a guard clause to `__getattr__` to immediately raise `AttributeError` for missing internal attributes, preventing the infinite loop.

## Test Plan
Reproduced the issue locally using the script provided in the issue.
**Before fix:** Script hangs/crashes with `RecursionError`.
**After fix:** Script completes successfully.

```python
import torch
import sys

def trace_func(frame, event, arg):
    return trace_func

sys.settrace(trace_func)

try:
    class VulnerablePacket(torch._ops.OpOverloadPacket):
        def __init__(self):
            try:
                # Triggers __getattr__ on uninitialized object
                print(f"Accessing: {self.__qualname__}")
            except AttributeError:
                pass
            def dummy(): pass
            super().__init__("aten::dummy", "dummy", dummy, [])

    v = VulnerablePacket()
    print("SUCCESS: No infinite loop.")
finally:
    sys.settrace(None)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @jataylo