### PR TITLE
Add reduce_scatter_tensor_coalesced support to ProcessGroupWrapper

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -371,6 +371,29 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
+        def test_reduce_scatter_tensor_coalesced_debug_mode(self):
+            torch.cuda.set_device(self.rank)
+            pg = self._create_wrapper_pg(with_new_group=True)
+            dev = torch.cuda.current_device()
+
+            out_shapes = [(2, 2), (3, 3)]
+            in_shapes = [(s[0] * self.world_size,) + s[1:] for s in out_shapes]
+
+            outputs = [torch.zeros(s, device=dev) for s in out_shapes]
+            inputs = [torch.ones(s, device=dev) * (self.rank + 1) for s in in_shapes]
+
+            work = pg.reduce_scatter_tensor_coalesced(outputs, inputs)
+            work.wait()
+
+            for i, (output, _) in enumerate(zip(outputs, inputs)):
+                expected = torch.ones(out_shapes[i], device=dev) * sum(
+                    range(1, self.world_size + 1)
+                )
+                self.assertTrue(torch.allclose(output, expected))
+
+        @requires_nccl()
+        @skip_if_lt_x_gpu(2)
+        @with_dist_debug_levels(levels=["DETAIL"])
         @patch("torch.distributed.distributed_c10d._GLOO_AVAILABLE", False)
         def test_debug_level_detail_no_gloo(self):
             with self.assertRaisesRegex(
@@ -523,6 +546,21 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
     def test_collective_shape_mismatch_cuda(self):
         pg = self._create_wrapper_pg(with_new_group=False)
         self._test_collective_shape_mismatch(pg, use_accel=True)
+
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_reduce_scatter_tensor_coalesced_debug_mode(self):
+        pg = self._create_wrapper_pg(with_new_group=True)
+
+        out_shapes = [(2, 2), (3, 3)]
+        in_shapes = [(s[0] * self.world_size,) + s[1:] for s in out_shapes]
+        outputs = [torch.zeros(s) for s in out_shapes]
+        inputs = [torch.ones(s) * (self.rank + 1) for s in in_shapes]
+
+        work = pg.reduce_scatter_tensor_coalesced(outputs, inputs)
+        work.wait()
+        for i, (output, _) in enumerate(zip(outputs, inputs)):
+            expected = torch.ones(out_shapes[i]) * sum(range(1, self.world_size + 1))
+            self.assertTrue(torch.allclose(output, expected))
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -51,6 +51,8 @@ std::string opTypeToString(OpType opType) {
       return "COALESCED";
     case OpType::_ALLREDUCE_SPARSE:
       return "_ALLREDUCE_SPARSE";
+    case OpType::REDUCE_SCATTER_TENSOR_COALESCED:
+      return "REDUCE_SCATTER_TENSOR_COALESCED";
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown op type!");
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -558,6 +558,18 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::_reduce_scatter_base(
   return backend_->_reduce_scatter_base(outputBuffer, inputBuffer, opts);
 }
 
+c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter_tensor_coalesced(
+    std::vector<at::Tensor>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const ReduceScatterOptions& opts) {
+  // NOTE: We don't enforce shape checking for reduce_scatter_tensor_coalesced
+  // because the implementation itself does not enforce it we have tests that
+  // use inconsistent shapes, see python implementation in distributed_c10d for
+  // details.
+  runCollectiveChecks(OpType::REDUCE_SCATTER_TENSOR_COALESCED, {});
+  return backend_->reduce_scatter_tensor_coalesced(outputs, inputs, opts);
+}
+
 void ProcessGroupWrapper::startCoalescing() {
   return backend_->startCoalescing();
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -124,6 +124,11 @@ class TORCH_API ProcessGroupWrapper : public Backend {
       at::Tensor& inputBuffer,
       const ReduceScatterOptions& opts) override;
 
+  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
   void startCoalescing() override;
 
   c10::intrusive_ptr<Work> endCoalescing() override;

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -31,6 +31,7 @@ enum class OpType : std::uint8_t {
   _REDUCE_SCATTER_BASE = 16,
   COALESCED = 17,
   _ALLREDUCE_SPARSE = 18,
+  REDUCE_SCATTER_TENSOR_COALESCED = 19,
   UNKNOWN = 100,
 };
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3713,11 +3713,11 @@ Returns:
       .value("RECVANYSOURCE", ::c10d::OpType::RECVANYSOURCE)
       .value("BARRIER", ::c10d::OpType::BARRIER)
       .value("_REDUCE_SCATTER_BASE", ::c10d::OpType::_REDUCE_SCATTER_BASE)
+      .value("COALESCED", ::c10d::OpType::COALESCED)
+      .value("_ALLREDUCE_SPARSE", ::c10d::OpType::_ALLREDUCE_SPARSE)
       .value(
           "REDUCE_SCATTER_TENSOR_COALESCED",
           ::c10d::OpType::REDUCE_SCATTER_TENSOR_COALESCED)
-      .value("COALESCED", ::c10d::OpType::COALESCED)
-      .value("_ALLREDUCE_SPARSE", ::c10d::OpType::_ALLREDUCE_SPARSE)
       .value("UNKNOWN", ::c10d::OpType::UNKNOWN);
 
   py::enum_<::c10d::WorkResult>(module, "WorkResult")

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3713,6 +3713,9 @@ Returns:
       .value("RECVANYSOURCE", ::c10d::OpType::RECVANYSOURCE)
       .value("BARRIER", ::c10d::OpType::BARRIER)
       .value("_REDUCE_SCATTER_BASE", ::c10d::OpType::_REDUCE_SCATTER_BASE)
+      .value(
+          "REDUCE_SCATTER_TENSOR_COALESCED",
+          ::c10d::OpType::REDUCE_SCATTER_TENSOR_COALESCED)
       .value("COALESCED", ::c10d::OpType::COALESCED)
       .value("_ALLREDUCE_SPARSE", ::c10d::OpType::_ALLREDUCE_SPARSE)
       .value("UNKNOWN", ::c10d::OpType::UNKNOWN);


### PR DESCRIPTION
When TORCH_DISTRIBUTED_DEBUG=DETAIL is enabled, ProcessGroup gets wrapped in ProcessGroupWrapper for additional debugging. However, ProcessGroupWrapper did not support reduce_scatter_tensor_coalesced, causing DTensor operations to fail with Backend does not support reduce_scatter_tensor_coalesced error.

This commit adds:
- REDUCE_SCATTER_TENSOR_COALESCED to OpType enum
- Adds string conversion for the new enum
- Adds Python bindings for the new enum
- Implements reduce_scatter_tensor_coalesced in ProcessGroupWrapper
- Adds regression tests for both NCCL and Gloo backends

Fixes #157622 
