### PR TITLE
[reland][Full Inductor][Pytorch] Prevent decomposition to support fallback of aten.native_layer_norm for MTIA

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -35,6 +35,7 @@ from torch._prims_common import (
     ELEMENTWISE_TYPE_PROMOTION_KIND,
     type_to_dtype,
 )
+from torch._refs import native_layer_norm as decomp_native_layer_norm
 from torch.fx.experimental.symbolic_shapes import guard_or_false, statically_known_true
 
 from . import config, inductor_prims
@@ -118,6 +119,7 @@ decomps_to_exclude: list[Union[torch._ops.OpOverload, torch._ops.OpOverloadPacke
     aten.clamp_max,
     aten.clamp_min,
     aten.embedding_dense_backward,  # we fall back on xpu
+    aten.native_layer_norm,  # we fall back on mtia
     aten.index_add,  # we conditionally call this decomp
     aten.glu,  # inductor lowers this directly
     aten.select_scatter,  # need to be in the ATen graph in order for it to work with the re-inplacing pass
@@ -157,6 +159,20 @@ def _embedding_dense_backward(
     return decomp_embedding_dense_backward(
         grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
     )
+
+
+@register_decomposition(aten.native_layer_norm)
+def _native_layer_norm(
+    input: torch.Tensor,
+    normalized_shape: utils.ShapeType,
+    weight: Optional[torch.Tensor],
+    bias: Optional[torch.Tensor],
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if input.is_mtia:
+        return NotImplemented
+    # We can write a util function to update decomp table if we have more ops to fallback.
+    return decomp_native_layer_norm(input, normalized_shape, weight, bias, eps)
 
 
 @register_decomposition([aten.sym_constrain_range_for_size.default])

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2902,6 +2902,10 @@ if torch.xpu.is_available():
         aten.embedding_dense_backward, warn=False
     )  # (XPU-only and faster than decomp)
 
+if torch.mtia._is_compiled():
+    make_fallback(
+        aten.native_layer_norm, warn=False
+    )  # (MTIA-only and faster than decomp)
 
 # 1.5) Easy or Impossible
 make_fallback(aten._cdist_forward)  # p=2 should be feasible


### PR DESCRIPTION
Differential Revision: D87665337

## Context

**Original context of [#168290](https://github.com/pytorch/pytorch/pull/168290):**
MTIA-Triton currently doesn't support aten.native_layer_norm and we need Inductor to fallback it to Aten. Currently `make_fallback` doesn't work for aten.native_layer_norm due to decomposition. This PR prevents the decomposition, following the PR [#151637](https://github.com/pytorch/pytorch/pull/151637) where XPU enabled fallback for embedding_dense_backward.


**This PR:**
https://github.com/pytorch/pytorch/pull/168290 was reverted because it caused runtime failures for mtia tests ([T245927718](https://www.internalfb.com/intern/tasks/?t=245927718)). Not sure why the internal CI didn't prevent the diff landing though.

After investigation, I think the failures were caused by `torch.mtia.is_available()`:
1. The API didn't run lazy initialization of mtia device, which caused error when this API was run by Inductor while mtia device hasn't been initialized. This issue should be fixed by D88058718.
2. I also found some failing tests were run without mtia device, which causes `torch.mtia.is_available()` returns false. 

## This PR
Exactly copy of https://github.com/pytorch/pytorch/pull/168290, except for changing `torch.mtia.is_available()` to `torch.mtia._is_compiled()`, which doesn't require mtia device to be initialized. And I verified the failed tests can pass with `torch.mtia._is_compiled()`.

`torch.mtia._is_compiled()` checks whether MTIA hook is registered, so should not affect non-MTIA program.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @egienvalue @chenyang78