### PR TITLE
[precompile] set strict_autograd_cache=True when precompiling

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -796,14 +796,16 @@ class _TorchDynamoContext:
                 raise RuntimeError("aot compile requires a callable dynamo callback.")
 
             assert self._hooks is not None
-            return aot_compile_fullgraph(
-                fn,
-                example_inputs,
-                hooks=self._hooks,
-                backend=innermost_fn(
-                    self.callback, unaltered_fn_attr="_torchdynamo_orig_backend"
-                ),
-            )
+
+            with torch._functorch.config.patch(strict_autograd_cache=True):
+                return aot_compile_fullgraph(
+                    fn,
+                    example_inputs,
+                    hooks=self._hooks,
+                    backend=innermost_fn(
+                        self.callback, unaltered_fn_attr="_torchdynamo_orig_backend"
+                    ),
+                )
 
         # add context containing GraphModule to any GraphModule forward functions
         if isinstance(fn, GraphModule):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #168988
* __->__ #168989

Right now we get a pretty hard to understand error message:

```
Traceback (most recent call last):
  File "/home/bobren/local/a/pytorch/spc.py", line 80, in <module>
    .save_compiled_function(path)
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile.py", line 129, in save_compiled_function
    f.write(type(self).serialize(self))
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile.py", line 145, in serialize
    type(compiled_fn).serialize_compile_artifacts(compiled_fn),
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile_types.py", line 54, in serialize_compile_artifacts
    def deserialize_compile_artifacts(cls, data: bytes) -> Any:
TypeError: 'NoneType' object is not callable
```

which happens because cache is bypassed, so the "serialize" field on compiled_fn is set to None.

after this PR we get a much more direct error message:

```
(/home/bobren/local/a/pytorch-env) [9:18] devgpu009:/home/bobren/local/a/pytorch [130]
❯ cache_tlp python spc.py
Wrapped class is <class '__main__.WrappedBasicNN_1'>
my_property: 123
Traceback (most recent call last):
  File "/home/bobren/local/a/pytorch/spc.py", line 79, in <module>
    .aot_compile(((input_tensor,), {}))
  File "/home/bobren/local/a/pytorch/torch/_dynamo/eval_frame.py", line 806, in aot_compile
    return aot_compile_fullgraph(
  File "/home/bobren/local/a/pytorch/torch/_dynamo/aot_compile.py", line 236, in aot_compile_fullgraph
    compiled_fn = backend(
  File "/home/bobren/local/a/pytorch/torch/__init__.py", line 2445, in __call__
    return compile_fx(model_, inputs_, config_patches=self.config)
  File "/home/bobren/local/a/pytorch/torch/_inductor/compile_fx.py", line 2525, in compile_fx
    return _maybe_wrap_and_compile_fx_main(
  File "/home/bobren/local/a/pytorch/torch/_inductor/compile_fx.py", line 2602, in _maybe_wrap_and_compile_fx_main
    return _compile_fx_main(
  File "/home/bobren/local/a/pytorch/torch/_inductor/compile_fx.py", line 2797, in _compile_fx_main
    return aot_autograd(
  File "/home/bobren/local/a/pytorch/torch/_dynamo/backends/common.py", line 117, in __call__
    cg = aot_module_simplified(gm, example_inputs, **self.kwargs)
  File "/home/bobren/local/a/pytorch/torch/_functorch/aot_autograd.py", line 1097, in aot_module_simplified
    compiled_fn = AOTAutogradCache.try_load(
  File "/home/bobren/local/a/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py", line 708, in try_load
    raise e
  File "/home/bobren/local/a/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py", line 639, in try_load
    cache_key, debug_lines = autograd_cache_key(
  File "/home/bobren/local/a/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py", line 499, in autograd_cache_key
    check_cacheable(gm)
  File "/home/bobren/local/a/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py", line 292, in check_cacheable
    check_node_safe(node)
  File "/home/bobren/local/a/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py", line 240, in check_node_safe
    raise BypassAOTAutogradCache(
torch._functorch._aot_autograd.autograd_cache.BypassAOTAutogradCache: Unsupported call_function target tag_activation_checkpoint.
 Function module: torch.ops.higher_order,
Function name: tag_activation_checkpoint
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @Lucaskabela @jataylo