### PR TITLE
[CI][CUDA][B200][Smoke Test] Add one more B200 smoke test. Change periodic frequency from every 6 hours to every 2 hours

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -354,6 +354,7 @@ test_python_smoke_b200() {
       nn/attention/test_fa4 \
       nn/attention/test_open_registry \
       inductor/test_flex_flash \
+      inductor/test_torchinductor \
     $PYTHON_TEST_EXTRA_OPTION \
     --upload-artifacts-while-running
   assert_git_not_dirty

--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -23,7 +23,7 @@ on:
       - .github/workflows/test-b200.yml
   workflow_dispatch:
   schedule:
-    - cron: 0 4,10,16,22 * * *  # every 6 hours
+    - cron: 0 */2 * * *  # every 2 hours
   push:
     tags:
       - ciflow/b200/*


### PR DESCRIPTION
Fix low utilization issue for linux.dgx.b200. 
linux.dgx.b200.8 is much busier. 
According to https://hud.pytorch.org/runners/pytorch?search=dgx.b200 

cc @drisspg @malfet @eqy @tinglvv @ptrblck @atalman @huydhn 