### PR TITLE
Dynamo backend guard log

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -703,10 +703,7 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
         _compiled_callable1(x, y)
         _compiled_callable2(x, y)
         record_str = "\n".join(r.getMessage() for r in records)
-        self.assertIn(
-            "backend mismatch between",
-            record_str
-        )
+        self.assertIn("backend mismatch between", record_str)
 
     @make_logging_test(guards=True, recompiles=True)
     def test_guards_recompiles(self, records):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4306,7 +4306,6 @@ def get_guard_fail_reason_helper(
     scope.update(guard_manager.closure_vars)
     reasons: list[str] = []
 
-    # Check if there was a backend mismatch detected in C++
     if hasattr(guard_manager, "_backend_mismatch_reason"):
         backend_mismatch_reason = getattr(
             guard_manager, "_backend_mismatch_reason", None

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4312,10 +4312,7 @@ def get_guard_fail_reason_helper(
         )
         if backend_mismatch_reason:
             reasons.append(backend_mismatch_reason)
-            try:
-                delattr(guard_manager, "_backend_mismatch_reason")
-            except AttributeError:
-                pass
+            delattr(guard_manager, "_backend_mismatch_reason")
             reason_str = f"{compile_id}: " + "; ".join(reasons)
             return strip_local_scope(reason_str)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4306,6 +4306,20 @@ def get_guard_fail_reason_helper(
     scope.update(guard_manager.closure_vars)
     reasons: list[str] = []
 
+    # Check if there was a backend mismatch detected in C++
+    if hasattr(guard_manager, "_backend_mismatch_reason"):
+        backend_mismatch_reason = getattr(
+            guard_manager, "_backend_mismatch_reason", None
+        )
+        if backend_mismatch_reason:
+            reasons.append(backend_mismatch_reason)
+            try:
+                delattr(guard_manager, "_backend_mismatch_reason")
+            except AttributeError:
+                pass
+            reason_str = f"{compile_id}: " + "; ".join(reasons)
+            return strip_local_scope(reason_str)
+
     no_tensor_aliasing_check_failed = False
 
     verbose_code_parts: list[str] = []

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -161,7 +161,15 @@ void lookup(
     bool valid = backend == Py_False ||
         backend_match(cache_entry.backend.ptr(), backend);
 
-    if (valid) {
+    if (!valid) {
+      py::object backend_repr = py::repr(py::handle(backend));
+      py::object cached_backend_repr = py::repr(cache_entry.backend);
+      std::string reason = std::string("backend instance mismatch between ") +
+          py::cast<std::string>(cached_backend_repr) + std::string(" and ") +
+          py::cast<std::string>(backend_repr);
+      cache_entry.guard_manager.attr("_backend_mismatch_reason") =
+          py::str(reason);
+    } else {
       try {
         if (is_skip_guard_eval_unsafe) {
           valid = torch::dynamo::run_root_guard_manager(

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -162,11 +162,11 @@ void lookup(
         backend_match(cache_entry.backend.ptr(), backend);
 
     if (!valid) {
-      py::object backend_repr = py::repr(py::handle(backend));
-      py::object cached_backend_repr = py::repr(cache_entry.backend);
-      std::string reason = std::string("backend instance mismatch between ") +
-          py::cast<std::string>(cached_backend_repr) + std::string(" and ") +
-          py::cast<std::string>(backend_repr);
+      py::handle backend_hdl = py::handle(backend);
+      std::string reason = std::string("backend mismatch between ") +
+          py::cast<std::string>(cache_entry.backend.attr("compiler_name")) +
+          std::string(" and ") +
+          py::cast<std::string>(backend_hdl.attr("compiler_name"));
       cache_entry.guard_manager.attr("_backend_mismatch_reason") =
           py::str(reason);
     } else {


### PR DESCRIPTION
Fixes #167453

The problem: 
Before checking guards for a cache entry, the backend associated to the cache entry is validated to ensure it matches the input backend. The check is not part of the current LeafGuard reporting workflow, so no statement is returned in TORCH_TRACE for why the recompilation occurred.

The proposed fix:
An attribute is added to the guard manager when a backend mismatch occurs for a cache entry. The python guard code then checks if the attribute is present and logs the contents of the attribute.  The big issues with this solution is that it doesn't follow the leafguard failure reporting paradigm & if there are future efforts to support free threading, this introduces tech debt.

Alternative solution:
Create a backend_match guard which inherits from leaf_guard on the cpp side. Register the guard on the python side when the cache entry is created. When checking guards, pass the backend along with f_locals for any of the runtime checks - this is a fairly large function signature refactoring. With these changes, the backend guard would be handled in a similar manner to guards on locals/globals.  
Additionally, this solution would probably need additional work to clean up backend from cache_entry. If reducing tech debt for future free threading support is important, this may be a better solution. But would require more significant changes.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78