### PR TITLE
[Pt. 1] Make some aspects of Dynamo/Inductor global state thread safe

### DIFF
--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -310,7 +310,12 @@ def setup_compilation_env():
 
 @contextmanager
 def _set_compilation_env():
-    _old_is_tracing = torch.fx._symbolic_trace._is_fx_tracing_flag
+    _symbolic_trace_tls = getattr(torch.fx._symbolic_trace, "_is_fx_tracing_tls", None)
+    _old_is_tracing = (
+        getattr(_symbolic_trace_tls, "flag", False)
+        if _symbolic_trace_tls is not None
+        else False
+    )
     _old_allow_empty_graphs = torch._dynamo.config.allow_empty_graphs
     _old_capture_scalar_outputs = torch._dynamo.config.capture_scalar_outputs
     # The issue is tracked in https://github.com/pytorch/pytorch/issues/144360: when dynamo finds
@@ -324,13 +329,13 @@ def _set_compilation_env():
     try:
         # We need to turn off the is_fx_tracing_flag. Remove this flag check from dynamo
         # once we are confident fx tracing works with dynamo.
-        torch.fx._symbolic_trace._is_fx_tracing_flag = False
+        torch.fx._symbolic_trace._set_is_fx_tracing(False)
         # pyrefly: ignore [bad-assignment]
         torch._dynamo.config.allow_empty_graphs = True
         torch._dynamo.config.capture_scalar_outputs = True
         yield
     finally:
-        torch.fx._symbolic_trace._is_fx_tracing_flag = _old_is_tracing
+        torch.fx._symbolic_trace._set_is_fx_tracing(_old_is_tracing)
         torch._dynamo.config.allow_empty_graphs = _old_allow_empty_graphs
         torch._dynamo.config.capture_scalar_outputs = _old_capture_scalar_outputs
 

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -310,7 +310,7 @@ def setup_compilation_env():
 
 @contextmanager
 def _set_compilation_env():
-    _old_is_tracing = getattr(torch.fx._symbolic_trace._is_fx_tracing_tls, "flag", False)
+    _old_is_tracing = torch.fx._symbolic_trace._get_is_fx_tracing()
     _old_allow_empty_graphs = torch._dynamo.config.allow_empty_graphs
     _old_capture_scalar_outputs = torch._dynamo.config.capture_scalar_outputs
     # The issue is tracked in https://github.com/pytorch/pytorch/issues/144360: when dynamo finds

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -310,12 +310,7 @@ def setup_compilation_env():
 
 @contextmanager
 def _set_compilation_env():
-    _symbolic_trace_tls = getattr(torch.fx._symbolic_trace, "_is_fx_tracing_tls", None)
-    _old_is_tracing = (
-        getattr(_symbolic_trace_tls, "flag", False)
-        if _symbolic_trace_tls is not None
-        else False
-    )
+    _old_is_tracing = getattr(torch.fx._symbolic_trace._is_fx_tracing_tls, "flag", False)
     _old_allow_empty_graphs = torch._dynamo.config.allow_empty_graphs
     _old_capture_scalar_outputs = torch._dynamo.config.capture_scalar_outputs
     # The issue is tracked in https://github.com/pytorch/pytorch/issues/144360: when dynamo finds

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -12,6 +12,7 @@ import operator
 import os
 import re
 import tempfile
+import threading
 from abc import ABC, abstractmethod
 from enum import auto, Enum
 from itertools import chain
@@ -380,6 +381,8 @@ class DeviceOpOverrides:
         raise NotImplementedError
 
 
+# Thread-safe lazy initialization for device op overrides
+device_op_overrides_lock = threading.RLock()
 device_op_overrides_dict: dict[str, DeviceOpOverrides] = {}
 _device_op_overrides_initialized = False
 custom_backend_passes: dict[str, CustomGraphModulePass | None] = {}
@@ -650,7 +653,8 @@ def index_prevent_reordering(
 def register_device_op_overrides(
     device: str, device_op_overrides: DeviceOpOverrides
 ) -> None:
-    device_op_overrides_dict[device] = device_op_overrides
+    with device_op_overrides_lock:
+        device_op_overrides_dict[device] = device_op_overrides
 
 
 def _initialize_device_op_overrides():
@@ -660,16 +664,20 @@ def _initialize_device_op_overrides():
     if _device_op_overrides_initialized:
         return
 
-    from . import mps_device_op_overrides  # noqa: F401
-    from .cpu_device_op_overrides import CpuDeviceOpOverrides
-    from .cuda import device_op_overrides  # noqa: F401
-    from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
-    from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
+    with device_op_overrides_lock:
+        if _device_op_overrides_initialized:
+            return
 
-    # TPU uses Pallas for codegen and only needs no-op overrides
-    register_device_op_overrides("tpu", CpuDeviceOpOverrides())
+        from . import mps_device_op_overrides  # noqa: F401
+        from .cpu_device_op_overrides import CpuDeviceOpOverrides
+        from .cuda import device_op_overrides  # noqa: F401
+        from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
+        from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
 
-    _device_op_overrides_initialized = True
+        # TPU uses Pallas for codegen and only needs no-op overrides
+        register_device_op_overrides("tpu", CpuDeviceOpOverrides())
+
+        _device_op_overrides_initialized = True
 
 
 def get_device_op_overrides(device: str) -> DeviceOpOverrides:

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -61,19 +61,19 @@ def is_fx_tracing_warning() -> None:
         "or torch.compiler.is_compiling() for specifically torch.export/compile."
     )
 
-
-def is_fx_tracing() -> bool:
-    is_fx_tracing_warning()
-    return getattr(_is_fx_tracing_tls, "flag", False)
-
-
 def _set_is_fx_tracing(value: bool) -> None:
     _is_fx_tracing_tls.flag = value
 
+def _get_is_fx_tracing() -> bool:
+    return getattr(_is_fx_tracing_tls, "flag", False)
+
+def is_fx_tracing() -> bool:
+    is_fx_tracing_warning()
+    return _get_is_fx_tracing()
 
 def is_fx_symbolic_tracing():
     return (
-        getattr(_is_fx_tracing_tls, "flag", False) and not torch.compiler.is_compiling()
+        _get_is_fx_tracing() and not torch.compiler.is_compiling()
     )
 
 
@@ -801,7 +801,7 @@ class Tracer(TracerBase):
 
             A ``Graph`` representing the semantics of the passed-in ``root``.
         """
-        old_is_fx_tracing_flag = getattr(_is_fx_tracing_tls, "flag", False)
+        old_is_fx_tracing_flag = _get_is_fx_tracing()
         _set_is_fx_tracing(True)
         try:
             if isinstance(root, torch.nn.Module):

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import math
 import os
+import threading
 import warnings
 from collections.abc import Callable, Iterable, Iterator
 from itertools import chain
@@ -41,7 +42,7 @@ _orig_module_getattr: Callable[..., Any] = torch.nn.Module.__getattr__
 
 _proxyable_classes: dict[type, None] = {}
 
-_is_fx_tracing_flag = False
+_is_fx_tracing_tls = threading.local()
 
 _ConstantAttributeType: TypeAlias = (
     torch.Tensor | torch.ScriptObject | FakeScriptObject | pytree.TreeSpec
@@ -63,11 +64,17 @@ def is_fx_tracing_warning() -> None:
 
 def is_fx_tracing() -> bool:
     is_fx_tracing_warning()
-    return _is_fx_tracing_flag
+    return getattr(_is_fx_tracing_tls, "flag", False)
 
 
-def is_fx_symbolic_tracing() -> bool:
-    return _is_fx_tracing_flag and not torch.compiler.is_compiling()
+def _set_is_fx_tracing(value: bool) -> None:
+    _is_fx_tracing_tls.flag = value
+
+
+def is_fx_symbolic_tracing():
+    return (
+        getattr(_is_fx_tracing_tls, "flag", False) and not torch.compiler.is_compiling()
+    )
 
 
 @compatibility(is_backward_compatible=True)
@@ -794,9 +801,8 @@ class Tracer(TracerBase):
 
             A ``Graph`` representing the semantics of the passed-in ``root``.
         """
-        global _is_fx_tracing_flag
-        old_is_fx_tracing_flag = _is_fx_tracing_flag
-        _is_fx_tracing_flag = True
+        old_is_fx_tracing_flag = getattr(_is_fx_tracing_tls, "flag", False)
+        _set_is_fx_tracing(True)
         try:
             if isinstance(root, torch.nn.Module):
                 # do real recompilation for _LazyGraphModule before retracing since the trace
@@ -928,7 +934,7 @@ class Tracer(TracerBase):
 
             raise
         finally:
-            _is_fx_tracing_flag = old_is_fx_tracing_flag
+            _set_is_fx_tracing(old_is_fx_tracing_flag)
         return self.graph
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "Tracer":

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -61,20 +61,22 @@ def is_fx_tracing_warning() -> None:
         "or torch.compiler.is_compiling() for specifically torch.export/compile."
     )
 
+
 def _set_is_fx_tracing(value: bool) -> None:
     _is_fx_tracing_tls.flag = value
 
+
 def _get_is_fx_tracing() -> bool:
     return getattr(_is_fx_tracing_tls, "flag", False)
+
 
 def is_fx_tracing() -> bool:
     is_fx_tracing_warning()
     return _get_is_fx_tracing()
 
-def is_fx_symbolic_tracing():
-    return (
-        _get_is_fx_tracing() and not torch.compiler.is_compiling()
-    )
+
+def is_fx_symbolic_tracing() -> bool:
+    return _get_is_fx_tracing() and not torch.compiler.is_compiling()
 
 
 @compatibility(is_backward_compatible=True)

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -70,6 +70,16 @@ def _get_is_fx_tracing() -> bool:
     return getattr(_is_fx_tracing_tls, "flag", False)
 
 
+@contextlib.contextmanager
+def _is_fx_tracing_context(value: bool) -> Iterator[None]:
+    previous = _get_is_fx_tracing()
+    _set_is_fx_tracing(value)
+    try:
+        yield
+    finally:
+        _set_is_fx_tracing(previous)
+
+
 def is_fx_tracing() -> bool:
     is_fx_tracing_warning()
     return _get_is_fx_tracing()

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1789,6 +1789,7 @@ def _checkpoint_without_reentrant_generator_impl(
     )
     error_on_nested_fx_trace = torch._dynamo.config.error_on_nested_fx_trace
     is_non_strict_tracing = torch.compiler._is_non_strict_tracing()
+    is_fx_tracing = torch.fx._symbolic_trace._get_is_fx_tracing()
 
     def recompute_fn(*args) -> None:
         # This will be called later during recomputation. This wrapping enables
@@ -1820,6 +1821,7 @@ def _checkpoint_without_reentrant_generator_impl(
                 recompute_context,
                 device_ctx,
                 nested_fx_trace_ctx,
+                torch.fx._symbolic_trace._is_fx_tracing_context(is_fx_tracing),
             ):  # type: ignore[attr-defined]
                 fn(*args, **kwargs)
 


### PR DESCRIPTION
This is the first part of an updated patch to [#168174](https://github.com/pytorch/pytorch/pull/168174) modifying specific parts of Dyanmo/Inductor's global state to be thread safe.

Summary: Currently, Dynamo/inductor configurations are reliant on global variables. This has led to many race conditions in workflows which call torch.compile (more specifically compile_fx) from multiple threads simultaneously. To resolve this, I propose replacing parts of this global state with thread local state.

Fixes [#126024](https://github.com/pytorch/pytorch/issues/126024)
Fixes errors three and four of [#168042](https://github.com/pytorch/pytorch/issues/168042)


CC @ezyang who has already approved these changes

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo