### PR TITLE
[pytorch] redirect `fbcode//caffe2/c10:c10` to the OSS/conda version

### DIFF
--- a/c10/build.bzl
+++ b/c10/build.bzl
@@ -1,6 +1,6 @@
-def define_targets(rules):
+def define_targets(rules, c10_name = "c10"):
     rules.cc_library(
-        name = "c10",
+        name = c10_name,
         visibility = ["//visibility:public"],
         deps = [
             "//c10/core:CPUAllocator",
@@ -24,7 +24,7 @@ def define_targets(rules):
     )
 
     rules.cc_library(
-        name = "c10_headers",
+        name = c10_name + "_headers",
         deps = [
             "//c10/core:base_headers",
             "//c10/macros",


### PR DESCRIPTION
Summary: Some build rules want to consume c10 from an external source. Convert it to an alias (like other pytorch entry points), and redirect conda builds to use the `fbcode//conda/buck_integration/toolchains/third-party:torch-cpp` target.

Test Plan: CI.

Reviewed By: athmasagar

Differential Revision: D81518888


