### PR TITLE
[GB300] [Triton] Disable experimental Triton API inside PyTorch when specified

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -45,7 +45,12 @@ def has_triton_experimental_host_tma() -> bool:
                     create_2d_tma_descriptor,
                 )
 
-                return True
+                try:
+                    from triton.tools.experimental_descriptor import enable_in_pytorch
+
+                    return enable_in_pytorch()
+                except ImportError:
+                    return True
             except ImportError:
                 pass
 


### PR DESCRIPTION
Adds an extra import check to allow disabling the experimental API inside PyTorch for newer internal Triton versions that must maintain backwards capability due to existing user code. This should hopefully help lead to eventual deprecation and removal soon. 