### PR TITLE
Replace vscode recommendation for type checker

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
         "ms-python.python",
         "charliermarsh.ruff",
         "ms-python.flake8",
-        "ms-python.mypy-type-checker",
+        "meta.pyrefly",
         "ms-vscode.cmake-tools",
         "EditorConfig.EditorConfig",
         "streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
Now that Pyrefly type checks instead of mypy we should recommend the correct vscode extension

<img width="843" height="624" alt="image" src="https://github.com/user-attachments/assets/aa22a09d-f653-490f-a4ad-4730430da0c8" />
