### PR TITLE
[xplat][caffe2] Fix -Wswitch-default issues

### DIFF
--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -96,8 +96,9 @@ struct TORCH_API LegacyEvent {
         return "pop";
       case EventKind::MemoryAlloc:
         return "memory_alloc";
+      default:
+        TORCH_CHECK(false, "unknown event kind");
     }
-    TORCH_CHECK(false, "unknown event kind");
   }
 
   EventKind kind() const {


### PR DESCRIPTION
Summary:
**Context:** https://fburl.com/switch-enum

----

Now that `-Wswitch-enum` is an error in all of `fbobjc`, making it such that all enum values need a case within a switch regardless of having a default case, we want to also enable `-Wswitch-default` as an error (ensuring we cover all values outside the given enum's values).  This will reduce SEVs as it will eliminate undefined behavior when a value outside the enum range is switched upon.

Test Plan: CI Pass

Differential Revision: D87817056


