### PR TITLE
[DTensor] Make shard -> replicate return contiguous tensor if padded

### DIFF
--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -285,7 +285,7 @@ class Shard(torch._C._distributed.Shard):
         if is_padded:
             full_chunk_size = (logical_dim_size + num_chunks - 1) // num_chunks
             unpad_size = full_chunk_size * num_chunks - logical_dim_size  # type: ignore[possibly-undefined]
-            local_tensor = unpad_tensor(local_tensor, self.dim, unpad_size)
+            local_tensor = unpad_tensor(local_tensor, self.dim, unpad_size).contiguous()
 
         return local_tensor
 


### PR DESCRIPTION
Roundtrip a tensor through DTensor (local -> Replicate -> Shard -> Replicate -> local) seems to leave the final local tensor with non-contiguous layout that breaks some downstream operations. 

Prospective fix for https://github.com/pytorch/pytorch/issues/143748

Testing: Adding unit tests
