### PR TITLE
[fx]Optionally Dump gm generated code to file

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -585,6 +585,32 @@ class TestDTensorDebugMode(TestCase):
     aten::add_.Tensor(t: i64[], 1)  ->  t: i64[]  # {'input_hash': ((2.0, None), {}), 'hash': 3.0}""",
         )
 
+    @torch.fx.experimental._config.patch({"dump_code_to_file": True})
+    def test_debug_trace_with_compile(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1 = torch.nn.Linear(4, 4)
+                self.l2 = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                y = self.l1(x)
+                return self.l2(y)
+
+        mod = Foo()
+        inp = torch.randn(4, 4)
+        compiled_mod = torch.compile(mod, backend="aot_eager")
+
+        with DebugMode(record_stack_trace=True) as debug_mode:
+            _ = compiled_mod(inp)
+
+        for op in debug_mode.operators:
+            # Should show actual graph module stack trace instead of <eval_with_key> in aot_eager
+            self.assertTrue("fx_generated" in op.stack_trace)
+            self.assertTrue("eval_with_key" not in op.stack_trace)
+
+        print(debug_mode.debug_string(show_stack_trace=True))
+
     @unittest.skipIf(not HAS_GPU, "requires GPU")
     @unittest.skipIf(not has_triton_package(), "requires triton")
     def test_triton_kernel_logs(self):

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -108,5 +108,11 @@ enrich_profiler_metadata: bool = Config(  # type: ignore[var-annotated]
     env_name_default="TORCH_ENRICH_RPOFILER_STACK_TRACE",
 )
 
+# Experimental: If True, dump code to file in /tmp and run from file
+dump_code_to_file: bool = Config(  # type: ignore[var-annotated]
+    default=False,
+    env_name_default="TORCH_FX_DUMP_CODE_TO_FILE",
+)
+
 
 install_config_module(sys.modules[__name__])

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -426,6 +426,7 @@ class _WrappedCall:
             "Call using an FX-traced Module, "
             f"line {err_lineno} of the traced Module's "
             "generated forward function:"
+            "Turn on torch.fx.experimental._config.dump_code_to_file if you want to breakpoint into the fx generated code. "
         )
         before_err = "".join(all_src_lines[err_lineno - 2 : err_lineno])
         marker = "~" * err_line_len + "~~~ <--- HERE"
@@ -445,7 +446,10 @@ class _WrappedCall:
             topmost_framesummary: traceback.FrameSummary = (
                 traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]
             )
-            if "eval_with_key" in topmost_framesummary.filename:
+            if (
+                "eval_with_key" in topmost_framesummary.filename
+                or topmost_framesummary.filename.startswith("fx_generated_")
+            ):
                 print(
                     _WrappedCall._generate_error_message(topmost_framesummary),
                     file=sys.stderr,
@@ -868,6 +872,8 @@ class {module_name}(torch.nn.Module):
         python_code = self._graph.python_code(
             root_module="self",
             record_func=fx_experimental_config.enrich_profiler_metadata,
+            # explicitly mark False because _lineno_map doesn't work when verbose is True
+            verbose=False,
         )
         self._code = python_code.src
         self._lineno_map = python_code._lineno_map
@@ -876,8 +882,11 @@ class {module_name}(torch.nn.Module):
         cls = type(self)
         co_fields = self._graph._co_fields if hasattr(self._graph, "_co_fields") else {}
 
-        if fx_experimental_config.enrich_profiler_metadata:
-            # Generate metadata and register for profiler augmentation
+        # Dump code to file and run from file if config is enabled
+        if (
+            fx_experimental_config.dump_code_to_file
+            or fx_experimental_config.enrich_profiler_metadata
+        ):
             node_metadata: dict[int, dict[str, Any]] = {}
             for i, node in enumerate(self._graph.nodes):
                 node_metadata[i] = {
@@ -892,11 +901,6 @@ class {module_name}(torch.nn.Module):
             hash_value = _metadata_hash(self._code, node_metadata)
             file_stem = f"{FX_GRAPH_MODULE_FILE_PREFIX}_{hash_value}"
             filename = f"{file_stem}.py"
-
-            # Only include co_filename to use it directly as the cache key
-            co_fields = {
-                "co_filename": filename,
-            }
 
             # Store metadata in global in-memory registry
             metadata = {
@@ -917,7 +921,36 @@ class {module_name}(torch.nn.Module):
                 f"torch._C._profiler._RecordFunctionFast('## {filename} ##')",
             )
 
-        cls.forward = _forward_from_src(self._code, python_code.globals, co_fields)
+            try:
+                from torch._inductor.codecache import write as codecache_write
+
+                key, file_path = codecache_write(
+                    self._code,
+                    extension="py",
+                    key=filename[0:-3],  # remove .py
+                )
+
+                # Read the code back from file in case user modified the file, i.e. breakpoint
+                with open(file_path, encoding="utf-8") as f:
+                    code_from_file = f.read()
+
+                # Use the file path in co_fields so the compiled code references the real file
+                co_fields = {"co_filename": file_path}
+            except Exception as e:
+                co_fields = {"co_filename": filename}
+                code_from_file = self._code
+
+                warnings.warn(
+                    f"Failed to read or write FX generated code file: {e}. "
+                    "You will not be able to open the file or set breakpoints in generated code. "
+                    "Set torch.fx.experimental._config.dump_code_to_file=False to disable writing codegen'd FX code to file. "
+                )
+
+            cls.forward = _forward_from_src(
+                code_from_file, python_code.globals, co_fields
+            )
+        else:
+            cls.forward = _forward_from_src(self._code, python_code.globals, co_fields)
 
         # Determine whether this class explicitly defines a __call__ implementation
         # to wrap. If it does, save it in order to have wrapped_call invoke it.

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -38,12 +38,14 @@ import inspect
 import logging
 import os
 import traceback
+import warnings
 import weakref
 from collections.abc import Callable
 from typing import Any, TYPE_CHECKING
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch.fx.experimental import _config as fx_experimental_config
 from torch.fx.graph import _parse_stack_trace
 from torch.utils._dtype_abbrs import dtype_abbrs
 from torch.utils._python_dispatch import (
@@ -234,6 +236,90 @@ def _get_user_stack_trace(stack_trace_str: str) -> str | None:
     if trace:
         return f"File: {trace.file}:{trace.lineno} in {trace.name}, code: {trace.code}"
     return None
+
+
+def _extract_node_meta_from_stack_summary(stack_summary: str) -> dict[str, Any] | None:
+    """
+    Extract FX node metadata from a stack summary string.
+
+    Similar to _augment_frames in torch/cuda/memory.py, this function extracts
+    FX debug information from a stack summary string that may reference
+    FX-generated code (e.g., from inductor).
+
+    Args:
+        stack_summary: A stack summary string in the format:
+            'File: /path/to/fx_generated_xxx.py:13 in forward, code: ...'
+
+    Returns:
+        A dictionary containing node metadata if found, None otherwise.
+        The dictionary may contain:
+        - fx_node_op: FX node operation type (e.g., 'call_function', 'output')
+        - fx_node_name: FX node name (e.g., 't', 'relu_1')
+        - fx_node_target: FX node target (e.g., 'torch.ops.aten.t.default')
+        - fx_original_trace: Original model source code stack trace
+    """
+    import re
+
+    if not stack_summary:
+        return None
+
+    # Parse the stack summary format: "File: {file}:{lineno} in {name}, code: {code}"
+    match = re.match(r"File: (.+):(\d+) in .+, code:", stack_summary)
+    if not match:
+        return None
+
+    filename = match.group(1)
+    filename = filename.split("/")[-1]
+    lineno = int(match.group(2))
+
+    # Check if this looks like an FX generated file
+    from torch.fx.graph_module import FX_GRAPH_MODULE_FILE_PREFIX
+
+    _FX_GENERATED_PATTERN = re.compile(
+        rf"{re.escape(FX_GRAPH_MODULE_FILE_PREFIX)}.*\.py$"
+    )
+
+    if not _FX_GENERATED_PATTERN.search(os.path.basename(filename)):
+        return None
+
+    # Look up metadata from the global registry
+    from torch.fx.traceback import _FX_METADATA_REGISTRY
+
+    metadata = _FX_METADATA_REGISTRY.get(filename)
+    if metadata is None:
+        return None
+
+    lineno_map = metadata.get("lineno_map", {})
+    node_metadata = metadata.get("node_metadata", {})
+    prologue_start = metadata.get("prologue_start", 0)
+
+    # Get the node index for this line
+    node_idx = lineno_map.get(lineno - prologue_start)
+
+    if node_idx is None or node_idx not in node_metadata:
+        return None
+
+    node_info = node_metadata[node_idx]
+    result: dict[str, Any] = {}
+
+    original_trace = node_info.get("stack_trace")
+    node_op = node_info.get("op")
+    node_name = node_info.get("name")
+    node_target = node_info.get("target")
+
+    # Add node metadata
+    if node_op is not None:
+        result["fx_node_op"] = node_op
+    if node_name is not None:
+        result["fx_node_name"] = node_name
+    if node_target is not None:
+        result["fx_node_target"] = str(node_target)
+
+    # Add original trace if available
+    if original_trace:
+        result["fx_original_trace"] = original_trace
+
+    return result if result else None
 
 
 def _maybe_get_autograd_trace() -> str | None:
@@ -896,6 +982,17 @@ class DebugMode(TorchDispatchMode):
                 True, check_nan=False
             )
             self.anomaly_for_traces.__enter__()
+
+        if self.record_stack_trace and not fx_experimental_config.dump_code_to_file:
+            # DebugMode cannot reliably turn on this flag for users because the flag needs to be turned on
+            # at compile time, but DebugMode may only wrap around the runtime call.
+            warnings.warn(
+                "If you're using DebugMode on compiled code such as aot_eager (i.e. not eager), you should consider "
+                "turn on torch.fx.experimental._config.dump_code_to_file=True at compiled time to dump "
+                "the FX codegen'd code for the compiled region. "
+                "This will help you to look at the generated code."
+            )
+
         return self
 
     # pyrefly: ignore [bad-override]
@@ -991,8 +1088,17 @@ class DebugMode(TorchDispatchMode):
                     stack_trace = op.stack_trace
 
                 stack_summary = None
+                original_user_code = None
                 if stack_trace:
                     stack_summary = _get_user_stack_trace(stack_trace)
+                    if stack_summary:
+                        node_metadata = _extract_node_meta_from_stack_summary(
+                            stack_summary
+                        )
+                        if node_metadata:
+                            original_user_code = _get_user_stack_trace(
+                                node_metadata.get("fx_original_trace", "")
+                            )
 
                 if stack_summary and stack_summary != prev_stack_summary:
                     # add blank line before stack trace comment for readability
@@ -1000,6 +1106,10 @@ class DebugMode(TorchDispatchMode):
                         lines.append("")
                     indent = "  " * (op.call_depth + 1)
                     lines.append(indent + "# " + stack_summary)
+                    if original_user_code:
+                        lines.append(
+                            indent + "# Original User Code: " + original_user_code
+                        )
                     prev_stack_summary = stack_summary
 
                 # Add the operation line


### PR DESCRIPTION
Fixes #168977

Dump the graph module code to a file

- user is able to breakpoint in an fx.graph file just like inductor-generated file and you should see this file in your exception stack trace.
- DebugMode will contain actual stack trace to gm file instead of <eval_with_key>. **But you need to turn on the torch.fx.experimental._config.dump_code_to_file flag explicitly.** DebugMode cannot reliably turn on this flag for users, because it might not be wrapped around the compile call, only around the runtime call.

In DebugMode, we can then post-process to get user stack trace.

```
    # File: /tmp/torchinductor_shangdiy/x_/fx_generated__wafmd7o65u6vuzl5v4objrxf7o7m5utgwjeyeogsxef37zzi6hj.py:12 in forward, code: t = torch.ops.aten.t.default(primals_1);  primals_1 = None
    # Original User Code: File: /data/users/shangdiy/pytorch/test/distributed/tensor/debug/test_debug_mode.py:597 in forward, code: y = self.l1(x)
    aten::t(t: f32[4, 4])  ->  t: f32[4, 4]

    # File: /tmp/torchinductor_shangdiy/x_/fx_generated__wafmd7o65u6vuzl5v4objrxf7o7m5utgwjeyeogsxef37zzi6hj.py:13 in forward, code: addmm = torch.ops.aten.addmm.default(primals_2, primals_3, t);  primals_2 = t = None
    # Original User Code: File: /data/users/shangdiy/pytorch/test/distributed/tensor/debug/test_debug_mode.py:597 in forward, code: y = self.l1(x)
    aten::addmm(t: f32[4], t: f32[4, 4], t: f32[4, 4])  ->  t: f32[4, 4]

    # File: /tmp/torchinductor_shangdiy/x_/fx_generated__wafmd7o65u6vuzl5v4objrxf7o7m5utgwjeyeogsxef37zzi6hj.py:14 in forward, code: t_1 = torch.ops.aten.t.default(primals_4)
    # Original User Code: File: /data/users/shangdiy/pytorch/test/distributed/tensor/debug/test_debug_mode.py:598 in forward, code: return self.l2(y)
    aten::t(t: f32[4, 4])  ->  t: f32[4, 4]

    # File: /tmp/torchinductor_shangdiy/x_/fx_generated__wafmd7o65u6vuzl5v4objrxf7o7m5utgwjeyeogsxef37zzi6hj.py:15 in forward, code: addmm_1 = torch.ops.aten.addmm.default(primals_5, addmm, t_1);  primals_5 = t_1 = None
    # Original User Code: File: /data/users/shangdiy/pytorch/test/distributed/tensor/debug/test_debug_mode.py:598 in forward, code: return self.l2(y)
    aten::addmm(t: f32[4], t: f32[4, 4], t: f32[4, 4])  ->  t: f32[4, 4]
```

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv