### PR TITLE
Fix CPU/CUDA inconsistency in cosine_similarity for large eps

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -327,14 +327,8 @@ Tensor cosine_similarity(const Tensor& x1_, const Tensor& x2_, int64_t dim, doub
   // with reduced floating types (float16/bfloat16) if the value overflows, while CPU converts to inf.
   // If both norms are non-reduced, use the higher precision one.
   // If eps is too large for the dtype, it will become inf, and subsequent operations will produce NaN
-  auto x1_dtype = x1_norm.scalar_type();
-  auto x2_dtype = x2_norm.scalar_type();
-  auto x1_is_reduced = at::isReducedFloatingType(x1_dtype);
-  auto x2_is_reduced = at::isReducedFloatingType(x2_dtype);
-  auto eps_dtype = (x1_is_reduced && x2_is_reduced) ? at::kFloat
-                   : x1_is_reduced ? x2_dtype
-                   : x2_is_reduced ? x1_dtype
-                   : at::promoteTypes(x1_dtype, x2_dtype);
+  auto common_is_reduced = at::isReducedFloatingType(commonDtype);
+  auto eps_dtype = common_is_reduced ? at::kFloat : commonDtype;
   auto eps_tensor = at::scalar_tensor(eps, at::TensorOptions().dtype(eps_dtype).device(x1_norm.device()));
 
   {


### PR DESCRIPTION
- Add validation: eps must be non-negative
- Convert eps to scalar tensor for consistent overflow handling
- Use higher precision dtype between norms to avoid unnecessary overflow
- Update tests to validate negative eps and overflow cases

When eps overflows the input dtype (e.g., eps=1e23 with float16 inputs), CPU previously threw an error while CUDA silently produced NaN. Now CPU handle overflow consistent with CUDA by converting eps to a tensor with appropriate dtype, allowing graceful overflow to inf.

Fixes #153209
