### PR TITLE
[OpenReg] Fixed the issue where streams and events could still be bou…

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -110,6 +110,9 @@ orError_t orEventRecord(orEvent_t event, orStream_t stream) {
   if (!event || !stream)
     return orErrorUnknown;
 
+  if (event->impl->device_index != stream->device_index)
+    return orErrorUnknown;
+
   auto event_impl = event->impl;
   event_impl->completed.store(false);
   auto record_task = [event_impl]() {


### PR DESCRIPTION
recording events to a stream is not allowed if the stream and the event are not on the same device. This should cause an error, but OpenReg did not. In this PR, we fixed this issue.