### PR TITLE
Add shape logging to autotuning to debug timeout issues

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2964,6 +2964,29 @@ class AlgorithmSelectorCache(PersistentCache):
             NoValidChoicesError: When all choices fail to compile or benchmark, or when all
                 timing results are non-finite.
         """
+        if log.isEnabledFor(logging.DEBUG):
+            # Log shape information for debugging timeout issues
+            sizevars = V.graph.sizevars
+            shapes = [
+                "x".join(
+                    map(
+                        str,
+                        sizevars.size_hints(
+                            node.get_size(),
+                            fallback=config.unbacked_symint_fallback,
+                            hint_override=hint_override,
+                        ),
+                    )
+                )
+                for node in input_nodes
+            ]
+            log.debug(
+                "[BENCHMARK DEBUG] Starting autotuning for '%s' with shapes: %s, device: %s",
+                name,
+                shapes,
+                layout.device.type if layout else "unknown",
+            )
+
         precompile_start_ts = time.time()
         with dynamo_timed(
             f"{name}_template_precompiling",


### PR DESCRIPTION
Summary: Add logging at the beginning of the autotuning process to capture the shapes being benchmarked before timeouts occur. This helps identify which specific tensor shapes cause compilation or benchmarking to hang, enabling faster debugging of timeout issues during kernel selection.

Test Plan: Ran the code with a model that previously timed out during autotuning and verified that the shape information is now logged before the timeout occurs, making it easy to identify problematic shapes.

Differential Revision: D87804069




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo