### PR TITLE
Avoid closing random file handles in Inductor

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -981,14 +981,6 @@ class CppBenchmarkRequest(CPUDeviceBenchmarkMixin, BenchmarkRequest):
             *self.extra_args,
         )
 
-    def cleanup_run_fn(self) -> None:
-        if self.DLL is not None:
-            """
-            Check close attr due to it crash on Windows.
-            """
-            if hasattr(self.DLL, "close"):
-                self.DLL.close()
-
     def __str__(self) -> str:
         return f"{self.kernel_name=}"
 
@@ -1037,9 +1029,6 @@ class CuteDSLBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
             return kernel_func(*input_tensors, out, stream=stream)
 
         return run_kernel
-
-    def cleanup_run_fn(self) -> None:
-        """Clean up any resources used by the kernel."""
 
 
 @functools.cache


### PR DESCRIPTION
`CppCodeCache.load` returns a `ctypes.CDLL`.
That does not have a (Python class) `close` function so calling `self.DLL.close()` calls whatever C function with name `close` happens to exist in the shared library. This is usually the glibc `close` that closes (file) handles. As the argument is missing it closes whatever happens to be in the register at that point.

In some tests this seems to close "fd=1", i.e. stdout. Subsequent writes/print then fails with
> OSError: [Errno 9] Bad file descriptor

Simply remove the `close` call for now.

It seems it was intended to be a `DLLWrapper` (likely should be returned by `CppCodeCache.load`) but that requires careful handling at all callsites: The DLLWrapper instance needs to be kept alive as long as there are reference to functions inside it.

https://github.com/pytorch/pytorch/blob/a5436a5e8e4ee42d1debf52c2786c7ae0043a434/torch/_inductor/async_compile.py#L508-L512

Is an issue, although the only one I found. While it works for a while (`CppCodeCache` effectively stores the DLL in the cache) it will fail when the caches get cleared and that `kernel` is still used somewhere.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo 

@xuhancn observed that `close` is missing on Windows ( https://github.com/pytorch/pytorch/pull/132630) and later [implemented the `FreeLibrary` on Windows](https://github.com/pytorch/pytorch/pull/133184).   
It was still missed that the instance is a `CDLL` not a `DLLWrapper` which is the reason why `close` is missing. (Additionally `DLL` could be a module which would also need to be checked)   
@xuhancn is that correct or was there supposed to be a `close` function implemented in   C/C++?

My suggestion for a complete fix:
- Make `CppCodeCache.load` return a `DLLWrapper` and NOT cache it (currently done via `lib`). Cache the compile library location instead (See `CUDACodeCache`)
- Add the `close` in `cleanup_run_fn` if DLL is a DLLWrapper
- Make `AsyncCompile.cpp()` return the DLLWrapper similar to the other functions  `cuda` and `cpp_pybinding`
- Fix `CppCodeCache.load_async` when `submit_fn` is passed. Currently it runs the `worker_fn` twice.