### PR TITLE
[inductor] skip the r2r determ test in fbcode

### DIFF
--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -21,6 +21,7 @@ from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU_AND_TRITON,
     IS_BIG_GPU,
+    IS_FBCODE,
 )
 
 
@@ -114,6 +115,7 @@ class DeterministicTest(TestCase):
             else:
                 self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
 
+    @unittest.skipIf(IS_FBCODE, "Skipping run2run determinism test in fbcode")
     @parametrize("model_name", ["GoogleFnet", "BertForMaskedLM", "DistillGPT2"])
     @parametrize("training_or_inference", ["training", "inference"])
     @parametrize("precision", ["float32", "bfloat16", "float16", "amp"])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169074

Claude generate the change and I review/test/publish it.

The tests will fail in fbcode (thanks Ed for flagging). Disabling it in fbcode for now.

I think for now oss signal is enough. If we really want signals in fbcode, we probably need replace the 'python' command running the benchmark script with 'buck' command.


One instance of the failure in fbcode: https://www.internalfb.com/tasks/?t=246383644 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo