### PR TITLE
Removed min_val > max_value error from torch.nn.functional.hardtanh

### DIFF
--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1046,9 +1046,6 @@ def hardtanh(
                 "Cannot do hardtanh on an unsigned type with negative limits"
             )
 
-    if min_val > max_val:  # type: ignore[operator]
-        raise ValueError("min_val cannot be greater than max_val")
-
     return torch.clamp(a, min_val, max_val)  # type: ignore[arg-type]
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1775,8 +1775,6 @@ def hardtanh(
         return handle_torch_function(
             hardtanh, (input,), input, min_val=min_val, max_val=max_val, inplace=inplace
         )
-    if min_val > max_val:
-        raise ValueError("min_val cannot be greater than max_val")
     if inplace:
         result = torch._C._nn.hardtanh_(input, min_val, max_val)
     else:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1775,6 +1775,8 @@ def hardtanh(
         return handle_torch_function(
             hardtanh, (input,), input, min_val=min_val, max_val=max_val, inplace=inplace
         )
+    if min_val > max_val:
+        raise ValueError("min_val cannot be greater than max_val")
     if inplace:
         result = torch._C._nn.hardtanh_(input, min_val, max_val)
     else:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6330,11 +6330,6 @@ def sample_inputs_hardtanh(op_info, device, dtype, requires_grad=False, **kwargs
 
     yield from sample_inputs_elementwise_unary(op_info, device, dtype, requires_grad)
 
-def error_inputs_hardtanh(op_info, device, **kwargs):
-    # Tests that hardtanh errors out when passed min_val > max_val.
-    yield ErrorInput(SampleInput(make_tensor((1,), dtype=torch.float, device=device), kwargs={"min_val": 0.5, "max_val": -0.5}),
-                     error_type=ValueError, error_regex="min_val cannot be greater than max_val")
-
 def sample_inputs_einsum(op_info, device, dtype, requires_grad=False, **kwargs):
     def c(t):
         return t.clone().requires_grad_(requires_grad)
@@ -17173,7 +17168,6 @@ op_db: list[OpInfo] = [
                    backward_dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
                    assert_autodiffed=True,
                    sample_inputs_func=sample_inputs_hardtanh,
-                   error_inputs_func=error_inputs_hardtanh,
                    supports_out=False,
                    supports_forward_ad=True,
                    supports_fwgrad_bwgrad=True,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6330,6 +6330,11 @@ def sample_inputs_hardtanh(op_info, device, dtype, requires_grad=False, **kwargs
 
     yield from sample_inputs_elementwise_unary(op_info, device, dtype, requires_grad)
 
+def error_inputs_hardtanh(op_info, device, **kwargs):
+    # Tests that hardtanh errors out when passed min_val > max_val.
+    yield ErrorInput(SampleInput(make_tensor((1,), dtype=torch.float, device=device), kwargs={"min_val": 0.5, "max_val": -0.5}),
+                     error_type=ValueError, error_regex="min_val cannot be greater than max_val")
+
 def sample_inputs_einsum(op_info, device, dtype, requires_grad=False, **kwargs):
     def c(t):
         return t.clone().requires_grad_(requires_grad)
@@ -17168,6 +17173,7 @@ op_db: list[OpInfo] = [
                    backward_dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
                    assert_autodiffed=True,
                    sample_inputs_func=sample_inputs_hardtanh,
+                   error_inputs_func=error_inputs_hardtanh,
                    supports_out=False,
                    supports_forward_ad=True,
                    supports_fwgrad_bwgrad=True,
@@ -23292,6 +23298,10 @@ python_ref_db = [
         "_refs.nn.functional.hardtanh",
         torch_opinfo_name="nn.functional.hardtanh",
         supports_out=True,
+        skips=(
+            DecorateInfo(unittest.skip("ATen allows min_val > max_val but nn.functional does not"),
+                         "TestCommon", "test_python_ref_errors"),
+        )
     ),
     PythonRefInfo(  # TODO: Port this to an UnaryOpInfo
         "_refs.nn.functional.gelu",


### PR DESCRIPTION
Removed check from reference implementation of torch.nn.functional.hardtanh so that it does not check for min_val > max_value since running this method in eager mode does not do this check. Removed error_inputs_func that checks for this error in the unit test.

Fixes #161081

@albanD 
