### PR TITLE
[CP] Add stored and dest num shards to ReadItems (#169071)

### DIFF
--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -99,6 +99,10 @@ class ReadItem:
 
     # Size of the hypercube to copy
     lengths: torch.Size
+    
+    # Number of shards for the same unsharded tensor with invalid default value
+    dest_num_shards: int = -1
+    stored_num_shards: int = -1
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Summary:

the number of shards in the stored and destination tensor (that make up the larger embedding table) is needed to properly calculate the file offset for non-contigous reads. 

This will unblock col-wise resharding limited to "even sharding" cases - where all shards have the exact same column dimension. 

In the next few diffs I will refactor how the file offset is calculated to account for non-contigous reads, which will then make use of these values added here

Differential Revision: D87833558


