### PR TITLE
Align CUDA clamp_min float16 overflow behavior with CPU

### DIFF
--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -400,6 +400,20 @@ class TestShapeOps(TestCase):
         with self.assertRaisesRegex(RuntimeError, error_msg):
             torch.clamp(X)
 
+    def test_clamp_min_float16_overflow_consistency(self, device):
+        # Test for issue #153187: clamp_min should raise error on overflow
+        # for float16 tensors consistently on both CPU and CUDA
+        tensor_data = [[1.0, float('nan')], [-1.0, 0.0]]
+        large_value = 4.35294e+26  # Value that exceeds float16 range
+
+        # Create float16 tensor
+        x = torch.tensor(tensor_data, device=device, dtype=torch.float16)
+
+        # Both CPU and CUDA should raise RuntimeError for overflow
+        error_msg = "value cannot be converted to type at::Half without overflow"
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            torch.clamp_min(x, large_value)
+
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_flip(self, device, dtype):
         make_from_data = partial(torch.tensor, device=device, dtype=dtype)


### PR DESCRIPTION
I have implemented forced scalar clamp limits to convert to scalar_t in launch_clamp_scalar before conversion to opmath_t, so overflow is detected for Half/BFloat16 on CUDA, and added a regression test in test_shape_ops.py.

Fixes #153187


Steps taken:
- CPU raises RuntimeError when clamping float16 with values exceeding range
- CUDA silently converted to infinity
- Now both raise RuntimeError consistently

Root cause:
CUDA implementation converted scalar directly to opmath_t (float),
bypassing overflow check that occurs when converting to scalar_t (Half).

Solution:
Added overflow check to scalar_t before converting to opmath_t in
launch_clamp_scalar function. This ensures consistent error handling
across CPU and CUDA.

Test Plan:
Added test_clamp_min_float16_overflow_consistency to verify both
CPU and CUDA raise RuntimeError for overflow values.

Thanks for your time ,waiting for your suggestions and improvement.