### PR TITLE
dynamo torch factory functions apply default device mirroring __torch…

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -808,24 +808,32 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         """Test that factory functions respect default device in compiled code"""
 
         @torch.compile(fullgraph=True)
-        def random_func(x: torch.Tensor) -> torch.Tensor:
+        def random_func(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
             # Test various factory functions
             rnd = torch.randint(0, 2**32, size=x.shape, dtype=torch.uint32)
-            return x + rnd, rnd
+            zeros = torch.zeros_like(rnd, device="cpu")
+            zeros_matched = torch.zeros_like(rnd)
+            return x + rnd, rnd, zeros, zeros_matched
 
         torch.set_default_device("cuda")
-        (result, rnd) = random_func(torch.randn(()))
+        (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
 
         # Verify tensors are on CUDA
         self.assertEqual(rnd.device.type, "cuda")
         self.assertEqual(result.device.type, "cuda")
+        self.assertEqual(zeros.device.type, "cpu")
+        self.assertEqual(zeros_matched.device.type, "cuda")
 
         torch.set_default_device("cpu")
-        (result, rnd) = random_func(torch.randn(()))
+        (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
 
         # Verify tensors are on cpu
         self.assertEqual(rnd.device.type, "cpu")
         self.assertEqual(result.device.type, "cpu")
+        self.assertEqual(zeros.device.type, "cpu")
+        self.assertEqual(zeros_matched.device.type, "cpu")
 
         torch.set_default_device(None)
 
@@ -834,7 +842,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         torch.set_default_device("cuda")
 
         @torch.compile(fullgraph=True)
-        def with_explicit_device(x: torch.Tensor) -> torch.Tensor:
+        def with_explicit_device(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
             rnd = torch.randint(
                 0, 2**32, size=x.shape, dtype=torch.uint32, device="cpu"
             )

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -824,7 +824,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(rnd.device.type, "cuda")
         self.assertEqual(result.device.type, "cuda")
         self.assertEqual(zeros.device.type, "cpu")
-        self.assertEqual(zeros_matched.device.type, "cuda")
+        self.assertEqual(zeros_matched.device.type, rnd.device.type)
 
         torch.set_default_device("cpu")
         (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
@@ -833,7 +833,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(rnd.device.type, "cpu")
         self.assertEqual(result.device.type, "cpu")
         self.assertEqual(zeros.device.type, "cpu")
-        self.assertEqual(zeros_matched.device.type, "cpu")
+        self.assertEqual(zeros_matched.device.type, rnd.device.type)
 
         torch.set_default_device(None)
 

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -803,6 +803,47 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
                         torch.ones(2, 2, 2, 2),
                     )
 
+    @requires_gpu
+    def test_default_device_factory_functions(self):
+        """Test that factory functions respect default device in compiled code"""
+
+        @torch.compile(fullgraph=True)
+        def random_func(x: torch.Tensor) -> torch.Tensor:
+            # Test various factory functions
+            rnd = torch.randint(0, 2**32, size=x.shape, dtype=torch.uint32)
+            return x + rnd, rnd
+
+        torch.set_default_device("cuda")
+        (result, rnd) = random_func(torch.randn(()))
+
+        # Verify tensors are on CUDA
+        self.assertEqual(rnd.device.type, "cuda")
+        self.assertEqual(result.device.type, "cuda")
+
+        torch.set_default_device("cpu")
+        (result, rnd) = random_func(torch.randn(()))
+
+        # Verify tensors are on cpu
+        self.assertEqual(rnd.device.type, "cpu")
+        self.assertEqual(result.device.type, "cpu")
+
+        torch.set_default_device(None)
+
+    @requires_gpu
+    def test_default_device_factory_functions_priority(self):
+        torch.set_default_device("cuda")
+
+        @torch.compile(fullgraph=True)
+        def with_explicit_device(x: torch.Tensor) -> torch.Tensor:
+            rnd = torch.randint(
+                0, 2**32, size=x.shape, dtype=torch.uint32, device="cpu"
+            )
+            return x + rnd, rnd
+
+        (result, rnd) = with_explicit_device(torch.randn(()))
+        self.assertEqual(rnd.device.type, "cpu")
+        self.assertEqual(result.device.type, "cuda")
+
 
 class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(force_compile_during_fx_trace=True)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -353,6 +353,13 @@ def get_overridable_functions() -> set[Callable[..., Any]]:
 
     funcs = set(chain.from_iterable(get_overridable_functions_().values()))
     funcs.update(_device_constructors())
+    more: set[Callable[..., Any]] = {
+        torch.ones_like,
+        torch.zeros_like,
+        torch.empty_like,
+        torch.full_like,
+    }
+    funcs.update(more)
     return funcs
 
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -349,17 +349,10 @@ def get_overridable_functions() -> set[Callable[..., Any]]:
     from itertools import chain
 
     from torch.overrides import get_overridable_functions as get_overridable_functions_
+    from torch.utils._device import _device_constructors
 
     funcs = set(chain.from_iterable(get_overridable_functions_().values()))
-    more: set[Callable[..., Any]] = {
-        torch.ones,
-        torch.ones_like,
-        torch.zeros,
-        torch.zeros_like,
-        torch.empty,
-        torch.full,
-    }
-    funcs.update(more)
+    funcs.update(_device_constructors())
     return funcs
 
 

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -15,10 +15,12 @@ def _device_constructors():
     return {
         # standard ones
         torch.empty,
+        torch.empty_like,
         torch.empty_permuted,
         torch.empty_strided,
         torch.empty_quantized,
         torch.ones,
+        torch.ones_like,
         torch.arange,
         torch.bartlett_window,
         torch.blackman_window,
@@ -26,6 +28,7 @@ def _device_constructors():
         torch.fft.fftfreq,
         torch.fft.rfftfreq,
         torch.full,
+        torch.full_like,
         torch.hamming_window,
         torch.hann_window,
         torch.kaiser_window,
@@ -36,7 +39,9 @@ def _device_constructors():
         # torch.normal,
         torch.rand,
         torch.randn,
+        torch.randn_like,
         torch.randint,
+        torch.randint_like,
         torch.randperm,
         torch.range,
         torch.sparse_coo_tensor,
@@ -48,6 +53,7 @@ def _device_constructors():
         torch.tril_indices,
         torch.triu_indices,
         torch.zeros,
+        torch.zeros_like,
         torch.asarray,
         # weird ones
         torch.tensor,

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -15,12 +15,10 @@ def _device_constructors():
     return {
         # standard ones
         torch.empty,
-        torch.empty_like,
         torch.empty_permuted,
         torch.empty_strided,
         torch.empty_quantized,
         torch.ones,
-        torch.ones_like,
         torch.arange,
         torch.bartlett_window,
         torch.blackman_window,
@@ -28,7 +26,6 @@ def _device_constructors():
         torch.fft.fftfreq,
         torch.fft.rfftfreq,
         torch.full,
-        torch.full_like,
         torch.hamming_window,
         torch.hann_window,
         torch.kaiser_window,
@@ -39,9 +36,7 @@ def _device_constructors():
         # torch.normal,
         torch.rand,
         torch.randn,
-        torch.randn_like,
         torch.randint,
-        torch.randint_like,
         torch.randperm,
         torch.range,
         torch.sparse_coo_tensor,
@@ -53,12 +48,19 @@ def _device_constructors():
         torch.tril_indices,
         torch.triu_indices,
         torch.zeros,
-        torch.zeros_like,
         torch.asarray,
         # weird ones
         torch.tensor,
         torch.as_tensor,
         torch.scalar_tensor,
+        # *_like may contain device kwarg, but the user implicitly
+        # expects a specific device even when kwarg unused.
+        # torch.zeros_like,
+        # torch.randint_like,
+        # torch.randn_like,
+        # torch.ones_like,
+        # torch.full_like,
+        # torch.empty_like,
     }
 
 


### PR DESCRIPTION
Fixes #168960

dynamo interception occurs before __torch_function__ can occur which sets the device to default_device for any torch functions which take device as a kwarg. This causes dynamo tracing to use those factory functions with cpu set as the default device.

This should run through - additionally resolves the issue of calling
`random_func(torch.randn((3)), 0)`

All tensors should now be traced on the appropriate devices.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo