### PR TITLE
update the MHA to enable cudnn-frontend 1.12.1

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -487,7 +487,11 @@ std::unique_ptr<fe::graph::Graph> build_graph(
   auto scaled_dot_product_flash_attention_options =
       fe::graph::SDPA_attributes()
           .set_name("CUDNN_SDPA")
+#if CUDNN_FRONTEND_VERSION <= 11200
+          .set_is_inference(!return_softmaxstats)
+#else
           .set_generate_stats(return_softmaxstats)
+#endif
           .set_causal_mask(is_causal)
           .set_attn_scale(attn_scale);
   if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
@@ -705,7 +709,11 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
   auto scaled_dot_product_flash_attention_options =
       fe::graph::SDPA_attributes()
           .set_name("CUDNN_SDPA_NESTEDTENSOR")
+#if CUDNN_FRONTEND_VERSION <= 11200
+          .set_is_inference(!return_softmaxstats)
+#else
           .set_generate_stats(return_softmaxstats)
+#endif
           .set_causal_mask(is_causal)
           .set_attn_scale(attn_scale)
           .set_seq_len_q(SEQ_LEN_Q_)


### PR DESCRIPTION
Summary:
As titled.
Before: 
```
fbcode/caffe2/aten/src/ATen/native/cudnn/MHA.cpp:490:12: error: no member named 'set_generate_stats' in 'cudnn_frontend::graph::SDPA_attributes'
  488 |       fe::graph::SDPA_attributes()
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  489 |           .set_name("CUDNN_SDPA")
      |           ~~~~~~~~~~~~~~~~~~~~~~~
  490 |           .set_generate_stats(return_softmaxstats)
      |            ^
fbcode/caffe2/aten/src/ATen/native/cudnn/MHA.cpp:708:12: error: no member named 'set_generate_stats' in 'cudnn_frontend::graph::SDPA_attributes'
  706 |       fe::graph::SDPA_attributes()
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  707 |           .set_name("CUDNN_SDPA_NESTEDTENSOR")
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  708 |           .set_generate_stats(return_softmaxstats)
      |            ^
2 errors generated.
```

Test Plan: sandcastle

Differential Revision: D87832011


