### PR TITLE
Triton 3.5+fb: Drop the legacy support for autoWS

### DIFF
--- a/torch/_inductor/runtime/triton_compat.py
+++ b/torch/_inductor/runtime/triton_compat.py
@@ -76,11 +76,8 @@ if triton is not None:
             return False
         return param_name in inspect.signature(triton.Config.__init__).parameters
 
-    HAS_WARP_SPEC = (
-        hasattr(tl, "async_task")
-        and _triton_config_has("num_consumer_groups")
-        and _triton_config_has("num_buffers_warp_spec")
-    )
+    # Drop the legacy support of autoWS
+    HAS_WARP_SPEC = False
 
     try:
         from triton import knobs


### PR DESCRIPTION
Summary: https://www.internalfb.com/intern/testinfra/diagnostics/11258999198456358.562950213489292.1763806758/

Test Plan: buck test fbcode//mode/opt fbcode//caffe2/test/inductor:triton_heuristics -- --exact 'fbcode//caffe2/test/inductor:triton_heuristics - test_template_function_ws (caffe2.test.inductor.test_triton_heuristics.TestTritonHeuristics)'

Differential Revision: D87881729




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo