### PR TITLE
[FX] Add disk-based code generation for debugging

### DIFF
--- a/torch/fx/codecache.py
+++ b/torch/fx/codecache.py
@@ -1,0 +1,111 @@
+"""Disk-based code cache for FX graph modules with stack trace support."""
+
+import os
+import re
+import hashlib
+import functools
+from typing import Any, Optional
+from types import ModuleType
+from bisect import bisect_right
+
+from torch._inductor.codecache import write_atomic, _reload_python_module
+
+
+class FXCodeCache:
+    """Cache for FX-generated code with hash-based naming."""
+
+    modules: list[ModuleType] = []
+    modules_no_attr: dict[str, ModuleType] = {}
+    linemaps: dict[str, tuple[list[int], list[str]]] = {}
+
+    @classmethod
+    def write(cls, source_code: str) -> tuple[str, str]:
+        """Write code to /tmp/fx_codegen with hash-based naming."""
+        fx_dir = "/tmp/fx_codegen"
+        os.makedirs(fx_dir, exist_ok=True)
+
+        hash_val = hashlib.sha256(source_code.strip().encode("utf-8")).hexdigest()[:16]
+        key = f"fx_{hash_val}"
+        path = os.path.join(fx_dir, f"{key}.py")
+
+        # Only write if file doesn't exist (cache reuse)
+        if not os.path.exists(path):
+            write_atomic(path, source_code, make_dirs=True)
+
+        return key, path
+
+    @classmethod
+    def load_by_key_path(
+        cls,
+        key: str,
+        path: str,
+        linemap: Optional[list[tuple[int, str]]] = None,
+        attrs: Optional[dict[str, Any]] = None,
+    ) -> ModuleType:
+        """Load module from disk and attach optional linemap and attributes."""
+        if linemap is None:
+            linemap = []
+
+        if attrs is None and path in cls.modules_no_attr:
+            return cls.modules_no_attr[path]
+
+        mod = _reload_python_module(key, path, set_sys_modules=True)
+
+        if linemap:
+            lines, stack_traces = zip(*linemap)
+            cls.linemaps[path] = (list(lines), list(stack_traces))
+
+        if attrs:
+            for k, v in attrs.items():
+                setattr(mod, k, v)
+
+        if attrs is None:
+            cls.modules_no_attr[path] = mod
+        cls.modules.append(mod)
+
+        return mod
+
+    @classmethod
+    @functools.cache
+    def stack_frames_for_code(
+        cls, path: str, lineno: int
+    ) -> Optional[list[dict[str, Any]]]:
+        """Map generated code line to original stack frames for error reporting."""
+        if path not in cls.linemaps or not cls.linemaps[path]:
+            return None
+
+        lines, stack_traces = cls.linemaps[path]
+
+        p = bisect_right(lines, lineno)
+        if p == 0:
+            return None
+
+        stack_trace_str = stack_traces[p - 1]
+        return _parse_stack_trace(stack_trace_str) if stack_trace_str else None
+
+    @classmethod
+    def cache_clear(cls, purge: bool = False) -> None:
+        """Clear module cache. If purge=True, also delete files from disk."""
+        if purge:
+            for mod in cls.modules:
+                try:
+                    if mod.__file__:
+                        os.remove(mod.__file__)
+                except FileNotFoundError:
+                    pass
+
+        cls.modules.clear()
+        cls.modules_no_attr.clear()
+        cls.linemaps.clear()
+
+    @classmethod
+    def get_dir(cls) -> str:
+        """Return /tmp/fx_codegen directory path."""
+        return "/tmp/fx_codegen"
+
+
+def _parse_stack_trace(stack_trace: str) -> list[dict[str, Any]]:
+    """Parse FX stack trace string into list of frame dicts."""
+    regex = r'File "(.+)", line (\d+), in (.+)\n'
+    matches = re.findall(regex, stack_trace)
+    return [{"filename": f, "line": int(l), "name": n} for f, l, n in reversed(matches)]

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -108,5 +108,11 @@ enrich_profiler_metadata: bool = Config(  # type: ignore[var-annotated]
     env_name_default="TORCH_ENRICH_RPOFILER_STACK_TRACE",
 )
 
+# Experimental: Save FX-generated code to /tmp/fx_codegen/ with hash-based naming
+save_fx_code_to_disk: bool = Config(  # type: ignore[var-annotated]
+    default=False,
+    env_name_default="FX_SAVE_CODE_TO_DISK",
+)
+
 
 install_config_module(sys.modules[__name__])

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -112,6 +112,19 @@ def _forward_from_src(src: str, globals: dict[str, Any], co_fields=None):
     )
 
 
+def _forward_from_disk(cache_path: str, globals: dict[str, Any]):
+    """Load forward function from disk-cached module."""
+    from torch.fx.codecache import FXCodeCache
+
+    key = os.path.basename(cache_path).replace(".py", "")
+    mod = FXCodeCache.load_by_key_path(key, cache_path, attrs=globals)
+
+    def forward_wrapper(self, *args, **kwargs):
+        return mod.call(*args, **kwargs)
+
+    return forward_wrapper
+
+
 def _method_from_src(
     method_name: str, src: str, globals: dict[str, Any], co_fields=None
 ) -> Callable:
@@ -917,7 +930,41 @@ class {module_name}(torch.nn.Module):
                 f"torch._C._profiler._RecordFunctionFast('## {filename} ##')",
             )
 
-        cls.forward = _forward_from_src(self._code, python_code.globals, co_fields)
+        # Disk-based compilation (when enabled)
+        if fx_experimental_config.save_fx_code_to_disk:
+            # Generate wrapper code with module-level call() function
+            wrapper_code = self._generate_wrapper_code(python_code, co_fields)
+
+            # Build linemap for stack trace support
+            linemap = self._build_linemap(python_code)
+
+            # Write to disk and load via FXCodeCache
+            from torch.fx.codecache import FXCodeCache
+
+            key, path = FXCodeCache.write(wrapper_code)
+
+            print(f"[FX] Saved generated code to: {path}")
+
+            # Load module with linemap
+            code_cache = FXCodeCache.load_by_key_path(
+                key=key,
+                path=path,
+                linemap=linemap,
+                attrs=python_code.globals,
+            )
+
+            # Store disk compilation attributes
+            self.cache_key = key
+            self.cache_path = path
+            self.cache_linemap = linemap
+            self.current_callable = code_cache.call
+            self._source_code = wrapper_code
+
+            # Set forward to use disk-loaded callable
+            cls.forward = _forward_from_disk(path, python_code.globals)
+        else:
+            # Standard in-memory compilation
+            cls.forward = _forward_from_src(self._code, python_code.globals, co_fields)
 
         # Determine whether this class explicitly defines a __call__ implementation
         # to wrap. If it does, save it in order to have wrapped_call invoke it.
@@ -938,6 +985,42 @@ class {module_name}(torch.nn.Module):
         cls.__call__ = call_wrapped  # type: ignore[method-assign]
 
         return python_code
+
+    def _generate_wrapper_code(
+        self, python_code: PythonCode, co_fields: dict[str, Any]
+    ) -> str:
+        """Generate wrapper code with module-level call() following inductor pattern."""
+        header_lines = ["# FX Graph Module - Generated Code"]
+        if co_fields:
+            if "co_filename" in co_fields:
+                header_lines.append(f"# Source: {co_fields['co_filename']}")
+            if "co_firstlineno" in co_fields:
+                header_lines.append(f"# Line: {co_fields['co_firstlineno']}")
+            if "co_name" in co_fields:
+                header_lines.append(f"# Function: {co_fields['co_name']}")
+
+        forward_src = self._code.replace("def forward(self, ", "def forward_impl(")
+        forward_src = forward_src.replace("def forward(self):", "def forward_impl():")
+
+        footer = """
+# Module-level call function (following inductor pattern)
+def call(*args, **kwargs):
+    '''Entry point for FX graph execution.'''
+    return forward_impl(*args, **kwargs)
+"""
+        return "\n".join(header_lines) + "\n\n" + forward_src + footer
+
+    def _build_linemap(self, python_code: PythonCode) -> list[tuple[int, str]]:
+        """Map generated code lines to FX node stack traces."""
+        linemap: list[tuple[int, str]] = []
+        header_lines = 4
+
+        for i, node in enumerate(self._graph.nodes):
+            if node.stack_trace:
+                line_no = header_lines + i + 2
+                linemap.append((line_no, node.stack_trace))
+
+        return linemap
 
     def _recompile_submodules(self) -> list[tuple[str, PythonCode]]:
         """


### PR DESCRIPTION
Add experimental support for saving FX-generated code to disk for debugging.

When enabled via torch.fx.experimental._config.save_fx_code_to_disk = True, generated code is saved to /tmp/fx_codegen/ with hash-based naming for deterministic caching.

Implementation follows TorchInductor's codecache pattern with thread-safe writes and stack trace support via linemap infrastructure.

Test Plan:
Tested with test_fx_disk_comprehensive.py covering file creation, module loading/execution, code modification/reloading, and stack trace infrastructure.

Verified hash-based naming prevents duplicate writes and modified code triggers proper stack traces.

Fixes #ISSUE_NUMBER


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv