### PR TITLE
Add failing test for PolynomialLR total_iters=0 closed-form crash

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2680,6 +2680,19 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+    def test_polylr_closed_form_total_iters_zero_division(self):
+        model = torch.nn.Linear(1, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+        # When total_iters=0, closed form stepping should immediately return
+        # the final learning rate instead of dividing by zero internally.
+        scheduler = PolynomialLR(optimizer, total_iters=0, power=1.0)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            scheduler.step(epoch=0)
+
+        self.assertEqual(optimizer.param_groups[0]["lr"], 0.0)
 
 instantiate_parametrized_tests(TestLRScheduler)
 


### PR DESCRIPTION
This PR introduces a failing test that exposes a `ZeroDivisionError` when calling
`scheduler.step(epoch=...)` on `PolynomialLR` with `total_iters=0`.

Closed form LR computation performs:

```
t = min(epoch, total_iters) / total_iters
```

which produces a `0 / 0` division by zero crash when `total_iters == 0`.

This PR is **tests only**, following the incremental plan discussed in the RFC.
A future PR will add validation logic or canonical behavior for this edge case.

**Related Discussion**
This test is part of the broader cleanup work proposed in the RFC:
"RFC: Internal Unification of LRScheduler Semantics for Correct Resuming and Composition" #168044