### PR TITLE
Implement make_reindexer for DtypeView to fix MXFP8 + torch.compile

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3471,6 +3471,18 @@ class DtypeView(BaseView):
     def get_size(self) -> Sequence[Expr]:
         return self.data.get_size()
 
+    def make_reindexer(
+        self,
+    ) -> Callable[[Sequence[Expr]], Sequence[Expr]]:
+        # DtypeView only changes the dtype, not the shape or layout,
+        # so the reindexer is an identity function
+        def reindex(
+            index: Sequence[Expr],
+        ) -> Sequence[Expr]:
+            return index
+
+        return reindex
+
     def make_loader(self) -> Callable[[Sequence[Expr]], OpsValue]:
         inner = self.data.make_loader()
 


### PR DESCRIPTION
This fixes issue #168995 where torch.compile throws NotImplementedError when using MXFP8 with DtypeView. The issue was that DtypeView didn't implement make_reindexer, which is required by BaseView.make_indexer() and BaseView.make_loader().

Since DtypeView only changes the dtype and not the shape or layout, the reindexer is an identity function that passes indices through unchanged.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo