### PR TITLE
[xpu][inductor] use fast math for exp on xpu device

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -234,7 +234,12 @@ allow_buffer_reuse = True
 memory_planning = os.environ.get("TORCHINDUCTOR_MEMORY_PLANNING", "0") == "1"
 
 # Enable to allow using ftz variant of exponenet instruction in triton codegen.
-use_fast_math = os.environ.get("TORCHINDUCTOR_USE_FAST_MATH") == "1"
+use_fast_math = (
+    os.environ.get(
+        "TORCHINDUCTOR_USE_FAST_MATH", "1" if torch.xpu.is_available() else "0"
+    )
+    == "1"
+)
 
 # Enable bfloat16 atomic adds (fbcode only until upstreamed to triton)
 bfloat16_atomic_adds_enabled = True


### PR DESCRIPTION
We should use tl.exp instead of libdevice.exp on xpu devices to use math instructions for better performance. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo