### PR TITLE
Rm platform args xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
@@ -90,22 +90,23 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
             "-Wno-empty-translation-unit",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse2",
+                "-mno-sse3",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse2",
+                "-mno-sse3",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
         force_static = True,
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "86",
-                [
-                    "-msse2",
-                    "-mno-sse3",
-                ],
-            ),
-        ],
         visibility = ["PUBLIC"],
         deps = [
             ":qnnp_interface",
@@ -137,30 +138,23 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
             "-Wno-empty-translation-unit",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mssse3",
+                "-mno-sse4",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mssse3",
+                "-mno-sse4",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
         force_static = True,
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "86",
-                [
-                    "-mssse3",
-                    "-mno-sse4",
-                ],
-            ),
-            (
-                # By default, osmeta compiler silently ignores -msseXX flags.
-                # This flag disables this behavior.
-                "osmeta",
-                [
-                    "-mosmeta-no-restrict-sse",
-                ],
-            ),
-        ],
         visibility = ["PUBLIC"],
         deps = [
             ":qnnp_interface",
@@ -192,30 +186,23 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
             "-Wno-empty-translation-unit",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse4.1",
+                "-mno-sse4.2",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse4.1",
+                "-mno-sse4.2",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
         force_static = True,
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "86",
-                [
-                    "-msse4.1",
-                    "-mno-sse4.2",
-                ],
-            ),
-            (
-                # By default, osmeta compiler silently ignores -msseXX flags.
-                # This flag disables this behavior.
-                "osmeta",
-                [
-                    "-mosmeta-no-restrict-sse",
-                ],
-            ),
-        ],
         visibility = ["PUBLIC"],
         deps = [
             ":qnnp_interface",
@@ -296,7 +283,18 @@ def define_qnnpack(third_party, labels = []):
             "-O2",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
             "-fvisibility=default",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:arm32": [
+                "-mfpu=neon",
+            ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:android-arm32": [
+                "-marm",
+                "-mfloat-abi=softfp",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
@@ -308,21 +306,6 @@ def define_qnnpack(third_party, labels = []):
         labels = [
             "supermodule:android/default/pytorch",
             "supermodule:ios/default/public.pytorch",
-        ],
-        platform_compiler_flags = [
-            (
-                "armv7",
-                [
-                    "-mfpu=neon",
-                ],
-            ),
-            (
-                "^android-armv7$",
-                [
-                    "-marm",
-                    "-mfloat-abi=softfp",
-                ],
-            ),
         ],
         # FIXME(T172572183): This should be removed when fbcode no longer uses
         # produce_interface_from_stub_shared_library; it's needed to work around a bug
@@ -405,28 +388,24 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-error=unused-variable",
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:arm32": [
+                "-mfpu=neon",
+            ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:android-arm32": [
+                "-marm",
+                "-mfloat-abi=softfp",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
         force_static = True,
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "armv7",
-                [
-                    "-mfpu=neon",
-                ],
-            ),
-            (
-                "^android-armv7$",
-                [
-                    "-marm",
-                    "-mfloat-abi=softfp",
-                ],
-            ),
-        ],
         visibility = ["PUBLIC"],
         deps = [
             ":qnnp_interface",
@@ -469,46 +448,32 @@ def define_qnnpack(third_party, labels = []):
         compiler_flags = [
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
             "-Wno-unused-command-line-argument",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            # iOS assembler doesn't let us specify ISA in the assembly file,
+            # so this must be set to the highest version of ISA of any of the
+            # assembly functions
+            "ovr_config//os:iphoneos-arm32": [
+                "-mfpu=neon-vfpv4",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
         force_static = True,
         labels = labels,
-        platform_compiler_flags = [
-            (
-                # iOS assembler doesn't let us specify ISA in the assembly file,
-                # so this must be set to the highest version of ISA of any of the
-                # assembly functions
-                "^iphoneos-armv7$",
-                [
-                    "-mfpu=neon-vfpv4",
-                ],
-            ),
-            (
-                "osmeta",
-                [
-                    "-mfpu=neon-vfpv4",
-                ],
-            ),
-        ],
-        platform_preprocessor_flags = [
-            (
-                "android",
-                [
-                    # Workaround for osmeta-android, which builds for ELF, but hides it
-                    "-D__ELF__=1",
-                ],
-            ),
-            (
-                "tizen",
-                [
-                    # Workaround for osmeta-tizen, which builds for ELF, but hides it
-                    "-D__ELF__=1",
-                ],
-            ),
-        ],
+        preprocessor_flags = select({
+            "DEFAULT": [],
+            "ovr_config//os:android": [
+                # Workaround for osmeta-android, which builds for ELF, but hides it
+                "-D__ELF__=1",
+            ],
+            "ovr_config//os:tizen": [
+                # Workaround for osmeta-tizen, which builds for ELF, but hides it
+                "-D__ELF__=1",
+            ],
+        }),
         visibility = ["PUBLIC"],
     )
 
@@ -530,28 +495,24 @@ def define_qnnpack(third_party, labels = []):
             "-O3",
             "-ffast-math",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:arm32": [
+                "-mfpu=neon",
+            ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:android-arm32": [
+                "-marm",
+                "-mfloat-abi=softfp",
+            ],
+        }),
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
             "-DQNNP_INTERNAL=",
         ],
         force_static = True,
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "armv7",
-                [
-                    "-mfpu=neon",
-                ],
-            ),
-            (
-                "^android-armv7$",
-                [
-                    "-marm",
-                    "-mfloat-abi=softfp",
-                ],
-            ),
-        ],
         visibility = ["PUBLIC"],
         deps = [
             ":qnnp_interface",
@@ -638,16 +599,14 @@ def define_qnnpack(third_party, labels = []):
             "-fexceptions",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
         ],
-        platform_linker_flags = [
-            (
-                "^linux.*$",
-                [
-                    "-Wl,--no-as-needed",
-                    "-ldl",
-                    "-pthread",
-                ],
-            ),
-        ],
+        linker_flags = select({
+            "DEFAULT": [],
+            "ovr_config//os:linux": [
+                "-Wl,--no-as-needed",
+                "-ldl",
+                "-pthread",
+            ],
+        }),
         env = {
             # These tests fail in sandcastle since they leak memory. Disable LeakSanitizer.
             "ASAN_OPTIONS": "detect_leaks=0",


### PR DESCRIPTION
Summary:
Get rid of platform args around the repo to unblock modernization with platforms.
Platform args were only needed in buck1

Test Plan: CI

Differential Revision: D87721827




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01