### PR TITLE
[AOTI] Use arg signature to derive the right kernel input type for "sympy.Integer" as well

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7741,6 +7741,30 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(Model(), example_inputs, move_model_to_device=False)
 
+    @requires_gpu
+    def test_constant_int_kernel_input(self):
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest("requires GPU")
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                u0 = x.item()
+                device = x.device
+
+                inp = torch.zeros(u0, device=device)
+                inp_rand0 = inp + torch.rand(u0, device=device)
+                inp_rand1 = inp_rand0 - torch.rand(u0, device=device)
+                return torch.where(
+                    torch.rand(u0, device=device) > 0.5,
+                    inp_rand0 + inp_rand1,
+                    inp_rand0 - inp_rand1,
+                )
+
+        example_inputs = (torch.tensor(6, dtype=torch.int64, device=self.device),)
+
+        with config.patch("triton.autotune_with_sample_inputs", True):
+            AOTIRunnerUtil.run(Model(), example_inputs)
+
 
 class AOTInductorLoggingTest(LoggingTestCase):
     @make_logging_test(dynamic=logging.DEBUG)

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -707,12 +707,6 @@ class CppWrapperGpu(CppWrapperCpu):
                     )
                 )
                 new_args.append(f"&{var_name}")
-            elif arg_type in (sympy.Integer, int):
-                code.writeline(f"int {var_name} = {cexpr(arg)};")
-                new_args.append(f"&{var_name}")
-            elif arg_type in (sympy.Float, float):
-                code.writeline(f"float {var_name} = {cexpr(arg)};")
-                new_args.append(f"&{var_name}")
             # For symbolic call arguments, examine the arg signatures from triton meta
             # to explicitly cast to the right type
             # Reason: `auto` can infer unexpected type against kernel input signature.
@@ -724,6 +718,12 @@ class CppWrapperGpu(CppWrapperCpu):
                 code.writeline(
                     f"{signature2dtype[arg_signature]} {var_name} = {cexpr(arg)};"
                 )
+                new_args.append(f"&{var_name}")
+            elif arg_type in (sympy.Integer, int):
+                code.writeline(f"int {var_name} = {cexpr(arg)};")
+                new_args.append(f"&{var_name}")
+            elif arg_type in (sympy.Float, float):
+                code.writeline(f"float {var_name} = {cexpr(arg)};")
                 new_args.append(f"&{var_name}")
             elif arg_signature and arg_signature.startswith("tensordesc<"):
                 new_args.extend(


### PR DESCRIPTION
## Issue

Previously when we have `arg_type` of sympy.Integer, we'll use `int` as its type in generated cpp wrapper code all the time. It'll cause IMA if the arg is actually of type i64.

Can see this [gist](https://gist.github.com/sevenEng/0cb7aaa2860fbc5a94ccf5b63ac83a59) for the generated cpp code from the model in added unit test, noticing "**int var_2 = load_seed_offset;**" from "**triton_poi_fused_rand_0**", where it should be **int64_t** instead.

## Fix

When matching and generating the arg declaration line in cpp wrapper code, give the "arg signature" branch more precedence over the default "int" and "float", so that we could find the right type.

## Unit test

before the patch, we'll see IMA from the unit test:

```
$ pytest -k test_constant_int_kernel_input test/inductor/test_aot_inductor.py
================================================================================================================================================================================= test session starts =================================================================================================================================================================================
platform linux -- Python 3.12.9, pytest-7.3.2, pluggy-1.5.0
rootdir: /data/users/q1l1/pytorch
configfile: pytest.ini
plugins: xdoctest-1.1.0, hypothesis-5.35.1, xdist-3.3.1, subtests-0.13.1, rerunfailures-14.0, flakefinder-1.1.0, cpp-2.3.0
collected 922 items / 919 deselected / 3 selected                                                                                                                                                                                                                                                                                                                                     
Running 3 items in this shard
test/inductor/test_aot_inductor.py sError: CUDA driver error: an illegal memory access was encountered
Fs                                                                                                                                                                                                                                                                                                                                          [100%]
====================================================================================================================================================================================== FAILURES =======================================================================================================================================================================================
_________________________________________________________________________________________________________________________________________________________ AOTInductorTestABICompatibleGpu.test_constant_int_kernel_input_cuda _________________________________________________________________________________________________________________________________________________________
Traceback (most recent call last):
  File "/data/users/q1l1/pytorch/test/inductor/test_torchinductor.py", line 14720, in new_test
    return value(self)
           ^^^^^^^^^^^
  File "/data/users/q1l1/pytorch/test/inductor/test_aot_inductor.py", line 7651, in test_constant_int_kernel_input
    AOTIRunnerUtil.run(Model(), example_inputs)
  File "/data/users/q1l1/pytorch/test/inductor/test_aot_inductor_utils.py", line 191, in run
    return optimized(*example_inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/q1l1/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/torch/export/pt2_archive/_package.py", line 732, in __call__
    flat_outputs = self.loader.boxed_run(flat_inputs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: run_func_( container_handle_, input_handles.data(), input_handles.size(), output_handles.data(), output_handles.size(), reinterpret_cast<AOTInductorStreamHandle>(stream_handle), proxy_executor_handle_) API call failed at /data/users/q1l1/pytorch/torch/csrc/inductor/aoti_runner/model_container_runner.cpp, line 145
To execute this test, run the following from the base repo dir:
    python test/inductor/test_aot_inductor.py AOTInductorTestABICompatibleGpu.test_constant_int_kernel_input_cuda
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
unimplemented []
stats [('calls_captured', 11), ('unique_graphs', 1)]
inductor [('benchmarking.InductorBenchmarker.benchmark', 6), ('benchmarking.InductorBenchmarker.benchmark_gpu', 6), ('extern_calls', 5), ('pattern_matcher_count', 3), ('pattern_matcher_nodes', 3), ('async_compile_cache_miss', 3)]
graph_break []
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- Captured stderr call ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/home/q1l1/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/torch/_dynamo/variables/user_defined.py:1815: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return ctor(*args, **kwargs)
/home/q1l1/.conda/envs/pytorch-3.12/lib/python3.12/copyreg.py:99: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return cls.__new__(cls, *args)
=============================================================================================================================================================================== short test summary info ===============================================================================================================================================================================
FAILED [5.8375s] test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleGpu::test_constant_int_kernel_input_cuda - RuntimeError: run_func_( container_handle_, input_handles.data(), input_handles.size(), output_handles.data(), output_handles.size(), reinterpret_cast<AOTInductorStreamHandle>(stream_handle), proxy_executor_handle_) API call failed at /data/users/q1l1/pytorch/torch/csrc/inductor/aoti_runner/model_container_runner.cpp, line 145
==================================================================================================================================================================== 1 failed, 2 skipped, 919 deselected in 10.31s ====================================================================================================================================================================
Failed to destroy CUDA event in AOTInductor model: an illegal memory access was encountered
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela