### PR TITLE
Fix an unsafe indexing in fx exception handling

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -881,7 +881,7 @@ class Tracer(TracerBase):
 
             self.submodule_paths = None
         except RuntimeError as e:
-            if isinstance(e.args[0], str) and "data-dependent" in e.args[0]:
+            if e.args and isinstance(e.args[0], str) and "data-dependent" in e.args[0]:
                 partial_fx_graph = self.graph.python_code(
                     root_module="self",
                     verbose=True,


### PR DESCRIPTION
There is an unsafe indexing into `e.args` in FX's exception handling, which would lead to nested exception and mask the actual error. This PR fixes it.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv