### PR TITLE
[effects] Various effect/dce fixes

### DIFF
--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -561,6 +561,43 @@ def forward(self, tangents_1, tangents_2, tangents_token):
     return (clone, clone_1, tangents_1, tangents_2, getitem_6)""",
             )
 
+    def test_dce(self):
+        # If an operator is marked as side effectful, it should not get DCEd by
+        # FX's eliminate_dead_code
+
+        with torch.library._scoped_library("mylib", "FRAGMENT") as m:
+            log3 = []
+
+            @torch.library.custom_op(
+                "mylib::my_logger3",
+                mutates_args=(),
+            )
+            def my_logger3(s: str, t: torch.Tensor) -> torch.Tensor:
+                log3.append(s)
+                return torch.zeros(1)
+
+            @my_logger3.register_fake
+            def my_logger3(s, t) -> torch.Tensor:
+                return torch.zeros(1)
+
+            # Registering an op as being effectful should also prevent FX DCE
+            from torch._library.effects import EffectType
+
+            torch.library._register_effectful_op(
+                "mylib::my_logger3", EffectType.ORDERED
+            )
+
+            def foo(x):
+                b = torch.scalar_tensor(x.shape[0])
+                torch.ops.mylib.my_logger3("moo", b)
+                return x + x
+
+            gm = make_fx(foo, tracing_mode="symbolic")(torch.ones(3, 3))
+            gm.graph.eliminate_dead_code()
+            gm.recompile()
+            gm(torch.ones(3, 3))
+            self.assertTrue(len(log3), 1)
+
     def test_effects_and_input_mutation_return(self):
         def fn(a, b):
             torch.ops.aten._print("effect")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14806,6 +14806,40 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             torch.compile(foo, fullgraph=True)(torch.ones(3, 3))
             self.assertTrue(len(log2), 1)
 
+            ########################################################3
+
+            log3 = []
+
+            @torch.library.custom_op(
+                "mylib::my_logger3",
+                mutates_args=(),
+            )
+            def my_logger3(s: str, t: torch.Tensor) -> torch.Tensor:
+                log3.append(s)
+                return torch.zeros(1)
+
+            @my_logger3.register_fake
+            def my_logger3(s, t) -> torch.Tensor:
+                return torch.zeros(1)
+
+            # Registering an op as being effectful should also prevent FX DCE
+            from torch._library.effects import EffectType
+
+            torch.library._register_effectful_op(
+                "mylib::my_logger3", EffectType.ORDERED
+            )
+
+            def foo(x):
+                b = torch.scalar_tensor(x.shape[0])
+                torch.ops.mylib.my_logger3("moo", b)
+                return x + x
+
+            gm = make_fx(foo, tracing_mode="symbolic")(torch.ones(3, 3))
+            gm.graph.eliminate_dead_code()
+            gm.recompile()
+            gm(torch.ones(3, 3))
+            self.assertTrue(len(log3), 1)
+
     @skipIfMPS  # Accuracy issue on MPS
     def test_weight_norm_conv2d(self):
         """

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14755,6 +14755,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @config.patch(implicit_fallbacks=True)
     def test_custom_op_dce(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as m:
+            # CASE 1: The op should get wrapped with auto_functionalized, and
+            # FX's DCE should not remove it because this op is registered as
+            # effectful
+
             log1 = []
 
             @torch.library.custom_op(
@@ -14774,13 +14778,11 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 torch.ops.mylib.my_logger1("moo", b)
                 return x + x
 
-            # The op should get wrapped with auto_functionalized, and FX's DCE
-            # should not remove it because this op is registered as effectful
             torch.fx.node.has_side_effect(torch.ops.mylib.my_logger1.default)
             torch.compile(foo, fullgraph=True)(torch.ones(3, 3))
             self.assertTrue(len(log1), 1)
 
-            ########################################################3
+            # CASE 2: The op should not get DCEd by TorchInductor
 
             log2 = []
 
@@ -14801,44 +14803,9 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 torch.ops.mylib.my_logger2("moo", b)
                 return x + x
 
-            # The op should not get DCEd by inductor
             torch.fx.node.has_side_effect(torch.ops.mylib.my_logger2.default)
             torch.compile(foo, fullgraph=True)(torch.ones(3, 3))
             self.assertTrue(len(log2), 1)
-
-            ########################################################3
-
-            log3 = []
-
-            @torch.library.custom_op(
-                "mylib::my_logger3",
-                mutates_args=(),
-            )
-            def my_logger3(s: str, t: torch.Tensor) -> torch.Tensor:
-                log3.append(s)
-                return torch.zeros(1)
-
-            @my_logger3.register_fake
-            def my_logger3(s, t) -> torch.Tensor:
-                return torch.zeros(1)
-
-            # Registering an op as being effectful should also prevent FX DCE
-            from torch._library.effects import EffectType
-
-            torch.library._register_effectful_op(
-                "mylib::my_logger3", EffectType.ORDERED
-            )
-
-            def foo(x):
-                b = torch.scalar_tensor(x.shape[0])
-                torch.ops.mylib.my_logger3("moo", b)
-                return x + x
-
-            gm = make_fx(foo, tracing_mode="symbolic")(torch.ones(3, 3))
-            gm.graph.eliminate_dead_code()
-            gm.recompile()
-            gm(torch.ones(3, 3))
-            self.assertTrue(len(log3), 1)
 
     @skipIfMPS  # Accuracy issue on MPS
     def test_weight_norm_conv2d(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14752,6 +14752,60 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             "Generated Triton code should use triton_helpers.minimum for clamping",
         )
 
+    @config.patch(implicit_fallbacks=True)
+    def test_custom_op_dce(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as m:
+            log1 = []
+
+            @torch.library.custom_op(
+                "mylib::my_logger1",
+                mutates_args="unknown",
+            )
+            def my_logger1(s: str, t: torch.Tensor) -> torch.Tensor:
+                log1.append(s)
+                return torch.zeros(1)
+
+            @my_logger1.register_fake
+            def my_logger1(s, t) -> torch.Tensor:
+                return torch.zeros(1)
+
+            def foo(x):
+                b = torch.scalar_tensor(x.shape[0])
+                torch.ops.mylib.my_logger1("moo", b)
+                return x + x
+
+            # The op should get wrapped with auto_functionalized, and FX's DCE
+            # should not remove it because this op is registered as effectful
+            torch.fx.node.has_side_effect(torch.ops.mylib.my_logger1.default)
+            torch.compile(foo, fullgraph=True)(torch.ones(3, 3))
+            self.assertTrue(len(log1), 1)
+
+            ########################################################3
+
+            log2 = []
+
+            @torch.library.custom_op(
+                "mylib::my_logger2",
+                mutates_args=(),
+            )
+            def my_logger2(s: str, t: torch.Tensor) -> torch.Tensor:
+                log2.append(s)
+                return torch.zeros(1)
+
+            @my_logger2.register_fake
+            def my_logger2(s, t) -> torch.Tensor:
+                return torch.zeros(1)
+
+            def foo(x):
+                b = torch.scalar_tensor(x.shape[0])
+                torch.ops.mylib.my_logger2("moo", b)
+                return x + x
+
+            # The op should not get DCEd by inductor
+            torch.fx.node.has_side_effect(torch.ops.mylib.my_logger2.default)
+            torch.compile(foo, fullgraph=True)(torch.ones(3, 3))
+            self.assertTrue(len(log2), 1)
+
     @skipIfMPS  # Accuracy issue on MPS
     def test_weight_norm_conv2d(self):
         """

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -62,7 +62,7 @@ from torch.fx.experimental.symbolic_shapes import (
     ShapeEnv,
     SymTypes,
 )
-from torch.fx.node import Node
+from torch.fx.node import _side_effectful_functions, Node
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import _disable_current_modes
 from torch.utils._sympy.functions import CleanDiv, FloorDiv, Mod, ModularIndexing
@@ -7884,7 +7884,10 @@ class FallbackKernel(ExternKernelAlloc):
     def has_side_effects(self) -> bool:
         if isinstance(self.op_overload, torch._ops.HigherOrderOperator):
             return False
-        return get_schema_info(self.op_overload).is_mutable()
+        return (
+            get_schema_info(self.op_overload).is_mutable()
+            or self.op_overload in _side_effectful_functions
+        )
 
     def get_inputs_that_alias_output(self) -> Sequence[str]:
         assert isinstance(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2705,6 +2705,8 @@ def require_channels_last(_, *args, **kwargs):
 
 
 def constrain_to_fake_tensor(arg, fake_arg):
+    if fake_arg is None:
+        return arg
     if isinstance(fake_arg, FakeScriptObject):
         return arg
     if isinstance(arg, ir.IRNode):

--- a/torch/_library/effects.py
+++ b/torch/_library/effects.py
@@ -11,6 +11,19 @@ class EffectType(Enum):
 from torch._library.utils import RegistrationHandle
 
 
+# These classes do not have side effects as they just store quantization
+# params, so we dont need to mark them as ordered
+skip_classes = (
+    "__torch__.torch.classes.quantized.Conv2dPackedParamsBase",
+    "__torch__.torch.classes.quantized.Conv3dPackedParamsBase",
+    "__torch__.torch.classes.quantized.EmbeddingPackedParamsBase",
+    "__torch__.torch.classes.quantized.LinearPackedParamsBase",
+    "__torch__.torch.classes.xnnpack.Conv2dOpContext",
+    "__torch__.torch.classes.xnnpack.LinearOpContext",
+    "__torch__.torch.classes.xnnpack.TransposeConv2dOpContext",
+)
+
+
 class EffectHolder:
     """A holder where one can register an effect impl to."""
 
@@ -42,6 +55,9 @@ class EffectHolder:
             schema = torch._C._get_schema(opname, overload)
             for arg in schema.arguments:
                 if isinstance(arg.type, torch.ClassType):
+                    type_str = arg.type.str()  # pyrefly: ignore[missing-attribute]
+                    if type_str in skip_classes:
+                        continue
                     self._effect = EffectType.ORDERED
                     return
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -554,3 +554,94 @@ def get_layout_constraint_tag(fn, *, with_default=True):
 
         return getattr(torch._C.Tag, config.custom_op_default_layout_constraint)
     return None
+
+
+# List of random functions that should be treated as impure
+_RANDOM_FUNCTIONS = {
+    torch.rand,
+    torch.randn,
+    torch.randint,
+    torch.randperm,
+    torch.rand_like,
+    torch.randn_like,
+    torch.randint_like,
+    torch.normal,
+    torch.poisson,
+    torch.bernoulli,
+    torch.multinomial,
+}
+
+
+def is_impure(
+    op: Callable,
+    *,
+    args: Optional[tuple[Any, ...]] = None,
+    kwargs: Optional[dict[str, Any]] = None,
+    impure_random: bool = True,
+) -> bool:
+    """
+    An operator is impure if it:
+    - Mutates its inputs (has a mutable schema)
+    - Has nondeterministic/random behavior that mutates RNG state
+    - Is explicitly marked as effectful via torch.library._register_effectful_op
+
+    Args:
+        op: The operator to check (function, OpOverload, HigherOrderOperator, etc.)
+        args: Optional arguments that would be passed to the callable
+        kwargs: Optional keyword arguments that would be passed to the callable
+        impure_random: Whether to treat random operations as impure (default: True)
+
+    Returns:
+        bool: True if the callable has side effects, False otherwise
+    """
+    # Import here to avoid circular dependencies
+    from torch._higher_order_ops.effects import _get_effect
+    from torch.fx.node import _side_effectful_functions
+
+    if isinstance(op, torch._ops.OpOverload):
+        schema = getattr(op, "_schema", None)
+        if schema is not None and schema.is_mutable:
+            return True
+
+        if op in _side_effectful_functions:
+            return True
+
+        if _get_effect(op) is not None:
+            return True
+
+    if isinstance(op, torch._ops.HigherOrderOperator):
+        if op in (
+            torch.ops.higher_order.auto_functionalized,
+            torch.ops.higher_order.auto_functionalized_v2,
+        ):
+            # Check if the auto-functionalized operator (the first argument) is
+            # side-effectful
+            if args and len(args) > 0:
+                return args[0] in _side_effectful_functions
+
+        if _get_effect(op) is not None:
+            return True
+
+        return False
+
+    # Impure since it mutates RNG state
+    if impure_random and getattr(op, "_nondeterministic_seeded", False):
+        return True
+
+    # Handle Python random functions that don't have _nondeterministic_seeded
+    # but still affect global RNG state (issue #151524)
+    # These should be impure regardless of impure_random setting to maintain
+    # consistency between eager and compiled execution
+    # All random operations are impure to ensure consistent behavior
+    # between eager and compiled execution, regardless of generator usage
+    if op in _RANDOM_FUNCTIONS:
+        return True
+
+    schema = getattr(op, "_schema", None)
+    if schema is not None and schema.is_mutable:
+        return True
+
+    if op in _side_effectful_functions:
+        return True
+
+    return False

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -6,6 +6,7 @@ import enum
 import functools
 import inspect
 import keyword
+import logging
 import math
 import os
 import pprint
@@ -29,6 +30,8 @@ from ._compatibility import compatibility
 from .immutable_collections import immutable_dict
 from .node import _get_qualified_name, _type_repr, Argument, Node, Target
 
+
+log = logging.getLogger(__name__)
 
 __all__ = ["PythonCode", "CodeGen", "Graph"]
 
@@ -2085,11 +2088,15 @@ class Graph:
         # Reverse iterate so that when we remove a node, any nodes used as an
         # input to that node have an updated user count that no longer reflects
         # the removed node.
-        changed = False
+        removed_nodes = set()
         for node in reversed(self.nodes):
             if not has_side_effect(node) and len(node.users) == 0:
                 self.erase_node(node)
-                changed = True
+                removed_nodes.add(node.name)
+
+        changed = len(removed_nodes) > 0
+        if changed:
+            log.info("The following nodes were dead code eliminated: %s", removed_nodes)
 
         # Call DCE on the subgraphs
         if self.owning_module is not None:

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -762,6 +762,14 @@ class Node(_NodeBase):
                 ):
                     return self.args[0] in _side_effectful_functions
 
+            from torch._higher_order_ops.effects import _get_effect
+
+            if (
+                isinstance(self.target, torch._ops.OpOverload)
+                and _get_effect(self.target) is not None
+            ):
+                return True
+
             return self.target in _side_effectful_functions
 
         # Check if an impure module.

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -755,6 +755,13 @@ class Node(_NodeBase):
                 # between eager and compiled execution, regardless of generator usage
                 return True
 
+            if isinstance(self.target, torch._ops.HigherOrderOperator):
+                if self.target in (
+                    torch.ops.higher_order.auto_functionalized,
+                    torch.ops.higher_order.auto_functionalized_v2,
+                ):
+                    return self.args[0] in _side_effectful_functions
+
             return self.target in _side_effectful_functions
 
         # Check if an impure module.

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -88,6 +88,14 @@ _side_effectful_need_to_be_preserved_pre_dispatch: list[Callable[..., Any]] = [
 
 # TODO: Either refactor this into 2 functions 1 dce for functional graphs and 1 dce for all graphs,
 # or add logic to correctly mark all inplace ops as side effectful.
+#
+# NOTE: For new operators, please do not add to this set!
+# Instead, consider using the effects system via
+# torch.library._register_effectful_op() for operators.
+#
+# This _side_effectful_functions set is only for:
+# - Legacy functions that aren't operators (e.g., profiler ops, asserts)
+# - Things that cannot be marked via the normal effects system
 _side_effectful_functions: set[Callable[..., Any]] = {
     torch._assert,
     torch._assert_async,
@@ -110,6 +118,18 @@ if hasattr(_ops.inductor, "resize_storage_bytes_"):
 
 @compatibility(is_backward_compatible=False)
 def has_side_effect(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+    """
+    Registers a function to not be dead code eliminated by
+    fx.graph.eliminate_dead_code
+
+    NOTE: For new operators, please do not add to this set!
+    Instead, consider using the effects system via
+    torch.library._register_effectful_op() for operators.
+
+    This _side_effectful_functions set is only for:
+    - Legacy functions that aren't operators (e.g., profiler ops, asserts)
+    - Things that cannot be marked via the normal effects system
+    """
     _side_effectful_functions.add(fn)
     return fn
 
@@ -718,59 +738,9 @@ class Node(_NodeBase):
 
             bool: If the op is impure or not.
         """
+        # Placeholders and outputs are always impure for DCE purposes
         if self.op in {"placeholder", "output"}:
             return True
-
-        if self.op == "call_function":
-            schema = getattr(self.target, "_schema", None)
-            if schema is not None and schema.is_mutable:
-                # impure since it mutates inputs
-                return True
-
-            if impure_random:
-                if getattr(self.target, "_nondeterministic_seeded", False):
-                    # impure since it mutates RNG state
-                    return True
-
-            # Handle Python random functions that don't have _nondeterministic_seeded
-            # but still affect global RNG state (issue #151524)
-            # These should be impure regardless of impure_random setting to maintain
-            # consistency between eager and compiled execution
-            _random_functions = {
-                torch.rand,
-                torch.randn,
-                torch.randint,
-                torch.randperm,
-                torch.rand_like,
-                torch.randn_like,
-                torch.randint_like,
-                torch.normal,
-                torch.poisson,
-                torch.bernoulli,
-                torch.multinomial,
-            }
-
-            if self.target in _random_functions:
-                # All random operations are impure to ensure consistent behavior
-                # between eager and compiled execution, regardless of generator usage
-                return True
-
-            if isinstance(self.target, torch._ops.HigherOrderOperator):
-                if self.target in (
-                    torch.ops.higher_order.auto_functionalized,
-                    torch.ops.higher_order.auto_functionalized_v2,
-                ):
-                    return self.args[0] in _side_effectful_functions
-
-            from torch._higher_order_ops.effects import _get_effect
-
-            if (
-                isinstance(self.target, torch._ops.OpOverload)
-                and _get_effect(self.target) is not None
-            ):
-                return True
-
-            return self.target in _side_effectful_functions
 
         # Check if an impure module.
         if self.op == "call_module":
@@ -786,6 +756,17 @@ class Node(_NodeBase):
             # because this function is used by graph.eliminate_dead_code,
             # and some users depend on current elimination behavior.
             return getattr(target_mod, "_is_impure", False)
+
+        # For call_function, delegate to the unified has_side_effects function
+        if self.op == "call_function":
+            from torch._library.utils import is_impure
+
+            return is_impure(
+                self.target,  # pyrefly: ignore[bad-argument-type]
+                args=self.args,
+                kwargs=self.kwargs,
+                impure_random=impure_random,
+            )
 
         return False
 


### PR DESCRIPTION
In torch.compile there are 2 places where DCE happens -- once in post-grad passes with a call to FX's `eliminate_dead_code`, and a second time where inductor's scheduler checks if a node `has_side_effects`. 

To prevent a node from being DCEd in FX's DCE, we can register `torch.fx.node.has_side_effect(op)`. However this does not propagate to inductor.

1. Fixes FX DCE such that if an operator is wrapped with auto_functionalize, then we check if the operator passed to auto_functionalized has side effects to determine if that call should be DCEd
2. Fixes inductor's FallbackKernel's has_side_effect function to also check if the operator is in FX's _side_effectful_fns. This way operators registered as having side effects through `torch.fx.node.has_side_effect` will show up
5. Update FX DCE to log what nodes have been DCEd. Inductor's nodes that are DCEd will show up in `TORCH_LOGS="+inductor"` logs with the prefix, `removed dead buffer: ...`
6. If an operator has side effects, marked through torch.library._register_effectful_op, this will also make sure FX's DCE does not DCE the operator.
a. Some additional changes needed to be made -- We mark all operators with ScriptObjects as inputs as being side effectful by default. However the above change causes an issue where if a graph contains a quantization op using a PackedParamsBase, then the op will not get DCEd, causing some unittest failures. So I marked some of the quantization ScriptObject classes as being not effectful.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo