### PR TITLE
enable port reuse option in tcp store

### DIFF
--- a/torch/csrc/distributed/c10d/socket.h
+++ b/torch/csrc/distributed/c10d/socket.h
@@ -51,11 +51,22 @@ class SocketOptions {
     return connect_backoff_;
   }
 
+  SocketOptions& reuse_port(bool value) noexcept {
+    reuse_port_ = value;
+    return *this;
+  }
+
+  bool reuse_port() const noexcept {
+    return reuse_port_;
+  }
+
+
  private:
   bool prefer_ipv6_ = true;
   std::chrono::milliseconds connect_timeout_{std::chrono::seconds{30}};
   std::shared_ptr<Backoff> connect_backoff_{
       std::make_shared<FixedBackoff>(std::chrono::milliseconds(1000))};
+  bool reuse_port_ = false;
 };
 
 class SocketImpl;


### PR DESCRIPTION
Hi,
We have following use case regarding setup tcp store in a distributed environment:
A orchestration node reserves an address and a port for master,  then share the master's address/port with others for them to setup tcp store.

The reason we want port reuse option is to avoid port conflict b/w port reservation in the orchestration node and actual port claiming by the master node, during which another process might grab the port. 

We can reserve the port with port reuse enabled in the orchestration node , and tcpstore can be created with this port later on. No port claiming could happen unless it's done with port reuse option again.

The flag defaults to false when creating tcp store, and is enabled only when explicitly set by user.


This PR is just the starting point of the series of this change, but just send it out early on to get some feedback on this idea.

Thanks.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci