### PR TITLE
Fix refcount bug in mode poping

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -5,6 +5,7 @@ import pickle
 import sys
 import tempfile
 import unittest
+import weakref
 from copy import deepcopy
 
 import torch

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -85,7 +85,7 @@ class TestPythonRegistration(TestCase):
             str(torch.rand(2))
 
         finally:
-            v_ref().__exit__()
+            v_ref().__exit__(None, None, None)
 
     def test_fallback(self) -> None:
         test_key = "TESTING_ONLY_GenericMode"

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1424,7 +1424,8 @@ static PyObject* pop_torch_dispatch_stack(
     auto mode = c10::impl::TorchDispatchModeTLS::pop_stack();
     r = mode->release();
   }
-  // No Py_INCREF needed - release() transfers ownership from SafePyObject to Python
+  // No Py_INCREF needed - release() transfers ownership from SafePyObject to
+  // Python
   return r;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1419,12 +1419,12 @@ static PyObject* pop_torch_dispatch_stack(
         c10::impl::to_string(mode_key.value()),
         ", but there wasn't one active.");
     auto mode = maybe_mode.value();
-    r = mode->ptr(getPyInterpreter());
+    r = mode->release();
   } else {
     auto mode = c10::impl::TorchDispatchModeTLS::pop_stack();
-    r = mode->ptr(getPyInterpreter());
+    r = mode->release();
   }
-  Py_INCREF(r);
+  // No Py_INCREF needed - release() transfers ownership from SafePyObject to Python
   return r;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1409,6 +1409,10 @@ static PyObject* pop_torch_dispatch_stack(
   HANDLE_TH_ERRORS
   std::optional<c10::impl::TorchDispatchModeKey> mode_key;
   PyObject* r = nullptr;
+  // Keep the mode alive until after Py_INCREF to prevent use-after-free.
+  // When the shared_ptr is destroyed, ~SafePyObject will Py_DECREF, so we must
+  // Py_INCREF first to give the caller a valid reference.
+  std::shared_ptr<c10::impl::PyObject_TorchDispatchMode> mode;
   if (maybe_mode_key != Py_None) {
     mode_key = py::cast<c10::impl::TorchDispatchModeKey>(maybe_mode_key);
     auto maybe_mode =
@@ -1418,14 +1422,17 @@ static PyObject* pop_torch_dispatch_stack(
         "Attempted to unset ",
         c10::impl::to_string(mode_key.value()),
         ", but there wasn't one active.");
-    auto mode = maybe_mode.value();
-    r = mode->release();
+    mode = maybe_mode.value();
   } else {
-    auto mode = c10::impl::TorchDispatchModeTLS::pop_stack();
-    r = mode->release();
+    mode = c10::impl::TorchDispatchModeTLS::pop_stack();
   }
-  // No Py_INCREF needed - release() transfers ownership from SafePyObject to
-  // Python
+  r = mode->ptr(getPyInterpreter());
+  // Increment refcount to give Python a reference. The SafePyObject destructor
+  // will decref when the shared_ptr is destroyed, so this balances out.
+  // Note: We cannot use release() here because the SafePyObject may be shared
+  // via ThreadLocalState copies, and release() would null out data_ causing
+  // other shared_ptr holders to see nullptr.
+  Py_INCREF(r);
   return r;
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
Fixes #165857

When the stack is the only owner of the python object, mode is the sole owner.
So when mode goes out of scope, the mode is destroyed, just before we incref it again!