### PR TITLE
[libtorch mps backend] Fix MPS backend when AT_PER_OPERATOR_HEADERS is not defined.

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -18,7 +18,6 @@
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
-#include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>

--- a/aten/src/ATen/native/mps/TensorFactory.cpp
+++ b/aten/src/ATen/native/mps/TensorFactory.cpp
@@ -15,8 +15,9 @@
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
-#endif
+#else
 #include <ATen/ops/_efficientzerotensor_native.h>
+#endif
 
 #include <utility>
 

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -4,10 +4,14 @@
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/mps/OperationUtils.h>
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/bitwise_and_native.h>
 #include <ATen/ops/bitwise_or_native.h>
 #include <ATen/ops/bitwise_xor_native.h>
 #include <ATen/ops/logical_not_native.h>
+#endif
 #include <fmt/format.h>
 
 namespace at::native {

--- a/aten/src/ATen/native/mps/operations/Blas.mm
+++ b/aten/src/ATen/native/mps/operations/Blas.mm
@@ -50,12 +50,13 @@ inline void dot_check(const Tensor& self, const Tensor& other) {
 }
 } // namespace mps
 
+
 Tensor dot_mps(const Tensor& self, const Tensor& other) {
   using namespace mps;
   using CachedGraph = MPSBinaryCachedGraph;
 
   if (self.numel() == 0 & other.numel() == 0) {
-    return zeros({}, self.options());
+    return at::zeros({}, self.options());
   }
 
   dot_check(self, other);

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -2,11 +2,17 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/ConvUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <fmt/format.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/_mps_convolution_native.h>
 #include <ATen/ops/_mps_convolution_transpose_native.h>
 #include <ATen/ops/mps_convolution_backward_native.h>
 #include <ATen/ops/mps_convolution_transpose_backward_native.h>
-#include <fmt/format.h>
+#endif
 
 namespace at::native {
 

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -3,6 +3,11 @@
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/_copy_from_and_resize_native.h>
 #include <ATen/ops/_copy_from_native.h>
 #include <ATen/ops/imag.h>
@@ -10,6 +15,7 @@
 #include <ATen/ops/real.h>
 #include <ATen/ops/view_as_real.h>
 #include <ATen/ops/zeros_like.h>
+#endif
 
 namespace at::native {
 namespace mps {

--- a/aten/src/ATen/native/mps/operations/Gamma.mm
+++ b/aten/src/ATen/native/mps/operations/Gamma.mm
@@ -5,9 +5,6 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <fmt/format.h>
 
-#include <ATen/ops/digamma_native.h>
-#include <ATen/ops/lgamma_native.h>
-#include <ATen/ops/polygamma_native.h>
 
 namespace at::native {
 namespace mps {
@@ -15,6 +12,15 @@ namespace mps {
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/Gamma_metallib.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/digamma_native.h>
+#include <ATen/ops/lgamma_native.h>
+#include <ATen/ops/polygamma_native.h>
+#endif
 #endif
 
 static id<MTLComputePipelineState> getCPLState(const Tensor& t1, const Tensor& t2, const std::string& fname) {

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -4,8 +4,14 @@
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/MPSGraphSequoiaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/linear_backward_native.h>
 #include <ATen/ops/linear_native.h>
+#endif
 
 namespace at::native {
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -856,7 +856,7 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 
         uint64_t elemInMatrix = resRows * resCols;
         // if largest supported batch size is zero, we need to split up the computation more
-        uint64_t largestSupportedBatchSize = floor(pow(2, 32) / elemInMatrix);
+        uint64_t largestSupportedBatchSize = std::floor(std::pow(2, 32) / elemInMatrix);
         bool tileEachMatmul = largestSupportedBatchSize == 0;
         uint64_t batchSize = largestSupportedBatchSize > 0 ? std::min(largestSupportedBatchSize, originalBatchSize) : 1;
         uint64_t lastBatchSize = originalBatchSize % batchSize;
@@ -864,7 +864,7 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
         uint64_t aRowsTiled = aRows;
         uint64_t resRowsTiled = resRows;
         if (tileEachMatmul) {
-          uint64_t maxNumRows = floor(pow(2, 32) / resCols);
+          uint64_t maxNumRows = std::floor(std::pow(2, 32) / resCols);
           aRowsTiled = std::min(uint64_t(512), maxNumRows);
           resRowsTiled = aRowsTiled;
         }
@@ -913,8 +913,8 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
           resDescLastTile_.preferPackedRows = true;
         }
 
-        uint64_t requiredIterations = ceil(float(originalBatchSize) / batchSize);
-        uint64_t requiredTileIterations = ceil(float(aRows) / aRowsTiled);
+        uint64_t requiredIterations = std::ceil(float(originalBatchSize) / batchSize);
+        uint64_t requiredTileIterations = std::ceil(float(aRows) / aRowsTiled);
         auto aDesc = aDesc_;
         auto bDesc = bDesc_;
         auto resDesc = resDesc_;
@@ -962,7 +962,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
 
   // Matmul not supported if any output dimension size is larger than 2**32
   for (auto elem : result.sizes()) {
-    TORCH_CHECK_NOT_IMPLEMENTED(elem <= pow(2, 32),
+    TORCH_CHECK_NOT_IMPLEMENTED(elem <= std::pow(2, 32),
                                 "Output dim sizes larger than 2**32 elements for matmul not supported on MPS device.");
   }
 
@@ -1001,7 +1001,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
 
   // Call tiled implementation if the number of elements exceeds 2^32
   uint64_t resultSize = batch1.size(0) * batch1.size(1) * batch2.size(2);
-  if (resultSize > pow(2, 32)) {
+  if (resultSize > std::pow(2, 32)) {
     result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;
   }
@@ -1160,11 +1160,11 @@ static void lu_unpack_mps_impl(const Tensor& LU_data,
   const auto batchSize = c10::multiply_integers(LU_data.sizes().begin(), LU_data.sizes().end() - 2);
 
   if (unpack_data) {
-    Tensor L_part = r < c ? slice(LU_data, -1, 0, k) : LU_data;
+    Tensor L_part = r < c ? at::slice(LU_data, -1, 0, k) : LU_data;
     L.copy_(L_part.tril());
     (ndim == 2 ? L.diagonal() : L.diagonal(0, -2, -1)).fill_(1);
 
-    Tensor U_part = r < c ? LU_data : slice(LU_data, -2, 0, k);
+    Tensor U_part = r < c ? LU_data : at::slice(LU_data, -2, 0, k);
     U.copy_(U_part.triu());
   }
 

--- a/aten/src/ATen/native/mps/operations/PixelShuffle.mm
+++ b/aten/src/ATen/native/mps/operations/PixelShuffle.mm
@@ -1,7 +1,13 @@
 #include <ATen/native/PixelShuffle.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/pixel_shuffle_native.h>
 #include <ATen/ops/pixel_unshuffle_native.h>
+#endif
 
 using namespace at::mps;
 

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -5,9 +5,13 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/RangeUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/arange_native.h>
 #include <ATen/ops/linspace_native.h>
 #include <ATen/ops/range_native.h>
+#endif
 #include <cmath>
 #include <limits>
 

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -5,9 +5,6 @@
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/Repeat.h>
 #include <ATen/native/mps/OperationUtils.h>
-#include <ATen/ops/permute_native.h>
-#include <ATen/ops/repeat_interleave_native.h>
-#include <ATen/ops/repeat_native.h>
 #include <fmt/format.h>
 
 namespace at::native {
@@ -89,6 +86,15 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
 static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/Repeat_metallib.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/permute_native.h>
+#include <ATen/ops/repeat_interleave_native.h>
+#include <ATen/ops/repeat_native.h>
+#endif
 #endif
 
 Tensor repeat_interleave_mps(const Tensor& repeat, std::optional<int64_t> output_size) {

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -5,8 +5,14 @@
 #include <ATen/native/RNN.h>
 #include <ATen/native/TypeProperties.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/_lstm_mps_native.h>
 #include <ATen/ops/lstm_mps_backward_native.h>
+#endif
 #import <MetalPerformanceShadersGraph/MPSGraphRNNOps.h>
 
 namespace at::native {

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -3,7 +3,13 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/_local_scalar_dense_native.h>
+#endif
 
 using namespace at::mps;
 

--- a/aten/src/ATen/native/mps/operations/SummaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/SummaryOps.mm
@@ -1,7 +1,13 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
 #include <ATen/ops/bincount_native.h>
+#endif
 namespace at::native {
 
 static Tensor& bincount_mps_impl(const Tensor& self, const Tensor& weights, Tensor& output) {

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -300,10 +300,10 @@ static void isin_Tensor_Tensor_out_mps(const Tensor& elements,
 
   if (test_elements.numel() == 0) {
     if (invert) {
-      auto ones = ones_like(out);
+      auto ones = ones_like(out, std::optional<at::ScalarType>{});
       out.copy_(ones);
     } else {
-      auto zeros = zeros_like(out);
+      auto zeros = zeros_like(out, std::optional<at::ScalarType>{});
       out.copy_(zeros);
     }
     return;

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -319,13 +319,13 @@ std::tuple<Tensor, Tensor, Tensor> _unique2_mps(const Tensor& self,
 static Tensor lexsort_rows_perm_mps(const Tensor& mat_2d) {
   const auto rows = mat_2d.size(0), cols = mat_2d.size(1);
   if (rows <= 1 || cols == 0) {
-    return arange(rows, mat_2d.options().dtype(kLong));
+    return at::arange(rows, mat_2d.options().dtype(kLong));
   }
 
-  auto perm = arange(rows, mat_2d.options().dtype(kLong));
+  auto perm = at::arange(rows, mat_2d.options().dtype(kLong));
   for (auto c = cols - 1; c >= 0; --c) {
     auto keys = mat_2d.select(1, c).index_select(0, perm);
-    const auto idx = argsort(keys, /*dim=*/0, /*descending=*/false);
+    const auto idx = at::argsort(keys, /*dim=*/0, /*descending=*/false);
     perm = perm.index_select(0, idx);
   }
   return perm;
@@ -379,7 +379,7 @@ static std::tuple<Tensor, Tensor, Tensor> unique_dim_sorted_mps_impl(const Tenso
   Tensor counts = empty({0}, self.options().dtype(kLong));
   if (return_counts) {
     const auto num_unique = unique_pos.size(0);
-    counts = zeros({num_unique}, self.options().dtype(kLong));
+    counts = at::zeros({num_unique}, self.options().dtype(kLong));
     counts.scatter_add_(0, group_id, ones_like(group_id, group_id.options().dtype(kLong)));
   }
 


### PR DESCRIPTION
Summary:
With this change the MPS backend respects the preprocessor flag AT_PER_OPERATOR_HEADERS. 

This diff is not only changing which headers are included depending on the flag, I had to slightly modify source code in the implementation because of newly introduced ambiguity between different namespace.
- sometime I had to prefix the method with at::
- sometime I had to give an explicit argument to remove some ambiguity in overload choice between at and native namespace.

This diff solves compilation issue on my setup, my I am unsure I choose the right overload in every above case when needed to disambiguate. Another pair of eyes on those will be welcomed.

Test Plan: I believe compilation CI should detect any issue with the diff.

Differential Revision: D87846163


