### PR TITLE
[cuDNN] Leak `BenchmarkCache` to avoid teardown segfault, correct compile-time cuDNN version to 9.10.2 in CI

### DIFF
--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -129,7 +129,7 @@ function install_129 {
 }
 
 function install_128 {
-  CUDNN_VERSION=9.8.0.87
+  CUDNN_VERSION=9.10.2.21
   echo "Installing CUDA 12.8.1 and cuDNN ${CUDNN_VERSION} and NVSHMEM and NCCL and cuSparseLt-0.7.1"
   # install CUDA 12.8.1 in the same container
   install_cuda 12.8.1 cuda_12.8.1_570.124.06_linux

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -363,6 +363,7 @@ BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>* _get_benchm
   static thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>
     *benchmark_cache_fused = new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
   return benchmark_cache_fused;
+}
 } // namespace
 
 void run_conv_plan(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -350,11 +350,19 @@ struct BenchmarkCache {
 // @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
 // be thread safe across all engines see Limitations in
 // https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
-thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>
-    benchmark_cache;
-thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>
-    benchmark_cache_fused;
+//
+// We also leak them due to apparent teardown segfaults observed since cuDNN
+// version 9.10+
+BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>* _get_benchmark_cache() {
+  static thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>
+    *benchmark_cache = new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>();
+  return benchmark_cache;
+}
 
+BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>* _get_benchmark_cache_fused() {
+  static thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>
+    *benchmark_cache_fused = new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
+  return benchmark_cache_fused;
 } // namespace
 
 void run_conv_plan(
@@ -876,7 +884,7 @@ void try_plans(
   for (auto& plan : plans) {
     try {
       run_conv_plan(handle, x, y, w, plan, operation);
-      benchmark_cache.update(key, plan);
+      _get_benchmark_cache()->update(key, plan);
       return;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -900,7 +908,7 @@ void try_plans_fused(
   for (auto& plan : plans) {
     try {
       run_conv_plan_fused(handle, x, y, w, z, b, plan);
-      benchmark_cache_fused.update(key, plan);
+      _get_benchmark_cache_fused()->update(key, plan);
       return;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -931,7 +939,7 @@ bool try_configs(
         continue;
       }
       run_conv_plan(handle, x, y, w, plan, operation);
-      benchmark_cache.update(key, plan);
+      _get_benchmark_cache()->update(key, plan);
       return true;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -962,7 +970,7 @@ bool try_configs_fused(
         continue;
       }
       run_conv_plan_fused(handle, x, y, w, z, b, plan);
-      benchmark_cache_fused.update(key, plan);
+      _get_benchmark_cache_fused()->update(key, plan);
       return true;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -998,7 +1006,7 @@ void run_single_conv(
       deterministic,
       allow_tf32);
   // TODO: is this thread safe if cache is updated? is pointer stale?
-  auto search = benchmark_cache.find(key);
+  auto search = _get_benchmark_cache()->find(key);
   if (search) {
     try {
       run_conv_plan(handle, x, y, w, *search, operation);
@@ -1098,7 +1106,7 @@ void run_fused_conv(
       groups,
       deterministic,
       allow_tf32);
-  auto search = benchmark_cache_fused.find(key);
+  auto search = _get_benchmark_cache_fused()->find(key);
   if (search) {
     try {
       run_conv_plan_fused(handle, x, y, w, z, b, *search);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -353,15 +353,21 @@ struct BenchmarkCache {
 //
 // We also leak them due to apparent teardown segfaults observed since cuDNN
 // version 9.10+
-BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>* _get_benchmark_cache() {
-  static thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>
-    *benchmark_cache = new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>();
+BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>*
+_get_benchmark_cache() {
+  static thread_local BenchmarkCache<
+      cudnn_frontend::ExecutionPlan,
+      CacheKeyWrapper> *benchmark_cache =
+      new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>();
   return benchmark_cache;
 }
 
-BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>* _get_benchmark_cache_fused() {
-  static thread_local BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>
-    *benchmark_cache_fused = new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
+BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>*
+_get_benchmark_cache_fused() {
+  static thread_local BenchmarkCache<
+      cudnn_frontend::ExecutionPlan,
+      CacheKeyFusedWrapper> *benchmark_cache_fused =
+      new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
   return benchmark_cache_fused;
 }
 } // namespace

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -357,7 +357,7 @@ BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>*
 _get_benchmark_cache() {
   static thread_local BenchmarkCache<
       cudnn_frontend::ExecutionPlan,
-      CacheKeyWrapper> *benchmark_cache =
+      CacheKeyWrapper>* benchmark_cache =
       new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyWrapper>();
   return benchmark_cache;
 }
@@ -366,7 +366,7 @@ BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>*
 _get_benchmark_cache_fused() {
   static thread_local BenchmarkCache<
       cudnn_frontend::ExecutionPlan,
-      CacheKeyFusedWrapper> *benchmark_cache_fused =
+      CacheKeyFusedWrapper>* benchmark_cache_fused =
       new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
   return benchmark_cache_fused;
 }


### PR DESCRIPTION
Apparent segfaults observed since 9.10.0 (thanks @nWEIdia for obtaining the stack trace!) seem to be due to teardown of `ExecutionPlan` objects in the benchmark cache, we attempt to workaround this by leaking the `BenchmarkCache` at teardown. The backend version of cuDNN in CI in the 12.8 build is also upgraded as a litmus test to verify that this change works.

cc @csarofeen @ptrblck @xwang233 @nWEIdia