### PR TITLE
Fix for #136012

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5969,6 +5969,19 @@ class CommonTemplate:
         if self.device != "cpu":
             assertGeneratedKernelCountEqual(self, 1)
 
+    def test_no_redundant_assignment(self):
+        def fn(x):
+            return x + 2
+
+        args = [torch.rand([4]).to(dtype=torch.complex64)]
+        expected = fn(*args)
+        fn = torch.compile(fn, fullgraph=True)
+        result, (source_code,) = run_and_get_code(fn, *args)
+        self.assertEqual(result, expected)
+        if "async_compile.multi_kernel" in source_code:
+            return
+        self.assertEqual(source_code.count("buf1 = buf0"), 0)
+
     def test_complex_from_real_imag(self):
         def fn(x, y):
             return aten.complex.default(x, y)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8109,12 +8109,12 @@ class FallbackKernel(ExternKernelAlloc):
             )
         else:
             wrapper.generate_fallback_kernel(self)
-            if isinstance(self.layout, Layout):
-                self.codegen_size_asserts(wrapper)
-                self.codegen_alignment_asserts(wrapper)
-                self.codegen_memory_tracking(wrapper)
 
         self.codegen_unbacked_symbol_defs(wrapper)
+        if not self.use_runtime_dispatch and isinstance(self.layout, Layout):
+            self.codegen_size_asserts(wrapper)
+            self.codegen_alignment_asserts(wrapper)
+            self.codegen_memory_tracking(wrapper)
 
     @staticmethod
     def tensor_to_layout(output: torch.Tensor) -> FixedLayout:
@@ -8218,6 +8218,14 @@ class FallbackKernel(ExternKernelAlloc):
                 return None
 
         outputs = generate_output(example_output, [])
+        #handle single output case
+        if (isinstance(outputs, MultiOutput)
+                and len(outputs.inputs) == 1 and
+                outputs.inputs[0] is packed and
+                not outputs.indices):
+            packed.layout = outputs.layout
+            packed.outputs = [packed]
+            return packed
         if isinstance(outputs, (list, tuple)):
             packed.outputs = outputs
         elif isinstance(outputs, dict):


### PR DESCRIPTION
Fixes redundant assignment issue while wrapping single output with MultiOutputLayout. Broke test_custom_op_unbacked_symints_cuda, included fix for the same.

Fixes https://github.com/pytorch/pytorch/issues/136012 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo