### PR TITLE
[fx] Fix Node.type pickling

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -796,6 +796,21 @@ class TestFX(JitTestCase):
             self.assertTrue(node.stack_trace is not None)
             assert "test_fx.py" in node.stack_trace
 
+    def test_node_pickle_type_preservation(self):
+        g = Graph()
+        n = g.placeholder("x")
+        n.type = torch.Tensor
+
+        dumped_node = pickle.dumps(n)
+        restored_node = pickle.loads(dumped_node)
+        self.assertEqual(restored_node.type, torch.Tensor)
+        self.assertNotEqual(restored_node.type, restored_node.target)
+
+        dumped_graph = pickle.dumps(g)
+        restored_graph = pickle.loads(dumped_graph)
+        restored_n = next(iter(restored_graph.nodes))
+        self.assertEqual(restored_n.type, torch.Tensor)
+
     def test_lineno_map(self):
         class M(torch.nn.Module):
             def forward(self, a, b):

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -359,7 +359,7 @@ class Node(_NodeBase):
             "name": self.name,
             "op": self.op,
             "target": self.target,
-            "type": self.target,
+            "type": self.type,
             "_sort_key": self._sort_key,
             "_args": self._args,
             "_kwargs": self._kwargs,


### PR DESCRIPTION
Fix `Node.__getstate__` so `type` is serialized correctly (it was storing `target`). Standard pickle of Node/Graph now preserves `type`.

Test: pickle round-trip for Node/Graph keeps `type`.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv