### PR TITLE
[fsdp2] fix split_with_sizes_copy() missing argument: 'dim'

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -203,7 +203,8 @@ lib.define(
 def split_with_sizes_copy(
     all_gather_output: torch.Tensor,
     all_gather_input_split_sizes: list[int],
-    dim: int,
+    dim: int = 0,
+    *,
     out: list[torch.Tensor],
 ) -> None:
     torch.split_with_sizes_copy(


### PR DESCRIPTION
if call fsdp.split_with_sizes_copy with argument 'dim=0' will report TypeError: split_with_sizes_copy() missing 1 required positional argument: 'dim'.

test case:
```python
import torch
from torch.distributed.fsdp._fully_shard import *


input = torch.randn(6, 3)
all_gather_input_split_sizes = [1, 2, 3]
out_a = torch.empty([1, 3])
out_b = torch.empty([2, 3])
out_c = torch.empty([3, 3])
out = [out_a, out_b, out_c]
torch.ops.fsdp.split_with_sizes_copy(input, all_gather_input_split_sizes, 0, out=out)
```

root cause: impl of split_with_sizes_copy doesn't match schema


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci