### PR TITLE
[xpu][fix] Fix OneDNN deconv when using output_padding

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -615,6 +615,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
             weight_,
             stride_,
             padding_,
+            output_padding_,
             dilation_,
             groups_,
             output_mask[2]);
@@ -646,6 +647,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
             input_,
             stride_,
             padding_,
+            output_padding_,
             dilation_,
             groups_);
       } else {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -88,6 +88,27 @@ dnnl::memory::dims compatible_dilation(Vec&& dilation) {
   return ret;
 }
 
+inline std::vector<int64_t> padding_r(
+    IntArrayRef padding, IntArrayRef output_padding)
+{
+  // ConvTranspose padding adjustment
+  //
+  // PyTorch uses padding/output_padding:
+  //   osize = (isize - 1) * stride - 2 * padding + dilation * (kernel_size - 1) + output_padding + 1
+  //
+  // MKLDNN uses padding_l/padding_r:
+  //   osize = (isize - 1) * stride - padding_l - padding_r + dilation * (kernel_size - 1) + 1
+  //
+  // So: padding_l = padding, padding_r = padding - output_padding
+  //
+  auto dim = padding.size();
+  std::vector<int64_t> pad_r(dim);
+  for (const auto d : c10::irange(dim)) {
+    pad_r[d] = padding[d] - output_padding[d];
+  }
+  return pad_r;
+}
+
 template <typename T>
 dnnl::memory dnnl_memory_from_host_scalar(
     T host_value,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -89,15 +89,17 @@ dnnl::memory::dims compatible_dilation(Vec&& dilation) {
 }
 
 inline std::vector<int64_t> padding_r(
-    IntArrayRef padding, IntArrayRef output_padding)
-{
+    IntArrayRef padding,
+    IntArrayRef output_padding) {
   // ConvTranspose padding adjustment
   //
   // PyTorch uses padding/output_padding:
-  //   osize = (isize - 1) * stride - 2 * padding + dilation * (kernel_size - 1) + output_padding + 1
+  //   osize = (isize - 1) * stride - 2 * padding + dilation * (kernel_size - 1)
+  //   + output_padding + 1
   //
   // MKLDNN uses padding_l/padding_r:
-  //   osize = (isize - 1) * stride - padding_l - padding_r + dilation * (kernel_size - 1) + 1
+  //   osize = (isize - 1) * stride - padding_l - padding_r + dilation *
+  //   (kernel_size - 1) + 1
   //
   // So: padding_l = padding, padding_r = padding - output_padding
   //

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
@@ -74,6 +74,7 @@ TORCH_API sycl::event deconvolution_backward_data(
     const at::Tensor& weight,
     IntArrayRef stride,
     IntArrayRef padding,
+    IntArrayRef dst_padding,
     IntArrayRef dilation,
     int64_t groups,
     bool bias_defined,
@@ -86,6 +87,7 @@ TORCH_API sycl::event deconvolution_backward_weights(
     const at::Tensor& src,
     IntArrayRef stride,
     IntArrayRef padding,
+    IntArrayRef dst_padding,
     IntArrayRef dilation,
     int64_t groups,
     const std::vector<sycl::event>& deps = {});

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -297,10 +297,6 @@ inductor_expected_failures_single_sample["xpu"] = {
     ("linalg.pinv", "singular"): {f64},
     # could not create a primitive
     "addmv": {f64},
-    # could not create a primitive descriptor for
-    # a deconvolution forward propagation primitive
-    "nn.functional.conv_transpose2d": {f32, f64},
-    "nn.functional.conv_transpose3d": {f32, f64},
     # [Begin] Incorrect XPU reference due to new driver.
     "masked.prod": {b8, i32, i64},
     "masked.amin": {i64},


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/1898. The output padding was not used. This PR takes this parameter into account.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo