### PR TITLE
Fix test_exclude_padding on H100 GPUs

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -423,7 +423,10 @@ class PadMMTest(TestCase):
         def mm(a, b):
             return a @ b
 
-        mm(torch.rand([25, 25], device=GPU_TYPE), torch.rand([25, 25], device=GPU_TYPE))
+        # Size must be big enough such that `is_mm_compute_bound` returns True and we need padding to 4 elements
+        # machine balance is ~8.3 (A100), 14.1 (H100), size must be 3x that, see arithmetic_intensity for M=N=K
+        size = [61, 61]
+        mm(torch.rand(size, device=GPU_TYPE), torch.rand(size, device=GPU_TYPE))
         local_cache = get_pad_cache().get_local_cache()
         self.assertTrue(len(local_cache) == 2)
         FileCheck().check_count("exclude_pad:False", 2, exactly=True).run(
@@ -434,7 +437,7 @@ class PadMMTest(TestCase):
         def mm(a, b):
             return (a + 1) @ b
 
-        mm(torch.rand([25, 25], device=GPU_TYPE), torch.rand([25, 25], device=GPU_TYPE))
+        mm(torch.rand(size, device=GPU_TYPE), torch.rand(size, device=GPU_TYPE))
         local_cache = get_pad_cache().get_local_cache()
         # reuse original base timing
         self.assertTrue(len(local_cache) == 3)

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -428,7 +428,7 @@ class PadMMTest(TestCase):
         size = [61, 61]
         mm(torch.rand(size, device=GPU_TYPE), torch.rand(size, device=GPU_TYPE))
         local_cache = get_pad_cache().get_local_cache()
-        self.assertTrue(len(local_cache) == 2)
+        self.assertEqual(len(local_cache), 2)
         FileCheck().check_count("exclude_pad:False", 2, exactly=True).run(
             repr(local_cache)
         )
@@ -440,7 +440,7 @@ class PadMMTest(TestCase):
         mm(torch.rand(size, device=GPU_TYPE), torch.rand(size, device=GPU_TYPE))
         local_cache = get_pad_cache().get_local_cache()
         # reuse original base timing
-        self.assertTrue(len(local_cache) == 3)
+        self.assertEqual(len(local_cache), 3)
 
         FileCheck().check_count("exclude_pad:False", 3, exactly=True).run(
             repr(local_cache)


### PR DESCRIPTION
The test relies on compute-bound MM ops.
For H100 we get:
`arithmetic_intensity(25) = 8.333333333333334` and `machine_balance = 14.08672917417959` So `is_mm_compute_bound` returns `False` and `_should_pad_bench` exits with `False`.

So we get this failure due to no cache entries:
```
  File "/pytorch-v2.9.0/test/inductor/test_pad_mm.py", line 435, in test_exclude_padding
    self.assertTrue(len(local_cache) == 2)
AssertionError: False is not true
```
BTW: Why is `assertTrue` used instead of `assertEqual`?

Change size to 61 which is bigger than 3x 14.1 and not a multiple of 4, requiring padding.

The number I choose was:
- 8.3 worked before
- 14.1 works now
- Extrapolate 1 step so it doesn't easily break again -> 19.9
- `arithmetic_intensity` must be bigger than that, i.e. `3*19.9 = 60`, and not a multiple of 4 to require padding at all -> 61




cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo