### PR TITLE
Higher tolerance for botnet on XPU

### DIFF
--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -71,6 +71,10 @@ REQUIRE_HIGHER_TOLERANCE = {
     "mobilenetv3_large_100",
 }
 
+REQUIRE_HIGHER_TOLERANCE_FP16_XPU = {
+    "botnet26t_256",
+}
+
 REQUIRE_HIGHER_TOLERANCE_AMP = {}
 
 REQUIRE_EVEN_HIGHER_TOLERANCE = {
@@ -364,6 +368,12 @@ class TimmRunner(BenchmarkRunner):
                 tolerance = 8 * 1e-2
             elif name in REQUIRE_HIGHER_TOLERANCE or (
                 self.args.amp and name in REQUIRE_HIGHER_TOLERANCE_AMP
+            ):
+                tolerance = 4 * 1e-2
+            elif (
+                name in REQUIRE_HIGHER_TOLERANCE_FP16_XPU
+                and self.args.float16
+                and current_device == "xpu"
             ):
                 tolerance = 4 * 1e-2
             else:


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/1305

Increasing tolerance for botnet26t_256

Analysis showed that this is due to noise on batch_norm. 
In compile we use batch_norm decomposition, if we disable this decomposition - we get results within tolerance. With decomposition enabled, each batch norm's result rmse is ~ 1e-5 which is ulp of float16. This error accumulates and causes bigger differences towards end of the iteration.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo