### PR TITLE
Avoid std::tie and returning value constructions in qconv_unpack.cpp

### DIFF
--- a/aten/src/ATen/native/quantized/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/qconv_unpack.cpp
@@ -82,32 +82,32 @@ class QConv1dUnpackWeightsInt8 final {
   static std::tuple<at::Tensor, std::optional<at::Tensor>> run(
       const c10::intrusive_ptr<ConvPackedParamsBase<2>>& packed_weight) {
     auto& ctx = at::globalContext();
-    at::Tensor weight;
-    std::optional<at::Tensor> bias;
 #ifdef USE_FBGEMM
     if (ctx.qEngine() == at::QEngine::FBGEMM ||
         ctx.qEngine() == at::QEngine::X86) {
-      std::tie(weight, bias) = packed_weight->unpack();
-      weight = weight.squeeze_(quant_utils::kConv1dSqueezeDim + 2);
-      return std::tuple<at::Tensor, std::optional<at::Tensor>>(weight, bias);
+      auto result = packed_weight->unpack();
+      auto& weight = std::get<0>(result);
+      weight = weight.squeeze(quant_utils::kConv1dSqueezeDim + 2);
+      return result;
     }
 #endif
 
 #ifdef USE_PYTORCH_QNNPACK
     if (ctx.qEngine() == at::QEngine::QNNPACK) {
-      std::tie(weight, bias) = packed_weight->unpack();
-      at::Tensor new_weight = weight.clone();
-      new_weight = new_weight.squeeze_(quant_utils::kConv1dSqueezeDim + 2);
-      return std::tuple<at::Tensor, std::optional<at::Tensor>>(new_weight, bias);
+      auto result = packed_weight->unpack();
+      auto& weight = std::get<0>(result);
+      weight = weight.clone().squeeze(quant_utils::kConv1dSqueezeDim + 2);
+      return result;
     }
 #endif
 
 #if AT_MKLDNN_ENABLED()
     if (ctx.qEngine() == at::QEngine::ONEDNN) {
-      std::tie(weight, bias) = packed_weight->unpack();
-      at::Tensor new_weight = weight.clone();
-      new_weight.squeeze_(quant_utils::kConv1dSqueezeDim + 2);
-      return std::tuple<at::Tensor, std::optional<at::Tensor>>(new_weight, bias);
+      // PackedConvWeightsOnednn::unpack() already returns a cloned weight.
+      auto result = packed_weight->unpack();
+      auto& weight = std::get<0>(result);
+      weight = weight.squeeze(quant_utils::kConv1dSqueezeDim + 2);
+      return result;
     }
 #endif
 


### PR DESCRIPTION
This PR avoids returning value construction in `qconv_unpack.cpp`.


cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel