### PR TITLE
Fix computation of NVRTC library hash

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -141,7 +141,7 @@ set(CUDA_NVRTC_LIB "${CUDA_nvrtc_LIBRARY}" CACHE FILEPATH "")
 if(CUDA_NVRTC_LIB AND NOT CUDA_NVRTC_SHORTHASH)
   find_package(Python COMPONENTS Interpreter)
   execute_process(
-    COMMAND Python::Interpreter -c
+    COMMAND "${Python_EXECUTABLE}" -c
     "import hashlib;hash=hashlib.sha256();hash.update(open('${CUDA_NVRTC_LIB}','rb').read());print(hash.hexdigest()[:8])"
     RESULT_VARIABLE _retval
     OUTPUT_VARIABLE CUDA_NVRTC_SHORTHASH)


### PR DESCRIPTION
CMake `execute_process` does not resolve targets so it tries to execute the target name as an executable which does not exist. Hence it always fails.

See https://gitlab.kitware.com/cmake/cmake/-/issues/18364

Use the variable set by the FindPython module instead.


