### PR TITLE
[ROCm][CI] Use hash for download-artifact action instead of tag

### DIFF
--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -37,7 +37,7 @@ jobs:
       pytorch-linux-jammy-rocm-n-py3-benchmarks: ${{ steps.process-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3-benchmarks }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           run-id: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
           path: ./docker-builds-artifacts

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -37,7 +37,7 @@ jobs:
       pytorch-linux-jammy-rocm-n-py3-benchmarks: ${{ steps.process-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3-benchmarks }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e #4.1.7
         with:
           run-id: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
           path: ./docker-builds-artifacts


### PR DESCRIPTION
Security-related update

Hash chosen from https://github.com/actions/download-artifact/tree/v4.1.7

Related to https://github.com/pytorch/pytorch/issues/169033

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang