### PR TITLE
Refactor: Remove redundant ConstantVariable wrapping in raise_observed_exception #168291

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -701,7 +701,7 @@ class BuiltinVariable(VariableTracker):
                 raise_observed_exception(
                     type(exc),
                     tx,
-                    args=list(map(ConstantVariable.create, exc.args)),
+                    args=list(exc.args),
                 )
 
         list_like_expansion_handlers: list[
@@ -729,7 +729,7 @@ class BuiltinVariable(VariableTracker):
                     raise_observed_exception(
                         type(exc),
                         tx,
-                        args=list(map(ConstantVariable.create, exc.args)),
+                        args=list(exc.args),
                     )
 
             result: list[
@@ -1142,7 +1142,7 @@ class BuiltinVariable(VariableTracker):
                         raise_observed_exception(
                             type(exc),
                             tx,
-                            args=list(map(ConstantVariable.create, exc.args)),
+                            args=list(exc.args),
                         )
                     except AsPythonConstantNotImplementedError as exc:
                         unimplemented(
@@ -1183,7 +1183,7 @@ class BuiltinVariable(VariableTracker):
                             raise_observed_exception(
                                 type(exc),
                                 tx,
-                                args=list(map(ConstantVariable.create, exc.args)),
+                                args=list(exc.args),
                             )
                         # pyrefly: ignore [unbound-name]
                         return VariableTracker.build(tx, res)

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -218,7 +218,7 @@ its type to `common_constant_types`.
                     raise_observed_exception(
                         type(exc),
                         tx,
-                        args=list(map(ConstantVariable.create, exc.args)),
+                        args=list(exc.args),
                     )
             if (
                 hasattr(operator, name)
@@ -240,7 +240,7 @@ its type to `common_constant_types`.
                         return ConstantVariable.create(op(self.value, add_target))
                     except Exception as e:
                         raise_observed_exception(
-                            type(e), tx, args=list(map(ConstantVariable.create, e.args))
+                            type(e), tx, args=list(e.args)
                         )
         elif isinstance(self.value, bytes) and name == "decode":
             method = getattr(self.value, name)
@@ -263,7 +263,7 @@ its type to `common_constant_types`.
                 )
             except Exception as e:
                 raise_observed_exception(
-                    type(e), tx, args=list(map(ConstantVariable.create, e.args))
+                    type(e), tx, args=list(e.args)
                 )
         elif name == "__contains__" and len(args) == 1 and args[0].is_python_constant():
             assert not kwargs
@@ -274,7 +274,7 @@ its type to `common_constant_types`.
                 return ConstantVariable.create(result)
             except TypeError as e:
                 raise_observed_exception(
-                    type(e), tx, args=list(map(ConstantVariable.create, e.args))
+                    type(e), tx, args=list(e.args)
                 )
         return super().call_method(tx, name, args, kwargs)
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -73,7 +73,7 @@ def raise_unhashable(
     raise_observed_exception(
         TypeError,
         tx,
-        args=[ConstantVariable(f"unhashable type: {type(arg.realize())}")],
+        args=[f"unhashable type: {type(arg.realize())}"],
     )
 
 
@@ -650,8 +650,7 @@ class ConstDictVariable(VariableTracker):
                 raise_args_mismatch(tx, name)
 
             if not self.items:
-                msg = ConstantVariable.create("popitem(): dictionary is empty")
-                raise_observed_exception(KeyError, tx, args=[msg])
+                raise_observed_exception(KeyError, tx, args=["popitem(): dictionary is empty"])
 
             if self.user_cls is collections.OrderedDict and (
                 len(args) == 1 or "last" in kwargs

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2241,7 +2241,7 @@ class CollectionsNamedTupleFunction(UserFunctionVariable):
                 raise_observed_exception(
                     type(exc),
                     tx,
-                    args=list(map(ConstantVariable.create, exc.args)),
+                    args=list(exc.args),
                 )
             return variables.UserDefinedClassVariable(
                 # pyrefly: ignore[unbound-name]

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -211,9 +211,8 @@ def bind_args_cached(
                 TypeError,
                 tx,
                 args=[
-                    ConstantVariable.create(
                         f"Missing required positional argument: {name}"
-                    )
+
                 ],
             )
 
@@ -226,9 +225,7 @@ def bind_args_cached(
             TypeError,
             tx,
             args=[
-                ConstantVariable.create(
                     f"Too many positional arguments: got {len(args)}, expected {len(spec.all_pos_names)}"
-                )
             ],
         )
 
@@ -246,9 +243,7 @@ def bind_args_cached(
                 TypeError,
                 tx,
                 args=[
-                    ConstantVariable.create(
                         f"Missing required keyword-only argument: {name}"
-                    )
                 ],
             )
 
@@ -260,7 +255,7 @@ def bind_args_cached(
             TypeError,
             tx,
             args=[
-                ConstantVariable.create(f"Unexpected keyword arguments: {list(rem_kw)}")
+                f"Unexpected keyword arguments: {list(rem_kw)}"
             ],
         )
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -468,7 +468,7 @@ class ExceptionVariable(VariableTracker):
         val: VariableTracker,
     ):
         def raise_error(msg):
-            raise_observed_exception(TypeError, tx, args=[ConstantVariable(msg)])
+            raise_observed_exception(TypeError, tx, args=[msg])
 
         name = name_var.as_python_constant()
         if name == "__context__":

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1460,7 +1460,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 raise_observed_exception(
                     type(exc),
                     tx,
-                    args=list(map(ConstantVariable.create, exc.args)),
+                    args=list(exc.args),
                 )
 
         if self.is_tensor_method():


### PR DESCRIPTION
Fixes #168291
This PR addresses unnecessary argument wrapping when calling `raise_observed_exception` across the `torch._dynamo` module.

Currently, exception messages (which are constant strings/f-strings) are explicitly wrapped using `ConstantVariable.create()`  before being passed in the `args` list. This wrapping is redundant, as `raise_observed_exception` can accept Python objects directly.

### 💡 Why This Change?

1.  **Improved Readability:** Removing the wrapper significantly cleans up the `Developer debug context` output, making it easier to read error reports.
2.  **Code Simplification:** Removes boilerplate code at many call sites across the Dynamo codebase.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo