### PR TITLE
Fix clang-tidy warnings on c10/xpu files

### DIFF
--- a/c10/xpu/XPUException.h
+++ b/c10/xpu/XPUException.h
@@ -5,18 +5,19 @@
 
 namespace c10::xpu {
 
-static inline sycl::async_handler asyncHandler = [](sycl::exception_list el) {
-  if (el.size() == 0) {
-    return;
-  }
-  for (const auto& e : el) {
-    try {
-      std::rethrow_exception(e);
-    } catch (sycl::exception& e) {
-      TORCH_WARN("SYCL Exception: ", e.what());
-    }
-  }
-  throw;
-};
+static inline sycl::async_handler asyncHandler =
+    [](const sycl::exception_list& el) {
+      if (el.size() == 0) {
+        return;
+      }
+      for (const auto& e : el) {
+        try {
+          std::rethrow_exception(e);
+        } catch (sycl::exception& e) {
+          TORCH_WARN("SYCL Exception: ", e.what());
+        }
+      }
+      throw;
+    };
 
 } // namespace c10::xpu

--- a/c10/xpu/XPUStream.cpp
+++ b/c10/xpu/XPUStream.cpp
@@ -5,7 +5,6 @@
 
 #include <atomic>
 #include <deque>
-#include <mutex>
 #include <vector>
 
 namespace c10::xpu {
@@ -30,6 +29,7 @@ std::deque<
     std::array<std::atomic<uint32_t>, max_compile_time_stream_priorities>>
     priority_counters;
 
+// NOLINTNEXTLINE(*c-arrays)
 thread_local std::unique_ptr<StreamId[]> current_streams = nullptr;
 
 /*
@@ -174,6 +174,7 @@ void initXPUStreamsOnce() {
   // Inits current streams (thread local) to the last queue in the "normal
   // priority" queue pool. Note: the queue pool have not been initialized yet.
   // It will be initialized in initDeviceStreamState for the specified device.
+  // NOLINTNEXTLINE(*c-arrays)
   current_streams = std::make_unique<StreamId[]>(num_gpus);
   for (const auto i : c10::irange(num_gpus)) {
     // Assigning the current stream to the last one in the pool can be
@@ -238,9 +239,11 @@ sycl::queue& XPUStream::queue() const {
   switch (st) {
     case StreamIdType::NORMAL:
     case StreamIdType::HIGH:
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
       return *streams[device_index][static_cast<uint8_t>(st)][si];
     // See Note [External XPU Stream]
     case StreamIdType::EXT:
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
       return *(reinterpret_cast<sycl::queue*>(stream_id));
     default:
       TORCH_CHECK(

--- a/c10/xpu/XPUStream.h
+++ b/c10/xpu/XPUStream.h
@@ -44,7 +44,7 @@ class C10_XPU_API XPUStream {
   }
 
   /// Construct a XPUStream from a Stream with no error checking.
-  explicit XPUStream(Unchecked, Stream stream) : stream_(stream) {}
+  explicit XPUStream(Unchecked /*unused*/, Stream stream) : stream_(stream) {}
 
   bool operator==(const XPUStream& other) const noexcept {
     return unwrap() == other.unwrap();

--- a/c10/xpu/test/impl/XPUStreamTest.cpp
+++ b/c10/xpu/test/impl/XPUStreamTest.cpp
@@ -20,7 +20,7 @@ TEST(XPUStreamTest, CopyAndMoveTest) {
     return;
   }
 
-  int32_t device = -1;
+  c10::DeviceIndex device = -1;
   sycl::queue queue;
   c10::xpu::XPUStream copyStream = c10::xpu::getStreamFromPool();
   {
@@ -119,8 +119,10 @@ TEST(XPUStreamTest, MultithreadStreamBehavior) {
 
   c10::xpu::XPUStream cur_stream = c10::xpu::getCurrentXPUStream();
 
-  EXPECT_NE(cur_stream, *s0);
-  EXPECT_NE(cur_stream, *s1);
+  EXPECT_TRUE(s0);
+  EXPECT_TRUE(s1);
+  EXPECT_NE(cur_stream, s0);
+  EXPECT_NE(cur_stream, s1);
   EXPECT_NE(s0, s1);
 }
 
@@ -167,6 +169,7 @@ TEST(XPUStreamTest, StreamFunction) {
   }
 
   constexpr int numel = 1024;
+  // NOLINTNEXTLINE(*-c-arrays)
   int hostData[numel];
   initHostData(hostData, numel);
 


### PR DESCRIPTION
This PR fixes clang-tidy warnings on c10/xpu files.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @EikanWang @voznesenskym @penguinwu @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo