### PR TITLE
[Fix] Add safeguard for unsafe index

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -646,10 +646,12 @@ def augment_exc_message(exc: Exception, msg: str = "\n", export: bool = False) -
     old_msg = "" if len(exc.args) == 0 else str(exc.args[0])
 
     if isinstance(exc, KeyError):
-        exc.args = (KeyErrorMsg(old_msg + msg),) + exc.args[1:]
+        exc.args = (KeyErrorMsg(old_msg + msg),) + (
+            exc.args[1:] if len(exc.args) > 1 else ()
+        )
     else:
         new_msg = old_msg + msg
-        exc.args = (new_msg,) + exc.args[1:]
+        exc.args = (new_msg,) + (exc.args[1:] if len(exc.args) > 1 else ())
 
 
 def get_exc_message(

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -646,12 +646,10 @@ def augment_exc_message(exc: Exception, msg: str = "\n", export: bool = False) -
     old_msg = "" if len(exc.args) == 0 else str(exc.args[0])
 
     if isinstance(exc, KeyError):
-        exc.args = (KeyErrorMsg(old_msg + msg),) + (
-            exc.args[1:] if len(exc.args) > 1 else ()
-        )
+        exc.args = (KeyErrorMsg(old_msg + msg),) + exc.args[1:]
     else:
         new_msg = old_msg + msg
-        exc.args = (new_msg,) + (exc.args[1:] if len(exc.args) > 1 else ())
+        exc.args = (new_msg,) + exc.args[1:]
 
 
 def get_exc_message(

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -53,9 +53,10 @@ def post_process_error_msg(
 
     orig_sig = inspect.signature(func)
     flat_input_paths = _get_input_paths((args, kwargs), orig_sig)
-    constraint_violation_error.args = (
-        _replace_sources(constraint_violation_error.args[0], flat_input_paths),
-    )
+    if constraint_violation_error.args:
+        constraint_violation_error.args = (
+            _replace_sources(constraint_violation_error.args[0], flat_input_paths),
+        )
     return constraint_violation_error
 
 
@@ -423,9 +424,12 @@ def _suggest_or_raise_constraint_violation(
             forced_specializations,
         )
         if constraint_violation_error:
-            constraint_violation_error.args = (
-                constraint_violation_error.args[0] + msg,
-            )
+            if constraint_violation_error.args:
+                constraint_violation_error.args = (
+                    constraint_violation_error.args[0] + msg,
+                )
+            else:
+                constraint_violation_error.args = (msg,)
         else:
             if forced_specializations:
                 constraint_violation_error = ConstraintViolationError(msg)

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -587,7 +587,12 @@ def produce_guards_and_solve_constraints(
     )
 
     if constraint_violation_error:
-        constraint_violation_error.args = (constraint_violation_error.args[0] + msg,)
+        if constraint_violation_error.args:
+            constraint_violation_error.args = (
+                constraint_violation_error.args[0] + msg,
+            )
+        else:
+            constraint_violation_error.args = (msg,)
     elif forced_specializations:
         constraint_violation_error = ConstraintViolationError(msg)
     if constraint_violation_error:


### PR DESCRIPTION
Inspired by #169140, without checking if the args tuple is empty, which could lead to IndexError and mask the actual error.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo