### PR TITLE
Fix mismatch in ProcessException.pid and ProcessException.error_pid

### DIFF
--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -836,7 +836,7 @@ class MultiprocessContext(PContext):
                 " of fn: %s (start_method: %s)",
                 failed_proc.exitcode,
                 failed_local_rank,
-                e.pid,
+                e.error_pid,
                 fn_name,
                 self.start_method,
             )
@@ -846,7 +846,7 @@ class MultiprocessContext(PContext):
                 failures={
                     failed_local_rank: ProcessFailure(
                         local_rank=failed_local_rank,
-                        pid=e.pid,
+                        pid=e.error_pid,
                         exitcode=failed_proc.exitcode,
                         error_file=error_filepath,
                     )

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -33,26 +33,18 @@ __all__ = [
 class ProcessException(Exception):
     __slots__ = ["error_index", "error_pid"]
 
-    def __init__(self, msg: str, error_index: int, pid: int):
+    def __init__(self, msg: str, error_index: int, error_pid: int):
         super().__init__(msg)
         self.msg = msg
         self.error_index = error_index
-        self.pid = pid
+        self.error_pid = error_pid
 
     def __reduce__(self):
-        return type(self), (self.msg, self.error_index, self.pid)
+        return type(self), (self.msg, self.error_index, self.error_pid)
 
 
 class ProcessRaisedException(ProcessException):
     """Exception raised when a process failed due to an exception raised by the code."""
-
-    def __init__(
-        self,
-        msg: str,
-        error_index: int,
-        error_pid: int,
-    ):
-        super().__init__(msg, error_index, error_pid)
 
 
 class ProcessExitedException(ProcessException):
@@ -75,7 +67,13 @@ class ProcessExitedException(ProcessException):
     def __reduce__(self):
         return (
             type(self),
-            (self.msg, self.error_index, self.pid, self.exit_code, self.signal_name),
+            (
+                self.msg,
+                self.error_index,
+                self.error_pid,
+                self.exit_code,
+                self.signal_name,
+            ),
         )
 
 


### PR DESCRIPTION
Given that `ProcessException.__slots__` contains `error_pid`, ProcessException should have `error_pid` as a member. ProcessException is an internal exception class so it is safe to fix.
