### PR TITLE
Remove unused TVM code in dynamo

### DIFF
--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -82,37 +82,14 @@ def tvm(
         # pyrefly: ignore [import-error]
         from tvm import auto_scheduler
 
-        log_file = tempfile.NamedTemporaryFile()
-
-        # pyrefly: ignore [bad-argument-type]
-        if not os.path.exists(log_file):
-            tasks, task_weights = auto_scheduler.extract_tasks(
-                mod["main"], params, target
-            )
-            if len(tasks) != 0:
-                tuner = auto_scheduler.TaskScheduler(tasks, task_weights)
-                # pyrefly: ignore [bad-argument-type]
-                if not os.path.exists(log_file):
-                    assert trials > 0
-                    tune_option = auto_scheduler.TuningOptions(
-                        num_measure_trials=trials,
-                        measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
-                        early_stopping=2000,
-                    )
-                    try:
-                        tuner.tune(tune_option)
-                    except Exception:
-                        # pyrefly: ignore [bad-argument-type]
-                        if os.path.exists(log_file):
-                            # pyrefly: ignore [bad-argument-type]
-                            os.unlink(log_file)
-                        raise
-
-        with auto_scheduler.ApplyHistoryBest(log_file):
-            with tvm.transform.PassContext(
+        with (
+            tempfile.NamedTemporaryFile() as log_file,
+            auto_scheduler.ApplyHistoryBest(log_file),
+            tvm.transform.PassContext(
                 opt_level=opt_level, config={"relay.backend.use_auto_scheduler": True}
-            ):
-                lib = relay.build(mod, target=target, params=params)
+            ),
+        ):
+            lib = relay.build(mod, target=target, params=params)
     elif scheduler == "meta_schedule":
         # pyrefly: ignore [import-error]
         from tvm import meta_schedule as ms


### PR DESCRIPTION
The returned `log_file` is always opened, it's unclear why the branch was created to check the file existence.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo