### PR TITLE
[Feature] Add model summary utility to torch.nn.utils

### DIFF
--- a/docs/source/nn.utils.summary.md
+++ b/docs/source/nn.utils.summary.md
@@ -1,0 +1,36 @@
+# torch.nn.utils.summary
+
+```{eval-rst}
+.. automodule:: torch.nn.utils.summary
+```
+
+This module provides a utility for inspecting `nn.Module` architectures,
+displaying layer names, output shapes, and parameter counts.
+
+## Quick Start
+
+```python
+import torch.nn as nn
+from torch.nn.utils import summary
+
+model = nn.Sequential(
+    nn.Conv2d(3, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.Flatten(),
+    nn.Linear(64 * 32 * 32, 10),
+)
+
+# Print summary for 32x32 RGB input
+summary(model, input_size=(3, 32, 32))
+```
+
+## API Reference
+
+```{eval-rst}
+.. autofunction:: torch.nn.utils.summary.summary
+.. autoclass:: torch.nn.utils.summary.ModelSummary
+   :members:
+.. autoclass:: torch.nn.utils.summary.LayerInfo
+   :members:
+```
+

--- a/test/test_nn_summary.py
+++ b/test/test_nn_summary.py
@@ -1,0 +1,154 @@
+# Owner(s): ["module: nn"]
+
+import unittest
+
+import torch
+import torch.nn as nn
+from torch.nn.utils import summary
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+try:
+    from torchvision import models as torchvision_models
+
+    HAS_TORCHVISION = True
+except ImportError:
+    HAS_TORCHVISION = False
+
+skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
+
+
+class TestSummary(TestCase):
+    """Tests for torch.nn.utils.summary"""
+
+    def test_simple_sequential(self):
+        """Basic Sequential model produces valid summary."""
+        model = nn.Sequential(
+            nn.Linear(10, 5),
+            nn.ReLU(),
+            nn.Linear(5, 2),
+        )
+        s = summary(model, input_size=(10,))
+        self.assertEqual(s.model_name, "Sequential")
+        self.assertGreater(len(s.layer_info), 0)
+        # Should have 4 layers: Sequential + 3 children
+        self.assertEqual(len(s.layer_info), 4)
+
+    def test_param_count_linear(self):
+        """Parameter counting is correct for Linear layer."""
+        model = nn.Linear(10, 5, bias=True)
+        s = summary(model, input_size=(10,))
+        # Linear(10, 5) with bias: 10*5 + 5 = 55 params
+        self.assertEqual(s.total_params, 55)
+        self.assertEqual(s.trainable_params, 55)
+
+    def test_param_count_conv2d(self):
+        """Parameter counting is correct for Conv2d layer."""
+        model = nn.Conv2d(3, 16, kernel_size=3, bias=True)
+        s = summary(model, input_size=(3, 32, 32))
+        # Conv2d(3, 16, 3): 3*16*3*3 + 16 = 432 + 16 = 448 params
+        self.assertEqual(s.total_params, 448)
+
+    def test_output_shape(self):
+        """Output shapes are captured correctly."""
+        model = nn.Linear(10, 5)
+        s = summary(model, input_size=(10,))
+        # Find the Linear layer info (root module)
+        self.assertEqual(len(s.layer_info), 1)
+        linear_info = s.layer_info[0]
+        self.assertEqual(linear_info.output_size, (1, 5))  # batch=1, out=5
+
+    def test_output_shape_conv(self):
+        """Output shapes are correct for Conv2d."""
+        model = nn.Conv2d(3, 16, kernel_size=3, padding=1)
+        s = summary(model, input_size=(3, 32, 32))
+        conv_info = s.layer_info[0]
+        # With padding=1 and kernel=3, output size = input size
+        self.assertEqual(conv_info.output_size, (1, 16, 32, 32))
+
+    def test_nested_modules(self):
+        """Nested modules are captured with correct depth."""
+        model = nn.Sequential(
+            nn.Sequential(
+                nn.Linear(10, 5),
+            ),
+        )
+        s = summary(model, input_size=(10,))
+        # Should have: Sequential (depth 0), Sequential (depth 1), Linear (depth 2)
+        depths = [layer.depth for layer in s.layer_info]
+        self.assertIn(0, depths)
+        self.assertIn(1, depths)
+        self.assertIn(2, depths)
+
+    def test_depth_parameter(self):
+        """Depth parameter limits displayed layers in output."""
+        model = nn.Sequential(
+            nn.Sequential(
+                nn.Linear(10, 5),
+            ),
+        )
+        s = summary(model, input_size=(10,), depth=1)
+        # max_depth should be set correctly
+        self.assertEqual(s.max_depth, 1)
+        # All layers should still be in layer_info (filtering happens in __repr__)
+        self.assertEqual(len(s.layer_info), 3)
+
+    def test_frozen_parameters(self):
+        """Frozen parameters are counted as non-trainable."""
+        model = nn.Linear(10, 5)
+        # Freeze the weights
+        model.weight.requires_grad = False
+        s = summary(model, input_size=(10,))
+        # Total: 55, trainable: only bias (5)
+        self.assertEqual(s.total_params, 55)
+        self.assertEqual(s.trainable_params, 5)
+
+    def test_input_data(self):
+        """Summary works with input_data instead of input_size."""
+        model = nn.Linear(10, 5)
+        x = torch.randn(2, 10)  # batch size 2
+        s = summary(model, input_data=x)
+        self.assertEqual(s.total_params, 55)
+        # Output shape should reflect batch size 2
+        self.assertEqual(s.layer_info[0].output_size, (2, 5))
+
+    def test_no_input_raises(self):
+        """ValueError raised when neither input_size nor input_data provided."""
+        model = nn.Linear(10, 5)
+        with self.assertRaises(ValueError) as ctx:
+            summary(model)
+        self.assertIn("input_size", str(ctx.exception))
+        self.assertIn("input_data", str(ctx.exception))
+
+    def test_model_mode_restored(self):
+        """Model's training mode is restored after summary."""
+        model = nn.Linear(10, 5)
+        model.train()
+        self.assertTrue(model.training)
+        summary(model, input_size=(10,))
+        self.assertTrue(model.training)
+
+        model.eval()
+        self.assertFalse(model.training)
+        summary(model, input_size=(10,))
+        self.assertFalse(model.training)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_cuda_model(self):
+        """Summary works on CUDA device."""
+        model = nn.Linear(10, 5).cuda()
+        s = summary(model, input_size=(10,))
+        self.assertEqual(s.total_params, 55)
+
+    @skipIfNoTorchVision
+    def test_resnet18(self):
+        """Integration test with ResNet18."""
+        model = torchvision_models.resnet18(weights=None)
+        s = summary(model, input_size=(3, 224, 224))
+        # ResNet18 has ~11.7M parameters
+        self.assertGreater(s.total_params, 11_000_000)
+        self.assertLess(s.total_params, 12_000_000)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -19,6 +19,7 @@ from .memory_format import (
     convert_conv3d_weight_memory_format,
 )
 from .spectral_norm import remove_spectral_norm, spectral_norm
+from .summary import LayerInfo, ModelSummary, summary
 from .weight_norm import remove_weight_norm, weight_norm
 
 
@@ -34,6 +35,8 @@ __all__ = [
     "fuse_linear_bn_eval",
     "fuse_linear_bn_weights",
     "get_total_norm",
+    "LayerInfo",
+    "ModelSummary",
     "parameters_to_vector",
     "parametrizations",
     "parametrize",
@@ -43,6 +46,7 @@ __all__ = [
     "skip_init",
     "spectral_norm",
     "stateless",
+    "summary",
     "vector_to_parameters",
     "weight_norm",
 ]

--- a/torch/nn/utils/summary.py
+++ b/torch/nn/utils/summary.py
@@ -1,0 +1,282 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+
+"""Model summary utilities for inspecting nn.Module architectures.
+
+This module provides a Keras-style summary function that displays layer names,
+output shapes, and parameter counts for PyTorch models.
+"""
+
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+import torch
+from torch import nn, Tensor
+
+
+if TYPE_CHECKING:
+    from torch.utils.hooks import RemovableHandle
+
+
+__all__ = ["summary", "ModelSummary", "LayerInfo"]
+
+
+@dataclass
+class LayerInfo:
+    """Information about a single layer in the model.
+
+    Attributes:
+        name: Fully qualified name of the module (e.g., "layer1.conv").
+        class_name: Class name of the module (e.g., "Conv2d").
+        depth: Nesting depth in the module hierarchy (0 = root).
+        output_size: Shape of the output tensor from this layer.
+        num_params: Total number of parameters in this layer (non-recursive).
+        trainable_params: Number of trainable parameters in this layer.
+    """
+
+    name: str
+    class_name: str
+    depth: int
+    output_size: tuple[int, ...]
+    num_params: int
+    trainable_params: int
+
+
+class ModelSummary:
+    """Container for model summary information.
+
+    This class holds the summary data for a model and provides formatted
+    string output when printed.
+
+    Attributes:
+        model_name: Name of the model class.
+        layer_info: List of LayerInfo objects for each module.
+        total_params: Total number of parameters in the model.
+        trainable_params: Number of trainable parameters.
+        max_depth: Maximum depth of modules to display.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        layer_info: list[LayerInfo],
+        total_params: int,
+        trainable_params: int,
+        max_depth: int,
+    ) -> None:
+        self.model_name = model_name
+        self.layer_info = layer_info
+        self.total_params = total_params
+        self.trainable_params = trainable_params
+        self.max_depth = max_depth
+
+    def __repr__(self) -> str:
+        return self._format_table()
+
+    def _format_table(self) -> str:
+        """Format summary as ASCII table."""
+        lines = []
+        sep = "=" * 80
+
+        lines.append(sep)
+        lines.append(f"{'Layer (type)':<45}{'Output Shape':<20}{'Param #':>15}")
+        lines.append(sep)
+
+        for info in self.layer_info:
+            if self.max_depth >= 0 and info.depth > self.max_depth:
+                continue
+
+            # Build indented name with tree characters
+            if info.depth == 0:
+                indent = ""
+                prefix = ""
+            else:
+                indent = "│   " * (info.depth - 1)
+                prefix = "├─"
+
+            # Use short name (last part of FQN) for display
+            short_name = info.name.split(".")[-1] if info.name else "root"
+            name_str = f"{indent}{prefix}{info.class_name}: {short_name}"
+
+            # Format output shape
+            if info.output_size:
+                shape_str = str(list(info.output_size))
+            else:
+                shape_str = "--"
+
+            # Format param count
+            if info.num_params > 0:
+                param_str = f"{info.num_params:,}"
+            else:
+                param_str = "--"
+
+            lines.append(f"{name_str:<45}{shape_str:<20}{param_str:>15}")
+
+        lines.append(sep)
+        lines.append(f"Total params: {self.total_params:,}")
+        lines.append(f"Trainable params: {self.trainable_params:,}")
+        non_trainable = self.total_params - self.trainable_params
+        lines.append(f"Non-trainable params: {non_trainable:,}")
+        lines.append(sep)
+
+        return "\n".join(lines)
+
+
+def _get_output_shape(output: Any) -> tuple[int, ...]:
+    """Extract shape from forward output.
+
+    Args:
+        output: Output from a module's forward pass. Can be a Tensor,
+            tuple/list of Tensors, or other types.
+
+    Returns:
+        Shape tuple of the output tensor, or empty tuple if no tensor found.
+    """
+    if isinstance(output, Tensor):
+        return tuple(output.shape)
+    if isinstance(output, (tuple, list)) and len(output) > 0:
+        # Return shape of first tensor in sequence
+        for item in output:
+            if isinstance(item, Tensor):
+                return tuple(item.shape)
+    return ()
+
+
+def summary(
+    model: nn.Module,
+    input_size: tuple[int, ...] | None = None,
+    input_data: Tensor | None = None,
+    *,
+    depth: int = 3,
+) -> ModelSummary:
+    r"""Generate a summary of a PyTorch model.
+
+    This function provides a Keras-style summary of the model architecture,
+    showing each layer's name, output shape, and parameter count.
+
+    Args:
+        model: The nn.Module to summarize.
+        input_size: Shape of input tensor, excluding batch dimension.
+            For example, ``(3, 224, 224)`` for an RGB image. A batch
+            dimension of 1 is automatically prepended.
+        input_data: Actual input tensor to use for the forward pass.
+            Alternative to ``input_size``. If provided, ``input_size``
+            is ignored.
+        depth: Maximum depth of nested modules to display. Default: 3.
+            Use -1 for unlimited depth.
+
+    Returns:
+        ModelSummary object containing the summary information.
+        The summary is also printed to stdout.
+
+    Raises:
+        ValueError: If neither ``input_size`` nor ``input_data`` is provided.
+
+    Example::
+
+        >>> import torch.nn as nn
+        >>> from torch.nn.utils import summary
+        >>> model = nn.Sequential(
+        ...     nn.Linear(784, 256),
+        ...     nn.ReLU(),
+        ...     nn.Linear(256, 10),
+        ... )
+        >>> s = summary(model, input_size=(784,))  # doctest: +SKIP
+        ================================================================================
+        Layer (type)                                 Output Shape        Param #
+        ================================================================================
+        Sequential: root                             [1, 10]                  --
+        ├─Linear: 0                                  [1, 256]            200,960
+        ├─ReLU: 1                                    [1, 256]                 --
+        ├─Linear: 2                                  [1, 10]               2,570
+        ================================================================================
+        Total params: 203,530
+        Trainable params: 203,530
+        Non-trainable params: 0
+        ================================================================================
+    """
+    # Validate inputs
+    if input_size is None and input_data is None:
+        raise ValueError(
+            "Either 'input_size' or 'input_data' must be provided.\n"
+            "Example: summary(model, input_size=(3, 224, 224))"
+        )
+
+    # Determine device from model
+    try:
+        device = next(model.parameters()).device
+        dtype = next(model.parameters()).dtype
+    except StopIteration:
+        # Model has no parameters, use defaults
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+    # Create input tensor if needed
+    if input_data is None:
+        assert input_size is not None  # for type checker
+        # Add batch dimension
+        input_shape = (1,) + input_size
+        input_data = torch.zeros(input_shape, device=device, dtype=dtype)
+
+    # Collect layer info via hooks
+    layer_info_dict: dict[str, LayerInfo] = {}
+    hooks: list[RemovableHandle] = []
+
+    def make_hook(name: str, mod: nn.Module):
+        def hook(module: nn.Module, inp: Any, out: Any) -> None:
+            # Count parameters for this module only (not children)
+            num_params = sum(p.numel() for p in module.parameters(recurse=False))
+            trainable = sum(
+                p.numel() for p in module.parameters(recurse=False) if p.requires_grad
+            )
+
+            layer_info_dict[name] = LayerInfo(
+                name=name,
+                class_name=module.__class__.__name__,
+                depth=name.count(".") + 1 if name else 0,
+                output_size=_get_output_shape(out),
+                num_params=num_params,
+                trainable_params=trainable,
+            )
+
+        return hook
+
+    # Register hooks on all modules
+    for name, module in model.named_modules():
+        hook = make_hook(name, module)
+        handle = module.register_forward_hook(hook)
+        hooks.append(handle)
+
+    # Run forward pass
+    original_mode = model.training
+    model.eval()
+    try:
+        with torch.no_grad():
+            model(input_data)
+    finally:
+        # Always cleanup: restore mode and remove hooks
+        model.train(original_mode)
+        for handle in hooks:
+            handle.remove()
+
+    # Calculate totals
+    total_params = sum(p.numel() for p in model.parameters())
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+    # Create summary object
+    # layer_info_dict preserves insertion order (Python 3.7+)
+    layer_info_list = list(layer_info_dict.values())
+
+    summary_obj = ModelSummary(
+        model_name=model.__class__.__name__,
+        layer_info=layer_info_list,
+        total_params=total_params,
+        trainable_params=trainable_params,
+        max_depth=depth,
+    )
+
+    # Print summary
+    print(summary_obj)
+
+    return summary_obj


### PR DESCRIPTION
This PR adds a Keras-style model.summary() utility to PyTorch that displays layer names, output shapes, and parameter counts for nn.Module architectures.

API:
  from torch.nn.utils import summary
  summary(model, input_size=(3, 224, 224))

Features:
- Displays layer hierarchy with tree-style indentation
- Shows output shapes captured via forward hooks
- Counts total, trainable, and non-trainable parameters
- Supports depth parameter to limit nested module display
- Works with both input_size tuple or input_data tensor

Files:
- torch/nn/utils/summary.py: Main implementation (~260 lines)
- torch/nn/utils/__init__.py: Added exports
- test/test_nn_summary.py: 13 unit tests
- docs/source/nn.utils.summary.md: Documentation


