### PR TITLE
Fix(rnn): Validate batch_sizes in pad_packed_sequence to prevent segf…

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7531,6 +7531,25 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))
         self.assertEqual(len(w), 0)
 
+    def test_pad_packed_sequence_validate_batch_sizes(self):
+        # Regression test for gh-169213
+        # Ensure that non-monotonic batch_sizes raise a ValueError
+        import torch.nn.utils.rnn as rnn_utils
+        
+        # Construct invalid batch_sizes (increasing at index 2->3)
+        batch_sizes = torch.tensor([4, 4, 1, 3, 1], dtype=torch.long)
+        data = torch.randn(batch_sizes.sum(), 3)
+        
+        packed = rnn_utils.PackedSequence(
+            data=data,
+            batch_sizes=batch_sizes,
+            sorted_indices=None,
+            unsorted_indices=None
+        )
+
+        with self.assertRaisesRegex(ValueError, "batch_sizes.*must be non-increasing"):
+            rnn_utils.pad_packed_sequence(packed)
+
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
     @given(X=hu.tensor(shapes=((5, 3, 5, 5),), dtype=np.double),

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -316,6 +316,7 @@ def pack_padded_sequence(
     Returns:
         a :class:`PackedSequence` object
     """
+
     if not isinstance(lengths, torch.Tensor):
         if torch._C._get_tracing_state():
             warnings.warn(
@@ -396,6 +397,10 @@ def pad_packed_sequence(
         Batch elements will be re-ordered as they were ordered originally when
         the batch was passed to ``pack_padded_sequence`` or ``pack_sequence``.
     """
+
+    if sequence.batch_sizes[1:].gt(sequence.batch_sizes[:-1]).any():
+        raise ValueError("batch_sizes in PackedSequence must be non-increasing")
+
     max_seq_length = sequence.batch_sizes.size(0)
     if total_length is not None:
         if total_length < max_seq_length:


### PR DESCRIPTION
**Summary**
Fixes #169213.

`pad_packed_sequence` was vulnerable to a segfault (Linux) and silent data corruption (Windows) when passed a constructed `PackedSequence` with non-monotonic `batch_sizes`. This violates the invariant that packed sequences must be sorted by length.

This PR adds a validation check to ensure `batch_sizes` are non-increasing, raising a clean `ValueError` instead of crashing the interpreter.

**Test Plan**
- Added regression test `test_pad_packed_sequence_validate_batch_sizes` in `test/test_nn.py`.
- Verified locally with the PoC provided in the issue.