### PR TITLE
Remove temporary error file after reading it

### DIFF
--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -190,7 +190,7 @@ class ProcessContext:
             with open(self.__error_files[error_index], "rb") as fh:
                 original_trace = pickle.load(fh)
                 msg += original_trace
-            with contextlib.suppress(BaseException):
+            with contextlib.suppress(FileNotFoundError, IOError):
                 os.remove(self.__error_files[error_index])
             raise ProcessRaisedException(msg, error_index, failed_process.pid)
         exitcode = self.processes[error_index].exitcode


### PR DESCRIPTION
Removes the temporary error file after reading a process error. The file is solely for communication and should be cleared after that to avoid wasting /tmp space.  


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @VitalyFedyunin @albanD @ppwwyyxx