### PR TITLE
[MPS] Add output_padding validation for ConvTranspose{1,2,3}d

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -638,58 +638,55 @@ Tensor _mps_convolution_transpose(const Tensor& input_t,
   const int64_t k = stride.size();
   if (k == 3) {
     // 3D convolution
-    TORCH_CHECK(
-        (output_padding[0] < stride[0] || output_padding[0] < dilation[0]) &&
-            (output_padding[1] < stride[1] || output_padding[1] < dilation[1]) &&
-            (output_padding[2] < stride[2] || output_padding[2] < dilation[2]),
-        "output padding must be smaller than either stride or dilation, "
-        "but got output_padding_depth: ",
-        output_padding[0],
-        " output_padding_height: ",
-        output_padding[1],
-        " output_padding_width: ",
-        output_padding[2],
-        " stride_depth: ",
-        stride[0],
-        " stride_height: ",
-        stride[1],
-        " stride_width: ",
-        stride[2],
-        " dilation_depth: ",
-        dilation[0],
-        " dilation_height: ",
-        dilation[1],
-        " dilation_width: ",
-        dilation[2]);
+    TORCH_CHECK((output_padding[0] < stride[0] || output_padding[0] < dilation[0]) &&
+                    (output_padding[1] < stride[1] || output_padding[1] < dilation[1]) &&
+                    (output_padding[2] < stride[2] || output_padding[2] < dilation[2]),
+                "output padding must be smaller than either stride or dilation, "
+                "but got output_padding_depth: ",
+                output_padding[0],
+                " output_padding_height: ",
+                output_padding[1],
+                " output_padding_width: ",
+                output_padding[2],
+                " stride_depth: ",
+                stride[0],
+                " stride_height: ",
+                stride[1],
+                " stride_width: ",
+                stride[2],
+                " dilation_depth: ",
+                dilation[0],
+                " dilation_height: ",
+                dilation[1],
+                " dilation_width: ",
+                dilation[2]);
   } else if (k == 2) {
     // 2D convolution
-    TORCH_CHECK(
-        (output_padding[0] < stride[0] || output_padding[0] < dilation[0]) &&
-            (output_padding[1] < stride[1] || output_padding[1] < dilation[1]),
-        "output padding must be smaller than either stride or dilation, "
-        "but got output_padding_height: ",
-        output_padding[0],
-        " output_padding_width: ",
-        output_padding[1],
-        " stride_height: ",
-        stride[0],
-        " stride_width: ",
-        stride[1],
-        " dilation_height: ",
-        dilation[0],
-        " dilation_width: ",
-        dilation[1]);
+    TORCH_CHECK((output_padding[0] < stride[0] || output_padding[0] < dilation[0]) &&
+                    (output_padding[1] < stride[1] || output_padding[1] < dilation[1]),
+                "output padding must be smaller than either stride or dilation, "
+                "but got output_padding_height: ",
+                output_padding[0],
+                " output_padding_width: ",
+                output_padding[1],
+                " stride_height: ",
+                stride[0],
+                " stride_width: ",
+                stride[1],
+                " dilation_height: ",
+                dilation[0],
+                " dilation_width: ",
+                dilation[1]);
   } else if (k == 1) {
     // 1D convolution
-    TORCH_CHECK(
-        output_padding[0] < stride[0] || output_padding[0] < dilation[0],
-        "output padding must be smaller than either stride or dilation, "
-        "but got output_padding_height: 0 output_padding_width: ",
-        output_padding[0],
-        " stride_height: 1 stride_width: ",
-        stride[0],
-        " dilation_height: 1 dilation_width: ",
-        dilation[0]);
+    TORCH_CHECK(output_padding[0] < stride[0] || output_padding[0] < dilation[0],
+                "output padding must be smaller than either stride or dilation, "
+                "but got output_padding_height: 0 output_padding_width: ",
+                output_padding[0],
+                " stride_height: 1 stride_width: ",
+                stride[0],
+                " dilation_height: 1 dilation_width: ",
+                dilation[0]);
   }
 
   auto output_t =

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -634,6 +634,64 @@ Tensor _mps_convolution_transpose(const Tensor& input_t,
       (input_t.dim() == 5 && (input_t.scalar_type() == kHalf || input_t.scalar_type() == kBFloat16));
   TORCH_CHECK(!is_unsupported_3d_dtype, "ConvTranspose 3D with BF16 or FP16 types is not supported on MPS");
 
+  // Validate output_padding < stride or dilation
+  const int64_t k = stride.size();
+  if (k == 3) {
+    // 3D convolution
+    TORCH_CHECK(
+        (output_padding[0] < stride[0] || output_padding[0] < dilation[0]) &&
+            (output_padding[1] < stride[1] || output_padding[1] < dilation[1]) &&
+            (output_padding[2] < stride[2] || output_padding[2] < dilation[2]),
+        "output padding must be smaller than either stride or dilation, "
+        "but got output_padding_depth: ",
+        output_padding[0],
+        " output_padding_height: ",
+        output_padding[1],
+        " output_padding_width: ",
+        output_padding[2],
+        " stride_depth: ",
+        stride[0],
+        " stride_height: ",
+        stride[1],
+        " stride_width: ",
+        stride[2],
+        " dilation_depth: ",
+        dilation[0],
+        " dilation_height: ",
+        dilation[1],
+        " dilation_width: ",
+        dilation[2]);
+  } else if (k == 2) {
+    // 2D convolution
+    TORCH_CHECK(
+        (output_padding[0] < stride[0] || output_padding[0] < dilation[0]) &&
+            (output_padding[1] < stride[1] || output_padding[1] < dilation[1]),
+        "output padding must be smaller than either stride or dilation, "
+        "but got output_padding_height: ",
+        output_padding[0],
+        " output_padding_width: ",
+        output_padding[1],
+        " stride_height: ",
+        stride[0],
+        " stride_width: ",
+        stride[1],
+        " dilation_height: ",
+        dilation[0],
+        " dilation_width: ",
+        dilation[1]);
+  } else if (k == 1) {
+    // 1D convolution
+    TORCH_CHECK(
+        output_padding[0] < stride[0] || output_padding[0] < dilation[0],
+        "output padding must be smaller than either stride or dilation, "
+        "but got output_padding_height: 0 output_padding_width: ",
+        output_padding[0],
+        " stride_height: 1 stride_width: ",
+        stride[0],
+        " dilation_height: 1 dilation_width: ",
+        dilation[0]);
+  }
+
   auto output_t =
       mps_convolution_transpose_forward(input_t, weight_t, padding, output_padding, stride, dilation, groups);
   return output_t;

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3922,6 +3922,55 @@ def conv_transpose_ref(input, weight, bias, stride=1, padding=0,
     return out.squeeze(0) if not is_batched else out
 
 
+def error_inputs_conv_transpose1d(op_info, device, **kwargs):
+    """Error inputs for conv_transpose1d: output_padding >= stride and output_padding >= dilation."""
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32)
+
+    # Test case: output_padding >= stride (and >= dilation with default dilation=1)
+    # This should raise an error
+    yield ErrorInput(
+        SampleInput(
+            make_arg((1, 1, 4)),
+            args=(make_arg((1, 1, 3)), None),
+            kwargs={'stride': 1, 'padding': 0, 'output_padding': 1}
+        ),
+        error_type=RuntimeError,
+        error_regex='output padding must be smaller than either stride or dilation'
+    )
+
+
+def error_inputs_conv_transpose2d(op_info, device, **kwargs):
+    """Error inputs for conv_transpose2d: output_padding >= stride and output_padding >= dilation."""
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32)
+
+    # Test case: output_padding >= stride (and >= dilation with default dilation=1)
+    yield ErrorInput(
+        SampleInput(
+            make_arg((1, 1, 4, 4)),
+            args=(make_arg((1, 1, 3, 3)), None),
+            kwargs={'stride': 1, 'padding': 0, 'output_padding': 1}
+        ),
+        error_type=RuntimeError,
+        error_regex='output padding must be smaller than either stride or dilation'
+    )
+
+
+def error_inputs_conv_transpose3d(op_info, device, **kwargs):
+    """Error inputs for conv_transpose3d: output_padding >= stride and output_padding >= dilation."""
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32)
+
+    # Test case: output_padding >= stride (and >= dilation with default dilation=1)
+    yield ErrorInput(
+        SampleInput(
+            make_arg((1, 1, 4, 4, 4)),
+            args=(make_arg((1, 1, 3, 3, 3)), None),
+            kwargs={'stride': 1, 'padding': 0, 'output_padding': 1}
+        ),
+        error_type=RuntimeError,
+        error_regex='output padding must be smaller than either stride or dilation'
+    )
+
+
 def sample_inputs_conv_transpose1d(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -15372,6 +15421,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.chalf,
                                                        torch.bfloat16),
            sample_inputs_func=sample_inputs_conv_transpose1d,
+           error_inputs_func=error_inputs_conv_transpose1d,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
@@ -15417,6 +15467,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.chalf,
                                                        torch.bfloat16),
            sample_inputs_func=sample_inputs_conv_transpose2d,
+           error_inputs_func=error_inputs_conv_transpose2d,
            # Runs very slowly on slow-gradcheck for complex.
            gradcheck_fast_mode=True,
            supports_forward_ad=True,
@@ -15465,6 +15516,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_and_complex_types_and(
                torch.float16, torch.chalf, torch.bfloat16),
            sample_inputs_func=sample_inputs_conv_transpose3d,
+           error_inputs_func=error_inputs_conv_transpose3d,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,


### PR DESCRIPTION
Add missing `output_padding` parameter validation for `nn.ConvTranspose{1,2,3}d` on MPS backend to match CPU behavior.

Previously, MPS backend silently ignored invalid `output_padding >= stride` and `output_padding >= dilation`, while CPU correctly raised RuntimeError.


Fixes  #169236

cc @malfet
