### PR TITLE
Fix native_matmul block numel exceeding Triton limit

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -112,6 +112,38 @@ class TestCoordinateDescentTuner(TestCase):
         self.assertFalse(tuner.value_too_large("R0_BLOCK", max_block["R0_"]))
         self.assertTrue(tuner.value_too_large("R0_BLOCK", max_block["R0_"] * 2))
 
+    def test_native_matmul_block_numel_limit(self):
+        # Test that native_matmul configs exceeding Triton's max tensor numel are rejected
+        tuner = CoordescTuner(is_native_matmul=True)
+
+        # Valid config: 128 * 128 * 64 = 1,048,576 (exactly at limit)
+        valid_config = triton.Config(
+            {"YBLOCK": 128, "XBLOCK": 128, "R0_BLOCK": 64}, num_warps=8, num_stages=1
+        )
+        self.assertTrue(tuner.is_valid_config(valid_config))
+
+        # Invalid config: 128 * 256 * 64 = 2,097,152 (exceeds limit)
+        invalid_config = triton.Config(
+            {"YBLOCK": 128, "XBLOCK": 256, "R0_BLOCK": 64}, num_warps=8, num_stages=1
+        )
+        self.assertFalse(tuner.is_valid_config(invalid_config))
+
+        # Invalid config: 256 * 128 * 64 = 2,097,152 (exceeds limit)
+        invalid_config2 = triton.Config(
+            {"YBLOCK": 256, "XBLOCK": 128, "R0_BLOCK": 64}, num_warps=8, num_stages=1
+        )
+        self.assertFalse(tuner.is_valid_config(invalid_config2))
+
+        # Invalid config: 128 * 128 * 128 = 2,097,152 (exceeds limit)
+        invalid_config3 = triton.Config(
+            {"YBLOCK": 128, "XBLOCK": 128, "R0_BLOCK": 128}, num_warps=8, num_stages=1
+        )
+        self.assertFalse(tuner.is_valid_config(invalid_config3))
+
+        # Non-native_matmul tuner should not apply this restriction
+        regular_tuner = CoordescTuner(is_native_matmul=False)
+        self.assertTrue(regular_tuner.is_valid_config(invalid_config))
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU:

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -20,6 +20,8 @@ TRITON_MAX_BLOCK = {
     "R1_": 2048 * 16,  # * 16 is multi-kernel only
 }
 TRITON_MAX_RSPLIT = 64
+# Triton enforces a maximum tensor numel of 2^20 elements per block
+TRITON_MAX_TENSOR_NUMEL = 1 << 20
 
 
 class ReductionHint(Enum):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2767,16 +2767,18 @@ def make_matmul_triton_config(sizes: dict[str, int], num_warps: int, num_stages:
     }
     # Remove keys with None values (i.e., missing in sizes)
     config = {k: v for k, v in config.items() if v is not None}
-    # Validate that block product doesn't exceed Triton's maximum tensor numel
+    # Validate that block product doesn't exceed Triton's maximum tensor numel.
+    # This is a hard invariant that cannot be disabled - Triton will crash otherwise.
     block_numel = (
         config.get("XBLOCK", 1)
         * config.get("YBLOCK", 1)
         * config.get("ZBLOCK", 1)
         * config.get("R0_BLOCK", 1)
     )
-    assert block_numel <= TRITON_MAX_TENSOR_NUMEL, (
-        f"Block numel {block_numel} exceeds Triton maximum {TRITON_MAX_TENSOR_NUMEL}"
-    )
+    if block_numel > TRITON_MAX_TENSOR_NUMEL:
+        raise AssertionError(
+            f"Block numel {block_numel} exceeds Triton maximum {TRITON_MAX_TENSOR_NUMEL}"
+        )
     return Config(config, num_warps=num_warps, num_stages=num_stages)
 
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -42,6 +42,7 @@ from .hints import (
     TileHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_RSPLIT,
+    TRITON_MAX_TENSOR_NUMEL,
 )
 from .runtime_utils import (
     ceildiv,
@@ -2766,6 +2767,16 @@ def make_matmul_triton_config(sizes: dict[str, int], num_warps: int, num_stages:
     }
     # Remove keys with None values (i.e., missing in sizes)
     config = {k: v for k, v in config.items() if v is not None}
+    # Validate that block product doesn't exceed Triton's maximum tensor numel
+    block_numel = (
+        config.get("XBLOCK", 1)
+        * config.get("YBLOCK", 1)
+        * config.get("ZBLOCK", 1)
+        * config.get("R0_BLOCK", 1)
+    )
+    assert block_numel <= TRITON_MAX_TENSOR_NUMEL, (
+        f"Block numel {block_numel} exceeds Triton maximum {TRITON_MAX_TENSOR_NUMEL}"
+    )
     return Config(config, num_warps=num_warps, num_stages=num_stages)
 
 


### PR DESCRIPTION
Fixes #167050

## Summary
When using `native_matmul` with coordinate descent tuning, the tuner could generate configs where `YBLOCK * XBLOCK * R0_BLOCK` exceeds Triton's maximum tensor numel limit of 2^20 (1,048,576) elements, causing compilation to fail with:
```
ValueError: numel (2097152) exceeds triton maximum tensor numel (1048576)
```

## Root Cause
The base configs in `_base_mm_configs` have a maximum product of 128×128×64 = 1,048,576 (exactly at the limit). During coordinate descent tuning, the tuner tries to double one dimension (e.g., XBLOCK from 128 to 256), resulting in configs like 128×256×64 = 2,097,152 which exceeds Triton's limit.

## Fix
1. Add `TRITON_MAX_TENSOR_NUMEL = 1 << 20` constant to `hints.py`
2. Add validation in `CoordescTuner.is_valid_config()` to reject `native_matmul` configs where the block product exceeds the limit
3. Add assertion in `make_matmul_triton_config()` as a defensive check for invalid base configs

## Test Plan
Added `test_native_matmul_block_numel_limit` in `test_coordinate_descent_tuner.py` which verifies:
- Valid configs at the limit (128×128×64) are accepted
- Invalid configs exceeding the limit (128×256×64, 256×128×64, 128×128×128) are rejected
- Non-native_matmul tuners don't apply this restriction

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @eellison @jansel