### PR TITLE
Include thrust/pair.h in each TU where thrust::pair is used

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <thrust/pair.h>
+
 namespace at::native {
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <thrust/pair.h>
+
 namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>

--- a/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <thrust/pair.h>
+
 namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>

--- a/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
@@ -15,6 +15,8 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <thrust/pair.h>
+
 namespace at::native {
 
 template <typename acc_t>

--- a/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
@@ -15,6 +15,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
+#include <thrust/pair.h>
 
 namespace at::native {
 

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -8,6 +8,8 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/ReduceOps.h>
 
+#include <thrust/pair.h>
+
 namespace at::native {
 
 template <typename scalar_t, typename out_t=scalar_t>

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -3,8 +3,6 @@
 
 #include <type_traits>
 
-#include <thrust/tuple.h>
-
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1,9 +1,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/layer_norm.h>
 
+#include <tuple>
 #include <type_traits>
-
-#include <thrust/tuple.h>
 
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -26,7 +26,6 @@
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
 #include <thrust/generate.h>
-#include <thrust/pair.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>


### PR DESCRIPTION
A change like https://github.com/NVIDIA/cccl/pull/6616 may break implicit transitive dependency resulting in build break due to type thrust::pair being undefined, as happened in CCCL:

https://github.com/NVIDIA/cccl/actions/runs/19802695165/job/56732283408?pr=6712

Fixes #169266
