### PR TITLE
[MTIA][RNG] Add torch bindings for get and set default generator

### DIFF
--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -187,6 +187,18 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
   virtual MempoolId_t graphPoolHandle() const {
     FAIL_MTIAHOOKS_FUNC(__func__);
   }
+
+  virtual const Generator& getDefaultGenerator(DeviceIndex) const override {
+    FAIL_MTIAHOOKS_FUNC(__func__);
+    static Generator dummy_generator;
+    return dummy_generator;
+  }
+
+  virtual Generator getNewGenerator(DeviceIndex) const override {
+    FAIL_MTIAHOOKS_FUNC(__func__);
+    static Generator dummy_generator;
+    return dummy_generator;
+  }
 };
 
 struct TORCH_API MTIAHooksArgs {};

--- a/test/cpp_extensions/mtia_extension.cpp
+++ b/test/cpp_extensions/mtia_extension.cpp
@@ -1,3 +1,4 @@
+#include <ATen/CPUGeneratorImpl.h>
 #include <ATen/detail/MTIAHooksInterface.h>
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
@@ -145,7 +146,7 @@ struct MTIAHooks : public at::MTIAHooksInterface {
   }
 
   c10::DeviceIndex deviceCount() const override {
-    torch::utils::device_lazy_init(at::kMTIA);
+    // Don't call device_lazy_init here to avoid recursive deadlock during initialization
     return c10::DeviceIndex(2);
   }
 
@@ -207,6 +208,20 @@ struct MTIAHooks : public at::MTIAHooksInterface {
     if (current_device != device) {
       current_device = device;
     }
+  }
+
+  const at::Generator& getDefaultGenerator(c10::DeviceIndex device) const override {
+    // Don't call device_lazy_init here to avoid recursive deadlock during initialization
+    static std::vector<at::Generator> default_gens = {
+      at::make_generator<at::CPUGeneratorImpl>(),
+      at::make_generator<at::CPUGeneratorImpl>()
+    };
+    return default_gens[device];
+  }
+
+  at::Generator getNewGenerator(c10::DeviceIndex device) const override {
+    torch::utils::device_lazy_init(at::kMTIA);
+    return at::make_generator<at::CPUGeneratorImpl>();
   }
 };
 

--- a/test/test_cpp_extensions_mtia_backend.py
+++ b/test/test_cpp_extensions_mtia_backend.py
@@ -140,6 +140,31 @@ class TestCppExtensionMTIABackend(common.TestCase):
         with torch.mtia.device(device_1):
             self.assertTrue(torch.mtia.current_device() == device_1.index)
 
+    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
+    def test_default_generators(self):
+        # Trigger lazy initialization first by calling current_stream()
+        torch.mtia.current_stream()
+        device_count = torch.mtia.device_count()
+
+        # Verify the interface exists and is properly initialized
+        self.assertTrue(hasattr(torch.mtia, "default_generators"))
+        self.assertIsInstance(torch.mtia.default_generators, tuple)
+        self.assertEqual(len(torch.mtia.default_generators), device_count)
+
+        # Verify we can access generators by device index
+        gen_0 = torch.mtia.default_generators[0]
+        gen_1 = torch.mtia.default_generators[1]
+        self.assertIsInstance(gen_0, torch.Generator)
+        self.assertIsInstance(gen_1, torch.Generator)
+        # Different devices should have different generator objects
+        self.assertIsNot(gen_0, gen_1)
+
+    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
+    def test_new_generator(self):
+        # Verify we can create a generator via the hooks interface
+        gen = torch.Generator(device="mtia:0")
+        self.assertIsInstance(gen, torch.Generator)
+
 
 if __name__ == "__main__":
     common.run_tests()

--- a/torch/csrc/mtia/Module.cpp
+++ b/torch/csrc/mtia/Module.cpp
@@ -56,6 +56,18 @@ void initModule(PyObject* module) {
     TORCH_INTERNAL_ASSERT(!torch::utils::is_device_in_bad_fork(at::kMTIA));
     torch::utils::register_fork_handler_for_device_init(at::kMTIA);
     at::globalContext().lazyInitDevice(c10::DeviceType::MTIA);
+
+    // Initialize default generators for each MTIA device
+    auto mtia_module = py::module_::import("torch.mtia");
+
+    auto num_devices = at::detail::getMTIAHooks().deviceCount();
+    py::tuple default_mtia_generators(num_devices);
+    for (const auto i : c10::irange(num_devices)) {
+      auto cast_gen = THPGenerator_initDefaultGenerator(
+          at::detail::getMTIAHooks().getDefaultGenerator(i));
+      default_mtia_generators[i] = py::reinterpret_steal<py::object>(cast_gen);
+    }
+    mtia_module.attr("default_generators") = default_mtia_generators;
   });
 
   m.def("_mtia_isBuilt", []() {

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -21,6 +21,8 @@ _device_t = Union[_device, str, int]
 # torch.mtia.Event/Stream is alias of torch.Event/Stream
 Event = torch.Event
 Stream = torch.Stream
+# Default generators are initialized inside _mtia_init
+default_generators: tuple[torch._C.Generator, ...] = ()  # type: ignore[assignment]
 
 _initialized = False
 _queued_calls: list[


### PR DESCRIPTION
Summary:
Implements MTIA RNG (Random Number Generator) integration into PyTorch following CUDA's architecture pattern. Adds default generators during device initialization and exposes them via `torch.mtia.default_generators`.

Key Changes

**C++ Infrastructure:**

*   Extended `MTIAHooksInterface` with `getDefaultGenerator()` and `getNewGenerator()` methods
*   Implemented hooks in `mtia_hooks.{h,cpp}` managing per-device RNG state
*   Added `createMTIAGenerator()` factory in `mtia_rng.{h,cpp}`
*   Modified `_mtia_init()` to create generators tuple mirroring CUDA implementation.

**Python Integration:**

*   Added `default_generators: tuple[torch._C.Generator] = ()` declaration to `torch/mtia/__init__.py`
*   Generators populated by C++ during lazy device initialization

**Architecture:**

*   Generators for same device share underlying RNG state. This is a key design choice for MTIA that users must be aware of.
*   Different devices maintain independent RNG states
*   Accessible via `torch.mtia.default_generators[device_idx]`

Test Plan:
buck2 test fbcode//mtia/host_runtime/torch_mtia/tests:test_mtia_rng_generators

https://www.internalfb.com/intern/testinfra/testrun/6192449762838044

Differential Revision: D88012916


