### PR TITLE
[MPS] Fix dlpack exports/imports for sliced tensors

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -439,13 +439,12 @@ at::Tensor fromDLPackImpl(T* src, std::function<void(void*)> deleter) {
   DLTensor& dl_tensor = src->dl_tensor;
   Device device = getATenDevice(dl_tensor.device.device_type, dl_tensor.device.device_id, dl_tensor.data);
   ScalarType stype = toScalarType(dl_tensor.dtype);
-  int64_t storage_offset = toStorageOffset(dl_tensor.byte_offset, stype);
 
   if (!dl_tensor.strides) {
+    TORCH_CHECK_VALUE(dl_tensor.byte_offset == 0, "Expected zero byte_offset");
     return at::from_blob(
         dl_tensor.data,
         IntArrayRef(dl_tensor.shape, dl_tensor.ndim),
-        storage_offset,
         std::move(deleter),
         at::device(device).dtype(stype),
         {device});
@@ -454,7 +453,7 @@ at::Tensor fromDLPackImpl(T* src, std::function<void(void*)> deleter) {
       dl_tensor.data,
       IntArrayRef(dl_tensor.shape, dl_tensor.ndim),
       IntArrayRef(dl_tensor.strides, dl_tensor.ndim),
-      storage_offset,
+      toStorageOffset(dl_tensor.byte_offset, stype),
       deleter,
       at::device(device).dtype(stype),
       {device});

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -356,7 +356,17 @@ ScalarType toScalarType(const DLDataType& dtype) {
   return stype;
 }
 
+
 namespace {
+
+int64_t toStorageOffset(int64_t byte_offset, ScalarType stype) {
+  if (byte_offset == 0) {
+    return 0;
+  }
+  const auto element_size = c10::elementSize(stype);
+  TORCH_CHECK_VALUE(byte_offset % element_size == 0, "byte offset must be multiple of element size");
+  return byte_offset / element_size;
+}
 
 // The templated classes below are needed for supporting both:
 //   - DLManagedTensor
@@ -393,13 +403,18 @@ T* toDLPackImpl(const Tensor& src) {
   atDLMTensor->handle = src;
   atDLMTensor->tensor.manager_ctx = atDLMTensor;
   atDLMTensor->tensor.deleter = &deleter<T>;
-  atDLMTensor->tensor.dl_tensor.data = src.data_ptr();
+  if (src.device().type()  == kMPS) {
+      atDLMTensor->tensor.dl_tensor.data = src.storage().mutable_data();
+      atDLMTensor->tensor.dl_tensor.byte_offset = src.storage_offset() * c10::elementSize(src.scalar_type());
+  } else {
+      atDLMTensor->tensor.dl_tensor.data = src.data_ptr();
+      atDLMTensor->tensor.dl_tensor.byte_offset = 0;
+  }
   atDLMTensor->tensor.dl_tensor.device = torchDeviceToDLDevice(src.device());
   atDLMTensor->tensor.dl_tensor.ndim = static_cast<int32_t>(src.dim());
   atDLMTensor->tensor.dl_tensor.dtype = getDLDataType(src);
   atDLMTensor->tensor.dl_tensor.shape = const_cast<int64_t*>(src.sizes().data());
   atDLMTensor->tensor.dl_tensor.strides = const_cast<int64_t*>(src.strides().data());
-  atDLMTensor->tensor.dl_tensor.byte_offset = 0;
   fillVersion(&atDLMTensor->tensor);
 
   return &(atDLMTensor->tensor);
@@ -424,11 +439,13 @@ at::Tensor fromDLPackImpl(T* src, std::function<void(void*)> deleter) {
   DLTensor& dl_tensor = src->dl_tensor;
   Device device = getATenDevice(dl_tensor.device.device_type, dl_tensor.device.device_id, dl_tensor.data);
   ScalarType stype = toScalarType(dl_tensor.dtype);
+  int64_t storage_offset = toStorageOffset(dl_tensor.byte_offset, stype);
 
   if (!dl_tensor.strides) {
     return at::from_blob(
         dl_tensor.data,
         IntArrayRef(dl_tensor.shape, dl_tensor.ndim),
+        storage_offset,
         std::move(deleter),
         at::device(device).dtype(stype),
         {device});
@@ -437,6 +454,7 @@ at::Tensor fromDLPackImpl(T* src, std::function<void(void*)> deleter) {
       dl_tensor.data,
       IntArrayRef(dl_tensor.shape, dl_tensor.ndim),
       IntArrayRef(dl_tensor.strides, dl_tensor.ndim),
+      storage_offset,
       deleter,
       at::device(device).dtype(stype),
       {device});

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -21,7 +21,6 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_utils import (
     IS_JETSON,
     run_tests,
-    skipIfMPS,
     skipIfTorchDynamo,
     TestCase,
 )
@@ -157,7 +156,6 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(x, y)
 
     @skipMeta
-    @skipIfMPS  # MPS crashes with noncontiguous now
     @onlyNativeDeviceTypes
     @dtypes(
         *all_types_and_complex_and(
@@ -167,6 +165,11 @@ class TestTorchDlPack(TestCase):
             torch.uint16,
             torch.uint32,
             torch.uint64,
+        )
+    )
+    @dtypesIfMPS(
+        *all_mps_types_and(
+            torch.bool, torch.cfloat, torch.chalf, torch.uint16, torch.uint32
         )
     )
     def test_from_dlpack_noncontinguous(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #169272

For MPS tensor, one must pass both `id<MTL_Buffer>` (which is `t.storage().data()` and `t.storage_offset()`)

Luckily, DLTensor already has `byte_offset` field, which feels natural to use as product of `storage_offset` and element_size.

Partially extends https://github.com/pytorch/pytorch/pull/168193, but instead of writing a completely new test, fix both export and import paths of sliced tensor and unskip test_from_dlpack_noncontinguous for MPS

Error out if one is attempting to create tensor with non-zero `byte_offsets` and no strides, as there are no `at::from_blob` variant that could be used

Fixes https://github.com/pytorch/pytorch/issues/168177