### PR TITLE
[test] use decomp for aten.stack sharding rule, use StridedShard in aten.cat sharding prop to avoid redistributes

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -434,7 +434,6 @@ dtensor_fails = {
     xfail("signal.windows.hann"),
     xfail("signal.windows.nuttall"),
     xfail("signal.windows.kaiser"),
-    xfail("stack"),
     xfail("std_mean"),
     xfail("std_mean", "unbiased"),
     xfail("stft"),

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -43,12 +43,14 @@ except ImportError:
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
+
 def stack_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ):
     import torch._prims_common as utils
+
     tensors = args[0]
     dim = 0 if len(args) == 1 else args[1]
     wrapped_dim = utils.canonicalize_dim(tensors[0].ndim + 1, dim)
@@ -61,6 +63,7 @@ def stack_handler(
 
     # If dim == tensors[0].ndim, view cannot efficiently handle it
     return torch.cat([t.unsqueeze(wrapped_dim) for t in tensors], dim)
+
 
 def as_strided_handler(
     op_call: torch._ops.OpOverload,

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.tensor._api as dtensor
 import torch.distributed.tensor._random as random
+from torch._decomp import get_decompositions
 from torch._library.utils import fill_defaults
 from torch.distributed._functional_collectives import _are_we_tracing
 from torch.distributed.device_mesh import DeviceMesh
@@ -43,26 +44,16 @@ except ImportError:
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 
+decomps = get_decompositions(
+    [
+        aten.stack.default,
+    ]
+)
 
-def stack_handler(
-    op_call: torch._ops.OpOverload,
-    args: tuple[object, ...],
-    kwargs: dict[str, object],
-):
-    import torch._prims_common as utils
 
-    tensors = args[0]
-    dim = 0 if len(args) == 1 else args[1]
-    wrapped_dim = utils.canonicalize_dim(tensors[0].ndim + 1, dim)
-    # Refs need sparse support to check other condition
-    if wrapped_dim < tensors[0].ndim:  # and not tensors[0].is_sparse:
-        result_sizes = list(tensors[0].shape)
-        result_sizes.insert(wrapped_dim, len(tensors))
-        out = torch.cat(tensors, wrapped_dim)
-        return out.view(result_sizes)
-
-    # If dim == tensors[0].ndim, view cannot efficiently handle it
-    return torch.cat([t.unsqueeze(wrapped_dim) for t in tensors], dim)
+def decomp_wrapper(op_overload, args, kwargs):
+    assert op_overload in decomps
+    return decomps[op_overload](*args, **kwargs)
 
 
 def as_strided_handler(
@@ -174,7 +165,7 @@ class OpDispatcher:
             aten.convolution_backward.default: convolution_backward_handler,
             aten._amp_foreach_non_finite_check_and_unscale_.default: found_inf_reduce_handler,
             aten.as_strided.default: as_strided_handler,
-            aten.stack.default: stack_handler,
+            aten.stack.default: lambda *args: decomp_wrapper(*args),
         }
 
     # ********************************************************************************************

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -792,7 +792,9 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
             # check if the tensor is sharded on the concat dim
             if is_tensor_dim_sharded(exemplar_spec, dim):
                 # Strategy 1: Unshard to replicate (original behavior)
-                exemplar_placement_replicate = unshard_tensor_dim(exemplar_spec.placements, dim)
+                exemplar_placement_replicate = unshard_tensor_dim(
+                    exemplar_spec.placements, dim
+                )
                 if exemplar_placement_replicate not in strategies_placement_pool:
                     strategies_placement_pool.add(exemplar_placement_replicate)
                     redistribute_costs = []
@@ -812,54 +814,89 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
                         )
                         input_specs.append(input_spec)
                         redistribute_costs.append(
-                            generate_redistribute_costs(that_tensor_strategy, input_spec)
+                            generate_redistribute_costs(
+                                that_tensor_strategy, input_spec
+                            )
                         )
                     op_strategy.strategies.append(
                         OpSpec(
-                            output_specs=DTensorSpec(mesh, exemplar_placement_replicate),
+                            output_specs=DTensorSpec(
+                                mesh, exemplar_placement_replicate
+                            ),
                             input_specs=tuple(input_specs),
                             redistribute_cost=redistribute_costs,
                         )
                     )
 
-                # Strategy 2: Convert Shard to _StridedShard (new behavior to avoid collectives)
+                # Strategy 2: Convert Shard to _StridedShard.
                 # When concatenating along a sharded dimension, we can use _StridedShard
                 # to represent the strided sharding pattern without requiring allgather
-                exemplar_placement_strided = tuple(
-                    _StridedShard(p.dim, split_factor=num_input_tensor)
-                    if isinstance(p, Shard) and p.dim == dim
-                    else p
-                    for p in exemplar_spec.placements
+                # Note: This only works when all input tensors have the same size
+                # on the concatenation dimension.
+                # This is the case for our aten.stack decomp.
+                all_same_size_on_cat_dim = True
+                first_tensor_meta = (
+                    input_tuple_strategy.children[0]
+                    .strategies[0]
+                    .output_spec.tensor_meta
                 )
-                if exemplar_placement_strided not in strategies_placement_pool:
-                    strategies_placement_pool.add(exemplar_placement_strided)
-                    redistribute_costs = []
-                    input_specs = []
-                    for idx in range(num_input_tensor):
-                        that_tensor_strategy = input_tuple_strategy.children[idx]
-                        if not isinstance(that_tensor_strategy, OpStrategy):
-                            raise AssertionError(
-                                f"Expected OpStrategy, got {type(that_tensor_strategy)}"
-                            )
-                        # Input should keep Shard placement (no redistribution needed)
-                        input_spec = DTensorSpec(
-                            mesh,
-                            exemplar_spec.placements,  # Keep original sharding
-                            tensor_meta=that_tensor_strategy.strategies[
-                                0
-                            ].output_spec.tensor_meta,
+                if first_tensor_meta is not None:
+                    first_size_on_cat_dim = first_tensor_meta.shape[dim]
+                    for idx in range(1, num_input_tensor):
+                        that_tensor_meta = (
+                            input_tuple_strategy.children[idx]
+                            .strategies[0]
+                            .output_spec.tensor_meta
                         )
-                        input_specs.append(input_spec)
-                        redistribute_costs.append(
-                            generate_redistribute_costs(that_tensor_strategy, input_spec)
-                        )
-                    op_strategy.strategies.append(
-                        OpSpec(
-                            output_specs=DTensorSpec(mesh, exemplar_placement_strided),
-                            input_specs=tuple(input_specs),
-                            redistribute_cost=redistribute_costs,
-                        )
+                        if (
+                            that_tensor_meta is None
+                            or that_tensor_meta.shape[dim] != first_size_on_cat_dim
+                        ):
+                            all_same_size_on_cat_dim = False
+                            break
+                else:
+                    all_same_size_on_cat_dim = False
+
+                if all_same_size_on_cat_dim:
+                    exemplar_placement_strided = tuple(
+                        _StridedShard(p.dim, split_factor=num_input_tensor)
+                        if isinstance(p, Shard) and p.dim == dim
+                        else p
+                        for p in exemplar_spec.placements
                     )
+                    if exemplar_placement_strided not in strategies_placement_pool:
+                        strategies_placement_pool.add(exemplar_placement_strided)
+                        redistribute_costs = []
+                        input_specs = []
+                        for idx in range(num_input_tensor):
+                            that_tensor_strategy = input_tuple_strategy.children[idx]
+                            if not isinstance(that_tensor_strategy, OpStrategy):
+                                raise AssertionError(
+                                    f"Expected OpStrategy, got {type(that_tensor_strategy)}"
+                                )
+                            # Input should keep Shard placement (no redistribution needed)
+                            input_spec = DTensorSpec(
+                                mesh,
+                                exemplar_spec.placements,  # Keep original sharding
+                                tensor_meta=that_tensor_strategy.strategies[
+                                    0
+                                ].output_spec.tensor_meta,
+                            )
+                            input_specs.append(input_spec)
+                            redistribute_costs.append(
+                                generate_redistribute_costs(
+                                    that_tensor_strategy, input_spec
+                                )
+                            )
+                        op_strategy.strategies.append(
+                            OpSpec(
+                                output_specs=DTensorSpec(
+                                    mesh, exemplar_placement_strided
+                                ),
+                                input_specs=tuple(input_specs),
+                                redistribute_cost=redistribute_costs,
+                            )
+                        )
             else:
                 exemplar_placement = exemplar_spec.placements
                 if exemplar_placement not in strategies_placement_pool:
@@ -881,7 +918,9 @@ def cat_strategy(op_schema: OpSchema) -> StrategyType:
                         )
                         input_specs.append(input_spec)
                         redistribute_costs.append(
-                            generate_redistribute_costs(that_tensor_strategy, input_spec)
+                            generate_redistribute_costs(
+                                that_tensor_strategy, input_spec
+                            )
                         )
                     op_strategy.strategies.append(
                         OpSpec(

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -615,7 +615,9 @@ def propagate_shape_and_sharding(
                 # Special case for _StridedShard: if we're splitting a _StridedShard dimension
                 # and the first split size equals the split_factor, we can convert to Shard
                 # on the last split dimension
-                shard_mesh_dim, shard_placement = maybe_get_shard_mesh_dim_and_placement(in_dim)
+                shard_mesh_dim, shard_placement = (
+                    maybe_get_shard_mesh_dim_and_placement(in_dim)
+                )
                 is_strided_shard = isinstance(shard_placement, _StridedShard)
 
                 if is_strided_shard and shard_mesh_dim is not None:
@@ -631,8 +633,10 @@ def propagate_shape_and_sharding(
                         shardable_dims[in_dim.input_dim] = [False] * mesh_ndim
                         if strict_view:
                             raise RuntimeError(
-                                f"Attempted to split _StridedShard dimension {in_dim.input_dim} with split_factor={shard_placement.split_factor} "  # type: ignore[union-attr]
-                                f"into subdimensions {cmd.group_shape}, but first dimension {cmd.group_shape[0]} != split_factor. "
+                                f"Attempted to split _StridedShard dimension {in_dim.input_dim} "
+                                f"with split_factor={shard_placement.split_factor} "  # type: ignore[union-attr]
+                                f"into subdimensions {cmd.group_shape}, but first dimension "
+                                f"{cmd.group_shape[0]} != split_factor. "
                                 "It cannot be performed without redistribution, which is disallowed by the current operator.",
                             )
                 else:
@@ -642,7 +646,11 @@ def propagate_shape_and_sharding(
                         out_size % mesh_dim_size == 0 for mesh_dim_size in mesh_sizes
                     ]
 
-                    if strict_view and shard_mesh_dim is not None and not is_strided_shard:
+                    if (
+                        strict_view
+                        and shard_mesh_dim is not None
+                        and not is_strided_shard
+                    ):
                         if not shardable_dims[in_dim.input_dim][shard_mesh_dim]:
                             raise RuntimeError(
                                 f"Attempted to split the sharded dimension {in_dim.input_dim} into multiple subdimensions. ",
@@ -652,7 +660,11 @@ def propagate_shape_and_sharding(
                     # 2. here we special case things like [Shard(0), Shard(0)]
                     submesh_size = 1
                     for size, shard in zip(mesh_sizes, input_src_placements):
-                        if isinstance(shard, Shard) and not isinstance(shard, _StridedShard) and shard.dim == in_dim.input_dim:
+                        if (
+                            isinstance(shard, Shard)
+                            and not isinstance(shard, _StridedShard)
+                            and shard.dim == in_dim.input_dim
+                        ):
                             submesh_size *= size
                     if submesh_size > 1 and not out_size % submesh_size == 0:
                         raise AssertionError(
@@ -690,11 +702,13 @@ def propagate_shape_and_sharding(
 
             # Check if this input dimension has a _StridedShard placement
             for placement in input_src_placements:
-                if isinstance(placement, _StridedShard) and placement.dim == input_dim_idx:
+                if (
+                    isinstance(placement, _StridedShard)
+                    and placement.dim == input_dim_idx
+                ):
                     # Map to the rightmost split dimension (last split_id)
                     if cmd.split_id == len(cmd.group_shape) - 1:
                         strided_shard_dim_map[input_dim_idx] = dim
-
 
     input_tgt_placements = [
         (
@@ -723,7 +737,9 @@ def propagate_shape_and_sharding(
                 return _StridedShard(shard_dim_map[p.dim], split_factor=p.split_factor)
             else:
                 # This shouldn't happen if shardable_dims is set correctly
-                raise AssertionError(f"_StridedShard dimension {p.dim} not found in shard_dim_map")
+                raise AssertionError(
+                    f"_StridedShard dimension {p.dim} not found in shard_dim_map"
+                )
         else:
             return Shard(shard_dim_map[p.dim])
 


### PR DESCRIPTION
Generated with claude. I want to run CI and read through the code a bit more before getting any reviews. The main idea was:

(1) use the existing decomp for `aten.stack` in DTensor (which runs `aten.cat` and `aten.view`)

(2) out of the box this is not ok, because `aten.cat([x, x], dim=0)` will force a redistribute if x has placement `Shard(0)`. I wanted to try out tweaking the `aten.cat` sharding prop rule to avoid a redistribute in this case by making the output a `StridedShard`

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169299

