### PR TITLE
Use enum.member starting in version 3.11

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
@@ -5,7 +5,8 @@ from functools import partial
 
 
 # To suppress FutureWarning from partial since 3.13
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 11):
+    # member was introduced in Python 3.11
     from enum import member
 
     def _enum_member(x):


### PR DESCRIPTION
In PR #163939 `enum_member` was introduced for backwards compatibility, but `enum.member` was introduced in Python 3.11, it's just the FutureWarning that was introduced in 3.13. This allows us to adopt the new member style earlier (and drop the compatibility shim earlier).