### PR TITLE
[dde] use is_contiguous_or_false for function with out= arg

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -674,6 +674,18 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
+    def test_fmod_with_out_arg(self, device):
+        def fn(x):
+            nz = torch.nonzero(x).float()
+            return torch.fmod(nz, 2.0, out=nz)
+
+        example_inputs = (torch.randn(32, device=device),)
+        actual = torch.compile(fn, fullgraph=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1660,7 +1660,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                             *graph_break_hints.SUPPORTABLE,
                         ],
                     )
-                if not torch._prims_common.is_contiguous(fake_out):
+                if not torch._prims_common.is_contiguous_or_false(fake_out):
                     # It's difficult to handle strides correctly in functionalization
                     # when calling an out= op with a non-contiguous out argument
                     unimplemented(


### PR DESCRIPTION
Summary:
Avoid DDE scenario by replacing `is_contiguous` -> `is_contiguous_or_false`.

### Codex prompt
```
Write a small unit test that tests that hits a data-dependent exception in the function is_contiguous specifically at `if maybe_guard_or_false(a.numel() < 2):`

https://github.com/pytorch/pytorch/blob/481e5ab336275bd3acd5fa8a611b05b4469012af/torch/_prims_common/__init__.py#L314

Use  torch.fmod to help you write the unit test.

Write the unit test in https://github.com/pytorch/pytorch/blob/481e5ab336275bd3acd5fa8a611b05b4469012af/test/inductor/test_unbacked_symints.py#L4

I expect the unit test to fail with "Could not guard on data-dependent expression"

Requirements:
- Try to make the unit test the smallest reproducible scenario. 
- Follow the conventions in test_unbacked_symints.py.
- The test must reproduce the error that says: "Could not guard on data-dependent expression"
- It must call torch.fmod 

Here is a stack trace to help you reproduce the error:
  File "/re_cwd/re-inplace#link-tree/torch/_dynamo/symbolic_convert.py", line 1285, in call_function
    self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
  File "/re_cwd/re-inplace#link-tree/torch/_dynamo/variables/lazy.py", line 218, in realize_and_forward
    return getattr(self.realize(), name)(*args, **kwargs)
  File "/re_cwd/re-inplace#link-tree/torch/_dynamo/variables/torch.py", line 1663, in call_function
    if not torch._prims_common.is_contiguous(fake_out):
  File "/re_cwd/re-inplace#link-tree/torch/_prims_common/__init__.py", line 314, in is_contiguous
    if maybe_guard_or_false(a.numel() < 2):
  File "/re_cwd/re-inplace#link-tree/torch/_prims_common/__init__.py", line 310, in eval_eager
    return bool(x)
  File "/re_cwd/re-inplace#link-tree/torch/__init__.py", line 763, in __bool__
    return self.node.bool_()
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/sym_node.py", line 602, in bool_
    return self.guard_bool("", 0)
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/sym_node.py", line 538, in guard_bool
    r = self.evaluate()
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/sym_node.py", line 512, in evaluate
    return self.shape_env.evaluate_sym_node(self, size_oblivious)
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/symbolic_shapes.py", line 7308, in evaluate_sym_node
    return self.evaluate_expr(
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/symbolic_shapes.py", line 7408, in evaluate_expr
    return self._inner_evaluate_expr(
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/recording.py", line 273, in wrapper
    return retlog(fn(*args, **kwargs))
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/symbolic_shapes.py", line 7431, in _inner_evaluate_expr
    return self._evaluate_expr(
  File "/re_cwd/re-inplace#link-tree/torch/fx/experimental/symbolic_shapes.py", line 7650, in _evaluate_expr
    raise self._make_data_dependent_error(
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression u11 < 2 (unhinted: u11 < 2).  (Size-like symbols: u11)

Caused by: fmod = torch.fmod(hash, 100, out = hash) in forward (_prims_common/__init__.py:310 in eval_eager)

Verify it works by running this test cmd:

python test/inductor/test_unbacked_symints.py -k <unit-test-name>
```

Differential Revision: D88087007




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela