### PR TITLE
[CUDA][ROCM] Use original wait method in `test_record_stream_on_shifted_view`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1168,7 +1168,10 @@ print(t.is_pinned())
 
         stream_record = torch.cuda.Stream()
         with torch.cuda.stream(stream_record):
-            torch.cuda._busy_wait_for_flag()
+            if TEST_WITH_ROCM:
+                torch.cuda._busy_wait_for_flag()
+            else:
+                torch.cuda._sleep(int(50 * get_cycles_per_ms()))
 
         view.record_stream(stream_record)
 
@@ -1181,7 +1184,8 @@ print(t.is_pinned())
 
         with torch.cuda.stream(stream_alloc):
             try_realloc = torch.cuda.FloatTensor([10, 10])
-        torch.cuda._clear_flag()
+        if TEST_WITH_ROCM:
+            torch.cuda._clear_flag()
 
         self.assertNotEqual(try_realloc.data_ptr(), data_ptr)
 


### PR DESCRIPTION
Reverting on CUDA for now as the test appears to deadlock following #166218

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang