### PR TITLE
[c10d][symm_mem] Implement all_gather_p2p_memcpy using copy engine

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -461,6 +461,8 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
       "multimem_all_gather_out(Tensor input, str group_name, Tensor(a!) out) -> Tensor(a!)");
   m.def(
+      "all_gather_p2p_memcpy(Tensor input, str group_name, Tensor(a!) out) -> Tensor(a!)");
+  m.def(
       "one_shot_all_reduce(Tensor input, str reduce_op, str group_name) -> Tensor");
   m.def(
       "one_shot_all_reduce_out(Tensor input, str reduce_op, str group_name, Tensor(a!) out) -> Tensor(a!)");


### PR DESCRIPTION
Summary:
Implement copy-engine-based all_gather for symmetric memory (all_gather_p2p_memcpy) using cudaMemcpyBatchAsync to issue batched device-to-device P2P copies between per-rank symmetric buffers.

Test Plan:
Run the symmetric memory tests:
```
PYTHONPATH=. python3 test/distributed/test_symmetric_memory.py -k test_all_gather_p2p_memcpy
```

