### PR TITLE
[refcycle-logger] Handle ReferenceErrors

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -15,6 +15,7 @@ import threading
 import time
 import unittest
 import warnings
+import weakref
 from collections import defaultdict
 from copy import deepcopy
 from itertools import product
@@ -4321,6 +4322,79 @@ class TestCudaMallocAsync(TestCase):
             # call so it doesn't actual fire until the next
             # method call after a gc.collect
             noop()
+            self.assertTrue(fired)
+        finally:
+            disarm()
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
+    )
+    @requiresCppContext
+    def test_cycles_containing_weakref_proxy(self):
+        """
+        Test that cycles containing dead weak proxies don't crash the observer.
+
+        This test reproduces the scenario where gc.garbage contains both CUDA tensor
+        cycles AND dead weak proxies, verifying that is_cuda_tensor() handles the
+        ReferenceError gracefully and the observer still fires correctly.
+        """
+        fired = False
+
+        def observer(html):
+            nonlocal fired
+            fired = True
+            self.assertTrue("torch.Tensor" in html)
+            self.assertTrue("test_cuda" in html)
+            self.assertTrue("cell_contents" in html)
+
+        disarm = observe_tensor_cycles(observer)
+
+        def noop():
+            pass
+
+        try:
+
+            def create():
+                # Create a CUDA tensor cycle
+                x = torch.empty(3, 4, device="cuda")
+
+                def foo(p):
+                    if p:
+                        return foo(not p)
+                    else:
+                        return x
+
+                # Create a weak proxy that will become dead and end up in gc.garbage
+                class Klass:
+                    pass
+
+                obj = Klass()
+                proxy = weakref.proxy(obj)
+
+                # Create a cycle that references the weak proxy
+                container = [proxy]
+                container.append(container)
+
+                # Delete the object, making the proxy dead
+                del obj
+
+                # Verify the proxy is dead (isinstance should raise ReferenceError)
+                with self.assertRaises(ReferenceError):
+                    isinstance(proxy, type)
+
+                return foo
+
+            create()
+
+            # Force garbage collection - this will create gc.garbage containing
+            # both the dead weak proxy AND the CUDA tensor cycle
+            gc.collect()
+
+            # The callback has to run outside of the collect call
+            # so it doesn't actually fire until the next method call after gc.collect
+            noop()
+
+            # The observer should still fire successfully despite the dead weak proxy
             self.assertTrue(fired)
         finally:
             disarm()

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -212,7 +212,11 @@ def object_annotation(obj):
     """
 
     def format_sequence(obj):
-        body = ','.join(repr(x) if isinstance(x, BASE_TYPES) else type(x).__name__ for x in obj[:8])
+        def safe_repr(x):
+            if isinstance(x, weakref.ProxyTypes):
+                return "weakref (dead)"
+            return repr(x) if isinstance(x, BASE_TYPES) else type(x).__name__
+        body = ','.join(safe_repr(x) for x in obj[:8])
         if len(obj) > 8:
             body = f'{body}, ...{len(obj) - 8}'
         return body
@@ -476,7 +480,7 @@ def observe_tensor_cycles(callback):
 
     def observer(garbage) -> None:
         if garbage:
-            if not any(is_cuda_tensor(obj) for obj in garbage):
+            if not any((not isinstance(obj, weakref.ProxyTypes) and is_cuda_tensor(obj)) for obj in garbage):
                 logger.info("No CUDA Tensors found in garbage")
                 return
             callback(to_html(create_graph(garbage)))


### PR DESCRIPTION
The ref-cycle logger currently throws errors if hit with a weakref proxy object, e.g:

```
class Klass:
    pass

obj = Klass()
proxy = weakref.proxy(obj)
del obj

# This should raise ReferenceError
isinstance(proxy, type)
```

This situation happens for the ref-cycle logger if a proxy object ends up in `gc.garbage` after `gc.collect()` is called. There's not much we can do when we hit this situation (since the underlying object has been GC'd already). Just swallow the exception and proceed with the rest of the objects.

Differential Revision: D88090361


