### PR TITLE
xpu: add a test to verify all torch xpu libraries are linked on Linux

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -119,7 +119,7 @@ class TestCppExtensionJIT(common.TestCase):
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
 
-    def _test_jit_xpu_extension(self, extra_sycl_cflags):
+    def _test_jit_xpu_extension(self, extra_sycl_cflags=None, extra_ldflags=None):
         # randomizing extension name and names of extension methods
         # for the case when we test building few extensions in a row
         # using this function
@@ -139,7 +139,8 @@ class TestCppExtensionJIT(common.TestCase):
             module = torch.utils.cpp_extension.load(
                 name=name,
                 sources=[sycl_file],
-                extra_sycl_cflags=extra_sycl_cflags,
+                extra_sycl_cflags=extra_sycl_cflags if extra_sycl_cflags else [],
+                extra_ldflags=extra_ldflags if extra_ldflags else [],
                 verbose=True,
                 build_directory=temp_dir,
             )
@@ -164,7 +165,7 @@ class TestCppExtensionJIT(common.TestCase):
     @unittest.skipIf(not (TEST_XPU), "XPU not found")
     def test_jit_xpu_extension(self):
         # NOTE: this test can be affected by setting TORCH_XPU_ARCH_LIST
-        self._test_jit_xpu_extension(extra_sycl_cflags=[])
+        self._test_jit_xpu_extension()
 
     @unittest.skipIf(not (TEST_XPU), "XPU not found")
     def test_jit_xpu_archlists(self):
@@ -175,14 +176,12 @@ class TestCppExtensionJIT(common.TestCase):
             {
                 # Testing JIT compilation
                 "archlist": "",
-                "extra_sycl_cflags": [],
             },
             {
                 # Testing JIT + AOT (full torch AOT arch list)
                 # NOTE: default cpp extension AOT arch list might be reduced
                 # from the full list
                 "archlist": ",".join(torch.xpu.get_arch_list()),
-                "extra_sycl_cflags": [],
             },
             {
                 # Testing AOT (full torch AOT arch list)
@@ -193,14 +192,33 @@ class TestCppExtensionJIT(common.TestCase):
                 "extra_sycl_cflags": ["-fsycl-targets=spir64_gen"],
             },
         ]
+        if IS_LINUX:
+            lib_python = f"-lpython{sys.version_info.major}.{sys.version_info.minor}"
+            cases.append(
+                {
+                    # Testing that we link with all potentially required dependencies.
+                    # The goal is to check that all python side libraries (c10_xpu, torch_xpu) are
+                    # included. We can't do that without linking against really all required libraries
+                    # including python. So we add -lpythonX.Y to the link command line for the test
+                    # purposes. That's not required and actually is recommended against in real life
+                    # applications as this reduces compatibility with python versions.
+                    "extra_ldflags": ["-Wl,--no-undefined", lib_python],
+                }
+            )
         old_envvar = os.environ.get("TORCH_XPU_ARCH_LIST", None)
         try:
             for c in cases:
-                os.environ["TORCH_XPU_ARCH_LIST"] = c["archlist"]
-                self._test_jit_xpu_extension(extra_sycl_cflags=c["extra_sycl_cflags"])
+                if "archlist" in c:
+                    os.environ["TORCH_XPU_ARCH_LIST"] = c["archlist"]
+                extra_sycl_cflags = c.get("extra_sycl_cflags", [])
+                extra_ldflags = c.get("extra_ldflags", [])
+                self._test_jit_xpu_extension(
+                    extra_sycl_cflags=extra_sycl_cflags, extra_ldflags=extra_ldflags
+                )
         finally:
             if old_envvar is None:
-                os.environ.pop("TORCH_XPU_ARCH_LIST")
+                if "TORCH_XPU_ARCH_LIST" in os.environ:
+                    os.environ.pop("TORCH_XPU_ARCH_LIST")
             else:
                 os.environ["TORCH_XPU_ARCH_LIST"] = old_envvar
 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -9,6 +9,7 @@ import shutil
 import string
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import unittest
 import warnings
@@ -193,15 +194,12 @@ class TestCppExtensionJIT(common.TestCase):
             },
         ]
         if IS_LINUX:
-            # In the case of virtual environment python .so library will be located at paths
-            # returned by python config in ldflags.
-            result = subprocess.run(
-                ["python3-config", "--ldflags"],
-                check=True,
-                capture_output=True,
-                text=True,
+            # In the case of virtual environment python .so library will be located at LIBDIR
+            # returned by python sysconfig.
+            (libdir,) = sysconfig.get_config_vars("LIBDIR")
+            lib_python = (
+                f"-L{libdir} -lpython{sys.version_info.major}.{sys.version_info.minor}"
             )
-            lib_python = f"{result.stdout.strip()} -lpython{sys.version_info.major}.{sys.version_info.minor}"
             cases.append(
                 {
                     # Testing that we link with all potentially required dependencies.

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -193,7 +193,15 @@ class TestCppExtensionJIT(common.TestCase):
             },
         ]
         if IS_LINUX:
-            lib_python = f"-lpython{sys.version_info.major}.{sys.version_info.minor}"
+            # In the case of virtual environment python .so library will be located at paths
+            # returned by python config in ldflags.
+            result = subprocess.run(
+                ["python3-config", "--ldflags"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            lib_python = f"{result.stdout.strip()} -lpython{sys.version_info.major}.{sys.version_info.minor}"
             cases.append(
                 {
                     # Testing that we link with all potentially required dependencies.


### PR DESCRIPTION
A follow up on the noticed Linux specific issue for sycl cpp extension. We need to link with more libraries we are linking so far. Issue got unnoticed as these libraries were already loaded during torch import. The dd18a75 commit has added missing libs formally to the linker cmdline. Current commit further adds test for such a case.

See https://github.com/pytorch/pytorch/pull/162579#discussion_r2478615147
