### PR TITLE
Fix failing dlpack tests

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -462,8 +462,7 @@ class TestTorchDlPack(TestCase):
     def test_numpy_dlpack_protocol_conversion(self, device, dtype):
         import numpy as np
 
-        N = 5
-        t = make_tensor((N,), dtype=dtype, device=device)
+        t = make_tensor((5,), dtype=dtype, device=device)
 
         if hasattr(np, "from_dlpack"):
             # DLPack support only available from NumPy 1.22 onwards.

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -487,7 +487,7 @@ class TestTorchDlPack(TestCase):
             expected_np_type = TORCH_DTYPE_TO_NP_DTYPE[dtype]
             assert arr.dtype == expected_np_type
             for i in range(N):
-                assert arr[i].item() == t[i].item() and arr[i] != 0
+                assert arr[i].item() == t[i].item()
 
         # We can't use the array created above as input to from_dlpack.
         # That's because DLPack imported NumPy arrays are read-only.

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -1,7 +1,5 @@
 # Owner(s): ["module: tests"]
 
-import numpy as np
-
 import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import (
@@ -462,6 +460,8 @@ class TestTorchDlPack(TestCase):
         )
     )
     def test_numpy_dlpack_protocol_conversion(self, device, dtype):
+        import numpy as np
+
         N = 5
         t = make_tensor((N,), dtype=dtype, device=device)
 

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -1,7 +1,8 @@
 # Owner(s): ["module: tests"]
 
-import torch
 import numpy as np
+
+import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -29,19 +29,6 @@ from torch.testing._internal.common_utils import (
 from torch.utils.dlpack import DLDeviceType, from_dlpack, to_dlpack
 
 
-TORCH_DTYPE_TO_NP_DTYPE = {
-    torch.bool: np.bool_,
-    torch.uint8: np.uint8,
-    torch.uint16: np.uint16,
-    torch.uint32: np.uint32,
-    torch.uint64: np.uint64,
-    torch.int8: np.int8,
-    torch.int16: np.int16,
-    torch.int32: np.int32,
-    torch.int64: np.int64,
-}
-
-
 # Wraps a tensor, exposing only DLPack methods:
 #    - __dlpack__
 #    - __dlpack_device__
@@ -482,12 +469,9 @@ class TestTorchDlPack(TestCase):
             # DLPack support only available from NumPy 1.22 onwards.
             # Here, we test having another framework (NumPy) calling our
             # Tensor.__dlpack__ implementation.
-            arr = np.from_dlpack(t)
-            assert arr.shape == t.shape
-            expected_np_type = TORCH_DTYPE_TO_NP_DTYPE[dtype]
-            assert arr.dtype == expected_np_type
-            for i in range(N):
-                assert arr[i].item() == t[i].item()
+            np_from_dlpack = np.from_dlpack(t)
+            np_from_copy = t.numpy()
+            self.assertEqual(np_from_dlpack, np_from_copy)
 
         # We can't use the array created above as input to from_dlpack.
         # That's because DLPack imported NumPy arrays are read-only.


### PR DESCRIPTION
Fix failing dlpack tests, which are currently failing on main.

On main, we get errors like:
```
File "/home/hugh/git/pytorch/torch/testing/_internal/common_utils.py", line 4298, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Object comparison failed: tensor([5, 1, 6, 5, 6], dtype=torch.uint8) != array([5, 1, 6, 5, 6], dtype=uint8)
```

Which if we dig a little give:
```
TestCase.assertEquals
try pair type <class 'torch.testing._comparison.NonePair'>
try pair type <class 'torch.testing._internal.common_utils.RelaxedBooleanPair'>
try pair type <class 'torch.testing._internal.common_utils.RelaxedNumberPair'>
try pair type <class 'torch.testing._internal.common_utils.TensorOrArrayPair'>
TensorOrArrayPair check inputs is instance
TensorOrArrayPair after check inputs is instance
_to_tensor tensor_like tensor([5, 1, 6, 5, 6], dtype=torch.uint8)
is torch tensor, returning tensor([5, 1, 6, 5, 6], dtype=torch.uint8)
_to_tensor tensor_like [5 1 6 5 6]
calling torch.as_tensor on  [5 1 6 5 6]
got exception Cannot export readonly array since signalling readonly is unsupported by DLPack.
```

This PR avoids this by doing the comparison without using TestCase.assertEquals.