### PR TITLE
[NOT FOR MERGE] Use dynamo_graph_capture for in and out_graph_shuffle

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -578,9 +578,10 @@ def forward(self, args_0):
         self.assertExpectedInline(
             ep._in_shuffle_graph.code.strip("\r\n "),
             """\
-def forward(self, arg0_1, arg1_1):
-    _tensor_constant0 = self._tensor_constant0
-    return (arg1_1, _tensor_constant0)""",
+def forward(self, unused_placeholder, L_flat_orig_inputs_1_ : torch.Tensor):
+    l_flat_orig_inputs_1_ = L_flat_orig_inputs_1_
+    l__input_extractor_____closure___1_cell_contents = self.L__input_extractor_____closure___1_cell_contents
+    return (l_flat_orig_inputs_1_, l__input_extractor_____closure___1_cell_contents)""",
         )
         self.assertExpectedInline(
             ep.code.strip("\r\n "),

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -273,9 +273,10 @@ class PyCodegen:
             # to keep the old behavior, as when `value_from_source` was
             # introduced. TODO sort out the invariants among side effect,
             # codegen and export.
+            # breakpoint()
             if (
                 isinstance(value.mutation_type, ValueMutationExisting)
-                or self.value_from_source
+                # or self.value_from_source
             ):
                 return self(value.source)
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2478,6 +2478,7 @@ class OutputGraph(OutputGraphCommon):
         # allows for the guard to be done using C++ guards.)  If we get
         # ShapeEnv guards to go into C++ guards, this will stop being a thing
         # though!
+        return
 
         assert self.should_exit
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3371,6 +3371,9 @@ def _module_dir(m: types.ModuleType) -> Optional[str]:
 # LEGACY_MOD_INLINELIST because it is less likely to break existing tests.
 LEGACY_MOD_INLINELIST = {
     "torch._dynamo.external_utils",
+    "torch._dynamo.functional_export",
+    # "torch._dynamo.utils",
+    # "torch._dynamo.source",
     "torch._export.db.examples",
     "torch._export.wrappers",
     "torch._functorch.apis",

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from typing import Any, final, Optional, Union
 from typing_extensions import Self
 
+import torch
+
 from ..utils import is_function_or_wrapper
 from .base import VariableTracker
 from .tensor import SymNodeVariable
@@ -67,6 +69,8 @@ class LazyVariableTracker(VariableTracker):
         assert isinstance(_cache, LazyCache)
         super().__init__(**kwargs)
         self._cache = _cache
+        if isinstance(_cache.value, torch.Tensor):
+            self.realize()
 
     def realize(self) -> VariableTracker:
         """Force construction of the real VariableTracker"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169337
* __->__ #169333

Reasons for doing this

1) make_fx seems a very big hammer
2) No worry about side effects getting played (though this PR might still have side effects to get out_spec, we will have to think about that)

Ofcourse this requires some more flags that will be turned on for
shuffling.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo