### PR TITLE
[DO NOT LAND] Support DTensor RNG in torch.compile

### DIFF
--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3558,6 +3558,29 @@ class RunWithRNGStateHigherOrderVariable(TorchHigherOrderOperatorVariable):
         )
 
 
+class RunWithStartEndRNGStateHigherOrderVariable(TorchHigherOrderOperatorVariable):
+    def _call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: "list[VariableTracker]",
+        kwargs: "dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        from .builder import wrap_fx_proxy
+
+        p_args = tuple(arg.as_proxy() for arg in args)
+        p_kwargs = {key: arg.as_proxy() for key, arg in kwargs.items()}
+        return wrap_fx_proxy(
+            tx=tx,
+            proxy=tx.output.create_proxy(
+                "call_function",
+                self.value,
+                args=p_args,
+                kwargs=p_kwargs,
+            ),
+            example_value=None,
+        )
+
+
 class AutoFunctionalizeHigherOrderVariable(TorchHigherOrderOperatorVariable):
     def _call_function(
         self, tx, args: "list[VariableTracker]", kwargs: "dict[str, VariableTracker]"
@@ -4654,6 +4677,7 @@ _hop_name_to_variable_class = {
     "trace_wrapped": TraceWrappedHigherOrderOperatorVariable,
     "strict_mode": StrictModeHigherOrderVariable,
     "run_with_rng_state": RunWithRNGStateHigherOrderVariable,
+    "run_with_start_end_rng_state": RunWithStartEndRNGStateHigherOrderVariable,
     "associative_scan": AssociativeScanHigherOrderVariable,
     "scan": ScanHigherOrderVariable,
     "call_torchbind": CallTorchbindHigherOrderVariable,


### PR DESCRIPTION
Trying to fix [#147757](https://github.com/pytorch/pytorch/issues/147757)

Context: https://docs.google.com/document/d/1ahwORvrUUyxqBErTmEtgDcWHqZZGLaoVGuFd_NjpQD4/

There are two issues when using torch.compile() on a random op with DTensor.

[THIS PR] 1. In order to guarantee correct randomness distribution across ranks, DTensor RNG has logic such as `set_rng()` and `fork_rng()`, which are not compiler-friendly. This can be addressed by introducing a HOP `run_with_start_end_rng_state()` and tweaking DTensor to call this HOP during dispatch.

[TODO] 2. DTensor maintains a sidecar global RNG state to treat random ops on torch.Tensor and DTensor independently. However, this global state is not seen by Dynamo (as it is lazily initialized and read/written during dispatch), so we will run into issues fakifying this global state. I have yet to figure out how to resolve this.

A toy example to verify the hop works, running the following example will give you a single graph

```python
import torch
from torch._prims.rng_prims import run_with_start_end_rng_state
from torch._dynamo.testing import EagerAndRecordGraphs

backend = EagerAndRecordGraphs()

@torch.compile(backend=backend)
def rand_func():
    start_offset = 0
    end_offset = 24

    start_rng_state = torch.zeros(16, dtype=torch.uint8, device='cuda')
    start_offset_tensor = torch.tensor([start_offset], dtype=torch.uint64, device='cpu').view(torch.uint8)
    start_rng_state[8:16] = start_offset_tensor

    end_rng_state = torch.zeros(16, dtype=torch.uint8, device='cuda')
    final_offset_tensor = torch.tensor([end_offset], dtype=torch.uint64, device='cpu').view(torch.uint8)
    end_rng_state[8:16] = final_offset_tensor

    out = run_with_start_end_rng_state(start_rng_state, end_rng_state, torch.ops.aten.randn.default, [8], device='cuda:0')

    return out

def main():
    torch.manual_seed(42)
    _ = rand_func()
    backend.graphs[0].print_readable()

if __name__ == "__main__":
    main()
```

=================================================================================

However, as 2 is not fixed, running the following code still fails

```python
import torch
from torch.distributed.device_mesh import init_device_mesh

from torch.distributed import get_rank, destroy_process_group

from torch.distributed.tensor.parallel import (
    SequenceParallel,
    parallelize_module,
)

class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.dropout = torch.nn.Dropout()

    def forward(self, x):
        x = self.dropout(x)
        return x

def main():
    mesh = init_device_mesh("cuda", (2,))
    device = torch.device(f"cuda:{get_rank()}")
    torch.set_default_device(device)
    torch.manual_seed(42)

    dt = torch.randn(2, 2, 2)
    model = Model()

    parallelize_module(
        model,
        mesh,
        {
            "dropout": SequenceParallel(),
        },
    )

    model = torch.compile(model, backend="eager")
    _ = model(dt)

    destroy_process_group()

if __name__ == "__main__":
    main()

```


Error Message

```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <function dropout at 0x7fba4b911c60>(*(DTensor(local_tensor=FakeTensor(..., device='cuda:1', size=(2, 2, 2)), device_mesh=DeviceMesh((2,), 'cuda', stride=(1,)), placements=(Shard(dim=1),)), 0.5, True, False), **{}): got AssertionError("Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode with 'allow_non_fake_inputs'. Found in aten.to.dtype_layout(tensor([...], size=(16,), dtype=torch.uint8), dtype=torch.uint8, layout=torch.strided, device=device(type='cuda', index=1))")
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo