### PR TITLE
Fix slotscheck warnings

### DIFF
--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -763,7 +763,7 @@ LevelList = list  # levels (distance from root of tree)
 
 
 class OutputAliasInfo:
-    pass
+    __slots__ = []
 
 
 class _UnaliasedStorage(OutputAliasInfo):

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -68,24 +68,26 @@ class FileTimerRequest(TimerRequest):
     process.
     """
 
-    __slots__ = ["version", "worker_pid", "scope_id", "expiration_time", "signal"]
+    __slots__ = ["version", "signal"]
 
     def __init__(
         self, worker_pid: int, scope_id: str, expiration_time: float, signal: int = 0
     ) -> None:
+        super().__init__(
+            worker_id=worker_pid, scope_id=scope_id, expiration_time=expiration_time
+        )
         self.version = 1
-        self.worker_pid = worker_pid
-        self.scope_id = scope_id
-        self.expiration_time = expiration_time
         self.signal = signal
+
+    @property
+    def worker_pid(self) -> int:
+        return self.worker_id
 
     def __eq__(self, other) -> bool:
         if isinstance(other, FileTimerRequest):
             return (
-                self.version == other.version
-                and self.worker_pid == other.worker_pid
-                and self.scope_id == other.scope_id
-                and self.expiration_time == other.expiration_time
+                super().__eq__(other)
+                and self.version == other.version
                 and self.signal == other.signal
             )
         return False

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -695,7 +695,7 @@ _ERR_MSG = _ERR_MSG_PREFIX + "{!r}"
 
 
 class _PathNode:
-    pass
+    __slots__ = []
 
 
 class _PackageNode(_PathNode):


### PR DESCRIPTION
This PR fixes some of slotscheck warnings. The some of them are:
```
ERROR: 'torch._inductor.cudagraph_trees:AliasesNewOutput' has slots but superclass does not.
ERROR: 'torch._inductor.cudagraph_trees:AliasesPriorGraphOutput' has slots but superclass does not.
ERROR: 'torch._subclasses.fake_tensor:_BypassDispatchCache' has slots but superclass does not.
ERROR: 'torch.distributed._functional_collectives:AsyncCollectiveTensor' has slots but superclass does not.
ERROR: 'torch.distributed.elastic.timer.file_based_local_timer:FileTimerRequest' defines overlapping slots.
ERROR: 'torch.distributed.tensor._shards_wrapper:LocalShardsWrapper' has slots but superclass does not.
ERROR: 'torch.distributed.tensor:DTensor' has slots but superclass does not.
ERROR: 'torch.multiprocessing.spawn:ProcessException' has slots but superclass does not.
ERROR: 'torch.package.package_importer:_ModuleNode' has slots but superclass does not.
ERROR: 'torch.sparse.semi_structured:SparseSemiStructuredTensor' has slots but superclass does not.
ERROR: 'torch.testing._internal.logging_tensor:LoggingTensor' has slots but superclass does not.
```
The fixes work by adding slot to their parent.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo