### PR TITLE
[ROCm] Enable group gemm on gfx90a

### DIFF
--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -672,7 +672,7 @@ std::optional<c10::ScalarType> out_dtype) {
   bool use_fast_path = false;
   // On non CK system(w/ ROCm), make sure use_fast_path is false
 #if defined(USE_ROCM_CK_GEMM)
-  if (at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950"})) {
+  if (at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950", "gfx90a"})) {
     use_fast_path = true;
   }
 #endif //USE_ROCM_CK_GEMM

--- a/aten/src/ATen/native/hip/ck_group_gemm.hip
+++ b/aten/src/ATen/native/hip/ck_group_gemm.hip
@@ -71,10 +71,7 @@ void launch_grouped_bgemm_ck_impl_dispatch(
 
     // Synchronize the stream to ensure all prior GPU ops
     // affecting host memory are done.
-    hipError_t err = hipStreamSynchronize(c10::hip::getCurrentHIPStream());
-    if (err != hipSuccess) {
-        TORCH_CHECK(false, "CK Group GEMM: HIP stream synchronization error ");
-    }
+    AT_CUDA_CHECK(hipStreamSynchronize(c10::hip::getCurrentHIPStream()));
 
     // for each group, calculate m,n,k,lda,ldb,ldc and A,B,out pointer base addresses.
     if (mat_a_dim == 2 && mat_b_dim == 2) {

--- a/aten/src/ATen/native/hip/ck_group_gemm.hip
+++ b/aten/src/ATen/native/hip/ck_group_gemm.hip
@@ -69,6 +69,15 @@ void launch_grouped_bgemm_ck_impl_dispatch(
     const size_t b_element_size = mat_b.element_size();
     const size_t out_element_size = out.element_size();
 
+    // On gfx90a only, Synchronize the stream to ensure all prior GPU ops
+    // affecting host memory are done.
+    if (at::detail::getCUDAHooks().isGPUArch({"gfx90a"})) {
+        hipError_t err = hipStreamSynchronize(c10::hip::getCurrentHIPStream());
+        if (err != hipSuccess) {
+            TORCH_CHECK(false, "CK Group GEMM: HIP stream synchronization error ");
+        }
+    }
+
     // for each group, calculate m,n,k,lda,ldb,ldc and A,B,out pointer base addresses.
     if (mat_a_dim == 2 && mat_b_dim == 2) {
         // 2D*2D case requires offset tensor

--- a/aten/src/ATen/native/hip/ck_group_gemm.hip
+++ b/aten/src/ATen/native/hip/ck_group_gemm.hip
@@ -69,13 +69,11 @@ void launch_grouped_bgemm_ck_impl_dispatch(
     const size_t b_element_size = mat_b.element_size();
     const size_t out_element_size = out.element_size();
 
-    // On gfx90a only, Synchronize the stream to ensure all prior GPU ops
+    // Synchronize the stream to ensure all prior GPU ops
     // affecting host memory are done.
-    if (at::detail::getCUDAHooks().isGPUArch({"gfx90a"})) {
-        hipError_t err = hipStreamSynchronize(c10::hip::getCurrentHIPStream());
-        if (err != hipSuccess) {
-            TORCH_CHECK(false, "CK Group GEMM: HIP stream synchronization error ");
-        }
+    hipError_t err = hipStreamSynchronize(c10::hip::getCurrentHIPStream());
+    if (err != hipSuccess) {
+        TORCH_CHECK(false, "CK Group GEMM: HIP stream synchronization error ");
     }
 
     // for each group, calculate m,n,k,lda,ldb,ldc and A,B,out pointer base addresses.


### PR DESCRIPTION
Fix concurrency race condition for group gemm and enable group gemm support on
gfx90a architecture.

Test command:
PYTORCH_TEST_WITH_ROCM=1 pytest test/test_matmul_cuda.py -v -k "test_grouped_gemm_2d_2d or test_grouped_gemm_2d_3d or or test_grouped_gemm_3d_3d or test_grouped_gemm_3d_2d"



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang