### PR TITLE
[Fix] Prevent segfault when converting UntypedStorage to bfloat16

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10270,6 +10270,15 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertTrue(m1[0])
         self.assertTrue(m2[0])
 
+    def test_storage_segfault(self):
+        # Regression test for gh-169210
+        # Ensure .bfloat16() on UntypedStorage raises a safe error instead of crashing
+        import torch
+        s = torch.UntypedStorage(10)
+        msg = "Direct conversion of UntypedStorage to bfloat16 is not supported"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            s.bfloat16()
+
     @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
     def test_storage_preserve_nonhermetic_in_hermetic_context(self):
         from torch.library import Library, impl

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -467,6 +467,10 @@ class UntypedStorage(torch._C.StorageBase, _StorageBase):
             raise NotImplementedError("Not available for 'meta' device type")
         return super().__getitem__(*args, **kwargs)
 
+    def bfloat16(self):
+        # Fixes gh-169210: Prevent segfault when converting UntypedStorage to bfloat16.
+        raise RuntimeError("Direct conversion of UntypedStorage to bfloat16 is not supported. Please wrap the storage in a Tensor first.")
+
     @property
     def is_cuda(self):
         return self.device.type == "cuda"


### PR DESCRIPTION
Fixes #169210.

Calling `.bfloat16()` on `UntypedStorage` (especially created via allocator pointers) causes a segmentation fault because the C++ backend attempts to interpret raw bytes without type checks. 

This PR adds a safety check in Python to raise a `RuntimeError` ("Direct conversion... is not supported") instead of crashing the interpreter.

**Test Plan**
- Added regression test `test_storage_segfault` to `test/test_torch.py`.
- Verified locally that the crash is replaced by a safe exception.