### PR TITLE
avoid overflow when casting float to integer on CPU eager mode

### DIFF
--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -57,10 +57,10 @@ struct maybe_bool<true, src_t> {
   }
 };
 
-// Note: deliberately ignores undefined behavior, consistent with NumPy.
-// PyTorch's type conversions can cause a variety of undefined behavior,
-// including float to integral overflow and signed to unsigned integer overflow.
-// Some of this undefined behavior is addressed below.
+// Note: PyTorch's type conversions can cause a variety of undefined behavior,
+// including signed to unsigned integer overflow. Float to integral overflow is
+// addressed below. Other undefined behaviors are deliberately ignored,
+// consistent with NumPy.
 template <typename dest_t, typename src_t, typename enable = void>
 struct static_cast_with_inter_type {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t apply(

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -80,9 +80,11 @@ template <typename dest_t, typename src_t>
 struct static_cast_with_inter_type<
     dest_t,
     src_t,
-    typename std::enable_if<std::is_floating_point<src_t>::value && std::is_signed<dest_t>::value &&
-                            std::is_integral<dest_t>::value>::type> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t apply(src_t src) {
+    typename std::enable_if<
+        std::is_floating_point<src_t>::value && std::is_signed<dest_t>::value &&
+        std::is_integral<dest_t>::value>::type> {
+  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t apply(
+      src_t src) {
     constexpr bool real = needs_real<dest_t, src_t>::value;
     auto r = maybe_real<real, src_t>::apply(src);
     if (r >= static_cast<src_t>(std::numeric_limits<dest_t>::max())) {
@@ -126,7 +128,10 @@ struct static_cast_with_inter_type<uint8_t, src_t, void> {
 };
 
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::BFloat16, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::BFloat16,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::BFloat16 src) {
@@ -135,7 +140,10 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::BFloat16, void>
 };
 
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e5m2, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::Float8_e5m2,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::Float8_e5m2 src) {
@@ -144,7 +152,10 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e5m2, vo
 };
 
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e5m2fnuz, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::Float8_e5m2fnuz,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::Float8_e5m2fnuz src) {
@@ -153,7 +164,10 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e5m2fnuz
 };
 
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e4m3fn, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::Float8_e4m3fn,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::Float8_e4m3fn src) {
@@ -162,7 +176,10 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e4m3fn, 
 };
 
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e4m3fnuz, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::Float8_e4m3fnuz,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::Float8_e4m3fnuz src) {
@@ -173,7 +190,10 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e4m3fnuz
 // TODO(#146647): Can we make all these template specialization happen
 // based off our apply macros?
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e8m0fnu, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::Float8_e8m0fnu,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::Float8_e8m0fnu src) {
@@ -191,7 +211,10 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Half, void> {
 };
 
 template <>
-struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::complex<double>, void> {
+struct static_cast_with_inter_type<
+    c10::complex<c10::Half>,
+    c10::complex<double>,
+    void> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::complex<double> src) {

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -85,15 +85,13 @@ struct static_cast_with_inter_type<
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t apply(src_t src) {
     constexpr bool real = needs_real<dest_t, src_t>::value;
     auto r = maybe_real<real, src_t>::apply(src);
-    if constexpr (std::is_floating_point_v<src_t> && std::is_integral_v<dest_t>) {
-      if (r >= static_cast<src_t>(std::numeric_limits<dest_t>::max()))
-        return std::numeric_limits<dest_t>::max();
-      else if (r < static_cast<src_t>(std::numeric_limits<dest_t>::min()))
-        return std::numeric_limits<dest_t>::min();
-      else
-        return static_cast<dest_t>(r);
+    if (r >= static_cast<src_t>(std::numeric_limits<dest_t>::max())) {
+      return std::numeric_limits<dest_t>::max();
+    } else if (r < static_cast<src_t>(std::numeric_limits<dest_t>::min())) {
+      return std::numeric_limits<dest_t>::min();
+    } else {
+      return static_cast<dest_t>(r);
     }
-    return static_cast<dest_t>(r);
   }
 };
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9522,6 +9522,11 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertEqual(x.int().type(torch.Tensor).dtype, torch.get_default_dtype())
         self.assertEqual(x.type(torch.int32).dtype, torch.int32)
 
+    def test_type_float_to_int_overflow(self):
+        x = torch.tensor([[float(torch.iinfo(torch.int64).max)]])
+        x = x.long()
+        self.assertEqual(x.item(), torch.iinfo(torch.int64).max)
+
     # FIXME: port to a quantization test suite
     @xfailIfS390X
     def test_qengine(self):


### PR DESCRIPTION
Fixes #151510
Float to integral overflow is a [known undefined behavior](https://github.com/pytorch/pytorch/blob/491731647f6b8a9345dcfb3bc9416aea254a7d96/c10/util/TypeCast.h#L62) 
CPU and GPU compilers exhibit divergent behavior.
The result of CPU is consistent with NumPy, however it cause a security vulnerability: [CVE-2025-55554](https://nvd.nist.gov/vuln/detail/CVE-2025-55554)
We clamp the float value and align the CPU results with the GPU when an overflow occurs.