### PR TITLE
[DTensor] Fix torch.equal with scalar DTensor inputs

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -163,7 +163,6 @@ dtensor_fails = {
     xfail("dist"),
     xfail("expand_copy"),
     xfail("exponential"),
-    xfail("equal"),
     xfail("eye"),
     xfail("fft.fft2"),
     xfail("fft.fft"),


### PR DESCRIPTION
equal_strategy fails when one input is 0D (scalar) because it tries to shard the scalar, but torch.chunk() cannot operate on 0D tensors. 
Fixed by using Replicate() when either input is a scalar.

Fixes #169361 
