### PR TITLE
Remove unnecessary code in exception registration

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -65,9 +65,6 @@ could not be completed because the input matrix is singular.",
           "Exception raised when device is out of memory",
           PyExc_RuntimeError,
           nullptr));
-  PyTypeObject* type =
-      reinterpret_cast<PyTypeObject*>(THPException_OutOfMemoryError);
-  type->tp_name = "torch.OutOfMemoryError";
   ASSERT_TRUE(
       PyModule_AddObject(
           module, "OutOfMemoryError", THPException_OutOfMemoryError) == 0);
@@ -134,7 +131,6 @@ could not be completed because the input matrix is singular.",
           "Exception raised while executing on device",
           PyExc_RuntimeError,
           nullptr));
-  type = reinterpret_cast<PyTypeObject*>(THPException_AcceleratorError);
   ASSERT_TRUE(
       PyModule_AddObject(
           module, "AcceleratorError", THPException_AcceleratorError) == 0);


### PR DESCRIPTION
This PR fixes redundant exception creation code in the case of using PyErr_NewExceptionWithDoc.
