### PR TITLE
Skip mutation propagation on aten.copy_.default

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1354,10 +1354,12 @@ class GraphLowering(torch.fx.Interpreter):
             else:
                 out = lowerings[target](*args, **kwargs)  # type: ignore[index]
 
-            if layout_constraints:
+            if layout_constraints and target is not torch.ops.aten.copy_.default:
                 # layout_constraints are allowed to make new copies of the inputs.
                 # if they do, and if the target is mutable, then we need to
                 # write the new values back into the original inputs.
+                # Since copy_ is the mutation propagation mechanism, skip mutation
+                # propagation for copy_ itself to avoid infinite recursion.
                 self.propagate_mutation(n, old_args, old_kwargs, args, kwargs)  # type: ignore[possibly-undefined]
 
             return out


### PR DESCRIPTION
Summary:
add a conditional check to skip mutation propagation for `torch.ops.aten.copy_.default` to avoid infinite recursion while applying layout contraints. 

Stack trace looks like:
```
File "/data/users/milliechen/fbsource/buck-out/v2/gen/fbcode/f24597fa260049bb/aps_models/ads/gmp/__launcher_with_publish__/launcher_with_publish#link-tree/torch/_inductor/graph.py", line 1583, in maybe_propagate
    self.call_function(
  File "/data/users/milliechen/fbsource/buck-out/v2/gen/fbcode/f24597fa260049bb/aps_models/ads/gmp/__launcher_with_publish__/launcher_with_publish#link-tree/torch/_inductor/graph.py", line 1341, in call_function
    raise LoweringException(e, target, args, kwargs).with_traceback(
  File "/data/users/milliechen/fbsource/buck-out/v2/gen/fbcode/f24597fa260049bb/aps_models/ads/gmp/__launcher_with_publish__/launcher_with_publish#link-tree/torch/_inductor/graph.py", line 1337, in call_function
    self.propagate_mutation(n, old_args, old_kwargs, args, kwargs)  # type: ignore[possibly-undefined]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/milliechen/fbsource/buck-out/v2/gen/fbcode/f24597fa260049bb/aps_models/ads/gmp/__launcher_with_publish__/launcher_with_publish#link-tree/torch/_inductor/graph.py", line 1590, in propagate_mutation
    maybe_propagate(schema_arg, old_arg, new_arg)
...
LoweringException: RecursionError: maximum recursion depth exceeded
  target: aten.copy_.default
  args[0]: TensorBox(StorageBox(
    ComputedBuffer(name='buf2924', layout=FixedLayout('mtia:0', torch.int64, size=[71680], stride=[1]), ...)))
  args[1]: TensorBox(StorageBox(
    ComputedBuffer(name='buf2924', layout=FixedLayout('mtia:0', torch.int64, size=[71680], stride=[1]), ...)))
  target: aten.copy_.default
...
```

Test Plan: CI

Differential Revision: D88124020




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo