### PR TITLE
Add `ciflow/inductor` to `inductor-unittest.yml`

### DIFF
--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -4,6 +4,9 @@
 name: inductor-unittest
 
 on:
+  push:
+    tags:
+      - ciflow/inductor/*
   workflow_call:
   schedule:
     - cron: 29 8 * * * # about 1:29am PDT, for mem leak check and rerun disabled tests.
@@ -164,7 +167,7 @@ jobs:
     needs: get-label-type
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12']
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang12
@@ -182,7 +185,7 @@ jobs:
     needs: [get-label-type, inductor-cpu-core-build]
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12']
     with:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang12
       docker-image: ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang12


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #169382
* #168293
* #167542
* #169032

Allow this CI job to be triggered with the ciflow/inductor label