### PR TITLE
Pass GPU_FLAGS inside container during the test

### DIFF
--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -105,7 +105,7 @@ jobs:
     uses: ./.github/workflows/_linux-test.yml
     needs: inductor-pallas-build
     with:
-      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm89
+      build-environment: linux-jammy-cuda12.8-py3.12-gcc11
       docker-image: ${{ needs.inductor-pallas-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-pallas-build.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -100,12 +100,12 @@ jobs:
         ]}
     secrets: inherit
 
-  inductor-pallas-cuda-test:
-    name: inductor-pallas-cuda-test
+  inductor-pallas-test:
+    name: inductor-pallas-test
     uses: ./.github/workflows/_linux-test.yml
     needs: inductor-pallas-build
     with:
-      build-environment: linux-jammy-py3.12-gcc11
+      build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm89
       docker-image: ${{ needs.inductor-pallas-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-pallas-build.outputs.test-matrix }}
     secrets: inherit

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -96,7 +96,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
         { include: [
-          { config: "inductor-pallas", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
+          { config: "inductor-pallas", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.12xlarge.nvidia.gpu" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -100,8 +100,8 @@ jobs:
         ]}
     secrets: inherit
 
-  inductor-pallas-test:
-    name: inductor-pallas-test
+  inductor-pallas-cuda-test:
+    name: inductor-pallas-cuda-test
     uses: ./.github/workflows/_linux-test.yml
     needs: inductor-pallas-build
     with:


### PR DESCRIPTION
By adding `cuda` to the `build-environment:` workflow parameter name
Also move it to g6 runners to match the build args