### PR TITLE
Add check for GPU/cuDNN compatibility on import

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -82,6 +82,20 @@ if _cudnn is not None:
                         )
                 else:
                     raise RuntimeError(base_error_msg)
+            # Check if cuDNN version is compatible with available CUDA devices
+            if torch.cuda.is_available() and not torch.version.hip:
+                min_cc = min(
+                    [
+                        torch.cuda.get_device_capability(i)
+                        for i in range(torch.cuda.device_count())
+                    ]
+                )
+                if __cudnn_version >= 91100 and min_cc < (7, 5):
+                    raise RuntimeError(
+                        f"cuDNN version {__cudnn_version} is not compatible with devices with SM < 7.5. "
+                        f"Please install a version of PyTorch with a compatible cuDNN version. "
+                        f"https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix"
+                    )
 
         return True
 


### PR DESCRIPTION
This PR adds a check for compatibility between available GPUs and cuDNN, since cuDNN 9.11+ no longer supports devices with SM < 7.5.

I have a couple questions to resolve before I think this is mergeable, and there may be more, given that this check can raise an error on `import torch`. 

First, are there any changes that need to be made for AMD devices? Right now this check *should* just be skipped in those cases, but confirmation and/or suggestions would be appreciated.

Second, is raising an error on import the best approach here? Would a warning be better, or should this check happen somewhere else?

Fixes #162574

cc @eqy 