### PR TITLE
Fix cuSPARSE memory alignment issue in batched sparse bmm

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1522,7 +1522,7 @@ class TestSparse(TestSparseBase):
     @dtypes(torch.float32, torch.double)
     @unittest.skipIf(
         IS_WINDOWS,
-        "bmm sparse-dense CUDA is not yet supported in Windows, at least up to CUDA 10.1"
+        "bmm sparse-dense CUDA is not yet supported in Windows, at least up to CUDA 12.6"
     )
     def test_bmm_large_sparse_dimensions(self, device, dtype):
         """Test bmm with large sparse dimension to catch memory access issues.

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1519,6 +1519,24 @@ class TestSparse(TestSparseBase):
         test_shape(10, 10, 100, 0, 20)
 
     @onlyCUDA
+    @dtypes(torch.float32, torch.double)
+    @unittest.skipIf(
+        IS_WINDOWS,
+        "bmm sparse-dense CUDA is not yet supported in Windows, at least up to CUDA 10.1"
+    )
+    def test_bmm_large_sparse_dimensions(self, device, dtype):
+        """Test bmm with large sparse dimension to catch memory access issues.
+
+        Regression test for compute-sanitizer detected memory access issues
+        with large sparse dimensions.
+        """
+        m1 = torch.randn(2, 291105, 1, dtype=dtype, device=device).to_sparse()
+        m2 = torch.randn(2, 1, 1, dtype=dtype, device=device)
+        result = torch.bmm(m1, m2)
+
+        self.assertEqual(result.shape, torch.Size([2, 291105, 1]))
+
+    @onlyCUDA
     @unittest.skipIf(
         IS_WINDOWS and TEST_CUDA,
         "bmm sparse-dense CUDA is not yet supported in Windows, at least up to CUDA 10.1"


### PR DESCRIPTION
Fixes #167901

**Problem**

When performing batched matrix multiplication (torch.bmm) with sparse CUDA tensors, cuSPARSE may encounter memory alignment errors. This occurs because pointer arithmetic used to access per-batch data within a flat sparse tensor array can produce addresses that are not 16-byte aligned; a requirement for cuSPARSE's vectorized memory operations.

**Solution**

Add an alignment check before passing sparse data pointers to cuSPARSE. When misalignment is detected, copy the batch data to properly aligned temporary buffers allocated via PyTorch's CUDA allocator (which guarantees 16-byte alignment). The buffers are reused across loop iterations when possible to minimize allocation overhead.

@vishalgoyal316 @cleonard530 @abhitorch81 @gaurav-redhat 
@mikaylagawarecki 
