### PR TITLE
Fix missing ConstantPooling header in passes.cpp

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
+#include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/variadic_ops.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>


### PR DESCRIPTION
Summary:
The previous diff (D88000002) removed the `constant_pooling.h` header from `/data/users/wouterdevriendt/fbsource/xplat/caffe2/torch/csrc/jit/runtime/static/passes.cpp`, but the file still uses the `ConstantPooling` function in the `SplitOutPrecomputeOpsForSparseNN` function. This caused a compilation error:

```
error: use of undeclared identifier 'ConstantPooling'
```

This diff adds back the necessary header to fix the compilation error.

Test Plan:
Buck build should now pass:
```
buck2 build fbcode//caffe2:_libtorch --mode=opt
```

Differential Revision: D88060085




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel