### PR TITLE
Fix deprecation warning

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1808,6 +1808,10 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
                 "currently can't reconstruct arbitrary frozen dataclass instances"
             )
 
+        # LeafSpec is deprecated, use treespec_leaf() instead
+        if istype(self.value, pytree.LeafSpec):
+            return pytree.treespec_leaf()
+
         args = []
         kwargs = {}
         for field in fields(self.value):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169433
* __->__ #169421


Fixes:

```Shell
/home/dev/meta/pytorch/torch/_dynamo/variables/user_defined.py:1824: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return ctor(*args, **kwargs)
/home/dev/meta/pytorch/torch/_dynamo/variables/user_defined.py:1824: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return ctor(*args, **kwargs)
Benchmarking (20 iters)...
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo