### PR TITLE
Generalize GraphView in manual bucketing

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1300,7 +1300,9 @@ def get_toy_model(device_type: str):
     return model
 
 
-def apply_manual_reordering_and_get_graph(graph, module_bucket_plans, out_li) -> None:
+def apply_manual_reordering_and_get_graph(
+    graph, module_bucket_plans, out_li, custom_module_stack_fn=None
+) -> None:
     gm = graph.owning_module
     from torch._inductor.fx_passes.overlap_manual_scheduling import (
         ManualOverlapScheduler,
@@ -1323,18 +1325,24 @@ def apply_manual_reordering_and_get_graph(graph, module_bucket_plans, out_li) ->
             node.meta["nn_module_stack"] = {"test": ["module_2", ""]}
 
     overlapped_gm = ManualOverlapScheduler(
-        gm, module_bucket_plans, insert_overlap_deps=False
+        gm,
+        module_bucket_plans,
+        insert_overlap_deps=False,
+        module_stack_fn=custom_module_stack_fn,
     ).run()
     overlapped_gm.graph.lint()
     out_li.append(overlapped_gm.graph)
 
 
-def run_and_get_manual_aten_graph(fn, module_bucket_plans, *inputs):
+def run_and_get_manual_aten_graph(
+    fn, module_bucket_plans, *inputs, custom_module_stack_fn=None
+):
     li = []
     apply = functools.partial(
         apply_manual_reordering_and_get_graph,
         module_bucket_plans=module_bucket_plans,
         out_li=li,
+        custom_module_stack_fn=custom_module_stack_fn,
     )
     with torch._inductor.config.patch(post_grad_custom_post_pass=apply):
         out = fn(*inputs)
@@ -1376,6 +1384,77 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             graph_view, ["layers.0.wq", "nonexistent.module.path"]
         )
         self.assertEqual([n.name for n in mixed_nodes], ["layers_0_wq"])
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_make_graph_view_and_get_subgraph_by_path_custom_module_stack_fn(self):
+        from torch._dynamo.functional_export import dynamo_graph_capture_for_export
+        from torch._inductor.fx_passes.graph_view import (
+            get_subgraph_by_path,
+            make_graph_view,
+        )
+
+        model = get_toy_model(device_type)
+
+        module_path_key = "module_path"
+        # Add annotation to node.meta["custom"]
+        for name, m in model.named_modules():
+            m.forward = torch.fx.traceback.annotate_fn({module_path_key: name})(
+                m.forward
+            )
+
+        def module_stack_fn(node):
+            module_stack = node.meta.get("custom", {}).get(module_path_key, "")
+            return [(module_stack, torch.nn.Module)]
+
+        gm = dynamo_graph_capture_for_export(model)(torch.randn(2, 4).to(device_type))
+
+        # delete "nn_module_stack" to make sure the graph view is only constructed from annotation
+        for n in gm.graph.nodes:
+            if "nn_module_stack" in n.meta:
+                del n.meta["nn_module_stack"]
+
+        graph_view = make_graph_view(gm.graph, module_stack_fn=module_stack_fn)
+        # Fetch subgraph for first transformer layer
+        sub_nodes = get_subgraph_by_path(graph_view, "layers.0.wq")
+        self.assertEqual(
+            [n.name for n in sub_nodes],
+            [
+                "l_func_self_modules_layers_modules_0_modules_wq_parameters_weight_",
+                "l_func_self_modules_layers_modules_0_modules_wq_parameters_bias_",
+                "linear",
+            ],
+        )
+
+        # Fetch multiple paths at once
+        multi_nodes = get_subgraph_by_path(graph_view, ["layers.0.wq", "layers.0.proj"])
+        self.assertEqual(
+            [n.name for n in multi_nodes],
+            [
+                "l_func_self_modules_layers_modules_0_modules_wq_parameters_weight_",
+                "l_func_self_modules_layers_modules_0_modules_wq_parameters_bias_",
+                "linear",
+                "l_func_self_modules_layers_modules_0_modules_proj_parameters_weight_",
+                "l_func_self_modules_layers_modules_0_modules_proj_parameters_bias_",
+                "x",
+            ],
+        )
+
+        # Fetch non existing paths
+        non_exist_nodes = get_subgraph_by_path(graph_view, "nonexistent.module.path")
+        self.assertEqual(non_exist_nodes, [])
+
+        # Fetch mixed of existing and non existing paths
+        mixed_nodes = get_subgraph_by_path(
+            graph_view, ["layers.0.wq", "nonexistent.module.path"]
+        )
+        self.assertEqual(
+            [n.name for n in mixed_nodes],
+            [
+                "l_func_self_modules_layers_modules_0_modules_wq_parameters_weight_",
+                "l_func_self_modules_layers_modules_0_modules_wq_parameters_bias_",
+                "linear",
+            ],
+        )
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_manual_reordering_bucketing_pass_separate_buckets(
@@ -1568,6 +1647,121 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
 
             correct = func(a, b, c, d, ranks=ranks)
             self.assertTrue(same(out, correct))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_bucketing_reordering_pass_single_bucket_custom_module_stack_fn(
+        self,
+    ):
+        module_path_key = "module_path"
+
+        def module_stack_fn(node):
+            module_stack = node.meta.get("custom", {}).get(module_path_key, "")
+            return [(module_stack, torch.nn.Module)]
+
+        def func(a, b, c, d, *, ranks):
+            # All 4 all-gathers are independent - COULD be bucketed together
+            with torch.fx.traceback.annotate({module_path_key: "my_module_1"}):
+                ag1 = _functional_collectives.all_gather_tensor(a, 0, ranks)
+                ag2 = _functional_collectives.all_gather_tensor(b, 0, ranks)
+            with torch.fx.traceback.annotate({module_path_key: "my_module_2"}):
+                ag3 = _functional_collectives.all_gather_tensor(c[:4], 0, ranks)
+                ag4 = _functional_collectives.all_gather_tensor(d[:4], 0, ranks)
+
+            # First compute - can hide ag1 and ag2
+            e = a * 5  # Use a to avoid fusion
+            mm1 = torch.matmul(e, e.T)
+
+            # Force ag1/ag2 to complete before mm2 (but ag3/ag4 can still be deferred)
+            # Use first 8x8 elements to match mm1's shape
+            intermediate = ag1[:8, :8] + ag2[:8, :8]
+
+            # Second compute - depends on ag1/ag2 through intermediate, can hide ag3/ag4
+            mm2 = torch.matmul(mm1 + intermediate, c[:8])
+
+            # Use all results
+            result = (
+                ag1.sum() * 1.1
+                + ag2.sum() * 1.2
+                + ag3.sum() * 1.3
+                + ag4.sum() * 1.4
+                + mm1.sum()
+                + mm2.sum()
+            )
+            return result
+
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            a = torch.ones(8, 8, dtype=torch.float, device=device_type)
+            b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
+            c = torch.ones(8, 8, dtype=torch.float, device=device_type) * 3
+            d = torch.ones(8, 8, dtype=torch.float, device=device_type) * 4
+            ranks = list(range(self.world_size))
+
+            func_c = functools.partial(func, ranks=ranks)
+            compiled = torch.compile(func_c)
+            out, aten_graph = run_and_get_manual_aten_graph(
+                compiled,
+                [["my_module_1", "my_module_2"]],
+                a,
+                b,
+                c,
+                d,
+                custom_module_stack_fn=module_stack_fn,
+            )
+
+            (
+                FileCheck()
+                .check("_pre_bucket_all_gather")
+                .check("all_gather_into_tensor_out")
+                .check("wait_tensor_4")
+                .run(str(aten_graph))
+            )
+
+            correct = func(a, b, c, d, ranks=ranks)
+            self.assertTrue(same(out, correct))
+
+            # Add metadata to the collective nodes to test preservation
+            test_metadata = {
+                "nn_module_stack": {
+                    "test": ("module_1", ""),
+                },
+                "custom": {
+                    "module_path": "my_module_1",
+                },
+            }
+
+            # Verify metadata preservation: new bucketed nodes should have the metadata
+            new_ag_nodes = aten_graph.find_nodes(
+                op="call_function",
+                target=torch.ops.bucketing._pre_bucket_all_gather.default,
+            )
+            new_wait_nodes = aten_graph.find_nodes(
+                op="call_function",
+                target=torch.ops._c10d_functional.wait_tensor.default,
+            )
+
+            all_new_nodes = list(new_ag_nodes) + list(new_wait_nodes)
+            self.assertGreater(len(all_new_nodes), 0, "Should have created new nodes")
+
+            for node in all_new_nodes:
+                self.assertEqual(
+                    node.meta.get("nn_module_stack"), test_metadata["nn_module_stack"]
+                )
+                self.assertEqual(node.meta.get("custom"), test_metadata["custom"])
+                self.assertTrue(node.meta.get("stack_trace", None) is not None)
+                self.assertTrue(
+                    node.meta.get("bucketing_stack_trace_sources", None) is not None
+                )
+                self.assertTrue(
+                    node.meta.get("bucketing_custom_sources", None) is not None
+                )
+                self.assertTrue(
+                    node.meta.get("bucketing_nn_module_stack_sources", None) is not None
+                )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/graph_view.py
+++ b/torch/_inductor/fx_passes/graph_view.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import itertools
 import re
-from typing import Any, Optional, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 
 import torch.fx as fx  # noqa: TC001
 from torch.utils._ordered_set import OrderedSet
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _get_module_stack(node: fx.Node) -> list[tuple[str, type[Any]]]:
@@ -105,7 +109,10 @@ def _is_root(stack: str) -> bool:
     return stack == ""
 
 
-def make_graph_view(graph: fx.Graph) -> Optional[GraphView]:
+def make_graph_view(
+    graph: fx.Graph,
+    module_stack_fn: None | Callable[[fx.Node], list[tuple[str, type[Any]]]] = None,
+) -> Optional[GraphView]:
     """
     Code from: https://github.com/meta-pytorch/autoparallel/pull/158
 
@@ -147,12 +154,45 @@ def make_graph_view(graph: fx.Graph) -> Optional[GraphView]:
     subgraph = get_subgraph_by_path(graph_view, "layers.0")
 
     where subgraph contains all the nodes that belong to this region
+
+    module_stack_fn: Optional callable for extracting module hierarchy information from nodes.
+
+        Signature: Callable[[fx.Node], list[tuple[str, type[Any]]]]
+
+        Takes an FX node and returns a list of (module_path, module_class) tuples representing
+        the nested module hierarchy for that node, ordered from outermost to innermost scope.
+
+        - module_path (str): Dot-separated path identifying the module in the hierarchy
+          (e.g., "layers.0.attention.wq")
+        - module_class (type): The Python class type of the module
+
+        This enables custom logic for determining module membership, useful for:
+        - Graphs without standard nn_module_stack metadata
+        - Filtering or grouping nodes by custom criteria
+
+        Example of getting the module stack from annotation:
+
+        def module_stack_fn(node):
+            module_stack = node.meta.get("custom", {}).get("module_path", "")
+            return [(module_stack, torch.nn.Module)]
+
+        If None, defaults to extracting from node.meta["nn_module_stack"] or
+        node.meta["fwd_nn_module_stack"].
     """
+
+    def nn_module_stack_meta(node: fx.Node) -> list[tuple[str, type[Any]]]:
+        result = []
+        for module_stack, module_class in _get_module_stack(node):
+            module_stack = _clean_stack_name(module_stack)
+            result.append((module_stack, module_class))
+        return result
+
+    if module_stack_fn is None:
+        module_stack_fn = nn_module_stack_meta
     nodes: list[fx.Node] = list(graph.nodes)
     nodes_by_module_stack_root: GraphView | None = None
     for node in nodes:
-        for module_stack, module_class in _get_module_stack(node):
-            module_stack = _clean_stack_name(module_stack)
+        for module_stack, module_class in module_stack_fn(node):
             nodes_by_module_stack: GraphView | None = nodes_by_module_stack_root
             for name in module_stack.split("."):
                 if nodes_by_module_stack is None:

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import heapq
 from collections import Counter, defaultdict
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import torch
 import torch.fx as fx
@@ -26,6 +26,10 @@ from torch._inductor.fx_passes.overlap_scheduling import (
 from torch.utils._ordered_set import OrderedSet
 
 from .graph_view import get_subgraph_by_path, GraphView, make_graph_view
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
@@ -106,14 +110,13 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         new_start = new_wait.args[0]
         assert isinstance(new_start, fx.Node)
 
+        # Set manual bucketing-specific metadata
+        # Note: Generic metadata (nn_module_stack, fwd_nn_module_stack, custom, stack_trace)
+        # is now preserved automatically by the bucketing functions in bucketing.py
         node_type = (
             "bucketed_all_gather" if is_all_gather(first) else "bucketed_reduce_scatter"
         )
         for n in new_nodes:
-            n.meta["nn_module_stack"] = coll_nodes[0].meta.get("nn_module_stack", "")
-            n.meta["fwd_nn_module_stack"] = coll_nodes[0].meta.get(
-                "fwd_nn_module_stack", ""
-            )
             if n == new_wait:
                 node_type = node_type + "_wait"
             n.meta["manual_bucket_node_type"] = node_type
@@ -161,6 +164,7 @@ class ManualOverlapScheduler(OverlapScheduler):
         gm: fx.GraphModule,
         module_bucket_plans: list[list[str] | str],
         insert_overlap_deps: bool,
+        module_stack_fn: None | Callable[[fx.Node], list[tuple[str, type[Any]]]] = None,
     ):
         super().__init__(
             gm,
@@ -187,6 +191,8 @@ class ManualOverlapScheduler(OverlapScheduler):
             scheduled=OrderedSet(self.graph.nodes),
         )
         self.insert_overlap_deps = insert_overlap_deps
+
+        self.module_stack_fn = module_stack_fn
 
     def _identify_collectives(self) -> None:
         """Identify all collective operations."""
@@ -318,7 +324,7 @@ class ManualOverlapScheduler(OverlapScheduler):
         """
         Obtain nodes in each subgraph from module_bucket_plans
         """
-        graph_view: GraphView | None = make_graph_view(self.graph)
+        graph_view: GraphView | None = make_graph_view(self.graph, self.module_stack_fn)
         if graph_view is None:
             return
 
@@ -341,6 +347,7 @@ def manual_overlap_bucketing(
     gm: torch.fx.GraphModule,
     module_bucket_plans: list[list[str] | str],
     insert_overlap_deps: bool = False,
+    module_stack_fn: None | Callable[[fx.Node], list[tuple[str, type[Any]]]] = None,
 ) -> torch.fx.GraphModule:
     """Schedule nodes based on user specifications in module_bucket_plans
     The manual overlapping consists of two steps:
@@ -353,10 +360,16 @@ def manual_overlap_bucketing(
     Args:
         gm: input graph module to optimize.
         module_bucket_plans: user specified FQNs
+        module_stack_fn: Optional callable for extracting module hierarchy from nodes.
+            Used to construct a GraphView for identifying nodes in module_bucket_plans.
+            The module_class component of the returned tuples is not used by this pass.
+
+            See the `module_stack_fn` parameter in `make_graph_view` (graph_view.py) for
+            detailed documentation on signature, return format, and usage examples.
     """
     # decode abbreviated FQNs to actual FQNs
     overlapped_gm = ManualOverlapScheduler(
-        gm, module_bucket_plans, insert_overlap_deps
+        gm, module_bucket_plans, insert_overlap_deps, module_stack_fn
     ).run()
     overlapped_gm.recompile()
     return overlapped_gm


### PR DESCRIPTION
Generalize the GraphView construction so it doesn't have to rely on `nn_module_stack`. 

`nn_module_stack` can be inaccurate sometimes if the module calls are wrapped in closures. To mitigate this, we allow users to use fx_annotate to annotate their modules and use annotation to construct GraphView. 

also, we preserve annotation and stack trace on newly created nodes, in addition to nn_module_stack node meta

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo