### PR TITLE
Add check_lowerbound config for AOTI lowering

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -423,7 +423,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     from torch.utils._sympy.value_ranges import bound_sympy
 
                     sym_range = bound_sympy(d, V.graph.sizevars.shape_env.var_to_range)
-                    if not math.isinf(sym_range.lower):
+                    if config.aot_inductor.check_lowerbound and not math.isinf(
+                        sym_range.lower
+                    ):
                         self.prefix.splice(
                             f"""
                                 if ({name}_size[{dim_idx}] < {sym_range.lower}) {{

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1739,6 +1739,12 @@ class aot_inductor:
         os.environ.get("AOTINDUCTOR_RAISE_ERROR_ON_IGNORED_OPTIMIZATION", "1") == "1"
     )
 
+    # Whether to check lowerbound constraints on dynamic shapes during runtime.
+    # When disabled, allows models with dynamic sizes of 0 or 1 to work with
+    # AOTI_RUNTIME_CHECK_INPUTS=1, avoiding errors from the [2+, ...] lowerbound
+    # restriction when backed_size_oblivious is off.
+    check_lowerbound: bool = True
+
     # dump an aoti minifier if program errors
     dump_aoti_minifier: bool = os.environ.get("DUMP_AOTI_MINIFIER", "0") == "1"
 


### PR DESCRIPTION
Summary:
## Why:
PT has a 0/1 specialization assumption. Thus, unless backed_size_oblivious is on, the greatest lowerbound is [2+, ...]. So, this trips up a lot of models who can have a dynamic size with 0 or 1.

I want a way for AOTI lowering users to easily check their dynamic shape spec is correct via `AOTI_RUNTIME_CHECK_INPUTS=1` which is a runtime env var. In-order to do that, I need to avoid any errors triggered by a wrong lowerbound.

## What does it look like?
```
    // this is a lowerbound check
    if (arg0_1_size[0] < 2) {
        std::stringstream ss;
        ss << "input_handles[0]: dim value is too small at 0, "
           << "expected it to be >= 2, " << "but got: "
           << arg0_1_size[0] << "\n";
        throw std::runtime_error(ss.str());
    }
```

Differential Revision: D88203028




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo