### PR TITLE
Clean up target names better

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -399,7 +399,7 @@ def forward(self, x):
         with torch._dynamo.config.patch(replay_side_effects=False):
             _ = dynamo_graph_capture_for_export(Foo())(torch.randn(4, 4))
             self.assertEqual(len(global_env), 0)
-    
+
     def test_export_method(self):
         class Foo(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169446


We still need to migrate to dynamo_graph_capture_for_export but some internal customers are still on old API. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo