### PR TITLE
[dynamo][benchmarks] add option to force amp to use bfloat16 instead of float16

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1796,7 +1796,10 @@ class BenchmarkRunner:
             self.autocast = functools.partial(
                 torch.amp.autocast, device_type=devices[0]
             )
-            if self.args.amp_dtype:
+            if self.args.amp_dtype is None:
+                if self.args.only in self.amp_dtype_bfloat16:
+                    self.autocast_arg["dtype"] = torch.bfloat16
+            else:
                 amp_dtype = (
                     torch.float16
                     if self.args.amp_dtype == "float16"
@@ -1879,6 +1882,10 @@ class BenchmarkRunner:
 
     @property
     def force_fp16_for_bf16_models(self):
+        return set()
+
+    @property
+    def amp_dtype_bfloat16(self):
         return set()
 
     @property
@@ -3877,6 +3884,7 @@ def run(runner, args, original_dir=None):
                     # xfail: https://github.com/pytorch/pytorch/issues/145773
                     "llama",
                     "cm3leon_generate",
+                    "modded_nanogpt",
                 }
             )
 

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -110,6 +110,8 @@ dtype:
   force_fp16_for_bf16_models:
     - vision_maskrcnn
 
+  amp_dtype_bfloat16:
+    - modded_nanogpt
 
 # models in canary_models that we should run anyway
 canary_models:
@@ -138,6 +140,7 @@ only_training:
   - hf_Reformer
   - pytorch_struct
   - yolov3
+  - modded_nanogpt
 
 
 trt_not_yet_working:
@@ -198,6 +201,7 @@ skip:
     cpu:
       # model is CUDA only
       - cm3leon_generate
+      - modded_nanogpt
       # timeout
       - nanogpt
       # timeout


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #169449

For models which hardcode bf16 like modded-nanogpt

Tested on `python benchmarks/dynamo/torchbench.py --performance --training --amp --backend inductor --device cuda --only modded_nanogpt --disable-cudagraphs` w/ https://github.com/pytorch/benchmark/pull/2660

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo