### PR TITLE
Fix torch.fx for the newer "|" union syntax

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2381,6 +2381,16 @@ class TestFX(JitTestCase):
 
         self.assertTrue("typing.List[float]" in str(graph))
 
+    def test_typename_print_union(self):
+        graph: torch.fx.Graph = torch.fx.Graph()
+        x: torch.fx.Node = graph.create_node("placeholder", "x")
+        b: torch.fx.Node = graph.create_node(
+            "call_function", target=torch.relu, args=(x,), type_expr=float|torch.Tensor|None
+        )
+        output: torch.fx.Node = graph.output(b)
+
+        self.assertTrue('float | torch.Tensor | None' in str(graph))
+
     def test_layout(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -10,6 +10,7 @@ import math
 import os
 import pprint
 import re
+import types
 import typing
 import warnings
 from collections import defaultdict
@@ -499,6 +500,10 @@ class CodeGen:
                 return "()"
 
             typename = _type_repr(o)
+            if isinstance(o, types.UnionType) and "|" in typename:
+                # str | int
+                args = [type_repr(arg) for arg in o.__args__]
+                return "|".join(args)
 
             if origin_type := getattr(o, "__origin__", None):
                 # list[...], typing.List[...], TensorType[...]

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -174,6 +174,8 @@ def _get_qualified_name(func: Callable[..., Any]) -> str:
     # Fixup segment_reduce mismatch
     if module == "torch" and name == "segment_reduce":
         name = "_" + name
+    if module == "torch.nn.functional" and name in ("_ScalingType", "_SwizzleType"):
+        name = name.removeprefix("_")
     return f"{module}.{name}"
 
 


### PR DESCRIPTION
This PR fixes torch.fx handling of the newer `|` type. Otherwise, they could be errors like
```
"/torch/package/importer.py", line 95, in get_name
     name = obj.__name__
    AttributeError: 'types.UnionType' object has no attribute '__name__'. Did you mean: '__ne__'?
```

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv