### PR TITLE
[inductor_on_demand] Refactor - scoop regions and then compile regions

### DIFF
--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -121,46 +121,100 @@ def _needs_inductor_compile(node: torch.fx.Node):
     )
 
 
-def _compile_fx_annotated_nodes_with_inductor(gm):
-    from torch.fx.graph import _BoxedCodeGen
-    from torch.fx.passes.operator_support import OperatorSupport
+class _RegionScooper:
+    """
+    Scoops out the inductor marked regions. It does NOT compile them.
+    """
 
-    found_marked_node = False
-    for node in gm.graph.nodes:
-        if _needs_inductor_compile(node):
-            found_marked_node = True
-            break
+    @staticmethod
+    def scoop_regions(gm):
+        from torch.fx.passes.operator_support import OperatorSupport
 
-    if not found_marked_node:
-        logger.info("No inductor marked nodes found")
+        found_marked_node = False
+        for node in gm.graph.nodes:
+            if _needs_inductor_compile(node):
+                found_marked_node = True
+                break
+
+        if not found_marked_node:
+            logger.info("No inductor marked nodes found")
+            return gm
+
+        class InductorMarkedNodes(OperatorSupport):
+            def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+                return _needs_inductor_compile(node)
+
+        marked_nodes = InductorMarkedNodes()
+        return _partition_by_supported_nodes(
+            gm, marked_nodes, "__marked_inductor_submod"
+        )
+
+    @staticmethod
+    def recursively_scoop_regions(gm):
+        for node in gm.graph.find_nodes(op="get_attr"):
+            if _needs_inductor_compile(node):
+                # If the get_attr itself is marked for compile, the outer graph will
+                # take care of it. If we dont do that, we end up with nested
+                # regional inductor compiles that do not work well.
+                continue
+            submod = getattr(gm, node.target)
+            if isinstance(submod, torch.fx.GraphModule):
+                _RegionScooper.recursively_scoop_regions(submod)
+
+        return _RegionScooper.scoop_regions(gm)
+
+    def __call__(self, gm):
+        with torch.fx.traceback.preserve_node_meta(enable=False):
+            return _RegionScooper.recursively_scoop_regions(gm)
+
+
+class _RegionCompiler:
+    """
+    Compiles the scooped out regions.
+    """
+
+    @staticmethod
+    def compile_region(gm):
+        from torch.fx.graph import _BoxedCodeGen
+
+        gm = _compile_submod(gm, "__marked_inductor_submod")
+        gm.graph.set_codegen(_BoxedCodeGen())
+        gm.recompile()
         return gm
 
-    class InductorMarkedNodes(OperatorSupport):
-        def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
-            return _needs_inductor_compile(node)
+    @staticmethod
+    def recursively_compile_regions(gm):
+        # Find if the graph module has a scooped out region
+        found_region = False
+        for node in gm.graph.find_nodes(op="call_module"):
+            submod = getattr(gm, node.target)
+            if isinstance(submod, torch.fx.GraphModule):
+                if node.target.startswith("__marked_inductor_submod"):
+                    found_region = True
 
-    marked_nodes = InductorMarkedNodes()
-    gm = _partition_by_supported_nodes(gm, marked_nodes, "__marked_inductor_submod")
-    gm = _compile_submod(gm, "__marked_inductor_submod")
+        # Recurse through the subgraphs
+        for node in gm.graph.find_nodes(op="get_attr"):
+            submod = getattr(gm, node.target)
+            if isinstance(submod, torch.fx.GraphModule):
+                _RegionCompiler.recursively_compile_regions(submod)
 
-    gm.graph.set_codegen(_BoxedCodeGen())
-    gm.recompile()
+        if found_region:
+            return _RegionCompiler.compile_region(gm)
+        return gm
 
-    return gm
+    def __call__(self, gm):
+        with torch.fx.traceback.preserve_node_meta(enable=False):
+            return _RegionCompiler.recursively_compile_regions(gm)
 
 
-def _recursive_compile_fx_annotated_nodes_with_inductor(gm):
-    for node in gm.graph.find_nodes(op="get_attr"):
-        if _needs_inductor_compile(node):
-            # If the get_attr itself is marked for compile, the outer graph will
-            # take care of it. If we dont do that, we end up with nested
-            # regional inductor compiles that do not work well.
-            continue
-        submod = getattr(gm, node.target)
-        if isinstance(submod, torch.fx.GraphModule):
-            _recursive_compile_fx_annotated_nodes_with_inductor(submod)
+def _create_inductor_marked_regions(gm):
+    with torch.fx.traceback.preserve_node_meta(enable=False):
+        return _RegionScooper()(gm)
 
-    return _compile_fx_annotated_nodes_with_inductor(gm)
+
+def _compile_inductor_marked_regions(gm):
+    with torch.fx.traceback.preserve_node_meta(enable=False):
+        return _RegionCompiler()(gm)
 
 
 @compatibility(is_backward_compatible=False)
@@ -181,4 +235,6 @@ def regional_inductor(gm, *example_args):
     # fuser utils create new nodes using create_proxy which retains the seq_nr
     # metadata and cause issues
     with torch.fx.traceback.preserve_node_meta(enable=False):
-        return _recursive_compile_fx_annotated_nodes_with_inductor(gm)
+        gm = _create_inductor_marked_regions(gm)
+        gm = _compile_inductor_marked_regions(gm)
+        return gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169457

The intention is to give power users capability to just scoop out the
regions in the beginning and then run their own passes and then finally
compile the scooped out regions. It might be easier to work with a graph
that already has scooped out regions for better abstraction.

If not done this way, it is necessary to run the regional inductor pass
at the very end of the compiler to avoid striding issues.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv