### PR TITLE
IGNORE: demonstrate issue with PYREFLY

### DIFF
--- a/torch/fx/experimental/unification/multipledispatch/utils.py
+++ b/torch/fx/experimental/unification/multipledispatch/utils.py
@@ -1,11 +1,13 @@
 # mypy: allow-untyped-defs
 from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any
 
 
 __all__ = ["raises", "expand_tuples", "reverse_dict", "groupby", "typename"]
 
 
-def raises(err, lamda):  # codespell:ignore lamda
+def raises(err, lamda: Callable[[], Any]):  # codespell:ignore lamda
     try:
         lamda()  # codespell:ignore lamda
         return False


### PR DESCRIPTION
This pull request is intended to demonstrate an issue where the PYREFLY linter generates hundreds of errors on a tiny, unrelated change.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169466



cc @ezyang @EikanWang @jgong5 @wenzhe-nrv