### PR TITLE
Clarify batch and broadcasting behavior in torch.linalg.solve

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2241,12 +2241,12 @@ Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batches of matrices, and if the inputs are batches of matrices then
 the output has the same batch dimensions.
 
-Letting `*` be zero or more batch dimensions:
+Letting `*` be zero or more batch dimensions,
 
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n,)` or `(*, n)` (a batch of vectors),  
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n,)` or `(*, n)` (a batch of vectors),
   this function returns `X` of shape `(*, n)`. The batch dimensions `*` of :attr:`A` and :attr:`B` must match exactly.
 
-- Otherwise, if :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n, k)` or `(*, n, k)` (a batch of matrices or “multiple right-hand sides”),  
+- Otherwise, if :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n, k)` or `(*, n, k)` (a batch of matrices or "multiple right-hand sides"),
   this function returns `X` of shape `(*, n, k)`. The batch dimensions `*` of :attr:`A` and :attr:`B` need only be broadcastable.
 
 .. note::

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2243,9 +2243,17 @@ the output has the same batch dimensions.
 
 Letting `*` be zero or more batch dimensions,
 
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n)` (a batch of vectors) or shape
-  `(*, n, k)` (a batch of matrices or "multiple right-hand sides"), this function returns `X` of shape
-  `(*, n)` or `(*, n, k)` respectively.
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n)` (a batch of vectors), 
+  the batch dimensions `*` of :attr:`A` and :attr:`B` must **exactly match**. Broadcasting is not allowed.
+  
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n, k)` (a batch of matrices or 
+  "multiple right-hand sides"), the batch dimensions `*` of :attr:`A` and :attr:`B` only need to be 
+  **broadcastable** with each other. This function returns `X` of shape `(**, n, k)` where `**` 
+  is the result of broadcasting the batch dimensions of :attr:`A` and :attr:`B`.
+
+- **Ambiguous cases**: If :attr:`B` could be interpreted as either a batch of vectors or a batch of matrices
+  (e.g., when :attr:`B` has shape `(n, n)`), PyTorch treats :attr:`B` as a **batch of vectors**.
+  
 - Otherwise, if :attr:`A` has shape `(*, n, n)` and  :attr:`B` has shape `(n,)`  or `(n, k)`, :attr:`B`
   is broadcasted to have shape `(*, n)` or `(*, n, k)` respectively.
   This function then returns the solution of the resulting batch of systems of linear equations.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2243,18 +2243,13 @@ the output has the same batch dimensions.
 
 Letting `*` be zero or more batch dimensions:
 
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n)` (a batch of vectors),  
-  the batch dimensions of :attr:`B` must exactly match those of :attr:`A`.  
-  Internally, :attr:`B` is treated as `(*, n, 1)` for solving, and the result is returned as `(*, n)`.
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n)` or `(*, n)` (a batch of vectors),  
+  this function returns `X` of shape `(*, n)`. The batch dimensions `*` of :attr:`A` and :attr:`B` must match exactly.
 
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n, k)` (a batch of matrices or  
-  “multiple right-hand sides”), the batch dimensions of :attr:`A` and :attr:`B` must be broadcastable,  
-  and the result has shape `(*, n, k)`.
-
-- In ambiguous cases (e.g., :attr:`B` has shape `(n, n)`),  
-  :attr:`B` is interpreted as a batch of vectors.
+- Otherwise, if :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n, k)` or `(*, n, k)` (a batch of matrices or “multiple right-hand sides”),  
+  this function returns `X` of shape `(*, n, k)`. The batch dimensions `*` of :attr:`A` and :attr:`B` need only be broadcastable.
   
-- Otherwise, if :attr:`A` has shape `(*, n, n)` and  :attr:`B` has shape `(n,)`  or `(n, k)`, :attr:`B`
+- Specifically, if :attr:`A` has shape `(*, n, n)` and  :attr:`B` has shape `(n,)`  or `(n, k)`, :attr:`B`
   is broadcasted to have shape `(*, n)` or `(*, n, k)` respectively.
   This function then returns the solution of the resulting batch of systems of linear equations.
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2248,10 +2248,6 @@ Letting `*` be zero or more batch dimensions:
 
 - Otherwise, if :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n, k)` or `(*, n, k)` (a batch of matrices or “multiple right-hand sides”),  
   this function returns `X` of shape `(*, n, k)`. The batch dimensions `*` of :attr:`A` and :attr:`B` need only be broadcastable.
-  
-- Specifically, if :attr:`A` has shape `(*, n, n)` and  :attr:`B` has shape `(n,)`  or `(n, k)`, :attr:`B`
-  is broadcasted to have shape `(*, n)` or `(*, n, k)` respectively.
-  This function then returns the solution of the resulting batch of systems of linear equations.
 
 .. note::
     This function computes `X = \ `:attr:`A`\ `.inverse() @ \ `:attr:`B` in a faster and

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2241,18 +2241,18 @@ Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batches of matrices, and if the inputs are batches of matrices then
 the output has the same batch dimensions.
 
-Letting `*` be zero or more batch dimensions,
+Letting `*` be zero or more batch dimensions:
 
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n)` (a batch of vectors), 
-  the batch dimensions `*` of :attr:`A` and :attr:`B` must **exactly match**. Broadcasting is not allowed.
-  
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n, k)` (a batch of matrices or 
-  "multiple right-hand sides"), the batch dimensions `*` of :attr:`A` and :attr:`B` only need to be 
-  **broadcastable** with each other. This function returns `X` of shape `(**, n, k)` where `**` 
-  is the result of broadcasting the batch dimensions of :attr:`A` and :attr:`B`.
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n)` (a batch of vectors),  
+  the batch dimensions of :attr:`B` must exactly match those of :attr:`A`.  
+  Internally, :attr:`B` is treated as `(*, n, 1)` for solving, and the result is returned as `(*, n)`.
 
-- **Ambiguous cases**: If :attr:`B` could be interpreted as either a batch of vectors or a batch of matrices
-  (e.g., when :attr:`B` has shape `(n, n)`), PyTorch treats :attr:`B` as a **batch of vectors**.
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n, k)` (a batch of matrices or  
+  “multiple right-hand sides”), the batch dimensions of :attr:`A` and :attr:`B` must be broadcastable,  
+  and the result has shape `(*, n, k)`.
+
+- In ambiguous cases (e.g., :attr:`B` has shape `(n, n)`),  
+  :attr:`B` is interpreted as a batch of vectors.
   
 - Otherwise, if :attr:`A` has shape `(*, n, n)` and  :attr:`B` has shape `(n,)`  or `(n, k)`, :attr:`B`
   is broadcasted to have shape `(*, n)` or `(*, n, k)` respectively.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2243,7 +2243,7 @@ the output has the same batch dimensions.
 
 Letting `*` be zero or more batch dimensions:
 
-- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n)` or `(*, n)` (a batch of vectors),  
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n,)` or `(*, n)` (a batch of vectors),  
   this function returns `X` of shape `(*, n)`. The batch dimensions `*` of :attr:`A` and :attr:`B` must match exactly.
 
 - Otherwise, if :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(n, k)` or `(*, n, k)` (a batch of matrices or “multiple right-hand sides”),  


### PR DESCRIPTION

- Clearly distinguish vector RHS vs. matrix RHS behavior.
- Explain ambiguous cases (e.g., `B.shape = (n, n)`) treated as vector RHS.
- Specify when broadcasting is allowed and when batch dimensions must match.

Fixes #167950
