### PR TITLE
[FlexAttention] fix support for amp

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -5113,6 +5113,20 @@ class GraphModule(torch.nn.Module):
             fa._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = original_flag
             fa._WARNINGS_SHOWN = original_warnings_shown
 
+    @supported_platform
+    @skip_on_cpu
+    def test_autocast(self, device):
+
+        q = torch.randn(1, 4, 128, 16, dtype=torch.float32, device=device)
+        k = torch.randn(1, 4, 128, 16, dtype=torch.float32, device=device)
+        v = torch.randn(1, 4, 128, 16, dtype=torch.float32, device=device)
+
+        with torch.autocast(device_type='cuda', dtype=torch.float16):
+            eager_out = flex_attention(q, k, v)
+            self.assertEqual(eager_out.dtype, torch.float16)
+
+            compiled_out = torch.compile(flex_attention)(q, k, v)
+            self.assertEqual(compiled_out.dtype, torch.float16)
 
 class TestBlockMask(InductorTestCase):
     def setUp(self):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -5116,17 +5116,17 @@ class GraphModule(torch.nn.Module):
     @supported_platform
     @skip_on_cpu
     def test_autocast(self, device):
-
         q = torch.randn(1, 4, 128, 16, dtype=torch.float32, device=device)
         k = torch.randn(1, 4, 128, 16, dtype=torch.float32, device=device)
         v = torch.randn(1, 4, 128, 16, dtype=torch.float32, device=device)
 
-        with torch.autocast(device_type='cuda', dtype=torch.float16):
+        with torch.autocast(device_type="cuda", dtype=torch.float16):
             eager_out = flex_attention(q, k, v)
             self.assertEqual(eager_out.dtype, torch.float16)
 
             compiled_out = torch.compile(flex_attention)(q, k, v)
             self.assertEqual(compiled_out.dtype, torch.float16)
+
 
 class TestBlockMask(InductorTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #165468 
Explicitly autocast q/k/v tensors before validation when autocast is enabled.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @drisspg @yanboliang @BoyuanFeng