### PR TITLE
[ROCm] roll kernel as grid stride loop

### DIFF
--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -132,8 +132,8 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   dim3 dim_grid;
 
   const int num_mp = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  const int max_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
-  dim_grid.x=num_mp*(max_threads/dim_block.x);
+  // Given a thread block size of 512, we launch with 4 blocks per SM/CU
+  dim_grid.x=num_mp*4;
   auto total_dims = in_tensor.dim();
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -129,11 +129,10 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   if( start < 0 ) start = start + size;
 
   dim3 dim_block = cuda::getApplyBlock();
-  dim3 dim_grid;
 
   const int num_mp = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
   // Given a thread block size of 512, we launch with 4 blocks per SM/CU
-  dim_grid.x = num_mp * 4;
+  dim3 dim_grid(num_mp * 4);
   auto total_dims = in_tensor.dim();
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -91,7 +91,7 @@ __global__ void roll_cuda_kernel(
     int64_t stride,
     int64_t total_dims) {
   for (int64_t linear_index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
-       linear_index<N; linear_index+=blockDim.x*gridDim.x)
+       linear_index < N; linear_index += blockDim.x*gridDim.x)
   {
     // roll dim idx is the index of linear_index along the rolling dimension.
     int64_t roll_dim_idx = linear_index % (stride * size) / stride;

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -133,7 +133,7 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
 
   const int num_mp = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
   // Given a thread block size of 512, we launch with 4 blocks per SM/CU
-  dim_grid.x=num_mp*4;
+  dim_grid.x = num_mp * 4;
   auto total_dims = in_tensor.dim();
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -79,6 +79,8 @@ __global__ void flip_cuda_kernel(
   out_tensor[linear_index] = in_tensor[dst_offset];
 }
 
+#if defined(USE_ROCM)
+
 template <typename scalar_t>
 C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
 __global__ void roll_cuda_kernel(
@@ -106,6 +108,37 @@ __global__ void roll_cuda_kernel(
   }
 }
 
+#else
+
+template <typename scalar_t>
+C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
+__global__ void roll_cuda_kernel(
+    const scalar_t* in_tensor,
+    scalar_t* out_tensor,
+    int64_t N,
+    int64_t roll_dim,
+    int64_t start,
+    int64_t size,
+    int64_t stride,
+    int64_t total_dims) {
+  int64_t linear_index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
+  if (linear_index >= N) {
+    return;
+  }
+  // roll dim idx is the index of linear_index along the rolling dimension.
+  int64_t roll_dim_idx = linear_index % (stride * size) / stride;
+  // index into the source data to find appropriate value.
+  int64_t source_idx = 0;
+  if( roll_dim_idx >= (size - start) ) {
+    source_idx = linear_index - ((size - start) * stride);
+  } else {
+    source_idx = linear_index + (start * stride);
+  }
+  out_tensor[linear_index] = in_tensor[source_idx];
+}
+
+#endif
+
 // Roll a tensor along a dimension
 Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   if (dims.size() != 1 || shifts.size() != 1) {
@@ -129,11 +162,16 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   if( start < 0 ) start = start + size;
 
   dim3 dim_block = cuda::getApplyBlock();
-
+#if defined(USE_ROCM)
   const int num_mp = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
   // Given a thread block size of 512, we launch with 4 blocks per SM/CU
   dim3 dim_grid(num_mp * 4);
-  auto total_dims = in_tensor.dim();
+#else
+  dim3 dim_grid;
+  TORCH_CHECK(cuda::getApplyGrid(N, dim_grid, in_tensor.get_device()), "unable to get dim grid");
+#endif
+
+auto total_dims = in_tensor.dim();
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
       at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -171,7 +171,7 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   TORCH_CHECK(cuda::getApplyGrid(N, dim_grid, in_tensor.get_device()), "unable to get dim grid");
 #endif
 
-auto total_dims = in_tensor.dim();
+  auto total_dims = in_tensor.dim();
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
       at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,


### PR DESCRIPTION
Reimplement the roll kernel as a grid stride loop. On AMD devices, we see launch failures in the original version when gridDim.x*blockDim.x exceeds 4294967295. This implementation should work and be performant on both AMD and Nvidia devices. The issue can be seen on AMD devices with the following small repro:

import torch
N = 21913096
input_tensor_torch = torch.randn(1, 2, N, 98, device='cuda')
output = input_tensor_torch.roll(-1, dims=1)
input_tensor_torch_cpu = input_tensor_torch.cpu()
output_cpu = input_tensor_torch_cpu.roll(-1, dims=1)
assert torch.equal(output.cpu(), output_cpu)

Gives:
torch.AcceleratorError: HIP error: invalid configuration argument

If you set N=21913095, the original version of the kernel runs successfully.

Performance (averaged across 20 invocations) on an MI325x:
N                 Original (us)   Grid Stride (us)
21913          12.5                12.4
219130        128.9              99.4
2191309      1286               1068
21913095    12381             10168

Fixes https://github.com/ROCm/pytorch/issues/2631


cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang