### PR TITLE
Restore ability to use global stableivalue from without template

### DIFF
--- a/test/cpp_extensions/libtorch_agnostic_2_9_extension/libtorch_agnostic_2_9/csrc/kernel.cpp
+++ b/test/cpp_extensions/libtorch_agnostic_2_9_extension/libtorch_agnostic_2_9/csrc/kernel.cpp
@@ -67,12 +67,23 @@ Tensor sgd_out_of_place(
   return out;
 }
 
+void boxed_sgd_out_of_place(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  Tensor res = sgd_out_of_place(
+    torch::stable::detail::to<Tensor>(stack[0]),
+    torch::stable::detail::to<Tensor>(stack[1]),
+    float(torch::stable::detail::to<double>(stack[2])),
+    torch::stable::detail::to<double>(stack[3]),
+    torch::stable::detail::to<bool>(stack[4]));
+
+  stack[0] = from(res);
+}
+
 STABLE_TORCH_LIBRARY(libtorch_agnostic_2_9, m) {
   m.def("sgd_out_of_place(Tensor param, Tensor grad, float weight_decay, float lr, bool maximize) -> Tensor");
 }
 
 STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic_2_9, CPU, m) {
-  m.impl("sgd_out_of_place", TORCH_BOX(&sgd_out_of_place));
+  m.impl("sgd_out_of_place", &boxed_sgd_out_of_place);
 }
 
 Tensor identity(Tensor t) {

--- a/torch/csrc/stable/stableivalue_conversions.h
+++ b/torch/csrc/stable/stableivalue_conversions.h
@@ -111,45 +111,45 @@ struct FromImpl<ScalarType> {
       [[maybe_unused]] bool is_internal) {
     switch (val) {
       case ScalarType::Byte:
-        return from(aoti_torch_dtype_uint8());
+        return torch::stable::detail::from(aoti_torch_dtype_uint8());
       case ScalarType::Char:
-        return from(aoti_torch_dtype_int8());
+        return torch::stable::detail::from(aoti_torch_dtype_int8());
       case ScalarType::Short:
-        return from(aoti_torch_dtype_int16());
+        return torch::stable::detail::from(aoti_torch_dtype_int16());
       case ScalarType::Int:
-        return from(aoti_torch_dtype_int32());
+        return torch::stable::detail::from(aoti_torch_dtype_int32());
       case ScalarType::Long:
-        return from(aoti_torch_dtype_int64());
+        return torch::stable::detail::from(aoti_torch_dtype_int64());
       case ScalarType::Half:
-        return from(aoti_torch_dtype_float16());
+        return torch::stable::detail::from(aoti_torch_dtype_float16());
       case ScalarType::Float:
-        return from(aoti_torch_dtype_float32());
+        return torch::stable::detail::from(aoti_torch_dtype_float32());
       case ScalarType::Double:
-        return from(aoti_torch_dtype_float64());
+        return torch::stable::detail::from(aoti_torch_dtype_float64());
       case ScalarType::ComplexHalf:
-        return from(aoti_torch_dtype_complex32());
+        return torch::stable::detail::from(aoti_torch_dtype_complex32());
       case ScalarType::ComplexFloat:
-        return from(aoti_torch_dtype_complex64());
+        return torch::stable::detail::from(aoti_torch_dtype_complex64());
       case ScalarType::ComplexDouble:
-        return from(aoti_torch_dtype_complex128());
+        return torch::stable::detail::from(aoti_torch_dtype_complex128());
       case ScalarType::Bool:
-        return from(aoti_torch_dtype_bool());
+        return torch::stable::detail::from(aoti_torch_dtype_bool());
       case ScalarType::BFloat16:
-        return from(aoti_torch_dtype_bfloat16());
+        return torch::stable::detail::from(aoti_torch_dtype_bfloat16());
       case ScalarType::Float8_e5m2:
-        return from(aoti_torch_dtype_float8_e5m2());
+        return torch::stable::detail::from(aoti_torch_dtype_float8_e5m2());
       case ScalarType::Float8_e4m3fn:
-        return from(aoti_torch_dtype_float8_e4m3fn());
+        return torch::stable::detail::from(aoti_torch_dtype_float8_e4m3fn());
       case ScalarType::Float8_e5m2fnuz:
-        return from(aoti_torch_dtype_float8_e5m2fnuz());
+        return torch::stable::detail::from(aoti_torch_dtype_float8_e5m2fnuz());
       case ScalarType::Float8_e4m3fnuz:
-        return from(aoti_torch_dtype_float8_e4m3fnuz());
+        return torch::stable::detail::from(aoti_torch_dtype_float8_e4m3fnuz());
       case ScalarType::UInt16:
-        return from(aoti_torch_dtype_uint16());
+        return torch::stable::detail::from(aoti_torch_dtype_uint16());
       case ScalarType::UInt32:
-        return from(aoti_torch_dtype_uint32());
+        return torch::stable::detail::from(aoti_torch_dtype_uint32());
       case ScalarType::UInt64:
-        return from(aoti_torch_dtype_uint64());
+        return torch::stable::detail::from(aoti_torch_dtype_uint64());
       default:
         STD_TORCH_CHECK(
             false,
@@ -182,17 +182,18 @@ struct FromImpl<DeviceType> {
       [[maybe_unused]] bool is_internal) {
     switch (val) {
       case DeviceType::CPU:
-        return from(aoti_torch_device_type_cpu());
+        return torch::stable::detail::from(aoti_torch_device_type_cpu());
       case DeviceType::CUDA:
-        return from(aoti_torch_device_type_cuda());
+        return torch::stable::detail::from(aoti_torch_device_type_cuda());
       case DeviceType::Meta:
-        return from(aoti_torch_device_type_meta());
+        return torch::stable::detail::from(aoti_torch_device_type_meta());
       case DeviceType::XPU:
-        return from(aoti_torch_device_type_xpu());
+        return torch::stable::detail::from(aoti_torch_device_type_xpu());
       case DeviceType::MPS:
-        return from(aoti_torch_device_type_mps());
+        return torch::stable::detail::from(aoti_torch_device_type_mps());
       case DeviceType::PrivateUse1:
-        return from(aoti_torch_device_type_privateuse1());
+        return torch::stable::detail::from(
+            aoti_torch_device_type_privateuse1());
       default:
         STD_TORCH_CHECK(
             false,
@@ -208,7 +209,7 @@ struct FromImpl<std::nullopt_t> {
       std::nullopt_t val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    return from(nullptr);
+    return torch::stable::detail::from(nullptr);
   }
 };
 
@@ -248,10 +249,11 @@ struct FromImpl<std::optional<T>> {
       uint64_t extension_build_version,
       bool is_internal) {
     if (!val.has_value()) {
-      return from(std::nullopt);
+      return torch::stable::detail::from(std::nullopt);
     }
-    return from(new StableIValue(detail::FromImpl<T>::call(
-        val.value(), extension_build_version, is_internal)));
+    return torch::stable::detail::from(
+        new StableIValue(detail::FromImpl<T>::call(
+            val.value(), extension_build_version, is_internal)));
   }
 };
 
@@ -265,7 +267,7 @@ struct FromImpl<torch::stable::Tensor> {
       [[maybe_unused]] bool is_internal) {
     AtenTensorHandle new_ath;
     TORCH_ERROR_CODE_CHECK(aoti_torch_new_tensor_handle(val.get(), &new_ath));
-    return from(new_ath);
+    return torch::stable::detail::from(new_ath);
   }
 };
 
@@ -286,21 +288,21 @@ struct FromImpl<Layout> {
       [[maybe_unused]] bool is_internal) {
     switch (val) {
       case Layout::Strided:
-        return from(aoti_torch_layout_strided());
+        return torch::stable::detail::from(aoti_torch_layout_strided());
       case Layout::Sparse:
-        return from(aoti_torch_layout_sparse_coo());
+        return torch::stable::detail::from(aoti_torch_layout_sparse_coo());
       case Layout::SparseCsr:
-        return from(aoti_torch_layout_sparse_csr());
+        return torch::stable::detail::from(aoti_torch_layout_sparse_csr());
       case Layout::SparseCsc:
-        return from(aoti_torch_layout_sparse_csc());
+        return torch::stable::detail::from(aoti_torch_layout_sparse_csc());
       case Layout::SparseBsr:
-        return from(aoti_torch_layout_sparse_bsr());
+        return torch::stable::detail::from(aoti_torch_layout_sparse_bsr());
       case Layout::SparseBsc:
-        return from(aoti_torch_layout_sparse_bsc());
+        return torch::stable::detail::from(aoti_torch_layout_sparse_bsc());
       case Layout::Mkldnn:
-        return from(aoti_torch_layout__mkldnn());
+        return torch::stable::detail::from(aoti_torch_layout__mkldnn());
       case Layout::Jagged:
-        return from(aoti_torch_layout_jagged());
+        return torch::stable::detail::from(aoti_torch_layout_jagged());
       default:
         STD_TORCH_CHECK(
             false,
@@ -321,13 +323,17 @@ struct FromImpl<MemoryFormat> {
       [[maybe_unused]] bool is_internal) {
     switch (val) {
       case MemoryFormat::Contiguous:
-        return from(aoti_torch_memory_format_contiguous_format());
+        return torch::stable::detail::from(
+            aoti_torch_memory_format_contiguous_format());
       case MemoryFormat::Preserve:
-        return from(aoti_torch_memory_format_preserve_format());
+        return torch::stable::detail::from(
+            aoti_torch_memory_format_preserve_format());
       case MemoryFormat::ChannelsLast:
-        return from(aoti_torch_memory_format_channels_last());
+        return torch::stable::detail::from(
+            aoti_torch_memory_format_channels_last());
       case MemoryFormat::ChannelsLast3d:
-        return from(aoti_torch_memory_format_channels_last_3d());
+        return torch::stable::detail::from(
+            aoti_torch_memory_format_channels_last_3d());
       default:
         STD_TORCH_CHECK(
             false,
@@ -349,10 +355,10 @@ struct FromImpl<torch::headeronly::HeaderOnlyArrayRef<T>> {
       TORCH_ERROR_CODE_CHECK(
           torch_new_list_reserve_size(val.size(), &new_list_handle));
       for (const auto& elem : val) {
-        TORCH_ERROR_CODE_CHECK(
-            torch_list_push_back(new_list_handle, from(elem)));
+        TORCH_ERROR_CODE_CHECK(torch_list_push_back(
+            new_list_handle, torch::stable::detail::from(elem)));
       }
-      return from(new_list_handle);
+      return torch::stable::detail::from(new_list_handle);
     } catch (const std::runtime_error&) {
       if (new_list_handle != nullptr) {
         // clean up memory if an error was thrown
@@ -372,7 +378,8 @@ struct FromImpl<std::vector<T>> {
       const std::vector<T>& val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    return from<torch::headeronly::HeaderOnlyArrayRef<T>>(val);
+    return torch::stable::detail::from<
+        torch::headeronly::HeaderOnlyArrayRef<T>>(val);
   }
 };
 
@@ -388,7 +395,7 @@ struct FromImpl<torch::stable::Device> {
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
     // Convert DeviceType to shim representation (int32_t)
-    StableIValue device_type_shim = from(val.type());
+    StableIValue device_type_shim = torch::stable::detail::from(val.type());
     // Pack: lower 32 bits = device index, upper 32 bits = device type (shim)
     uint64_t device_index_bits =
         static_cast<uint64_t>(static_cast<uint32_t>(val.index()));
@@ -409,7 +416,7 @@ struct FromImpl<std::string> {
     StringHandle handle;
     TORCH_ERROR_CODE_CHECK(
         torch_new_string_handle(val.c_str(), val.length(), &handle))
-    return from(handle);
+    return torch::stable::detail::from(handle);
   }
 };
 
@@ -822,11 +829,31 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 // WARNING! Will be removed. Only exists for BC. See [global from/to deprecation
 // note]
 template <typename T>
-C10_DEPRECATED_MESSAGE("Use torch::stable::detail::from instead.")
-auto from = &torch::stable::detail::from<T>;
+[[deprecated("Use torch::stable::detail::from instead.")]]
+inline StableIValue from(T val) {
+  return torch::stable::detail::from(val);
+}
 
 // WARNING! Will be removed. Only exists for BC. See [global from/to deprecation
 // note]
 template <typename T>
-C10_DEPRECATED_MESSAGE("Use torch::stable::detail::to instead.")
-auto to = &torch::stable::detail::to<T>;
+[[deprecated("Use torch::stable::detail::from instead.")]]
+inline StableIValue from(const std::optional<T>& val) {
+  return torch::stable::detail::from(val);
+}
+
+// WARNING! Will be removed. Only exists for BC. See [global from/to deprecation
+// note]
+[[deprecated(
+    "Use torch::stable::detail::from instead.")]] [[maybe_unused]] inline StableIValue
+from(const torch::stable::Tensor& val) {
+  return torch::stable::detail::from(val);
+}
+
+// WARNING! Will be removed. Only exists for BC. See [global from/to deprecation
+// note]
+template <typename T>
+[[deprecated("Use torch::stable::detail::to instead.")]]
+inline T to(StableIValue val) {
+  return torch::stable::detail::to<T>(val);
+}

--- a/torch/csrc/stable/stableivalue_conversions.h
+++ b/torch/csrc/stable/stableivalue_conversions.h
@@ -485,7 +485,7 @@ struct ToImpl<ScalarType> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    int32_t shim_scalartype = to<int32_t>(val);
+    int32_t shim_scalartype = torch::stable::detail::to<int32_t>(val);
     if (shim_scalartype == aoti_torch_dtype_uint8()) {
       return ScalarType::Byte;
     } else if (shim_scalartype == aoti_torch_dtype_int8()) {
@@ -544,7 +544,7 @@ struct ToImpl<DeviceType> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    int32_t shim_devicetype = to<int32_t>(val);
+    int32_t shim_devicetype = torch::stable::detail::to<int32_t>(val);
     if (shim_devicetype == aoti_torch_device_type_cpu()) {
       return DeviceType::CPU;
     } else if (shim_devicetype == aoti_torch_device_type_cuda()) {
@@ -588,7 +588,7 @@ struct ToImpl<std::optional<T>> {
       StableIValue val,
       uint64_t extension_build_version,
       bool is_internal) {
-    auto sivp = to<StableIValue*>(val);
+    auto sivp = torch::stable::detail::to<StableIValue*>(val);
 
     // sivp is either nullptr or a pointer to a StableIValue
     if (sivp == nullptr) {
@@ -613,7 +613,8 @@ struct ToImpl<torch::stable::Tensor> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    return torch::stable::Tensor(to<AtenTensorHandle>(val));
+    return torch::stable::Tensor(
+        torch::stable::detail::to<AtenTensorHandle>(val));
   }
 };
 
@@ -629,7 +630,7 @@ struct ToImpl<Layout> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    int32_t shim_layout = to<int32_t>(val);
+    int32_t shim_layout = torch::stable::detail::to<int32_t>(val);
     if (shim_layout == aoti_torch_layout_strided()) {
       return Layout::Strided;
     } else if (shim_layout == aoti_torch_layout_sparse_coo()) {
@@ -663,7 +664,7 @@ struct ToImpl<MemoryFormat> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    int32_t shim_memory_format = to<int32_t>(val);
+    int32_t shim_memory_format = torch::stable::detail::to<int32_t>(val);
     if (shim_memory_format == aoti_torch_memory_format_contiguous_format()) {
       return MemoryFormat::Contiguous;
     } else if (
@@ -695,7 +696,7 @@ struct ToImpl<std::vector<T>> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    auto list_handle = to<StableListHandle>(val);
+    auto list_handle = torch::stable::detail::to<StableListHandle>(val);
     size_t size;
     try {
       TORCH_ERROR_CODE_CHECK(torch_list_size(list_handle, &size));
@@ -704,7 +705,7 @@ struct ToImpl<std::vector<T>> {
       for (size_t i = 0; i < size; i++) {
         StableIValue element;
         TORCH_ERROR_CODE_CHECK(torch_list_get_item(list_handle, i, &element));
-        result.push_back(to<T>(element));
+        result.push_back(torch::stable::detail::to<T>(element));
       }
       TORCH_ERROR_CODE_CHECK(torch_delete_list(list_handle));
       return result;
@@ -729,7 +730,8 @@ struct ToImpl<torch::stable::Device> {
     // Unpack: lower 32 bits = device index, upper 32 bits = device type (shim)
     int32_t device_index = static_cast<int32_t>(val & 0xFFFFFFFF);
     StableIValue device_type_shim = (val >> 32) & 0xFFFFFFFF;
-    DeviceType device_type = to<DeviceType>(device_type_shim);
+    DeviceType device_type =
+        torch::stable::detail::to<DeviceType>(device_type_shim);
     return torch::stable::Device(device_type, device_index);
   }
 };
@@ -742,7 +744,7 @@ struct ToImpl<std::string> {
       StableIValue val,
       [[maybe_unused]] uint64_t extension_build_version,
       [[maybe_unused]] bool is_internal) {
-    StringHandle handle = to<StringHandle>(val);
+    StringHandle handle = torch::stable::detail::to<StringHandle>(val);
     size_t length;
     TORCH_ERROR_CODE_CHECK(torch_string_length(handle, &length));
     const char* data;


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/168155 was needed to fix Windows CI in torchaudio that looked like such


<details>
<summary><b>click for example of torchaudio windows CI error</b></summary>
<br>

```
2025-11-15T21:11:03.9005985Z   C:/actions-runner/_work/audio/audio/pytorch/audio/env/Lib/site-packages/torch/include\torch/csrc/stable/stableivalue_conversions.h(244): error: more than one instance of overloaded function "torch::stable::detail::from" matches the argument list:
2025-11-15T21:11:03.9007831Z               function template "StableIValue from(T)" (declared at line 593)
2025-11-15T21:11:03.9008639Z               function template "StableIValue torch::stable::detail::from(T)" (declared at line 528)
2025-11-15T21:11:03.9009336Z               argument types are: (StableListHandle)
2025-11-15T21:11:03.9009839Z           return from(new_list_handle);
2025-11-15T21:11:03.9010244Z                  ^
2025-11-15T21:11:03.9011886Z   C:/actions-runner/_work/audio/audio/pytorch/audio/env/Lib/site-packages/torch/include\torch/csrc/stable/stableivalue_conversions.h(541): note #3326-D: function "torch::stable::detail::from(const torch::stable::Tensor &)" does not match because argument #1 does not match parameter
2025-11-15T21:11:03.9013826Z     [[maybe_unused]] inline StableIValue from(const torch::stable::Tensor& val) {
2025-11-15T21:11:03.9014403Z                                          ^
2025-11-15T21:11:03.9016129Z   C:/actions-runner/_work/audio/audio/pytorch/audio/env/Lib/site-packages/torch/include\torch/csrc/stable/stableivalue_conversions.h(534): note #3327-D: candidate function template "torch::stable::detail::from(const std::optional<T> &)" failed deduction
2025-11-15T21:11:03.9017869Z     inline StableIValue from(const std::optional<T>& val) {
2025-11-15T21:11:03.9018335Z                         ^
2025-11-15T21:11:03.9019885Z   C:/actions-runner/_work/audio/audio/pytorch/audio/env/Lib/site-packages/torch/include\torch/csrc/stable/stableivalue_conversions.h(609): note #3326-D: function "from(const torch::stable::Tensor &)" does not match because argument #1 does not match parameter
2025-11-15T21:11:03.9021652Z     from(const torch::stable::Tensor& val) {
2025-11-15T21:11:03.9022058Z     ^
2025-11-15T21:11:03.9023430Z   C:/actions-runner/_work/audio/audio/pytorch/audio/env/Lib/site-packages/torch/include\torch/csrc/stable/stableivalue_conversions.h(601): note #3327-D: candidate function template "from(const std::optional<T> &)" failed deduction
2025-11-15T21:11:03.9025327Z     inline StableIValue from(const std::optional<T>& val) {
2025-11-15T21:11:03.9025793Z                         ^
2025-11-15T21:11:03.9026102Z             detected during:
2025-11-15T21:11:03.9027321Z               instantiation of "StableIValue torch::stable::detail::FromImpl<c10::HeaderOnlyArrayRef<T>>::call(const c10::HeaderOnlyArrayRef<T> &, uint64_t, __nv_bool) [with T=int64_t]" at line 529
2025-11-15T21:11:03.9029527Z               instantiation of "StableIValue torch::stable::detail::from(T) [with T=torch::headeronly::IntHeaderOnlyArrayRef]" at line 319 of C:/actions-runner/_work/audio/audio/pytorch/audio/env/Lib/site-packages/torch/include\torch/csrc/stable/ops.h
2025-11-15T21:11:03.9030992Z 
2025-11-15T21:11:03.9031753Z   1 error detected in the compilation of "C:/actions-runner/_work/audio/audio/pytorch/audio/src/libtorchaudio/forced_align/gpu/compute.cu"
```


</details>



But this broke BC in that after that PR `from(...)` is no longer usable without template arguments, which makes the code in fa3 https://github.com/Dao-AILab/flash-attention/blob/ad70a007e6287d4f7e766f94bcf2f9a813f20f6b/hopper/flash_api_stable.cpp#L1797-L1800 no longer compilable in 2.10

We could update the code in FA3, but that might require ifdefs for 2.9 vs 2.10 -- as a general principle for stable extensions, I'm not sure whether updating the extension code or not breaking BC of the headers is what we should go with here. But I'm leaning towards the latter.

This PR takes the alternative approach of restoring torchaudio Windows CI sanity by replacing all `{from/to}` in torch/csrc/stable/stableivalue_conversions.h with `torch::stable::detail::{from/to}` rather than making the `from`/`to` in the global namespace a function pointer

Confirmed that audio CI passes https://github.com/pytorch/audio/pull/4133

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169475

