### PR TITLE
Fixing Unit CommonTemplate.test_conv_inference_heuristics

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4344,7 +4344,7 @@ class CommonTemplate:
                     code[0]
                 )
             else:
-                FileCheck().check(".run(").check("convolution(").run(code[0])
+                FileCheck().check("convolution(").check(".run(").run(code[0])
 
     def test_upsample_cat_conv(self):
         if self.device == GPU_TYPE:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4293,7 +4293,6 @@ class CommonTemplate:
                 (v,),
             )
 
-    @skipIfRocm
     @xfail_if_mps  # Expected to find .run(
     def test_conv_inference_heuristics(self):
         if self.device != GPU_TYPE:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4343,7 +4343,12 @@ class CommonTemplate:
                     code[0]
                 )
             else:
-                FileCheck().check("convolution(").check(".run(").run(code[0])
+                if config.cpp_wrapper:
+                    # with cpp_wrapper, the pattern is .run( and then .convolution(
+                    FileCheck().check(".run(").check("convolution(").run(code[0])
+                else:
+                    # without cpp_wrapper, the pattern is .convolution( and then .run(
+                    FileCheck().check("convolution(").check(".run(").run(code[0])
 
     def test_upsample_cat_conv(self):
         if self.device == GPU_TYPE:

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -86,11 +86,6 @@ test_failures = {
     ),
 }
 
-if not torch._inductor.config.cpp_wrapper:
-    test_failures["test_conv_inference_heuristics_dynamic_shapes"] = TestFailure(
-        ("cuda",)
-    )
-
 if any(os.getenv("BUILD_ENVIRONMENT", "").endswith(x) for x in ("-debug", "-asan")):
     # Fails with TORCH_INTERNAL_ASSERT(!is_heap_allocated()), see https://github.com/pytorch/pytorch/issues/130073
     # After https://github.com/pytorch/pytorch/pull/161586, starts failing UBSAN so we can't even xfail.


### PR DESCRIPTION
The pattern check was not correct, which was leading test to fail.

This PR tries to fix 2 scenerios and enables a test which was marked to fail, but with this 

Normal Scenerio
-------------------

```sh
pytest -s test/inductor/test_torchinductor.py -k "test_conv_inference_heuristics_cuda" -v
```

pytest tries to find the line starting with ".run(" then try to find ".convolution(" after it

but with rocm, the `run_and_get_code` generate code like below, where we don't have mutliple instances of `triton_poi_fused_convolution_0` unlike cuda

```py
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            # Topologically Sorted Source Nodes: [conv2d], Original ATen: [aten.convolution]
            buf0 = extern_kernels.convolution(arg2_1, arg0_1, stride=(1, 1), padding=(0, 0), dilation=(1, 1), transposed=False, output_padding=(0, 0), groups=1, bias=None)
            assert_size_stride(buf0, (1, 4, 8, 8), (256, 64, 8, 1), 'torch.ops.aten.convolution.default')
            del arg0_1
            del arg2_1
            buf1 = buf0; del buf0  # reuse
            # Topologically Sorted Source Nodes: [conv2d], Original ATen: [aten.convolution]
            stream0 = get_raw_stream(0)
            triton_poi_fused_convolution_0.run(buf1, arg1_1, 256, stream=stream0)
            del arg1_1
        return (buf1, )
```

Hence change it to check ".convolution(" first and the ".run(" fixes the issue.

With cpp_wrapper
---------------------

```sh
INDUCTOR_CPP_WRAPPER=1 pytest -s test/inductor/test_torchinductor.py -k "test_conv_inference_heuristics_cuda" -v
```
In this scenerio there will be only one pattern, with `.run(` and then `convolution` for both Cuda and ROCm
Hence added a condition for cpp_wrapper to keep the old behavior

test_conv_inference_heuristics_dynamic_shapes_cuda - Failed due unexpected success
-----------------------------------------------------------------
Caught by CI after this fix, hence Re-enable this test now.

Fixes #168680


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo