### PR TITLE
test_decompose_mem_bound_mm: Increase tolerance for navi3

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -343,8 +343,8 @@ class TestDecomposeMemMM(TestCase):
     # GEMMs operations have an accuracy issue caused by hardware limitation
     @patch_test_members(
         {
-            "atol": 3e-3 if is_navi3_arch() else 1e-3,
-            "rtol": 4e-3 if is_navi3_arch() else 1e-3,
+            "atol": 8e-3 if is_navi3_arch() else 1e-3,
+            "rtol": 8e-3 if is_navi3_arch() else 1e-3,
         }
     )
     @parametrize(


### PR DESCRIPTION
This issue was discovered when running pytorch tests on Radeon PRO V710 (gfx1101) and ROCm 7.1.
`test_decompose_mem_bound_mm.py::TestDecomposeMemMM::test_decompose_mm_mixed_precision_m_20480_k_5_n_2_should_decompose_True_has_bias_False` and
`test_decompose_mem_bound_mm.py::TestDecomposeMemMM::test_decompose_mm_mixed_precision_m_20480_k_5_n_2_should_decompose_True_has_bias_True` fail with:

```
AssertionError: Tensor-likes are not close!

 Mismatched elements: 1 / 40960 (0.0%)
 Greatest absolute difference: 0.0078125 at index (17739, 1) (up to 0.003 allowed)
 Greatest relative difference: 0.007354736328125 at index (17739, 1) (up to 0.004 allowed)
```

This PR addresses this by increasing the tolerance to 0.008 for the relevant platform.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo