### PR TITLE
[dynamo, 3.14] Don't use _PyObject_GC_TRACK which is internal and calls an unexported API symbol

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -252,7 +252,7 @@ static void THP_take_ownership(PyFrameObject* f, _PyInterpreterFrame* frame) {
     PyErr_SetRaisedException(exc);
   }
   if (!_PyObject_GC_IS_TRACKED((PyObject*)f)) {
-    _PyObject_GC_TRACK((PyObject*)f);
+    PyObject_GC_Track((PyObject*)f);
   }
   Py_END_CRITICAL_SECTION();
 }


### PR DESCRIPTION
Summary: In CPython 3.14.1 _PyObject_GC_TRACK calls an unexported function causing build failures. Switch to using the public exported PyObject_GC_Track.

Test Plan: `buck build --flagfile fbcode//mode/opt fbsource//third-party/pypi/docling-ibm-models/__test__:test-cpython3.14` succceds now.

Reviewed By: itamaro

Differential Revision: D88288162




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo