### PR TITLE
Fix update slow test workflow after #168334

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install requirements
         shell: bash
         run: |


### PR DESCRIPTION
Looks like https://github.com/pytorch/pytorch/pull/168334 switched update slow test to python 3.10 however workflow itself is using python 3.9. 
And has been failing since then: https://github.com/pytorch/pytorch/actions/runs/19815030887/job/56764391794
