### PR TITLE
[CI] Use py3.10 in upload-utilization-stats

### DIFF
--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -38,6 +38,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup Python
+        uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
     - name: Print Inputs
       shell: bash
       run: |

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-        uses: actions/setup-python@v6
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     - name: Print Inputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169533
* __->__ #169501

Summary: To fix failures like this on CI,

```
2025-12-03T19:04:16.4264214Z ##[endgroup]
2025-12-03T19:04:16.8364369Z Traceback (most recent call last):
2025-12-03T19:04:16.8365336Z   File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
2025-12-03T19:04:16.8366153Z     return _run_code(code, main_globals, None,
2025-12-03T19:04:16.8366898Z   File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
2025-12-03T19:04:16.8368113Z     exec(code, run_globals)
2025-12-03T19:04:16.8368891Z   File "/home/ec2-user/actions-runner/_work/pytorch/pytorch/tools/stats/upload_utilization_stats/upload_utilization_stats.py", line 17, in <module>
2025-12-03T19:04:16.8369619Z     from tools.stats.utilization_stats_lib import (
2025-12-03T19:04:16.8370231Z   File "/home/ec2-user/actions-runner/_work/pytorch/pytorch/tools/stats/utilization_stats_lib.py", line 13, in <module>
2025-12-03T19:04:16.8370807Z     class UtilizationStats:
2025-12-03T19:04:16.8371390Z   File "/home/ec2-user/actions-runner/_work/pytorch/pytorch/tools/stats/utilization_stats_lib.py", line 14, in UtilizationStats
2025-12-03T19:04:16.8371999Z     avg: float | None = None
2025-12-03T19:04:16.8372353Z TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

e.g. https://productionresultssa17.blob.core.windows.net/actions-results/e3792057-a4cd-4eaa-b759-317aa47a149b/workflow-job-run-9ddd4c2f-8892-5cca-89c2-e6d976902e9d/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-12-03T21%3A15%3A42Z&sig=gvBdBvL2Z6KRploHfvLZF07GZvwLvR7SvN%2FxM1Vo2Fw%3D&ske=2025-12-04T06%3A43%3A09Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-12-03T18%3A43%3A09Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-12-03T21%3A05%3A37Z&sv=2025-11-05