### PR TITLE
improve accuracy of division by scalar

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
@@ -39,7 +39,11 @@ void div_true_kernel_cuda(TensorIteratorBase& iter) {
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
         kHalf, kBFloat16, common_dtype, "div_true_cuda", [&]() {
           using opmath_t = at::opmath_type<scalar_t>;
-          auto inv_b = opmath_t(1.0) / iter.scalar_value<opmath_t>(2);
+          using high_prec_t = std::conditional_t<
+              c10::is_complex<scalar_t>::value,
+              c10::complex<double>,
+              double>;
+          auto inv_b = static_cast<opmath_t>(high_prec_t(1.0) / iter.scalar_value<high_prec_t>(2));
           iter.remove_operand(2);
           gpu_kernel(
               iter,

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1149,6 +1149,15 @@ class TestBinaryUfuncs(TestCase):
         res = nom / denom
         self.assertEqual(res, expected)
 
+    @dtypes(torch.float, torch.bfloat16)
+    def test_division_by_scalar(self, device, dtype):
+        num = torch.rand(1024, device=device, dtype=dtype)
+        denom = torch.logspace(-4, 4, steps=20)
+        denom = [d.item() for d in denom]
+        res = [num / d for d in denom]
+        ref = [num * (1 / d) for d in denom]
+        self.assertEqual(res, ref, atol=0, rtol=0)
+
     # Tests that trying to add, inplace, a CUDA tensor to a CPU tensor
     #   throws the correct error message
     @onlyCUDA

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1149,6 +1149,7 @@ class TestBinaryUfuncs(TestCase):
         res = nom / denom
         self.assertEqual(res, expected)
 
+    @onlyCUDA
     @dtypes(torch.float, torch.bfloat16)
     def test_division_by_scalar(self, device, dtype):
         num = torch.rand(1024, device=device, dtype=dtype)


### PR DESCRIPTION
Pytorch emulates division by scalar as multiplication by 1/scalar, which already can throw results off by 1 ulp. However, since it computes 1/scalar in float as opposed to double, the results are different compared to what you'd get in python by writing `x * (1/scalar)`. This PR remedies that. 