### PR TITLE
Fix Triton group_m config

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2318,7 +2318,9 @@ class TestMaxAutotune(TestCase):
 
             # Traditionally, this would be set of all possible configs
             # We mock out the code path for the sake of the unit test
-            config_heuristics.exhaustive_configs = [GemmConfig(32, 32, 32, 1, 8, 8)]
+            config_heuristics.exhaustive_configs = [
+                GemmConfig(32, 32, 32, 1, 8, group_m=8)
+            ]
             config_mock.return_value = config_heuristics
 
             from torch._dynamo.utils import counters

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -284,9 +284,9 @@ class TestTritonHeuristics(TestCase):
 
         expected_count = 1 if do_pruning else 2
         mm_configs = [
-            GemmConfig(32, 32, 32, 1, 8, 8),
+            GemmConfig(32, 32, 32, 1, 8, group_m=8),
             GemmConfig(
-                128, 128, 128, 100, 8, 4
+                128, 128, 128, 100, 8, group_m=4
             ),  # intentionally large to exceed shared memory limit
         ]
         with config.patch(

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -58,7 +58,7 @@ class BaseConfig:
     block_k: int
     num_stages: int
     num_warps: int
-    hint_override: Optional[int] = None
+    hint_override: Optional[int] = dataclasses.field(kw_only=True, default=None)
 
 
 @dataclasses.dataclass
@@ -67,7 +67,7 @@ class GemmConfig(BaseConfig):
     Gemm configuration used for most backends (CPU, CUDA)
     """
 
-    group_m: int = 8
+    group_m: int = dataclasses.field(kw_only=True, default=8)
 
 
 ConvConfig = BaseConfig
@@ -251,7 +251,9 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         # Exhaustive search for mm configs
         self.exhaustive_configs: list[BaseConfig] = [
-            GemmConfig(BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps, group_m)
+            GemmConfig(
+                BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps, group_m=group_m
+            )
             for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
                 [16, 32, 64, 128, 256], repeat=3
             )
@@ -1176,10 +1178,10 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 BLOCK_K,
                 num_stages,
                 num_warps,
-                group_m,
-                matrix_instr_nonkdim,
-                waves_per_eu,
-                kpack,
+                group_m=group_m,
+                matrix_instr_nonkdim=matrix_instr_nonkdim,
+                waves_per_eu=waves_per_eu,
+                kpack=kpack,
             )
             for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
                 [16, 32, 64, 128, 256], repeat=3


### PR DESCRIPTION
Summary: A value intended for `GemmConfig.group_m` was being sent to `hint_override` as a positional argument. I made both keyword only so dataclasses will ensure the correct behavior.

Test Plan: Assert trips when only the `dataclasses.field`s are added, but compilation succeeds when group_m is passed as kw.

Differential Revision: D88305338




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos