### PR TITLE
Add original_dtensor to node meta

### DIFF
--- a/test/distributed/tensor/test_dtensor_export.py
+++ b/test/distributed/tensor/test_dtensor_export.py
@@ -495,6 +495,17 @@ class DTensorExportTest(TestCase):
             2,
         )
 
+        # check that original_dtensor meta exist on node.meta
+        nodes_with_dtensor_meta = []
+        num_addmm_nodes = 0
+        for node in joint_gm.graph.nodes:
+            if "original_dtensor" in node.meta:
+                nodes_with_dtensor_meta.append(node.name)
+                if node.target == torch.ops.aten.addmm.default:
+                    num_addmm_nodes += 1
+        self.assertEqual(num_addmm_nodes, 4)
+        self.assertEqual(len(nodes_with_dtensor_meta), 20)
+
     def test_union_typed_annotation(self):
         def fn(leaf: torch.Tensor | DTensor):
             def nest_fn(leaf: torch.Tensor | DTensor):


### PR DESCRIPTION
It would be useful to know the original dtensor's placement for a fx.node in DebugMode

We add node.meta["original_dtensor"], just like what we did for node.meta["val"] to track FakeTensor

original dtensor is the output of the original node that the tracer is tracing, not necessarily the output of the current node, as it can be decomposed to multiple nodes


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv