### PR TITLE
    [inductor] [wip] Add fusion region detection for overlap scheduling

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -822,5 +822,171 @@ class TestCrossPGOverlap(InductorTestCase):
         self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 1)
 
 
+@unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+class TestFusionRegions(InductorTestCase):
+    """Unit tests for fusion region detection, collapse, and expand."""
+
+    def test_build_fusion_regions_detects_pointwise_ops(self):
+        """Test that build_fusion_regions detects consecutive pointwise ops."""
+        from torch._inductor.fx_passes.fusion_regions import (
+            build_fusion_regions,
+            is_fusible_node,
+        )
+
+        # Create a graph with pointwise ops
+        graph = fx.Graph()
+        a = graph.placeholder("a")
+        b = graph.placeholder("b")
+
+        # Pointwise ops that should be detected as fusible
+        add1 = graph.call_function(aten.add.Tensor, (a, 1))
+        add2 = graph.call_function(aten.add.Tensor, (b, 2))
+        add3 = graph.call_function(aten.add.Tensor, (add1, add2))
+        graph.output(add3)
+
+        # Verify is_fusible_node works
+        self.assertTrue(is_fusible_node(add1))
+        self.assertTrue(is_fusible_node(add2))
+        self.assertTrue(is_fusible_node(add3))
+
+        # Build regions
+        region_of = build_fusion_regions(list(graph.nodes))
+
+        # All three add ops should be in the same region
+        if region_of:  # May be empty if cost is 0 due to missing metadata
+            regions = set(id(r) for r in region_of.values())
+            # Should have at most 1 region (all connected)
+            self.assertLessEqual(len(regions), 1)
+
+    def test_collapse_and_expand_preserves_graph_semantics(self):
+        """Test that collapse followed by expand preserves graph structure."""
+        from torch._inductor.fx_passes.fusion_regions import (
+            build_fusion_regions,
+            collapse_fusion_regions,
+            expand_fusion_regions,
+        )
+
+        # Create a simple module to get a proper graph with owning_module
+        class SimpleModule(torch.nn.Module):
+            def forward(self, a, b):
+                x = a + 1
+                y = b + 2
+                return x + y
+
+        mod = SimpleModule()
+        gm = torch.fx.symbolic_trace(mod)
+
+        # Get original graph structure
+        original_nodes = [
+            (n.name, n.op, str(n.target)) for n in gm.graph.nodes
+        ]
+
+        # Build regions (may be empty for non-ATen ops)
+        region_of = build_fusion_regions(list(gm.graph.nodes))
+
+        if region_of:
+            # Collapse
+            new_region_of, replaced = collapse_fusion_regions(gm.graph, region_of)
+
+            # Verify subgraph nodes were created
+            self.assertTrue(len(new_region_of) > 0)
+
+            # Expand
+            replaced = expand_fusion_regions(gm.graph, new_region_of, replaced)
+
+            # Graph should still be valid
+            gm.graph.lint()
+
+    def test_fusion_region_with_aten_ops(self):
+        """Test fusion regions with actual ATen ops."""
+        from torch._inductor.fx_passes.fusion_regions import (
+            FusionRegion,
+            build_fusion_regions,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        # Create graph with ATen ops
+        def func(a, b):
+            x = a + 1
+            y = b + 2
+            z = x * y
+            return z.sum()
+
+        with FakeTensorMode():
+            a = torch.randn(4, 4)
+            b = torch.randn(4, 4)
+            traced = make_fx(func)(a, b)
+
+        region_of = build_fusion_regions(list(traced.graph.nodes))
+
+        # Should detect fusible regions
+        # (may be multiple or one depending on connectivity)
+        if region_of:
+            for node, region in region_of.items():
+                self.assertIsInstance(region, FusionRegion)
+                self.assertIn(node, region.nodes)
+
+    def test_replacement_chain_resolution(self):
+        """Test that replacement chains are properly resolved."""
+        from torch._inductor.fx_passes.fusion_regions import resolve_replacement_chain
+
+        # Create a mock replacement chain: A -> B -> C
+        class MockNode:
+            def __init__(self, name):
+                self.name = name
+
+        a = MockNode("a")
+        b = MockNode("b")
+        c = MockNode("c")
+        d = MockNode("d")
+
+        replaced = {a: b, b: c}
+
+        # a should resolve to c
+        self.assertEqual(resolve_replacement_chain(a, replaced), c)
+        # b should resolve to c
+        self.assertEqual(resolve_replacement_chain(b, replaced), c)
+        # c should resolve to itself (not in chain)
+        self.assertEqual(resolve_replacement_chain(c, replaced), c)
+        # d should resolve to itself (not in chain)
+        self.assertEqual(resolve_replacement_chain(d, replaced), d)
+
+    def test_augmented_graph_fixup_replaced_nodes(self):
+        """Test that AugmentedGraphHelper.fixup_replaced_nodes works correctly."""
+        from torch._inductor.augmented_graph_helper import AugmentedGraphHelper
+
+        # Create a simple graph
+        graph = fx.Graph()
+        a = graph.placeholder("a")
+        b = graph.placeholder("b")
+        c = graph.call_function(aten.add.Tensor, (a, b))
+        graph.output(c)
+
+        # Create augmented graph helper
+        aug = AugmentedGraphHelper(graph)
+
+        # Add some extra deps
+        aug.add_extra_dep(n=c, dep=a)
+        aug.add_extra_dep(n=c, dep=b)
+
+        # Simulate replacement: a was replaced by a_new
+        class MockNode:
+            def __init__(self, name):
+                self.name = name
+
+        a_new = MockNode("a_new")
+        replaced = {a: a_new}
+
+        # Fixup
+        aug.fixup_replaced_nodes(replaced)
+
+        # Verify deps were updated
+        deps = aug.get_all_extra_deps()
+        # c's deps should now include a_new instead of a
+        if c in deps:
+            self.assertIn(a_new, deps[c])
+            self.assertNotIn(a, deps[c])
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/augmented_graph_helper.py
+++ b/torch/_inductor/augmented_graph_helper.py
@@ -80,10 +80,17 @@ class AugmentedGraphHelper:
         """
         deps: OrderedSet[fx.Node] = OrderedSet()
 
+        # Handle nodes not in merge_sets (e.g., erased nodes)
+        if node not in self.merge_sets:
+            return deps
+
         # For each node in the merge set
         for merged_node in self.merge_sets[node]:
             # Add direct dependencies from all_input_nodes
-            deps.update(merged_node.all_input_nodes)
+            # Filter to only include nodes that are still valid in merge_sets
+            for input_node in merged_node.all_input_nodes:
+                if input_node in self.merge_sets:
+                    deps.add(input_node)
             # Add extra dependencies
             deps.update(self.extra_deps[merged_node])
 
@@ -168,6 +175,56 @@ class AugmentedGraphHelper:
             self.extra_deps[old_node].clear()
             self.extra_uses[old_node].clear()
             del self.merge_sets[old_node]
+
+    def fixup_replaced_nodes(self, replaced: dict[fx.Node, fx.Node]) -> None:
+        """
+        Fixup extra_deps and extra_uses after nodes have been replaced.
+
+        Follows replacement chains to resolve all stale node references.
+
+        Args:
+            replaced: Mapping from old nodes to their replacements
+        """
+        if not replaced:
+            return
+
+        def resolve(node: fx.Node) -> fx.Node:
+            """Follow replacement chain to get final node."""
+            visited = set()
+            while node in replaced and node not in visited:
+                visited.add(node)
+                node = replaced[node]
+            return node
+
+        # Fixup extra_deps
+        new_extra_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        for node, deps in self.extra_deps.items():
+            resolved_node = resolve(node)
+            for dep in deps:
+                resolved_dep = resolve(dep)
+                new_extra_deps[resolved_node].add(resolved_dep)
+        self.extra_deps = new_extra_deps
+
+        # Fixup extra_uses
+        new_extra_uses: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        for node, uses in self.extra_uses.items():
+            resolved_node = resolve(node)
+            for use in uses:
+                resolved_use = resolve(use)
+                new_extra_uses[resolved_node].add(resolved_use)
+        self.extra_uses = new_extra_uses
+
+        # Fixup merge_sets - remove stale nodes, add resolved ones
+        nodes_to_remove = []
+        for node in self.merge_sets:
+            if node in replaced:
+                nodes_to_remove.append(node)
+
+        for node in nodes_to_remove:
+            resolved = resolve(node)
+            if resolved not in self.merge_sets:
+                self.merge_sets[resolved] = OrderedSet([resolved])
+            del self.merge_sets[node]
 
     def get_all_extra_deps(self) -> dict[fx.Node, OrderedSet[fx.Node]]:
         """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2236,6 +2236,11 @@ class test_configs:
     # Assume bucketing reduces latency (mostly for testing)
     assume_bucketing_reduces_latency: bool = True
 
+    # Enable fusion region detection for overlap scheduling.
+    # When enabled, groups of fusible operations (pointwise, reduction, views)
+    # are treated as cohesive regions for better overlap scheduling.
+    enable_fusion_regions: bool = True
+
     # A test config to ease the test for perf of reduction config filtering
     force_filter_reduction_configs = (
         os.getenv("TORCHINDUCTOR_FORCE_FILTER_REDUCTION_CONFIGS") == "1"

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -354,6 +354,24 @@ class OverlapScheduler:
         self.scheduled: OrderedSet[fx.Node] = OrderedSet()
         self.max_compute_pre_fetch = max_compute_pre_fetch
 
+        # Build fusion regions early for overlap calculation
+        # This allows us to use fused kernel costs when computing overlap
+        self.region_of: dict[fx.Node, Any] = {}
+        self.counted_region_ids: set[int] = set()  # Track regions already counted for overlap
+        if torch._inductor.config.test_configs.enable_fusion_regions:
+            from torch._inductor.fx_passes.fusion_regions import build_fusion_regions
+
+            self.region_of = build_fusion_regions(self.nodes)
+            if self.region_of:
+                unique_regions: set[int] = set()
+                for region in self.region_of.values():
+                    unique_regions.add(id(region))
+                log.info(
+                    "Fusion regions for overlap: detected %d regions containing %d nodes",
+                    len(unique_regions),
+                    len(self.region_of),
+                )
+
     def _collect_node_ancestors(self) -> dict[fx.Node, OrderedSet[fx.Node]]:
         """Collect all ancestors for each node."""
         ancestors: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
@@ -710,14 +728,65 @@ class OverlapScheduler:
                 # Wait depends on compute (wait must wait for compute to finish)
                 additional_deps[info.wait_node].add(hn)
 
+        # Redirect dependencies to fusion region outputs instead of internal nodes
+        # This avoids creating dependencies on nodes that will fuse together
+        if self.region_of and additional_deps:
+            additional_deps = self._redirect_deps_to_fusion_outputs(additional_deps)
+
         # Apply effect tokens to preserve these dependencies
         if additional_deps:
             preserve_node_ordering(self.graph, additional_deps)
 
+    def _redirect_deps_to_fusion_outputs(
+        self, deps_map: dict[fx.Node, OrderedSet[fx.Node]]
+    ) -> dict[fx.Node, OrderedSet[fx.Node]]:
+        """Redirect dependencies to target fusion group outputs instead of internal nodes."""
+        if not self.region_of:
+            return deps_map
+
+        def get_fusion_rep(node: fx.Node) -> fx.Node:
+            """Get the fusion region's output node (representative) for a node."""
+            region = self.region_of.get(node)
+            if region is not None:
+                return region.end  # Last node (output) of the fusion region
+            return node
+
+        redirected_deps: dict[fx.Node, OrderedSet[fx.Node]] = {}
+
+        for node, deps in deps_map.items():
+            rep_node = get_fusion_rep(node)
+            rep_deps = OrderedSet()
+            for dep in deps:
+                rep_dep = get_fusion_rep(dep)
+                # Only add if not self-dependency after redirection
+                if rep_dep != rep_node:
+                    rep_deps.add(rep_dep)
+
+            if rep_deps:
+                if rep_node in redirected_deps:
+                    redirected_deps[rep_node].update(rep_deps)
+                else:
+                    redirected_deps[rep_node] = rep_deps
+
+        return redirected_deps
+
     def get_non_collective_runtime_estimate(self, node: fx.Node) -> float | None:
         """Get runtime estimation for a node in ms. Returns None if no estimation is available."""
 
-        # TODO: non custom estimation of aten nodes, potentially requires notion of fusion group
+        # If node is in a fusion region, use region cost (memory bandwidth-based)
+        # This gives a more accurate estimate since these ops will fuse together
+        # Only count each region's cost once (when we see the first node from it)
+        if node in self.region_of:
+            region = self.region_of[node]
+            region_id = id(region)
+            if region_id in self.counted_region_ids:
+                # Already used this region's cost for overlap, return 0 to avoid double-counting
+                return 0.0
+            # Mark as counted and return region cost
+            self.counted_region_ids.add(region_id)
+            return region.cost_ms
+
+        # For nodes not in fusion regions, use existing logic
         if is_compute_node(node):
             return benchmark_node(node, self.custom_runtime_estimation)
 
@@ -1190,12 +1259,12 @@ class OverlapScheduler:
         self.reorder_graph()
 
     def _bucket_collectives(self) -> None:
-        from torch._inductor.fx_passes.fusion_regions import build_fusion_regions
         from torch._inductor.fx_passes.overlap_preserving_bucketer import (
             OverlapPreservingBucketer,
         )
 
-        region_of = build_fusion_regions(list(self.graph.nodes))
+        # Use fusion regions built during __init__ (already used for overlap scheduling)
+        replaced: dict[fx.Node, fx.Node] = {}
 
         bucketer = OverlapPreservingBucketer(
             graph=self.graph,
@@ -1204,7 +1273,8 @@ class OverlapScheduler:
             max_bucket_memory_gb=2.0,  # Could make this configurable
             max_coll_distance=self.max_node_distance,
             insert_overlap_deps=self.insert_overlap_deps,
-            region_of=region_of,
+            region_of=self.region_of,
+            replaced=replaced,
         )
         bucketer.bucket_collectives()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #169523
* #169522

Add fusion region detection to improve compute-collective overlap scheduling.
    Groups of fusible operations (pointwise, reduction, views) are detected and
    treated as cohesive regions, providing more accurate cost estimates for
    overlap computation.

    Key changes:
    - Build fusion regions early in OverlapScheduler.__init__
    - Use region costs (memory bandwidth-based) when computing overlap instead of
      benchmarking individual ops that will fuse together
    - Redirect dependencies to fusion region outputs to avoid creating deps on
      internal fusion nodes
    - Fix topological sort issue by applying dependency redirection BEFORE the sort
      in overlap_preserving_bucketer (ensures consistent node references)
    - Add config flag test_configs.enable_fusion_regions (default True)
    - Add unit tests for fusion region detection, collapse, and expand