### PR TITLE
    [inductor] [wip] Add fusion region detection for overlap scheduling

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -822,5 +822,171 @@ class TestCrossPGOverlap(InductorTestCase):
         self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 1)
 
 
+@unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+class TestFusionRegions(InductorTestCase):
+    """Unit tests for fusion region detection, collapse, and expand."""
+
+    def test_build_fusion_regions_detects_pointwise_ops(self):
+        """Test that build_fusion_regions detects consecutive pointwise ops."""
+        from torch._inductor.fx_passes.fusion_regions import (
+            build_fusion_regions,
+            is_fusible_node,
+        )
+
+        # Create a graph with pointwise ops
+        graph = fx.Graph()
+        a = graph.placeholder("a")
+        b = graph.placeholder("b")
+
+        # Pointwise ops that should be detected as fusible
+        add1 = graph.call_function(aten.add.Tensor, (a, 1))
+        add2 = graph.call_function(aten.add.Tensor, (b, 2))
+        add3 = graph.call_function(aten.add.Tensor, (add1, add2))
+        graph.output(add3)
+
+        # Verify is_fusible_node works
+        self.assertTrue(is_fusible_node(add1))
+        self.assertTrue(is_fusible_node(add2))
+        self.assertTrue(is_fusible_node(add3))
+
+        # Build regions
+        region_of = build_fusion_regions(list(graph.nodes))
+
+        # All three add ops should be in the same region
+        if region_of:  # May be empty if cost is 0 due to missing metadata
+            regions = set(id(r) for r in region_of.values())
+            # Should have at most 1 region (all connected)
+            self.assertLessEqual(len(regions), 1)
+
+    def test_collapse_and_expand_preserves_graph_semantics(self):
+        """Test that collapse followed by expand preserves graph structure."""
+        from torch._inductor.fx_passes.fusion_regions import (
+            build_fusion_regions,
+            collapse_fusion_regions,
+            expand_fusion_regions,
+        )
+
+        # Create a simple module to get a proper graph with owning_module
+        class SimpleModule(torch.nn.Module):
+            def forward(self, a, b):
+                x = a + 1
+                y = b + 2
+                return x + y
+
+        mod = SimpleModule()
+        gm = torch.fx.symbolic_trace(mod)
+
+        # Get original graph structure
+        original_nodes = [
+            (n.name, n.op, str(n.target)) for n in gm.graph.nodes
+        ]
+
+        # Build regions (may be empty for non-ATen ops)
+        region_of = build_fusion_regions(list(gm.graph.nodes))
+
+        if region_of:
+            # Collapse
+            new_region_of, replaced = collapse_fusion_regions(gm.graph, region_of)
+
+            # Verify subgraph nodes were created
+            self.assertTrue(len(new_region_of) > 0)
+
+            # Expand
+            replaced = expand_fusion_regions(gm.graph, new_region_of, replaced)
+
+            # Graph should still be valid
+            gm.graph.lint()
+
+    def test_fusion_region_with_aten_ops(self):
+        """Test fusion regions with actual ATen ops."""
+        from torch._inductor.fx_passes.fusion_regions import (
+            FusionRegion,
+            build_fusion_regions,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        # Create graph with ATen ops
+        def func(a, b):
+            x = a + 1
+            y = b + 2
+            z = x * y
+            return z.sum()
+
+        with FakeTensorMode():
+            a = torch.randn(4, 4)
+            b = torch.randn(4, 4)
+            traced = make_fx(func)(a, b)
+
+        region_of = build_fusion_regions(list(traced.graph.nodes))
+
+        # Should detect fusible regions
+        # (may be multiple or one depending on connectivity)
+        if region_of:
+            for node, region in region_of.items():
+                self.assertIsInstance(region, FusionRegion)
+                self.assertIn(node, region.nodes)
+
+    def test_replacement_chain_resolution(self):
+        """Test that replacement chains are properly resolved."""
+        from torch._inductor.fx_passes.fusion_regions import resolve_replacement_chain
+
+        # Create a mock replacement chain: A -> B -> C
+        class MockNode:
+            def __init__(self, name):
+                self.name = name
+
+        a = MockNode("a")
+        b = MockNode("b")
+        c = MockNode("c")
+        d = MockNode("d")
+
+        replaced = {a: b, b: c}
+
+        # a should resolve to c
+        self.assertEqual(resolve_replacement_chain(a, replaced), c)
+        # b should resolve to c
+        self.assertEqual(resolve_replacement_chain(b, replaced), c)
+        # c should resolve to itself (not in chain)
+        self.assertEqual(resolve_replacement_chain(c, replaced), c)
+        # d should resolve to itself (not in chain)
+        self.assertEqual(resolve_replacement_chain(d, replaced), d)
+
+    def test_augmented_graph_fixup_replaced_nodes(self):
+        """Test that AugmentedGraphHelper.fixup_replaced_nodes works correctly."""
+        from torch._inductor.augmented_graph_helper import AugmentedGraphHelper
+
+        # Create a simple graph
+        graph = fx.Graph()
+        a = graph.placeholder("a")
+        b = graph.placeholder("b")
+        c = graph.call_function(aten.add.Tensor, (a, b))
+        graph.output(c)
+
+        # Create augmented graph helper
+        aug = AugmentedGraphHelper(graph)
+
+        # Add some extra deps
+        aug.add_extra_dep(n=c, dep=a)
+        aug.add_extra_dep(n=c, dep=b)
+
+        # Simulate replacement: a was replaced by a_new
+        class MockNode:
+            def __init__(self, name):
+                self.name = name
+
+        a_new = MockNode("a_new")
+        replaced = {a: a_new}
+
+        # Fixup
+        aug.fixup_replaced_nodes(replaced)
+
+        # Verify deps were updated
+        deps = aug.get_all_extra_deps()
+        # c's deps should now include a_new instead of a
+        if c in deps:
+            self.assertIn(a_new, deps[c])
+            self.assertNotIn(a, deps[c])
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/augmented_graph_helper.py
+++ b/torch/_inductor/augmented_graph_helper.py
@@ -80,10 +80,17 @@ class AugmentedGraphHelper:
         """
         deps: OrderedSet[fx.Node] = OrderedSet()
 
+        # Handle nodes not in merge_sets (e.g., erased nodes)
+        if node not in self.merge_sets:
+            return deps
+
         # For each node in the merge set
         for merged_node in self.merge_sets[node]:
             # Add direct dependencies from all_input_nodes
-            deps.update(merged_node.all_input_nodes)
+            # Filter to only include nodes that are still valid in merge_sets
+            for input_node in merged_node.all_input_nodes:
+                if input_node in self.merge_sets:
+                    deps.add(input_node)
             # Add extra dependencies
             deps.update(self.extra_deps[merged_node])
 
@@ -168,6 +175,56 @@ class AugmentedGraphHelper:
             self.extra_deps[old_node].clear()
             self.extra_uses[old_node].clear()
             del self.merge_sets[old_node]
+
+    def fixup_replaced_nodes(self, replaced: dict[fx.Node, fx.Node]) -> None:
+        """
+        Fixup extra_deps and extra_uses after nodes have been replaced.
+
+        Follows replacement chains to resolve all stale node references.
+
+        Args:
+            replaced: Mapping from old nodes to their replacements
+        """
+        if not replaced:
+            return
+
+        def resolve(node: fx.Node) -> fx.Node:
+            """Follow replacement chain to get final node."""
+            visited = set()
+            while node in replaced and node not in visited:
+                visited.add(node)
+                node = replaced[node]
+            return node
+
+        # Fixup extra_deps
+        new_extra_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        for node, deps in self.extra_deps.items():
+            resolved_node = resolve(node)
+            for dep in deps:
+                resolved_dep = resolve(dep)
+                new_extra_deps[resolved_node].add(resolved_dep)
+        self.extra_deps = new_extra_deps
+
+        # Fixup extra_uses
+        new_extra_uses: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        for node, uses in self.extra_uses.items():
+            resolved_node = resolve(node)
+            for use in uses:
+                resolved_use = resolve(use)
+                new_extra_uses[resolved_node].add(resolved_use)
+        self.extra_uses = new_extra_uses
+
+        # Fixup merge_sets - remove stale nodes, add resolved ones
+        nodes_to_remove = []
+        for node in self.merge_sets:
+            if node in replaced:
+                nodes_to_remove.append(node)
+
+        for node in nodes_to_remove:
+            resolved = resolve(node)
+            if resolved not in self.merge_sets:
+                self.merge_sets[resolved] = OrderedSet([resolved])
+            del self.merge_sets[node]
 
     def get_all_extra_deps(self) -> dict[fx.Node, OrderedSet[fx.Node]]:
         """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2236,6 +2236,11 @@ class test_configs:
     # Assume bucketing reduces latency (mostly for testing)
     assume_bucketing_reduces_latency: bool = True
 
+    # Enable fusion region detection for overlap scheduling.
+    # When enabled, groups of fusible operations (pointwise, reduction, views)
+    # are treated as cohesive regions for better overlap scheduling.
+    enable_fusion_regions: bool = True
+
     # A test config to ease the test for perf of reduction config filtering
     force_filter_reduction_configs = (
         os.getenv("TORCHINDUCTOR_FORCE_FILTER_REDUCTION_CONFIGS") == "1"

--- a/torch/_inductor/fx_passes/fusion_regions.py
+++ b/torch/_inductor/fx_passes/fusion_regions.py
@@ -1,0 +1,589 @@
+"""Detect fusion regions for overlap scheduling."""
+
+import operator
+from dataclasses import dataclass
+
+import torch
+import torch.fx as fx
+from torch.utils._ordered_set import OrderedSet
+
+
+@dataclass
+class FusionRegion:
+    """Represents a connected set of fusible operations that will fuse together."""
+
+    nodes: OrderedSet[fx.Node]  # All nodes in topo order
+    cost_ms: float = 0.0  # Estimated cost in milliseconds
+    external_inputs: OrderedSet[fx.Node] = None  # Inputs from outside the region
+    external_outputs: OrderedSet[fx.Node] = None  # Nodes with users outside the region
+    external_users: OrderedSet[fx.Node] = None  # Users outside the region
+    subgraph_node: fx.Node | None = None  # The subgraph node representing this region
+
+    def __post_init__(self):
+        """Compute cost and external inputs/outputs."""
+        from torch._inductor.utils import get_gpu_dram_gbps
+
+        region_set = set(self.nodes)
+        self.external_inputs = OrderedSet()
+        self.external_outputs = OrderedSet()
+        self.external_users = OrderedSet()
+
+        for node in self.nodes:
+            # Collect all external inputs (not just tensors)
+            for inp in node.all_input_nodes:
+                if inp not in region_set:
+                    self.external_inputs.add(inp)
+
+            # Collect all external outputs (not just tensors)
+            if any(u not in region_set for u in node.users) or len(node.users) == 0:
+                self.external_outputs.add(node)
+
+            # Collect all external users
+            for user in node.users:
+                if user not in region_set:
+                    self.external_users.add(user)
+
+        # Calculate cost from tensor metadata of external IO
+        total_bytes = 0
+        for node in self.external_inputs | self.external_outputs:
+            val = node.meta.get("val")
+            if not isinstance(val, torch.Tensor):
+                continue
+
+            total_bytes += val.numel() * val.element_size()
+
+        if total_bytes > 0:
+            fusion_bw_gbps = get_gpu_dram_gbps()
+            fusion_bw_bytes_per_s = fusion_bw_gbps * 1e9
+            self.cost_ms = (total_bytes / fusion_bw_bytes_per_s) * 1000
+
+    @property
+    def start(self) -> fx.Node:
+        """First node in the region."""
+        return next(iter(self.nodes))
+
+    @property
+    def end(self) -> fx.Node:
+        """Last node (anchor) in the region."""
+        return list(self.nodes)[-1]
+
+
+def is_fusible_node(n: fx.Node) -> bool:
+    """Check if a node is fusible (pointwise, reduction, views, indexing ops).
+
+    Excludes: mm/conv, collectives, waits, placeholders, outputs.
+    """
+    # Include pointwise, reduction, views
+    tags = getattr(n.target, "tags", ())
+    if torch.Tag.pointwise in tags or torch.Tag.reduction in tags:
+        return True
+
+    if getattr(n.target, "is_view", False):
+        return True
+
+    # Include specific indexing ops
+    aten = torch.ops.aten
+    if n.target in (aten.slice.Tensor, aten.gather.default, aten.embedding.default):
+        return True
+
+    return False
+
+
+def build_fusion_regions(
+    graph_nodes: list[fx.Node],
+) -> dict[fx.Node, FusionRegion]:
+    """Build fusion regions from the graph.
+
+    Returns a dict mapping each node to its containing region (if any).
+
+    Algorithm:
+    1. Split graph into segments separated by non-fusible nodes
+    2. Within each segment, group connected nodes via data dependencies
+    """
+    # Find segments: consecutive fusible nodes separated by non-fusible nodes
+    segments: list[list[fx.Node]] = []
+    current_segment: list[fx.Node] = []
+
+    for node in graph_nodes:
+        if is_fusible_node(node):
+            current_segment.append(node)
+        else:
+            if current_segment:
+                segments.append(current_segment)
+                current_segment = []
+
+    if current_segment:
+        segments.append(current_segment)
+
+    # Build fusion regions within each segment
+    region_of: dict[fx.Node, FusionRegion] = {}
+
+    for segment in segments:
+        if len(segment) < 2:
+            continue
+
+        segment_set = set(segment)
+        # Map each node to its region members (initially just itself)
+        node_to_region: dict[fx.Node, OrderedSet[fx.Node]] = {}
+        for n in segment:
+            node_to_region[n] = OrderedSet([n])
+
+        # Build adjacency mapping for shared inputs
+        input_to_consumers: dict[fx.Node, list[fx.Node]] = {}
+        for node in segment:
+            for inp in node.all_input_nodes:
+                if inp not in segment_set:  # External input
+                    if inp not in input_to_consumers:
+                        input_to_consumers[inp] = []
+                    input_to_consumers[inp].append(node)
+
+        # First, merge nodes that share the same external inputs
+        for inp, consumers in input_to_consumers.items():
+            if len(consumers) > 1:  # Multiple consumers of the same input
+                first_region = node_to_region[consumers[0]]
+                for consumer in consumers[1:]:
+                    consumer_region = node_to_region[consumer]
+                    if first_region is not consumer_region:
+                        # Merge smaller into larger
+                        if len(first_region) < len(consumer_region):
+                            smaller, larger = first_region, consumer_region
+                        else:
+                            smaller, larger = consumer_region, first_region
+
+                        larger |= smaller
+                        for n in smaller:
+                            node_to_region[n] = larger
+                        first_region = larger
+
+        # Second, merge producer-consumer pairs within the segment
+        for node in segment:
+            fusible_inputs = [
+                inp for inp in node.all_input_nodes if inp in segment_set
+            ]
+
+            for inp in fusible_inputs:
+                # Merge regions (union by size)
+                node_region = node_to_region[node]
+                inp_region = node_to_region[inp]
+                if node_region is not inp_region:
+                    # Merge smaller into larger
+                    if len(node_region) < len(inp_region):
+                        smaller, larger = node_region, inp_region
+                    else:
+                        smaller, larger = inp_region, node_region
+
+                    larger |= smaller
+                    for n in smaller:
+                        node_to_region[n] = larger
+
+        # Extract unique regions
+        seen_regions: set[int] = set()
+        for node in segment:
+            region_set = node_to_region[node]
+            region_id = id(region_set)
+            if region_id in seen_regions:
+                continue
+            seen_regions.add(region_id)
+
+            members = list(region_set)
+            if len(members) < 2:
+                continue
+
+            # Topologically sort members based on their dependencies
+            members_sorted = _topological_sort_region(members)
+
+            region = FusionRegion(nodes=OrderedSet(members_sorted))
+            if region.cost_ms > 0:
+                # Map all nodes to this region
+                for n in members_sorted:
+                    region_of[n] = region
+
+    return region_of
+
+
+def _topological_sort_region(nodes: list[fx.Node]) -> list[fx.Node]:
+    """
+    Topologically sort nodes within a region with sub-group awareness.
+
+    Strategy:
+    1. Identify sub-groups of nodes that share external inputs
+    2. Sort within each sub-group by dependency order
+    3. Sort sub-groups topologically relative to each other
+    """
+    node_set = set(nodes)
+
+    # First, identify sub-groups based on shared external inputs
+    subgroups = _identify_subgroups_in_region(nodes, node_set)
+
+    # Sort each sub-group internally
+    sorted_subgroups = []
+    for subgroup in subgroups:
+        sorted_subgroup = _sort_subgroup(subgroup, node_set)
+        sorted_subgroups.append(sorted_subgroup)
+
+    # Sort sub-groups relative to each other topologically
+    return _sort_subgroups_topologically(sorted_subgroups, node_set)
+
+
+def _identify_subgroups_in_region(nodes: list[fx.Node], node_set: set[fx.Node]) -> list[list[fx.Node]]:
+    """Identify sub-groups within a region based on shared external inputs."""
+    # Group nodes by their external input signature
+    input_signatures: dict[tuple, list[fx.Node]] = {}
+
+    for node in nodes:
+        external_inputs = tuple(sorted(
+            inp.name for inp in node.all_input_nodes
+            if inp not in node_set
+        ))
+
+        if external_inputs not in input_signatures:
+            input_signatures[external_inputs] = []
+        input_signatures[external_inputs].append(node)
+
+    return list(input_signatures.values())
+
+
+def _sort_subgroup(subgroup: list[fx.Node], node_set: set[fx.Node]) -> list[fx.Node]:
+    """Sort nodes within a sub-group topologically."""
+    if len(subgroup) <= 1:
+        return subgroup
+
+    subgroup_set = set(subgroup)
+    in_degree = {n: 0 for n in subgroup}
+
+    # Calculate in-degrees within the sub-group
+    for node in subgroup:
+        for inp in node.all_input_nodes:
+            if inp in subgroup_set:
+                in_degree[node] += 1
+
+    # Kahn's algorithm for the sub-group
+    queue = [n for n in subgroup if in_degree[n] == 0]
+    result = []
+
+    while queue:
+        queue.sort(key=lambda n: n.name)  # Deterministic ordering
+        node = queue.pop(0)
+        result.append(node)
+
+        for user in node.users:
+            if user in subgroup_set:
+                in_degree[user] -= 1
+                if in_degree[user] == 0:
+                    queue.append(user)
+
+    return result if len(result) == len(subgroup) else subgroup
+
+
+def _sort_subgroups_topologically(sorted_subgroups: list[list[fx.Node]], node_set: set[fx.Node]) -> list[fx.Node]:
+    """Sort sub-groups relative to each other based on inter-subgroup dependencies."""
+    if len(sorted_subgroups) <= 1:
+        return sum(sorted_subgroups, [])  # Flatten single or empty list
+
+    # Build dependency graph between sub-groups
+    subgroup_deps: dict[int, set[int]] = {i: set() for i in range(len(sorted_subgroups))}
+
+    for i, subgroup_i in enumerate(sorted_subgroups):
+        for j, subgroup_j in enumerate(sorted_subgroups):
+            if i != j:
+                # Check if any node in subgroup_i depends on any node in subgroup_j
+                for node_i in subgroup_i:
+                    for inp in node_i.all_input_nodes:
+                        if inp in node_set and any(inp == node_j for node_j in subgroup_j):
+                            subgroup_deps[i].add(j)
+                            break
+
+    # Topologically sort sub-groups
+    in_degree = {i: 0 for i in range(len(sorted_subgroups))}
+    for i, deps in subgroup_deps.items():
+        for dep in deps:
+            in_degree[i] += 1
+
+    queue = [i for i in range(len(sorted_subgroups)) if in_degree[i] == 0]
+    ordered_subgroups = []
+
+    while queue:
+        queue.sort()  # Deterministic ordering
+        subgroup_idx = queue.pop(0)
+        ordered_subgroups.append(sorted_subgroups[subgroup_idx])
+
+        for dependent_idx in range(len(sorted_subgroups)):
+            if subgroup_idx in subgroup_deps[dependent_idx]:
+                in_degree[dependent_idx] -= 1
+                if in_degree[dependent_idx] == 0:
+                    queue.append(dependent_idx)
+
+    # Flatten the ordered sub-groups
+    return sum(ordered_subgroups, [])
+
+
+def _create_fusion_subgraph(
+    graph: fx.Graph,
+    region: "FusionRegion",
+) -> fx.GraphModule:
+    """
+    Create a subgraph GraphModule for a fusion region.
+
+    Args:
+        graph: The parent graph
+        region: The fusion region to wrap
+
+    Returns:
+        A GraphModule containing the subgraph
+    """
+    owning_module = graph.owning_module
+    subgraph = fx.Graph(owning_module)
+
+    # Map from parent graph nodes to subgraph nodes
+    node_map: dict[fx.Node, fx.Node] = {}
+
+    # Create placeholders for external inputs
+    for i, ext_input in enumerate(region.external_inputs):
+        placeholder = subgraph.placeholder(f"input_{i}")
+        if "val" in ext_input.meta:
+            placeholder.meta.update(ext_input.meta)
+        node_map[ext_input] = placeholder
+
+    # Copy region nodes into subgraph
+    for node in region.nodes:
+        # Map args through node_map
+        def map_arg(arg, nm=node_map):
+            if isinstance(arg, fx.Node):
+                return nm.get(arg, arg)
+            elif isinstance(arg, (list, tuple)):
+                return type(arg)(map_arg(a, nm) for a in arg)
+            elif isinstance(arg, dict):
+                return {k: map_arg(v, nm) for k, v in arg.items()}
+            return arg
+
+        new_args = tuple(map_arg(a) for a in node.args)
+        new_kwargs = {k: map_arg(v) for k, v in node.kwargs.items()}
+
+        new_node = subgraph.call_function(
+            node.target,
+            new_args,
+            new_kwargs,
+        )
+        new_node.meta.update(node.meta)
+        node_map[node] = new_node
+
+    # Output the last node (or multiple outputs if needed)
+    nodes_list = list(region.nodes)
+    output_node = node_map[nodes_list[-1]]
+    subgraph.output(output_node)
+
+    return fx.GraphModule(owning_module, subgraph)
+
+
+def collapse_fusion_regions(
+    graph: fx.Graph,
+    region_of: dict[fx.Node, "FusionRegion"],
+) -> tuple[dict[fx.Node, "FusionRegion"], dict[fx.Node, fx.Node]]:
+    """
+    Collapse fusion regions into subgraph HOP nodes.
+
+    Each fusion region is replaced with a single call_function node that
+    invokes a subgraph. The original nodes are stored in the region
+    for later inlining.
+
+    Args:
+        graph: The FX graph to modify
+        region_of: Mapping of nodes to their fusion regions
+
+    Returns:
+        (new_region_of, replaced) where:
+        - new_region_of: Mapping from subgraph nodes to their regions
+        - replaced: Mapping from original nodes to subgraph node
+    """
+    replaced: dict[fx.Node, fx.Node] = {}
+
+    if not region_of:
+        return region_of, replaced
+
+    # Get unique regions
+    unique_regions: list[FusionRegion] = []
+    seen_region_ids: set[int] = set()
+    for region in region_of.values():
+        region_id = id(region)
+        if region_id not in seen_region_ids:
+            seen_region_ids.add(region_id)
+            unique_regions.append(region)
+
+    new_region_of: dict[fx.Node, FusionRegion] = {}
+    owning_module = graph.owning_module
+
+    for region_idx, region in enumerate(unique_regions):
+        nodes_list = list(region.nodes)
+        if len(nodes_list) < 2:
+            # Single node region - keep as is
+            if nodes_list:
+                new_region_of[nodes_list[0]] = region
+            continue
+
+        last_node = nodes_list[-1]
+
+        # Create subgraph GraphModule
+        subgraph_module = _create_fusion_subgraph(graph, region)
+
+        # Register subgraph on owning module
+        subgraph_name = f"_fusion_region_{region_idx}"
+        setattr(owning_module, subgraph_name, subgraph_module)
+
+        # Create get_attr node for the subgraph
+        with graph.inserting_after(last_node):
+            get_subgraph = graph.get_attr(subgraph_name)
+
+            # Create invoke_subgraph node
+            subgraph_node = graph.call_function(
+                torch.ops.higher_order.invoke_subgraph,
+                args=(get_subgraph, subgraph_name, *tuple(region.external_inputs)),
+            )
+            # Copy metadata from the last node
+            subgraph_node.meta.update(last_node.meta)
+
+        # Replace all external uses of region nodes with subgraph node
+        for node in nodes_list:
+            for user in list(node.users.keys()):
+                if user not in region.nodes and user not in (subgraph_node, get_subgraph):
+                    user.replace_input_with(node, subgraph_node)
+            replaced[node] = subgraph_node
+
+        # Erase all region nodes (reverse order)
+        for node in reversed(nodes_list):
+            graph.erase_node(node)
+
+        # Store subgraph info in region for later inlining
+        region.subgraph_node = subgraph_node
+        new_region_of[subgraph_node] = region
+
+    return new_region_of, replaced
+
+
+def expand_fusion_regions(
+    graph: fx.Graph,
+    region_of: dict[fx.Node, "FusionRegion"],
+    replaced: dict[fx.Node, fx.Node],
+) -> dict[fx.Node, fx.Node]:
+    """
+    Expand invoke_subgraph HOP nodes back to their original nodes.
+
+    Args:
+        graph: The FX graph
+        region_of: Mapping from subgraph nodes to their fusion regions
+        replaced: Mapping from original nodes to subgraph nodes (will be updated)
+
+    Returns:
+        Updated replaced mapping (original_node -> new_node)
+    """
+    if not region_of:
+        return replaced
+
+    owning_module = graph.owning_module
+
+    for subgraph_node, region in region_of.items():
+        if subgraph_node not in graph.nodes:
+            continue
+
+        nodes_list = list(region.nodes)
+        if len(nodes_list) < 2:
+            continue
+
+        # Get the subgraph from the invoke_subgraph args
+        # args = (get_attr_node, subgraph_name, *inputs)
+        if len(subgraph_node.args) < 2:
+            continue
+
+        get_attr_node = subgraph_node.args[0]
+        subgraph_name = subgraph_node.args[1]
+        subgraph_inputs = subgraph_node.args[2:]
+
+        # Get the subgraph module
+        subgraph_module = getattr(owning_module, subgraph_name, None)
+        if subgraph_module is None:
+            continue
+
+        # Map from subgraph nodes to main graph nodes
+        node_map: dict[fx.Node, fx.Node] = {}
+
+        # Map subgraph placeholders to actual inputs
+        subgraph_graph = subgraph_module.graph
+        placeholder_idx = 0
+        for sg_node in subgraph_graph.nodes:
+            if sg_node.op == "placeholder":
+                if placeholder_idx < len(subgraph_inputs):
+                    node_map[sg_node] = subgraph_inputs[placeholder_idx]
+                placeholder_idx += 1
+
+        # Map old region nodes to external inputs for replaced tracking
+        for i, ext_input in enumerate(region.external_inputs):
+            if i < len(subgraph_inputs):
+                # The external input is what's passed to the subgraph
+                pass  # external inputs don't need mapping in replaced
+
+        # Inline subgraph nodes into main graph
+        last_inlined_node = None
+        with graph.inserting_before(subgraph_node):
+            for sg_node in subgraph_graph.nodes:
+                if sg_node.op == "placeholder":
+                    continue
+                if sg_node.op == "output":
+                    continue
+
+                # Map args through node_map
+                def map_arg(arg, nm=node_map):
+                    if isinstance(arg, fx.Node):
+                        return nm.get(arg, arg)
+                    elif isinstance(arg, (list, tuple)):
+                        return type(arg)(map_arg(a, nm) for a in arg)
+                    elif isinstance(arg, dict):
+                        return {k: map_arg(v, nm) for k, v in arg.items()}
+                    return arg
+
+                new_args = tuple(map_arg(a) for a in sg_node.args)
+                new_kwargs = {k: map_arg(v) for k, v in sg_node.kwargs.items()}
+
+                new_node = graph.create_node(
+                    op=sg_node.op,
+                    target=sg_node.target,
+                    args=new_args,
+                    kwargs=new_kwargs,
+                )
+                new_node.meta.update(sg_node.meta)
+                node_map[sg_node] = new_node
+                last_inlined_node = new_node
+
+        # Update replaced mapping: map original region nodes to new inlined nodes
+        # We need to match by position in the region
+        sg_call_nodes = [n for n in subgraph_graph.nodes if n.op == "call_function"]
+        for i, old_node in enumerate(nodes_list):
+            if i < len(sg_call_nodes):
+                sg_node = sg_call_nodes[i]
+                if sg_node in node_map:
+                    replaced[old_node] = node_map[sg_node]
+
+        # Replace uses of subgraph node with the last inlined node
+        if last_inlined_node is not None:
+            subgraph_node.replace_all_uses_with(last_inlined_node)
+
+        # Erase the subgraph node and get_attr
+        graph.erase_node(subgraph_node)
+        if get_attr_node.users == {}:
+            graph.erase_node(get_attr_node)
+
+        # Clean up the subgraph attribute
+        if hasattr(owning_module, subgraph_name):
+            delattr(owning_module, subgraph_name)
+
+    return replaced
+
+
+def resolve_replacement_chain(
+    node: fx.Node,
+    replaced: dict[fx.Node, fx.Node],
+) -> fx.Node:
+    """Follow replacement chain to get the final node."""
+    visited = set()
+    while node in replaced and node not in visited:
+        visited.add(node)
+        node = replaced[node]
+    return node

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -136,17 +136,27 @@ class OverlapPreservingBucketer:
         max_coll_distance: int = 1000,
         insert_overlap_deps: bool = False,
         bucket_mode: BucketMode = "custom_ops_multidtype",
+        region_of: dict[fx.Node, any] = None,
+        replaced: dict[fx.Node, fx.Node] = None,
     ):
         self.graph = graph
         self.collective_info = collective_info
-        self.scheduled = scheduled
         self.max_bucket_memory_gb = max_bucket_memory_gb
-        self.node_idx = {n: i for i, n in enumerate(scheduled)}
         self.max_coll_distance = max_coll_distance
         self.insert_overlap_deps = insert_overlap_deps
         self.bucket_mode = bucket_mode
+        self.region_of = region_of or {}
+        self.replaced = replaced or {}  # Tracks collapsed nodes for later expansion
         self.node_to_event: dict[fx.Node, PGEvent] = {}
         self.all_hiding_nodes: OrderedSet[fx.Node] = OrderedSet()
+
+        # Update scheduled to reflect collapsed nodes
+        # Nodes that were collapsed are replaced by their subgraph representatives
+        self.scheduled = self._update_scheduled_for_collapsed(scheduled)
+        self.node_idx = {n: i for i, n in enumerate(self.scheduled)}
+
+        # Build fusion region helpers
+        self._region_representatives = self._build_region_representatives()
 
         # Compute ancestors including original graph edges and hiding interval dependencies
         self.node_ancestors = self._compute_node_ancestors()
@@ -155,6 +165,126 @@ class OverlapPreservingBucketer:
         # Build timelines and add constraints to aug_graph
         self.pg_to_timeline_head: dict[str, Optional[PGEvent]] = self.build_timelines()
         self._add_hiding_interval_constraints()
+
+    def _update_scheduled_for_collapsed(
+        self, scheduled: OrderedSet[fx.Node]
+    ) -> OrderedSet[fx.Node]:
+        """
+        Update scheduled to reflect collapsed fusion regions.
+
+        Nodes that were collapsed into subgraphs are removed and replaced
+        by the subgraph node at their first occurrence position.
+        """
+        if not self.replaced:
+            return scheduled
+
+        # Build set of valid graph nodes for quick lookup
+        valid_nodes = set(self.graph.nodes)
+
+        # Track which replacement nodes we've already added
+        added_replacements: set[fx.Node] = set()
+
+        new_scheduled: OrderedSet[fx.Node] = OrderedSet()
+        for node in scheduled:
+            if node in valid_nodes:
+                # Node is still valid in the graph
+                new_scheduled.add(node)
+            elif node in self.replaced:
+                # Node was collapsed - add its replacement if not already added
+                replacement = self.replaced[node]
+                if replacement not in added_replacements:
+                    added_replacements.add(replacement)
+                    new_scheduled.add(replacement)
+            # else: node was erased (e.g., internal fusion region node), skip it
+
+        # Also update hiding_nodes in collective_info to use replacement nodes
+        self._update_collective_info_for_collapsed(valid_nodes)
+
+        return new_scheduled
+
+    def _update_collective_info_for_collapsed(
+        self, valid_nodes: set[fx.Node]
+    ) -> None:
+        """
+        Update hiding_nodes in collective_info to use replacement nodes.
+
+        Nodes that were collapsed into subgraphs need to be replaced with
+        their subgraph representative.
+        """
+        for info in self.collective_info.values():
+            updated_hiding_nodes: OrderedSet[fx.Node] = OrderedSet()
+            for hn in info.hiding_nodes:
+                if hn in valid_nodes:
+                    updated_hiding_nodes.add(hn)
+                elif hn in self.replaced:
+                    updated_hiding_nodes.add(self.replaced[hn])
+                # else: node was erased and not in replaced, skip
+            info.hiding_nodes = updated_hiding_nodes
+
+    def _build_region_representatives(self) -> dict[int, fx.Node]:
+        """Build a mapping from region ID to representative node (last node in region)."""
+        region_representatives = {}
+        if self.region_of:
+            # Use id() to get unique regions since FusionRegion is not hashable
+            seen_region_ids: set[int] = set()
+            for region in self.region_of.values():
+                region_id = id(region)
+                if region_id not in seen_region_ids:
+                    seen_region_ids.add(region_id)
+                    # Use the last node (anchor) as the representative
+                    region_representatives[region_id] = region.end
+        return region_representatives
+
+    def _get_region_for_node(self, node: fx.Node):
+        """Get the fusion region for a node, if any."""
+        return self.region_of.get(node)
+
+    def _get_region_cost(self, node: fx.Node) -> float:
+        """Get the cost of the fusion region containing this node, or 0 if no region."""
+        region = self._get_region_for_node(node)
+        return region.cost_ms if region else 0.0
+
+    def _nodes_in_same_region(self, node1: fx.Node, node2: fx.Node) -> bool:
+        """Check if two nodes belong to the same fusion region."""
+        region1 = self._get_region_for_node(node1)
+        region2 = self._get_region_for_node(node2)
+        return region1 is not None and region1 is region2
+
+    def _get_fusion_group_representative(self, node: fx.Node) -> fx.Node:
+        """Get the fusion group output/representative for a node, or the node itself."""
+        region = self._get_region_for_node(node)
+        if region is not None:
+            # Return the last node (output) of the fusion region
+            return region.end
+        return node
+
+    def _redirect_deps_to_fusion_outputs(self, deps_map: dict[fx.Node, OrderedSet[fx.Node]]) -> dict[fx.Node, OrderedSet[fx.Node]]:
+        """Redirect dependencies to target fusion group outputs instead of internal nodes."""
+        if not self.region_of:
+            return deps_map
+
+        redirected_deps: dict[fx.Node, OrderedSet[fx.Node]] = {}
+
+        for node, deps in deps_map.items():
+            # Get representative for the target node
+            rep_node = self._get_fusion_group_representative(node)
+
+            # Get representatives for all dependency nodes
+            rep_deps = OrderedSet()
+            for dep in deps:
+                rep_dep = self._get_fusion_group_representative(dep)
+                # Only add if not self-dependency after redirection
+                if rep_dep != rep_node:
+                    rep_deps.add(rep_dep)
+
+            # Only add if we have actual dependencies
+            if rep_deps:
+                if rep_node in redirected_deps:
+                    redirected_deps[rep_node].update(rep_deps)
+                else:
+                    redirected_deps[rep_node] = rep_deps
+
+        return redirected_deps
 
     def _compute_node_ancestors(self) -> dict[fx.Node, OrderedSet[fx.Node]]:
         """
@@ -264,6 +394,17 @@ class OverlapPreservingBucketer:
             self.all_hiding_nodes |= info.hiding_nodes
 
     def bucket_collectives(self) -> None:
+        # Build region cost map for fusion-aware bucketing
+        region_costs = {}
+        if self.region_of:
+            # Use id() to get unique regions since FusionRegion is not hashable
+            seen_region_ids: set[int] = set()
+            for region in self.region_of.values():
+                region_id = id(region)
+                if region_id not in seen_region_ids:
+                    seen_region_ids.add(region_id)
+                    region_costs[region_id] = region.cost_ms
+
         # Group collectives by PG first
         pg_collectives: dict[str, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
         for start in self.collective_info:
@@ -303,6 +444,16 @@ class OverlapPreservingBucketer:
             counters["inductor"]["collective_buckets"] += 1
             self._apply_bucket(coll_bucket)
 
+        # Expand collapsed fusion regions back to original nodes
+        if self.region_of and self.replaced:
+            from torch._inductor.fx_passes.fusion_regions import expand_fusion_regions
+
+            self.replaced = expand_fusion_regions(
+                self.graph, self.region_of, self.replaced
+            )
+            # Fixup aug_graph deps to use the new node identities
+            self.aug_graph.fixup_replaced_nodes(self.replaced)
+
         # Extract all dependencies from augmented graph
         # This includes:
         # - Sequential timeline deps (added during build_timeline)
@@ -310,7 +461,23 @@ class OverlapPreservingBucketer:
         # - All transferred deps from bucketing (transferred during _apply_bucket)
         additional_deps = self.aug_graph.get_all_extra_deps()
 
-        # Apply topological sort with all dependencies
+        # Filter to only include valid graph nodes
+        valid_nodes = set(self.graph.nodes)
+        filtered_additional_deps: dict[fx.Node, OrderedSet[fx.Node]] = {}
+        for n, deps in additional_deps.items():
+            if n not in valid_nodes:
+                continue
+            valid_deps = OrderedSet(d for d in deps if d in valid_nodes)
+            if valid_deps:
+                filtered_additional_deps[n] = valid_deps
+        additional_deps = filtered_additional_deps
+
+        # Redirect dependencies to fusion region outputs BEFORE topological sort
+        # This ensures the sort and effect tokens use consistent node references
+        if self.region_of:
+            additional_deps = self._redirect_deps_to_fusion_outputs(additional_deps)
+
+        # Apply topological sort with all dependencies (now fusion-aware)
         from torch._dynamo.graph_deduplication import _stable_topological_sort
 
         for n, deps in additional_deps.items():
@@ -331,7 +498,7 @@ class OverlapPreservingBucketer:
             for node, deps in additional_deps.items():
                 filtered_node_deps: OrderedSet[fx.Node] = OrderedSet()
 
-                # only preserve comm-comptue overlap for now, although we could more
+                # only preserve comm-compute overlap for now, although we could more
                 # generally constrain
                 for dep in deps:
                     if not (is_collective_or_wait(node) and is_collective_or_wait(dep)):
@@ -340,6 +507,7 @@ class OverlapPreservingBucketer:
                 if filtered_node_deps:
                     filtered_deps[node] = filtered_node_deps
 
+            # filtered_deps is already fusion-aware since additional_deps was redirected
             self._preserve_dependencies_with_tokens(filtered_deps)
 
         self.graph.lint()
@@ -443,12 +611,13 @@ class OverlapPreservingBucketer:
         hiding_intervals = []
         if info.hiding_nodes:
             for hiding_node in info.hiding_nodes:
-                hiding_intervals.append(
-                    (
-                        start_event.position,
-                        self.node_to_event[hiding_node].position,
+                if hiding_node in self.node_to_event:
+                    hiding_intervals.append(
+                        (
+                            start_event.position,
+                            self.node_to_event[hiding_node].position,
+                        )
                     )
-                )
 
         return execution_interval, hiding_intervals
 
@@ -479,9 +648,10 @@ class OverlapPreservingBucketer:
         bucket_hiding_compute_positions = []
         for coll in all_bucketed_colls:
             for coll_hiding_node in self.collective_info[coll].hiding_nodes:
-                bucket_hiding_compute_positions.append(
-                    self.node_to_event[coll_hiding_node].position
-                )
+                if coll_hiding_node in self.node_to_event:
+                    bucket_hiding_compute_positions.append(
+                        self.node_to_event[coll_hiding_node].position
+                    )
 
         # Get new positions
         new_start_event = self.node_to_event[start_pos]

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -354,6 +354,24 @@ class OverlapScheduler:
         self.scheduled: OrderedSet[fx.Node] = OrderedSet()
         self.max_compute_pre_fetch = max_compute_pre_fetch
 
+        # Build fusion regions early for overlap calculation
+        # This allows us to use fused kernel costs when computing overlap
+        self.region_of: dict[fx.Node, Any] = {}
+        self.counted_region_ids: set[int] = set()  # Track regions already counted for overlap
+        if torch._inductor.config.test_configs.enable_fusion_regions:
+            from torch._inductor.fx_passes.fusion_regions import build_fusion_regions
+
+            self.region_of = build_fusion_regions(self.nodes)
+            if self.region_of:
+                unique_regions: set[int] = set()
+                for region in self.region_of.values():
+                    unique_regions.add(id(region))
+                log.info(
+                    "Fusion regions for overlap: detected %d regions containing %d nodes",
+                    len(unique_regions),
+                    len(self.region_of),
+                )
+
     def _collect_node_ancestors(self) -> dict[fx.Node, OrderedSet[fx.Node]]:
         """Collect all ancestors for each node."""
         ancestors: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
@@ -710,14 +728,65 @@ class OverlapScheduler:
                 # Wait depends on compute (wait must wait for compute to finish)
                 additional_deps[info.wait_node].add(hn)
 
+        # Redirect dependencies to fusion region outputs instead of internal nodes
+        # This avoids creating dependencies on nodes that will fuse together
+        if self.region_of and additional_deps:
+            additional_deps = self._redirect_deps_to_fusion_outputs(additional_deps)
+
         # Apply effect tokens to preserve these dependencies
         if additional_deps:
             preserve_node_ordering(self.graph, additional_deps)
 
+    def _redirect_deps_to_fusion_outputs(
+        self, deps_map: dict[fx.Node, OrderedSet[fx.Node]]
+    ) -> dict[fx.Node, OrderedSet[fx.Node]]:
+        """Redirect dependencies to target fusion group outputs instead of internal nodes."""
+        if not self.region_of:
+            return deps_map
+
+        def get_fusion_rep(node: fx.Node) -> fx.Node:
+            """Get the fusion region's output node (representative) for a node."""
+            region = self.region_of.get(node)
+            if region is not None:
+                return region.end  # Last node (output) of the fusion region
+            return node
+
+        redirected_deps: dict[fx.Node, OrderedSet[fx.Node]] = {}
+
+        for node, deps in deps_map.items():
+            rep_node = get_fusion_rep(node)
+            rep_deps = OrderedSet()
+            for dep in deps:
+                rep_dep = get_fusion_rep(dep)
+                # Only add if not self-dependency after redirection
+                if rep_dep != rep_node:
+                    rep_deps.add(rep_dep)
+
+            if rep_deps:
+                if rep_node in redirected_deps:
+                    redirected_deps[rep_node].update(rep_deps)
+                else:
+                    redirected_deps[rep_node] = rep_deps
+
+        return redirected_deps
+
     def get_non_collective_runtime_estimate(self, node: fx.Node) -> float | None:
         """Get runtime estimation for a node in ms. Returns None if no estimation is available."""
 
-        # TODO: non custom estimation of aten nodes, potentially requires notion of fusion group
+        # If node is in a fusion region, use region cost (memory bandwidth-based)
+        # This gives a more accurate estimate since these ops will fuse together
+        # Only count each region's cost once (when we see the first node from it)
+        if node in self.region_of:
+            region = self.region_of[node]
+            region_id = id(region)
+            if region_id in self.counted_region_ids:
+                # Already used this region's cost for overlap, return 0 to avoid double-counting
+                return 0.0
+            # Mark as counted and return region cost
+            self.counted_region_ids.add(region_id)
+            return region.cost_ms
+
+        # For nodes not in fusion regions, use existing logic
         if is_compute_node(node):
             return benchmark_node(node, self.custom_runtime_estimation)
 
@@ -1194,6 +1263,9 @@ class OverlapScheduler:
             OverlapPreservingBucketer,
         )
 
+        # Use fusion regions built during __init__ (already used for overlap scheduling)
+        replaced: dict[fx.Node, fx.Node] = {}
+
         bucketer = OverlapPreservingBucketer(
             graph=self.graph,
             collective_info=self.collective_info,
@@ -1201,6 +1273,8 @@ class OverlapScheduler:
             max_bucket_memory_gb=2.0,  # Could make this configurable
             max_coll_distance=self.max_node_distance,
             insert_overlap_deps=self.insert_overlap_deps,
+            region_of=self.region_of,
+            replaced=replaced,
         )
         bucketer.bucket_collectives()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #169524

Add fusion region detection to improve compute-collective overlap scheduling.
    Groups of fusible operations (pointwise, reduction, views) are detected and
    treated as cohesive regions, providing more accurate cost estimates for
    overlap computation.

    Key changes:
    - Build fusion regions early in OverlapScheduler.__init__
    - Use region costs (memory bandwidth-based) when computing overlap instead of
      benchmarking individual ops that will fuse together
    - Redirect dependencies to fusion region outputs to avoid creating deps on
      internal fusion nodes
    - Fix topological sort issue by applying dependency redirection BEFORE the sort
      in overlap_preserving_bucketer (ensures consistent node references)
    - Add config flag test_configs.enable_fusion_regions (default True)
    - Add unit tests for fusion region detection, collapse, and expand