### PR TITLE
[pytorch] Fix hg version detection to work from any repo subdirectory

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -22,10 +22,16 @@ def get_sha(pytorch_root: str | Path) -> str:
             rev = subprocess.check_output(
                 ["git", "rev-parse", "HEAD"], cwd=pytorch_root
             )
-        elif os.path.exists(os.path.join(pytorch_root, ".hg")):
-            rev = subprocess.check_output(
-                ["hg", "identify", "-r", "."], cwd=pytorch_root
-            )
+        else:
+            # Try hg command - works anywhere inside an hg repo
+            try:
+                rev = subprocess.check_output(
+                    ["hg", "identify", "-r", "."],
+                    cwd=pytorch_root,
+                    stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                pass
         if rev:
             return rev.decode("ascii").strip()
     except Exception:


### PR DESCRIPTION
Summary:
The previous implementation checked for a `.hg` directory in `pytorch_root` to determine if the repo uses Mercurial. However, this check fails when `pytorch_root` is a subdirectory of the actual hg repository root, since `.hg` only exists at the repo root.

This change removes the `.hg` directory check and instead attempts the `hg identify` command directly with proper error handling. The command works from any subdirectory within an hg repository, making the version detection more robust.

Differential Revision: D88319437
