### PR TITLE
Add activation funcs to operator benchmarks

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1796,7 +1796,7 @@ test_operator_microbenchmark() {
 
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
 
-  for OP_BENCHMARK_TESTS in matmul mm addmm bmm conv optimizer; do
+  for OP_BENCHMARK_TESTS in activation; do
     $TASKSET python -m pt.${OP_BENCHMARK_TESTS}_test --tag-filter long \
       --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${OP_BENCHMARK_TESTS}_compile.json" \
       --benchmark-name "PyTorch operator microbenchmark" --use-compile

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -292,6 +292,8 @@ class BenchmarkRunner:
             "latency unit": "us",
             "peak memory": results["peak_memory"],
             "memory unit": "KB",
+            "memory bandwidth": results.get("memory_bandwidth_gb_s"),
+            "memory bandwidth unit": "GB/s",
         }
 
         # parsing test_case.test_config.input_config, adding it as entries to the 'out' dictionary

--- a/benchmarks/operator_benchmark/pt/activation_test.py
+++ b/benchmarks/operator_benchmark/pt/activation_test.py
@@ -1,0 +1,67 @@
+import operator_benchmark as op_bench
+
+import torch
+import torch.nn as nn
+
+
+"""Microbenchmarks for activation operators."""
+
+
+activation_list = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["gelu", nn.GELU],
+        ["silu", nn.SiLU],
+        ["relu", nn.ReLU],
+        ["leaky_relu", nn.LeakyReLU],
+    ],
+)
+
+activation_short_configs = op_bench.config_list(
+    attr_names=["shape"],
+    attrs=[
+        [(1,)],
+        [(64,)],
+        [(4096,)],
+        [(8192,)],
+    ],
+    cross_product_configs={
+        "device": ["cpu", "cuda"],
+    },
+    tags=["short"],
+)
+
+activation_long_configs = op_bench.cross_product_configs(
+    shape=[(1,), (64,), (4096,), (8192,),(131072,), (262144,), (524288,), (1048576,)],
+    device=["cpu", "cuda"],
+    tags=["long"],
+)
+
+
+class ActivationBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, op_func, device, shape):
+        self.inputs = {
+            "input": torch.rand(shape, device=device, requires_grad=self.auto_set())
+        }
+        self.op_func = op_func()
+        self.set_module_name(op_func.__name__)
+
+    def forward(self, input):
+        return self.op_func(input)
+
+
+op_bench.generate_pt_tests_from_op_list(
+    activation_list,
+    activation_long_configs,
+    ActivationBenchmark,
+)
+
+op_bench.generate_pt_gradient_tests_from_op_list(
+    activation_list,
+    activation_long_configs,
+    ActivationBenchmark,
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Following activation ops are being benchmarked: nn.GELU, nn.SiLU, nn.ReLU, nn.LeakyReLU