### PR TITLE
Test: CommonTemplate.test_conv_with_as_strided #168684

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -11616,7 +11616,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             (torch.randn(32), torch.randn(32)),
         )
 
-    @skipIfRocm
     def test_conv_with_as_strided(self):
         class Model(nn.Module):
             def __init__(self) -> None:


### PR DESCRIPTION
The case fails to reproduce locally on several GFX942 platforms. It appears to be a specific issue, possibly random or caused by interference from prior CI tests.

Therefore, we should remove the skipIfRocm decorator first to confirm if it is a real issue.

Fixes #168684


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo