### PR TITLE
Optimizes the performance of the int_mm which mat2 tensor is non-contiguous on Intel GPU

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -550,7 +550,7 @@ Tensor& _int_mm_out_xpu(
       self.contiguous(),
       1.0,
       0,
-      mat2.contiguous(),
+      mat2,
       mat2_scales,
       mat2_zero_points,
       bias,


### PR DESCRIPTION
Optimizes the performance of the int_mm which mat2 tensor is non-contiguous on Intel GPU.  The test__int_mm( https://github.com/pytorch/pytorch/blob/main/test/xpu/test_gemm.py#L1381) has covered the functionality of this scenario. And, the currently performance of  meta-llama/Llama-3.2-1B(config: input-tokens 1024, max-new-tokens 128, batch-size 32) is ~2x of before.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01