### PR TITLE
[Dynamo] Supports `from_number` method for `float` and `complex` in Python3.14

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -994,6 +994,26 @@ class FunctionTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         y += float("1.2")
         return torch.add(x, y)
 
+    def test_float_or_complex_from_number(self):
+        @make_test
+        def _float_from_number_impl(x):
+            y = float.from_number(10)
+            return torch.add(x, y)
+
+        @make_test
+        def _complex_from_number_impl(x):
+            y = complex.from_number(10)
+            return torch.add(x, y)
+
+        if sys.version_info < (3, 14):
+            with self.assertRaises(AttributeError):
+                _float_from_number_impl(self)
+            with self.assertRaises(AttributeError):
+                _complex_from_number_impl(self)
+        else:
+            _float_from_number_impl(self)
+            _complex_from_number_impl(self)
+
     @make_test
     def test_is_floating_point(x):
         y = x + 1

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1503,21 +1503,25 @@ class BuiltinVariable(VariableTracker):
                     args[1:],
                 )
 
-        if self.fn in (float, complex) and len(args) == 1:
-            if (self.fn is float and name in ("fromhex", "hex")) or (
-                name == "from_number" and sys.version_info >= (3, 14)
-            ):
-                if isinstance(args[0], ConstantVariable):
-                    try:
-                        fn = getattr(self.fn, name)
-                        res = fn(args[0].as_python_constant())
-                        return variables.ConstantVariable.create(res)
-                    except (OverflowError, ValueError) as e:
-                        raise_observed_exception(
-                            type(e),
-                            tx,
-                            args=list(map(ConstantVariable.create, e.args)),
-                        )
+        if (
+            self.fn in (float, complex)
+            and len(args) == 1
+            and (
+                (self.fn is float and name in ("fromhex", "hex"))
+                or (name == "from_number" and sys.version_info >= (3, 14))
+            )
+        ):
+            if isinstance(args[0], ConstantVariable):
+                try:
+                    fn = getattr(self.fn, name)
+                    res = fn(args[0].as_python_constant())
+                    return variables.ConstantVariable.create(res)
+                except (OverflowError, ValueError) as e:
+                    raise_observed_exception(
+                        type(e),
+                        tx,
+                        args=list(map(ConstantVariable.create, e.args)),
+                    )
 
         if self.fn is object and name == "__init__":
             # object.__init__ is a no-op

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1503,18 +1503,21 @@ class BuiltinVariable(VariableTracker):
                     args[1:],
                 )
 
-        if self.fn is float and len(args) == 1 and name in ("fromhex", "hex"):
-            if isinstance(args[0], ConstantVariable):
-                try:
-                    fn = getattr(float, name)
-                    res = fn(args[0].as_python_constant())
-                    return variables.ConstantVariable.create(res)
-                except (OverflowError, ValueError) as e:
-                    raise_observed_exception(
-                        type(e),
-                        tx,
-                        args=list(map(ConstantVariable.create, e.args)),
-                    )
+        if self.fn in (float, complex) and len(args) == 1:
+            if (self.fn is float and name in ("fromhex", "hex")) or (
+                name == "from_number" and sys.version_info >= (3, 14)
+            ):
+                if isinstance(args[0], ConstantVariable):
+                    try:
+                        fn = getattr(self.fn, name)
+                        res = fn(args[0].as_python_constant())
+                        return variables.ConstantVariable.create(res)
+                    except (OverflowError, ValueError) as e:
+                        raise_observed_exception(
+                            type(e),
+                            tx,
+                            args=list(map(ConstantVariable.create, e.args)),
+                        )
 
         if self.fn is object and name == "__init__":
             # object.__init__ is a no-op


### PR DESCRIPTION
`from_number` is a newly added method for `float` and `complex` type in Python3.14. Refer to this [link](https://docs.python.org/3.14/library/stdtypes.html#float.from_number). Consider adding it to the dynamo module to support some basic types (int, float, complex) as inputs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @williamwen42 