### PR TITLE
[PyTorch]: Fix pinned host allocator active counter updates

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -385,6 +385,8 @@ struct CachingHostAllocatorImpl {
       auto index = size_index(block->size_);
       std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
       pool.free_list_[index].list_.push_back(block);
+      stats_.active_bucket_stats[index].decrease(1);
+      stats_.active_bytes_bucket_stats[index].decrease(block->size_);
     } else if (allocated_during_capture) {
       // pass: No events are ever recorded during stream capture.
 
@@ -723,7 +725,7 @@ struct CachingHostAllocatorImpl {
         std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
         pool.free_list_[index].list_.push_back(block);
         stats_.active_bucket_stats[index].decrease(1);
-        stats_.active_bytes_bucket_stats[index].decrease(size);
+        stats_.active_bytes_bucket_stats[index].decrease(block->size_);
         if (size != -1) {
           return;
         }


### PR DESCRIPTION
fix host pinned allocator stats and cover the behavior in tests.

* Fix missing active_requests/active_bytes decrements on synchronous frees and use the block size for event-driven frees so active stats drop correctly.  
* Extend test_host_memory_stats to verify active counters drop after frees and pool counters/timing/free counts advance after emptying the host cache, preventing regressions.


cc @jbschlosser @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia