### PR TITLE
Fix test_dlpack_tensor_on_different_device to use torch.cuda.device

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -354,7 +354,7 @@ class TestTorchDlPack(TestCase):
         with self.assertRaisesRegex(
             BufferError, r"Can't export tensors on a different CUDA device"
         ):
-            with torch.device(dev1):
+            with torch.cuda.device(dev1):
                 x.__dlpack__()
 
     # TODO: add interchange tests once NumPy 1.22 (dlpack support) is required


### PR DESCRIPTION
The test checks that __dlpack__() raises an error when the tensor's device differs from the current CUDA device. It was using torch.device(dev1) which doesn't change torch.cuda.current_device(), so the error was never raised.

Changed to use torch.cuda.device(dev1) instead, which properly sets the current CUDA device and makes the test pass.

Fixes #169567
