### PR TITLE
Add `ccache` support to ACL/OpenBLAS and manywheel build script

### DIFF
--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -6,6 +6,18 @@ set -eux
 ACL_VERSION=${ACL_VERSION:-"v52.6.0"}
 ACL_INSTALL_DIR="/acl"
 
+# Optional ccache support
+USE_CCACHE=${USE_CCACHE:-0}
+SCONS_CACHE_ARG=""
+if [ "${USE_CCACHE}" != "0" ]; then
+  if command -v ccache >/dev/null 2>&1; then
+    echo "Using ccache for ACL build"
+    SCONS_CACHE_ARG="compiler_cache=ccache"
+  else
+    echo "USE_CCACHE is set but 'ccache' is not available on PATH; proceeding without ccache"
+  fi
+fi
+
 # Clone ACL
 git clone https://github.com/ARM-software/ComputeLibrary.git -b "${ACL_VERSION}" --depth 1 --shallow-submodules
 
@@ -14,7 +26,8 @@ ACL_CHECKOUT_DIR="ComputeLibrary"
 pushd $ACL_CHECKOUT_DIR
 scons -j8  Werror=0 debug=0 neon=1 opencl=0 embed_kernels=0 \
   os=linux arch=armv8a build=native multi_isa=1 \
-  fixed_format_kernels=1 openmp=1 cppthreads=0
+  fixed_format_kernels=1 openmp=1 cppthreads=0 \
+  ${SCONS_CACHE_ARG}
 popd
 
 # Install ACL

--- a/.ci/docker/common/install_openblas.sh
+++ b/.ci/docker/common/install_openblas.sh
@@ -4,23 +4,36 @@
 set -ex
 
 OPENBLAS_VERSION=${OPENBLAS_VERSION:-"v0.3.30"}
+MAX_JOBS=${MAX_JOBS:-$(nproc --ignore=2)}
+
+# Optional ccache support
+USE_CCACHE=${USE_CCACHE:-0}
+
+CC_FOR_OPENBLAS="gcc"
+if [ "${USE_CCACHE}" != "0" ]; then
+  if command -v ccache >/dev/null 2>&1; then
+    echo "Using ccache for OpenBLAS build"
+    CC_FOR_OPENBLAS="ccache gcc"
+  else
+    echo "WARNING: USE_CCACHE is enabled but 'ccache' is not installed; falling back to plain gcc" >&2
+  fi
+fi
 
 # Clone OpenBLAS
 git clone https://github.com/OpenMathLib/OpenBLAS.git -b "${OPENBLAS_VERSION}" --depth 1 --shallow-submodules
 
 OPENBLAS_CHECKOUT_DIR="OpenBLAS"
-OPENBLAS_BUILD_FLAGS="
-CC=gcc
-NUM_THREADS=128
-USE_OPENMP=1
-NO_SHARED=0
-DYNAMIC_ARCH=1
-TARGET=ARMV8
-CFLAGS=-O3
-BUILD_BFLOAT16=1
-"
+make -j"${MAX_JOBS}" \
+  CC="${CC_FOR_OPENBLAS}" \
+  NUM_THREADS=128 \
+  USE_OPENMP=1 \
+  NO_SHARED=0 \
+  DYNAMIC_ARCH=1 \
+  TARGET=ARMV8 \
+  CFLAGS=-O3 \
+  BUILD_BFLOAT16=1 \
+  -C "$OPENBLAS_CHECKOUT_DIR"
 
-make -j8 ${OPENBLAS_BUILD_FLAGS} -C $OPENBLAS_CHECKOUT_DIR
 sudo make install -C $OPENBLAS_CHECKOUT_DIR
 
 rm -rf $OPENBLAS_CHECKOUT_DIR

--- a/.ci/docker/manywheel/Dockerfile_2_28_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_2_28_aarch64
@@ -16,6 +16,7 @@ RUN yum install -y \
   automake \
   bison \
   bzip2 \
+  ccache \
   curl \
   diffutils \
   file \
@@ -58,11 +59,13 @@ RUN git config --global --add safe.directory "*"
 FROM base as openblas
 # Install openblas
 ARG OPENBLAS_VERSION
+ARG USE_CCACHE=0
 ADD ./common/install_openblas.sh install_openblas.sh
 RUN bash ./install_openblas.sh && rm install_openblas.sh
 
 # Install Arm Compute Library
 FROM base as arm_compute
+ARG USE_CCACHE=0
 # use python3.9 to install scons
 RUN python3.9 -m pip install scons==4.7.0
 RUN ln -sf /opt/python/cp39-cp39/bin/scons /usr/local/bin

--- a/.ci/docker/manywheel/Dockerfile_cuda_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_cuda_aarch64
@@ -17,6 +17,7 @@ RUN yum install -y \
   automake \
   bison \
   bzip2 \
+  ccache \
   curl \
   diffutils \
   file \
@@ -74,6 +75,7 @@ RUN bash ./install_nvpl.sh && rm install_nvpl.sh
 
 # Install Arm Compute Library
 FROM base as arm_compute
+ARG USE_CCACHE=0
 # use python3.9 to install scons
 RUN python3.9 -m pip install scons==4.7.0
 RUN ln -sf /opt/python/cp39-cp39/bin/scons /usr/local/bin

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -129,6 +129,7 @@ DOCKER_BUILDKIT=1 docker build  \
     --build-arg "GPU_IMAGE=${GPU_IMAGE}" \
     --build-arg "OPENBLAS_VERSION=${OPENBLAS_VERSION:-}" \
     --build-arg "ACL_VERSION=${ACL_VERSION:-}" \
+    --build-arg "USE_CCACHE=${USE_CCACHE:-0}" \
     --target "${TARGET}" \
     -t "${tmp_tag}" \
     $@ \

--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -151,12 +151,15 @@ else
     USE_KINETO=1
 fi
 
+USE_CCACHE=${USE_CCACHE:-0}
+
 echo "Calling setup.py bdist at $(date)"
 
 time CMAKE_ARGS=${CMAKE_ARGS[@]} \
     EXTRA_CAFFE2_CMAKE_FLAGS=${EXTRA_CAFFE2_CMAKE_FLAGS[@]} \
     BUILD_LIBTORCH_CPU_WITH_DEBUG=$BUILD_DEBUG_INFO \
     USE_NCCL=${USE_NCCL} USE_RCCL=${USE_RCCL} USE_KINETO=${USE_KINETO} \
+    USE_CCACHE=${USE_CCACHE} \
     python -m build --wheel --no-isolation --outdir /tmp/$WHEELHOUSE_DIR
 echo "Finished setup.py bdist at $(date)"
 


### PR DESCRIPTION
This PR adds _optional_ `ccache` support to some of the build scripts.

For the ACL installation, it assumes `gcc`/`g++` as the _default_ compilers if none are specified so that it can wrap them with `ccache`.

For the OpenBLAS installation, it assumes `gcc`, as was previously the case.

The generic builder script passes the `USE_CCACHE` environment variable to the build script which gets propagated to the CMake build system.