### PR TITLE
Fix out-of-bounds read in Unpickler::rebuildTensorFromTypeV2

### DIFF
--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -1028,6 +1028,13 @@ void Unpickler::rebuildTensorFromTypeV2() {
     // base tensor.
     // Eg. `rebuildTensor`, `rebuildSpareTensor`.
     stack_.emplace_back(base_tensor_args);
+
+    TORCH_CHECK(
+        curr_globals_idx + 1 < globals_.size(),
+        "Parsing error: expected base tensor rebuild function after "
+        "torch._tensor._rebuild_from_type_v2, but globals_ has size ",
+        globals_.size());
+
     globals_[curr_globals_idx + 1]();
     stack_.emplace_back(pop(stack_));
   });


### PR DESCRIPTION
### Summary

This PR fixes an out-of-bounds read in `torch::jit::Unpickler::rebuildTensorFromTypeV2` when loading a crafted TorchScript archive with a malformed `constants.pkl`.
The crafted archive uses `_rebuild_from_type_v2` without the expected subsequent `GLOBAL` opcodes.

On current `main` and on `2.9.1`, this manifests as a crash (SIGBUS / SIGSEGV in non-ASan builds, heap-use-after-free under ASan) when calling `torch.jit.load("model.pt")` on the model from:

- https://huggingface.co/TencentAIGC-Lab/TestByTencent/blob/main/model.pt

### Reproduction

Minimal reproduction script:

```python
import torch

path = "model.pt"
print("loading TorchScript ...", flush=True)
m = torch.jit.load(path)
print("loaded:", m)
```

I'm attaching the full [asan.log](https://github.com/user-attachments/files/23927088/asan.log).

### Root cause

`torch::jit::Unpickler::rebuildTensorFromTypeV2` assumes that after `_rebuild_from_type_v2` it will see subsequent `GLOBAL` opcodes providing `(func, type(self))`. It records `curr_globals_idx = globals_.size()`, pushes an outer lambda at `globals_[curr_globals_idx]`, and later calls:

```cpp
globals_[curr_globals_idx + 1]();
```

In the `model.pt`, `constants.pkl` contains `_rebuild_from_type_v2` but no subsequent `GLOBAL` opcodes. In this case `curr_globals_idx == 0` and `globals_.size() == 1`, so `globals_[curr_globals_idx + 1]` becomes an out-of-bounds read (`globals_[1]`), which shows up as a crash / heap-use-after-free under ASan.

### Security impact

Based on my investigation, the out-of-bounds access does not appear practically exploitable beyond crashing the process: the pickle input cannot directly control the contents of `globals_` (GLOBAL encodes module/class names, not raw pointers), and when accessing a non-existent element we cannot control what data lives at that heap location. I therefore treat this as a denial-of-service bug for applications that load untrusted models.

### Fix

Before calling `globals_[curr_globals_idx + 1]`, we check that the expected base tensor rebuild function has actually been registered:

```cpp
stack_.emplace_back(base_tensor_args);

TORCH_CHECK(
    curr_globals_idx + 1 < globals_.size(),
    "Parsing error: expected base tensor rebuild function after "
    "torch._tensor._rebuild_from_type_v2, but globals_ has size ",
    globals_.size());

globals_[curr_globals_idx + 1]();
stack_.emplace_back(pop(stack_));
```

Malformed pickles now raise a `RuntimeError` instead of causing an out-of-bounds access.

### Testing

- `2.9.1a0+gitd38164a` (ASan build):
  - Before: `torch.jit.load("model.pt")` crashes with heap-use-after-free in `rebuildTensorFromTypeV2`.
  - After: same call raises the `TORCH_CHECK` parsing error shown above.
- Current `main` (`2.10.0a0+gitdd18a75`):
  - Verified that the same `model.pt` triggers the `TORCH_CHECK` and no longer crashes as follows:
```
root@3105c5a7ebac:/work/samples/segv/TestByTencent# python crash_repro.py
loading TorchScript ...
Traceback (most recent call last):
  File "/work/samples/segv/TestByTencent/crash_repro.py", line 4, in <module>
    m = torch.jit.load(path)
        ^^^^^^^^^^^^^^^^^^^^
  File "/work/pytorch/torch/jit/_serialization.py", line 192, in load
    cpp_module = torch._C.import_ir_module(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Parsing error: expected base tensor rebuild function after torch._tensor._rebuild_from_type_v2, but globals_ has size 1
```




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel