### PR TITLE
[DLPack] Enable cross-device transfers in from_dlpack

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -516,6 +516,24 @@ class TestTorchDlPack(TestCase):
         with self.assertRaisesRegex(ValueError, r"cannot move .* tensor from .*"):
             self._test_from_dlpack(device, out_device="cpu", copy=False)
 
+    def test_dlpack_copy_fallback(self):
+        """Test that copy parameter works even with producers that don't support it"""
+        import numpy as np
+
+        # Test copy=True - should work even if NumPy doesn't support copy parameter
+        np_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        t = from_dlpack(np_array, copy=True)
+
+        # Verify it's a copy by modifying tensor and checking NumPy unchanged
+        t[0] = 999.0
+        self.assertEqual(np_array[0], 1.0)
+
+        # Test copy=None (default) - should be zero-copy view
+        np_array2 = np.array([10.0, 20.0, 30.0], dtype=np.float32)
+        t2 = from_dlpack(np_array2)
+        t2[0] = 999.0
+        self.assertEqual(np_array2[0], 999.0)
+
     @skipMeta
     @onlyNativeDeviceTypes
     def test_unsupported_device_error(self, device):
@@ -769,6 +787,81 @@ class TestTorchDlPack(TestCase):
 
         # Run the comprehensive C++ test
         module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda"))
+
+    @skipMeta
+    @onlyCUDA
+    def test_numpy_cross_device_transfer(self, device):
+        """Test cross-device transfer from NumPy (CPU) to PyTorch (CUDA).
+
+        This tests the fix for issue #169186 where torch.from_dlpack(numpy_array, device="cuda")
+        would fail with "unsupported device requested" because PyTorch incorrectly asked
+        NumPy to create a CUDA DLPack capsule instead of handling the device transfer itself.
+
+        According to the DLPack spec, the consumer (PyTorch) is responsible for constructing
+        the final array on the target device, not the producer (NumPy).
+        """
+        import numpy as np
+
+        np_array = np.arange(10, dtype=np.float32)
+        expected = torch.arange(10, dtype=torch.float32, device=device)
+
+        # Test 1: copy=None (default) - should allow copy for cross-device
+        t1 = from_dlpack(np_array, device=device)
+        self.assertEqual(t1.device.type, "cuda")
+        self.assertEqual(t1, expected)
+
+        # Test 2: copy=True - explicit copy
+        t2 = from_dlpack(np_array, device=device, copy=True)
+        self.assertEqual(t2.device.type, "cuda")
+        self.assertEqual(t2, expected)
+
+        # Test 3: copy=False - should raise ValueError (can't do cross-device without copy)
+        with self.assertRaisesRegex(
+            ValueError, r"cannot move .* tensor from .* to .* without copying"
+        ):
+            from_dlpack(np_array, device=device, copy=False)
+
+        # Test 4: device as string vs torch.device object (both should work)
+        t_str = from_dlpack(np_array, device="cuda")
+        t_obj = from_dlpack(np_array, device=torch.device("cuda"))
+        self.assertEqual(t_str.device.type, "cuda")
+        self.assertEqual(t_obj.device.type, "cuda")
+        self.assertEqual(t_str, t_obj)
+
+        # Test 5: Regression - CPU -> CPU should still be zero-copy (share memory)
+        np_array2 = np.arange(5, dtype=np.float32)
+        t_cpu = from_dlpack(np_array2, device="cpu", copy=None)
+        self.assertEqual(t_cpu.device.type, "cpu")
+        # Should share memory
+        self.assertEqual(t_cpu.data_ptr(), torch.from_numpy(np_array2).data_ptr())
+        # Mutation should affect both
+        t_cpu[0] = 999
+        self.assertEqual(np_array2[0], 999)
+
+    @skipMeta
+    @onlyCUDA
+    @deviceCountAtLeast(2)
+    def test_numpy_cross_device_multi_gpu(self, devices):
+        """Test cross-device transfer to specific CUDA devices (cuda:0, cuda:1, etc)."""
+        import numpy as np
+
+        dev0, dev1 = devices[:2]
+        np_array = np.arange(5, dtype=np.float32)
+
+        # Test transfer to cuda:0
+        t0 = from_dlpack(np_array, device=dev0)
+        self.assertEqual(t0.device, torch.device(dev0))
+        expected = torch.arange(5, dtype=torch.float32, device=dev0)
+        self.assertEqual(t0, expected)
+
+        # Test transfer to cuda:1
+        t1 = from_dlpack(np_array, device=dev1)
+        self.assertEqual(t1.device, torch.device(dev1))
+        expected = torch.arange(5, dtype=torch.float32, device=dev1)
+        self.assertEqual(t1, expected)
+
+        # Verify they're on different devices
+        self.assertNotEqual(t0.device, t1.device)
 
 
 instantiate_device_type_tests(TestTorchDlPack, globals(), allow_mps=True)

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -207,11 +207,7 @@ def from_dlpack(
         # Attempt 4: Remove dl_device
         if dlpack is None:
             kwargs.pop("dl_device", None)
-            try:
-                dlpack = ext_tensor.__dlpack__(**kwargs)
-            except TypeError:
-                # All fallbacks already tried
-                raise
+            dlpack = ext_tensor.__dlpack__(**kwargs)
 
         tensor = torch._C._from_dlpack(dlpack)
 

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -118,11 +118,17 @@ def from_dlpack(
         tensor([-9, -1,  2,  3])
 
     """
+
     if hasattr(ext_tensor, '__dlpack__'):
         # Only populate kwargs if any of the optional arguments are, in fact, not None. Otherwise,
         # leave them out, since we might end up falling back to no-extra-kwargs __dlpack__ call.
         kwargs: dict[str, Any] = {}
         kwargs["max_version"] = (1, 0)
+
+        # Track copy request for potential manual handling
+        requested_copy = copy
+        producer_handled_copy = True
+        cross_device_transfer = False  # Will be set to True if device transfer is needed
 
         if copy is not None:
             kwargs["copy"] = copy
@@ -130,14 +136,33 @@ def from_dlpack(
         # Parse the device parameter.
         # At this moment, it can either be a torch.device or a str representing
         # a torch.device, e.g. "cpu", "cuda", etc.
+        # Get source device first (we need it to detect cross-device transfers)
+        ext_device = ext_tensor.__dlpack_device__()
+
         if device is not None:
             if isinstance(device, str):
                 device = torch.device(device)
             if not isinstance(device, torch.device):
                 raise AssertionError(f"from_dlpack: unsupported device type: {type(device)}")
-            kwargs["dl_device"] = torch._C._torchDeviceToDLDevice(device)
 
-        ext_device = ext_tensor.__dlpack_device__()
+            # Convert target device to DLPack format
+            target_dl_device = torch._C._torchDeviceToDLDevice(device)
+
+            # Detect cross-device transfer by comparing source and target devices
+            # E.g. CPU->CUDA, cuda:0->cuda:1, etc.
+            cross_device_transfer = (ext_device != target_dl_device)
+
+            # Only pass dl_device to producer if NOT cross-device transfer
+            if not cross_device_transfer:
+                kwargs["dl_device"] = target_dl_device
+
+            # Cross-device transfer always requires a copy
+            if cross_device_transfer and copy is False:
+                raise ValueError(
+                    f"cannot move DLPack tensor from device {ext_device} to {target_dl_device} "
+                    "without copying. Set copy=None or copy=True."
+                )
+
         # ext_device is either CUDA or ROCm, we need to pass the current
         # stream
         if ext_device[0] in (DLDeviceType.kDLCUDA, DLDeviceType.kDLROCM):
@@ -153,13 +178,52 @@ def from_dlpack(
             stream_ptr = 1 if is_cuda and stream.cuda_stream == 0 else stream.cuda_stream
             kwargs["stream"] = stream_ptr
 
+        # Try different parameter combinations until one works
+        dlpack = None
+
+        # Attempt 1: Try with all the parameters
         try:
-            # Try running __dlpack__ while specifying `max_version` argument.
             dlpack = ext_tensor.__dlpack__(**kwargs)
         except TypeError:
-            # If that doesn't work, try removing the `max_version` argument.
-            kwargs.pop("max_version")
-            dlpack = ext_tensor.__dlpack__(**kwargs)
+            pass
+
+        # Attempt 2: Remove max_version
+        if dlpack is None:
+            kwargs.pop("max_version", None)
+            try:
+                dlpack = ext_tensor.__dlpack__(**kwargs)
+            except TypeError:
+                pass
+
+        # Attempt 3: Remove copy
+        if dlpack is None:
+            kwargs.pop("copy", None)
+            producer_handled_copy = False
+            try:
+                dlpack = ext_tensor.__dlpack__(**kwargs)
+            except TypeError:
+                pass
+
+        # Attempt 4: Remove dl_device
+        if dlpack is None:
+            kwargs.pop("dl_device", None)
+            try:
+                dlpack = ext_tensor.__dlpack__(**kwargs)
+            except TypeError:
+                # All fallbacks already tried
+                raise
+
+        tensor = torch._C._from_dlpack(dlpack)
+
+        # Manual copy if producer didn't handle it (cross-device already copies via .to())
+        if requested_copy is True and not producer_handled_copy and not cross_device_transfer:
+            tensor = tensor.clone()
+
+        # Handle cross-device transfer by moving tensor to target device
+        if cross_device_transfer:
+            tensor = tensor.to(device)
+
+        return tensor
 
     else:
         if device is not None or copy is not None:
@@ -168,4 +232,4 @@ def from_dlpack(
             )
         # Old versions just call the converter
         dlpack = ext_tensor
-    return torch._C._from_dlpack(dlpack)
+        return torch._C._from_dlpack(dlpack)


### PR DESCRIPTION
Enables torch.from_dlpack() to handle cross-device transfers (e.g., CPU→CUDA, cuda:0→cuda:1) by having the consumer perform the device transfer.

Previously, from_dlpack(numpy_array, device="cuda") would fail with:

RuntimeError: Specified device cuda:0 does not match device of data cpu

This occurred because PyTorch was incorrectly passing the target device to the producer (NumPy) via dl_device in the dlpack() call. Since NumPy doesn't support CUDA, it would fail. According to thePython Specification for DLPack, the consumer (PyTorch) is responsible for constructing the final array on the target device, not the producer.

Modified torch.utils.dlpack.from_dlpack() to:

  1. Detect cross-device transfers by comparing source device (from dlpack_device()) with target device
  2. Skip passing dl_device to producer when devices differ (let producer export on its native device)
  3. Validate copy parameter: Raise ValueError if copy=False is specified with cross-device transfer (copying is required)
  4. Perform device transfer in consumer using .to(device) after importing the DLPack tensor

test/test_dlpack.py:
  - Added test_numpy_cross_device_transfer: Tests CPU→CUDA transfer with various copy parameter values
  - Added test_numpy_cross_device_multi_gpu: Tests transfers to specific CUDA devices (cuda:0, cuda:1)

Note: The 1 pre-existing failure (test_dlpack_tensor_on_different_device) is unrelated to this PR and has a PR open #169568.

  **Edit:** 

Also adds backward compatibility with older DLPack implementations (NumPy < 2.1.0) that don't support optional parameters.

  Additional changes:
  - Progressive fallback when producers don't support DLPack v1 parameters (max_version, copy, dl_device)
  - Manual copy handling when producer doesn't support the copy parameter
  - Added test_dlpack_copy_fallback to validate fallback behavior

Fixes #169186
