### PR TITLE
[CUDA][CUDA Graphs] Use `count` when allocating storage for `edgeData`

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1769,7 +1769,8 @@ class DeviceCachingAllocator {
         C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, nullptr, count));
       } else {
         cudaGraphEdgeData edgeData[*count];
-        C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, &edgeData[0], count));
+        C10_CUDA_CHECK(
+            cudaGraphNodeGetDependencies(n, deps, &edgeData[0], count));
       }
 #else
       C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, count));

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1770,7 +1770,7 @@ class DeviceCachingAllocator {
         C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, nullptr, count));
       } else {
         SmallVector<cudaGraphEdgeData> edgeData;
-        edgeData.resize(count);
+        edgeData.resize(*count);
         C10_CUDA_CHECK(
             cudaGraphNodeGetDependencies(n, deps, edgeData.data(), count));
       }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/Gauge.h>
 #include <c10/util/Logging.h>
 #include <c10/util/ScopeExit.h>
+#include <c10/util/SmallVector.h>
 #include <c10/util/UniqueVoidPtr.h>
 #include <c10/util/env.h>
 #include <c10/util/error.h>
@@ -1768,9 +1769,10 @@ class DeviceCachingAllocator {
       if (deps == nullptr) {
         C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, nullptr, count));
       } else {
-        cudaGraphEdgeData edgeData[*count];
+        SmallVector<cudaGraphEdgeData> edgeData;
+        edgeData.reserve(count);
         C10_CUDA_CHECK(
-            cudaGraphNodeGetDependencies(n, deps, &edgeData[0], count));
+            cudaGraphNodeGetDependencies(n, deps, edgeData.data(), count));
       }
 #else
       C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, count));

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1768,8 +1768,8 @@ class DeviceCachingAllocator {
       if (deps == nullptr) {
         C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, nullptr, count));
       } else {
-        cudaGraphEdgeData edgeData;
-        C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, &edgeData, count));
+        cudaGraphEdgeData edgeData[*count];
+        C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, &edgeData[0], count));
       }
 #else
       C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, count));

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1770,7 +1770,7 @@ class DeviceCachingAllocator {
         C10_CUDA_CHECK(cudaGraphNodeGetDependencies(n, deps, nullptr, count));
       } else {
         SmallVector<cudaGraphEdgeData> edgeData;
-        edgeData.reserve(count);
+        edgeData.resize(count);
         C10_CUDA_CHECK(
             cudaGraphNodeGetDependencies(n, deps, edgeData.data(), count));
       }


### PR DESCRIPTION
`cudaGraphNodeGetDependencies` expects the pointer to `edgeData` to have enough storage for as many entries as `deps` 

For #169390 

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng