### PR TITLE
[dynamo] Remove deprecated minimum_call_count config flag

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -38,9 +38,6 @@ verbose = os.environ.get("TORCHDYNAMO_VERBOSE", "0") == "1"
 # [@compile_ignored: runtime_behaviour] verify the correctness of optimized backend
 verify_correctness = False
 
-# need this many ops to create an FX graph (deprecated: not used)
-minimum_call_count = 1
-
 # turn on/off DCE pass (deprecated: always true)
 dead_code_elimination = True
 


### PR DESCRIPTION
## Description

This PR removes the deprecated `minimum_call_count` configuration flag from `torch/_dynamo/config.py`.

## Motivation

The `minimum_call_count` flag was explicitly marked as deprecated with the comment "deprecated: not used". It no longer has any effect on Dynamo's behavior and removing it will:
- Reduce dead code
- Improve clarity
- Easier maintenance

## Changes

- Removed the `minimum_call_count = 1` declaration from `torch/_dynamo/config.py`
- Removed the associated comment indicating deprecation

## Testing

Verified that no references to `minimum_call_count` exist anywhere in the codebase after this removal.

## Related Issues

This is part of issue #169578, which tracks removing deprecated config flags in separate, focused PRs to allow for isolated removals that are easier to test and revert if needed.

Fixes part of #169578

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo