### PR TITLE
[inductor] Fix graph partition signature for globally-dead buffers

### DIFF
--- a/test/inductor/test_graph_partition_globally_dead_buffer.py
+++ b/test/inductor/test_graph_partition_globally_dead_buffer.py
@@ -1,0 +1,147 @@
+# Owner(s): ["module: inductor"]
+
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import SM70OrLater
+from torch.testing._internal.common_device_type import skipCUDAIf
+from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+
+class TestGraphPartitionGloballyDeadBuffer(TestCase):
+    """
+    Test for issue #169232: When graph partitioning is enabled with forbidden cudagraph ops,
+    buffers marked as globally dead during whole-graph dead code elimination may still be
+    needed as inputs to specific partitions.
+    
+    Without the fix, this causes NameError when triton kernels try to reference them.
+    """
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
+    @skipIfRocm
+    def test_globally_dead_buffer_in_partition_with_forbidden_op(self):
+        """
+        Test that globally-dead buffers are kept in partition signatures when needed.
+        
+        This test creates a scenario where:
+        1. Graph partitioning is enabled due to forbidden cudagraph ops
+        2. An intermediate buffer (buf13) is created in one partition
+        3. The buffer is used in a subsequent partition but not in the final graph output
+        4. The buffer is marked as "globally dead" by whole-graph DCE
+        5. Without the fix, the buffer is incorrectly removed from the partition signature
+        6. This causes NameError when the triton kernel tries to use it
+        """
+        
+        def model(x, y):
+            # Partition 1: Create intermediate buffers
+            a = x + 1.0
+            b = y * 2.0
+            
+            # This buffer will be globally dead (not in final output)
+            # but needed as input to the next partition
+            intermediate = a * b
+            
+            # Partition 2: Use the intermediate buffer
+            # clamp is a forbidden cudagraph op, forcing a partition boundary
+            c = torch.clamp(intermediate, min=0.0, max=1.0)
+            
+            # Partition 3: Continue computation
+            d = c / (c + 1e-6)
+            e = d.view(-1)
+            
+            # Final output doesn't directly include 'intermediate',
+            # making it globally dead, but it's still needed by Partition 2
+            return e.sum()
+        
+        # Enable config that triggers the bug
+        with torch._inductor.config.patch({
+            "triton.cudagraphs": True,  # Enable cudagraphs to trigger partitioning
+            "triton.cudagraph_support_input_mutation": True,
+        }):
+            x = torch.randn(10, 10, device="cuda", requires_grad=False)
+            y = torch.randn(10, 10, device="cuda", requires_grad=False)
+            
+            # Compile the model
+            compiled_model = torch.compile(model, backend="inductor")
+            
+            # This should not raise NameError: name 'bufXX' is not defined
+            # Without the fix, triton kernel in partition would reference
+            # a buffer that was incorrectly removed from the partition signature
+            try:
+                result = compiled_model(x, y)
+                expected = model(x, y)
+                
+                # Verify correctness
+                self.assertTrue(torch.allclose(result, expected, rtol=1e-4, atol=1e-5))
+                
+            except NameError as e:
+                # If we get NameError about a buffer, the fix is not working
+                if "buf" in str(e) and "is not defined" in str(e):
+                    self.fail(
+                        f"Graph partition signature fix failed: {e}\n"
+                        "A globally-dead buffer was incorrectly removed from partition signature."
+                    )
+                else:
+                    # Re-raise if it's a different NameError
+                    raise
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
+    @skipIfRocm
+    def test_multiple_partitions_with_intermediate_buffers(self):
+        """
+        More complex test with multiple partitions and intermediate buffers.
+        """
+        
+        def complex_model(x, y, z):
+            # Partition 1
+            a = x + y
+            b = a * 2.0
+            
+            # Intermediate buffer (globally dead but needed by later partitions)
+            temp1 = b.expand(20, -1, -1)
+            
+            # Partition 2: clamp forces partition boundary
+            c = torch.clamp(temp1, -1.0, 1.0)
+            
+            # Another intermediate (globally dead)
+            temp2 = c * z
+            
+            # Partition 3: another forbidden op
+            d = torch.clamp(temp2, 0.0, 10.0)
+            
+            # Partition 4: final computation
+            e = d.sum(dim=0)
+            result = e.view(-1)
+            
+            return result
+        
+        with torch._inductor.config.patch({
+            "triton.cudagraphs": True,
+            "triton.cudagraph_support_input_mutation": True,
+        }):
+            x = torch.randn(10, 20, device="cuda")
+            y = torch.randn(10, 20, device="cuda")
+            z = torch.randn(20, 10, 20, device="cuda")
+            
+            compiled_model = torch.compile(complex_model, backend="inductor")
+            
+            try:
+                result = compiled_model(x, y, z)
+                expected = complex_model(x, y, z)
+                
+                self.assertTrue(torch.allclose(result, expected, rtol=1e-4, atol=1e-5))
+                
+            except NameError as e:
+                if "buf" in str(e) and "is not defined" in str(e):
+                    self.fail(
+                        f"Graph partition signature fix failed with multiple partitions: {e}"
+                    )
+                else:
+                    raise
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5666,7 +5666,7 @@ class Scheduler:
         buffers_removed_during_codegen = (
             V.graph.removed_buffers - removed_buffers_before_codegen
         )
-        
+
         input_nodes = {
             name: buffer
             for name, buffer in signature.input_nodes.items()
@@ -5882,12 +5882,12 @@ class Scheduler:
                 parent_wrapper_code=parent_wrapper_code,
                 partition_signatures=signature,
             )
-            
+
             # Snapshot removed_buffers before partition codegen to distinguish
             # buffers removed during this partition's codegen from those marked
             # as dead globally. See Note: [Removed Graph Partition Arguments]
             removed_buffers_before_codegen = V.graph.removed_buffers.copy()
-            
+
             self._codegen(partition)
 
             # Note: [Removed Graph Partition Arguments]

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5657,7 +5657,6 @@ class Scheduler:
         """
         Updates the partition signature by removing buffers that were fused into
         kernels during partition codegen. See [Note: Removed Graph Partition Arguments]
-        
         We only remove buffers that were added to V.graph.removed_buffers DURING
         this partition's codegen, not buffers that were marked as globally dead
         before partition codegen. This is because a globally-dead buffer might still


### PR DESCRIPTION
## Summary

Fixes #169232 

When graph partitioning is enabled with forbidden cudagraph ops, buffers marked as globally dead during whole-graph dead code elimination may still be needed as inputs to specific partitions, causing  when triton kernels try to reference them.

## Problem

The error manifested as:
```
File "/tmp/torchinductor.../partition_4"
  triton_poi_fused_clamp_div_expand_view_12.run(buf17, buf13, buf20, ...)
NameError: name 'buf13' is not defined
```

The issue occurred because:
1. During whole-graph dead code elimination, `buf13` was marked as removed in `V.graph.removed_buffers` (e.g., created in partition 3, used in partition 4, but not a graph output)
2. `clean_removed_buffer_from_partition_signatures()` removed ALL buffers in `V.graph.removed_buffers` from partition signatures
3. Partition 4 still needed `buf13` as an input, but it wasn't included in the partition's arguments
4. Triton kernel within partition 4 tried to use `buf13`, causing NameError

## Solution

Modified `clean_removed_buffer_from_partition_signatures()` to distinguish between:
- **Globally-dead buffers**: Marked as removed during whole-graph analysis but still needed as partition inputs
- **Partition-fused buffers**: Buffers fused into kernels DURING partition codegen

The fix:
1. Takes a snapshot of `V.graph.removed_buffers` before partition codegen
2. Only removes buffers that were added DURING the partition's codegen (i.e., truly fused into kernels)
3. Keeps globally-dead buffers in the signature if they're needed as partition inputs

## Testing

This fix ensures that partition signatures include all necessary inputs, preventing NameError when triton kernels reference buffers within partitions.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @BoyuanFeng @eellison