### PR TITLE
Fix viable strict update when no green commit found

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -44,6 +44,8 @@ jobs:
           echo "${PUSH_RESULT}"
           if [ "$PUSH_RESULT" = "Everything up-to-date" ]; then
             echo "No update pushed"
+          elif [ "${LATEST_SHA}" == "None" ]; then
+            echo "No viable/strict candidate found"
           else
             echo "{\"sha\": \"${LATEST_SHA}\", \"repository\":\"pytorch/pytorch\", \"timestamp\": ${TIME}}" > "/tmp/${LATEST_SHA}.json"
             pip install awscli==1.29.40


### PR DESCRIPTION
If it gets to the end of the list and doesn't find a green commit, the LATEST_SHA is None