### PR TITLE
[dynamo] Remove deprecated skip_code_recursive_on_recompile_limit_hit config

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -69,7 +69,7 @@ recompile_limit = 8
 accumulated_recompile_limit = 256
 
 # [@compile_ignored: runtime_behaviour] skip tracing recursively if cache limit is hit (deprecated: does not do anything)
-skip_code_recursive_on_recompile_limit_hit = True
+skip_code_recursive_on_recompile_limit_hit = None
 
 # raise a hard error if cache limit is hit.  If you are on a model where you
 # know you've sized the cache correctly, this can help detect problems when
@@ -84,9 +84,7 @@ accumulated_cache_size_limit: int = Config(
 )
 
 # (deprecated: does not do anything)
-skip_code_recursive_on_cache_limit_hit: bool = Config(
-    alias="torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit"
-)
+skip_code_recursive_on_cache_limit_hit = None
 fail_on_cache_limit_hit: bool = Config(
     alias="torch._dynamo.config.fail_on_recompile_limit_hit"
 )

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -62,7 +62,6 @@ from torch._guards import compile_context, CompileContext, CompileId, tracing
 from torch._logging import structured
 from torch._utils_internal import (
     compile_time_strobelight_meta,
-    justknobs_check,
     maybe_upload_prof_stats_to_manifold,
     signpost_event,
 )
@@ -1688,21 +1687,8 @@ def _compile(
                     "recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider "
                     "increasing torch._dynamo.config.cache_size_limit to an appropriate value."
                 )
-            elif justknobs_check(
-                "pytorch/compiler:skip_code_recursive_on_recompile_limit_hit"
-            ):
-                raise RecompileLimitExceeded(f"{limit_type} reached")
             else:
-                # do not recursively skip frames
-                unimplemented(
-                    gb_type="Dynamo cache limit exceeded",
-                    context=f"Limit type: {limit_type}",
-                    explanation="Dynamo attempted to recompile the code object too many times, "
-                    f"exceeding the {limit_type} cache size limit."
-                    "Giving up on compiling as the compile time tradeoff is likely not "
-                    "worth the performance gain.",
-                    hints=[],
-                )
+                raise RecompileLimitExceeded(f"{limit_type} reached")
 
         log.debug(
             "torchdynamo start compiling %s %s:%s, stack (elided %s frames):\n%s",


### PR DESCRIPTION
Part of #169578

## Summary

Spring cleaning time! Removing the `skip_code_recursive_on_recompile_limit_hit` config variable that's been sitting around with a "deprecated: does not do anything" for some time now.

## _deprecated: does not do anything_

Here's where it gets interesting: the config was marked as deprecated and "does not do anything"... but the tests had other ideas. Turns out that the justknobs did not make it clear-cut how active this is. 

This PR removes both the deprecated config AND the justknobs check, while keeping everything working exactly as it does today (_in theory_)

## Changes

**torch/_dynamo/config.py:**
- Removed `skip_code_recursive_on_recompile_limit_hit` config variable
- Removed `skip_code_recursive_on_cache_limit_hit` alias

**torch/_dynamo/convert_frame.py:**
- Removed unused `justknobs_check` import
- Deleted the justknobs conditional that was doing the actual work
- Changed the control flow to directly raise `RecompileLimitExceeded`

These last two points could use verification of correctness.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo