### PR TITLE
Integrate GroupedFP8Linear into lowering pass with `enable_fp8_grouping` option

### DIFF
--- a/aten/src/ATen/native/cuda/GroupMMCommon.cuh
+++ b/aten/src/ATen/native/cuda/GroupMMCommon.cuh
@@ -78,8 +78,9 @@ __global__ void prepare_grouped_gemm_data(
       if (N < 0) {
         int align = 128 / cutlass::sizeof_bits<DtypeOutput>::value;
         CUDA_KERNEL_ASSERT(
-                           delta % align == 0 &&
-                           "expected output tensor dynamic dimension byte size to be non-negative multiple of 16\n");
+            delta % align == 0 &&
+            "expected output tensor dynamic dimension byte size to be non-negative multiple of 16");
+
       }
     }
   }


### PR DESCRIPTION
Summary:
This is not to be landed:

This diff attempts to use grouping in fp8_models.py. Right now, this is being deprecated in favor of this file: https://www.internalfb.com/code/fbsource/fbcode/deeplearning/trt/torch_tensorrt/py/torch_tensorrt/fb/passes/lower_basic_pass_fp8.py

Similar integration of grouped_fp8_linear needs to be done to that file instead of fp8_models.

Test Plan:
TBD


Unit tests
First, need to do this once (get it from mlhub for a model):
MODEL_ID=
SNAPSHOT_ID=
manifold get ads_storage_fblearner/tree/user/facebook/fblearner/predictor/$MODEL_ID/$SNAPSHOT_ID/gpu_lowering/input.predictor.disagg.gpu.merge $HOME/models/MODEL_ID/input.predictor.disagg.gpu.merge
Repro
CUDA_VISIBLE_DEVICES=3 buck2 run mode/{opt,inplace} -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100a -c fbcode.use_link_groups=True //caffe2/torch/fb/model_transform/fx2trt/packaging:generate_merge_net_file -- --action=generate --hardware_type=SM90_X86 --input-file=$HOME/models/$MODEL_ID/input.predictor.disagg.gpu.merge --output-file=$HOME/models/$MODEL_ID/sm90_output.predictor.disagg.gpu.merge --lower-backend=aot_inductor --get_lower_settings_from_scuba --merge-lowered-entity-id=$MODEL_ID --merge-lowered-snapshot-id=$SNAPSHOT_ID  --node_replacement_dict="{'torch.nn.Linear':{'(1000+,1000+)':'fp8_float_model_dynamic_quantization_pytorch'}}" |& tee /tmp/aoti_with_regex.out
Error: https://www.internalfb.com/intern/everpaste/?handle=GECIpCC_vKJgwfYDAAnnmt0l1NkVbsIXAAAB&phabricator_paste_number=1961020394

Differential Revision: D86984467


