### PR TITLE
[Inductor] Create benchmark request for Extern Kernels

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -32,6 +32,7 @@ from torch._inductor.codecache import (
     PyCodeCache,
 )
 from torch._inductor.utils import (
+    do_bench_using_profiling,
     get_gpu_type,
     get_ld_library_path,
     is_gpu,
@@ -433,10 +434,11 @@ class BenchmarkRequest:
         self.kernel_name = kernel_name
 
         if isinstance(input_tensor_meta, TensorMeta):
-            input_tensor_meta = [input_tensor_meta]
-        self.input_tensor_meta = input_tensor_meta
+            self.input_tensor_meta: list[TensorMeta] = [input_tensor_meta]
+        else:
+            self.input_tensor_meta: list[TensorMeta] = input_tensor_meta
 
-        if isinstance(output_tensor_meta, (tuple, list)):
+        if output_tensor_meta and isinstance(output_tensor_meta, (tuple, list)):
             if len(output_tensor_meta) > 1:
                 # Each output with same meta for Grouped GEMM
                 assert all(
@@ -444,8 +446,9 @@ class BenchmarkRequest:
                     for x in output_tensor_meta
                     for attr in ["device", "dtype", "sizes", "strides", "offset"]
                 )
-            output_tensor_meta = output_tensor_meta[0]
-        self.output_tensor_meta = output_tensor_meta
+            self.output_tensor_meta = output_tensor_meta[0]
+        else:
+            self.output_tensor_meta: TensorMeta = output_tensor_meta
 
         self.extra_args = extra_args
 
@@ -476,6 +479,9 @@ class BenchmarkRequest:
 
         # create args and out tensor
         if out is None:
+            assert self.input_tensor_meta and self.output_tensor_meta, (
+                "Input and output tensor meta must be populated when input_tensors is empty"
+            )
             assert len(input_tensors) == 0
             input_tensors = tuple(x.to_tensor() for x in self.input_tensor_meta)
             out = self.output_tensor_meta.to_tensor()
@@ -685,6 +691,93 @@ class TritonGPUBenchmarkRequest(GPUDeviceBenchmarkMixin, TritonBenchmarkRequest)
 
 
 class TritonCPUBenchmarkRequest(CPUDeviceBenchmarkMixin, TritonBenchmarkRequest):
+    pass
+
+
+class ExternKernelBenchmarkRequest(BenchmarkRequest):
+    """
+    A class to handle extern kernel benchmark requests. This allows extern kernels
+    (like aten::mm) to be benchmarked in a subprocess, similar to Triton kernels.
+
+    Important: Instances of this class have to be serializable across
+    process boundaries. Do not put CUDA Tensors in here!
+    """
+
+    def __init__(
+        self,
+        kernel_name: str,
+        input_tensor_meta: Union[TensorMeta, list[TensorMeta]],
+        output_tensor_meta: Union[TensorMeta, list[TensorMeta]],
+        extra_args: Iterable[Any],
+        callable_path: str,  # Module path to the callable (e.g., "extern_kernels.mm")
+        kwargs: Optional[dict[str, Any]] = None,
+        has_out_variant: bool = True,
+    ) -> None:
+        super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
+        self.callable_path = callable_path
+        self.kwargs = kwargs or {}
+        self.has_out_variant = has_out_variant
+
+    def make_run_fn(
+        self, *input_tensors: torch.Tensor, out: torch.Tensor
+    ) -> Callable[[], None]:
+        fn = self.to_callable()
+        if self.has_out_variant:
+            # For out=variant, pass output as keyword arg
+            return functools.partial(fn, *input_tensors, out=out)
+        else:
+            # For non-out variant, just call with inputs
+            return functools.partial(fn, *input_tensors)
+
+    def benchmark(
+        self, *input_tensors: torch.Tensor, out: Optional[torch.Tensor] = None
+    ):
+        if out is not None and out.numel() == 0:
+            # no need to run the kernel of do benchmarking
+            return 0.0
+        if self.has_out_variant or len(input_tensors) == 0:
+            return super().benchmark(*input_tensors, out=out)
+        else:
+            algo = self.to_callable()
+            out_new = algo(*input_tensors)
+            if out is not None:
+                torch._C._dynamo.guards.assert_size_stride(
+                    out_new, tuple(out.size()), tuple(out.stride())
+                )
+                out.copy_(out_new)  # for correctness checking
+            if config.profile_bandwidth_with_do_bench_using_profiling:
+                return do_bench_using_profiling(lambda: algo(*input_tensors))
+            return benchmarker.benchmark(algo, input_tensors, {})
+
+    def precompile(self) -> None:
+        # Extern kernels don't need precompilation - they're already compiled
+        pass
+
+    def to_callable(self):
+        # While ExternKernelChoice also has a to_callable method,
+        # we avoid calling the ExternKernelChoice version here to make sure
+        # this is picklable
+        from torch._inductor.select_algorithm import extern_kernels
+
+        fn = getattr(extern_kernels, self.kernel_name)
+        if self.kwargs:
+            return functools.partial(fn, **self.kwargs)
+
+        return fn
+
+    def __str__(self) -> str:
+        return f"ExternKernelBenchmarkRequest({self.callable_path})"
+
+
+class ExternKernelGPUBenchmarkRequest(
+    GPUDeviceBenchmarkMixin, ExternKernelBenchmarkRequest
+):
+    pass
+
+
+class ExternKernelCPUBenchmarkRequest(
+    CPUDeviceBenchmarkMixin, ExternKernelBenchmarkRequest
+):
     pass
 
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -73,7 +73,6 @@ from .exc import CUDACompileError
 from .fx_utils import count_flops_fx
 from .ir import ChoiceCaller, PrimitiveInfoType
 from .ops_handler import StoreMode
-from .runtime.benchmarking import benchmarker
 from .runtime.hints import DeviceProperties
 from .runtime.triton_compat import HAS_WARP_SPEC
 from .runtime.triton_heuristics import FixedGrid
@@ -106,6 +105,7 @@ DEBUG = False
 if TYPE_CHECKING:
     import concurrent
 
+    from torch._inductor.autotune_process import BenchmarkRequest
     from torch._inductor.codegen.simd import IterationRangesEntry, IterationRangesRoot
 
     from .codegen.common import CSE
@@ -2353,26 +2353,54 @@ class ExternKernelCaller(ChoiceCaller):
         self.kwargs = kwargs or {}
         self.has_out_variant = has_out_variant
         self.gm = choice.gm
+        self.bmreq: Optional[BenchmarkRequest] = None
+
+        from torch._inductor.autotune_process import (
+            ExternKernelBenchmarkRequest,
+            ExternKernelCPUBenchmarkRequest,
+            ExternKernelGPUBenchmarkRequest,
+        )
+
+        # Determine if this is a GPU or CPU kernel
+        if self.layout:
+            device = self.layout.device
+        else:
+            device = None
+            for inp_node in self.input_nodes:
+                dev = inp_node.get_device()
+                if dev and dev.type != "cpu":
+                    device = dev
+                    break
+
+            if not device:
+                device = torch.device("cpu")
+
+        self.input_tensor_meta: Union[list[TensorMeta], TensorMeta]
+        self.output_tensor_meta: Union[list[TensorMeta], TensorMeta]
+        if device.type == "cpu":
+            self.input_tensor_meta, self.output_tensor_meta = [], []
+            benchmark_cls = ExternKernelCPUBenchmarkRequest
+        else:
+            self.input_tensor_meta = TensorMeta.from_irnodes(self.input_nodes)
+            self.output_tensor_meta = TensorMeta.from_irnodes(self.layout)
+            benchmark_cls = ExternKernelGPUBenchmarkRequest
+
+        self.bmreq: ExternKernelBenchmarkRequest = benchmark_cls(
+            kernel_name=self.choice.name,
+            input_tensor_meta=self.input_tensor_meta,
+            output_tensor_meta=self.output_tensor_meta,
+            extra_args=(),
+            callable_path=self.choice.call_name(),
+            kwargs=self.kwargs,
+            has_out_variant=self.has_out_variant,
+        )
 
     def __str__(self) -> str:
         return f"ExternKernelCaller({self.choice.call_name()})"
 
     def benchmark(self, *args, out):
-        if out.numel() == 0:
-            # no need to run the kerrnel of do benchmarking
-            return 0.0
-        if self.has_out_variant:
-            return super().benchmark(*args, out=out)
-        else:
-            algo = self.to_callable()
-            out_new = algo(*args)
-            torch._C._dynamo.guards.assert_size_stride(
-                out_new, tuple(out.size()), tuple(out.stride())
-            )
-            out.copy_(out_new)  # for correctness checking
-            if config.profile_bandwidth_with_do_bench_using_profiling:
-                return do_bench_using_profiling(lambda: algo(*args))
-            return benchmarker.benchmark(algo, args, {})
+        # pyrefly: ignore [missing-attribute]
+        return self.bmreq.benchmark(*args, out=out)
 
     def benchmark_collective(self, *args, out):
         """
@@ -2388,10 +2416,8 @@ class ExternKernelCaller(ChoiceCaller):
             algo(*args)
 
     def to_callable(self):
-        fn = self.choice.to_callable()
-        if self.kwargs:
-            return functools.partial(fn, **self.kwargs)
-        return fn
+        # pyrefly: ignore [missing-attribute]
+        return self.bmreq.to_callable()
 
     def hash_key(self):
         return "-".join(


### PR DESCRIPTION
Differential Revision: D88387420

Make benchmark request for ExternKernelCallers, mirroring TritonTemplateCallers. This allows a more elegant solution to Async Pipelined Autotuning, in which a BenchmarkRequest is pickled to a subprocess for autotuning. All benchmarking for ExternKernels are now directed to the BenchmarkRequest.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo