### PR TITLE
Disable GC in process based async checkpointing

### DIFF
--- a/test/distributed/checkpoint/test_async_process_executor.py
+++ b/test/distributed/checkpoint/test_async_process_executor.py
@@ -299,6 +299,56 @@ class TestProcessGroupInitInfo(DTensorTestBase):
             pg_init_info = _ProcessGroupInitInfo()
             self.assertFalse(pg_init_info.use_prefix_store)
 
+    @with_comms
+    def test_process_group_init_info_gc_env_vars(self) -> None:
+        """Test that ProcessGroupInitInfo correctly reads GC-related environment variables."""
+
+        # Test with both GC env vars enabled
+        with patch.dict(
+            os.environ,
+            {
+                "DCP_DISABLE_AUTOMATIC_GC": "1",
+                "DCP_DISABLE_MANUAL_GC": "1",
+            },
+        ):
+            pg_init_info = _ProcessGroupInitInfo()
+            self.assertTrue(pg_init_info.disable_automatic_gc)
+            self.assertTrue(pg_init_info.disable_manual_gc)
+
+        # Test with automatic GC disabled, manual GC enabled
+        with patch.dict(
+            os.environ,
+            {
+                "DCP_DISABLE_AUTOMATIC_GC": "1",
+            },
+        ):
+            pg_init_info = _ProcessGroupInitInfo()
+            self.assertTrue(pg_init_info.disable_automatic_gc)
+            self.assertFalse(pg_init_info.disable_manual_gc)
+
+        # Test with automatic GC enabled, manual GC disabled
+        with patch.dict(
+            os.environ,
+            {
+                "DCP_DISABLE_MANUAL_GC": "1",
+            },
+        ):
+            pg_init_info = _ProcessGroupInitInfo()
+            self.assertFalse(pg_init_info.disable_automatic_gc)
+            self.assertTrue(pg_init_info.disable_manual_gc)
+
+        # Test with both GC env vars disabled
+        with patch.dict(
+            os.environ,
+            {
+                "DCP_DISABLE_AUTOMATIC_GC": "0",
+                "DCP_DISABLE_MANUAL_GC": "0",
+            },
+        ):
+            pg_init_info = _ProcessGroupInitInfo()
+            self.assertFalse(pg_init_info.disable_automatic_gc)
+            self.assertFalse(pg_init_info.disable_manual_gc)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Summary:
I've been investigating the source for the large (10 min for 1k jobs) planning collectives. The source of the issue seems to be the GC running in the process during the all gather deserialization of objects https://fburl.com/code/6wdvfioi causing spikes and increase in deserialization time. With GC disabled, for a 96 gpu job, the planning collective is 4s https://fburl.com/scuba/pytorch_dcp_logging/elytxg2y. It's 30s without this enabled https://fburl.com/scuba/pytorch_dcp_logging/hkn233tz. On a 256 gpu job, the deserialization of one save plan when gc is enabled, can take as long as 25s https://fburl.com/mlhub/ewtu6439, when normally it should be in the order of milliseconds.

This diff, behind a JK, will disable the automatic gc, and behind another jk, won't run the manual gc at all. The cost of running manual gc is ~10s (https://fburl.com/mlhub/q4uauv20, https://fburl.com/mlhub/j52cv5mj) for the 96 gpu job. So ideally, we wouldn't have to run it. Based on some testing (https://fburl.com/mlhub/kcw221ly), we aren't actually leaking anything and we shouldn't need to run manual GC, but adding a JK in case this not true, so we don't OOM.

Test Plan:
unit tests
ran a job aps-ankitageorge-2a3f549ddc

Reviewed By: kevinmtang

Differential Revision: D88274329


