### PR TITLE
Fix ATen amd therock clang compiler errors with amdgpu-coerce-illegal-types argument

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -301,13 +301,23 @@ IF(USE_FBGEMM_GENAI)
 
       # Add additional HIPCC compiler flags for performance
       set(FBGEMM_GENAI_EXTRA_HIPCC_FLAGS
-        -mllvm
-        -amdgpu-coerce-illegal-types=1
-        -mllvm
-        -enable-post-misched=0
+	-mllvm
+	-enable-post-misched=0
         -mllvm
         -greedy-reverse-local-assignment=1
         -fhip-new-launch-api)
+
+      # check compiler support for "-amdgpu-coerce-illegal-types" clang extension
+      # clang++ versions from ROCM_SDK 7.2 and newer does not support this flag
+      include(CheckCXXCompilerFlag)
+      set(AMDGPU_COERCE_ILLEGAL_TYPES_FLAG "-mllvm -amdgpu-coerce-illegal-types")
+      check_cxx_compiler_flag("${AMDGPU_COERCE_ILLEGAL_TYPES_FLAG}" AMDGPU_COERCE_ILLEGAL_TYPES_SUPPORTED)
+      if(AMDGPU_COERCE_ILLEGAL_TYPES_SUPPORTED)
+          message(STATUS "${CMAKE_CXX_COMPILER_ID} compiler in use supports ${AMDGPU_COERCE_ILLEGAL_TYPES_FLAG}. Enabling option.")
+	      string(APPEND FBGEMM_GENAI_EXTRA_HIPCC_FLAGS "-mllvm -amdgpu-coerce-illegal-types=1")
+      else()
+          message(STATUS "${CMAKE_CXX_COMPILER_ID} compiler in use does not support ${AMDGPU_COERCE_ILLEGAL_TYPES_FLAG}. Option not enabled.")
+      endif()
 
       hip_add_library(
         fbgemm_genai STATIC


### PR DESCRIPTION
clang++ and amdclang++ provided by therock versions 7.10 and 7.11 failed to 
build Pytorch for a following error:

clang++: error: unknown argument: '-amdgpu-coerce-illegal-types=1'

Fix by this by checking during the configuration time whether the currently used compiler supports this compiler option. This option is supported by ROCM SDK clang versions but not by the newest ones.
