### PR TITLE
[dynamo] Remove code dependency on deprecated `dead_code_elimination`

### DIFF
--- a/test/inductor/test_fuzzer.py
+++ b/test/inductor/test_fuzzer.py
@@ -160,14 +160,11 @@ class TestConfigFuzzer(TestCase):
     )
     def test_config_fuzzer_dynamo_bisect(self):
         # these values just chosen randomly, change to different ones if necessary
-        key_1 = {"dead_code_elimination": False, "specialize_int": True}
+        key_1 = {"specialize_int": True}
 
         def create_key_1():
             def myfn():
-                if (
-                    not dynamo_config.dead_code_elimination
-                    and dynamo_config.specialize_int
-                ):
+                if dynamo_config.specialize_int:
                     return False
                 return True
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -55,7 +55,7 @@ debug_backend_override: str = os.environ.get("TORCH_COMPILE_OVERRIDE_BACKENDS", 
 minimum_call_count = 1
 
 # turn on/off DCE pass (deprecated: always true)
-dead_code_elimination = True
+dead_code_elimination = None
 
 # Enable or disable side effect replay after graph execution.
 # When False, mutations to Python objects (lists, dicts, attributes) won't be


### PR DESCRIPTION
Part of #169578

## Summary

This one is very tiny. Cleaning up a test case dependency on a deprecated value to save some future dev the hassle once it's fully removed. This should remove all usage of the value, let me know if it should be replaced with something else that is currently in use.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela