### PR TITLE
Improve robolectric load by moving fb_xplat_robolectric4_test out of pt_defs.bzl

### DIFF
--- a/pt_test_host.bzl
+++ b/pt_test_host.bzl
@@ -1,0 +1,9 @@
+"""pt_test_host rule definition."""
+
+load("@fbsource//tools/build_defs:fb_xplat_robolectric4_test.bzl", "fb_xplat_robolectric4_test")
+
+def pt_test_host(*args, **kwargs):
+    fb_xplat_robolectric4_test(
+        *args,
+        **kwargs
+    )


### PR DESCRIPTION
Reviewed By: NavidQar

Differential Revision: D88406268


