### PR TITLE
[dynamo] add new graph break registry entries via linter to random spots

### DIFF
--- a/tools/dynamo/gb_id_mapping.py
+++ b/tools/dynamo/gb_id_mapping.py
@@ -203,7 +203,8 @@ def create_registry(dynamo_dir: str, registry_path: str) -> None:
     for info in calls:
         gb_types[info["gb_type"]] = info
 
-    GB_ID_INDEX = 0000
+    # Use sequential IDs for initial registry creation
+    GB_ID_INDEX = 0
     for i, (gb_type, info) in enumerate(sorted(gb_types.items()), GB_ID_INDEX):
         gb_id = f"GB{i:04d}"
         hints = info["hints"]

--- a/tools/linter/adapters/gb_registry_linter.py
+++ b/tools/linter/adapters/gb_registry_linter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 import sys
 from enum import Enum
 from pathlib import Path
@@ -109,6 +110,9 @@ def _update_registry_with_changes(
         del latest_entry[old_gb_type]
         del gb_type_to_key[old_gb_type]
 
+    # Collect new entries separately to insert them all at once
+    new_entries: list[tuple[str, list[dict[str, Any]]]] = []
+
     for gb_type, (call, file_path) in calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
@@ -126,11 +130,34 @@ def _update_registry_with_changes(
                     registry_key
                 ]
         else:
+            # Collect new entries to add later
             new_key = next_gb_id(updated_registry)
             new_entry = _create_registry_entry(
                 gb_type, call["context"], call["explanation"], call["hints"]
             )
+            new_entries.append((new_key, [new_entry]))
+            # Temporarily add to updated_registry so next_gb_id works correctly
             updated_registry[new_key] = [new_entry]
+
+    # Insert all new entries at the same random position to reduce merge conflicts
+    if new_entries:
+        # Remove temporarily added entries
+        for new_key, _ in new_entries:
+            del updated_registry[new_key]
+
+        registry_items = list(updated_registry.items())
+        if registry_items:
+            # Pick one random position for all new entries
+            insert_pos = random.randint(0, len(registry_items))
+            # Insert all new entries at the same position
+            for new_key, new_entry in new_entries:
+                registry_items.insert(insert_pos, (new_key, new_entry))
+                insert_pos += 1  # Keep them together
+            updated_registry = dict(registry_items)
+        else:
+            # Empty registry, just add all entries
+            for new_key, new_entry in new_entries:
+                updated_registry[new_key] = new_entry
 
     return updated_registry
 

--- a/tools/test/test_gb_registry_linter.py
+++ b/tools/test/test_gb_registry_linter.py
@@ -280,26 +280,30 @@ def test(self):
         # Parse the replacement to get the actual GB ID that was generated
         self.assertEqual(len(messages), 1)
         replacement_registry = json.loads(messages[0].replacement)
-        new_gb_id = next(k for k in replacement_registry if k != "GB0000")
 
-        expected_registry = {
-            "GB0000": [
-                {
-                    "Gb_type": "original_testing",
-                    "Context": "original_context",
-                    "Explanation": "original_explanation",
-                    "Hints": ["original_hint"],
-                }
-            ],
-            new_gb_id: [
-                {
-                    "Gb_type": "completely_new_testing",
-                    "Context": "completely_new_context",
-                    "Explanation": "completely_new_explanation",
-                    "Hints": ["completely_new_hint"],
-                }
-            ],
-        }
+        # Build expected_registry in the same order as replacement_registry
+        # since random insertion means order is not deterministic
+        expected_registry = {}
+        for gb_id in replacement_registry:
+            if gb_id == "GB0000":
+                expected_registry[gb_id] = [
+                    {
+                        "Gb_type": "original_testing",
+                        "Context": "original_context",
+                        "Explanation": "original_explanation",
+                        "Hints": ["original_hint"],
+                    }
+                ]
+            else:
+                expected_registry[gb_id] = [
+                    {
+                        "Gb_type": "completely_new_testing",
+                        "Context": "completely_new_context",
+                        "Explanation": "completely_new_explanation",
+                        "Hints": ["completely_new_hint"],
+                    }
+                ]
+
         expected_replacement = (
             json.dumps(expected_registry, indent=2, ensure_ascii=False) + "\n"
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169632
* __->__ #169624
* #169617

Randomize graph break registry linter placement to further reduce merge conflicts.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo