### PR TITLE
[partitioner] New configuration for considering custom operations in knapsack optimization (#167083)

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -139,6 +139,9 @@ ban_recompute_reductions = True
 # Prevents the partitioner from ever saving views (i.e. always recompute them).
 # Generally a good idea since views are free to recompute.
 recompute_views = False
+# Set this flag to enable considering non-built-in ops, including triton and custom
+# ops, for recomputation during the knapsack optimization solver.
+is_non_builtin_to_include = False
 
 # Rematerialize AC nodes for graphs with forward+loss+backward in one graph.
 # This optimization minimizes activation checkpoint node lifetimes by computing them

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -26,6 +26,7 @@ from torch._functorch._activation_checkpointing.ac_logging_utils import (
     create_structured_trace_for_min_cut_info,
 )
 from torch._inductor import config as inductor_config
+from torch._library.utils import is_builtin
 from torch._logging import trace_structured
 from torch._subclasses.fake_tensor import extract_tensor_metadata
 from torch.fx.experimental._backward_state import BackwardState
@@ -283,6 +284,13 @@ def _is_primal(node: fx.Node) -> bool:
 
 def _is_tangent(node: fx.Node) -> bool:
     return node.op == "placeholder" and "tangents" in str(node.target)
+
+
+def is_non_builtin_to_include(node: fx.Node) -> bool:
+    return config.is_non_builtin_to_include and (
+        (isinstance(node.target, torch._ops.OpOverload) and not is_builtin(node.target))
+        or node.target == torch.ops.higher_order.triton_kernel_wrapper_functional
+    )
 
 
 def _is_bwd_seed_offset(node: fx.Node) -> bool:
@@ -1857,7 +1865,11 @@ def solve_min_cut(
             if not op_types.is_recomputable(node):
                 return True
         else:
-            if op_types.is_random(node) or op_types.is_compute_intensive(node):
+            if (
+                op_types.is_random(node)
+                or op_types.is_compute_intensive(node)
+                or is_non_builtin_to_include(node)
+            ):
                 return True
 
         # If a node *must* be materialized in the backwards pass, then we
@@ -2543,7 +2555,10 @@ def choose_saved_values_set(
             if (
                 # Only allow recomputing nodes that are actually required for BW
                 i.dist_from_bw < int(1e9)  # type: ignore[attr-defined]
-                and get_node_storage(i) not in input_storages
+                and (
+                    get_node_storage(i) not in input_storages
+                    or is_non_builtin_to_include(i)
+                )
             )
         ]
 


### PR DESCRIPTION
Summary:

Creates new configuration: `include_custom_and_triton_kernel_wrappers_in_knapsack_optimization`

 ---

If config toggle is set to true, then nodes meeting the following criteria no longer just recomputed by default:

```
op.namespace not in {"aten", "prim", "prims"}
```

or

```
node.target == torch.ops.higher_order.triton_kernel_wrapper_functional
```

Test Plan:
# E2E Testing

### Baseline

Here is the [tlparse link](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-omnifm_0908_6kx_fakecomm_base01-828d285622/attempt_0/version_0/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000) for the [baseline training run](https://fburl.com/mlhub/bdmauhug). Observe that for [graph_11, it does not contain triton kernels](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-omnifm_0908_6kx_fakecomm_base01-828d285622/attempt_0/version_0/rank_0/-_11_0_0/min_cut_information_58.json?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000).

```
  "Recomputable Banned Nodes Order": [
    "addmm_2",
    "addmm_4",
    "addmm_7",
    "addmm_6",
    "addmm",
    "addmm_1",
    "addmm_3",
    "addmm_8",
    "addmm_9",
    "bucketize",
    "bucketize_3",
    "bucketize_9",
    "bucketize_24",
    "bucketize_27",
    "ge",
    "ge_1",
    "ge_2",
    "ge_3",
    "ge_4",
    "ge_5",
    "ge_6",
    "ge_7",
    "ge_8",
    "ge_9"
  ]
```

### Test: Config Set to False(Default)

Here is the [tlparse link](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-omnifm_0908_6kx_fakecomm_updated2-608c18f4ae/attempt_1/version_0/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000&fbclid=IwY2xjawOdijtleHRuA2FlbQIxMQBicmlkETFoalJ3cG5lOTRFS2RDWElQc3J0YwZhcHBfaWQBMAABHkxt0N11P8qkVV5uz19tLQCqLdLrgLEBuZPqmIiqZ4XnTOn0ZR1JU-6-acPX_aem_leYEAAWYUXVq9xezW37bcA) for the [test training run](https://fburl.com/mlhub/u5ebucs3). Observe that for [graph_11, it does not contain triton kernels](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-omnifm_0908_6kx_fakecomm_updated2-608c18f4ae/attempt_1/version_0/rank_0/-_11_0_0/min_cut_information_58.json?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000&fbclid=IwY2xjawOdijtleHRuA2FlbQIxMQBicmlkETFoalJ3cG5lOTRFS2RDWElQc3J0YwZhcHBfaWQBMAABHkxt0N11P8qkVV5uz19tLQCqLdLrgLEBuZPqmIiqZ4XnTOn0ZR1JU-6-acPX_aem_leYEAAWYUXVq9xezW37bcA).

```
  "Recomputable Banned Nodes Order": [
    "addmm_2",
    "addmm_4",
    "addmm_7",
    "addmm_6",
    "addmm",
    "addmm_1",
    "addmm_3",
    "addmm_8",
    "addmm_9",
    "bucketize",
    "bucketize_3",
    "bucketize_9",
    "bucketize_24",
    "bucketize_27",
    "ge",
    "ge_1",
    "ge_2",
    "ge_3",
    "ge_4",
    "ge_5",
    "ge_6",
    "ge_7",
    "ge_8",
    "ge_9"
  ]
```

### Test: Config Set to True

Here is the [tlparse link](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-omnifm_0908_6kx_fakecomm_updated3-2d9a31068f/attempt_0/version_0/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000) for the [test training run](https://fburl.com/mlhub/qlscz25s). Observe that for [graph_11, it does contain triton kernels](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-omnifm_0908_6kx_fakecomm_updated3-2d9a31068f/attempt_0/version_0/rank_0/-_11_0_0/min_cut_information_58.json?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000).

```
  "Recomputable Banned Nodes Order": [
    "triton_kernel_wrapper_functional_proxy_8",
    "triton_kernel_wrapper_functional_proxy_4",
    "addmm_2",
    "triton_kernel_wrapper_functional_proxy_11",
    "triton_kernel_wrapper_functional_proxy_13",
    "addmm_4",
    "triton_kernel_wrapper_functional_proxy_10",
    "addmm_7",
    "addmm_6",
    "triton_kernel_wrapper_functional_proxy_2",
    "triton_kernel_wrapper_functional_proxy",
    "triton_kernel_wrapper_functional_proxy_15",
    "offsets_range_2",
    "triton_kernel_wrapper_functional_proxy_17",
    "triton_kernel_wrapper_functional_proxy_6",
    "addmm",
    "addmm_1",
    "offsets_range_7",
    "addmm_3",
    "addmm_8",
    "addmm_9",
    "offsets_range_4",
    "offsets_range_5",
    "offsets_range_6",
    "asynchronous_complete_cumsum",
    "asynchronous_complete_cumsum_1",
    "asynchronous_complete_cumsum_2",
    "asynchronous_complete_cumsum_3",
    "asynchronous_complete_cumsum_4",
    "asynchronous_complete_cumsum_5",
    "asynchronous_complete_cumsum_6",
    "asynchronous_complete_cumsum_7",
    "asynchronous_complete_cumsum_8",
    "asynchronous_complete_cumsum_9",
    "bucketize",
    "offsets_range",
    "bucketize_3",
    "offsets_range_1",
    "bucketize_9",
    "offsets_range_3",
    "bucketize_24",
    "offsets_range_8",
    "bucketize_27",
    "offsets_range_9",
    "ge",
    "ge_1",
    "ge_2",
    "ge_3",
    "ge_4",
    "ge_5",
    "ge_6",
    "ge_7",
    "ge_8",
    "ge_9"
  ]
```

Differential Revision: D85683496
