### PR TITLE
[Py 3.14] Cleanup graphs for failed tracer outputs

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -671,7 +671,6 @@ class TestNNParametrization(NNTestCase):
         self.assertFalse(parametrize.is_parametrized(module))
         self.assertEqual(module.weight, weight_init)
 
-    @unittest.skipIf(sys.version_info >= (3, 14), "Failing on Python 3.14+")
     @swap([True, False])
     def test_errors_parametrized_tensor_parametrization(self):
         # Test errors when registering a parametrization on a parametrized tensor
@@ -856,7 +855,6 @@ class TestNNParametrization(NNTestCase):
     # FIXME: Rewrite this test using functions not depending on LAPACK
     #        and remove the `@skipIfNoLapack` (see #70995)
     @skipIfNoLapack
-    @unittest.skipIf(sys.version_info >= (3, 14), "Failing on Python 3.14+")
     @swap([True, False])
     def test_caching_parametrization(self):
         r"""Test the caching system of a parametrization"""
@@ -919,7 +917,6 @@ class TestNNParametrization(NNTestCase):
             # test that the results are distinct objects for each module
             self.assertNotEqual(id(A), id(X))
 
-    @unittest.skipIf(sys.version_info >= (3, 14), "Failing on Python 3.14+")
     @swap([True, False])
     def test_parametrization_same_training_mode(self):
         r"""Test training mode updated on parametrization registration"""
@@ -937,7 +934,6 @@ class TestNNParametrization(NNTestCase):
         self.assertTrue(module.parametrizations.weight[0].training)
         self.assertTrue(module.parametrizations.weight[1].training)
 
-    @unittest.skipIf(sys.version_info >= (3, 14), "Failing on Python 3.14+")
     @swap([True, False])
     def test_type_before_parametrizations(self):
         r"""Test that type_before_parametrizations always retrieves original type"""
@@ -1553,7 +1549,6 @@ class TestNNParametrization(NNTestCase):
             snm._u.shape, m.parametrizations.weight.original[0, :, 0, 0].shape
         )
 
-    @unittest.skipIf(sys.version_info >= (3, 14), "Failing on Python 3.14+")
     @swap([True, False])
     def test_new_spectral_norm_forward(self):
         input = torch.randn(3, 5)

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -883,7 +883,6 @@ class TestNNParametrization(NNTestCase):
     # FIXME: Rewrite this test using functions not depending on LAPACK
     #        and remove the `@skipIfNoLapack` (see #70995)
     @skipIfNoLapack
-    @unittest.skipIf(sys.version_info >= (3, 14), "Failing on Python 3.14+")
     @swap([True, False])
     def test_caching_parametrization_with_transfer_parametrizations_and_params(self):
         r"""Test that transferring parametrizations doesn't cause issues with caching"""

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1,7 +1,5 @@
 # Owner(s): ["module: nn"]
 import pickle
-import sys
-import unittest
 from copy import deepcopy
 from itertools import product
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1355,16 +1355,7 @@ def compile_frame(  # type: ignore[return]
             # Clean up the failed tracer output's graph to break reference cycles
             failed_tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)
             if failed_tracer_output:
-                og = failed_tracer_output.output_graph_for_cleanup
-                if og:
-                    for tracer in og.tracers:
-                        tracer.graph.clear_nodes()
-                    # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
-                    if (
-                        og.tracing_context.fake_mode
-                        and og.tracing_context.fake_mode.shape_env
-                    ):
-                        og.tracing_context.fake_mode.shape_env.tracked_fakes = None
+                failed_tracer_output._cleanup_output_graph()
             # If restart reason is None just log the type of the exception
             restart_reasons.add(e.restart_reason or str(type(e)))
             # We now have a new "last attempt", reset the clock
@@ -1384,16 +1375,7 @@ def compile_frame(  # type: ignore[return]
             # Clean up the failed tracer output's graph to break reference cycles
             failed_tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)
             if failed_tracer_output:
-                og = failed_tracer_output.output_graph_for_cleanup
-                if og:
-                    for tracer in og.tracers:
-                        tracer.graph.clear_nodes()
-                    # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
-                    if (
-                        og.tracing_context.fake_mode
-                        and og.tracing_context.fake_mode.shape_env
-                    ):
-                        og.tracing_context.fake_mode.shape_env.tracked_fakes = None
+                failed_tracer_output._cleanup_output_graph()
             log.debug(  # noqa: G200
                 "Skipping frame %s %s \
                 %s %s",

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1359,6 +1359,12 @@ def compile_frame(  # type: ignore[return]
                 if og:
                     for tracer in og.tracers:
                         tracer.graph.clear_nodes()
+                    # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
+                    if (
+                        og.tracing_context.fake_mode
+                        and og.tracing_context.fake_mode.shape_env
+                    ):
+                        og.tracing_context.fake_mode.shape_env.tracked_fakes = None
             # If restart reason is None just log the type of the exception
             restart_reasons.add(e.restart_reason or str(type(e)))
             # We now have a new "last attempt", reset the clock
@@ -1382,6 +1388,12 @@ def compile_frame(  # type: ignore[return]
                 if og:
                     for tracer in og.tracers:
                         tracer.graph.clear_nodes()
+                    # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
+                    if (
+                        og.tracing_context.fake_mode
+                        and og.tracing_context.fake_mode.shape_env
+                    ):
+                        og.tracing_context.fake_mode.shape_env.tracked_fakes = None
             log.debug(  # noqa: G200
                 "Skipping frame %s %s \
                 %s %s",

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1903,6 +1903,13 @@ def _compile(
                     else _get_error_on_graph_break()
                 )
 
+            if tracer_output.output_graph is not None:
+                nodes = tracer_output.output_graph.graph.nodes
+                for node in nodes:
+                    if "example_value" in node.meta:
+                        del node.meta["example_value"]
+                gc.collect()
+import gc
 
 class ConvertFrame:
     def __init__(

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1916,6 +1916,7 @@ def _compile(
                     else _get_error_on_graph_break()
                 )
 
+
 class ConvertFrame:
     def __init__(
         self,

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1903,13 +1903,13 @@ def _compile(
                     else _get_error_on_graph_break()
                 )
 
-            if tracer_output.output_graph is not None:
+            if tracer_output is not None and tracer_output.output_graph is not None:
                 nodes = tracer_output.output_graph.graph.nodes
                 for node in nodes:
                     if "example_value" in node.meta:
                         del node.meta["example_value"]
                 gc.collect()
-import gc
+
 
 class ConvertFrame:
     def __init__(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2787,6 +2787,9 @@ class DynamoTracerOutput:
     error_on_graph_break: bool
     is_tracing_resume_prologue: bool
     output_graph: Optional[OutputGraph]
+    # output_graph_for_cleanup is set even when there's an error, to allow
+    # cleanup of graph nodes to break reference cycles
+    output_graph_for_cleanup: Optional[OutputGraph]
     closure: Optional[tuple[Any, ...]]
     f_globals: dict[str, Any]
 
@@ -2797,6 +2800,7 @@ class DynamoTracerOutput:
         self.is_tracing_resume_prologue = tracer.is_tracing_resume_prologue
         self.closure = tracer.closure
         self.f_globals = tracer.f_globals
+        self.output_graph_for_cleanup = tracer.output
         if error:
             self.output_graph = None
         else:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2806,6 +2806,15 @@ class DynamoTracerOutput:
         else:
             self.output_graph = tracer.output
 
+    def _cleanup_output_graph(self) -> None:
+        og = self.output_graph_for_cleanup
+        if og:
+            for tracer in og.tracers:
+                tracer.graph._clear_nodes()
+            # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
+            if og.tracing_context.fake_mode and og.tracing_context.fake_mode.shape_env:
+                og.tracing_context.fake_mode.shape_env.tracked_fakes = None
+
 
 err_epilogue = (
     "With the current config, we will graph break "

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2807,13 +2807,16 @@ class DynamoTracerOutput:
             self.output_graph = tracer.output
 
     def _cleanup_output_graph(self) -> None:
-        og = self.output_graph_for_cleanup
-        if og:
-            for tracer in og.tracers:
+        output_graph = self.output_graph_for_cleanup
+        if output_graph:
+            for tracer in output_graph.tracers:
                 tracer.graph._clear_nodes()
             # Also clear tracked_fakes to break FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor cycle
-            if og.tracing_context.fake_mode and og.tracing_context.fake_mode.shape_env:
-                og.tracing_context.fake_mode.shape_env.tracked_fakes = None
+            if (
+                output_graph.tracing_context.fake_mode
+                and output_graph.tracing_context.fake_mode.shape_env
+            ):
+                output_graph.tracing_context.fake_mode.shape_env.tracked_fakes = None
 
 
 err_epilogue = (

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2247,6 +2247,7 @@ class SubclassSymbolicContext(StatefulSymbolicContext):
             # pyrefly: ignore [bad-assignment]
             self.inner_contexts = {}
 
+
 @dataclass
 class TrackedFake:
     """
@@ -2254,18 +2255,31 @@ class TrackedFake:
     Used by shape guard computation.
     """
 
-    _fake: weakref.ReferenceType[Union[FakeTensor, SymInt]]
+    _fake: Union[weakref.ReferenceType[FakeTensor], SymInt]
     source: Source
     symbolic_context: Optional[SymbolicContext]
 
     @property
-    def fake(self) -> Union[FakeTensor, SymInt]:
-        return self._fake()
+    def fake(self) -> Optional[Union[FakeTensor, SymInt]]:
+        return (
+            self._fake()
+            if isinstance(self._fake, weakref.ReferenceType)
+            else self._fake
+        )
+
     @fake.setter
     def fake(self, value: Union[FakeTensor, SymInt]) -> None:
-        self._fake = weakref.ref(value)
+        if isinstance(value, SymInt):
+            self._fake = value
+        else:
+            self._fake = weakref.ref(value)
 
-    def __init__(self, fake: Union[FakeTensor, SymInt], source: Source, symbolic_context: Optional[SymbolicContext]) -> None:
+    def __init__(
+        self,
+        fake: Union[FakeTensor, SymInt],
+        source: Source,
+        symbolic_context: Optional[SymbolicContext],
+    ) -> None:
         self.fake = fake
         self.source = source
         self.symbolic_context = symbolic_context

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2254,35 +2254,9 @@ class TrackedFake:
     Used by shape guard computation.
     """
 
-    # _fake: Union[weakref.ReferenceType[FakeTensor], SymInt]
     fake: Union[FakeTensor, SymInt]
     source: Source
     symbolic_context: Optional[SymbolicContext]
-
-    # @property
-    # def fake(self) -> Optional[Union[FakeTensor, SymInt]]:
-    #     return (
-    #         self._fake()
-    #         if isinstance(self._fake, weakref.ReferenceType)
-    #         else self._fake
-    #     )
-
-    # @fake.setter
-    # def fake(self, value: Union[FakeTensor, SymInt]) -> None:
-    #     if isinstance(value, SymInt):
-    #         self._fake = value
-    #     else:
-    #         self._fake = weakref.ref(value)
-
-    def __init__(
-        self,
-        fake: Union[FakeTensor, SymInt],
-        source: Source,
-        symbolic_context: Optional[SymbolicContext],
-    ) -> None:
-        self.fake = fake
-        self.source = source
-        self.symbolic_context = symbolic_context
 
     def __hash__(self) -> int:
         return hash((self.fake, self.source.name))

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -30,7 +30,6 @@ import re
 import sys
 import threading
 import traceback
-import weakref
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
 from contextlib import _GeneratorContextManager, contextmanager
@@ -2255,24 +2254,25 @@ class TrackedFake:
     Used by shape guard computation.
     """
 
-    _fake: Union[weakref.ReferenceType[FakeTensor], SymInt]
+    # _fake: Union[weakref.ReferenceType[FakeTensor], SymInt]
+    fake: Union[FakeTensor, SymInt]
     source: Source
     symbolic_context: Optional[SymbolicContext]
 
-    @property
-    def fake(self) -> Optional[Union[FakeTensor, SymInt]]:
-        return (
-            self._fake()
-            if isinstance(self._fake, weakref.ReferenceType)
-            else self._fake
-        )
+    # @property
+    # def fake(self) -> Optional[Union[FakeTensor, SymInt]]:
+    #     return (
+    #         self._fake()
+    #         if isinstance(self._fake, weakref.ReferenceType)
+    #         else self._fake
+    #     )
 
-    @fake.setter
-    def fake(self, value: Union[FakeTensor, SymInt]) -> None:
-        if isinstance(value, SymInt):
-            self._fake = value
-        else:
-            self._fake = weakref.ref(value)
+    # @fake.setter
+    # def fake(self, value: Union[FakeTensor, SymInt]) -> None:
+    #     if isinstance(value, SymInt):
+    #         self._fake = value
+    #     else:
+    #         self._fake = weakref.ref(value)
 
     def __init__(
         self,

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -2223,7 +2223,7 @@ class Graph:
 
         return on_generate_code_context_manager()
 
-    def clear_nodes(self) -> None:
+    def _clear_nodes(self) -> None:
         nodes = [n for n in reversed(self.nodes)]
         for node in nodes:
             node.meta.clear()

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -2223,6 +2223,19 @@ class Graph:
 
         return on_generate_code_context_manager()
 
+    def clear_nodes(self) -> None:
+        nodes = [n for n in reversed(self.nodes)]
+        for node in nodes:
+            node.meta.clear()
+            self.erase_node(node)
+        # assert len(self.nodes) == 0
+        self._used_names.clear()
+        self._insert = self._root.prepend
+        self._len = 0
+        self._graph_namespace = _Namespace()
+        self._owning_module = None
+        self._tracer_cls = None
+        self._tracer_extras = None
 
 @contextmanager
 def _override_sym_repr(

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -2237,6 +2237,7 @@ class Graph:
         self._tracer_cls = None
         self._tracer_extras = None
 
+
 @contextmanager
 def _override_sym_repr(
     override: Callable[["torch.types.PySymType"], str],

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -2224,18 +2224,9 @@ class Graph:
         return on_generate_code_context_manager()
 
     def _clear_nodes(self) -> None:
-        nodes = [n for n in reversed(self.nodes)]
-        for node in nodes:
+        for node in reversed(self.nodes):
             node.meta.clear()
             self.erase_node(node)
-        # assert len(self.nodes) == 0
-        self._used_names.clear()
-        self._insert = self._root.prepend
-        self._len = 0
-        self._graph_namespace = _Namespace()
-        self._owning_module = None
-        self._tracer_cls = None
-        self._tracer_extras = None
 
 
 @contextmanager


### PR DESCRIPTION
Fixes #169388

This PR adds a cleanup for graphs from failed dynamo tracer outputs. These graphs hold onto reference cycles:
1. The nodes of the graph form a doubly linked list and point back to the graph, which creates a cycle
2. FakeTensorMode → ShapeEnv → TrackedFake → FakeTensor → FakeTensorMode creates a cycle

To avoid needing to do a full garbage collection, this change instead manually cleans up these reference cycles to allow for immediate garbage collection. Manually cleaning up in the unit tests mentioned takes 0.000453s on average. I measured this my manually timing all the cleanups and adding them up. On the other hand, garbage collecting at the start of swap_tensors takes 0.291s on average. The massive difference is why the manual cleanup is preferred.

Full benchmark results with 100 iterations with and w/o the manual cleanup
```
Average GC time WITHOUT cleanup: 0.290863s
Average GC time WITH cleanup:    0.269120s
Average cleanup overhead:        0.000453s

GC time difference (without - with): 0.021743s
Percentage reduction in GC time:     7.48%

Net benefit (gc_saved - cleanup_overhead): 0.021290s
```

**Test Plan:** In 3.14
```
test/nn/test_parametrization.py::TestNNParametrization::test_caching_parametrization_swap_True
test/nn/test_parametrization.py::TestNNParametrization::test_errors_parametrized_tensor_parametrization_swap_True
test/nn/test_parametrization.py::TestNNParametrization::test_new_spectral_norm_forward_swap_True
test/nn/test_parametrization.py::TestNNParametrization::test_parametrization_same_training_mode_swap_True
test/nn/test_parametrization.py::TestNNParametrization::test_type_before_parametrizations_swap_True
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo 