### PR TITLE
Remove platform_srcs from xplat/caffe2/third_party/xnnpack.buck.bzl (#169293)

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -144,7 +144,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("sse"),
+
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -160,12 +162,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("sse"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -208,7 +204,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse2"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse2"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("sse2"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -224,12 +221,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("sse2"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -272,7 +263,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("ssse3"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("ssse3"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("ssse3"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -288,12 +280,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("ssse3"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -336,7 +322,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse41"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse41"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("sse41"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -352,12 +339,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("sse41"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -400,7 +381,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -424,12 +406,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -473,7 +449,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx512vnnigfni"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -513,12 +490,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512vnnigfni"),
-            ),
-        ] if not is_arvr_mode() else []),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -565,7 +536,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vnni"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vnni"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx512vnni"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -604,12 +576,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512vnni"),
-            ),
-        ] if not is_arvr_mode() else []),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         exported_preprocessor_flags = [
@@ -657,7 +623,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
 
     fb_xplat_cxx_library(
         name = "ukernels_avxvnni",
-        srcs = prod_srcs_for_arch_wrapper("avxvnni") if is_arvr_mode() else [],
+        srcs = select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avxvnni"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avxvnni"),
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avxvnni"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -679,12 +650,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avxvnni"),
-            ),
-        ] if not is_arvr_mode() else []),
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -726,7 +691,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("f16c"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("f16c"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("f16c"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -750,12 +716,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("f16c"),
-            ),
-        ] if not is_arvr_mode() else []),
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -801,7 +761,9 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("fma3"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("fma3"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("fma3"),
+
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -828,12 +790,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("fma3"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -891,7 +847,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx2"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx2"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx2"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -921,12 +878,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx2"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -991,7 +942,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512f"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512f"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx512f"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1015,12 +967,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512f"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1036,7 +982,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512vbmi"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512vbmi"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx512vbmi"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1075,12 +1022,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512vbmi"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1138,7 +1079,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("avx512skx"),
             "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("avx512skx"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("avx512skx"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1174,12 +1116,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = ([
-            (
-                "x86|x86_64|platform009|platform010",
-                prod_srcs_for_arch_wrapper("avx512skx"),
-            ),
-        ] if not is_arvr_mode() else []),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1256,7 +1192,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("armsimd32"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1277,12 +1213,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("armsimd32"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1298,7 +1228,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neon"),
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1323,16 +1253,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neon"),
-            ),
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neon"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1346,20 +1266,14 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         name = "ukernels_neon_aarch64",
         srcs = select({
             "DEFAULT": [],
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon_aarch64"), 
-        }) if is_arvr_mode() else [],
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neon_aarch64"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neon_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1375,7 +1289,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1407,12 +1321,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neonfma"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1427,7 +1335,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1435,12 +1343,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-O2",
         ],
         labels = labels,
-        platform_srcs = [
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonfma") + prod_srcs_for_arch_wrapper("neonfma_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1456,8 +1358,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("fp16arith"),
-            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("fp16arith"),
-        }) if is_arvr_mode() else [],
+            "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("fp16arith") + prod_srcs_for_arch_wrapper("fp16arith_aarch64"),
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1504,16 +1406,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             )
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("fp16arith"),
-            ),
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("fp16arith") + prod_srcs_for_arch_wrapper("fp16arith_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1529,7 +1421,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16"),
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1554,16 +1446,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)$",
-                prod_srcs_for_arch_wrapper("neonfp16"),
-            ),
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonfp16"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1579,7 +1461,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonv8"),
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonv8"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1618,16 +1500,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)$",
-                prod_srcs_for_arch_wrapper("neonv8"),
-            ),
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonv8"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1642,7 +1514,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondot"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1667,12 +1539,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neondot"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1687,7 +1553,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1706,12 +1572,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neondot") + prod_srcs_for_arch_wrapper("neondot_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1726,7 +1586,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neondotfp16arith"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1750,12 +1610,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neondotfp16arith"),
-            ),
-        ] if not is_arvr_mode() else [],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1771,7 +1625,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1791,12 +1645,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neondotfp16arith") + prod_srcs_for_arch_wrapper("neondotfp16arith_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1812,7 +1660,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfp16arith"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1837,12 +1685,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("neonfp16arith"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1857,7 +1699,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1876,12 +1718,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("neonfp16arith") + prod_srcs_for_arch_wrapper("neonfp16arith_aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1897,7 +1733,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1931,16 +1767,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)$",
-                prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-            ),
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neonfma_i8mm"),
-            ),
-        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1956,7 +1782,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("neoni8mm"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = get_xnnpack_headers(),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1977,12 +1803,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(arm64|aarch64)",
-                prod_srcs_for_arch_wrapper("neoni8mm"),
-            ),
-        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1998,7 +1818,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("aarch32"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = subdir_glob([
             ("XNNPACK/src", "xnnpack/assembly.h"),
             ("XNNPACK/src", "**/*.S"),
@@ -2026,12 +1846,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch32|arm32|armv7)",
-                prod_srcs_for_arch_wrapper("aarch32"),
-            ),
-        ] if not is_arvr_mode() else [],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -2047,7 +1861,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         srcs = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("aarch64"),
-        }) if is_arvr_mode() else [],
+        }),
         headers = subdir_glob([
             ("XNNPACK/src", "xnnpack/assembly.h"),
             ("XNNPACK/src", "**/*.S"),
@@ -2071,12 +1885,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 ],
             ),
         ],
-        platform_srcs = [
-            (
-                "(aarch64|arm64)",
-                prod_srcs_for_arch_wrapper("aarch64"),
-            ),
-        ] if not is_arvr_mode() else [],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,


### PR DESCRIPTION
Summary:

Get rid of platform args around the repo to unblock modernization with platforms.
Platform args were only needed in buck1

Test Plan: CI

Differential Revision: D87744413


