### PR TITLE
[MPS][Inductor] Add _print_Where method to MetalExprPrinter for ReflectionPad support

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -74,7 +74,6 @@ test_failures = {
     "test_reduction2_dynamic_shapes": TestFailure(("mps",)),
     "test_reduction3_dynamic_shapes": TestFailure(("mps",)),
     "test_reduction5_dynamic_shapes": TestFailure(("mps",)),
-    "test_reflection_pad2d_dynamic_shapes": TestFailure(("mps",)),
     "test_roll_dynamic_shapes": TestFailure(("mps",)),
     "test_std_dynamic_shapes": TestFailure(("mps",)),
     "test_var_correction_dynamic_shapes": TestFailure(("mps",)),

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -167,6 +167,12 @@ class MetalExprPrinter(ExprPrinter_):
         x = self.doprint(expr.args[0])
         return f"metal::log2({x})"
 
+    def _print_Where(self, expr: sympy.Expr) -> str:
+        c, p, q = (
+            self.parenthesize(arg, PRECEDENCE["Atom"] - 0.5) for arg in expr.args
+        )
+        return f"{c} ? {p} : {q}"
+
 
 class MetalOverrides(OpOverrides):
     """Implements Metal-specific overrides for ops. Base class emits Python-friendly overrides."""


### PR DESCRIPTION
The `MetalExprPrinter` class was missing a `_print_Where()` method, causing sympy `Where` expressions to be emitted as raw `Where(...)` function calls in generated Metal Shading Language (MSL) code. Since `Where` is not a standard MSL function,compilation failed with "undeclared identifier 'Where'" error.

This PR adds the missing `_print_Where()` method to convert `Where(condition, true_val, false_val)` to Metal's C-style ternary operator `condition ? true_val : false_val`, following the same pattern as `CppPrinter`.

Fixes #169643

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
