### PR TITLE
[Memory Snapshot] Release alloc_buffer memory after stopping recording history

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3989,7 +3989,9 @@ class NativeCachingAllocator : public CUDAAllocator {
       const std::vector<std::string>& skip_actions) override {
     record_history = enabled;
     annotation_buffer.setMaxEntries(alloc_buffer_max_entries);
-    annotation_buffer.clear();
+    if (!enabled || clearHistory) {
+      annotation_buffer.clear();
+    }
     for (auto& allocator : device_allocator) {
       allocator->recordHistory(
           enabled,

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1097,6 +1097,7 @@ class RingBuffer {
     std::lock_guard<std::mutex> lk(alloc_trace_lock);
     alloc_trace_next = 0;
     alloc_trace->clear();
+    alloc_trace->shrink_to_fit();
   }
 
  private:


### PR DESCRIPTION
In our use case, we use memory snapshots for on-demand GPU memory allocation analysis. We found that after completion, memory usage would increase significantly. One important reason is that the buffer recording GPU memory allocation history is not released after finishing, so I want to release this buffer.