### PR TITLE
[ATen][FBGEMM] Add sm103a and sm110a flags to the FBGEMM GENAI kernels

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -272,7 +272,7 @@ IF(USE_FBGEMM_GENAI)
     foreach(cu_file ${fbgemm_genai_native_cuda_cu})
       _BUILD_FOR_ADDITIONAL_ARCHS(
         "${cu_file}"
-        "100a")
+        "100a;103a")
     endforeach()
 
     file(GLOB_RECURSE fbgemm_genai_native_cuda_cpp

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -272,7 +272,7 @@ IF(USE_FBGEMM_GENAI)
     foreach(cu_file ${fbgemm_genai_native_cuda_cu})
       _BUILD_FOR_ADDITIONAL_ARCHS(
         "${cu_file}"
-        "100a;103a")
+        "100a;103a;110a")
     endforeach()
 
     file(GLOB_RECURSE fbgemm_genai_native_cuda_cpp


### PR DESCRIPTION
Per title, adds `103a` and `110a` flags to the FBGEMM GENAI kernels to make them functional on B300/GB300 and THOR.

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia