### PR TITLE
[caffe2] add kineto header dep

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -979,6 +979,7 @@ def define_buck_targets(
         visibility = ["PUBLIC"],
         deps = [
             ":generated-version-header",
+            third_party("libkineto_headers"),
         ],
     )
 


### PR DESCRIPTION
Summary: The kineto headers are included in the `torch_headers` target, so require the target as a dep to build correctly.

Test Plan: CI

Differential Revision: D88487870


