### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from caffe2/torch/csrc/StorageSharing.cpp

### DIFF
--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -397,7 +397,7 @@ static PyObject* THPStorage_releaseIPCCounter(
         sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
         nullptr);
     *(static_cast<int64_t*>(sptr.get()) + ref_counter_offset) -= 1;
-  } catch (c10::Error& err) {
+  } catch (c10::Error&) {
     // Already warned inside of producer process
   }
   Py_RETURN_NONE;
@@ -538,7 +538,7 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
               sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
               nullptr);
           *(static_cast<int64_t*>(sptr.get()) + ctx->ref_counter_offset) -= 1;
-        } catch (c10::Error& err) {
+        } catch (c10::Error&) {
           // Already warned inside of producer process
         }
       },

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -321,7 +321,7 @@ void PyRRef::backwardOwnerRRef(
     py::object obj = torch::jit::toPyObject(value);
     try {
       value = torch::jit::toIValue(obj, c10::TensorType::get());
-    } catch (py::cast_error& e) {
+    } catch (py::cast_error&) {
       TORCH_CHECK(false, "RRef should contain a tensor for .backward()");
     }
   }

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<Operator> matchBuiltinOp(
         opWithStack;
     try {
       opWithStack = torch::jit::getOpWithStack(c10OpsForSymbol, args, kwargs);
-    } catch (const std::runtime_error& e) {
+    } catch (const std::runtime_error&) {
       opWithStack = torch::jit::getOpWithStack(ops, args, kwargs);
     }
     matchedOperator = std::move(std::get<0>(opWithStack));
@@ -170,7 +170,7 @@ c10::intrusive_ptr<JitFuture> toPyJitFuture(
               e.restore();
               PyErr_Clear();
               return;
-            } catch (std::exception& e) {
+            } catch (std::exception&) {
               child->setErrorIfNeeded(std::current_exception());
               return;
             }

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -121,7 +121,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::runPythonFunction(
     e.restore();
     PyErr_Clear();
     return future;
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     return asFuture(std::current_exception());
   }
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -70,7 +70,7 @@ AOTIModelContainerRunner::AOTIModelContainerRunner(
 #define TRY_LOAD_SYMBOL(var, name_str)                                               \
   try {                                                                              \
     var = reinterpret_cast<decltype(var)>(model_so_->sym(name_str));                 \
-  } catch (const at::DynamicLibraryError& e) {                                       \
+  } catch (const at::DynamicLibraryError&) {                                         \
     std::cerr                                                                        \
         << "[WARNING] Could not dlsym " << name_str                                  \
         << ". This is okay if you don't need functionality from " << name_str        \

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -173,7 +173,7 @@ std::shared_ptr<Graph> ToONNX(
         operator_export_type,
         env,
         values_in_env);
-  } catch (std::runtime_error& ex) {
+  } catch (std::runtime_error&) {
     ONNX_LOG(
         "ONNX graph being constructed during exception:\n",
         new_graph->toString());
@@ -443,7 +443,7 @@ void NodeToONNX(
       } else {
         outputs = py::cast<std::vector<Value*>>(raw_output);
       }
-    } catch (const std::exception& ex) {
+    } catch (const std::exception&) {
       std::ostringstream ss;
       ss << "Error casting results of symbolic for " << op_name
          << ": expected to return list of op nodes, instead received type ''"

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -159,7 +159,7 @@ std::optional<IValue> toTypeInferredIValueOptional(py::handle input) {
   // on various object types, but we want it to work with all types.
   try {
     return toTypeInferredIValue(input);
-  } catch (const c10::Error& e) {
+  } catch (const c10::Error&) {
     return std::nullopt;
   }
 }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -381,7 +381,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, std::optional<int32_t> N) {
       try {
         auto script_dict = py::cast<ScriptDict>(obj);
         return script_dict.dict_;
-      } catch (py::cast_error& e) {
+      } catch (py::cast_error&) {
       }
 
       // If not (i.e. it is a regular Python dictionary), make a new

--- a/torch/csrc/jit/python/python_dict.cpp
+++ b/torch/csrc/jit/python/python_dict.cpp
@@ -105,7 +105,7 @@ void initScriptDictBindings(PyObject* module) {
             try {
               return toPyObject(self->contains(
                   toIValue(std::move(key), self->type()->getKeyType())));
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::key_error();
             }
           })
@@ -117,7 +117,7 @@ void initScriptDictBindings(PyObject* module) {
             // Convert key to IValue.
             try {
               value = toIValue(std::move(key), self->type()->getKeyType());
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               // It would be nice to throw py::type_error here but py::key_error
               // needs to be thrown for parity with eager mode.
               throw py::key_error();
@@ -126,7 +126,7 @@ void initScriptDictBindings(PyObject* module) {
             // Call getItem on self.
             try {
               value = self->getItem(value);
-            } catch (const std::out_of_range& e) { // Key doesn't exist.
+            } catch (const std::out_of_range&) { // Key doesn't exist.
               throw py::key_error();
             }
 
@@ -145,7 +145,7 @@ void initScriptDictBindings(PyObject* module) {
             // Try to convert the key to an IValue.
             try {
               key_ivalue = toIValue(std::move(key), self->type()->getKeyType());
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
 
@@ -153,7 +153,7 @@ void initScriptDictBindings(PyObject* module) {
             try {
               value_ivalue =
                   toIValue(std::move(value), self->type()->getValueType());
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
 
@@ -167,7 +167,7 @@ void initScriptDictBindings(PyObject* module) {
             // Try to convert the key to an IValue.
             try {
               key_ivalue = toIValue(std::move(key), self->type()->getKeyType());
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
 

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -104,7 +104,7 @@ void initScriptListBindings(PyObject* module) {
             try {
               return toPyObject(self->contains(
                   toIValue(std::move(elem), self->type()->getElementType())));
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })
@@ -115,7 +115,7 @@ void initScriptListBindings(PyObject* module) {
             try {
               auto value = self->getItem(idx);
               return toPyObject(value);
-            } catch (const std::out_of_range& e) {
+            } catch (const std::out_of_range&) {
               throw py::index_error();
             }
           },
@@ -151,9 +151,9 @@ void initScriptListBindings(PyObject* module) {
               self->setItem(
                   idx,
                   toIValue(std::move(value), self->type()->getElementType()));
-            } catch (const std::out_of_range& e) {
+            } catch (const std::out_of_range&) {
               throw py::index_error();
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })
@@ -179,7 +179,7 @@ void initScriptListBindings(PyObject* module) {
                 self->setItem(
                     static_cast<ptrdiff_t>(start),
                     toIValue(value[i], self->type()->getElementType()));
-              } catch (const py::cast_error& e) {
+              } catch (const py::cast_error&) {
                 throw py::type_error();
               }
               start += step;
@@ -191,7 +191,7 @@ void initScriptListBindings(PyObject* module) {
              ScriptList::diff_type idx) {
             try {
               self->delItem(idx);
-            } catch (const std::out_of_range& e) {
+            } catch (const std::out_of_range&) {
               throw py::index_error();
             }
           })
@@ -207,7 +207,7 @@ void initScriptListBindings(PyObject* module) {
               return self->count(
                   toIValue(std::move(value), self->type()->getElementType()));
 
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })
@@ -217,7 +217,7 @@ void initScriptListBindings(PyObject* module) {
             try {
               return self->remove(
                   toIValue(std::move(value), self->type()->getElementType()));
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })
@@ -227,7 +227,7 @@ void initScriptListBindings(PyObject* module) {
             try {
               return self->append(
                   toIValue(std::move(value), self->type()->getElementType()));
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })
@@ -239,7 +239,7 @@ void initScriptListBindings(PyObject* module) {
           [](const std::shared_ptr<ScriptList>& self, py::list list) {
             try {
               self->extend(toIValue(std::move(list), self->type()));
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })
@@ -255,7 +255,7 @@ void initScriptListBindings(PyObject* module) {
                     py::reinterpret_borrow<py::object>(obj),
                     self->type()->getElementType()));
               }
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
 
@@ -279,7 +279,7 @@ void initScriptListBindings(PyObject* module) {
               self->insert(
                   toIValue(std::move(obj), self->type()->getElementType()),
                   idx);
-            } catch (const py::cast_error& e) {
+            } catch (const py::cast_error&) {
               throw py::type_error();
             }
           })

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -188,7 +188,7 @@ py::object PythonValue::getattr(
     const std::string& name) {
   try {
     return py::getattr(self, name.c_str());
-  } catch (py::error_already_set& e) {
+  } catch (py::error_already_set&) {
     throw(ErrorReport(loc) << "object has no attribute " << name);
   }
 }
@@ -907,7 +907,7 @@ bool PythonClassValue::hasAttr(
   try {
     py::getattr(py_type_, field.c_str());
     return true;
-  } catch (py::error_already_set& e) {
+  } catch (py::error_already_set&) {
     return false;
   }
 }

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -932,7 +932,7 @@ void initDispatchBindings(PyObject* module) {
       [](const char* dispatch_key) -> std::optional<c10::DispatchKey> {
         try {
           return c10::parseDispatchKey(dispatch_key);
-        } catch (const c10::Error& err) {
+        } catch (const c10::Error&) {
           return std::nullopt;
         }
       });


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Differential Revision: D88448354




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel