### PR TITLE
TestTritonDotReduction.test_matmul_fp16 correct tol

### DIFF
--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -20,10 +20,7 @@ aten = torch.ops.aten
 @inductor_config.patch({"triton.native_matmul": True})
 class TestTritonDotReduction(TestCase):
     def _check_equal(
-        self,
-        f: Callable,
-        example_inputs: tuple[torch.Tensor],
-        tol: float = 1e-4
+        self, f: Callable, example_inputs: tuple[torch.Tensor], tol: float = 1e-4
     ):
         compiled = torch.compile(f)
         actual = compiled(*example_inputs)

--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -23,11 +23,12 @@ class TestTritonDotReduction(TestCase):
         self,
         f: Callable,
         example_inputs: tuple[torch.Tensor],
+        tol: float = 1e-4
     ):
         compiled = torch.compile(f)
         actual = compiled(*example_inputs)
         expect = f(*example_inputs)
-        self.assertTrue(same(expect, actual))
+        self.assertTrue(same(expect, actual, tol=tol))
 
     def _check_code(
         self,
@@ -93,7 +94,11 @@ class TestTritonDotReduction(TestCase):
         x = rand_strided((M, K), (K, 1), dtype=torch.float16, device=GPU_TYPE)
         y = rand_strided((K, N), (N, 1), dtype=torch.float32, device=GPU_TYPE)
 
-        self._check_equal(f, (x, y))
+        # _check_equal calls torch._dynamo.utils.same with kwarg tol=1e-4.
+        # For fp16 dtype, torch.allclose() defaults to atol=1e-3 rtol=1e-5,
+        # but same() uses the single value to assign both, resulting in
+        # Accuracy failed: allclose not within tol=0.0001.
+        self._check_equal(f, (x, y), tol=1e-3)
         self._check_code(f, (x, y), 1, 1)
 
     def test_reduction_mask_zeroout(self):


### PR DESCRIPTION
Fixes #168196.  Replaces #169588.

_check_equal calls torch._dynamo.utils.same with kwarg tol=1e-4. For fp16 dtype, torch.allclose() defaults to atol=1e-3 rtol=1e-5, but same() uses the single tol value to assign both, resulting in

Accuracy failed: allclose not within tol=0.0001.

Replacing _check_equal's `self.assertTrue(same(expect, actual))` with `self.assertEqual(expect, actual, atol=1e-4, rtol=1e-4)` reveals

```
AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 16384 (0.0%)
Greatest absolute difference: 0.00390625 at index (66, 102) (up to 0.0001 allowed)
Greatest relative difference: 0.0006270408630371094 at index (66, 102) (up to 0.0001 allowed)
```

The solution here is to use same() with a tol=1e-3 to match default tolerance values for allclose and assertEqual.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo