### PR TITLE
Fix pin memory return type when input is a tuple

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -77,12 +77,10 @@ def pin_memory(data, device=None):
             # The mapping type may not support `copy()` / `update(mapping)`
             # or `__init__(iterable)`.
             return {k: pin_memory(sample, device) for k, sample in data.items()}
-    elif isinstance(data, tuple) and hasattr(data, "_fields"):  # namedtuple
-        return type(data)(*(pin_memory(sample, device) for sample in data))
     elif isinstance(data, tuple):
-        return [
-            pin_memory(sample, device) for sample in data
-        ]  # Backwards compatibility.
+        if hasattr(data, "_fields"):  # namedtuple
+            return type(data)(*(pin_memory(sample, device) for sample in data))
+        return type(data)(pin_memory(sample, device) for sample in data)
     elif isinstance(data, collections.abc.Sequence):
         try:
             if isinstance(data, collections.abc.MutableSequence):


### PR DESCRIPTION
Fixes #48419.

Will be refactoring the pin_memory function a little bit in another PR.
