### PR TITLE
Remove use of deprecated NumPy symbols.

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -4027,14 +4027,20 @@ class TestBinaryUfuncs(TestCase):
         def test_dx(sizes, dim, dx, device):
             t = torch.randn(sizes, device=device)
             actual = torch.trapezoid(t, dx=dx, dim=dim)
-            expected = np.trapz(t.cpu().numpy(), dx=dx, axis=dim)  # noqa: NPY201
+            if int(np.__version__.split(".")[0]) >= 2:
+                expected = np.trapezoid(t.cpu().numpy(), dx=dx, axis=dim)  # noqa: NPY201
+            else:
+                expected = np.trapz(t.cpu().numpy(), dx=dx, axis=dim)  # noqa: NPY201
             self.assertEqual(expected.shape, actual.shape)
             self.assertEqual(expected, actual, exact_dtype=False)
 
         def test_x(sizes, dim, x, device):
             t = torch.randn(sizes, device=device)
             actual = torch.trapezoid(t, x=torch.tensor(x, device=device), dim=dim)
-            expected = np.trapz(t.cpu().numpy(), x=x, axis=dim)  # noqa: NPY201
+            if int(np.__version__.split(".")[0]) >= 2:
+                expected = np.trapezoid(t.cpu().numpy(), x=x, axis=dim)  # noqa: NPY201
+            else:
+                expected = np.trapz(t.cpu().numpy(), x=x, axis=dim)  # noqa: NPY201
             self.assertEqual(expected.shape, actual.shape)
             self.assertEqual(expected, actual.cpu(), exact_dtype=False)
 

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -257,8 +257,8 @@ class TestTensorBoardUtils(BaseTestCase):
             total_frame = s[1]
             V_input = np.swapaxes(V_input, 0, 1)
             for f in range(total_frame):
-                x = np.reshape(V_input[f], newshape=(-1))
-                y = np.reshape(V_after[f], newshape=(-1))
+                x = np.reshape(V_input[f], -1)
+                y = np.reshape(V_after[f], -1)
                 np.testing.assert_array_almost_equal(np.sum(x), np.sum(y))
 
     def test_numpy_vid_uint8(self):

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -67,9 +67,9 @@ def _prepare_video(V):
     # pyrefly: ignore [index-error]
     n_cols = V.shape[0] // n_rows
 
-    V = np.reshape(V, newshape=(n_rows, n_cols, t, c, h, w))
+    V = np.reshape(V, (n_rows, n_cols, t, c, h, w))
     V = np.transpose(V, axes=(2, 0, 4, 1, 5, 3))
-    V = np.reshape(V, newshape=(t, n_rows * h, n_cols * w, c))
+    V = np.reshape(V, (t, n_rows * h, n_cols * w, c))
 
     return V
 


### PR DESCRIPTION
np.trapz and np.reshape(..., newshape=...) are being removed in numpy 2.4

https://github.com/numpy/numpy/commit/95cdc307c91b53b33e48cffb66184209bfe7eff5
https://github.com/numpy/numpy/commit/e4d64414394cbb2ae62e0f61c3230ba88f537090
