### PR TITLE
Dynamo bug fix: Missing meta kernel for aten::quantize_per_tensor.tensor_qparams

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4036,6 +4036,7 @@ class GraphModule(torch.nn.Module):
         g = torch.compile(fn, backend="eager", fullgraph=True)(t)
         self.assertEqual(e, g)
 
+    @unittest.skipIf(sys.platform == "darwin", "No mkldnn on MacOS")
     def test_quantize_per_tensor(self):
         def fn(t, scale, zero_point):
             return torch.quantize_per_tensor(t, scale, zero_point, torch.quint8)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4036,6 +4036,19 @@ class GraphModule(torch.nn.Module):
         g = torch.compile(fn, backend="eager", fullgraph=True)(t)
         self.assertEqual(e, g)
 
+    def test_quantize_per_tensor(self):
+        def fn(t, scale, zero_point):
+            return torch.quantize_per_tensor(t, scale, zero_point, torch.quint8)
+
+        scale = torch.tensor(2.0)
+        zero_point = torch.tensor(10.0)
+        t = torch.rand((2, 2)) * scale + zero_point
+
+        result = fn(t, scale, zero_point)
+        compiled_fn = torch.compile(fn, fullgraph=True)
+        compiled_result = compiled_fn(t, scale, zero_point)
+        self.assertEqual(compiled_result, result)
+
     def test_map_return(self):
         def fn(a, b):
             return map(lambda x: x + 1, [a, b])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2938,6 +2938,12 @@ if torch._C._has_mkldnn:
         "quantized", "IMPL", "Meta"
     )
 
+    @register_meta(aten.quantize_per_tensor)
+    def meta_quantize_per_tensor(
+        input: torch.Tensor, scale: float, zero_point: int, dtype: torch.dtype
+    ) -> torch.Tensor:
+        return torch.empty_like(input, device="meta")
+
     @register_meta(torch.ops.quantized.max_pool2d)
     def meta_quantized_max_pool2d(
         input,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2942,7 +2942,7 @@ if torch._C._has_mkldnn:
     def meta_quantize_per_tensor(
         input: torch.Tensor, scale: float, zero_point: int, dtype: torch.dtype
     ) -> torch.Tensor:
-        return torch.empty_like(input, device="meta")
+        return torch.empty_like(input)
 
     @register_meta(torch.ops.quantized.max_pool2d)
     def meta_quantized_max_pool2d(


### PR DESCRIPTION
Fixes #157729
added meta registration for quantize_per_tensor

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98