### PR TITLE
[WIP] Fix bw graph input ordering bug in default partitioner

### DIFF
--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -249,9 +249,21 @@ def aot_eager(
 
 register_backend(name="aot_eager", compiler_fn=aot_eager)
 
-aot_eager_default_partitioner = aot_autograd(
-    fw_compiler=boxed_nop, keep_inference_input_mutations=True
-)
+
+def aot_eager_default_partitioner(
+    gm: torch.fx.GraphModule,
+    fake_tensor_inputs: list[torch.Tensor],
+    fw_compiler: Optional[Callable[..., Any]] = None,
+    bw_compiler: Optional[Callable[..., Any]] = None,
+    **kwargs: Any,
+) -> Callable[..., Any]:
+    return aot_autograd(
+        fw_compiler=fw_compiler or boxed_nop,
+        bw_compiler=bw_compiler or boxed_nop,
+        keep_inference_input_mutations=True,
+    )(gm, fake_tensor_inputs, **kwargs)
+
+
 register_backend(
     name="aot_eager_default_partitioner", compiler_fn=aot_eager_default_partitioner
 )

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -984,8 +984,10 @@ def _extract_fwd_bwd_modules(
     )
     bwd_graph = _extract_graph_with_inputs_outputs(
         joint_module.graph,
-        saved_sym_nodes
-        + saved_values
+        # The ordering here should match the ordering of the output
+        # of fwd_graph
+        saved_values
+        + saved_sym_nodes
         + tangent_inputs
         + bwd_seed_offset_inputs
         + backward_state_inputs,


### PR DESCRIPTION
Fixes #169712

The ordering of the inputs to the backward should match the ordering of the outputs of the forward graph.

The only real change is in `partitioners.py`, all other changes are just to make testing easier, e.g. allow `aot_eager_default_partitioner` to take in fw/bw compilers.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo