### PR TITLE
[CI] Workaround `relocation truncated to fit: R_AARCH64_CALL26` linker error

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1172,7 +1172,7 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
     # Workaround for relocation truncated to fit: R_AARCH64_CALL26 against symbol __aarch64_swp4_relax'
     # When compiling for ARMv8.0, build uv with embedded atomics, which are slightly slower
     # But are used only once during shutdown
-    if(CMAKE_SYSTEM_PROCESSOR EQUAL aarch64)
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
       target_compile_options_if_supported(tensorpipe_uv -mno-outline-atomics)
     endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1170,7 +1170,8 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
     # See https://github.com/pytorch/pytorch/issues/151316
     target_compile_options_if_supported(tensorpipe -Wno-missing-template-arg-list-after-template-kw)
     # Workaround for relocation truncated to fit: R_AARCH64_CALL26 against symbol __aarch64_swp4_relax'
-    # On aarch64 platform - embed atomics
+    # When compiling for ARMv8.0, build uv with embedded atomics, which are slightly slower
+    # But are used only once during shutdown
     if(CMAKE_SYSTEM_PROCESSOR EQUAL aarch64)
       target_compile_options_if_supported(tensorpipe_uv -mno-outline-atomics)
     endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1169,6 +1169,11 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
     # Suppress warning to unblock libnop compilation by clang-17
     # See https://github.com/pytorch/pytorch/issues/151316
     target_compile_options_if_supported(tensorpipe -Wno-missing-template-arg-list-after-template-kw)
+    # Workaround for relocation truncated to fit: R_AARCH64_CALL26 against symbol __aarch64_swp4_relax'
+    # On aarch64 platform - embed atomics
+    if(CMAKE_SYSTEM_PROCESSOR EQUAL aarch64)
+      target_compile_options_if_supported(tensorpipe_uv -mno-outline-atomics)
+    endif()
 
     list(APPEND Caffe2_DEPENDENCY_LIBS tensorpipe)
     list(APPEND Caffe2_DEPENDENCY_LIBS nlohmann)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #169723

By using `-mno-outline-atomics` compiler option, that will embed atomic instructions, instead of inserting `__aarch64_swp4_relax` call