### PR TITLE
[DLPack] Change C Exchange API to __dlpack_c_exchange_api__ PyCapsule

### DIFF
--- a/aten/src/ATen/dlpack.h
+++ b/aten/src/ATen/dlpack.h
@@ -391,7 +391,7 @@ typedef struct DLManagedTensorVersioned {
  * \param error_ctx Context for `SetError`.
  * \param SetError The function to set the error.
  * \return The owning DLManagedTensorVersioned* or NULL on failure.
- *         SetError is called exactly when NULL is returned (the implementor
+ *         SetError is called exactly when NULL is returned (the implementer
  *         must ensure this).
  * \note - As a C function, must not thrown C++ exceptions.
  *       - Error propagation via SetError to avoid any direct need
@@ -430,16 +430,17 @@ typedef int (*DLPackManagedTensorFromPyObjectNoSync)(                 //
 /*!
  * \brief Exports a PyObject* Tensor/NDArray to a provided DLTensor.
  *
- * This function provides a faster interface for temporary, non-owning, exchange.
- * The producer (implementor) still owns the memory of data, strides, shape.
- * The liveness of the DLTensor and the data it views is only guaranteed until
- * control is returned.
+ * This function provides a faster interface for temporary, non-owning,
+ * exchange. The producer (implementer) still owns the memory of data, strides,
+ * shape. The liveness of the DLTensor and the data it views is only guaranteed
+ * until control is returned.
  *
- * This function currently assumes that the producer (implementor) can fill
+ * This function currently assumes that the producer (implementer) can fill
  * in the DLTensor shape and strides without the need for temporary allocations.
  *
- * This function does not perform any stream synchronization. The consumer should query
- * DLPackCurrentWorkStream to get the current work stream and launch kernels on it.
+ * This function does not perform any stream synchronization. The consumer
+ * should query DLPackCurrentWorkStream to get the current work stream and
+ * launch kernels on it.
  *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
@@ -487,7 +488,7 @@ typedef int (*DLPackCurrentWorkStream)(                         //
  * \brief Imports a DLManagedTensorVersioned to a PyObject* Tensor/NDArray.
  *
  * Convert an owning DLManagedTensorVersioned* to the Python tensor of the
- * producer (implementor) library with the correct type.
+ * producer (implementer) library with the correct type.
  *
  * This function does not perform any stream synchronization.
  *

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -542,8 +542,8 @@ class TestTorchDlPack(TestCase):
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it
-        self.assertTrue(hasattr(torch.Tensor, "__c_dlpack_exchange_api__"))
-        api_capsule = torch.Tensor.__c_dlpack_exchange_api__
+        self.assertTrue(hasattr(torch.Tensor, "__dlpack_c_exchange_api__"))
+        api_capsule = torch.Tensor.__dlpack_c_exchange_api__
         self.assertEqual(
             type(api_capsule).__name__, "PyCapsule", "API should be a PyCapsule"
         )

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -109,7 +109,7 @@ def _dtype_to_typestr(dtype):
 # otherwise, it will not show up in autocomplete.
 class Tensor(torch._C.TensorBase):
     _is_param: bool
-    __c_dlpack_exchange_api__: object = torch._C._dlpack_exchange_api()
+    __dlpack_c_exchange_api__: object = torch._C._dlpack_exchange_api()
 
     def _clear_non_serializable_cached_data(self):
         r"""Clears any data cached in the tensor's ``__dict__`` that would prevent the tensor


### PR DESCRIPTION
As per discussion https://github.com/dmlc/dlpack/issues/179 and https://github.com/pytorch/pytorch/issues/162845#issuecomment-3609127149, we decide to change DLPack C exchange API from `__c_dlpack_exchange_api__` to `__dlpack_c_exchange_api__` and expose it as PyCapsule. This PR conforms to the latest convention.