### PR TITLE
[CI][CD][Docker] Fix a Typo For Nightly Docker Image Tag and Publish

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           make -f docker.Makefile "${BUILD_IMAGE_TYPE}-image"
       - name: Push nightly tags
-        if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' && matrix.platform == 'linux/amd4' }}
+        if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' && matrix.platform == 'linux/amd64' }}
         run: |
           PYTORCH_DOCKER_TAG="${PYTORCH_VERSION}-cuda${CUDA_VERSION_SHORT}-cudnn${CUDNN_VERSION}-runtime"
           CUDA_SUFFIX="-cu${CUDA_VERSION}"


### PR DESCRIPTION
Trace back to 2024 https://github.com/pytorch/pytorch/pull/125845

Credits go to AI Agent for noticing this typo.

Repro: pull the latest pytorch nightly tag: ghcr.io/pytorch/pytorch-nightly:latest 
pip list shows: 
torch                     2.4.0.dev20240509 

cc @ptrblck @eqy @tinglvv @atalman @malfet @Skylion007 