### PR TITLE
Maintain contiguity in sdpa

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5864,17 +5864,24 @@ def meta__scaled_dot_product_flash_attention_for_cpu(
     batch_size = query.size(0)
     num_heads = query.size(1)
     max_seqlen_batch_q = query.size(2)
+    head_dim = query.size(3)
 
-    attention = torch.empty_like(query)
+    # Return a contiguous output tensor to ensure consistent strides across
+    # all SDPA backends. This is important for export/decomposition flows.
+    attention = torch.empty(
+        (batch_size, num_heads, max_seqlen_batch_q, head_dim),
+        dtype=query.dtype,
+        device=query.device,
+    )
     logsumexp = torch.empty(
         (
             batch_size,
-            max_seqlen_batch_q,
             num_heads,
+            max_seqlen_batch_q,
         ),
         dtype=torch.float,
         device=query.device,
-    ).transpose(1, 2)
+    )
     return (
         attention,
         logsumexp,


### PR DESCRIPTION
See: https://fb.workplace.com/groups/1028545332188949/permalink/1379574600419352/

Note: used claude, not sure if it's the correct fix.

Confirm that we can 
1. export sdpa math backend
2. functionalize with ep.run_decompositions({})
3. re-export

without errors. This seems to replace the original contiguous function with a clone.

Original error:
```

1. First export...
   First export succeeded! Trying to run
...
scaled_dot_product_attention: shape=torch.Size([1, 16, s11, 128]), stride=(2048*s11, 128*s11, 128, 1)
transpose_3: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 128, 128*s11, 1)
contiguous: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 2048, 128, 1)
view_3: shape=torch.Size([1, s11, 2048]), stride=(2048*s11, 2048, 1)

2. run_decompositions({})...
...
scaled_dot_product_attention: shape=torch.Size([1, 16, s11, 128]), stride=(2048*s11, 128, 2048, 1)
transpose_3: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 2048, 128, 1)
view_3: shape=torch.Size([1, s11, 2048]), stride=(2048*s11, 2048, 1)

   run_decompositions succeeded!

5. Second export (simulating export_to_edge)...
E1205 20:48:47.367000 426542 pytorch/torch/export/_trace.py:1250] always_classified is unsupported.
E1205 20:48:47.368000 426542 pytorch/torch/export/_trace.py:1250] always_classified is unsupported.
   FAILED (expected): TorchRuntimeError, Dynamo failed to run FX node with fake tensors: call_function aten.view.default(*(FakeTensor(..., size=(1, s11, 16, 128)), [1, s11, 2048]), **{}): got ValueError('Cannot view a tensor with shape torch.Size([1, s11, 16, 128]) and strides (2048*s11, 128, 128*s11, 1) as a tensor with shape (1, s11, 2048)!')
```
Notice that
1. scaled_dot_product_attention has different strides after run_decompositions({}), and is no longer contiguous. 
2. The contiguous() call is gone after run_decompositions({})
3. The failure is related to view, which could be because we can't (always) view on an uncontiguous tensor.

```
1. First export...
   First export succeeded! Trying to run
...
scaled_dot_product_attention: shape=torch.Size([1, 16, s11, 128]), stride=(2048*s11, 128*s11, 128, 1)
transpose_3: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 128, 128*s11, 1)
contiguous: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 2048, 128, 1)
view_3: shape=torch.Size([1, s11, 2048]), stride=(2048*s11, 2048, 1)
linear_3: shape=torch.Size([1, s11, 2048]), stride=(2048*s11, 2048, 1)
linear_4: shape=torch.Size([1, s11, 1000]), stride=(1000*s11, 1000, 1)

4. run_decompositions({})...
...
scaled_dot_product_attention: shape=torch.Size([1, 16, s11, 128]), stride=(2048*s11, 128*s11, 128, 1)
transpose_3: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 128, 128*s11, 1)
clone: shape=torch.Size([1, s11, 16, 128]), stride=(2048*s11, 2048, 128, 1)
view_3: shape=torch.Size([1, s11, 2048]), stride=(2048*s11, 2048, 1)
linear_3: shape=torch.Size([1, s11, 2048]), stride=(2048*s11, 2048, 1)
linear_4: shape=torch.Size([1, s11, 1000]), stride=(1000*s11, 1000, 1)
   run_decompositions succeeded!
```

Test
```
python test/test_fake_tensor.py FakeTensorTest.test_sdpa_flash_attention_cpu_output_contiguous
```
