### PR TITLE
Removing unnecessary wait_tensor interception in LocalTensor

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1307,8 +1307,6 @@ class LocalTensorMode(TorchDispatchMode):
                 return _c10d._local_functional_reduce_scatter_tensor(*args, **kwargs)
             elif func is torch.ops._c10d_functional.all_to_all_single.default:
                 return _c10d._local_functional_all_to_all_single(*args, **kwargs)
-            elif func is torch.ops._c10d_functional.wait_tensor.default:
-                return _c10d._local_functional_wait_tensor(*args, **kwargs)
             else:
                 with LocalTensorMode(self.ranks):
                     return func._op_dk(

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -281,15 +281,6 @@ def _local_functional_all_to_all_single(
     return output
 
 
-def _local_functional_wait_tensor(tensor: torch.Tensor) -> torch.Tensor:
-    # "wait_tensor(Tensor input) -> Tensor"
-    from . import LocalTensor
-
-    assert isinstance(tensor, LocalTensor), "Input tensor must be a LocalTensor"
-
-    return tensor
-
-
 def _local_broadcast_(
     tensors: list[torch.Tensor],
     process_group_so: ScriptObject,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169734

Base implementation for wait_tensor pops work from registry, waits
on it and then returns passed in object. Not draining registry
(as current implementation incorrectly does) results in leaking
work objects and may result in incorrect outcome when using LocalRunner.