### PR TITLE
Fix vhappi_common_backend GCC build by moving Clang-specific flags

### DIFF
--- a/c10/util/BUILD_MODE.bzl
+++ b/c10/util/BUILD_MODE.bzl
@@ -1,0 +1,36 @@
+""" build mode definitions for caffe2/c10/util """
+
+load("@fbcode//:BUILD_MODE.bzl", get_parent_modes = "get_empty_modes")
+load("@fbcode_macros//build_defs:create_build_mode.bzl", "extend_build_modes")
+
+_extra_cflags = [
+]
+
+_common_flags = [
+]
+
+_extra_clang_flags = _common_flags + [
+    # Clang-specific warning flags (not supported by GCC)
+    # The -pedantic flag enables strict ISO C++ compliance checks
+    # GCC's -pedantic rejects __int128 which is used in folly headers
+    "-pedantic",
+]
+
+_extra_gcc_flags = _common_flags + [
+    # GCC doesn't work well with -pedantic due to __int128 usage in folly
+]
+
+_tags = [
+]
+
+_modes = extend_build_modes(
+    get_parent_modes(),
+    c_flags = _extra_cflags,
+    clang_flags = _extra_clang_flags,
+    gcc_flags = _extra_gcc_flags,
+    tags = _tags,
+)
+
+def get_modes():
+    """ Return modes for this file """
+    return _modes


### PR DESCRIPTION
Summary: The vhappi_common_backend target was applying the Clang-specific warning flag -Wdeprecated-non-prototype to all compiler builds, causing GCC builds to fail since GCC doesn't support this flag. This moves the Clang-specific flag from the target's cpp_compiler_flags to be applied only during Clang compilation via the BUILD_MODE.bzl file, allowing the target to build successfully with both compilers.

Test Plan:
```
buck build fbcode//mode/dbg-gcc fbcode//infra_asic_fpga/validation/common_gen2:vhappi_common_backend
buck build fbcode//mode/dev fbcode//infra_asic_fpga/validation/common_gen2:vhappi_common_backend
```
Both builds succeed.

Reviewed By: ghua-fb

Differential Revision: D88011353


