### PR TITLE
[MPS][BugFix] Fix `adaptive_max_pool2d` on MPS to properly check for non-divisible input sizes.

### DIFF
--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -200,7 +200,7 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_out_mps)
   int64_t strideH = 0, strideW = 0;
   int64_t kernel_sizeH = 0, kernel_sizeW = 0;
 
-  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW);
+  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW, true);
 
   at::max_pool2d_with_indices_out(const_cast<Tensor&>(output),
                                   const_cast<Tensor&>(indices),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5064,6 +5064,7 @@ class CommonTemplate:
             (torch.randn(2, 4, 6, 6),),
         )
 
+    @xfail_if_mps
     @skip_if_gpu_halide  # slow
     def test_adaptive_max_pool2d2(self):
         # Big kernel size, use fallback


### PR DESCRIPTION
Enable `check_avg_pooling` parameter in `set_kernel_params()` call for `adaptive_max_pool2d`

Fixes #169738

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @malfet

This is a **temporary fix**. The proper solution would be to implement true adaptive max pooling on MPS that supports non-divisible input sizes, similar to the CPU and CUDA implementations where each output element can have a different sized input window. See [issue #96056](https://github.com/pytorch/pytorch/issues/96056) for tracking.
