### PR TITLE
Rm platform compiler flags from xplat/caffe2/third_party/xnnpack.buck.bzl

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -152,16 +152,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-msse",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -178,16 +178,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-msse",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -211,16 +211,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse2",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse2",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-msse2",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -237,16 +237,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse2",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse2",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-msse2",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -270,16 +270,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mssse3",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mssse3",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-mssse3",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -296,16 +296,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mssse3",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mssse3",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-mssse3",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -329,16 +329,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse4.1",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse4.1",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-msse4.1",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -355,16 +355,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-msse4.1",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-msse4.1",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-msse4.1",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -398,14 +398,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -423,16 +415,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         compiler_flags = [
             "-O2",
             "-mavx",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-mavx",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -474,27 +466,17 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-mavx512bw",
                 "-mavx512dq",
             ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:windows": WINDOWS_FLAGS + ["-mavx"] + select({
+                "DEFAULT": [],
+                "ovr_config//compiler:clang-windows": WINDOWS_CLANG_COMPILER_FLAGS,
+            }),
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                    "-mavx512vnni",
-                    "-mgfni",
-                ],
-            ),
-        ],
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
-        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mavx"],
-        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mavx"],
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
 
@@ -505,27 +487,37 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx512f",
+                "-mavx512cd",
+                "-mavx512bw",
+                "-mavx512dq",
+                "-mavx512vl",
+                "-mavx512vnni",
+                "-mgfni",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx512f",
+                "-mavx512cd",
+                "-mavx512bw",
+                "-mavx512dq",
+                "-mavx512vl",
+                "-mavx512vnni",
+                "-mgfni",
+            ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:windows": WINDOWS_FLAGS + ["-mavx"] + select({
+                "DEFAULT": [],
+                "ovr_config//compiler:clang-windows": WINDOWS_CLANG_COMPILER_FLAGS,
+            }),
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                    "-mavx512vnni",
-                    "-mgfni",
-                ],
-            ),
-        ],
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
-        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mavx"],
-        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mavx"],
         windows_srcs = prod_srcs_for_arch_wrapper("avx512vnnigfni"),
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
@@ -561,29 +553,20 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-mavx512vl",
                 "-mavx512vnni",
             ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:windows": WINDOWS_FLAGS + ["-mavx"] + select({
+                "DEFAULT": [],
+                "ovr_config//compiler:clang-windows": WINDOWS_CLANG_COMPILER_FLAGS,
+            }),
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                    "-mavx512vnni",
-                ],
-            ),
-        ],
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         exported_preprocessor_flags = [
             "-DXNN_ENABLE_AVX512VNNI"
         ],
         visibility = ["PUBLIC"],
-        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mavx"],
-        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mavx"],
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
 
@@ -594,29 +577,38 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx512f",
+                "-mavx512cd",
+                "-mavx512bw",
+                "-mavx512dq",
+                "-mavx512vl",
+                "-mavx512vnni",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx512f",
+                "-mavx512cd",
+                "-mavx512bw",
+                "-mavx512dq",
+                "-mavx512vl",
+                "-mavx512vnni",
+            ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:windows": WINDOWS_FLAGS + ["-mavx"] + select({
+                "DEFAULT": [],
+                "ovr_config//compiler:clang-windows": WINDOWS_CLANG_COMPILER_FLAGS,
+            }),
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                    "-mavx512vnni",
-                ],
-            ),
-        ],
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         exported_preprocessor_flags = [
             "-DXNN_ENABLE_AVX512VNNI"
         ],
         visibility = ["PUBLIC"],
-        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mavx"],
-        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mavx"],
         windows_srcs = prod_srcs_for_arch_wrapper("avx512vnni"),
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
@@ -637,19 +629,22 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-mavxvnni",
             "-mf16c",
             "-mfma",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx2",
+                "-mavxvnni",
+                "-mf16c",
+                "-mfma",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx2",
+                "-mavxvnni",
+                "-mf16c",
+                "-mfma",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx2",
-                    "-mavxvnni",
-                    "-mf16c",
-                    "-mfma",
-                ],
-            ),
-        ],
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -665,17 +660,18 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         apple_sdks = (IOS, MACOSX),
         compiler_flags = [
             "-O2",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx2",
+                "-mavxvnni",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx2",
+                "-mavxvnni",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx2",
-                    "-mavxvnni",
-                ],
-            ),
-        ],
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
@@ -708,14 +704,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mf16c",
-                ],
-            ),
-        ],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -734,16 +722,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         compiler_flags = [
             "-O2",
             "-mf16c",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mf16c",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mf16c",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-mf16c",
-                ],
-            ),
-        ],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -781,15 +769,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(i[3-6]86|x86|x86_64|AMD64)",
-                [
-                    "-mfma",
-                    "-mf16c",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -814,17 +793,18 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-O2",
             "-mfma",
             "-mf16c",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mfma",
+                "-mf16c",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mfma",
+                "-mf16c",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "^(i[3-6]86|x86|x86_64|AMD64)$",
-                [
-                    "-mfma",
-                    "-mf16c",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -868,16 +848,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx2",
-                    "-mfma",
-                    "-mf16c",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -905,18 +875,20 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-mavx2",
             "-mfma",
             "-mf16c",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx2",
+                "-mfma",
+                "-mf16c",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx2",
+                "-mfma",
+                "-mf16c",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-mavx2",
-                    "-mfma",
-                    "-mf16c",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -959,14 +931,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86|x86_64|platform009|platform010",
-                [
-                    "-mavx512f",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1009,19 +973,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(i[3-6]86|x86|x86_64|AMD64)",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                    "-mavx512vbmi",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1053,16 +1004,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         compiler_flags = [
             "-O2",
             "-mavx512f",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx512f",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx512f",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "x86",
-                [
-                    "-mavx512f",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1104,18 +1055,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(i[3-6]86|x86|x86_64|AMD64)",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1150,20 +1089,24 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-mavx512bw",
             "-mavx512dq",
             "-mavx512vl",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": [
+                "-mavx512f",
+                "-mavx512cd",
+                "-mavx512bw",
+                "-mavx512dq",
+                "-mavx512vl",
+            ],
+            "ovr_config//cpu:x86_64": [
+                "-mavx512f",
+                "-mavx512cd",
+                "-mavx512bw",
+                "-mavx512dq",
+                "-mavx512vl",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "^(i[3-6]86|x86|x86_64|AMD64)$",
-                [
-                    "-mavx512f",
-                    "-mavx512cd",
-                    "-mavx512bw",
-                    "-mavx512dq",
-                    "-mavx512vl",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1200,19 +1143,16 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-O2",
             "-fno-fast-math",
             "-fno-math-errno",
-        ],
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:arm32": [
+                "-marm",
+                "-march=armv6",
+                "-mfpu=vfp",
+                "-munaligned-access",
+            ],
+        }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(arm32|aarch32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv6",
-                    "-mfpu=vfp",
-                    "-munaligned-access",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1243,16 +1183,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv7-a",
-                    "-mfpu=neon",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1302,25 +1232,14 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-march=armv7-a",
                 "-mfpu=neon-vfpv4",
             ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:iphoneos-arm32": [
+                "-mcpu=cyclone",
+                "-mtune=generic",
+            ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "^iphoneos-armv7$",
-                [
-                    "-mcpu=cyclone",
-                    "-mtune=generic",
-                ],
-            ),
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv7-a",
-                    "-mfpu=neon-vfpv4",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1385,27 +1304,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv8.2-a+fp16",
-                    # GCC emits wrong directives for assembler with -mfpu=fp-armv8
-                    "-mfpu=neon-fp-armv8",
-                    # For vsqrth_f16 polyfill using sqrtf
-                    "-fno-math-errno",
-                    # For vminh_f16/vmaxh_f16 polyfills using compare + select
-                    "-ffinite-math-only",
-                ],
-            ),
-            (
-                "(aarch64|arm64)",
-                [
-                    "-march=armv8.2-a+fp16",
-                ],
-            )
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1436,16 +1334,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv7-a",
-                    "-mfpu=neon-fp16",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1475,31 +1363,21 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-march=armv8-a",
                 "-mfpu=neon-fp-armv8",
             ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:android-arm32": [
+                "-marm",
+                "-march=armv8-a",
+                "-mfpu=neon-fp-armv8",
+            ],
+        }) + select({
+            "DEFAULT": [],
+            "ovr_config//os:iphoneos-arm32": [
+                "-mcpu=cyclone",
+                "-mtune=generic",
+            ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch64|arm64)",
-                [
-                    "-march=armv8-a",
-                ],
-            ),
-            (
-                "^android-armv7$",
-                [
-                    "-marm",
-                    "-march=armv8-a",
-                    "-mfpu=neon-fp-armv8",
-                ],
-            ),
-            (
-                "^iphoneos-armv7$",
-                [
-                    "-mcpu=cyclone",
-                    "-mtune=generic",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1529,16 +1407,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-march=armv8.2-a+dotprod",
-                    "-mfpu=neon-fp-armv8",
-                    "-mfloat-abi=softfp",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1564,14 +1432,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "ovr_config//cpu:arm64": ["-march=armv8.2-a+dotprod"],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch64|arm64)",
-                [
-                    "-march=armv8.2-a+dotprod",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1600,16 +1460,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-mfpu=neon-fp-armv8",
             ],
         }),
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv8.2-a+dotprod+fp16",
-                    "-mfpu=neon-fp-armv8",
-                ],
-            ),
-        ],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1637,14 +1487,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
                 "-march=armv8.2-a+dotprod+fp16",
             ],
         }),
-        platform_compiler_flags = [
-            (
-                "(aarch64|arm64)",
-                [
-                    "-march=armv8.2-a+dotprod+fp16",
-                ],
-            ),
-        ],
         labels = labels,
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1675,16 +1517,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv8.2-a+fp16",
-                    "-mfpu=neon-fp-armv8",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1710,14 +1542,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "ovr_config//cpu:arm64": ["-march=armv8.2-a+fp16"],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch64|arm64)",
-                [
-                    "-march=armv8.2-a+fp16",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
@@ -1751,22 +1575,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)$",
-                [
-                    "-marm",
-                    "-march=armv8.2-a+i8mm+fp16",
-                    "-mfpu=neon-fp-armv8",
-                ],
-            ),
-            (
-                "(arm64|aarch64)",
-                [
-                    "-march=armv8.2-a+i8mm+fp16",
-                ],
-            ),
-        ],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1795,14 +1603,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(arm64|aarch64)",
-                [
-                    "-march=armv8.2-a+i8mm+fp16",
-                ],
-            ),
-        ],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1836,16 +1636,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch32|arm32|armv7)",
-                [
-                    "-marm",
-                    "-march=armv8.2-a+dotprod+fp16",
-                    "-mfpu=neon-fp-armv8",
-                ],
-            ),
-        ],
         platforms = (APPLE, ANDROID, CXX, WINDOWS),
         fbandroid_link_whole = True,
         preferred_linkage = "static",
@@ -1877,14 +1667,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ],
         }),
         labels = labels,
-        platform_compiler_flags = [
-            (
-                "(aarch64|arm64)",
-                [
-                    "-march=armv8.2-a+fp16+dotprod",
-                ],
-            ),
-        ],
         fbandroid_link_whole = True,
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,


### PR DESCRIPTION
Summary:
Get rid of platform args around the repo to unblock modernization with platforms.
Platform args were only needed in buck1

Test Plan: CI

Differential Revision: D88049099


