### PR TITLE
Workaround for "Add GroupName NewType" tracing issue

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -787,7 +787,11 @@ def _resolve_group_name(group: RANK_TYPES, tag: str = "") -> c10d.GroupName:
     if isinstance(group, dist.ProcessGroup):
         return group.group_name
     elif isinstance(group, str):
-        return c10d.GroupName(group)
+        # In some cases Dynamo doesn't like tracing through NewType constructors
+        # - so use a cast instead (the actual newtype representation is
+        # literally the underlying type so this is fine). I haven't been able to
+        # reproduce it in isolation (see T247631668).
+        return cast(c10d.GroupName, group)  # c10d.GroupName(group)
     elif isinstance(group, DeviceMesh):
         if group.ndim != 1:
             raise AssertionError(


### PR DESCRIPTION
In some cases Dynamo doesn't like tracing through NewType constructors so use a cast instead (the actual newtype representation is literally the underlying type so this is fine).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169759

