### PR TITLE
[MPS] Binary dense scalar kernels

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -775,4 +775,22 @@ void MetalShaderLibrary::exec_binary_kernel_with_params(TensorIteratorBase& iter
   });
 }
 
+// Checks if one tensor is broadcastable into another
+static bool is_dense_broadcastable(const Tensor& from, const Tensor& into) {
+  if (!from.is_contiguous() || !into.is_contiguous()) {
+    return false;
+  }
+  bool checking_squeezable_dims = false;
+  for (const auto dim : c10::irange(from.ndimension())) {
+    if (checking_squeezable_dims) {
+      if (from.size(-dim - 1) == 1) {
+        continue;
+      }
+      return false;
+    }
+    checking_squeezable_dims = from.size(-dim - 1) != into.size(-dim - 1);
+  }
+  return true;
+}
+
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -702,24 +702,6 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
   return output;
 }
 
-// Checks if one tensor is broadcastable into another
-static bool is_dense_broadcastable(const Tensor& from, const Tensor& into) {
-  if (!from.is_contiguous() || !into.is_contiguous()) {
-    return false;
-  }
-  bool checking_squeezable_dims = false;
-  for (const auto dim : c10::irange(from.ndimension())) {
-    if (checking_squeezable_dims) {
-      if (from.size(-dim - 1) == 1) {
-        continue;
-      }
-      return false;
-    }
-    checking_squeezable_dims = from.size(-dim - 1) != into.size(-dim - 1);
-  }
-  return true;
-}
-
 Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Scalar& value) {
   using namespace mps;
 

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -209,7 +209,7 @@ inline device T& ref_at_offs(device void* ptr, long offs) {
 // strided
 // - binary_dense_cast - inputs are dense, but of different dtypes
 // - binary_strided_cast - inputs or output are strided and of different dtypes
-// - binary_dense_scalar - one input is dense, another one is scalar
+// - binary_dense_broadcast - one input is dense, another one is broadcastable
 // Note about accuracy (for more info see
 // https://github.com/pytorch/pytorch/issues/152736) Sometimes when kernel is
 // invoked to produce `half` output, but one of the arguments is float arguments
@@ -369,47 +369,129 @@ kernel void binary_alpha_dense_cast(
 }
 
 template <typename T, typename F, typename om_t = opmath_t<T>>
-kernel void binary_dense_scalar(
+kernel void binary_dense_broadcast(
     device result_of<F, T, T>* out [[buffer(0)]],
     constant T* input [[buffer(1)]],
-    constant T& scalar [[buffer(2)]],
+    constant T* broadcast [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T>;
-  out[tid] = static_cast<res_t>(f(om_t(input[tid]), om_t(scalar)));
+  out[tid] = static_cast<res_t>(
+      f(om_t(input[tid]), om_t(broadcast[tid % broadcast_numel])));
 }
 
 template <typename T, typename F, typename om_t = opmath_t<T>>
-kernel void binary_dense_scalar_rhs(
+kernel void binary_dense_broadcast_rhs(
     device result_of<F, T, T>* out [[buffer(0)]],
-    constant T& scalar [[buffer(1)]],
+    constant T* broadcast [[buffer(1)]],
     constant T* input [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T>;
-  out[tid] = static_cast<res_t>(f(om_t(scalar), om_t(input[tid])));
+  out[tid] = static_cast<res_t>(
+      f(om_t(broadcast[tid % broadcast_numel]), om_t(input[tid])));
 }
 
 template <typename T, typename T2, typename F>
-kernel void binary_alpha_dense_scalar(
+kernel void binary_alpha_dense_broadcast(
     device result_of<F, T, T, T2>* out [[buffer(0)]],
     constant T* input [[buffer(1)]],
-    constant T& scalar [[buffer(2)]],
-    constant T2& alpha [[buffer(3)]],
+    constant T* broadcast [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
+    constant T2& alpha [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
-  out[tid] = f(input[tid], scalar, alpha);
+  out[tid] = f(input[tid], broadcast[tid % broadcast_numel], alpha);
 }
 
 template <typename T, typename T2, typename F>
-kernel void binary_alpha_dense_scalar_rhs(
+kernel void binary_alpha_dense_broadcast_rhs(
     device result_of<F, T, T, T2>* out [[buffer(0)]],
-    constant T& scalar [[buffer(1)]],
+    constant T* broadcast [[buffer(1)]],
     constant T* input [[buffer(2)]],
-    constant T2& alpha [[buffer(3)]],
+    constant long& broadcast_numel [[buffer(3)]],
+    constant T2& alpha [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
-  out[tid] = f(scalar, input[tid], alpha);
+  out[tid] = f(broadcast[tid % broadcast_numel], input[tid], alpha);
+}
+
+template <typename T, typename F, typename om_t = T>
+kernel void binary_dense_broadcast_cast(
+    device result_of<F, T, T>* out [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* broadcast [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
+    constant uint4& sizes_types [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T>;
+  const auto a = val_at_offs<om_t>(
+      input, tid * sizes_types.x, static_cast<ScalarType>(sizes_types.z));
+  const auto b = val_at_offs<om_t>(
+      broadcast,
+      (tid % broadcast_numel) * sizes_types.y,
+      static_cast<ScalarType>(sizes_types.w));
+  out[tid] = static_cast<res_t>(f(a, b));
+}
+
+template <typename T, typename F, typename om_t = T>
+kernel void binary_dense_broadcast_rhs_cast(
+    device result_of<F, T, T>* out [[buffer(0)]],
+    constant void* broadcast [[buffer(1)]],
+    constant void* input [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
+    constant uint4& sizes_types [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T>;
+  const auto a = val_at_offs<om_t>(
+      broadcast,
+      (tid % broadcast_numel) * sizes_types.x,
+      static_cast<ScalarType>(sizes_types.z));
+  const auto b = val_at_offs<om_t>(
+      input, tid * sizes_types.y, static_cast<ScalarType>(sizes_types.w));
+  out[tid] = static_cast<res_t>(f(a, b));
+}
+
+template <typename T, typename T2, typename F>
+kernel void binary_alpha_dense_broadcast_cast(
+    device result_of<F, T, T, T2>* out [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* broadcast [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
+    constant T2& alpha [[buffer(4)]],
+    constant uint4& sizes_types [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  const auto a = val_at_offs<T>(
+      input, tid * sizes_types.x, static_cast<ScalarType>(sizes_types.z));
+  const auto b = val_at_offs<T>(
+      broadcast,
+      (tid % broadcast_numel) * sizes_types.y,
+      static_cast<ScalarType>(sizes_types.w));
+  out[tid] = f(a, b, alpha);
+}
+
+template <typename T, typename T2, typename F>
+kernel void binary_alpha_dense_broadcast_rhs_cast(
+    device result_of<F, T, T, T2>* out [[buffer(0)]],
+    constant void* broadcast [[buffer(1)]],
+    constant void* input [[buffer(2)]],
+    constant long& broadcast_numel [[buffer(3)]],
+    constant T2& alpha [[buffer(4)]],
+    constant uint4& sizes_types [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  const auto a = val_at_offs<T>(
+      broadcast,
+      (tid % broadcast_numel) * sizes_types.x,
+      static_cast<ScalarType>(sizes_types.z));
+  const auto b = val_at_offs<T>(
+      input, tid * sizes_types.y, static_cast<ScalarType>(sizes_types.w));
+  out[tid] = f(a, b, alpha);
 }
 
 #define REGISTER_BINARY_OP_(NAME, DTYPEI, DTYPEO, OMT)                         \
@@ -455,19 +537,43 @@ kernel void binary_alpha_dense_scalar_rhs(
           constant void* other,                                                \
           constant uint4& sizes_types,                                         \
           uint tid);                                                           \
-  template [[host_name(#NAME "_dense_scalar_" #DTYPEO "_" #DTYPEI)]]           \
-  kernel void ::c10::metal::binary_dense_scalar<DTYPEI, NAME##_functor, OMT>(  \
-      device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> * out_,   \
-      constant DTYPEI * input_,                                                \
-      constant DTYPEI & scalar_,                                               \
-      uint tid);                                                               \
-  template [[host_name(#NAME "_dense_scalar_rhs_" #DTYPEO "_" #DTYPEI)]]       \
+  template [[host_name(#NAME "_dense_broadcast_" #DTYPEO "_" #DTYPEI)]]        \
   kernel void ::c10::metal::                                                   \
-      binary_dense_scalar_rhs<DTYPEI, NAME##_functor, OMT>(                    \
+      binary_dense_broadcast<DTYPEI, NAME##_functor, OMT>(                     \
           device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
               out_,                                                            \
-          constant DTYPEI & scalar_,                                           \
           constant DTYPEI * input_,                                            \
+          constant DTYPEI * broadcast_,                                        \
+          constant long& broadcast_numel,                                      \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_broadcast_rhs_" #DTYPEO "_" #DTYPEI)]]    \
+  kernel void ::c10::metal::                                                   \
+      binary_dense_broadcast_rhs<DTYPEI, NAME##_functor, OMT>(                 \
+          device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
+              out_,                                                            \
+          constant DTYPEI * broadcast_,                                        \
+          constant DTYPEI * input_,                                            \
+          constant long& broadcast_numel,                                      \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_broadcast_cast_" #DTYPEI)]]               \
+  kernel void ::c10::metal::                                                   \
+      binary_dense_broadcast_cast<DTYPEI, NAME##_functor, OMT>(                \
+          device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
+              out_,                                                            \
+          constant void* input_,                                               \
+          constant void* broadcast_,                                           \
+          constant long& broadcast_numel,                                      \
+          constant uint4& sizes_types,                                         \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_broadcast_rhs_cast_" #DTYPEI)]]           \
+  kernel void ::c10::metal::                                                   \
+      binary_dense_broadcast_rhs_cast<DTYPEI, NAME##_functor, OMT>(            \
+          device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
+              out_,                                                            \
+          constant void* broadcast_,                                           \
+          constant void* input_,                                               \
+          constant long& broadcast_numel,                                      \
+          constant uint4& sizes_types,                                         \
           uint tid)
 
 // OpMath Binary Op promotes inputs to higher precision type before Functor call
@@ -530,25 +636,51 @@ kernel void binary_alpha_dense_scalar_rhs(
               constant DTYPEA& alpha,                                          \
               constant uint4& sizes_types,                                     \
               uint tid);                                                       \
-  template [[host_name(#NAME "_dense_scalar_" #DTYPEO "_" #DTYPEI              \
+  template [[host_name(#NAME "_dense_broadcast_" #DTYPEO "_" #DTYPEI           \
                              "_" #DTYPEA)]] kernel void ::c10::metal::         \
-      binary_alpha_dense_scalar<DTYPEI, DTYPEA, NAME##_functor>(               \
+      binary_alpha_dense_broadcast<DTYPEI, DTYPEA, NAME##_functor>(            \
           device ::c10::metal::                                                \
                   result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *          \
               out_,                                                            \
           constant DTYPEI * input_,                                            \
-          constant DTYPEI & scalar_,                                           \
-          constant DTYPEA & alpha,                                             \
+          constant DTYPEI * broadcast_,                                        \
+          constant long& broadcast_numel,                                      \
+          constant DTYPEA& alpha,                                              \
           uint tid);                                                           \
-  template [[host_name(#NAME "_dense_scalar_rhs_" #DTYPEO "_" #DTYPEI          \
+  template [[host_name(#NAME "_dense_broadcast_rhs_" #DTYPEO "_" #DTYPEI       \
                              "_" #DTYPEA)]] kernel void ::c10::metal::         \
-      binary_alpha_dense_scalar_rhs<DTYPEI, DTYPEA, NAME##_functor>(           \
+      binary_alpha_dense_broadcast_rhs<DTYPEI, DTYPEA, NAME##_functor>(        \
           device ::c10::metal::                                                \
                   result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *          \
               out_,                                                            \
-          constant DTYPEI & scalar_,                                           \
+          constant DTYPEI * broadcast_,                                        \
           constant DTYPEI * input_,                                            \
-          constant DTYPEA & alpha,                                             \
+          constant long& broadcast_numel,                                      \
+          constant DTYPEA& alpha,                                              \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_broadcast_cast_" #DTYPEI                  \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::         \
+      binary_alpha_dense_broadcast_cast<DTYPEI, DTYPEA, NAME##_functor>(       \
+          device ::c10::metal::                                                \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *          \
+              out_,                                                            \
+          constant void* input_,                                               \
+          constant void* broadcast_,                                           \
+          constant long& broadcast_numel,                                      \
+          constant DTYPEA& alpha,                                              \
+          constant uint4& sizes_types,                                         \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_broadcast_rhs_cast_" #DTYPEI              \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::         \
+      binary_alpha_dense_broadcast_rhs_cast<DTYPEI, DTYPEA, NAME##_functor>(   \
+          device ::c10::metal::                                                \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *          \
+              out_,                                                            \
+          constant void* broadcast_,                                           \
+          constant void* input_,                                               \
+          constant long& broadcast_numel,                                      \
+          constant DTYPEA& alpha,                                              \
+          constant uint4& sizes_types,                                         \
           uint tid)
 
 // Ternary elementwise ops kernels

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8258,6 +8258,94 @@ class TestMPS(TestCaseMPS):
         b = torch.rand((0), device="mps")
         self.assertEqual(a.dot(b), a.cpu().dot(b.cpu()))
 
+    def test_binary_kernels(self):
+        def check(a, b, ops="+-*/"):
+            op_funcs = {'+': lambda x, y: x + y, '-': lambda x, y: x - y,
+                        '*': lambda x, y: x * y, '/': lambda x, y: x / y}
+            for op in ops:
+                self.assertEqual(op_funcs[op](a, b), op_funcs[op](a.cpu(), b.cpu()))
+                self.assertEqual(op_funcs[op](b, a), op_funcs[op](b.cpu(), a.cpu()))
+
+        def rand(*shape, **kw):
+            return torch.rand(shape, device="mps", **kw)
+
+        def randint(*shape, **kw):
+            return torch.randint(0, 100, shape, device="mps", **kw)
+
+        # basic case
+        check(rand(100), rand(100))
+        # empty tensors
+        check(rand(0), rand(0), "+-")
+        # strided tensors
+        check(rand(100, 100).t(), rand(100, 100).t(), "+*")
+
+        # broadcasting cases
+        for sa, sb in [((100, 100), (100,)), ((100, 10, 100), (100, 1, 100)), ((100, 1, 10), (1, 100, 10))]:
+            check(rand(*sa), rand(*sb), "+*")
+
+        # scalar cases
+        a = rand(100)
+        self.assertEqual(a + 2.0, a.cpu() + 2.0)
+        self.assertEqual(a * 2.0, a.cpu() * 2.0)
+        self.assertEqual(torch.add(a, a, alpha=2.0), torch.add(a.cpu(), a.cpu(), alpha=2.0))
+
+        # cast cases
+        check(rand(100, dtype=torch.float32), rand(100, dtype=torch.float16), "+*-")
+        check(rand(100, dtype=torch.float32), rand(100, dtype=torch.bfloat16), "+*-")
+        check(randint(100, dtype=torch.int32), randint(100, dtype=torch.int64), "+*-")
+
+        # non contiguous cases/slices
+        check(rand(100, 100)[10:50, 20:80], rand(100, 100)[10:50, 20:80])
+        check(rand(100, 100)[::2, ::3], rand(100, 100)[::2, ::3], "+*")
+        check(rand(10, 20, 30).permute(2, 0, 1), rand(10, 20, 30).permute(2, 0, 1), "+*")
+        check(rand(50, 50).flip(0), rand(50, 50).flip(1), "+*")
+        check(rand(100, 100).diagonal(), rand(100, 100).diagonal(), "+*")
+        check(rand(1).expand(100, 100), rand(1), "+*-")
+
+        # integer ops
+        a_int, b_int = randint(100, dtype=torch.int32), torch.randint(1, 100, (100,), device="mps", dtype=torch.int32)
+        self.assertEqual(a_int // b_int, a_int.cpu() // b_int.cpu())
+        self.assertEqual(a_int % b_int, a_int.cpu() % b_int.cpu())
+
+        # boolean. bitwise
+        a_bool, b_bool = rand(100) > 0.5, rand(100) > 0.5
+        self.assertEqual(a_bool & b_bool, a_bool.cpu() & b_bool.cpu())
+        self.assertEqual(a_bool | b_bool, a_bool.cpu() | b_bool.cpu())
+
+        # comparisons
+        a, b = rand(100), rand(100)
+        self.assertEqual(a > b, a.cpu() > b.cpu())
+        self.assertEqual(a < b, a.cpu() < b.cpu())
+        self.assertEqual(a >= b, a.cpu() >= b.cpu())
+        self.assertEqual(a <= b, a.cpu() <= b.cpu())
+        self.assertEqual(a == b, a.cpu() == b.cpu())
+        self.assertEqual(a != b, a.cpu() != b.cpu())
+
+        # power
+        a_pow, b_pow = rand(100) + 0.5, rand(100) * 3
+        self.assertEqual(a_pow ** b_pow, a_pow.cpu() ** b_pow.cpu())
+
+        # complex
+        check(rand(100, dtype=torch.complex64), rand(100, dtype=torch.complex64))
+
+        # inplace
+        a, b = rand(100), rand(100)
+        a_cpu = a.cpu().clone()
+        a.add_(b)
+        a_cpu.add_(b.cpu())
+        self.assertEqual(a, a_cpu)
+
+        # with out parameter
+        a, b, c = rand(100), rand(100), torch.empty(100, device="mps")
+        c_cpu = torch.empty(100)
+        torch.add(a, b, out=c)
+        torch.add(a.cpu(), b.cpu(), out=c_cpu)
+        self.assertEqual(c, c_cpu)
+
+        # where
+        cond, a, b = rand(100) > 0.5, rand(100), rand(100)
+        self.assertEqual(torch.where(cond, a, b), torch.where(cond.cpu(), a.cpu(), b.cpu()))
+
 
 class TestLargeTensors(TestCaseMPS):
     @serialTest()


### PR DESCRIPTION
Partially addresses #168964

This:
```python
import torch
import time

input = torch.rand(16, 8, 343, 64).to("mps")
scalar = 1.0

start = time.time()

for _ in range(10000):
    out = input.mul(scalar)

torch.mps.synchronize()
end = time.time()
print(f"Took {end - start}")
```

Takes 0.89 seconds for torch 2.6(MPS Graph implementation). 
On main it takes 2.95 seconds
After these changes, it takes 0.71-0.76 seconds