### PR TITLE
[2/N] Call parent init method

### DIFF
--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -20,6 +20,7 @@ __all__ = [
 @functional_datapipe("_dataframes_as_tuples")
 class DataFramesAsTuplesPipe(IterDataPipe):
     def __init__(self, source_datapipe) -> None:
+        super().__init__()
         self.source_datapipe = source_datapipe
 
     def __iter__(self):

--- a/torch/utils/data/datapipes/iter/sharding.py
+++ b/torch/utils/data/datapipes/iter/sharding.py
@@ -44,6 +44,7 @@ class ShardingFilterIterDataPipe(_ShardingIterDataPipe):
     def __init__(
         self, source_datapipe: IterDataPipe, sharding_group_filter=None
     ) -> None:
+        super().__init__()
         self.source_datapipe = source_datapipe
         self.sharding_group_filter = sharding_group_filter
         self.groups: dict[int, tuple[int, int]] = {}


### PR DESCRIPTION
This PR adds missing ``super().__init__`` calls to some python classes.

