### PR TITLE
[MPS] Adding missing backward for _upsample_bicubic2d_aa support

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UpSample.metal
+++ b/aten/src/ATen/native/mps/kernels/UpSample.metal
@@ -614,8 +614,81 @@ kernel void upsample_2d_aa(
       }
       outputData
           [n * output_strides.x + c * output_strides.y +
-           output_y * output_strides.z + output_x * output_strides.w] =
+          output_y * output_strides.z + output_x * output_strides.w] =
               static_cast<T>(res / ws);
+    }
+  }
+}
+
+template <typename T, typename F>
+kernel void upsample_2d_aa_backward(
+    device AtomicType_t<T>* gradInputData [[buffer(0)]],
+    constant T* gradOutputData [[buffer(1)]],
+    constant ulong4& input_strides [[buffer(2)]],
+    constant ulong4& output_strides [[buffer(3)]],
+    constant long4& input_sizes [[buffer(4)]],
+    constant long4& output_sizes [[buffer(5)]],
+    constant float2& scales [[buffer(6)]],
+    constant bool& align_corners [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  auto output_x = thread_index % static_cast<uint>(output_sizes.w);
+  auto output_y = thread_index / static_cast<uint>(output_sizes.w);
+  (void)align_corners; // Align corners is unused for AA algorithm
+  F f;
+
+  auto x_center = area_pixel_compute_source_index(
+      scales.x,
+      output_x,
+      /*align_corners=*/false,
+      /*cubic=*/F::area_factor == 2.0);
+  auto y_center = area_pixel_compute_source_index(
+      scales.y,
+      output_y,
+      /*align_corners=*/false,
+      /*cubic=*/F::area_factor == 2.0);
+  auto clamped_scales = max(1.0, scales);
+  auto x_min =
+      max(0L, long(floor(x_center - f.area_factor * clamped_scales.x + 1)));
+  auto x_max = min(
+      input_sizes.w, long(ceil(x_center + f.area_factor * clamped_scales.x)));
+  auto y_min =
+      max(0L, long(floor(y_center - f.area_factor * clamped_scales.y + 1)));
+  auto y_max = min(
+      input_sizes.z, long(ceil(y_center + f.area_factor * clamped_scales.y)));
+
+  float ws = 0.0f;
+  for (auto y = y_min; y < y_max; ++y) {
+    auto dy = f((y - y_center) / clamped_scales.y);
+    for (auto x = x_min; x < x_max; ++x) {
+      auto dx = f((x - x_center) / clamped_scales.x);
+      ws += dx * dy;
+    }
+  }
+  if (ws == 0.0f) {
+    return;
+  }
+
+  for (int n = 0; n < output_sizes.x; n++) {
+    for (int c = 0; c < output_sizes.y; c++) {
+      auto out_value = gradOutputData
+          [n * output_strides.x + c * output_strides.y +
+           output_y * output_strides.z + output_x * output_strides.w];
+      for (auto y = y_min; y < y_max; ++y) {
+        auto dy = f((y - y_center) / clamped_scales.y);
+        for (auto x = x_min; x < x_max; ++x) {
+          auto dx = f((x - x_center) / clamped_scales.x);
+          auto w = dx * dy / ws;
+          upsample_increment_value_bounded<T>(
+              gradInputData,
+              input_sizes.wz,
+              input_strides,
+              n,
+              c,
+              y,
+              x,
+              static_cast<float>(out_value) * w);
+        }
+      }
     }
   }
 }
@@ -778,11 +851,24 @@ kernel void upsample_bicubic2d_backward(
           constant DTYPE * gradOutputData [[buffer(1)]],                    \
           constant ulong4 & input_strides [[buffer(2)]],                    \
           constant ulong4 & output_strides [[buffer(3)]],                   \
-          constant long4 & input_sizes [[buffer(4)]],                       \
-          constant long4 & output_sizes [[buffer(5)]],                      \
-          constant float2 & scales [[buffer(6)]],                           \
-          constant bool& align_corners [[buffer(7)]],                       \
-          uint thread_index [[thread_position_in_grid]])
+      constant long4 & input_sizes [[buffer(4)]],                       \
+      constant long4 & output_sizes [[buffer(5)]],                      \
+      constant float2 & scales [[buffer(6)]],                           \
+      constant bool& align_corners [[buffer(7)]],                       \
+      uint thread_index [[thread_position_in_grid]])
+
+#define INSTANTIATE_UPSAMPLE_2D_AA_BACKWARD(NAME, FUNCTOR, DTYPE)       \
+  template [[host_name("upsample_" #NAME "_backward_" #DTYPE)]] kernel void \
+  upsample_2d_aa_backward<DTYPE, FUNCTOR>(                              \
+      device AtomicType_t<DTYPE> * gradInputData [[buffer(0)]],         \
+      constant DTYPE * gradOutputData [[buffer(1)]],                    \
+      constant ulong4 & input_strides [[buffer(2)]],                    \
+      constant ulong4 & output_strides [[buffer(3)]],                   \
+      constant long4 & input_sizes [[buffer(4)]],                       \
+      constant long4 & output_sizes [[buffer(5)]],                      \
+      constant float2 & scales [[buffer(6)]],                           \
+      constant bool& align_corners [[buffer(7)]],                       \
+      uint thread_index [[thread_position_in_grid]])
 
 #define INSTANTIATE_UPSAMPLE_LINEAR(DTYPE)                        \
   template [[host_name("upsample_linear1d_" #DTYPE)]] kernel void \
@@ -841,9 +927,11 @@ kernel void upsample_bicubic2d_backward(
 #define INSTANTIATE_UPSAMPLE_ALL(DTYPE)                              \
   INSTANTIATE_UPSAMPLE_2D(bicubic2d, DTYPE);                         \
   INSTANTIATE_UPSAMPLE_2D_AA(bicubic2d_aa, BicubicFunctor, DTYPE);   \
+  INSTANTIATE_UPSAMPLE_2D_AA_BACKWARD(bicubic2d_aa, BicubicFunctor, DTYPE); \
   INSTANTIATE_UPSAMPLE_2D_BACKWARD(bicubic2d, DTYPE);                \
   INSTANTIATE_UPSAMPLE_2D(bilinear2d, DTYPE);                        \
   INSTANTIATE_UPSAMPLE_2D_AA(bilinear2d_aa, BilinearFunctor, DTYPE); \
+  INSTANTIATE_UPSAMPLE_2D_AA_BACKWARD(bilinear2d_aa, BilinearFunctor, DTYPE); \
   INSTANTIATE_UPSAMPLE_LINEAR(DTYPE);                                \
   INSTANTIATE_UPSAMPLE_3D_BACKWARD(DTYPE);                           \
   INSTANTIATE_UPSAMPLE_3D(DTYPE)

--- a/aten/src/ATen/native/mps/kernels/UpSample.metal
+++ b/aten/src/ATen/native/mps/kernels/UpSample.metal
@@ -614,7 +614,7 @@ kernel void upsample_2d_aa(
       }
       outputData
           [n * output_strides.x + c * output_strides.y +
-          output_y * output_strides.z + output_x * output_strides.w] =
+           output_y * output_strides.z + output_x * output_strides.w] =
               static_cast<T>(res / ws);
     }
   }
@@ -851,6 +851,19 @@ kernel void upsample_bicubic2d_backward(
           constant DTYPE * gradOutputData [[buffer(1)]],                    \
           constant ulong4 & input_strides [[buffer(2)]],                    \
           constant ulong4 & output_strides [[buffer(3)]],                   \
+      constant long4 & input_sizes [[buffer(4)]],                       \
+      constant long4 & output_sizes [[buffer(5)]],                      \
+      constant float2 & scales [[buffer(6)]],                           \
+      constant bool& align_corners [[buffer(7)]],                       \
+      uint thread_index [[thread_position_in_grid]])
+
+#define INSTANTIATE_UPSAMPLE_2D_AA_BACKWARD(NAME, FUNCTOR, DTYPE)       \
+  template [[host_name("upsample_" #NAME "_backward_" #DTYPE)]] kernel void \
+  upsample_2d_aa_backward<DTYPE, FUNCTOR>(                              \
+      device AtomicType_t<DTYPE> * gradInputData [[buffer(0)]],         \
+      constant DTYPE * gradOutputData [[buffer(1)]],                    \
+      constant ulong4 & input_strides [[buffer(2)]],                    \
+      constant ulong4 & output_strides [[buffer(3)]],                   \
       constant long4 & input_sizes [[buffer(4)]],                       \
       constant long4 & output_sizes [[buffer(5)]],                      \
       constant float2 & scales [[buffer(6)]],                           \

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -11,6 +11,7 @@
 #include <ATen/ops/_upsample_bicubic2d_aa_native.h>
 #include <ATen/ops/_upsample_bilinear2d_aa_backward_native.h>
 #include <ATen/ops/_upsample_bilinear2d_aa_native.h>
+#include <ATen/ops/_upsample_bicubic2d_aa_backward_native.h>
 #include <ATen/ops/_upsample_nearest_exact1d.h>
 #include <ATen/ops/_upsample_nearest_exact1d_backward.h>
 #include <ATen/ops/_upsample_nearest_exact1d_backward_native.h>
@@ -556,6 +557,18 @@ TORCH_IMPL_FUNC(_upsample_bicubic2d_aa_out_mps)
   TORCH_CHECK(at::isFloatingType(input.scalar_type()),
               "_upsample_bicubic2d_aa_out_mps only supports floating-point dtypes");
   mps::upsample_kernel_out_template(input, output_size, align_corners, scales_h, scales_w, output, "bicubic2d_aa");
+}
+
+TORCH_IMPL_FUNC(_upsample_bicubic2d_aa_backward_out_mps)
+(const Tensor& grad_output,
+ IntArrayRef output_size,
+ IntArrayRef input_size,
+ bool align_corners,
+ std::optional<double> scales_h,
+ std::optional<double> scales_w,
+ const Tensor& grad_input) {
+  mps::upsample_kernel_backward_out_template(
+      grad_input, grad_output, output_size, input_size, align_corners, scales_h, scales_w, "bicubic2d_aa");
 }
 
 TORCH_IMPL_FUNC(upsample_nearest3d_out_mps)(const Tensor& input,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13049,6 +13049,7 @@
   dispatch:
     CPU: _upsample_bicubic2d_aa_backward_out_cpu
     CUDA: _upsample_bicubic2d_aa_backward_out_cuda
+    MPS: _upsample_bicubic2d_aa_backward_out_mps
 
 - func: _upsample_bicubic2d_aa_backward(Tensor grad_output, SymInt[2] output_size, SymInt[4] input_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor
   python_module: nn

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6075,6 +6075,38 @@ class TestMPS(TestCaseMPS):
                 return F.interpolate(x, 3, mode='linear', align_corners=align_corners)
             self.assertEqual(interp(inp).cpu(), interp(inp.cpu()))
 
+    def test_interpolate_bicubic2d_aa(self):
+        def helper(shape, scale_factors, output_size=None, align_corners=False):
+            input_cpu = torch.randn(shape, device="cpu", dtype=torch.float, requires_grad=True)
+            input_cpu.retain_grad()
+            input_mps = input_cpu.detach().clone().to("mps").requires_grad_()
+
+            out_cpu = F.interpolate(
+                input_cpu,
+                size=output_size,
+                scale_factor=scale_factors,
+                mode="bicubic",
+                align_corners=align_corners,
+                antialias=True,
+            )
+            out_mps = F.interpolate(
+                input_mps,
+                size=output_size,
+                scale_factor=scale_factors,
+                mode="bicubic",
+                align_corners=align_corners,
+                antialias=True,
+            )
+            self.assertEqual(out_cpu, out_mps)
+
+            grad = torch.full_like(out_cpu, 0.3)
+            out_cpu.backward(grad)
+            out_mps.backward(grad.to("mps"))
+            self.assertEqual(input_cpu.grad, input_mps.grad)
+
+        helper([2, 3, 4, 5], [1.4, 1.7])
+        helper([1, 1, 3, 3], [0.6, 0.7])
+
     # Test concat forward
     def test_cat1(self):
         def helper(shape_x, shape_y, shape_z):
@@ -12614,6 +12646,8 @@ class TestConsistency(TestCaseMPS):
             if op.name in ["renorm", "norm", "linalg.norm"] and dtype == torch.float16:
                 atol = 7e-4
                 rtol = 1.5e-3
+            if op.name in ["_upsample_bilinear2d_aa", "_upsample_bicubic2d_aa"] and cpu_kwargs.get("scale_factors") == [1.7, 0.9]:
+                atol, rtol = 2e-5, 2e-6
 
             self.assertEqual(cpu_out, mps_out, atol=atol, rtol=rtol)
 

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -681,7 +681,6 @@ if torch.backends.mps.is_available():
             "_segment_reduce": [torch.float16, torch.float32],
             "_chunk_cat": [torch.float16, torch.float32],
             "_upsample_bilinear2d_aa": None,  # `_upsample_bilinear2d_aa_backward_out` not implemented for MPS
-            "_upsample_bicubic2d_aa": None,  # `_upsample_bilinear2d_aa_backward_out` not implemented for MPS
             "sparse.mmreduce": [torch.float32],  # csr not supported
             "linalg.householder_product": None,
             "unique_consecutive": [torch.float16, torch.float32],


### PR DESCRIPTION
Fixes #141287 

Implemented missing backward for already implemented _upsample_bilinear2d_aa mps support.
Confirmed this is under to-be-implemented from the [tracking board](https://github.com/users/kulinseth/projects/1/views/1)

**Summary**:

- Implemented _upsample_bicubic2d_aa backward for MPS with a dedicated AA kernel, pipeline instantiation, and dispatch wiring.
- Enabled MPS dispatch in native_functions.yaml and wired host-side _out/functional wrappers.
- Added MPS test coverage for bicubic antialias interpolate and adjusted tolerances/skips to match CPU.
