### PR TITLE
[XPU] Migrate 2 test cases autograd, creation_ops for XPU

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4468,40 +4468,27 @@ class TestAutograd(TestCase):
         self.assertEqual(type(dvar.grad), type(dvar))
 
     @skipIfXpu(
-        msg="torch.xpu' has no attribute 'FloatTensor', issue https://github.com/intel/torch-xpu-ops/issues/2792"
+        msg="It's a deprecated api, issue closed https://github.com/intel/torch-xpu-ops/issues/2792"
     )
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
         self.assertIsInstance(x.int(), torch.IntTensor)
-        if torch.accelerator.is_available():
-            self.assertIsInstance(
-                x.float().to(device_type),
-                torch.get_device_module(device_type).FloatTensor,
-            )
-            self.assertIsInstance(
-                x.int().to(device_type), torch.get_device_module(device_type).IntTensor
-            )
-            self.assertIsInstance(x.int().to(device_type).cpu(), torch.IntTensor)
-            if torch.accelerator.device_count() >= 2:
-                x2 = x.float().to(device_type)(1)
-                self.assertIsInstance(
-                    x2, torch.get_device_module(device_type).FloatTensor
-                )
+        if torch.cuda.is_available():
+            self.assertIsInstance(x.float().cuda(), torch.cuda.FloatTensor)
+            self.assertIsInstance(x.int().cuda(), torch.cuda.IntTensor)
+            self.assertIsInstance(x.int().cuda().cpu(), torch.IntTensor)
+            if torch.cuda.device_count() >= 2:
+                x2 = x.float().cuda(1)
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
-                x2 = x.float().to(device_type)
-                self.assertIsInstance(
-                    x2, torch.get_device_module(device_type).FloatTensor
-                )
+                x2 = x.float().cuda()
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 0)
-                x2 = x2.get_device_module(device_type)(1)
-                self.assertIsInstance(
-                    x2, torch.get_device_module(device_type).FloatTensor
-                )
+                x2 = x2.cuda(1)
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
-                y = Variable(
-                    torch.randn(5).get_device_module(device_type)(1), requires_grad=True
-                )
+                y = Variable(torch.randn(5).cuda(1), requires_grad=True)
                 y.cpu().sum().backward()
                 self.assertIs(y.grad.get_device(), 1)
                 self.assertIs(y.long().get_device(), 1)
@@ -4522,35 +4509,27 @@ class TestAutograd(TestCase):
                 self.assertIsInstance(x.type(t_dtype), t)
                 self.assertIs(t_dtype, x.type(t_dtype).dtype)
                 self.assertEqual(y.data_ptr(), y.type(t).data_ptr())
-                if torch.accelerator.is_available():
-                    for x_acc in (True, False):
-                        for y_acc in (True, False):
-                            x_c = x.to(device_type) if x_acc else x
-                            y_c = y.to(device_type) if y_acc else y
+                if torch.cuda.is_available():
+                    for x_cuda in (True, False):
+                        for y_cuda in (True, False):
+                            x_c = x.cuda() if x_cuda else x
+                            y_c = y.cuda() if y_cuda else y
                             _, y_type = y_c.type().rsplit(".", 1)
-                            y_typestr = (
-                                f"torch.{device_type}." if y_acc else "torch."
-                            ) + y_type
+                            y_typestr = ("torch.cuda." if y_cuda else "torch.") + y_type
                             self.assertEqual(y_c.type(), x_c.type(y_typestr).type())
                             self.assertIs(y_c.dtype, x_c.type(y_c.dtype).dtype)
                             self.assertEqual(
                                 y_c.data_ptr(),
-                                y_c.to(device_type).data_ptr()
-                                if y_acc
-                                else y_c.data_ptr(),
+                                y_c.cuda().data_ptr() if y_cuda else y_c.data_ptr(),
                             )
 
         self._test_type_conversion_backward(lambda x: x)
-        if torch.accelerator.is_available():
-            self._test_type_conversion_backward(lambda x: x.to(device_type))
-            if torch.accelerator.device_count() >= 2:
+        if torch.cuda.is_available():
+            self._test_type_conversion_backward(lambda x: x.cuda())
+            if torch.cuda.device_count() >= 2:
                 # one of these has to be the non-default device
-                self._test_type_conversion_backward(
-                    lambda x: x.get_device_module(device_type)(0)
-                )
-                self._test_type_conversion_backward(
-                    lambda x: x.get_device_module(device_type)(1)
-                )
+                self._test_type_conversion_backward(lambda x: x.cuda(0))
+                self._test_type_conversion_backward(lambda x: x.cuda(1))
 
     def test_isolated_node(self):
         x = torch.randn(5, 5, requires_grad=True)
@@ -11647,7 +11626,7 @@ for shape in [(1,), ()]:
             a = torch.ones(1, requires_grad=True, device=device_type)
             y = f(a)
             memory_with_hooks = (
-            memory_with_hooks = torch.cuda.memory_allocated()
+            memory_with_hooks = torch.device(device_type).memory_allocated()
                 if TEST_CUDA
                 else torch.xpu.memory_allocated()
             )
@@ -14774,7 +14753,7 @@ class TestAutogradStreamSynchronization(TestCase):
     @expectedFailureMPS
     @skipCUDANonDefaultStreamIf(True)
     @skipIfXpu(
-        msg="'torch.xpu' has no attribute 'default_stream', issue https://github.com/intel/torch-xpu-ops/issues/2793"
+        msg="XPU doesn't have an exact counterpart of the default stream, closed issue https://github.com/intel/torch-xpu-ops/issues/2793"
     )
     def test_consumer_to_single_producer_case_2_correctness(self, device):
         if device == "cpu":
@@ -14888,7 +14867,7 @@ class TestAutogradStreamSynchronization(TestCase):
         torch.accelerator.device_count() < 2, "accelerator count is less than 2"
     )
     @skipIfXpu(
-        msg="'torch.xpu' has no attribute 'default_stream', issue https://github.com/intel/torch-xpu-ops/issues/2793"
+        msg="XPU doesn't have an exact counterpart of the default stream, closed issue https://github.com/intel/torch-xpu-ops/issues/2793"
     )
     def test_consumer_to_single_producer_case_3_correctness_non_default_ambient_stream(
         self, device
@@ -16629,10 +16608,6 @@ class TestSelectiveActivationCheckpoint(TestCase):
 
 
 class TestAutogradMultipleDispatch(TestCase):
-    @skipIfXpu(
-        msg="Skip the failed test case test_autograd_multiple_dispatch_registrations due to tensor not closed, \
-                    issue https://github.com/intel/torch-xpu-ops/issues/2794"
-    )
     def test_autograd_multiple_dispatch_registrations(self, device):
         t = torch.randn(3, 3, device=device, requires_grad=True)
         # using _test_autograd_multiple_dispatch.fullcoverage which has

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -49,6 +49,7 @@ from torch.autograd.profiler_util import (
     FunctionEventAvg,
 )
 from torch.testing import make_tensor
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     dtypes,
@@ -83,7 +84,6 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
     slowTest,
-    TEST_CUDA,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -11611,6 +11611,7 @@ for shape in [(1,), ()]:
             y = f(a)
         memory_without_grad = torch.get_device_module(device_type).memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
+
         del a
         del y
 
@@ -11621,7 +11622,7 @@ for shape in [(1,), ()]:
             memory_with_hooks = torch.get_device_module(device_type).memory_allocated()
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA and XPU")
     def test_scalar_grad_mixed_device(self):
         device_type = torch.accelerator.current_accelerator().type
         x = torch.tensor(1.0, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11601,7 +11601,7 @@ for shape in [(1,), ()]:
         # with grad
         a = torch.ones(1, requires_grad=True, device=device_type)
         y = f(a)
-        memory_with_grad = torch.accelerator.memory_allocated()
+        memory_with_grad = torch.get_device_module(device_type).memory_allocated()
         del a
         del y
 
@@ -11609,7 +11609,7 @@ for shape in [(1,), ()]:
         a = torch.ones(1, requires_grad=True, device=device_type)
         with torch.no_grad():
             y = f(a)
-        memory_without_grad = torch.accelerator.memory_allocated()
+        memory_without_grad = torch.get_device_module(device_type).memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
         del a
         del y

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7728,7 +7728,7 @@ for shape in [(1,), ()]:
 
     @unittest.skipIf(
         not TEST_GPU or not torch.get_device_module(device_type).is_bf16_supported(),
-		"Test requires GPU bf16 support",
+        "Test requires GPU bf16 support",
     )
     def test_checkpointing_non_reentrant_autocast_gpu(self):
         """
@@ -11601,10 +11601,7 @@ for shape in [(1,), ()]:
         # with grad
         a = torch.ones(1, requires_grad=True, device=device_type)
         y = f(a)
-        memory_with_grad = (
         memory_with_grad = torch.accelerator.memory_allocated()
-        )
-
         del a
         del y
 
@@ -11612,12 +11609,8 @@ for shape in [(1,), ()]:
         a = torch.ones(1, requires_grad=True, device=device_type)
         with torch.no_grad():
             y = f(a)
-        memory_without_grad = (
         memory_without_grad = torch.accelerator.memory_allocated()
-        )
-
         self.assertGreater(memory_with_grad, memory_without_grad)
-
         del a
         del y
 
@@ -11625,11 +11618,7 @@ for shape in [(1,), ()]:
         with torch.autograd.graph.save_on_cpu():
             a = torch.ones(1, requires_grad=True, device=device_type)
             y = f(a)
-            memory_with_hooks = (
             memory_with_hooks = torch.device(device_type).memory_allocated()
-                if TEST_CUDA
-                else torch.xpu.memory_allocated()
-            )
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11618,7 +11618,7 @@ for shape in [(1,), ()]:
         with torch.autograd.graph.save_on_cpu():
             a = torch.ones(1, requires_grad=True, device=device_type)
             y = f(a)
-            memory_with_hooks = torch.device(device_type).memory_allocated()
+            memory_with_hooks = torch.get_device_module(device_type).memory_allocated()
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -84,6 +84,7 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
     slowTest,
+    TEST_CUDA,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -101,6 +102,11 @@ from torch.utils.checkpoint import (
 from torch.utils.flop_counter import FlopCounterMode
 from torch.utils.weak import WeakTensorKeyDictionary
 
+
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+TEST_GPU = TEST_CUDA or TEST_XPU
 
 if TYPE_CHECKING:
     from torch.utils.hooks import RemovableHandle
@@ -4462,25 +4468,41 @@ class TestAutograd(TestCase):
         self.assertEqual(dvar.grad, torch.ones_like(dvar))
         self.assertEqual(type(dvar.grad), type(dvar))
 
+    @skipIfXpu(
+        msg="torch.xpu' has no attribute 'FloatTensor', issue https://github.com/intel/torch-xpu-ops/issues/2792"
+    )
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
         self.assertIsInstance(x.int(), torch.IntTensor)
-        if torch.cuda.is_available():
-            self.assertIsInstance(x.float().cuda(), torch.cuda.FloatTensor)
-            self.assertIsInstance(x.int().cuda(), torch.cuda.IntTensor)
-            self.assertIsInstance(x.int().cuda().cpu(), torch.IntTensor)
-            if torch.cuda.device_count() >= 2:
-                x2 = x.float().cuda(1)
-                self.assertIsInstance(x2, torch.cuda.FloatTensor)
+        if torch.accelerator.is_available():
+            self.assertIsInstance(
+                x.float().to(device_type),
+                torch.get_device_module(device_type).FloatTensor,
+            )
+            self.assertIsInstance(
+                x.int().to(device_type), torch.get_device_module(device_type).IntTensor
+            )
+            self.assertIsInstance(x.int().to(device_type).cpu(), torch.IntTensor)
+            if torch.accelerator.device_count() >= 2:
+                x2 = x.float().to(device_type)(1)
+                self.assertIsInstance(
+                    x2, torch.get_device_module(device_type).FloatTensor
+                )
                 self.assertIs(x2.get_device(), 1)
-                x2 = x.float().cuda()
-                self.assertIsInstance(x2, torch.cuda.FloatTensor)
+                x2 = x.float().to(device_type)
+                self.assertIsInstance(
+                    x2, torch.get_device_module(device_type).FloatTensor
+                )
                 self.assertIs(x2.get_device(), 0)
-                x2 = x2.cuda(1)
-                self.assertIsInstance(x2, torch.cuda.FloatTensor)
+                x2 = x2.get_device_module(device_type)(1)
+                self.assertIsInstance(
+                    x2, torch.get_device_module(device_type).FloatTensor
+                )
                 self.assertIs(x2.get_device(), 1)
-                y = Variable(torch.randn(5).cuda(1), requires_grad=True)
+                y = Variable(
+                    torch.randn(5).get_device_module(device_type)(1), requires_grad=True
+                )
                 y.cpu().sum().backward()
                 self.assertIs(y.grad.get_device(), 1)
                 self.assertIs(y.long().get_device(), 1)
@@ -4501,27 +4523,35 @@ class TestAutograd(TestCase):
                 self.assertIsInstance(x.type(t_dtype), t)
                 self.assertIs(t_dtype, x.type(t_dtype).dtype)
                 self.assertEqual(y.data_ptr(), y.type(t).data_ptr())
-                if torch.cuda.is_available():
-                    for x_cuda in (True, False):
-                        for y_cuda in (True, False):
-                            x_c = x.cuda() if x_cuda else x
-                            y_c = y.cuda() if y_cuda else y
+                if torch.accelerator.is_available():
+                    for x_acc in (True, False):
+                        for y_acc in (True, False):
+                            x_c = x.to(device_type) if x_acc else x
+                            y_c = y.to(device_type) if y_acc else y
                             _, y_type = y_c.type().rsplit(".", 1)
-                            y_typestr = ("torch.cuda." if y_cuda else "torch.") + y_type
+                            y_typestr = (
+                                f"torch.{device_type}." if y_acc else "torch."
+                            ) + y_type
                             self.assertEqual(y_c.type(), x_c.type(y_typestr).type())
                             self.assertIs(y_c.dtype, x_c.type(y_c.dtype).dtype)
                             self.assertEqual(
                                 y_c.data_ptr(),
-                                y_c.cuda().data_ptr() if y_cuda else y_c.data_ptr(),
+                                y_c.to(device_type).data_ptr()
+                                if y_acc
+                                else y_c.data_ptr(),
                             )
 
         self._test_type_conversion_backward(lambda x: x)
-        if torch.cuda.is_available():
-            self._test_type_conversion_backward(lambda x: x.cuda())
-            if torch.cuda.device_count() >= 2:
+        if torch.accelerator.is_available():
+            self._test_type_conversion_backward(lambda x: x.to(device_type))
+            if torch.accelerator.device_count() >= 2:
                 # one of these has to be the non-default device
-                self._test_type_conversion_backward(lambda x: x.cuda(0))
-                self._test_type_conversion_backward(lambda x: x.cuda(1))
+                self._test_type_conversion_backward(
+                    lambda x: x.get_device_module(device_type)(0)
+                )
+                self._test_type_conversion_backward(
+                    lambda x: x.get_device_module(device_type)(1)
+                )
 
     def test_isolated_node(self):
         x = torch.randn(5, 5, requires_grad=True)
@@ -5042,7 +5072,7 @@ class TestAutograd(TestCase):
         run_test((10, 10), torch.zeros(10, 10))
         run_test((10,), 0)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_node_ordering_when_none_returned(self):
         class Matmul(torch.autograd.Function):
             @staticmethod
@@ -5076,9 +5106,13 @@ class TestAutograd(TestCase):
         def hook(*args, **kwargs):
             executed.append("B")
 
-        x = torch.randn((3, 3), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        x = torch.randn(
+            (3, 3), dtype=torch.bfloat16, device=device_type, requires_grad=True
+        )
         x = HookFunction.apply(x)
-        w = torch.randn((3, 3), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        w = torch.randn(
+            (3, 3), dtype=torch.bfloat16, device=device_type, requires_grad=True
+        )
         w.register_hook(hook)
         o = Matmul.apply(x, w)
         o.sum().backward()
@@ -7546,7 +7580,7 @@ Done""",
 
     @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
     def test_thread_shutdown(self):
-        code = """import torch
+        code = f"""import torch
 from torch.autograd import Function
 class MyFunction(Function):
     @staticmethod
@@ -7557,9 +7591,9 @@ class MyFunction(Function):
     def backward(ctx, grad):
         return grad
 
-# Run on cuda if it is available to ensure that the worker thread
+# Run on GPU if it is available to ensure that the worker thread
 # is properly initialized by the time we exit.
-device = "cuda" if torch.cuda.is_available() else "cpu"
+device = "{device_type}"
 
 for shape in [(1,), ()]:
     v = torch.ones(shape, requires_grad=True, device=device)
@@ -7569,7 +7603,7 @@ for shape in [(1,), ()]:
         # The autograd engine creates worker threads only when GPU devices are present.
         # So make sure that we do shutdown threads when we're testing cuda and make sure
         # that there is no thread to shutdown when we're not using cuda.
-        if TEST_CUDA or torch.backends.mps.is_available() or torch.xpu.is_available():
+        if TEST_GPU or torch.backends.mps.is_available():
             self.assertRegex(s, "PYTORCH_API_USAGE torch.autograd.thread_shutdown")
         else:
             self.assertNotRegex(s, "PYTORCH_API_USAGE torch.autograd.thread_shutdown")
@@ -7715,9 +7749,8 @@ for shape in [(1,), ()]:
         self._test_checkpointing_non_reentrant_autocast(device_type="cpu")
 
     @unittest.skipIf(
-        (not torch.cuda.is_available() or not torch.cuda.is_bf16_supported())
-        and (not torch.xpu.is_available() or not torch.xpu.is_bf16_supported()),
-        "Test requires CUDA or XPU bf16 support",
+        not TEST_GPU or not torch.get_device_module(device_type).is_bf16_supported(),
+		"Test requires GPU bf16 support",
     )
     def test_checkpointing_non_reentrant_autocast_gpu(self):
         """
@@ -7727,7 +7760,7 @@ for shape in [(1,), ()]:
         device_type = "cuda" if torch.cuda.is_available() else "xpu"
         self._test_checkpointing_non_reentrant_autocast(device_type=device_type)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+    @unittest.skipIf(TEST_GPU, "Test requires GPU")
     @slowTest
     def test_checkpointing_without_reentrant_memory_savings(self):
         class MyModel(nn.Module):
@@ -7760,32 +7793,32 @@ for shape in [(1,), ()]:
 
                 return x
 
-        model_no_checkpoint = MyModel(
-            8, use_checkpoint=False, use_reentrant=False
-        ).cuda()
+        model_no_checkpoint = MyModel(8, use_checkpoint=False, use_reentrant=False).to(
+            device_type
+        )
         model_reentrant_checkpoint = MyModel(
             8, use_checkpoint=True, use_reentrant=True
-        ).cuda()
+        ).to(device_type)
         model_no_reentrant_checkpoint = MyModel(
             8, use_checkpoint=True, use_reentrant=False
-        ).cuda()
+        ).to(device_type)
 
-        x = torch.randn(100, 256, requires_grad=True, device="cuda")
+        x = torch.randn(100, 256, requires_grad=True, device=device_type)
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         loss = model_no_checkpoint(x.clone()).sum()
         loss.backward()
-        mem_no_checkpoint = torch.cuda.max_memory_allocated()
+        mem_no_checkpoint = torch.accelerator.max_memory_allocated()
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         loss = model_reentrant_checkpoint(x.clone()).sum()
         loss.backward()
-        mem_reentrant_checkpoint = torch.cuda.max_memory_allocated()
+        mem_reentrant_checkpoint = torch.accelerator.max_memory_allocated()
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         loss = model_no_reentrant_checkpoint(x.clone()).sum()
         loss.backward()
-        mem_no_reentrant_checkpoint = torch.cuda.max_memory_allocated()
+        mem_no_reentrant_checkpoint = torch.accelerator.max_memory_allocated()
 
         self.assertTrue(mem_reentrant_checkpoint < mem_no_checkpoint)
         self.assertTrue(mem_no_reentrant_checkpoint < mem_no_checkpoint)
@@ -8510,12 +8543,12 @@ for shape in [(1,), ()]:
                 return self.linear(inp)
 
         a = torch.randn(2, 2, requires_grad=True)
-        if torch.cuda.is_available():
-            a = a.cuda()
+        if torch.accelerator.is_available():
+            a = a.to(device_type)
 
         model = LinearModule()
-        if torch.cuda.is_available():
-            model = model.cuda()
+        if torch.accelerator.is_available():
+            model = model.to(device_type)
 
         b = deepcopy(model)(a).sum()
         b.backward()
@@ -8616,7 +8649,7 @@ for shape in [(1,), ()]:
 
         self.assertEqual(called[0], 2)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_callback_propagates_errors_from_device_thread(self):
         def callback():
             raise RuntimeError("blah")
@@ -8624,7 +8657,9 @@ for shape in [(1,), ()]:
         def hook_with_callback(*args):
             torch.autograd.Variable._execution_engine.queue_callback(callback)
 
-        t = torch.tensor([1.0, 2.0], requires_grad=True, device=torch.device("cuda"))
+        t = torch.tensor(
+            [1.0, 2.0], requires_grad=True, device=torch.device(device_type)
+        )
         t.register_hook(hook_with_callback)
         output = t**2
         loss = output.sum()
@@ -11531,11 +11566,11 @@ for shape in [(1,), ()]:
             torch.autograd.grad(out, (a,))
 
     def test_graph_save_on_cpu(self):
-        def test(get_input, cuda, pin_memory):
+        def test(get_input, is_accelerator_avaliable, pin_memory):
             with torch.autograd.graph.save_on_cpu(pin_memory):
                 a = get_input()
-                if cuda:
-                    a.cuda()
+                if is_accelerator_avaliable:
+                    a.to(device_type)
                 y = a * a
                 self.assertEqual(a, y.grad_fn._saved_self)
                 self.assertEqual(a, y.grad_fn._saved_other)
@@ -11553,14 +11588,20 @@ for shape in [(1,), ()]:
 
                 self.assertEqual(actual, expected)
 
-        for cuda in [False] + ([True] if torch.cuda.is_available() else []):
+        for is_accelerator_avaliable in [False] + (
+            [True] if torch.accelerator.is_available() else []
+        ):
             for pin_memory in [True, False]:
                 # FloatTensor
-                test(lambda: torch.randn(5, requires_grad=True), cuda, pin_memory)
+                test(
+                    lambda: torch.randn(5, requires_grad=True),
+                    is_accelerator_avaliable,
+                    pin_memory,
+                )
                 # DoubleTensor
                 test(
                     lambda: torch.randn(5, requires_grad=True, dtype=torch.double),
-                    cuda,
+                    is_accelerator_avaliable,
                     pin_memory,
                 )
                 # Sparse tensor
@@ -11569,10 +11610,10 @@ for shape in [(1,), ()]:
                     torch.tensor([1.0, 1.0]),
                     requires_grad=True,
                 )
-                test(lambda: x, cuda, pin_memory)
+                test(lambda: x, is_accelerator_avaliable, pin_memory)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA or XPU")
-    def test_graph_save_on_cpu_cuda(self):
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
+    def test_graph_save_on_cpu_gpu(self):
         device_type = torch.accelerator.current_accelerator().type
 
         def f(x):
@@ -11583,7 +11624,7 @@ for shape in [(1,), ()]:
         a = torch.ones(1, requires_grad=True, device=device_type)
         y = f(a)
         memory_with_grad = (
-            torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
+        memory_with_grad = torch.accelerator.memory_allocated()
         )
 
         del a
@@ -11594,7 +11635,7 @@ for shape in [(1,), ()]:
         with torch.no_grad():
             y = f(a)
         memory_without_grad = (
-            torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
+        memory_without_grad = torch.accelerator.memory_allocated()
         )
 
         self.assertGreater(memory_with_grad, memory_without_grad)
@@ -11607,13 +11648,13 @@ for shape in [(1,), ()]:
             a = torch.ones(1, requires_grad=True, device=device_type)
             y = f(a)
             memory_with_hooks = (
-                torch.cuda.memory_allocated()
+            memory_with_hooks = torch.cuda.memory_allocated()
                 if TEST_CUDA
                 else torch.xpu.memory_allocated()
             )
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA and XPU")
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_scalar_grad_mixed_device(self):
         device_type = torch.accelerator.current_accelerator().type
         x = torch.tensor(1.0, requires_grad=True)
@@ -12088,11 +12129,11 @@ get_out().sum().backward()
         self.assertEqual(y, y2)
         self.assertEqual(y_expected, y2_expected)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_gradcheck_default_device_placement_context(self):
         # During gradcheck with fast_mode=True, we create a random vector on the CPU device using a CPU generator.
         # This test ensures that this still works when the default device is set to something else by the user.
-        with torch.device("cuda"):
+        with torch.device(device_type):
             x = torch.randn(3, dtype=torch.double, requires_grad=True)
 
             def func(inp):
@@ -13438,7 +13479,7 @@ class TestAutogradDeviceType(TestCase):
                 t_cpu.grad = torch.randn(5, 5, device=devices[0])
 
         # Tests half type on CUDA
-        if self.device_type == "cuda":
+        if self.device_type == device_type:
             x = x.to(dtype=torch.half, device=devices[0])
             x.grad = torch.zeros_like(x)
 
@@ -13841,11 +13882,11 @@ class TestAutogradDeviceType(TestCase):
 
     @onlyCUDA
     def test_gradcheck_input_output_different_device(self, device):
-        x = torch.ones((1,), dtype=torch.double, device="cuda", requires_grad=True)
+        x = torch.ones((1,), dtype=torch.double, device=device_type, requires_grad=True)
         gradcheck(lambda x: x.to("cpu"), (x,))
 
         x = torch.ones((1,), dtype=torch.double, device="cpu", requires_grad=True)
-        gradcheck(lambda x: x.to("cuda"), (x,))
+        gradcheck(lambda x: x.to(device_type), (x,))
 
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181229"
@@ -14690,7 +14731,7 @@ def _set_device_index(target_device):
         torch.accelerator.set_device_index(orig_device)
 
 
-def _sleep_if_cuda(cycles):
+def _sleep_if_gpu(cycles):
     if "cuda" == torch.accelerator.current_accelerator().type:
         return torch.cuda._sleep(cycles)
     else:
@@ -14733,6 +14774,9 @@ class TestAutogradStreamSynchronization(TestCase):
     # AttributeError: module 'torch.mps' has no attribute 'default_stream'
     @expectedFailureMPS
     @skipCUDANonDefaultStreamIf(True)
+    @skipIfXpu(
+        msg="'torch.xpu' has no attribute 'default_stream', issue https://github.com/intel/torch-xpu-ops/issues/2793"
+    )
     def test_consumer_to_single_producer_case_2_correctness(self, device):
         if device == "cpu":
             self.skipTest("requires accelerator")
@@ -14749,7 +14793,7 @@ class TestAutogradStreamSynchronization(TestCase):
             @staticmethod
             def backward(ctx, gO):
                 out = gO.clone()
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 out.add_(1)
                 return out
 
@@ -14796,7 +14840,7 @@ class TestAutogradStreamSynchronization(TestCase):
             def backward(ctx, gO):
                 out = gO.to(_get_device_name(0))
                 with _set_device_index(0):
-                    _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                    _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 # It's the node's responsibility to sync back to its canonical stream.
                 out.add_(1)
                 ctx.node_stream.wait_stream(torch.accelerator.current_stream(0))
@@ -14812,7 +14856,7 @@ class TestAutogradStreamSynchronization(TestCase):
             # when FuncBackward produces a gradient on a default stream
             # a sync is necessary.
             with torch.Stream(0) as s0:
-                a = torch.ones(256, 256, requires_grad=True, device="cuda")
+                a = torch.ones(256, 256, requires_grad=True, device=device_type)
                 b = a * 2
 
             default_stream_0.wait_stream(s0)
@@ -14843,6 +14887,9 @@ class TestAutogradStreamSynchronization(TestCase):
     @skipCUDANonDefaultStreamIf(True)
     @unittest.skipIf(
         torch.accelerator.device_count() < 2, "accelerator count is less than 2"
+    )
+    @skipIfXpu(
+        msg="'torch.xpu' has no attribute 'default_stream', issue https://github.com/intel/torch-xpu-ops/issues/2793"
     )
     def test_consumer_to_single_producer_case_3_correctness_non_default_ambient_stream(
         self, device
@@ -14888,7 +14935,7 @@ class TestAutogradStreamSynchronization(TestCase):
             @staticmethod
             def backward(ctx, gO):
                 out = gO.clone()
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 return out.add_(1)
 
         class Consumer(torch.autograd.Function):
@@ -14969,7 +15016,7 @@ class TestAutogradStreamSynchronization(TestCase):
             @staticmethod
             def backward(ctx, gO):
                 out = gO.clone()
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 return out.mul_(2)
 
         class Consumer(torch.autograd.Function):
@@ -15068,7 +15115,7 @@ class TestAutogradStreamSynchronization(TestCase):
                 evt.record()
                 events["side_backward_start"] = evt
 
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 result = gO.clone()
 
                 evt = torch.Event(enable_timing=True)
@@ -15404,6 +15451,7 @@ class TestMultithreadAutograd(TestCase):
         self.assertEqual(err_count[0], 1)
         self.assertEqual(res, "foo")
 
+    @skipIfXpu(msg="torch._C._scatter Not implemented on XPU, issue #143239")
     def test_dataparallel_saved_tensors_hooks(self):
         def pack(x):
             warnings.warn("pack")
@@ -15415,7 +15463,7 @@ class TestMultithreadAutograd(TestCase):
             def forward(self, x):
                 with warnings.catch_warnings(record=True) as w:
                     y = x * x
-                    if torch.cuda.device_count() >= 2:
+                    if torch.accelerator.device_count() >= 2:
                         # DataParallel is calling the forward in different threads
                         # without propagating TLS, so hooks should not be called here
                         _self.assertEqual(len(w), 0)
@@ -15585,7 +15633,7 @@ class TestMultithreadAutograd(TestCase):
         torch.autograd.set_multithreading_enabled(True)
         self.assertTrue(torch.autograd.is_multithreading_enabled())
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_custom_function_propagates_errors_from_device_thread(self):
         class MyFunc(Function):
             @staticmethod
@@ -15597,7 +15645,9 @@ class TestMultithreadAutograd(TestCase):
                 raise RuntimeError("blah")
                 return gO
 
-        t = torch.tensor([1.0, 2.0], requires_grad=True, device=torch.device("cuda"))
+        t = torch.tensor(
+            [1.0, 2.0], requires_grad=True, device=torch.device(device_type)
+        )
         out = MyFunc.apply(t).sum()
 
         with self.assertRaisesRegex(RuntimeError, "blah"):
@@ -16050,16 +16100,16 @@ class _AutoNamingMode(TorchDispatchMode):
 
 
 class TestSelectiveActivationCheckpoint(TestCase):
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "requires GPU")
     def test_flops_and_mem(self):
         # From https://github.com/pytorch/pytorch/pull/126320
         def get_act_mem(f):
             out = f()
             out.backward()
             # Why do one forward and backward?
-            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            start_mem = torch.accelerator.memory_stats()["requested_bytes.all.current"]
             out = f()
-            cur_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            cur_mem = torch.accelerator.memory_stats()["requested_bytes.all.current"]
             act_mem = (cur_mem - start_mem) / (1024 * 1024)
             out.backward()
             return act_mem
@@ -16074,8 +16124,8 @@ class TestSelectiveActivationCheckpoint(TestCase):
                 out.backward()
             return mode.get_total_flops() / (512**3 * 2)
 
-        x = torch.randn(512, 512, requires_grad=True, device="cuda")
-        y = torch.randn(512, 512, requires_grad=True, device="cuda")
+        x = torch.randn(512, 512, requires_grad=True, device=device_type)
+        y = torch.randn(512, 512, requires_grad=True, device=device_type)
 
         def fn(x, y):
             return torch.mm(x.cos(), y).sin().sum()
@@ -16580,6 +16630,10 @@ class TestSelectiveActivationCheckpoint(TestCase):
 
 
 class TestAutogradMultipleDispatch(TestCase):
+    @skipIfXpu(
+        msg="Skip the failed test case test_autograd_multiple_dispatch_registrations due to tensor not closed, \
+                    issue https://github.com/intel/torch-xpu-ops/issues/2794"
+    )
     def test_autograd_multiple_dispatch_registrations(self, device):
         t = torch.randn(3, 3, device=device, requires_grad=True)
         # using _test_autograd_multiple_dispatch.fullcoverage which has
@@ -16671,6 +16725,7 @@ class TestAutogradMultipleDispatch(TestCase):
             else:
                 torch._test_autograd_multiple_dispatch(dual_input)
 
+    @skipIfXpu(msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914")
     def test_view_copy(self, device):
         # tests that view_copy derivative formulas are also generated per dispatch key
         # from their respective view ops in derivatives.yaml
@@ -16688,7 +16743,7 @@ class TestAutogradMultipleDispatch(TestCase):
         self.assertEqual(t_view_copy, t_view)
         self.assertEqual(t.grad, t_ref.grad)
         # backward results are per-dispatch-key in derivatives.yaml
-        if "cuda" in device:
+        if device_type in device:
             # gradient registered to AutogradCUDA is grad.reshape_as(self) + 1
             self.assertEqual(t.grad, grad.reshape_as(t) + 1)
         else:
@@ -16949,10 +17004,13 @@ from autograd.test_logging import TestAutogradLogging  # noqa: F401
 instantiate_device_type_tests(TestAutogradDeviceType, globals(), except_for=None)
 
 instantiate_device_type_tests(
-    TestAutogradMultipleDispatch, globals(), only_for=("cpu", "cuda")
+    TestAutogradMultipleDispatch,
+    globals(),
+    only_for=("cpu", "cuda", "xpu"),
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
-    TestAutogradStreamSynchronization, globals(), except_for=None
+    TestAutogradStreamSynchronization, globals(), except_for=None, allow_xpu=True
 )
 
 instantiate_parametrized_tests(TestAutograd)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16689,7 +16689,7 @@ class TestAutogradMultipleDispatch(TestCase):
                 torch._test_autograd_multiple_dispatch(dual_input)
 
     @skipIfXpu(
-        msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914"
+        msg="The skip to test_view_copy as a permanent skip as mentioned here https://github.com/pytorch/pytorch/pull/180969"
     )
     def test_view_copy(self, device):
         # tests that view_copy derivative formulas are also generated per dispatch key

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -49,7 +49,6 @@ from torch.autograd.profiler_util import (
     FunctionEventAvg,
 )
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     dtypes,
@@ -16725,7 +16724,9 @@ class TestAutogradMultipleDispatch(TestCase):
             else:
                 torch._test_autograd_multiple_dispatch(dual_input)
 
-    @skipIfXpu(msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914")
+    @skipIfXpu(
+        msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914"
+    )
     def test_view_copy(self, device):
         # tests that view_copy derivative formulas are also generated per dispatch key
         # from their respective view ops in derivatives.yaml

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16708,7 +16708,7 @@ class TestAutogradMultipleDispatch(TestCase):
         self.assertEqual(t_view_copy, t_view)
         self.assertEqual(t.grad, t_ref.grad)
         # backward results are per-dispatch-key in derivatives.yaml
-        if device_type in device:
+        if "cuda" in device:
             # gradient registered to AutogradCUDA is grad.reshape_as(self) + 1
             self.assertEqual(t.grad, grad.reshape_as(t) + 1)
         else:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4474,34 +4474,21 @@ class TestAutograd(TestCase):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
         self.assertIsInstance(x.int(), torch.IntTensor)
-        if torch.accelerator.is_available():
-            self.assertIsInstance(
-                x.float().to(device_type),
-                torch.get_device_module(device_type).FloatTensor,
-            )
-            self.assertIsInstance(
-                x.int().to(device_type), torch.get_device_module(device_type).IntTensor
-            )
-            self.assertIsInstance(x.int().to(device_type).cpu(), torch.IntTensor)
-            if torch.accelerator.device_count() >= 2:
-                x2 = x.float().to(device_type)(1)
-                self.assertIsInstance(
-                    x2, torch.get_device_module(device_type).FloatTensor
-                )
+        if torch.cuda.is_available():
+            self.assertIsInstance(x.float().cuda(), torch.cuda.FloatTensor)
+            self.assertIsInstance(x.int().cuda(), torch.cuda.IntTensor)
+            self.assertIsInstance(x.int().cuda().cpu(), torch.IntTensor)
+            if torch.cuda.device_count() >= 2:
+                x2 = x.float().cuda(1)
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
-                x2 = x.float().to(device_type)
-                self.assertIsInstance(
-                    x2, torch.get_device_module(device_type).FloatTensor
-                )
+                x2 = x.float().cuda()
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 0)
-                x2 = x2.get_device_module(device_type)(1)
-                self.assertIsInstance(
-                    x2, torch.get_device_module(device_type).FloatTensor
-                )
+                x2 = x2.cuda(1)
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
-                y = Variable(
-                    torch.randn(5).get_device_module(device_type)(1), requires_grad=True
-                )
+                y = Variable(torch.randn(5).cuda(1), requires_grad=True)
                 y.cpu().sum().backward()
                 self.assertIs(y.grad.get_device(), 1)
                 self.assertIs(y.long().get_device(), 1)
@@ -4522,35 +4509,27 @@ class TestAutograd(TestCase):
                 self.assertIsInstance(x.type(t_dtype), t)
                 self.assertIs(t_dtype, x.type(t_dtype).dtype)
                 self.assertEqual(y.data_ptr(), y.type(t).data_ptr())
-                if torch.accelerator.is_available():
-                    for x_acc in (True, False):
-                        for y_acc in (True, False):
-                            x_c = x.to(device_type) if x_acc else x
-                            y_c = y.to(device_type) if y_acc else y
+                if torch.cuda.is_available():
+                    for x_cuda in (True, False):
+                        for y_cuda in (True, False):
+                            x_c = x.cuda() if x_cuda else x
+                            y_c = y.cuda() if y_cuda else y
                             _, y_type = y_c.type().rsplit(".", 1)
-                            y_typestr = (
-                                f"torch.{device_type}." if y_acc else "torch."
-                            ) + y_type
+                            y_typestr = ("torch.cuda." if y_cuda else "torch.") + y_type
                             self.assertEqual(y_c.type(), x_c.type(y_typestr).type())
                             self.assertIs(y_c.dtype, x_c.type(y_c.dtype).dtype)
                             self.assertEqual(
                                 y_c.data_ptr(),
-                                y_c.to(device_type).data_ptr()
-                                if y_acc
-                                else y_c.data_ptr(),
+                                y_c.cuda().data_ptr() if y_cuda else y_c.data_ptr(),
                             )
 
         self._test_type_conversion_backward(lambda x: x)
-        if torch.accelerator.is_available():
-            self._test_type_conversion_backward(lambda x: x.to(device_type))
-            if torch.accelerator.device_count() >= 2:
+        if torch.cuda.is_available():
+            self._test_type_conversion_backward(lambda x: x.cuda())
+            if torch.cuda.device_count() >= 2:
                 # one of these has to be the non-default device
-                self._test_type_conversion_backward(
-                    lambda x: x.get_device_module(device_type)(0)
-                )
-                self._test_type_conversion_backward(
-                    lambda x: x.get_device_module(device_type)(1)
-                )
+                self._test_type_conversion_backward(lambda x: x.cuda(0))
+                self._test_type_conversion_backward(lambda x: x.cuda(1))
 
     def test_isolated_node(self):
         x = torch.randn(5, 5, requires_grad=True)
@@ -16619,10 +16598,6 @@ class TestSelectiveActivationCheckpoint(TestCase):
 
 
 class TestAutogradMultipleDispatch(TestCase):
-    @skipIfXpu(
-        msg="Skip the failed test case test_autograd_multiple_dispatch_registrations due to tensor not closed, \
-                    issue https://github.com/intel/torch-xpu-ops/issues/2794"
-    )
     def test_autograd_multiple_dispatch_registrations(self, device):
         t = torch.randn(3, 3, device=device, requires_grad=True)
         # using _test_autograd_multiple_dispatch.fullcoverage which has

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -84,6 +84,7 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
     slowTest,
+    TEST_CUDA,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -4474,21 +4475,34 @@ class TestAutograd(TestCase):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
         self.assertIsInstance(x.int(), torch.IntTensor)
-        if torch.cuda.is_available():
-            self.assertIsInstance(x.float().cuda(), torch.cuda.FloatTensor)
-            self.assertIsInstance(x.int().cuda(), torch.cuda.IntTensor)
-            self.assertIsInstance(x.int().cuda().cpu(), torch.IntTensor)
-            if torch.cuda.device_count() >= 2:
-                x2 = x.float().cuda(1)
-                self.assertIsInstance(x2, torch.cuda.FloatTensor)
+        if torch.accelerator.is_available():
+            self.assertIsInstance(
+                x.float().to(device_type),
+                torch.get_device_module(device_type).FloatTensor,
+            )
+            self.assertIsInstance(
+                x.int().to(device_type), torch.get_device_module(device_type).IntTensor
+            )
+            self.assertIsInstance(x.int().to(device_type).cpu(), torch.IntTensor)
+            if torch.accelerator.device_count() >= 2:
+                x2 = x.float().to(device_type)(1)
+                self.assertIsInstance(
+                    x2, torch.get_device_module(device_type).FloatTensor
+                )
                 self.assertIs(x2.get_device(), 1)
-                x2 = x.float().cuda()
-                self.assertIsInstance(x2, torch.cuda.FloatTensor)
+                x2 = x.float().to(device_type)
+                self.assertIsInstance(
+                    x2, torch.get_device_module(device_type).FloatTensor
+                )
                 self.assertIs(x2.get_device(), 0)
-                x2 = x2.cuda(1)
-                self.assertIsInstance(x2, torch.cuda.FloatTensor)
+                x2 = x2.get_device_module(device_type)(1)
+                self.assertIsInstance(
+                    x2, torch.get_device_module(device_type).FloatTensor
+                )
                 self.assertIs(x2.get_device(), 1)
-                y = Variable(torch.randn(5).cuda(1), requires_grad=True)
+                y = Variable(
+                    torch.randn(5).get_device_module(device_type)(1), requires_grad=True
+                )
                 y.cpu().sum().backward()
                 self.assertIs(y.grad.get_device(), 1)
                 self.assertIs(y.long().get_device(), 1)
@@ -4509,27 +4523,35 @@ class TestAutograd(TestCase):
                 self.assertIsInstance(x.type(t_dtype), t)
                 self.assertIs(t_dtype, x.type(t_dtype).dtype)
                 self.assertEqual(y.data_ptr(), y.type(t).data_ptr())
-                if torch.cuda.is_available():
-                    for x_cuda in (True, False):
-                        for y_cuda in (True, False):
-                            x_c = x.cuda() if x_cuda else x
-                            y_c = y.cuda() if y_cuda else y
+                if torch.accelerator.is_available():
+                    for x_acc in (True, False):
+                        for y_acc in (True, False):
+                            x_c = x.to(device_type) if x_acc else x
+                            y_c = y.to(device_type) if y_acc else y
                             _, y_type = y_c.type().rsplit(".", 1)
-                            y_typestr = ("torch.cuda." if y_cuda else "torch.") + y_type
+                            y_typestr = (
+                                f"torch.{device_type}." if y_acc else "torch."
+                            ) + y_type
                             self.assertEqual(y_c.type(), x_c.type(y_typestr).type())
                             self.assertIs(y_c.dtype, x_c.type(y_c.dtype).dtype)
                             self.assertEqual(
                                 y_c.data_ptr(),
-                                y_c.cuda().data_ptr() if y_cuda else y_c.data_ptr(),
+                                y_c.to(device_type).data_ptr()
+                                if y_acc
+                                else y_c.data_ptr(),
                             )
 
         self._test_type_conversion_backward(lambda x: x)
-        if torch.cuda.is_available():
-            self._test_type_conversion_backward(lambda x: x.cuda())
-            if torch.cuda.device_count() >= 2:
+        if torch.accelerator.is_available():
+            self._test_type_conversion_backward(lambda x: x.to(device_type))
+            if torch.accelerator.device_count() >= 2:
                 # one of these has to be the non-default device
-                self._test_type_conversion_backward(lambda x: x.cuda(0))
-                self._test_type_conversion_backward(lambda x: x.cuda(1))
+                self._test_type_conversion_backward(
+                    lambda x: x.get_device_module(device_type)(0)
+                )
+                self._test_type_conversion_backward(
+                    lambda x: x.get_device_module(device_type)(1)
+                )
 
     def test_isolated_node(self):
         x = torch.randn(5, 5, requires_grad=True)
@@ -11601,7 +11623,7 @@ for shape in [(1,), ()]:
         # with grad
         a = torch.ones(1, requires_grad=True, device=device_type)
         y = f(a)
-        memory_with_grad = torch.get_device_module(device_type).memory_allocated()
+        memory_with_grad = torch.accelerator.memory_allocated()
         del a
         del y
 
@@ -11609,7 +11631,7 @@ for shape in [(1,), ()]:
         a = torch.ones(1, requires_grad=True, device=device_type)
         with torch.no_grad():
             y = f(a)
-        memory_without_grad = torch.get_device_module(device_type).memory_allocated()
+            torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
 
         del a
@@ -11622,7 +11644,7 @@ for shape in [(1,), ()]:
             memory_with_hooks = torch.get_device_module(device_type).memory_allocated()
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA and XPU")
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_scalar_grad_mixed_device(self):
         device_type = torch.accelerator.current_accelerator().type
         x = torch.tensor(1.0, requires_grad=True)
@@ -16598,6 +16620,10 @@ class TestSelectiveActivationCheckpoint(TestCase):
 
 
 class TestAutogradMultipleDispatch(TestCase):
+    @skipIfXpu(
+        msg="Skip the failed test case test_autograd_multiple_dispatch_registrations due to tensor not closed, \
+                    issue https://github.com/intel/torch-xpu-ops/issues/2794"
+    )
     def test_autograd_multiple_dispatch_registrations(self, device):
         t = torch.randn(3, 3, device=device, requires_grad=True)
         # using _test_autograd_multiple_dispatch.fullcoverage which has
@@ -16689,9 +16715,7 @@ class TestAutogradMultipleDispatch(TestCase):
             else:
                 torch._test_autograd_multiple_dispatch(dual_input)
 
-    @skipIfXpu(
-        msg="The skip to test_view_copy as a permanent skip as mentioned here https://github.com/pytorch/pytorch/pull/180969"
-    )
+    @skipIfXpu(msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914")
     def test_view_copy(self, device):
         # tests that view_copy derivative formulas are also generated per dispatch key
         # from their respective view ops in derivatives.yaml
@@ -16709,7 +16733,7 @@ class TestAutogradMultipleDispatch(TestCase):
         self.assertEqual(t_view_copy, t_view)
         self.assertEqual(t.grad, t_ref.grad)
         # backward results are per-dispatch-key in derivatives.yaml
-        if "cuda" in device:
+        if device_type in device:
             # gradient registered to AutogradCUDA is grad.reshape_as(self) + 1
             self.assertEqual(t.grad, grad.reshape_as(t) + 1)
         else:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -49,6 +49,7 @@ from torch.autograd.profiler_util import (
     FunctionEventAvg,
 )
 from torch.testing import make_tensor
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     dtypes,
@@ -83,7 +84,6 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
     slowTest,
-    TEST_CUDA,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -11611,6 +11611,7 @@ for shape in [(1,), ()]:
             y = f(a)
         memory_without_grad = torch.accelerator.memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
+
         del a
         del y
 
@@ -11621,7 +11622,7 @@ for shape in [(1,), ()]:
             memory_with_hooks = torch.get_device_module(device_type).memory_allocated()
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA and XPU")
     def test_scalar_grad_mixed_device(self):
         device_type = torch.accelerator.current_accelerator().type
         x = torch.tensor(1.0, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11601,7 +11601,7 @@ for shape in [(1,), ()]:
         # with grad
         a = torch.ones(1, requires_grad=True, device=device_type)
         y = f(a)
-        memory_with_grad = torch.accelerator.memory_allocated()
+        memory_with_grad = torch.get_device_module(device_type).memory_allocated()
         del a
         del y
 
@@ -11609,7 +11609,7 @@ for shape in [(1,), ()]:
         a = torch.ones(1, requires_grad=True, device=device_type)
         with torch.no_grad():
             y = f(a)
-            torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
+        memory_without_grad = torch.accelerator.memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
         del a
         del y

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11611,7 +11611,6 @@ for shape in [(1,), ()]:
             y = f(a)
             torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
-
         del a
         del y
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -49,7 +49,6 @@ from torch.autograd.profiler_util import (
     FunctionEventAvg,
 )
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     dtypes,
@@ -16715,7 +16714,9 @@ class TestAutogradMultipleDispatch(TestCase):
             else:
                 torch._test_autograd_multiple_dispatch(dual_input)
 
-    @skipIfXpu(msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914")
+    @skipIfXpu(
+        msg="Skip due to AssertionError: Tensor-likes are not close!, https://github.com/intel/torch-xpu-ops/issues/2914"
+    )
     def test_view_copy(self, device):
         # tests that view_copy derivative formulas are also generated per dispatch key
         # from their respective view ops in derivatives.yaml

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -103,6 +103,11 @@ from torch.utils.flop_counter import FlopCounterMode
 from torch.utils.weak import WeakTensorKeyDictionary
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+TEST_GPU = TEST_CUDA or TEST_XPU
+
 if TYPE_CHECKING:
     from torch.utils.hooks import RemovableHandle
 
@@ -4842,6 +4847,9 @@ class TestAutograd(TestCase):
         self.assertEqual(dvar.grad, torch.ones_like(dvar))
         self.assertEqual(type(dvar.grad), type(dvar))
 
+    @skipIfXpu(
+        msg="It's a deprecated api, issue closed https://github.com/intel/torch-xpu-ops/issues/2792"
+    )
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
@@ -5422,7 +5430,7 @@ class TestAutograd(TestCase):
         run_test((10, 10), torch.zeros(10, 10))
         run_test((10,), 0)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_node_ordering_when_none_returned(self):
         class Matmul(torch.autograd.Function):
             @staticmethod
@@ -5456,9 +5464,13 @@ class TestAutograd(TestCase):
         def hook(*args, **kwargs):
             executed.append("B")
 
-        x = torch.randn((3, 3), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        x = torch.randn(
+            (3, 3), dtype=torch.bfloat16, device=device_type, requires_grad=True
+        )
         x = HookFunction.apply(x)
-        w = torch.randn((3, 3), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        w = torch.randn(
+            (3, 3), dtype=torch.bfloat16, device=device_type, requires_grad=True
+        )
         w.register_hook(hook)
         o = Matmul.apply(x, w)
         o.sum().backward()
@@ -7926,7 +7938,7 @@ Done""",
 
     @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
     def test_thread_shutdown(self):
-        code = """import torch
+        code = f"""import torch
 from torch.autograd import Function
 class MyFunction(Function):
     @staticmethod
@@ -7937,9 +7949,9 @@ class MyFunction(Function):
     def backward(ctx, grad):
         return grad
 
-# Run on cuda if it is available to ensure that the worker thread
+# Run on GPU if it is available to ensure that the worker thread
 # is properly initialized by the time we exit.
-device = "cuda" if torch.cuda.is_available() else "cpu"
+device = "{device_type}"
 
 for shape in [(1,), ()]:
     v = torch.ones(shape, requires_grad=True, device=device)
@@ -7949,7 +7961,7 @@ for shape in [(1,), ()]:
         # The autograd engine creates worker threads only when GPU devices are present.
         # So make sure that we do shutdown threads when we're testing cuda and make sure
         # that there is no thread to shutdown when we're not using cuda.
-        if TEST_CUDA or torch.backends.mps.is_available() or torch.xpu.is_available():
+        if TEST_GPU or torch.backends.mps.is_available():
             self.assertRegex(s, "PYTORCH_API_USAGE torch.autograd.thread_shutdown")
         else:
             self.assertNotRegex(s, "PYTORCH_API_USAGE torch.autograd.thread_shutdown")
@@ -8095,9 +8107,8 @@ for shape in [(1,), ()]:
         self._test_checkpointing_non_reentrant_autocast(device_type="cpu")
 
     @unittest.skipIf(
-        (not torch.cuda.is_available() or not torch.cuda.is_bf16_supported())
-        and (not torch.xpu.is_available() or not torch.xpu.is_bf16_supported()),
-        "Test requires CUDA or XPU bf16 support",
+        not TEST_GPU or not torch.get_device_module(device_type).is_bf16_supported(),
+        "Test requires GPU bf16 support",
     )
     def test_checkpointing_non_reentrant_autocast_gpu(self):
         """
@@ -8107,7 +8118,7 @@ for shape in [(1,), ()]:
         device_type = "cuda" if torch.cuda.is_available() else "xpu"
         self._test_checkpointing_non_reentrant_autocast(device_type=device_type)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+    @unittest.skipIf(TEST_GPU, "Test requires GPU")
     @slowTest
     def test_checkpointing_without_reentrant_memory_savings(self):
         class MyModel(nn.Module):
@@ -8140,32 +8151,32 @@ for shape in [(1,), ()]:
 
                 return x
 
-        model_no_checkpoint = MyModel(
-            8, use_checkpoint=False, use_reentrant=False
-        ).cuda()
+        model_no_checkpoint = MyModel(8, use_checkpoint=False, use_reentrant=False).to(
+            device_type
+        )
         model_reentrant_checkpoint = MyModel(
             8, use_checkpoint=True, use_reentrant=True
-        ).cuda()
+        ).to(device_type)
         model_no_reentrant_checkpoint = MyModel(
             8, use_checkpoint=True, use_reentrant=False
-        ).cuda()
+        ).to(device_type)
 
-        x = torch.randn(100, 256, requires_grad=True, device="cuda")
+        x = torch.randn(100, 256, requires_grad=True, device=device_type)
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         loss = model_no_checkpoint(x.clone()).sum()
         loss.backward()
-        mem_no_checkpoint = torch.cuda.max_memory_allocated()
+        mem_no_checkpoint = torch.accelerator.max_memory_allocated()
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         loss = model_reentrant_checkpoint(x.clone()).sum()
         loss.backward()
-        mem_reentrant_checkpoint = torch.cuda.max_memory_allocated()
+        mem_reentrant_checkpoint = torch.accelerator.max_memory_allocated()
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         loss = model_no_reentrant_checkpoint(x.clone()).sum()
         loss.backward()
-        mem_no_reentrant_checkpoint = torch.cuda.max_memory_allocated()
+        mem_no_reentrant_checkpoint = torch.accelerator.max_memory_allocated()
 
         self.assertTrue(mem_reentrant_checkpoint < mem_no_checkpoint)
         self.assertTrue(mem_no_reentrant_checkpoint < mem_no_checkpoint)
@@ -8890,12 +8901,12 @@ for shape in [(1,), ()]:
                 return self.linear(inp)
 
         a = torch.randn(2, 2, requires_grad=True)
-        if torch.cuda.is_available():
-            a = a.cuda()
+        if torch.accelerator.is_available():
+            a = a.to(device_type)
 
         model = LinearModule()
-        if torch.cuda.is_available():
-            model = model.cuda()
+        if torch.accelerator.is_available():
+            model = model.to(device_type)
 
         b = deepcopy(model)(a).sum()
         b.backward()
@@ -8996,7 +9007,7 @@ for shape in [(1,), ()]:
 
         self.assertEqual(called[0], 2)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_callback_propagates_errors_from_device_thread(self):
         def callback():
             raise RuntimeError("blah")
@@ -9004,7 +9015,9 @@ for shape in [(1,), ()]:
         def hook_with_callback(*args):
             torch.autograd.Variable._execution_engine.queue_callback(callback)
 
-        t = torch.tensor([1.0, 2.0], requires_grad=True, device=torch.device("cuda"))
+        t = torch.tensor(
+            [1.0, 2.0], requires_grad=True, device=torch.device(device_type)
+        )
         t.register_hook(hook_with_callback)
         output = t**2
         loss = output.sum()
@@ -12258,11 +12271,11 @@ for shape in [(1,), ()]:
             torch.autograd.grad(out, (a,))
 
     def test_graph_save_on_cpu(self):
-        def test(get_input, cuda, pin_memory):
+        def test(get_input, is_accelerator_avaliable, pin_memory):
             with torch.autograd.graph.save_on_cpu(pin_memory):
                 a = get_input()
-                if cuda:
-                    a.cuda()
+                if is_accelerator_avaliable:
+                    a.to(device_type)
                 y = a * a
                 self.assertEqual(a, y.grad_fn._saved_self)
                 self.assertEqual(a, y.grad_fn._saved_other)
@@ -12280,14 +12293,20 @@ for shape in [(1,), ()]:
 
                 self.assertEqual(actual, expected)
 
-        for cuda in [False] + ([True] if torch.cuda.is_available() else []):
+        for is_accelerator_avaliable in [False] + (
+            [True] if torch.accelerator.is_available() else []
+        ):
             for pin_memory in [True, False]:
                 # FloatTensor
-                test(lambda: torch.randn(5, requires_grad=True), cuda, pin_memory)
+                test(
+                    lambda: torch.randn(5, requires_grad=True),
+                    is_accelerator_avaliable,
+                    pin_memory,
+                )
                 # DoubleTensor
                 test(
                     lambda: torch.randn(5, requires_grad=True, dtype=torch.double),
-                    cuda,
+                    is_accelerator_avaliable,
                     pin_memory,
                 )
                 # Sparse tensor
@@ -12296,10 +12315,10 @@ for shape in [(1,), ()]:
                     torch.tensor([1.0, 1.0]),
                     requires_grad=True,
                 )
-                test(lambda: x, cuda, pin_memory)
+                test(lambda: x, is_accelerator_avaliable, pin_memory)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA or XPU")
-    def test_graph_save_on_cpu_cuda(self):
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
+    def test_graph_save_on_cpu_gpu(self):
         device_type = torch.accelerator.current_accelerator().type
 
         def f(x):
@@ -12309,10 +12328,7 @@ for shape in [(1,), ()]:
         # with grad
         a = torch.ones(1, requires_grad=True, device=device_type)
         y = f(a)
-        memory_with_grad = (
-            torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
-        )
-
+        memory_with_grad = torch.get_device_module(device_type).memory_allocated()
         del a
         del y
 
@@ -12320,10 +12336,7 @@ for shape in [(1,), ()]:
         a = torch.ones(1, requires_grad=True, device=device_type)
         with torch.no_grad():
             y = f(a)
-        memory_without_grad = (
-            torch.cuda.memory_allocated() if TEST_CUDA else torch.xpu.memory_allocated()
-        )
-
+        memory_without_grad = torch.accelerator.memory_allocated()
         self.assertGreater(memory_with_grad, memory_without_grad)
 
         del a
@@ -12333,11 +12346,7 @@ for shape in [(1,), ()]:
         with torch.autograd.graph.save_on_cpu():
             a = torch.ones(1, requires_grad=True, device=device_type)
             y = f(a)
-            memory_with_hooks = (
-                torch.cuda.memory_allocated()
-                if TEST_CUDA
-                else torch.xpu.memory_allocated()
-            )
+            memory_with_hooks = torch.get_device_module(device_type).memory_allocated()
             self.assertEqual(memory_with_hooks, memory_without_grad)
 
     @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "test requires CUDA and XPU")
@@ -12815,11 +12824,11 @@ get_out().sum().backward()
         self.assertEqual(y, y2)
         self.assertEqual(y_expected, y2_expected)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_gradcheck_default_device_placement_context(self):
         # During gradcheck with fast_mode=True, we create a random vector on the CPU device using a CPU generator.
         # This test ensures that this still works when the default device is set to something else by the user.
-        with torch.device("cuda"):
+        with torch.device(device_type):
             x = torch.randn(3, dtype=torch.double, requires_grad=True)
 
             def func(inp):
@@ -14175,7 +14184,7 @@ class TestAutogradDeviceType(TestCase):
                 t_cpu.grad = torch.randn(5, 5, device=devices[0])
 
         # Tests half type on CUDA
-        if self.device_type == "cuda":
+        if self.device_type == device_type:
             x = x.to(dtype=torch.half, device=devices[0])
             x.grad = torch.zeros_like(x)
 
@@ -14578,11 +14587,11 @@ class TestAutogradDeviceType(TestCase):
 
     @onlyCUDA
     def test_gradcheck_input_output_different_device(self, device):
-        x = torch.ones((1,), dtype=torch.double, device="cuda", requires_grad=True)
+        x = torch.ones((1,), dtype=torch.double, device=device_type, requires_grad=True)
         gradcheck(lambda x: x.to("cpu"), (x,))
 
         x = torch.ones((1,), dtype=torch.double, device="cpu", requires_grad=True)
-        gradcheck(lambda x: x.to("cuda"), (x,))
+        gradcheck(lambda x: x.to(device_type), (x,))
 
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181229"
@@ -15534,7 +15543,7 @@ def _set_device_index(target_device):
         torch.accelerator.set_device_index(orig_device)
 
 
-def _sleep_if_cuda(cycles):
+def _sleep_if_gpu(cycles):
     if "cuda" == torch.accelerator.current_accelerator().type:
         return torch.cuda._sleep(cycles)
     else:
@@ -15577,6 +15586,9 @@ class TestAutogradStreamSynchronization(TestCase):
     # AttributeError: module 'torch.mps' has no attribute 'default_stream'
     @expectedFailureMPS
     @skipCUDANonDefaultStreamIf(True)
+    @skipIfXpu(
+        msg="XPU doesn't have an exact counterpart of the default stream, closed issue https://github.com/intel/torch-xpu-ops/issues/2793"
+    )
     def test_consumer_to_single_producer_case_2_correctness(self, device):
         if device == "cpu":
             self.skipTest("requires accelerator")
@@ -15593,7 +15605,7 @@ class TestAutogradStreamSynchronization(TestCase):
             @staticmethod
             def backward(ctx, gO):
                 out = gO.clone()
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 out.add_(1)
                 return out
 
@@ -15640,7 +15652,7 @@ class TestAutogradStreamSynchronization(TestCase):
             def backward(ctx, gO):
                 out = gO.to(_get_device_name(0))
                 with _set_device_index(0):
-                    _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                    _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 # It's the node's responsibility to sync back to its canonical stream.
                 out.add_(1)
                 ctx.node_stream.wait_stream(torch.accelerator.current_stream(0))
@@ -15656,7 +15668,7 @@ class TestAutogradStreamSynchronization(TestCase):
             # when FuncBackward produces a gradient on a default stream
             # a sync is necessary.
             with torch.Stream(0) as s0:
-                a = torch.ones(256, 256, requires_grad=True, device="cuda")
+                a = torch.ones(256, 256, requires_grad=True, device=device_type)
                 b = a * 2
 
             default_stream_0.wait_stream(s0)
@@ -15687,6 +15699,9 @@ class TestAutogradStreamSynchronization(TestCase):
     @skipCUDANonDefaultStreamIf(True)
     @unittest.skipIf(
         torch.accelerator.device_count() < 2, "accelerator count is less than 2"
+    )
+    @skipIfXpu(
+        msg="XPU doesn't have an exact counterpart of the default stream, closed issue https://github.com/intel/torch-xpu-ops/issues/2793"
     )
     def test_consumer_to_single_producer_case_3_correctness_non_default_ambient_stream(
         self, device
@@ -15732,7 +15747,7 @@ class TestAutogradStreamSynchronization(TestCase):
             @staticmethod
             def backward(ctx, gO):
                 out = gO.clone()
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 return out.add_(1)
 
         class Consumer(torch.autograd.Function):
@@ -15813,7 +15828,7 @@ class TestAutogradStreamSynchronization(TestCase):
             @staticmethod
             def backward(ctx, gO):
                 out = gO.clone()
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 return out.mul_(2)
 
         class Consumer(torch.autograd.Function):
@@ -15912,7 +15927,7 @@ class TestAutogradStreamSynchronization(TestCase):
                 evt.record()
                 events["side_backward_start"] = evt
 
-                _sleep_if_cuda(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
+                _sleep_if_gpu(NUM_GPU_CYCLES_IN_ONE_SEC // 2)
                 result = gO.clone()
 
                 evt = torch.Event(enable_timing=True)
@@ -16248,6 +16263,7 @@ class TestMultithreadAutograd(TestCase):
         self.assertEqual(err_count[0], 1)
         self.assertEqual(res, "foo")
 
+    @skipIfXpu(msg="torch._C._scatter Not implemented on XPU, issue #143239")
     def test_dataparallel_saved_tensors_hooks(self):
         def pack(x):
             warnings.warn("pack")
@@ -16259,7 +16275,7 @@ class TestMultithreadAutograd(TestCase):
             def forward(self, x):
                 with warnings.catch_warnings(record=True) as w:
                     y = x * x
-                    if torch.cuda.device_count() >= 2:
+                    if torch.accelerator.device_count() >= 2:
                         # DataParallel is calling the forward in different threads
                         # without propagating TLS, so hooks should not be called here
                         _self.assertEqual(len(w), 0)
@@ -16429,7 +16445,7 @@ class TestMultithreadAutograd(TestCase):
         torch.autograd.set_multithreading_enabled(True)
         self.assertTrue(torch.autograd.is_multithreading_enabled())
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "test requires GPU")
     def test_custom_function_propagates_errors_from_device_thread(self):
         class MyFunc(Function):
             @staticmethod
@@ -16441,7 +16457,9 @@ class TestMultithreadAutograd(TestCase):
                 raise RuntimeError("blah")
                 return gO
 
-        t = torch.tensor([1.0, 2.0], requires_grad=True, device=torch.device("cuda"))
+        t = torch.tensor(
+            [1.0, 2.0], requires_grad=True, device=torch.device(device_type)
+        )
         out = MyFunc.apply(t).sum()
 
         with self.assertRaisesRegex(RuntimeError, "blah"):
@@ -16978,16 +16996,16 @@ class _AutoNamingMode(TorchDispatchMode):
 
 
 class TestSelectiveActivationCheckpoint(TestCase):
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_GPU, "requires GPU")
     def test_flops_and_mem(self):
         # From https://github.com/pytorch/pytorch/pull/126320
         def get_act_mem(f):
             out = f()
             out.backward()
             # Why do one forward and backward?
-            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            start_mem = torch.accelerator.memory_stats()["requested_bytes.all.current"]
             out = f()
-            cur_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            cur_mem = torch.accelerator.memory_stats()["requested_bytes.all.current"]
             act_mem = (cur_mem - start_mem) / (1024 * 1024)
             out.backward()
             return act_mem
@@ -17002,8 +17020,8 @@ class TestSelectiveActivationCheckpoint(TestCase):
                 out.backward()
             return mode.get_total_flops() / (512**3 * 2)
 
-        x = torch.randn(512, 512, requires_grad=True, device="cuda")
-        y = torch.randn(512, 512, requires_grad=True, device="cuda")
+        x = torch.randn(512, 512, requires_grad=True, device=device_type)
+        y = torch.randn(512, 512, requires_grad=True, device=device_type)
 
         def fn(x, y):
             return torch.mm(x.cos(), y).sin().sum()
@@ -17934,6 +17952,9 @@ class TestAutogradMultipleDispatch(TestCase):
             else:
                 torch._test_autograd_multiple_dispatch(dual_input)
 
+    @skipIfXpu(
+        msg="The skip to test_view_copy as a permanent skip as mentioned here https://github.com/pytorch/pytorch/pull/180969"
+    )
     def test_view_copy(self, device):
         # tests that view_copy derivative formulas are also generated per dispatch key
         # from their respective view ops in derivatives.yaml
@@ -18289,11 +18310,11 @@ instantiate_device_type_tests(TestAutogradDeviceType, globals(), except_for=None
 instantiate_device_type_tests(
     TestAutogradMultipleDispatch,
     globals(),
-    only_for=("cpu", "xpu", "cuda"),
+    only_for=("cpu", "cuda", "xpu"),
     allow_xpu=True,
 )
 instantiate_device_type_tests(
-    TestAutogradStreamSynchronization, globals(), except_for=None
+    TestAutogradStreamSynchronization, globals(), except_for=None, allow_xpu=True
 )
 
 instantiate_parametrized_tests(TestAutograd)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -47,6 +47,10 @@ from torch.testing._internal.common_dtype import (
 )
 
 from torch.utils.dlpack import to_dlpack
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
 
 # TODO: replace with make_tensor
 def _generate_input(shape, dtype, device, with_extremal):
@@ -1941,6 +1945,9 @@ class TestTensorCreation(TestCase):
         if device_type == 'cuda':
             do_test_empty_full(self, dtypes, torch.strided, None)
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
+        if device_type == 'xpu':
+            do_test_empty_full(self, dtypes, torch.strided, None)
+            do_test_empty_full(self, dtypes, torch.strided, torch_device)
 
     # TODO: this test should be updated
     @suppress_warnings
@@ -1993,6 +2000,42 @@ class TestTensorCreation(TestCase):
 
                 self.assertEqual('cuda:1',
                                  str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
+        if device_type == 'xpu':
+            self.assertEqual('xpu:0', str(torch.tensor(5).xpu(0).device))
+            self.assertEqual('xpu:0', str(torch.tensor(5).xpu('xpu:0').device))
+            self.assertEqual('xpu:0',
+                             str(torch.tensor(5, dtype=torch.int64, device=0).device))
+            self.assertEqual('xpu:0',
+                             str(torch.tensor(5, dtype=torch.int64, device='xpu:0').device))
+            self.assertEqual('xpu:0',
+                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='xpu:0').device))
+
+            self.assertEqual('xpu:0', str(torch.tensor(np.random.randn(2, 3), device='xpu:0').device))
+
+            for device in devices:
+                with torch.xpu.device(device):
+                    device_string = 'xpu:' + str(torch.xpu.current_device())
+                    self.assertEqual(device_string,
+                                     str(torch.tensor(5, dtype=torch.int64, device='xpu').device))
+
+            with self.assertRaises(RuntimeError):
+                torch.tensor(5).xpu('cpu')
+            with self.assertRaises(RuntimeError):
+                torch.tensor(5).xpu('cpu:0')
+
+            if len(devices) > 1:
+                self.assertEqual('xpu:1', str(torch.tensor(5).xpu(1).device))
+                self.assertEqual('xpu:1', str(torch.tensor(5).xpu('xpu:1').device))
+                self.assertEqual('xpu:1',
+                                 str(torch.tensor(5, dtype=torch.int64, device=1).device))
+                self.assertEqual('xpu:1',
+                                 str(torch.tensor(5, dtype=torch.int64, device='xpu:1').device))
+                self.assertEqual('xpu:1',
+                                 str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
+                                     device='xpu:1').device))
+
+                self.assertEqual('xpu:1',
+                                 str(torch.tensor(np.random.randn(2, 3), device='xpu:1').device))
 
     # TODO: this test should be updated
     @onlyNativeDeviceTypes
@@ -2825,6 +2868,10 @@ class TestTensorCreation(TestCase):
                     with torch.cuda.device(device):
                         self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
+                if self.device_type == 'xpu':
+                    with torch.xpu.device(device):
+                        self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
+
         # Tests sparse ctor
         indices = torch.tensor([[0, 1, 1],
                                 [2, 0, 1],
@@ -2842,6 +2889,13 @@ class TestTensorCreation(TestCase):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
+
+        if self.device_type == 'xpu':
+            with torch.xpu.device(device):
+                sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
+                                                            sparse_size, dtype=torch.float64)
+                self.assertEqual(sparse_with_dtype.device, torch.device('xpu'))
+
 
     @onlyCUDA
     @onlyNativeDeviceTypes
@@ -3716,6 +3770,7 @@ class TestRandomTensorCreation(TestCase):
 
     @largeTensorTest("10GB", "cpu")
     @largeTensorTest("40GB", "cuda")
+    @largeTensorTest("40GB", "xpu")
     @slowTest
     def test_randperm_large(self, device):
         # Test even distribution where rand32 might produce skewed "uniform" distribution
@@ -4203,6 +4258,9 @@ def get_another_device(device):
 
     return acc.type if acc is not None else None
 
+def get_another_xpu_device(device):
+    return "xpu" if torch.device(device).type == "cpu" else "cpu"
+
 def identity(tensor):
     return tensor
 def to_numpy(tensor):
@@ -4401,6 +4459,13 @@ class TestAsArray(TestCase):
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)
+
+        if torch.xpu.is_available():
+            other_device = get_another_xpu_device(device)
+            with self.assertRaisesRegex(ValueError,
+                                        f"from device '{device}' to '{other_device}'"):
+                torch.asarray(original, device=other_device, copy=False)
+
 
         with self.assertRaisesRegex(ValueError,
                                     "with dtype '.*' into dtype '.*'"):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4249,14 +4249,7 @@ class TestFromBlob(TestCase):
 #   The implementation itself is based on the Python Array API:
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
-    device = torch.device(device)
-
-    if device.type != "cpu":
-        return "cpu"
-
-    acc = torch.accelerator.current_accelerator(True)
-
-    return acc.type if acc is not None else None
+    return device_type if torch.device(device).type == "cpu" else "cpu"
 
 def get_another_xpu_device(device):
     return "xpu" if torch.device(device).type == "cpu" else "cpu"
@@ -4454,18 +4447,11 @@ class TestAsArray(TestCase):
     def test_unsupported_alias(self, device, dtype):
         original = make_tensor((5, 5), dtype=dtype, device=device)
 
-        other_device = get_another_device(device)
-        if other_device is not None:
+        if torch.accelerator.is_available():
+            other_device = get_another_device(device)
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)
-
-        if torch.xpu.is_available():
-            other_device = get_another_xpu_device(device)
-            with self.assertRaisesRegex(ValueError,
-                                        f"from device '{device}' to '{other_device}'"):
-                torch.asarray(original, device=other_device, copy=False)
-
 
         with self.assertRaisesRegex(ValueError,
                                     "with dtype '.*' into dtype '.*'"):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1962,8 +1962,8 @@ class TestTensorCreation(TestCase):
                              torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cpu:0').device.type)
             self.assertEqual('cpu', torch.tensor(np.random.randn(2, 3), device='cpu').device.type)
         if device_type in ('cuda', 'xpu'):
-            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).cuda(0).device))
-            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).cuda(f"{device_type}:0").device))
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).to(0).device))
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).to(f"{device_type}:0").device))
             self.assertEqual(f"{device_type}:0",
                              str(torch.tensor(5, dtype=torch.int64, device=0).device))
             self.assertEqual(f"{device_type}:0",
@@ -1974,19 +1974,19 @@ class TestTensorCreation(TestCase):
             self.assertEqual(f"{device_type}:0", str(torch.tensor(np.random.randn(2, 3), device=f"{device_type}:0").device))
 
             for device in devices:
-                with torch.cuda.device(device):
-                    device_string = f"{device_type}:" + str(torch.cuda.current_device())
+                with torch.get_device_module(device_type).device(device):
+                    device_string = f"{device_type}:" + str(torch.accelerator.current_accelerator())
                     self.assertEqual(device_string,
                                      str(torch.tensor(5, dtype=torch.int64, device=device_type).device))
 
             with self.assertRaises(RuntimeError):
-                torch.tensor(5).cuda('cpu')
+                torch.tensor(5).to('cpu')
             with self.assertRaises(RuntimeError):
-                torch.tensor(5).cuda('cpu:0')
+                torch.tensor(5).to('cpu:0')
 
             if len(devices) > 1:
-                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).cuda(1).device))
-                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).cuda(f"{device_type}:1").device))
+                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).to(1).device))
+                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).to(f"{device_type}:1").device))
                 self.assertEqual(f"{device_type}:1",
                                  str(torch.tensor(5, dtype=torch.int64, device=1).device))
                 self.assertEqual(f"{device_type}:1",
@@ -2826,7 +2826,7 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(op(values, dtype=torch.float64).device, torch_device)
 
                 if self.device_type in ('cuda', 'xpu'):
-                    with torch.accelerator.device_index(0):
+                    with torch.get_device_module(device_type).device(device):
                         self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
         # Tests sparse ctor
@@ -2841,8 +2841,8 @@ class TestTensorCreation(TestCase):
         sparse_with_dtype = torch.sparse_coo_tensor(indices, values, sparse_size, dtype=torch.float64)
         self.assertEqual(sparse_with_dtype.device, torch_device)
 
-        if torch.accelerator.is_available():
-            with torch.accelerator.device_index(0):
+        if self.device_type in ('cuda', 'xpu'):
+            with torch.get_device_module(device_type).device(device):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1942,10 +1942,7 @@ class TestTensorCreation(TestCase):
         dtypes = get_all_dtypes(include_half=False, include_bfloat16=False, include_complex32=True)
         if device_type == 'cpu':
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
-        if device_type == 'cuda':
-            do_test_empty_full(self, dtypes, torch.strided, None)
-            do_test_empty_full(self, dtypes, torch.strided, torch_device)
-        if device_type == 'xpu':
+        if device_type in ('cuda', 'xpu'):
             do_test_empty_full(self, dtypes, torch.strided, None)
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
 
@@ -1964,23 +1961,23 @@ class TestTensorCreation(TestCase):
             self.assertEqual('cpu',
                              torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cpu:0').device.type)
             self.assertEqual('cpu', torch.tensor(np.random.randn(2, 3), device='cpu').device.type)
-        if device_type == 'cuda':
-            self.assertEqual('cuda:0', str(torch.tensor(5).cuda(0).device))
-            self.assertEqual('cuda:0', str(torch.tensor(5).cuda('cuda:0').device))
-            self.assertEqual('cuda:0',
+        if device_type in ('cuda', 'xpu'):
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).cuda(0).device))
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).cuda(f"{device_type}:0").device))
+            self.assertEqual(f"{device_type}:0",
                              str(torch.tensor(5, dtype=torch.int64, device=0).device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(5, dtype=torch.int64, device='cuda:0').device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cuda:0').device))
+            self.assertEqual(f"{device_type}:0",
+                             str(torch.tensor(5, dtype=torch.int64, device=f"{device_type}:0").device))
+            self.assertEqual(f"{device_type}:0",
+                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device=f"{device_type}:0").device))
 
-            self.assertEqual('cuda:0', str(torch.tensor(np.random.randn(2, 3), device='cuda:0').device))
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(np.random.randn(2, 3), device=f"{device_type}:0").device))
 
             for device in devices:
                 with torch.cuda.device(device):
-                    device_string = 'cuda:' + str(torch.cuda.current_device())
+                    device_string = f"{device_type}:" + str(torch.cuda.current_device())
                     self.assertEqual(device_string,
-                                     str(torch.tensor(5, dtype=torch.int64, device='cuda').device))
+                                     str(torch.tensor(5, dtype=torch.int64, device=device_type).device))
 
             with self.assertRaises(RuntimeError):
                 torch.tensor(5).cuda('cpu')
@@ -1988,54 +1985,18 @@ class TestTensorCreation(TestCase):
                 torch.tensor(5).cuda('cpu:0')
 
             if len(devices) > 1:
-                self.assertEqual('cuda:1', str(torch.tensor(5).cuda(1).device))
-                self.assertEqual('cuda:1', str(torch.tensor(5).cuda('cuda:1').device))
-                self.assertEqual('cuda:1',
+                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).cuda(1).device))
+                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).cuda(f"{device_type}:1").device))
+                self.assertEqual(f"{device_type}:1",
                                  str(torch.tensor(5, dtype=torch.int64, device=1).device))
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(5, dtype=torch.int64, device='cuda:1').device))
-                self.assertEqual('cuda:1',
+                self.assertEqual(f"{device_type}:1",
+                                 str(torch.tensor(5, dtype=torch.int64, device=f"{device_type}:1").device))
+                self.assertEqual(f"{device_type}:1",
                                  str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
-                                     device='cuda:1').device))
+                                     device=f"{device_type}:1").device))
 
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
-        if device_type == 'xpu':
-            self.assertEqual('xpu:0', str(torch.tensor(5).xpu(0).device))
-            self.assertEqual('xpu:0', str(torch.tensor(5).xpu('xpu:0').device))
-            self.assertEqual('xpu:0',
-                             str(torch.tensor(5, dtype=torch.int64, device=0).device))
-            self.assertEqual('xpu:0',
-                             str(torch.tensor(5, dtype=torch.int64, device='xpu:0').device))
-            self.assertEqual('xpu:0',
-                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='xpu:0').device))
-
-            self.assertEqual('xpu:0', str(torch.tensor(np.random.randn(2, 3), device='xpu:0').device))
-
-            for device in devices:
-                with torch.xpu.device(device):
-                    device_string = 'xpu:' + str(torch.xpu.current_device())
-                    self.assertEqual(device_string,
-                                     str(torch.tensor(5, dtype=torch.int64, device='xpu').device))
-
-            with self.assertRaises(RuntimeError):
-                torch.tensor(5).xpu('cpu')
-            with self.assertRaises(RuntimeError):
-                torch.tensor(5).xpu('cpu:0')
-
-            if len(devices) > 1:
-                self.assertEqual('xpu:1', str(torch.tensor(5).xpu(1).device))
-                self.assertEqual('xpu:1', str(torch.tensor(5).xpu('xpu:1').device))
-                self.assertEqual('xpu:1',
-                                 str(torch.tensor(5, dtype=torch.int64, device=1).device))
-                self.assertEqual('xpu:1',
-                                 str(torch.tensor(5, dtype=torch.int64, device='xpu:1').device))
-                self.assertEqual('xpu:1',
-                                 str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
-                                     device='xpu:1').device))
-
-                self.assertEqual('xpu:1',
-                                 str(torch.tensor(np.random.randn(2, 3), device='xpu:1').device))
+                self.assertEqual(f"{device_type}:1",
+                                 str(torch.tensor(np.random.randn(2, 3), device=f"{device_type}:1").device))
 
     # TODO: this test should be updated
     @onlyNativeDeviceTypes
@@ -2864,12 +2825,8 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(op(values).device, torch_device)
                 self.assertEqual(op(values, dtype=torch.float64).device, torch_device)
 
-                if self.device_type == 'cuda':
-                    with torch.cuda.device(device):
-                        self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
-
-                if self.device_type == 'xpu':
-                    with torch.xpu.device(device):
+                if self.device_type in ('cuda', 'xpu'):
+                    with torch.accelerator.device_index(0):
                         self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
         # Tests sparse ctor
@@ -2884,18 +2841,11 @@ class TestTensorCreation(TestCase):
         sparse_with_dtype = torch.sparse_coo_tensor(indices, values, sparse_size, dtype=torch.float64)
         self.assertEqual(sparse_with_dtype.device, torch_device)
 
-        if self.device_type == 'cuda':
-            with torch.cuda.device(device):
+        if torch.accelerator.is_available():
+            with torch.accelerator.device_index(0):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
-
-        if self.device_type == 'xpu':
-            with torch.xpu.device(device):
-                sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
-                                                            sparse_size, dtype=torch.float64)
-                self.assertEqual(sparse_with_dtype.device, torch.device('xpu'))
-
 
     @onlyCUDA
     @onlyNativeDeviceTypes
@@ -4250,9 +4200,6 @@ class TestFromBlob(TestCase):
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
     return device_type if torch.device(device).type == "cpu" else "cpu"
-
-def get_another_xpu_device(device):
-    return "xpu" if torch.device(device).type == "cpu" else "cpu"
 
 def identity(tensor):
     return tensor

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4199,7 +4199,14 @@ class TestFromBlob(TestCase):
 #   The implementation itself is based on the Python Array API:
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
-    return device_type if torch.device(device).type == "cpu" else "cpu"
+    device = torch.device(device)
+
+    if device.type != "cpu":
+        return "cpu"
+
+    acc = torch.accelerator.current_accelerator(True)
+
+    return acc.type if acc is not None else None
 
 def identity(tensor):
     return tensor

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2826,11 +2826,7 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(op(values, dtype=torch.float64).device, torch_device)
 
                 if self.device_type in ('cuda', 'xpu'):
-                    with torch.get_device_module(device_type).device(device):
-                        self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
-
-                if self.device_type == 'xpu':
-                    with torch.xpu.device(device):
+                    with torch.accelerator.device_index(0):
                         self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
         # Tests sparse ctor
@@ -2845,8 +2841,8 @@ class TestTensorCreation(TestCase):
         sparse_with_dtype = torch.sparse_coo_tensor(indices, values, sparse_size, dtype=torch.float64)
         self.assertEqual(sparse_with_dtype.device, torch_device)
 
-        if self.device_type in ('cuda', 'xpu'):
-            with torch.cuda.device(device):
+        if torch.accelerator.is_available():
+            with torch.accelerator.device_index(0):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1945,6 +1945,9 @@ class TestTensorCreation(TestCase):
         if device_type in ('cuda', 'xpu'):
             do_test_empty_full(self, dtypes, torch.strided, None)
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
+        if device_type == 'xpu':
+            do_test_empty_full(self, dtypes, torch.strided, None)
+            do_test_empty_full(self, dtypes, torch.strided, torch_device)
 
     # TODO: this test should be updated
     @suppress_warnings
@@ -2829,6 +2832,10 @@ class TestTensorCreation(TestCase):
                     with torch.get_device_module(device_type).device(device):
                         self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
+                if self.device_type == 'xpu':
+                    with torch.xpu.device(device):
+                        self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
+
         # Tests sparse ctor
         indices = torch.tensor([[0, 1, 1],
                                 [2, 0, 1],
@@ -2846,6 +2853,13 @@ class TestTensorCreation(TestCase):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
+
+        if self.device_type == 'xpu':
+            with torch.xpu.device(device):
+                sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
+                                                            sparse_size, dtype=torch.float64)
+                self.assertEqual(sparse_with_dtype.device, torch.device('xpu'))
+
 
     @onlyCUDA
     @onlyNativeDeviceTypes
@@ -4208,6 +4222,9 @@ def get_another_device(device):
 
     return acc.type if acc is not None else None
 
+def get_another_xpu_device(device):
+    return "xpu" if torch.device(device).type == "cpu" else "cpu"
+
 def identity(tensor):
     return tensor
 def to_numpy(tensor):
@@ -4406,6 +4423,13 @@ class TestAsArray(TestCase):
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)
+
+        if torch.xpu.is_available():
+            other_device = get_another_xpu_device(device)
+            with self.assertRaisesRegex(ValueError,
+                                        f"from device '{device}' to '{other_device}'"):
+                torch.asarray(original, device=other_device, copy=False)
+
 
         with self.assertRaisesRegex(ValueError,
                                     "with dtype '.*' into dtype '.*'"):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4213,14 +4213,7 @@ class TestFromBlob(TestCase):
 #   The implementation itself is based on the Python Array API:
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
-    device = torch.device(device)
-
-    if device.type != "cpu":
-        return "cpu"
-
-    acc = torch.accelerator.current_accelerator(True)
-
-    return acc.type if acc is not None else None
+    return device_type if torch.device(device).type == "cpu" else "cpu"
 
 def get_another_xpu_device(device):
     return "xpu" if torch.device(device).type == "cpu" else "cpu"
@@ -4423,13 +4416,6 @@ class TestAsArray(TestCase):
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)
-
-        if torch.xpu.is_available():
-            other_device = get_another_xpu_device(device)
-            with self.assertRaisesRegex(ValueError,
-                                        f"from device '{device}' to '{other_device}'"):
-                torch.asarray(original, device=other_device, copy=False)
-
 
         with self.assertRaisesRegex(ValueError,
                                     "with dtype '.*' into dtype '.*'"):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1945,9 +1945,6 @@ class TestTensorCreation(TestCase):
         if device_type in ('cuda', 'xpu'):
             do_test_empty_full(self, dtypes, torch.strided, None)
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
-        if device_type == 'xpu':
-            do_test_empty_full(self, dtypes, torch.strided, None)
-            do_test_empty_full(self, dtypes, torch.strided, torch_device)
 
     # TODO: this test should be updated
     @suppress_warnings
@@ -2849,17 +2846,10 @@ class TestTensorCreation(TestCase):
         self.assertEqual(sparse_with_dtype.device, torch_device)
 
         if self.device_type in ('cuda', 'xpu'):
-            with torch.get_device_module(device_type).device(device):
+            with torch.cuda.device(device):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
-
-        if self.device_type == 'xpu':
-            with torch.xpu.device(device):
-                sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
-                                                            sparse_size, dtype=torch.float64)
-                self.assertEqual(sparse_with_dtype.device, torch.device('xpu'))
-
 
     @onlyCUDA
     @onlyNativeDeviceTypes
@@ -4214,9 +4204,6 @@ class TestFromBlob(TestCase):
 #   https://data-apis.org/array-api/latest/API_specification/creation_functions.html
 def get_another_device(device):
     return device_type if torch.device(device).type == "cpu" else "cpu"
-
-def get_another_xpu_device(device):
-    return "xpu" if torch.device(device).type == "cpu" else "cpu"
 
 def identity(tensor):
     return tensor

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -48,6 +48,10 @@ from torch.testing._internal.common_dtype import (
 )
 
 from torch.utils.dlpack import to_dlpack
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
 
 # TODO: replace with make_tensor
 def _generate_input(shape, dtype, device, with_extremal):
@@ -1969,7 +1973,7 @@ class TestTensorCreation(TestCase):
         dtypes = get_all_dtypes(include_half=False, include_bfloat16=False, include_complex32=True)
         if device_type == 'cpu':
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
-        if device_type == 'cuda':
+        if device_type in ('cuda', 'xpu'):
             do_test_empty_full(self, dtypes, torch.strided, None)
             do_test_empty_full(self, dtypes, torch.strided, torch_device)
 
@@ -1988,42 +1992,42 @@ class TestTensorCreation(TestCase):
             self.assertEqual('cpu',
                              torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cpu:0').device.type)
             self.assertEqual('cpu', torch.tensor(np.random.randn(2, 3), device='cpu').device.type)
-        if device_type == 'cuda':
-            self.assertEqual('cuda:0', str(torch.tensor(5).cuda(0).device))
-            self.assertEqual('cuda:0', str(torch.tensor(5).cuda('cuda:0').device))
-            self.assertEqual('cuda:0',
+        if device_type in ('cuda', 'xpu'):
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).to(0).device))
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(5).to(f"{device_type}:0").device))
+            self.assertEqual(f"{device_type}:0",
                              str(torch.tensor(5, dtype=torch.int64, device=0).device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(5, dtype=torch.int64, device='cuda:0').device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cuda:0').device))
+            self.assertEqual(f"{device_type}:0",
+                             str(torch.tensor(5, dtype=torch.int64, device=f"{device_type}:0").device))
+            self.assertEqual(f"{device_type}:0",
+                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device=f"{device_type}:0").device))
 
-            self.assertEqual('cuda:0', str(torch.tensor(np.random.randn(2, 3), device='cuda:0').device))
+            self.assertEqual(f"{device_type}:0", str(torch.tensor(np.random.randn(2, 3), device=f"{device_type}:0").device))
 
             for device in devices:
-                with torch.cuda.device(device):
-                    device_string = 'cuda:' + str(torch.cuda.current_device())
+                with torch.get_device_module(device_type).device(device):
+                    device_string = f"{device_type}:" + str(torch.accelerator.current_accelerator())
                     self.assertEqual(device_string,
-                                     str(torch.tensor(5, dtype=torch.int64, device='cuda').device))
+                                     str(torch.tensor(5, dtype=torch.int64, device=device_type).device))
 
             with self.assertRaises(RuntimeError):
-                torch.tensor(5).cuda('cpu')
+                torch.tensor(5).to('cpu')
             with self.assertRaises(RuntimeError):
-                torch.tensor(5).cuda('cpu:0')
+                torch.tensor(5).to('cpu:0')
 
             if len(devices) > 1:
-                self.assertEqual('cuda:1', str(torch.tensor(5).cuda(1).device))
-                self.assertEqual('cuda:1', str(torch.tensor(5).cuda('cuda:1').device))
-                self.assertEqual('cuda:1',
+                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).to(1).device))
+                self.assertEqual(f"{device_type}:1", str(torch.tensor(5).to(f"{device_type}:1").device))
+                self.assertEqual(f"{device_type}:1",
                                  str(torch.tensor(5, dtype=torch.int64, device=1).device))
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(5, dtype=torch.int64, device='cuda:1').device))
-                self.assertEqual('cuda:1',
+                self.assertEqual(f"{device_type}:1",
+                                 str(torch.tensor(5, dtype=torch.int64, device=f"{device_type}:1").device))
+                self.assertEqual(f"{device_type}:1",
                                  str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
-                                     device='cuda:1').device))
+                                     device=f"{device_type}:1").device))
 
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
+                self.assertEqual(f"{device_type}:1",
+                                 str(torch.tensor(np.random.randn(2, 3), device=f"{device_type}:1").device))
 
     # TODO: this test should be updated
     @onlyNativeDeviceTypes
@@ -2852,8 +2856,8 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(op(values).device, torch_device)
                 self.assertEqual(op(values, dtype=torch.float64).device, torch_device)
 
-                if self.device_type == 'cuda':
-                    with torch.cuda.device(device):
+                if self.device_type in ('cuda', 'xpu'):
+                    with torch.accelerator.device_index(0):
                         self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
         # Tests sparse ctor
@@ -2868,8 +2872,8 @@ class TestTensorCreation(TestCase):
         sparse_with_dtype = torch.sparse_coo_tensor(indices, values, sparse_size, dtype=torch.float64)
         self.assertEqual(sparse_with_dtype.device, torch_device)
 
-        if self.device_type == 'cuda':
-            with torch.cuda.device(device):
+        if torch.accelerator.is_available():
+            with torch.accelerator.device_index(0):
                 sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
                                                             sparse_size, dtype=torch.float64)
                 self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
@@ -3748,6 +3752,7 @@ class TestRandomTensorCreation(TestCase):
 
     @largeTensorTest("10GB", "cpu")
     @largeTensorTest("40GB", "cuda")
+    @largeTensorTest("40GB", "xpu")
     @slowTest
     def test_randperm_large(self, device):
         # Test even distribution where rand32 might produce skewed "uniform" distribution
@@ -4428,8 +4433,8 @@ class TestAsArray(TestCase):
     def test_unsupported_alias(self, device, dtype):
         original = make_tensor((5, 5), dtype=dtype, device=device)
 
-        other_device = get_another_device(device)
-        if other_device is not None:
+        if torch.accelerator.is_available():
+            other_device = get_another_device(device)
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4433,8 +4433,8 @@ class TestAsArray(TestCase):
     def test_unsupported_alias(self, device, dtype):
         original = make_tensor((5, 5), dtype=dtype, device=device)
 
-        if torch.accelerator.is_available():
-            other_device = get_another_device(device)
+        other_device = get_another_device(device)
+        if other_device is not None:
             with self.assertRaisesRegex(ValueError,
                                         f"from device '{device}' to '{other_device}'"):
                 torch.asarray(original, device=other_device, copy=False)


### PR DESCRIPTION
# Description
Fixes #114850, we will port dynamo, fsdp tests to Intel GPU
We could enable Intel GPU with following methods and try the best to keep the original code styles:

# Changes
1. Get device type with from accelerator and get_devtype helper method
2. Replace the requires cuda statement with requires_gpu.
3. Replace the cuda() with to(device_type).
4. Use torch.accelerator.is_avaliable() replace cuda avaliable check.
5. Use get_device_module replace the torch.cuda 
6. Use requires_cuda_and_triton replace requires_gpu_and_triton


# Notify
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @chenyang78 @mingfeima @sanchitintel @ashokei @jingxu10 @jerryzh168 @ipiszy @muchulee8 @aakhundov @coconutruben @gujinghui @fengyuan14 @guangyey