### PR TITLE
[wip][invoke_subgraph] Make invoke_subgraph has same input order as original fn

### DIFF
--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -848,6 +848,11 @@ def validate_args_and_maybe_create_graph_inputs(
             if set_subgraph_inputs == "automatic":
                 args.append(a)
                 continue
+            elif set_subgraph_inputs == "automatic_with_ordered_insertion":
+                if isinstance(a, variables.TensorVariable):
+                    a = tracer.maybe_lift_tracked_freevar_to_input(a)
+                args.append(a)
+                continue
             elif set_subgraph_inputs == "automatic_with_forced_inputs":
                 if isinstance(a, variables.TensorVariable):
                     node = a.maybe_fx_node()
@@ -1367,10 +1372,14 @@ def speculate_subgraph_with_auto_output_flattening(
         "semi_automatic",
         "flatten_manual",
         "manual",
+        "automatic_with_ordered_insertion",
     }, "Please use one of the supported set_subgraph_inputs options."
 
     # See NOTE [Temporary argument `set_subgraph_inputs`]
-    if sub_kwargs and set_subgraph_inputs != "automatic":
+    if sub_kwargs and set_subgraph_inputs not in (
+        "automatic",
+        "automatic_with_ordered_insertion",
+    ):
         unimplemented(
             gb_type="invalid set_subgraph_inputs and sub_kwargs settings",
             context=f"set_subgraph_inputs: {set_subgraph_inputs}, sub_kwargs: {sub_kwargs}",
@@ -2905,6 +2914,8 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
     supports_input_mutation = True
     supports_aliasing = True
     allow_side_effects = False
+    # TODO - Consider unifying automatic,automatic_with_forced_inputs, automatic_with_ordered_insertion
+    set_subgraph_inputs = "automatic"
 
     def install_subgraph_in_output_graph(
         self, tx, fn_vt, fn_args_vt, kwargs, body_gmod, attr_name="wrap_body"
@@ -2936,6 +2947,7 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             fn_args_vt,
             kwargs,
             description,
+            set_subgraph_inputs=self.set_subgraph_inputs,
             source_target=self.value,
             allow_side_effects=self.allow_side_effects,
             supports_input_mutation=self.supports_input_mutation,
@@ -4264,6 +4276,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
     supports_aliasing = False
     # TODO - make this true to support mutation
     allow_side_effects = False
+    set_subgraph_inputs = "automatic_with_ordered_insertion"
 
     def install_subgraph_in_output_graph(
         self, tx, fn_vt, fn_args_vt, kwargs, body_gmod, attr_name
@@ -4294,6 +4307,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
             assert isinstance(fn_vt, UnspecializedNNModuleVariable)
             fn_id = id(fn_vt.value.forward.__func__)
             fn_name = fn_vt.value.forward.__name__
+
         previously_installed_submodules = []
         if invoke_subgraph_cache:
             previously_installed_submodules = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169801
* __->__ #169800



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo