### PR TITLE
[Inductor] Add Blackwell specs to comm analysis

### DIFF
--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -44,6 +44,8 @@ def get_gpu_type() -> NVIDIA_GPU_TYPE:
         return NVIDIA_GPU_TYPE.AMPERE
     elif "H100" in gpu_info:
         return NVIDIA_GPU_TYPE.HOPPER
+    elif any(gpu in gpu_info for gpu in ("B100", "B200", "B300")):
+        NVIDIA_GPU_TYPE.BLACKWELL
     else:
         # for other gpu types, assume Ampere
         return NVIDIA_GPU_TYPE.AMPERE

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -32,6 +32,7 @@ class NVIDIA_GPU_TYPE(IntEnum):
     VOLTA = 0
     AMPERE = 1
     HOPPER = 2
+    BLACKWELL = 3
 
 
 @functools.lru_cache
@@ -180,6 +181,12 @@ llMaxBws = [
         87.7,
         22.5,  # avg of ring & tree
         19.0,
+    ],
+    # Blackwell-N1/AMD-N2/AMD-N4
+    [
+        282.0,
+        90.0,  # avg of ring & tree
+        70.0,
     ],
 ]
 

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -180,9 +180,9 @@ llMaxBws = [
     ],
     # Hopper-N1/AMD-N2/AMD-N4
     [
-        87.7,
-        22.5,  # avg of ring & tree
-        19.0,
+        141.0,
+        45.0,  # avg of ring & tree
+        35.0,
     ],
     # Blackwell-N1/AMD-N2/AMD-N4
     [

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -45,7 +45,7 @@ def get_gpu_type() -> NVIDIA_GPU_TYPE:
     elif "H100" in gpu_info:
         return NVIDIA_GPU_TYPE.HOPPER
     elif any(gpu in gpu_info for gpu in ("B100", "B200", "B300")):
-        NVIDIA_GPU_TYPE.BLACKWELL
+        return NVIDIA_GPU_TYPE.BLACKWELL
     else:
         # for other gpu types, assume Ampere
         return NVIDIA_GPU_TYPE.AMPERE


### PR DESCRIPTION
Per title, adds bandwidth info of Blackwell GPUs.

The numerical values were taken from the [NCCL source code](https://github.com/NVIDIA/nccl/blob/master/src/graph/tuning.cc).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo