### PR TITLE
[BE] Fix SyntaxWarning when a return statement in the finally block in Python3.14

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1355,7 +1355,7 @@ class LocalTensorMode(TorchDispatchMode):
                 # re-disable if the yield messed
                 # with the state
                 self.disable_()
-            return  # noqa: B012
+            return
 
         self.disable_()
         try:

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1355,7 +1355,7 @@ class LocalTensorMode(TorchDispatchMode):
                 # re-disable if the yield messed
                 # with the state
                 self.disable_()
-                return  # noqa: B012
+            return  # noqa: B012
 
         self.disable_()
         try:


### PR DESCRIPTION
As state in the title. The refer link is [this](https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-finally-syntaxwarning).
