### PR TITLE
Fixes for s390x CI

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -359,7 +359,12 @@ jobs:
           )
 
           if [[ ${BUILD_ENVIRONMENT} == *"s390x"* ]]; then
-            docker exec -t "${container_name}" sh -c "python3 -m pip install -r requirements.txt"
+            # sometimes there are intermittent network errors, do a couple of retries
+            docker exec -t "${container_name}" sh -c "python3 -m pip install -r requirements.txt || \
+                (sleep 15 && python3 -m pip install -r requirements.txt) || \
+                (sleep 30 && python3 -m pip install -r requirements.txt) || \
+                (sleep 60 && python3 -m pip install -r requirements.txt) || \
+                (sleep 300 && python3 -m pip install -r requirements.txt)"
           fi
 
           docker exec -t "${container_name}" sh -c '.ci/pytorch/build.sh'

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -448,7 +448,12 @@ jobs:
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
 
           if [[ ${BUILD_ENVIRONMENT} == *"s390x"* ]]; then
-            docker exec -t "${container_name}" sh -c "python3 -m pip install -r .ci/docker/requirements-ci.txt"
+            # sometimes there are intermittent network errors, do a couple of retries
+            docker exec -t "${container_name}" sh -c "python3 -m pip install -r .ci/docker/requirements-ci.txt || \
+              (sleep 15 && python3 -m pip install -r .ci/docker/requirements-ci.txt) || \
+              (sleep 30 && python3 -m pip install -r .ci/docker/requirements-ci.txt) || \
+              (sleep 60 && python3 -m pip install -r .ci/docker/requirements-ci.txt) || \
+              (sleep 300 && python3 -m pip install -r .ci/docker/requirements-ci.txt)"
           fi
 
           docker exec -t "${container_name}" sh -c "python3 -m pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -76,6 +76,7 @@ from torch.testing._internal.common_utils import (
     skipIfHpu,
     skipIfWindows,
     TEST_WITH_ROCM,
+    xfailIfS390X,
 )
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 from torch.testing._internal.two_tensor import TwoTensor
@@ -7488,6 +7489,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
             msg,
         )
 
+    @xfailIfS390X
     @unittest.skipIf(
         sys.version_info < (3, 12) or sys.version_info >= (3, 14),
         "only 3.12, 3.13 affected by c recursion limit",

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -9,7 +9,12 @@ import unittest
 from pathlib import Path
 
 import torch
-from torch.testing._internal.common_utils import run_tests, set_cwd, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    set_cwd,
+    TestCase,
+    xfailIfS390X,
+)
 
 
 try:
@@ -91,6 +96,8 @@ def get_all_examples():
 
 
 class TestTypeHints(TestCase):
+    # when this test fails on s390x, it also leads to OOM on test reruns
+    @xfailIfS390X
     @unittest.skipIf(not HAVE_MYPY, "need mypy")
     def test_doc_examples(self):
         """


### PR DESCRIPTION
Test test_type_hints.py::TestTypeHints::test_doc_examples fails on s390x.

When test is rerunning, it's also leading to OOM.
Mark it as a failing test.

dynamo/test_repros.py::ReproTests::test_dynamo_set_recursion_limit also fails on s390x.

Add retries when downloading sources or packages.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo