### PR TITLE
[Inductor] Async Pipelined Autotuning

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -6,16 +6,18 @@ import ctypes
 import dataclasses
 import functools
 import logging
+import multiprocessing as mp
 import os
 import pickle
 import queue
 import selectors
 import subprocess
 import sys
+import threading
 import time
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from ctypes import byref, c_size_t, c_void_p, CDLL
 from typing import Any, IO, Optional, TYPE_CHECKING, Union
 
@@ -45,7 +47,11 @@ from torch.utils._ordered_set import OrderedSet
 if TYPE_CHECKING:
     from types import ModuleType
 
-    from torch._inductor.select_algorithm import PartialRender, TritonTemplateCaller
+    from torch._inductor.select_algorithm import (
+        ChoiceCaller,
+        PartialRender,
+        TritonTemplateCaller,
+    )
 
 from . import config
 from .runtime.benchmarking import benchmarker
@@ -1050,3 +1056,266 @@ def benchmark_in_sub_process(
     Do benchmarking in a subprocess and return the perf number (latency).
     """
     return get_tuning_process_pool().benchmark(choices)
+
+
+class AutotuneProcessPool:
+    """
+    Singleton pool manager for running autotuning (precompilation + benchmarking)
+    in a separate process.
+
+    Uses num_workers=1 to prevent GPU contention during benchmarking, since
+    multiple concurrent GPU kernels would interfere with accurate timing.
+
+    This pool is separate from AsyncMultiTemplateBufferPool (which handles
+    template selection in parallel) because autotuning requires exclusive
+    GPU access for accurate benchmarking.
+    """
+
+    _instance: Optional[AutotuneProcessPool] = None
+    _lock: threading.Lock = threading.Lock()
+
+    def __init__(self, num_workers: int = 1):
+        self._num_workers = num_workers
+        self._pool: ProcessPoolExecutor | None = None
+        self._warmup_future: Future[Any] | None = None
+        self._warmup_start_time: float | None = None
+
+    @classmethod
+    def get_instance(cls, num_workers: int = 1):
+        """Get or create the singleton pool instance."""
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls(num_workers=num_workers)
+        return cls._instance
+
+    @property
+    def pool(self):
+        """
+        Get or create the process pool.
+
+        Uses ProcessPoolExecutor with 'spawn' context for CUDA safety.
+        ProcessPoolExecutor is lazily initialized - workers are not spawned
+        until the first submit() call, making this property non-blocking.
+        """
+        if self._pool is None:
+            with self._lock:
+                if self._pool is None:
+                    # Use 'spawn' context to avoid CUDA fork issues
+                    # Workers are spawned lazily on first submit(), not here
+                    ctx = mp.get_context("forkserver")
+                    self._pool = ProcessPoolExecutor(
+                        max_workers=self._num_workers,
+                        mp_context=ctx,
+                    )
+                    atexit.register(self._shutdown)
+                    autotuning_log.info(
+                        "AutotuneProcessPool created (workers spawn lazily)"
+                    )
+        return self._pool
+
+    def warm_up(self) -> Future[Any]:
+        """
+        Submit a warmup job to eagerly spawn workers and initialize CUDA.
+
+        This is optional - call it early to hide spawn latency.
+        Returns the warmup future which can be ignored or awaited.
+        """
+        if self._warmup_future is None:
+            self._warmup_start_time = time.perf_counter()
+            self._warmup_future = self.pool.submit(_warmup_autotune_subprocess)
+            self._warmup_future.add_done_callback(self._on_warmup_complete)
+            autotuning_log.info("Warmup job submitted")
+        return self._warmup_future
+
+    def _on_warmup_complete(self, future: Future[Any]) -> None:
+        """Callback invoked when the warmup job completes."""
+        warmup_elapsed_time = None
+        if self._warmup_start_time is not None:
+            warmup_elapsed_time = time.perf_counter() - self._warmup_start_time
+
+        try:
+            result = future.result()
+            autotuning_log.error(
+                "AutotuneProcessPool warmup completed successfully in %.4f seconds: %s",
+                warmup_elapsed_time,
+                result,
+            )
+        except Exception as e:
+            autotuning_log.error(
+                "AutotuneProcessPool warmup failed after %.4f seconds",
+                warmup_elapsed_time,
+            )
+            raise e
+
+    def submit(self, fn, *args, **kwargs) -> Future[Any]:
+        """Submit a job to the pool and return a Future."""
+        return self.pool.submit(fn, *args, **kwargs)
+
+    def _shutdown(self):
+        """Shutdown the pool on exit."""
+        if self._pool is not None:
+            self._pool.shutdown(wait=False)
+            self._pool = None
+
+    @classmethod
+    def shutdown_instance(cls):
+        """Explicitly shutdown the singleton instance."""
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance._shutdown()
+                cls._instance = None
+
+
+def _warmup_autotune_subprocess() -> bool:
+    """
+    Warmup function run in the autotune subprocess.
+    """
+    import torch
+
+    # Initialize dummy tensor for CUDA context
+    if torch.cuda.is_available():
+        torch.zeros(1, device="cuda")
+
+    return True
+
+
+def run_autotune_in_subprocess(
+    benchmark_request: BenchmarkRequest,
+) -> float:
+    """
+    Run autotuning benchmarks in a subprocess.
+
+    This function is submitted to AutotuneProcessPool and runs in isolation
+    to prevent GPU contention with the main compilation process.
+
+    Args:
+        picklable_choices: List of picklable choice information
+
+    Returns:
+        timing
+    """
+
+    try:
+        # Run the benchmark directly - bmreq is already a BenchmarkRequest
+        timing = benchmark_request.benchmark()
+
+        return timing
+
+    except Exception:
+        autotuning_log.error(
+            "Failed to benchmark choice %s",
+            benchmark_request,
+            exc_info=True,
+        )
+        # Use infinity for failed benchmarks so they're not selected
+        return float("inf")
+
+
+class PrecompileThreadPool:
+    """
+    Thread pool for running precompilation asynchronously.
+
+    This allows the main compilation process to continue while
+    precompilation happens in background threads.
+    """
+
+    _instance: Optional[PrecompileThreadPool] = None
+    _lock = threading.Lock()
+
+    def __init__(self, max_workers: int = 4):
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    @classmethod
+    def get_instance(cls, num_workers: int = 4) -> PrecompileThreadPool:
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls(num_workers)
+        return cls._instance
+
+    def submit(self, fn, *args, **kwargs):
+        return self._executor.submit(fn, *args, **kwargs)
+
+    def shutdown(self, wait: bool = False):
+        return self._executor.shutdown(wait=wait)
+
+    @classmethod
+    def shutdown_instance(cls) -> None:
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance._executor.shutdown(wait=False)
+                cls._instance = None
+
+
+class AsyncAutotuner:
+    """
+    Handles asynchronous autotuning of kernel choices in a separate process.
+
+    This class manages the lifecycle of autotuning:
+    1. Accepts precompiled choices from the main process
+    2. Submits benchmarking work to AutotuneProcessPool
+    3. Returns results via a Future
+
+    Usage:
+        autotuner = AsyncAutotuner(choices)
+        autotuner.start()  # Kicks off async benchmarking
+        timings = autotuner.get_results()  # Blocks until complete
+    """
+
+    choice_hash_to_future = {}
+
+    @staticmethod
+    def get_choice_hash(choice: ChoiceCaller, inputs_key: str) -> str:
+        return choice.hash_key() + inputs_key
+
+    @classmethod
+    def start(cls, choices: list[ChoiceCaller], inputs_key: str):
+        """
+        Start asynchronous autotuning in a subprocess.
+
+        This method:
+        1. Extracts picklable benchmark requests from choices
+        2. Submits benchmarking work to AutotuneProcessPool
+        3. Returns immediately (non-blocking)
+        """
+
+        for choice in choices:
+            choice_hash = AsyncAutotuner.get_choice_hash(choice, inputs_key)
+
+            if choice_hash in AsyncAutotuner.choice_hash_to_future:
+                continue
+            
+            if getattr(choice, "bmreq", None) is None:
+                raise RuntimeError(
+                    f"Choice {choice} does not have a benchmark request. "
+                )
+
+            autotune_future = AutotuneProcessPool.get_instance().submit(
+                run_autotune_in_subprocess,
+                choice.bmreq,
+            )
+
+            AsyncAutotuner.choice_hash_to_future[choice_hash] = autotune_future
+
+    @classmethod
+    def get_results(
+        cls, choices: list[ChoiceCaller], inputs_key: str, timeout: float | None = None
+    ) -> dict[ChoiceCaller, float]:
+        """
+        Get autotuning results, blocking until complete.
+
+        Args:
+            timeout: Maximum time to wait in seconds. None means wait forever.
+
+        Returns:
+            Dict mapping ChoiceCaller to benchmark timing
+        """
+
+        timings = {}
+        for choice in choices:
+            choice_hash = AsyncAutotuner.get_choice_hash(choice, inputs_key)
+            timings[choice] = AsyncAutotuner.choice_hash_to_future[choice_hash].result(
+                timeout=timeout
+            )
+        return timings

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -824,6 +824,16 @@ def _compile_fx_inner(
     """
     aot_mode: bool = V.aot_compilation
 
+    if (
+        config.max_autotune_gemm or config.max_autotune
+    ) and config.pipeline_max_autotune_gemm:
+        # Warm up max-autotune process pool asap
+        from torch._inductor.autotune_process import AutotuneProcessPool
+
+        pool_instance = AutotuneProcessPool.get_instance()
+        pool_instance.pool
+        pool_instance.warm_up()
+
     # Clean up Compiled Triton Kernels per inductor compile, as the future objects
     # may not be valid for use after they are run/autotuned
     torch._inductor.async_compile.CompiledTritonKernels.cache_clear()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -466,6 +466,11 @@ distributed_max_autotune_gemm = (
     os.environ.get("TORCHINDUCTOR_DISTRIBUTED_MAX_AUTOTUNE_GEMM") == "1"
 )
 
+# Pipeline autotuning for max-autotune-gemm. Overlap lowering and benchmarking on GPU
+pipeline_max_autotune_gemm = (
+    os.environ.get("TORCHINDUCTOR_PIPELINE_GEMM_AUTOTUNING") == "1"
+)
+
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2819,6 +2819,9 @@ class Scheduler:
 
         self.merge_loops()
         self.finalize_multi_template_buffers()
+        if config.max_autotune_gemm or config.max_autotune:
+            torch._inductor.select_algorithm.PrecompileThreadPool.shutdown_instance()
+
         if config.combo_kernels:
             with dynamo_timed(
                 "Scheduler.create_combo_kernel_nodes",

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -15,7 +15,7 @@ import sys
 import textwrap
 import time
 from collections.abc import Callable, Sequence
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import as_completed
 from io import StringIO
 from pathlib import Path
 from types import ModuleType
@@ -44,6 +44,8 @@ from torch.utils._ordered_set import OrderedSet
 from ..utils._sympy.functions import CeilDiv
 from . import config, ir
 from .autotune_process import (
+    AsyncAutotuner,
+    PrecompileThreadPool,
     TensorMeta,
     TritonBenchmarkRequest,
     TritonCPUBenchmarkRequest,
@@ -2824,40 +2826,95 @@ class AlgorithmSelectorCache(PersistentCache):
         )
 
         if return_multi_template and (config.max_autotune or config.max_autotune_gemm):
-
-            def get_timings(hint_override: Optional[int] = None):
-                filtered_choices = [
-                    c
-                    for c in choices
-                    if not hasattr(c, "hint_override")
-                    or c.hint_override == hint_override
+            if config.pipeline_max_autotune_gemm:
+                assert not config.epilogue_fusion and not config.prologue_fusion, (
+                    "Pipelined autotuning not compatible yet with fusion benchmarking, will cause contention on gpu"
+                )
+                assert all(
+                    not isinstance(c, SubgraphChoiceCaller) for c in choices
+                ), "Pipelined autotuning not compatible yet with subgraph choices"
+                extern_kernels = [
+                    c for c in choices if AlgorithmSelectorCache._is_extern(c)
                 ]
-                timings = self.do_autotuning(
+                # Make sure the autotune subprocess for benchmarking is fed as much as possible
+                # Extern kernels do not have to precompile, so can feed them before triton
+                AsyncAutotuner.start(extern_kernels, inputs_key)
+                triton_kernels = [
+                    c for c in choices if not AlgorithmSelectorCache._is_extern(c)
+                ]
+                precompile_instance = PrecompileThreadPool.get_instance(
+                    num_workers=get_num_workers()
+                )
+                precompile_future = precompile_instance.submit(
+                    self.do_autotuning,
                     name,
                     input_nodes,
                     layout,
                     input_gen_fns,
                     inputs_key,
-                    filtered_choices,
+                    triton_kernels,
                     precompile_fn,
-                    hint_override=hint_override,
-                    best_config_future=best_config_future,
                 )
-                min_extern_choice = float("inf")
-                for choice, timing in timings.items():
-                    if isinstance(choice, ExternKernelCaller):
-                        min_extern_choice = min(min_extern_choice, timing)
 
-                timings = {
-                    choice: time
-                    for choice, time in timings.items()
-                    if (
-                        time <= min_extern_choice
-                        or not isinstance(choice, ExternKernelCaller)
+                def get_timings(hint_override: Optional[int] = None):
+                    assert not hint_override, (
+                        "Hint not supported with pipelined autotuning"
                     )
-                }
+                    # Await precompilation future, thread pool
+                    precompile_start_ts = time.time()
+                    precompile_future.result()
+                    precompile_elapse = time.time() - precompile_start_ts
 
-                return timings
+                    # Await autotuning in subproc pool
+                    autotune_start_ts = time.time()
+                    results = AsyncAutotuner.get_results(choices, inputs_key)
+                    autotune_wait_ts = time.time() - autotune_start_ts
+                    AlgorithmSelectorCache.log_results(
+                        name,
+                        input_nodes,
+                        results,
+                        # TODO: Currently placeholder values for logging
+                        # Need to assess autotuning time on subprocess
+                        precompile_elapse,
+                        autotune_wait_ts,
+                    )
+
+                    return results
+            else:
+
+                def get_timings(hint_override: Optional[int] = None):
+                    filtered_choices = [
+                        c
+                        for c in choices
+                        if not hasattr(c, "hint_override")
+                        or c.hint_override == hint_override
+                    ]
+                    timings = self.do_autotuning(
+                        name,
+                        input_nodes,
+                        layout,
+                        input_gen_fns,
+                        inputs_key,
+                        filtered_choices,
+                        precompile_fn,
+                        hint_override=hint_override,
+                        best_config_future=best_config_future,
+                    )
+                    min_extern_choice = float("inf")
+                    for choice, timing in timings.items():
+                        if isinstance(choice, ExternKernelCaller):
+                            min_extern_choice = min(min_extern_choice, timing)
+
+                    timings = {
+                        choice: time
+                        for choice, time in timings.items()
+                        if (
+                            time <= min_extern_choice
+                            or not isinstance(choice, ExternKernelCaller)
+                        )
+                    }
+
+                    return timings
 
             # We take the union of allowed prologue inputs from all choices,
             # and, within benchmark fusion, don't allow prologue fusion for
@@ -3087,6 +3144,10 @@ class AlgorithmSelectorCache(PersistentCache):
             prescreening_elapse = time.time() - prescreening_start_ts
             log.debug("Prescreening elapsed time: %.02fs", prescreening_elapse)
 
+        if config.pipeline_max_autotune_gemm:
+            AsyncAutotuner.start(choices, inputs_key)
+            return
+
         autotune_start_ts = time.time()
 
         if best_config_future is not None:
@@ -3294,7 +3355,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     elapsed_seconds,
                 )
 
-        executor = ThreadPoolExecutor(max_workers=num_workers)
+        executor = PrecompileThreadPool.get_instance(num_workers=get_num_workers())
         async_compile = torch._inductor.async_compile.AsyncCompile()
 
         futures: dict[concurrent.futures.Future[Any], ChoiceCaller] = {}
@@ -3387,8 +3448,6 @@ class AlgorithmSelectorCache(PersistentCache):
                     exceptions.append((choice, timeout_exc))
             if exceptions:
                 _log_autotune_exceptions(exceptions)
-
-            executor.shutdown(wait=True)
 
         self.precompile_cache[precompile_key] = wait_on_futures
 
@@ -4315,6 +4374,7 @@ def autotune_select_algorithm(*args, **kwargs):
     if "return_multi_template" not in kwargs:
         kwargs["return_multi_template"] = (
             torch._inductor.config.benchmark_epilogue_fusion
+            or torch._inductor.config.pipeline_max_autotune_gemm
         )
 
     if "precompilation_timeout_seconds" not in kwargs:


### PR DESCRIPTION
Differential Revision: D88889871

Async-Pipelined Autotuning allows for max-autotune-gemm to do autotuning in a subprocess during lowering time, overlapping autotuning with lowering/scheduling time in parallel to reduce compilation overhead. Below is a diagram of the general architecture with Diode, the ML GEMM model that can be plugged into Inductor:

<img width="4733" height="5371" alt="image" src="https://github.com/user-attachments/assets/70fd83c6-e629-4a35-a08c-9e52647c16b4" />


**TODO**

* Support Prologue/Epilogue Fusion
* Support Subgraph Choice Callers


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo