### PR TITLE
[Compile] Add deprecation support to config module system

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1390,6 +1390,8 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
             env["TORCH_LOGS_OUT"] = file_path
             _, stderr = self.run_process_no_exception(
                 """\
+import warnings
+warnings.filterwarnings("ignore", category=FutureWarning, module="torch.utils._config_module")
 import torch
 @torch.compile(backend="eager")
 def fn(a):

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -266,7 +266,6 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
         )
 
     def test_dict_copy_semantics(self):
-
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning)
             p = config.shallow_copy_dict()

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -118,7 +118,10 @@ class TestConfigModule(TestCase):
         self.assertTrue(config2.e_env_force_multi)
 
     def test_save_config(self):
-        p = config.save_config()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            p = config.save_config()
+
         self.assertDictEqual(
             pickle.loads(p),
             {
@@ -157,7 +160,10 @@ class TestConfigModule(TestCase):
         self.assertFalse(config.e_ignored)
 
     def test_save_config_portable(self):
-        p = config.save_config_portable()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            p = config.save_config_portable()
+
         self.assertDictEqual(
             p,
             {
@@ -225,19 +231,23 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
 
     def test_get_hash(self):
         hash_value = b"#d\x8b\xd3\xbc'\xf5\x0c\xcd\xb6\x87zDw6g"
-        self.assertEqual(
-            config.get_hash(),
-            hash_value,
-        )
-        # Test cached value
-        self.assertEqual(
-            config.get_hash(),
-            hash_value,
-        )
-        self.assertEqual(
-            config.get_hash(),
-            hash_value,
-        )
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            self.assertEqual(
+                config.get_hash(),
+                hash_value,
+            )
+            # Test cached value
+            self.assertEqual(
+                config.get_hash(),
+                hash_value,
+            )
+            self.assertEqual(
+                config.get_hash(),
+                hash_value,
+            )
+
         config._hash_digest = "fake"
         self.assertEqual(config.get_hash(), "fake")
 
@@ -256,7 +266,12 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
         )
 
     def test_dict_copy_semantics(self):
-        p = config.shallow_copy_dict()
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            p = config.shallow_copy_dict()
+            p2 = config.to_dict()
+
         self.assertDictEqual(
             p,
             {
@@ -289,7 +304,6 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
                 "e_not_deprecated": False,
             },
         )
-        p2 = config.to_dict()
         self.assertEqual(
             p2,
             {
@@ -322,7 +336,11 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
                 "e_not_deprecated": False,
             },
         )
-        p3 = config.get_config_copy()
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            p3 = config.get_config_copy()
+
         self.assertEqual(
             p3,
             {

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -107,8 +107,11 @@ recompile_limit = 8
 # [@compile_ignored: runtime_behaviour] safeguarding to prevent horrible recomps
 accumulated_recompile_limit = 256
 
-# [@compile_ignored: runtime_behaviour] skip tracing recursively if cache limit is hit (deprecated: does not do anything)
-skip_code_recursive_on_recompile_limit_hit = True
+skip_code_recursive_on_recompile_limit_hit: bool = Config(
+    default=True,
+    deprecated=True,
+    deprecation_message="does not do anything"
+)
 
 # raise a hard error if cache limit is hit.  If you are on a model where you
 # know you've sized the cache correctly, this can help detect problems when
@@ -122,10 +125,12 @@ accumulated_cache_size_limit: int = Config(
     alias="torch._dynamo.config.accumulated_recompile_limit"
 )
 
-# (deprecated: does not do anything)
 skip_code_recursive_on_cache_limit_hit: bool = Config(
-    alias="torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit"
+    alias="torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit",
+    deprecated=True,
+    deprecation_message="does not do anything"
 )
+
 fail_on_cache_limit_hit: bool = Config(
     alias="torch._dynamo.config.fail_on_recompile_limit_hit"
 )

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -108,9 +108,7 @@ recompile_limit = 8
 accumulated_recompile_limit = 256
 
 skip_code_recursive_on_recompile_limit_hit: bool = Config(
-    default=True,
-    deprecated=True,
-    deprecation_message="does not do anything"
+    default=True, deprecated=True, deprecation_message="does not do anything"
 )
 
 # raise a hard error if cache limit is hit.  If you are on a model where you
@@ -128,7 +126,7 @@ accumulated_cache_size_limit: int = Config(
 skip_code_recursive_on_cache_limit_hit: bool = Config(
     alias="torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit",
     deprecated=True,
-    deprecation_message="does not do anything"
+    deprecation_message="does not do anything",
 )
 
 fail_on_cache_limit_hit: bool = Config(

--- a/torch/testing/_internal/fake_config_module.py
+++ b/torch/testing/_internal/fake_config_module.py
@@ -32,15 +32,13 @@ e_aliased_bool: bool = Config(
     alias="torch.testing._internal.fake_config_module2.e_aliasing_bool"
 )
 e_deprecated: bool = Config(
-    default=True,
-    deprecated=True,
-    deprecation_message="is no longer needed"
+    default=True, deprecated=True, deprecation_message="is no longer needed"
 )
 e_not_deprecated: bool = Config(default=False)
 e_deprecated_alias: bool = Config(
     alias="torch.testing._internal.fake_config_module.e_not_deprecated",
     deprecated=True,
-    deprecation_message="use something else instead"
+    deprecation_message="use something else instead",
 )
 
 

--- a/torch/testing/_internal/fake_config_module.py
+++ b/torch/testing/_internal/fake_config_module.py
@@ -31,6 +31,17 @@ e_env_force: bool = Config(env_name_force="ENV_TRUE", default=False)
 e_aliased_bool: bool = Config(
     alias="torch.testing._internal.fake_config_module2.e_aliasing_bool"
 )
+e_deprecated: bool = Config(
+    default=True,
+    deprecated=True,
+    deprecation_message="is no longer needed"
+)
+e_not_deprecated: bool = Config(default=False)
+e_deprecated_alias: bool = Config(
+    alias="torch.testing._internal.fake_config_module.e_not_deprecated",
+    deprecated=True,
+    deprecation_message="use something else instead"
+)
 
 
 class nested:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
         alias: str | None = None,
         # Deprecation support
         deprecated: bool = False,
-        deprecation_message: str | None = None
+        deprecation_message: str | None = None,
     ) -> T: ...
 
 else:
@@ -141,8 +141,7 @@ else:
         alias: str | None = None,
         # Deprecation support
         deprecated: bool = False,
-        deprecation_message: str | None = None
-
+        deprecation_message: str | None = None,
     ) -> _Config[T]:
         return _Config(
             default=default,
@@ -153,7 +152,7 @@ else:
             alias=alias,
             # Deprecation support
             deprecated=deprecated,
-            deprecation_message=deprecation_message
+            deprecation_message=deprecation_message,
         )
 
 
@@ -388,6 +387,7 @@ class ConfigModule(ModuleType):
             config = self._config[name]
             if config.deprecated and not config._deprecation_warned:
                 import warnings
+
                 msg = f"{self.__name__}.{name} is deprecated"
                 if config.deprecation_message:
                     msg += f" and {config.deprecation_message}"
@@ -409,6 +409,7 @@ class ConfigModule(ModuleType):
             # Issue deprecation warning on read (once per config)
             if config.deprecated and not config._deprecation_warned:
                 import warnings
+
                 msg = f"{self.__name__}.{name} is deprecated"
                 if config.deprecation_message:
                     msg += f" and {config.deprecation_message}"

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -75,6 +75,9 @@ class _Config(Generic[T]):
     env_name_force: list[str] | None = None
     value_type: type | None = None
     alias: str | None = None
+    # Deprecation support
+    deprecated: bool = False
+    deprecation_message: str | None = None
 
     def __post_init__(self) -> None:
         self.env_name_default = _Config.string_or_list_of_string_to_list(
@@ -122,6 +125,9 @@ if TYPE_CHECKING:
         env_name_force: str | list[str] | None = None,
         value_type: type | None = None,
         alias: str | None = None,
+        # Deprecation support
+        deprecated: bool = False,
+        deprecation_message: str | None = None
     ) -> T: ...
 
 else:
@@ -133,6 +139,10 @@ else:
         env_name_force: str | list[str] | None = None,
         value_type: type | None = None,
         alias: str | None = None,
+        # Deprecation support
+        deprecated: bool = False,
+        deprecation_message: str | None = None
+
     ) -> _Config[T]:
         return _Config(
             default=default,
@@ -141,6 +151,9 @@ else:
             env_name_force=env_name_force,
             value_type=value_type,
             alias=alias,
+            # Deprecation support
+            deprecated=deprecated,
+            deprecation_message=deprecation_message
         )
 
 
@@ -298,6 +311,10 @@ class _ConfigEntry:
     # upstream bug - python/cpython#126886
     hide: bool = False
     alias: str | None = None
+    # Deprecation support
+    deprecated: bool = False
+    deprecation_message: str | None = None
+    _deprecation_warned: bool = False
 
     def __init__(self, config: _Config) -> None:
         self.default = config.default
@@ -306,6 +323,11 @@ class _ConfigEntry:
         )
         self.justknob = config.justknob
         self.alias = config.alias
+        # Deprecation fields
+        self.deprecated = config.deprecated
+        self.deprecation_message = config.deprecation_message
+        self._deprecation_warned = False
+
         if config.env_name_default is not None:
             for val in config.env_name_default:
                 if (env_value := _read_env_variable(val)) is not None:
@@ -362,9 +384,20 @@ class ConfigModule(ModuleType):
         elif self._config[name].alias is not None:
             self._set_alias_val(self._config[name], value)
         else:
-            self._config[name].user_override = value
+            # Issue deprecation warning on write (once per config)
+            config = self._config[name]
+            if config.deprecated and not config._deprecation_warned:
+                import warnings
+                msg = f"{self.__name__}.{name} is deprecated"
+                if config.deprecation_message:
+                    msg += f" and {config.deprecation_message}"
+                msg += ". It will be removed in a future version of PyTorch."
+                warnings.warn(msg, FutureWarning, stacklevel=2)
+                config._deprecation_warned = True
+
+            config.user_override = value
             self._is_dirty = True
-            self._config[name].hide = False
+            config.hide = False
 
     def __getattr__(self, name: str) -> Any:
         try:
@@ -372,6 +405,16 @@ class ConfigModule(ModuleType):
 
             if config.hide:
                 raise AttributeError(f"{self.__name__}.{name} does not exist")
+
+            # Issue deprecation warning on read (once per config)
+            if config.deprecated and not config._deprecation_warned:
+                import warnings
+                msg = f"{self.__name__}.{name} is deprecated"
+                if config.deprecation_message:
+                    msg += f" and {config.deprecation_message}"
+                msg += ". It will be removed in a future version of PyTorch."
+                warnings.warn(msg, FutureWarning, stacklevel=2)
+                config._deprecation_warned = True
 
             alias_val = self._get_alias_val(config)
             if alias_val is not _UNSET_SENTINEL:


### PR DESCRIPTION
Fixes #169835

## Background

This PR provides a middle ground: keep the configs around for backward compatibility, but warn users they're living on borrowed time.

## Changes

```python
# Before: a variable with a comment that nobody reads
# skip_code_recursive_on_recompile_limit_hit = True  # (deprecated: does not do anything)

# After: a Config that tells you it's deprecated when you use it
skip_code_recursive_on_recompile_limit_hit: bool = Config(
    default=True,
    deprecated=True,
    deprecation_message="does not do anything"
)
```
## Example Output

A warning will be given to a user if he does the following to a value marked as deprecated:
- Reads value
- Writes value
- Reads alias
- Writes alias

```python
>>> import torch._dynamo.config as config
>>> value = config.skip_code_recursive_on_recompile_limit_hit
FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
```

## Discussion

If this change makes upstream, then we have some much needed tools at our disposal to cleanly maintain current and future config deprecations. Current changes are limited to a single example use case and would be incorporated into #169578.

## TODO
- [x] Add relevant tests.
- [x] Confirm the assumption that this functionality would in fact be triggered by external dependencies. 
- [x] Get feedback on proposed solution.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos