### PR TITLE
torch.compile: build graph for top-level TorchInGraph functions

### DIFF
--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -12,6 +12,7 @@ import torch
 import torch._dynamo.config as config
 import torch._dynamo.test_case
 import torch._functorch.deprecated as deprecated_func
+from torch._dynamo.testing import CompileCounter
 from torch._dynamo.trace_rules import (
     LEGACY_MOD_INLINELIST,
     load_object,
@@ -21,7 +22,6 @@ from torch._dynamo.trace_rules import (
     torch_c_binding_in_graph_functions,
     torch_non_c_binding_in_graph_functions,
 )
-from torch._dynamo.testing import CompileCounter
 from torch._dynamo.utils import hashable, is_safe_constant, istype
 from torch._dynamo.variables import (
     SkipFunctionVariable,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -881,7 +881,12 @@ class _TorchDynamoContext:
         # when traced inside a frame. When such a function is passed directly to
         # torch.compile, we detect it here so we can force it through wrap_inline.
         from .variables import TorchInGraphFunctionVariable
-        top_level_in_graph = issubclass(trace_rules.lookup(fn), TorchInGraphFunctionVariable)
+        top_level_in_graph = isinstance(rule, type) and issubclass(rule, TorchInGraphFunctionVariable)
+
+        rule = trace_rules.lookup(fn)
+        top_level_in_graph = isinstance(rule, type) and issubclass(
+            rule, TorchInGraphFunctionVariable
+        )
 
         try:
             filename = inspect.getsourcefile(fn)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -912,7 +912,7 @@ class _TorchDynamoContext:
         if config.debug_force_nested_calls:
             fn = external_utils.wrap_inline(fn)
         elif config.wrap_top_frame or (
-            (filename is None or trace_rules.check(fn))
+            (filename is None or trace_rules.check(fn) or top_level_in_graph)
             and (
                 getattr(fn, "__name__", "")
                 not in ["_call_impl", "_wrapped_call_impl", "_lazy_forward"]

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -881,6 +881,7 @@ class _TorchDynamoContext:
         # when traced inside a frame. When such a function is passed directly to
         # torch.compile, we detect it here so we can force it through wrap_inline.
         from .variables import TorchInGraphFunctionVariable
+
         rule = trace_rules.lookup(fn)
         top_level_in_graph = isinstance(rule, type) and issubclass(
             rule, TorchInGraphFunctionVariable

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -881,8 +881,6 @@ class _TorchDynamoContext:
         # when traced inside a frame. When such a function is passed directly to
         # torch.compile, we detect it here so we can force it through wrap_inline.
         from .variables import TorchInGraphFunctionVariable
-        top_level_in_graph = isinstance(rule, type) and issubclass(rule, TorchInGraphFunctionVariable)
-
         rule = trace_rules.lookup(fn)
         top_level_in_graph = isinstance(rule, type) and issubclass(
             rule, TorchInGraphFunctionVariable

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -876,6 +876,35 @@ class _TorchDynamoContext:
             f"A callable function is expected, but {type(fn)} is provided."
         )
 
+        # NOTE [Top-level TorchInGraph functions]
+        # Some callables (e.g. torch.exp, math.exp, many torch.* ops) are
+        # registered in trace_rules as TorchInGraphFunctionVariable. When they
+        # are called from *inside* a traced Python frame, Dynamo does not trace
+        # into them; instead it emits a single FX node for the op.
+        # However, when such a function is passed directly to torch.compile,
+        # there is no user Python frame for us to attach the eval frame handler
+        # to, so we previously fell back to eager:
+        #
+        #     torch.compile(torch.exp)(x)  # no graph
+        #
+        # To make this consistent with:
+        #     torch.compile(lambda x: torch.exp(x))(x)
+        # we detect top-level TorchInGraph functions here and force them
+        # through the same wrap_inline path that we already use for
+        # builtins/skiplist functions, so Dynamo can build a 1-node FX graph.
+        top_level_in_graph = False
+        try:
+            rule = trace_rules.lookup(fn)
+        except Exception:
+            rule = None
+
+        if isinstance(rule, type):
+            torch_in_graph_cls = getattr(
+                trace_rules, "TorchInGraphFunctionVariable", None
+            )
+            if torch_in_graph_cls is not None and issubclass(rule, torch_in_graph_cls):
+                top_level_in_graph = True
+
         try:
             filename = inspect.getsourcefile(fn)
         except TypeError:


### PR DESCRIPTION
Fixes #168284

Summary:
Previously, `torch.compile(torch.exp)(x)` would bypass Dynamo and run eager, while `torch.compile(lambda x: torch.exp(x))(x)` would go through Dynamo and build a graph. This is because `torch.exp` is a top-level function mapped to `TorchInGraphFunctionVariable`, but Dynamo did not wrap it with a frame when used directly as `torch.compile(torch.exp)`.

This PR makes top-level functions mapped to `TorchInGraphFunctionVariable` behave consistently with the lambda case by routing them through `wrap_inline`, so Dynamo can build a 1-node FX graph for them.

Changes:
- In `_TorchDynamoContext.__call__`, detect when the top-level `fn` is a `TorchInGraphFunctionVariable` target via `trace_rules.lookup(fn)`.
- When such a function is compiled, treat it like other “builtins without a frame” and call `external_utils.wrap_inline(fn)`, so Dynamo can trace the wrapper and emit a single FX node for the op.
- Add a regression test `SingleOpCompileTests.test_top_level_torch_exp_compiles_through_dynamo` in `test/dynamo/test_trace_rules.py` to assert that:
  - `torch.compile(lambda t: torch.exp(t))` and `torch.compile(torch.exp)` both go through Dynamo (FRAME_COUNTER increases), and Their outputs match.

This PR only addresses the first part of #168284 (handling top-level `TorchInGraphFunctionVariable` functions). The `fullgraph=True` behavior when no graph is traced will be handled in a separate PR as requested.

Test Plan:
- `pytest test/dynamo/test_trace_rules.py -vv` - Passed all test in local

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos