### PR TITLE
Enhance GCP runner check for Google Cloud Platform

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -17,7 +17,7 @@ runs:
           runner_name_str=${{ runner.name }}
           if [[ -f /.inarc ]]; then
             echo "ARC Runner, no info on ec2 metadata"
-          elif [[ $runner_name_str == *"gcp"* ]]; then
+          elif [[ $runner_name_str == *"gcp"* || $runner_name_str == *"google"* ]]; then
             echo "Runner is from Google Cloud Platform, No info on ec2 metadata"
           else
             curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"


### PR DESCRIPTION
GCP runners can have "google" in their name