### PR TITLE
[ROCm] Use rocm_sdk preloaded libraries for hiprtc and amdhip64

### DIFF
--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -13,7 +13,7 @@ def _get_hip_runtime_library() -> ctypes.CDLL:
     # path to the library provided by those packages, including any version suffix.
     # See https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md#dynamic-library-resolution
     try:
-        # pyrefly: ignore[missing-import]
+        # pyrefly: ignore[import-error]
         import rocm_sdk
 
         lib = ctypes.CDLL(str(rocm_sdk.find_libraries("amdhip64")[0]))
@@ -61,7 +61,7 @@ def _check_cuda(result: int) -> None:
 
 def _get_hiprtc_library() -> ctypes.CDLL:
     try:
-        # pyrefly: ignore[missing-import]
+        # pyrefly: ignore[import-error]
         import rocm_sdk
 
         lib = ctypes.CDLL(str(rocm_sdk.find_libraries("hiprtc")[0]))

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -9,6 +9,9 @@ from torch._utils import _get_device_index as _torch_get_device_index
 
 
 def _get_hip_runtime_library() -> ctypes.CDLL:
+    # If ROCm python packages are available, query the OS-independent absolute
+    # path to the library provided by those packages, including any version suffix.
+    # See https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md#dynamic-library-resolution
     try:
         import rocm_sdk
 

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -13,6 +13,7 @@ def _get_hip_runtime_library() -> ctypes.CDLL:
     # path to the library provided by those packages, including any version suffix.
     # See https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md#dynamic-library-resolution
     try:
+        # pyrefly: ignore[missing-import]
         import rocm_sdk
 
         lib = ctypes.CDLL(str(rocm_sdk.find_libraries("amdhip64")[0]))
@@ -60,6 +61,7 @@ def _check_cuda(result: int) -> None:
 
 def _get_hiprtc_library() -> ctypes.CDLL:
     try:
+        # pyrefly: ignore[missing-import]
         import rocm_sdk
 
         lib = ctypes.CDLL(str(rocm_sdk.find_libraries("hiprtc")[0]))

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -12,8 +12,8 @@ def _get_hip_runtime_library() -> ctypes.CDLL:
     try:
         import rocm_sdk
 
-        lib = rocm_sdk._ALL_CDLLS["amdhip64"]
-    except (ImportError, KeyError):
+        lib = ctypes.CDLL(str(rocm_sdk.find_libraries("amdhip64")[0]))
+    except (ImportError, IndexError):
         if sys.platform == "win32":
             lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
         else:  # Unix-based systems
@@ -59,8 +59,8 @@ def _get_hiprtc_library() -> ctypes.CDLL:
     try:
         import rocm_sdk
 
-        lib = rocm_sdk._ALL_CDLLS["hiprtc"]
-    except (ImportError, KeyError):
+        lib = ctypes.CDLL(str(rocm_sdk.find_libraries("hiprtc")[0]))
+    except (ImportError, IndexError):
         if sys.platform == "win32":
             version_str = "".join(
                 ["0", torch.version.hip[0], "0", torch.version.hip[2]]


### PR DESCRIPTION
TheRock-based ROCm wheels include libraries in the _rocm_sdk_core package, but PyTorch does not know about this location. Libraries are preloaded from _rocm_sdk_core via preload_libraries() in _rocm_init.py during torch init.

This change uses the preloaded library handles from rocm_sdk._ALL_CDLLS when available, falling back to system library search for non-TheRock installations.

Test `test/test_cuda.py::TestCompileKernel::test_compile_kernel` now passing, and addressed `lintrunner` output.

Fixes: ROCm/TheRock#2166

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang, @jammm, @ScottTodd