### PR TITLE
[profiler] Change dynamo_timed to use torch._C._profiler._RecordFunctionFast

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -555,7 +555,6 @@ class TestDTensorDebugMode(TestCase):
       aten::detach(t: f32[4, 8])  ->  t: f32[4, 8]
       aten::detach(t: f32[2, 4])  ->  t: f32[2, 4]
     aten::ones_like(t: f32[], pin_memory=False, memory_format=torch.preserve_format)  ->  t: f32[]
-  [record function] backward._backward_impl (dynamo_timed)
     aten::expand(t: f32[], [8, 2])  ->  t: f32[8, 2]
     aten::mm(t: f32[4, 8], t: f32[8, 2])  ->  t: f32[4, 2]
     aten::mm(t: f32[8, 2], t: f32[2, 4])  ->  t: f32[8, 4]

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -659,6 +659,30 @@ _dynamo_timed_tls = threading.local()
 
 
 @contextmanager
+def compile_time_record_function(name: str) -> Generator[Any, None, None]:
+    """
+    A context manager for compile-time profiling that uses _RecordFunctionFast
+    for lower overhead than torch.profiler.record_function.
+
+    This is intended for use during compilation (dynamo, inductor, etc.) where
+    we want profiling support but with minimal overhead. Moreover, we do not
+    want the record_function call inside torch.compile to be dispatched.
+
+    Args:
+        name: The name of the record function event that will appear in profiles.
+    """
+    if torch.autograd.profiler._is_profiler_enabled:
+        rf = torch._C._profiler._RecordFunctionFast(name)
+        rf.__enter__()
+        try:
+            yield
+        finally:
+            rf.__exit__(None, None, None)
+    else:
+        yield
+
+
+@contextmanager
 def dynamo_timed(
     key: str,
     # TODO(masneral): Deprecate this param.
@@ -737,9 +761,7 @@ def dynamo_timed(
         event_name, start_ns, event_metadata, log_pt2_compile_event, compile_id
     )
 
-    cx_mgrs: list[typing.Any] = [
-        torch.profiler.record_function(f"{key} (dynamo_timed)")
-    ]
+    cx_mgrs: list[typing.Any] = [compile_time_record_function(f"{key} (dynamo_timed)")]
     if log_waitcounter:
         wc_name = waitcounter_name_override if waitcounter_name_override else key
         cx_mgrs.append(_WaitCounter(f"pytorch.wait_counter.{wc_name}").guard())


### PR DESCRIPTION
Implement the suggestion in https://github.com/pytorch/pytorch/pull/167787#discussion_r2538644767 

Example tlparse perfetto trace, showing that compiled times are still tracked fine

<img width="998" height="321" alt="Screenshot 2025-12-08 at 2 15 48 PM" src="https://github.com/user-attachments/assets/43f14ffd-ab4c-43ff-904f-b34f302f897f" />

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo