### PR TITLE
[inductor] Disable mixed-order reduction for cpp-wrapper

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1722,7 +1722,7 @@ class SIMDScheduling(BaseScheduling):
                 if node.get_outputs()[0].node.get_name() not in rename:
                     node.mark_run()
 
-        V.graph.wrapper_code.make_comment("# Call mix order reduction kernel")
+        V.graph.wrapper_code.make_comment("Call mix order reduction kernel")
         self.codegen_comment(node_schedule, None)
         # workspace args is still needed after the call
         kernel.call_kernel(kernel.kernel_name, deallocate_ws=False)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1722,7 +1722,7 @@ class SIMDScheduling(BaseScheduling):
                 if node.get_outputs()[0].node.get_name() not in rename:
                     node.mark_run()
 
-        V.graph.wrapper_code.make_comment("Call mix order reduction kernel")
+        V.graph.wrapper_code.make_comment("# Call mix order reduction kernel")
         self.codegen_comment(node_schedule, None)
         # workspace args is still needed after the call
         kernel.call_kernel(kernel.kernel_name, deallocate_ws=False)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -225,6 +225,10 @@ class MixOrderReduction:
         if not config.triton.mix_order_reduction:
             return False
 
+        # TODO: Mix order reduction is not supported with cpp_wrapper yet
+        if V.graph.cpp_wrapper:
+            return False
+
         if not node1.is_gpu() or not node2.is_gpu():
             return False
         device_type = node1.get_device().type  # type: ignore[union-attr]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169859

Summary: Fixes https://github.com/pytorch/pytorch/issues/169664. A temporary fix to bring CI to back to green. Will work on another PR to add proper cpp-wrapper codegen support for mixed-order reduction.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos