### PR TITLE
add mechanism to restore default flash attn impl after override

### DIFF
--- a/docs/source/nn.attention.rst
+++ b/docs/source/nn.attention.rst
@@ -18,7 +18,6 @@ Utils
     activate_flash_attention_impl
     list_flash_attention_impls
     current_flash_attention_impl
-    previous_flash_attention_impl
     restore_flash_attention_impl
 
 Submodules

--- a/docs/source/nn.attention.rst
+++ b/docs/source/nn.attention.rst
@@ -18,6 +18,8 @@ Utils
     activate_flash_attention_impl
     list_flash_attention_impls
     current_flash_attention_impl
+    previous_flash_attention_impl
+    restore_flash_attention_impl
 
 Submodules
 ----------

--- a/test/nn/attention/test_fa4.py
+++ b/test/nn/attention/test_fa4.py
@@ -12,6 +12,8 @@ from torch.backends.cuda import SDPBackend
 from torch.nn.attention import (
     activate_flash_attention_impl,
     restore_flash_attention_impl,
+    register_flash_attention_impl,
+    current_flash_attention_impl,
     sdpa_kernel,
 )
 from torch.profiler import profile, ProfilerActivity
@@ -118,6 +120,14 @@ def flash_vs_math(test_case, q, k, v, is_causal=False, rtol=2):
     )
 
     return out_flash, out_math_low, out_math_fp32
+
+class DummyHandle:
+    def __init__(self, name):
+        self.name = name
+        self.removed = False
+
+    def remove(self):
+        self.removed = True
 
 
 class TestFlashAttentionFA4(TestCase):
@@ -228,6 +238,7 @@ class TestFlashAttentionFA4(TestCase):
             test_backward=test_backward,
         )
 
+
     @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_fa4_kernel_called(self, device, dtype):
@@ -268,6 +279,38 @@ class TestFlashAttentionFA4(TestCase):
             )
         finally:
             activate_flash_attention_impl("FA4")  # reset for next test
+
+    @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
+    def test_multiple_activate(self):
+        try:
+            handles = {}
+            def make_dummy_impl(name):
+                def impl():
+                    handle = DummyHandle(name)
+                    handles[name] = handle
+                    return handle
+                return impl
+
+            restore_flash_attention_impl() # back to default
+
+            register_flash_attention_impl("dummy_impl_1", register_fn=make_dummy_impl("dummy_impl_1"))
+            register_flash_attention_impl("dummy_impl_2", register_fn=make_dummy_impl("dummy_impl_2"))
+
+            self.assertIsNone(current_flash_attention_impl())
+
+            activate_flash_attention_impl("dummy_impl_1")
+            self.assertEqual(current_flash_attention_impl(), "dummy_impl_1")
+            self.assertIn("dummy_impl_1", handles)
+
+            activate_flash_attention_impl("dummy_impl_2")
+            self.assertEqual(current_flash_attention_impl(), "dummy_impl_2")
+            self.assertIn("dummy_impl_2", handles)
+
+            # with every subsequent activate() call, the previously registered custom impl should be removed
+            self.assertTrue(handles["dummy_impl_1"].removed, "dummy_impl_1 should be removed")
+        finally:
+            activate_flash_attention_impl("FA4") # reset for next test
+
 
     @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
     @parametrize("dtype", [torch.float16, torch.bfloat16])

--- a/test/nn/attention/test_open_registry.py
+++ b/test/nn/attention/test_open_registry.py
@@ -5,6 +5,11 @@ from torch.nn.attention import _registry
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
+class FakeHandle:
+    def remove(self):
+        pass
+
+
 class TestFlashAttentionRegistry(TestCase):
     def setUp(self):
         super().setUp()
@@ -24,6 +29,7 @@ class TestFlashAttentionRegistry(TestCase):
 
         def fake_register():
             calls["called"] = True
+            return FakeHandle()
 
         attention.register_flash_attention_impl("TEST_FA", register_fn=fake_register)
         self.assertIn("TEST_FA", attention.list_flash_attention_impls())

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -23,7 +23,6 @@ __all__: list[str] = [
     "activate_flash_attention_impl",
     "list_flash_attention_impls",
     "current_flash_attention_impl",
-    "previous_flash_attention_impl",
     "restore_flash_attention_impl",
 ]
 
@@ -179,14 +178,12 @@ register_flash_attention_impl = _registry.register_flash_attention_impl
 activate_flash_attention_impl = _registry.activate_flash_attention_impl
 list_flash_attention_impls = _registry.list_flash_attention_impls
 current_flash_attention_impl = _registry.current_flash_attention_impl
-previous_flash_attention_impl = _registry.previous_flash_attention_impl
 restore_flash_attention_impl = _registry.restore_flash_attention_impl
 
 register_flash_attention_impl.__module__ = __name__
 activate_flash_attention_impl.__module__ = __name__
 list_flash_attention_impls.__module__ = __name__
 current_flash_attention_impl.__module__ = __name__
-previous_flash_attention_impl.__module__ = __name__
 restore_flash_attention_impl.__module__ = __name__
 
 # Import built-in implementations to trigger self-registration

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -23,6 +23,8 @@ __all__: list[str] = [
     "activate_flash_attention_impl",
     "list_flash_attention_impls",
     "current_flash_attention_impl",
+    "previous_flash_attention_impl",
+    "restore_flash_attention_impl",
 ]
 
 
@@ -177,11 +179,15 @@ register_flash_attention_impl = _registry.register_flash_attention_impl
 activate_flash_attention_impl = _registry.activate_flash_attention_impl
 list_flash_attention_impls = _registry.list_flash_attention_impls
 current_flash_attention_impl = _registry.current_flash_attention_impl
+previous_flash_attention_impl = _registry.previous_flash_attention_impl
+restore_flash_attention_impl = _registry.restore_flash_attention_impl
 
 register_flash_attention_impl.__module__ = __name__
 activate_flash_attention_impl.__module__ = __name__
 list_flash_attention_impls.__module__ = __name__
 current_flash_attention_impl.__module__ = __name__
+previous_flash_attention_impl.__module__ = __name__
+restore_flash_attention_impl.__module__ = __name__
 
 # Import built-in implementations to trigger self-registration
 from . import _fa4  # noqa: F401

--- a/torch/nn/attention/_registry.py
+++ b/torch/nn/attention/_registry.py
@@ -5,8 +5,12 @@ This module contains the registration system for flash attention implementations
 It has no torch dependencies to avoid circular imports during initialization.
 """
 
+import logging
 from collections.abc import Callable
 from typing import Literal, Protocol
+
+
+logger = logging.getLogger(__name__)
 
 
 class FlashAttentionHandle(Protocol):
@@ -18,8 +22,7 @@ _FlashAttentionImpl = Literal["FA4"]
 
 _FLASH_ATTENTION_IMPLS: dict[str, _RegisterFn] = {}
 
-_FLASH_ATTENTION_ACTIVE: str | None = None
-_FLASH_ATTENTION_HANDLES: dict[str, FlashAttentionHandle] = {}
+_FLASH_ATTENTION_ACTIVE: tuple[str, FlashAttentionHandle] | None = None
 
 
 def register_flash_attention_impl(
@@ -51,6 +54,7 @@ def register_flash_attention_impl(
         ...     "MyImpl", register_fn=my_impl_register
         ... )  # doctest: +SKIP
     """
+    global _FLASH_ATTENTION_IMPLS
     _FLASH_ATTENTION_IMPLS[impl] = register_fn
 
 
@@ -77,9 +81,11 @@ def activate_flash_attention_impl(
     Example:
         >>> activate_flash_attention_impl("FA4")  # doctest: +SKIP
     """
-    global _FLASH_ATTENTION_ACTIVE, _PREVIOUS_FLASH_ATTENTIONS
+    global _FLASH_ATTENTION_ACTIVE, _FLASH_ATTENTION_IMPLS
 
-    restore_flash_attention_impl() # first restore any prev overrides (if any) to default
+    restore_flash_attention_impl(
+        _raise_warn=False
+    )  # first restore any prev overrides (if any) to default
 
     register_fn = _FLASH_ATTENTION_IMPLS.get(impl)
     if register_fn is None:
@@ -87,15 +93,10 @@ def activate_flash_attention_impl(
             f"Unknown flash attention impl '{impl}'. "
             f"Available implementations: {list_flash_attention_impls()}"
         )
-    # TODO: The only way to actually register a new impl is to unregister the current impl
-    # reinstall the default impl and then register the new impl
-    if _FLASH_ATTENTION_ACTIVE == impl:
-        return
 
     handle = register_fn()
     if handle is not None:
-        _FLASH_ATTENTION_HANDLES[impl] = handle
-    _FLASH_ATTENTION_ACTIVE = impl
+        _FLASH_ATTENTION_ACTIVE = (impl, handle)
 
 
 def list_flash_attention_impls() -> list[str]:
@@ -109,22 +110,28 @@ def current_flash_attention_impl() -> str | None:
 
     ``None`` indicates that no custom impl has been activated.
     """
-    return _FLASH_ATTENTION_ACTIVE
+    return (
+        _FLASH_ATTENTION_ACTIVE[0]
+        if _FLASH_ATTENTION_ACTIVE is not None
+        else _FLASH_ATTENTION_ACTIVE
+    )
 
-def restore_flash_attention_impl() -> None:
+
+def restore_flash_attention_impl(_raise_warn: bool = True) -> None:
     """
-    Restore the previous flash attention implementation before the last
-    call to activate_flash_attention_impl()
-
-    If the previous implementation is None (implies default FA2), we
-    deactivate the current custom implementation to fall back to default FA2
+    Restore the default FA2 implementation
     """
-    global _FLASH_ATTENTION_ACTIVE, _FLASH_ATTENTION_HANDLES
+    global _FLASH_ATTENTION_ACTIVE
 
-    current = _FLASH_ATTENTION_ACTIVE
+    handle = None
+    if _FLASH_ATTENTION_ACTIVE is not None:
+        handle = _FLASH_ATTENTION_ACTIVE[1]
 
-    if current is not None and current in _FLASH_ATTENTION_HANDLES:
-        handle = _FLASH_ATTENTION_HANDLES[current]
-        if handle is not None:
-            handle.remove()
-        _FLASH_ATTENTION_ACTIVE = None # default
+    if handle is not None:
+        handle.remove()
+    elif _raise_warn:
+        logger.warning(
+            "Trying to restore default FA2 impl when no custom impl was activated"
+        )
+
+    _FLASH_ATTENTION_ACTIVE = None  # default

--- a/torch/nn/attention/_registry.py
+++ b/torch/nn/attention/_registry.py
@@ -79,7 +79,7 @@ def activate_flash_attention_impl(
     """
     global _FLASH_ATTENTION_ACTIVE, _PREVIOUS_FLASH_ATTENTIONS
 
-    restore_flash_attention_impl()
+    restore_flash_attention_impl() # first restore any prev overrides (if any) to default
 
     register_fn = _FLASH_ATTENTION_IMPLS.get(impl)
     if register_fn is None:

--- a/torch/nn/attention/_registry.py
+++ b/torch/nn/attention/_registry.py
@@ -20,6 +20,7 @@ _FLASH_ATTENTION_IMPLS: dict[str, _RegisterFn] = {}
 
 _FLASH_ATTENTION_ACTIVE: str | None = None
 _FLASH_ATTENTION_HANDLES: dict[str, FlashAttentionHandle] = {}
+_FLASH_ATTENTION_PREVIOUS: str | None = None
 
 
 def register_flash_attention_impl(
@@ -77,7 +78,8 @@ def activate_flash_attention_impl(
     Example:
         >>> activate_flash_attention_impl("FA4")  # doctest: +SKIP
     """
-    global _FLASH_ATTENTION_ACTIVE
+    global _FLASH_ATTENTION_ACTIVE, _FLASH_ATTENTION_PREVIOUS
+
     register_fn = _FLASH_ATTENTION_IMPLS.get(impl)
     if register_fn is None:
         raise ValueError(
@@ -88,6 +90,8 @@ def activate_flash_attention_impl(
     # reinstall the default impl and then register the new impl
     if _FLASH_ATTENTION_ACTIVE == impl:
         return
+
+    _FLASH_ATTENTION_PREVIOUS = _FLASH_ATTENTION_ACTIVE
 
     handle = register_fn()
     if handle is not None:
@@ -107,3 +111,37 @@ def current_flash_attention_impl() -> str | None:
     ``None`` indicates that no custom impl has been activated.
     """
     return _FLASH_ATTENTION_ACTIVE
+
+
+def previous_flash_attention_impl() -> str | None:
+    """
+    Return the previously activated flash attention impl name
+
+    None indicates default FA2
+    """
+    return _FLASH_ATTENTION_PREVIOUS
+
+
+def restore_flash_attention_impl() -> None:
+    """
+    Restore the previous flash attention implementation before the last
+    call to activate_flash_attention_impl()
+
+    If the previous implementation is None (implies default FA2), we
+    deactivate the current custom implementation to fall back to default FA2
+    """
+    global _FLASH_ATTENTION_ACTIVE, _FLASH_ATTENTION_PREVIOUS, _FLASH_ATTENTION_HANDLES
+
+    previous = _FLASH_ATTENTION_PREVIOUS
+    current = _FLASH_ATTENTION_ACTIVE
+
+    _FLASH_ATTENTION_PREVIOUS = current
+
+    if previous is None:  # previous was default FA2
+        if current is not None and current in _FLASH_ATTENTION_HANDLES:
+            handle = _FLASH_ATTENTION_HANDLES[current]
+            if handle is not None:
+                handle.remove()
+        _FLASH_ATTENTION_ACTIVE = None
+    else:
+        activate_flash_attention_impl(previous)


### PR DESCRIPTION
Fixes #168123

**Testing** 

Trace with FA4 (calls cute backend):
<img width="1689" height="607" alt="Screenshot 2025-12-08 at 2 32 10 PM" src="https://github.com/user-attachments/assets/a33709cf-4a85-452f-9a4e-971d3a8a6ddb" />

Trace with FA2 (calls default flash_bwd):
<img width="1677" height="415" alt="Screenshot 2025-12-08 at 2 33 07 PM" src="https://github.com/user-attachments/assets/433a5d0e-8067-4638-a877-31c44725b5c7" />

Unit Test:  `python test_fa4.py -k test_fa4_kernel_called`

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki