### PR TITLE
[Kineto Protobuf] update test_profiler to allow protobuf format data from log

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1207,8 +1207,8 @@ class TestProfiler(TestCase):
                     parts[-4].isdigit() and int(parts[-4]) > 0,
                     "Wrong tracing file name pattern",
                 )
-                self.assertEqual(parts[-3:], ["pt", "trace", "json"])
-                file_num += 1
+                if parts[-3:] == ["pt", "trace", "json"]:
+                    file_num += 1
             self.assertEqual(file_num, 3)
 
         # test case for gzip file format


### PR DESCRIPTION
Summary:
In next diff, we create PerfettoTraceBuilder to generate protobuf format trace data and upload to manifold and log the url in the log. This test is checking if the logged trace format and the new protobuf trace is breaking it. 

Let's remove the assertion

Test Plan: CI

Differential Revision: D88658203


