### PR TITLE
Add full to stable ops (supported via generate c shim rather than torch_call_dispatcher)

### DIFF
--- a/test/cpp_extensions/libtorch_agnostic_2_10_extension/libtorch_agnostic_2_10/csrc/my_full.cpp
+++ b/test/cpp_extensions/libtorch_agnostic_2_10_extension/libtorch_agnostic_2_10/csrc/my_full.cpp
@@ -1,0 +1,27 @@
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+
+#include <optional>
+
+using torch::stable::Tensor;
+
+Tensor my_full(
+    std::vector<int64_t> size,
+    double fill_value,
+    std::optional<torch::headeronly::ScalarType> dtype,
+    std::optional<torch::headeronly::Layout> layout,
+    std::optional<torch::stable::Device> device,
+    std::optional<bool> pin_memory) {
+  return torch::stable::full(size, fill_value, dtype, layout, device, pin_memory);
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(libtorch_agnostic_2_10, m) {
+  m.def(
+      "my_full(int[] size, float fill_value, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(libtorch_agnostic_2_10, CompositeExplicitAutograd, m) {
+  m.impl("my_full", TORCH_BOX(&my_full));
+}

--- a/test/cpp_extensions/libtorch_agnostic_2_10_extension/libtorch_agnostic_2_10/ops.py
+++ b/test/cpp_extensions/libtorch_agnostic_2_10_extension/libtorch_agnostic_2_10/ops.py
@@ -640,7 +640,9 @@ def my_sum_dim1(self) -> Tensor:
     return torch.ops.libtorch_agnostic_2_10.my_sum_dim1.default(self)
 
 
-def my_full(size, fill_value, dtype=None, device=None, pin_memory=None) -> Tensor:
+def my_full(
+    size, fill_value, dtype=None, layout=None, device=None, pin_memory=None
+) -> Tensor:
     """
     Creates a tensor filled with a scalar value.
 
@@ -648,11 +650,12 @@ def my_full(size, fill_value, dtype=None, device=None, pin_memory=None) -> Tenso
         size: list[int] - size of the tensor to create
         fill_value: float - value to fill the tensor with
         dtype: ScalarType or None - data type of the tensor
+        layout: Layout or None - layout of the tensor
         device: Device or None - device on which to create the tensor
         pin_memory: bool or None - whether to use pinned memory
 
     Returns: Tensor - a tensor filled with fill_value
     """
     return torch.ops.libtorch_agnostic_2_10.my_full.default(
-        size, fill_value, dtype, device, pin_memory
+        size, fill_value, dtype, layout, device, pin_memory
     )

--- a/test/cpp_extensions/libtorch_agnostic_2_10_extension/libtorch_agnostic_2_10/ops.py
+++ b/test/cpp_extensions/libtorch_agnostic_2_10_extension/libtorch_agnostic_2_10/ops.py
@@ -638,3 +638,21 @@ def my_sum_dim1(self) -> Tensor:
     Returns: Tensor - the sum of the tensor along dimension 1
     """
     return torch.ops.libtorch_agnostic_2_10.my_sum_dim1.default(self)
+
+
+def my_full(size, fill_value, dtype=None, device=None, pin_memory=None) -> Tensor:
+    """
+    Creates a tensor filled with a scalar value.
+
+    Args:
+        size: list[int] - size of the tensor to create
+        fill_value: float - value to fill the tensor with
+        dtype: ScalarType or None - data type of the tensor
+        device: Device or None - device on which to create the tensor
+        pin_memory: bool or None - whether to use pinned memory
+
+    Returns: Tensor - a tensor filled with fill_value
+    """
+    return torch.ops.libtorch_agnostic_2_10.my_full.default(
+        size, fill_value, dtype, device, pin_memory
+    )

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -900,6 +900,34 @@ if not IS_WINDOWS:
             self.assertEqual(result, expected)
             self.assertEqual(result.shape, torch.Size([3, 5]))
 
+        @skipIfTorchVersionLessThan(2, 10)
+        def test_my_full(self, device):
+            import libtorch_agnostic_2_10 as libtorch_agnostic
+
+            # Test basic full with default parameters
+            result = libtorch_agnostic.ops.my_full([2, 3], 3.14)
+            expected = torch.full([2, 3], 3.14)
+            self.assertEqual(result, expected)
+
+            # Test with dtype
+            result_dtype = libtorch_agnostic.ops.my_full(
+                [3, 4], 42.0, dtype=torch.int64
+            )
+            expected_dtype = torch.full([3, 4], 42, dtype=torch.int64)
+            self.assertEqual(result_dtype, expected_dtype)
+
+            # Test with device
+            result_device = libtorch_agnostic.ops.my_full([2, 2], 1.5, device=device)
+            expected_device = torch.full([2, 2], 1.5, device=device)
+            self.assertEqual(result_device, expected_device, exact_device=True)
+
+            # Test with dtype and device
+            result_both = libtorch_agnostic.ops.my_full(
+                [4, 5], 2.5, dtype=torch.float64, device=device
+            )
+            expected_both = torch.full([4, 5], 2.5, dtype=torch.float64, device=device)
+            self.assertEqual(result_both, expected_both, exact_device=True)
+
         def test_mv_tensor_accessor(self, device):
             import libtorch_agnostic_2_9 as libtorch_agnostic
 

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h
@@ -16,6 +16,7 @@ extern "C" {
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_amax(AtenTensorHandle self, const int64_t* dim, int64_t dim_len_, int32_t keepdim, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_fill__Scalar(AtenTensorHandle self, double value);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_full(const int64_t* size, int64_t size_len_, double fill_value, int32_t* dtype, int32_t* layout, int32_t* device, int32_t device_index_, int32_t* pin_memory, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_narrow(AtenTensorHandle self, int64_t dim, int64_t start, int64_t length, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_new_empty(AtenTensorHandle self, const int64_t* size, int64_t size_len_, int32_t* dtype, int32_t* layout, int32_t* device, int32_t device_index_, int32_t* pin_memory, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_new_zeros(AtenTensorHandle self, const int64_t* size, int64_t size_len_, int32_t* dtype, int32_t* layout, int32_t* device, int32_t device_index_, int32_t* pin_memory, AtenTensorHandle* ret0);

--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -189,4 +189,5 @@ aten_shimified_ops: dict[str, dict[str, list[str]]] = {
     "aten.amax.default": {},
     "aten.new_empty.default": {},
     "aten.new_zeros.default": {},
+    "aten.full.default": {},
 }


### PR DESCRIPTION
Scalar's StableIValue conversion is not supported yet.

If we don't land this we can recommend `fill_(empty(...))` instead 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169880
* __->__ #169872
* #168062
* #169711
* #169709
* #169703

