### PR TITLE
[pytorch][PR] [Flop Counter] Support Flop counter for a decomposed custom triton kernel in torch op

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1055,6 +1055,10 @@ class TritonKernelWrapperFunctional(HigherOrderOperator):
 triton_kernel_wrapper_functional = TritonKernelWrapperFunctional()
 
 
+def get_kernel(kernel_idx: int) -> "TritonKernelType":
+    return kernel_side_table.get_kernel(kernel_idx)
+
+
 @triton_kernel_wrapper_mutation.py_impl(DispatchKey.CompositeExplicitAutograd)
 def triton_kernel_wrapper_mutation_dense(
     *,


### PR DESCRIPTION
Summary:
Modify our flop formula API to registering triton kernels, and provide an example of how to escape hatch triton op to leverage this API

Context: For some custom `torch.library.op`, the operator decomposes into one or more custom kernels.  To date, there has not been a good system for having these counted by FlopCounterMode, as the function will decompose to the wrapped kernels, and then check the registry.

To support this use case, we modify the API, `register_flop_formula` on GPU kernels, and demonstrate how it is used to unwrap kernels in custom ops.

### Unit Test
```
python test/test_flop_counter.py TestFlopCounter.test_flop_counter_custom_triton
```

```
.
----------------------------------------------------------------------
Ran 1 test in 0.005s
```

Differential Revision: D81943083

Pulled By: Lucaskabela


