### PR TITLE
[CI] Fix NVSHMEM errors in H100 symm mem job

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -368,20 +368,26 @@ test_h100_distributed() {
   assert_git_not_dirty
 }
 
-test_h100_symm_mem() {
+_run_symm_mem_tests() {
   # symmetric memory test
-
-  # Configure NVSHMEM to use smaller heap and work without NVSwitch
-  # Default heap is 128GB which fails cuMemMap on AWS H100 instances
-  export NVSHMEM_SYMMETRIC_SIZE=4G
-  # Disable NVLink Switch features (not available on AWS H100 instances)
-  export NVSHMEM_DISABLE_NVLS=1
-
   time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nvshmem_triton.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nccl.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
+}
+
+test_h100_symm_mem() {
+  # Configure NVSHMEM to use smaller heap and work without NVSwitch
+  # Default heap is 128GB which fails cuMemMap on AWS H100 instances
+  export NVSHMEM_SYMMETRIC_SIZE=4G
+  # Disable NVLink Switch features (not available on AWS H100 instances)
+  export NVSHMEM_DISABLE_NVLS=1
+  _run_symm_mem_tests
+}
+
+test_b200_symm_mem() {
+  _run_symm_mem_tests
 }
 
 test_h100_cutlass_backend() {
@@ -2008,7 +2014,7 @@ elif [[ "${TEST_CONFIG}" == h100_distributed ]]; then
 elif [[ "${TEST_CONFIG}" == "h100-symm-mem" ]]; then
   test_h100_symm_mem
 elif [[ "${TEST_CONFIG}" == "b200-symm-mem" ]]; then
-  test_h100_symm_mem
+  test_b200_symm_mem
 elif [[ "${TEST_CONFIG}" == h100_cutlass_backend ]]; then
   test_h100_cutlass_backend
 elif [[ "${TEST_CONFIG}" == openreg ]]; then

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -370,6 +370,13 @@ test_h100_distributed() {
 
 test_h100_symm_mem() {
   # symmetric memory test
+
+  # Configure NVSHMEM to use smaller heap and work without NVSwitch
+  # Default heap is 128GB which fails cuMemMap on AWS H100 instances
+  export NVSHMEM_SYMMETRIC_SIZE=4G
+  # Disable NVLink Switch features (not available on AWS H100 instances)
+  export NVSHMEM_DISABLE_NVLS=1
+
   time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nvshmem_triton.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -3,6 +3,7 @@
 # To run:
 # python test/distributed/test_nvshmem.py
 
+import os
 
 import torch
 import torch.distributed as dist
@@ -31,14 +32,7 @@ def requires_nvshmem():
 
 
 def requires_nvls():
-    """Skip test if NVLS (NVLink Switch) is not available.
-
-    Kernels like tile_reduce use NVLS algorithms which require NVSwitch hardware.
-    When NVSHMEM_DISABLE_NVLS=1 is set (to allow NVSHMEM to initialize on machines
-    without NVSwitch, e.g., AWS H100), these operations will fail with illegal
-    memory access errors.
-    """
-    import os
+    """Skip test if NVLS (NVLink Switch) is not available."""
     nvls_disabled = os.environ.get("NVSHMEM_DISABLE_NVLS", "0") == "1"
     return skip_but_pass_in_sandcastle_if(
         nvls_disabled,


### PR DESCRIPTION
Example error:
```
2025-12-08T12:46:36.6787890Z distributed/test_nvshmem.py::NVSHMEMSymmetricMemoryTest::test_alloc I1208 09:18:18.140000 4559 site-packages/torch/testing/_internal/common_distributed.py:1857] Testing class NVSHMEMSymmetricMemoryTest on 4 cuda
2025-12-08T12:46:36.6790166Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal_nvls.cpp:258: non-zero status: 401 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal_nvls.cpp:258: non-zero status: 401 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal_nvls.cpp:258: non-zero status: 401 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal_nvls.cpp:258: non-zero status: 401 cuMemMap failed to map 137438953472 bytes handle at address: 0x17700000000 offset 0 on device 3
2025-12-08T12:46:36.6792068Z cuMemMap failed to map 137438953472 bytes handle at address: 0x17700000000 offset 0 on device 1
2025-12-08T12:46:36.6792601Z cuMemMap failed to map 137438953472 bytes handle at address: 0x17700000000 offset 0 on device 0
2025-12-08T12:46:36.6793267Z cuMemMap failed to map 137438953472 bytes handle at address: 0x17700000000 offset 0 on device 2
2025-12-08T12:46:36.6793589Z 
2025-12-08T12:46:36.6793592Z 
2025-12-08T12:46:36.6793595Z 
2025-12-08T12:46:36.6793597Z 
2025-12-08T12:46:36.6795118Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/mem/mem_heap.cpp:1574: non-zero status: 7 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/mem/mem_heap.cpp:1574: non-zero status: 7 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/mem/mem_heap.cpp:1574: non-zero status: 7 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/mem/mem_heap.cpp:1574: non-zero status: 7 Mapping mem size 137438953472 to MC group 110764794866528 failed 
2025-12-08T12:46:36.6796737Z Mapping mem size 137438953472 to MC group 104026137521056 failed 
2025-12-08T12:46:36.6797132Z Mapping mem size 137438953472 to MC group 110603466046304 failed 
2025-12-08T12:46:36.6797514Z Mapping mem size 137438953472 to MC group 99516125599472 failed 
2025-12-08T12:46:36.6797734Z 
2025-12-08T12:46:36.6797737Z 
2025-12-08T12:46:36.6797740Z 
2025-12-08T12:46:36.6798044Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:791: non-zero status: 7 
2025-12-08T12:46:36.6799232Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:791: non-zero status: 7 /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:791: non-zero status: 7 Mapping multicast groups for UC heap failed for pe 0 team ID 0
2025-12-08T12:46:36.6800726Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:791: non-zero status: 7 Mapping multicast groups for UC heap failed for pe 3 team ID 0
2025-12-08T12:46:36.6801444Z Mapping multicast groups for UC heap failed for pe 2 team ID 0
2025-12-08T12:46:36.6801672Z 
2025-12-08T12:46:36.6801848Z Mapping multicast groups for UC heap failed for pe 1 team ID 0
2025-12-08T12:46:36.6802070Z 
2025-12-08T12:46:36.6802072Z 
2025-12-08T12:46:36.6802075Z 
2025-12-08T12:46:36.6802536Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:841: non-zero status: 7 NVLS resource initialization failed for team ID: 0
2025-12-08T12:46:36.6803187Z 
2025-12-08T12:46:36.6803602Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:1358: non-zero status: 7 NVLS resource setup failed for team ID: 0
2025-12-08T12:46:36.6804122Z 
2025-12-08T12:46:36.6804550Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:841: non-zero status: 7 NVLS resource initialization failed for team ID: 0
2025-12-08T12:46:36.6805085Z 
2025-12-08T12:46:36.6805492Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:1358: non-zero status: 7 NVLS resource setup failed for team ID: 0
2025-12-08T12:46:36.6805975Z 
2025-12-08T12:46:36.6806423Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:841: non-zero status: 7 NVLS resource initialization failed for team ID: 0
2025-12-08T12:46:36.6806924Z 
2025-12-08T12:46:36.6807365Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:1358: non-zero status: 7 NVLS resource setup failed for team ID: 0
2025-12-08T12:46:36.6807848Z 
2025-12-08T12:46:36.6808169Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/init/init.cu:1079: non-zero status: 7 team setup failed 
2025-12-08T12:46:36.6808594Z 
2025-12-08T12:46:36.6809023Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:841: non-zero status: 7 NVLS resource initialization failed for team ID: 0
2025-12-08T12:46:36.6809559Z 
2025-12-08T12:46:36.6809972Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/team/team_internal.cpp:1358: non-zero status: 7 NVLS resource setup failed for team ID: 0
2025-12-08T12:46:36.6810453Z 
2025-12-08T12:46:36.6810793Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/init/init.cu:1079: non-zero status: 7 team setup failed 
2025-12-08T12:46:36.6811187Z 
2025-12-08T12:46:36.6811532Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/init/init.cu:1079: non-zero status: 7 team setup failed 
2025-12-08T12:46:36.6811924Z 
2025-12-08T12:46:36.6812231Z /dvs/p4/build/sw/rel/gpgpu/toolkit/r12.9/main_nvshmem/src/host/init/init.cu:1079: non-zero status: 7 team setup failed 
```