### PR TITLE
[BE][2/N] Replace IDEEP_PREREQ with DNNL_PREPREQ

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -843,7 +843,7 @@ Tensor mkldnn_convolution_backward_input(
       padding.vec(),
       padding.vec(),
       groups,
-#if IDEEP_PREREQ(3, 4, 1, 3)
+#if DNNL_PREREQ(3, 4, 1)
       is_channels_last,
       op_attr);
 #else
@@ -851,12 +851,12 @@ Tensor mkldnn_convolution_backward_input(
   if (mkldnn_conv_enabled_fpmath_mode_bf16() &&
       weight.scalar_type() == at::kFloat) {
     TORCH_WARN_ONCE(
-        "Unexpected ideep version to support fpmath_mode_bf16, please update ideep version to align with pytorch main branch");
+        "Unexpected oneDNN version to support fpmath_mode_bf16, please update oneDNN version to align with pytorch main branch");
       }
   if (mkldnn_conv_enabled_fpmath_mode_tf32() &&
       weight.scalar_type() == at::kFloat) {
     TORCH_WARN_ONCE(
-        "Unexpected ideep version to support fpmath_mode_tf32, please update ideep version to align with pytorch main branch");
+        "Unexpected oneDNN version to support fpmath_mode_tf32, please update oneDNN version to align with pytorch main branch");
       }
 #endif
 

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -83,11 +83,11 @@ at::Tensor mkldnn_tensor_from_data_ptr(
   std::vector<uint8_t> vector_serialized_md{
       opaque_metadata, opaque_metadata + opaque_metadata_size};
   ideep::tensor::desc deserialized_ideep_desc;
-#if IDEEP_PREREQ(3, 4, 1, 2)
+#if DNNL_PREREQ(3, 4, 1)
   // groups is needed for grouped conv
   deserialized_ideep_desc = ideep::tensor::desc(vector_serialized_md);
 #else
-  TORCH_CHECK(false, "Unexpected IDeep version to do weight deserialization.");
+  TORCH_CHECK(false, "Unexpected oneDNN version to do weight deserialization.");
 #endif
 
   auto a = ideep::tensor(deserialized_ideep_desc, data_ptr);

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -7,17 +7,17 @@
 #include <ideep.hpp>
 #include <dnnl.hpp>
 
-#ifndef IDEEP_PREREQ
-// Please find definitions of version numbers in ideep.hpp
-#if defined(IDEEP_VERSION_MAJOR) && defined(IDEEP_VERSION_MINOR) && \
-  defined(IDEEP_VERSION_PATCH) && defined(IDEEP_VERSION_REVISION)
-#define IDEEP_PREREQ(major, minor, patch, revision) \
-  (((IDEEP_VERSION_MAJOR << 16) + (IDEEP_VERSION_MINOR << 8) + \
-   (IDEEP_VERSION_PATCH << 0)) >= \
-   ((major << 16) + (minor << 8) + (patch << 0)) && \
-   (IDEEP_VERSION_REVISION >= revision))
+#ifndef DNNL_PREREQ
+// oneDNN version check macro
+// Checks if the current oneDNN version is >= the specified version
+#if defined(DNNL_VERSION_MAJOR) && defined(DNNL_VERSION_MINOR) && \
+  defined(DNNL_VERSION_PATCH)
+#define DNNL_PREREQ(major, minor, patch) \
+  (((DNNL_VERSION_MAJOR << 16) + (DNNL_VERSION_MINOR << 8) + \
+   (DNNL_VERSION_PATCH << 0)) >= \
+   ((major << 16) + (minor << 8) + (patch << 0)))
 #else
-#define IDEEP_PREREQ(major, minor, patch, revision) 0
+#define DNNL_PREREQ(major, minor, patch) 0
 #endif
 #endif
 

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -525,10 +525,10 @@ static Tensor get_mkldnn_serialized_md(const Tensor& self) {
   auto packed_w_desc = packed_w.get_desc();
   std::vector<uint8_t> serialized_wei_desc;
 
-#if IDEEP_PREREQ(3, 4, 1, 2)
+#if DNNL_PREREQ(3, 4, 1)
   serialized_wei_desc = packed_w_desc.get_blob();
 #else
-      TORCH_CHECK(false, "Unexpected IDeep version to do weight serialization.");
+      TORCH_CHECK(false, "Unexpected oneDNN version to do weight serialization.");
 #endif
   Tensor serialized_md = at::from_blob((void*)serialized_wei_desc.data(), {static_cast<int64_t>(serialized_wei_desc.size())}, at::TensorOptions(at::kByte));
   auto res = at::empty_like(serialized_md);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #169886
* __->__ #169885
* #169884

Again, this abstraction is not needed, let's use oneDNN APIs/macros directly

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01