### PR TITLE
[DTensor] Add complete OpSpec metadata to create_like_strategy

### DIFF
--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -186,9 +186,16 @@ def create_like_strategy(op_schema: OpSchema) -> StrategyType:
                 Replicate() if isinstance(p, Partial) else p
                 for p in arg_spec.placements
             ),
+            tensor_meta=arg_spec.tensor_meta,
         )
         create_like_strategy.strategies.append(
-            OpSpec(output_specs=output_spec, input_specs=(arg_spec,))
+            OpSpec(
+                output_specs=output_spec,
+                input_specs=(arg_spec,),
+                redistribute_cost=[
+                    generate_redistribute_costs(select_strategy, arg_spec),
+                ],
+            )
         )
 
     return create_like_strategy


### PR DESCRIPTION
Contributes to  #157495 
Add redistribute_cost and tensor_meta to the OpSpec returned by create_like_strategy, enabling cost-based optimization for 6 factory ops:
- zeros_like, ones_like, empty_like, full_like, randn_like, randint_like




