### PR TITLE
Protect files that ET depends on to be pinned to c++17

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,9 +119,9 @@ jobs:
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running all other linters"
         if [ "$CHANGED_FILES" = '*' ]; then
-          ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGFORMAT,PYREFLY --all-files" .github/scripts/lintrunner.sh
+          ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY --all-files" .github/scripts/lintrunner.sh
         else
-          ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGFORMAT,PYREFLY ${CHANGED_FILES}" .github/scripts/lintrunner.sh
+          ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY ${CHANGED_FILES}" .github/scripts/lintrunner.sh
         fi
 
   quick-checks:

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -231,6 +231,7 @@ exclude_patterns = [
     'c10/util/SmallVector.h',
     'c10/util/win32-headers.h',
     'c10/test/**/*.h',
+    'c10/test/**/*.cpp',
     'third_party/**/*',
     'torch/csrc/autograd/generated/**',
     'torch/csrc/distributed/**/*.cu',
@@ -258,6 +259,59 @@ command = [
     'tools/linter/adapters/clangtidy_linter.py',
     '--binary=.lintbin/clang-tidy',
     '--build_dir=./build',
+    '--',
+    '@{{PATHSFILE}}'
+]
+
+[[linter]]
+code = 'CLANGTIDY_EXECUTORCH_COMPATIBILITY'
+include_patterns = [
+    # c10 headers that must be C++17 compatible
+    'c10/macros/Export.h',
+    'c10/macros/Macros.h',
+    'c10/macros/cmake_macros.h',
+    'c10/util/BFloat16.h',
+    'c10/util/BFloat16-inl.h',
+    'c10/util/BFloat16-math.h',
+    'c10/util/Half.h',
+    'c10/util/Half-inl.h',
+    'c10/util/TypeSafeSignMath.h',
+    'c10/util/bit_cast.h',
+    'c10/util/complex.h',
+    'c10/util/floating_point_utils.h',
+    'c10/util/irange.h',
+    'c10/util/llvmMathExtras.h',
+    'c10/util/overflows.h',
+    'c10/util/safe_numerics.h',
+    # torch/headeronly headers that must be C++17 compatible
+    'torch/headeronly/macros/cmake_macros.h',
+    'torch/headeronly/macros/Export.h',
+    'torch/headeronly/macros/Macros.h',
+    'torch/headeronly/util/BFloat16.h',
+    'torch/headeronly/util/Half.h',
+    'torch/headeronly/util/TypeSafeSignMath.h',
+    'torch/headeronly/util/bit_cast.h',
+    'torch/headeronly/util/complex.h',
+    'torch/headeronly/util/floating_point_utils.h',
+]
+exclude_patterns = [
+    '**/fb/**',
+]
+init_command = [
+    'python3',
+    'tools/linter/adapters/s3_init.py',
+    '--config-json=tools/linter/adapters/s3_init_config.json',
+    '--linter=clang-tidy',
+    '--dry-run={{DRYRUN}}',
+    '--output-dir=.lintbin',
+    '--output-name=clang-tidy',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/clangtidy_linter.py',
+    '--binary=.lintbin/clang-tidy',
+    '--build_dir=./build',
+    '--std=c++17',
     '--',
     '@{{PATHSFILE}}'
 ]

--- a/c10/test/CMakeLists.txt
+++ b/c10/test/CMakeLists.txt
@@ -17,3 +17,14 @@ if(BUILD_TEST)
     endif()
   endforeach()
 endif()
+
+# ---[ C++17 header compilation test
+if(BUILD_TEST)
+  add_executable(c10_cpp17_header_build_test util/cpp17_header_build_check.cpp)
+  target_link_libraries(c10_cpp17_header_build_test ${C10_LIB} gmock gtest gtest_main)
+  set_target_properties(c10_cpp17_header_build_test PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+  )
+  add_test(NAME c10_cpp17_header_build_test COMMAND $<TARGET_FILE:c10_cpp17_header_build_test>)
+endif()

--- a/c10/test/util/cpp17_header_build_check.cpp
+++ b/c10/test/util/cpp17_header_build_check.cpp
@@ -1,0 +1,30 @@
+// Compile-only test to verify that c10 headers mirrored
+// to ExecuTorch build with C++17.
+
+#include <gtest/gtest.h>
+
+#include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
+#include <c10/util/TypeSafeSignMath.h>
+#include <c10/util/bit_cast.h>
+#include <c10/util/complex.h>
+#include <c10/util/floating_point_utils.h>
+#include <c10/util/irange.h>
+#include <c10/util/llvmMathExtras.h>
+#include <c10/util/overflows.h>
+#include <c10/util/safe_numerics.h>
+
+#include <torch/headeronly/macros/Export.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+#include <torch/headeronly/util/TypeSafeSignMath.h>
+#include <torch/headeronly/util/bit_cast.h>
+#include <torch/headeronly/util/complex.h>
+#include <torch/headeronly/util/floating_point_utils.h>
+
+TEST(Cpp17HeaderBuildCheckTest, HeadersCompile) {
+  EXPECT_TRUE(true);
+}

--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -138,6 +138,7 @@ include_dir = [
     "/usr/lib/llvm-11/include/openmp",
     get_python_include_dir(),
     os.path.join(PYTORCH_ROOT, "third_party/pybind11/include"),
+    PYTORCH_ROOT,
 ] + clang_search_dirs()
 for dir in include_dir:
     include_args += ["--extra-arg", f"-I{dir}"]
@@ -147,11 +148,21 @@ def check_file(
     filename: str,
     binary: str,
     build_dir: Path,
+    std: str,
 ) -> list[LintMessage]:
+    # Explicitly pass include path for linters that only check headers.
+    build_include_args = include_args + ["--extra-arg", f"-I{build_dir}"]
+    cmd = [
+        binary,
+        f"-p={build_dir}",
+        *build_include_args,
+        filename,
+        "--",
+        f"-std={std}",
+    ]
+
     try:
-        proc = run_command(
-            [binary, f"-p={build_dir}", *include_args, filename],
-        )
+        proc = run_command(cmd)
     except OSError as err:
         return [
             LintMessage(
@@ -218,6 +229,11 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--std",
+        default="c++17",
+        help="C++ standard to use for compilation (e.g., c++17, c++20)",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="verbose logging",
@@ -277,6 +293,7 @@ def main() -> None:
                 filename,
                 binary_path,
                 abs_build_dir,
+                args.std,
             ): filename
             for filename in args.filenames
         }

--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -148,7 +148,7 @@ def check_file(
     filename: str,
     binary: str,
     build_dir: Path,
-    std: str,
+    std: str | None,
 ) -> list[LintMessage]:
     # Explicitly pass include path for linters that only check headers.
     build_include_args = include_args + ["--extra-arg", f"-I{build_dir}"]
@@ -157,9 +157,10 @@ def check_file(
         f"-p={build_dir}",
         *build_include_args,
         filename,
-        "--",
-        f"-std={std}",
     ]
+    # Only add -- and -std flag if std is explicitly specified
+    if std is not None:
+        cmd.extend(["--", f"-std={std}"])
 
     try:
         proc = run_command(cmd)
@@ -230,8 +231,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--std",
-        default="c++17",
-        help="C++ standard to use for compilation (e.g., c++17, c++20)",
+        default=None,
+        help="C++ standard to use for compilation (e.g., c++17, c++20). If not specified, uses the standard from compile_commands.json.",
     )
     parser.add_argument(
         "--verbose",

--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -232,7 +232,10 @@ def main() -> None:
     parser.add_argument(
         "--std",
         default=None,
-        help="C++ standard to use for compilation (e.g., c++17, c++20). If not specified, uses the standard from compile_commands.json.",
+        help=(
+            "C++ standard to use for compilation (e.g., c++17, c++20). "
+            "If not specified, uses the standard from compile_commands.json."
+        ),
     )
     parser.add_argument(
         "--verbose",


### PR DESCRIPTION
Needed for https://github.com/pytorch/pytorch/issues/167822

ExecuTorch is still pinned to c++17 and will remain that way for the forseeable future. We take a dep on these headers and pytorch/pytorch wants to bump to c++20. This is a pretty minimal way to avoid the issue recommended by @r-barnes

Added a unittest with the version restricted and then added a new linter that I manually tested by modifying the files to use a c++20 feature and verified it died.

Previous version that went under review before I trashed the git history and broke the CLA job: https://github.com/pytorch/pytorch/pull/168204 