### PR TITLE
Silence expected double registration warning

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2979,6 +2979,14 @@ class TestCustomOpAPI(TestCase):
                 continue
             self.assertGreater(after, prev)
 
+    def test_mutated_no_warning(self):
+        def f():
+            @torch.library.custom_op("mylib::func", mutates_args=("x",))
+            def func(x: Tensor) -> None:
+                x.add_(1)
+
+        self.assertNotWarn(f)
+
     def test_mutated_unknown(self):
         @torch.library.custom_op(
             "_torch_testing::f", mutates_args="unknown", device_types="cpu"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2980,12 +2980,31 @@ class TestCustomOpAPI(TestCase):
             self.assertGreater(after, prev)
 
     def test_mutated_no_warning(self):
-        def f():
-            @torch.library.custom_op("mylib::func", mutates_args=("x",))
-            def func(x: Tensor) -> None:
-                x.add_(1)
+        # Run in subprocess since the warning is emitted only once
+        script = """\
+import warnings
+import torch
+from torch import Tensor
 
-        self.assertNotWarn(f)
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    torch.set_warn_always(True)
+
+    @torch.library.custom_op("mylib::func", mutates_args=("x",))
+    def func(x: Tensor) -> None:
+        x.add_(1)
+
+    if len(w) > 0:
+        raise AssertionError(f"Unexpected warning: {w[0].message}")
+"""
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", script],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+            )
+        except subprocess.CalledProcessError as e:
+            self.fail(e.output.decode("utf-8"))
 
     def test_mutated_unknown(self):
         @torch.library.custom_op(

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -2,6 +2,7 @@
 import collections
 import inspect
 import logging
+import warnings
 import weakref
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager
@@ -660,12 +661,18 @@ class CustomOpDef:
                 # Handle view + mutation that are in the schema
                 return original_kernel.call_boxed(keyset, *args, **kwargs)
 
-            lib.impl(
-                self._name,
-                adinplaceorview_impl,
-                "ADInplaceOrView",
-                with_keyset=True,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Warning only once for all operators",
+                    category=UserWarning,
+                )
+                lib.impl(
+                    self._name,
+                    adinplaceorview_impl,
+                    "ADInplaceOrView",
+                    with_keyset=True,
+                )
 
     def _register_backend_select_dispatcher(self, device_arg_index: int):
         """


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/169839

Passing a flag to the impl() registration would also be feasible but would be a significantly larger change (100s LOC). So I'm going with the simplest here.
