### PR TITLE
[vLLM] Remove xformers in vLLM build workflow

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/vllm/vllm_test.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/vllm_test.py
@@ -82,7 +82,6 @@ class VllmTestRunner(BaseRunner):
 
         # Match the structure of the artifacts.zip from vllm external build
         self.VLLM_TEST_WHLS_REGEX = [
-            "xformers/*.whl",
             "vllm/vllm*.whl",
         ]
 
@@ -222,14 +221,13 @@ def preprocess_test_in(
     """
     This modifies the target_file file in place in vllm work directory.
     It removes torch and unwanted packages in target_file and replace with local torch whls
-    package  with format "$WHEEL_PACKAGE_NAME @ file://<LOCAL_PATH>"
+    package with format "$WHEEL_PACKAGE_NAME @ file://<LOCAL_PATH>"
     """
     additional_package_to_move = list(additional_packages or ())
     pkgs_to_remove = [
         "torch",
         "torchvision",
         "torchaudio",
-        "xformers",
         "mamba_ssm",
     ] + additional_package_to_move
     # Read current requirements
@@ -273,7 +271,7 @@ def check_versions():
     check installed packages version
     """
     logger.info("Double check installed packages")
-    patterns = ["torch", "xformers", "torchvision", "torchaudio", "vllm"]
+    patterns = ["torch", "torchvision", "torchaudio", "vllm"]
     for pkg in patterns:
         pkg_exists(pkg)
     logger.info("Done. checked installed packages")

--- a/.github/ci_configs/vllm/Dockerfile
+++ b/.github/ci_configs/vllm/Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VERSION=12.9.1
 ARG PYTHON_VERSION=3.12
 
-# BUILD_BASE_IMAGE: used to setup python build xformers, and vllm wheels, It can be replaced with a different base image from local machine,
+# BUILD_BASE_IMAGE: used to build vllm wheels, It can be replaced with a different base image from local machine,
 # by default, it uses the torch-nightly-base stage from this docker image
 ARG BUILD_BASE_IMAGE=torch-nightly-base
 ARG FINAL_BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
@@ -116,28 +116,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -r requirements/common.txt
 
-ARG max_jobs=16
-ENV MAX_JOBS=${max_jobs}
-
-RUN --mount=type=cache,target=/root/.cache/uv bash - <<'BASH'
-    export TORCH_CUDA_ARCH_LIST='7.5 8.0+PTX 9.0a'
-    git clone https://github.com/facebookresearch/xformers.git
-
-    pushd xformers
-    git checkout v0.0.33.post1
-    git submodule update --init --recursive
-    python3 setup.py bdist_wheel --dist-dir=../xformers-dist --verbose
-    popd
-
-    rm -rf xformers
-BASH
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system xformers-dist/*.whl
-
 RUN uv pip freeze | grep -i '^torch\|^torchvision\|^torchaudio' > torch_build_versions.txt
 RUN cat torch_build_versions.txt
-RUN pip freeze | grep -E 'torch|xformers|torchvision|torchaudio'
+RUN pip freeze | grep -E 'torch|torchvision|torchaudio'
 #################### BASE BUILD IMAGE ####################
 
 
@@ -240,7 +221,6 @@ RUN if command -v apt-get >/dev/null; then \
 
 # Get the torch versions, and whls used in previous stage
 COPY --from=base /workspace/torch_build_versions.txt ./torch_build_versions.txt
-COPY --from=base /workspace/xformers-dist /wheels/xformers
 COPY --from=build /workspace/vllm-dist /wheels/vllm
 RUN echo "[INFO] Listing current directory before torch install step:" && \
     ls -al && \
@@ -290,13 +270,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system /wheels/vllm/*.whl --verbose
 
-# Install xformers wheel from previous stage
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system /wheels/xformers/*.whl --verbose
-
 # Logging to confirm the torch versions
-RUN pip freeze | grep -E 'torch|xformers|vllm'
-RUN uv pip freeze | grep -i '^torch\|^torchvision\|^torchaudio\|^xformers\|^vllm' > build_summary.txt
+RUN pip freeze | grep -E 'torch|vllm'
+RUN uv pip freeze | grep -i '^torch\|^torchvision\|^torchaudio\|^vllm' > build_summary.txt
 ################### VLLM INSTALLED IMAGE ####################
 
 
@@ -304,6 +280,5 @@ RUN uv pip freeze | grep -i '^torch\|^torchvision\|^torchaudio\|^xformers\|^vllm
 FROM scratch as export-wheels
 
 # Just copy the wheels we prepared in previous stages
-COPY --from=base /workspace/xformers-dist /wheels/xformers
 COPY --from=build /workspace/vllm-dist /wheels/vllm
 COPY --from=vllm-base /workspace/build_summary.txt /wheels/build_summary.txt

--- a/.github/scripts/prepare_vllm_wheels.sh
+++ b/.github/scripts/prepare_vllm_wheels.sh
@@ -37,7 +37,7 @@ change_wheel_version() {
   # Update the version in METADATA and its SHA256 hash
   sed -i "s/Version: ${f_version}/Version: ${t_version}/g" METADATA
   # then add PyTorch nightly dependency of vLLM
-  if [[ "${package}" == vllm ]] || [[ "${package}" == xformers ]]; then
+  if [[ "${package}" == vllm ]]; then
     sed -i "/License-File/a\Requires-Dist: torch==${torch_version}" METADATA
   fi
   sed -i '/METADATA,sha256/d' RECORD
@@ -88,7 +88,7 @@ repackage_wheel() {
 ${PYTHON_EXECUTABLE} -mpip install wheel==0.45.1
 
 pushd externals/vllm/wheels
-for package in xformers vllm; do
+for package in vllm; do
   repackage_wheel $package
 done
 popd


### PR DESCRIPTION
This is not needed anymore after https://github.com/vllm-project/vllm/pull/29262.  So, we only need to build vLLM wheel on PyTorch CI now.

1. https://github.com/vllm-project/vllm/pull/29262 has removed xformers from vLLM, and this PR applies that change to our end
2. This vLLM nightly wheel will be used to power nightly benchmark runs on PyTorch CI.  It's good that we just need to rebuild vLLM now and none of its dependencies
3. I'm trying to get rid of the Dockerfile on PyTorch eventually, and just use the official one from vLLM instead.  This is a work in progress
