### PR TITLE
Enforce contiguous input in Convolution if running on M5 device

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -10,7 +10,7 @@
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
 typedef id<MTLDevice> MTLDevice_t;
-typedef MTLGPUFamily MTLGPUFamily_t;
+typedef NSInteger MTLGPUFamily_t;
 #else
 typedef void* MTLDevice_t;
 typedef void* MTLGPUFamily_t;

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -10,8 +10,10 @@
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
 typedef id<MTLDevice> MTLDevice_t;
+typedef MTLGPUFamily MTLGPUFamily_t;
 #else
 typedef void* MTLDevice_t;
+typedef void* MTLGPUFamily_t;
 #endif
 
 namespace at::mps {
@@ -57,6 +59,13 @@ class TORCH_API MPSDevice {
   bool isMacOS13Plus(MacOSVersion version) const;
 
   /**
+   * Returns whether device supports the GPU family
+   * Possible family values:
+   * https://developer.apple.com/documentation/metal/mtlgpufamily?language=objc
+   */
+  bool isGPUFamily(MTLGPUFamily_t family) const;
+
+  /**
    * Returns device name
    */
   std::string getName() const;
@@ -78,6 +87,7 @@ class TORCH_API MPSDevice {
 TORCH_API bool is_available();
 TORCH_API bool is_macos_13_or_newer(MacOSVersion version);
 TORCH_API at::Allocator* GetMPSAllocator();
+TORCH_API bool is_gpu_family(MTLGPUFamily_t family);
 
 inline Device getDeviceFromPtr(void* ptr) {
   return {c10::DeviceType::MPS, 0};

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -55,7 +55,7 @@ MPSDevice::MPSDevice() : _mtl_device(nil) {
 
 bool MPSDevice::isGPUFamily(MTLGPUFamily_t family) const {
   @autoreleasepool {
-    return [_mtl_device supportsFamily:family];
+    return [_mtl_device supportsFamily:(MTLGPUFamily)family];
   }
 }
 

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -53,6 +53,12 @@ MPSDevice::MPSDevice() : _mtl_device(nil) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(_mtl_device);
 }
 
+bool MPSDevice::isGPUFamily(MTLGPUFamily_t family) const {
+  @autoreleasepool {
+    return [_mtl_device supportsFamily:family];
+  }
+}
+
 bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   auto is_os_version_at_least = [](int major, int minor) {
     @autoreleasepool {
@@ -119,6 +125,10 @@ bool is_available() {
 
 bool is_macos_13_or_newer(MacOSVersion version) {
   return MPSDevice::getInstance()->isMacOS13Plus(version);
+}
+
+bool is_gpu_family(MTLGPUFamily_t family) {
+  return MPSDevice::getInstance()->isGPUFamily(family);
 }
 
 } // namespace at::mps

--- a/aten/src/ATen/native/mps/MPSGraphTahoeOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphTahoeOps.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#if !defined(__MAC_26_0) &&             \
+    (!defined(MAC_OS_X_VERSION_26_0) || \
+     (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_26_0))
+constexpr NSInteger MTLGPUFamilyApple10 = 1010;
+#endif

--- a/aten/src/ATen/native/mps/MPSGraphTahoeOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphTahoeOps.h
@@ -2,8 +2,6 @@
 
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
-#if !defined(__MAC_26_0) &&             \
-    (!defined(MAC_OS_X_VERSION_26_0) || \
-     (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_26_0))
+#if !defined(__MAC_26_0) && (!defined(MAC_OS_X_VERSION_26_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_26_0))
 constexpr NSInteger MTLGPUFamilyApple10 = 1010;
 #endif

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -301,7 +301,10 @@ Tensor _mps_convolution(const Tensor& input_t,
                         IntArrayRef stride,
                         IntArrayRef dilation,
                         int64_t groups) {
-  return _mps_convolution_impl(input_t, weight_t, bias_opt, padding, stride, dilation, groups, std::nullopt);
+  // https://github.com/pytorch/pytorch/issues/169342 Need to avoid strided inputs
+  // until bug fix lands in the OS. Issue started in MacOS26 on M5 devices.
+  const bool is_m5_device = is_gpu_family(MTLGPUFamilyApple10);
+  return _mps_convolution_impl(is_m5_device ? input_t.contiguous() : input_t, weight_t, bias_opt, padding, stride, dilation, groups, std::nullopt);
 }
 
 static Tensor mps_convolution_backward_input(IntArrayRef input_size,

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -304,7 +304,14 @@ Tensor _mps_convolution(const Tensor& input_t,
   // https://github.com/pytorch/pytorch/issues/169342 Need to avoid strided inputs
   // until bug fix lands in the OS. Issue started in MacOS26 on M5 devices.
   const bool is_m5_device = is_gpu_family(MTLGPUFamilyApple10);
-  return _mps_convolution_impl(is_m5_device ? input_t.contiguous() : input_t, weight_t, bias_opt, padding, stride, dilation, groups, std::nullopt);
+  return _mps_convolution_impl(is_m5_device ? input_t.contiguous() : input_t,
+                               weight_t,
+                               bias_opt,
+                               padding,
+                               stride,
+                               dilation,
+                               groups,
+                               std::nullopt);
 }
 
 static Tensor mps_convolution_backward_input(IntArrayRef input_size,

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/ConvUtils.h>
+#include <ATen/native/mps/MPSGraphTahoeOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_mps_convolution_native.h>
 #include <ATen/ops/_mps_convolution_transpose_native.h>


### PR DESCRIPTION
Fixes #169342

Fixes the correctness issue with strided input on M5 devices at the cost of making the input contiguous. Need to revisit this once the kernel side fix is available in the OS so we can limit the check to only `MTLGPUFamilyApple10 && <pre OS version>`.

Adds helper to check if device belongs to a particular GPU family.