### PR TITLE
Fix `TestSaveLoad.test_version_error`

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -7,6 +7,7 @@ with test_sym_bool)
 import copy
 import io
 import math
+import os
 import tempfile
 import unittest
 import zipfile
@@ -2229,7 +2230,7 @@ class TestSaveLoad(TestCase):
             with tempfile.NamedTemporaryFile(suffix=".pt2") as f:
                 save(ep, f.name)
                 f.seek(0)
-                file_prefix = f.name.split("/")[2].split(".")[0]
+                file_prefix = os.path.splitext(os.path.basename(f.name))[0]
 
                 # Create a new file and copy things over, but modify the
                 # archive version

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -7,6 +7,7 @@ with test_sym_bool)
 import copy
 import io
 import math
+import os
 import tempfile
 import unittest
 import zipfile
@@ -2324,7 +2325,7 @@ class TestSaveLoad(TestCase):
             with tempfile.NamedTemporaryFile(suffix=".pt2") as f:
                 save(ep, f.name)
                 f.seek(0)
-                file_prefix = f.name.split("/")[2].split(".")[0]
+                file_prefix = os.path.splitext(os.path.basename(f.name))[0]
 
                 # Create a new file and copy things over, but modify the
                 # archive version


### PR DESCRIPTION
The test makes an implicit assumption that `$TMP=/tmp` which isn't neccessarily the case.
The code tries to extract the file stem (name without extension) which can be done clearer and without hardcoding offsets.

I suspect the skip condition:
```
    @unittest.skipIf(
        IS_FBCODE or IS_MACOS or IS_WINDOWS, "The file path is different in fbcode CI"
    )
```

Was added for this reason without fixing the actual cause. So it might be possible to remove with this fix.