### PR TITLE
[ROCm] Fixing Unit Test TestExportOnFakeCuda.test_fake_export

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2026,7 +2026,11 @@ flex_attention_supported_platform = unittest.skipUnless(
     ),
     "Requires CUDA and Triton, Intel GPU and triton, or CPU with avx2 and later",
 )
-if torch.version.hip and torch.cuda.device_count() > 0 and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName:
+if (
+    torch.version.hip
+    and torch.cuda.device_count() > 0
+    and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+):
     e4m3_type = torch.float8_e4m3fnuz
     e5m2_type = torch.float8_e5m2fnuz
     E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fnuz).max

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2026,7 +2026,7 @@ flex_attention_supported_platform = unittest.skipUnless(
     ),
     "Requires CUDA and Triton, Intel GPU and triton, or CPU with avx2 and later",
 )
-if torch.version.hip and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName:
+if torch.version.hip and torch.cuda.device_count() > 0 and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName:
     e4m3_type = torch.float8_e4m3fnuz
     e5m2_type = torch.float8_e5m2fnuz
     E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fnuz).max


### PR DESCRIPTION
Fixes [#168551](https://github.com/pytorch/pytorch/issues/168551)

This test is executed with `CUDA_VISIBLE_DEVICES=""` and due to which it crash

Hence, when running with rocm, we should check if the device count is great than 0 if yes then allow to call `torch.cuda.get_device_properties(0).gcnArchName`


```
===================================== test session starts =====================================
platform linux -- Python 3.12.3, pytest-7.3.2, pluggy-1.6.0
rootdir: /home/rahjain/src/pytorch
configfile: pytest.ini
plugins: cpp-2.3.0, flakefinder-1.1.0, xdist-3.3.1, xdoctest-1.3.0, hypothesis-6.56.4, rerunfailures-14.0, subtests-0.13.1
collected 1 item
Running 1 items in this shard

test/export/test_export_opinfo.py Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "/home/rahjain/src/pytorch/torch/testing/_internal/common_methods_invocations.py", line 27, in <module>
    from torch.testing._internal.common_device_type import \
  File "/home/rahjain/src/pytorch/torch/testing/_internal/common_device_type.py", line 2029, in <module>
    if torch.version.hip and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName:
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahjain/src/pytorch/torch/cuda/__init__.py", line 632, in get_device_properties
    _lazy_init()  # will define _get_device_properties
    ^^^^^^^^^^^^
  File "/home/rahjain/src/pytorch/torch/cuda/__init__.py", line 424, in _lazy_init
    torch._C._cuda_init()
RuntimeError: No HIP GPUs are available
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang