### PR TITLE
[ROCm] enable decompose k tests for functional coverage

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -926,7 +926,9 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
             operation, tensors, {"triton.enable_persistent_tma_matmul": True}
         )
 
+    # Enable decompose_k for this test (disabled by default on ROCm)
     @fresh_cache()
+    @inductor_config.patch({"triton.enable_decompose_k": True})
     def test_decompose_k_lookup_table_entry(self):
         """Test decompose_k template entry"""
         tensors = self.create_tensors("mm", m=32, n=32, k=32 * 32)
@@ -941,9 +943,7 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
             )
         )
         
-        # Enable decompose_k for this test (disabled by default on ROCm)
-        with inductor_config.patch({"triton.enable_decompose_k": True}):
-            self.run_model("mm", tensors)
+        self.run_model("mm", tensors)
 
     @fresh_cache()
     def test_bias_addmm_lookup_table_entry(self):

--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -942,7 +942,7 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
                 verify_choice_names, pattern="decompose_k|bmm_dtype", expected_count=1
             )
         )
-        
+
         self.run_model("mm", tensors)
 
     @fresh_cache()

--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -27,6 +27,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA_AND_TRITON, HAS_GPU
 from torch.utils._triton import has_triton_stable_tma_api, has_triton_tma_device
 
+
 # Conditional patch for decompose_k tests - override to 10 on ROCm, no-op elsewhere
 _DECOMPOSE_K_PATCH_ROCM = (
     {"triton.num_decompose_k_splits": 10} if torch.version.hip else {}
@@ -944,7 +945,9 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
             self.setup_lookup_table("mm", tensors, [config])
             add_preprocessing_fn(
                 partial(
-                    verify_choice_names, pattern="decompose_k|bmm_dtype", expected_count=1
+                    verify_choice_names,
+                    pattern="decompose_k|bmm_dtype",
+                    expected_count=1,
                 )
             )
 

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1315,7 +1315,6 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
-
     )
     def test_max_autotune_decompose_k_dynamic_input(self):
         def f(a, b):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -102,6 +102,11 @@ else:
 if HAS_CUDA_AND_TRITON:
     torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 
+# Conditional patch for decompose_k tests - override to 10 on ROCm, no-op elsewhere
+_DECOMPOSE_K_PATCH_ROCM = (
+    {"triton.num_decompose_k_splits": 10} if torch.version.hip else {}
+)
+
 
 def benchmark_choice(choice, args, out, expected_out, timings):
     result = choice.benchmark(*args, out=out)
@@ -1210,100 +1215,100 @@ class TestMaxAutotune(TestCase):
         comprehensive_padding=False,
         shape_padding=False,
     )
-    @config.patch({"triton.enable_decompose_k": True})
     def test_max_autotune_decompose_k(self, sizes, dtype, dynamic):
-        fp16_red_setting = (
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
-        )
-        bf16_red_setting = (
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
-        )
-        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
-        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
-
-        M, N, K = sizes
-
-        a = torch.randn(M, K, dtype=dtype, device=GPU_TYPE, requires_grad=True)
-        b = torch.randn(K, N, dtype=dtype, device=GPU_TYPE, requires_grad=True)
-
-        possible_splits = range(2, min(K // M, K // N) + 1)
-
-        divisors = {split for split in possible_splits if K % split == 0}
-
-        def check_divisors(code):
-            for kernel in code:
-                if "decompose_k" in kernel:
-                    divisor_found = False
-                    for divisor in divisors:
-                        if f"{divisor}_split" in kernel:
-                            divisor_found = True
-                            break
-
-                    self.assertTrue(
-                        divisor_found,
-                        f"Could not find a split in {divisors} in {kernel}",
-                    )
-
-        compiled_func = torch.compile(lambda a, b: a @ b, dynamic=dynamic)
-        # We assume with the large k dim relative to m, n, decompose_k will be most performant
-        out, code = run_and_get_code(compiled_func, a, b)
-
-        if dynamic:
-            FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
-                "decompose_k"
-            ).run(code[0])
-        else:
-            FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_0.run"
-            ).check("decompose_k").run(code[0])
-            check_divisors(code)
-            torch.testing.assert_close(out, a @ b, atol=1e-2, rtol=1e-2)
-
-        # Test adding epilogue also equivalent to eager
-        compiled_func = torch.compile(lambda a, b: (a @ b).relu(), dynamic=dynamic)
-        out, code = run_and_get_code(compiled_func, a, b)
-        if dynamic:
-            FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
-                "decompose_k"
-            ).run(code[0])
-        else:
-            FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_mm_0.run"
-            ).check("decompose_k").run(code[0])
-            check_divisors(code)
-            torch.testing.assert_close(
-                compiled_func(a, b), (a @ b).relu(), atol=1e-2, rtol=1e-2
+        with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+            fp16_red_setting = (
+                torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
             )
-
-        # Test adding reinterpret view before subgraph
-        a = a.transpose(0, 1)
-        compiled_func = torch.compile(
-            lambda a, b: (a.transpose(0, 1) @ b).relu(), dynamic=dynamic
-        )
-        out, code = run_and_get_code(compiled_func, a, b)
-
-        if dynamic:
-            FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
-                "decompose_k"
-            ).run(code[0])
-        else:
-            FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_.*_0.run"
-            ).check("decompose_k").run(code[0])
-            check_divisors(code)
-            torch.testing.assert_close(
-                compiled_func(a, b),
-                (a.transpose(0, 1) @ b).relu(),
-                atol=1e-2,
-                rtol=1e-2,
+            bf16_red_setting = (
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
             )
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
 
-        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
-            fp16_red_setting
-        )
-        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
-            bf16_red_setting
-        )
+            M, N, K = sizes
+
+            a = torch.randn(M, K, dtype=dtype, device=GPU_TYPE, requires_grad=True)
+            b = torch.randn(K, N, dtype=dtype, device=GPU_TYPE, requires_grad=True)
+
+            possible_splits = range(2, min(K // M, K // N) + 1)
+
+            divisors = {split for split in possible_splits if K % split == 0}
+
+            def check_divisors(code):
+                for kernel in code:
+                    if "decompose_k" in kernel:
+                        divisor_found = False
+                        for divisor in divisors:
+                            if f"{divisor}_split" in kernel:
+                                divisor_found = True
+                                break
+
+                        self.assertTrue(
+                            divisor_found,
+                            f"Could not find a split in {divisors} in {kernel}",
+                        )
+
+            compiled_func = torch.compile(lambda a, b: a @ b, dynamic=dynamic)
+            # We assume with the large k dim relative to m, n, decompose_k will be most performant
+            out, code = run_and_get_code(compiled_func, a, b)
+
+            if dynamic:
+                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
+                    "decompose_k"
+                ).run(code[0])
+            else:
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_0.run"
+                ).check("decompose_k").run(code[0])
+                check_divisors(code)
+                torch.testing.assert_close(out, a @ b, atol=1e-2, rtol=1e-2)
+
+            # Test adding epilogue also equivalent to eager
+            compiled_func = torch.compile(lambda a, b: (a @ b).relu(), dynamic=dynamic)
+            out, code = run_and_get_code(compiled_func, a, b)
+            if dynamic:
+                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
+                    "decompose_k"
+                ).run(code[0])
+            else:
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_mm_0.run"
+                ).check("decompose_k").run(code[0])
+                check_divisors(code)
+                torch.testing.assert_close(
+                    compiled_func(a, b), (a @ b).relu(), atol=1e-2, rtol=1e-2
+                )
+
+            # Test adding reinterpret view before subgraph
+            a = a.transpose(0, 1)
+            compiled_func = torch.compile(
+                lambda a, b: (a.transpose(0, 1) @ b).relu(), dynamic=dynamic
+            )
+            out, code = run_and_get_code(compiled_func, a, b)
+
+            if dynamic:
+                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
+                    "decompose_k"
+                ).run(code[0])
+            else:
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_.*_0.run"
+                ).check("decompose_k").run(code[0])
+                check_divisors(code)
+                torch.testing.assert_close(
+                    compiled_func(a, b),
+                    (a.transpose(0, 1) @ b).relu(),
+                    atol=1e-2,
+                    rtol=1e-2,
+                )
+
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
+                fp16_red_setting
+            )
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
+                bf16_red_setting
+            )
 
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
@@ -1363,44 +1368,44 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    @config.patch({"triton.enable_decompose_k": True})
     def test_max_autotune_decompose_k_dynamic_input_bwd(self):
-        def f(a, b):
-            # 256 * s0
-            a_in = torch.cat([a for _ in range(256)], dim=0)
-            return (a_in @ b).relu().sum()
+        with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+            def f(a, b):
+                # 256 * s0
+                a_in = torch.cat([a for _ in range(256)], dim=0)
+                return (a_in @ b).relu().sum()
 
-        a = torch.randn(
-            8, 64, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
-        )
-        b = torch.randn(
-            64, 32768, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
-        )
-
-        torch._dynamo.reset()
-        torch._dynamo.maybe_mark_dynamic(a, 0)
-        compiled_func = torch.compile(f)
-        res = compiled_func(a, b)
-        res.backward()
-
-        with mock.patch(
-            "torch._inductor.kernel.mm.use_decompose_k_choice"
-        ) as decomp_mock:
-            decomp_mock.side_effect = (
-                lambda *args, **kwargs: kwargs.get("threshold_multiple", 1) == 1
+            a = torch.randn(
+                8, 64, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+            )
+            b = torch.randn(
+                64, 32768, dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
             )
 
-            out, code = run_and_get_code(compiled_func, a, b)
-            out.backward()
+            torch._dynamo.reset()
+            torch._dynamo.maybe_mark_dynamic(a, 0)
+            compiled_func = torch.compile(f)
+            res = compiled_func(a, b)
+            res.backward()
 
-            FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                "triton_.*_fused_0.run"
-            ).check("decompose_k").check_regex(r"s[0-9]+ = s[0-9]+").check_regex(
-                r"256\*s[0-9]+"
-            ).check_regex("s[0-9]+ = 8").run(
-                # code[1] in this case given backwards
-                code[1]
-            )
+            with mock.patch(
+                "torch._inductor.kernel.mm.use_decompose_k_choice"
+            ) as decomp_mock:
+                decomp_mock.side_effect = (
+                    lambda *args, **kwargs: kwargs.get("threshold_multiple", 1) == 1
+                )
+
+                out, code = run_and_get_code(compiled_func, a, b)
+                out.backward()
+
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_0.run"
+                ).check("decompose_k").check_regex(r"s[0-9]+ = s[0-9]+").check_regex(
+                    r"256\*s[0-9]+"
+                ).check_regex("s[0-9]+ = 8").run(
+                    # code[1] in this case given backwards
+                    code[1]
+                )
 
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
@@ -1413,40 +1418,40 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    @config.patch({"triton.enable_decompose_k": True})
     def test_max_autotune_decompose_k_output_stride(self):
-        def f(a, b):
-            a = a.transpose(0, 1)
-            return a @ b
+        with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+            def f(a, b):
+                a = a.transpose(0, 1)
+                return a @ b
 
-        a = torch.randn((32768, 256), device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn((32768, 1152), device=GPU_TYPE, dtype=torch.bfloat16)
+            a = torch.randn((32768, 256), device=GPU_TYPE, dtype=torch.bfloat16)
+            b = torch.randn((32768, 1152), device=GPU_TYPE, dtype=torch.bfloat16)
 
-        b = b[:, :1096]
+            b = b[:, :1096]
 
-        # Force only decomposeK choice
-        with (
-            override_template_heuristics(
-                device_type=GPU_TYPE,
-                template_op_pairs=[(torch._inductor.kernel.mm.mm_template.name, "mm")],
-            ),
-            mock.patch(
-                "torch._inductor.kernel.mm.use_decompose_k_choice"
-            ) as decompose_mock,
-        ):
-            decompose_mock.return_value = True
-            compiled_f = torch.compile(f)
-            out, code = run_and_get_code(compiled_f, a, b)
+            # Force only decomposeK choice
+            with (
+                override_template_heuristics(
+                    device_type=GPU_TYPE,
+                    template_op_pairs=[(torch._inductor.kernel.mm.mm_template.name, "mm")],
+                ),
+                mock.patch(
+                    "torch._inductor.kernel.mm.use_decompose_k_choice"
+                ) as decompose_mock,
+            ):
+                decompose_mock.return_value = True
+                compiled_f = torch.compile(f)
+                out, code = run_and_get_code(compiled_f, a, b)
 
-            # Output stride equal to original gm output stride
-            # If output stride is not correctly checked, this will be (1152, 1) which can cause nans
-            self.assertEqual(out.stride(), (1096, 1))
+                # Output stride equal to original gm output stride
+                # If output stride is not correctly checked, this will be (1152, 1) which can cause nans
+                self.assertEqual(out.stride(), (1096, 1))
 
-            FileCheck().check_not("extern_kernels.bmm_dtype").check(
-                "decompose_k"
-            ).check(
-                f" empty_strided_{GPU_TYPE}((256, 1096), (1096, 1), torch.bfloat16)"
-            ).run(code[0])
+                FileCheck().check_not("extern_kernels.bmm_dtype").check(
+                    "decompose_k"
+                ).check(
+                    f" empty_strided_{GPU_TYPE}((256, 1096), (1096, 1), torch.bfloat16)"
+                ).run(code[0])
 
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
@@ -1990,7 +1995,6 @@ class TestMaxAutotune(TestCase):
         max_autotune_gemm_backends="TRITON",
         autotune_fallback_to_aten=False,
     )
-    @config.patch({"triton.enable_decompose_k": True})
     @parametrize("num_decompose_k_splits", (0, 5, 20))
     @parametrize("decompose_k_threshold", (8, 16))
     def test_max_autotune_decompose_k_envvars(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1370,6 +1370,7 @@ class TestMaxAutotune(TestCase):
     )
     def test_max_autotune_decompose_k_dynamic_input_bwd(self):
         with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+
             def f(a, b):
                 # 256 * s0
                 a_in = torch.cat([a for _ in range(256)], dim=0)
@@ -1420,6 +1421,7 @@ class TestMaxAutotune(TestCase):
     )
     def test_max_autotune_decompose_k_output_stride(self):
         with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+
             def f(a, b):
                 a = a.transpose(0, 1)
                 return a @ b
@@ -1433,7 +1435,9 @@ class TestMaxAutotune(TestCase):
             with (
                 override_template_heuristics(
                     device_type=GPU_TYPE,
-                    template_op_pairs=[(torch._inductor.kernel.mm.mm_template.name, "mm")],
+                    template_op_pairs=[
+                        (torch._inductor.kernel.mm.mm_template.name, "mm")
+                    ],
                 ),
                 mock.patch(
                     "torch._inductor.kernel.mm.use_decompose_k_choice"

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1305,7 +1305,6 @@ class TestMaxAutotune(TestCase):
             bf16_red_setting
         )
 
-    @skipIfXpu
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1354,7 +1353,6 @@ class TestMaxAutotune(TestCase):
                 rtol=1e-2,
             )
 
-    @skipIfXpu
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1405,7 +1403,6 @@ class TestMaxAutotune(TestCase):
                 code[1]
             )
 
-    @skipIfXpu
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1209,8 +1209,8 @@ class TestMaxAutotune(TestCase):
         max_autotune_gemm_backends="TRITON",
         comprehensive_padding=False,
         shape_padding=False,
-        triton.enable_decompose_k=True,
     )
+    @config.patch({"triton.enable_decompose_k": True})
     def test_max_autotune_decompose_k(self, sizes, dtype, dynamic):
         fp16_red_setting = (
             torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
@@ -1365,8 +1365,8 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
-        triton.enable_decompose_k=True,
     )
+    @config.patch({"triton.enable_decompose_k": True})
     def test_max_autotune_decompose_k_dynamic_input_bwd(self):
         def f(a, b):
             # 256 * s0
@@ -1416,8 +1416,8 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
-        triton.enable_decompose_k=True,
     )
+    @config.patch({"triton.enable_decompose_k": True})
     def test_max_autotune_decompose_k_output_stride(self):
         def f(a, b):
             a = a.transpose(0, 1)
@@ -1993,8 +1993,8 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
         autotune_fallback_to_aten=False,
-        triton.enable_decompose_k: True,
     )
+    @config.patch({"triton.enable_decompose_k": True})
     @parametrize("num_decompose_k_splits", (0, 5, 20))
     @parametrize("decompose_k_threshold", (8, 16))
     def test_max_autotune_decompose_k_envvars(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1670,19 +1670,10 @@ class triton:
     # Note: it may also need to be used with config.compile_threads = 1
     disallow_failing_autotune_kernels_TESTING_ONLY = False
 
-    # Enable decompose_k optimization. Disabled on ROCm by default pending performance validation.
-    # Set to True or use TORCHINDUCTOR_ENABLE_DECOMPOSE_K=1 to enable.
-    # Will be toggled on for unit tests.
-    enable_decompose_k = bool(
-        os.environ.get(
-            "TORCHINDUCTOR_ENABLE_DECOMPOSE_K", "0" if torch.version.hip else "1"
-        )
-        == "1"
-    )
-
     # specify number of splits to autotune on for decompose_k. 0 disables decompose_k
+    # Disabled on ROCm by default pending performance validation.
     num_decompose_k_splits = int(
-        os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "10")
+        os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "0" if torch.version.hip else "10")
     )
 
     # specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1670,6 +1670,16 @@ class triton:
     # Note: it may also need to be used with config.compile_threads = 1
     disallow_failing_autotune_kernels_TESTING_ONLY = False
 
+    # Enable decompose_k optimization. Disabled on ROCm by default pending performance validation.
+    # Set to True or use TORCHINDUCTOR_ENABLE_DECOMPOSE_K=1 to enable.
+    # Will be toggled on for unit tests.
+    enable_decompose_k = bool(
+        os.environ.get(
+            "TORCHINDUCTOR_ENABLE_DECOMPOSE_K",
+            "0" if torch.version.hip else "1"
+        ) == "1"
+    )
+
     # specify number of splits to autotune on for decompose_k. 0 disables decompose_k
     num_decompose_k_splits = int(
         os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "10")

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1675,9 +1675,9 @@ class triton:
     # Will be toggled on for unit tests.
     enable_decompose_k = bool(
         os.environ.get(
-            "TORCHINDUCTOR_ENABLE_DECOMPOSE_K",
-            "0" if torch.version.hip else "1"
-        ) == "1"
+            "TORCHINDUCTOR_ENABLE_DECOMPOSE_K", "0" if torch.version.hip else "1"
+        )
+        == "1"
     )
 
     # specify number of splits to autotune on for decompose_k. 0 disables decompose_k

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1673,7 +1673,9 @@ class triton:
     # specify number of splits to autotune on for decompose_k. 0 disables decompose_k
     # Disabled on ROCm by default pending performance validation.
     num_decompose_k_splits = int(
-        os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "0" if torch.version.hip else "10")
+        os.environ.get(
+            "TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "0" if torch.version.hip else "10"
+        )
     )
 
     # specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables

--- a/torch/_inductor/template_heuristics/decompose_k.py
+++ b/torch/_inductor/template_heuristics/decompose_k.py
@@ -4,8 +4,6 @@ from typing import Any, TYPE_CHECKING
 
 import sympy
 
-import torch
-
 from ..ir import get_free_symbols
 from ..kernel.mm import decompose_k_subgraph_template
 from ..kernel_inputs import KernelInputs, MMKernelInputs

--- a/torch/_inductor/template_heuristics/decompose_k.py
+++ b/torch/_inductor/template_heuristics/decompose_k.py
@@ -30,15 +30,13 @@ class EmptyDecomposeKConfigHeuristics(TemplateConfigHeuristics):
     "xpu",
     op_name="mm",
 )
-# on CUDA, we don't support hip for decompose_k yet
+# Register on CUDA (both NVIDIA and ROCm/HIP)
+# Runtime enablement is controlled by config.triton.enable_decompose_k
 @register_template_heuristic(
     decompose_k_subgraph_template.uid,
     "cuda",
-    register=torch.version.hip is None,
     op_name="mm",
 )
-# TODO(coconutruben): enable decompose k on AMD by removing the register bool
-# and benchmarking it for performance and stability
 # TODO(coconutruben): enable decompose k on other devices (xpu, cpu, mps, mtia)
 # by either adding specific register_template_heuristic tags, or setting the
 # device to None (enabled on all devices)

--- a/torch/_inductor/template_heuristics/decompose_k.py
+++ b/torch/_inductor/template_heuristics/decompose_k.py
@@ -29,7 +29,7 @@ class EmptyDecomposeKConfigHeuristics(TemplateConfigHeuristics):
     op_name="mm",
 )
 # Register on CUDA (both NVIDIA and ROCm/HIP)
-# Runtime enablement is controlled by config.triton.enable_decompose_k
+# Runtime enablement is controlled by config.triton.num_decompose_k_splits (0 disables)
 @register_template_heuristic(
     decompose_k_subgraph_template.uid,
     "cuda",

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2093,8 +2093,7 @@ def use_decompose_k_choice(
     decompose_k_threshold = config.triton.decompose_k_threshold * threshold_multiple
 
     return (
-        config.triton.enable_decompose_k
-        and V.graph.sizevars.statically_known_true(
+        V.graph.sizevars.statically_known_true(
             sympy.And(
                 sympy.Ge(k, decompose_k_threshold * m),
                 sympy.Ge(k, decompose_k_threshold * n),

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2093,7 +2093,7 @@ def use_decompose_k_choice(
     decompose_k_threshold = config.triton.decompose_k_threshold * threshold_multiple
 
     return (
-        not torch.version.hip
+        config.triton.enable_decompose_k
         and V.graph.sizevars.statically_known_true(
             sympy.And(
                 sympy.Ge(k, decompose_k_threshold * m),


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/168617
Fixes https://github.com/pytorch/pytorch/issues/168615
Fixes https://github.com/pytorch/pytorch/issues/168614
Fixes https://github.com/pytorch/pytorch/issues/168613
Fixes https://github.com/pytorch/pytorch/issues/168599
Fixes https://github.com/pytorch/pytorch/issues/168600
Fixes https://github.com/pytorch/pytorch/issues/168601
Fixes https://github.com/pytorch/pytorch/issues/168602
Fixes https://github.com/pytorch/pytorch/issues/168603
Fixes https://github.com/pytorch/pytorch/issues/168604
Fixes https://github.com/pytorch/pytorch/issues/168605
Fixes https://github.com/pytorch/pytorch/issues/168606
Fixes https://github.com/pytorch/pytorch/issues/168607



Enables testing for decompose K mode on ROCm. This is still disabled by default pending perf testing but we can get the functional coverage by adding an inductor config for decompose k enablement.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben