### PR TITLE
Disable autoheuristic for flakey mixed_mm tests

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -146,6 +146,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -245,6 +246,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -292,6 +294,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -339,6 +342,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -374,6 +378,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -400,6 +405,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -431,6 +437,7 @@ class TestPatternMatcher(TestCase):
             "benchmark_epilogue_fusion": "False",
             "max_autotune_gemm_backends": "TRITON",
             "max_autotune_gemm": True,
+            "autoheuristic_use": "",  # Disable autoheuristic for determinism
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
@@ -480,6 +487,7 @@ class TestPatternMatcher(TestCase):
                 "benchmark_epilogue_fusion": "False",
                 "max_autotune_gemm_backends": "TRITON",
                 "max_autotune_gemm": True,
+                "autoheuristic_use": "",  # Disable autoheuristic for determinism
             }
         ):
             self._test_mixed_impl(fn, args, True, False)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/126489
Fixes https://github.com/pytorch/pytorch/issues/128487
Fixes https://github.com/pytorch/pytorch/issues/145192
Fixes https://github.com/pytorch/pytorch/issues/147853

Removes the model for heuristics which should improve determinism in these flakey tests.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben