### PR TITLE
Update conditions in test__int_mm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_dtype import (
     all_types, all_types_and_complex_and, floating_and_complex_types, integral_types,
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
-from torch.testing._internal.common_cuda import SM80OrLater, SM90OrLater, tf32_on_and_off, _get_magma_version, \
+from torch.testing._internal.common_cuda import SM80OrLater, tf32_on_and_off, _get_magma_version, \
     _get_torch_cuda_version, TEST_MULTIGPU
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
@@ -7694,7 +7694,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(c, cpu_result)
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
-    @unittest.skipIf(SM90OrLater and not TEST_WITH_ROCM, "Expected failure on sm90")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @onlyCUDA
     @parametrize("k", [16, 32])
@@ -7762,12 +7761,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
                     _test(17, k, n, use_transpose_a, use_transpose_b)
 
             if not use_transpose_a and not use_transpose_b:
-                if SM80OrLater or (version >= (12, 3) and (SM70 or SM75)):
-                    _test(17, k, n, use_transpose_a, use_transpose_b)
-                else:
-                    with self.assertRaisesRegex(RuntimeError,
-                                                "CUDA error: CUBLAS_STATUS_NOT_SUPPORTED when calling cublasLtMatmul"):
-                        _test(17, k, n, use_transpose_a, use_transpose_b)
+                self.skipTest("NN case not yet supported by cuBLAS, behavior is liable to change")
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")


### PR DESCRIPTION
This PR updates the conditions in `TestLinalgCUDA.test__int_mm` to align with current cuBLAS behavior. In particular, IMMA kernels are only supported on specific SM versions in the case where neither matrix is transposed- this is not explicitly documented but the cuBLAS team has been notified and is working to update docs.

Note: this uses `IS_THOR` and thus depends on #169719- I figured it would be better to keep that separate but can combine if preferred

Fixes #169956 

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia