### PR TITLE
[Inductor] ExternKernelBenchmarkRequest best attempt

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2376,12 +2376,18 @@ class ExternKernelCaller(ChoiceCaller):
 
         self.input_tensor_meta: Union[list[TensorMeta], TensorMeta]
         self.output_tensor_meta: Union[list[TensorMeta], TensorMeta]
+        self.input_tensor_meta, self.output_tensor_meta = [], []
         if device.type == "cpu":
-            self.input_tensor_meta, self.output_tensor_meta = [], []
             benchmark_cls = ExternKernelCPUBenchmarkRequest
         else:
-            self.input_tensor_meta = TensorMeta.from_irnodes(self.input_nodes)
-            self.output_tensor_meta = TensorMeta.from_irnodes(self.layout)
+            try:
+                self.input_tensor_meta = TensorMeta.from_irnodes(self.input_nodes)
+                self.output_tensor_meta = TensorMeta.from_irnodes(self.layout)
+            except Exception:
+                log.warning(
+                    "Constructing input/output tensor meta failed for Extern Choice"
+                )
+
             benchmark_cls = ExternKernelGPUBenchmarkRequest
 
         self.bmreq: ExternKernelBenchmarkRequest = benchmark_cls(


### PR DESCRIPTION
Differential Revision: D88759335

Fixes some issues caused by https://github.com/pytorch/pytorch/pull/169605. Best effort at constructing input/output tensor meta for ExternKernel bmreq


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo