### PR TITLE
Rewrite adaptive avg pool2d MPS to handle non-divisible shapes and ad…

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6577,6 +6577,39 @@ class TestMPS(TestCaseMPS):
         except Exception as e:
             pass
 
+    @parametrize(
+        "input_shape,output_shape",
+        [
+            ((1, 1, 4, 4), (2, 2)),
+            ((1, 1, 3, 3), (2, 2)),
+            ((1, 2, 2, 3), (5, 4)),
+            ((1, 64, 10, 9), (None, 7)),
+        ],
+    )
+    @parametrize("channels_last", [False, True])
+    def test_adaptive_avg_pool2d_nondivisible_sizes(self, input_shape, output_shape, channels_last):
+        # Covers https://github.com/pytorch/pytorch/issues/143864
+        cpu_x = torch.randn(input_shape, device='cpu', dtype=torch.float32)
+        if channels_last:
+            cpu_x = cpu_x.to(memory_format=torch.channels_last)
+        cpu_x.requires_grad_()
+
+        x_mps = cpu_x.detach().to('mps')
+        if channels_last:
+            x_mps = x_mps.to(memory_format=torch.channels_last)
+        x_mps.requires_grad_()
+        pool = torch.nn.AdaptiveAvgPool2d(output_shape)
+
+        ref = pool(cpu_x)
+        out = pool(x_mps)
+        self.assertEqual(out, ref)
+
+        grad = torch.randn_like(ref)
+        ref.backward(grad)
+        grad_mps = grad.to(out.device)
+        out.backward(grad_mps)
+        self.assertEqual(x_mps.grad, cpu_x.grad)
+
     # Test max avg pool2d - when the input size is a multiple of output size
     # Not testing for channels last right now
     def test_adaptive_max_pool2d_simple(self):

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -114,6 +114,8 @@ if torch.backends.mps.is_available():
             "nn.functional.conv_transpose1d",
             "nn.functional.conv_transpose2d",
             "nn.functional.conv_transpose3d",
+            "nn.functional.adaptive_avg_pool1d",
+            "nn.functional.adaptive_avg_pool2d",
             "nn.functional.feature_alpha_dropoutwithout_train",
             "nn.functional.padcircular",
             "nn.functional.softsign",
@@ -399,9 +401,6 @@ if torch.backends.mps.is_available():
             "linalg.matrix_rankhermitian": None,
             "linalg.pinvhermitian": None,
             "nonzero_static": None,
-            # MPS: input sizes must be divisible by output sizes
-            "nn.functional.adaptive_avg_pool1d": None,
-            "nn.functional.adaptive_avg_pool2d": None,
             # Convolution for integral types is not supported on MPS
             "nn.functional.conv1d": [torch.int64],
             "nn.functional.conv2d": [torch.int64],


### PR DESCRIPTION
Added support for `adaptive_avg_pool2d` on MPS for cases where input/output sizes aren’t divisible. This removes the old restriction and aligns behavior with other backends.
Also added a focused test (including `channels_last`) to cover a range of shape combinations.

Fixes: [https://github.com/pytorch/pytorch/issues/143864](https://github.com/pytorch/pytorch/issues/143864)