### PR TITLE
[ROCm] Enable shared memory based pruning for Triton configs

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -15,7 +15,6 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     parametrize,
     runOnRocm,
-    skipIfRocm,
     skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import (
@@ -273,13 +272,13 @@ class TestTritonHeuristics(TestCase):
         self.assertEqual(ref, res)
 
     @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/2331")
-    @skipIfRocm
     @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
     @parametrize("do_pruning", [False, True])
     def test_prune_configs_over_shared_memory_limit(self, do_pruning):
         from torch._inductor.template_heuristics.triton import (
             CUDAConfigHeuristic,
             GemmConfig,
+            ROCmConfigHeuristic,
         )
 
         expected_count = 1 if do_pruning else 2
@@ -292,7 +291,10 @@ class TestTritonHeuristics(TestCase):
         with config.patch(
             {"max_autotune_prune_choices_based_on_shared_mem": do_pruning}
         ):
-            config_heuristic = CUDAConfigHeuristic()
+            if torch.version.hip:
+                config_heuristic = ROCmConfigHeuristic()
+            else:
+                config_heuristic = CUDAConfigHeuristic()
             config_heuristic.should_scale_configs = False
             config_heuristic.mm_configs = mm_configs
             configs = list(

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2248,6 +2248,7 @@ class _CudaDeviceProperties:
     clock_rate: _int
     memory_clock_rate: _int
     memory_bus_width: _int
+    shared_memory_per_block: _int
 
 # Functions related to SDPA
 class _SDPAParams:

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -649,9 +649,13 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         try:
             device = torch.cuda.current_device()
             props = torch.cuda.get_device_properties(device)
-            if not hasattr(props, "shared_memory_per_block_optin"):  # for NVidia GPUs
+            if hasattr(props, "shared_memory_per_block_optin"):  # for NVidia GPUs
+                sm_available = int(props.shared_memory_per_block_optin)
+            elif hasattr(props, "shared_memory_per_block"):  # for ROCm
+                sm_available = int(props.shared_memory_per_block)
+            else:
                 return None
-            sm_available = int(props.shared_memory_per_block_optin)
+
         except Exception:
             # If CUDA is not available or properties cannot be queried, return None
             return None

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1093,6 +1093,11 @@ static void registerCudaDeviceProperties(PyObject* module) {
           "shared_memory_per_multiprocessor",
           &cudaDeviceProp::sharedMemPerMultiprocessor)
 #endif
+#if USE_ROCM
+      // ROCm: expose shared_memory_per_block for shared memory based pruning
+      .def_readonly(
+          "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
+#endif
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60100) || !USE_ROCM
       .def_readonly(
           "regs_per_multiprocessor", &cudaDeviceProp::regsPerMultiprocessor)


### PR DESCRIPTION
## Summary
Enables shared memory based config pruning for ROCm GPUs in Inductor's Triton template heuristics.

Previously, pruning based on shared memory limits only worked on NVIDIA GPUs (using `shared_memory_per_block_optin`). This PR exposes `shared_memory_per_block` for ROCm and updates the pruning logic to use it as a fallback.

## Changes
- `torch/csrc/cuda/Module.cpp`: Expose `shared_memory_per_block` property for ROCm builds
- `torch/_C/__init__.pyi.in`: Add type hint for the new property
- `torch/_inductor/template_heuristics/triton.py`: Update `_get_exceeding_shared_memory_checker()` to fall back to `shared_memory_per_block` when `shared_memory_per_block_optin` is unavailable
- `test/inductor/test_triton_heuristics.py`: Enable `test_prune_configs_over_shared_memory_limit` for ROCm

## Testing
- `pytest test/inductor/test_triton_heuristics.py -k test_prune_configs_over_shared_memory_limit` passes on ROCm

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos