### PR TITLE
[Inductor] MixOrderReduction support low precision reduction

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -60,10 +60,11 @@ class MixOrderReductionTest(TestBase):
             "mean",
         ],
     )
+    @parametrize("dtype", (torch.bfloat16, torch.float))
     @parametrize("swap", (False, True))
     @parametrize("split_reductions", (False, True))
     @parametrize("shape", ((32768, 768), (32769, 768), (32, 1024, 768)))
-    def test_mix_order_reduction(self, name, swap, split_reductions, shape):
+    def test_mix_order_reduction(self, name, dtype, swap, split_reductions, shape):
         # torch.prod does not accept tuple for dim argument
         if name == "prod" and len(shape) == 3:
             self.skipTest("Invalid combination")
@@ -82,7 +83,6 @@ class MixOrderReductionTest(TestBase):
                 return reduction_fn(x, dim=-1), outer_red()
 
         reduction_fn = getattr(torch, name)
-        dtype = torch.float
         x = torch.randn(shape, dtype=dtype, device=GPU_TYPE)
 
         opt_f = torch.compile(
@@ -94,8 +94,8 @@ class MixOrderReductionTest(TestBase):
 
         ref = f(x)
         act = opt_f(x)
-
-        self.assertTrue(same(ref, act, tol=1e-3), f"ref:\n{ref}\nact:\n{act}")
+        tol = 1e-3 if dtype == torch.float else 1e-2
+        self.assertTrue(same(ref, act, tol=tol), f"ref:\n{ref}\nact:\n{act}")
         self.assertEqual(
             inductor_config.triton.mix_order_reduction,
             metrics.codegen_mix_order_reduction,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #169978

The issue does not appear for RMSNorm/LayerNorm since even if input is in low precision, RMSNorm will cast the inputs to FP32 first and do a down cast in the end. The reduction output is actually in FP32.

This PR fixes the issue if the reduction output is in low precision. Better to fix it to make MixOrderReduction a general feature.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo