### PR TITLE
.ci: Introduce ecr-login action

### DIFF
--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -1,0 +1,71 @@
+name: Login to ECR via OIDC
+
+description: |
+  Configures AWS credentials via OIDC and logs into Amazon ECR.
+  Works uniformly on all runner types (AWS EC2, GCP, ROCm, b200, etc.)
+
+inputs:
+  aws-role-to-assume:
+    description: IAM role to assume via OIDC
+    required: false
+    default: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+  aws-region:
+    description: AWS region
+    required: false
+    default: us-east-1
+  role-duration-seconds:
+    description: Duration for the assumed role session
+    required: false
+    default: "18000"
+  use-iam-profile-if-available:
+    description: If true, will check for and use an IAM instance profile if available.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Check for IAM instance profile
+      id: check_iam_profile
+      if: inputs.use-iam-profile-if-available == 'true'
+      shell: bash
+      run: |
+        if curl -s --connect-timeout 5 http://169.254.169.254/latest/meta-data/iam/info >/dev/null 2>&1; then
+          echo "has_profile=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_profile=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Configure AWS credentials via OIDC
+      if: inputs.use-iam-profile-if-available == 'false' || steps.check_iam_profile.outputs.has_profile == 'false'
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      with:
+        # Use provided role or fall back to default if empty
+        role-to-assume: ${{ inputs.aws-role-to-assume != '' && inputs.aws-role-to-assume || 'arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only' }}
+        role-session-name: gha-ecr-login
+        aws-region: ${{ inputs.aws-region }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        role-skip-session-tagging: true
+
+    - name: Log in to ECR
+      uses: nick-fields/retry@v3.0.0
+      env:
+        AWS_RETRY_MODE: standard
+        AWS_MAX_ATTEMPTS: "5"
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+      with:
+        shell: bash
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 30
+        command: |
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+          aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
+              --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
+
+          # For LF Runners also login to Meta's ECR registry
+          META_AWS_ACCOUNT_ID=308535385114
+          if [ "$AWS_ACCOUNT_ID" != "$META_AWS_ACCOUNT_ID" ] ; then
+              aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
+                  --password-stdin "$META_AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
+          fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #169969
* #169968
* #169962
* __->__ #169980

Consolidates login logic for ECR into a single action making it easier
for us to onboard non-AWS runners / k8s based runners that would depend
  on OIDC instead of IAM profiles like our current runner infra.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>