### PR TITLE
[MTIA][RNG] Implement Python RNG API layer

### DIFF
--- a/docs/source/mtia.md
+++ b/docs/source/mtia.md
@@ -1,6 +1,7 @@
 # torch.mtia
 
-The MTIA backend is implemented out of the tree, only interfaces are defined here.
+The MTIA backend is implemented out of the tree, only interfaces are defined
+here.
 
 ```{eval-rst}
 .. automodule:: torch.mtia
@@ -37,6 +38,13 @@ The MTIA backend is implemented out of the tree, only interfaces are defined her
     device
     set_rng_state
     get_rng_state
+    set_rng_state_all
+    get_rng_state_all
+    manual_seed
+    manual_seed_all
+    seed
+    seed_all
+    initial_seed
     DeferredMtiaCallError
 ```
 

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -4,7 +4,7 @@ This package enables an interface for accessing MTIA backend in python
 """
 
 import threading
-import warnings
+import traceback
 from collections.abc import Callable
 from typing import Any, Optional, Union
 
@@ -60,6 +60,20 @@ def init():
 def is_initialized():
     r"""Return whether PyTorch's MTIA state has been initialized."""
     return _initialized and not _is_in_bad_fork()
+
+
+def _lazy_call(callable, **kwargs):
+    with _initialization_lock:
+        if is_initialized():
+            return callable()
+        else:
+            global _lazy_seed_tracker
+            if kwargs.get("seed_all", False):
+                _lazy_seed_tracker.queue_seed_all(callable, traceback.format_stack())
+            elif kwargs.get("seed", False):
+                _lazy_seed_tracker.queue_seed(callable, traceback.format_stack())
+            else:
+                _queued_calls.append((callable, traceback.format_stack()))
 
 
 def _is_in_bad_fork() -> bool:
@@ -366,35 +380,151 @@ def stream(stream: Optional["torch.mtia.Stream"]) -> StreamContext:
 
 
 def get_rng_state(device: Union[int, str, torch.device] = "mtia") -> Tensor:
-    r"""Returns the random number generator state as a ByteTensor.
+    r"""Returns the random number generator state of the specified MTIA device as a ByteTensor.
 
     Args:
         device (torch.device or int, optional): The device to return the RNG state of.
             Default: ``'mtia'`` (i.e., ``torch.device('mtia')``, the current mtia device).
+
+    .. warning::
+        This function eagerly initializes MTIA.
     """
-    warnings.warn(
-        "get_rng_state is not implemented in torch.mtia",
-        UserWarning,
-        stacklevel=2,
-    )
-    return torch.zeros([1], dtype=torch.uint8, device=device)
+    _lazy_init()
+    idx = _get_device_index(device, optional=True)
+    if idx is None:
+        idx = current_device()
+    default_generator = default_generators[idx]
+    return default_generator.get_state()
+
+
+def get_rng_state_all() -> list[Tensor]:
+    r"""Returns a list of ByteTensor representing the random number states of all devices."""
+    results = [get_rng_state(i) for i in range(device_count())]
+    return results
 
 
 def set_rng_state(
     new_state: Tensor, device: Union[int, str, torch.device] = "mtia"
 ) -> None:
-    r"""Sets the random number generator state.
+    r"""Sets the random number generator state of the specified MTIA device.
 
     Args:
         new_state (torch.ByteTensor): The desired state
         device (torch.device or int, optional): The device to set the RNG state.
             Default: ``'mtia'`` (i.e., ``torch.device('mtia')``, the current mtia device).
     """
-    warnings.warn(
-        "set_rng_state is not implemented in torch.mtia",
-        UserWarning,
-        stacklevel=2,
-    )
+    if not is_initialized():
+        with torch._C._DisableFuncTorch():
+            # Clone the state because the callback will be triggered
+            # later when MTIA is lazy initialized.
+            new_state = new_state.clone(memory_format=torch.contiguous_format)
+
+    idx = _get_device_index(device, optional=True)
+    if idx is None:
+        idx = current_device()
+
+    def cb():
+        default_generator = default_generators[idx]
+        default_generator.set_state(new_state)
+
+    _lazy_call(cb)
+
+
+def set_rng_state_all(new_states: list[Tensor]) -> None:
+    r"""Sets the random number generator state of all devices.
+
+    Args:
+        new_states (Iterable of torch.ByteTensor): The desired state for each device.
+    """
+    for i, state in enumerate(new_states):
+        set_rng_state(state, i)
+
+
+def manual_seed(seed: int) -> None:
+    r"""Sets the seed for generating random numbers for the current MTIA device.
+    It's safe to call this function if MTIA is not available; in that case, it is silently ignored.
+
+    Args:
+        seed (int): The desired seed.
+
+    .. warning::
+        If you are working with a multi-GPU model, this function is insufficient
+        to get determinism.  To seed all GPUs, use :func:`manual_seed_all`.
+    """
+    seed = int(seed)
+
+    def cb():
+        idx = current_device()
+        default_generator = default_generators[idx]
+        default_generator.manual_seed(seed)
+
+    _lazy_call(cb, seed=True)
+
+
+def manual_seed_all(seed: int) -> None:
+    r"""Sets the seed for generating random numbers on all MTIA devices.
+    It's safe to call this function if MTIA is not available; in that case, it is silently ignored.
+
+    Args:
+        seed (int): The desired seed.
+    """
+    seed = int(seed)
+
+    def cb():
+        for i in range(device_count()):
+            default_generator = default_generators[i]
+            default_generator.manual_seed(seed)
+
+    _lazy_call(cb, seed_all=True)
+
+
+def seed() -> int:
+    r"""Sets the seed for generating random numbers to a random number for the current MTIA device.
+    It's safe to call this function if MTIA is not available; in that case, it is silently ignored.
+
+    .. warning::
+        If you are working with a multi-GPU model, this function will only initialize
+        the seed on one GPU.  To initialize all GPUs, use :func:`seed_all`.
+    """
+
+    def cb():
+        idx = current_device()
+        default_generator = default_generators[idx]
+        return default_generator.seed()
+
+    return _lazy_call(cb, seed=True)
+
+
+def seed_all() -> int:
+    r"""Sets the seed for generating random numbers to a random number on all MTIA devices.
+
+    It's safe to call this function if MTIA is not available; in that case, it is silently ignored.
+    """
+
+    def cb():
+        random_seed = 0
+        seeded = False
+        for i in range(device_count()):
+            default_generator = default_generators[i]
+            if not seeded:
+                random_seed = default_generator.seed()
+                seeded = True
+            else:
+                default_generator.manual_seed(random_seed)
+        return random_seed
+
+    return _lazy_call(cb, seed_all=True)
+
+
+def initial_seed() -> int:
+    r"""Returns the current random seed of the current MTIA device.
+
+    .. warning::
+        This function eagerly initializes MTIA.
+    """
+    _lazy_init()
+    idx = current_device()
+    return default_generators[idx].initial_seed()
 
 
 from .memory import *  # noqa: F403
@@ -426,6 +556,13 @@ __all__ = [
     "device",
     "set_rng_state",
     "get_rng_state",
+    "set_rng_state_all",
+    "get_rng_state_all",
+    "manual_seed",
+    "manual_seed_all",
+    "seed",
+    "seed_all",
+    "initial_seed",
     "is_bf16_supported",
     "MTIAGraph",
     "graph",

--- a/torch/random.py
+++ b/torch/random.py
@@ -59,6 +59,11 @@ def _manual_seed_impl(seed) -> torch._C.Generator:
     if not torch.xpu._is_in_bad_fork():
         torch.xpu.manual_seed_all(seed)
 
+    import torch.mtia
+
+    if not torch.mtia._is_in_bad_fork():
+        torch.mtia.manual_seed_all(seed)
+
     _seed_custom_device(seed)
 
     return default_generator.manual_seed(seed)
@@ -83,6 +88,11 @@ def seed() -> int:
 
     if not torch.xpu._is_in_bad_fork():
         torch.xpu.manual_seed_all(seed)
+
+    import torch.mtia
+
+    if not torch.mtia._is_in_bad_fork():
+        torch.mtia.manual_seed_all(seed)
 
     _seed_custom_device(seed)
 


### PR DESCRIPTION
Summary:
The implementation adds 9 RNG functions (get/set_rng_state, manual_seed, seed, initial_seed, and their _all variants) that integrate with the existing C++ generator infrastructure. The lazy initialization pattern ensures RNG operations queue correctly before device initialization and execute during _lazy_init(). We follow the existing CUDA pattern. In addition, we integrated with the general torch.manual_seed and torch.seed functions following the exisiting custom accelerator pattern.

Added comprehensive test coverage for all API calls as well as for the torch integration.

Test Plan:
buck2 test //mtia/host_runtime/torch_mtia/tests:test_torch_mtia_api

https://www.internalfb.com/intern/testinfra/testrun/2533275122809554

buck2 test fbcode//mtia/host_runtime/torch_mtia/tests:test_mtia_rng_generators

https://www.internalfb.com/intern/testinfra/testrun/9288674362815734

Reviewed By: StellarrZ

Differential Revision: D88014851


