### PR TITLE
[ROCm][CI] Fix failure for test ProcessGroupNCCLGroupTest::test_nan_assert

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -349,11 +349,11 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
         # These tests are expected to throw SIGABRT(6);
         # But if we are in Sandcastle, `skip_but_pass_in_sandcastle` would return 0.
-        # 
-        # CUDA: Uses native __trap() instruction → CUDA runtime catches it → 
+        #
+        # CUDA: Uses native __trap() instruction → CUDA runtime catches it →
         #       clean exit(6) → exit code 6
-        # ROCm: No native trap instruction, uses assert(0) (NanCheck.cu:24-27) → 
-        #       calls abort() → OS sends SIGABRT signal → process killed by signal → 
+        # ROCm: No native trap instruction, uses assert(0) (NanCheck.cu:24-27) →
+        #       calls abort() → OS sends SIGABRT signal → process killed by signal →
         #       exit code -6
         TEST_NAN_ASSERT_RETURN = (
             0
@@ -568,7 +568,6 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
             torch.float8_e5m2,
         ],
     )
-    
     def test_nan_assert(self, type):
         # Expecting a device-side error when NaN is detected
         os.environ["TORCH_NCCL_NAN_CHECK"] = "1"

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -349,10 +349,16 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
         # These tests are expected to throw SIGABRT(6);
         # But if we are in Sandcastle, `skip_but_pass_in_sandcastle` would return 0.
+        # 
+        # CUDA: Uses native __trap() instruction → CUDA runtime catches it → 
+        #       clean exit(6) → exit code 6
+        # ROCm: No native trap instruction, uses assert(0) (NanCheck.cu:24-27) → 
+        #       calls abort() → OS sends SIGABRT signal → process killed by signal → 
+        #       exit code -6
         TEST_NAN_ASSERT_RETURN = (
             0
             if (IS_SANDCASTLE and not (TEST_MULTIGPU and CUDA_12_AND_ABOVE))
-            else signal.SIGABRT
+            else (-signal.SIGABRT if torch.version.hip else signal.SIGABRT)
         )
         self.special_return_code_checks = {
             self.test_nan_assert_float16.__wrapped__: TEST_NAN_ASSERT_RETURN,
@@ -562,7 +568,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
             torch.float8_e5m2,
         ],
     )
-    @skip_if_rocm_multiprocess
+    
     def test_nan_assert(self, type):
         # Expecting a device-side error when NaN is detected
         os.environ["TORCH_NCCL_NAN_CHECK"] = "1"


### PR DESCRIPTION
Fixes #168463

CUDA: Uses native `__trap()` instruction → CUDA runtime catches it → clean exit(6) → exit code 6

ROCm: No native trap instruction, uses `assert(0) (NanCheck.cu:24-27)` → calls abort() → OS sends SIGABRT signal → process killed by signal → exit code -6

Test expected exit code 6, got -6 → test failed (AssertionError)

With this change, test will correctly expect `-6` on ROCm

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang