### PR TITLE
Fix fbgemm_genai build race condition by adding torch_cpu dependency

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -356,6 +356,9 @@ IF(USE_FBGEMM_GENAI)
     list(APPEND ATen_HIP_INCLUDE ${PROJECT_SOURCE_DIR}/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/include)
     list(APPEND ATen_HIP_INCLUDE ${PROJECT_SOURCE_DIR}/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/common/include)
   endif()
+
+  # Ensure torch_cpu is built before fbgemm_genai to avoid race conditions
+  add_dependencies(fbgemm_genai torch_cpu)
 endif()
 
 # XNNPACK


### PR DESCRIPTION
Adds an explicit CMake dependency to ensure `torch_cpu` is built before `fbgemm_genai`. This prevents occasional build failures when `USE_FBGEMM_GENAI` is enabled, where `fbgemm_genai` target  (linked into `torch_cuda`)
could start building before codegen (part of torch_cpu) is finished, which results in missing headers build errors.

Claude generated, but hope it works

