### PR TITLE
Fix CPU L2 norm accumulator precision for float32

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1983,6 +1983,18 @@ class TestLinalg(TestCase):
                     result = torch.linalg.norm(x, ord=ord)
                     self.assertEqual(result, result_n, msg=msg)
 
+    @onlyCPU
+    @dtypes(torch.float32)
+    def test_norm_large_tensor_precision(self, device, dtype):
+        # 100M elements of value 100: L2 norm = 100 * sqrt(100M) = 1,000,000
+        size = 100_000_000
+        value = 100.0
+        expected = value * math.sqrt(size)
+        t = torch.full((size,), value, dtype=dtype, device=device)
+        result = torch.linalg.norm(t).item()
+        rel_error = abs(result - expected) / expected
+        self.assertLess(rel_error, 0.001)
+
     # Test degenerate shape results match numpy for linalg.norm vector norms
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack


### PR DESCRIPTION
Fixes #169237 where CPU L2 norm produces incorrect results for large float32 tensors due to accumulator precision issues.

  The vectorized CPU L2 norm kernel was using a single float32 accumulator for all input elements. For large tensors (100M+ elements), this causes the accumulator to saturate when the sum exceeds float32 precision limits, causing results to plateau.

  The fix divides the input into 512-element chunks, reduces each chunk with its own float32 accumulator, then combines the partial sums using pairwise summation.

  A test was added to verify that CPU L2 norm produces correct results for 100 million element float32 tensors within 0.1% relative error.

Fixes #169237


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01