### PR TITLE
[MPS] Add shader error reporting mechanism from Python

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -64,7 +64,7 @@ class MetalKernelFunction {
   void startEncoding();
   void setArg(unsigned idx, const at::TensorBase& t);
   void setArg(unsigned idx, const void* ptr, uint64_t size);
-  void setBuffer(unsigned idx, const void* buf);
+  void setErrorBufferIndex(unsigned idx);
   template <
       typename T,
       typename = std::enable_if_t<

--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -64,6 +64,7 @@ class MetalKernelFunction {
   void startEncoding();
   void setArg(unsigned idx, const at::TensorBase& t);
   void setArg(unsigned idx, const void* ptr, uint64_t size);
+  void setBuffer(unsigned idx, const void* buf);
   template <
       typename T,
       typename = std::enable_if_t<

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -8,6 +8,7 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/MPSGraphSequoiaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <fmt/format.h>
@@ -1289,8 +1290,9 @@ void MetalKernelFunction::setArg(unsigned idx, const void* ptr, uint64_t size) {
   [encoder setBytes:ptr length:size atIndex:idx];
 }
 
-void MetalKernelFunction::setBuffer(unsigned idx, const void* buffer) {
-  [encoder setBuffer:(id<MTLBuffer>)buffer offset:0 atIndex:idx];
+void MetalKernelFunction::setErrorBufferIndex(unsigned idx) {
+  auto stream = ::at::mps::getCurrentMPSStream();
+  [encoder setBuffer:stream->getErrorBuffer() offset:0 atIndex:idx];
 }
 
 uint64_t MetalKernelFunction::getMaxThreadsPerThreadgroup() const {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1289,6 +1289,10 @@ void MetalKernelFunction::setArg(unsigned idx, const void* ptr, uint64_t size) {
   [encoder setBytes:ptr length:size atIndex:idx];
 }
 
+void MetalKernelFunction::setBuffer(unsigned idx, const void* buffer) {
+  [encoder setBuffer:(id<MTLBuffer>)buffer offset:0 atIndex:idx];
+}
+
 uint64_t MetalKernelFunction::getMaxThreadsPerThreadgroup() const {
   return [cps maxTotalThreadsPerThreadgroup];
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13105,6 +13105,36 @@ class TestMetalLibrary(TestCaseMPS):
         self.assertGreater(len(capture_listdir), 3,
                            f"Capture file {capture_dirname} contains only metadata, i.e. {capture_listdir}")
 
+    def test_metal_error_buffer(self):
+        # Test that error_buf_idx parameter works correctly
+        lib = torch.mps.compile_shader("""
+            #include <c10/metal/error.h>
+
+            kernel void check_bounds(device float* x,
+                                    constant int& limit,
+                                    device c10::metal::ErrorMessages* error_buf,
+                                    uint idx [[thread_position_in_grid]]) {
+                if (idx >= limit) {
+                    TORCH_REPORT_ERROR(error_buf, "Index ", idx, " exceeds limit ", limit);
+                    x[idx] = -1.0;
+                } else {
+                    x[idx] = idx;
+                }
+            }
+        """)
+
+        x = torch.zeros(10, device="mps")
+        # Should work without errors when limit is large enough
+        lib.check_bounds(x, 10, error_buf_idx=2)
+        self.assertEqual(x, torch.arange(10, device='mps', dtype=x.dtype))
+
+        # Test with a smaller limit that should trigger an error report
+        # The error should be raised as AcceleratorError when synchronize is called
+        y = torch.zeros(10, device="mps")
+        lib.check_bounds(y, 5, error_buf_idx=2)
+        with self.assertRaisesRegex(RuntimeError, "Index .* exceeds limit"):
+            torch.mps.synchronize()
+
 
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -14,7 +14,6 @@
 
 #ifdef USE_MPS
 #include <ATen/mps/MPSProfiler.h>
-#include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #endif
 
@@ -446,8 +445,7 @@ void initModule(PyObject* module) {
               // Set error buffer if error_buf_idx is provided
               if (!error_buf_idx.is_none()) {
                 auto error_idx = error_buf_idx.cast<unsigned>();
-                auto stream = ::at::mps::getCurrentMPSStream();
-                self.setBuffer(error_idx, stream->getErrorBuffer());
+                self.setErrorBufferIndex(error_idx);
               }
               TORCH_CHECK(
                   threads.has_value() && threads->size() < 4,

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -14,6 +14,7 @@
 
 #ifdef USE_MPS
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #endif
 
@@ -424,7 +425,8 @@ void initModule(PyObject* module) {
              const py::args& args,
              const py::object& py_threads,
              const py::object& py_group_size,
-             const py::object& arg_casts) {
+             const py::object& arg_casts,
+             const py::object& error_buf_idx) {
             auto threads = optional_vec_from_pyobject(py_threads);
             auto group_size = optional_vec_from_pyobject(py_group_size);
             OptionalArgCaster caster(arg_casts);
@@ -440,6 +442,12 @@ void initModule(PyObject* module) {
                   continue;
                 }
                 caster.setValue(self, idx, args[idx]);
+              }
+              // Set error buffer if error_buf_idx is provided
+              if (!error_buf_idx.is_none()) {
+                auto error_idx = error_buf_idx.cast<unsigned>();
+                auto stream = ::at::mps::getCurrentMPSStream();
+                self.setBuffer(error_idx, stream->getErrorBuffer());
               }
               TORCH_CHECK(
                   threads.has_value() && threads->size() < 4,
@@ -478,7 +486,8 @@ void initModule(PyObject* module) {
           py::kw_only(),
           py::arg("threads") = py::none(),
           py::arg("group_size") = py::none(),
-          py::arg("arg_casts") = py::none())
+          py::arg("arg_casts") = py::none(),
+          py::arg("error_buf_idx") = py::none())
       .def_property_readonly(
           "max_threads_per_threadgroup",
           &MetalKernelFunction::getMaxThreadsPerThreadgroup)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #170050
* __->__ #170002

Introduce infrastructure for Metal shaders compiled from Python to report runtime errors back to the host.
- Added `MetalKernelFunction::setErrorBufferIndex` method that
    binds the error buffer from the current MPS stream to a specified argument
    index in the Metal kernel
- Extended kernel invocation Python bindings to accept an optional `error_buf_idx` parameter
- Add `TestMetalLibrary.test_metal_error_buffer` unit test

