### PR TITLE
[SymmMem] Add get_mem_pool wrapper

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1385,8 +1385,7 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         dtype = torch.float
         numel = 1024
 
-        allocator = symm_mem.get_mempool_allocator(self.device)
-        mempool = torch.cuda.MemPool(allocator, no_split=True)
+        mempool = symm_mem.get_mem_pool(self.device)
 
         with torch.cuda.use_mem_pool(mempool):
             tensor = torch.arange(numel, dtype=dtype, device=self.device)
@@ -1410,8 +1409,7 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         w = torch.ones(dim, dim, dtype=dtype, device=self.device)
         x = torch.ones(1, dim, dtype=dtype, device=self.device)
 
-        allocator = symm_mem.get_mempool_allocator(self.device)
-        mempool = torch.cuda.MemPool(allocator, no_split=True)
+        mempool = symm_mem.get_mem_pool(self.device)
 
         with torch.cuda.use_mem_pool(mempool):
             y = torch.mm(x, w)

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -2074,6 +2074,57 @@ def get_signal_pad_size() -> int:
     return _SymmetricMemory.signal_pad_size
 
 
+# An internal map from device to the symmetric memory pool for that device.
+_symm_mem_pools: dict[_device, torch.cuda.MemPool] = {}
+
+
+def get_mem_pool(device: _device) -> torch.cuda.MemPool:
+    """
+    Get the symmetric memory pool for a given device. If not found, create a new
+    pool.
+
+    The tensor allocations with this pool must be symmetric across ranks.  The
+    allocated tensors can be used with symmetric operations, for example,
+    operations defined under `torch.ops.symm_mem`.
+
+    Args:
+        device (`torch.device` or str): the device for which to get the symmetric memory pool.
+
+    Returns:
+        `torch.cuda.MemPool`: the symmetric memory pool for the given device.
+
+    Example::
+
+        >>> # doctest: +SKIP
+        >>> pool = torch.distributed._symmetric_memory.get_mem_pool("cuda:0")
+        >>> with torch.cuda.use_mem_pool(pool):
+        >>>     tensor = torch.randn(1000, device="cuda:0")
+        >>> tensor = torch.ops.symm_mem.one_shot_all_reduce(tensor, "sum", group_name)
+
+    """
+    # This function is a wrapper around the `torch.cuda.MemPool` constructor.
+    # Due to special requirements of SymmetricMemory, we preset certain options for the pool.
+    # - use_on_oom=False: we don't want to lend the space of the pool for
+    # non-symmetric allocations because this could desync the allocation state
+    # across ranks.
+    # - no_split=True: we don't want to split segments, because today a segment
+    # is associated with a signal pad, if two allocated tensors share a segment
+    # and their kernels concurrently use (the same) signal pad, this could cause
+    # undefined behaviors. We could consider relaxing this in the future if we
+    # establish stream tracking and implicit synchronization around an
+    # allocation.
+    if device not in _symm_mem_pools:
+        allocator = get_mempool_allocator(device)
+        # Create a new pool with the given allocator and the preset options.
+        _symm_mem_pools[device] = torch.cuda.MemPool(
+            allocator,
+            use_on_oom=False,
+            no_split=True,
+        )
+
+    return _symm_mem_pools[device]
+
+
 __all__ = [
     "empty",
     "rendezvous",
@@ -2082,4 +2133,5 @@ __all__ = [
     "get_backend",
     "set_signal_pad_size",
     "get_signal_pad_size",
+    "get_mem_pool",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170008
* #169740

We'd like to default some flags for SymmetricMemory pools, e.g. 
- use_on_oom=False
- no_split=True

to improve UX and to fortify safety.

We thus provide a wrapper with the above flags preset:
```
pool = torch.distributed._symmetric_memory.get_mem_pool(device)
```

Since these flags are internal to the wrapper, we also maintain the flexibility to vary it in the future.