### PR TITLE
[inductor] fix reading _TORCHINDUCTOR_PYOBJECT_TENSOR_DATA_PTR in module

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2986,6 +2986,7 @@ class CppPythonBindingsCodeCache(CppCodeCache):
         #include <Python.h>
         #include <sstream>
         #include <cstdlib>
+        #include <cerrno>
 
         #ifndef _MSC_VER
         #if __cplusplus < 202002L
@@ -3057,9 +3058,14 @@ class CppPythonBindingsCodeCache(CppCodeCache):
                 PyErr_SetString(PyExc_RuntimeError, "_TORCHINDUCTOR_PYOBJECT_TENSOR_DATA_PTR must be set");
                 return nullptr;
             }}
-            std::istringstream iss(str_addr);
-            uintptr_t addr = 0;
-            iss >> addr;
+
+            char* endptr = nullptr;
+            errno = 0;
+            uintptr_t addr = std::strtoull(str_addr, &endptr, 10);
+            if(errno != 0 || endptr == str_addr || addr == 0) {{
+                PyErr_SetString(PyExc_RuntimeError, "Failed to parse _TORCHINDUCTOR_PYOBJECT_TENSOR_DATA_PTR");
+                return nullptr;
+            }}
             _torchinductor_pyobject_tensor_data_ptr =
                 reinterpret_cast<decltype(_torchinductor_pyobject_tensor_data_ptr)>(addr);
             PyObject* module = PyModule_Create(&py_module);


### PR DESCRIPTION
For an internal test, we're seeing the following with the old code.

Since `addr` is 0, but we didn't have a check on `iss.fail()`, the code will sefgault later when we run the compiled module. 

```
_TORCHINDUCTOR_PYOBJECT_TENSOR_DATA_PTR 140719011151296
str_addr: [140719011151296]
parsed addr: 0
iss.fail(): 1, iss.eof(): 0, iss.bad(): 1
```

In this PR, we change to use a more robust parsing approach that avoids the C++ iostream issues, e.g. if some program corrupts locale. This PR pass the internal test.

We also add a check so the module load error out early if the parsing fails.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo