### PR TITLE
[BE] Use `shelx.split` rather than shell=True when launching subprocess

### DIFF
--- a/torch/csrc/jit/tensorexpr/scripts/bisect.py
+++ b/torch/csrc/jit/tensorexpr/scripts/bisect.py
@@ -19,7 +19,7 @@ def test(cmd, limit):
             encoding="utf-8",
             check=False,
         )
-    except (FileNotFoundError, OSError):
+    except OSError:
         print("bad")
         return 0
     print(p.stdout)

--- a/torch/csrc/jit/tensorexpr/scripts/bisect.py
+++ b/torch/csrc/jit/tensorexpr/scripts/bisect.py
@@ -10,14 +10,18 @@ def test(cmd, limit):
     cur_env["PYTORCH_JIT_OPT_LIMIT"] = f"tensorexpr_fuser={limit}"
     is_posix = os.name == "posix"
     cmd = shlex.split(cmd, posix=is_posix)
-    p = subprocess.run(
-        cmd,
-        env=cur_env,
-        shell=False,
-        capture_output=True,
-        encoding="utf-8",
-        check=False,
-    )
+    try:
+        p = subprocess.run(
+            cmd,
+            env=cur_env,
+            shell=False,
+            capture_output=True,
+            encoding="utf-8",
+            check=False,
+        )
+    except (FileNotFoundError, OSError) as e:
+        print(f"Error: {e}")
+        return 0
     print(p.stdout)
     f = "INTERNAL ASSERT FAILED"
     if f in p.stdout or f in p.stderr:

--- a/torch/csrc/jit/tensorexpr/scripts/bisect.py
+++ b/torch/csrc/jit/tensorexpr/scripts/bisect.py
@@ -1,13 +1,18 @@
 # mypy: ignore-errors
-
+import os
+import shlex
 import subprocess
 
 
 def test(cmd, limit):
     print(f"Testing PYTORCH_JIT_OPT_LIMIT=tensorexpr_fuser={limit} {cmd}")
+    cur_env = os.environ.copy()
+    cur_env["PYTORCH_JIT_OPT_LIMIT"] = f"tensorexpr_fuser={limit}"
+    cmd_args = shlex.split(cmd)
     p = subprocess.run(
-        f"PYTORCH_JIT_OPT_LIMIT=tensorexpr_fuser={limit} {cmd}",
-        shell=True,
+        cmd_args,
+        env=cur_env,
+        shell=False,
         capture_output=True,
         encoding="utf-8",
         check=False,

--- a/torch/csrc/jit/tensorexpr/scripts/bisect.py
+++ b/torch/csrc/jit/tensorexpr/scripts/bisect.py
@@ -8,9 +8,10 @@ def test(cmd, limit):
     print(f"Testing PYTORCH_JIT_OPT_LIMIT=tensorexpr_fuser={limit} {cmd}")
     cur_env = os.environ.copy()
     cur_env["PYTORCH_JIT_OPT_LIMIT"] = f"tensorexpr_fuser={limit}"
-    cmd_args = shlex.split(cmd)
+    is_posix = os.name == "posix"
+    cmd = shlex.split(cmd, posix=is_posix)
     p = subprocess.run(
-        cmd_args,
+        cmd,
         env=cur_env,
         shell=False,
         capture_output=True,

--- a/torch/csrc/jit/tensorexpr/scripts/bisect.py
+++ b/torch/csrc/jit/tensorexpr/scripts/bisect.py
@@ -19,8 +19,8 @@ def test(cmd, limit):
             encoding="utf-8",
             check=False,
         )
-    except (FileNotFoundError, OSError) as e:
-        print(f"Error: {e}")
+    except (FileNotFoundError, OSError):
+        print("bad")
         return 0
     print(p.stdout)
     f = "INTERNAL ASSERT FAILED"

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -8,6 +8,7 @@ import json
 import locale
 import os
 import re
+import shlex
 import subprocess
 import sys
 from collections import namedtuple
@@ -119,9 +120,11 @@ PIP_PATTERNS = [
 
 def run(command):
     """Return (return-code, stdout, stderr)."""
-    shell = type(command) is str
+    if isinstance(command, str):
+        is_posix = os.name == 'posix'
+        command = shlex.split(command, posix=is_posix)
     p = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,shell=False
     )
     raw_output, raw_err = p.communicate()
     rc = p.returncode

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -123,11 +123,15 @@ def run(command):
     if isinstance(command, str):
         is_posix = os.name == 'posix'
         command = shlex.split(command, posix=is_posix)
-    p = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
-    )
-    raw_output, raw_err = p.communicate()
-    rc = p.returncode
+    try:
+        p = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
+        )
+        raw_output, raw_err = p.communicate()
+        rc = p.returncode
+    except (FileNotFoundError, OSError) as e:
+        return 127, "", str(e)
+
     if get_platform() == "win32":
         enc = "oem"
     else:

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -129,7 +129,7 @@ def run(command):
         )
         raw_output, raw_err = p.communicate()
         rc = p.returncode
-    except (FileNotFoundError, OSError) as e:
+    except OSError as e:
         return 127, "", str(e)
 
     if get_platform() == "win32":

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -124,7 +124,7 @@ def run(command):
         is_posix = os.name == 'posix'
         command = shlex.split(command, posix=is_posix)
     p = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,shell=False
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False
     )
     raw_output, raw_err = p.communicate()
     rc = p.returncode

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2690,9 +2690,12 @@ def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> 
         # To work around this, we pass in the fileno directly and hope that
         # it is valid.
         stdout_fileno = 1
+        if isinstance(command, str):
+            is_posix = os.name == 'posix'
+            command = shlex.split(command, posix=is_posix)
         subprocess.run(
             command,
-            shell=IS_WINDOWS and IS_HIP_EXTENSION,
+            shell=False,
             stdout=stdout_fileno if verbose else subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=build_directory,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2701,7 +2701,7 @@ def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> 
             cwd=build_directory,
             check=True,
             env=env)
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
+    except (subprocess.CalledProcessError, OSError) as e:
         # Python 2 and 3 compatible way of getting the error object.
         _, error, _ = sys.exc_info()
         # error.output contains the stdout and stderr of the build attempt.

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2701,7 +2701,7 @@ def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> 
             cwd=build_directory,
             check=True,
             env=env)
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
         # Python 2 and 3 compatible way of getting the error object.
         _, error, _ = sys.exc_info()
         # error.output contains the stdout and stderr of the build attempt.


### PR DESCRIPTION
Inspired by https://github.com/pytorch/pytorch/pull/167502

Fixes #169955

Follow malfet's suggestion:       https://github.com/pytorch/pytorch/pull/167502#issuecomment-3515041182

This is only for torch folder, there're a lot of cases in other folders though.

cc @EikanWang @jgong5 @malfet @cyyever 