### PR TITLE
[dtensor][partial] preventing redistribution when linearity is 0

### DIFF
--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -535,7 +535,7 @@ def common_pointwise_strategy(
                 partial_supports_linearity = placement.is_partial(
                     "sum"
                 ) or placement.is_partial("avg")
-                if linearity > 0 and partial_supports_linearity:
+                if linearity >= 0 and partial_supports_linearity:
                     # propagate the partial placement
                     out_placements.append(placement)
                 else:


### PR DESCRIPTION
**Summary:** When users multiply a partial dtensor by a scalar, we should keep the output as a partial dtensor. However, we incorrectly force the partial to be redistributed to replicate placement. The iterative process to arriving at this PR can be viewed in https://github.com/pytorch/pytorch/pull/167813. The proof for why we don't need to redistribute is shown below:

<img width="4032" height="692" alt="image" src="https://github.com/user-attachments/assets/efaba8a3-0882-463d-8a28-5c72007525a1" />




**Test Case**
1. pytest test/distributed/tensor/test_pointwise_ops.py -k test_mul_div_scalar_partial

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170040
* #170035
* #170030
* __->__ #170025



cc @wanchaol @tianyu-l @wz337 @XilunWu @d4l3k @pragupta @SherlockNoMad @ppwwyyxx