### PR TITLE
[Fix] Remove use of deprecated NumPy symbols.

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -267,8 +267,8 @@ class TestTensorBoardUtils(BaseTestCase):
         total_frame = V_input.shape[1]
         V_input = np.swapaxes(V_input, 0, 1)
         for f in range(total_frame):
-            x = np.reshape(V_input[f], newshape=(-1))
-            y = np.reshape(V_after[f], newshape=(-1))
+            x = np.reshape(V_input[f], -1)
+            y = np.reshape(V_after[f], -1)
             np.testing.assert_array_almost_equal(np.sum(x), np.sum(y))
 
 


### PR DESCRIPTION
Inspired by https://github.com/pytorch/pytorch/pull/169695

np.reshape(..., newshape=...) is being removed in numpy 2.4
https://github.com/numpy/numpy/commit/95cdc307c91b53b33e48cffb66184209bfe7eff5

cc @mruberry @rgommers @cyyever @jakeharmon8 @albanD 