### PR TITLE
Explicitly remove move operations

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -147,7 +147,7 @@ struct Workspace {
     data = c10::cuda::CUDACachingAllocator::raw_alloc(size);
   }
   Workspace(const Workspace&) = delete;
-  Workspace(Workspace&&) = default;
+  Workspace(Workspace&& other): data(std::exchange(other.data, nullptr)) {}
   Workspace& operator=(Workspace&&) = delete;
   ~Workspace() {
     if (data) {

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -148,7 +148,7 @@ struct Workspace {
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&&) = default;
-  Workspace& operator=(Workspace&&) = default;
+  Workspace& operator=(Workspace&&) = delete;
   ~Workspace() {
     if (data) {
       c10::cuda::CUDACachingAllocator::raw_delete(data);

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -152,8 +152,10 @@ struct Workspace {
         data(std::exchange(other.data, nullptr)) {}
   Workspace& operator=(const Workspace& other) = delete;
   Workspace& operator=(Workspace&& other) noexcept {
-    size = std::exchange(other.size, 0);
-    data = std::exchange(other.data, nullptr);
+    if (this != &other) {
+      std::swap(size, other.size);
+      std::swap(data, other.data);
+    }
     return *this;
   }
   ~Workspace() {

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -147,7 +147,9 @@ struct Workspace {
     data = c10::cuda::CUDACachingAllocator::raw_alloc(size);
   }
   Workspace(const Workspace&) = delete;
-  Workspace(Workspace&& other): data(std::exchange(other.data, nullptr)) {}
+  Workspace(Workspace&& other) noexcept
+      : size(std::exchage(other.size, 0)),
+      data(std::exchange(other.data, nullptr)) {}
   Workspace& operator=(Workspace&&) = delete;
   ~Workspace() {
     if (data) {

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -148,9 +148,14 @@ struct Workspace {
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&& other) noexcept
-      : size(std::exchage(other.size, 0)),
-      data(std::exchange(other.data, nullptr)) {}
-  Workspace& operator=(Workspace&&) = delete;
+      : size(std::exchange(other.size, 0)),
+        data(std::exchange(other.data, nullptr)) {}
+  Workspace& operator=(const Workspace& other) = delete;
+  Workspace& operator=(Workspace&& other) noexcept {
+    size = std::exchange(other.size, 0);
+    data = std::exchange(other.data, nullptr);
+    return *this;
+  }
   ~Workspace() {
     if (data) {
       c10::cuda::CUDACachingAllocator::raw_delete(data);

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -281,8 +281,9 @@ struct Workspace {
     data = c10::hip::HIPCachingAllocator::raw_alloc(size);
   }
   Workspace(const Workspace&) = delete;
-  Workspace(Workspace&&) = default;
-  Workspace& operator=(Workspace&&) = default;
+  Workspace(Workspace&&) = delete;
+  Workspace& operator=(const Workspace&) = delete;
+  Workspace& operator=(Workspace&&) = delete;
   ~Workspace() {
     if (data) {
       c10::hip::HIPCachingAllocator::raw_delete(data);

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -79,8 +79,8 @@ namespace {
             data = c10::hip::HIPCachingAllocator::raw_alloc(size);
         }
         DropoutState(const DropoutState&) = delete;
-        DropoutState(DropoutState&&) = default;
-        DropoutState& operator=(DropoutState&&) = default;
+        DropoutState(DropoutState&&) = delete;
+        DropoutState& operator=(DropoutState&&) = delete;
         ~DropoutState() {
             if (data) {
                 c10::hip::HIPCachingAllocator::raw_delete(data);


### PR DESCRIPTION
Explicitly remove move operations of RAII classes for managing memory.
