### PR TITLE
[Inductor][FP8] Simplify load_scales in main loop scaled_mm

### DIFF
--- a/torch/_inductor/kernel/templates/triton_main_loop_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_main_loop_scaled_mm.py.jinja
@@ -42,8 +42,6 @@
 
     num_pid_in_group = GROUP_M * num_pid_n
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
-    a_scale = load_scales(A_inverse_scale, SCALE_RECIPE_A)
-    b_scale = load_scales(B_inverse_scale, SCALE_RECIPE_B)
 
     for _ in range(0, k_tiles * tiles_per_SM):
         ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
@@ -71,7 +69,7 @@
         {%- if SCALE_RECIPE_A == 5 %}  # ScalingType.Blockwise128x128
         scale_a_block = blockwise128x128_scaling(
             pid_m,
-            a_scale,
+            A_inverse_scale,
             ki,
             am_blocks,
             ak_blocks,
@@ -83,7 +81,7 @@
         {%- else %}  # ScalingType.Blockwise1xTILESIZE
         scale_a_block = blockwise1xTILESIZE_scaling(
             pid_m,
-            a_scale,
+            A_inverse_scale,
             ki,
             M,
             am_blocks,
@@ -98,7 +96,7 @@
         {%- if SCALE_RECIPE_A == 5 %}  # ScalingType.Blockwise128x128
         scale_b_block = blockwise128x128_scaling(
             pid_n,
-            b_scale,
+            B_inverse_scale,
             ki,
             bn_blocks,
             bk_blocks,
@@ -110,7 +108,7 @@
         {%- else %}  # ScalingType.Blockwise1xTILESIZE
         scale_b_block = blockwise1xTILESIZE_scaling(
             pid_n,
-            b_scale,
+            B_inverse_scale,
             ki,
             N,
             bn_blocks,
@@ -139,14 +137,6 @@
                 block_indexing=True,
             )}}
             accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-
-@triton.jit
-def load_scales(scale_ptr, SCALE_RECIPE: tl.constexpr):
-    if SCALE_RECIPE == 0:
-        return tl.load(scale_ptr)  # For tensor-wise scaling, we'll load the scalar values
-    else:
-        return scale_ptr  # For all other scaling recipes, we'll return the pointers
 
 
 @triton.jit


### PR DESCRIPTION
Summary: Remove `load_scales` function from jinja template for `scaled_mm` main loop scaling, which handles block-wise scaling variants. All main loop scaling variants need to load the pointer to the scale tensor and will never hit the first `if` block (reserved for per-tensor scaling).

Test Plan:
```
TRITON_PRINT_AUTOTUNING=1 TRITON_ALWAYS_COMPILE=1 TORCH_LOGS=+inductor TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 ENABLE_PERSISTENT_TMA_MATMUL=1 buck2 run mode/{opt,inplace} pytorch/tritonbench:run -- --op fp8_gemm --only pt2_fp8_gemm --m 10
24 --n 256 --k 256 --scaling-pair BlockWise1x128,BlockWise128x128 2>&1 | tee ~/personal/random.log
```

Differential Revision: D88804518




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo