### PR TITLE
[Fix] Fix incorrect comma operator usage in return statement

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -278,7 +278,7 @@ TEST(CustomAutogradTest, CustomFunctionReturnInputAsIsAndSavesIt) {
         Variable var1,
         Variable var2) {
       ctx->save_for_backward({var1, var2});
-      return var1 * var2, var1;
+      return var1 * var2;
     }
 
     static variable_list backward(


### PR DESCRIPTION
Fix incorrect comma operator usage in return statement

cc @cyyever 
