### PR TITLE
[Inductor] Fix wrong assumption introduced by #169605 that trying to get metadata from a Pointwise IRNode.

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2380,8 +2380,15 @@ class ExternKernelCaller(ChoiceCaller):
             self.input_tensor_meta, self.output_tensor_meta = [], []
             benchmark_cls = ExternKernelCPUBenchmarkRequest
         else:
-            self.input_tensor_meta = TensorMeta.from_irnodes(self.input_nodes)
-            self.output_tensor_meta = TensorMeta.from_irnodes(self.layout)
+            try:
+                self.input_tensor_meta = TensorMeta.from_irnodes(self.input_nodes)
+            except Exception:
+                self.input_tensor_meta = None
+            try:
+                self.output_tensor_meta = TensorMeta.from_irnodes(self.layout)
+            except Exception:
+                self.output_tensor_meta = None
+
             benchmark_cls = ExternKernelGPUBenchmarkRequest
 
         self.bmreq: ExternKernelBenchmarkRequest = benchmark_cls(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170061

The PR #169605 is causing a large number of failures on XPU. For example: https://hud.pytorch.org/pr/pytorch/pytorch/168328#57614268055
. In that case, self.input_nodes contains a TensorBox(StorageBox(Pointwise)), which does not implement get_stride, leading to runtime errors. This PR avoid get metadata from such IRNodes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo