### PR TITLE
Fix branch logic for xfail in test_main_loop_scaling

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -14,6 +14,7 @@ from torch._inductor.utils import run_and_get_code
 from torch.nn.functional import ScalingType  # type: ignore[attr-defined]
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
+    IS_SM90,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MX_GEMM,
 )
@@ -875,7 +876,8 @@ class TestFP8Lowering(TestCase):
             return y
 
         # BlockWise1x128 and BlockWise128x128 scaling modes are not compatible with fast_accum
-        if use_fast_accum:
+        # Only take this branch on SM90 because other versions xfail everything
+        if use_fast_accum and IS_SM90:
             with self.assertRaisesRegex(
                 RuntimeError, "scaled_gemm doesn't support fast accum"
             ):


### PR DESCRIPTION
This PR adds an extra condition to branching logic in `test_main_loop_scaling` to resolve an unexpected success on devices with SM != 9.0 caused by overlapping `xfailIf` and `self.assertRaisesRegex`.

This is a patch for #169317 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy