### PR TITLE
Add half precision binding for MPI backend

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -43,18 +43,14 @@ std::map<at::ScalarType, MPI_Datatype> mpiDatatype = {
     {at::kFloat, MPI_FLOAT},
 // FP16 is generally supported if MPIX_C_FLOAT16 exists
 // for now the NVIDIA hpc sdk is built without (OpenMPI)
-#ifdef MPIX_C_FLOAT16
+#if  defined(MPIX_C_FLOAT16)
     {at::kHalf, MPIX_C_FLOAT16},
 #endif
-// BF16 support per MPI implementation
-#ifdef I_MPI_VERSION // Intel MPI
-#ifdef MPIX_C_BF16
+#if defined(MPIX_C_BF16)
     {at::kBFloat16, MPIX_C_BF16},
 #endif
-#elif defined(MPICH) // MPICH
-#ifdef MPIX_BFLOAT16
+#if defined(MPIX_BFLOAT16)
     {at::kBFloat16, MPIX_BFLOAT16},
-#endif
 #endif
     {at::kInt, MPI_INT},
     {at::kLong, MPI_LONG},

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -43,7 +43,7 @@ std::map<at::ScalarType, MPI_Datatype> mpiDatatype = {
     {at::kFloat, MPI_FLOAT},
 // FP16 is generally supported if MPIX_C_FLOAT16 exists
 // for now the NVIDIA hpc sdk is built without (OpenMPI)
-#if  defined(MPIX_C_FLOAT16)
+#if defined(MPIX_C_FLOAT16)
     {at::kHalf, MPIX_C_FLOAT16},
 #endif
 #if defined(MPIX_C_BF16)

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -41,6 +41,21 @@ std::map<at::ScalarType, MPI_Datatype> mpiDatatype = {
     {at::kChar, MPI_CHAR},
     {at::kDouble, MPI_DOUBLE},
     {at::kFloat, MPI_FLOAT},
+// FP16 is generally supported if MPIX_C_FLOAT16 exists
+// for now the NVIDIA hpc sdk is built without (OpenMPI)
+#ifdef MPIX_C_FLOAT16
+    {at::kHalf, MPIX_C_FLOAT16},
+#endif
+// BF16 support per MPI implementation
+#ifdef I_MPI_VERSION // Intel MPI
+#ifdef MPIX_C_BF16
+    {at::kBFloat16, MPIX_C_BF16},
+#endif
+#elif defined(MPICH) // MPICH
+#ifdef MPIX_BFLOAT16
+    {at::kBFloat16, MPIX_BFLOAT16},
+#endif
+#endif
     {at::kInt, MPI_INT},
     {at::kLong, MPI_LONG},
     {at::kShort, MPI_SHORT},


### PR DESCRIPTION
The binding doing the correspondance betweem torch type and MPI type does not contain the correspondance from torch.half to fp16/bf16, MPIX_C_FLOAT16 for FP16 and MPIX_C_BF16 for BF16

Fixes #170073
