### PR TITLE
[ROCm] Enable SDPA pattern rewriter tests for Pattern 16 and 18

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     SM80OrLater,
 )
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
+from torch.testing._internal.common_utils import IS_LINUX, TEST_WITH_ROCM
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
@@ -741,7 +741,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         self._check_common(dot_prod_attention, check_train=False)
 
-    @skipIfRocm
     def _test_sdpa_rewriter_16(self):
         def dot_prod_attention(
             query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, training
@@ -756,14 +755,18 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             q = query.permute(0, 2, 1, 3)
             k = key.permute(0, 2, 1, 3)
             v = value.permute(0, 2, 1, 3)
-            return torch.nn.functional.dropout(
-                (torch.matmul(q, k.transpose(-2, -1)).div(3.0) + attn_mask).softmax(
-                    dim=-1
-                ),
-                p=0.4,
-                training=training,
-                inplace=False,
-            ).matmul(v)
+            return (
+                torch.nn.functional.dropout(
+                    (torch.matmul(q, k.transpose(-2, -1)).div(3.0) + attn_mask).softmax(
+                        dim=-1
+                    ),
+                    p=0.4,
+                    training=training,
+                    inplace=False,
+                )
+                .to(dtype=query.dtype)
+                .matmul(v)
+            )
 
         self._check_common(dot_prod_attention, contains=False, has_dropout=True)
 
@@ -778,7 +781,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             dot_prod_attention, args1=args, contains=False, has_dropout=True
         )
 
-    @skipIfRocm
     def _test_sdpa_rewriter_16_fp32_mask(self):
         def dot_prod_attention(
             query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, training
@@ -790,14 +792,18 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             q = query.permute(0, 2, 1, 3)
             k = key.permute(0, 2, 1, 3)
             v = value.permute(0, 2, 1, 3)
-            return torch.nn.functional.dropout(
-                (torch.matmul(q, k.transpose(-2, -1)).div(3.0) + attn_mask).softmax(
-                    dim=-1
-                ),
-                p=0.4,
-                training=training,
-                inplace=False,
-            ).matmul(v)
+            return (
+                torch.nn.functional.dropout(
+                    (torch.matmul(q, k.transpose(-2, -1)).div(3.0) + attn_mask).softmax(
+                        dim=-1
+                    ),
+                    p=0.4,
+                    training=training,
+                    inplace=False,
+                )
+                .to(dtype=query.dtype)
+                .matmul(v)
+            )
 
         self._check_common(dot_prod_attention, contains=False, has_dropout=True)
 
@@ -839,7 +845,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         self._check_common(dot_prod_attention, check_train=False, has_dropout=True)
 
-    @skipIfRocm
     def _test_sdpa_rewriter_18(self):
         def dot_prod_attention(
             query: torch.Tensor,
@@ -1171,8 +1176,19 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         test_sdpa_rewriter_15_gpu = functools.partialmethod(
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_15
         )
+        # Pattern 16 is disabled on NVIDIA CUDA (disable_cuda=True) but enabled on ROCm
+        if TEST_WITH_ROCM:
+            test_sdpa_rewriter_16_gpu = functools.partialmethod(
+                TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_16
+            )
+            test_sdpa_rewriter_16_fp32_mask_gpu = functools.partialmethod(
+                TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_16_fp32_mask
+            )
         test_sdpa_rewriter_17_gpu = functools.partialmethod(
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_17
+        )
+        test_sdpa_rewriter_18_gpu = functools.partialmethod(
+            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_18
         )
         test_sdpa_rewriter_19_gpu = functools.partialmethod(
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_19

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -967,20 +967,24 @@ def _get_sfdp_patterns():
                 {},
                 _sfdp_extra_check(aten.div.Tensor),
             ),
-            # TODO: Enable CUDA after solving Bert accuracy issue of calling efficient attention
+            # disable_cuda only for NVIDIA CUDA (not ROCm) due to Bert accuracy issue
             (
                 _sfdp_pattern_16,
                 _sfdp_replacement_16,
                 [g(), g(), g(), m(), c()],
                 d,
-                _sfdp_extra_check(aten.div.Tensor, disable_cuda=True),
+                _sfdp_extra_check(
+                    aten.div.Tensor, disable_cuda=torch.version.hip is None
+                ),
             ),
             (
                 _sfdp_pattern_16,
                 _sfdp_replacement_16,
                 [g_bs1(), g_bs1(), g_bs1(), m_bs1(), c()],
                 d,
-                _sfdp_extra_check(aten.div.Tensor, disable_cuda=True),
+                _sfdp_extra_check(
+                    aten.div.Tensor, disable_cuda=torch.version.hip is None
+                ),
             ),
             (
                 _sfdp_pattern_17,
@@ -1076,7 +1080,10 @@ def _get_sfdp_patterns():
                     _sfdp_replacement_16,
                     [g(), g(), g(), m_float(), c()],
                     d,
-                    _sfdp_extra_check(aten.div.Tensor, disable_cuda=True),
+                    # disable_cuda only for NVIDIA CUDA (not ROCm) due to Bert accuracy issue
+                    _sfdp_extra_check(
+                        aten.div.Tensor, disable_cuda=torch.version.hip is None
+                    ),
                 )
             )
             candidates.append(
@@ -1085,7 +1092,10 @@ def _get_sfdp_patterns():
                     _sfdp_replacement_16,
                     [g_bs1(), g_bs1(), g_bs1(), m_bs1_float(), c()],
                     d,
-                    _sfdp_extra_check(aten.div.Tensor, disable_cuda=True),
+                    # disable_cuda only for NVIDIA CUDA (not ROCm) due to Bert accuracy issue
+                    _sfdp_extra_check(
+                        aten.div.Tensor, disable_cuda=torch.version.hip is None
+                    ),
                 )
             )
 


### PR DESCRIPTION
## Summary

This PR enables SDPA (Scaled Dot-Product Attention) pattern rewriter tests(for patterns 16 and 18) on ROCm that were previously not running.

## Changes

### 1. Fix Pattern 16 Test Helper (`test_fused_attention.py`)

Added missing `.to(dtype=query.dtype)` cast to `_test_sdpa_rewriter_16` and `_test_sdpa_rewriter_16_fp32_mask` helper methods to match the pattern definition in `_sfdp_pattern_16`.

Pattern matching requires **exact structural matching** - the test was missing this cast, causing the pattern to never match.

### 2. Enable Pattern 16 on ROCm (`fuse_attention.py`)

Changed the `disable_cuda` parameter from a static `True` to a conditional check at the call sites:


### 3. Register GPU Tests (`test_fused_attention.py`)

- **Pattern 16 & 16_fp32_mask**: Registered only for ROCm (`if TEST_WITH_ROCM:`)
- **Pattern 18**: Registered for all GPU platforms (no `disable_cuda` flag)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben