### PR TITLE
ci: Ensure we pass through TPU env variables

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -416,6 +416,19 @@ jobs:
             -e SCRIBE_GRAPHQL_ACCESS_TOKEN \
             -e DASHBOARD_TAG \
             -e ARTIFACTS_FILE_SUFFIX \
+            -e TPU_SKIP_MDS_QUERY \
+            -e TPU_TOPOLOGY \
+            -e TPU_WORKER_ID \
+            -e TPU_TOPOLOGY_WRAP \
+            -e TPU_CHIPS_PER_HOST_BOUNDS \
+            -e TPU_ACCELERATOR_TYPE \
+            -e TPU_RUNTIME_METRICS_PORTS \
+            -e TPU_TOPOLOGY_ALT \
+            -e HOST_BOUNDS \
+            -e TPU_HOST_BOUNDS \
+            -e VBAR_CONTROL_SERVICE_URL \
+            -e CHIPS_PER_HOST_BOUNDS \
+            -e TPU_WORKER_HOSTNAMES \
             --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
             --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -429,6 +429,8 @@ jobs:
             -e VBAR_CONTROL_SERVICE_URL \
             -e CHIPS_PER_HOST_BOUNDS \
             -e TPU_WORKER_HOSTNAMES \
+            --privileged \
+            --network=host \
             --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
             --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170099

These are needed in order to ensure that TPUs can work correctly in our
DinD setup.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>