### PR TITLE
[xplat] Fix build warnings and update mcf dependency

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1778,7 +1778,7 @@ static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tens
     try {
       mkldnn_matmul(batch1, batch2, self_or_result, beta.to<float>(), alpha.to<float>());
       return;
-    } catch (const std::exception& e) {
+    } catch ([[maybe_unused]]const std::exception& e) {
       TORCH_WARN("mkldnn_matmul failed, switching to baddbmm:", e.what());
       at::globalContext().setUserEnabledMkldnn(false);
     }


### PR DESCRIPTION
Summary:
Update mcfDirectAndroid to mcfAndroid in dragon BUCK file to reflect the renamed target.

Add [[maybe_unused]] attribute to exception variable in LinearAlgebra.cpp to suppress unused variable warning when the exception message is only used in TORCH_WARN.

Test Plan: Lease a dragon emulator and run ar1 a b -d

Reviewed By: shreerag-meta

Differential Revision: D88793906


