### PR TITLE
Marking _fft_c2r as core ATen ops

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3048,6 +3048,7 @@
     CPU: _fft_c2r_mkl
     CUDA: _fft_c2r_cufft
     MPS: _fft_c2r_mps
+  tags: core
 
 - func: _fft_c2r.out(Tensor self, int[] dim, int normalization, SymInt last_dim_size, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
@@ -3063,6 +3064,7 @@
     CPU: _fft_c2c_mkl
     CUDA: _fft_c2c_cufft
     MPS: _fft_c2c_mps
+  tags: core
 
 - func: _fft_c2c.out(Tensor self, SymInt[] dim, int normalization, bool forward, *, Tensor(a!) out) -> Tensor(a!)
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3064,7 +3064,6 @@
     CPU: _fft_c2c_mkl
     CUDA: _fft_c2c_cufft
     MPS: _fft_c2c_mps
-  tags: core
 
 - func: _fft_c2c.out(Tensor self, SymInt[] dim, int normalization, bool forward, *, Tensor(a!) out) -> Tensor(a!)
   variants: function


### PR DESCRIPTION
Since _fft_r2c is a core ATen op, I don't see why we leave _fft_c2r out.

There's a discussion in discord: https://discord.com/channels/1334270993966825602/1336777807509979188/1448270601293795438

also relevant issue: https://github.com/pytorch/executorch/issues/5381
