### PR TITLE
Tune max segment length per cta in triton table batched embeddings, and expose the param via cli

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -154,6 +154,14 @@ void Context::setDeterministicFillUninitializedMemory(bool b) {
   _deterministic_fill_uninitialized_memory = b;
 }
 
+int32_t Context::maxSegmentLengthPerCta() const {
+  return _max_segment_length_per_cta;
+}
+
+void Context::setMaxSegmentLengthPerCta(int32_t length) {
+  _max_segment_length_per_cta = length;
+}
+
 void Context::alertNotDeterministic(std::string_view const& caller) {
   if (globalContext().deterministicAlgorithms()) {
     if (globalContext().deterministicAlgorithmsWarnOnly()) {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -322,6 +322,8 @@ class TORCH_API Context {
   void setDeterministicAlgorithms(bool /*b*/, bool /*warn_only*/);
   bool deterministicFillUninitializedMemory() const;
   void setDeterministicFillUninitializedMemory(bool /*b*/);
+  int32_t maxSegmentLengthPerCta() const;
+  void setMaxSegmentLengthPerCta(int32_t /*length*/);
 
   // Note [Writing Nondeterministic Operations]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -455,6 +457,7 @@ class TORCH_API Context {
   bool _deterministic_algorithms = false;
   bool _deterministic_algorithms_warn_only = false;
   bool _deterministic_fill_uninitialized_memory = true;
+  int32_t _max_segment_length_per_cta = -1; // -1 means use default
   std::array<at::SDPBackend, at::num_sdp_backends> sdp_priority_order = {
       at::SDPBackend::flash_attention,
       at::SDPBackend::efficient_attention,

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1250,6 +1250,10 @@ def _get_deterministic_fill_uninitialized_memory() -> (
 def _set_deterministic_fill_uninitialized_memory(
     arg: _bool,
 ) -> None: ...  # THPModule_setDeterministicFillUninitializedMemory
+def _get_max_segment_length_per_cta() -> int: ...  # THPModule_maxSegmentLengthPerCta
+def _set_max_segment_length_per_cta(
+    arg: int,
+) -> None: ...  # THPModule_setMaxSegmentLengthPerCta
 def _get_nnpack_enabled() -> _bool: ...  # THPModule_userEnabledNNPACK
 def _set_nnpack_enabled(arg: _bool) -> None: ...  # THPModule_setUserEnabledNNPACK
 def _get_warnAlways() -> _bool: ...  # THPModule_warnAlways

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1189,6 +1189,26 @@ static PyObject* THPModule_deterministicAlgorithmsWarnOnly(
   Py_RETURN_FALSE;
 }
 
+static PyObject* THPModule_maxSegmentLengthPerCta(
+    PyObject* _unused,
+    PyObject* noargs) {
+  return THPUtils_packInt32(at::globalContext().maxSegmentLengthPerCta());
+}
+
+static PyObject* THPModule_setMaxSegmentLengthPerCta(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkLong(arg),
+      "_set_max_segment_length_per_cta expects an int, "
+      "but got ",
+      THPUtils_typename(arg));
+  at::globalContext().setMaxSegmentLengthPerCta(THPUtils_unpackInt(arg));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPModule_setDeterministicFillUninitializedMemory(
     PyObject* _unused,
     PyObject* arg) {
@@ -1895,6 +1915,14 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
      nullptr},
     {"_set_deterministic_fill_uninitialized_memory",
      THPModule_setDeterministicFillUninitializedMemory,
+     METH_O,
+     nullptr},
+    {"_get_max_segment_length_per_cta",
+     THPModule_maxSegmentLengthPerCta,
+     METH_NOARGS,
+     nullptr},
+    {"_set_max_segment_length_per_cta",
+     THPModule_setMaxSegmentLengthPerCta,
      METH_O,
      nullptr},
     {"_get_nnpack_enabled", THPModule_userEnabledNNPACK, METH_NOARGS, nullptr},


### PR DESCRIPTION
Summary:
Tune max segment length per cta in triton table batched embeddings, and expose the param via cli.
Improves performance by ~2% on B200

We were using hardcoded 1024, tuned for H100.
This change sets the default for B200 to 4096 (after testing smaller and larger values).

It also exposes this flag via command line, if used together with --no-deterministic, you can add --max-cta-segment-length 4096 to change this via cmdline (for whatever cuda device you're building for).

Tested at 512/1024/2048/4096/8192 values, 4096 outperforms at the two tested batch sizes of 256 and 512

```
Embedding Dim: 256
┌─────────────────────┬───────────────────┬──────────────┐
│ CTA Segment Length  │ Backward Time (μs)│ vs 1024      │
├─────────────────────┼───────────────────┼──────────────┤
│ 512                 │ 24,651            │ -4.1% slower │
│ 1024 (default)      │ 23,680            │ baseline     │
│ 4096                │ 23,118            │ +2.4% faster │
│ 8192                │ 28,698            │ -21.2% slower│
└─────────────────────┴───────────────────┴──────────────┘

Embedding Dim: 512
┌─────────────────────┬───────────────────┬──────────────┐
│ CTA Segment Length  │ Backward Time (μs)│ vs 1024      │
├─────────────────────┼───────────────────┼──────────────┤
│ 1024 (default)      │ 42,067            │ baseline     │
│ 2048                │ 41,471            │ +1.4% faster │
│ 4096                │ 41,235            │ +2.0% faster │
│ 8192                │ 41,414            │ +1.6% faster │
└─────────────────────┴───────────────────┴──────────────┘

Test Plan: buck run -m ovr_config//triton:beta -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 -c python.package_style=inplace fbcode//deeplearning/fbgemm/fbgemm_gpu/fb/triton:triton_table_batched_embeddings_bench -- device --alpha=1.15 --batch-size=131072 --embedding-dim=512 --weights-precision=fp32 --iters=5 --no-deterministic --max-cta-segment-length 4096

Reviewed By: stashuk-olek

Differential Revision: D88338051


