### PR TITLE
Link fbgemm_genai and glog

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -304,6 +304,10 @@ IF(USE_FBGEMM_GENAI)
       ${FBGEMM_GENAI_SRCS}/include/          # includes fbgemm_gpu/torch_ops.h
     )
 
+    if(USE_GLOG AND TARGET glog::glog)
+      target_link_libraries(fbgemm_genai PRIVATE glog::glog)
+    endif()
+
     # Add FBGEMM_GENAI include directories for torch_ops.h
     list(APPEND ATen_CUDA_INCLUDE ${PROJECT_SOURCE_DIR}/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/include)
     list(APPEND ATen_CUDA_INCLUDE ${PROJECT_SOURCE_DIR}/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/common/include)


### PR DESCRIPTION
Seeing linker errors: P2075551292

```
      In file included from
      $SRC_DIR/c10/util/Logging.h:27,
                       from
      $SRC_DIR/aten/src/ATen/core/ivalue_inl.h:27,
                       from
      $SRC_DIR/aten/src/ATen/core/ivalue.h:1637,
                       from
      $SRC_DIR/aten/src/ATen/core/List_inl.h:4,
                       from
      $SRC_DIR/aten/src/ATen/core/List.h:491,
                       from
      $SRC_DIR/aten/src/ATen/core/IListRef_inl.h:3,
                       from
      $SRC_DIR/aten/src/ATen/core/IListRef.h:633,
                       from
      $SRC_DIR/aten/src/ATen/DeviceGuard.h:3,
                       from
      $SRC_DIR/aten/src/ATen/ATen.h:9,
                       from
      $SRC_DIR/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16/f4f4bf16_common.cuh:9,
                       from
      $SRC_DIR/third_party/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16/f4f4bf16_128_128_1_2_1_t.cu:9:
      $SRC_DIR/c10/util/logging_is_google_glog.h:51:10:
      fatal error: glog/logging.h: No such file or directory
         51 | #include <glog/logging.h>
            |          ^~~~~~~~~~~~~~~~
      compilation terminated.
```