### PR TITLE
[inductor][overlap] Config to log final collectives runtime estimations to compare with profile

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -2785,6 +2785,7 @@ class TestSyncDecisionCrossRanks(MultiProcessTestCase):
                 insert_overlap_deps=True,
                 max_memory_increase_ratio=0.0,
                 collective_estimator="benchmark",
+                log_final_collectives_estimations=True,
             )
 
         torch._inductor.config.post_grad_custom_post_pass = _pass

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -982,6 +982,7 @@ class aten_distributed_optimizations:
 
     # Maximum prefetch or bucketing candidates. Mainly intended for compile time.
     max_coll_distance: Optional[int] = None
+    log_final_collectives_estimations: bool = False
 
 
 def parallel_compile_enabled_internally() -> bool:

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 import torch.fx as fx
+from torch._inductor.fx_passes.bucketing import _schedulable_wait_node
 from torch._inductor.utils import clear_on_fresh_cache, tabulate_2d
 from torch._logging import getArtifactLogger, trace_structured
 from torch.fx.operator_schemas import normalize_function
@@ -256,11 +257,77 @@ def _log_compute_estimations(
     )
 
 
+def _log_graph_collective_benchmarks(gm: fx.GraphModule, artifact_name: str) -> None:
+    from torch._inductor import fx_utils
+
+    collective_nodes = []
+    collective_keys = []
+    benchmarked = []
+
+    for node in gm.graph.nodes:
+        if _schedulable_wait_node(node):
+            start = node.args[0]
+            collective_nodes.append(start)
+            opt_args_kwargs = normalize_function(
+                start.target,  # type: ignore[arg-type]
+                args=start.args,
+                kwargs=start.kwargs,
+                normalize_to_only_use_kwargs=True,
+            )
+            assert opt_args_kwargs is not None
+            _, kwargs = opt_args_kwargs
+            group_name = kwargs.get("group_name", None)
+            group_size = kwargs.get("group_size", None)
+
+            # Extract first tensor input size in bytes
+            tensor_bytes: Optional[int] = None
+            success, args, kw = fx_utils.get_fake_args_kwargs(start)
+            if success:
+
+                def extract_first_tensor_bytes(t: torch.Tensor) -> torch.Tensor:
+                    nonlocal tensor_bytes
+                    if tensor_bytes is None:
+                        shape = [get_hint(dim) for dim in t.shape]
+                        if all(s is not None for s in shape):
+                            total_elems = 1
+                            for dim in shape:
+                                total_elems *= (
+                                    dim  # pyrefly: ignore[unsupported-operation]
+                                )
+                            tensor_bytes = total_elems * t.dtype.itemsize
+                    return t
+
+                torch.utils._pytree.tree_map_only(
+                    torch.Tensor, extract_first_tensor_bytes, (args, kw)
+                )
+
+            collective_keys.append(
+                f"{start.target} group_size:{group_size} group_name:{group_name} input_bytes:{tensor_bytes}"
+            )
+            benchmarked_ms, _ = benchmark_collective_with_cuda_events(start, nruns=5)
+            benchmarked.append(benchmarked_ms if benchmarked_ms else 0.0)
+
+    if collective_nodes:
+        world_size = (
+            torch.distributed.get_world_size()
+            if torch.distributed.is_initialized()
+            else 1
+        )
+        _log_collective_benchmarks(
+            collective_nodes,
+            collective_keys,
+            benchmarked,
+            world_size,
+            artifact_name,
+        )
+
+
 def _log_collective_benchmarks(
     collective_nodes: list[fx.Node],
     collective_keys: list[str],
     benchmarked_medians: list[float],
     world_size: int,
+    artifact_name: str,
 ) -> None:
     """Log collective benchmarks with analytical comparisons for tlparse."""
     headers = [
@@ -268,8 +335,8 @@ def _log_collective_benchmarks(
         "Benchmarked(ms)",
         "NCCL Est(ms)",
         "Inductor Est(ms)",
-        "NCCL Diff(%)",
-        "Inductor Diff(%)",
+        "NCCL Diff(ratio)",
+        "Inductor Diff(ratio)",
     ]
 
     rows = []
@@ -303,7 +370,7 @@ def _log_collective_benchmarks(
 
         rows.append(
             [
-                key[:80],
+                key[:100],
                 f"{benchmarked_ms:.4f}",
                 f"{nccl_ms:.4f}",
                 f"{inductor_ms:.4f}",
@@ -318,7 +385,7 @@ def _log_collective_benchmarks(
     trace_structured(
         "artifact",
         metadata_fn=lambda: {
-            "name": "fx_collectives_node_runtime_estimation",
+            "name": artifact_name,
             "encoding": "string",
         },
         payload_fn=lambda: log_str,

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -289,6 +289,7 @@ class OverlapScheduler:
         collective_estimator: Literal["analytical", "benchmark"],
         max_memory_increase_gb: float | None = 1.0,
         max_memory_increase_ratio: float | None = 0.05,
+        log_final_collectives_estimations: bool = False,
     ):
         self.gm = gm
         self.graph = gm.graph
@@ -300,6 +301,7 @@ class OverlapScheduler:
         self.insert_overlap_deps = insert_overlap_deps
         self.max_compute_pre_fetch = max_compute_pre_fetch
         self.collective_estimator = collective_estimator
+        self.log_final_collectives_estimations = log_final_collectives_estimations
 
         # Build structures
         stable_topological_sort(self.graph)
@@ -644,6 +646,7 @@ class OverlapScheduler:
                 collective_keys,
                 collective_medians,
                 world_size,
+                "fx_collectives_node_runtime_estimation",
             )
 
         log.info("Overlap scheduling: Runtime estimations aligned")
@@ -682,6 +685,15 @@ class OverlapScheduler:
         elif self.insert_overlap_deps:
             # If not bucketing, add effect tokens to preserve hiding dependencies
             self._add_effect_tokens_for_overlap()
+
+        if self.log_final_collectives_estimations:
+            from torch._inductor.fx_passes.node_runtime_estimation import (
+                _log_graph_collective_benchmarks,
+            )
+
+            _log_graph_collective_benchmarks(
+                self.gm, "fx_collectives_estimations_after_overlap_bucketing"
+            )
 
         return self.gm
 
@@ -1253,6 +1265,7 @@ def schedule_overlap_bucketing(
     collective_estimator: Literal["analytical", "benchmark"] = "analytical",
     max_memory_increase_gb: float | None = 1.0,
     max_memory_increase_ratio: float | None = 0.05,
+    log_final_collectives_estimations: bool = False,
 ) -> torch.fx.GraphModule:
     """Schedule nodes to maximize compute-collective overlap.
 
@@ -1288,6 +1301,7 @@ def schedule_overlap_bucketing(
         collective_estimator=collective_estimator,
         max_memory_increase_gb=max_memory_increase_gb,
         max_memory_increase_ratio=max_memory_increase_ratio,
+        log_final_collectives_estimations=log_final_collectives_estimations,
     ).run()
 
 
@@ -1316,6 +1330,7 @@ def schedule_overlap_bucketing_from_inductor_configs(
         "compute_overlap_multipler",
         "max_in_flight_gb",
         "max_coll_distance",
+        "log_final_collectives_estimations",
     )
     for key in config_keys:
         if (val := getattr(dist_opts, key, None)) is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170120

We already have logging before overlap/bucketing.
But this we can not compare with profile that will have collectives after overlap and bucketing.

Adding this ability to verify logged collectives in the order how we they see them in profile.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo