### PR TITLE
[dynamo][DebugMode] make ModTracker a no-op in compiled regions

### DIFF
--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -529,6 +529,11 @@ class TestDTensorDebugMode(TestCase):
             "self.l2(self.l1(x))" in debug_mode.debug_string(show_stack_trace=True)
         )
 
+        # check that nn_module doesn't graph break in compiled regions
+        fn = torch.compile(mod, backend="eager", fullgraph=True)
+        with DebugMode(record_nn_module=True) as debug_mode:
+            fn(inp)
+
     def test_record_function(self):
         def fn(x, y):
             z = x @ y

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -145,7 +145,7 @@ cached_backends: dict[int, CompilerFn] = {}
 
 unset = Unset.token
 
-_in_compiled_region = False
+_in_optimized_module = False
 
 
 if DISABLE_JUSTKNOBS:
@@ -206,21 +206,24 @@ def get_example_inputs(key: str) -> list[Any]:
 
 
 @contextlib.contextmanager
-def _set_in_compiled_region():
-    global _in_compiled_region
-    _old_in_compiled_region = (
-        _in_compiled_region  # do we need this? can we just set it to False after
+def _set_in_optimized_module():
+    # Set in dynamo's OptimizedModule forward, to have better coverage than is_compiling().
+    # Prevents graph-breaking forward hooks from being registered & traced.
+    # TODO(pianpwk): subsume this flag with better is_compiling() coverage
+    global _in_optimized_module
+    _old_in_optimized_module = (
+        _in_optimized_module  # do we need this? can we just set it to False after
     )
-    _in_compiled_region = True
+    _in_optimized_module = True
     try:
         yield
     finally:
-        _in_compiled_region = _old_in_compiled_region
+        _in_optimized_module = _old_in_optimized_module
 
 
-def _is_in_compiled_region() -> bool:
-    global _in_compiled_region
-    return _in_compiled_region
+def _is_in_optimized_module() -> bool:
+    global _in_optimized_module
+    return _in_optimized_module
 
 
 def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
@@ -458,8 +461,7 @@ class OptimizedModule(torch.nn.Module):
                 ", or use the per-module hooks instead",
                 stacklevel=2,
             )
-        with _set_in_compiled_region():
-            # TODO(pianpwk): subsume this flag with better is_compiling() coverage
+        with _set_in_optimized_module():
             return super().__call__(*args, **kwargs)
 
     def _aot_compile(self, inputs: list[torch._dynamo.aot_compile.ModelInput]) -> None:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -459,6 +459,7 @@ class OptimizedModule(torch.nn.Module):
                 stacklevel=2,
             )
         with _set_in_compiled_region():
+            # TODO(pianpwk): subsume this flag with better is_compiling() coverage
             return super().__call__(*args, **kwargs)
 
     def _aot_compile(self, inputs: list[torch._dynamo.aot_compile.ModelInput]) -> None:

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -180,6 +180,7 @@ manual_torch_name_rule_map: dict[
     "torch.compiler.is_compiling": TorchInGraphFunctionVariable,
     "torch.compiler.is_dynamo_compiling": TorchInGraphFunctionVariable,
     "torch.compiler.is_exporting": TorchInGraphFunctionVariable,
+    "torch._dynamo.eval_frame._is_in_compiled_region": TorchInGraphFunctionVariable,
     "torch._C._to_dlpack": SkipFunctionVariable,
     "torch.to_dlpack": SkipFunctionVariable,
     "torch._check": TorchInGraphFunctionVariable,

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -180,7 +180,7 @@ manual_torch_name_rule_map: dict[
     "torch.compiler.is_compiling": TorchInGraphFunctionVariable,
     "torch.compiler.is_dynamo_compiling": TorchInGraphFunctionVariable,
     "torch.compiler.is_exporting": TorchInGraphFunctionVariable,
-    "torch._dynamo.eval_frame._is_in_compiled_region": TorchInGraphFunctionVariable,
+    "torch._dynamo.eval_frame._is_in_optimized_module": TorchInGraphFunctionVariable,
     "torch._C._to_dlpack": SkipFunctionVariable,
     "torch.to_dlpack": SkipFunctionVariable,
     "torch._check": TorchInGraphFunctionVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -209,6 +209,7 @@ def tracing_state_functions() -> dict[Callable[[], Any], Optional[bool]]:
         torch.compiler.is_compiling: True,
         torch.compiler.is_dynamo_compiling: True,
         torch.compiler.is_exporting: True,
+        torch._dynamo.eval_frame._is_in_compiled_region: True,
         # Look into https://github.com/pytorch/pytorch/pull/164721 why this is
         # turned to True for Dynamo.
         torch.nn.modules.activation._is_make_fx_tracing: True,
@@ -547,6 +548,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 torch.compiler.is_compiling,
                 torch.compiler.is_dynamo_compiling,
                 torch.compiler.is_exporting,
+                torch._dynamo.eval_frame._is_in_compiled_region,
             ):
                 tx.mark_inconsistent_side_effects()
             return ConstantVariable.create(tracing_state_functions()[self.value])

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -209,7 +209,7 @@ def tracing_state_functions() -> dict[Callable[[], Any], Optional[bool]]:
         torch.compiler.is_compiling: True,
         torch.compiler.is_dynamo_compiling: True,
         torch.compiler.is_exporting: True,
-        torch._dynamo.eval_frame._is_in_compiled_region: True,
+        torch._dynamo.eval_frame._is_in_optimized_module: True,
         # Look into https://github.com/pytorch/pytorch/pull/164721 why this is
         # turned to True for Dynamo.
         torch.nn.modules.activation._is_make_fx_tracing: True,
@@ -548,7 +548,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 torch.compiler.is_compiling,
                 torch.compiler.is_dynamo_compiling,
                 torch.compiler.is_exporting,
-                torch._dynamo.eval_frame._is_in_compiled_region,
+                torch._dynamo.eval_frame._is_in_optimized_module,
             ):
                 tx.mark_inconsistent_side_effects()
             return ConstantVariable.create(tracing_state_functions()[self.value])

--- a/torch/distributed/_tools/mod_tracker.py
+++ b/torch/distributed/_tools/mod_tracker.py
@@ -214,6 +214,9 @@ class ModTracker:
         return fn
 
     def _fw_pre_hook(self, mod, input):
+        if torch._dynamo.eval_frame._is_in_compiled_region():
+            return
+
         name = self._get_mod_name(mod)
         w_mod = weakref.ref(mod)
         self._get_append_fn(w_mod, name, False)()
@@ -230,6 +233,9 @@ class ModTracker:
                 )
 
     def _fw_post_hook(self, mod, input, output):
+        if torch._dynamo.eval_frame._is_in_compiled_region():
+            return
+
         name = self._get_mod_name(mod)
         w_mod = weakref.ref(mod)
         if self._user_post_fw_hook is not None:

--- a/torch/distributed/_tools/mod_tracker.py
+++ b/torch/distributed/_tools/mod_tracker.py
@@ -214,7 +214,7 @@ class ModTracker:
         return fn
 
     def _fw_pre_hook(self, mod, input):
-        if torch._dynamo.eval_frame._is_in_compiled_region():
+        if torch._dynamo.eval_frame._is_in_optimized_module():
             return
 
         name = self._get_mod_name(mod)
@@ -233,7 +233,7 @@ class ModTracker:
                 )
 
     def _fw_post_hook(self, mod, input, output):
-        if torch._dynamo.eval_frame._is_in_compiled_region():
+        if torch._dynamo.eval_frame._is_in_optimized_module():
             return
 
         name = self._get_mod_name(mod)


### PR DESCRIPTION
ModTracker causes a graph break in compiled regions: https://github.com/pytorch/pytorch/issues/169995, so this makes it a no-op by introducing the `torch._dynamo.eval_frame._is_in_compiled_region()` check.

The next PR in the stack makes nn.Module tracking work for DebugMode by introducing an interpreter.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170126
* #170125
* __->__ #170124



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo