### PR TITLE
Add python stack and fix js formatting

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4172,6 +4172,48 @@ class TestCudaMallocAsync(TestCase):
         finally:
             torch.cuda.memory._record_memory_history(None)
 
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
+    )
+    def test_memory_snapshot_forward_trace(self):
+        """Test that forward traces from anomaly mode are captured in memory snapshots."""
+        try:
+            torch.cuda.memory.empty_cache()
+            torch.cuda.memory._record_memory_history("all", stacks="python")
+
+            # Create a simple model with a backward pass
+            # Use detect_anomaly(check_nan=False) to capture forward traces
+            x = torch.randn(10, 10, device="cuda", requires_grad=True)
+
+            with torch.autograd.detect_anomaly(check_nan=False):
+                y = x * 2  # Forward pass - creates autograd node
+                z = y.sum()
+                z.backward()  # Backward pass - allocations here should have forward traces
+
+            ss = torch.cuda.memory._snapshot()
+
+            # Check that we have device traces with forward_frames
+            found_forward_frames = False
+            if "device_traces" in ss:
+                for device_trace in ss["device_traces"]:
+                    for entry in device_trace:
+                        if isinstance(entry, dict) and "forward_frames" in entry:
+                            # forward_frames should be a list of strings
+                            self.assertIsInstance(entry["forward_frames"], list)
+                            if len(entry["forward_frames"]) > 0:
+                                found_forward_frames = True
+                                # The forward frames should be strings
+                                self.assertIsInstance(entry["forward_frames"][0], str)
+
+            # forward_frames must be present when using detect_anomaly
+            self.assertTrue(
+                found_forward_frames,
+                "forward_frames should be present in memory snapshot when using detect_anomaly",
+            )
+
+        finally:
+            torch.cuda.memory._record_memory_history(None)
+
     @skipIfRocm(msg="ROCTracer does not capture Python stack frames in profiler output")
     def test_memory_profiler_viz(self):
         with torch.profiler.profile(

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -772,6 +772,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str blocks_s = "blocks";
   py::str is_expandable_s = "is_expandable";
   py::str frames_s = "frames";
+  py::str forward_frames_s = "forward_frames";
   py::str time_us_s = "time_us";
   py::str compile_context_s = "compile_context";
   py::str user_metadata_s = "user_metadata";
@@ -956,6 +957,17 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   auto frames = py_symbolize(to_gather_frames);
   for (auto i : c10::irange(frames.size())) {
     to_gather_dest.at(i)[frames_s] = frames.at(i);
+
+    // Add forward frames if available
+    auto* tb = to_gather_frames.at(i);
+    const auto& forward_tb = tb->forward_traceback();
+    if (forward_tb.has_value() && !forward_tb->empty()) {
+      py::list forward_list;
+      for (const auto& frame_str : *forward_tb) {
+        forward_list.append(py::str(frame_str));
+      }
+      to_gather_dest.at(i)[forward_frames_s] = forward_list;
+    }
   }
 
   return result.release().ptr();

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -309,6 +309,7 @@ std::string _memory_snapshot_pickled() {
   IValue name_s = "name";
   IValue line_s = "line";
   IValue frames_s = "frames";
+  IValue forward_frames_s = "forward_frames";
   IValue blocks_s = "blocks";
   IValue is_expandable_s = "is_expandable";
   IValue time_us_s = "time_us";
@@ -506,6 +507,17 @@ std::string _memory_snapshot_pickled() {
   auto frames = ivalue_symbolize(frame_tracebacks);
   for (auto i : c10::irange(frames.size())) {
     frame_dict.at(i).insert(frames_s, frames.at(i));
+
+    // Add forward frames if available
+    auto* tb = frame_tracebacks.at(i);
+    const auto& forward_tb = tb->forward_traceback();
+    if (forward_tb.has_value() && !forward_tb->empty()) {
+      auto forward_list = new_list();
+      for (const auto& frame_str : *forward_tb) {
+        forward_list.push_back(IValue(frame_str));
+      }
+      frame_dict.at(i).insert(forward_frames_s, forward_list);
+    }
   }
 
   return write_pickle(result);

--- a/torch/csrc/profiler/combined_traceback.cpp
+++ b/torch/csrc/profiler/combined_traceback.cpp
@@ -20,6 +20,13 @@ std::shared_ptr<CapturedTraceback> CapturedTraceback::gather(
       }
       p = p->next_;
     }
+    // Try to gather forward traceback from current autograd node
+    if (r->python_) {
+      auto forward_tb = r->python_->gatherForwardTraceback();
+      if (!forward_tb.empty()) {
+        r->forward_traceback_ = std::move(forward_tb);
+      }
+    }
   }
   if (script) {
     r->script_frames_ = torch::jit::currentCallstack();

--- a/torch/csrc/profiler/combined_traceback.h
+++ b/torch/csrc/profiler/combined_traceback.h
@@ -3,6 +3,10 @@
 #include <torch/csrc/jit/runtime/interpreter.h>
 #include <torch/csrc/profiler/unwind/unwind.h>
 
+#include <optional>
+#include <string>
+#include <vector>
+
 namespace torch {
 
 // struct that holds the result of symbolizing multiple tracebacks
@@ -50,6 +54,12 @@ struct TORCH_API CapturedTraceback : public c10::GatheredContext {
         visitproc visit,
         void* arg) = 0;
     virtual int clear(std::vector<PyFrame>& frames) = 0;
+    // Gather forward traceback from the current autograd node's anomaly
+    // metadata. Returns a vector of strings representing the forward stack
+    // trace, or empty if not available.
+    virtual std::vector<std::string> gatherForwardTraceback() {
+      return {};
+    }
     virtual ~Python() = default;
     Python* next_ = nullptr;
   };
@@ -71,6 +81,23 @@ struct TORCH_API CapturedTraceback : public c10::GatheredContext {
   // non-owning reference to one of the immortal Python* objects
   // registered above.
   Python* python_ = nullptr;
+
+  // Optional forward traceback from anomaly mode.
+  // This is a list of Python strings representing the forward stack trace
+  // when the autograd Node was created. Used to correlate backward allocations
+  // with forward operations.
+  std::optional<std::vector<std::string>> forward_traceback_;
+
+ public:
+  // Set the forward traceback from anomaly mode metadata
+  void set_forward_traceback(std::vector<std::string> traceback) {
+    forward_traceback_ = std::move(traceback);
+  }
+
+  // Get the forward traceback if available
+  const std::optional<std::vector<std::string>>& forward_traceback() const {
+    return forward_traceback_;
+  }
 };
 
 TORCH_API SymbolizedTracebacks

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -1,3 +1,5 @@
+#include <torch/csrc/autograd/function.h>
+#include <torch/csrc/autograd/python_anomaly_mode.h>
 #include <torch/csrc/profiler/python/combined_traceback.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
@@ -124,6 +126,73 @@ struct PythonTraceback : public CapturedTraceback::Python {
         }
       }
     }
+  }
+
+  // Extract forward traceback from the current autograd node's anomaly
+  // metadata. Returns a vector of strings representing the forward stack trace,
+  // or empty if not available.
+  std::vector<std::string> gatherForwardTraceback() override {
+    std::vector<std::string> result;
+
+    // Get the currently executing backward node
+    auto node = torch::autograd::get_current_node();
+    if (!node) {
+      return result;
+    }
+
+    // Get metadata from the node.
+    // Note: metadata() may create new metadata if it doesn't exist, but we need
+    // to check the dict for ANOMALY_TRACE_KEY anyway to know if forward tracing
+    // was actually enabled during forward pass.
+    auto* base_metadata = node->metadata();
+    if (!base_metadata) {
+      return result;
+    }
+
+    // Check if the metadata is a Python anomaly metadata (which contains the
+    // dict)
+    auto* metadata =
+        dynamic_cast<torch::autograd::PyAnomalyMetadata*>(base_metadata);
+    if (!metadata) {
+      return result;
+    }
+
+    // Get the traceback from the metadata dict
+    py::gil_scoped_acquire gil;
+    PyObject* dict = metadata->dict();
+    if (!dict || !PyDict_Check(dict)) {
+      return result;
+    }
+
+    PyObject* traceback = nullptr;
+    if (PyDict_GetItemStringRef(
+            dict,
+            torch::autograd::PyAnomalyMetadata::ANOMALY_TRACE_KEY,
+            &traceback) < 0) {
+      PyErr_Clear();
+      return result;
+    }
+
+    if (!traceback || !PyList_Check(traceback)) {
+      Py_XDECREF(traceback);
+      return result;
+    }
+
+    // Convert Python list of strings to vector of strings
+    Py_ssize_t size = PyList_Size(traceback);
+    result.reserve(size);
+    for (Py_ssize_t i = 0; i < size; ++i) {
+      PyObject* item = PyList_GetItem(traceback, i); // borrowed reference
+      if (item && PyUnicode_Check(item)) {
+        const char* str = PyUnicode_AsUTF8(item);
+        if (str) {
+          result.emplace_back(str);
+        }
+      }
+    }
+
+    Py_DECREF(traceback);
+    return result;
   }
 };
 


### PR DESCRIPTION
This PR contains a couple changes:
- Make the python trace gatherer also gather forward trace when they're available.
- Fix the formatting of the web page to ensure we show all the way to the bottom (which it doesn't today). I realized this was happening because part of the stack was missing.

This is what the rendered version looks like:
<img width="3452" height="612" alt="image" src="https://github.com/user-attachments/assets/6994d364-a9c1-4106-99ea-f3d80398556c" />

We could make these more consistent looking by using the same capture tool in anomaly mode, but migrating anomaly_mode is significantly more involved so left as a follow up.