### PR TITLE
Fix silent incorrectness of mm_plus_mm numerics test

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1361,6 +1361,9 @@ class TestMaxAutotune(TestCase):
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",
     )
+    @config.patch(
+        max_autotune_gemm_backends="TRITON"
+    )
     def test_non_contiguous_input_mm_plus_mm(self):
         x1 = rand_strided((50257, 2048), (1, 50304), device=GPU_TYPE)
         y1 = rand_strided((2048, 768), (768, 1), device=GPU_TYPE)

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1361,9 +1361,7 @@ class TestMaxAutotune(TestCase):
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",
     )
-    @config.patch(
-        max_autotune_gemm_backends="TRITON"
-    )
+    @config.patch(max_autotune_gemm_backends="TRITON")
     def test_non_contiguous_input_mm_plus_mm(self):
         x1 = rand_strided((50257, 2048), (1, 50304), device=GPU_TYPE)
         y1 = rand_strided((2048, 768), (768, 1), device=GPU_TYPE)

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1744,6 +1744,19 @@ class MMPlusMMTemplateConfigMixin(MMTemplateConfigMixin):
             if V.graph.sizevars.statically_known_lt(kwargs.get("BLOCK_K", k), k):
                 yield kwargs
 
+    def get_extra_kwargs(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> dict[str, Any]:
+        assert isinstance(kernel_inputs, MMKernelInputs)
+        m, n, k = kernel_inputs.mnk_symbolic()
+        # We do not want to allow tf32 for MM+MM, can cause
+        # accuracy issues
+        return {
+            "ALLOW_TF32": False,
+        }
+
 
 class TMAWorkspaceMixin(MMTemplateConfigMixin):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170133

`test_non_contiguous_input_mm_plus_mm` used max-autotune, but regularly chose aten, so the numerical difference between Triton and aten was uncaptured. With the case of triton winning, there is a large numerical difference, isolated to TF32. This disallows mm_plus_mm to use TF32 for numerical reasons


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo