### PR TITLE
[Inductor][Triton] Disable mm_template for main loop scaling templates

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -824,7 +824,7 @@ class TestFP8Lowering(TestCase):
     @xfailIf(
         torch.cuda.is_available() and torch.cuda.get_device_capability() != (9, 0)
     )  # cuBLAS 128-element blockwise scaling is only supported for CC 9.0
-    @parametrize("shape", ((16, 256, 256), (1024, 512, 1024)))
+    @parametrize("shape", ((16, 256, 256), (1024, 512, 1024), (32768, 4096, 4096)))
     @parametrize("use_fast_accum", (False, True))
     @parametrize(
         "scaling_block_sizes", ((1, 128, 128, 128), (1, 128, 1, 128))

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -50,6 +50,7 @@ from ..utils import (
     use_cutlass_template,
     use_decompose_k_choice,
     use_triton_blackwell_tma_template,
+    use_triton_scaling_template,
     use_triton_template,
     use_triton_tma_template,
 )
@@ -921,28 +922,27 @@ def tuned_scaled_mm(
     ):
         overriders = dict(USE_FAST_ACCUM=use_fast_accum)
 
+        scale_a_size, scale_b_size = scale_a_real.shape, scale_b_real.shape
+
+        scale_option_a, scale_option_b = get_scaling_options(
+            mat_a, mat_b, scale_a_size, scale_b_size
+        )
+
         # TODO (paulzhan): There is no template that exists for bias and TMA
         # Don't run tma template currently if bias exist
         if use_triton_tma_template(mat_a, mat_b, output_layout=layout) and not bias:
-            scale_a_size, scale_b_size = scale_a_real.shape, scale_b_real.shape
-
-            scale_option_a, scale_option_b = get_scaling_options(
-                mat_a, mat_b, scale_a_size, scale_b_size
-            )
             overriders["SCALE_RECIPE_A"] = scale_option_a.value
             overriders["SCALE_RECIPE_B"] = scale_option_b.value
 
-            if (
-                scale_option_a in epilogue_scaling_types
-                and scale_option_b in epilogue_scaling_types
+            if use_triton_scaling_template(
+                scale_option_a, scale_option_b, epilogue_scaling_types
             ):
                 templates_to_use.append(scaled_mm_device_tma_epilogue_scaling_template)
                 kwarg_overrides[scaled_mm_device_tma_epilogue_scaling_template.uid] = (
                     overriders
                 )
-            elif (
-                scale_option_a in main_loop_scaling_types
-                and scale_option_b in main_loop_scaling_types
+            elif use_triton_scaling_template(
+                scale_option_a, scale_option_b, main_loop_scaling_types
             ):
                 overriders["TILE_SIZE_A"] = get_tile_size(scale_option_a)
                 overriders["TILE_SIZE_B"] = get_tile_size(scale_option_b)
@@ -966,8 +966,11 @@ def tuned_scaled_mm(
                 overriders
             )
 
-        templates_to_use.append(mm_template)
-        kwarg_overrides[mm_template.uid] = overriders
+        if use_triton_scaling_template(
+            scale_option_a, scale_option_b, epilogue_scaling_types
+        ):
+            templates_to_use.append(mm_template)
+            kwarg_overrides[mm_template.uid] = overriders
 
     # Single unified call for all templates
     choices.extend(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -64,9 +64,6 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_flatten, tree_map_only
 
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 OPTIMUS_EXCLUDE_POST_GRAD = [
     "activation_quantization_aten_pass",
     "inductor_autotune_lookup_table",
@@ -82,11 +79,13 @@ from torch.fx.experimental.symbolic_shapes import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence, ValuesView
+    from pathlib import Path
 
     from torch import SymBool, SymFloat, SymInt
     from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
     from torch.fx import GraphModule
     from torch.fx.node import Node
+    from torch.nn.functional import ScalingType  # type: ignore[attr-defined]
 
     from .codegen.common import WorkspaceArg
     from .codegen.wrapper import PythonWrapperCodegen
@@ -1953,6 +1952,14 @@ def use_triton_blackwell_tma_template(
 
     # Blackwell template require the tensor descriptor API, not the experimental API.
     return has_triton_tensor_descriptor_host_tma() and is_datacenter_blackwell_arch()
+
+
+def use_triton_scaling_template(
+    scale_option_a: ScalingType,
+    scale_option_b: ScalingType,
+    scaling_types: list[ScalingType],
+) -> bool:
+    return scale_option_a in scaling_types and scale_option_b in scaling_types
 
 
 @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
Summary:
Disable `mm_template` as a template option for `scaled_mm`. `mm_template` leverages epilogue scaling for `scaled_mm`; however, block-wise scaling, which uses the main loop scaling template, must apply scaling to each input tensor before accumulation, rather than as an epilogue after accumulation.

NOTE: It is interesting that for small-enough shapes, `mm_template` seems to actually pass in Inductor without a CUDA error or IMA, and it is the winner over the main loop scaling template. The same generated kernel fails when attempting to repro locally. As a follow-up, it would be useful to investigate whether there is an implementation gap in `mm_template` or `main_loop_scaling_template`.

Test Plan:
```
CUDA_LAUNCH_BLOCKING=1 MAX_AUTOTUNE_PRUNE_CHOICES_BASED_ON_SHARED_MEM=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 TRITON_PRINT_AUTOTUNING=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCHINDUCTOR_CACHE_DIR=~/personal/cache_dir TORCH_LOGS=+inductor,"output_code" python3 run.py --op fp8_gemm --only torch_fp8_gemm,pt2_fp8_gemm --metrics accuracy,tflops,latency --m 32768 --n 8192 --k 8192 --output ~/personal/fp8_scaling_benchmarks/blockwise1x128_blockwise128x128.csv --scaling-pair BlockWise1x128,BlockWise128x128 --bypass-fail 2<&1 | tee ~/personal/fp8_scaling_benchmarks/blockwise1x128_blockwise128x128_2.log
```

Differential Revision: D88900710




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo