### PR TITLE
Fix _backward function to return correct number of gradients for varlen_attn

### DIFF
--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -298,7 +298,7 @@ def _varlen_attn_backward_fake(
 
 
 def _backward(
-    ctx: Any, grad_out: torch.Tensor, grad_lse: torch.Tensor, grad_rng: torch.Tensor
+    ctx: Any, grad_out: torch.Tensor
 ) -> tuple[torch.Tensor | None, ...]:
     query, key, value, cu_seq_q, cu_seq_k, out, lse, rng_state = ctx.saved_tensors
 
@@ -320,7 +320,7 @@ def _backward(
         is_causal,
         rng_state,
     )
-    return dq, dk, dv, None, None, None, None, None, None
+    return dq, dk, dv, None, None, None, None, None
 
 
 _varlen_attn.register_autograd(_backward, setup_context=_setup_context)


### PR DESCRIPTION
### Summary
This PR fixes the `_backward` function for the `varlen_attn` custom op. Previously, `_backward` returned 9 items while the forward function has 8 inputs, which could cause runtime errors in PyTorch autograd.

The fix ensures that `_backward` returns exactly 8 elements, matching the forward inputs:
- Returns gradients (`dq`, `dk`, `dv`) for `query`, `key`, and `value`
- Returns `None` for the other non-differentiable inputs: `cu_seq_q`, `cu_seq_k`, `max_q`, `max_k`, `is_causal`

### Motivation
- Prevents runtime errors due to mismatched return length in the backward pass
- Improves autograd compatibility and clarity
- Ensures only tensor inputs that require gradients receive them

### Changes
- Updated `_backward` to return `(dq, dk, dv, None, None, None, None, None)`
- Removed unused gradient arguments (`grad_lse`, `grad_rng`) from the function signature

### Testing
- Verified that `_backward` runs without errors with typical query/key/value inputs
- Confirms existing behavior when auxiliary outputs are not requested