### PR TITLE
[DTensor][BE] remove is_backward from redistribute_local_tensor

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -149,9 +149,7 @@ class RedistributeTest(DTensorTestBase):
             )
         self.assertEqual(partial_tensor.size(), partial_local.size())
         self.assertEqual(partial_tensor, reshard_partial_tensor)
-        self.assertEqual(
-            partial_tensor.to_local(), reshard_partial_tensor.to_local()
-        )
+        self.assertEqual(partial_tensor.to_local(), reshard_partial_tensor.to_local())
         # Verify no communication in forward
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
@@ -159,15 +157,13 @@ class RedistributeTest(DTensorTestBase):
         grad_output = DTensor.from_local(
             torch.ones(12, 3, device=self.device_type, dtype=dtype),
             device_mesh,
-            partial_spec  # ← Use Partial placement!
+            partial_spec,  # ← Use Partial placement!
         )
         with comm_mode:
             reshard_partial_tensor.backward(grad_output)
         grad_input = partial_tensor.grad
         self.assertEqual(grad_input.placements, partial_spec)
-        self.assertEqual(
-            grad_input.to_local(), torch.ones(12, 3, dtype=dtype)
-        )
+        self.assertEqual(grad_input.to_local(), torch.ones(12, 3, dtype=dtype))
         # Verify no communication in backward
         self.assertEqual(comm_mode.get_total_counts(), 0)
 

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -128,6 +128,51 @@ class RedistributeTest(DTensorTestBase):
 
     @with_comms
     @parametrize("dtype", [torch.float32, torch.cfloat])
+    def test_partial_to_partial_forward_backward(self, dtype):
+        device_mesh = self.build_device_mesh()
+        partial_spec = [Partial()]
+
+        # Create a partial tensor - each rank has the same local tensor
+        # When reduced, it would be multiplied by world_size
+        partial_local = torch.ones(
+            12, 3, device=self.device_type, requires_grad=True, dtype=dtype
+        )
+
+        comm_mode = CommDebugMode()
+
+        # 1) test partial -> partial forward: should be no-op
+        partial_tensor = distribute_tensor(partial_local, device_mesh, partial_spec)
+
+        with comm_mode:
+            reshard_partial_tensor = partial_tensor.redistribute(
+                device_mesh, partial_spec
+            )
+        self.assertEqual(partial_tensor.size(), partial_local.size())
+        self.assertEqual(partial_tensor, reshard_partial_tensor)
+        self.assertEqual(
+            partial_tensor.to_local(), reshard_partial_tensor.to_local()
+        )
+        # Verify no communication in forward
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+
+        # 2) test partial -> partial backward: should be no-op
+        grad_output = DTensor.from_local(
+            torch.ones(12, 3, device=self.device_type, dtype=dtype),
+            device_mesh,
+            partial_spec  # ← Use Partial placement!
+        )
+        with comm_mode:
+            reshard_partial_tensor.backward(grad_output)
+        grad_input = partial_tensor.grad
+        self.assertEqual(grad_input.placements, partial_spec)
+        self.assertEqual(
+            grad_input.to_local(), torch.ones(12, 3, dtype=dtype)
+        )
+        # Verify no communication in backward
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+
+    @with_comms
+    @parametrize("dtype", [torch.float32, torch.cfloat])
     def test_replicate_to_local_partial_grad(self, dtype):
         device_mesh = self.build_device_mesh()
         replica_spec = [Replicate()]

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -208,13 +208,6 @@ class _FromTorchTensor(torch.autograd.Function):
         # local gradients directly
         if grad_output.placements != previous_placement:
             current_spec = grad_output._spec
-            # skip the replicate to partial transformation when we are in backward pass
-            # In this case we keep the grad as replicate, this is because we don't
-            # want to convert the replicated gradients back to partial, although
-            # that's logically conform with the same layout, converting the gradients
-            # back to partial is actually useless as you would have to do reduce later
-            # which would be more expensive than keeping it replicate! For this reason,
-            # we keep the replicate grad here.
 
             # for backward shard -> partial, we just do shard -> replicate
             # for backward replicate -> partial, we skip the transformation

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -211,10 +211,12 @@ class _FromTorchTensor(torch.autograd.Function):
 
             # for backward shard -> partial, we do shard -> replicate
             # for backward replicate -> partial, we do replicate -> replicate / skip transformation
-            # TODO: for backward partial -> partial, right now we keep it unchanged, 
+            # TODO: for backward partial -> partial, right now we keep it unchanged,
             # but this might need revisit
             normalized_placements: list[Placement] = []
-            for current, target in zip(current_spec.placements, forward_input_placements):
+            for current, target in zip(
+                current_spec.placements, forward_input_placements
+            ):
                 if (
                     current.is_shard() or current.is_replicate()
                 ) and target.is_partial():

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -792,7 +792,6 @@ def redistribute_local_tensor(
     target_spec: DTensorSpec,
     *,
     async_op: bool = False,
-    is_backward: bool = False,
     use_graph_based_transform: bool | None = None,
 ) -> torch.Tensor:
     """
@@ -904,27 +903,12 @@ def redistribute_local_tensor(
             elif target.is_partial():
                 if current.is_replicate():
                     partial_spec = cast(Partial, target)
-                    # skip the replicate to partial transformation when we are in backward pass
-                    # In this case we keep the grad as replicate, this is because we don't
-                    # want to convert the replicated gradients back to partial, although
-                    # that's logically conform with the same layout, converting the gradients
-                    # back to partial is actually useless as you would have to do reduce later
-                    # which would be more expensive than keeping it replicate! For this reason,
-                    # we keep the replicate grad here.
-                    new_local_tensor = (
-                        partial_spec._partition_value(local_tensor, device_mesh, i)
-                        if not is_backward
-                        else local_tensor
+                    new_local_tensor = partial_spec._partition_value(
+                        local_tensor, device_mesh, i
                     )
                 elif current.is_shard():
-                    if not is_backward:
-                        raise RuntimeError(
-                            f"redistribute from {current} to {target} not supported yet"
-                        )
-                    # for backward shard -> partial, we just need to convert the shard to replicate
-                    current_placement = cast(Shard, current)
-                    new_local_tensor = current_placement._to_replicate_tensor(
-                        local_tensor, device_mesh, i, transform_info.logical_shape
+                    raise RuntimeError(
+                        f"redistribute from {current} to {target} not supported yet"
                     )
                 else:
                     # partial -> partial no op, should never hit
@@ -1019,25 +1003,30 @@ class Redistribute(torch.autograd.Function):
             local_tensor = grad_output._local_tensor
             current_spec = grad_output._spec
 
+        # for backward shard -> partial, we just do shard -> replicate
+        # for backward replicate -> partial, we skip the transformation
+        normalized_placements: list[Placement] = []
+        for current, target in zip(current_spec.placements, previous_spec.placements):
+            if (current.is_shard() or current.is_replicate()) and target.is_partial():
+                normalized_placements.append(Replicate())
+            else:
+                normalized_placements.append(target)
+
+        previous_spec = DTensorSpec(
+            previous_spec.device_mesh,
+            placements=tuple(normalized_placements),
+            tensor_meta=previous_spec.tensor_meta,
+        )
+
         output = redistribute_local_tensor(
             local_tensor,
             current_spec,
             previous_spec,
             async_op=async_op,
-            is_backward=True,
         )
 
         if output.dtype != ctx.original_dtype:
             output = output.to(ctx.original_dtype)
-
-        # normalize the target placement to replicate if it is partial
-        normalized_placements: list[Placement] = []
-        for previous_placement in previous_spec.placements:
-            if previous_placement.is_partial():
-                # keep target placement to replicate instead of partial in this case
-                normalized_placements.append(Replicate())
-            else:
-                normalized_placements.append(previous_placement)
 
         spec = DTensorSpec(
             previous_spec.device_mesh,

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1002,6 +1002,12 @@ class Redistribute(torch.autograd.Function):
         else:
             local_tensor = grad_output._local_tensor
             current_spec = grad_output._spec
+        # skip the replicate to partial transformation when we are in backward pass
+        # In this case we keep the grad as replicate, this is because we don't
+        # want to convert the replicated gradients back to partial, although
+        # that's logically conform with the same layout, converting the gradients
+        # back to partial is actually useless as you would have to do reduce later
+        # which would be more expensive than keeping it replicate!
 
         # for backward shard -> partial, we just do shard -> replicate
         # for backward replicate -> partial, we skip the transformation


### PR DESCRIPTION
1. remove the `is_backward` parameter from `redistribute_local_tensor`, instead, do the backward conversion before we call `redistribute_local_tensor`.

Specifically, during backward, if we want to redistribute from
```
shard -> partial: replace with shard -> replicated
replicate -> partial: replace with replicate -> replicate(no-op)
```

2. Also fix a bug when redistribute forward is `partial -> partial`, during backward we annotate it the output `partial` to `replicate`. Added a unit test to catch this bug. 

before this PR
```
AssertionError: Object comparison failed: Replicate() != Partial(sum)
```
after this PR, the test will pass. 

## Test plan: 

```
python3 test/distributed/tensor/test_redistribute.py
```