### PR TITLE
[ROCm] Fix UT jit_test_freezing.py::TestFrozenOptimizations

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -33,8 +33,6 @@ except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
-TEST_ROCM = torch.cuda.is_available() and torch.version.hip is not None
-
 
 def removeExceptions(graph):
     for n in graph.findAllNodes("prim::RaiseException"):


### PR DESCRIPTION
Fixes #168689
Fixes #168690
Fixes #168691

I believe these issues being caused by CI environment variables, not issues within the code. Creating an empty PR to trigger ROCM CI test.

If it passes, we could close those issues without merging the PR.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang