### PR TITLE
[xpu][feature] Support do bench using profiling on XPU.

### DIFF
--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -78,10 +78,6 @@ class DeviceInterface:
         def get_device_properties(device: torch.types.Device = None) -> Any:
             raise NotImplementedError
 
-    class profilerActivity:
-        def __new__(cls) -> Any:
-            raise NotImplementedError
-
     @staticmethod
     def current_device() -> int:
         raise NotImplementedError
@@ -208,7 +204,6 @@ class CudaInterface(DeviceInterface):
     # make sure Event and Stream are implemented and inherited from the torch.Event and torch.Stream
     Event = torch.cuda.Event  # type: ignore[assignment]
     Stream = torch.cuda.Stream  # type: ignore[assignment]
-    profilerActivity = torch.profiler.ProfilerActivity.CUDA  # type: ignore[assignment]
 
     # pyrefly: ignore [bad-override]
     class Worker:
@@ -389,7 +384,6 @@ class XpuInterface(DeviceInterface):
     device = torch.xpu.device  # type: ignore[assignment]
     Event = torch.xpu.Event  # type: ignore[assignment]
     Stream = torch.xpu.Stream  # type: ignore[assignment]
-    profilerActivity = torch.profiler.ProfilerActivity.XPU  # type: ignore[assignment]
 
     # pyrefly: ignore [bad-override]
     class Worker:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -78,6 +78,10 @@ class DeviceInterface:
         def get_device_properties(device: torch.types.Device = None) -> Any:
             raise NotImplementedError
 
+    class profilerActivity:
+        def __new__(cls) -> Any:
+            raise NotImplementedError
+
     @staticmethod
     def current_device() -> int:
         raise NotImplementedError
@@ -204,6 +208,7 @@ class CudaInterface(DeviceInterface):
     # make sure Event and Stream are implemented and inherited from the torch.Event and torch.Stream
     Event = torch.cuda.Event  # type: ignore[assignment]
     Stream = torch.cuda.Stream  # type: ignore[assignment]
+    profilerActivity = torch.profiler.ProfilerActivity.CUDA  # type: ignore[assignment]
 
     # pyrefly: ignore [bad-override]
     class Worker:
@@ -384,6 +389,7 @@ class XpuInterface(DeviceInterface):
     device = torch.xpu.device  # type: ignore[assignment]
     Event = torch.xpu.Event  # type: ignore[assignment]
     Stream = torch.xpu.Stream  # type: ignore[assignment]
+    profilerActivity = torch.profiler.ProfilerActivity.XPU  # type: ignore[assignment]
 
     # pyrefly: ignore [bad-override]
     class Worker:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -314,19 +314,21 @@ def _do_bench_using_profiling(
 
         may_ban_benchmarking()
 
+    device_type = get_gpu_type()
+    device_interface = get_interface_for_device(device_type)
     fn()
-    torch.cuda.synchronize()
-    cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
+    device_interface.synchronize()
+    cache = torch.empty(int(256e6 // 4), dtype=torch.int, device=device_type)
 
     # Estimate the runtime of the function
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
+    start_event = device_interface.Event(enable_timing=True)
+    end_event = device_interface.Event(enable_timing=True)
     start_event.record()
     for _ in range(5):
         cache.zero_()
         fn()
     end_event.record()
-    torch.cuda.synchronize()
+    device_interface.synchronize()
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # compute number of warmup and repeat
@@ -337,11 +339,11 @@ def _do_bench_using_profiling(
     for _ in range(n_warmup):
         fn()
 
-    torch.cuda.synchronize()
+    device_interface.synchronize()
 
     with torch.profiler.profile(
         activities=[
-            torch.profiler.ProfilerActivity.CUDA,
+            device_interface.profilerActivity,
         ]
     ) as p:
         # Benchmark
@@ -351,7 +353,7 @@ def _do_bench_using_profiling(
             # record time of `fn`
             fn()
         # Record clocks
-        torch.cuda.synchronize()
+        device_interface.synchronize()
 
     log.debug("raw events")
     log.debug(p.key_averages().table(sort_by="self_device_time_total", row_limit=-1))

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -340,10 +340,9 @@ def _do_bench_using_profiling(
         fn()
 
     device_interface.synchronize()
-
     with torch.profiler.profile(
         activities=[
-            device_interface.profilerActivity,
+            getattr(torch.profiler.ProfilerActivity, device_type.upper()),
         ]
     ) as p:
         # Benchmark
@@ -368,7 +367,8 @@ def _do_bench_using_profiling(
     if len(filtered_events) % n_repeat != 0:
         raise RuntimeError(
             "Failed to divide all profiling events into #repeat groups. "
-            "#CUDA events: %d, #repeats: %s",
+            "#%s events: %d, #repeats: %s",
+            device_type,
             len(filtered_events),
             n_repeat,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170157

Fixes #170020

#### Test plan: 
The output of `test_extern_kernel_benchmark_request_variations`
has_out_variant: time =  0.01264
no_out_variant with no args: time =  0.01256
no_out_variant with args: time =  0.0124
profile_with_profiling: time =  0.01077999999998974


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela