### PR TITLE
Fix cooperative reduction deadlocks due to too many CTAs

### DIFF
--- a/test/inductor/test_cooperative_reductions.py
+++ b/test/inductor/test_cooperative_reductions.py
@@ -1,5 +1,4 @@
 # Owner(s): ["module: inductor"]
-import unittest
 from typing import Any
 
 import sympy
@@ -13,7 +12,6 @@ from torch._inductor.codegen.triton import FixedTritonConfig, TritonKernel
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import assert_close
-from torch.testing._internal.common_cuda import IS_SM89
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -169,9 +167,6 @@ class CooperativeReductionTests(TestCase):
     )
     @parametrize("dtype", [torch.float16, torch.float32, torch.float64])
     def test_reduction_fns(self, name, dtype):
-        if IS_SM89 and dtype == torch.float64 and name in ["std", "var_mean"]:
-            raise unittest.SkipTest("Timeouts on SM89")
-
         def fn(x, y):
             return reduction_fn(x + y, dim=-1)
 


### PR DESCRIPTION
Cooperative reductions currently use a hardcoded target number of CTAs of 64. This means that on systems with fewer than 64 SMs (e.g. Nvidia L4), we may have more CTAs than SMs. This is a problem because there are points where each CTA blocks waiting for all other CTAs computing the same reduction value to complete. If there are more CTAs than SMs, some of those CTAs may never get scheduled, so we deadlock.

This does increase the target number of CTAs on platforms that have more than 64 SMs. If this turns out to be bad, we can cap it back at 64 so we fix the correctness issue while maintaing the current behaviour for other GPUs.

Even with this change, I have some concerns about whether we can guarantee that this will not deadlock, especially if it is possible to have multiple kernels running on the GPU at the same time. For instance, is it possible to have two cooperative reductions scheduled simultaneously, such that only half of the CTAs in each reduction actually get to run?

Addresses some of the failures identified in #141915.

Fixes #169492


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo