### PR TITLE
[MPS][BugFix] Fix nonzero() stride to match CPU/CUDA behavior

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -304,7 +304,10 @@ static Tensor& nonzero_out_native_mps(const Tensor& self, Tensor& out_) {
     stream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
   int64_t total_nonzero = at::count_nonzero(self).item<int64_t>();
-  at::native::resize_output(out_, {total_nonzero, nDim});
+  if (at::native::resize_output(out_, {total_nonzero, nDim})) {
+    // Default to fortran-contiguous output to match CPU/CUDA behavior (see gh-46224)
+    out_.as_strided_({total_nonzero, nDim}, {1, total_nonzero});
+  }
   if (out_.numel() == 0) {
     return out_;
   }
@@ -389,7 +392,10 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
     stream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
   int64_t total_nonzero = at::count_nonzero(self).item<int64_t>();
-  at::native::resize_output(out_, {total_nonzero, nDim});
+  if (at::native::resize_output(out_, {total_nonzero, nDim})) {
+    // Default to fortran-contiguous output to match CPU/CUDA behavior (see gh-46224)
+    out_.as_strided_({total_nonzero, nDim}, {1, total_nonzero});
+  }
   if (out_.numel() == 0) {
     return out_;
   }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11469,6 +11469,16 @@ class TestAdvancedIndexing(TestCaseMPS):
         t1.start()
         t2.start()
 
+    def test_nonzero_stride(self):
+        # Test that nonzero preserves non-contiguous strides from gradient
+        # This ensures MPS behavior matches CPU/CUDA
+        # See https://github.com/pytorch/pytorch/issues/170175
+        device = "mps"
+        x = torch.randn(1, 1, 3, 3, device=device)
+        grad = torch.gradient(x, dim=(2, 3))[0]
+        with self.assertRaises(RuntimeError):
+            torch.nonzero(grad).view(-1)
+
     def test_sliced_view_cast(self):
         # This used to crash on MacOS Sequoia
         # See https://github.com/pytorch/pytorch/issues/137800


### PR DESCRIPTION
Previously, MPS's nonzero() always returned C-contiguous tensors, while CPU/CUDA return Fortran-contiguous tensors with stride (1, total_nonzero). This inconsistency caused .view() operations to succeed on MPS but fail on CPU/CUDA.

Inspired by

https://github.com/pytorch/pytorch/blob/8121f2c5d0dbbee6322c7fadea90729573b85d4d/aten/src/ATen/native/TensorAdvancedIndexing.cpp#L2914-L2920

Fixes #170175

cc @malfet 