### PR TITLE
ci: Remove workspace deletion in binary build/test workflows

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -171,9 +171,6 @@ jobs:
         run: |
           set -eux
 
-          rm -rf "${GITHUB_WORKSPACE}"
-          mkdir "${GITHUB_WORKSPACE}"
-
           if [[ ${{ inputs.build_environment }} == 'linux-aarch64-binary-manywheel' ]] || [[ ${{ inputs.build_environment }} == 'linux-s390x-binary-manywheel' ]] ; then
             rm -rf "${RUNNER_TEMP}/artifacts"
             mkdir "${RUNNER_TEMP}/artifacts"

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -150,12 +150,6 @@ jobs:
         with:
           ALPINE_IMAGE: ${{ inputs.ALPINE_IMAGE }}
 
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE}"
-          mkdir "${GITHUB_WORKSPACE}"
-
       - name: Checkout PyTorch to pytorch dir
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170192

The workspace deletion (`rm -rf "${GITHUB_WORKSPACE}"`) was causing
"Post Login to ECR" steps to fail with:

  Can't find 'action.yml' under '.github/actions/ecr-login'

This happened because:
1. The ecr-login action uses aws-actions/configure-aws-credentials and
   aws-actions/amazon-ecr-login, which have Post cleanup steps
2. The "Clean workspace" step deleted the workspace mid-job
3. When GitHub ran Post steps, the action files no longer existed

The workspace deletion was originally introduced when binary builds
checked out both pytorch/pytorch and pytorch/builder as subdirectories.
Since pytorch/builder is no longer used (build scripts now live in
pytorch/.ci/), this deletion serves no purpose.

The second checkout with `path: pytorch` works fine alongside the
existing root checkout - the build only uses ${GITHUB_WORKSPACE}/pytorch
which gets mounted to /pytorch in Docker.

Issue was originally introduced in 
* #169962 

Resolves https://github.com/pytorch/pytorch/issues/170184