### PR TITLE
ci: Fix aws-region default in ecr-login action

### DIFF
--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.aws-role-to-assume != '' && inputs.aws-role-to-assume || 'arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only' }}
         role-session-name: gha-ecr-login
-        aws-region: ${{ inputs.aws-region }}
+        aws-region: ${{ inputs.aws-region || 'us-east-1' }}
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
         role-skip-session-tagging: true
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170193

When ecr-login is called from within another composite action (like
setup-rocm) without explicit inputs, the input defaults may not be
properly applied. Add explicit fallback to ensure aws-region is
always set to us-east-1, fixing "Region is missing" errors on ROCm
workflows.

Errors look like:

https://github.com/pytorch/pytorch/actions/runs/20114415988/job/57722812739

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>