### PR TITLE
[DTensor] Refactor _select_min_cost_strategy as a util

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -534,9 +534,7 @@ def detect_exists_identical_opspec(*args, op, mesh, strategy_function) -> bool:
 
 class DistTensorReplicateStrategyRegistrationTest(DTensorTestBase):
     @with_comms
-    @patch(
-        "torch.distributed.tensor._sharding_prop.ShardingPropagator._select_strategy"
-    )
+    @patch("torch.distributed.tensor._sharding_prop._select_min_cost_strategy")
     def test_replicate_strategy_placement(self, mock_select_strategy):
         costs_from__select_strategy = []
 

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -56,6 +56,73 @@ class LocalLRUCache(threading.local):
         return self.cache.cache_clear()
 
 
+def _select_min_cost_strategy(
+    strategy: OpStrategy, op_schema: OpSchema | None = None
+) -> OpSpec:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if len(strategy.strategies) == 1:
+        # short cut with only one possible OpSpec
+        return strategy.strategies[0]
+
+    op_spec_costs: list[torch.types.FloatLikeType] = []
+    no_redistribute_strategy_index: int = -1
+    negative_cost_index: int = -1
+    zero_cost_index: int = -1
+    for strategy_idx, op_spec in enumerate(strategy.strategies):
+        assert op_spec.redistribute_cost is not None, (
+            "must set redistribute cost each OpSpec!"
+        )
+        redistribute_cost = sum(chain.from_iterable(op_spec.redistribute_cost))
+        op_spec_costs.append(redistribute_cost)
+
+        # If there are strategies with negative/zero/no redistribute cost,
+        # we record those indices.
+        # TODO: Currently this only applies to OpStrategy selection. Requires extra
+        # logic to make it work for TupleStrategy, if needed.
+        if op_schema is not None:
+            if guard_or_false(redistribute_cost < 0):
+                if (
+                    negative_cost_index == -1
+                    or redistribute_cost < op_spec_costs[negative_cost_index]
+                ):
+                    negative_cost_index = strategy_idx
+            elif guard_or_false(redistribute_cost == 0):
+                needs_redistribute = False
+                for spec_idx, input_spec in enumerate(op_schema.args_spec):
+                    desired_spec = (
+                        op_spec.output_spec
+                        if op_spec.input_specs is None
+                        else op_spec.input_specs[spec_idx]
+                    )
+                    if input_spec.placements != desired_spec.placements:
+                        needs_redistribute = True
+                        break
+
+                if not needs_redistribute:
+                    no_redistribute_strategy_index = strategy_idx
+                elif zero_cost_index == -1:
+                    zero_cost_index = strategy_idx
+
+    # prioritize negative/zero/no redistribute cost strategies
+    if negative_cost_index != -1:
+        # If there's negative cost, we select the one with the minimal cost,
+        # even if this means we need to redistribute, e.g. via local chunking.
+        # E.g. this can happen for ops in self.op_to_shape_and_stride_idx
+        # when the inputs / outputs are sharded.
+        selected_strategy_index = negative_cost_index
+    elif no_redistribute_strategy_index != -1:
+        selected_strategy_index = no_redistribute_strategy_index
+    elif zero_cost_index != -1:
+        selected_strategy_index = zero_cost_index
+    else:
+        # default to choosing minimal redistribute cost
+        min_cost = min(op_spec_costs)
+        selected_strategy_index = op_spec_costs.index(min_cost)
+
+    return strategy.strategies[selected_strategy_index]
+
+
 class ShardingPropagator:
     def __init__(self) -> None:
         self.op_to_rules: dict[OpOverload, Callable[[OpSchema], OutputSharding]] = {}
@@ -373,7 +440,7 @@ class ShardingPropagator:
 
             if isinstance(op_strategy, OpStrategy):
                 # single Op strategy
-                output_strategy = self._select_strategy(op_strategy, op_schema)
+                output_strategy = _select_min_cost_strategy(op_strategy, op_schema)
 
                 # check if we need to redistribute the input
                 needs_redistribute = False
@@ -461,7 +528,7 @@ class ShardingPropagator:
                 out_spec_list: list[DTensorSpec] = []
                 for strategy in op_strategy.children:
                     assert isinstance(strategy, OpStrategy)
-                    selected_strategy = self._select_strategy(strategy)
+                    selected_strategy = _select_min_cost_strategy(strategy)
                     selected_strategies.append(selected_strategy)
                     out_spec_list.append(selected_strategy.output_spec)
 
@@ -580,72 +647,6 @@ class ShardingPropagator:
             raise NotImplementedError(
                 f"Operator {op_schema.op} does not have a sharding strategy registered."
             )
-
-    def _select_strategy(
-        self, strategy: OpStrategy, op_schema: OpSchema | None = None
-    ) -> OpSpec:
-        from torch.fx.experimental.symbolic_shapes import guard_or_false
-
-        if len(strategy.strategies) == 1:
-            # short cut with only one possible OpSpec
-            return strategy.strategies[0]
-
-        op_spec_costs: list[torch.types.FloatLikeType] = []
-        no_redistribute_strategy_index: int = -1
-        negative_cost_index: int = -1
-        zero_cost_index: int = -1
-        for strategy_idx, op_spec in enumerate(strategy.strategies):
-            assert op_spec.redistribute_cost is not None, (
-                "must set redistribute cost each OpSpec!"
-            )
-            redistribute_cost = sum(chain.from_iterable(op_spec.redistribute_cost))
-            op_spec_costs.append(redistribute_cost)
-
-            # If there are strategies with negative/zero/no redistribute cost,
-            # we record those indices.
-            # TODO: Currently this only applies to OpStrategy selection. Requires extra
-            # logic to make it work for TupleStrategy, if needed.
-            if op_schema is not None:
-                if guard_or_false(redistribute_cost < 0):
-                    if (
-                        negative_cost_index == -1
-                        or redistribute_cost < op_spec_costs[negative_cost_index]
-                    ):
-                        negative_cost_index = strategy_idx
-                elif guard_or_false(redistribute_cost == 0):
-                    needs_redistribute = False
-                    for spec_idx, input_spec in enumerate(op_schema.args_spec):
-                        desired_spec = (
-                            op_spec.output_spec
-                            if op_spec.input_specs is None
-                            else op_spec.input_specs[spec_idx]
-                        )
-                        if input_spec.placements != desired_spec.placements:
-                            needs_redistribute = True
-                            break
-
-                    if not needs_redistribute:
-                        no_redistribute_strategy_index = strategy_idx
-                    elif zero_cost_index == -1:
-                        zero_cost_index = strategy_idx
-
-        # prioritize negative/zero/no redistribute cost strategies
-        if negative_cost_index != -1:
-            # If there's negative cost, we select the one with the minimal cost,
-            # even if this means we need to redistribute, e.g. via local chunking.
-            # E.g. this can happen for ops in self.op_to_shape_and_stride_idx
-            # when the inputs / outputs are sharded.
-            selected_strategy_index = negative_cost_index
-        elif no_redistribute_strategy_index != -1:
-            selected_strategy_index = no_redistribute_strategy_index
-        elif zero_cost_index != -1:
-            selected_strategy_index = zero_cost_index
-        else:
-            # default to choosing minimal redistribute cost
-            min_cost = min(op_spec_costs)
-            selected_strategy_index = op_spec_costs.index(min_cost)
-
-        return strategy.strategies[selected_strategy_index]
 
     def _adjust_shape_and_stride_args(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #167677
* __->__ #170197

Easier to use from other unit tests when not attached to
ShardingPropagator object.  Doesn't use `self` in the first place.