### PR TITLE
[ROCm][CI] skip tests for mi200

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -501,7 +501,7 @@ class MixOrderReductionTest(TestBase):
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
 
-        if dtype is torch.bfloat16 and runOnRocmArch(MI200_ARCH):
+        if dtype is torch.bfloat16 and isRocmArchAnyOf(MI200_ARCH):
             self.skipTest("Currently failing on rocm mi200") 
 
         def f(xs, w, eps):

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -10,6 +10,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    MI200_ARCH,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
@@ -494,6 +495,7 @@ class MixOrderReductionTest(TestBase):
             metrics.codegen_mix_order_reduction,
         )
 
+    @skipIfRocmArch(MI200_ARCH)
     @parametrize("split_reductions", (False, True))
     @parametrize("dtype", [torch.bfloat16, torch.float])
     def test_rms_norm_sharing_weights(self, split_reductions, dtype):

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -9,6 +9,7 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    isRocmArchAnyOf,
     parametrize,
     MI200_ARCH,
 )

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -495,12 +495,14 @@ class MixOrderReductionTest(TestBase):
             metrics.codegen_mix_order_reduction,
         )
 
-    @skipIfRocmArch(MI200_ARCH)
     @parametrize("split_reductions", (False, True))
     @parametrize("dtype", [torch.bfloat16, torch.float])
     def test_rms_norm_sharing_weights(self, split_reductions, dtype):
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
+
+        if dtype is torch.bfloat16 and runOnRocmArch(MI200_ARCH):
+            self.skipTest("Currently failing non rocm mi200") 
 
         def f(xs, w, eps):
             ys = []

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -8,9 +8,9 @@ from torch._inductor import metrics, utils
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
-    MI200_ARCH,
     instantiate_parametrized_tests,
     isRocmArchAnyOf,
+    MI200_ARCH,
     parametrize,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
@@ -503,7 +503,7 @@ class MixOrderReductionTest(TestBase):
             self.skipTest("Mix order reduction not enabled")
 
         if dtype is torch.bfloat16 and isRocmArchAnyOf(MI200_ARCH):
-            self.skipTest("Currently failing on rocm mi200") 
+            self.skipTest("Currently failing on rocm mi200")
 
         def f(xs, w, eps):
             ys = []

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -8,10 +8,10 @@ from torch._inductor import metrics, utils
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
+    MI200_ARCH,
     instantiate_parametrized_tests,
     isRocmArchAnyOf,
     parametrize,
-    MI200_ARCH,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -502,7 +502,7 @@ class MixOrderReductionTest(TestBase):
             self.skipTest("Mix order reduction not enabled")
 
         if dtype is torch.bfloat16 and runOnRocmArch(MI200_ARCH):
-            self.skipTest("Currently failing non rocm mi200") 
+            self.skipTest("Currently failing on rocm mi200") 
 
         def f(xs, w, eps):
             ys = []

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -40,6 +40,7 @@ from torch.testing._internal.inductor_utils import (
     MI200_ARCH,
     requires_gpu,
     requires_triton,
+    skipIfRocmArch,
 )
 
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -37,9 +37,9 @@ from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
+    MI200_ARCH,
     requires_gpu,
     requires_triton,
-    MI200_ARCH,
 )
 
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -39,6 +39,7 @@ from torch.testing._internal.inductor_utils import (
     HAS_GPU,
     requires_gpu,
     requires_triton,
+    MI200_ARCH,
 )
 
 
@@ -538,6 +539,7 @@ class TestExternKernelCaller(TestCase):
         # Only autotune once, cache hit
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
+    @skipIfRocmArch(MI200_ARCH)
     @patches
     def test_extern_kernel_benchmark_valid_timing(self):
         def fn(a, b):

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -33,13 +33,17 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import is_big_gpu, run_and_get_kernels
 from torch._inductor.virtualized import V
 from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
-from torch.testing._internal.common_utils import IS_LINUX, MI200_ARCH, skipIfRocm
+from torch.testing._internal.common_utils import (
+    IS_LINUX,
+    MI200_ARCH,
+    skipIfRocm,
+    skipIfRocmArch,
+)
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
     requires_gpu,
     requires_triton,
-    skipIfRocmArch,
 )
 
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -33,11 +33,10 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import is_big_gpu, run_and_get_kernels
 from torch._inductor.virtualized import V
 from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
+from torch.testing._internal.common_utils import IS_LINUX, MI200_ARCH, skipIfRocm
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
-    MI200_ARCH,
     requires_gpu,
     requires_triton,
     skipIfRocmArch,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -95,6 +95,7 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_X86,
     MACOS_VERSION,
+    MI200_ARCH,
     parametrize,
     serialTest,
     skipIfMPS,
@@ -105,7 +106,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     xfailIfS390X,
-    MI200_ARCH
 )
 from torch.testing._internal.logging_utils import logs_to_string
 from torch.utils import _pytree as pytree

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -658,6 +658,7 @@ def check_model(
 
     torch._dynamo.reset()
 
+
 @skipIfRocmArch(MI200_ARCH)
 @torch._inductor.config.patch("triton.cudagraphs", False)
 def check_model_gpu(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -100,6 +100,7 @@ from torch.testing._internal.common_utils import (
     serialTest,
     skipIfMPS,
     skipIfRocm,
+    skipIfRocmArch,
     skipIfWindows,
     skipIfXpu,
     subtest,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -105,6 +105,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     xfailIfS390X,
+    MI200_ARCH
 )
 from torch.testing._internal.logging_utils import logs_to_string
 from torch.utils import _pytree as pytree
@@ -656,7 +657,7 @@ def check_model(
 
     torch._dynamo.reset()
 
-
+@skipIfRocmArch(MI200_ARCH)
 @torch._inductor.config.patch("triton.cudagraphs", False)
 def check_model_gpu(
     self: TestCase,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -68,6 +68,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     IS_X86,
     load_tests,
+    MI200_ARCH,
     MI300_ARCH,
     parametrize,
     recover_orig_fp32_precision,
@@ -5793,6 +5794,7 @@ class TestMemPool(TestCase):
             f"but got {blocks_no_split} vs {blocks_split}",
         )
 
+    @skipIfRocmArch(MI200_ARCH)
     @serialTest()
     def test_deleted_mempool_not_used_on_oom(self):
         """

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2834,7 +2834,7 @@ class TestLinalg(TestCase):
         from torch.testing._internal.common_utils import random_lowrank_matrix, random_sparse_matrix
 
         if isRocmArchAnyOf(MI200_ARCH) and dtype is torch.complex128:
-            self.skipTest("Currently failing on rocm mi200") 
+            self.skipTest("Currently failing on rocm mi200")
 
         def run_subtest(actual_rank, matrix_size, batches, device, svd_lowrank, **options):
             density = options.pop('density', 1)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2827,12 +2827,14 @@ class TestLinalg(TestCase):
         self.assertRaisesRegex(RuntimeError, "must be different", torch.norm, x, "nuc", (0, 0))
         self.assertRaisesRegex(IndexError, "Dimension out of range", torch.norm, x, "nuc", (0, 2))
 
-    @skipIfRocmArch(MI200_ARCH)
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.double, torch.cdouble)
     def test_svd_lowrank(self, device, dtype):
         from torch.testing._internal.common_utils import random_lowrank_matrix, random_sparse_matrix
+
+        if runOnRocmArch(MI200_ARCH) and dtype is torch.complex128:
+            self.skipTest("Currently failing on rocm mi200") 
 
         def run_subtest(actual_rank, matrix_size, batches, device, svd_lowrank, **options):
             density = options.pop('density', 1)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -26,7 +26,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
-     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
+     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, NAVI_ARCH, TEST_CUDA)
 from torch.testing._internal.common_device_type import \

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import \
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest,
-     runOnRocmArch, MI300_ARCH, NAVI_ARCH, TEST_CUDA)
+     runOnRocmArch, MI200_ARCH, MI300_ARCH, NAVI_ARCH, TEST_CUDA)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, has_hipsolver,
      onlyCPU, skipIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
@@ -2827,6 +2827,7 @@ class TestLinalg(TestCase):
         self.assertRaisesRegex(RuntimeError, "must be different", torch.norm, x, "nuc", (0, 0))
         self.assertRaisesRegex(IndexError, "Dimension out of range", torch.norm, x, "nuc", (0, 2))
 
+    @skipIfRocmArch(MI200_ARCH)
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.double, torch.cdouble)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2833,7 +2833,7 @@ class TestLinalg(TestCase):
     def test_svd_lowrank(self, device, dtype):
         from torch.testing._internal.common_utils import random_lowrank_matrix, random_sparse_matrix
 
-        if runOnRocmArch(MI200_ARCH) and dtype is torch.complex128:
+        if isRocmArchAnyOf(MI200_ARCH) and dtype is torch.complex128:
             self.skipTest("Currently failing on rocm mi200") 
 
         def run_subtest(actual_rank, matrix_size, batches, device, svd_lowrank, **options):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2833,7 +2833,7 @@ class TestLinalg(TestCase):
     def test_svd_lowrank(self, device, dtype):
         from torch.testing._internal.common_utils import random_lowrank_matrix, random_sparse_matrix
 
-        if isRocmArchAnyOf(MI200_ARCH) and dtype is torch.complex128:
+        if torch.version.hip and isRocmArchAnyOf(MI200_ARCH) and dtype is torch.complex128:
             self.skipTest("Currently failing on rocm mi200")
 
         def run_subtest(actual_rank, matrix_size, batches, device, svd_lowrank, **options):


### PR DESCRIPTION
This PR is intended to skip the following unit tests for MI200:


- inductor.test_compile_subprocess::GPUTests::test_conv_with_as_strided_cuda
- inductor.test_compile_subprocess::GPUTests::test_remove_noop_slice_cuda
- inductor.test_mix_order_reduction::MixOrderReductionTest::test_rms_norm_sharing_weights_split_reductions_False_bfloat16
- inductor.test_mix_order_reduction::MixOrderReductionTest::test_rms_norm_sharing_weights_split_reductions_True_bfloat16
- inductor.test_select_algorithm::TestExternKernelCaller::test_extern_kernel_benchmark_valid_timing
- inductor.test_torchinductor::GPUTests::test_conv_with_as_strided_cuda
- inductor.test_torchinductor_dynamic_shapes::DynamicShapesGPUTests::test_conv_with_as_strided_dynamic_shapes_cuda
- test_cuda::TestMemPool::test_deleted_mempool_not_used_on_oom

Get MI200 CI green again.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben