### PR TITLE
[nativert] Add MTIA device support in isSameDevice

### DIFF
--- a/torch/nativert/executor/PlacementUtils.cpp
+++ b/torch/nativert/executor/PlacementUtils.cpp
@@ -18,7 +18,10 @@ bool isSameDevice(const c10::Device& a, const c10::Device& b) {
   if (a.is_meta()) {
     return b.is_meta();
   }
-  TORCH_CHECK(false, "Unsupported device type", a, " and ", b);
+  if (a.is_mtia()) {
+    return b.is_mtia();
+  }
+  TORCH_CHECK(false, "isSameDevice: Unsupported device type ", a, " and ", b);
   return false;
 }
 } // namespace torch::nativert


### PR DESCRIPTION
Summary: Add MTIA device type handling in `isSameDevice()` for nativert executor.

Also fix a typo on the assert.


