### PR TITLE
Use r7i for debug-build job

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -377,7 +377,7 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: linux.2xlarge.memory
+      runner: linux.r7i.2xlarge
       build-environment: linux-jammy-py3.10-gcc11-full-debug-build-only
       docker-image-name: ci-image:pytorch-linux-jammy-py3.10-gcc11
     secrets: inherit


### PR DESCRIPTION
The instance r7i runs roughly 20% faster than r5 which would reduce the cost of the job here by about 15%.

Relates to pytorch/test-infra#7175.
