### PR TITLE
cmake: Prefer OpenMP-parallel OpenBLAS variant on Fedora/RHEL

### DIFF
--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -173,6 +173,19 @@ if((NOT BLAS_LIBRARIES)
   BLAS
   sgemm
   ""
+  "openblaso")
+  if(BLAS_LIBRARIES)
+    set(BLAS_INFO "open")
+  endif(BLAS_LIBRARIES)
+endif()
+
+if((NOT BLAS_LIBRARIES)
+    AND ((NOT WITH_BLAS) OR (WITH_BLAS STREQUAL "open")))
+  check_fortran_libraries(
+  BLAS_LIBRARIES
+  BLAS
+  sgemm
+  ""
   "openblas")
   if(BLAS_LIBRARIES)
     set(BLAS_INFO "open")


### PR DESCRIPTION
## Summary
Prefer OpenMP-parallel OpenBLAS variant on Fedora/RHEL systems.

## Problem
On Fedora/RHEL, multiple OpenBLAS variants exist:
- `libopenblas.so` (serial/single-threaded)
- `libopenblaso.so` (OpenMP-parallel)
- `libopenblasp.so` (pthread-based)

CMake was selecting the serial variant, missing multi-threaded performance.

## Solution
Update `FindBLAS.cmake` and `FindOpenBLAS.cmake` to prefer `openblaso` over `openblas`.

## Testing
Validated on Fedora that OpenMP-parallel variant is now selected, providing proper multi-threaded BLAS operations.