### PR TITLE
Switch ASAN build to c7i.4xlarge

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -129,7 +129,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner: linux.2xlarge.memory
+      runner: linux.c7i.4xlarge
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-py3.10-clang18-asan
       docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-asan

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -139,7 +139,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      runner: linux.2xlarge.memory
+      runner: linux.c7i.4xlarge
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-py3.10-clang18-asan
       docker-image-name: ci-image:pytorch-linux-jammy-py3-clang18-asan


### PR DESCRIPTION
This build job appears to use <32 GB of RAM while benefiting from more CPU. This change moves the job to newer generation c7i system with 4xlarge with 32 GB of RAM. This job should run faster while moving to a more efficient CPU reducing costs when compared to r5.2xlarge.

Relates to pytorch/test-infra#7175.
