### PR TITLE
[inductor][caching] simplify impls

### DIFF
--- a/torch/_inductor/runtime/caching/__init__.py
+++ b/torch/_inductor/runtime/caching/__init__.py
@@ -4,14 +4,11 @@ from .exceptions import (
     CacheError,
     FileLockTimeoutError,
     KeyEncodingError,
-    KeyPicklingError,
     LockTimeoutError,
     SystemError,
     UserError,
     ValueDecodingError,
     ValueEncodingError,
-    ValuePicklingError,
-    ValueUnPicklingError,
 )
 
 
@@ -20,7 +17,6 @@ __all__ = [
     "FileLockTimeoutError",
     "IsolationSchema",
     "KeyEncodingError",
-    "KeyPicklingError",
     "LockTimeoutError",
     "SelectedCompileContext",
     "SelectedRuntimeContext",
@@ -28,6 +24,4 @@ __all__ = [
     "UserError",
     "ValueDecodingError",
     "ValueEncodingError",
-    "ValuePicklingError",
-    "ValueUnPicklingError",
 ]

--- a/torch/_inductor/runtime/caching/exceptions.py
+++ b/torch/_inductor/runtime/caching/exceptions.py
@@ -8,7 +8,6 @@ for user-facing errors that also inherit from TypeError for compatibility.
 """
 
 from threading import Lock
-from typing import Any
 
 from filelock import FileLock
 
@@ -83,24 +82,6 @@ class KeyEncodingError(UserError):
     """
 
 
-class KeyPicklingError(KeyEncodingError):
-    """Error raised when a cache key cannot be pickled for serialization.
-
-    This typically occurs when trying to cache objects with keys that contain
-    non-serializable components, lambda functions, or other unpickleable types.
-    """
-
-    def __init__(self, key: Any) -> None:
-        """Initialize the key pickling error with detailed key information.
-
-        Args:
-            key: The cache key that failed to be pickled.
-        """
-        super().__init__(
-            f"Failed to pickle cache key with type {type(key)} and value {key!r}."
-        )
-
-
 class ValueEncodingError(UserError):
     """Base class for errors that occur during cache value encoding operations.
 
@@ -109,45 +90,9 @@ class ValueEncodingError(UserError):
     """
 
 
-class ValuePicklingError(ValueEncodingError):
-    """Error raised when a cache value cannot be pickled for serialization.
-
-    This occurs when trying to cache objects that contain non-serializable
-    components, file handles, network connections, or other unpickleable types.
-    """
-
-    def __init__(self, value: Any) -> None:
-        """Initialize the value pickling error with detailed value information.
-
-        Args:
-            value: The cache value that failed to be pickled.
-        """
-        super().__init__(
-            f"Failed to pickle cache value with type {type(value)} and value {value!r}."
-        )
-
-
 class ValueDecodingError(UserError):
     """Base class for errors that occur during cache value decoding operations.
 
     Raised when cached values cannot be properly decoded during retrieval.
     This includes deserialization, decompression, or other decoding-related failures.
     """
-
-
-class ValueUnPicklingError(ValueDecodingError):
-    """Error raised when cached value data cannot be unpickled during retrieval.
-
-    This typically indicates corruption, version incompatibility, or missing
-    dependencies required to reconstruct the cached object.
-    """
-
-    def __init__(self, pickled_value: bytes) -> None:
-        """Initialize the value unpickling error with the problematic data.
-
-        Args:
-            pickled_value: The bytes that failed to be unpickled.
-        """
-        super().__init__(
-            f"Failed to unpickle cache value from pickled value {pickled_value!r}."
-        )

--- a/torch/_inductor/runtime/caching/implementations.py
+++ b/torch/_inductor/runtime/caching/implementations.py
@@ -15,25 +15,32 @@ from io import BufferedReader, BufferedWriter
 from os import PathLike
 from pathlib import Path
 from threading import Lock
-from typing import Any
+from typing import Generic, TypeVar
 from typing_extensions import override
 
 from filelock import FileLock
 
-from . import locks, utils
+from . import locks
+
+
+# Type variable for cache value types
+_V = TypeVar("_V")
 
 
 @dataclass
-class Hit:
+class Hit(Generic[_V]):
     """Result wrapper for hits on cache get operations.
 
     Allows distinguishing between a cache miss and a cached None value.
 
     Attributes:
-        value: The cached value.
+        value: The cached value. The type depends on the cache implementation:
+              - InMemoryCache: object (any Python object)
+              - OnDiskCache: bytes
+              - RemoteCache: bytes
     """
 
-    value: Any
+    value: _V
 
 
 class Miss:
@@ -48,18 +55,16 @@ class Miss:
 miss = Miss()
 
 
-class _CacheImpl(ABC):
+class _CacheImpl(ABC, Generic[_V]):
     """Abstract base class for cache implementations.
 
     This class defines the interface that all cache implementations must follow.
     It provides thread-safe operations through a locking mechanism and supports
     both get and insert operations.
 
-    Note: We don't use generics here as doing so would require that callers
-    know which k/v types the implementation can work with. Instead, we leave that
-    determination up to the implementation itself and require that callers
-    handle any potential errors from invalid k/v types being passed to the
-    implementation.
+    Type Parameters:
+        _V: The type of values stored in the cache. Each implementation specifies
+           its own value type (e.g., object for in-memory, bytes for on-disk).
     """
 
     def __init__(self) -> None:
@@ -90,11 +95,11 @@ class _CacheImpl(ABC):
         return _lock_with_timeout
 
     @abstractmethod
-    def get(self, key: Any) -> Hit | None:
+    def get(self, key: str) -> Hit[_V] | None:
         """Retrieve a value from the cache.
 
         Args:
-            key: The key to look up in the cache.
+            key: The key to look up in the cache (must be str).
 
         Returns:
             A Hit object on cache hit where Hit.value is the cached value,
@@ -102,11 +107,11 @@ class _CacheImpl(ABC):
         """
 
     @abstractmethod
-    def insert(self, key: Any, value: Any) -> bool:
+    def insert(self, key: str, value: _V) -> bool:
         """Insert a key-value pair into the cache.
 
         Args:
-            key: The key to insert.
+            key: The key to insert (must be str).
             value: The value to associate with the key.
 
         Returns:
@@ -114,55 +119,55 @@ class _CacheImpl(ABC):
         """
 
 
-class _InMemoryCacheImpl(_CacheImpl):
+class _InMemoryCacheImpl(_CacheImpl[object]):
     """In-memory cache implementation using a dictionary.
 
     This implementation stores key-value pairs in a Python dictionary,
     with keys being pickled for consistent hashing. It provides fast
     access but is limited by available memory and process lifetime.
+
+    The value type is 'object' since any Python object can be stored in memory.
     """
 
     def __init__(self) -> None:
         """Initialize the in-memory cache with an empty dictionary."""
         super().__init__()
-        self._memory: dict[bytes, Any] = {}
+        self._memory: dict[str, object] = {}
 
     @override
-    def get(self, key: Any) -> Hit | None:
+    def get(self, key: str) -> Hit[object] | None:
         """Retrieve a value from the in-memory cache.
 
         Args:
-            key: The key to look up. Will be pickled for storage.
+            key: The key to look up (must be str).
 
         Returns:
             A Hit object on cache hit where Hit.value is the cached value,
             or None on cache miss.
         """
-        pickled_key: bytes = utils._try_pickle_key(key)
-        if (value := self._memory.get(pickled_key, miss)) is not miss:
+        if (value := self._memory.get(key, miss)) is not miss:
             return Hit(value=value)
         return None
 
     @override
-    def insert(self, key: Any, value: Any) -> bool:
+    def insert(self, key: str, value: object) -> bool:
         """Insert a key-value pair into the in-memory cache.
 
         Args:
-            key: The key to insert. Will be pickled for storage.
-            value: The value to associate with the key.
+            key: The key to insert (must be str).
+            value: The value to associate with the key (can be any object).
 
         Returns:
             True if the insertion was successful (key was new),
             False if not inserted (key already existed).
         """
-        pickled_key: bytes = utils._try_pickle_key(key)
-        if pickled_key not in self._memory:
-            self._memory[pickled_key] = value
+        if key not in self._memory:
+            self._memory[key] = value
             return True
         return False
 
 
-class _OnDiskCacheImpl(_CacheImpl):
+class _OnDiskCacheImpl(_CacheImpl[bytes]):
     """On-disk cache implementation using file system storage.
 
     This implementation stores cached data as files on disk, with version
@@ -170,8 +175,10 @@ class _OnDiskCacheImpl(_CacheImpl):
     thread safety across processes and provides persistent storage that
     survives process restarts.
 
+    The value type is 'bytes' since data must be serialized to bytes for disk storage.
+
     Attributes:
-        _version: Version number for cache format compatibility.
+        _version: _Version number for cache format compatibility.
         _version_header_length: Length of the version header in bytes.
     """
 
@@ -201,17 +208,16 @@ class _OnDiskCacheImpl(_CacheImpl):
 
         return Path(default_cache_dir(), "cache")
 
-    def _fpath_from_key(self, key: Any) -> Path:
+    def _fpath_from_key(self, key: str) -> Path:
         """Generate a file path from a cache key.
 
         Args:
-            key: The cache key to convert to a file path.
+            key: The cache key to convert to a file path (must be str).
 
         Returns:
             A Path object representing the file location for this key.
         """
-        pickled_key: bytes = utils._try_pickle_key(key)
-        return self._cache_dir / sha256(pickled_key).hexdigest()[:32]
+        return self._cache_dir / key
 
     @classmethod
     def _version_header(cls) -> bytes:
@@ -263,14 +269,14 @@ class _OnDiskCacheImpl(_CacheImpl):
         return _lock_with_timeout
 
     @override
-    def get(self, key: Any) -> Hit | None:
+    def get(self, key: str) -> Hit[bytes] | None:
         """Retrieve a value from the on-disk cache.
 
         Args:
-            key: The key to look up in the cache.
+            key: The key to look up in the cache (must be str).
 
         Returns:
-            A Hit object on cache hit where Hit.value is the cached value,
+            A Hit object on cache hit where Hit.value is the cached value (bytes),
             or None on cache miss or version mismatch.
         """
         fpath: Path = self._fpath_from_key(key)
@@ -292,15 +298,15 @@ class _OnDiskCacheImpl(_CacheImpl):
             fpath.unlink()
             return None
 
-        return Hit(value=utils._try_unpickle_value(pickled_value))
+        return Hit(value=pickled_value)
 
     @override
-    def insert(self, key: Any, value: Any) -> bool:
+    def insert(self, key: str, value: bytes) -> bool:
         """Insert a key-value pair into the on-disk cache.
 
         Args:
-            key: The key to insert.
-            value: The value to associate with the key.
+            key: The key to insert (must be str).
+            value: The value to associate with the key (must be bytes).
 
         Returns:
             True if successfully inserted, False if the key already exists
@@ -328,9 +334,8 @@ class _OnDiskCacheImpl(_CacheImpl):
         finally:
             if w_fp:
                 try:
-                    pickled_value: bytes = utils._try_pickle_value(value)
                     self._write_version_header(w_fp)
-                    w_fp.write(pickled_value)
+                    w_fp.write(value)
                     inserted = True
                 finally:
                     w_fp.close()
@@ -342,15 +347,17 @@ try:
     from .fb.implementations import _RemoteCacheImpl
 except ModuleNotFoundError:
 
-    class _RemoteCacheImpl(_CacheImpl):  # type: ignore[no-redef]
+    class _RemoteCacheImpl(_CacheImpl[bytes]):  # type: ignore[no-redef]
         """Fallback remote cache implementation for non-Facebook environments.
 
         This is a no-op implementation that always raises NotImplementedError.
         The actual remote cache implementation is provided in the `.fb` module
         for Facebook-specific environments.
 
+        The value type is 'bytes' for consistency with the FB implementation.
+
         Attributes:
-            _version: Version number for cache format compatibility.
+            _version: _Version number for cache format compatibility.
             has_strong_consistency: Whether the remote cache provides strong
                                    consistency guarantees.
         """
@@ -390,11 +397,11 @@ except ModuleNotFoundError:
             return pseudo_lock
 
         @override
-        def get(self, key: Any) -> Hit | None:
+        def get(self, key: str) -> Hit[bytes] | None:
             """Raise NotImplementedError for remote cache get operations.
 
             Args:
-                key: The key to look up (ignored).
+                key: The key to look up (must be str, ignored).
 
             Raises:
                 NotImplementedError: Always raised as this is a fallback implementation.
@@ -402,12 +409,12 @@ except ModuleNotFoundError:
             raise NotImplementedError
 
         @override
-        def insert(self, key: Any, value: Any) -> bool:
+        def insert(self, key: str, value: bytes) -> bool:
             """Raise NotImplementedError for remote cache insert operations.
 
             Args:
-                key: The key to insert (ignored).
-                value: The value to insert (ignored).
+                key: The key to insert (must be str, ignored).
+                value: The value to insert (must be bytes, ignored).
 
             Raises:
                 NotImplementedError: Always raised as this is a fallback implementation.

--- a/torch/_inductor/runtime/caching/utils.py
+++ b/torch/_inductor/runtime/caching/utils.py
@@ -1,17 +1,12 @@
 """Utility functions for caching operations in PyTorch Inductor runtime.
 
-This module provides helper functions for pickling/unpickling operations
-with error handling, LRU caching decorators, and type-safe serialization
-utilities used throughout the caching system.
+This module provides helper functions for LRU caching decorators used
+throughout the caching system.
 """
 
-import pickle
 from collections.abc import Callable
-from functools import lru_cache, partial, wraps
-from typing import Any
+from functools import lru_cache, wraps
 from typing_extensions import ParamSpec, TypeVar
-
-from . import exceptions
 
 
 # Type specification for function parameters
@@ -43,67 +38,3 @@ def _lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
             return fn(*args, **kwargs)
 
     return wrapper
-
-
-@_lru_cache
-def _try_pickle(to_pickle: Any, raise_if_failed: type = exceptions.CacheError) -> bytes:
-    """Attempt to pickle an object with error handling.
-
-    Tries to serialize an object using pickle.dumps with appropriate error
-    handling and custom exception raising.
-
-    Args:
-        to_pickle: The object to be pickled.
-        raise_if_failed: Exception class to raise if pickling fails.
-
-    Returns:
-        The pickled bytes representation of the object.
-
-    Raises:
-        The exception class specified in raise_if_failed if pickling fails.
-    """
-    try:
-        pickled: bytes = pickle.dumps(to_pickle)
-    except (pickle.PicklingError, AttributeError) as err:
-        raise raise_if_failed(to_pickle) from err
-    return pickled
-
-
-# Specialized pickle function for cache keys with KeyPicklingError handling.
-_try_pickle_key: Callable[[Any], bytes] = partial(
-    _try_pickle, raise_if_failed=exceptions.KeyPicklingError
-)
-# Specialized pickle function for cache values with ValuePicklingError handling.
-_try_pickle_value: Callable[[Any], bytes] = partial(
-    _try_pickle, raise_if_failed=exceptions.ValuePicklingError
-)
-
-
-@_lru_cache
-def _try_unpickle(pickled: bytes, raise_if_failed: type = exceptions.CacheError) -> Any:
-    """Attempt to unpickle bytes with error handling.
-
-    Tries to deserialize bytes using pickle.loads with appropriate error
-    handling and custom exception raising.
-
-    Args:
-        pickled: The bytes to be unpickled.
-        raise_if_failed: Exception class to raise if unpickling fails.
-
-    Returns:
-        The unpickled object.
-
-    Raises:
-        The exception class specified in raise_if_failed if unpickling fails.
-    """
-    try:
-        unpickled: Any = pickle.loads(pickled)
-    except pickle.UnpicklingError as err:
-        raise raise_if_failed(pickled) from err
-    return unpickled
-
-
-# Specialized unpickle function for cache keys with KeyUnPicklingError handling.
-_try_unpickle_value: Callable[[Any], bytes] = partial(
-    _try_unpickle, raise_if_failed=exceptions.ValueUnPicklingError
-)


### PR DESCRIPTION
Summary:
Previously, when the interfaces were quite complex it made sense to abstract away the types that we put into the cache implementations. That way we shared complexity between interfaces and implementations.

Not that the interfaces are less complex, we can move this abstraction out of the implementations.

Mainly:
- cache impls now take str keys and bytes values
- except for the InMemoryCache, which takes Any values (with the assumption that Any is JSON-able)

This also has the added benefit of making InMemoryCache memory completely human readable (whether it is human readable in a way that actually makes sense is up to the user's encoding of results)

Test Plan: ```buck test fbcode//mode/opt caffe2/test/inductor:caching```

Differential Revision: D88979063




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo