### PR TITLE
[CI][CUDA][Distributed][B200] Add CUDA13 based distributed periodic tests

### DIFF
--- a/.github/workflows/b200-cuda13-distributed.yml
+++ b/.github/workflows/b200-cuda13-distributed.yml
@@ -1,0 +1,63 @@
+name: CI for distributed tests on B200 with CUDA 13.0
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/b200-cuda13-distributed.yml
+  workflow_dispatch:
+  push:
+    tags:
+      - ciflow/b200-cuda13-distributed/*
+  schedule:
+    - cron: 46 20 * * *  # about 1:46pm PDT
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  linux-jammy-cuda13_0-py3_10-gcc11-build-distributed-b200:
+    name: linux-jammy-cuda13.0-py3.10-gcc11-build-distributed-b200
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner: linux.r7i.4xlarge
+      build-environment: linux-jammy-cuda13.0-py3.10-gcc11-distributed-b200
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
+      cuda-arch-list: '10.0'
+      test-matrix: |
+        { include: [
+          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.dgx.b200.8" },
+          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.dgx.b200.8" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-cuda13_0-py3_10-gcc11-test-distributed-b200:
+    name: linux-jammy-cuda13.0-py3.10-gcc11-test-b200
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-cuda13_0-py3_10-gcc11-build-distributed-b200
+    with:
+      timeout-minutes: 1200
+      build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build-distributed-b200.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build-distributed-b200.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build-distributed-b200.outputs.test-matrix }}
+      aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+    secrets: inherit
+


### PR DESCRIPTION
Currently the distributed jobs are running with cuda12.8 based containers. 
This PR uses: https://github.com/pytorch/pytorch/blob/63fc2b4813f3c6f1f425fa5a9cd66aa8847c4347/.ci/docker/build.sh#L118 to run distributed tests. 
 
cc @ptrblck @eqy @tinglvv @malfet @atalman @Skylion007 @kwen2501 