### PR TITLE
[ONNX] Handle complex initializers

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -711,6 +711,34 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(ep)
         onnx_testing.assert_onnx_program(onnx_program)
 
+    def test_complex_initializer(self):
+        class ComplexInitModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.buffer = torch.nn.parameter.Buffer(
+                    torch.complex(
+                        torch.tensor([1.0, 2.0, 3.0]), torch.tensor([4.0, 5.0, 6.0])
+                    )
+                )
+                self.weight = torch.nn.Parameter(
+                    torch.complex(
+                        torch.tensor([7.0, 8.0, 9.0]), torch.tensor([10.0, 11.0, 12.0])
+                    )
+                )
+
+            def forward(self, x):
+                constant = torch.complex(
+                    torch.tensor([11.0, 12.0, 13.0]), torch.tensor([14.0, 15.0, 16.0])
+                )
+                return (x + constant + self.buffer) * self.weight
+
+        x = torch.complex(
+            torch.tensor([10.0, 20.0, 30.0]), torch.tensor([40.0, 50.0, 60.0])
+        )
+
+        onnx_program = self.export(ComplexInitModel(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
 
 @common_utils.instantiate_parametrized_tests
 class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -269,15 +269,10 @@ def _set_shape_type(
         # In this case, we don't change the dtype or the shape of the tensor.
         if value.dtype is None:
             value.dtype = torch_dtype_to_onnx_dtype(meta_val.dtype)
-            if complex_to_float:
-                if meta_val.dtype == torch.complex64:
-                    value.dtype = ir.DataType.FLOAT
-                    # Add 2 as the last dimension if the tensor is complex to hold the real/imag parts
-                    dims.append(2)
-                elif meta_val.dtype == torch.complex128:
-                    value.dtype = ir.DataType.DOUBLE
-                    # Add 2 as the last dimension if the tensor is complex to hold the real/imag parts
-                    dims.append(2)
+            if complex_to_float and meta_val.dtype.is_complex:
+                value.dtype = torch_dtype_to_onnx_dtype(meta_val.dtype.to_real())
+                # Add 2 as the last dimension if the tensor is complex to hold the real/imag parts
+                dims.append(2)
 
         value.shape = ir.Shape(dims)
     elif isinstance(meta_val, (int, torch.SymInt)):
@@ -1256,7 +1251,7 @@ def _exported_program_to_onnx_program(
         # Turn complex tensors into float tensors when converting to ONNX
         complex_to_float = lower != "none"
         if complex_to_float:
-            if torch_tensor.dtype in (torch.complex64, torch.complex128):
+            if torch_tensor.dtype.is_complex:
                 torch_tensor = torch.view_as_real(torch_tensor)
 
         ir_tensor = TorchTensor(torch_tensor, name=name)

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -1252,12 +1252,19 @@ def _exported_program_to_onnx_program(
                 f"Tensor '{name}' should be a torch.Tensor. Actual type is '{type(torch_tensor)}': {torch_tensor!r}. "
                 "This is unexpected and not yet supported."
             )
+
+        # Turn complex tensors into float tensors when converting to ONNX
+        complex_to_float = lower != "none"
+        if complex_to_float:
+            if torch_tensor.dtype in (torch.complex64, torch.complex128):
+                torch_tensor = torch.view_as_real(torch_tensor)
+
         ir_tensor = TorchTensor(torch_tensor, name=name)
         initializer.const_value = ir_tensor
         _set_shape_type(
             initializer,
             torch_tensor,
-            complex_to_float=lower != "none",
+            complex_to_float=complex_to_float,
         )
 
     # TODO: Decide if we should keep mutated buffers as inputs/outputs


### PR DESCRIPTION
Handle complex initializers by turning them into floats. Also leverage dtype.to_real() and dtype.complex to simplify dtype conversion logic.

Fixes https://github.com/pytorch/pytorch/issues/170054


cc @titaiwangms