### PR TITLE
Update combined_traceback to work with 3.11 and 3.12 python.

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1028,15 +1028,26 @@ def f(x):
         if sys.version_info >= (3, 11):
             # Count how many times our function names appear
             # (should be at least 5: innermost, middle2, middle1, outer, test function)
-            python_frame_count = sum([
-                formatted.count(name) for name in
-                ["innermost", "middle2", "middle1", "outer", "test_captured_traceback_interleaving"]
-            ])
+            python_frame_count = sum(
+                [
+                    formatted.count(name)
+                    for name in [
+                        "innermost",
+                        "middle2",
+                        "middle1",
+                        "outer",
+                        "test_captured_traceback_interleaving",
+                    ]
+                ]
+            )
 
             # The interleaving should show all these frames
             # even though they may be within a single or few PyEval_EvalFrame calls
-            self.assertGreaterEqual(python_frame_count, 5,
-                "Expected at least 5 Python frames to demonstrate interleaving")
+            self.assertGreaterEqual(
+                python_frame_count,
+                5,
+                "Expected at least 5 Python frames to demonstrate interleaving",
+            )
 
     def test_captured_traceback_interleaving_with_torch_ops(self):
         """
@@ -1050,7 +1061,7 @@ def f(x):
 
         def compute_something(x):
             # Trigger a torch operation which may involve C++ code
-            result = x + 1
+            x + 1
             # Capture at this point
             return CapturedTraceback.extract(cpp=True)
 
@@ -1078,12 +1089,16 @@ def f(x):
             # This validates that multiple Python frames within the same
             # PyEval_EvalFrame are being captured
             self.assertGreaterEqual(
-                len([n for n in function_names if n in ["compute_something", "process_data", "main_function"]]),
+                len(
+                    [
+                        n
+                        for n in function_names
+                        if n in ["compute_something", "process_data", "main_function"]
+                    ]
+                ),
                 3,
-                "All Python frames should be visible with interleaving"
+                "All Python frames should be visible with interleaving",
             )
-
-
 
 
 class TestTryImport(TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1083,22 +1083,20 @@ def f(x):
         self.assertIn("process_data", function_names)
         self.assertIn("main_function", function_names)
 
-        # On Python 3.11+, the implementation should properly interleave frames
-        if sys.version_info >= (3, 11):
-            # All three of our functions should be visible in the trace
-            # This validates that multiple Python frames within the same
-            # PyEval_EvalFrame are being captured
-            self.assertGreaterEqual(
-                len(
-                    [
-                        n
-                        for n in function_names
-                        if n in ["compute_something", "process_data", "main_function"]
-                    ]
-                ),
-                3,
-                "All Python frames should be visible with interleaving",
-            )
+        # All three of our functions should be visible in the trace
+        # This validates that multiple Python frames within the same
+        # PyEval_EvalFrame are being captured
+        self.assertGreaterEqual(
+            len(
+                [
+                    n
+                    for n in function_names
+                    if n in ["compute_something", "process_data", "main_function"]
+                ]
+            ),
+            3,
+            "All Python frames should be visible with interleaving",
+        )
 
 
 class TestTryImport(TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1057,7 +1057,6 @@ def f(x):
         which then call back into Python. The interleaving should properly
         show all Python frames even when C++ (PyEval_EvalFrame) frames are involved.
         """
-        import sys
 
         def compute_something(x):
             # Trigger a torch operation which may involve C++ code

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -987,6 +987,104 @@ def f(x):
         self.assertEqual(len(rs), 2)
         self.assertIn("test_captured_traceback_format_all", "".join(rs[0]))
 
+    def test_captured_traceback_interleaving(self):
+        """
+        Test py-spy style interleaving of Python and C++ stack traces.
+
+        When multiple Python function calls occur within a single C++ eval frame,
+        they should all appear in the traceback with proper interleaving.
+        This tests the is_entry flag implementation in combined_traceback.cpp.
+        """
+        import sys
+
+        # Create a nested call stack with multiple Python frames
+        def innermost():
+            # Capture traceback at the deepest point
+            return CapturedTraceback.extract(cpp=True)
+
+        def middle2():
+            return innermost()
+
+        def middle1():
+            return middle2()
+
+        def outer():
+            return middle1()
+
+        tb = outer()
+        formatted = "".join(tb.format())
+
+        # Verify all Python function names appear in the traceback
+        # This ensures interleaving is working - if it wasn't, we might only
+        # see one Python frame per PyEval_EvalFrame C++ frame
+        self.assertIn("innermost", formatted)
+        self.assertIn("middle2", formatted)
+        self.assertIn("middle1", formatted)
+        self.assertIn("outer", formatted)
+        self.assertIn("test_captured_traceback_interleaving", formatted)
+
+        # On Python 3.11+, verify that we have more Python frames than
+        # PyEval_EvalFrame C++ frames, which would indicate interleaving
+        if sys.version_info >= (3, 11):
+            # Count how many times our function names appear
+            # (should be at least 5: innermost, middle2, middle1, outer, test function)
+            python_frame_count = sum([
+                formatted.count(name) for name in
+                ["innermost", "middle2", "middle1", "outer", "test_captured_traceback_interleaving"]
+            ])
+
+            # The interleaving should show all these frames
+            # even though they may be within a single or few PyEval_EvalFrame calls
+            self.assertGreaterEqual(python_frame_count, 5,
+                "Expected at least 5 Python frames to demonstrate interleaving")
+
+    def test_captured_traceback_interleaving_with_torch_ops(self):
+        """
+        Test interleaving when PyTorch operations are involved.
+
+        This creates a stack with Python functions calling torch operations,
+        which then call back into Python. The interleaving should properly
+        show all Python frames even when C++ (PyEval_EvalFrame) frames are involved.
+        """
+        import sys
+
+        def compute_something(x):
+            # Trigger a torch operation which may involve C++ code
+            result = x + 1
+            # Capture at this point
+            return CapturedTraceback.extract(cpp=True)
+
+        def process_data(x):
+            return compute_something(x * 2)
+
+        def main_function():
+            x = torch.tensor([1.0, 2.0, 3.0])
+            return process_data(x)
+
+        tb = main_function()
+        summary = tb.summary()
+
+        # Extract function names from the stack summary
+        function_names = [frame.name for frame in summary]
+
+        # Verify our Python functions appear
+        self.assertIn("compute_something", function_names)
+        self.assertIn("process_data", function_names)
+        self.assertIn("main_function", function_names)
+
+        # On Python 3.11+, the implementation should properly interleave frames
+        if sys.version_info >= (3, 11):
+            # All three of our functions should be visible in the trace
+            # This validates that multiple Python frames within the same
+            # PyEval_EvalFrame are being captured
+            self.assertGreaterEqual(
+                len([n for n in function_names if n in ["compute_something", "process_data", "main_function"]]),
+                3,
+                "All Python frames should be visible with interleaving"
+            )
+
+
+
 
 class TestTryImport(TestCase):
     def test_import_imported(self):

--- a/torch/csrc/profiler/combined_traceback.cpp
+++ b/torch/csrc/profiler/combined_traceback.cpp
@@ -139,7 +139,8 @@ SymbolizedTracebacks symbolize(
     // Lambda to consume multiple Python frames until we hit an entry boundary
     // This implements py-spy style interleaving
     auto append_python_frames_until_entry = [&]() {
-      if (py_it == py_end) return;
+      if (py_it == py_end)
+        return;
 
       // Consume Python frames until we hit an entry frame
       // This allows multiple Python function calls within one PyEval_EvalFrame
@@ -149,7 +150,8 @@ SymbolizedTracebacks symbolize(
         append_python(frame);
         ++py_it;
 
-        // Stop at entry frames - these mark boundaries where Python was called from native
+        // Stop at entry frames - these mark boundaries where Python was called
+        // from native
         if (frame.is_entry) {
           break;
         }
@@ -182,8 +184,8 @@ SymbolizedTracebacks symbolize(
       uint64_t cpp_frame = ip_to_frame_offset.at(f);
       const unwind::Frame& uf = r.all_frames.at(cpp_frame);
       if (uf.funcname.find("PyEval_EvalFrame") != std::string::npos) {
-        // When we hit PyEval_EvalFrame, consume Python frames until entry boundary
-        // This implements py-spy style interleaving
+        // When we hit PyEval_EvalFrame, consume Python frames until entry
+        // boundary This implements py-spy style interleaving
         append_python_frames_until_entry();
       } else if (
           uf.funcname.rfind("torch::jit::InterpreterStateImpl::run", 0) !=

--- a/torch/csrc/profiler/combined_traceback.h
+++ b/torch/csrc/profiler/combined_traceback.h
@@ -24,7 +24,8 @@ struct TORCH_API CapturedTraceback : public c10::GatheredContext {
   struct PyFrame {
     void* code; // PyCodeObject*, but python headers not present
     int lasti;
-    bool is_entry; // true if this frame is an entry point from native code (Python 3.11+)
+    bool is_entry; // true if this frame is an entry point from native code
+                   // (Python 3.11+)
   };
 
   static std::shared_ptr<CapturedTraceback> gather(

--- a/torch/csrc/profiler/combined_traceback.h
+++ b/torch/csrc/profiler/combined_traceback.h
@@ -24,6 +24,7 @@ struct TORCH_API CapturedTraceback : public c10::GatheredContext {
   struct PyFrame {
     void* code; // PyCodeObject*, but python headers not present
     int lasti;
+    bool is_entry; // true if this frame is an entry point from native code (Python 3.11+)
   };
 
   static std::shared_ptr<CapturedTraceback> gather(

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -6,55 +6,134 @@
 #include <torch/csrc/utils/python_compat.h>
 #include <torch/csrc/utils/pythoncapi_compat.h>
 
-// Include Python's internal frame headers for interleaving support
-// These provide access to _PyInterpreterFrame structure
-#if IS_PYTHON_3_11_PLUS
-#include <internal/pycore_frame.h>
-#endif
-
 namespace py = pybind11;
 
+// Forward declarations for Python internal structures needed for frame interleaving.
+// We define these ourselves instead of including internal headers (which require
+// Py_BUILD_CORE in Python 3.14+) to maintain compatibility across Python versions.
+// These structures are based on CPython's internal/pycore_frame.h
+#if IS_PYTHON_3_11_PLUS
+
+// Minimal PyFrameObject structure definition (opaque in Python 3.11+)
+// We only need to access the f_frame field
+struct _PyFrameObject {
+    PyObject_HEAD
+    PyFrameObject *f_back;      /* previous frame, or NULL */
+    void *f_frame;              /* points to _PyInterpreterFrame - we'll cast this */
+    // ... other fields we don't need
+};
+
+#if IS_PYTHON_3_13_PLUS
+// Python 3.13+ _PyInterpreterFrame layout
+// Changed f_code -> f_executable and prev_instr -> instr_ptr
+struct _PyInterpreterFrame {
+    PyObject *f_executable;     // Changed from f_code in 3.13+
+    struct _PyInterpreterFrame *previous;
+    PyObject *f_funcobj;
+    PyObject *f_globals;
+    PyObject *f_builtins;
+    PyObject *f_locals;
+    PyFrameObject *frame_obj;
+    void *instr_ptr;            // Changed from prev_instr in 3.13+
+    int stacktop;
+    uint16_t return_offset;
+    char owner;                 // The field we need
+    // ... rest of structure
+};
+
+#define FRAME_OWNED_BY_CSTACK 3
+
 // Helper function to extract is_entry flag from Python frames
-// This enables py-spy style interleaving of Python and C++ stack traces
-#if IS_PYTHON_3_12_PLUS
-// Python 3.12+ uses owner field to determine frame ownership
 static bool get_is_entry_from_frame(PyFrameObject* frame) {
   if (!frame) return true;
 
   // Access the internal interpreter frame
-  // In Python 3.12+, PyFrameObject has f_frame field pointing to _PyInterpreterFrame
-  struct _frame* frame_struct = reinterpret_cast<struct _frame*>(frame);
-  _PyInterpreterFrame* iframe = frame_struct->f_frame;
+  struct _PyFrameObject* frame_obj = reinterpret_cast<struct _PyFrameObject*>(frame);
+  if (!frame_obj->f_frame) return true;
 
-  if (!iframe) return true;
+  struct _PyInterpreterFrame* iframe =
+      reinterpret_cast<struct _PyInterpreterFrame*>(frame_obj->f_frame);
 
   // Frames owned by the C stack are entry frames
-  // These mark the boundary where Python was called from native code
   return iframe->owner == FRAME_OWNED_BY_CSTACK;
 }
 
-#elif IS_PYTHON_3_11_PLUS
-// Python 3.11 has explicit is_entry field
+#elif IS_PYTHON_3_12_PLUS
+// Python 3.12 _PyInterpreterFrame layout
+// The owner field determines frame ownership
+struct _PyInterpreterFrame {
+    PyCodeObject *f_code;
+    struct _PyInterpreterFrame *previous;
+    PyObject *f_funcobj;
+    PyObject *f_globals;
+    PyObject *f_builtins;
+    PyObject *f_locals;
+    PyFrameObject *frame_obj;
+    void *prev_instr;           // _Py_CODEUNIT*
+    int stacktop;
+    uint16_t return_offset;
+    char owner;                 // The field we need for Python 3.12+
+    // ... rest of structure
+};
+
+#define FRAME_OWNED_BY_CSTACK 3
+
+// Helper function to extract is_entry flag from Python frames
 static bool get_is_entry_from_frame(PyFrameObject* frame) {
   if (!frame) return true;
 
   // Access the internal interpreter frame
-  struct _frame* frame_struct = reinterpret_cast<struct _frame*>(frame);
-  _PyInterpreterFrame* iframe = frame_struct->f_frame;
+  struct _PyFrameObject* frame_obj = reinterpret_cast<struct _PyFrameObject*>(frame);
+  if (!frame_obj->f_frame) return true;
 
-  if (!iframe) return true;
+  struct _PyInterpreterFrame* iframe =
+      reinterpret_cast<struct _PyInterpreterFrame*>(frame_obj->f_frame);
+
+  // Frames owned by the C stack are entry frames
+  return iframe->owner == FRAME_OWNED_BY_CSTACK;
+}
+
+#else // Python 3.11.x
+// Python 3.11 _PyInterpreterFrame layout with explicit is_entry field
+struct _PyInterpreterFrame {
+    PyObject *f_func;
+    PyObject *f_globals;
+    PyObject *f_builtins;
+    PyObject *f_locals;
+    PyCodeObject *f_code;
+    PyFrameObject *frame_obj;
+    struct _PyInterpreterFrame *previous;
+    void *prev_instr;           // _Py_CODEUNIT*
+    int stacktop;
+    bool is_entry;              // The field we need for Python 3.11
+    char owner;
+    // ... rest of structure
+};
+
+// Helper function to extract is_entry flag from Python frames
+static bool get_is_entry_from_frame(PyFrameObject* frame) {
+  if (!frame) return true;
+
+  // Access the internal interpreter frame
+  struct _PyFrameObject* frame_obj = reinterpret_cast<struct _PyFrameObject*>(frame);
+  if (!frame_obj->f_frame) return true;
+
+  struct _PyInterpreterFrame* iframe =
+      reinterpret_cast<struct _PyInterpreterFrame*>(frame_obj->f_frame);
 
   // Use the is_entry field directly
   return iframe->is_entry;
 }
 
-#else
+#endif // IS_PYTHON_3_12_PLUS
+
+#else // Python < 3.11
 // Python < 3.11: No interleaving support, treat all frames as entry frames
 static bool get_is_entry_from_frame(PyFrameObject* frame) {
   return true;
 }
 
-#endif
+#endif // IS_PYTHON_3_11_PLUS
 
 
 namespace torch {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170238

Summary:
This adds support for having multiple python frames correspond to one interpreter eval frame.