### PR TITLE
Fix for test_ddp_apply_optim_in_backward for gloo

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupGlooCuda.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGlooCuda.cpp
@@ -119,9 +119,7 @@ class AsyncAllreduceCUDAHostWork : public AsyncAllreduceWork {
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
     for (const auto i : c10::irange(inputs.size())) {
-      c10::Device device = inputs[i].device();
-      events[i].block(
-          c10::impl::VirtualGuardImpl(device.type()).getStream(device));
+      events[i].synchronize();
     }
   }
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -84,11 +84,8 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_SANDCASTLE,
     IS_WINDOWS,
-    MI200_ARCH,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
-    skipIfRocm,
-    skipIfRocmArch,
     TemporaryFileName,
 )
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -4862,7 +4859,6 @@ class DistributedTest:
                         # case.
                         optim.zero_grad(set_to_none=True)
 
-        @skipIfRocm
         @skip_if_lt_x_gpu(2)
         def test_ddp_apply_optim_in_backward(self):
             for optim_cls, init_before in itertools.product(
@@ -4885,7 +4881,6 @@ class DistributedTest:
                     gradient_as_bucket_view=False,
                 )
 
-        @skipIfRocmArch(MI200_ARCH)
         @skip_if_lt_x_gpu(2)
         def test_ddp_apply_optim_in_backward_ignored_params(self):
             torch.cuda.set_device(self.rank)


### PR DESCRIPTION
Fixes #155714

## Problem

`AsyncAllreduceCUDAHostWork` in ProcessGroupGloo was producing incorrect results when performing allreduce operations on CUDA/HIP tensors, causing `test_ddp_apply_optim_in_backward` to fail. The problem is common for both CUDA and HIP however it was hidden by different CI setup (no torchvision installed so the test execution was incomplete).

## Root Cause

ProcessGroupGloo is a CPU-based collective communication backend. For CUDA tensors, it:
1. Copies tensors from GPU to pinned CPU memory (async)
2. Performs allreduce on CPU using Gloo
3. Copies results back to GPU (async)

The bug was in the `synchronize()` method, which used: `events[i].block(c10::impl::VirtualGuardImpl(device.type()).getStream(device));`
- `event.block(stream)` calls `cudaStreamWaitEvent()/hipStreamWaitEvent()`, providing only **GPU-GPU synchronization** 
- it makes a CUDA stream wait for an event but doesn't synchronize with the CPU. Since Gloo needs data on the CPU side, this is insufficient.

## Fix

Changed to `event.synchronize()`:
- this calls `cudaEventSynchronize()/hipEventSynchronize()`, which blocks the **CPU thread** until the event completes, providing proper **CPU-GPU synchronization**. This ensures GPU copy operations have actually completed before Gloo accesses the data.