### PR TITLE
Make it explicit that PyTorchStreamReader miniz errors likely indicate corrupt checkpoint

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -246,7 +246,7 @@ void PyTorchStreamReader::valid(const char* what, const char* info) {
       info,
       ": ",
       mz_zip_get_error_string(err),
-      " This is an internal miniz error. If you are seeing this error, there "
+      ". This is an internal miniz error. If you are seeing this error, there "
       "is a high likelihood that your checkpoint file is corrupted. "
       "This can happen if the checkpoint was not saved properly, "
       "was transferred incorrectly, or the file was modified after saving.");

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -246,7 +246,7 @@ void PyTorchStreamReader::valid(const char* what, const char* info) {
       info,
       ": ",
       mz_zip_get_error_string(err),
-      "This is an internal miniz error. If you are seeing this error, there "
+      " This is an internal miniz error. If you are seeing this error, there "
       "is a high likelihood that your checkpoint file is corrupted. "
       "This can happen if the checkpoint was not saved properly, "
       "was transferred incorrectly, or the file was modified after saving.");

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -245,7 +245,11 @@ void PyTorchStreamReader::valid(const char* what, const char* info) {
       what,
       info,
       ": ",
-      mz_zip_get_error_string(err));
+      mz_zip_get_error_string(err),
+      "This is an internal miniz error. If you are seeing this error, there "
+      "is a high likelihood that your checkpoint file is corrupted. "
+      "This can happen if the checkpoint was not saved properly, "
+      "was transferred incorrectly, or the file was modified after saving.");
 }
 
 constexpr int MZ_ZIP_LOCAL_DIR_HEADER_SIZE = 30;

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4753,7 +4753,7 @@ class TestSerialization(TestCase, SerializationMixin):
 
             with self.assertRaisesRegex(
                 RuntimeError,
-                r"invalid header or archive is corrupted"
+                r"invalid header or archive is corrupted\. "
                 r"This is an internal miniz error[\s\S]*"
                 r"there is a high likelihood that your checkpoint file is corrupted"
             ):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4726,6 +4726,40 @@ class TestSerialization(TestCase, SerializationMixin):
                     self.assertTrue(opened_zipfile.has_record(".format_version"))
                     self.assertEqual(opened_zipfile.get_record(".format_version"), b'1')
 
+    @unittest.skipIf(IS_WINDOWS, "TemporaryFileName on windows")
+    def test_corrupted_checkpoint_error_message(self):
+        """Test that corrupted checkpoint files produce helpful error messages."""
+        sd = torch.nn.Linear(2, 3).state_dict()
+
+        with TemporaryFileName() as filepath:
+            torch.save(sd, filepath)
+
+            with open(filepath, 'r+b') as f:
+                data = bytearray(f.read())
+
+                # Find and corrupt a local file header signature (PK\x03\x04)
+                # This triggers MZ_ZIP_INVALID_HEADER_OR_CORRUPTED in miniz
+                local_header_sig = b'PK\x03\x04'
+                first_idx = data.find(local_header_sig)
+                if first_idx != -1:
+                    second_idx = data.find(local_header_sig, first_idx + 1)
+                    if second_idx != -1:
+                        # Corrupt the signature
+                        data[second_idx] = 0x00
+                        data[second_idx + 1] = 0x00
+
+                f.seek(0)
+                f.write(data)
+
+            # Verify that loading the corrupted file produces a helpful error message
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"invalid header or archive is corrupted"
+                r"This is an internal miniz error[\s\S]*"
+                r"there is a high likelihood that your checkpoint file is corrupted"
+            ):
+                torch.load(filepath)
+
     def test_storage_alignment(self):
         sd = torch.nn.Linear(10, 10).state_dict()
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4751,7 +4751,6 @@ class TestSerialization(TestCase, SerializationMixin):
                 f.seek(0)
                 f.write(data)
 
-            # Verify that loading the corrupted file produces a helpful error message
             with self.assertRaisesRegex(
                 RuntimeError,
                 r"invalid header or archive is corrupted"


### PR DESCRIPTION
Error message

```
*** RuntimeError: PytorchStreamReader failed reading file .format_version: invalid header or archive is corrupted. This is an internal miniz error. If you are seeing this error, there is a high likelihood that your checkpoint file is corrupted. This can happen if the checkpoint was not saved properly, was transferred incorrectly, or the file was modified after saving.
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170332
* __->__ #170244



cc @albanD