### PR TITLE
[dynamo][hops] Ignore side effects for _reparameterize_module

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -812,6 +812,129 @@ class GraphModule(torch.nn.Module):
             ignore_empty_lines=True,
         )
 
+    def test_no_raise_on_reparameterize_module(self):
+        mod = torch.nn.Linear(10, 10)
+        params = dict(mod.named_parameters())
+        buffers = dict(mod.named_buffers())
+        params_and_buffers = {
+            **dict(params),
+            **dict(buffers),
+        }
+
+        @nested_compile_region
+        def gn(x):
+            return torch.func.functional_call(
+                mod, parameter_and_buffer_dicts=params_and_buffers, args=(x,)
+            )
+
+        def fn(x):
+            return gn(x) + gn(x)
+
+        x = torch.randn(10, 10)
+        ref = fn(x)
+        backend = AotEagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        with mock.patch(
+            "torch._dynamo.variables.higher_order_ops.InvokeSubgraphHigherOrderVariable.allow_side_effects",
+            False,
+        ):
+            res = opt_fn(x)
+
+        self.assertEqual(ref, res)
+
+        if not TEST_WITH_CROSSREF:
+            self.assertExpectedInline(
+                normalize_gm(backend.graphs[0].print_readable(print_output=False)),
+                """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_: "f32[10, 10]", L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_: "f32[10, 10]", L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_: "f32[10]"):
+        l_x_ = L_x_
+        l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_ = L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_
+        l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_ = L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_
+
+        subgraph_0 = self.subgraph_0
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_);  subgraph_0 = None
+        getitem: "f32[10, 10]" = invoke_subgraph[0];  invoke_subgraph = None
+        subgraph_1 = self.subgraph_0
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_);  subgraph_1 = l_x_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_ = None
+        getitem_1: "f32[10, 10]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+
+        add: "f32[10, 10]" = getitem + getitem_1;  getitem = getitem_1 = None
+        return (add,)
+
+    class subgraph_0(torch.nn.Module):
+        def forward(self, l_x_: "f32[10, 10]", l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_: "f32[10, 10]", l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_: "f32[10]"):
+            linear: "f32[10, 10]" = torch._C._nn.linear(l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_);  l_x_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_ = None
+            return (linear,)
+""",
+            )
+
+        self.assertExpectedInline(
+            normalize_gm(backend.fw_graphs[0].print_readable(print_output=False)),
+            """\
+class GraphModule(torch.nn.Module):
+    def forward(self, primals_1: "f32[10, 10]", primals_2: "f32[10, 10]", primals_3: "f32[10]"):
+        partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+        invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1, primals_2, primals_3);  partitioned_fw_subgraph_0_0 = None
+        getitem_10: "f32[10, 10]" = invoke_subgraph_4[1]
+        getitem: "f32[10, 10]" = invoke_subgraph_4[0];  invoke_subgraph_4 = None
+        partitioned_fw_subgraph_0_1 = self.partitioned_fw_subgraph_0_0
+        invoke_subgraph_6 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_1, 'partitioned_fw_subgraph_0_0', primals_1, primals_2, primals_3);  partitioned_fw_subgraph_0_1 = primals_1 = primals_2 = primals_3 = None
+        getitem_11: "f32[10, 10]" = invoke_subgraph_6[1]
+        getitem_1: "f32[10, 10]" = invoke_subgraph_6[0];  invoke_subgraph_6 = None
+        add: "f32[10, 10]" = torch.ops.aten.add.Tensor(getitem, getitem_1);  getitem = getitem_1 = None
+        return (add, getitem_10, getitem_11)
+    class partitioned_fw_subgraph_0_0(torch.nn.Module):
+        def forward(self, primals_0: "f32[10, 10]", primals_1: "f32[10, 10]", primals_2: "f32[10]"):
+            t: "f32[10, 10]" = torch.ops.aten.t.default(primals_1);  primals_1 = None
+            addmm: "f32[10, 10]" = torch.ops.aten.addmm.default(primals_2, primals_0, t);  primals_2 = t = None
+            return (addmm, primals_0)""",
+            ignore_empty_lines=True,
+        )
+
+    def test_raise_with_reparameterize_but_module_mutation(self):
+        foo = 0
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                nonlocal foo
+                foo = 1
+                return self.linear(x)
+
+        mod = Mod()
+        params = dict(mod.named_parameters())
+        buffers = dict(mod.named_buffers())
+        params_and_buffers = {
+            **dict(params),
+            **dict(buffers),
+        }
+
+        @nested_compile_region
+        def gn(x):
+            return torch.func.functional_call(
+                mod, parameter_and_buffer_dicts=params_and_buffers, args=(x,)
+            )
+
+        def fn(x):
+            return gn(x) + gn(x)
+
+        x = torch.randn(10, 10)
+        backend = AotEagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        with mock.patch(
+            "torch._dynamo.variables.higher_order_ops.InvokeSubgraphHigherOrderVariable.allow_side_effects",
+            False,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"Higher Order Operator: torch\.ops\.higher_order\.invoke_subgraph",
+            ):
+                opt_fn(x)
+
     def test_dce(self):
         @nested_compile_region
         def gn(x):

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -847,24 +847,24 @@ class GraphModule(torch.nn.Module):
                 normalize_gm(backend.graphs[0].print_readable(print_output=False)),
                 """\
 class GraphModule(torch.nn.Module):
-    def forward(self, L_x_: "f32[10, 10]", L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_: "f32[10, 10]", L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_: "f32[10]"):
+    def forward(self, L_x_: "f32[10, 10]", L_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_: "f32[10, 10]", L_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_: "f32[10]"):
         l_x_ = L_x_
-        l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_ = L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_
-        l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_ = L_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_
+        l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_ = L_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_
+        l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_ = L_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_
 
         subgraph_0 = self.subgraph_0
-        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_);  subgraph_0 = None
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_);  subgraph_0 = None
         getitem: "f32[10, 10]" = invoke_subgraph[0];  invoke_subgraph = None
         subgraph_1 = self.subgraph_0
-        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_);  subgraph_1 = l_x_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_ = None
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_0', l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_);  subgraph_1 = l_x_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_ = None
         getitem_1: "f32[10, 10]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
 
         add: "f32[10, 10]" = getitem + getitem_1;  getitem = getitem_1 = None
         return (add,)
 
     class subgraph_0(torch.nn.Module):
-        def forward(self, l_x_: "f32[10, 10]", l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_: "f32[10, 10]", l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_: "f32[10]"):
-            linear: "f32[10, 10]" = torch._C._nn.linear(l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_);  l_x_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_weight_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_modules_mod_parameters_bias_ = None
+        def forward(self, l_x_: "f32[10, 10]", l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_: "f32[10, 10]", l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_: "f32[10]"):
+            linear: "f32[10, 10]" = torch._C._nn.linear(l_x_, l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_, l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_);  l_x_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_weight_ = l_gn_closure_0_cell_contents_closure_0_cell_contents_parameters_bias_ = None
             return (linear,)
 """,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169801
* #170301
* #170258
* #170257
* __->__ #170251

_reparameterize_module has two side effects that cancel each other out.
Even if we don't allow side effects in a region (will be used for
is_pure impl in future), we still want to ignore the side effects inside
this function. We already do this (check the impl) but we were not doing
this for hops.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo