### PR TITLE
Add `/opt/python-venv/bin` to the PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         git \
         libjpeg-dev \
         libpng-dev \
-        python-is-python3 \
         python3 \
         python3-pip \
         python3-venv \
@@ -77,7 +76,7 @@ ENV PATH /opt/pytorch-venv/bin:$PATH
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
+ENV PATH /opt/pytorch-venv/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 ENV PYTORCH_VERSION ${PYTORCH_VERSION}
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         git \
         libjpeg-dev \
         libpng-dev \
+        python-is-python3 \
         python3 \
         python3-pip \
         python3-venv \


### PR DESCRIPTION
To solve `python not found` when official docker images are used
Fixes: https://github.com/pytorch/pytorch/issues/170252