### PR TITLE
[Inductor] Add more tests for selective fallbacks

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -326,8 +326,7 @@ class FxirTestCase(InductorTestCase):
 
     def test_reshape_fallback(self):
         """
-        Test falling back to aten.reshape. This is tricky because the output arg needs
-        to be a tuple instead of sympy.Tuple.
+        Test falling back to aten.reshape. This uses a custom pass to enable more fallbacks.
         """
 
         def always_fallback(node: torch.fx.Node) -> bool:
@@ -340,12 +339,10 @@ class FxirTestCase(InductorTestCase):
         with patch_custom_fallback_pass(always_fallback):
             (gm,) = self._compile_and_check(foo, args, expected_num_triton_kernels=0)
 
-        # Check that the reshape has a tuple argument, rather than sympy.Tuple.
+        # Check for the reshape.
         (reshape_node,) = gm.graph.find_nodes(
             op="call_function", target=torch.ops.aten.reshape.default
         )
-        (input_node, shape) = reshape_node.args
-        self.assertTrue(isinstance(shape), tuple)
 
     def test_extern_multi_output(self):
         """

--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
+    patch_custom_fallback_pass,
     requires_gpu,
     TRITON_HAS_CPU,
 )
@@ -322,6 +323,29 @@ class FxirTestCase(InductorTestCase):
         # Check for as_strided. We map ReinterpretView to this.
         num_as_strided = self._count_ops(gm, torch.as_strided)
         self.assertEqual(num_as_strided, 1)
+
+    def test_reshape_fallback(self):
+        """
+        Test falling back to aten.reshape. This is tricky because the output arg needs
+        to be a tuple instead of sympy.Tuple.
+        """
+
+        def always_fallback(node: torch.fx.Node) -> bool:
+            return True
+
+        def foo(x):
+            return x.reshape((2, 5))
+
+        args = (torch.randn(10, device=self.device),)
+        with patch_custom_fallback_pass(always_fallback):
+            (gm,) = self._compile_and_check(foo, args, expected_num_triton_kernels=0)
+
+        # Check that the reshape has a tuple argument, rather than sympy.Tuple.
+        (reshape_node,) = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.reshape.default
+        )
+        (input_node, shape) = reshape_node.args
+        self.assertTrue(isinstance(shape), tuple)
 
     def test_extern_multi_output(self):
         """

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -444,8 +444,9 @@ def patch_inductor_backend(
 
 def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]):
     """
-    Create a custom pass which falls back based on the specified predicate.
-    Then, return a context activating this config.
+    Create a custom pass which falls back based on the provided predicate. For example,
+    we could provide a predicate which returns True for all aten.add.default nodes.
+    Returns a context activating the pass.
     """
     class Pass(CustomGraphPass):
         def __call__(self, graph: torch.fx.Graph):

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -442,7 +442,7 @@ def patch_inductor_backend(
             original_custom_backend_config,
         )
 
-def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]):
+def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> contextlib.ContextDecorator:
     """
     Create a custom pass which falls back based on the provided predicate. For example,
     we could provide a predicate which returns True for all aten.add.default nodes.

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -11,6 +11,7 @@ from subprocess import CalledProcessError
 
 import torch
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.config as config
 from torch._inductor.codecache import CppCodeCache
 from torch._inductor.codegen.common import (
     get_custom_backend_config_for_device,
@@ -22,7 +23,7 @@ from torch._inductor.codegen.common import (
 )
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.compile_fx import shape_env_from_inputs
-from torch._inductor.custom_graph_pass import CustomGraphModulePass
+from torch._inductor.custom_graph_pass import CustomGraphModulePass, CustomGraphPass
 from torch._inductor.graph import GraphLowering
 from torch._inductor.utils import (
     get_gpu_shared_memory,
@@ -47,6 +48,8 @@ from torch.testing._internal.common_utils import (
     LazyVal,
     TestCase,
 )
+
+from collections.abc import Callable
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -438,3 +441,20 @@ def patch_inductor_backend(
             original_custom_pass,
             original_custom_backend_config,
         )
+
+def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]):
+    """
+    Create a custom pass which falls back based on the specified predicate.
+    Then, return a context activating this config.
+    """
+    class Pass(CustomGraphPass):
+        def __call__(self, graph: torch.fx.Graph):
+            for node in graph.nodes:
+                if predicate(node):
+                    node.meta["should_fallback"] = True
+
+        def uuid(self):
+            return None
+
+
+    return config.patch(post_grad_custom_pre_pass=Pass())


### PR DESCRIPTION
This PR adds a few tests for the existing selective fallback feature, and refactors some of the test infra so it can be shared across test suites.
- Add a helper function to create a post-grad pass for selective fallbacks. This replaces the previous mechanism based on custom torch.compile backends. The old mechanism did not function as intended because AOTAutograd did not preserve the node metadata added by the custom backend. Thus, we add metadata for selective fallbacks in a post-grad pass instead.
- Refactor existing tests to check the generated Python code, confirming that the intended fallback took place.
- Add a selective fallback test to the FX backend, in addition to the existing Python tests.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo