### PR TITLE
[inductor][caching] applying PersistentMemoizer to _should_pad

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -24,6 +24,8 @@ from torch._inductor.runtime.caching import (
     implementations as impls,
     interfaces,
     locks,
+    Memoizer,
+    PersistentMemoizer,
     utils,
 )
 from torch._inductor.test_case import run_tests, TestCase
@@ -895,7 +897,7 @@ class InterfacesTest(TestMixin, TestCase):
         is cached and can be retrieved later.
         """
         # Setup: create a memoizer and a function that tracks call count
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
         call_count = 0
 
         @memoizer.record()
@@ -921,7 +923,7 @@ class InterfacesTest(TestMixin, TestCase):
         results from cache without executing the original function.
         """
         # Setup: create a memoizer, record a result, then try to replay it
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
         call_count = 0
 
         @memoizer.record()
@@ -953,7 +955,7 @@ class InterfacesTest(TestMixin, TestCase):
         result, it raises a KeyError.
         """
         # Setup: create a memoizer with replay decorator
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
 
         @memoizer.replay()
         def compute(x: int) -> int:
@@ -972,7 +974,7 @@ class InterfacesTest(TestMixin, TestCase):
         - Subsequent calls retrieve from cache without executing
         """
         # Setup: create a memoizer and a function that tracks call count
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
         call_count = 0
 
         @memoizer.memoize()
@@ -1000,7 +1002,7 @@ class InterfacesTest(TestMixin, TestCase):
         returns the original function without any caching behavior.
         """
         # Setup: create a memoizer with caching disabled
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
         call_count = 0
 
         @memoizer.record()
@@ -1026,7 +1028,7 @@ class InterfacesTest(TestMixin, TestCase):
         always raises KeyError regardless of what's in the cache.
         """
         # Setup: create a memoizer with caching disabled
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
 
         @memoizer.replay()
         def compute(x: int) -> int:
@@ -1045,7 +1047,7 @@ class InterfacesTest(TestMixin, TestCase):
         returns the original function without any caching behavior.
         """
         # Setup: create a memoizer with caching disabled
-        memoizer = interfaces.Memoizer()
+        memoizer = Memoizer()
         call_count = 0
 
         @memoizer.memoize()
@@ -1074,7 +1076,7 @@ class InterfacesTest(TestMixin, TestCase):
         is cached in both the in-memory cache and the on-disk cache.
         """
         # Setup: create a persistent memoizer
-        persistent = interfaces.PersistentMemoizer(sub_dir=self.sub_dir())
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
         call_count = 0
 
         @persistent.record()
@@ -1114,7 +1116,7 @@ class InterfacesTest(TestMixin, TestCase):
         3. Populate memory cache from disk on disk hit
         """
         # Setup: create a persistent memoizer and store only to disk
-        persistent = interfaces.PersistentMemoizer(sub_dir=self.sub_dir())
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
 
         # Store a value directly to disk cache only (as CacheEntry)
         cache_key = interfaces._BaseMemoizer._make_key(None, 5)
@@ -1161,7 +1163,7 @@ class InterfacesTest(TestMixin, TestCase):
         - After clearing memory, retrieves from disk
         """
         # Setup: create a persistent memoizer
-        persistent = interfaces.PersistentMemoizer(sub_dir=self.sub_dir())
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
         call_count = 0
 
         @persistent.memoize()
@@ -1202,7 +1204,7 @@ class InterfacesTest(TestMixin, TestCase):
         returns the original function without any caching to memory or disk.
         """
         # Setup: create a persistent memoizer with caching disabled
-        persistent = interfaces.PersistentMemoizer(sub_dir=self.sub_dir())
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
         call_count = 0
 
         @persistent.record()
@@ -1236,7 +1238,7 @@ class InterfacesTest(TestMixin, TestCase):
         always raises KeyError.
         """
         # Setup: create a persistent memoizer with caching disabled
-        persistent = interfaces.PersistentMemoizer(sub_dir=self.sub_dir())
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
 
         @persistent.replay()
         def compute(x: int) -> int:
@@ -1256,7 +1258,7 @@ class InterfacesTest(TestMixin, TestCase):
         returns the original function without any caching behavior.
         """
         # Setup: create a persistent memoizer with caching disabled
-        persistent = interfaces.PersistentMemoizer(sub_dir=self.sub_dir())
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
         call_count = 0
 
         @persistent.memoize()
@@ -1516,6 +1518,459 @@ class InterfacesTest(TestMixin, TestCase):
 
         self.assertEqual(next(iter(feature_a_entries.values()))["result"], 10)
         self.assertEqual(next(iter(feature_b_entries.values()))["result"], 30)
+
+
+@instantiate_parametrized_tests
+class ShouldPadMemoizerTest(TestMixin, TestCase):
+    """Test class for _should_pad memoizer integration.
+
+    These tests verify that the PersistentMemoizer applied to _should_pad
+    correctly memoizes and replays results based on tensor metadata and
+    operation parameters.
+    """
+
+    @classmethod
+    def sub_dir(cls) -> str:
+        return f"testing-should-pad-memoizer-{cls.cls_id}"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        rmtree(
+            impls._OnDiskCacheImpl(sub_dir=cls.sub_dir())._cache_dir,
+            ignore_errors=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        rmtree(
+            impls._OnDiskCacheImpl(sub_dir=cls.sub_dir())._cache_dir,
+            ignore_errors=True,
+        )
+
+    def _create_mock_match(self) -> Any:
+        """Create a mock Match object for testing.
+
+        Returns a mock that simulates the Match object from pattern_matcher,
+        providing the minimal interface needed for the should_pad_params_encoder.
+        """
+        from unittest.mock import MagicMock
+
+        mock_match = MagicMock()
+
+        # Create mock FX nodes for mat1 and mat2 kwargs
+        mock_mat1_node = MagicMock()
+        mock_mat1_node.op = "placeholder"
+
+        mock_mat2_node = MagicMock()
+        mock_mat2_node.op = "placeholder"
+
+        mock_match.kwargs = {
+            "mat1": mock_mat1_node,
+            "mat2": mock_mat2_node,
+        }
+
+        return mock_match
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_caches_result(self) -> None:
+        """Test that the should_pad_memoizer caches function results.
+
+        Verifies that when a function decorated with should_pad_memoizer.memoize
+        is called, the result is cached and can be retrieved on subsequent calls.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return True
+
+        # Create test inputs
+        mock_match = self._create_mock_match()
+        mat1 = torch.randn(8, 16, dtype=torch.float32)
+        mat2 = torch.randn(16, 32, dtype=torch.float32)
+        op = torch.ops.aten.mm
+
+        # Execute: call the function twice with the same parameters
+        result1 = mock_should_pad(mock_match, mat1, mat2, op)
+        self.assertEqual(call_count, 1)
+
+        result2 = mock_should_pad(mock_match, mat1, mat2, op)
+        self.assertEqual(call_count, 1)  # Should use cached result
+
+        # Assert: both calls return the same result
+        self.assertTrue(result1)
+        self.assertTrue(result2)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_different_shapes_different_cache_entries(
+        self,
+    ) -> None:
+        """Test that different tensor shapes result in different cache entries.
+
+        Verifies that the encoder correctly distinguishes between tensors with
+        different shapes, ensuring they don't share cached results.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            # Return different values based on shape to verify no cross-caching
+            return mat1.shape[0] > 10
+
+        mock_match = self._create_mock_match()
+
+        # Execute: call with different shapes
+        mat1_small = torch.randn(8, 16, dtype=torch.float32)
+        mat2_small = torch.randn(16, 32, dtype=torch.float32)
+
+        mat1_large = torch.randn(12, 16, dtype=torch.float32)
+        mat2_large = torch.randn(16, 32, dtype=torch.float32)
+
+        op = torch.ops.aten.mm
+
+        result_small = mock_should_pad(mock_match, mat1_small, mat2_small, op)
+        self.assertEqual(call_count, 1)
+
+        result_large = mock_should_pad(mock_match, mat1_large, mat2_large, op)
+        self.assertEqual(call_count, 2)  # Should be a cache miss
+
+        # Assert: results are different (based on shape)
+        self.assertFalse(result_small)  # 8 <= 10
+        self.assertTrue(result_large)  # 12 > 10
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_different_dtypes_different_cache_entries(
+        self,
+    ) -> None:
+        """Test that different tensor dtypes result in different cache entries.
+
+        Verifies that the encoder correctly distinguishes between tensors with
+        different dtypes, ensuring they don't share cached results.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return mat1.dtype == torch.float32
+
+        mock_match = self._create_mock_match()
+        op = torch.ops.aten.mm
+
+        # Execute: call with different dtypes but same shapes
+        mat1_fp32 = torch.randn(8, 16, dtype=torch.float32)
+        mat2_fp32 = torch.randn(16, 32, dtype=torch.float32)
+
+        mat1_fp16 = torch.randn(8, 16, dtype=torch.float16)
+        mat2_fp16 = torch.randn(16, 32, dtype=torch.float16)
+
+        result_fp32 = mock_should_pad(mock_match, mat1_fp32, mat2_fp32, op)
+        self.assertEqual(call_count, 1)
+
+        result_fp16 = mock_should_pad(mock_match, mat1_fp16, mat2_fp16, op)
+        self.assertEqual(call_count, 2)  # Should be a cache miss
+
+        # Assert: results are different (based on dtype)
+        self.assertTrue(result_fp32)
+        self.assertFalse(result_fp16)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_different_ops_different_cache_entries(
+        self,
+    ) -> None:
+        """Test that different operations result in different cache entries.
+
+        Verifies that the encoder correctly distinguishes between different
+        operation types (mm vs bmm), ensuring they don't share cached results.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+        call_ops: list[Any] = []
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            call_ops.append(op)
+            return op is torch.ops.aten.mm
+
+        mock_match = self._create_mock_match()
+
+        # Create 2D tensors for mm
+        mat1 = torch.randn(8, 16, dtype=torch.float32)
+        mat2 = torch.randn(16, 32, dtype=torch.float32)
+
+        # Execute: call with different operations
+        result_mm = mock_should_pad(mock_match, mat1, mat2, torch.ops.aten.mm)
+        self.assertEqual(call_count, 1)
+
+        result_addmm = mock_should_pad(mock_match, mat1, mat2, torch.ops.aten.addmm)
+        self.assertEqual(call_count, 2)  # Should be a cache miss
+
+        # Assert: results are different (based on op)
+        self.assertTrue(result_mm)
+        self.assertFalse(result_addmm)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_replays_from_disk_cache(self) -> None:
+        """Test that the memoizer replays results from disk cache after memory clear.
+
+        Verifies that PersistentMemoizer correctly stores results to disk and
+        can replay them after the in-memory cache is cleared.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return True
+
+        mock_match = self._create_mock_match()
+        mat1 = torch.randn(8, 16, dtype=torch.float32)
+        mat2 = torch.randn(16, 32, dtype=torch.float32)
+        op = torch.ops.aten.mm
+
+        # Execute: cache a result
+        result1 = mock_should_pad(mock_match, mat1, mat2, op)
+        self.assertEqual(call_count, 1)
+        self.assertTrue(result1)
+
+        # Clear the in-memory cache to simulate a new process
+        test_memoizer._memoizer._cache = impls._InMemoryCacheImpl()
+
+        # Execute: call again - should replay from disk
+        result2 = mock_should_pad(mock_match, mat1, mat2, op)
+        self.assertEqual(call_count, 1)  # Function should NOT be called again
+        self.assertTrue(result2)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(False)
+    def test_should_pad_memoizer_disabled_does_not_cache(self) -> None:
+        """Test that the memoizer does not cache when caching is disabled.
+
+        Verifies that when IS_CACHING_MODULE_ENABLED is False, the function
+        is called every time without caching.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return True
+
+        mock_match = self._create_mock_match()
+        mat1 = torch.randn(8, 16, dtype=torch.float32)
+        mat2 = torch.randn(16, 32, dtype=torch.float32)
+        op = torch.ops.aten.mm
+
+        # Execute: call the function twice
+        result1 = mock_should_pad(mock_match, mat1, mat2, op)
+        result2 = mock_should_pad(mock_match, mat1, mat2, op)
+
+        # Assert: function was called both times (no caching)
+        self.assertEqual(call_count, 2)
+        self.assertTrue(result1)
+        self.assertTrue(result2)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_with_input_tensor(self) -> None:
+        """Test that the memoizer correctly handles the optional input tensor.
+
+        Verifies that different input tensors (for addmm) result in different
+        cache entries, and that None vs non-None input are distinguished.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return input is not None
+
+        mock_match = self._create_mock_match()
+        mat1 = torch.randn(8, 16, dtype=torch.float32)
+        mat2 = torch.randn(16, 32, dtype=torch.float32)
+        input_tensor = torch.randn(32, dtype=torch.float32)
+        op = torch.ops.aten.addmm
+
+        # Execute: call with and without input tensor
+        result_with_input = mock_should_pad(
+            mock_match, mat1, mat2, op, input=input_tensor
+        )
+        self.assertEqual(call_count, 1)
+
+        result_without_input = mock_should_pad(mock_match, mat1, mat2, op, input=None)
+        self.assertEqual(call_count, 2)  # Should be a cache miss
+
+        # Assert: results are different
+        self.assertTrue(result_with_input)
+        self.assertFalse(result_without_input)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_params_encoder_produces_consistent_keys(self) -> None:
+        """Test that the encoder produces consistent keys for the same inputs.
+
+        Verifies that calling the encoder with the same tensor metadata produces
+        the same cache key, ensuring reliable cache hits.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        mock_match = self._create_mock_match()
+        mat1 = torch.randn(8, 16, dtype=torch.float32)
+        mat2 = torch.randn(16, 32, dtype=torch.float32)
+        op = torch.ops.aten.mm
+
+        # Execute: encode the same parameters multiple times
+        encoded1 = encoders.should_pad_params_encoder(mock_match, mat1, mat2, op)
+        encoded2 = encoders.should_pad_params_encoder(mock_match, mat1, mat2, op)
+
+        # Assert: encodings are identical
+        self.assertEqual(encoded1, encoded2)
+
+        # Also verify the structure of the encoded output
+        self.assertIn("mat1", encoded1)
+        self.assertIn("mat2", encoded1)
+        self.assertIn("op", encoded1)
+        self.assertEqual(encoded1["mat1"]["shape"], tuple(mat1.shape))
+        self.assertEqual(encoded1["mat2"]["shape"], tuple(mat2.shape))
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_should_pad_memoizer_same_shape_different_data_uses_cache(self) -> None:
+        """Test that tensors with the same metadata but different data share cache.
+
+        Verifies that the memoizer caches based on tensor metadata (shape, stride,
+        dtype) and not on the actual tensor data values.
+        """
+        import torch
+        from torch._inductor.runtime.caching import encoders
+
+        # Setup: create a new memoizer instance for isolation
+        test_memoizer = PersistentMemoizer(sub_dir=self.sub_dir())
+        call_count = 0
+
+        @test_memoizer.memoize(custom_params_encoder=encoders.should_pad_params_encoder)
+        def mock_should_pad(
+            match: Any,
+            mat1: torch.Tensor,
+            mat2: torch.Tensor,
+            op: Any,
+            input: torch.Tensor | None = None,
+        ) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return True
+
+        mock_match = self._create_mock_match()
+        op = torch.ops.aten.mm
+
+        # Execute: call with different tensors that have the same metadata
+        mat1_a = torch.randn(8, 16, dtype=torch.float32)
+        mat2_a = torch.randn(16, 32, dtype=torch.float32)
+
+        mat1_b = torch.randn(8, 16, dtype=torch.float32)  # Different data, same shape
+        mat2_b = torch.randn(16, 32, dtype=torch.float32)  # Different data, same shape
+
+        result1 = mock_should_pad(mock_match, mat1_a, mat2_a, op)
+        self.assertEqual(call_count, 1)
+
+        result2 = mock_should_pad(mock_match, mat1_b, mat2_b, op)
+        self.assertEqual(call_count, 1)  # Should use cached result
+
+        # Assert: both return the same cached result
+        self.assertTrue(result1)
+        self.assertTrue(result2)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -21,6 +21,7 @@ from torch._inductor.autoheuristic.autoheuristic_utils import (
     pad_mm_operations,
     pad_mm_precondition,
 )
+from torch._inductor.runtime.caching import encoders, memoizers
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.utils._mode_utils import no_dispatch
 
@@ -483,6 +484,9 @@ def get_do_bench() -> Callable[[Callable[[], Any]], float]:
         )
 
 
+@memoizers.should_pad_memoizer.memoize(
+    custom_params_encoder=encoders.should_pad_params_encoder
+)
 def _should_pad(
     match: Match,
     mat1: Tensor,

--- a/torch/_inductor/runtime/caching/__init__.py
+++ b/torch/_inductor/runtime/caching/__init__.py
@@ -1,4 +1,4 @@
-from . import config
+from . import config, encoders, memoizers
 from .context import IsolationSchema, SelectedCompileContext, SelectedRuntimeContext
 from .exceptions import (
     CacheError,
@@ -10,6 +10,7 @@ from .exceptions import (
     ValueDecodingError,
     ValueEncodingError,
 )
+from .interfaces import Memoizer, PersistentMemoizer
 
 
 __all__ = [
@@ -18,10 +19,14 @@ __all__ = [
     "IsolationSchema",
     "KeyEncodingError",
     "LockTimeoutError",
+    "Memoizer",
+    "PersistentMemoizer",
     "SelectedCompileContext",
     "SelectedRuntimeContext",
     "SystemError",
     "UserError",
     "ValueDecodingError",
     "ValueEncodingError",
+    "encoders",
+    "memoizers",
 ]

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -1,0 +1,71 @@
+# pyre-strict
+
+"""
+Custom encoder functions for use with PersistentMemoizer.
+
+This module provides reusable encoder functions that convert function parameters
+into JSON-serializable dictionaries for caching purposes.
+"""
+
+from typing import cast
+from typing_extensions import TypedDict
+
+import torch
+from torch import Tensor
+from torch._inductor.pattern_matcher import Match
+from torch._inductor.runtime.caching.utils import _encode_tensor, EncodedTensor
+
+
+class ShouldPadEncodedParams(TypedDict):
+    """TypedDict for encoded should_pad parameters."""
+
+    mat1: EncodedTensor
+    mat2: EncodedTensor
+    op: str
+    input: EncodedTensor | None
+    mat1_exclude_padding_time: bool
+    mat2_exclude_padding_time: bool
+    tf32: bool
+
+
+def should_pad_params_encoder(
+    match: Match,
+    mat1: Tensor,
+    mat2: Tensor,
+    op: torch._ops.OpOverloadPacket,
+    input: Tensor | None = None,
+) -> ShouldPadEncodedParams:
+    """Encode parameters for _should_pad into a human-readable dict.
+
+    This encoder extracts only the information needed for caching:
+    - Tensor shape, stride, and dtype (not the actual data)
+    - Whether padding time should be excluded for mat1 and mat2
+    - The operation as a string
+
+    Args:
+        match: The pattern match object
+        mat1: First matrix tensor
+        mat2: Second matrix tensor
+        op: The operation being performed
+        input: Optional input tensor for addmm
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    # Import here to avoid circular dependency
+    from torch._inductor.fx_passes.pad_mm import should_exclude_padding_time
+
+    return ShouldPadEncodedParams(
+        mat1=_encode_tensor(mat1),
+        mat2=_encode_tensor(mat2),
+        op=str(op),
+        input=_encode_tensor(input) if input is not None else None,
+        mat1_exclude_padding_time=should_exclude_padding_time(match, "mat1"),
+        mat2_exclude_padding_time=should_exclude_padding_time(match, "mat2"),
+        tf32=False
+        if mat1.dtype != torch.float32
+        else cast(
+            bool,
+            torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32,
+        ),
+    )

--- a/torch/_inductor/runtime/caching/memoizers.py
+++ b/torch/_inductor/runtime/caching/memoizers.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from .interfaces import PersistentMemoizer
+
+
+# Memoizer for _should_pad in pad_mm
+should_pad_memoizer = PersistentMemoizer(sub_dir=Path("should_pad"))

--- a/torch/_inductor/runtime/caching/utils.py
+++ b/torch/_inductor/runtime/caching/utils.py
@@ -6,7 +6,9 @@ throughout the caching system.
 
 from collections.abc import Callable
 from functools import lru_cache, wraps
-from typing_extensions import ParamSpec, TypeVar
+from typing_extensions import ParamSpec, TypedDict, TypeVar
+
+from torch import Tensor
 
 
 # Type specification for function parameters
@@ -38,3 +40,27 @@ def _lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
             return fn(*args, **kwargs)
 
     return wrapper
+
+
+class EncodedTensor(TypedDict):
+    """TypedDict for encoded tensor metadata."""
+
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: str
+
+
+def _encode_tensor(t: Tensor) -> EncodedTensor:
+    """Encode a tensor's metadata into a JSON-serializable dict.
+
+    Args:
+        t: PyTorch tensor to encode
+
+    Returns:
+        Dict containing shape, stride, and dtype information
+    """
+    return EncodedTensor(
+        shape=tuple(t.shape),
+        stride=tuple(t.stride()),
+        dtype=str(t.dtype),
+    )


### PR DESCRIPTION
Summary: Similar to D85684098, but using the new PersistentMemoizer, one readable, and less constrictive keys (since _should_pad was refactored)

Test Plan: ```buck test fbcode//mode/opt caffe2/test/inductor:caching```

Differential Revision: D88999540




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela