### PR TITLE
ci: Add check-tpu composite action for TPU detection

### DIFF
--- a/.github/actions/check-tpu/action.yml
+++ b/.github/actions/check-tpu/action.yml
@@ -16,12 +16,21 @@ runs:
       run: |
         set +e  # Don't exit on error - TPU detection may fail on non-TPU runners
 
+        # Create a temporary venv to avoid uv run's overhead
+        tmp_venv=$(mktemp -d)/venv
+        uv venv "$tmp_venv" --quiet
+        uv pip install --quiet --python "$tmp_venv/bin/python" tpu-info
+
         # get_local_chips() returns Tuple[Optional[TpuChip], int] where:
         #   - First element is the chip type (None if no TPU)
         #   - Second element is the count of chips
         # We check if count > 0 to determine TPU presence
-        result=$(uv run --with tpu-info python -c "from tpu_info import device; chip, count = device.get_local_chips(); print('true' if count > 0 else 'false')" 2>/dev/null)
+        result=$("$tmp_venv/bin/python" -c "from tpu_info import device; chip, count = device.get_local_chips(); print('true' if count > 0 else 'false')" 2>/dev/null)
         exit_code=$?
+
+        # Cleanup
+        rm -rf "$(dirname "$tmp_venv")"
+
         set -e
 
         if [[ $exit_code -ne 0 ]]; then

--- a/.github/actions/check-tpu/action.yml
+++ b/.github/actions/check-tpu/action.yml
@@ -1,0 +1,36 @@
+name: Check TPU Availability
+
+description: Checks if the current runner has a TPU connected. Requires setup-linux to have been run first.
+
+outputs:
+  has_tpu:
+    description: Whether the runner has a TPU connected (true/false)
+    value: ${{ steps.check-tpu.outputs.has_tpu }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check for TPU
+      id: check-tpu
+      shell: bash
+      run: |
+        set +e  # Don't exit on error - TPU detection may fail on non-TPU runners
+
+        # get_local_chips() returns Tuple[Optional[TpuChip], int] where:
+        #   - First element is the chip type (None if no TPU)
+        #   - Second element is the count of chips
+        # We check if count > 0 to determine TPU presence
+        result=$(uv run --with tpu-info python -c "from tpu_info import device; chip, count = device.get_local_chips(); print('true' if count > 0 else 'false')" 2>/dev/null)
+        exit_code=$?
+        set -e
+
+        if [[ $exit_code -ne 0 ]]; then
+          echo "TPU detection command failed (exit code: $exit_code) - assuming no TPU"
+          echo "has_tpu=false" >> "$GITHUB_OUTPUT"
+        elif [[ "$result" == "true" ]]; then
+          echo "TPU detected"
+          echo "has_tpu=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No TPU detected"
+          echo "has_tpu=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/check-tpu/action.yml
+++ b/.github/actions/check-tpu/action.yml
@@ -15,28 +15,39 @@ runs:
       shell: bash
       run: |
         set +e  # Don't exit on error - TPU detection may fail on non-TPU runners
+        set -x  # Debug: print commands
 
         # Create a temporary venv to avoid uv run's overhead
         tmp_venv=$(mktemp -d)/venv
-        uv venv "$tmp_venv" --quiet
-        uv pip install --quiet --python "$tmp_venv/bin/python" tpu-info
+        echo "Creating venv at: $tmp_venv"
+        uv venv "$tmp_venv"
 
+        echo "Installing tpu-info..."
+        uv pip install --python "$tmp_venv/bin/python" tpu-info
+
+        echo "Checking for TPU chips..."
         # get_local_chips() returns Tuple[Optional[TpuChip], int] where:
         #   - First element is the chip type (None if no TPU)
         #   - Second element is the count of chips
         # We check if count > 0 to determine TPU presence
-        result=$("$tmp_venv/bin/python" -c "from tpu_info import device; chip, count = device.get_local_chips(); print('true' if count > 0 else 'false')" 2>/dev/null)
+        result=$("$tmp_venv/bin/python" -c "from tpu_info import device; chip, count = device.get_local_chips(); print(f'chip={chip}, count={count}'); print('true' if count > 0 else 'false')")
         exit_code=$?
+
+        echo "Python exit code: $exit_code"
+        echo "Python output: $result"
 
         # Cleanup
         rm -rf "$(dirname "$tmp_venv")"
 
         set -e
 
+        # Get the last line which should be true/false
+        has_tpu=$(echo "$result" | tail -1)
+
         if [[ $exit_code -ne 0 ]]; then
           echo "TPU detection command failed (exit code: $exit_code) - assuming no TPU"
           echo "has_tpu=false" >> "$GITHUB_OUTPUT"
-        elif [[ "$result" == "true" ]]; then
+        elif [[ "$has_tpu" == "true" ]]; then
           echo "TPU detected"
           echo "has_tpu=true" >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #170271
* #170267
* #170270
* __->__ #170269
* #170272

Add a composite action that detects whether the current runner has a TPU
connected. Uses tpu-info library to query local TPU chips via PCI device
scanning. Outputs `has_tpu` as true/false for use in workflow conditionals.

Requires setup-linux to have been run first (for uv availability).

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>