### PR TITLE
ci: Use uv tool install to install pip

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -64,6 +64,7 @@ runs:
           echo "pip3 is already installed."
         else
           echo "pip3 not found, installing..."
+          uv python install 3.12
           uv pip install --system pip==25.3
         fi
 

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -64,7 +64,7 @@ runs:
           echo "pip3 is already installed."
         else
           echo "pip3 not found, installing..."
-          uv run pip install pip==25.3 --system
+          uv pip install --system pip==25.3
         fi
 
     - name: Preserve github env variables for use in docker

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -64,8 +64,7 @@ runs:
           echo "pip3 is already installed."
         else
           echo "pip3 not found, installing..."
-          uv python install 3.12
-          uv pip install --system pip==25.3
+          uv tool install pip
         fi
 
     - name: Preserve github env variables for use in docker


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #170271
* #170267
* #170270
* #170269
* __->__ #170272

`uv run` actually attempts to build all of pytorch so we shouldn't do
that just to install pip

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>