### PR TITLE
[BE] Use [[maybe_unused]] in unused params

### DIFF
--- a/aten/src/ATen/native/GroupedMMUtils.h
+++ b/aten/src/ATen/native/GroupedMMUtils.h
@@ -103,7 +103,7 @@ std::optional<c10::ScalarType> out_dtype) {
   TORCH_CHECK(!bias.has_value(), "Bias not supported yet");
 }
 
-inline c10::ScalarType _resolve_grouped_mm_out_dtype(const Tensor& mat_a, const Tensor& mat_b,
+inline c10::ScalarType _resolve_grouped_mm_out_dtype(const Tensor& mat_a, [[maybe_unused]] const Tensor& mat_b,
 std::optional<c10::ScalarType> out_dtype) {
   const auto out_dtype_ = out_dtype.value_or(mat_a.scalar_type());
   // TODO(future PR): enable float32 output dtype for bfloat16 and float16 inputs

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -30,7 +30,7 @@ using namespace at;
 
 template<typename scalar_type>
 struct Foo {
-  static void apply(Tensor a, Tensor b) {
+  static void apply(Tensor a, [[maybe_unused]] Tensor b) {
     scalar_type s = 1;
     std::stringstream ss;
     ss << "hello, dispatch: " << a.toString() << s << '\n';


### PR DESCRIPTION
Inspired by https://github.com/pytorch/pytorch/pull/166865

This is a C++17 standard feature.

cc @malfet @cyyever
