### PR TITLE
[inductor] Fix unbacked floats being downcast to fp32

### DIFF
--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -1082,6 +1082,91 @@ class ForeachTests(TestCase):
                 _ = run_fw_bw_and_get_code(lambda: torch.compile(fn)(*inps))
 
     @requires_gpu
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
+    @parametrize(
+        "value",
+        [
+            0.123456789,
+            -1.987654321,
+            0.0,
+            1e-8,
+            1e8,
+            3.141592653589793,  # pi - more precision than fp32
+            -2.718281828459045,  # -e - more precision than fp32
+            0.000000001234567890123456,
+            # Values that expose fp32/fp64 casting issues:
+            1.0000001192092896,  # 1 + 2^-23 (smallest diff from 1.0 in fp32)
+            1.00000001,  # Between fp32 representable values
+            1e-38,  # Very small but not subnormal
+            1.1754944e-38,  # Near fp32 min normal
+            0.333333333333333333,  # 1/3 with full fp64 precision
+            0.1,  # Cannot be exactly represented in binary
+            1.0000000000000002,  # 1 + eps in fp64, rounds to 1.0 in fp32
+            0.30000000000000004,  # 0.1 + 0.2 in fp64 (famous precision issue)
+        ],
+    )
+    def test_addcmul_scalar_value_vs_tensor_value(self, value):
+        """Test that torch._foreach_addcmul with python scalar value kwarg
+        matches tensor scalar value kwarg in both eager and compiled modes."""
+
+        def fn_python_scalar(a0, a1, b0, b1, c0, c1):
+            return torch._foreach_addcmul([a0, a1], [b0, b1], [c0, c1], value=1 - value)
+
+        def fn_tensor_scalar(a0, a1, b0, b1, c0, c1, val):
+            return torch._foreach_addcmul(
+                [a0, a1], [b0, b1], [c0, c1], value=1 - val.item()
+            )
+
+        # Use specific values that are sensitive to fp32/fp64 precision differences
+        inputs = (
+            torch.tensor(
+                [[1.0000001192092896, 0.333333333333333333], [1e-7, 3.4028235e30]],
+                device=GPU_TYPE,
+                dtype=torch.float32,
+            ),
+            torch.tensor(
+                [[1.0000000000000002, 0.1], [1e-38, 2.718281828459045]],
+                device=GPU_TYPE,
+                dtype=torch.float32,
+            ),
+            torch.tensor(
+                [[0.5, 0.5], [0.5, 0.5]], device=GPU_TYPE, dtype=torch.float32
+            ),
+            torch.tensor(
+                [[1.0, 1.0], [1.0, 1.0]], device=GPU_TYPE, dtype=torch.float32
+            ),
+            torch.tensor(
+                [[2.0, 2.0], [2.0, 2.0]], device=GPU_TYPE, dtype=torch.float32
+            ),
+            torch.tensor(
+                [[0.25, 0.25], [0.25, 0.25]], device=GPU_TYPE, dtype=torch.float32
+            ),
+        )
+        scalar_tensor = torch.tensor(value, device=GPU_TYPE, dtype=torch.float64)
+
+        # Eager mode comparison - assert bitwise equality
+        eager_python_scalar = fn_python_scalar(*inputs)
+        eager_tensor_scalar = fn_tensor_scalar(*inputs, scalar_tensor)
+        for a, b in zip(eager_python_scalar, eager_tensor_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+
+        # Compiled mode comparison - assert bitwise equality
+        compiled_python_scalar = torch.compile(fn_python_scalar, fullgraph=True)(
+            *inputs
+        )
+        compiled_tensor_scalar = torch.compile(fn_tensor_scalar, fullgraph=True)(
+            *inputs, scalar_tensor
+        )
+        for a, b in zip(compiled_python_scalar, compiled_tensor_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+
+        # Cross comparison: eager vs compiled - assert bitwise equality
+        for a, b in zip(eager_python_scalar, compiled_python_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+        for a, b in zip(eager_tensor_scalar, compiled_tensor_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+
+    @requires_gpu
     @foreach_map_un_ops
     def test_foreach_map_backward_unary(self, op):
         from torch._dynamo.polyfills import foreach_map_fn

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -71,11 +71,13 @@ def signature_of(arg: KernelArgType, *, size_dtype: Optional[str]) -> str:
             # it should be marked as "constexpr" in the signature.
             return "constexpr"
         elif isinstance(arg.expr, (float, sympy.Float)):
-            return "fp32"
+            # Python floats are natively fp64, so use fp64 to preserve precision
+            return "fp64"
         elif isinstance(arg.expr, sympy.Symbol) and symbol_is_type(
             arg.expr, (SymT.UNBACKED_FLOAT)
         ):
-            return "fp32"
+            # Unbacked floats from .item() should preserve fp64 precision
+            return "fp64"
         elif isinstance(arg.expr, bool):
             return "i1"
 


### PR DESCRIPTION
I found this issue when investigating laprop numerics w/ TorchInductor. Looks like inductor mistakenly downcast sym floats to fp32? 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170287



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela