### PR TITLE
[dynamo] Add ignore_fresh_unbacked_symbols for foreach ops with scalar values

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5924,7 +5924,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         # Test _foreach_addcmul with value arg
         def fn_addcmul(a, b, c, val):
-            return torch._foreach_addcmul([a], [b], [c], value=val.item())
+            return torch._foreach_addcmul([a], [b], [c], value=1 - val)
 
         expected = fn_addcmul(a, b, c, val)
         actual = torch.compile(fn_addcmul, backend="eager", fullgraph=True)(
@@ -5934,7 +5934,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         # Test _foreach_addcdiv with value arg
         def fn_addcdiv(a, b, c, val):
-            return torch._foreach_addcdiv([a], [b], [c], value=val.item())
+            return torch._foreach_addcdiv([a], [b], [c], value=1 - val)
 
         expected = fn_addcdiv(a, b, c, val)
         actual = torch.compile(fn_addcdiv, backend="eager", fullgraph=True)(
@@ -5944,7 +5944,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         # Test _foreach_add with scalar arg
         def fn_add(a, val):
-            return torch._foreach_add([a], val.item())
+            return torch._foreach_add([a], 1 - val)
 
         expected = fn_add(a, val)
         actual = torch.compile(fn_add, backend="eager", fullgraph=True)(a, val)
@@ -5952,7 +5952,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         # Test _foreach_mul with scalar arg
         def fn_mul(a, val):
-            return torch._foreach_mul([a], val.item())
+            return torch._foreach_mul([a], 1 - val)
 
         expected = fn_mul(a, val)
         actual = torch.compile(fn_mul, backend="eager", fullgraph=True)(a, val)
@@ -5960,7 +5960,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         # Test _foreach_pow with scalar exponent
         def fn_pow(a, val):
-            return torch._foreach_pow([a.abs()], val.item())
+            return torch._foreach_pow([a.abs()], 1 - val.item())
 
         expected = fn_pow(a, val)
         actual = torch.compile(fn_pow, backend="eager", fullgraph=True)(a, val)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1630,6 +1630,27 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # PendingUnbackedSymbolNotFound errors. We ignore these fresh unbacked symbols
         # since they only affect tensor values, not shapes.
         ops_consuming_unbacked_scalars = {
+            # foreach ops with scalar/alpha arguments
+            torch._foreach_add,
+            torch._foreach_add_,
+            torch._foreach_sub,
+            torch._foreach_sub_,
+            torch._foreach_mul,
+            torch._foreach_mul_,
+            torch._foreach_div,
+            torch._foreach_div_,
+            torch._foreach_clamp_max,
+            torch._foreach_clamp_max_,
+            torch._foreach_clamp_min,
+            torch._foreach_clamp_min_,
+            torch._foreach_maximum,
+            torch._foreach_maximum_,
+            torch._foreach_minimum,
+            torch._foreach_minimum_,
+            torch._foreach_pow,
+            torch._foreach_pow_,
+            torch._foreach_lerp,
+            torch._foreach_lerp_,
             torch._foreach_addcmul,
             torch._foreach_addcmul_,
             torch._foreach_addcdiv,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170289
* __->__ #170288

When capture_scalar_outputs is enabled and a tensor scalar is passed to
foreach ops like _foreach_addcmul, the .item() call creates an unbacked
symbol that is not tracked in output tensor shapes. This causes
PendingUnbackedSymbolNotFound errors.

Fix by wrapping the wrap_fx_proxy call with ignore_fresh_unbacked_symbols
for ops that consume scalar values for computation only (not for output shapes).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo