### PR TITLE
[ROCm][CI] Enable pre- and post-merge `default` and `distributed` config ROCm CI jobs on trunk.yml

### DIFF
--- a/.github/workflows/inductor-rocm-mi355.yml
+++ b/.github/workflows/inductor-rocm-mi355.yml
@@ -2,6 +2,9 @@ name: inductor-rocm-mi355
 
 on:
   push:
+    branches:
+      - main
+      - release/*
     tags:
       - ciflow/inductor-rocm-mi355/*
   workflow_dispatch:

--- a/.github/workflows/inductor-rocm-mi355.yml
+++ b/.github/workflows/inductor-rocm-mi355.yml
@@ -2,9 +2,6 @@ name: inductor-rocm-mi355
 
 on:
   push:
-    branches:
-      - main
-      - release/*
     tags:
       - ciflow/inductor-rocm-mi355/*
   workflow_dispatch:

--- a/.github/workflows/periodic-rocm-mi355.yml
+++ b/.github/workflows/periodic-rocm-mi355.yml
@@ -2,7 +2,6 @@ name: periodic-rocm-mi355
 
 on:
   schedule:
-    - cron: 0 0,3,6,9,12,15,18,21 * * *
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   push:
     tags:

--- a/.github/workflows/rocm-mi355.yml
+++ b/.github/workflows/rocm-mi355.yml
@@ -2,9 +2,6 @@ name: rocm-mi355
 
 on:
   push:
-    branches:
-      - main
-      - release/*
     tags:
       - ciflow/rocm-mi355/*
   workflow_dispatch:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -295,10 +295,6 @@ jobs:
     secrets: inherit
 
   linux-jammy-rocm-py3_10-build:
-    #NS: Trunk jobs should run on both PR if ciflow/trunk is added an on trunk
-    # But https://github.com/pytorch/pytorch/pull/165674 always skips them on trunk
-    if: 0
-    # if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/trunk') || (needs.job-filter.outputs.jobs != '' && contains(needs.job-filter.outputs.jobs, ' linux-jammy-rocm-py3.10 ')) }}
     name: linux-jammy-rocm-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs:
@@ -324,7 +320,6 @@ jobs:
     secrets: inherit
 
   linux-jammy-rocm-py3_10-test:
-    if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/trunk') || (needs.job-filter.outputs.jobs != '' && contains(needs.job-filter.outputs.jobs, ' linux-jammy-rocm-py3.10 ')) }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
* To enable developers to triage PR-based ROCm CI failures on trunk.yml with the runs on main commits, it's helpful to have trunk.yml jobs running on both PRs and main commits. 
* Remove main and release branch triggers for `rocm-mi355.yml` since trunk.yml will provide that coverage for `default` and `distributed` config now
* Remove most cron schedules for `periodic-rocm-mi355.yml` since trunk.yml will provide that coverage for `distributed` config now.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang