### PR TITLE
[ROCm] add gfx1152 & gfx1153 to supported gemm lists

### DIFF
--- a/.ci/docker/almalinux/build.sh
+++ b/.ci/docker/almalinux/build.sh
@@ -36,7 +36,7 @@ case ${DOCKER_TAG_PREFIX} in
     ;;
   rocm*)
     BASE_TARGET=rocm
-    PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
+    PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151;gfx1152;gfx1153"
     EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}"
     ;;
   *)

--- a/.ci/docker/libtorch/build.sh
+++ b/.ci/docker/libtorch/build.sh
@@ -53,7 +53,7 @@ case ${DOCKER_TAG_PREFIX} in
         fi
         BASE_TARGET=rocm
         GPU_IMAGE=rocm/dev-ubuntu-22.04:${GPU_ARCH_VERSION}-complete
-        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
+        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151;gfx1152;gfx1153"
         DOCKER_GPU_BUILD_ARG="--build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg ROCM_VERSION=${GPU_ARCH_VERSION}"
         ;;
     *)

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -91,7 +91,7 @@ case ${image} in
         MANY_LINUX_VERSION="2_28"
         DEVTOOLSET_VERSION="11"
         GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
-        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
+        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151;gfx1152;gfx1153"
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
         ;;
     manylinux2_28-builder:xpu)

--- a/.ci/magma-rocm/Makefile
+++ b/.ci/magma-rocm/Makefile
@@ -5,7 +5,7 @@ DESIRED_ROCM ?= 7.1
 DESIRED_ROCM_SHORT = $(subst .,,$(DESIRED_ROCM))
 PACKAGE_NAME = magma-rocm
 # inherit this from underlying docker image, do not pass this env var to docker
-#PYTORCH_ROCM_ARCH ?= gfx900;gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201
+#PYTORCH_ROCM_ARCH ?= gfx900;gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201
 
 DOCKER_RUN = set -eou pipefail; ${DOCKER_CMD} run --rm -i \
 	-v $(shell git rev-parse --show-toplevel)/.ci:/builder \

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -465,7 +465,7 @@ at::BlasBackend Context::blasPreferredBackend() {
           "gfx1100", "gfx1101", "gfx1200", "gfx1201", "gfx908",
 #endif
 #if ROCM_VERSION >= 70000
-          "gfx950", "gfx1150", "gfx1151"
+          "gfx950", "gfx1150", "gfx1151", "gfx1152", "gfx1153"
 #endif
       };
       for (auto index: c10::irange(detail::getCUDAHooks().deviceCount())) {

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -126,7 +126,7 @@ static bool isGloballyDisabledAddmmCudaLt(const at::Device& device) {
         "gfx1100", "gfx1101", "gfx1200", "gfx1201", "gfx908",
     #endif
     #if ROCM_VERSION >= 70000
-        "gfx950", "gfx1150", "gfx1151"
+        "gfx950", "gfx1150", "gfx1151", "gfx1152", "gfx1153"
     #endif
   };
   const auto is_hipblas_lt_arch_supported = at::detail::getCUDAHooks().isGPUArch(archs, device.index());

--- a/aten/src/ATen/native/hip/ck_gemm_bfloat16.hip
+++ b/aten/src/ATen/native/hip/ck_gemm_bfloat16.hip
@@ -775,7 +775,7 @@ void gemm_internal_ck<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16)) {
   static const std::vector<std::string> wmma_archs = {
     "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
 #if ROCM_VERSION >= 70000
-    "gfx1150", "gfx1151"
+    "gfx1150", "gfx1151", "gfx1152","gfx1153"
 #endif
   };
   if (at::detail::getCUDAHooks().isGPUArch(wmma_archs)) {

--- a/aten/src/ATen/native/hip/ck_gemm_half.hip
+++ b/aten/src/ATen/native/hip/ck_gemm_half.hip
@@ -602,7 +602,7 @@ void gemm_internal_ck<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
   static const std::vector<std::string> wmma_archs = {
     "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
 #if ROCM_VERSION >= 70000
-    "gfx1150", "gfx1151"
+    "gfx1150", "gfx1151", "gfx1152", "gfx1153"
 #endif
   };
   if (at::detail::getCUDAHooks().isGPUArch(wmma_archs)) {

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -63,7 +63,7 @@ def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:
         arch_list = ["gfx90a", "gfx942", "gfx1201", "gfx950"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
-            arch_list += ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
+            arch_list += ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1152", "gfx1153", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
         return not IS_WINDOWS and SM80OrLater
@@ -73,7 +73,7 @@ def evaluate_platform_supports_efficient_attention():
     if TEST_WITH_ROCM:
         arch_list = ["gfx90a", "gfx942", "gfx1201", "gfx950"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
-            arch_list += ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
+            arch_list += ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1152", "gfx1153", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
         return True


### PR DESCRIPTION
Let me know if I should prefer other way of testing.

gfx1152:
```
(.venv) amd@ctr-krkn-at48-1:/tmp/rogarcia$ pytest -v smoke-tests/
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /tmp/rogarcia/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /tmp/rogarcia
collected 14 items

smoke-tests/pytorch_smoke_test.py::TestROCmAvailability::test_rocm_available PASSED                                                                                                  [  7%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication PASSED                                                                                           [ 14%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_batch_matrix_multiplication PASSED                                                                                     [ 21%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication_at_operator PASSED                                                                               [ 28%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_elementwise_multiplication PASSED                                                                                      [ 35%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_transpose PASSED                                                                                                       [ 42%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_dot_product PASSED                                                                                                     [ 50%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_vector_multiplication PASSED                                                                                    [ 57%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication_matmul PASSED                                                                                    [ 64%]
smoke-tests/pytorch_smoke_test.py::TestConvolutions::test_conv_transpose2d PASSED                                                                                                    [ 71%]
smoke-tests/pytorch_smoke_test.py::TestConvolutions::test_conv_cudnn_nhwc_support PASSED                                                                                             [ 78%]
smoke-tests/pytorch_smoke_test.py::TestOpenBLASAvailability::test_openblas_is_selected_blas PASSED                                                                                   [ 85%]
smoke-tests/pytorch_smoke_test.py::TestOpenBLASAvailability::test_config_indicates_lapack_enabled PASSED                                                                             [ 92%]
smoke-tests/pytorch_smoke_test.py::TestOpenBLASAvailability::test_lapack_available_svd PASSED                                                                                        [100%]

==================================================================================== 14 passed in 1.09s ====================================================================================
(.venv) amd@ctr-krkn-at48-1:/tmp/rogarcia$ rocminfo | grep -C 2 1152
Agent 2
*******
  Name:                    gfx1152
```


gfx1153:
```
(.pytorch_venv) atg@KOR-KRA2e-U-01:/tmp/rogarcia$ pytest -v smoke-tests/
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /tmp/rogarcia/.pytorch_venv/bin/python
cachedir: .pytest_cache
rootdir: /tmp/rogarcia
collected 14 items

smoke-tests/pytorch_smoke_test.py::TestROCmAvailability::test_rocm_available PASSED                                                                                                  [  7%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication PASSED                                                                                           [ 14%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_batch_matrix_multiplication PASSED                                                                                     [ 21%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication_at_operator PASSED                                                                               [ 28%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_elementwise_multiplication PASSED                                                                                      [ 35%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_transpose PASSED                                                                                                       [ 42%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_dot_product PASSED                                                                                                     [ 50%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_vector_multiplication PASSED                                                                                    [ 57%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication_matmul PASSED                                                                                    [ 64%]
smoke-tests/pytorch_smoke_test.py::TestConvolutions::test_conv_transpose2d PASSED                                                                                                    [ 71%]
smoke-tests/pytorch_smoke_test.py::TestConvolutions::test_conv_cudnn_nhwc_support PASSED                                                                                             [ 78%]
smoke-tests/pytorch_smoke_test.py::TestOpenBLASAvailability::test_openblas_is_selected_blas PASSED                                                                                   [ 85%]
smoke-tests/pytorch_smoke_test.py::TestOpenBLASAvailability::test_config_indicates_lapack_enabled PASSED                                                                             [ 92%]
smoke-tests/pytorch_smoke_test.py::TestOpenBLASAvailability::test_lapack_available_svd PASSED                                                                                        [100%]

==================================================================================== 14 passed in 1.26s ====================================================================================
(.pytorch_venv) atg@KOR-KRA2e-U-01:/tmp/rogarcia$ rocminfo | grep -C 2 1153
Agent 2
*******
  Name:                    gfx1153
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang