### PR TITLE
[codemod][lowrisk] Enable `-Wunused-exception-parameter` in caffe2/PACKAGE +2

### DIFF
--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -605,7 +605,7 @@ Workspace chooseAlgorithm(
   search::wsscache().find(args.params, &workspace_size);
   try {
     return Workspace(workspace_size);
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     std::ignore = hipGetLastError(); // clear OOM error
 
     // switch to default algorithm and record it in the cache to prevent
@@ -626,7 +626,7 @@ Workspace chooseSolution(const ConvolutionArgs& args, uint64_t* solution_id)
   try {
     *solution_id = solution.solution_id;
     return Workspace(solution.workspace_size);
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     std::ignore = hipGetLastError(); // clear OOM error
 
     // switch to default algorithm

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -18,7 +18,7 @@ using namespace at;
       fn;                                                      \
       _passed = true;                                          \
       els;                                                     \
-    } catch (std::exception & e) {                             \
+    } catch (std::exception&) {                                \
       ASSERT_FALSE(_passed);                                   \
       catc;                                                    \
     }                                                          \

--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -207,7 +207,7 @@ class ProcessGroupNCCLNoHeartbeatCaught
     void runLoop() override {
       try {
         c10d::ProcessGroupNCCL::HeartbeatMonitor::runLoop();
-      } catch (std::runtime_error& e) {
+      } catch (const std::runtime_error&) {
         // Safe cast because we know it's a ProcessGroupNCCLNoHeartbeatCaught
         auto* pg = static_cast<ProcessGroupNCCLNoHeartbeatCaught*>(pg_);
         pg->hasMonitorThreadCaughtError_ = true;


### PR DESCRIPTION
Summary:
This diff enables compilation warning flags for the directory in question. Further details are in [this workplace post](https://fb.workplace.com/permalink.php?story_fbid=pfbid02XaWNiCVk69r1ghfvDVpujB8Hr9Y61uDvNakxiZFa2jwiPHscVdEQwCBHrmWZSyMRl&id=100051201402394).

This is a low-risk diff. There are **no run-time effects** and the diff has already been observed to compile locally. **If the code compiles, it work; test errors are spurious.**

Test Plan: Sandcastle

Differential Revision: D87365557


