### PR TITLE
Makes BlockMask registerable via register_constant

### DIFF
--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -471,6 +471,27 @@ def register_constant(cls: type[Any]) -> None:
         CONSTANT_NODES.add(cls)
 
 
+def deregister_constant(cls: type[Any]) -> None:
+    """Deregisters a type previously registered with :func:`register_constant`.
+
+    This is the inverse of :func:`register_constant`. After calling this function,
+    instances of `cls` will no longer be treated as constant pytree nodes.
+
+    Args:
+        cls: the type to deregister.
+
+    Raises:
+        ValueError: if `cls` was not previously registered with :func:`register_constant`.
+    """
+    with _NODE_REGISTRY_LOCK:
+        if cls not in CONSTANT_NODES:
+            raise ValueError(
+                f"{cls} is not registered as a constant. "
+                "Only types registered with register_constant can be deregistered with deregister_constant."
+            )
+        _deregister_pytree_node(cls)
+
+
 def is_constant_class(cls: type[Any]) -> bool:
     return isinstance(cls, type) and cls in CONSTANT_NODES
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170312


We make BlockMask flexible type that user can control the behaviour (whether it can be pytree leaf or legit pytree node). To make BlockMask leaf, we need to define nontrivial __eq__ and __hash__ so that Dynamo can properly guard on them. 

I also add a util function _deregister_constant so that i can clean up the test environment gracefully. 

