### PR TITLE
ci: Switch everything over to use temp envs + uv

### DIFF
--- a/.github/actions/build-external-packages/action.yml
+++ b/.github/actions/build-external-packages/action.yml
@@ -66,7 +66,7 @@ runs:
         docker images
         START_TIME=$(date +%s)
 
-        tmp_venv=$(mktemp -d)/venv
+        tmp_venv="$RUNNER_TEMP/build-external-packages-venv"
         uv venv -p 3.12 "$tmp_venv"
         uv pip install --python "$tmp_venv/bin/python" -e .ci/lumen_cli
 
@@ -81,8 +81,6 @@ runs:
           echo "Building external package: $target in directory $OUTPUT_DIR"
           "$tmp_venv/bin/python" -m cli.run build external "$target"
         done
-
-        rm -rf "$(dirname "$tmp_venv")"
 
         END_TIME=$(date +%s)
         {

--- a/.github/actions/build-external-packages/action.yml
+++ b/.github/actions/build-external-packages/action.yml
@@ -44,6 +44,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     - name: Build external packages in sequence
       id: build-external
       env:

--- a/.github/actions/build-external-packages/action.yml
+++ b/.github/actions/build-external-packages/action.yml
@@ -44,11 +44,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
-      with:
-        python-version: 3.12
-
     - name: Build external packages in sequence
       id: build-external
       env:
@@ -63,13 +58,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        python3 --version
         docker images
         START_TIME=$(date +%s)
-
-        tmp_venv="$RUNNER_TEMP/build-external-packages-venv"
-        uv venv -p 3.12 "$tmp_venv"
-        uv pip install --python "$tmp_venv/bin/python" -e .ci/lumen_cli
-
+        (
+          cd .ci/lumen_cli
+          python3 -m pip install -e .
+        )
         MAX_JOBS="$(nproc --ignore=10)"
         export MAX_JOBS
 
@@ -79,7 +74,7 @@ runs:
           OUTPUT_DIR="$PARENT_OUTPUT_DIR/$target"
           export OUTPUT_DIR
           echo "Building external package: $target in directory $OUTPUT_DIR"
-          "$tmp_venv/bin/python" -m cli.run build external "$target"
+          python3 -m cli.run build external "$target"
         done
 
         END_TIME=$(date +%s)

--- a/.github/actions/build-external-packages/action.yml
+++ b/.github/actions/build-external-packages/action.yml
@@ -58,13 +58,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        python3 --version
         docker images
         START_TIME=$(date +%s)
-        (
-          cd .ci/lumen_cli
-          python3 -m pip install -e .
-        )
+
+        tmp_venv=$(mktemp -d)/venv
+        uv venv -p 3.12 "$tmp_venv"
+        uv pip install --python "$tmp_venv/bin/python" -e .ci/lumen_cli
+
         MAX_JOBS="$(nproc --ignore=10)"
         export MAX_JOBS
 
@@ -74,8 +74,10 @@ runs:
           OUTPUT_DIR="$PARENT_OUTPUT_DIR/$target"
           export OUTPUT_DIR
           echo "Building external package: $target in directory $OUTPUT_DIR"
-          python3 -m cli.run build external "$target"
+          "$tmp_venv/bin/python" -m cli.run build external "$target"
         done
+
+        rm -rf "$(dirname "$tmp_venv")"
 
         END_TIME=$(date +%s)
         {

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -68,9 +68,12 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eux
+          tmp_venv=$(mktemp -d)/venv
+          uv venv -p 3.12 "$tmp_venv"
           # PyYAML 6.0 doesn't work with MacOS x86 anymore
           # This must run on Python-3.7 (AmazonLinux2) so can't use request=3.32.2
-          python3 -m pip install requests==2.27.1 pyyaml==6.0.2
+          uv pip install --python "$tmp_venv/bin/python" requests==2.27.1 pyyaml==6.0.2
+          echo "FILTER_VENV=$tmp_venv" >> "$GITHUB_ENV"
 
     - name: Parse ref
       id: parse-ref
@@ -80,7 +83,7 @@ runs:
 
         # Use relative path here as this could be checked out anywhere, not necessarily
         # in runner workspace
-        python3 "${GITHUB_ACTION_PATH}/../../scripts/parse_ref.py"
+        "$FILTER_VENV/bin/python" "${GITHUB_ACTION_PATH}/../../scripts/parse_ref.py"
 
     - name: Get the job name
       id: get-job-name
@@ -133,7 +136,7 @@ runs:
 
         # Use relative path here as this could be checked out anywhere, not necessarily
         # in runner workspace
-        python3 "${GITHUB_ACTION_PATH}/../../scripts/filter_test_configs.py" \
+        "$FILTER_VENV/bin/python" "${GITHUB_ACTION_PATH}/../../scripts/filter_test_configs.py" \
           --workflow "${GITHUB_WORKFLOW}" \
           --job-name "${JOB_NAME}" \
           --test-matrix "${{ inputs.test-matrix }}" \
@@ -161,3 +164,11 @@ runs:
 
         echo
         echo "Reenabled issues? ${{ steps.filter.outputs.reenabled-issues }}"
+
+    - name: Cleanup temp venv
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${FILTER_VENV:-}" ] && [ -d "$(dirname "$FILTER_VENV")" ]; then
+          rm -rf "$(dirname "$FILTER_VENV")"
+        fi

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -57,6 +57,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies
       env:

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -73,7 +73,7 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eux
-          tmp_venv=$(mktemp -d)/venv
+          tmp_venv="$RUNNER_TEMP/filter-test-configs-venv"
           uv venv -p 3.12 "$tmp_venv"
           # PyYAML 6.0 doesn't work with MacOS x86 anymore
           # This must run on Python-3.7 (AmazonLinux2) so can't use request=3.32.2
@@ -169,11 +169,3 @@ runs:
 
         echo
         echo "Reenabled issues? ${{ steps.filter.outputs.reenabled-issues }}"
-
-    - name: Cleanup temp venv
-      if: always()
-      shell: bash
-      run: |
-        if [ -n "${FILTER_VENV:-}" ] && [ -d "$(dirname "$FILTER_VENV")" ]; then
-          rm -rf "$(dirname "$FILTER_VENV")"
-        fi

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -73,12 +73,8 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eux
-          tmp_venv="$RUNNER_TEMP/filter-test-configs-venv"
-          uv venv -p 3.12 "$tmp_venv"
-          # PyYAML 6.0 doesn't work with MacOS x86 anymore
-          # This must run on Python-3.7 (AmazonLinux2) so can't use request=3.32.2
-          uv pip install --python "$tmp_venv/bin/python" requests==2.27.1 pyyaml==6.0.2
-          echo "FILTER_VENV=$tmp_venv" >> "$GITHUB_ENV"
+          # Pre-fetch dependencies to cache them for later uv run calls
+          uv run --no-project --with requests==2.27.1 --with pyyaml==6.0.2 python -c "import requests, yaml; print('Dependencies ready')"
 
     - name: Parse ref
       id: parse-ref
@@ -88,7 +84,7 @@ runs:
 
         # Use relative path here as this could be checked out anywhere, not necessarily
         # in runner workspace
-        "$FILTER_VENV/bin/python" "${GITHUB_ACTION_PATH}/../../scripts/parse_ref.py"
+        uv run --no-project --with requests==2.27.1 --with pyyaml==6.0.2 python "${GITHUB_ACTION_PATH}/../../scripts/parse_ref.py"
 
     - name: Get the job name
       id: get-job-name
@@ -141,7 +137,7 @@ runs:
 
         # Use relative path here as this could be checked out anywhere, not necessarily
         # in runner workspace
-        "$FILTER_VENV/bin/python" "${GITHUB_ACTION_PATH}/../../scripts/filter_test_configs.py" \
+        uv run --no-project --with requests==2.27.1 --with pyyaml==6.0.2 python "${GITHUB_ACTION_PATH}/../../scripts/filter_test_configs.py" \
           --workflow "${GITHUB_WORKFLOW}" \
           --job-name "${JOB_NAME}" \
           --test-matrix "${{ inputs.test-matrix }}" \

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -17,6 +17,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies
       with:

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -31,7 +31,7 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          tmp_venv=$(mktemp -d)/venv
+          tmp_venv="$RUNNER_TEMP/pytest-cache-venv"
           uv venv -p 3.12 "$tmp_venv"
           uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
           echo "PYTEST_CACHE_VENV=$tmp_venv" >> "$GITHUB_ENV"
@@ -52,11 +52,3 @@ runs:
           --temp_dir "$RUNNER_TEMP" \
           --repo "$REPO" \
           --bucket "$BUCKET"
-
-    - name: Cleanup temp venv
-      if: always()
-      shell: bash
-      run: |
-        if [ -n "${PYTEST_CACHE_VENV:-}" ] && [ -d "$(dirname "$PYTEST_CACHE_VENV")" ]; then
-          rm -rf "$(dirname "$PYTEST_CACHE_VENV")"
-        fi

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -31,10 +31,8 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          tmp_venv="$RUNNER_TEMP/pytest-cache-venv"
-          uv venv -p 3.12 "$tmp_venv"
-          uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
-          echo "PYTEST_CACHE_VENV=$tmp_venv" >> "$GITHUB_ENV"
+          # Pre-fetch dependencies to cache them for later uv run calls
+          uv run --no-project --with boto3==1.35.42 python -c "import boto3; print('Dependencies ready')"
 
     - name: Download the cache
       shell: bash
@@ -44,7 +42,7 @@ runs:
         REPO: ${{ github.repository }}
         BUCKET: ${{ inputs.s3_bucket }}
       run: |
-        "$PYTEST_CACHE_VENV/bin/python" .github/scripts/pytest_cache.py \
+        uv run --no-project --with boto3==1.35.42 python .github/scripts/pytest_cache.py \
           --download \
           --cache_dir "$GITHUB_WORKSPACE/$CACHE_DIR" \
           --pr_identifier "$GITHUB_REF" \

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -26,7 +26,10 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          python3 -m pip install boto3==1.35.42
+          tmp_venv=$(mktemp -d)/venv
+          uv venv -p 3.12 "$tmp_venv"
+          uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
+          echo "PYTEST_CACHE_VENV=$tmp_venv" >> "$GITHUB_ENV"
 
     - name: Download the cache
       shell: bash
@@ -36,11 +39,19 @@ runs:
         REPO: ${{ github.repository }}
         BUCKET: ${{ inputs.s3_bucket }}
       run: |
-        python3 .github/scripts/pytest_cache.py \
+        "$PYTEST_CACHE_VENV/bin/python" .github/scripts/pytest_cache.py \
           --download \
           --cache_dir "$GITHUB_WORKSPACE/$CACHE_DIR" \
           --pr_identifier "$GITHUB_REF" \
           --job_identifier "$JOB_IDENTIFIER" \
           --temp_dir "$RUNNER_TEMP" \
           --repo "$REPO" \
-          --bucket "$BUCKET" \
+          --bucket "$BUCKET"
+
+    - name: Cleanup temp venv
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${PYTEST_CACHE_VENV:-}" ] && [ -d "$(dirname "$PYTEST_CACHE_VENV")" ]; then
+          rm -rf "$(dirname "$PYTEST_CACHE_VENV")"
+        fi

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -38,7 +38,7 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          tmp_venv=$(mktemp -d)/venv
+          tmp_venv="$RUNNER_TEMP/pytest-cache-venv"
           uv venv -p 3.12 "$tmp_venv"
           uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
           echo "PYTEST_CACHE_VENV=$tmp_venv" >> "$GITHUB_ENV"
@@ -63,11 +63,3 @@ runs:
           --shard "$SHARD" \
           --repo "$REPO" \
           --temp_dir "$RUNNER_TEMP"
-
-    - name: Cleanup temp venv
-      if: always()
-      shell: bash
-      run: |
-        if [ -n "${PYTEST_CACHE_VENV:-}" ] && [ -d "$(dirname "$PYTEST_CACHE_VENV")" ]; then
-          rm -rf "$(dirname "$PYTEST_CACHE_VENV")"
-        fi

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -24,6 +24,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies
       with:

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -38,10 +38,8 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          tmp_venv="$RUNNER_TEMP/pytest-cache-venv"
-          uv venv -p 3.12 "$tmp_venv"
-          uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
-          echo "PYTEST_CACHE_VENV=$tmp_venv" >> "$GITHUB_ENV"
+          # Pre-fetch dependencies to cache them for later uv run calls
+          uv run --no-project --with boto3==1.35.42 python -c "import boto3; print('Dependencies ready')"
 
     - name: Upload the cache
       shell: bash
@@ -53,7 +51,7 @@ runs:
         SHARD: ${{ inputs.shard }}
         REPO: ${{ github.repository }}
       run: |
-        "$PYTEST_CACHE_VENV/bin/python" .github/scripts/pytest_cache.py \
+        uv run --no-project --with boto3==1.35.42 python .github/scripts/pytest_cache.py \
           --upload \
           --cache_dir "$GITHUB_WORKSPACE/$CACHE_DIR" \
           --pr_identifier "$GITHUB_REF" \

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -33,7 +33,10 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          python3 -m pip install boto3==1.35.42
+          tmp_venv=$(mktemp -d)/venv
+          uv venv -p 3.12 "$tmp_venv"
+          uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
+          echo "PYTEST_CACHE_VENV=$tmp_venv" >> "$GITHUB_ENV"
 
     - name: Upload the cache
       shell: bash
@@ -45,7 +48,7 @@ runs:
         SHARD: ${{ inputs.shard }}
         REPO: ${{ github.repository }}
       run: |
-        python3 .github/scripts/pytest_cache.py \
+        "$PYTEST_CACHE_VENV/bin/python" .github/scripts/pytest_cache.py \
           --upload \
           --cache_dir "$GITHUB_WORKSPACE/$CACHE_DIR" \
           --pr_identifier "$GITHUB_REF" \
@@ -54,4 +57,12 @@ runs:
           --test_config "$TEST_CONFIG" \
           --shard "$SHARD" \
           --repo "$REPO" \
-          --temp_dir "$RUNNER_TEMP" \
+          --temp_dir "$RUNNER_TEMP"
+
+    - name: Cleanup temp venv
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${PYTEST_CACHE_VENV:-}" ] && [ -d "$(dirname "$PYTEST_CACHE_VENV")" ]; then
+          rm -rf "$(dirname "$PYTEST_CACHE_VENV")"
+        fi

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -45,10 +45,7 @@ runs:
         JOB_NAME: ${{ inputs.job-name }}
       run: |
         set -x
-        tmp_venv="$RUNNER_TEMP/reuse-old-whl-venv"
-        uv venv -p 3.12 "$tmp_venv"
-        uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42 requests==2.32.3
-        "$tmp_venv/bin/python" ${GITHUB_ACTION_PATH}/reuse_old_whl.py \
+        uv run --no-project --with boto3==1.35.42 --with requests==2.32.3 python ${GITHUB_ACTION_PATH}/reuse_old_whl.py \
           --build-environment "${{ inputs.build-environment }}" \
           --run-id "${{ inputs.run-id }}" \
           --github-ref "${{ github.ref }}"

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -45,11 +45,10 @@ runs:
         JOB_NAME: ${{ inputs.job-name }}
       run: |
         set -x
-        tmp_venv=$(mktemp -d)/venv
+        tmp_venv="$RUNNER_TEMP/reuse-old-whl-venv"
         uv venv -p 3.12 "$tmp_venv"
         uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
         "$tmp_venv/bin/python" ${GITHUB_ACTION_PATH}/reuse_old_whl.py \
           --build-environment "${{ inputs.build-environment }}" \
           --run-id "${{ inputs.run-id }}" \
           --github-ref "${{ github.ref }}"
-        rm -rf "$(dirname "$tmp_venv")"

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -47,7 +47,7 @@ runs:
         set -x
         tmp_venv="$RUNNER_TEMP/reuse-old-whl-venv"
         uv venv -p 3.12 "$tmp_venv"
-        uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
+        uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42 requests==2.32.3
         "$tmp_venv/bin/python" ${GITHUB_ACTION_PATH}/reuse_old_whl.py \
           --build-environment "${{ inputs.build-environment }}" \
           --run-id "${{ inputs.run-id }}" \

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -40,8 +40,11 @@ runs:
         JOB_NAME: ${{ inputs.job-name }}
       run: |
         set -x
-        python3 -m pip install boto3==1.35.42
-        python3 ${GITHUB_ACTION_PATH}/reuse_old_whl.py \
+        tmp_venv=$(mktemp -d)/venv
+        uv venv -p 3.12 "$tmp_venv"
+        uv pip install --python "$tmp_venv/bin/python" boto3==1.35.42
+        "$tmp_venv/bin/python" ${GITHUB_ACTION_PATH}/reuse_old_whl.py \
           --build-environment "${{ inputs.build-environment }}" \
           --run-id "${{ inputs.run-id }}" \
           --github-ref "${{ github.ref }}"
+        rm -rf "$(dirname "$tmp_venv")"

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -29,6 +29,11 @@ runs:
   using: composite
 
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     # Check out pytorch with fetch depth 0
     - name: Check file changes
       id: check-file-changes

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -45,16 +45,14 @@ runs:
                     if f.is_file():
                         z.write(f, os.path.relpath(f, d))
         '
-        tmp_venv="$RUNNER_TEMP/upload-artifacts-venv"
-        uv venv -p 3.12 "$tmp_venv"
-        "$tmp_venv/bin/python" -c "$ZIP_CMD" \
+        uv run --no-project python -c "$ZIP_CMD" \
           test/test-reports "test-jsons-${FILE_SUFFIX}.zip" '**/*.json'
-        "$tmp_venv/bin/python" -c "$ZIP_CMD" \
+        uv run --no-project python -c "$ZIP_CMD" \
           . "test-reports-${FILE_SUFFIX}.zip" 'test/test-reports/**/*.xml' 'test/test-reports/**/*.csv'
-        "$tmp_venv/bin/python" -c "$ZIP_CMD" \
+        uv run --no-project python -c "$ZIP_CMD" \
           . "logs-${FILE_SUFFIX}.zip" 'usage_log.txt' 'test/test-reports/**/*.log'
         if [ -d 'test/debug' ]; then
-          "$tmp_venv/bin/python" -c "$ZIP_CMD" \
+          uv run --no-project python -c "$ZIP_CMD" \
             test/debug "debug-${FILE_SUFFIX}.zip" '**/*'
         fi
 

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -45,7 +45,7 @@ runs:
                     if f.is_file():
                         z.write(f, os.path.relpath(f, d))
         '
-        tmp_venv=$(mktemp -d)/venv
+        tmp_venv="$RUNNER_TEMP/upload-artifacts-venv"
         uv venv -p 3.12 "$tmp_venv"
         "$tmp_venv/bin/python" -c "$ZIP_CMD" \
           test/test-reports "test-jsons-${FILE_SUFFIX}.zip" '**/*.json'
@@ -57,7 +57,6 @@ runs:
           "$tmp_venv/bin/python" -c "$ZIP_CMD" \
             test/debug "debug-${FILE_SUFFIX}.zip" '**/*'
         fi
-        rm -rf "$(dirname "$tmp_venv")"
 
     # Windows zip
     - name: Zip JSONs for upload

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -19,6 +19,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup uv
+      if: runner.os != 'Windows' && !inputs.use-gha
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     - name: Zip artifacts for upload
       if: runner.os != 'Windows' && !inputs.use-gha
       shell: bash

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -63,7 +63,7 @@ runs:
           set -eu
           tmp_venv="$RUNNER_TEMP/upload-utilization-stats-venv"
           uv venv -p 3.12 "$tmp_venv"
-          uv pip install --python "$tmp_venv/bin/python" python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7
+          uv pip install --python "$tmp_venv/bin/python" python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7 requests==2.32.3
           echo "UTIL_STATS_VENV=$tmp_venv" >> "$GITHUB_ENV"
     - name: Upload utilizatoin stats to s3
       shell: bash

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -38,10 +38,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.10'
     - name: Print Inputs
       shell: bash
       run: |
@@ -51,7 +47,6 @@ runs:
         echo "job_id: ${{inputs.job_id}}"
         echo "job_name:  ${{inputs.job_name}}"
         echo "artifact_prefix: ${{inputs.artifact_prefix}}"
-        python3 --version
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies
       with:
@@ -61,11 +56,14 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          python3 -m pip install python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7
+          tmp_venv=$(mktemp -d)/venv
+          uv venv -p 3.12 "$tmp_venv"
+          uv pip install --python "$tmp_venv/bin/python" python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7
+          echo "UTIL_STATS_VENV=$tmp_venv" >> "$GITHUB_ENV"
     - name: Upload utilizatoin stats to s3
       shell: bash
       run: |
-        python3 -m tools.stats.upload_utilization_stats.upload_utilization_stats \
+        "$UTIL_STATS_VENV/bin/python" -m tools.stats.upload_utilization_stats.upload_utilization_stats \
           --workflow-run-id "${{inputs.workflow_run_id}}" \
           --workflow-name "${{inputs.workflow_name}}" \
           --workflow-run-attempt "${{inputs.workflow_attempt}}" \
@@ -73,3 +71,10 @@ runs:
           --job-name "${{inputs.job_name}}" \
           --local-path "${{inputs.local_path}}" \
           --artifact-prefix "${{inputs.artifact_prefix}}"
+    - name: Cleanup temp venv
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${UTIL_STATS_VENV:-}" ] && [ -d "$(dirname "$UTIL_STATS_VENV")" ]; then
+          rm -rf "$(dirname "$UTIL_STATS_VENV")"
+        fi

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -38,6 +38,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        python-version: 3.12
+
     - name: Print Inputs
       shell: bash
       run: |

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -61,14 +61,12 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          tmp_venv="$RUNNER_TEMP/upload-utilization-stats-venv"
-          uv venv -p 3.12 "$tmp_venv"
-          uv pip install --python "$tmp_venv/bin/python" python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7 requests==2.32.3
-          echo "UTIL_STATS_VENV=$tmp_venv" >> "$GITHUB_ENV"
+          # Pre-fetch dependencies to cache them for later uv run calls
+          uv run --no-project --with python-dateutil==2.8.2 --with boto3==1.35.42 --with pandas==2.1.3 --with dataclasses_json==0.6.7 --with requests==2.32.3 python -c "print('Dependencies ready')"
     - name: Upload utilizatoin stats to s3
       shell: bash
       run: |
-        "$UTIL_STATS_VENV/bin/python" -m tools.stats.upload_utilization_stats.upload_utilization_stats \
+        uv run --no-project --with python-dateutil==2.8.2 --with boto3==1.35.42 --with pandas==2.1.3 --with dataclasses_json==0.6.7 --with requests==2.32.3 python -m tools.stats.upload_utilization_stats.upload_utilization_stats \
           --workflow-run-id "${{inputs.workflow_run_id}}" \
           --workflow-name "${{inputs.workflow_name}}" \
           --workflow-run-attempt "${{inputs.workflow_attempt}}" \

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -61,7 +61,7 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eu
-          tmp_venv=$(mktemp -d)/venv
+          tmp_venv="$RUNNER_TEMP/upload-utilization-stats-venv"
           uv venv -p 3.12 "$tmp_venv"
           uv pip install --python "$tmp_venv/bin/python" python-dateutil==2.8.2 boto3==1.35.42 pandas==2.1.3 dataclasses_json==0.6.7
           echo "UTIL_STATS_VENV=$tmp_venv" >> "$GITHUB_ENV"
@@ -76,10 +76,3 @@ runs:
           --job-name "${{inputs.job_name}}" \
           --local-path "${{inputs.local_path}}" \
           --artifact-prefix "${{inputs.artifact_prefix}}"
-    - name: Cleanup temp venv
-      if: always()
-      shell: bash
-      run: |
-        if [ -n "${UTIL_STATS_VENV:-}" ] && [ -d "$(dirname "$UTIL_STATS_VENV")" ]; then
-          rm -rf "$(dirname "$UTIL_STATS_VENV")"
-        fi

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -212,9 +212,12 @@ jobs:
           MONITOR_LOG_INTERVAL: ${{ inputs.monitor-log-interval }}
           MONITOR_DATA_COLLECT_INTERVAL: ${{ inputs.monitor-data-collect-interval }}
         run: |
-          python3 -m pip install psutil==5.9.8 dataclasses_json==0.6.7 nvidia-ml-py==11.525.84
-          python3 -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
+          tmp_venv=$(mktemp -d)/venv
+          uv venv -p 3.12 "$tmp_venv"
+          uv pip install --python "$tmp_venv/bin/python" psutil==5.9.8 dataclasses_json==0.6.7 nvidia-ml-py==11.525.84
+          "$tmp_venv/bin/python" -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
+          echo "MONITOR_VENV=$tmp_venv" >> "${GITHUB_ENV}"
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
@@ -487,6 +490,15 @@ jobs:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
         run: |
           kill "$MONITOR_SCRIPT_PID"
+
+      - name: Cleanup monitoring script venv
+        if: always()
+        shell: bash
+        continue-on-error: true
+        run: |
+          if [ -n "${MONITOR_VENV:-}" ] && [ -d "$(dirname "$MONITOR_VENV")" ]; then
+            rm -rf "$(dirname "$MONITOR_VENV")"
+          fi
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -212,12 +212,11 @@ jobs:
           MONITOR_LOG_INTERVAL: ${{ inputs.monitor-log-interval }}
           MONITOR_DATA_COLLECT_INTERVAL: ${{ inputs.monitor-data-collect-interval }}
         run: |
-          tmp_venv=$(mktemp -d)/venv
+          tmp_venv="$RUNNER_TEMP/monitor-script-venv"
           uv venv -p 3.12 "$tmp_venv"
           uv pip install --python "$tmp_venv/bin/python" psutil==5.9.8 dataclasses_json==0.6.7 nvidia-ml-py==11.525.84
           "$tmp_venv/bin/python" -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
-          echo "MONITOR_VENV=$tmp_venv" >> "${GITHUB_ENV}"
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
@@ -490,15 +489,6 @@ jobs:
           MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
         run: |
           kill "$MONITOR_SCRIPT_PID"
-
-      - name: Cleanup monitoring script venv
-        if: always()
-        shell: bash
-        continue-on-error: true
-        run: |
-          if [ -n "${MONITOR_VENV:-}" ] && [ -d "$(dirname "$MONITOR_VENV")" ]; then
-            rm -rf "$(dirname "$MONITOR_VENV")"
-          fi
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -212,10 +212,7 @@ jobs:
           MONITOR_LOG_INTERVAL: ${{ inputs.monitor-log-interval }}
           MONITOR_DATA_COLLECT_INTERVAL: ${{ inputs.monitor-data-collect-interval }}
         run: |
-          tmp_venv="$RUNNER_TEMP/monitor-script-venv"
-          uv venv -p 3.12 "$tmp_venv"
-          uv pip install --python "$tmp_venv/bin/python" psutil==5.9.8 dataclasses_json==0.6.7 nvidia-ml-py==11.525.84
-          "$tmp_venv/bin/python" -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
+          uv run --no-project --with psutil==5.9.8 --with dataclasses_json==0.6.7 --with nvidia-ml-py==11.525.84 python -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Download build artifacts


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #170316
* #169969

Switches all of the tools that run locally on our runners to rely on
temp environments, this should enable us to be able to run on any
machine that has uv and also has the benefit of not intermixing virtual
envs between different utilities we have built.

A nice follow-up to this would be to just write python utils for all of
these and include the dependencies in the front matter but I think
that's a more involved PR that I will save for when I have more time.

This adds the setup-uv action which should be idempotent to every
composite action that may need it in order to run.

I've confirmed that setup-uv should be a noop if uv is already installed
so ideally this should be a noop after its run once.

https://github.com/astral-sh/setup-uv/blob/main/src/setup-uv.ts

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>