### PR TITLE
[CUDA][CUDA Graphs] Restore previous current stream with green context and check underlying stream at capture end

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -119,7 +119,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
 void CUDAGraph::capture_end() {
   auto stream = at::cuda::getCurrentCUDAStream();
 
-  TORCH_CHECK(stream == capture_stream_,
+  TORCH_CHECK(stream.stream() == capture_stream_.stream(),
               "Capture must end on the same stream it began on.");
 
   AT_CUDA_CHECK(cudaStreamEndCapture(capture_stream_, &graph_));

--- a/aten/src/ATen/cuda/CUDAGreenContext.cpp
+++ b/aten/src/ATen/cuda/CUDAGreenContext.cpp
@@ -180,7 +180,9 @@ GreenContext::GreenContext(uint32_t device_id, uint32_t num_sms) {
         c10::cuda::DriverAPI::get()->cuCtxPopCurrent_(&popped));
     TORCH_INTERNAL_ASSERT(
         popped == context_, "expected popped context to be the current ctx");
-    ev.block(c10::cuda::getStreamFromExternal(parent_stream_, device_id_));
+    auto parent_stream = c10::cuda::getStreamFromExternal(parent_stream_, device_id_);
+    ev.block(parent_stream);
+    c10::cuda::setCurrentCUDAStream(parent_stream);
 #else
     TORCH_CHECK(false, "Green Context is only supported on CUDA 12.8+!");
 #endif

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6460,7 +6460,9 @@ class TestCudaOptims(TestCase):
             self.assertEqual(scaler._growth_tracker, growth_tracker)
 
 
-@unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green context not available, skipping tests")
+@unittest.skipIf(
+    not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green context not available, skipping tests"
+)
 class TestGreenContext(TestCase):
     def test_greencontext_restores_stream(self):
         # need to start on a side stream as we are comparing pointers and want to avoid


### PR DESCRIPTION
@galv pointed out that #170148 is extraneous as the default stream within a green-context should be capturable. Indeed this doesn't seem to be the reason that graph capture wasn't working, rather the issue was the parent stream at capture time was not properly restored and the check for it was also too restrictive (the underlying `CUDAStream` needs to be equal, not the wrapped object). 

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng