### PR TITLE
Use SHA-256 for hashing PyTorch Dynamo Source class

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -4,7 +4,9 @@ import contextlib
 import dataclasses
 import enum
 import functools
+import hashlib
 import logging
+import pickle
 import re
 import sys
 import threading
@@ -1141,13 +1143,24 @@ def dataclass_with_cached_hash(
     cls: type[T] | None = None, **kwargs: Any
 ) -> type[T] | Callable[[type[T]], type[T]]:
     def wrap(cls_inner: type[T]) -> type[T]:
-        new_cls = dataclasses.dataclass(cls_inner, **kwargs)
+        new_cls = dataclasses.dataclass(cls_inner, unsafe_hash=False, **kwargs)
         old_hash = cls_inner.__hash__
 
         def __hash__(self) -> int:
-            if not hasattr(self, "_hash"):
-                object.__setattr__(self, "_hash", old_hash(self))
-            return self._hash
+            if hasattr(self, "_hash"):
+                return self._hash
+            try:
+                field_values = tuple(
+                    getattr(self, f.name) for f in dataclasses.fields(self)
+                )
+                hash_result = int(
+                    hashlib.sha256(pickle.dumps(field_values)).hexdigest(), 16
+                )
+            except Exception:
+                # Fall back to dataclass-generated hash if pickling fails
+                hash_result = old_hash(self)
+            object.__setattr__(self, "_hash", hash_result)
+            return hash_result
 
         def __reduce__(self):
             # Exclude _hash from pickling to ensure deterministic cache keys.


### PR DESCRIPTION
Summary:
`Source` class contains a `_hash` field, which is calculated from Python's default `__hash__()` function. The hash value changes across runs because it doesn't use the attributes in the object. 

Since each instance of `Source` object has a different `_hash` field, it causes a downstream issue of generating inconsistent cache key for `AOTAutogradCache`. The cache key partly relies on the content of `AOTConfig`, which saves a list of `Source` in `aot_autograd_arg_pos_to_source`.  Therefore, `AOTAutogradCache` generates a different cache key for the same graph, causing a cache miss.

This diff saves a consistent hash value in the `_hash` field of the `Source` object. The SHA-256 algorithm creates the same hash value if the attributes in the `Source` object are the same.

Test Plan:
```
buck test //mtia/compiler/graph_compiler/test_library:unittest_aot_autograd_cache -- test_dynamic_shapes_different_sizes
```

Differential Revision: D89007953


