### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from caffe2

### DIFF
--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -605,7 +605,7 @@ Workspace chooseAlgorithm(
   search::wsscache().find(args.params, &workspace_size);
   try {
     return Workspace(workspace_size);
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     std::ignore = hipGetLastError(); // clear OOM error
 
     // switch to default algorithm and record it in the cache to prevent
@@ -626,7 +626,7 @@ Workspace chooseSolution(const ConvolutionArgs& args, uint64_t* solution_id)
   try {
     *solution_id = solution.solution_id;
     return Workspace(solution.workspace_size);
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     std::ignore = hipGetLastError(); // clear OOM error
 
     // switch to default algorithm

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -18,7 +18,7 @@ using namespace at;
       fn;                                                      \
       _passed = true;                                          \
       els;                                                     \
-    } catch (std::exception & e) {                             \
+    } catch (std::exception&) {                                \
       ASSERT_FALSE(_passed);                                   \
       catc;                                                    \
     }                                                          \

--- a/test/cpp/c10d/ProcessGroupGlooTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooTest.cpp
@@ -67,7 +67,7 @@ class SignalTest {
       work = pg.allreduce(tensors);
       try {
         work->wait();
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         break;
       }
       sem_.post();

--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -207,7 +207,7 @@ class ProcessGroupNCCLNoHeartbeatCaught
     void runLoop() override {
       try {
         c10d::ProcessGroupNCCL::HeartbeatMonitor::runLoop();
-      } catch (std::runtime_error& e) {
+      } catch (const std::runtime_error&) {
         // Safe cast because we know it's a ProcessGroupNCCLNoHeartbeatCaught
         auto* pg = static_cast<ProcessGroupNCCLNoHeartbeatCaught*>(pg_);
         pg->hasMonitorThreadCaughtError_ = true;


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D89071569


