### PR TITLE
[codemod] Fix deprecated-literal-operator in caffe2/aten/src/ATen/native/cudnn/Conv_v7.cpp +4

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -64,7 +64,7 @@
 // algo, under the hood, cudnn will run with the slower kernel since it sees
 // fastest algorithm combination with a sub optimal mathType.
 
-constexpr size_t operator"" _TiB(unsigned long long n) {
+constexpr size_t operator""_TiB(unsigned long long n) {
   return static_cast<size_t>(n) * 1024 * 1024 * 1024 * 1024;
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -44,7 +44,7 @@ namespace at::native {
 namespace {
 
 // TODO: remove duplicate code in Conv_v7.cpp
-constexpr int64_t operator"" _TiB(unsigned long long n) {
+constexpr int64_t operator""_TiB(unsigned long long n) {
   return static_cast<size_t>(n) << 40;
 }
 


### PR DESCRIPTION
Summary:
`-Wdeprecated-literal-operator` makes the following illegal:
```
constexpr std::uint64_t operator"" _bytes(unsigned long long int bytes);
```
and requires
```
constexpr std::uint64_t operator""_bytes(unsigned long long int bytes);
```
instead. Note that the space in `operator""_bytes` has gone away.

This whitespace is a deprecated point of language flexibility and the `-Wdeprecated-literal-operator` becomes default in LLVM-21, which we are upgrading to. Let's fix it now.

Test Plan: Sandcastle

Differential Revision: D87457341


