### PR TITLE
[ROCm] enable fastSpecializedAtomicAdd for gfx950

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -11,6 +11,7 @@
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
 
+#if ROCM_VERSION < 60400
 __device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(__hip_bfloat162* address, __hip_bfloat162 value) {
 #if (defined(__gfx942__)) && \
   __has_builtin(__builtin_amdgcn_flat_atomic_fadd_v2bf16)
@@ -68,6 +69,9 @@ __device__ inline __half2 preview_unsafeAtomicAdd(__half2* address, __half2 valu
 #endif
 }
 #define ATOMICADD preview_unsafeAtomicAdd
+#else
+#define ATOMICADD unsafeAtomicAdd
+#endif
 #define NATIVE_ZERO_BF16 __float2bfloat16(0.0f)
 #else
 #define ATOMICADD atomicAdd


### PR DESCRIPTION
Use standard HIP headers for unsafeAtomicAdd. Cannot remove copy/paste of unsafeAtomicAdd as "preview" implementation until ROCm 6.2 can be fully deprecated.

Re-land of https://github.com/pytorch/pytorch/pull/167661

Co-author: @jeffdaily 


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @xinyazhang