### PR TITLE
[flex_attention] adds support for low precision K/V inputs. Allow Keys and Values to be in lower precision than Queries for memory

### DIFF
--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -38,6 +38,7 @@ def forward_block_mn(
     {%- endif %}
 
     k = tl.trans(k)
+    k = k.to(q.dtype)
     # -- compute qk ---
     qk = tl.dot(q, k, input_precision=FLOAT32_PRECISION) # TODO: use cuda matmul when q_len <= 2.
     if not PRESCALE_QK:
@@ -112,6 +113,7 @@ def forward_block_mn(
     v = load_checked_2d(V, offs_n_load, offs_v, stride_vn, stride_vk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
     {%- endif %}
     acc = tl.dot(p.to(MATMUL_PRECISION), v, acc, input_precision=FLOAT32_PRECISION)
+    acc = tl.dot(p.to(MATMUL_PRECISION), v.to(q.dtype), acc, input_precision=FLOAT32_PRECISION)
 
     # -- update m_i
     m_i = m_ij

--- a/torch/nn/attention/_utils.py
+++ b/torch/nn/attention/_utils.py
@@ -39,13 +39,15 @@ def _validate_sdpa_input(
     dropout_p=0.0,
     is_causal=False,
     scale=None,
+    allow_lowp_kv=False,
 ) -> None:
-    if query.dtype != key.dtype or query.dtype != value.dtype:
-        raise ValueError(
-            f"Expected query, key, and value to have the same dtype, "
-            f"but got query.dtype: {query.dtype}, key.dtype: {key.dtype}, "
-            f"and value.dtype: {value.dtype} instead."
-        )
+    if not allow_lowp_kv:
+        if query.dtype != key.dtype or query.dtype != value.dtype:
+            raise ValueError(
+                f"Expected query, key, and value to have the same dtype, "
+                f"but got query.dtype: {query.dtype}, key.dtype: {key.dtype}, "
+                f"and value.dtype: {value.dtype} instead."
+            )
     if query.device != key.device or query.device != value.device:
         raise ValueError(
             f"Expected query, key, and value to have the same device type, "

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1470,7 +1470,7 @@ def flex_attention(
 
     """
     # Some basic input validation
-    _validate_sdpa_input(query, key, value)
+    _validate_sdpa_input(query, key, value, allow_lowp_kv=True)
     _validate_embed_dim(query, key, value)
     _validate_device(query, key, value)
     query, key, value = _enforce_mem_layouts(query, key, value)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170446
* __->__ #170336

efficiency. K and V are automatically upcast to Q's dtype in the kernel
  before matmul operations.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo