### PR TITLE
Official Docker builds forward fix. Use default python env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         libpng-dev \
         python3 \
         python3-pip \
+        python-is-python3 \
         python3-dev && \
     rm -rf /var/lib/apt/lists/*
 # Remove PEP 668 restriction (safe in containers)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,26 +19,23 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         libpng-dev \
         python3 \
         python3-pip \
-        python3-venv \
         python3-dev && \
     rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks
 RUN mkdir /opt/ccache && ccache --set-config=cache_dir=/opt/ccache
-ENV PATH /opt/pytorch-venv/bin:$PATH
 
-FROM dev-base as python-venv
+FROM dev-base as python-deps
 COPY requirements.txt requirements-build.txt .
-# Create virtual environment and install packages
-RUN python3 -m venv /opt/pytorch-venv && \
-    /opt/pytorch-venv/bin/pip install --upgrade pip setuptools wheel && \
-    /opt/pytorch-venv/bin/pip install cmake pyyaml numpy ipython -r requirements.txt
+# Install Python packages to system Python
+RUN pip3 install --break-system-packages --upgrade pip setuptools wheel && \
+    pip3 install --break-system-packages cmake pyyaml numpy ipython -r requirements.txt
 
 FROM dev-base as submodule-update
 WORKDIR /opt/pytorch
 COPY . .
 RUN git submodule update --init --recursive
 
-FROM python-venv as pytorch-installs
+FROM python-deps as pytorch-installs
 ARG CUDA_PATH=cu121
 ARG INSTALL_CHANNEL=whl/nightly
 # Automatically set by buildx
@@ -46,11 +43,11 @@ ARG TARGETPLATFORM
 
 # INSTALL_CHANNEL whl - release, whl/nightly - nightly, whl/test - test channels
 RUN case ${TARGETPLATFORM} in \
-         "linux/arm64")  /opt/pytorch-venv/bin/pip install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
-         *)              /opt/pytorch-venv/bin/pip install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH#.}/ torch torchvision torchaudio ;; \
+         "linux/arm64")  pip3 install --break-system-packages --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
+         *)              pip3 install --break-system-packages --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH#.}/ torch torchvision torchaudio ;; \
     esac
-RUN /opt/pytorch-venv/bin/pip install torchelastic
-RUN IS_CUDA=$(python -c 'import torch ; print(torch.cuda._is_compiled())'); \
+RUN pip3 install --break-system-packages torchelastic
+RUN IS_CUDA=$(python3 -c 'import torch ; print(torch.cuda._is_compiled())'); \
     echo "Is torch compiled with cuda: ${IS_CUDA}"; \
     if test "${IS_CUDA}" != "True" -a ! -z "${CUDA_VERSION}"; then \
         exit 1; \
@@ -66,21 +63,25 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         ca-certificates \
         libjpeg-dev \
         libpng-dev \
+        python3 \
+        python3-pip \
         && rm -rf /var/lib/apt/lists/*
-COPY --from=pytorch-installs /opt/pytorch-venv /opt/pytorch-venv
+# Copy Python packages from pytorch-installs stage
+COPY --from=pytorch-installs /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=pytorch-installs /usr/local/bin /usr/local/bin
 RUN if test -n "${TRITON_VERSION}" -a "${TARGETPLATFORM}" != "linux/arm64"; then \
         DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends gcc; \
         rm -rf /var/lib/apt/lists/*; \
     fi
-ENV PATH /opt/pytorch-venv/bin:$PATH
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-ENV PATH /opt/pytorch-venv/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 ENV PYTORCH_VERSION ${PYTORCH_VERSION}
 WORKDIR /workspace
 
 FROM official as dev
 # Should override the already installed version from the official-image stage
-COPY --from=python-venv /opt/pytorch-venv /opt/pytorch-venv
+COPY --from=python-deps /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=python-deps /usr/local/bin /usr/local/bin
 COPY --from=submodule-update /opt/pytorch /opt/pytorch

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         ca-certificates \
         libjpeg-dev \
         libpng-dev \
+        python-is-python3 \
         python3 \
         python3-pip \
         && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir /opt/ccache && ccache --set-config=cache_dir=/opt/ccache
 FROM dev-base as python-deps
 COPY requirements.txt requirements-build.txt .
 # Install Python packages to system Python
-RUN pip3 install --upgrade pip setuptools wheel && \
+RUN pip3 install --upgrade --ignore-installed pip setuptools wheel && \
     pip3 install cmake pyyaml numpy ipython -r requirements.txt
 
 FROM dev-base as submodule-update


### PR DESCRIPTION
Fixes #https://github.com/pytorch/pytorch/issues/170252

test:
Build Docker image.
Run:
```
docker run -it 3fdc10220753 /bin/bash
root@79ddf7440bc4:/workspace# python3
Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> torch.__version__
'2.10.0.dev20251210+cu126'
>>> 
```
