### PR TITLE
Test Copy Engine All-to-all

### DIFF
--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -141,9 +141,6 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         self.assertEqual(out, out_golden)
         self.assertEqual(out2, out_golden)
 
-        # if self.rank == 0:
-        #     prof.export_chrome_trace("test_ce_alltoall.json")
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -104,6 +104,46 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         # if self.rank == 0:
         #     prof.export_chrome_trace("test_ce_allgather.json")
 
+    @skip_if_lt_x_gpu(2)
+    def test_ce_alltoall(self):
+        group_name, prof = self._init()
+        dtype = torch.float
+        numel = 1024 * 1024 * self.world_size
+
+        # Regular implementation
+        inp_golden = torch.randn(numel, dtype=dtype, device=self.device)
+        out_golden = torch.empty(numel, dtype=dtype, device=self.device)
+
+        # Copy engine implementation
+        inp = symm_mem.empty(numel, dtype=dtype, device=self.device).copy_(inp_golden)
+        out = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        out2 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        symm_mem.rendezvous(inp, group=group_name)
+        symm_mem.rendezvous(out, group=group_name)
+        symm_mem.rendezvous(out2, group=group_name)
+
+        current_stream = torch.cuda.current_stream()
+        # Create a side stream
+        stream = torch.cuda.Stream()
+
+        with prof:
+            # SM
+            dist.all_to_all_single(out_golden, inp_golden)
+            # CE + async
+            work = dist.all_to_all_single(out, inp, async_op=True)
+            work.wait()
+            # CE + side stream
+            stream.wait_stream(current_stream)
+            with torch.cuda.stream(stream):
+                dist.all_to_all_single(out2, inp)
+            prof.step()
+
+        self.assertEqual(out, out_golden)
+        self.assertEqual(out2, out_golden)
+
+        # if self.rank == 0:
+        #     prof.export_chrome_trace("test_ce_alltoall.json")
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170344

NCCL 2.28 added Copy Engine (CE) support.

Condition:
- Tensors be symmetrically registered (e.g. coming from symm_mem.empty)
- NCCL_CTA_POLICY_ZERO be passed to ncclConfig or env var NCCL_CTA_POLICY=2

Confirmed use of CE via profile:
<img width="612" height="167" alt="Screenshot 2025-12-12 at 2 44 23 PM" src="https://github.com/user-attachments/assets/5efb6e9c-40a4-43a0-878f-36733b8b64dd" />

(First kernel is from `all_to_all_single` on regular tensor, second kernel is from `all_to_all_single` on tensors that have been window registered)

Caveat:
As of 2.28.9, CE collectives cannot be run on default stream, so we are testing it with `async_op=True` or with a side stream.