### PR TITLE
[DTensor] Add OpSchema.args_meta, kwargs_meta helpers

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -25,6 +25,7 @@ from torch.distributed.tensor._op_schema import (
     OpSpec,
     OpStrategy,
     RuntimeSchemaInfo,
+    TupleStrategy,
 )
 from torch.distributed.tensor._ops._einsum_strategy import (
     EinsumDims,
@@ -44,6 +45,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
+from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
 try:
@@ -708,6 +710,146 @@ DistTensorReplicateStrategyRegistrationTestWithLocalTensor = (
 TestStrategyHashingWithLocalTensor = create_local_tensor_test_class(
     TestStrategyHashing,
 )
+
+
+class TestOpSchemaMetaProperties(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.world_size = 8
+        store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=self.world_size, store=store
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
+
+    def test_args_meta_mixed_opstrategy_and_tuplestrategy(self):
+        """Test args_meta with both OpStrategy and TupleStrategy"""
+        # Create a simple mesh
+        mesh = DeviceMesh("cpu", torch.arange(4))
+
+        # Create tensor metadata
+        tensor_meta1 = TensorMeta(
+            shape=torch.Size([10, 20]),
+            stride=(20, 1),
+            dtype=torch.float32,
+        )
+        tensor_meta2 = TensorMeta(
+            shape=torch.Size([5, 10]),
+            stride=(10, 1),
+            dtype=torch.float32,
+        )
+        tensor_meta3 = TensorMeta(
+            shape=torch.Size([5, 10]),
+            stride=(10, 1),
+            dtype=torch.float32,
+        )
+        tensor_meta4 = TensorMeta(
+            shape=torch.Size([20, 30]),
+            stride=(30, 1),
+            dtype=torch.float32,
+        )
+
+        # Create OpStrategies
+        op_strategy1 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Shard(0),), tensor_meta1))]
+        )
+        op_strategy2 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Shard(1),), tensor_meta2))]
+        )
+        op_strategy3 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Replicate(),), tensor_meta3))]
+        )
+        op_strategy4 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Shard(1),), tensor_meta4))]
+        )
+
+        # Create TupleStrategy
+        tuple_strategy = TupleStrategy([op_strategy2, op_strategy3])
+
+        # Create OpSchema: (OpStrategy, TupleStrategy, OpStrategy)
+        op_schema = OpSchema(
+            torch.ops.aten.add.Tensor,
+            args_schema=(op_strategy1, tuple_strategy, op_strategy4),
+            kwargs_schema={},
+        )
+
+        # Test args_meta
+        args_meta = op_schema.args_meta
+        self.assertEqual(len(args_meta), 3)
+        # First arg should be TensorMeta
+        self.assertIsInstance(args_meta[0], TensorMeta)
+        self.assertEqual(args_meta[0].shape, torch.Size([10, 20]))
+        # Second arg should be tuple of TensorMeta
+        self.assertIsInstance(args_meta[1], tuple)
+        self.assertEqual(len(args_meta[1]), 2)
+        self.assertIsInstance(args_meta[1][0], TensorMeta)
+        self.assertIsInstance(args_meta[1][1], TensorMeta)
+        self.assertEqual(args_meta[1][0].shape, torch.Size([5, 10]))
+        self.assertEqual(args_meta[1][1].shape, torch.Size([5, 10]))
+        # Third arg should be TensorMeta
+        self.assertIsInstance(args_meta[2], TensorMeta)
+        self.assertEqual(args_meta[2].shape, torch.Size([20, 30]))
+
+    def test_kwargs_meta_mixed(self):
+        """Test kwargs_meta with mixed types"""
+        # Create a simple mesh
+        mesh = DeviceMesh("cpu", torch.arange(4))
+
+        # Create tensor metadata
+        tensor_meta1 = TensorMeta(
+            shape=torch.Size([10, 20]),
+            stride=(20, 1),
+            dtype=torch.float32,
+        )
+        tensor_meta2 = TensorMeta(
+            shape=torch.Size([5, 10]),
+            stride=(10, 1),
+            dtype=torch.float32,
+        )
+        tensor_meta3 = TensorMeta(
+            shape=torch.Size([5, 10]),
+            stride=(10, 1),
+            dtype=torch.float32,
+        )
+
+        # Create OpStrategies
+        op_strategy1 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Shard(0),), tensor_meta1))]
+        )
+        op_strategy2 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Shard(1),), tensor_meta2))]
+        )
+        op_strategy3 = OpStrategy(
+            [OpSpec(DTensorSpec(mesh, (Replicate(),), tensor_meta3))]
+        )
+
+        # Create TupleStrategy
+        tuple_strategy = TupleStrategy([op_strategy2, op_strategy3])
+
+        # Create OpSchema with mixed kwargs
+        op_schema = OpSchema(
+            torch.ops.aten.add.Tensor,
+            args_schema=(),
+            kwargs_schema={
+                "input": op_strategy1,
+                "tensors": tuple_strategy,
+                "dim": 0,
+                "alpha": 1.0,
+            },
+        )
+
+        # Test kwargs_meta
+        kwargs_meta = op_schema.kwargs_meta
+        self.assertEqual(len(kwargs_meta), 4)
+        self.assertIsInstance(kwargs_meta["input"], TensorMeta)
+        self.assertIsInstance(kwargs_meta["tensors"], tuple)
+        self.assertEqual(len(kwargs_meta["tensors"]), 2)
+        self.assertEqual(kwargs_meta["dim"], 0)
+        self.assertEqual(kwargs_meta["alpha"], 1.0)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -36,7 +36,7 @@ from torch._C import (
 )
 from torch._ops import OpOverload
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor.placement_types import Placement
 
 
@@ -229,6 +229,12 @@ class OpStrategy(StrategyType):
     def shape(self):
         return self.strategies[0].output_spec.shape
 
+    @property
+    def tensor_meta(self) -> TensorMeta:
+        # TODO upstream this assert to DTensorSpec itself and fill any missing TensorMetas
+        assert self.strategies[0].output_spec.tensor_meta is not None
+        return self.strategies[0].output_spec.tensor_meta
+
 
 class TupleStrategy(StrategyType):
     """
@@ -370,6 +376,42 @@ class OpSchema:
             else self.kwargs_schema.values()
         )
         return tuple(item for item in kwargs_vals if isinstance(item, OpStrategy))
+
+    @property
+    def args_meta(self) -> tuple[TensorMeta | Any, ...]:
+        # Used for calling single_dim strategy functions, which aren't allowed to see DTensorSpecs/Meshes
+        # like args_spec, but has OpStrategy replaced with corresponding TensorMeta,
+        # and TupleStrategy replaced with tuple of TensorMeta
+        # preserves the original pytree structure
+        # example:
+        # args_schema = (OpStrategy1, TupleStrategy([OpStrategy2, OpStrategy3]), OpStrategy4)
+        # args_meta: (TensorMeta1, (TensorMeta2, TensorMeta3), TensorMeta4)
+
+        def convert_to_meta(item):
+            if isinstance(item, OpStrategy):
+                return item.tensor_meta
+            elif isinstance(item, TupleStrategy):
+                return tuple(convert_to_meta(child) for child in item.children)
+            else:
+                return item
+
+        return tuple(convert_to_meta(arg) for arg in self.args_schema)
+
+    @property
+    def kwargs_meta(self) -> dict[str, object]:
+        # like args_meta, but for kwargs
+
+        def convert_to_meta(item):
+            if isinstance(item, OpStrategy):
+                return item.tensor_meta
+            elif isinstance(item, TupleStrategy):
+                return tuple(convert_to_meta(child) for child in item.children)
+            else:
+                return item
+
+        return {
+            key: convert_to_meta(value) for key, value in self.kwargs_schema.items()
+        }
 
     def __repr__(self) -> str:
         args_schema = ", ".join([str(arg_schema) for arg_schema in self.args_schema])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #167677
* __->__ #170358
* #170197

Similar to args_strategy, which gets a flat list of OpStrategies out of
the args_spec, args_meta helps provide a version of args_spec usable by
single_dim_strategy functions: it has the same pytree structure as the
original arg_spec, and contains all non-tensor args, but OpStrategy
values are replaced with TensorMeta values and TupleStrategy values are
replaced with Tuples of TensorMeta.