### PR TITLE
[DTensor] Fix DTensor shardable with StridedShard

### DIFF
--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -17,6 +17,10 @@ from torch.distributed._local_tensor import (
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DeviceMesh, distribute_tensor, DTensor
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
+from torch.distributed.tensor._ops.utils import (
+    is_tensor_evenly_shardable,
+    is_tensor_shardable,
+)
 from torch.distributed.tensor._utils import (
     _compute_local_shape_and_global_offset,
     compute_global_tensor_info,
@@ -1560,6 +1564,43 @@ class TestExplicitRedistribute(LocalTensorTestBase):
                 # and re-enable
                 with self.assertRaisesRegex(RuntimeError, "Implicit redistribution"):
                     loss.backward(retain_graph=True)
+
+
+class TestIsTensorShardable(LocalTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
+    def _create_spec(
+        self, mesh_shape: tuple[int, ...], placements: list[Placement]
+    ) -> DTensorSpec:
+        mesh = init_device_mesh("cpu", mesh_shape)
+        return DTensorSpec(mesh=mesh, placements=tuple(placements))
+
+    def test_is_tensor_shardable(self):
+        spec = self._create_spec((4,), [Shard(0)])
+        self.assertTrue(is_tensor_shardable([8], spec))
+        self.assertFalse(is_tensor_shardable([2], spec))
+
+        spec = self._create_spec((4, 2), [Shard(0), Shard(0)])
+        self.assertTrue(is_tensor_shardable([8, 8], spec))
+
+        spec = self._create_spec((4, 2), [Shard(0), _StridedShard(0, split_factor=2)])
+        # not shardable now because of the split_factor
+        self.assertFalse(is_tensor_shardable([8, 8], spec))
+
+    def test_is_tensor_evenly_shardable(self):
+        spec = self._create_spec((4,), [Shard(0)])
+        self.assertTrue(is_tensor_evenly_shardable([8], spec))
+        self.assertFalse(is_tensor_evenly_shardable([10], spec))
+
+        # 2D mesh with _StridedShard
+        spec = self._create_spec((4, 2), [Shard(0), Shard(0)])
+        self.assertTrue(is_tensor_evenly_shardable([16, 8], spec))
+
+        spec = self._create_spec((4, 2), [_StridedShard(0, split_factor=3), Shard(0)])
+        # not evenly shardable now because of the split_factor
+        self.assertFalse(is_tensor_evenly_shardable([16, 8], spec))
 
 
 UtilTestWithLocalTensor = create_local_tensor_test_class(UtilTest)

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -1580,6 +1580,7 @@ class TestIsTensorShardable(LocalTensorTestBase):
     def test_is_tensor_shardable(self):
         spec = self._create_spec((4,), [Shard(0)])
         self.assertTrue(is_tensor_shardable([8], spec))
+        self.assertTrue(is_tensor_shardable([10], spec))
         self.assertFalse(is_tensor_shardable([2], spec))
 
         spec = self._create_spec((4, 2), [Shard(0), Shard(0)])
@@ -1594,7 +1595,6 @@ class TestIsTensorShardable(LocalTensorTestBase):
         self.assertTrue(is_tensor_evenly_shardable([8], spec))
         self.assertFalse(is_tensor_evenly_shardable([10], spec))
 
-        # 2D mesh with _StridedShard
         spec = self._create_spec((4, 2), [Shard(0), Shard(0)])
         self.assertTrue(is_tensor_evenly_shardable([16, 8], spec))
 


### PR DESCRIPTION
Consider shardable check for `_StridedShard`. Because the `_split_tensor` function for `_StridedShard` is to shard on `split_factor` first and then shard on tensor dim and concatenate, we need to check `split_factor` also.
