### PR TITLE
Suppress 'noexcept' warnings

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -220,6 +220,8 @@ class TORCH_API Tensor: public TensorBase {
   Tensor& operator=(const Tensor &rhs) && {
     return copy_(rhs);
   }
+
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor)
   Tensor& operator=(Tensor&& rhs) && {
     return copy_(rhs);
   }


### PR DESCRIPTION
This PR suppresses  `noexcept` warnings  in TensorBody.h .
