### PR TITLE
[BE] Cleanup some deprecated steps in _linux-test

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -185,13 +185,6 @@ jobs:
         run: echo "SCCACHE_SERVER_PORT_DOCKER_FLAG=-e SCCACHE_SERVER_PORT=$((RUNNER_UID + 4226))" >> "${GITHUB_ENV}"
         if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'true' && !contains(matrix.runner, 'b200') }}
 
-      - name: Lock NVIDIA A100 40GB Frequency
-        run: |
-          sudo nvidia-smi -pm 1
-          sudo nvidia-smi -ac 1215,1410
-          nvidia-smi
-        if: ${{ contains(matrix.runner, 'a100') && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
-
       - name: Get workflow job id
         id: get-job-id
         uses: ./.github/actions/get-workflow-job-id
@@ -524,81 +517,6 @@ jobs:
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
         if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false'
-
-      # NB: We are currently having an intermittent GPU-related issue on G5 runners with
-      # A10G GPU. Once this happens, trying to reset the GPU as done in setup-nvidia does
-      # not seem to help. Here are some symptoms:
-      #   * Calling nvidia-smi timeouts after 60 second
-      #   * Fail to run nvidia-smi with an unable to determine the device handle for GPU
-      #     unknown error
-      #   * Test fails with a missing CUDA GPU error when initializing CUDA in PyTorch
-      #   * Run docker --gpus all fails with error response from daemon
-      #
-      # As both the root cause and recovery path are unclear, let's take the runner out of
-      # service so that it doesn't get any more jobs
-      - name: Check NVIDIA driver installation step
-        if: failure() && steps.install-nvidia-driver.outputs.has-nvidia == 'true' && !contains(matrix.runner, 'b200')
-        shell: bash
-        run: |
-          set +e
-          set -x
-
-          nvidia-smi
-          # NB: Surprisingly, nvidia-smi command returns successfully with return code 0 even in
-          # the case where the driver has already crashed as it still can get the driver version
-          # and some basic information like the bus ID.  However, the rest of the information
-          # would be missing (ERR!), for example:
-          #
-          # +-----------------------------------------------------------------------------+
-          # | NVIDIA-SMI 525.89.02    Driver Version: 525.89.02    CUDA Version: 12.0     |
-          # |-------------------------------+----------------------+----------------------+
-          # | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
-          # | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
-          # |                               |                      |               MIG M. |
-          # |===============================+======================+======================|
-          # |   0  ERR!                Off  | 00000000:00:1E.0 Off |                 ERR! |
-          # |ERR!  ERR! ERR!    ERR! / ERR! |   4184MiB / 23028MiB |    ERR!      Default |
-          # |                               |                      |                 ERR! |
-          # +-------------------------------+----------------------+----------------------+
-          #
-          # +-----------------------------------------------------------------------------+
-          # | Processes:                                                                  |
-          # |  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
-          # |        ID   ID                                                   Usage      |
-          # |=============================================================================|
-          # +-----------------------------------------------------------------------------+
-          #
-          # This should be reported as a failure instead as it will guarantee to fail when
-          # Docker tries to run with --gpus all
-          #
-          # So, the correct check here is to query one of the missing piece of info like
-          # GPU name, so that the command can fail accordingly
-          nvidia-smi --query-gpu=gpu_name --format=csv,noheader --id=0
-          NVIDIA_SMI_STATUS=$?
-
-          # These are acceptable return code from nvidia-smi as copied from setup-nvidia GitHub action
-          if [ "$NVIDIA_SMI_STATUS" -ne 0 ] && [ "$NVIDIA_SMI_STATUS" -ne 14 ]; then
-            echo "NVIDIA driver installation has failed, shutting down the runner..."
-            .github/scripts/stop_runner_service.sh
-          fi
-
-          # For runner with multiple GPUs, we also want to confirm that the number of GPUs are the
-          # power of 2, i.e. 1, 2, 4, or 8. This is to avoid flaky test issue when one GPU fails
-          # https://github.com/pytorch/test-infra/issues/4000
-          GPU_COUNT=$(nvidia-smi --list-gpus | wc -l)
-          NVIDIA_SMI_STATUS=$?
-
-          # These are acceptable return code from nvidia-smi as copied from setup-nvidia GitHub action
-          if [ "$NVIDIA_SMI_STATUS" -ne 0 ] && [ "$NVIDIA_SMI_STATUS" -ne 14 ]; then
-            echo "NVIDIA driver installation has failed, shutting down the runner..."
-            .github/scripts/stop_runner_service.sh
-          fi
-
-          # Check the GPU count to be a power of 2
-          if [ "$GPU_COUNT" -le 8 ] && [ "$GPU_COUNT" -ne 1 ] && [ "$GPU_COUNT" -ne 2 ] && [ "$GPU_COUNT" -ne 4 ] && [ "$GPU_COUNT" -ne 8 ]; then
-            echo "NVIDIA driver detects $GPU_COUNT GPUs. The runner has a broken GPU, shutting it down..."
-            .github/scripts/stop_runner_service.sh
-          fi
 
       - name: Cleanup docker
         if: always() && inputs.build-environment == 'linux-s390x-binary-manywheel'


### PR DESCRIPTION
They are not needed anymore

* We are locking A100 clock at the runner level already.
* Checking NVIDIA driver when the job finishes was to mitigate a driver error from years ago. We don't need to run it now.
