### PR TITLE
Run vLLM tests periodically in the meantime

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -3,13 +3,12 @@ name: vllm-test
 on:
   push:
     branches:
-      - main
       - release/*
     tags:
       - ciflow/vllm/*
   workflow_dispatch:
   schedule:
-    - cron: '0 */8 * * *'  # every 8 hours at minute 0 (UTC)
+    - cron: '0 */2 * * *'  # every 8 hours at minute 0 (UTC)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Mitigate https://github.com/pytorch/pytorch/issues/170150 until we have caching setup.  After 2.10 brand cut, there is not a pressing need to run vLLM on every trunk commit now IMO.  I'll prioritize the cache setup on infra side.  This is set to run every 2 hours, probably enough to not trigger HF rate limit.

cc @zou3519 @atalman