### PR TITLE
feat: Allow custom storage in selective activation checkpointing for  async offloading

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1396,7 +1396,7 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         return out
 
 
-def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mutation=False):
+def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mutation=False, storage=None,):
     """
     Helper to avoid recomputing certain ops during activation checkpointing.
 
@@ -1475,7 +1475,8 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
     else:
         raise TypeError("policy_fn_or_list must be either a function or a list of ops.")
 
-    storage: Dict[Any, List[Any]] = defaultdict(list)
+    if storage is None:
+        storage = defaultdict(list)
     return (
         _CachingTorchDispatchMode(policy_fn, storage),
         _CachedTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation),
@@ -1653,7 +1654,25 @@ class GraphExecGroup:
         # Private API to be used by utils like AC
         return torch._C._get_graph_exec_group()
 
+def get_tensors_from_selective_storage(storage: Dict[Any, List[Any]]) -> List[torch.Tensor]:
+    """
+    Utility to flatten and retrieve all tensors currently held in the
+    selective checkpointing storage.
+    """
+    all_tensors = []
+    for tensor_list in storage.values():
+        for item in tensor_list:
+            if isinstance(item, torch.Tensor):
+                all_tensors.append(item)
+            # Handle PyTorch's internal _VersionWrapper
+            elif hasattr(item, 'val') and isinstance(item.val, torch.Tensor):
+                all_tensors.append(item.val)
+    return all_tensors
 
+def clean_selective_storage(storage: Dict[Any, List[Any]]) -> None:
+    """Helper to clear storage after offloading."""
+    storage.clear()
+    
 # Note: [compiled autograd and checkpoint unpack hook]
 # When tracing via compiled autograd, this hook will be visible to the
 # compiler if the forward of this checkpointed region ran in eager.


### PR DESCRIPTION
Fixes #170284   
### **Title**
`[checkpoint] Allow custom storage in selective activation checkpointing for async offloading`

### **Description**

**Summary**
This PR introduces an optional `storage` argument to the `create_selective_checkpoint_contexts` API in `torch/utils/checkpoint.py`.

**Motivation**
Enabling **asynchronous offloading** of activations during selective activation checkpointing requires the ability to intercept and manage the tensors saved by the checkpointing mechanism. Previously, the internal storage for these tensors was not exposed, limiting such advanced use cases. This change allows users to inject a custom storage object, providing the necessary control for offloading strategies.


**Implementation Details**
*   The `create_selective_checkpoint_contexts` function's signature is updated to include an optional `storage` parameter, defaulting to `None`:
    ```python
    def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mutation=False, storage=None):
    ```
*   If `storage` is explicitly provided, it is used directly by the internal dispatch modes.
*   If `storage` is `None`, a `defaultdict(list)` is created internally, preserving existing behavior.
*   The chosen `storage` object is passed to both `_CachingTorchDispatchMode` (responsible for saving tensors during the forward pass) and `_CachedTorchDispatchMode` (responsible for retrieving/recomputing during the backward pass).

**Test Plan**
*   A new unit test, `test_selective_checkpoint_custom_storage`, has been added to `test/test_utils.py`.
*   This test instantiates `create_selective_checkpoint_contexts` with a `defaultdict(list)` passed as the `storage` argument.
*   It then performs a simple operation (`torch.mm`) within the checkpoint context, with a policy set to `CheckpointPolicy.MUST_SAVE` for `torch.ops.aten.mm.default`.
*   The test asserts that the custom `storage` object is correctly populated with the saved tensor, confirming the functionality.
*   The existing `TestCheckpoint` suite was also run to ensure no regressions were introduced.
