### PR TITLE
suppress error message of unused variable in debug mode

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -85,7 +85,7 @@ bool check_prefer_cudnn_attention() {
     auto dprops = at::cuda::getCurrentDeviceProperties();
     auto major = dprops->major;
     return (major == 9 || major == 10) && !dprops->minor;
-  } catch (c10::Error const& e) {
+  } catch ([[maybe_unused]] c10::Error const& e) {
 #ifdef DEBUG
     TORCH_WARN("check_prefer_cudnn_attention() caught exception ", e.what());
 #endif


### PR DESCRIPTION
Summary:
we only look at the exception value when we run in debug mode, ignored in optimized
add a hint to the compiler that this is the case

Test Plan: run the target buck build --flagfile fbcode//mode/opt fbcode//fblearner/predictor/py/applications/concord:ip_python_predictor_concord_publisher

Reviewed By: vinayakawanti-fb

Differential Revision: D89121639

@pytorchbot label "topic: not user facing"



