### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from caffe2/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -85,7 +85,7 @@ bool check_prefer_cudnn_attention() {
     auto dprops = at::cuda::getCurrentDeviceProperties();
     auto major = dprops->major;
     return (major == 9 || major == 10) && !dprops->minor;
-  } catch (c10::Error const& e) {
+  } catch ([[maybe_unused]] c10::Error const& e) {
 #ifdef DEBUG
     TORCH_WARN("check_prefer_cudnn_attention() caught exception ", e.what());
 #endif

--- a/aten/src/ATen/test/cuda_cublas_handle_pool_test.cpp
+++ b/aten/src/ATen/test/cuda_cublas_handle_pool_test.cpp
@@ -39,7 +39,7 @@ TEST(CUDABlasHandlePoolTest, ConcurrentGetAndClearWorkspaces) {
             error_count++;
           }
         }
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         error_count++;
       }
     });
@@ -53,7 +53,7 @@ TEST(CUDABlasHandlePoolTest, ConcurrentGetAndClearWorkspaces) {
           at::cuda::clearCublasWorkspaces();
           std::this_thread::yield();
         }
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         error_count++;
       }
     });

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -143,7 +143,7 @@ TEST(FromQualStringTest, Basic) {
     try {
       Symbol::fromQualString(input);
       ASSERT_TRUE(0);
-    } catch (const std::exception& c) {
+    } catch (const std::exception&) {
     }
   }
 }
@@ -2395,7 +2395,7 @@ def a(x, y:int=1):
   try {
     compile(text_non_hinted);
     ASSERT_TRUE(0);
-  } catch (const std::exception& c) {
+  } catch (const std::exception&) {
   }
 
   auto cu = compile(text_hinted);


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: meyering

Differential Revision: D89122514




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel