### PR TITLE
Remove MSVC AVX256/512 restrictions

### DIFF
--- a/aten/src/ATen/cpu/vec/functional_base.h
+++ b/aten/src/ATen/cpu/vec/functional_base.h
@@ -52,8 +52,7 @@ struct VecReduceAllSIMD {
   }
 };
 
-#if defined(__GNUC__) && (__GNUC__ > 5) && !defined(_MSC_VER) && \
-    !defined(C10_MOBILE)
+#if !defined(C10_MOBILE)
 #if defined(CPU_CAPABILITY_AVX2)
 template <typename Op>
 struct VecReduceAllSIMD<float, Op> {
@@ -99,8 +98,7 @@ struct VecReduceAllSIMD<float, Op> {
   }
 };
 #endif // defined(CPU_CAPABILITY_AVX512)
-#endif // defined(__GNUC__) && (__GNUC__ > 5) && !defined(_MSC_VER) &&
-       // !defined(C10_MOBILE)
+#endif // !defined(C10_MOBILE)
 
 #if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__) && \
     !defined(CPU_CAPABILITY_SVE)

--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -110,47 +110,62 @@ inline Vectorized<double> cast<double, int64_t>(
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#ifndef _MSC_VER
-// MSVC is not working well on complex function overload.
-template <int64_t scale = 1>
-std::enable_if_t<
-    scale == 1 || scale == 2 || scale == 4 || scale == 8,
-    Vectorized<
-        double>> inline gather(const double* base_addr, const Vectorized<int64_t>& vindex) {
-  return _mm256_i64gather_pd(base_addr, vindex, scale);
-}
+#define GATHER_DOUBLE_IMPL(SCALE)                                   \
+  template <>                                                       \
+  Vectorized<double> inline gather<SCALE, double>(                  \
+      const double* base_addr, const Vectorized<int64_t>& vindex) { \
+    return _mm256_i64gather_pd(base_addr, vindex, SCALE);           \
+  }
 
-template <int64_t scale = 1>
-std::enable_if_t<
-    scale == 1 || scale == 2 || scale == 4 || scale == 8,
-    Vectorized<
-        float>> inline gather(const float* base_addr, const Vectorized<int32_t>& vindex) {
-  return _mm256_i32gather_ps(base_addr, vindex, scale);
-}
-#endif
+GATHER_DOUBLE_IMPL(1)
+GATHER_DOUBLE_IMPL(2)
+GATHER_DOUBLE_IMPL(4)
+GATHER_DOUBLE_IMPL(8)
+
+#define GATHER_FLOAT_IMPL(SCALE)                                   \
+  template <>                                                      \
+  Vectorized<float> inline gather<SCALE, float>(                   \
+      const float* base_addr, const Vectorized<int32_t>& vindex) { \
+    return _mm256_i32gather_ps(base_addr, vindex, SCALE);          \
+  }
+
+GATHER_FLOAT_IMPL(1)
+GATHER_FLOAT_IMPL(2)
+GATHER_FLOAT_IMPL(4)
+GATHER_FLOAT_IMPL(8)
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MASK GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#ifndef _MSC_VER
-// MSVC is not working well on complex function overload.
-template <int64_t scale = 1>
-std::
-    enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vectorized<double>> inline mask_gather(
-        const Vectorized<double>& src,
-        const double* base_addr,
-        const Vectorized<int64_t>& vindex,
-        Vectorized<double>& mask) {
-  return _mm256_mask_i64gather_pd(src, base_addr, vindex, mask, scale);
-}
 
-template <int64_t scale = 1>
-std::
-    enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vectorized<float>> inline mask_gather(
-        const Vectorized<float>& src,
-        const float* base_addr,
-        const Vectorized<int32_t>& vindex,
-        Vectorized<float>& mask) {
-  return _mm256_mask_i32gather_ps(src, base_addr, vindex, mask, scale);
-}
-#endif
+#define MASK_GATHER_DOUBLE_IMPL(SCALE)                                    \
+  template <>                                                             \
+  Vectorized<double> inline mask_gather<SCALE, double>(                   \
+      const Vectorized<double>& src,                                      \
+      const double* base_addr,                                            \
+      const Vectorized<int64_t>& vindex,                                  \
+      Vectorized<double>& mask) {                                         \
+    return _mm256_mask_i64gather_pd(src, base_addr, vindex, mask, SCALE); \
+  }
+
+MASK_GATHER_DOUBLE_IMPL(1)
+MASK_GATHER_DOUBLE_IMPL(2)
+MASK_GATHER_DOUBLE_IMPL(4)
+MASK_GATHER_DOUBLE_IMPL(8)
+
+#define MASK_GATHER_FLOAT_IMPL(SCALE)                                     \
+  template <>                                                             \
+  Vectorized<float> inline mask_gather<SCALE, float>(                     \
+      const Vectorized<float>& src,                                       \
+      const float* base_addr,                                             \
+      const Vectorized<int32_t>& vindex,                                  \
+      Vectorized<float>& mask) {                                          \
+    return _mm256_mask_i32gather_ps(src, base_addr, vindex, mask, SCALE); \
+  }
+
+MASK_GATHER_FLOAT_IMPL(1)
+MASK_GATHER_FLOAT_IMPL(2)
+MASK_GATHER_FLOAT_IMPL(4)
+MASK_GATHER_FLOAT_IMPL(8)
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CONVERT ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // Only works for inputs in the range: [-2^51, 2^51]

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -8,7 +8,7 @@
 namespace at::vec {
 inline namespace CPU_CAPABILITY {
 
-#if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2)
 
 template <>
 struct VecConvert<float, 1, BFloat16, 1> {
@@ -278,9 +278,9 @@ struct VecConvert<
   }
 };
 
-#endif /* defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER) */
+#endif /* defined(CPU_CAPABILITY_AVX2) */
 
-#if (defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER))
+#if defined(CPU_CAPABILITY_AVX2)
 template <typename src_t>
 struct VecConvert<
     float,

--- a/aten/src/ATen/cpu/vec/vec256/vec256_mask.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_mask.h
@@ -7,7 +7,7 @@
 namespace at::vec {
 inline namespace CPU_CAPABILITY {
 
-#if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2)
 
 template <typename T, int dst_n, typename mask_t, int mask_n>
 struct VecMaskLoad<

--- a/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
@@ -8,7 +8,7 @@
 namespace at::vec {
 inline namespace CPU_CAPABILITY {
 
-#if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX512)
 
 template <>
 struct VecConvert<float, 1, BFloat16, 1> {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
@@ -14,7 +14,7 @@ namespace at::vec {
 // See Note [CPU_CAPABILITY namespace]
 inline namespace CPU_CAPABILITY {
 
-#if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX512)
 
 static inline void cvtfp8e4m3_fp32(const __m128i& a, __m512& o) {
   // Zero Extend

--- a/aten/src/ATen/cpu/vec/vec512/vec512_mask.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_mask.h
@@ -7,7 +7,7 @@
 namespace at::vec {
 inline namespace CPU_CAPABILITY {
 
-#if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX512)
 
 template <typename T, int dst_n, typename mask_t, int mask_n>
 struct VecMaskLoad<

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -977,11 +977,7 @@ void cpu_flash_attention_backward(
                 fill_stub(row_ptr + last_col + 1, static_cast<accum_t>(0), kvBlockSize - last_col - 1);
               }
             }
-  #ifdef _MSC_VER
-            if (is_reduced_type) {
-  #else
             if constexpr (is_reduced_type) {
-  #endif
               for (const auto row : c10::irange(qBlockSize)) {
                 convert<accum_t, scalar_t>(
                   attn_data + row * kvBlockSize,
@@ -1033,11 +1029,7 @@ void cpu_flash_attention_backward(
                 grad_attn_data + row * kvBlockSize,
                 kvBlockSize);
             }
-  #ifdef _MSC_VER
-            if (is_reduced_type) {
-  #else
             if constexpr (is_reduced_type) {
-  #endif
               for (const auto row : c10::irange(qBlockSize)) {
                 convert<accum_t, scalar_t>(
                   grad_attn_data + row * kvBlockSize,

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -977,7 +977,11 @@ void cpu_flash_attention_backward(
                 fill_stub(row_ptr + last_col + 1, static_cast<accum_t>(0), kvBlockSize - last_col - 1);
               }
             }
+  #ifdef _MSC_VER
+            if (is_reduced_type) {
+  #else
             if constexpr (is_reduced_type) {
+  #endif
               for (const auto row : c10::irange(qBlockSize)) {
                 convert<accum_t, scalar_t>(
                   attn_data + row * kvBlockSize,
@@ -1029,7 +1033,11 @@ void cpu_flash_attention_backward(
                 grad_attn_data + row * kvBlockSize,
                 kvBlockSize);
             }
+  #ifdef _MSC_VER
+            if (is_reduced_type) {
+  #else
             if constexpr (is_reduced_type) {
+  #endif
               for (const auto row : c10::irange(qBlockSize)) {
                 convert<accum_t, scalar_t>(
                   grad_attn_data + row * kvBlockSize,

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -471,8 +471,7 @@ inline Vectorized<scalar_t> _nan_to_num_replace(
     Vectorized<scalar_t> a, scalar_t nan, scalar_t posinf, scalar_t neginf) {
   using vec_t = Vectorized<scalar_t>;
   vec_t inf(std::numeric_limits<scalar_t>::infinity());
-  vec_t result;
-  result = vec_t::blendv(a, vec_t(nan), a.isnan());
+  vec_t result = vec_t::blendv(a, vec_t(nan), a.isnan());
   result = vec_t::blendv(result, vec_t(posinf), a == inf);
   return vec_t::blendv(result, vec_t(neginf), a == inf.neg());
 }
@@ -480,7 +479,7 @@ inline Vectorized<scalar_t> _nan_to_num_replace(
 template <typename scalar_t>
 inline Vectorized<c10::complex<scalar_t>> _nan_to_num_replace(
     Vectorized<c10::complex<scalar_t>> a, scalar_t nan, scalar_t posinf, scalar_t neginf) {
-#if !defined(_MSC_VER) && (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512))
+#if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
   return {_nan_to_num_replace(Vectorized<scalar_t>(a), nan, posinf, neginf)};
 #else
   __at_align__ c10::complex<scalar_t> buffer[a.size()];

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -1667,7 +1667,7 @@ void do_avg_pool_nhwc_on_AVX_n(
     int hsize,
     int wsize,
     int csize) {
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
   // buffer for channel accumulator, used to interchange channel-loop
   // to inner-most, so that memory access of the input tensor data is
   // continuous.
@@ -1682,9 +1682,9 @@ void do_avg_pool_nhwc_on_AVX_n(
   Vectorized<float> acc_buffer_fp[cb_size];
 
 #ifdef CPU_CAPABILITY_AVX2
-  if (vec_width == 8) {
+  if constexpr (vec_width == 8) {
 #else
-  if (vec_width == 16) {
+  if constexpr (vec_width == 16) {
 #endif
     for (int c = c_start; c < csize; c += cb_step) {
       int cend = std::min(cb_size, (csize - c) / vec_width);
@@ -1754,12 +1754,12 @@ void do_avg_pool_on_AVX_n(
     int64_t stride_D,
     int64_t stride_H,
     int64_t stride_W) {
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
   constexpr int vec_width = Vectorized<T>::size() / 4;
 #ifdef CPU_CAPABILITY_AVX2
-  if (vec_width == 8) {
+  if constexpr (vec_width == 8) {
 #else
-  if (vec_width == 16) {
+  if constexpr (vec_width == 16) {
 #endif
     for (; c + vec_width <= channel_size; c += vec_width) {
       int64_t tcntr = 0;
@@ -2199,12 +2199,12 @@ int64_t do_quantized_bilinear_on_AVX_n(
     const int64_t h1p,
     const int64_t w1p) {
   int64_t c = 0;
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
   constexpr auto vec_width = Vectorized<T>::size() / 4;
 #ifdef CPU_CAPABILITY_AVX2
-  if (vec_width == 8) {
+  if constexpr (vec_width == 8) {
 #else
-  if (vec_width == 16) {
+  if constexpr (vec_width == 16) {
 #endif
     for (; c + vec_width <= channels; c += vec_width) {
       Vectorized<float> pos1_fp_v[4];

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -82,7 +82,7 @@ namespace {
     using ALLTestedTypes = ::testing::Types<vfloat, vdouble, vcomplex, vlong, vint, vshort, vqint8, vquint8, vqint>;
     using QuantTestedTypes = ::testing::Types<vqint8, vquint8, vqint>;
     using Quantization8BitTestedTypes = ::testing::Types<vqint8, vquint8>;
-#if (defined(CPU_CAPABILITY_AVX2) ||  defined(CPU_CAPABILITY_AVX512))  && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
     using Quantization8BitWithTailTestedTypes =
         ::testing::Types<vqint8, vquint8>;
 #endif

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -121,7 +121,7 @@ namespace {
     TYPED_TEST_SUITE(QuantizationTests, QuantTestedTypes);
     TYPED_TEST_SUITE(Quantization8BitTests, Quantization8BitTestedTypes);
     TYPED_TEST_SUITE(InfiniteTests, RealFloatTestedTypes);
-#if (defined(CPU_CAPABILITY_AVX2) ||  defined(CPU_CAPABILITY_AVX512))  && !defined(_MSC_VER)
+#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512))
     TYPED_TEST_SUITE(
         Quantization8BitWithTailTests,
         Quantization8BitWithTailTestedTypes);
@@ -1291,7 +1291,7 @@ namespace {
             return;
         } // trials;
     }
-#if (defined(CPU_CAPABILITY_AVX2) ||  defined(CPU_CAPABILITY_AVX512))  && !defined(_MSC_VER)
+#if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
     // This test case aims to test at::vec::QuantizeAvx512 and
     // at::vec::QuantizeAVX2 which do not support CPU_CAPABILITY_DEFAULT case
     TYPED_TEST(Quantization8BitWithTailTests, QuantizeTile) {


### PR DESCRIPTION
This PR enables vec256/vec512 on MSVC builds by fixing their template instantiation.
 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01