### PR TITLE
[typing] Fix return type annotation for Tensor.split

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1785,12 +1785,12 @@ def gen_pyi(
                 defs(
                     "split",
                     ["self", "split_size: _int", "dim: _int = 0"],
-                    "Sequence[Tensor]",
+                    "tuple[Tensor, ...]",
                 ),
                 defs(
                     "split",
                     ["self", "split_size: tuple[_int, ...]", "dim: _int = 0"],
-                    "Sequence[Tensor]",
+                    "tuple[Tensor, ...]",
                 ),
             ],
             "div": [

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1049,7 +1049,7 @@ class Tensor(torch._C.TensorBase):
 
         return Resize.apply(self, tensor.size())
 
-    def split(self, split_size, dim=0):
+    def split(self, split_size, dim=0) -> tuple["Tensor", ...]:
         r"""See :func:`torch.split`"""
         if has_torch_function_unary(self):
             return handle_torch_function(


### PR DESCRIPTION
## Summary

Fix the return type annotation for `Tensor.split` from `Sequence[Tensor]` to `tuple[Tensor, ...]`.

## Problem

The previous return type `Sequence[Tensor]` caused type checkers (e.g., Pyright) to infer the return type of `split()` as:
`Any | Unknown | tuple[Tensor, ...]`.

In the documentation https://docs.pytorch.org/docs/stable/generated/torch.split.html
it is stated that the return type shall be only `tuple[Tensor, ...]`

## Solution

Changed the return type to `tuple[Tensor, ...]` which:
1. More accurately reflects the actual runtime return type (split always returns a tuple)
2. Allows type checkers to correctly infer `tuple[Tensor, ...]`

Defining the return type as Sequence, does not make sense since it will be always a tuple. So it should be defined as a tuple.

## Test

import torch

t = torch.zeros(10)
result = t.split(2)

Type checkers (Pyright/mypy) now correctly infer result as: tuple[Tensor, ...]