### PR TITLE
variable: set_data supports a custom TensorImpl

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -209,6 +209,14 @@ class TORCH_API TensorBase {
     return std::move(impl_);
   }
 
+  void unsafeSetTensorImpl(const TensorBase &x) {
+    impl_ = x.impl_;
+  }
+
+  void unsafeSetTensorImpl(TensorBase &&x) {
+    impl_ = std::move(x.impl_);
+  }
+
   bool defined() const {
     return impl_;
   }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2176,6 +2176,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     version_counter_.bump();
   }
 
+  void unsafe_move_autograd(c10::TensorImpl *other) {
+    if (!(is_inference() && other->version_counter().enabled()))
+      this->set_version_counter(other->version_counter());
+    this->set_autograd_meta(std::move(other->autograd_meta_));
+  }
+
   impl::PyObjectSlot* pyobj_slot() {
     return &pyobj_slot_;
   }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -519,7 +519,13 @@ void VariableHooks::set_data(
   // hatch for changing a tensor's metadata regardless of its
   // `allow_tensor_metadata_change_` value, and the users are responsible for
   // ensuring this is the behavior they want.
-  self.unsafeGetTensorImpl()->shallow_copy_from(new_data.getIntrusivePtr());
+  c10::TensorImpl *self_impl = self_base.unsafeGetTensorImpl();
+  c10::TensorImpl *new_impl = new_data.unsafeGetTensorImpl();
+  new_impl->unsafe_move_autograd(self_impl);
+
+  // It enables an instance of a subclass of TensorImpl to keep its attributes.
+  at::TensorBase *_self_base = const_cast<at::TensorBase*>(&self_base);
+  _self_base->unsafeSetTensorImpl(new_data);
 }
 
 at::TensorBase VariableHooks::data(const at::TensorBase& self) const {


### PR DESCRIPTION
Exiting set_data(self_base, new_data_base) does shallow-copy. It's okay if the TensorImpl subclass of self_base is same as that of new_data_base. If the class types are different each other, the attributes of new_data_base are discarded.
When a custom TensorImpl with its own attributes is implemented for PrivateUse1 and `Module::to(new_device)` is executed, the custom attributes are completely lost.
This patch enables set_data to support new_data_base of custom TensorImpl class used in various cases such as PrivateUse1, as long as '_has_compatible_shallow_copy_type' returns true.

Fixes #136258 

This resolution is cpp level like python level (https://github.com/pytorch/pytorch/pull/117167)