### PR TITLE
Docs: Add warning about inverted boolean mask semantics in SDPA

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5989,6 +5989,19 @@ scaled_dot_product_attention = _add_docstr(
                     return F.scaled_dot_product_attention(...,
                         dropout_p=(self.p if self.training else 0.0))
 
+    .. warning::
+        The boolean mask semantics for ``attn_mask`` are the inverse of
+        :class:`torch.nn.MultiHeadAttention`'s ``key_padding_mask``.
+
+        In :func:`scaled_dot_product_attention`, ``True`` indicates values
+        to participate in attention.
+
+        In :class:`torch.nn.MultiHeadAttention`, ``True`` indicates values
+        to be masked out (padding).
+
+        If migrating from MHA, ensure you invert your boolean mask (e.g.,
+        using ``~mask`` or ``mask.logical_not()``).
+
     Note:
 
         There are currently three supported implementations of scaled dot product attention:


### PR DESCRIPTION
Fixes #170400 
### Summary
I've updated the docstring for `torch.nn.functional.scaled_dot_product_attention` to warn users about the inverted boolean mask semantics compared to `nn.MultiHeadAttention`.

### Motivation
As brought up in #170400, migrating between `nn.MultiHeadAttention` (MHA) and `F.scaled_dot_product_attention` (SDPA) is a common "gotcha" because the boolean logic is flipped:
* **MHA** uses `True` to indicate **padding** (ignore).
* **SDPA** uses `True` to indicate **attention** (keep).

This difference can easily lead to silent bugs where the network attends to padding instead of valid tokens. I added a clear `.. warning::` block to the SDPA docs so developers catch this immediately.

### Changes
* Added a ReST warning block to `torch/nn/functional.py` inside `scaled_dot_product_attention`.
* Added a specific note advising users to invert their mask (e.g. using `~mask`) if coming from MHA.

### Verification
* Checked the ReST syntax for the warning block.
* Verified indentation aligns with the existing docstring.
* Ran `flake8 torch/nn/functional.py` to confirm no linting errors.

