### PR TITLE
[BE]: Mark Symbol std hash as noexcept

### DIFF
--- a/aten/src/ATen/core/operator_name.h
+++ b/aten/src/ATen/core/operator_name.h
@@ -90,7 +90,7 @@ TORCH_API std::ostream& operator<<(std::ostream& /*os*/, const OperatorName& /*o
 namespace std {
 template <>
 struct hash<::c10::OperatorName> {
-  size_t operator()(const ::c10::OperatorName& x) const {
+  size_t operator()(const ::c10::OperatorName& x) const noexcept {
     return std::hash<std::string>()(x.name) ^
         (~std::hash<std::string>()(x.overload_name));
   }

--- a/aten/src/ATen/core/symbol.h
+++ b/aten/src/ATen/core/symbol.h
@@ -140,7 +140,7 @@ inline Symbol Symbol::dimname(const std::string & s) { return Symbol::fromQualSt
 namespace std {
 template <>
 struct hash<c10::Symbol> {
-  size_t operator()(c10::Symbol s) const {
+  size_t operator()(c10::Symbol s) const noexcept {
     return std::hash<uint32_t>()(static_cast<uint32_t>(s));
   }
 };

--- a/aten/src/ATen/core/symbol.h
+++ b/aten/src/ATen/core/symbol.h
@@ -89,7 +89,7 @@ struct TORCH_API Symbol {
   bool is_dimname() const;
 
   // So we can switch on this
-  constexpr operator unique_t() const {
+  constexpr operator unique_t() const noexcept {
     return value;
   }
 


### PR DESCRIPTION
This optimizers its representation in the std::unordered_map hash table so it doesn't have to store the hash, it can recompute as needed.
