### PR TITLE
Add Inductor mm template in TLX

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -291,6 +291,79 @@ class TestMaxAutotuneBlackwell(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device() or not config.is_fbcode(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("dynamic", (False, True))
+    @parametrize("epilogue_subtile", (False, True))
+    def test_tlx_mm(
+        self,
+        dynamic: bool,
+        epilogue_subtile: bool,
+    ):
+        try:
+            import triton.language.extra.tlx  # noqa: F401
+
+            # TODO. remove try/except once TLX is available by default
+
+            template = "blackwell_gemm_clc"
+            a_transposed: bool = False
+            b_transposed: bool = False
+
+            def mm(a, b):
+                # TMA requires 16-byte alignment: here we repeat the dims
+                # by the factor of 8, as float16 is 2-byte. All dims are
+                # repeated due to the possible transpositions below.
+                # a = a.repeat(8, 8)
+                # b = b.repeat(8, 8)
+                if a_transposed:
+                    a = a.T
+                if b_transposed:
+                    b = b.T
+
+                return torch.mm(a, b)
+
+            def next_multiple_16(a: int) -> int:
+                return ((a + 15) // 16) * 16
+
+            M, N, K = 4096, 4096, 4096
+            a_shape = (K, M) if a_transposed else (M, K)
+            a_stride = (
+                (next_multiple_16(M), 1) if a_transposed else (next_multiple_16(K), 1)
+            )
+            a = torch.empty_strided(a_shape, a_stride, dtype=torch.float16).to(GPU_TYPE)
+            a[:] = torch.randn(a_shape, dtype=torch.float16)
+            a = a.to(GPU_TYPE)
+            b_shape = (N, K) if b_transposed else (K, N)
+            b_stride = (
+                (next_multiple_16(K), 1) if a_transposed else (next_multiple_16(N), 1)
+            )
+            b = torch.empty_strided(b_shape, b_stride, dtype=torch.float16)
+            b[:] = torch.randn(b_shape, dtype=torch.float16)
+            b = b.to(GPU_TYPE)
+
+            with config.patch(
+                {
+                    "triton.enable_tlx_templates": True,
+                    "max_autotune": True,
+                    "test_configs.autotune_choice_name_regex": template,
+                    "triton.enable_epilogue_subtiling": epilogue_subtile,
+                }
+            ):
+                c_actual, code = run_and_get_code(
+                    torch.compile(mm, dynamic=dynamic), a, b
+                )
+                c_expected = mm(a, b)
+
+            torch.testing.assert_close(c_actual, c_expected)
+
+            FileCheck().check("triton_tem_fused_mm").check(
+                "tlx.async_descriptor_load"
+            ).run(code[0])
+        except ImportError:
+            pass
+
 
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -192,6 +192,16 @@ def gen_common_triton_imports() -> str:
         import triton.language as tl
         """
     )
+    try:
+        import triton.language.extra.tlx  # noqa: F401
+
+        imports.splice(
+            """
+           import triton.language.extra.tlx as tlx  # noqa: F401
+           """
+        )
+    except ImportError:
+        pass
     if attr_desc := gen_attr_descriptor_import():
         imports.writeline(attr_desc)
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1703,6 +1703,10 @@ class triton:
         == "1"
     )
 
+    enable_tlx_templates: bool = (
+        os.environ.get("TORCHINDUCTOR_ENABLE_TLX_TEMPLATES", "0") == "1"
+    )
+
 
 class aot_inductor:
     """

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -424,6 +424,14 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
             if use_triton_blackwell_tma_template(mat1, mat2, output_layout=layout):
                 templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
 
+            if (
+                inductor_config.is_fbcode()
+                and inductor_config.triton.enable_tlx_templates
+            ):
+                from torch._inductor.fb.tlx_templates.mm_templates import append_tlx
+
+                templates_to_use = append_tlx(templates_to_use)
+
         templates_to_use.append(mm_contiguous_subgraph_template)
 
     choices.extend(

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -261,3 +261,6 @@ def is_batch_stride_largest_or_zero(mat1, mat2, layout) -> bool:
 
 _KERNEL_TEMPLATE_DIR = Path(__file__).parent / "templates"
 load_kernel_template = partial(load_template, template_dir=_KERNEL_TEMPLATE_DIR)
+
+_KERNEL_TEMPLATE_FB_DIR = Path(__file__).parent.parent / "fb" / "tlx_templates"
+load_fb_kernel_template = partial(load_template, template_dir=_KERNEL_TEMPLATE_FB_DIR)

--- a/torch/_inductor/template_heuristics/__init__.py
+++ b/torch/_inductor/template_heuristics/__init__.py
@@ -1,6 +1,6 @@
 # NOTE: add new template heuristics here, so they get imported and registered
 # TODO: write a simple glob if there are many heuristics to auto import them in the right order
-from . import aten, base, contiguous_mm, decompose_k, registry, triton
+from . import aten, base, contiguous_mm, decompose_k, registry, tlx, triton
 
 # expose the entry function
 from .registry import get_template_heuristic

--- a/torch/_inductor/template_heuristics/tlx.py
+++ b/torch/_inductor/template_heuristics/tlx.py
@@ -1,0 +1,7 @@
+from torch._inductor import config
+
+
+if config.is_fbcode():
+    import torch._inductor.fb.tlx_templates.registry  # noqa: F401  # type: ignore[import-not-used]
+
+# TODO. Move the registry to this file once the TLX template is more complete.


### PR DESCRIPTION
Summary:
Adds new Triton TLX mm templates. The changes include:

- New TLX mm template (gemm-CLC)
- Template registration: Added templates in mm.py
- Config heuristics: Added and registered config heuristic configs in torch/_inductor/fb/tlx_templates/registry.py
- Integration: Modified tuned_mm() to include the TLX template as a choice when conditions are met
- Tests: Added test_blackwell_tlx_mm test case

NOTE: We plan to gate most future iterations (modifying templates and tuning heuristics/config options) within the `fb/` folder until they are production-ready.

Differential Revision: D89151760




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo