### PR TITLE
[dynamo] remove special handling for fsdp wrapping

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -412,7 +412,6 @@ class OptimizedModule(torch.nn.Module):
             isinstance(self._orig_mod.forward, types.MethodType)
             and (
                 trace_rules.check(self._orig_mod.forward)
-                or getattr(self._orig_mod, "_is_fsdp_managed_module", False)
             )
         ):
             # This may be a torch.nn.* instance in trace_rules.py which

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -410,9 +410,7 @@ class OptimizedModule(torch.nn.Module):
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
         elif config.wrap_top_frame or (
             isinstance(self._orig_mod.forward, types.MethodType)
-            and (
-                trace_rules.check(self._orig_mod.forward)
-            )
+            and (trace_rules.check(self._orig_mod.forward))
         ):
             # This may be a torch.nn.* instance in trace_rules.py which
             # won't trigger a frame evaluation workaround to add an extra


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170413

This PR reverts the change in https://github.com/pytorch/pytorch/pull/149758/changes which does special handling for fsdp2 wrapped modules since

1) The underlying issue the patch fixes is now fixed without the patch as evidenced by `python test/dynamo/test_hooks.py -k test_wrap_top_frame_with_hooks` passing
2) This change results in us capturing the transformer block modules in the `closure` field of `DynamoTracerOutput` and because these modules have all sorts of different hooks on them, this results in precompile failing since we can't serialize the runtime environment. After reverting this change we can now successfully do per transformer block precompile.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo