### PR TITLE
[Docs] Clarify boolean mask polarity in SDPA (Fixes #170400)

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5989,6 +5989,20 @@ scaled_dot_product_attention = _add_docstr(
                     return F.scaled_dot_product_attention(...,
                         dropout_p=(self.p if self.training else 0.0))
 
+    .. warning::
+        The boolean mask semantics for ``attn_mask`` are the inverse of
+        :class:`~torch.nn.MultiheadAttention`'s ``key_padding_mask``.
+
+        In :func:`scaled_dot_product_attention`, ``True`` indicates values
+        to **participate** in attention.
+
+        In :class:`~torch.nn.MultiheadAttention`, ``True`` indicates values
+        to be **masked out** (padding).
+
+        If migrating from MHA, ensure you invert your boolean mask (e.g.,
+        using ``~mask`` or ``mask.logical_not()``).
+
+
     Note:
 
         There are currently three supported implementations of scaled dot product attention:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5989,7 +5989,8 @@ scaled_dot_product_attention = _add_docstr(
                     return F.scaled_dot_product_attention(...,
                         dropout_p=(self.p if self.training else 0.0))
 
-    .. warning::
+    Note:
+    
         The boolean mask semantics for ``attn_mask`` are the inverse of
         :class:`~torch.nn.MultiheadAttention`'s ``key_padding_mask``.
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5990,7 +5990,7 @@ scaled_dot_product_attention = _add_docstr(
                         dropout_p=(self.p if self.training else 0.0))
 
     Note:
-    
+
         The boolean mask semantics for ``attn_mask`` are the inverse of
         :class:`~torch.nn.MultiheadAttention`'s ``key_padding_mask``.
 


### PR DESCRIPTION
Fixes #170400 
### Summary
This PR adds a warning to `F.scaled_dot_product_attention` documentation to clarify that its boolean mask semantics are the **inverse** of `nn.MultiheadAttention`.

- SDPA: `True` = Keep (Attend)
- MHA: `True` = Ignore (Mask out)

### Motivation
Fixes #170400.
The inconsistency leads to silent bugs during migration.

### Note on existing PR
This PR supersedes #170404. I am submitting this alternative PR because the existing one contains a typo in the class name reference (`MultiHeadAttention` instead of the correct `MultiheadAttention`), which would break the documentation linking.

cc @svekars @sekyondaMeta @AlannaBurke