### PR TITLE
add wrapper of forward

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2915,6 +2915,72 @@ class Module:
         """
         return self.train(False)
 
+    def forward_by_train(self, *args: Any, **kwargs: Any) -> Any:
+        r"""Execute forward pass in training mode.
+
+        This method automatically sets the module to training mode before
+        calling forward. This is a convenience method to ensure the module
+        is in the correct mode for training.
+
+        .. warning::
+            This method calls :meth:`train()` on every invocation, which may
+            have performance implications in training loops. Consider calling
+            :meth:`train()` once before the loop instead.
+
+        Args:
+            *args: Variable length argument list passed to forward.
+            **kwargs: Arbitrary keyword arguments passed to forward.
+
+        Returns:
+            The output of the forward pass.
+
+        Example::
+
+            >>> model = nn.Linear(10, 5)
+            >>> input = torch.randn(3, 10)
+            >>> # Automatically sets training mode
+            >>> output = model.forward_by_train(input)
+            >>> assert model.training == True
+        """
+        self.train()
+        return self(*args, **kwargs)
+
+    def forward_by_eval(self, *args: Any, **kwargs: Any) -> Any:
+        r"""Execute forward pass in evaluation mode.
+
+        This method automatically sets the module to evaluation mode before
+        calling forward. This is a convenience method to ensure the module
+        is in the correct mode for inference.
+
+        .. warning::
+            This method calls :meth:`eval()` on every invocation, which may
+            have performance implications. Consider calling :meth:`eval()` once
+            before inference instead.
+
+        .. note::
+            This method does not disable gradient computation. Use
+            :func:`torch.no_grad()` or :func:`torch.inference_mode()` context
+            managers for that purpose.
+
+        Args:
+            *args: Variable length argument list passed to forward.
+            **kwargs: Arbitrary keyword arguments passed to forward.
+
+        Returns:
+            The output of the forward pass.
+
+        Example::
+
+            >>> model = nn.Linear(10, 5)
+            >>> input = torch.randn(3, 10)
+            >>> # Automatically sets evaluation mode
+            >>> with torch.no_grad():
+            >>>     output = model.forward_by_eval(input)
+            >>> assert model.training == False
+        """
+        self.eval()
+        return self(*args, **kwargs)
+
     def requires_grad_(self, requires_grad: bool = True) -> Self:
         r"""Change if autograd should record operations on parameters in this module.
 


### PR DESCRIPTION
# Add `forward_by_train()` and `forward_by_eval()` convenience methods to nn.Module

## Summary

Adds two new methods to `nn.Module` that automatically set the training mode before executing forward pass:
- `forward_by_train(*args, **kwargs)` - calls `train()` then forwards
- `forward_by_eval(*args, **kwargs)` - calls `eval()` then forwards

## Motivation

Users sometimes forget to call `model.train()` or `model.eval()` before inference, leading to incorrect behavior with modules like `Dropout` and `BatchNorm`. These methods make the intent explicit and prevent such errors.

## Implementation

```python
def forward_by_train(self, *args: Any, **kwargs: Any) -> Any:
    self.train()
    return self(*args, **kwargs)

def forward_by_eval(self, *args: Any, **kwargs: Any) -> Any:
    self.eval()
    return self(*args, **kwargs)
```

## Example Usage

```python
# Before
model.eval()
with torch.no_grad():
    output = model(input)

# After
with torch.no_grad():
    output = model.forward_by_eval(input)
```