### PR TITLE
[BE] Rename MaskPartial back to _MaskPartial

### DIFF
--- a/docs/source/distributed.tensor.md
+++ b/docs/source/distributed.tensor.md
@@ -88,6 +88,12 @@ DTensor supports the following types of {class}`Placement` on each {class}`Devic
 ```
 
 ```{eval-rst}
+.. autoclass:: _StridedShard
+  :members:
+  :undoc-members:
+```
+
+```{eval-rst}
 .. autoclass:: Replicate
   :members:
   :undoc-members:
@@ -100,7 +106,7 @@ DTensor supports the following types of {class}`Placement` on each {class}`Devic
 ```
 
 ```{eval-rst}
-.. autoclass:: MaskPartial
+.. autoclass:: _MaskPartial
   :members:
   :undoc-members:
 ```

--- a/test/distributed/tensor/test_embedding_ops.py
+++ b/test/distributed/tensor/test_embedding_ops.py
@@ -168,7 +168,7 @@ class TestEmbeddingOp(DTensorTestBase):
         self._run_embedding_op_test(mesh, 0, [6, 7, 6], 13, 22)
         self._run_embedding_op_test(mesh, 0, [34], 15, 14, padding_idx=10)
 
-        from torch.distributed.tensor.placement_types import MaskPartial
+        from torch.distributed.tensor.placement_types import _MaskPartial
 
         # test collectives
         embedding_mod = torch.nn.Embedding(10, 20, device=self.device_type)
@@ -176,7 +176,7 @@ class TestEmbeddingOp(DTensorTestBase):
         inp = torch.randint(0, 10, (8, 8), device=self.device_type)
         replicated_inp = DTensor.from_local(inp, mesh, [Replicate()], run_check=False)
         output = sharded_embedding(replicated_inp)
-        self.assertIsInstance(output.placements[0], MaskPartial)
+        self.assertIsInstance(output.placements[0], _MaskPartial)
 
         comm_mode = CommDebugMode()
 
@@ -192,9 +192,9 @@ class TestEmbeddingOp(DTensorTestBase):
         inp = torch.randint(0, 10, (4, 4), device=self.device_type)
         replicated_inp = DTensor.from_local(inp, mesh, [Replicate()], run_check=False)
 
-        from torch.distributed.tensor.placement_types import MaskPartial
+        from torch.distributed.tensor.placement_types import _MaskPartial
 
-        # case 1: two embeddings with the same shape, thus sharing the underlying MaskPartial
+        # case 1: two embeddings with the same shape, thus sharing the underlying _MaskPartial
         # and MaskBuffer, because of cache hit from sharding propagation
 
         emb1 = torch.nn.Embedding(10, 23, device=self.device_type)
@@ -206,23 +206,23 @@ class TestEmbeddingOp(DTensorTestBase):
         output2 = sharded_emb2(replicated_inp)
 
         partial_placement1 = output1.placements[0]
-        self.assertIsInstance(partial_placement1, MaskPartial)
+        self.assertIsInstance(partial_placement1, _MaskPartial)
         output1.full_tensor()
 
         partial_placement2 = output2.placements[0]
-        self.assertIsInstance(partial_placement2, MaskPartial)
+        self.assertIsInstance(partial_placement2, _MaskPartial)
         output2.full_tensor()
 
         self.assertTrue(id(partial_placement1), id(partial_placement2))
 
         # case 2: two embeddings with the same logical_dim_size, but different logical_shape
-        # thus they will have different MaskPartial placements (with no cache hit)
+        # thus they will have different _MaskPartial placements (with no cache hit)
 
         emb3 = torch.nn.Embedding(10, 29, device=self.device_type)
         sharded_emb3 = self._apply_sharding(emb3, 0, mesh)
         output3 = sharded_emb3(replicated_inp)
         partial_placement3 = output3.placements[0]
-        self.assertIsInstance(partial_placement3, MaskPartial)
+        self.assertIsInstance(partial_placement3, _MaskPartial)
         output2.full_tensor()
 
         # not equal because of different logical_shape, despite of same logical_dim_size

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -26,7 +26,7 @@ from torch.distributed.tensor._redistribute import (
     use_min_cost_redistribution_plan,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.distributed.tensor.placement_types import _StridedShard, _MaskPartial
+from torch.distributed.tensor.placement_types import _MaskPartial, _StridedShard
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -26,7 +26,7 @@ from torch.distributed.tensor._redistribute import (
     use_min_cost_redistribution_plan,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.distributed.tensor.placement_types import _StridedShard, MaskPartial
+from torch.distributed.tensor.placement_types import _StridedShard, _MaskPartial
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -1110,7 +1110,7 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
         input_data = torch.randn((8, 8), device=self.device_type)
         src_placement = [Shard(1)]
         tgt_placement = [
-            (MaskPartial(offset_shape=torch.Size([10, 20]), offset_dim=0),)
+            (_MaskPartial(offset_shape=torch.Size([10, 20]), offset_dim=0),)
         ]
         sharded_dt = _distribute_tensor(
             input_data.clone(),

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -565,7 +565,7 @@ class DistTensorOpsTest(DTensorTestBase):
         # case 2 input sharding: input sharded, index replicated, output mask partial
         # only works when index has size 1 on the gather dimension and
         # input is sharded on the gather dimension
-        from torch.distributed.tensor.placement_types import MaskPartial
+        from torch.distributed.tensor.placement_types import _MaskPartial
 
         gather_dim = 1
         global_input = torch.randn(12, 8, 16)
@@ -576,7 +576,7 @@ class DistTensorOpsTest(DTensorTestBase):
         with comm_mode:
             output_dt = torch.gather(input_dt, gather_dim, index_dt)
             self.assertEqual(comm_mode.get_total_counts(), 0)
-        self.assertIsInstance(output_dt.placements[0], MaskPartial)
+        self.assertIsInstance(output_dt.placements[0], _MaskPartial)
         self.assertEqual(output_dt.full_tensor(), global_output)
 
         # case 3 index sharding: input replicated, index sharded, output sharded

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -7,8 +7,8 @@ from typing import Any, cast, NamedTuple, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
+    _MaskPartial,
     _StridedShard,
-    MaskPartial,
     Partial,
     Placement,
     Replicate,
@@ -321,10 +321,10 @@ class DTensorSpec:
                     # _StridedShard is not convertible to ShardOrder
                     return None
             else:
-                if not isinstance(cur_placement, Replicate | Partial | MaskPartial):
+                if not isinstance(cur_placement, Replicate | Partial | _MaskPartial):
                     raise ValueError(
                         f"Unsupported placement type {type(cur_placement)} encountered in "
-                        f"{placements}; expected Replicate, Partial, or MaskPartial."
+                        f"{placements}; expected Replicate, Partial, or _MaskPartial."
                     )
         for tensor_dim in range(max_tensor_dim):
             if len(tensor_dim_to_mesh_dims_order[tensor_dim]) > 0:

--- a/torch/distributed/tensor/_ops/_embedding_ops.py
+++ b/torch/distributed/tensor/_ops/_embedding_ops.py
@@ -13,7 +13,7 @@ from torch.distributed.tensor._op_schema import (
 from torch.distributed.tensor._ops.registration import register_op_strategy
 from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
 from torch.distributed.tensor.placement_types import (
-    MaskPartial,
+    _MaskPartial,
     Partial,
     Replicate,
     Shard,
@@ -49,7 +49,7 @@ def embedding_strategy(op_schema: OpSchema) -> StrategyType:
     single_mesh_dim_strategies.append(colwise_sharding)
 
     # rowwise sharding, output is embedding partial, weight shard on dim 0, input accepts embedding partial
-    embedding_partial_placement = MaskPartial(offset_shape=weight_shape, offset_dim=0)
+    embedding_partial_placement = _MaskPartial(offset_shape=weight_shape, offset_dim=0)
 
     # NOTE we want to reuse the same mask partial placement so that we can reuse the same mask that generates
     # from the input indices and use it for output reduction

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -17,7 +17,7 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops._common_rules import pointwise_rule
-from torch.distributed.tensor._ops._embedding_ops import MaskPartial
+from torch.distributed.tensor._ops._embedding_ops import _MaskPartial
 from torch.distributed.tensor._ops.registration import (
     register_op_strategy,
     register_prop_rule,
@@ -661,7 +661,7 @@ def gather_strategy(op_schema: OpSchema) -> StrategyType:
     # this only works when the input is sharded on the gather dimension, and
     # index has size 1 on the gather dimension
     if dim < len(index_shape) and index_shape[dim] == 1:
-        index_partial_placement = MaskPartial(offset_shape=input_shape, offset_dim=dim)
+        index_partial_placement = _MaskPartial(offset_shape=input_shape, offset_dim=dim)
         input_sharding: PlacementList = [
             index_partial_placement,
             Shard(dim),

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -11,7 +11,7 @@ from torch import Tensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
-from torch.distributed.tensor._ops._embedding_ops import MaskPartial
+from torch.distributed.tensor._ops._embedding_ops import _MaskPartial
 from torch.distributed.tensor._ops._math_ops import (
     _skip_dim,
     Reduction,
@@ -237,7 +237,7 @@ def _nll_loss_forward(
 
     # The following code block is a distributed version of
     # result = -torch.gather(self, channel_dim, safe_target_).squeeze(channel_dim)
-    partial_placement = MaskPartial(offset_shape=input_shape, offset_dim=channel_dim)
+    partial_placement = _MaskPartial(offset_shape=input_shape, offset_dim=channel_dim)
     safe_target_partial_ = partial_placement._partition_value(
         safe_target_, mesh, mesh_dim
     )
@@ -376,7 +376,7 @@ def _nll_loss_and_log_softmax_backward(
 
     # The following code block is a distributed version of
     # grad_input = torch.scatter(grad_input, channel_dim, safe_target, -1.0)
-    partial_placement = MaskPartial(offset_shape=input_shape, offset_dim=channel_dim)
+    partial_placement = _MaskPartial(offset_shape=input_shape, offset_dim=channel_dim)
     safe_target = safe_target.squeeze(channel_dim).flatten()
     masked_safe_target = partial_placement._partition_value(safe_target, mesh, mesh_dim)
     # only update grad_input to -1 if not masked

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -499,13 +499,15 @@ class _StridedShard(torch._C._distributed.StridedShard):
     _StridedShard is only introduced to support 2D FSDP2 + TP sharding where the tensor
     is sharded on the TP mesh dimension first, then sharded on the FSDP mesh dimension.
     We call this right-to-left sharding which is the opposite of the default
-    left-to-right sharding. See the example below:
+    left-to-right sharding. See the example below::
+
         tensor shape: [8, 8]
         mesh: [[0, 1], [2, 3]], names=("dp", "tp")
         placements: [Shard(0), Shard(0)]
 
     The default sharding behavior shards the tensor on "dp" mesh dimension first then
-    "tp" dimension. The sharding result will be:
+    "tp" dimension. The sharding result will be::
+
         Rank    |   Mesh Coordinate |   Shard Index
         ------------------------------------------------
         0       |   (0, 0)          |   0 (row 0-1)
@@ -515,7 +517,8 @@ class _StridedShard(torch._C._distributed.StridedShard):
 
     While the FSDP2 + TP sharding behavior does the opposite: it shards the tensor on
     "tp" mesh dim first then "dp" dim. This right-to-left sharding will produce the
-    result:
+    result::
+
         Rank    |   Mesh Coordinate |   Shard Index
         ------------------------------------------------
         0       |   (0, 0)          |   0 (row 0-1)
@@ -529,13 +532,15 @@ class _StridedShard(torch._C._distributed.StridedShard):
     this, we use _StridedShard placement to make this right-to-left sharding compatible
     with our left-to-right convention on both tensor distribution and redistribution.
 
-    Now with _StridedShard, the right-to-left sharding above can be represented as:
+    Now with _StridedShard, the right-to-left sharding above can be represented as::
+
         tensor shape: [8, 8]
         mesh: [[0, 1], [2, 3]], names=("dp", "tp")
         placements: [_StridedShard(0, split_factor=2), Shard(0)]
 
     And a left-to-right processing of `placements` will produce the same result, which is
-    different from using the `Shard` placement:
+    different from using the `Shard` placement::
+
         Rank    |   Mesh Coordinate |   Shard Index
         ------------------------------------------------
         0       |   (0, 0)          |   0 (row 0-1)


### PR DESCRIPTION
`MaskPartial` was made to a public class in https://github.com/pytorch/pytorch/pull/164414, this PR changes it back to a private class, as this class is [used internally](https://github.com/pytorch/pytorch/blob/95f7d70fbacf4bbdedec6912d614f4912d42d18d/torch/distributed/tensor/_ops/_embedding_ops.py#L52) to achieve vocab parallel.

Test:
```
python3 test/distributed/tensor/test_embedding_ops.py 
python3 test/distributed/tensor/test_tensor_ops.py
```