### PR TITLE
Fixes memory leak in async_save in distributed checkpoint

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_stager.py
+++ b/test/distributed/checkpoint/test_state_dict_stager.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import dataclasses
-import gc
 import os
 import tempfile
 import unittest
@@ -864,7 +863,6 @@ class TestDTensorStateDictStager(DTensorTestBase):
             )
             f.result()
 
-            gc.collect()
             baseline = psutil.Process().memory_info().rss / (1024 * 1024)
 
             num_saves = 5
@@ -876,7 +874,6 @@ class TestDTensorStateDictStager(DTensorTestBase):
                 )
                 f.result()
 
-            gc.collect()
             final = psutil.Process().memory_info().rss / (1024 * 1024)
 
             growth = final - baseline

--- a/torch/distributed/checkpoint/_state_dict_stager.py
+++ b/torch/distributed/checkpoint/_state_dict_stager.py
@@ -265,8 +265,13 @@ class StateDictStager:
         This method clears the internal storage cache, allowing garbage collection
         of cached CPU storages. Any pinned memory associated with cached storages
         will be automatically unpinned through weak reference finalizers.
+
+        It also clears the _deepcopy_dispatch dict to break the reference cycle
+        created by closures that capture self. Without this, it may
+        cause memory leaks.
         """
         self._cached_storage_mapping.clear()
+        self._deepcopy_dispatch.clear()
 
     @torch.no_grad()
     def deepcopy_with_tensor_offload(self, x, memo=None, _nil=[], non_blocking=False):  # noqa: B006

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -1,4 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+# ruff: noqa: F821
+# flake8: noqa: F821
 from collections.abc import Callable, Collection, Mapping, MutableMapping
 from typing import cast, TypeVar, Union
 
@@ -64,6 +66,9 @@ def traverse_state_dict(
     for key, value in state_dict.items():
         _traverse_obj((str(key),), value)
 
+    # release reference cycle to prevent memory leaks in async_save
+    del _traverse_obj, _is_terminal
+
 
 def traverse_state_dict_v_2_3(
     state_dict: STATE_DICT_TYPE,
@@ -106,6 +111,9 @@ def traverse_state_dict_v_2_3(
 
     for key, value in state_dict.items():
         _traverse_obj((str(key),), value)
+
+    # release reference cycle to prevent memory leaks in async_save
+    del _traverse_obj, _is_terminal
 
 
 def set_element(

--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -247,6 +247,11 @@ class DefaultStager(AsyncStager):
             self._staging_stream.synchronize() if self._staging_stream else torch.accelerator.synchronize()
         else:
             state_dict = self._state_dict_stager.stage(state_dict, non_blocking=False)
+
+        # release reference cycle to prevent memory leaks in async_save
+        # created by _deepcopy_dispatch that capture self
+        self._state_dict_stager.close()
+
         return state_dict
 
     def close(self) -> None:
@@ -265,7 +270,6 @@ class DefaultStager(AsyncStager):
         """
         if self._staging_executor:
             self._staging_executor.shutdown(wait=True)
-
         self._state_dict_stager.close()
 
     def synchronize_staging(self) -> None:

--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -266,6 +266,8 @@ class DefaultStager(AsyncStager):
         if self._staging_executor:
             self._staging_executor.shutdown(wait=True)
 
+        self._state_dict_stager.close()
+
     def synchronize_staging(self) -> None:
         """
         When use_async_staging is True, this method will wait until staging is complete.

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
+import gc
 import inspect
 import os
 import warnings
@@ -299,6 +300,7 @@ def async_save(
                 "A CPU backend must be enabled for async save; try initializing process group with 'cpu:gloo,cuda:nccl'"
             )
 
+    _internally_created_stager = False
     if async_stager is None:
         if storage_writer is not None and isinstance(storage_writer, AsyncStager):
             # bwc with old storage_writers
@@ -312,6 +314,7 @@ def async_save(
                     False,
                 )
             )
+            _internally_created_stager = True
 
     state_dict = _stateful_to_state_dict(state_dict)
 
@@ -320,6 +323,9 @@ def async_save(
         return async_stager.stage(state_dict)
 
     staging_future_or_state_dict = stage_state_dict()
+
+    if _internally_created_stager:
+        async_stager.close()
 
     upload_executor: _AsyncCheckpointExecutor = (
         _ProcessBasedAsyncCheckpointExecutor()
@@ -336,6 +342,11 @@ def async_save(
         no_dist=no_dist,
         use_collectives=use_collectives,
     )
+
+    def _gc_callback(_: Future) -> None:
+        gc.collect()
+
+    upload_future.add_done_callback(_gc_callback)
 
     if isinstance(staging_future_or_state_dict, Future):
         staging_future = staging_future_or_state_dict

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -324,9 +324,6 @@ def async_save(
 
     staging_future_or_state_dict = stage_state_dict()
 
-    if _internally_created_stager:
-        async_stager.close()
-
     upload_executor: _AsyncCheckpointExecutor = (
         _ProcessBasedAsyncCheckpointExecutor()
         if async_checkpointer_type == AsyncCheckpointerType.PROCESS
@@ -379,6 +376,8 @@ def async_save(
                 async_stager.synchronize_staging()
 
         maybe_synchronize_staging()
+        if _internally_created_stager:
+            async_stager.close()
         return upload_future
 
 


### PR DESCRIPTION
Fixes #170163 

**Cause**
When `async_save` is called without a user-provided `async_stager`, it creates an internal `DefaultStager` that caches CPU storage copies. This cache wasn't being cleared, and the stager went out of scope without cleanup

**Changes**
_1. _traverse.py: del _traverse_obj, _is_terminal

_2. state_dict_saver.py: clear _deepcopy_dispatch in close()

Tracked the memory leak and used this changes to fix it



cc @LucasLLC @pradeepfn @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci