### PR TITLE
[Inductor] [Blackwell] [Triton] Update Blackwell templates to use an explicit config

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -71,13 +71,14 @@ class TestMaxAutotuneBlackwell(TestCase):
             .to(GPU_TYPE)
         )
 
+        epilogue_subtile_regex = f"EPILOGUE_SUBTILE={epilogue_subtile}"
         with config.patch(
             {
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": True,
                 "triton.enable_template_tma_store": tma_store,
-                "triton.enable_epilogue_subtiling": epilogue_subtile,
                 "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                "test_configs.autotune_choice_desc_regex": epilogue_subtile_regex,
             }
         ):
             c_actual, code = run_and_get_code(torch.compile(mm, dynamic=dynamic), a, b)
@@ -269,13 +270,14 @@ class TestMaxAutotuneBlackwell(TestCase):
         )
         x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
 
+        epilogue_subtile_regex = f"EPILOGUE_SUBTILE={epilogue_subtile}"
         with config.patch(
             {
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": True,
                 "triton.enable_template_tma_store": tma_store,
-                "triton.enable_epilogue_subtiling": epilogue_subtile,
                 "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                "test_configs.autotune_choice_desc_regex": epilogue_subtile_regex,
             }
         ):
             c_actual, code = run_and_get_code(
@@ -350,6 +352,8 @@ class TestMaxAutotuneBlackwell(TestCase):
         b[:] = torch.randn(b_shape, dtype=torch.float16)
         b = b.to(GPU_TYPE)
 
+        epilogue_subtile_regex = f"EPILOGUE_SUBTILE={epilogue_subtile}"
+
         with config.patch(
             {
                 "force_disable_caches": True,
@@ -357,7 +361,7 @@ class TestMaxAutotuneBlackwell(TestCase):
                 "triton.enable_tlx_templates": True,
                 "max_autotune": True,
                 "test_configs.autotune_choice_name_regex": template,
-                "triton.enable_epilogue_subtiling": epilogue_subtile,
+                "test_configs.autotune_choice_desc_regex": epilogue_subtile_regex,
             }
         ):
             c_actual, code = run_and_get_code(torch.compile(mm, dynamic=dynamic), a, b)

--- a/test/inductor/test_template_heuristics_registry.py
+++ b/test/inductor/test_template_heuristics_registry.py
@@ -6,7 +6,50 @@ from torch._inductor.template_heuristics.registry import (
     get_template_heuristic,
     register_template_heuristic,
 )
+from torch._inductor.template_heuristics.triton import BlackwellGPUGemmConfig
 from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestBlackwellGPUGemmConfig(TestCase):
+    """Tests for BlackwellGPUGemmConfig class."""
+
+    def test_default_values(self):
+        """Test that BlackwellGPUGemmConfig has correct default values."""
+        config = BlackwellGPUGemmConfig(
+            block_m=128,
+            block_n=256,
+            block_k=64,
+            num_stages=3,
+            num_warps=8,
+        )
+        # Verify inherited GemmConfig fields
+        self.assertEqual(config.block_m, 128)
+        self.assertEqual(config.block_n, 256)
+        self.assertEqual(config.block_k, 64)
+        self.assertEqual(config.num_stages, 3)
+        self.assertEqual(config.num_warps, 8)
+
+        # Verify new BlackwellGPUGemmConfig-specific fields with default values
+        self.assertFalse(config.epilogue_subtile)  # default=False
+        self.assertTrue(config.warp_specialize)  # default=True
+        self.assertTrue(config.flatten)  # default=True
+
+    def test_custom_values(self):
+        """Test that BlackwellGPUGemmConfig accepts custom values for new fields."""
+        config = BlackwellGPUGemmConfig(
+            block_m=64,
+            block_n=128,
+            block_k=32,
+            num_stages=2,
+            num_warps=4,
+            epilogue_subtile=True,
+            warp_specialize=False,
+            flatten=False,
+        )
+        # Verify custom values are set correctly
+        self.assertTrue(config.epilogue_subtile)
+        self.assertFalse(config.warp_specialize)
+        self.assertFalse(config.flatten)
 
 
 class TestTemplateHeuristicsRegistry(TestCase):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1706,8 +1706,6 @@ class triton:
     # Should TMA store be enable from templates. TODO: Remove once we
     # can autotune over the result.
     enable_template_tma_store = os.environ.get("ENABLE_TEMPLATE_TMA_STORE", "0") == "1"
-    # Use epilogue subtiling. We allow disabling it due to limited B200 testing.
-    enable_epilogue_subtiling = os.environ.get("ENABLE_EPILOGUE_SUBTILING", "1") == "1"
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"
 


### PR DESCRIPTION
Summary:
Adds an explicit config class for Blackwell templates. This enables tuning over subtitling and updating the default configs.

The motivation is that we found disabling subtiling is often useful. However, I don't want to update the defaults at this time.

Test Plan: Depends on CI.

Differential Revision: D89186750




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo