### PR TITLE
[precompile][ez] Use a separate config flag for autograd key bypassing.

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -231,6 +231,7 @@ def aot_compile_fullgraph(
             torch._guards.tracing(tracing_context),
             torch._functorch.config.patch(
                 {
+                    "bypass_autograd_cache_key": True,
                     "bundled_autograd_cache": True,
                     "force_non_lazy_backward_lowering": True,
                 }

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -557,7 +557,7 @@ def autograd_cache_key(
         # want to use fallback nonce keys. Unlike caching, it's fine if we can't generate
         # a proper key because we are guaranteed in an AOT precompile world users are in
         # complete control of distributing and loading artifacts.
-        if torch._dynamo.config.enable_aot_compile:
+        if torch._functorch.config.bypass_autograd_cache_key:
             log.info(
                 "Failed to generate AOTAutograd cache key; falling back to nonce due to enable_aot_compile",
                 exc_info=True,

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -71,6 +71,8 @@ autograd_cache_allow_custom_autograd_functions: bool = Config(
 # need to add env vars or make it configurable
 bundled_autograd_cache: bool = False
 
+bypass_autograd_cache_key: bool = False
+
 # Whether or not to normalize placeholder names in graphs
 # from dynaom in AOTAutogradCache
 autograd_cache_normalize_inputs = not is_fbcode()


### PR DESCRIPTION
Summary: Use a dedicated config option to bypass cache key errors to decouple concerns.

Test Plan: CI

Differential Revision: D89196027




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo