### PR TITLE
Update tensor_attributes.rst with additional float4 information

### DIFF
--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -77,7 +77,7 @@ dtype                                      description
   The `torch.float4_e2m1fn_x2` dtype represents two 4-bit values packed into a byte.
   Note that PyTorch operations which modify the shape/strides of a tensor (such as transposing)
   operate at the byte boundary and will **not** unpack/repack sub-byte values.
-  
+
 
 **Note**: legacy constructors such as ``torch.*.FloatTensor``, ``torch.*.DoubleTensor``, ``torch.*.HalfTensor``,
 ``torch.*.BFloat16Tensor``, ``torch.*.ByteTensor``, ``torch.*.CharTensor``, ``torch.*.ShortTensor``, ``torch.*.IntTensor``,

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -19,23 +19,23 @@ A :class:`torch.dtype` is an object that represents the data type of a
 
 **Floating point dtypes**
 
-=========================================  ===============================
-dtype                                      description
-=========================================  ===============================
-``torch.float32`` or ``torch.float``       32-bit floating point, as defined in https://en.wikipedia.org/wiki/IEEE_754
-``torch.float64`` or ``torch.double``      64-bit floating point, as defined in https://en.wikipedia.org/wiki/IEEE_754
-``torch.float16`` or ``torch.half``        16-bit floating point, as defined in https://en.wikipedia.org/wiki/IEEE_754, S-E-M 1-5-10
-``torch.bfloat16``                         16-bit floating point, sometimes referred to as Brain floating point, S-E-M 1-8-7
-``torch.complex32`` or ``torch.chalf``     32-bit complex with two `float16` components
-``torch.complex64`` or ``torch.cfloat``    64-bit complex with two `float32` components
-``torch.complex128`` or ``torch.cdouble``  128-bit complex with two `float64` components
-``torch.float8_e4m3fn`` [shell]_, [1]_     8-bit floating point, S-E-M 1-4-3, from https://arxiv.org/abs/2209.05433
-``torch.float8_e5m2`` [shell]_             8-bit floating point, S-E-M 1-5-2, from https://arxiv.org/abs/2209.05433
-``torch.float8_e4m3fnuz`` [shell]_, [1]_   8-bit floating point, S-E-M 1-4-3, from https://arxiv.org/pdf/2206.02915
-``torch.float8_e5m2fnuz`` [shell]_, [1]_   8-bit floating point, S-E-M 1-5-2, from https://arxiv.org/pdf/2206.02915
-``torch.float8_e8m0fnu`` [shell]_, [1]_    8-bit floating point, S-E-M 0-8-0, from https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
-``torch.float4_e2m1fn_x2`` [shell]_, [1]_  packed 4-bit floating point, S-E-M 1-2-1, from https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
-=========================================  ===============================
+===============================================  ===============================
+dtype                                            description
+===============================================  ===============================
+``torch.float32`` or ``torch.float``             32-bit floating point, as defined in https://en.wikipedia.org/wiki/IEEE_754
+``torch.float64`` or ``torch.double``            64-bit floating point, as defined in https://en.wikipedia.org/wiki/IEEE_754
+``torch.float16`` or ``torch.half``              16-bit floating point, as defined in https://en.wikipedia.org/wiki/IEEE_754, S-E-M 1-5-10
+``torch.bfloat16``                               16-bit floating point, sometimes referred to as Brain floating point, S-E-M 1-8-7
+``torch.complex32`` or ``torch.chalf``           32-bit complex with two `float16` components
+``torch.complex64`` or ``torch.cfloat``          64-bit complex with two `float32` components
+``torch.complex128`` or ``torch.cdouble``        128-bit complex with two `float64` components
+``torch.float8_e4m3fn`` [shell]_, [1]_           8-bit floating point, S-E-M 1-4-3, from https://arxiv.org/abs/2209.05433
+``torch.float8_e5m2`` [shell]_                   8-bit floating point, S-E-M 1-5-2, from https://arxiv.org/abs/2209.05433
+``torch.float8_e4m3fnuz`` [shell]_, [1]_         8-bit floating point, S-E-M 1-4-3, from https://arxiv.org/pdf/2206.02915
+``torch.float8_e5m2fnuz`` [shell]_, [1]_         8-bit floating point, S-E-M 1-5-2, from https://arxiv.org/pdf/2206.02915
+``torch.float8_e8m0fnu`` [shell]_, [1]_          8-bit floating point, S-E-M 0-8-0, from https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
+``torch.float4_e2m1fn_x2`` [shell]_, [1]_, [3]_  packed 4-bit floating point, S-E-M 1-2-1, from https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
+===============================================  ===============================
 
 **Integer dtypes**
 
@@ -53,7 +53,7 @@ dtype                                      description
 ``torch.bool``                             Boolean
 =========================================  ===============================
 
-.. [shell] a shell dtype a specialized dtype with limited op and backend support.
+.. [shell] a shell dtype is a specialized dtype with limited op and backend support.
   Specifically, ops that support tensor creation (``torch.empty``, ``torch.fill``, ``torch.zeros``)
   and operations which do not peek inside the data elements (``torch.cat``, ``torch.view``, ``torch.reshape``)
   are supported.  Ops that peek inside the data elements such as casting,
@@ -72,6 +72,12 @@ dtype                                      description
   torch.compile); if you need eager support and the extra range is not needed,
   we recommend using their signed variants instead.  See
   https://github.com/pytorch/pytorch/issues/58734 for more details.
+
+.. [3]
+  The `torch.float4_e2m1fn_x2` dtype represents two 4-bit values packed into a byte. 
+  Note that PyTorch operations which modify the shape/strides of a tensor (such as transposing)
+  operate at the byte boundary and will **not** unpack/repack sub-byte values.
+  
 
 **Note**: legacy constructors such as ``torch.*.FloatTensor``, ``torch.*.DoubleTensor``, ``torch.*.HalfTensor``,
 ``torch.*.BFloat16Tensor``, ``torch.*.ByteTensor``, ``torch.*.CharTensor``, ``torch.*.ShortTensor``, ``torch.*.IntTensor``,

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -74,7 +74,7 @@ dtype                                      description
   https://github.com/pytorch/pytorch/issues/58734 for more details.
 
 .. [3]
-  The `torch.float4_e2m1fn_x2` dtype represents two 4-bit values packed into a byte. 
+  The `torch.float4_e2m1fn_x2` dtype represents two 4-bit values packed into a byte.
   Note that PyTorch operations which modify the shape/strides of a tensor (such as transposing)
   operate at the byte boundary and will **not** unpack/repack sub-byte values.
   


### PR DESCRIPTION
Update documentation clarifying the semantics of the `torch.float4_e2m1fn_x2` dtype.

Test plan: looked that preview of the docs, it renders correctly
