### PR TITLE
docs: replace broken /docs/main links with /docs/stable

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -192,7 +192,7 @@ bool Context::allowTF32CuDNN(std::optional<Float32Op> op) const {
         "but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.",
         "This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. ",
         "We suggest only using the new API to set the TF32 flag(s). See also: ",
-        "https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+        "https://docs.pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
   } else {
     return float32Precision(Float32Backend::CUDA, op.value()) == Float32Precision::TF32;
   }
@@ -319,7 +319,7 @@ bool Context::allowTF32CuBLAS() const {
       "PyTorch is checking whether allow_tf32_new is enabled for cuBlas matmul,",
       "Current status indicate that you have used mix of the legacy and new APIs to set the TF32 status for cublas matmul. ",
       "We suggest only using the new API to set the TF32 flag. See also: ",
-      "https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+      "https://docs.pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
   return allow_tf32_new;
 }
 
@@ -342,7 +342,7 @@ Float32MatmulPrecision Context::float32MatmulPrecision() const {
       "PyTorch is checking the matmul precision without a specific backend name,",
       "Current status indicate that you have used mix of the legacy and new APIs to set the matmul precision. ",
       "We suggest only using the new API for matmul precision. See also: ",
-      "https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+      "https://docs.pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
   return float32_matmul_precision;
 }
 
@@ -794,7 +794,7 @@ bool NoTF32Guard::should_disable_tf32() {
 // Ops can query this flag to know they are in the backward pass.
 // This information can be used, for example, to select implementations
 // with different numerical or performance characteristics.
-// See https://pytorch.org/docs/stable/notes/numerical_accuracy.html for details.
+// See https://docs.pytorch.org/docs/stable/notes/numerical_accuracy.html for details.
 thread_local static bool rocm_is_backward_pass;
 
 ROCmBackwardPassGuard::ROCmBackwardPassGuard() {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -192,7 +192,7 @@ bool Context::allowTF32CuDNN(std::optional<Float32Op> op) const {
         "but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.",
         "This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. ",
         "We suggest only using the new API to set the TF32 flag(s). See also: ",
-        "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+        "https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
   } else {
     return float32Precision(Float32Backend::CUDA, op.value()) == Float32Precision::TF32;
   }
@@ -319,7 +319,7 @@ bool Context::allowTF32CuBLAS() const {
       "PyTorch is checking whether allow_tf32_new is enabled for cuBlas matmul,",
       "Current status indicate that you have used mix of the legacy and new APIs to set the TF32 status for cublas matmul. ",
       "We suggest only using the new API to set the TF32 flag. See also: ",
-      "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+      "https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
   return allow_tf32_new;
 }
 
@@ -342,7 +342,7 @@ Float32MatmulPrecision Context::float32MatmulPrecision() const {
       "PyTorch is checking the matmul precision without a specific backend name,",
       "Current status indicate that you have used mix of the legacy and new APIs to set the matmul precision. ",
       "We suggest only using the new API for matmul precision. See also: ",
-      "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+      "https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
   return float32_matmul_precision;
 }
 

--- a/docs/source/community/build_ci_governance.rst
+++ b/docs/source/community/build_ci_governance.rst
@@ -12,7 +12,7 @@ For the person to be a maintainer, a person needs to:
 * At least one of these commits must be submitted in the last six months
 
 To add a qualified person to the maintainers' list, please create
-a PR that adds a person to the `persons of interests <https://pytorch.org/docs/stable/community/persons_of_interest.html>`__ page and
+a PR that adds a person to the `persons of interests <https://docs.pytorch.org/docs/stable/community/persons_of_interest.html>`__ page and
 `merge_rules <https://github.com/pytorch/pytorch/blob/main/.github/merge_rules.yaml>`__ files. Current maintainers will cast their votes of
 support. Decision criteria for approving the PR:
 

--- a/docs/source/community/build_ci_governance.rst
+++ b/docs/source/community/build_ci_governance.rst
@@ -12,7 +12,7 @@ For the person to be a maintainer, a person needs to:
 * At least one of these commits must be submitted in the last six months
 
 To add a qualified person to the maintainers' list, please create
-a PR that adds a person to the `persons of interests <https://pytorch.org/docs/main/community/persons_of_interest.html>`__ page and
+a PR that adds a person to the `persons of interests <https://pytorch.org/docs/stable/community/persons_of_interest.html>`__ page and
 `merge_rules <https://github.com/pytorch/pytorch/blob/main/.github/merge_rules.yaml>`__ files. Current maintainers will cast their votes of
 support. Decision criteria for approving the PR:
 

--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -94,7 +94,7 @@ here is the basic process.
       everything, but if you happen to know who the maintainer for a
       given subsystem affected by your patch is, feel free to include
       them directly on the pull request. You can learn more about
-      `Persons of Interest <https://pytorch.org/docs/main/community/persons_of_interest.html>`_
+      `Persons of Interest <https://pytorch.org/docs/stable/community/persons_of_interest.html>`_
       that could review your code.
 
 -  **Iterate on the pull request until it's accepted!**
@@ -325,13 +325,13 @@ Python Docs
 PyTorch documentation is generated from python source using
 `Sphinx <https://www.sphinx-doc.org/en/master/>`__. Generated HTML is
 copied to the docs folder in the main branch of
-`pytorch.org/docs <https://pytorch.org/docs/main>`__,
+`pytorch.org/docs <https://pytorch.org/docs/stable>`__,
 and is served via GitHub pages.
 
 -  Site: https://pytorch.org/docs
 -  GitHub: https://github.com/pytorch/pytorch/tree/main/docs
 -  Served from:
-   `https://pytorch.org/docs/main <https://pytorch.org/docs/main>`__
+   `https://pytorch.org/docs/stable <https://pytorch.org/docs/stable>`__
 
 C++ Docs
 ~~~~~~~~

--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -94,7 +94,7 @@ here is the basic process.
       everything, but if you happen to know who the maintainer for a
       given subsystem affected by your patch is, feel free to include
       them directly on the pull request. You can learn more about
-      `Persons of Interest <https://pytorch.org/docs/stable/community/persons_of_interest.html>`_
+      `Persons of Interest <https://docs.pytorch.org/docs/stable/community/persons_of_interest.html>`_
       that could review your code.
 
 -  **Iterate on the pull request until it's accepted!**

--- a/docs/source/community/design.rst
+++ b/docs/source/community/design.rst
@@ -10,7 +10,7 @@ serve as a guide to help trade off different concerns and to resolve
 disagreements that may come up while developing PyTorch. For more
 information on contributing, module maintainership, and how to escalate a
 disagreement to the Core Maintainers, please see `PyTorch
-Governance <https://pytorch.org/docs/stable/community/governance.html>`__.
+Governance <https://docs.pytorch.org/docs/stable/community/governance.html>`__.
 
 Design Principles
 -----------------
@@ -66,7 +66,7 @@ Python <https://peps.python.org/pep-0020/>`__:
 A more concise way of describing these two goals is `Simple Over
 Easy <https://www.infoq.com/presentations/Simple-Made-Easy/>`_. Let’s start with an example because *simple* and *easy* are
 often used interchangeably in everyday English. Consider how one may
-model `devices <https://pytorch.org/docs/stable/tensor_attributes.html#torch.device>`__
+model `devices <https://docs.pytorch.org/docs/stable/tensor_attributes.html#torch.device>`__
 in PyTorch:
 
 -  **Simple / Explicit (to understand, debug):** every tensor is associated
@@ -143,11 +143,11 @@ Python usability end of the curve:
 -  `TorchDynamo <https://dev-discuss.pytorch.org/t/torchdynamo-an-experiment-in-dynamic-python-bytecode-transformation/361>`__,
    a Python frame evaluation tool capable of speeding up existing
    eager-mode PyTorch programs with minimal user intervention.
--  `torch_function <https://pytorch.org/docs/stable/notes/extending.html#extending-torch>`__
+-  `torch_function <https://docs.pytorch.org/docs/stable/notes/extending.html#extending-torch>`__
    and `torch_dispatch <https://dev-discuss.pytorch.org/t/what-and-why-is-torch-dispatch/557>`__
    extension points, which have enabled Python-first functionality to be
    built on-top of C++ internals, such as the `torch.fx
-   tracer <https://pytorch.org/docs/stable/fx.html>`__
+   tracer <https://docs.pytorch.org/docs/stable/fx.html>`__
    and `functorch <https://github.com/pytorch/functorch>`__
    respectively.
 

--- a/docs/source/community/design.rst
+++ b/docs/source/community/design.rst
@@ -10,7 +10,7 @@ serve as a guide to help trade off different concerns and to resolve
 disagreements that may come up while developing PyTorch. For more
 information on contributing, module maintainership, and how to escalate a
 disagreement to the Core Maintainers, please see `PyTorch
-Governance <https://pytorch.org/docs/main/community/governance.html>`__.
+Governance <https://pytorch.org/docs/stable/community/governance.html>`__.
 
 Design Principles
 -----------------
@@ -66,7 +66,7 @@ Python <https://peps.python.org/pep-0020/>`__:
 A more concise way of describing these two goals is `Simple Over
 Easy <https://www.infoq.com/presentations/Simple-Made-Easy/>`_. Let’s start with an example because *simple* and *easy* are
 often used interchangeably in everyday English. Consider how one may
-model `devices <https://pytorch.org/docs/main/tensor_attributes.html#torch.device>`__
+model `devices <https://pytorch.org/docs/stable/tensor_attributes.html#torch.device>`__
 in PyTorch:
 
 -  **Simple / Explicit (to understand, debug):** every tensor is associated
@@ -143,7 +143,7 @@ Python usability end of the curve:
 -  `TorchDynamo <https://dev-discuss.pytorch.org/t/torchdynamo-an-experiment-in-dynamic-python-bytecode-transformation/361>`__,
    a Python frame evaluation tool capable of speeding up existing
    eager-mode PyTorch programs with minimal user intervention.
--  `torch_function <https://pytorch.org/docs/main/notes/extending.html#extending-torch>`__
+-  `torch_function <https://pytorch.org/docs/stable/notes/extending.html#extending-torch>`__
    and `torch_dispatch <https://dev-discuss.pytorch.org/t/what-and-why-is-torch-dispatch/557>`__
    extension points, which have enabled Python-first functionality to be
    built on-top of C++ internals, such as the `torch.fx

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -661,7 +661,7 @@ with torch.profiler():
     dist.all_reduce(tensor)
 ```
 
-Please refer to the [profiler documentation](https://pytorch.org/docs/main/profiler.html) for a full overview of profiler features.
+Please refer to the [profiler documentation](https://pytorch.org/docs/stable/profiler.html) for a full overview of profiler features.
 
 ## Multi-GPU collective functions
 

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -478,7 +478,7 @@ that the CUDA operation is completed, since CUDA operations are asynchronous. Fo
 further function calls utilizing the output of the collective call will behave as expected. For CUDA collectives,
 function calls utilizing the output on the same CUDA stream will behave as expected. Users must take care of
 synchronization under the scenario of running under different streams. For details on CUDA semantics such as stream
-synchronization, see [CUDA Semantics](https://pytorch.org/docs/stable/notes/cuda.html).
+synchronization, see [CUDA Semantics](https://docs.pytorch.org/docs/stable/notes/cuda.html).
 See the below script to see examples of differences in these semantics for CPU and CUDA operations.
 
 **Asynchronous operation** - when `async_op` is set to True. The collective operation function
@@ -661,7 +661,7 @@ with torch.profiler():
     dist.all_reduce(tensor)
 ```
 
-Please refer to the [profiler documentation](https://pytorch.org/docs/stable/profiler.html) for a full overview of profiler features.
+Please refer to the [profiler documentation](https://docs.pytorch.org/docs/stable/profiler.html) for a full overview of profiler features.
 
 ## Multi-GPU collective functions
 

--- a/docs/source/distributed.pipelining.md
+++ b/docs/source/distributed.pipelining.md
@@ -394,7 +394,7 @@ are subclasses of `PipelineScheduleMulti`.
 
 ## Logging
 
-You can turn on additional logging using the `TORCH_LOGS` environment variable from [torch.\_logging](https://pytorch.org/docs/main/logging.html#module-torch._logging):
+You can turn on additional logging using the `TORCH_LOGS` environment variable from [torch.\_logging](https://pytorch.org/docs/stable/logging.html#module-torch._logging):
 
 - `TORCH_LOGS=+pp` will display `logging.DEBUG` messages and all levels above it.
 - `TORCH_LOGS=pp` will display `logging.INFO` messages and above.

--- a/docs/source/distributed.pipelining.md
+++ b/docs/source/distributed.pipelining.md
@@ -394,7 +394,7 @@ are subclasses of `PipelineScheduleMulti`.
 
 ## Logging
 
-You can turn on additional logging using the `TORCH_LOGS` environment variable from [torch.\_logging](https://pytorch.org/docs/stable/logging.html#module-torch._logging):
+You can turn on additional logging using the `TORCH_LOGS` environment variable from [torch.\_logging](https://docs.pytorch.org/docs/stable/logging.html#module-torch._logging):
 
 - `TORCH_LOGS=+pp` will display `logging.DEBUG` messages and all levels above it.
 - `TORCH_LOGS=pp` will display `logging.INFO` messages and above.

--- a/docs/source/distributed.tensor.md
+++ b/docs/source/distributed.tensor.md
@@ -20,7 +20,7 @@ when working with multi-dimensional sharding.
 
 Please see examples from the PyTorch native parallelism solutions that are built on top of `DTensor`:
 
-- [Tensor Parallel](https://pytorch.org/docs/stable/distributed.tensor.parallel.html)
+- [Tensor Parallel](https://docs.pytorch.org/docs/stable/distributed.tensor.parallel.html)
 - [FSDP2](https://github.com/pytorch/torchtitan/blob/main/docs/fsdp.md)
 
 ```{eval-rst}
@@ -216,7 +216,7 @@ DTensor's RNG infra is based on the philox based RNG algorithm, and supports any
 ### Logging
 
 When launching the program, you can turn on additional logging using the `TORCH_LOGS` environment variable from
-[torch._logging](https://pytorch.org/docs/stable/logging.html#module-torch._logging) :
+[torch._logging](https://docs.pytorch.org/docs/stable/logging.html#module-torch._logging) :
 
 - `TORCH_LOGS=+dtensor` will display `logging.DEBUG` messages and all levels above it.
 - `TORCH_LOGS=dtensor` will display `logging.INFO` messages and above.

--- a/docs/source/distributed.tensor.md
+++ b/docs/source/distributed.tensor.md
@@ -20,7 +20,7 @@ when working with multi-dimensional sharding.
 
 Please see examples from the PyTorch native parallelism solutions that are built on top of `DTensor`:
 
-- [Tensor Parallel](https://pytorch.org/docs/main/distributed.tensor.parallel.html)
+- [Tensor Parallel](https://pytorch.org/docs/stable/distributed.tensor.parallel.html)
 - [FSDP2](https://github.com/pytorch/torchtitan/blob/main/docs/fsdp.md)
 
 ```{eval-rst}
@@ -216,7 +216,7 @@ DTensor's RNG infra is based on the philox based RNG algorithm, and supports any
 ### Logging
 
 When launching the program, you can turn on additional logging using the `TORCH_LOGS` environment variable from
-[torch._logging](https://pytorch.org/docs/main/logging.html#module-torch._logging) :
+[torch._logging](https://pytorch.org/docs/stable/logging.html#module-torch._logging) :
 
 - `TORCH_LOGS=+dtensor` will display `logging.DEBUG` messages and all levels above it.
 - `TORCH_LOGS=dtensor` will display `logging.INFO` messages and above.

--- a/docs/source/fx.md
+++ b/docs/source/fx.md
@@ -223,7 +223,7 @@ get unwieldy as the transformations get more complex.
 -  [Conv/Batch Norm
    fusion](https://github.com/pytorch/pytorch/blob/40cbf342d3c000712da92cfafeaca651b3e0bd3e/torch/fx/experimental/optimization.py#L50)
 -  [replace_pattern: Basic usage](https://github.com/pytorch/examples/blob/master/fx/subgraph_rewriter_basic_use.py)
--  [Quantization](https://pytorch.org/docs/stable/quantization.html#prototype-fx-graph-mode-quantization)
+-  [Quantization](https://docs.pytorch.org/docs/stable/quantization.html#prototype-fx-graph-mode-quantization)
 -  [Invert Transformation](https://github.com/pytorch/examples/blob/master/fx/invert.py)
 
 ### Proxy/Retracing

--- a/docs/source/fx.md
+++ b/docs/source/fx.md
@@ -223,7 +223,7 @@ get unwieldy as the transformations get more complex.
 -  [Conv/Batch Norm
    fusion](https://github.com/pytorch/pytorch/blob/40cbf342d3c000712da92cfafeaca651b3e0bd3e/torch/fx/experimental/optimization.py#L50)
 -  [replace_pattern: Basic usage](https://github.com/pytorch/examples/blob/master/fx/subgraph_rewriter_basic_use.py)
--  [Quantization](https://pytorch.org/docs/main/quantization.html#prototype-fx-graph-mode-quantization)
+-  [Quantization](https://pytorch.org/docs/stable/quantization.html#prototype-fx-graph-mode-quantization)
 -  [Invert Transformation](https://github.com/pytorch/examples/blob/master/fx/invert.py)
 
 ### Proxy/Retracing

--- a/docs/source/notes/modules.rst
+++ b/docs/source/notes/modules.rst
@@ -534,7 +534,7 @@ The following class demonstrates the various ways of registering parameters and 
 For more information, check out:
 
 * Saving and loading: https://pytorch.org/tutorials/beginner/saving_loading_models.html
-* Serialization semantics: https://pytorch.org/docs/main/notes/serialization.html
+* Serialization semantics: https://pytorch.org/docs/stable/notes/serialization.html
 * What is a state dict? https://pytorch.org/tutorials/recipes/recipes/what_is_state_dict.html
 
 Module Initialization

--- a/docs/source/notes/modules.rst
+++ b/docs/source/notes/modules.rst
@@ -284,7 +284,7 @@ In the next section, we give a full example of training a neural network.
 
 For more information, check out:
 
-* Library of PyTorch-provided modules: `torch.nn <https://pytorch.org/docs/stable/nn.html>`_
+* Library of PyTorch-provided modules: `torch.nn <https://docs.pytorch.org/docs/stable/nn.html>`_
 * Defining neural net modules: https://pytorch.org/tutorials/beginner/examples_nn/polynomial_module.html
 
 .. _Neural Network Training with Modules:
@@ -534,7 +534,7 @@ The following class demonstrates the various ways of registering parameters and 
 For more information, check out:
 
 * Saving and loading: https://pytorch.org/tutorials/beginner/saving_loading_models.html
-* Serialization semantics: https://pytorch.org/docs/stable/notes/serialization.html
+* Serialization semantics: https://docs.pytorch.org/docs/stable/notes/serialization.html
 * What is a state dict? https://pytorch.org/tutorials/recipes/recipes/what_is_state_dict.html
 
 Module Initialization
@@ -715,7 +715,7 @@ Improving Performance with Quantization
 
 Applying quantization techniques to modules can improve performance and memory usage by utilizing lower
 bitwidths than floating-point precision. Check out the various PyTorch-provided mechanisms for quantization
-`here <https://pytorch.org/docs/stable/quantization.html>`_.
+`here <https://docs.pytorch.org/docs/stable/quantization.html>`_.
 
 Improving Memory Usage with Pruning
 ***********************************
@@ -736,7 +736,7 @@ further allows for custom constraints to be defined.
 Transforming Modules with FX
 ****************************
 
-The `FX <https://pytorch.org/docs/stable/fx.html>`_ component of PyTorch provides a flexible way to transform
+The `FX <https://docs.pytorch.org/docs/stable/fx.html>`_ component of PyTorch provides a flexible way to transform
 modules by operating directly on module computation graphs. This can be used to programmatically generate or
 manipulate modules for a broad array of use cases. To explore FX, check out these examples of using FX for
 `convolution + batch norm fusion <https://pytorch.org/tutorials/intermediate/fx_conv_bn_fuser.html>`_ and

--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -55,7 +55,7 @@ Saving tensors preserves their view relationships:
     tensor([ 1,  4,  3,  8,  5, 12,  7, 16,  9])
 
 Behind the scenes, these tensors share the same "storage." See
-`Tensor Views <https://pytorch.org/docs/main/tensor_view.html>`_ for more
+`Tensor Views <https://pytorch.org/docs/stable/tensor_view.html>`_ for more
 on views and storage.
 
 When PyTorch saves tensors it saves their storage objects and tensor

--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -55,7 +55,7 @@ Saving tensors preserves their view relationships:
     tensor([ 1,  4,  3,  8,  5, 12,  7, 16,  9])
 
 Behind the scenes, these tensors share the same "storage." See
-`Tensor Views <https://pytorch.org/docs/stable/tensor_view.html>`_ for more
+`Tensor Views <https://docs.pytorch.org/docs/stable/tensor_view.html>`_ for more
 on views and storage.
 
 When PyTorch saves tensors it saves their storage objects and tensor

--- a/docs/source/rpc.md
+++ b/docs/source/rpc.md
@@ -269,7 +269,7 @@ rpc/distributed_autograd
 
 ## Distributed Optimizer
 
-See the [torch.distributed.optim](https://pytorch.org/docs/main/distributed.optim.html) page for documentation on distributed optimizers.
+See the [torch.distributed.optim](https://pytorch.org/docs/stable/distributed.optim.html) page for documentation on distributed optimizers.
 
 ## Design Notes
 

--- a/docs/source/rpc.md
+++ b/docs/source/rpc.md
@@ -206,7 +206,7 @@ An ``RRef`` (Remote REFerence) is a reference to a value of some type ``T``
 (e.g. ``Tensor``) on a remote worker. This handle keeps the referenced remote
 value alive on the owner, but there is no implication that the value will be
 transferred to the local worker in the future. RRefs can be used in
-multi-machine training by holding references to [nn.Modules](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) that exist on
+multi-machine training by holding references to [nn.Modules](https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Module) that exist on
 other workers, and calling the appropriate functions to retrieve or modify their
 parameters during training. See {ref}`remote-reference-protocol` for more
 details.
@@ -269,7 +269,7 @@ rpc/distributed_autograd
 
 ## Distributed Optimizer
 
-See the [torch.distributed.optim](https://pytorch.org/docs/stable/distributed.optim.html) page for documentation on distributed optimizers.
+See the [torch.distributed.optim](https://docs.pytorch.org/docs/stable/distributed.optim.html) page for documentation on distributed optimizers.
 
 ## Design Notes
 
@@ -285,7 +285,7 @@ The RRef design note covers the design of the {ref}`rref` (Remote REFerence) pro
 
 The RPC tutorials introduce users to the RPC framework, provide several example applications
 using {ref}`torch.distributed.rpc<distributed-rpc-framework>` APIs, and demonstrate how
-to use [the profiler](https://pytorch.org/docs/stable/autograd.html#profiler) to profile RPC-based workloads.
+to use [the profiler](https://docs.pytorch.org/docs/stable/autograd.html#profiler) to profile RPC-based workloads.
 
 -  [Getting started with Distributed RPC Framework](https://pytorch.org/tutorials/intermediate/rpc_tutorial.html)
 -  [Implementing a Parameter Server using Distributed RPC Framework](https://pytorch.org/tutorials/intermediate/rpc_param_server_tutorial.html)

--- a/docs/source/torch.compiler_troubleshooting_old.md
+++ b/docs/source/torch.compiler_troubleshooting_old.md
@@ -10,7 +10,7 @@ orphan: true
 
 :::{note}
 This document is outdated and is now mainly a primary resource on how to run the `torch.compile` minifier.
-Please see the [updated troubleshooting document](https://pytorch.org/docs/main/torch.compiler_troubleshooting.html).
+Please see the [updated troubleshooting document](https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html).
 There is also a more [comprehensive manual for torch.compile](https://docs.google.com/document/d/1y5CRfMLdwEoF1nTk9q8qEu1mgMUuUtvhklPKJ2emLU8/edit#heading=h.ivdr7fmrbeab)
 available.
 :::
@@ -75,7 +75,7 @@ tools and their typical usage. For additional help see
 ```
 
 In addition to info and debug logging,
-you can use [torch.\_logging](https://pytorch.org/docs/main/logging.html)
+you can use [torch.\_logging](https://pytorch.org/docs/stable/logging.html)
 for more fine-grained logging.
 
 (diagnosing-runtime-errors)=

--- a/docs/source/torch.compiler_troubleshooting_old.md
+++ b/docs/source/torch.compiler_troubleshooting_old.md
@@ -10,7 +10,7 @@ orphan: true
 
 :::{note}
 This document is outdated and is now mainly a primary resource on how to run the `torch.compile` minifier.
-Please see the [updated troubleshooting document](https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html).
+Please see the [updated troubleshooting document](https://docs.pytorch.org/docs/stable/torch.compiler_troubleshooting.html).
 There is also a more [comprehensive manual for torch.compile](https://docs.google.com/document/d/1y5CRfMLdwEoF1nTk9q8qEu1mgMUuUtvhklPKJ2emLU8/edit#heading=h.ivdr7fmrbeab)
 available.
 :::
@@ -75,7 +75,7 @@ tools and their typical usage. For additional help see
 ```
 
 In addition to info and debug logging,
-you can use [torch.\_logging](https://pytorch.org/docs/stable/logging.html)
+you can use [torch.\_logging](https://docs.pytorch.org/docs/stable/logging.html)
 for more fine-grained logging.
 
 (diagnosing-runtime-errors)=

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -788,7 +788,7 @@ Optimizations
 
     compile
 
-`torch.compile documentation <https://pytorch.org/docs/main/torch.compiler.html>`__
+`torch.compile documentation <https://pytorch.org/docs/stable/torch.compiler.html>`__
 
 Operator Tags
 ------------------------------------

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -788,7 +788,7 @@ Optimizations
 
     compile
 
-`torch.compile documentation <https://pytorch.org/docs/stable/torch.compiler.html>`__
+`torch.compile documentation <https://docs.pytorch.org/docs/stable/torch.compiler.html>`__
 
 Operator Tags
 ------------------------------------

--- a/docs/source/user_guide/torch_compiler/export.md
+++ b/docs/source/user_guide/torch_compiler/export.md
@@ -528,7 +528,7 @@ As we can see, the previously in-place operator,
 ### Core ATen IR
 
 We can further lower the Inference IR to the
-`Core ATen Operator Set <https://pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir>`__,
+`Core ATen Operator Set <https://docs.pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir>`__,
 which contains only ~180 operators. This is achieved by passing `decomp_table=None`
 (which uses the default decomposition table) to `run_decompositions()`. This IR
 is optimal for backends who want to minimize the number of operators they need

--- a/docs/source/user_guide/torch_compiler/export.md
+++ b/docs/source/user_guide/torch_compiler/export.md
@@ -528,7 +528,7 @@ As we can see, the previously in-place operator,
 ### Core ATen IR
 
 We can further lower the Inference IR to the
-`Core ATen Operator Set <https://pytorch.org/docs/main/torch.compiler_ir.html#core-aten-ir>`__,
+`Core ATen Operator Set <https://pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir>`__,
 which contains only ~180 operators. This is achieved by passing `decomp_table=None`
 (which uses the default decomposition table) to `run_decompositions()`. This IR
 is optimal for backends who want to minimize the number of operators they need

--- a/docs/source/user_guide/torch_compiler/export/programming_model.md
+++ b/docs/source/user_guide/torch_compiler/export/programming_model.md
@@ -26,11 +26,11 @@ covered in the {ref}`export IR spec <export.ir_spec>`.
 In *non-strict mode*, we trace through the program using the normal Python
 interpreter. Your code executes exactly as it would in eager mode; the only
 difference is that all Tensors are replaced by
-[fake Tensors](https://pytorch.org/docs/main/torch.compiler_fake_tensor.html),
+[fake Tensors](https://pytorch.org/docs/stable/torch.compiler_fake_tensor.html),
 **which have shapes and other forms of metadata but no data**, wrapped in
-[Proxy objects](https://pytorch.org/docs/main/fx.html) that record all
+[Proxy objects](https://pytorch.org/docs/stable/fx.html) that record all
 operations on them into a graph. We also capture
-[conditions on Tensor shapes](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html#the-guard-model)
+[conditions on Tensor shapes](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#the-guard-model)
 **that guard the correctness of the generated code**.
 
 In *strict mode*, we first trace through the program using
@@ -50,7 +50,7 @@ time, the possibility of hitting unsupported Python features in TorchDynamo
 presents an unnecessary risk.
 
 In the rest of this document we assume we are tracing in
-[non-strict mode](https://pytorch.org/docs/main/export.html#non-strict-export);
+[non-strict mode](https://pytorch.org/docs/stable/export.html#non-strict-export);
 in particular, we assume that **all Python features are supported**.
 
 ## Values: Static vs. Dynamic
@@ -111,7 +111,7 @@ Whether a value is static or dynamic depends on its type:
 
     - By default, shapes of all input Tensors are considered static.
       The user can override this behavior for any input Tensor by specifying
-      a [dynamic shape](https://pytorch.org/docs/main/export.html#expressing-dynamism)
+      a [dynamic shape](https://pytorch.org/docs/stable/export.html#expressing-dynamism)
       for it.
     - Tensors that are part of module state, i.e., parameters and buffers,
       always have static shapes.
@@ -123,7 +123,7 @@ Whether a value is static or dynamic depends on its type:
   - There are dynamic variants for some primitive types (`SymInt`,
     `SymFloat`, `SymBool`). Typically users do not have to deal with them.
   - Users can specify integer inputs as dynamic by specifying
-    a [dynamic shape](https://pytorch.org/docs/main/export.html#expressing-dynamism)
+    a [dynamic shape](https://pytorch.org/docs/stable/export.html#expressing-dynamism)
     for it.
 
 - For Python *standard containers* (`list`, `tuple`, `dict`, `namedtuple`):
@@ -247,7 +247,7 @@ model are different in these cases.
 #### Dynamic Shape-Dependent Control Flow
 
 When the value involved in a control flow is a
-[dynamic shape](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html),
+[dynamic shape](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html),
 in most cases **we will also know the concrete value of the dynamic shape
 during tracing**: see the following section for more details on how the
 compiler tracks this information.
@@ -297,7 +297,7 @@ class M_new(torch.nn.Module):
 ```
 
 A special case of data-dependent control flow is where it involves a
-[data-dependent dynamic shape](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html#unbacked-symints):
+[data-dependent dynamic shape](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#unbacked-symints):
 typically, the shape of some intermediate Tensor that depends on input data
 rather than on input shapes (thus not shape-dependent). Instead of using a
 control flow operator, in this case you can provide an assertion that decides
@@ -351,7 +351,7 @@ Moreover, as we encounter control flow in the program, we create boolean
 expressions, typically involving relational operators, describing conditions
 along the traced path. These **expressions are evaluated to decide which path
 to trace through the program**, and recorded in a
-[shape environment](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html#overall-architecture)
+[shape environment](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#overall-architecture)
 to guard the correctness of the traced path and to evaluate subsequently
 created expressions.
 
@@ -360,7 +360,7 @@ We briefly introduce these subsystems next.
 ### Fake Implementations of PyTorch Operators
 
 Recall that during tracing, we are executing the program with
-[fake Tensors](https://pytorch.org/docs/main/torch.compiler_fake_tensor.html),
+[fake Tensors](https://pytorch.org/docs/stable/torch.compiler_fake_tensor.html),
 which have no data. In general we cannot call the actual implementations of
 PyTorch operators with fake Tensors. Thus each operator needs to have an
 additional fake (a.k.a. "meta") implementation, which inputs and outputs fake

--- a/docs/source/user_guide/torch_compiler/export/programming_model.md
+++ b/docs/source/user_guide/torch_compiler/export/programming_model.md
@@ -26,11 +26,11 @@ covered in the {ref}`export IR spec <export.ir_spec>`.
 In *non-strict mode*, we trace through the program using the normal Python
 interpreter. Your code executes exactly as it would in eager mode; the only
 difference is that all Tensors are replaced by
-[fake Tensors](https://pytorch.org/docs/stable/torch.compiler_fake_tensor.html),
+[fake Tensors](https://docs.pytorch.org/docs/stable/torch.compiler_fake_tensor.html),
 **which have shapes and other forms of metadata but no data**, wrapped in
-[Proxy objects](https://pytorch.org/docs/stable/fx.html) that record all
+[Proxy objects](https://docs.pytorch.org/docs/stable/fx.html) that record all
 operations on them into a graph. We also capture
-[conditions on Tensor shapes](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#the-guard-model)
+[conditions on Tensor shapes](https://docs.pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#the-guard-model)
 **that guard the correctness of the generated code**.
 
 In *strict mode*, we first trace through the program using
@@ -50,7 +50,7 @@ time, the possibility of hitting unsupported Python features in TorchDynamo
 presents an unnecessary risk.
 
 In the rest of this document we assume we are tracing in
-[non-strict mode](https://pytorch.org/docs/stable/export.html#non-strict-export);
+[non-strict mode](https://docs.pytorch.org/docs/stable/export.html#non-strict-export);
 in particular, we assume that **all Python features are supported**.
 
 ## Values: Static vs. Dynamic
@@ -111,7 +111,7 @@ Whether a value is static or dynamic depends on its type:
 
     - By default, shapes of all input Tensors are considered static.
       The user can override this behavior for any input Tensor by specifying
-      a [dynamic shape](https://pytorch.org/docs/stable/export.html#expressing-dynamism)
+      a [dynamic shape](https://docs.pytorch.org/docs/stable/export.html#expressing-dynamism)
       for it.
     - Tensors that are part of module state, i.e., parameters and buffers,
       always have static shapes.
@@ -123,7 +123,7 @@ Whether a value is static or dynamic depends on its type:
   - There are dynamic variants for some primitive types (`SymInt`,
     `SymFloat`, `SymBool`). Typically users do not have to deal with them.
   - Users can specify integer inputs as dynamic by specifying
-    a [dynamic shape](https://pytorch.org/docs/stable/export.html#expressing-dynamism)
+    a [dynamic shape](https://docs.pytorch.org/docs/stable/export.html#expressing-dynamism)
     for it.
 
 - For Python *standard containers* (`list`, `tuple`, `dict`, `namedtuple`):
@@ -247,7 +247,7 @@ model are different in these cases.
 #### Dynamic Shape-Dependent Control Flow
 
 When the value involved in a control flow is a
-[dynamic shape](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html),
+[dynamic shape](https://docs.pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html),
 in most cases **we will also know the concrete value of the dynamic shape
 during tracing**: see the following section for more details on how the
 compiler tracks this information.
@@ -297,7 +297,7 @@ class M_new(torch.nn.Module):
 ```
 
 A special case of data-dependent control flow is where it involves a
-[data-dependent dynamic shape](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#unbacked-symints):
+[data-dependent dynamic shape](https://docs.pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#unbacked-symints):
 typically, the shape of some intermediate Tensor that depends on input data
 rather than on input shapes (thus not shape-dependent). Instead of using a
 control flow operator, in this case you can provide an assertion that decides
@@ -351,7 +351,7 @@ Moreover, as we encounter control flow in the program, we create boolean
 expressions, typically involving relational operators, describing conditions
 along the traced path. These **expressions are evaluated to decide which path
 to trace through the program**, and recorded in a
-[shape environment](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#overall-architecture)
+[shape environment](https://docs.pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#overall-architecture)
 to guard the correctness of the traced path and to evaluate subsequently
 created expressions.
 
@@ -360,7 +360,7 @@ We briefly introduce these subsystems next.
 ### Fake Implementations of PyTorch Operators
 
 Recall that during tracing, we are executing the program with
-[fake Tensors](https://pytorch.org/docs/stable/torch.compiler_fake_tensor.html),
+[fake Tensors](https://docs.pytorch.org/docs/stable/torch.compiler_fake_tensor.html),
 which have no data. In general we cannot call the actual implementations of
 PyTorch operators with fake Tensors. Thus each operator needs to have an
 additional fake (a.k.a. "meta") implementation, which inputs and outputs fake

--- a/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
@@ -81,7 +81,7 @@ Registration serves two purposes:
 
 - You can pass a string containing your backend function's name to `torch.compile` instead of the function itself,
   for example, `torch.compile(model, backend="my_compiler")`.
-- It is required for use with the [minifier](https://pytorch.org/docs/stable/torch.compiler_troubleshooting_old.html#minifier). Any generated
+- It is required for use with the [minifier](https://docs.pytorch.org/docs/stable/torch.compiler_troubleshooting_old.html#minifier). Any generated
   code from the minifier must call your code that registers your backend function, typically through an `import` statement.
 
 ## Custom Backends after AOTAutograd
@@ -90,7 +90,7 @@ It is possible to define custom backends that are called by AOTAutograd rather t
 This is useful for 2 main reasons:
 
 - Users can define backends that support model training, as AOTAutograd can generate the backward graph for compilation.
-- AOTAutograd produces FX graphs consisting of [core Aten ops](https://pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir). As a result,
+- AOTAutograd produces FX graphs consisting of [core Aten ops](https://docs.pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir). As a result,
   custom backends only need to support the core Aten opset, which is a significantly smaller opset than the entire torch/Aten opset.
 
 Wrap your backend with
@@ -238,7 +238,7 @@ on which one is encountered first by the just-in-time compiler.
 
 Integrating a custom backend that offers superior performance is also
 easy and we’ll integrate a real one
-with [optimize_for_inference](https://pytorch.org/docs/stable/generated/torch.jit.optimize_for_inference.html):
+with [optimize_for_inference](https://docs.pytorch.org/docs/stable/generated/torch.jit.optimize_for_inference.html):
 
 ```python
 def optimize_for_inference_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):

--- a/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
@@ -81,7 +81,7 @@ Registration serves two purposes:
 
 - You can pass a string containing your backend function's name to `torch.compile` instead of the function itself,
   for example, `torch.compile(model, backend="my_compiler")`.
-- It is required for use with the [minifier](https://pytorch.org/docs/main/torch.compiler_troubleshooting_old.html#minifier). Any generated
+- It is required for use with the [minifier](https://pytorch.org/docs/stable/torch.compiler_troubleshooting_old.html#minifier). Any generated
   code from the minifier must call your code that registers your backend function, typically through an `import` statement.
 
 ## Custom Backends after AOTAutograd
@@ -90,7 +90,7 @@ It is possible to define custom backends that are called by AOTAutograd rather t
 This is useful for 2 main reasons:
 
 - Users can define backends that support model training, as AOTAutograd can generate the backward graph for compilation.
-- AOTAutograd produces FX graphs consisting of [core Aten ops](https://pytorch.org/docs/main/torch.compiler_ir.html#core-aten-ir). As a result,
+- AOTAutograd produces FX graphs consisting of [core Aten ops](https://pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir). As a result,
   custom backends only need to support the core Aten opset, which is a significantly smaller opset than the entire torch/Aten opset.
 
 Wrap your backend with

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
@@ -60,7 +60,7 @@ def forward(l_x_: torch.Tensor, l_y_: torch.Tensor):
 
 We call this a **graph (or trace) of the function for the given
 inputs**. This is represented via an [FX
-graph](https://pytorch.org/docs/main/fx.html). We will simply think
+graph](https://pytorch.org/docs/stable/fx.html). We will simply think
 of an FX graph as a container that stores a list of function calls.
 
 The first thing we should notice is that the graph is a linear sequence
@@ -351,7 +351,7 @@ discuss how Dynamo addresses a rather important correctness issue.
 At this point, we have a way to trace programs completely disregarding control flow.
 And for that, we have reimplemented all of CPython… If this sounds like a bit of an
 overkill, that is because it is.
-[torch.jit.trace](https://pytorch.org/docs/main/generated/torch.jit.trace.html)
+[torch.jit.trace](https://pytorch.org/docs/stable/generated/torch.jit.trace.html)
 already implements this without all this machinery, so what gives?
 
 The issue with `torch.jit.trace`, as it is warned in its docs, is that
@@ -848,7 +848,7 @@ Below are additional details and references for concepts mentioned in this docum
 
 [^5]: Interestingly enough, it does understand NumPy code! Have a look at
     [this blogpost](https://pytorch.org/blog/compiling-numpy-code/)
-    and [the docs](https://pytorch.org/docs/main/torch.compiler_faq.html#does-numpy-work-with-torch-compile).
+    and [the docs](https://pytorch.org/docs/stable/torch.compiler_faq.html#does-numpy-work-with-torch-compile).
     Now, this is just possible because we reimplemented NumPy using
     PyTorch. Good luck implementing Django in PyTorch though…
 

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
@@ -60,7 +60,7 @@ def forward(l_x_: torch.Tensor, l_y_: torch.Tensor):
 
 We call this a **graph (or trace) of the function for the given
 inputs**. This is represented via an [FX
-graph](https://pytorch.org/docs/stable/fx.html). We will simply think
+graph](https://docs.pytorch.org/docs/stable/fx.html). We will simply think
 of an FX graph as a container that stores a list of function calls.
 
 The first thing we should notice is that the graph is a linear sequence
@@ -351,7 +351,7 @@ discuss how Dynamo addresses a rather important correctness issue.
 At this point, we have a way to trace programs completely disregarding control flow.
 And for that, we have reimplemented all of CPython… If this sounds like a bit of an
 overkill, that is because it is.
-[torch.jit.trace](https://pytorch.org/docs/stable/generated/torch.jit.trace.html)
+[torch.jit.trace](https://docs.pytorch.org/docs/stable/generated/torch.jit.trace.html)
 already implements this without all this machinery, so what gives?
 
 The issue with `torch.jit.trace`, as it is warned in its docs, is that
@@ -848,7 +848,7 @@ Below are additional details and references for concepts mentioned in this docum
 
 [^5]: Interestingly enough, it does understand NumPy code! Have a look at
     [this blogpost](https://pytorch.org/blog/compiling-numpy-code/)
-    and [the docs](https://pytorch.org/docs/stable/torch.compiler_faq.html#does-numpy-work-with-torch-compile).
+    and [the docs](https://docs.pytorch.org/docs/stable/torch.compiler_faq.html#does-numpy-work-with-torch-compile).
     Now, this is just possible because we reimplemented NumPy using
     PyTorch. Good luck implementing Django in PyTorch though…
 

--- a/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
@@ -566,7 +566,7 @@ with a {ref}`minimal reproducer <torch.compiler_troubleshooting>`.
 ### I `torch.compile` some NumPy code and I did not see any speed-up.
 
 The best place to start is the
-[tutorial with general advice for how to debug these sort of torch.compile issues](https://pytorch.org/docs/main/torch.compiler_faq.html#why-am-i-not-seeing-speedups).
+[tutorial with general advice for how to debug these sort of torch.compile issues](https://pytorch.org/docs/stable/torch.compiler_faq.html#why-am-i-not-seeing-speedups).
 
 Some graph breaks may happen because of the use of unsupported features. See
 {ref}`nonsupported-numpy-feats`. More generally, it is useful to keep in mind

--- a/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
@@ -37,7 +37,7 @@ dispatcher hooks.
 The basic strategy for optimizing DDP with Dynamo is outlined in
 [distributed.py](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/backends/distributed.py)
 where the main idea will be to graph break on [DDP bucket
-boundaries](https://pytorch.org/docs/stable/notes/ddp.html#internal-design).
+boundaries](https://docs.pytorch.org/docs/stable/notes/ddp.html#internal-design).
 
 When each node in DDP needs to synchronize its weights with the other
 nodes it organizes its gradients and parameters into buckets which
@@ -566,7 +566,7 @@ with a {ref}`minimal reproducer <torch.compiler_troubleshooting>`.
 ### I `torch.compile` some NumPy code and I did not see any speed-up.
 
 The best place to start is the
-[tutorial with general advice for how to debug these sort of torch.compile issues](https://pytorch.org/docs/stable/torch.compiler_faq.html#why-am-i-not-seeing-speedups).
+[tutorial with general advice for how to debug these sort of torch.compile issues](https://docs.pytorch.org/docs/stable/torch.compiler_faq.html#why-am-i-not-seeing-speedups).
 
 Some graph breaks may happen because of the use of unsupported features. See
 {ref}`nonsupported-numpy-feats`. More generally, it is useful to keep in mind

--- a/docs/source/user_guide/torch_compiler/torch.compiler_troubleshooting.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_troubleshooting.md
@@ -495,7 +495,7 @@ def fn(y):
         return y - x
 ```
 
-- Use higher-order ops like `torch.cond` (<https://pytorch.org/docs/main/cond.html>) in place of data-dependent control flow
+- Use higher-order ops like `torch.cond` (<https://pytorch.org/docs/stable/cond.html>) in place of data-dependent control flow
 
 ```py
 # old

--- a/docs/source/user_guide/torch_compiler/torch.compiler_troubleshooting.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_troubleshooting.md
@@ -281,8 +281,8 @@ torch._logging.set_logs(graph_breaks=True)
 ```
 
 More `TORCH_LOGS` options are {ref}`troubleshooting-torch-logs-options`.
-For the full list of options, see [torch.\_logging](https://pytorch.org/docs/stable/logging.html)
-and [torch.\_logging.set_logs](https://pytorch.org/docs/stable/generated/torch._logging.set_logs.html#torch._logging.set_logs).
+For the full list of options, see [torch.\_logging](https://docs.pytorch.org/docs/stable/logging.html)
+and [torch.\_logging.set_logs](https://docs.pytorch.org/docs/stable/generated/torch._logging.set_logs.html#torch._logging.set_logs).
 
 ### tlparse vs. TORCH_LOGS
 
@@ -495,7 +495,7 @@ def fn(y):
         return y - x
 ```
 
-- Use higher-order ops like `torch.cond` (<https://pytorch.org/docs/stable/cond.html>) in place of data-dependent control flow
+- Use higher-order ops like `torch.cond` (<https://docs.pytorch.org/docs/stable/cond.html>) in place of data-dependent control flow
 
 ```py
 # old
@@ -802,7 +802,7 @@ This is likely because bugs that can be automatically reproduced in this manner 
 and have already been addressed, leaving more complex issues that do not reproduce easily.
 However, it is straightforward to attempt using the minifier, so it is worth trying even if it may not succeed.
 
-Instructions for operating the minifier can be found [here](https://pytorch.org/docs/stable/torch.compiler_troubleshooting_old.html).
+Instructions for operating the minifier can be found [here](https://docs.pytorch.org/docs/stable/torch.compiler_troubleshooting_old.html).
 If the compiler is crashing, you can set `TORCHDYNAMO_REPRO_AFTER="dynamo"` or `TORCHDYNAMO_REPRO_AFTER="aot"`
 The `aot` option is more likely to succeed, although it may not identify the `AOTAutograd` issues. This will generate the `repro.py` file which may help to diagnose the problem.
 For accuracy-related issues, consider setting `TORCHDYNAMO_REPRO_LEVEL=4`. Please note that this may not always successfully identify the problematic subgraph.
@@ -1071,17 +1071,17 @@ A summary of helpful `TORCH_LOGS` options is:
       - Output Inductor fusion logs
 ```
 
-For the full list of options, see [torch.\_logging](https://pytorch.org/docs/stable/logging.html)
-and [torch.\_logging.set_logs](https://pytorch.org/docs/stable/generated/torch._logging.set_logs.html#torch._logging.set_logs).
+For the full list of options, see [torch.\_logging](https://docs.pytorch.org/docs/stable/logging.html)
+and [torch.\_logging.set_logs](https://docs.pytorch.org/docs/stable/generated/torch._logging.set_logs.html#torch._logging.set_logs).
 
 ## Related Articles
 
 - [torch.compile tutorial](https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html)
-- [torch.compile fine-grained APIs](https://pytorch.org/docs/stable/torch.compiler_fine_grain_apis.html)
-- [torch.compile FAQ](https://pytorch.org/docs/stable/torch.compiler_faq.html)
-- [torch.compiler namespace overview](https://pytorch.org/docs/stable/torch.compiler.html#torch-compiler-overview)
-- [torch.compiler API reference](https://pytorch.org/docs/stable/torch.compiler_api.html)
-- [Profiling torch.compile](https://pytorch.org/docs/stable/torch.compiler_profiling_torch_compile.html)
+- [torch.compile fine-grained APIs](https://docs.pytorch.org/docs/stable/torch.compiler_fine_grain_apis.html)
+- [torch.compile FAQ](https://docs.pytorch.org/docs/stable/torch.compiler_faq.html)
+- [torch.compiler namespace overview](https://docs.pytorch.org/docs/stable/torch.compiler.html#torch-compiler-overview)
+- [torch.compiler API reference](https://docs.pytorch.org/docs/stable/torch.compiler_api.html)
+- [Profiling torch.compile](https://docs.pytorch.org/docs/stable/torch.compiler_profiling_torch_compile.html)
 - [torch.compile missing manual](https://docs.google.com/document/d/1y5CRfMLdwEoF1nTk9q8qEu1mgMUuUtvhklPKJ2emLU8/edit?usp=sharing)
 - [The dynamic shapes manual](https://docs.google.com/document/d/1GgvOe7C8_NVOMLOCwDaYV1mXXyHMXY7ExoewHqooxrs/edit#heading=h.fh8zzonyw8ng)
 - [TorchInductor caching tutorial](https://pytorch.org/tutorials/recipes/torch_compile_caching_tutorial.html)

--- a/functorch/docs/source/functorch.rst
+++ b/functorch/docs/source/functorch.rst
@@ -8,8 +8,8 @@ functorch
    We've integrated functorch into PyTorch. As the final step of the
    integration, the functorch APIs are deprecated as of PyTorch 2.0.
    Please use the torch.func APIs instead and see the
-   `migration guide <https://pytorch.org/docs/stable/func.migrating.html>`_
-   and `docs <https://pytorch.org/docs/stable/func.html>`_
+   `migration guide <https://docs.pytorch.org/docs/stable/func.migrating.html>`_
+   and `docs <https://docs.pytorch.org/docs/stable/func.html>`_
    for more details.
 
 Function Transforms

--- a/functorch/docs/source/functorch.rst
+++ b/functorch/docs/source/functorch.rst
@@ -8,8 +8,8 @@ functorch
    We've integrated functorch into PyTorch. As the final step of the
    integration, the functorch APIs are deprecated as of PyTorch 2.0.
    Please use the torch.func APIs instead and see the
-   `migration guide <https://pytorch.org/docs/main/func.migrating.html>`_
-   and `docs <https://pytorch.org/docs/main/func.html>`_
+   `migration guide <https://pytorch.org/docs/stable/func.migrating.html>`_
+   and `docs <https://pytorch.org/docs/stable/func.html>`_
    for more details.
 
 Function Transforms

--- a/functorch/docs/source/index.rst
+++ b/functorch/docs/source/index.rst
@@ -12,8 +12,8 @@ functorch is `JAX-like <https://github.com/google/jax>`_ composable function tra
    We've integrated functorch into PyTorch. As the final step of the
    integration, the functorch APIs are deprecated as of PyTorch 2.0.
    Please use the torch.func APIs instead and see the
-   `migration guide <https://pytorch.org/docs/stable/func.migrating.html>`_
-   and `docs <https://pytorch.org/docs/stable/func.html>`_
+   `migration guide <https://docs.pytorch.org/docs/stable/func.migrating.html>`_
+   and `docs <https://docs.pytorch.org/docs/stable/func.html>`_
    for more details.
 
 What are composable function transforms?

--- a/functorch/docs/source/index.rst
+++ b/functorch/docs/source/index.rst
@@ -12,8 +12,8 @@ functorch is `JAX-like <https://github.com/google/jax>`_ composable function tra
    We've integrated functorch into PyTorch. As the final step of the
    integration, the functorch APIs are deprecated as of PyTorch 2.0.
    Please use the torch.func APIs instead and see the
-   `migration guide <https://pytorch.org/docs/main/func.migrating.html>`_
-   and `docs <https://pytorch.org/docs/main/func.html>`_
+   `migration guide <https://pytorch.org/docs/stable/func.migrating.html>`_
+   and `docs <https://pytorch.org/docs/stable/func.html>`_
    for more details.
 
 What are composable function transforms?

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/README.md
@@ -180,7 +180,7 @@ print(f"Device of z: {z.device}")
 
 ## Documentation
 
-Please refer to [this](https://docs.pytorch.org/docs/main/accelerator/index.html) for a series of documents on integrating new accelerators into PyTorch, which will be kept in sync with the `OpenReg` codebase as well.
+Please refer to [this](https://docs.pytorch.org/docs/stable/accelerator/index.html) for a series of documents on integrating new accelerators into PyTorch, which will be kept in sync with the `OpenReg` codebase as well.
 
 ## Future Plans
 

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -247,7 +247,7 @@ class TestExplainWithBackend(torch._dynamo.test_case.TestCase):
 
 
 class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
-    """Test APIs documented by https://pytorch.org/docs/stable/torch.compiler_custom_backends.html"""
+    """Test APIs documented by https://docs.pytorch.org/docs/stable/torch.compiler_custom_backends.html"""
 
     def test_register_backend_api(self):
         from torch._dynamo import register_backend

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -247,7 +247,7 @@ class TestExplainWithBackend(torch._dynamo.test_case.TestCase):
 
 
 class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
-    """Test APIs documented by https://pytorch.org/docs/main/torch.compiler_custom_backends.html"""
+    """Test APIs documented by https://pytorch.org/docs/stable/torch.compiler_custom_backends.html"""
 
     def test_register_backend_api(self):
         from torch._dynamo import register_backend

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -92,7 +92,7 @@ def _rand_shape(dim, min_size, max_size):
 # DOES NOT INCLUDE view ops, which are tested in TestViewOps (currently in
 #   test_torch.py) OR numpy interop (which is also still tested in test_torch.py)
 #
-# See https://pytorch.org/docs/stable/torch.html#creation-ops
+# See https://docs.pytorch.org/docs/stable/torch.html#creation-ops
 
 class TestTensorCreation(TestCase):
     exact_dtype = True

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -92,7 +92,7 @@ def _rand_shape(dim, min_size, max_size):
 # DOES NOT INCLUDE view ops, which are tested in TestViewOps (currently in
 #   test_torch.py) OR numpy interop (which is also still tested in test_torch.py)
 #
-# See https://pytorch.org/docs/main/torch.html#creation-ops
+# See https://pytorch.org/docs/stable/torch.html#creation-ops
 
 class TestTensorCreation(TestCase):
     exact_dtype = True

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2608,7 +2608,7 @@ def compile(
         - Experimental or debug in-tree backends can be seen with `torch._dynamo.list_backends(None)`
 
         - To register an out-of-tree custom backend:
-          https://pytorch.org/docs/stable/torch.compiler_custom_backends.html#registering-custom-backends
+          https://docs.pytorch.org/docs/stable/torch.compiler_custom_backends.html#registering-custom-backends
        mode (str): Can be either "default", "reduce-overhead", "max-autotune" or "max-autotune-no-cudagraphs"
 
         - "default" is the default mode, which is a good balance between performance and overhead

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2608,7 +2608,7 @@ def compile(
         - Experimental or debug in-tree backends can be seen with `torch._dynamo.list_backends(None)`
 
         - To register an out-of-tree custom backend:
-          https://pytorch.org/docs/main/torch.compiler_custom_backends.html#registering-custom-backends
+          https://pytorch.org/docs/stable/torch.compiler_custom_backends.html#registering-custom-backends
        mode (str): Can be either "default", "reduce-overhead", "max-autotune" or "max-autotune-no-cudagraphs"
 
         - "default" is the default mode, which is a good balance between performance and overhead

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 def exportdb_error_message(case_name: str) -> str:
     return (
         "For more information about this error, see: "
-        + "https://pytorch.org/docs/stable/generated/exportdb/index.html#"
+        + "https://docs.pytorch.org/docs/stable/generated/exportdb/index.html#"
         + case_name.replace("_", "-")
     )
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 def exportdb_error_message(case_name: str) -> str:
     return (
         "For more information about this error, see: "
-        + "https://pytorch.org/docs/main/generated/exportdb/index.html#"
+        + "https://pytorch.org/docs/stable/generated/exportdb/index.html#"
         + case_name.replace("_", "-")
     )
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -170,9 +170,9 @@ counters: collections.defaultdict[str, Counter[str]] = collections.defaultdict(
 )
 optimus_scuba_log: dict[str, Any] = {}
 troubleshooting_url = (
-    "https://pytorch.org/docs/stable/compile/programming_model.recompilation.html"
+    "https://docs.pytorch.org/docs/stable/compile/programming_model.recompilation.html"
 )
-nnmodule_doc_url = "https://pytorch.org/docs/stable/torch.compiler_nn_module.html"
+nnmodule_doc_url = "https://docs.pytorch.org/docs/stable/torch.compiler_nn_module.html"
 nnmodule_doc_url_msg = f"See {nnmodule_doc_url} for more information and limitations."
 log = logging.getLogger(__name__)
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -170,9 +170,9 @@ counters: collections.defaultdict[str, Counter[str]] = collections.defaultdict(
 )
 optimus_scuba_log: dict[str, Any] = {}
 troubleshooting_url = (
-    "https://pytorch.org/docs/main/compile/programming_model.recompilation.html"
+    "https://pytorch.org/docs/stable/compile/programming_model.recompilation.html"
 )
-nnmodule_doc_url = "https://pytorch.org/docs/main/torch.compiler_nn_module.html"
+nnmodule_doc_url = "https://pytorch.org/docs/stable/torch.compiler_nn_module.html"
 nnmodule_doc_url_msg = f"See {nnmodule_doc_url} for more information and limitations."
 log = logging.getLogger(__name__)
 

--- a/torch/_export/db/logging.py
+++ b/torch/_export/db/logging.py
@@ -9,7 +9,7 @@ def exportdb_error_message(case_name: str) -> str:
     if case_name in ALL_EXAMPLES:
         url_case_name = case_name.replace("_", "-")
         return f"See {case_name} in exportdb for unsupported case. \
-                https://pytorch.org/docs/main/generated/exportdb/index.html#{url_case_name}"
+                https://pytorch.org/docs/stable/generated/exportdb/index.html#{url_case_name}"
     else:
         log_export_usage(
             event="export.error.casenotregistered",

--- a/torch/_export/db/logging.py
+++ b/torch/_export/db/logging.py
@@ -9,7 +9,7 @@ def exportdb_error_message(case_name: str) -> str:
     if case_name in ALL_EXAMPLES:
         url_case_name = case_name.replace("_", "-")
         return f"See {case_name} in exportdb for unsupported case. \
-                https://pytorch.org/docs/stable/generated/exportdb/index.html#{url_case_name}"
+                https://docs.pytorch.org/docs/stable/generated/exportdb/index.html#{url_case_name}"
     else:
         log_export_usage(
             event="export.error.casenotregistered",

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -194,7 +194,7 @@ def wrap_outputs_maintaining_identity(
                 f"out_dims has structure {pytree.tree_flatten(out_dims)[1]} "
                 f"but output has structure {spec}. "
                 f"For more details, please see "
-                f"https://pytorch.org/docs/stable/notes/extending.func.html"
+                f"https://docs.pytorch.org/docs/stable/notes/extending.func.html"
             )
 
     for i, output in enumerate(flat_outputs):
@@ -296,7 +296,7 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands, **kwarg
                 f"staticmethod. Please set generate_vmap_rule=False or delete "
                 f"the overridden vmap staticmethod to avoid ambiguity. "
                 f"For more details, please see "
-                f"https://pytorch.org/docs/stable/notes/extending.func.html"
+                f"https://docs.pytorch.org/docs/stable/notes/extending.func.html"
             )
         return custom_function_call_vmap_generate_rule(
             interpreter, autograd_function, *operands
@@ -310,7 +310,7 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands, **kwarg
             f"it does not have vmap support. Please override and implement the "
             f"vmap staticmethod or set generate_vmap_rule=True. "
             f"For more details, please see "
-            f"https://pytorch.org/docs/stable/notes/extending.func.html"
+            f"https://docs.pytorch.org/docs/stable/notes/extending.func.html"
         )
 
     return custom_function_call_vmap_helper(

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -194,7 +194,7 @@ def wrap_outputs_maintaining_identity(
                 f"out_dims has structure {pytree.tree_flatten(out_dims)[1]} "
                 f"but output has structure {spec}. "
                 f"For more details, please see "
-                f"https://pytorch.org/docs/main/notes/extending.func.html"
+                f"https://pytorch.org/docs/stable/notes/extending.func.html"
             )
 
     for i, output in enumerate(flat_outputs):
@@ -296,7 +296,7 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands, **kwarg
                 f"staticmethod. Please set generate_vmap_rule=False or delete "
                 f"the overridden vmap staticmethod to avoid ambiguity. "
                 f"For more details, please see "
-                f"https://pytorch.org/docs/main/notes/extending.func.html"
+                f"https://pytorch.org/docs/stable/notes/extending.func.html"
             )
         return custom_function_call_vmap_generate_rule(
             interpreter, autograd_function, *operands
@@ -310,7 +310,7 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands, **kwarg
             f"it does not have vmap support. Please override and implement the "
             f"vmap staticmethod or set generate_vmap_rule=True. "
             f"For more details, please see "
-            f"https://pytorch.org/docs/main/notes/extending.func.html"
+            f"https://pytorch.org/docs/stable/notes/extending.func.html"
         )
 
     return custom_function_call_vmap_helper(

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -30,7 +30,7 @@ def get_warning(api, new_api=None, replace_newlines=False):
         f"2.0 and will be deleted in a future version of PyTorch >= 2.3. \n"
         f"Please use `{new_api}` instead; see the PyTorch 2.0 release notes \n"
         f"and/or the `torch.func` migration guide for more details \n"
-        f"https://pytorch.org/docs/main/func.migrating.html"
+        f"https://pytorch.org/docs/stable/func.migrating.html"
     )
     if replace_newlines:
         warning = warning.replace("\n", "")

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -30,7 +30,7 @@ def get_warning(api, new_api=None, replace_newlines=False):
         f"2.0 and will be deleted in a future version of PyTorch >= 2.3. \n"
         f"Please use `{new_api}` instead; see the PyTorch 2.0 release notes \n"
         f"and/or the `torch.func` migration guide for more details \n"
-        f"https://pytorch.org/docs/stable/func.migrating.html"
+        f"https://docs.pytorch.org/docs/stable/func.migrating.html"
     )
     if replace_newlines:
         warning = warning.replace("\n", "")

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -780,7 +780,7 @@ class Tensor(torch._C.TensorBase):
             trim(
                 r"""reinforce() was removed.
             Use torch.distributions instead.
-            See https://pytorch.org/docs/main/distributions.html
+            See https://pytorch.org/docs/stable/distributions.html
 
             Instead of:
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -780,7 +780,7 @@ class Tensor(torch._C.TensorBase):
             trim(
                 r"""reinforce() was removed.
             Use torch.distributions instead.
-            See https://pytorch.org/docs/stable/distributions.html
+            See https://docs.pytorch.org/docs/stable/distributions.html
 
             Instead of:
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -587,7 +587,7 @@ class Function(_SingleLevelFunction):
                 "In order to use an autograd.Function with functorch transforms "
                 "(vmap, grad, jvp, jacrev, ...), it must override the setup_context "
                 "staticmethod. For more details, please see "
-                "https://pytorch.org/docs/main/notes/extending.func.html"
+                "https://pytorch.org/docs/stable/notes/extending.func.html"
             )
 
         return custom_function_call(cls, *args, **kwargs)

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -517,7 +517,7 @@ class Function(_SingleLevelFunction):
         raise RuntimeError(
             "Legacy autograd function with non-static forward method is deprecated. "
             "Please use new-style autograd function with static forward method. "
-            "(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)"
+            "(Example: https://docs.pytorch.org/docs/stable/autograd.html#torch.autograd.Function)"
         )
 
     """
@@ -587,7 +587,7 @@ class Function(_SingleLevelFunction):
                 "In order to use an autograd.Function with functorch transforms "
                 "(vmap, grad, jvp, jacrev, ...), it must override the setup_context "
                 "staticmethod. For more details, please see "
-                "https://pytorch.org/docs/stable/notes/extending.func.html"
+                "https://docs.pytorch.org/docs/stable/notes/extending.func.html"
             )
 
         return custom_function_call(cls, *args, **kwargs)

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -396,7 +396,7 @@ def cudagraph_mark_step_begin():
             torch.compiler.cudagraph_mark_step_begin()
             rand_foo() + rand_foo()
 
-    For more details, see `torch.compiler_cudagraph_trees <https://pytorch.org/docs/stable/torch.compiler_cudagraph_trees.html>`__
+    For more details, see `torch.compiler_cudagraph_trees <https://docs.pytorch.org/docs/stable/torch.compiler_cudagraph_trees.html>`__
     """
     from torch._inductor import cudagraph_trees
 

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -396,7 +396,7 @@ def cudagraph_mark_step_begin():
             torch.compiler.cudagraph_mark_step_begin()
             rand_foo() + rand_foo()
 
-    For more details, see `torch.compiler_cudagraph_trees <https://pytorch.org/docs/main/torch.compiler_cudagraph_trees.html>`__
+    For more details, see `torch.compiler_cudagraph_trees <https://pytorch.org/docs/stable/torch.compiler_cudagraph_trees.html>`__
     """
     from torch._inductor import cudagraph_trees
 

--- a/torch/csrc/api/include/torch/fft.h
+++ b/torch/csrc/api/include/torch/fft.h
@@ -8,7 +8,7 @@
 namespace torch::fft {
 
 /// Computes the 1 dimensional fast Fourier transform over a given dimension.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.fft.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fft.
 ///
 /// Example:
 /// ```
@@ -24,7 +24,7 @@ inline Tensor fft(
 }
 
 /// Computes the 1 dimensional inverse Fourier transform over a given dimension.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifft.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifft.
 ///
 /// Example:
 /// ```
@@ -40,7 +40,7 @@ inline Tensor ifft(
 }
 
 /// Computes the 2-dimensional fast Fourier transform over the given dimensions.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.fft2.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fft2.
 ///
 /// Example:
 /// ```
@@ -56,7 +56,7 @@ inline Tensor fft2(
 }
 
 /// Computes the inverse of torch.fft.fft2
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifft2.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifft2.
 ///
 /// Example:
 /// ```
@@ -72,7 +72,7 @@ inline Tensor ifft2(
 }
 
 /// Computes the N dimensional fast Fourier transform over given dimensions.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.fftn.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fftn.
 ///
 /// Example:
 /// ```
@@ -88,7 +88,7 @@ inline Tensor fftn(
 }
 
 /// Computes the N dimensional fast Fourier transform over given dimensions.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifftn.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifftn.
 ///
 /// Example:
 /// ```
@@ -104,7 +104,7 @@ inline Tensor ifftn(
 }
 
 /// Computes the 1 dimensional FFT of real input with onesided Hermitian output.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.rfft.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.rfft.
 ///
 /// Example:
 /// ```
@@ -123,7 +123,7 @@ inline Tensor rfft(
 /// Computes the inverse of torch.fft.rfft
 ///
 /// The input is a onesided Hermitian Fourier domain signal, with real-valued
-/// output. See https://pytorch.org/docs/main/fft.html#torch.fft.irfft
+/// output. See https://pytorch.org/docs/stable/fft.html#torch.fft.irfft
 ///
 /// Example:
 /// ```
@@ -140,7 +140,7 @@ inline Tensor irfft(
 }
 
 /// Computes the 2-dimensional FFT of real input. Returns a onesided Hermitian
-/// output. See https://pytorch.org/docs/main/fft.html#torch.fft.rfft2
+/// output. See https://pytorch.org/docs/stable/fft.html#torch.fft.rfft2
 ///
 /// Example:
 /// ```
@@ -156,7 +156,7 @@ inline Tensor rfft2(
 }
 
 /// Computes the inverse of torch.fft.rfft2.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.irfft2.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.irfft2.
 ///
 /// Example:
 /// ```
@@ -172,7 +172,7 @@ inline Tensor irfft2(
 }
 
 /// Computes the N dimensional FFT of real input with onesided Hermitian output.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.rfftn
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.rfftn
 ///
 /// Example:
 /// ```
@@ -188,7 +188,7 @@ inline Tensor rfftn(
 }
 
 /// Computes the inverse of torch.fft.rfftn.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.irfftn.
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.irfftn.
 ///
 /// Example:
 /// ```
@@ -207,7 +207,7 @@ inline Tensor irfftn(
 ///
 /// The input represents a Hermitian symmetric time domain signal. The returned
 /// Fourier domain representation of such a signal is a real-valued. See
-/// https://pytorch.org/docs/main/fft.html#torch.fft.hfft
+/// https://pytorch.org/docs/stable/fft.html#torch.fft.hfft
 ///
 /// Example:
 /// ```
@@ -226,7 +226,7 @@ inline Tensor hfft(
 /// Computes the inverse FFT of a real-valued Fourier domain signal.
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/main/fft.html#torch.fft.ihfft.
+/// domain signal. See https://pytorch.org/docs/stable/fft.html#torch.fft.ihfft.
 ///
 /// Example:
 /// ```
@@ -245,7 +245,7 @@ inline Tensor ihfft(
 /// Computes the 2-dimensional FFT of a Hermitian symmetric input signal.
 ///
 /// The input is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/main/fft.html#torch.fft.hfft2.
+/// domain signal. See https://pytorch.org/docs/stable/fft.html#torch.fft.hfft2.
 ///
 /// Example:
 /// ```
@@ -265,7 +265,7 @@ inline Tensor hfft2(
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
 /// domain signal. See
-/// https://pytorch.org/docs/main/fft.html#torch.fft.ihfft2.
+/// https://pytorch.org/docs/stable/fft.html#torch.fft.ihfft2.
 ///
 /// Example:
 /// ```
@@ -284,7 +284,7 @@ inline Tensor ihfft2(
 /// Computes the N-dimensional FFT of a Hermitian symmetric input signal.
 ///
 /// The input is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/main/fft.html#torch.fft.hfftn.
+/// domain signal. See https://pytorch.org/docs/stable/fft.html#torch.fft.hfftn.
 ///
 /// Example:
 /// ```
@@ -304,7 +304,7 @@ inline Tensor hfftn(
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
 /// domain signal. See
-/// https://pytorch.org/docs/main/fft.html#torch.fft.ihfftn.
+/// https://pytorch.org/docs/stable/fft.html#torch.fft.ihfftn.
 ///
 /// Example:
 /// ```
@@ -323,7 +323,7 @@ inline Tensor ihfftn(
 /// Computes the discrete Fourier Transform sample frequencies for a signal of
 /// size n.
 ///
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.fftfreq
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fftfreq
 ///
 /// Example:
 /// ```
@@ -340,7 +340,7 @@ inline Tensor fftfreq(int64_t n, const TensorOptions& options = {}) {
 /// Computes the sample frequencies for torch.fft.rfft with a signal of size n.
 ///
 /// Like torch.fft.rfft, only the positive frequencies are included.
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.rfftfreq
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.rfftfreq
 ///
 /// Example:
 /// ```
@@ -357,7 +357,7 @@ inline Tensor rfftfreq(int64_t n, const TensorOptions& options) {
 /// Reorders n-dimensional FFT output to have negative frequency terms first, by
 /// a torch.roll operation.
 ///
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.fftshift
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fftshift
 ///
 /// Example:
 /// ```
@@ -372,7 +372,7 @@ inline Tensor fftshift(
 
 /// Inverse of torch.fft.fftshift
 ///
-/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifftshift
+/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifftshift
 ///
 /// Example:
 /// ```

--- a/torch/csrc/api/include/torch/fft.h
+++ b/torch/csrc/api/include/torch/fft.h
@@ -8,7 +8,7 @@
 namespace torch::fft {
 
 /// Computes the 1 dimensional fast Fourier transform over a given dimension.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fft.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.fft.
 ///
 /// Example:
 /// ```
@@ -24,7 +24,7 @@ inline Tensor fft(
 }
 
 /// Computes the 1 dimensional inverse Fourier transform over a given dimension.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifft.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ifft.
 ///
 /// Example:
 /// ```
@@ -40,7 +40,7 @@ inline Tensor ifft(
 }
 
 /// Computes the 2-dimensional fast Fourier transform over the given dimensions.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fft2.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.fft2.
 ///
 /// Example:
 /// ```
@@ -56,7 +56,7 @@ inline Tensor fft2(
 }
 
 /// Computes the inverse of torch.fft.fft2
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifft2.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ifft2.
 ///
 /// Example:
 /// ```
@@ -72,7 +72,7 @@ inline Tensor ifft2(
 }
 
 /// Computes the N dimensional fast Fourier transform over given dimensions.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fftn.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.fftn.
 ///
 /// Example:
 /// ```
@@ -88,7 +88,7 @@ inline Tensor fftn(
 }
 
 /// Computes the N dimensional fast Fourier transform over given dimensions.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifftn.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ifftn.
 ///
 /// Example:
 /// ```
@@ -104,7 +104,7 @@ inline Tensor ifftn(
 }
 
 /// Computes the 1 dimensional FFT of real input with onesided Hermitian output.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.rfft.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.rfft.
 ///
 /// Example:
 /// ```
@@ -123,7 +123,7 @@ inline Tensor rfft(
 /// Computes the inverse of torch.fft.rfft
 ///
 /// The input is a onesided Hermitian Fourier domain signal, with real-valued
-/// output. See https://pytorch.org/docs/stable/fft.html#torch.fft.irfft
+/// output. See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.irfft
 ///
 /// Example:
 /// ```
@@ -140,7 +140,7 @@ inline Tensor irfft(
 }
 
 /// Computes the 2-dimensional FFT of real input. Returns a onesided Hermitian
-/// output. See https://pytorch.org/docs/stable/fft.html#torch.fft.rfft2
+/// output. See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.rfft2
 ///
 /// Example:
 /// ```
@@ -156,7 +156,7 @@ inline Tensor rfft2(
 }
 
 /// Computes the inverse of torch.fft.rfft2.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.irfft2.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.irfft2.
 ///
 /// Example:
 /// ```
@@ -172,7 +172,7 @@ inline Tensor irfft2(
 }
 
 /// Computes the N dimensional FFT of real input with onesided Hermitian output.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.rfftn
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.rfftn
 ///
 /// Example:
 /// ```
@@ -188,7 +188,7 @@ inline Tensor rfftn(
 }
 
 /// Computes the inverse of torch.fft.rfftn.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.irfftn.
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.irfftn.
 ///
 /// Example:
 /// ```
@@ -207,7 +207,7 @@ inline Tensor irfftn(
 ///
 /// The input represents a Hermitian symmetric time domain signal. The returned
 /// Fourier domain representation of such a signal is a real-valued. See
-/// https://pytorch.org/docs/stable/fft.html#torch.fft.hfft
+/// https://docs.pytorch.org/docs/stable/fft.html#torch.fft.hfft
 ///
 /// Example:
 /// ```
@@ -226,7 +226,7 @@ inline Tensor hfft(
 /// Computes the inverse FFT of a real-valued Fourier domain signal.
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/stable/fft.html#torch.fft.ihfft.
+/// domain signal. See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ihfft.
 ///
 /// Example:
 /// ```
@@ -245,7 +245,7 @@ inline Tensor ihfft(
 /// Computes the 2-dimensional FFT of a Hermitian symmetric input signal.
 ///
 /// The input is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/stable/fft.html#torch.fft.hfft2.
+/// domain signal. See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.hfft2.
 ///
 /// Example:
 /// ```
@@ -265,7 +265,7 @@ inline Tensor hfft2(
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
 /// domain signal. See
-/// https://pytorch.org/docs/stable/fft.html#torch.fft.ihfft2.
+/// https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ihfft2.
 ///
 /// Example:
 /// ```
@@ -284,7 +284,7 @@ inline Tensor ihfft2(
 /// Computes the N-dimensional FFT of a Hermitian symmetric input signal.
 ///
 /// The input is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/stable/fft.html#torch.fft.hfftn.
+/// domain signal. See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.hfftn.
 ///
 /// Example:
 /// ```
@@ -304,7 +304,7 @@ inline Tensor hfftn(
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
 /// domain signal. See
-/// https://pytorch.org/docs/stable/fft.html#torch.fft.ihfftn.
+/// https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ihfftn.
 ///
 /// Example:
 /// ```
@@ -323,7 +323,7 @@ inline Tensor ihfftn(
 /// Computes the discrete Fourier Transform sample frequencies for a signal of
 /// size n.
 ///
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fftfreq
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.fftfreq
 ///
 /// Example:
 /// ```
@@ -340,7 +340,7 @@ inline Tensor fftfreq(int64_t n, const TensorOptions& options = {}) {
 /// Computes the sample frequencies for torch.fft.rfft with a signal of size n.
 ///
 /// Like torch.fft.rfft, only the positive frequencies are included.
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.rfftfreq
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.rfftfreq
 ///
 /// Example:
 /// ```
@@ -357,7 +357,7 @@ inline Tensor rfftfreq(int64_t n, const TensorOptions& options) {
 /// Reorders n-dimensional FFT output to have negative frequency terms first, by
 /// a torch.roll operation.
 ///
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.fftshift
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.fftshift
 ///
 /// Example:
 /// ```
@@ -372,7 +372,7 @@ inline Tensor fftshift(
 
 /// Inverse of torch.fft.fftshift
 ///
-/// See https://pytorch.org/docs/stable/fft.html#torch.fft.ifftshift
+/// See https://docs.pytorch.org/docs/stable/fft.html#torch.fft.ifftshift
 ///
 /// Example:
 /// ```

--- a/torch/csrc/api/include/torch/nested.h
+++ b/torch/csrc/api/include/torch/nested.h
@@ -10,7 +10,7 @@ namespace torch::nested {
 /// Nested tensor
 ///
 /// See
-/// https://pytorch.org/docs/stable/nested.html#torch.nested.nested_tensor
+/// https://docs.pytorch.org/docs/stable/nested.html#torch.nested.nested_tensor
 ///
 /// ```
 // implemented on python object to allow torch.nested.nested_tensor to be
@@ -66,7 +66,7 @@ inline at::Tensor nested_tensor(
 /// As Nested Tensor
 ///
 /// See
-/// https://pytorch.org/docs/stable/nested.html#torch.nested.as_nested_tensor
+/// https://docs.pytorch.org/docs/stable/nested.html#torch.nested.as_nested_tensor
 ///
 /// ```
 inline at::Tensor as_nested_tensor(
@@ -80,7 +80,7 @@ inline at::Tensor as_nested_tensor(
 /// Nested to padded tensor
 ///
 /// See
-/// https://pytorch.org/docs/stable/nested.html#torch.nested.to_padded_tensor
+/// https://docs.pytorch.org/docs/stable/nested.html#torch.nested.to_padded_tensor
 ///
 /// ```
 inline at::Tensor to_padded_tensor(

--- a/torch/csrc/api/include/torch/nested.h
+++ b/torch/csrc/api/include/torch/nested.h
@@ -10,7 +10,7 @@ namespace torch::nested {
 /// Nested tensor
 ///
 /// See
-/// https://pytorch.org/docs/main/nested.html#torch.nested.nested_tensor
+/// https://pytorch.org/docs/stable/nested.html#torch.nested.nested_tensor
 ///
 /// ```
 // implemented on python object to allow torch.nested.nested_tensor to be
@@ -66,7 +66,7 @@ inline at::Tensor nested_tensor(
 /// As Nested Tensor
 ///
 /// See
-/// https://pytorch.org/docs/main/nested.html#torch.nested.as_nested_tensor
+/// https://pytorch.org/docs/stable/nested.html#torch.nested.as_nested_tensor
 ///
 /// ```
 inline at::Tensor as_nested_tensor(
@@ -80,7 +80,7 @@ inline at::Tensor as_nested_tensor(
 /// Nested to padded tensor
 ///
 /// See
-/// https://pytorch.org/docs/main/nested.html#torch.nested.to_padded_tensor
+/// https://pytorch.org/docs/stable/nested.html#torch.nested.to_padded_tensor
 ///
 /// ```
 inline at::Tensor to_padded_tensor(

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -25,7 +25,7 @@ inline Tensor elu(Tensor input, double alpha, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.elu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.elu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ELUFuncOptions` class to
@@ -55,7 +55,7 @@ inline Tensor selu(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.selu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.selu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SELUFuncOptions` class to
@@ -81,7 +81,7 @@ inline Tensor hardshrink(const Tensor& input, double lambda) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.hardshrink
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hardshrink
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HardshrinkFuncOptions`
@@ -117,7 +117,7 @@ inline Tensor hardtanh(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.hardtanh
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hardtanh
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HardtanhFuncOptions` class
@@ -152,7 +152,7 @@ inline Tensor leaky_relu(Tensor input, double negative_slope, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.leaky_relu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.leaky_relu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LeakyReLUFuncOptions`
@@ -206,7 +206,7 @@ inline Tensor gumbel_softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.gumbel_softmax
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.gumbel_softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GumbelSoftmaxFuncOptions`
@@ -246,7 +246,7 @@ inline Tensor softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softmax
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftmaxFuncOptions` class
@@ -283,7 +283,7 @@ inline Tensor softmin(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softmin
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softmin
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftminFuncOptions` class
@@ -320,7 +320,7 @@ inline Tensor log_softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.log_softmax
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.log_softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LogSoftmaxFuncOptions`
@@ -351,7 +351,7 @@ inline Tensor glu(const Tensor& input, int64_t dim) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.glu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.glu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GLUFuncOptions` class to
@@ -413,7 +413,7 @@ inline Tensor relu(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.relu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.relu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ReLUFuncOptions` class to
@@ -443,7 +443,7 @@ inline Tensor relu6(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.relu6
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.relu6
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ReLU6FuncOptions` class to
@@ -478,7 +478,7 @@ inline Tensor rrelu(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.rrelu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.rrelu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::RReLUFuncOptions` class to
@@ -513,7 +513,7 @@ inline Tensor celu(Tensor input, double alpha, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.celu
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.celu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CELUFuncOptions` class to
@@ -539,7 +539,7 @@ inline Tensor softplus(const Tensor& input, double beta, double threshold) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softplus
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softplus
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftplusFuncOptions` class
@@ -567,7 +567,7 @@ inline Tensor softshrink(const Tensor& input, double lambda) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softshrink
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softshrink
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftshrinkFuncOptions`
@@ -615,7 +615,7 @@ inline Tensor threshold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.threshold
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.threshold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ThresholdFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -25,7 +25,7 @@ inline Tensor elu(Tensor input, double alpha, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.elu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.elu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ELUFuncOptions` class to
@@ -55,7 +55,7 @@ inline Tensor selu(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.selu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.selu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SELUFuncOptions` class to
@@ -81,7 +81,7 @@ inline Tensor hardshrink(const Tensor& input, double lambda) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hardshrink
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hardshrink
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HardshrinkFuncOptions`
@@ -117,7 +117,7 @@ inline Tensor hardtanh(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hardtanh
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hardtanh
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HardtanhFuncOptions` class
@@ -152,7 +152,7 @@ inline Tensor leaky_relu(Tensor input, double negative_slope, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.leaky_relu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.leaky_relu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LeakyReLUFuncOptions`
@@ -206,7 +206,7 @@ inline Tensor gumbel_softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.gumbel_softmax
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.gumbel_softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GumbelSoftmaxFuncOptions`
@@ -246,7 +246,7 @@ inline Tensor softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softmax
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftmaxFuncOptions` class
@@ -283,7 +283,7 @@ inline Tensor softmin(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softmin
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softmin
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftminFuncOptions` class
@@ -320,7 +320,7 @@ inline Tensor log_softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.log_softmax
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.log_softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LogSoftmaxFuncOptions`
@@ -351,7 +351,7 @@ inline Tensor glu(const Tensor& input, int64_t dim) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.glu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.glu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GLUFuncOptions` class to
@@ -413,7 +413,7 @@ inline Tensor relu(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.relu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.relu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ReLUFuncOptions` class to
@@ -443,7 +443,7 @@ inline Tensor relu6(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.relu6
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.relu6
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ReLU6FuncOptions` class to
@@ -478,7 +478,7 @@ inline Tensor rrelu(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.rrelu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.rrelu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::RReLUFuncOptions` class to
@@ -513,7 +513,7 @@ inline Tensor celu(Tensor input, double alpha, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.celu
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.celu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CELUFuncOptions` class to
@@ -539,7 +539,7 @@ inline Tensor softplus(const Tensor& input, double beta, double threshold) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softplus
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softplus
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftplusFuncOptions` class
@@ -567,7 +567,7 @@ inline Tensor softshrink(const Tensor& input, double lambda) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softshrink
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.softshrink
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftshrinkFuncOptions`
@@ -615,7 +615,7 @@ inline Tensor threshold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.threshold
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.threshold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ThresholdFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -48,7 +48,7 @@ inline Tensor batch_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.batch_norm
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.batch_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::BatchNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -48,7 +48,7 @@ inline Tensor batch_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.batch_norm
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.batch_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::BatchNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/conv.h
+++ b/torch/csrc/api/include/torch/nn/functional/conv.h
@@ -40,7 +40,7 @@ inline Tensor conv1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv1dFuncOptions` class
@@ -86,7 +86,7 @@ inline Tensor conv2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv2dFuncOptions` class
@@ -132,7 +132,7 @@ inline Tensor conv3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv3dFuncOptions` class
@@ -177,7 +177,7 @@ inline Tensor conv_transpose1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -222,7 +222,7 @@ inline Tensor conv_transpose2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -267,7 +267,7 @@ inline Tensor conv_transpose3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/conv.h
+++ b/torch/csrc/api/include/torch/nn/functional/conv.h
@@ -40,7 +40,7 @@ inline Tensor conv1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv1dFuncOptions` class
@@ -86,7 +86,7 @@ inline Tensor conv2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv2dFuncOptions` class
@@ -132,7 +132,7 @@ inline Tensor conv3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv3dFuncOptions` class
@@ -177,7 +177,7 @@ inline Tensor conv_transpose1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv_transpose1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -222,7 +222,7 @@ inline Tensor conv_transpose2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv_transpose2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -267,7 +267,7 @@ inline Tensor conv_transpose3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv_transpose3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.conv_transpose3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/distance.h
+++ b/torch/csrc/api/include/torch/nn/functional/distance.h
@@ -17,7 +17,7 @@ inline Tensor cosine_similarity(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cosine_similarity
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cosine_similarity
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -53,7 +53,7 @@ inline Tensor pairwise_distance(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pairwise_distance
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pairwise_distance
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/distance.h
+++ b/torch/csrc/api/include/torch/nn/functional/distance.h
@@ -17,7 +17,7 @@ inline Tensor cosine_similarity(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cosine_similarity
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cosine_similarity
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -53,7 +53,7 @@ inline Tensor pairwise_distance(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.pairwise_distance
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pairwise_distance
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -25,7 +25,7 @@ inline Tensor dropout(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::DropoutFuncOptions` class
@@ -94,7 +94,7 @@ inline Tensor dropout2d(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Dropout2dFuncOptions`
@@ -126,7 +126,7 @@ inline Tensor dropout3d(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Dropout3dFuncOptions`
@@ -166,7 +166,7 @@ inline Tensor alpha_dropout(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.alpha_dropout
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.alpha_dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AlphaDropoutFuncOptions`
@@ -207,7 +207,7 @@ inline Tensor feature_alpha_dropout(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.feature_alpha_dropout
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.feature_alpha_dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -25,7 +25,7 @@ inline Tensor dropout(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.dropout
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::DropoutFuncOptions` class
@@ -94,7 +94,7 @@ inline Tensor dropout2d(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.dropout2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Dropout2dFuncOptions`
@@ -126,7 +126,7 @@ inline Tensor dropout3d(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.dropout3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.dropout3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Dropout3dFuncOptions`
@@ -166,7 +166,7 @@ inline Tensor alpha_dropout(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.alpha_dropout
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.alpha_dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AlphaDropoutFuncOptions`
@@ -207,7 +207,7 @@ inline Tensor feature_alpha_dropout(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.feature_alpha_dropout
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.feature_alpha_dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/embedding.h
+++ b/torch/csrc/api/include/torch/nn/functional/embedding.h
@@ -56,7 +56,7 @@ inline Tensor embedding(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.embedding
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.embedding
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::EmbeddingFuncOptions`
@@ -173,7 +173,7 @@ inline Tensor embedding_bag(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.embedding_bag
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.embedding_bag
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::EmbeddingBagFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/embedding.h
+++ b/torch/csrc/api/include/torch/nn/functional/embedding.h
@@ -56,7 +56,7 @@ inline Tensor embedding(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.embedding
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.embedding
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::EmbeddingFuncOptions`
@@ -173,7 +173,7 @@ inline Tensor embedding_bag(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.embedding_bag
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.embedding_bag
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::EmbeddingBagFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/fold.h
+++ b/torch/csrc/api/include/torch/nn/functional/fold.h
@@ -29,7 +29,7 @@ inline Tensor fold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.fold
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.fold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::FoldFuncOptions` class to
@@ -75,7 +75,7 @@ inline Tensor unfold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.unfold
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.unfold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::UnfoldFuncOptions` class

--- a/torch/csrc/api/include/torch/nn/functional/fold.h
+++ b/torch/csrc/api/include/torch/nn/functional/fold.h
@@ -29,7 +29,7 @@ inline Tensor fold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.fold
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.fold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::FoldFuncOptions` class to
@@ -75,7 +75,7 @@ inline Tensor unfold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.unfold
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.unfold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::UnfoldFuncOptions` class

--- a/torch/csrc/api/include/torch/nn/functional/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/instancenorm.h
@@ -30,7 +30,7 @@ inline Tensor instance_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.instance_norm
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.instance_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::InstanceNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/instancenorm.h
@@ -30,7 +30,7 @@ inline Tensor instance_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.instance_norm
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.instance_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::InstanceNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -18,7 +18,7 @@ inline Tensor l1_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.l1_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.l1_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::L1LossFuncOptions` class
@@ -74,7 +74,7 @@ inline Tensor kl_div(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.kl_div
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.kl_div
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::KLDivFuncOptions` class to
@@ -123,7 +123,7 @@ inline Tensor mse_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.mse_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.mse_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MSELossFuncOptions` class
@@ -176,7 +176,7 @@ inline Tensor binary_cross_entropy(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.binary_cross_entropy
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.binary_cross_entropy
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -213,7 +213,7 @@ inline Tensor hinge_embedding_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.hinge_embedding_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hinge_embedding_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -262,7 +262,7 @@ inline Tensor multi_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.multi_margin_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multi_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -305,7 +305,7 @@ inline Tensor cosine_embedding_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cosine_embedding_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cosine_embedding_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -368,7 +368,7 @@ inline Tensor smooth_l1_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.smooth_l1_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.smooth_l1_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SmoothL1LossFuncOptions`
@@ -388,7 +388,7 @@ inline Tensor smooth_l1_loss(
 }
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.smooth_l1_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.smooth_l1_loss
 /// about the exact behavior of this functional.
 ///
 /// Example:
@@ -440,7 +440,7 @@ inline Tensor huber_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.huber_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.huber_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HuberLossFuncOptions`
@@ -475,7 +475,7 @@ inline Tensor multilabel_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.multilabel_margin_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multilabel_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -510,7 +510,7 @@ inline Tensor soft_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.soft_margin_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.soft_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftMarginLossFuncOptions`
@@ -568,7 +568,7 @@ inline Tensor multilabel_soft_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -616,7 +616,7 @@ inline Tensor triplet_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.triplet_margin_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.triplet_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -698,7 +698,7 @@ inline Tensor triplet_margin_with_distance_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.triplet_margin_with_distance_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.triplet_margin_with_distance_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -751,7 +751,7 @@ inline Tensor ctc_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.ctc_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.ctc_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CTCLossFuncOptions` class
@@ -802,7 +802,7 @@ inline Tensor poisson_nll_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.poisson_nll_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.poisson_nll_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PoissonNLLLossFuncOptions`
@@ -853,7 +853,7 @@ inline Tensor margin_ranking_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.margin_ranking_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.margin_ranking_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -910,7 +910,7 @@ inline Tensor nll_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.nll_loss
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.nll_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::NLLLossFuncOptions` class
@@ -957,7 +957,7 @@ inline Tensor cross_entropy(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cross_entropy
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cross_entropy
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CrossEntropyFuncOptions`
@@ -1011,7 +1011,7 @@ inline Tensor binary_cross_entropy_with_logits(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.binary_cross_entropy_with_logits
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.binary_cross_entropy_with_logits
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -18,7 +18,7 @@ inline Tensor l1_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.l1_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.l1_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::L1LossFuncOptions` class
@@ -74,7 +74,7 @@ inline Tensor kl_div(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.kl_div
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.kl_div
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::KLDivFuncOptions` class to
@@ -123,7 +123,7 @@ inline Tensor mse_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.mse_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.mse_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MSELossFuncOptions` class
@@ -176,7 +176,7 @@ inline Tensor binary_cross_entropy(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.binary_cross_entropy
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.binary_cross_entropy
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -213,7 +213,7 @@ inline Tensor hinge_embedding_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hinge_embedding_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.hinge_embedding_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -262,7 +262,7 @@ inline Tensor multi_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multi_margin_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multi_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -305,7 +305,7 @@ inline Tensor cosine_embedding_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cosine_embedding_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cosine_embedding_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -368,7 +368,7 @@ inline Tensor smooth_l1_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.smooth_l1_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.smooth_l1_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SmoothL1LossFuncOptions`
@@ -388,7 +388,7 @@ inline Tensor smooth_l1_loss(
 }
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.smooth_l1_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.smooth_l1_loss
 /// about the exact behavior of this functional.
 ///
 /// Example:
@@ -440,7 +440,7 @@ inline Tensor huber_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.huber_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.huber_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HuberLossFuncOptions`
@@ -475,7 +475,7 @@ inline Tensor multilabel_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multilabel_margin_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multilabel_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -510,7 +510,7 @@ inline Tensor soft_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.soft_margin_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.soft_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftMarginLossFuncOptions`
@@ -568,7 +568,7 @@ inline Tensor multilabel_soft_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -616,7 +616,7 @@ inline Tensor triplet_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.triplet_margin_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.triplet_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -698,7 +698,7 @@ inline Tensor triplet_margin_with_distance_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.triplet_margin_with_distance_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.triplet_margin_with_distance_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -751,7 +751,7 @@ inline Tensor ctc_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.ctc_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.ctc_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CTCLossFuncOptions` class
@@ -802,7 +802,7 @@ inline Tensor poisson_nll_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.poisson_nll_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.poisson_nll_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PoissonNLLLossFuncOptions`
@@ -853,7 +853,7 @@ inline Tensor margin_ranking_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.margin_ranking_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.margin_ranking_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -910,7 +910,7 @@ inline Tensor nll_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.nll_loss
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.nll_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::NLLLossFuncOptions` class
@@ -957,7 +957,7 @@ inline Tensor cross_entropy(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cross_entropy
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.cross_entropy
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CrossEntropyFuncOptions`
@@ -1011,7 +1011,7 @@ inline Tensor binary_cross_entropy_with_logits(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.binary_cross_entropy_with_logits
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.binary_cross_entropy_with_logits
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/normalization.h
+++ b/torch/csrc/api/include/torch/nn/functional/normalization.h
@@ -27,7 +27,7 @@ inline Tensor normalize(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.normalize
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.normalize
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::NormalizeFuncOptions`
@@ -61,7 +61,7 @@ inline Tensor layer_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.layer_norm
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.layer_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LayerNormFuncOptions`
@@ -141,7 +141,7 @@ inline Tensor local_response_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.local_response_norm
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.local_response_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -182,7 +182,7 @@ inline Tensor group_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.group_norm
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.group_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GroupNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/normalization.h
+++ b/torch/csrc/api/include/torch/nn/functional/normalization.h
@@ -27,7 +27,7 @@ inline Tensor normalize(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.normalize
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.normalize
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::NormalizeFuncOptions`
@@ -61,7 +61,7 @@ inline Tensor layer_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.layer_norm
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.layer_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LayerNormFuncOptions`
@@ -141,7 +141,7 @@ inline Tensor local_response_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.local_response_norm
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.local_response_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -182,7 +182,7 @@ inline Tensor group_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.group_norm
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.group_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GroupNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -35,7 +35,7 @@ inline Tensor pad(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.pad
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pad
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PadFuncOptions` class to

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -35,7 +35,7 @@ inline Tensor pad(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pad
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pad
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PadFuncOptions` class to

--- a/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
@@ -17,7 +17,7 @@ inline Tensor pixel_unshuffle(const Tensor& input, int64_t downscale_factor) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.pixel_shuffle
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pixel_shuffle
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PixelShuffleFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
@@ -17,7 +17,7 @@ inline Tensor pixel_unshuffle(const Tensor& input, int64_t downscale_factor) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pixel_shuffle
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.pixel_shuffle
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PixelShuffleFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -23,7 +23,7 @@ inline Tensor avg_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.avg_pool1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool1dFuncOptions`
@@ -69,7 +69,7 @@ inline Tensor avg_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.avg_pool2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool2dFuncOptions`
@@ -116,7 +116,7 @@ inline Tensor avg_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.avg_pool3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool3dFuncOptions`
@@ -158,7 +158,7 @@ inline Tensor max_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_pool1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool1dFuncOptions`
@@ -232,7 +232,7 @@ inline Tensor max_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_pool2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool2dFuncOptions`
@@ -306,7 +306,7 @@ inline Tensor max_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_pool3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool3dFuncOptions`
@@ -400,7 +400,7 @@ inline Tensor adaptive_max_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_max_pool1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -456,7 +456,7 @@ inline Tensor adaptive_max_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_max_pool2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -512,7 +512,7 @@ inline Tensor adaptive_max_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_max_pool3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -543,7 +543,7 @@ inline Tensor adaptive_avg_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_avg_pool1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -574,7 +574,7 @@ inline Tensor adaptive_avg_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_avg_pool2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -605,7 +605,7 @@ inline Tensor adaptive_avg_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_avg_pool3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -698,7 +698,7 @@ inline Tensor max_unpool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_unpool1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool1dFuncOptions`
@@ -741,7 +741,7 @@ inline Tensor max_unpool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_unpool2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool2dFuncOptions`
@@ -784,7 +784,7 @@ inline Tensor max_unpool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_unpool3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool3dFuncOptions`
@@ -1025,7 +1025,7 @@ inline Tensor lp_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.lp_pool1d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool1dFuncOptions` class
@@ -1074,7 +1074,7 @@ inline Tensor lp_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.lp_pool2d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool2dFuncOptions` class
@@ -1124,7 +1124,7 @@ inline Tensor lp_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.lp_pool3d
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool3dFuncOptions` class

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -23,7 +23,7 @@ inline Tensor avg_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool1dFuncOptions`
@@ -69,7 +69,7 @@ inline Tensor avg_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool2dFuncOptions`
@@ -116,7 +116,7 @@ inline Tensor avg_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.avg_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool3dFuncOptions`
@@ -158,7 +158,7 @@ inline Tensor max_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool1dFuncOptions`
@@ -232,7 +232,7 @@ inline Tensor max_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool2dFuncOptions`
@@ -306,7 +306,7 @@ inline Tensor max_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool3dFuncOptions`
@@ -400,7 +400,7 @@ inline Tensor adaptive_max_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -456,7 +456,7 @@ inline Tensor adaptive_max_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -512,7 +512,7 @@ inline Tensor adaptive_max_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_max_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -543,7 +543,7 @@ inline Tensor adaptive_avg_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -574,7 +574,7 @@ inline Tensor adaptive_avg_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -605,7 +605,7 @@ inline Tensor adaptive_avg_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.adaptive_avg_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -698,7 +698,7 @@ inline Tensor max_unpool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool1dFuncOptions`
@@ -741,7 +741,7 @@ inline Tensor max_unpool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool2dFuncOptions`
@@ -784,7 +784,7 @@ inline Tensor max_unpool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.max_unpool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool3dFuncOptions`
@@ -1025,7 +1025,7 @@ inline Tensor lp_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool1d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool1dFuncOptions` class
@@ -1074,7 +1074,7 @@ inline Tensor lp_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool2d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool2dFuncOptions` class
@@ -1124,7 +1124,7 @@ inline Tensor lp_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool3d
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.lp_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool3dFuncOptions` class

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -258,7 +258,7 @@ inline Tensor interpolate(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::InterpolateFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -258,7 +258,7 @@ inline Tensor interpolate(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.interpolate
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::InterpolateFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -92,7 +92,7 @@ inline Tensor grid_sample(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
+/// https://docs.pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GridSampleFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -92,7 +92,7 @@ inline Tensor grid_sample(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.grid_sample
+/// https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GridSampleFuncOptions`

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -13,7 +13,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies elu over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ELU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ELUOptions` class to learn what
@@ -48,7 +48,7 @@ TORCH_MODULE(ELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the selu function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.SELU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.SELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SELUOptions` class to learn what
@@ -83,7 +83,7 @@ TORCH_MODULE(SELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the hard shrinkage function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Hardshrink to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Hardshrink to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HardshrinkOptions` class to learn what
@@ -118,7 +118,7 @@ TORCH_MODULE(Hardshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardtanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the HardTanh function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Hardtanh to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Hardtanh to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HardtanhOptions` class to learn what
@@ -154,7 +154,7 @@ TORCH_MODULE(Hardtanh);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LeakyReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LeakyReLU function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LeakyReLU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LeakyReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LeakyReLUOptions` class to learn what
@@ -189,7 +189,7 @@ TORCH_MODULE(LeakyReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LogSigmoid function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LogSigmoid to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LogSigmoid to learn
 /// about the exact behavior of this module.
 class TORCH_API LogSigmoidImpl : public torch::nn::Cloneable<LogSigmoidImpl> {
  public:
@@ -210,7 +210,7 @@ TORCH_MODULE(LogSigmoid);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmax function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softmax to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Softmax to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftmaxOptions` class to learn what
@@ -245,7 +245,7 @@ TORCH_MODULE(Softmax);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmin ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmin function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softmin to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Softmin to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftminOptions` class to learn what
@@ -280,7 +280,7 @@ TORCH_MODULE(Softmin);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSoftmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LogSoftmax function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LogSoftmax to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LogSoftmax to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LogSoftmaxOptions` class to learn what
@@ -316,7 +316,7 @@ TORCH_MODULE(LogSoftmax);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmax2d function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softmax2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Softmax2d to learn
 /// about the exact behavior of this module.
 class TORCH_API Softmax2dImpl : public torch::nn::Cloneable<Softmax2dImpl> {
  public:
@@ -337,7 +337,7 @@ TORCH_MODULE(Softmax2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the PReLU function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.PReLU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.PReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PReLUOptions` class to learn what
@@ -375,7 +375,7 @@ TORCH_MODULE(PReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ReLU function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReLU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReLUOptions` class to learn what
@@ -410,7 +410,7 @@ TORCH_MODULE(ReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU6 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ReLU6 function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReLU6 to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReLU6 to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReLU6Options` class to learn what
@@ -445,7 +445,7 @@ TORCH_MODULE(ReLU6);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the RReLU function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.RReLU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.RReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RReLUOptions` class to learn what
@@ -480,7 +480,7 @@ TORCH_MODULE(RReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies celu over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CELU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.CELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CELUOptions` class to learn what
@@ -515,7 +515,7 @@ TORCH_MODULE(CELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies glu over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GLU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.GLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GLUOptions` class to learn what
@@ -550,7 +550,7 @@ TORCH_MODULE(GLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies gelu over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GELU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.GELU to learn
 /// about the exact behavior of this module.
 class TORCH_API GELUImpl : public torch::nn::Cloneable<GELUImpl> {
  public:
@@ -576,7 +576,7 @@ TORCH_MODULE(GELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SiLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies silu over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.SiLU to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.SiLU to learn
 /// about the exact behavior of this module.
 class TORCH_API SiLUImpl : public torch::nn::Cloneable<SiLUImpl> {
  public:
@@ -597,7 +597,7 @@ TORCH_MODULE(SiLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Mish ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies mish over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Mish to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Mish to learn
 /// about the exact behavior of this module.
 class TORCH_API MishImpl : public torch::nn::Cloneable<MishImpl> {
  public:
@@ -618,7 +618,7 @@ TORCH_MODULE(Mish);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies sigmoid over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Sigmoid to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Sigmoid to learn
 /// about the exact behavior of this module.
 class TORCH_API SigmoidImpl : public torch::nn::Cloneable<SigmoidImpl> {
  public:
@@ -639,7 +639,7 @@ TORCH_MODULE(Sigmoid);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softplus ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies softplus over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softplus to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Softplus to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftplusOptions` class to learn what
@@ -674,7 +674,7 @@ TORCH_MODULE(Softplus);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the soft shrinkage function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softshrink to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Softshrink to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftshrinkOptions` class to learn what
@@ -709,7 +709,7 @@ TORCH_MODULE(Softshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softsign ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Softsign over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softsign to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Softsign to learn
 /// about the exact behavior of this module.
 class TORCH_API SoftsignImpl : public torch::nn::Cloneable<SoftsignImpl> {
  public:
@@ -730,7 +730,7 @@ TORCH_MODULE(Softsign);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Tanh over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Tanh to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Tanh to learn
 /// about the exact behavior of this module.
 class TORCH_API TanhImpl : public torch::nn::Cloneable<TanhImpl> {
  public:
@@ -751,7 +751,7 @@ TORCH_MODULE(Tanh);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanhshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Tanhshrink over a given input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Tanhshrink to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Tanhshrink to learn
 /// about the exact behavior of this module.
 class TORCH_API TanhshrinkImpl : public torch::nn::Cloneable<TanhshrinkImpl> {
  public:
@@ -772,7 +772,7 @@ TORCH_MODULE(Tanhshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Threshold ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Threshold function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Threshold to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Threshold to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ThresholdOptions` class to learn what
@@ -809,7 +809,7 @@ TORCH_MODULE(Threshold);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiheadAttention ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the MultiheadAttention function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MultiheadAttention
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MultiheadAttention
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiheadAttentionOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -13,7 +13,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies elu over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ELU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ELUOptions` class to learn what
@@ -48,7 +48,7 @@ TORCH_MODULE(ELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the selu function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.SELU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.SELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SELUOptions` class to learn what
@@ -83,7 +83,7 @@ TORCH_MODULE(SELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the hard shrinkage function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Hardshrink to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Hardshrink to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HardshrinkOptions` class to learn what
@@ -118,7 +118,7 @@ TORCH_MODULE(Hardshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardtanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the HardTanh function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Hardtanh to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Hardtanh to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HardtanhOptions` class to learn what
@@ -154,7 +154,7 @@ TORCH_MODULE(Hardtanh);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LeakyReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LeakyReLU function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LeakyReLU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LeakyReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LeakyReLUOptions` class to learn what
@@ -189,7 +189,7 @@ TORCH_MODULE(LeakyReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LogSigmoid function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LogSigmoid to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LogSigmoid to learn
 /// about the exact behavior of this module.
 class TORCH_API LogSigmoidImpl : public torch::nn::Cloneable<LogSigmoidImpl> {
  public:
@@ -210,7 +210,7 @@ TORCH_MODULE(LogSigmoid);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmax function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softmax to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softmax to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftmaxOptions` class to learn what
@@ -245,7 +245,7 @@ TORCH_MODULE(Softmax);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmin ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmin function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softmin to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softmin to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftminOptions` class to learn what
@@ -280,7 +280,7 @@ TORCH_MODULE(Softmin);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSoftmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LogSoftmax function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LogSoftmax to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LogSoftmax to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LogSoftmaxOptions` class to learn what
@@ -316,7 +316,7 @@ TORCH_MODULE(LogSoftmax);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmax2d function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softmax2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softmax2d to learn
 /// about the exact behavior of this module.
 class TORCH_API Softmax2dImpl : public torch::nn::Cloneable<Softmax2dImpl> {
  public:
@@ -337,7 +337,7 @@ TORCH_MODULE(Softmax2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the PReLU function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.PReLU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.PReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PReLUOptions` class to learn what
@@ -375,7 +375,7 @@ TORCH_MODULE(PReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ReLU function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReLU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReLUOptions` class to learn what
@@ -410,7 +410,7 @@ TORCH_MODULE(ReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU6 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ReLU6 function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReLU6 to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReLU6 to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReLU6Options` class to learn what
@@ -445,7 +445,7 @@ TORCH_MODULE(ReLU6);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the RReLU function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.RReLU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.RReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RReLUOptions` class to learn what
@@ -480,7 +480,7 @@ TORCH_MODULE(RReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies celu over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.CELU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CELUOptions` class to learn what
@@ -515,7 +515,7 @@ TORCH_MODULE(CELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies glu over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.GLU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GLUOptions` class to learn what
@@ -550,7 +550,7 @@ TORCH_MODULE(GLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies gelu over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.GELU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GELU to learn
 /// about the exact behavior of this module.
 class TORCH_API GELUImpl : public torch::nn::Cloneable<GELUImpl> {
  public:
@@ -576,7 +576,7 @@ TORCH_MODULE(GELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SiLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies silu over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.SiLU to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.SiLU to learn
 /// about the exact behavior of this module.
 class TORCH_API SiLUImpl : public torch::nn::Cloneable<SiLUImpl> {
  public:
@@ -597,7 +597,7 @@ TORCH_MODULE(SiLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Mish ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies mish over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Mish to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Mish to learn
 /// about the exact behavior of this module.
 class TORCH_API MishImpl : public torch::nn::Cloneable<MishImpl> {
  public:
@@ -618,7 +618,7 @@ TORCH_MODULE(Mish);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies sigmoid over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Sigmoid to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Sigmoid to learn
 /// about the exact behavior of this module.
 class TORCH_API SigmoidImpl : public torch::nn::Cloneable<SigmoidImpl> {
  public:
@@ -639,7 +639,7 @@ TORCH_MODULE(Sigmoid);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softplus ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies softplus over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softplus to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softplus to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftplusOptions` class to learn what
@@ -674,7 +674,7 @@ TORCH_MODULE(Softplus);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the soft shrinkage function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softshrink to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softshrink to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftshrinkOptions` class to learn what
@@ -709,7 +709,7 @@ TORCH_MODULE(Softshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softsign ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Softsign over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softsign to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Softsign to learn
 /// about the exact behavior of this module.
 class TORCH_API SoftsignImpl : public torch::nn::Cloneable<SoftsignImpl> {
  public:
@@ -730,7 +730,7 @@ TORCH_MODULE(Softsign);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Tanh over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Tanh to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Tanh to learn
 /// about the exact behavior of this module.
 class TORCH_API TanhImpl : public torch::nn::Cloneable<TanhImpl> {
  public:
@@ -751,7 +751,7 @@ TORCH_MODULE(Tanh);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanhshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Tanhshrink over a given input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Tanhshrink to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Tanhshrink to learn
 /// about the exact behavior of this module.
 class TORCH_API TanhshrinkImpl : public torch::nn::Cloneable<TanhshrinkImpl> {
  public:
@@ -772,7 +772,7 @@ TORCH_MODULE(Tanhshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Threshold ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Threshold function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Threshold to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Threshold to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ThresholdOptions` class to learn what
@@ -809,7 +809,7 @@ TORCH_MODULE(Threshold);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiheadAttention ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the MultiheadAttention function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MultiheadAttention
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MultiheadAttention
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiheadAttentionOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/adaptive.h
+++ b/torch/csrc/api/include/torch/nn/modules/adaptive.h
@@ -31,7 +31,7 @@ struct TORCH_API ASMoutput {
 /// `Efficient softmax approximation for GPUs`_ by Edouard Grave, Armand Joulin,
 /// Moustapha Cissé, David Grangier, and Hervé Jégou.
 /// See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveLogSoftmaxWithLoss
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveLogSoftmaxWithLoss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveLogSoftmaxWithLossOptions`

--- a/torch/csrc/api/include/torch/nn/modules/adaptive.h
+++ b/torch/csrc/api/include/torch/nn/modules/adaptive.h
@@ -31,7 +31,7 @@ struct TORCH_API ASMoutput {
 /// `Efficient softmax approximation for GPUs`_ by Edouard Grave, Armand Joulin,
 /// Moustapha Cissé, David Grangier, and Hervé Jégou.
 /// See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveLogSoftmaxWithLoss
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveLogSoftmaxWithLoss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveLogSoftmaxWithLossOptions`

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -153,7 +153,7 @@ class BatchNormImplBase : public NormImplBase<D, Derived, BatchNormOptions> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm1d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm1dOptions` class to learn
@@ -183,7 +183,7 @@ TORCH_MODULE(BatchNorm1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm2d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm2dOptions` class to learn
@@ -213,7 +213,7 @@ TORCH_MODULE(BatchNorm2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm3d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -153,7 +153,7 @@ class BatchNormImplBase : public NormImplBase<D, Derived, BatchNormOptions> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm1d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.BatchNorm1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm1dOptions` class to learn
@@ -183,7 +183,7 @@ TORCH_MODULE(BatchNorm1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm2d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.BatchNorm2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm2dOptions` class to learn
@@ -213,7 +213,7 @@ TORCH_MODULE(BatchNorm2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm3d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.BatchNorm3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -166,7 +166,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Conv1d to learn about
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Conv1d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv1dOptions` class to learn what
@@ -198,7 +198,7 @@ TORCH_MODULE(Conv1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Conv2d to learn about
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Conv2d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv2dOptions` class to learn what
@@ -233,7 +233,7 @@ TORCH_MODULE(Conv2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Conv3d to learn about
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Conv3d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv3dOptions` class to learn what
@@ -323,7 +323,7 @@ class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose1d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose1d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose1dOptions` class to learn
@@ -365,7 +365,7 @@ TORCH_MODULE(ConvTranspose1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose2d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose2d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose2dOptions` class to learn
@@ -407,7 +407,7 @@ TORCH_MODULE(ConvTranspose2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose3d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose3d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -166,7 +166,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Conv1d to learn about
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Conv1d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv1dOptions` class to learn what
@@ -198,7 +198,7 @@ TORCH_MODULE(Conv1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Conv2d to learn about
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Conv2d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv2dOptions` class to learn what
@@ -233,7 +233,7 @@ TORCH_MODULE(Conv2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Conv3d to learn about
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Conv3d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv3dOptions` class to learn what
@@ -323,7 +323,7 @@ class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose1d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConvTranspose1d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose1dOptions` class to learn
@@ -365,7 +365,7 @@ TORCH_MODULE(ConvTranspose1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose2d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConvTranspose2d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose2dOptions` class to learn
@@ -407,7 +407,7 @@ TORCH_MODULE(ConvTranspose2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose3d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConvTranspose3d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/distance.h
+++ b/torch/csrc/api/include/torch/nn/modules/distance.h
@@ -12,7 +12,7 @@ namespace torch::nn {
 
 /// Returns the cosine similarity between :math:`x_1` and :math:`x_2`, computed
 /// along `dim`.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CosineSimilarity to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.CosineSimilarity to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CosineSimilarityOptions` class to
@@ -48,7 +48,7 @@ TORCH_MODULE(CosineSimilarity);
 
 /// Returns the batchwise pairwise distance between vectors :math:`v_1`,
 /// :math:`v_2` using the p-norm.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.PairwiseDistance to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.PairwiseDistance to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PairwiseDistanceOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/distance.h
+++ b/torch/csrc/api/include/torch/nn/modules/distance.h
@@ -12,7 +12,7 @@ namespace torch::nn {
 
 /// Returns the cosine similarity between :math:`x_1` and :math:`x_2`, computed
 /// along `dim`.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.CosineSimilarity to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CosineSimilarity to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CosineSimilarityOptions` class to
@@ -48,7 +48,7 @@ TORCH_MODULE(CosineSimilarity);
 
 /// Returns the batchwise pairwise distance between vectors :math:`v_1`,
 /// :math:`v_2` using the p-norm.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.PairwiseDistance to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.PairwiseDistance to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PairwiseDistanceOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -36,7 +36,7 @@ class _DropoutNd : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Dropout to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::DropoutOptions` class to learn what
@@ -66,7 +66,7 @@ TORCH_MODULE(Dropout);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Dropout2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Dropout2dOptions` class to learn what
@@ -96,7 +96,7 @@ TORCH_MODULE(Dropout2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Dropout3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Dropout3dOptions` class to learn what
@@ -126,7 +126,7 @@ TORCH_MODULE(Dropout3d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AlphaDropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Alpha Dropout over the input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AlphaDropout to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AlphaDropout to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AlphaDropoutOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -36,7 +36,7 @@ class _DropoutNd : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Dropout to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::DropoutOptions` class to learn what
@@ -66,7 +66,7 @@ TORCH_MODULE(Dropout);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Dropout2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Dropout2dOptions` class to learn what
@@ -96,7 +96,7 @@ TORCH_MODULE(Dropout2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Dropout3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Dropout3dOptions` class to learn what
@@ -126,7 +126,7 @@ TORCH_MODULE(Dropout3d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AlphaDropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Alpha Dropout over the input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AlphaDropout to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AlphaDropout to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AlphaDropoutOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -15,7 +15,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Performs a lookup in a fixed size embedding table.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Embedding to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Embedding to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::EmbeddingOptions` class to learn what
@@ -89,7 +89,7 @@ class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
 
 /// Computes sums or means of 'bags' of embeddings, without instantiating the
 /// intermediate embeddings.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.EmbeddingBag to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.EmbeddingBag to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::EmbeddingBagOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -15,7 +15,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Performs a lookup in a fixed size embedding table.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Embedding to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Embedding to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::EmbeddingOptions` class to learn what
@@ -89,7 +89,7 @@ class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
 
 /// Computes sums or means of 'bags' of embeddings, without instantiating the
 /// intermediate embeddings.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.EmbeddingBag to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.EmbeddingBag to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::EmbeddingBagOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/fold.h
+++ b/torch/csrc/api/include/torch/nn/modules/fold.h
@@ -10,7 +10,7 @@
 namespace torch::nn {
 
 /// Applies fold over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Fold to learn about
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Fold to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FoldOptions` class to learn what
@@ -48,7 +48,7 @@ TORCH_MODULE(Fold);
 // ============================================================================
 
 /// Applies unfold over a 4-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Unfold to learn about
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Unfold to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UnfoldOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/fold.h
+++ b/torch/csrc/api/include/torch/nn/modules/fold.h
@@ -10,7 +10,7 @@
 namespace torch::nn {
 
 /// Applies fold over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Fold to learn about
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Fold to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FoldOptions` class to learn what
@@ -48,7 +48,7 @@ TORCH_MODULE(Fold);
 // ============================================================================
 
 /// Applies unfold over a 4-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Unfold to learn about
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Unfold to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UnfoldOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/instancenorm.h
@@ -61,7 +61,7 @@ class InstanceNormImpl
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm1d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm1dOptions` class to learn
@@ -92,7 +92,7 @@ TORCH_MODULE(InstanceNorm1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm2d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm2dOptions` class to learn
@@ -123,7 +123,7 @@ TORCH_MODULE(InstanceNorm2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm3d function.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/instancenorm.h
@@ -61,7 +61,7 @@ class InstanceNormImpl
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm1d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.InstanceNorm1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm1dOptions` class to learn
@@ -92,7 +92,7 @@ TORCH_MODULE(InstanceNorm1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm2d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.InstanceNorm2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm2dOptions` class to learn
@@ -123,7 +123,7 @@ TORCH_MODULE(InstanceNorm2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm3d function.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.InstanceNorm3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.InstanceNorm3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -16,7 +16,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Identity ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder identity operator that is argument-insensitive.
-/// See https://pytorch.org/docs/stable/generated/torch.nn.Identity.html to
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.Identity.html to
 /// learn about the exact behavior of this module.
 class TORCH_API IdentityImpl : public Cloneable<IdentityImpl> {
  public:
@@ -37,7 +37,7 @@ TORCH_MODULE(Identity);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Linear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a linear transformation with optional bias.
-/// See https://pytorch.org/docs/stable/generated/torch.nn.Linear.html to learn
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LinearOptions` class to learn what
@@ -85,7 +85,7 @@ TORCH_MODULE(Linear);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flatten ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for Flatten operator
-/// See https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html to learn
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.Flatten.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FlattenOptions` class to learn what
@@ -122,7 +122,7 @@ TORCH_MODULE(Flatten);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for unflatten operator
-/// See https://pytorch.org/docs/stable/generated/torch.nn.Unflatten.html to
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.Unflatten.html to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UnflattenOptions` class to learn what
@@ -164,7 +164,7 @@ TORCH_MODULE(Unflatten);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Bilinear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a billinear transformation with optional bias.
-/// See https://pytorch.org/docs/stable/generated/torch.nn.Bilinear.html to
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.Bilinear.html to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BilinearOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -16,7 +16,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Identity ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder identity operator that is argument-insensitive.
-/// See https://pytorch.org/docs/main/generated/torch.nn.Identity.html to
+/// See https://pytorch.org/docs/stable/generated/torch.nn.Identity.html to
 /// learn about the exact behavior of this module.
 class TORCH_API IdentityImpl : public Cloneable<IdentityImpl> {
  public:
@@ -37,7 +37,7 @@ TORCH_MODULE(Identity);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Linear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a linear transformation with optional bias.
-/// See https://pytorch.org/docs/main/generated/torch.nn.Linear.html to learn
+/// See https://pytorch.org/docs/stable/generated/torch.nn.Linear.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LinearOptions` class to learn what
@@ -85,7 +85,7 @@ TORCH_MODULE(Linear);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flatten ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for Flatten operator
-/// See https://pytorch.org/docs/main/generated/torch.nn.Flatten.html to learn
+/// See https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FlattenOptions` class to learn what
@@ -122,7 +122,7 @@ TORCH_MODULE(Flatten);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for unflatten operator
-/// See https://pytorch.org/docs/main/generated/torch.nn.Unflatten.html to
+/// See https://pytorch.org/docs/stable/generated/torch.nn.Unflatten.html to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UnflattenOptions` class to learn what
@@ -164,7 +164,7 @@ TORCH_MODULE(Unflatten);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Bilinear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a billinear transformation with optional bias.
-/// See https://pytorch.org/docs/main/generated/torch.nn.Bilinear.html to
+/// See https://pytorch.org/docs/stable/generated/torch.nn.Bilinear.html to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BilinearOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -18,7 +18,7 @@ namespace torch::nn {
 
 /// Creates a criterion that measures the mean absolute error (MAE) between each
 /// element in the input : math :`x` and target : `y`.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.L1Loss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.L1Loss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::L1LossOptions` class to learn what
@@ -53,7 +53,7 @@ TORCH_MODULE(L1Loss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The Kullback-Leibler divergence loss measure
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.KLDivLoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.KLDivLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::KLDivLossOptions` class to learn what
@@ -88,7 +88,7 @@ TORCH_MODULE(KLDivLoss);
 
 /// Creates a criterion that measures the mean squared error (squared L2 norm)
 /// between each element in the input :math:`x` and target :math:`y`.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MSELoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MSELoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MSELossOptions` class to learn what
@@ -123,7 +123,7 @@ TORCH_MODULE(MSELoss);
 
 /// Creates a criterion that measures the Binary Cross Entropy
 /// between the target and the output.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.BCELoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BCELoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BCELossOptions` class to learn what
@@ -159,7 +159,7 @@ TORCH_MODULE(BCELoss);
 
 /// Creates a criterion that measures the loss given an input tensor :math:`x`
 /// and a labels tensor :math:`y` (containing 1 or -1).
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.HingeEmbeddingLoss to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.HingeEmbeddingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HingeEmbeddingLossOptions` class to
@@ -198,7 +198,7 @@ TORCH_MODULE(HingeEmbeddingLoss);
 /// loss (margin-based loss) between input :math:`x` (a 2D mini-batch `Tensor`)
 /// and output :math:`y` (which is a 1D tensor of target class indices, :math:`0
 /// \leq y \leq \text{x.size}(1)-1`). See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.MultiMarginLoss to learn
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.MultiMarginLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiMarginLossOptions` class to learn
@@ -237,7 +237,7 @@ TORCH_MODULE(MultiMarginLoss);
 /// -1. This is used for measuring whether two inputs are similar or
 /// dissimilar, using the cosine distance, and is typically used for learning
 /// nonlinear embeddings or semi-supervised learning.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.CosineEmbeddingLoss to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CosineEmbeddingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CosineEmbeddingLossOptions` class to
@@ -279,7 +279,7 @@ TORCH_MODULE(CosineEmbeddingLoss);
 /// element-wise error falls below beta and an L1 term otherwise.
 /// It is less sensitive to outliers than the `MSELoss` and in some cases
 /// prevents exploding gradients (e.g. see the paper `Fast R-CNN` by Ross
-/// Girshick). See https://pytorch.org/docs/main/nn.html#torch.nn.SmoothL1Loss
+/// Girshick). See https://pytorch.org/docs/stable/nn.html#torch.nn.SmoothL1Loss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SmoothL1LossOptions` class to learn
@@ -315,7 +315,7 @@ TORCH_MODULE(SmoothL1Loss);
 
 /// Creates a criterion that uses a squared term if the absolute
 /// element-wise error falls below delta and a delta-scaled L1 term otherwise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.HuberLoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.HuberLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HuberLossOptions` class to learn what
@@ -353,7 +353,7 @@ TORCH_MODULE(HuberLoss);
 /// hinge loss (margin-based loss) between input :math:`x` (a 2D mini-batch
 /// `Tensor`) and output :math:`y` (which is a 2D `Tensor` of target class
 /// indices). See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.MultiLabelMarginLoss to
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.MultiLabelMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiLabelMarginLossOptions` class to
@@ -391,7 +391,7 @@ TORCH_MODULE(MultiLabelMarginLoss);
 /// Creates a criterion that optimizes a two-class classification
 /// logistic loss between input tensor :math:`x` and target tensor :math:`y`
 /// (containing 1 or -1).
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.SoftMarginLoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.SoftMarginLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftMarginLossOptions` class to learn
@@ -428,7 +428,7 @@ TORCH_MODULE(SoftMarginLoss);
 /// Creates a criterion that optimizes a multi-label one-versus-all
 /// loss based on max-entropy, between input :math:`x` and target :math:`y` of
 /// size :math:`(N, C)`. See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.MultiLabelSoftMarginLoss to
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.MultiLabelSoftMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiLabelSoftMarginLossOptions` class
@@ -472,7 +472,7 @@ TORCH_MODULE(MultiLabelSoftMarginLoss);
 /// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`,
 /// `positive examples` and `negative examples` respectively). The
 /// shapes of all input tensors should be :math:`(N, D)`.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.TripletMarginLoss to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.TripletMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TripletMarginLossOptions` class to
@@ -519,7 +519,7 @@ TORCH_MODULE(TripletMarginLoss);
 /// and positive example ("positive distance") and the anchor and negative
 /// example ("negative distance").
 /// See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.TripletMarginWithDistanceLoss
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.TripletMarginWithDistanceLoss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TripletMarginWithDistanceLossOptions`
@@ -562,7 +562,7 @@ TORCH_MODULE(TripletMarginWithDistanceLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CTCLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The Connectionist Temporal Classification loss.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.CTCLoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CTCLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CTCLossOptions` class to learn what
@@ -602,7 +602,7 @@ TORCH_MODULE(CTCLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Negative log likelihood loss with Poisson distribution of target.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.PoissonNLLLoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.PoissonNLLLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PoissonNLLLossOptions` class to learn
@@ -640,7 +640,7 @@ TORCH_MODULE(PoissonNLLLoss);
 /// Creates a criterion that measures the loss given
 /// inputs :math:`x1`, :math:`x2`, two 1D mini-batch `Tensors`,
 /// and a label 1D mini-batch tensor :math:`y` (containing 1 or -1).
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MarginRankingLoss to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MarginRankingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MarginRankingLossOptions` class to
@@ -680,7 +680,7 @@ TORCH_MODULE(MarginRankingLoss);
 
 /// The negative log likelihood loss. It is useful to train a classification
 /// problem with `C` classes.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.NLLLoss to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::NLLLossOptions` class to learn what
@@ -719,7 +719,7 @@ TORCH_MODULE(NLLLoss);
 
 /// Creates a criterion that computes cross entropy loss between input and
 /// target. See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.CrossEntropyLoss to learn
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.CrossEntropyLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CrossEntropyLossOptions` class to
@@ -761,7 +761,7 @@ TORCH_MODULE(CrossEntropyLoss);
 /// class. This version is more numerically stable than using a plain `Sigmoid`
 /// followed by a `BCELoss` as, by combining the operations into one layer,
 /// we take advantage of the log-sum-exp trick for numerical stability.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.BCEWithLogitsLoss to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BCEWithLogitsLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BCEWithLogitsLossOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -18,7 +18,7 @@ namespace torch::nn {
 
 /// Creates a criterion that measures the mean absolute error (MAE) between each
 /// element in the input : math :`x` and target : `y`.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.L1Loss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.L1Loss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::L1LossOptions` class to learn what
@@ -53,7 +53,7 @@ TORCH_MODULE(L1Loss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The Kullback-Leibler divergence loss measure
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.KLDivLoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.KLDivLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::KLDivLossOptions` class to learn what
@@ -88,7 +88,7 @@ TORCH_MODULE(KLDivLoss);
 
 /// Creates a criterion that measures the mean squared error (squared L2 norm)
 /// between each element in the input :math:`x` and target :math:`y`.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MSELoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MSELoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MSELossOptions` class to learn what
@@ -123,7 +123,7 @@ TORCH_MODULE(MSELoss);
 
 /// Creates a criterion that measures the Binary Cross Entropy
 /// between the target and the output.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BCELoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.BCELoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BCELossOptions` class to learn what
@@ -159,7 +159,7 @@ TORCH_MODULE(BCELoss);
 
 /// Creates a criterion that measures the loss given an input tensor :math:`x`
 /// and a labels tensor :math:`y` (containing 1 or -1).
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.HingeEmbeddingLoss to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.HingeEmbeddingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HingeEmbeddingLossOptions` class to
@@ -198,7 +198,7 @@ TORCH_MODULE(HingeEmbeddingLoss);
 /// loss (margin-based loss) between input :math:`x` (a 2D mini-batch `Tensor`)
 /// and output :math:`y` (which is a 1D tensor of target class indices, :math:`0
 /// \leq y \leq \text{x.size}(1)-1`). See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.MultiMarginLoss to learn
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MultiMarginLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiMarginLossOptions` class to learn
@@ -237,7 +237,7 @@ TORCH_MODULE(MultiMarginLoss);
 /// -1. This is used for measuring whether two inputs are similar or
 /// dissimilar, using the cosine distance, and is typically used for learning
 /// nonlinear embeddings or semi-supervised learning.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CosineEmbeddingLoss to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.CosineEmbeddingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CosineEmbeddingLossOptions` class to
@@ -279,7 +279,7 @@ TORCH_MODULE(CosineEmbeddingLoss);
 /// element-wise error falls below beta and an L1 term otherwise.
 /// It is less sensitive to outliers than the `MSELoss` and in some cases
 /// prevents exploding gradients (e.g. see the paper `Fast R-CNN` by Ross
-/// Girshick). See https://pytorch.org/docs/stable/nn.html#torch.nn.SmoothL1Loss
+/// Girshick). See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.SmoothL1Loss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SmoothL1LossOptions` class to learn
@@ -315,7 +315,7 @@ TORCH_MODULE(SmoothL1Loss);
 
 /// Creates a criterion that uses a squared term if the absolute
 /// element-wise error falls below delta and a delta-scaled L1 term otherwise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.HuberLoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.HuberLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HuberLossOptions` class to learn what
@@ -353,7 +353,7 @@ TORCH_MODULE(HuberLoss);
 /// hinge loss (margin-based loss) between input :math:`x` (a 2D mini-batch
 /// `Tensor`) and output :math:`y` (which is a 2D `Tensor` of target class
 /// indices). See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.MultiLabelMarginLoss to
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MultiLabelMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiLabelMarginLossOptions` class to
@@ -391,7 +391,7 @@ TORCH_MODULE(MultiLabelMarginLoss);
 /// Creates a criterion that optimizes a two-class classification
 /// logistic loss between input tensor :math:`x` and target tensor :math:`y`
 /// (containing 1 or -1).
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.SoftMarginLoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.SoftMarginLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftMarginLossOptions` class to learn
@@ -428,7 +428,7 @@ TORCH_MODULE(SoftMarginLoss);
 /// Creates a criterion that optimizes a multi-label one-versus-all
 /// loss based on max-entropy, between input :math:`x` and target :math:`y` of
 /// size :math:`(N, C)`. See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.MultiLabelSoftMarginLoss to
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MultiLabelSoftMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiLabelSoftMarginLossOptions` class
@@ -472,7 +472,7 @@ TORCH_MODULE(MultiLabelSoftMarginLoss);
 /// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`,
 /// `positive examples` and `negative examples` respectively). The
 /// shapes of all input tensors should be :math:`(N, D)`.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.TripletMarginLoss to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.TripletMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TripletMarginLossOptions` class to
@@ -519,7 +519,7 @@ TORCH_MODULE(TripletMarginLoss);
 /// and positive example ("positive distance") and the anchor and negative
 /// example ("negative distance").
 /// See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.TripletMarginWithDistanceLoss
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.TripletMarginWithDistanceLoss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TripletMarginWithDistanceLossOptions`
@@ -562,7 +562,7 @@ TORCH_MODULE(TripletMarginWithDistanceLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CTCLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The Connectionist Temporal Classification loss.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.CTCLoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.CTCLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CTCLossOptions` class to learn what
@@ -602,7 +602,7 @@ TORCH_MODULE(CTCLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Negative log likelihood loss with Poisson distribution of target.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.PoissonNLLLoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.PoissonNLLLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PoissonNLLLossOptions` class to learn
@@ -640,7 +640,7 @@ TORCH_MODULE(PoissonNLLLoss);
 /// Creates a criterion that measures the loss given
 /// inputs :math:`x1`, :math:`x2`, two 1D mini-batch `Tensors`,
 /// and a label 1D mini-batch tensor :math:`y` (containing 1 or -1).
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MarginRankingLoss to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MarginRankingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MarginRankingLossOptions` class to
@@ -680,7 +680,7 @@ TORCH_MODULE(MarginRankingLoss);
 
 /// The negative log likelihood loss. It is useful to train a classification
 /// problem with `C` classes.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::NLLLossOptions` class to learn what
@@ -719,7 +719,7 @@ TORCH_MODULE(NLLLoss);
 
 /// Creates a criterion that computes cross entropy loss between input and
 /// target. See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.CrossEntropyLoss to learn
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.CrossEntropyLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CrossEntropyLossOptions` class to
@@ -761,7 +761,7 @@ TORCH_MODULE(CrossEntropyLoss);
 /// class. This version is more numerically stable than using a plain `Sigmoid`
 /// followed by a `BCELoss` as, by combining the operations into one layer,
 /// we take advantage of the log-sum-exp trick for numerical stability.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.BCEWithLogitsLoss to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.BCEWithLogitsLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BCEWithLogitsLossOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/normalization.h
+++ b/torch/csrc/api/include/torch/nn/modules/normalization.h
@@ -17,7 +17,7 @@ namespace torch::nn {
 
 /// Applies Layer Normalization over a mini-batch of inputs as described in
 /// the paper `Layer Normalization`_ .
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LayerNorm to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LayerNorm to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LayerNormOptions` class to learn what
@@ -78,7 +78,7 @@ TORCH_MODULE(LayerNorm);
 /// Applies local response normalization over an input signal composed
 /// of several input planes, where channels occupy the second dimension.
 /// Applies normalization across channels.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LocalResponseNorm to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LocalResponseNorm to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LocalResponseNormOptions` class to
@@ -152,7 +152,7 @@ TORCH_MODULE(CrossMapLRN2d);
 
 /// Applies Group Normalization over a mini-batch of inputs as described in
 /// the paper `Group Normalization`_ .
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.GroupNorm to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GroupNorm to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GroupNormOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/normalization.h
+++ b/torch/csrc/api/include/torch/nn/modules/normalization.h
@@ -17,7 +17,7 @@ namespace torch::nn {
 
 /// Applies Layer Normalization over a mini-batch of inputs as described in
 /// the paper `Layer Normalization`_ .
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LayerNorm to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LayerNorm to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LayerNormOptions` class to learn what
@@ -78,7 +78,7 @@ TORCH_MODULE(LayerNorm);
 /// Applies local response normalization over an input signal composed
 /// of several input planes, where channels occupy the second dimension.
 /// Applies normalization across channels.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LocalResponseNorm to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LocalResponseNorm to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LocalResponseNormOptions` class to
@@ -152,7 +152,7 @@ TORCH_MODULE(CrossMapLRN2d);
 
 /// Applies Group Normalization over a mini-batch of inputs as described in
 /// the paper `Group Normalization`_ .
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GroupNorm to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.GroupNorm to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GroupNormOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/padding.h
+++ b/torch/csrc/api/include/torch/nn/modules/padding.h
@@ -31,7 +31,7 @@ class TORCH_API ReflectionPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReflectionPad1d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad1dOptions` class to learn
@@ -58,7 +58,7 @@ TORCH_MODULE(ReflectionPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReflectionPad2d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad2dOptions` class to learn
@@ -85,7 +85,7 @@ TORCH_MODULE(ReflectionPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReflectionPad3d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad3dOptions` class to learn
@@ -134,7 +134,7 @@ class TORCH_API ReplicationPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReplicationPad1d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad1dOptions` class to
@@ -161,7 +161,7 @@ TORCH_MODULE(ReplicationPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReplicationPad2d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad2dOptions` class to
@@ -188,7 +188,7 @@ TORCH_MODULE(ReplicationPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReplicationPad3d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad3dOptions` class to
@@ -298,7 +298,7 @@ class TORCH_API ConstantPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConstantPad1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad1dOptions` class to learn
@@ -324,7 +324,7 @@ TORCH_MODULE(ConstantPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConstantPad2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad2dOptions` class to learn
@@ -350,7 +350,7 @@ TORCH_MODULE(ConstantPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConstantPad3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/padding.h
+++ b/torch/csrc/api/include/torch/nn/modules/padding.h
@@ -31,7 +31,7 @@ class TORCH_API ReflectionPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad1d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad1dOptions` class to learn
@@ -58,7 +58,7 @@ TORCH_MODULE(ReflectionPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad2d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad2dOptions` class to learn
@@ -85,7 +85,7 @@ TORCH_MODULE(ReflectionPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad3d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReflectionPad3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad3dOptions` class to learn
@@ -134,7 +134,7 @@ class TORCH_API ReplicationPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad1d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad1dOptions` class to
@@ -161,7 +161,7 @@ TORCH_MODULE(ReplicationPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad2d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad2dOptions` class to
@@ -188,7 +188,7 @@ TORCH_MODULE(ReplicationPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad3d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ReplicationPad3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad3dOptions` class to
@@ -298,7 +298,7 @@ class TORCH_API ConstantPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad1dOptions` class to learn
@@ -324,7 +324,7 @@ TORCH_MODULE(ConstantPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad2dOptions` class to learn
@@ -350,7 +350,7 @@ TORCH_MODULE(ConstantPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.ConstantPad3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
@@ -14,7 +14,7 @@ namespace torch::nn {
 /// Rearranges elements in a tensor of shape :math:`(*, C \times r^2, H, W)`
 /// to a tensor of shape :math:`(*, C, H \times r, W \times r)`, where r is an
 /// upscale factor. See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.PixelShuffle to learn about
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.PixelShuffle to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PixelShuffleOptions` class to learn
@@ -51,7 +51,7 @@ TORCH_MODULE(PixelShuffle);
 /// Reverses the PixelShuffle operation by rearranging elements in a tensor of
 /// shape :math:`(*, C, H \times r, W \times r)` to a tensor of shape :math:`(*,
 /// C \times r^2, H, W)`, where r is a downscale factor. See
-/// https://pytorch.org/docs/stable/nn.html#torch.nn.PixelUnshuffle to learn
+/// https://docs.pytorch.org/docs/stable/nn.html#torch.nn.PixelUnshuffle to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PixelUnshuffleOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
@@ -14,7 +14,7 @@ namespace torch::nn {
 /// Rearranges elements in a tensor of shape :math:`(*, C \times r^2, H, W)`
 /// to a tensor of shape :math:`(*, C, H \times r, W \times r)`, where r is an
 /// upscale factor. See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.PixelShuffle to learn about
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.PixelShuffle to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PixelShuffleOptions` class to learn
@@ -51,7 +51,7 @@ TORCH_MODULE(PixelShuffle);
 /// Reverses the PixelShuffle operation by rearranging elements in a tensor of
 /// shape :math:`(*, C, H \times r, W \times r)` to a tensor of shape :math:`(*,
 /// C \times r^2, H, W)`, where r is a downscale factor. See
-/// https://pytorch.org/docs/main/nn.html#torch.nn.PixelUnshuffle to learn
+/// https://pytorch.org/docs/stable/nn.html#torch.nn.PixelUnshuffle to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PixelUnshuffleOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -30,7 +30,7 @@ class TORCH_API AvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AvgPool1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AvgPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool1dOptions` class to learn what
@@ -56,7 +56,7 @@ TORCH_MODULE(AvgPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AvgPool2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AvgPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool2dOptions` class to learn what
@@ -82,7 +82,7 @@ TORCH_MODULE(AvgPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AvgPool3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AvgPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool3dOptions` class to learn what
@@ -127,7 +127,7 @@ class TORCH_API MaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxPool1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool1dOptions` class to learn what
@@ -157,7 +157,7 @@ TORCH_MODULE(MaxPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxPool2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool2dOptions` class to learn what
@@ -187,7 +187,7 @@ TORCH_MODULE(MaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxPool3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool3dOptions` class to learn what
@@ -243,7 +243,7 @@ class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveMaxPool1d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool1dOptions` class to
@@ -276,7 +276,7 @@ TORCH_MODULE(AdaptiveMaxPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveMaxPool2d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool2dOptions` class to
@@ -313,7 +313,7 @@ TORCH_MODULE(AdaptiveMaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveMaxPool3d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool3dOptions` class to
@@ -376,7 +376,7 @@ class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveAvgPool1d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool1dOptions` class to
@@ -405,7 +405,7 @@ TORCH_MODULE(AdaptiveAvgPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveAvgPool2d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool2dOptions` class to
@@ -438,7 +438,7 @@ TORCH_MODULE(AdaptiveAvgPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveAvgPool3d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool3dOptions` class to
@@ -490,7 +490,7 @@ class TORCH_API MaxUnpoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 1-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxUnpool1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool1dOptions` class to learn
@@ -522,7 +522,7 @@ TORCH_MODULE(MaxUnpool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxUnpool2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool2dOptions` class to learn
@@ -554,7 +554,7 @@ TORCH_MODULE(MaxUnpool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxUnpool3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool3dOptions` class to learn
@@ -587,7 +587,7 @@ TORCH_MODULE(MaxUnpool3d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 2-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.FractionalMaxPool2d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.FractionalMaxPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FractionalMaxPool2dOptions` class to
@@ -632,7 +632,7 @@ TORCH_MODULE(FractionalMaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 3-D input.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.FractionalMaxPool3d to
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.FractionalMaxPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FractionalMaxPool3dOptions` class to
@@ -694,7 +694,7 @@ class TORCH_API LPPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool1d function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LPPool1d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LPPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool1dOptions` class to learn what
@@ -721,7 +721,7 @@ TORCH_MODULE(LPPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool2d function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LPPool2d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LPPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool2dOptions` class to learn what
@@ -749,7 +749,7 @@ TORCH_MODULE(LPPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool3d function element-wise.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LPPool3d to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LPPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool3dOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -30,7 +30,7 @@ class TORCH_API AvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AvgPool1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AvgPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool1dOptions` class to learn what
@@ -56,7 +56,7 @@ TORCH_MODULE(AvgPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AvgPool2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AvgPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool2dOptions` class to learn what
@@ -82,7 +82,7 @@ TORCH_MODULE(AvgPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AvgPool3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AvgPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool3dOptions` class to learn what
@@ -127,7 +127,7 @@ class TORCH_API MaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxPool1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MaxPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool1dOptions` class to learn what
@@ -157,7 +157,7 @@ TORCH_MODULE(MaxPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxPool2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MaxPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool2dOptions` class to learn what
@@ -187,7 +187,7 @@ TORCH_MODULE(MaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxPool3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MaxPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool3dOptions` class to learn what
@@ -243,7 +243,7 @@ class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool1d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool1dOptions` class to
@@ -276,7 +276,7 @@ TORCH_MODULE(AdaptiveMaxPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool2d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool2dOptions` class to
@@ -313,7 +313,7 @@ TORCH_MODULE(AdaptiveMaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool3d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveMaxPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool3dOptions` class to
@@ -376,7 +376,7 @@ class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool1d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool1dOptions` class to
@@ -405,7 +405,7 @@ TORCH_MODULE(AdaptiveAvgPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool2d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool2dOptions` class to
@@ -438,7 +438,7 @@ TORCH_MODULE(AdaptiveAvgPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool3d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.AdaptiveAvgPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool3dOptions` class to
@@ -490,7 +490,7 @@ class TORCH_API MaxUnpoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 1-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool1dOptions` class to learn
@@ -522,7 +522,7 @@ TORCH_MODULE(MaxUnpool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool2dOptions` class to learn
@@ -554,7 +554,7 @@ TORCH_MODULE(MaxUnpool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.MaxUnpool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool3dOptions` class to learn
@@ -587,7 +587,7 @@ TORCH_MODULE(MaxUnpool3d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 2-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.FractionalMaxPool2d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.FractionalMaxPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FractionalMaxPool2dOptions` class to
@@ -632,7 +632,7 @@ TORCH_MODULE(FractionalMaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 3-D input.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.FractionalMaxPool3d to
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.FractionalMaxPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FractionalMaxPool3dOptions` class to
@@ -694,7 +694,7 @@ class TORCH_API LPPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool1d function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LPPool1d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LPPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool1dOptions` class to learn what
@@ -721,7 +721,7 @@ TORCH_MODULE(LPPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool2d function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LPPool2d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LPPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool2dOptions` class to learn what
@@ -749,7 +749,7 @@ TORCH_MODULE(LPPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool3d function element-wise.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LPPool3d to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LPPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool3dOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -90,7 +90,7 @@ class TORCH_API RNNImplBase : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer Elman RNN module with Tanh or ReLU activation.
-/// See https://pytorch.org/docs/main/generated/torch.nn.RNN.html to learn
+/// See https://pytorch.org/docs/stable/generated/torch.nn.RNN.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RNNOptions` class to learn what
@@ -139,7 +139,7 @@ TORCH_MODULE(RNN);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LSTM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer long-short-term-memory (LSTM) module.
-/// See https://pytorch.org/docs/main/generated/torch.nn.LSTM.html to learn
+/// See https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LSTMOptions` class to learn what
@@ -204,7 +204,7 @@ TORCH_MODULE(LSTM);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer gated recurrent unit (GRU) module.
-/// See https://pytorch.org/docs/main/generated/torch.nn.GRU.html to learn
+/// See https://pytorch.org/docs/stable/generated/torch.nn.GRU.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GRUOptions` class to learn what
@@ -285,7 +285,7 @@ class TORCH_API RNNCellImplBase : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// An Elman RNN cell with tanh or ReLU non-linearity.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.RNNCell to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.RNNCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RNNCellOptions` class to learn what
@@ -325,7 +325,7 @@ TORCH_MODULE(RNNCell);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A long short-term memory (LSTM) cell.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.LSTMCell to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LSTMCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LSTMCellOptions` class to learn what
@@ -364,7 +364,7 @@ TORCH_MODULE(LSTMCell);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A gated recurrent unit (GRU) cell.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.GRUCell to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GRUCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GRUCellOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -90,7 +90,7 @@ class TORCH_API RNNImplBase : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer Elman RNN module with Tanh or ReLU activation.
-/// See https://pytorch.org/docs/stable/generated/torch.nn.RNN.html to learn
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.RNN.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RNNOptions` class to learn what
@@ -139,7 +139,7 @@ TORCH_MODULE(RNN);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LSTM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer long-short-term-memory (LSTM) module.
-/// See https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html to learn
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.LSTM.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LSTMOptions` class to learn what
@@ -204,7 +204,7 @@ TORCH_MODULE(LSTM);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer gated recurrent unit (GRU) module.
-/// See https://pytorch.org/docs/stable/generated/torch.nn.GRU.html to learn
+/// See https://docs.pytorch.org/docs/stable/generated/torch.nn.GRU.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GRUOptions` class to learn what
@@ -285,7 +285,7 @@ class TORCH_API RNNCellImplBase : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// An Elman RNN cell with tanh or ReLU non-linearity.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.RNNCell to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.RNNCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RNNCellOptions` class to learn what
@@ -325,7 +325,7 @@ TORCH_MODULE(RNNCell);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A long short-term memory (LSTM) cell.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.LSTMCell to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LSTMCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LSTMCellOptions` class to learn what
@@ -364,7 +364,7 @@ TORCH_MODULE(LSTMCell);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A gated recurrent unit (GRU) cell.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.GRUCell to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.GRUCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GRUCellOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/transformercoder.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformercoder.h
@@ -19,7 +19,7 @@ namespace torch::nn {
 
 /// TransformerEncoder module.
 /// See
-/// https://pytorch.org/docs/stable/generated/torch.nn.TransformerEncoder.html
+/// https://docs.pytorch.org/docs/stable/generated/torch.nn.TransformerEncoder.html
 /// to learn abouut the exact behavior of this encoder layer module.
 ///
 /// See the documentation for `torch::nn::TransformerEncoder` class to learn
@@ -78,7 +78,7 @@ TORCH_MODULE(TransformerEncoder);
 
 /// TransformerDecoder is a stack of N decoder layers.
 /// See
-/// https://pytorch.org/docs/stable/generated/torch.nn.TransformerDecoder.html
+/// https://docs.pytorch.org/docs/stable/generated/torch.nn.TransformerDecoder.html
 /// to learn abouut the exact behavior of this decoder module
 ///
 /// See the documentation for `torch::nn::TransformerDecoderOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/transformercoder.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformercoder.h
@@ -19,7 +19,7 @@ namespace torch::nn {
 
 /// TransformerEncoder module.
 /// See
-/// https://pytorch.org/docs/main/generated/torch.nn.TransformerEncoder.html
+/// https://pytorch.org/docs/stable/generated/torch.nn.TransformerEncoder.html
 /// to learn abouut the exact behavior of this encoder layer module.
 ///
 /// See the documentation for `torch::nn::TransformerEncoder` class to learn
@@ -78,7 +78,7 @@ TORCH_MODULE(TransformerEncoder);
 
 /// TransformerDecoder is a stack of N decoder layers.
 /// See
-/// https://pytorch.org/docs/main/generated/torch.nn.TransformerDecoder.html
+/// https://pytorch.org/docs/stable/generated/torch.nn.TransformerDecoder.html
 /// to learn abouut the exact behavior of this decoder module
 ///
 /// See the documentation for `torch::nn::TransformerDecoderOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
@@ -21,7 +21,7 @@ namespace torch::nn {
 
 /// TransformerEncoderLayer module.
 /// See
-/// https://pytorch.org/docs/main/generated/torch.nn.TransformerEncoderLayer.html
+/// https://pytorch.org/docs/stable/generated/torch.nn.TransformerEncoderLayer.html
 /// to learn abouut the exact behavior of this encoder layer model
 ///
 /// See the documentation for `torch::nn::TransformerEncoderLayer` class to
@@ -96,7 +96,7 @@ TORCH_MODULE(TransformerEncoderLayer);
 /// Polosukhin. 2017. Attention is all you need. In Advances in Neural
 /// Information Processing Systems, pages 6000-6010. Users may modify or
 /// implement in a different way during application. See
-/// https://pytorch.org/docs/main/nn.html#transformer-layers to learn about
+/// https://pytorch.org/docs/stable/nn.html#transformer-layers to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TransformerDecoderLayerOptions` class

--- a/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
@@ -21,7 +21,7 @@ namespace torch::nn {
 
 /// TransformerEncoderLayer module.
 /// See
-/// https://pytorch.org/docs/stable/generated/torch.nn.TransformerEncoderLayer.html
+/// https://docs.pytorch.org/docs/stable/generated/torch.nn.TransformerEncoderLayer.html
 /// to learn abouut the exact behavior of this encoder layer model
 ///
 /// See the documentation for `torch::nn::TransformerEncoderLayer` class to
@@ -96,7 +96,7 @@ TORCH_MODULE(TransformerEncoderLayer);
 /// Polosukhin. 2017. Attention is all you need. In Advances in Neural
 /// Information Processing Systems, pages 6000-6010. Users may modify or
 /// implement in a different way during application. See
-/// https://pytorch.org/docs/stable/nn.html#transformer-layers to learn about
+/// https://docs.pytorch.org/docs/stable/nn.html#transformer-layers to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TransformerDecoderLayerOptions` class

--- a/torch/csrc/api/include/torch/nn/modules/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/modules/upsampling.h
@@ -17,7 +17,7 @@ namespace torch::nn {
 
 /// Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D
 /// (volumetric) data.
-/// See https://pytorch.org/docs/main/nn.html#torch.nn.Upsample to learn
+/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Upsample to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UpsampleOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/modules/upsampling.h
@@ -17,7 +17,7 @@ namespace torch::nn {
 
 /// Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D
 /// (volumetric) data.
-/// See https://pytorch.org/docs/stable/nn.html#torch.nn.Upsample to learn
+/// See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.Upsample to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UpsampleOptions` class to learn what

--- a/torch/csrc/api/include/torch/special.h
+++ b/torch/csrc/api/include/torch/special.h
@@ -6,7 +6,7 @@
 namespace torch::special {
 
 /// Computes the natural logarithm of the absolute value of the gamma function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.gammaln.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.gammaln.
 ///
 /// Example:
 /// ```
@@ -22,7 +22,7 @@ inline Tensor& gammaln_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the regularized lower incomplete gamma function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.gammainc.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.gammainc.
 ///
 /// Example:
 /// ```
@@ -42,7 +42,7 @@ inline Tensor& gammainc_out(
 }
 
 /// Computes the regularized upper incomplete gamma function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.gammainc.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.gammainc.
 ///
 /// Example:
 /// ```
@@ -62,7 +62,7 @@ inline Tensor& gammaincc_out(
 }
 
 /// Computes the multivariate log-gamma function with dimension `p`, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.multigammaln.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.multigammaln.
 ///
 /// Example:
 /// ```
@@ -78,7 +78,7 @@ inline Tensor& multigammaln_out(Tensor& result, const Tensor& self, int64_t p) {
 }
 
 /// Computes the nth derivative of the digamma function on the input.
-/// See https://pytorch.org/docs/stable/special.html#torch.special.polygamma.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.polygamma.
 ///
 /// Example:
 /// ```
@@ -94,7 +94,7 @@ inline Tensor& polygamma_out(Tensor& result, int64_t n, const Tensor& self) {
 }
 
 /// Computes the logarithmic derivative of the gamma function on input
-/// See https://pytorch.org/docs/stable/special.html#torch.special.psi
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.psi
 ///
 /// Example:
 /// ```
@@ -110,7 +110,7 @@ inline Tensor& psi_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the logarithmic derivative of the gamma function on input
-/// See https://pytorch.org/docs/stable/special.html#torch.special.digamma
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.digamma
 ///
 /// Example:
 /// ```
@@ -126,7 +126,7 @@ inline Tensor& digamma_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes entropy of input, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.entr.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.entr.
 ///
 /// Example:
 /// ```
@@ -142,7 +142,7 @@ inline Tensor& entr_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the error function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.erf.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.erf.
 ///
 /// Example:
 /// ```
@@ -158,7 +158,7 @@ inline Tensor& erf_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the complementary error function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.erfc.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.erfc.
 ///
 /// Example:
 /// ```
@@ -174,7 +174,7 @@ inline Tensor& erfc_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the scaled complementary error function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.erfcx.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.erfcx.
 ///
 /// Example:
 /// ```
@@ -190,7 +190,7 @@ inline Tensor& erfcx_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the inverse error function
-/// See https://pytorch.org/docs/stable/special.html#torch.special.erfinv.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.erfinv.
 ///
 /// Example:
 /// ```
@@ -207,7 +207,7 @@ inline Tensor& erfinv_out(Tensor& result, const Tensor& self) {
 
 /// Computes the log of summed exponentials of each row of input in the given
 /// dimension dim See
-/// https://pytorch.org/docs/stable/special.html#torch.special.logsumexp.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.logsumexp.
 ///
 /// Example:
 /// ```
@@ -229,7 +229,7 @@ inline Tensor& logsumexp_out(
 /// Computes the argument, x, for which the area under the Gaussian probability
 /// density function (integrated from minus infinity to x) is equal to input,
 /// elementwise. See
-/// https://pytorch.org/docs/stable/special.html#torch.special.ndtri
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.ndtri
 ///
 /// Example:
 /// ```
@@ -246,7 +246,7 @@ inline Tensor& ndtri_out(Tensor& result, const Tensor& self) {
 
 /// Computes the log of area under the standard Gaussian probability density
 /// function, integrated from minus infinity to :attr:`input`, elementwise See
-/// https://pytorch.org/docs/stable/special.html#torch.special.log_ndtr
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.log_ndtr
 ///
 /// Example:
 /// ```
@@ -262,7 +262,7 @@ inline Tensor& log_ndtr_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the logit of input, elementwise.
-/// See https://pytorch.org/docs/stable/special.html#torch.special.logit.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.logit.
 ///
 /// Example:
 /// ```
@@ -279,7 +279,7 @@ inline Tensor& logit_out(Tensor& result, const Tensor& self) {
 
 /// Computes the expit (also known as the logistic sigmoid function) of input,
 /// elementwise See
-/// https://pytorch.org/docs/stable/special.html#torch.special.expit.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.expit.
 ///
 /// Example:
 /// ```
@@ -295,7 +295,7 @@ inline Tensor& expit_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the base two exponential function of :attr:`input`, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.exp2.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.exp2.
 ///
 /// Example:
 /// ```
@@ -311,7 +311,7 @@ inline Tensor& exp2_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the exponential of the elements minus 1, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.expm1.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.expm1.
 ///
 /// Example:
 /// ```
@@ -327,7 +327,7 @@ inline Tensor& expm1_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes x * log(y) for inputs, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.xlogy.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.xlogy.
 ///
 /// Example:
 /// ```
@@ -369,7 +369,7 @@ inline Tensor& xlogy_out(
 }
 
 /// Computes x * log1p(y) for inputs, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.xlog1py.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.xlog1py.
 ///
 /// Example:
 /// ```
@@ -411,7 +411,7 @@ inline Tensor& xlog1py_out(
 }
 
 /// Computes Hurwitz Zeta function for inputs, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.zeta.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.zeta.
 ///
 /// Example:
 /// ```
@@ -454,7 +454,7 @@ inline Tensor& zeta_out(
 
 /// Computes the zeroth order modified Bessel function of the first kind of
 /// input, elementwise See
-/// https://pytorch.org/docs/stable/special.html#torch.special.i0
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.i0
 ///
 /// Example:
 /// ```
@@ -471,7 +471,7 @@ inline Tensor& i0_out(Tensor& result, const Tensor& self) {
 
 /// Computes the area under the standard Gaussian probability density function,
 /// integrated from minus infinity to :attr:`input`, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.ndtr
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.ndtr
 ///
 /// Example:
 /// ```
@@ -488,7 +488,7 @@ inline Tensor& ndtr_out(Tensor& result, const Tensor& self) {
 
 /// Computes the exponentially scaled zeroth order modified Bessel function of
 /// the first kind See
-/// https://pytorch.org/docs/stable/special.html#torch.special.i0e.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.i0e.
 ///
 /// Example:
 /// ```
@@ -504,7 +504,7 @@ inline Tensor& i0e_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the first order modified Bessel function of the first kind
-/// See https://pytorch.org/docs/stable/special.html#torch.special.i1.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.i1.
 ///
 /// Example:
 /// ```
@@ -521,7 +521,7 @@ inline Tensor& i1_out(Tensor& result, const Tensor& self) {
 
 /// Computes the exponentially scaled first order modified Bessel function of
 /// the first kind See
-/// https://pytorch.org/docs/stable/special.html#torch.special.i1e.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.i1e.
 ///
 /// Example:
 /// ```
@@ -537,7 +537,7 @@ inline Tensor& i1e_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the sinc of input, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.sinc.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.sinc.
 ///
 /// Example:
 /// ```
@@ -553,7 +553,7 @@ inline Tensor& sinc_out(Tensor& result, const Tensor& self) {
 }
 
 /// Rounds the elements of the input
-/// See https://pytorch.org/docs/stable/special.html#torch.special.round.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.round.
 ///
 /// Example:
 /// ```
@@ -569,7 +569,7 @@ inline Tensor& round_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes log(1 + x) of the input, elementwise
-/// See https://pytorch.org/docs/stable/special.html#torch.special.log1p.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.log1p.
 ///
 /// Example:
 /// ```
@@ -585,7 +585,7 @@ inline Tensor& log1p_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes log followed by softmax(x) of the input
-/// See https://pytorch.org/docs/stable/special.html#torch.special.log_softmax.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.log_softmax.
 ///
 /// Example:
 /// ```
@@ -600,7 +600,7 @@ inline Tensor log_softmax(
 }
 
 /// Computes softmax of the input along a given dimension
-/// See https://pytorch.org/docs/stable/special.html#torch.special.softmax.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.softmax.
 ///
 /// Example:
 /// ```
@@ -616,7 +616,7 @@ inline Tensor softmax(
 
 /// Airy function Ai.
 ///
-/// See https://pytorch.org/docs/stable/special.html#torch.special.airy_ai.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.airy_ai.
 ///
 /// Example:
 ///
@@ -635,7 +635,7 @@ inline Tensor& airy_ai_out(Tensor& y, const Tensor& x) {
 
 /// Bessel function of the first kind of order 0.
 ///
-/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_j0.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.bessel_j0.
 ///
 /// Example:
 ///
@@ -654,7 +654,7 @@ inline Tensor& bessel_j0_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the first kind of order 1.
 ///
-/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_j1.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.bessel_j1.
 ///
 /// Example:
 ///
@@ -673,7 +673,7 @@ inline Tensor& bessel_j1_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the second kind of order 0.
 ///
-/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_y0.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.bessel_y0.
 ///
 /// Example:
 ///
@@ -692,7 +692,7 @@ inline Tensor& bessel_y0_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the second kind of order 1.
 ///
-/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_y1.
+/// See https://docs.pytorch.org/docs/stable/special.html#torch.special.bessel_y1.
 ///
 /// Example:
 ///
@@ -712,7 +712,7 @@ inline Tensor& bessel_y1_out(Tensor& result, const Tensor& self) {
 /// Chebyshev polynomial of the first kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_t.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_t.
 ///
 /// Example:
 ///
@@ -758,7 +758,7 @@ inline Tensor& chebyshev_polynomial_t_out(
 /// Chebyshev polynomial of the second kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_u.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_u.
 ///
 /// Example:
 ///
@@ -804,7 +804,7 @@ inline Tensor& chebyshev_polynomial_u_out(
 /// Chebyshev polynomial of the third kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_v.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_v.
 ///
 /// Example:
 ///
@@ -850,7 +850,7 @@ inline Tensor& chebyshev_polynomial_v_out(
 /// Chebyshev polynomial of the fourth kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_w.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_w.
 ///
 /// Example:
 ///
@@ -896,7 +896,7 @@ inline Tensor& chebyshev_polynomial_w_out(
 /// Physicist’s Hermite polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.hermite_polynomial_h.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.hermite_polynomial_h.
 ///
 /// Example:
 ///
@@ -942,7 +942,7 @@ inline Tensor& hermite_polynomial_h_out(
 /// Probabilist’s Hermite polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.hermite_polynomial_he.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.hermite_polynomial_he.
 ///
 /// Example:
 ///
@@ -988,7 +988,7 @@ inline Tensor& hermite_polynomial_he_out(
 /// Laguerre polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.laguerre_polynomial_l.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.laguerre_polynomial_l.
 ///
 /// Example:
 ///
@@ -1034,7 +1034,7 @@ inline Tensor& laguerre_polynomial_l_out(
 /// Legendre polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.legendre_polynomial_p.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.legendre_polynomial_p.
 ///
 /// Example:
 ///
@@ -1080,7 +1080,7 @@ inline Tensor& legendre_polynomial_p_out(
 /// Modified Bessel function of the first kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_i0.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.modified_bessel_i0.
 ///
 /// Example:
 ///
@@ -1100,7 +1100,7 @@ inline Tensor& modified_bessel_i0_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the first kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_i1.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.modified_bessel_i1.
 ///
 /// Example:
 ///
@@ -1120,7 +1120,7 @@ inline Tensor& modified_bessel_i1_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the second kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_k0.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.modified_bessel_k0.
 ///
 /// Example:
 ///
@@ -1140,7 +1140,7 @@ inline Tensor& modified_bessel_k0_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the second kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_k1.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.modified_bessel_k1.
 ///
 /// Example:
 ///
@@ -1160,7 +1160,7 @@ inline Tensor& modified_bessel_k1_out(Tensor& result, const Tensor& self) {
 /// Scaled modified Bessel function of the second kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.scaled_modified_bessel_k0.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.scaled_modified_bessel_k0.
 ///
 /// Example:
 ///
@@ -1180,7 +1180,7 @@ inline Tensor& scaled_modified_bessel_k0_out(Tensor& y, const Tensor& x) {
 /// Scaled modified Bessel function of the second kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.scaled_modified_bessel_k1.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.scaled_modified_bessel_k1.
 ///
 /// Example:
 ///
@@ -1200,7 +1200,7 @@ inline Tensor& scaled_modified_bessel_k1_out(Tensor& y, const Tensor& x) {
 /// Shifted Chebyshev polynomial of the first kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_t.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_t.
 ///
 /// Example:
 ///
@@ -1246,7 +1246,7 @@ inline Tensor& shifted_chebyshev_polynomial_t_out(
 /// Shifted Chebyshev polynomial of the second kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_u.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_u.
 ///
 /// Example:
 ///
@@ -1292,7 +1292,7 @@ inline Tensor& shifted_chebyshev_polynomial_u_out(
 /// Shifted Chebyshev polynomial of the third kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_v.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_v.
 ///
 /// Example:
 ///
@@ -1338,7 +1338,7 @@ inline Tensor& shifted_chebyshev_polynomial_v_out(
 /// Shifted Chebyshev polynomial of the fourth kind.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_w.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_w.
 ///
 /// Example:
 ///
@@ -1384,7 +1384,7 @@ inline Tensor& shifted_chebyshev_polynomial_w_out(
 /// Spherical Bessel function of the first kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/stable/special.html#torch.special.spherical_bessel_j0.
+/// https://docs.pytorch.org/docs/stable/special.html#torch.special.spherical_bessel_j0.
 ///
 /// Example:
 ///

--- a/torch/csrc/api/include/torch/special.h
+++ b/torch/csrc/api/include/torch/special.h
@@ -6,7 +6,7 @@
 namespace torch::special {
 
 /// Computes the natural logarithm of the absolute value of the gamma function
-/// See https://pytorch.org/docs/main/special.html#torch.special.gammaln.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.gammaln.
 ///
 /// Example:
 /// ```
@@ -22,7 +22,7 @@ inline Tensor& gammaln_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the regularized lower incomplete gamma function
-/// See https://pytorch.org/docs/main/special.html#torch.special.gammainc.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.gammainc.
 ///
 /// Example:
 /// ```
@@ -42,7 +42,7 @@ inline Tensor& gammainc_out(
 }
 
 /// Computes the regularized upper incomplete gamma function
-/// See https://pytorch.org/docs/main/special.html#torch.special.gammainc.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.gammainc.
 ///
 /// Example:
 /// ```
@@ -62,7 +62,7 @@ inline Tensor& gammaincc_out(
 }
 
 /// Computes the multivariate log-gamma function with dimension `p`, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.multigammaln.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.multigammaln.
 ///
 /// Example:
 /// ```
@@ -78,7 +78,7 @@ inline Tensor& multigammaln_out(Tensor& result, const Tensor& self, int64_t p) {
 }
 
 /// Computes the nth derivative of the digamma function on the input.
-/// See https:://pytorch.org/docs/main/special.html#torch.special.polygamma.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.polygamma.
 ///
 /// Example:
 /// ```
@@ -94,7 +94,7 @@ inline Tensor& polygamma_out(Tensor& result, int64_t n, const Tensor& self) {
 }
 
 /// Computes the logarithmic derivative of the gamma function on input
-/// See https://pytorch.org/docs/main/special.html#torch.special.psi
+/// See https://pytorch.org/docs/stable/special.html#torch.special.psi
 ///
 /// Example:
 /// ```
@@ -110,7 +110,7 @@ inline Tensor& psi_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the logarithmic derivative of the gamma function on input
-/// See https://pytorch.org/docs/main/special.html#torch.special.digamma
+/// See https://pytorch.org/docs/stable/special.html#torch.special.digamma
 ///
 /// Example:
 /// ```
@@ -126,7 +126,7 @@ inline Tensor& digamma_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes entropy of input, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.entr.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.entr.
 ///
 /// Example:
 /// ```
@@ -142,7 +142,7 @@ inline Tensor& entr_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the error function
-/// See https://pytorch.org/docs/main/special.html#torch.special.erf.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.erf.
 ///
 /// Example:
 /// ```
@@ -158,7 +158,7 @@ inline Tensor& erf_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the complementary error function
-/// See https://pytorch.org/docs/main/special.html#torch.special.erfc.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.erfc.
 ///
 /// Example:
 /// ```
@@ -174,7 +174,7 @@ inline Tensor& erfc_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the scaled complementary error function
-/// See https://pytorch.org/docs/main/special.html#torch.special.erfcx.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.erfcx.
 ///
 /// Example:
 /// ```
@@ -190,7 +190,7 @@ inline Tensor& erfcx_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the inverse error function
-/// See https://pytorch.org/docs/main/special.html#torch.special.erfinv.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.erfinv.
 ///
 /// Example:
 /// ```
@@ -207,7 +207,7 @@ inline Tensor& erfinv_out(Tensor& result, const Tensor& self) {
 
 /// Computes the log of summed exponentials of each row of input in the given
 /// dimension dim See
-/// https://pytorch.org/docs/main/special.html#torch.special.logsumexp.
+/// https://pytorch.org/docs/stable/special.html#torch.special.logsumexp.
 ///
 /// Example:
 /// ```
@@ -229,7 +229,7 @@ inline Tensor& logsumexp_out(
 /// Computes the argument, x, for which the area under the Gaussian probability
 /// density function (integrated from minus infinity to x) is equal to input,
 /// elementwise. See
-/// https://pytorch.org/docs/main/special.html#torch.special.ndtri
+/// https://pytorch.org/docs/stable/special.html#torch.special.ndtri
 ///
 /// Example:
 /// ```
@@ -246,7 +246,7 @@ inline Tensor& ndtri_out(Tensor& result, const Tensor& self) {
 
 /// Computes the log of area under the standard Gaussian probability density
 /// function, integrated from minus infinity to :attr:`input`, elementwise See
-/// https://pytorch.org/docs/main/special.html#torch.special.log_ndtr
+/// https://pytorch.org/docs/stable/special.html#torch.special.log_ndtr
 ///
 /// Example:
 /// ```
@@ -262,7 +262,7 @@ inline Tensor& log_ndtr_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the logit of input, elementwise.
-/// See https://pytorch.org/docs/main/special.html#torch.special.logit.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.logit.
 ///
 /// Example:
 /// ```
@@ -279,7 +279,7 @@ inline Tensor& logit_out(Tensor& result, const Tensor& self) {
 
 /// Computes the expit (also known as the logistic sigmoid function) of input,
 /// elementwise See
-/// https://pytorch.org/docs/main/special.html#torch.special.expit.
+/// https://pytorch.org/docs/stable/special.html#torch.special.expit.
 ///
 /// Example:
 /// ```
@@ -295,7 +295,7 @@ inline Tensor& expit_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the base two exponential function of :attr:`input`, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.exp2.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.exp2.
 ///
 /// Example:
 /// ```
@@ -311,7 +311,7 @@ inline Tensor& exp2_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the exponential of the elements minus 1, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.expm1.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.expm1.
 ///
 /// Example:
 /// ```
@@ -327,7 +327,7 @@ inline Tensor& expm1_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes x * log(y) for inputs, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.xlogy.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.xlogy.
 ///
 /// Example:
 /// ```
@@ -369,7 +369,7 @@ inline Tensor& xlogy_out(
 }
 
 /// Computes x * log1p(y) for inputs, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.xlog1py.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.xlog1py.
 ///
 /// Example:
 /// ```
@@ -411,7 +411,7 @@ inline Tensor& xlog1py_out(
 }
 
 /// Computes Hurwitz Zeta function for inputs, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.zeta.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.zeta.
 ///
 /// Example:
 /// ```
@@ -454,7 +454,7 @@ inline Tensor& zeta_out(
 
 /// Computes the zeroth order modified Bessel function of the first kind of
 /// input, elementwise See
-/// https://pytorch.org/docs/main/special.html#torch.special.i0
+/// https://pytorch.org/docs/stable/special.html#torch.special.i0
 ///
 /// Example:
 /// ```
@@ -471,7 +471,7 @@ inline Tensor& i0_out(Tensor& result, const Tensor& self) {
 
 /// Computes the area under the standard Gaussian probability density function,
 /// integrated from minus infinity to :attr:`input`, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.ndtr
+/// See https://pytorch.org/docs/stable/special.html#torch.special.ndtr
 ///
 /// Example:
 /// ```
@@ -488,7 +488,7 @@ inline Tensor& ndtr_out(Tensor& result, const Tensor& self) {
 
 /// Computes the exponentially scaled zeroth order modified Bessel function of
 /// the first kind See
-/// https://pytorch.org/docs/main/special.html#torch.special.i0e.
+/// https://pytorch.org/docs/stable/special.html#torch.special.i0e.
 ///
 /// Example:
 /// ```
@@ -504,7 +504,7 @@ inline Tensor& i0e_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the first order modified Bessel function of the first kind
-/// See https://pytorch.org/docs/main/special.html#torch.special.i1.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.i1.
 ///
 /// Example:
 /// ```
@@ -521,7 +521,7 @@ inline Tensor& i1_out(Tensor& result, const Tensor& self) {
 
 /// Computes the exponentially scaled first order modified Bessel function of
 /// the first kind See
-/// https://pytorch.org/docs/main/special.html#torch.special.i1e.
+/// https://pytorch.org/docs/stable/special.html#torch.special.i1e.
 ///
 /// Example:
 /// ```
@@ -537,7 +537,7 @@ inline Tensor& i1e_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the sinc of input, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.sinc.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.sinc.
 ///
 /// Example:
 /// ```
@@ -553,7 +553,7 @@ inline Tensor& sinc_out(Tensor& result, const Tensor& self) {
 }
 
 /// Rounds the elements of the input
-/// See https://pytorch.org/docs/main/special.html#torch.special.round.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.round.
 ///
 /// Example:
 /// ```
@@ -569,7 +569,7 @@ inline Tensor& round_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes log(1 + x) of the input, elementwise
-/// See https://pytorch.org/docs/main/special.html#torch.special.log1p.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.log1p.
 ///
 /// Example:
 /// ```
@@ -585,7 +585,7 @@ inline Tensor& log1p_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes log followed by softmax(x) of the input
-/// See https://pytorch.org/docs/main/special.html#torch.special.log_softmax.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.log_softmax.
 ///
 /// Example:
 /// ```
@@ -600,7 +600,7 @@ inline Tensor log_softmax(
 }
 
 /// Computes softmax of the input along a given dimension
-/// See https://pytorch.org/docs/main/special.html#torch.special.softmax.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.softmax.
 ///
 /// Example:
 /// ```
@@ -616,7 +616,7 @@ inline Tensor softmax(
 
 /// Airy function Ai.
 ///
-/// See https://pytorch.org/docs/main/special.html#torch.special.airy_ai.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.airy_ai.
 ///
 /// Example:
 ///
@@ -635,7 +635,7 @@ inline Tensor& airy_ai_out(Tensor& y, const Tensor& x) {
 
 /// Bessel function of the first kind of order 0.
 ///
-/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_j0.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_j0.
 ///
 /// Example:
 ///
@@ -654,7 +654,7 @@ inline Tensor& bessel_j0_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the first kind of order 1.
 ///
-/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_j1.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_j1.
 ///
 /// Example:
 ///
@@ -673,7 +673,7 @@ inline Tensor& bessel_j1_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the second kind of order 0.
 ///
-/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_y0.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_y0.
 ///
 /// Example:
 ///
@@ -692,7 +692,7 @@ inline Tensor& bessel_y0_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the second kind of order 1.
 ///
-/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_y1.
+/// See https://pytorch.org/docs/stable/special.html#torch.special.bessel_y1.
 ///
 /// Example:
 ///
@@ -712,7 +712,7 @@ inline Tensor& bessel_y1_out(Tensor& result, const Tensor& self) {
 /// Chebyshev polynomial of the first kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_t.
+/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_t.
 ///
 /// Example:
 ///
@@ -758,7 +758,7 @@ inline Tensor& chebyshev_polynomial_t_out(
 /// Chebyshev polynomial of the second kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_u.
+/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_u.
 ///
 /// Example:
 ///
@@ -804,7 +804,7 @@ inline Tensor& chebyshev_polynomial_u_out(
 /// Chebyshev polynomial of the third kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_v.
+/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_v.
 ///
 /// Example:
 ///
@@ -850,7 +850,7 @@ inline Tensor& chebyshev_polynomial_v_out(
 /// Chebyshev polynomial of the fourth kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_w.
+/// https://pytorch.org/docs/stable/special.html#torch.special.chebyshev_polynomial_w.
 ///
 /// Example:
 ///
@@ -896,7 +896,7 @@ inline Tensor& chebyshev_polynomial_w_out(
 /// Physicist’s Hermite polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.hermite_polynomial_h.
+/// https://pytorch.org/docs/stable/special.html#torch.special.hermite_polynomial_h.
 ///
 /// Example:
 ///
@@ -942,7 +942,7 @@ inline Tensor& hermite_polynomial_h_out(
 /// Probabilist’s Hermite polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.hermite_polynomial_he.
+/// https://pytorch.org/docs/stable/special.html#torch.special.hermite_polynomial_he.
 ///
 /// Example:
 ///
@@ -988,7 +988,7 @@ inline Tensor& hermite_polynomial_he_out(
 /// Laguerre polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.laguerre_polynomial_l.
+/// https://pytorch.org/docs/stable/special.html#torch.special.laguerre_polynomial_l.
 ///
 /// Example:
 ///
@@ -1034,7 +1034,7 @@ inline Tensor& laguerre_polynomial_l_out(
 /// Legendre polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.legendre_polynomial_p.
+/// https://pytorch.org/docs/stable/special.html#torch.special.legendre_polynomial_p.
 ///
 /// Example:
 ///
@@ -1080,7 +1080,7 @@ inline Tensor& legendre_polynomial_p_out(
 /// Modified Bessel function of the first kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_i0.
+/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_i0.
 ///
 /// Example:
 ///
@@ -1100,7 +1100,7 @@ inline Tensor& modified_bessel_i0_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the first kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_i1.
+/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_i1.
 ///
 /// Example:
 ///
@@ -1120,7 +1120,7 @@ inline Tensor& modified_bessel_i1_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the second kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_k0.
+/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_k0.
 ///
 /// Example:
 ///
@@ -1140,7 +1140,7 @@ inline Tensor& modified_bessel_k0_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the second kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_k1.
+/// https://pytorch.org/docs/stable/special.html#torch.special.modified_bessel_k1.
 ///
 /// Example:
 ///
@@ -1160,7 +1160,7 @@ inline Tensor& modified_bessel_k1_out(Tensor& result, const Tensor& self) {
 /// Scaled modified Bessel function of the second kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.scaled_modified_bessel_k0.
+/// https://pytorch.org/docs/stable/special.html#torch.special.scaled_modified_bessel_k0.
 ///
 /// Example:
 ///
@@ -1180,7 +1180,7 @@ inline Tensor& scaled_modified_bessel_k0_out(Tensor& y, const Tensor& x) {
 /// Scaled modified Bessel function of the second kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.scaled_modified_bessel_k1.
+/// https://pytorch.org/docs/stable/special.html#torch.special.scaled_modified_bessel_k1.
 ///
 /// Example:
 ///
@@ -1200,7 +1200,7 @@ inline Tensor& scaled_modified_bessel_k1_out(Tensor& y, const Tensor& x) {
 /// Shifted Chebyshev polynomial of the first kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_t.
+/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_t.
 ///
 /// Example:
 ///
@@ -1246,7 +1246,7 @@ inline Tensor& shifted_chebyshev_polynomial_t_out(
 /// Shifted Chebyshev polynomial of the second kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_u.
+/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_u.
 ///
 /// Example:
 ///
@@ -1292,7 +1292,7 @@ inline Tensor& shifted_chebyshev_polynomial_u_out(
 /// Shifted Chebyshev polynomial of the third kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_v.
+/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_v.
 ///
 /// Example:
 ///
@@ -1338,7 +1338,7 @@ inline Tensor& shifted_chebyshev_polynomial_v_out(
 /// Shifted Chebyshev polynomial of the fourth kind.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_w.
+/// https://pytorch.org/docs/stable/special.html#torch.special.shifted_chebyshev_polynomial_w.
 ///
 /// Example:
 ///
@@ -1384,7 +1384,7 @@ inline Tensor& shifted_chebyshev_polynomial_w_out(
 /// Spherical Bessel function of the first kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/main/special.html#torch.special.spherical_bessel_j0.
+/// https://pytorch.org/docs/stable/special.html#torch.special.spherical_bessel_j0.
 ///
 /// Example:
 ///

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -482,7 +482,7 @@ std::optional<at::Tensor> runTorchBackendForOnnx(
     at::Tensor indices = inputTensorValues[1];
     auto q = indices.dim();
     // at::index_select only supports indices with rank <= 1.
-    // See https://pytorch.org/docs/main/generated/torch.index_select.html
+    // See https://pytorch.org/docs/stable/generated/torch.index_select.html
     if (q > 1) {
       return std::nullopt;
     }

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -315,7 +315,7 @@ std::optional<at::Tensor> runTorchBackendForOnnx(
       std::vector<int64_t> axes;
       for (int64_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
         // ONNX unsqueeze accepts negative axes
-        // From https://pytorch.org/docs/stable/generated/torch.unsqueeze.html
+        // From https://docs.pytorch.org/docs/stable/generated/torch.unsqueeze.html
         // Negative dim will correspond to unsqueeze() applied at dim = dim +
         // input.dim() + 1.
         axes_a[i] +=
@@ -482,7 +482,7 @@ std::optional<at::Tensor> runTorchBackendForOnnx(
     at::Tensor indices = inputTensorValues[1];
     auto q = indices.dim();
     // at::index_select only supports indices with rank <= 1.
-    // See https://pytorch.org/docs/stable/generated/torch.index_select.html
+    // See https://docs.pytorch.org/docs/stable/generated/torch.index_select.html
     if (q > 1) {
       return std::nullopt;
     }

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -546,7 +546,7 @@ static void fixDefaultRnnHiddenState(Block* b, int opset_version) {
       continue;
     }
     // Hidden state is the sixth input for RNN, LSTM, GRU.
-    // See https://pytorch.org/docs/stable/nn.html#torch.nn.RNN
+    // See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.RNN
     if (n->inputs().size() < 6) {
       continue;
     }
@@ -565,7 +565,7 @@ static void fixDefaultLstmCellState(Block* b, int opset_version) {
       continue;
     }
     // Cell state is the seventh input for LSTM.
-    // See https://pytorch.org/docs/stable/nn.html#torch.nn.LSTM
+    // See https://docs.pytorch.org/docs/stable/nn.html#torch.nn.LSTM
     if (n->inputs().size() < 7) {
       continue;
     }

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -546,7 +546,7 @@ static void fixDefaultRnnHiddenState(Block* b, int opset_version) {
       continue;
     }
     // Hidden state is the sixth input for RNN, LSTM, GRU.
-    // See https://pytorch.org/docs/main/nn.html#torch.nn.RNN
+    // See https://pytorch.org/docs/stable/nn.html#torch.nn.RNN
     if (n->inputs().size() < 6) {
       continue;
     }
@@ -565,7 +565,7 @@ static void fixDefaultLstmCellState(Block* b, int opset_version) {
       continue;
     }
     // Cell state is the seventh input for LSTM.
-    // See https://pytorch.org/docs/main/nn.html#torch.nn.LSTM
+    // See https://pytorch.org/docs/stable/nn.html#torch.nn.LSTM
     if (n->inputs().size() < 7) {
       continue;
     }

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -110,7 +110,7 @@ static std::optional<c10::ScalarType> PromoteScalarTypes(
 
 // Type promotion between scalars and tensors
 // per logic here
-// https://pytorch.org/docs/main/tensor_attributes.html#tensor-attributes
+// https://pytorch.org/docs/stable/tensor_attributes.html#tensor-attributes
 static std::optional<c10::ScalarType> PromoteScalarTypesWithCategory(
     const std::vector<c10::ScalarType>& typesFromTensors,
     const std::vector<c10::ScalarType>& typesFromScalars) {
@@ -271,7 +271,7 @@ static std::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
       // are tensors or scalars. (Previously only scalars support implicit
       // casting).
       // Per logic here
-      // https://pytorch.org/docs/main/tensor_attributes.html#tensor-attributes
+      // https://pytorch.org/docs/stable/tensor_attributes.html#tensor-attributes
       st = PromoteScalarTypesWithCategory(typesFromTensors, typesFromScalars);
     }
   }

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -110,7 +110,7 @@ static std::optional<c10::ScalarType> PromoteScalarTypes(
 
 // Type promotion between scalars and tensors
 // per logic here
-// https://pytorch.org/docs/stable/tensor_attributes.html#tensor-attributes
+// https://docs.pytorch.org/docs/stable/tensor_attributes.html#tensor-attributes
 static std::optional<c10::ScalarType> PromoteScalarTypesWithCategory(
     const std::vector<c10::ScalarType>& typesFromTensors,
     const std::vector<c10::ScalarType>& typesFromScalars) {
@@ -271,7 +271,7 @@ static std::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
       // are tensors or scalars. (Previously only scalars support implicit
       // casting).
       // Per logic here
-      // https://pytorch.org/docs/stable/tensor_attributes.html#tensor-attributes
+      // https://docs.pytorch.org/docs/stable/tensor_attributes.html#tensor-attributes
       st = PromoteScalarTypesWithCategory(typesFromTensors, typesFromScalars);
     }
   }

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -117,7 +117,7 @@ void ImplicitCastForBinaryInplaceOps(Block* b) {
       if ((shape_node->kind() == prim::NumToTensor) &&
           (shape_node->inputs().at(0)->node()->kind() == aten::size)) {
         std::cerr
-            << "In-place op on output of tensor.shape. See https://pytorch.org/docs/main/onnx.html#"
+            << "In-place op on output of tensor.shape. See https://pytorch.org/docs/stable/onnx.html#"
             << "avoid-inplace-operations-when-using-tensor-shape-in-tracing-mode"
             << '\n';
       }

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -117,7 +117,7 @@ void ImplicitCastForBinaryInplaceOps(Block* b) {
       if ((shape_node->kind() == prim::NumToTensor) &&
           (shape_node->inputs().at(0)->node()->kind() == aten::size)) {
         std::cerr
-            << "In-place op on output of tensor.shape. See https://pytorch.org/docs/stable/onnx.html#"
+            << "In-place op on output of tensor.shape. See https://docs.pytorch.org/docs/stable/onnx.html#"
             << "avoid-inplace-operations-when-using-tensor-shape-in-tracing-mode"
             << '\n';
       }

--- a/torch/distributed/benchmarks/README.md
+++ b/torch/distributed/benchmarks/README.md
@@ -7,22 +7,22 @@ This Benchmark is used to measure distributed training iteration time. It combin
 There are different training paradigms where combining these two techniques might be useful. For example:
 1) If we have a model with a sparse part (large embedding table) and a dense
    part (FC layers), we might want to set the embedding table on a parameter
-   server and replicate the FC layer across multiple trainers using [DistributedDataParallel](https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel). The [Distributed RPC framework](https://pytorch.org/docs/main/rpc.html) comes handy to perform embedding lookups on the parameter servers.
-2) Enable hybrid parallelism as described in the [PipeDream](https://arxiv.org/abs/1806.03377) paper. We can use the [Distributed RPC framework](https://pytorch.org/docs/main/rpc.html) to pipeline stages of the model across multiple workers and replicate each stage (if needed) using [DistributedDataParallel](https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel).
+   server and replicate the FC layer across multiple trainers using [DistributedDataParallel](https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel). The [Distributed RPC framework](https://pytorch.org/docs/stable/rpc.html) comes handy to perform embedding lookups on the parameter servers.
+2) Enable hybrid parallelism as described in the [PipeDream](https://arxiv.org/abs/1806.03377) paper. We can use the [Distributed RPC framework](https://pytorch.org/docs/stable/rpc.html) to pipeline stages of the model across multiple workers and replicate each stage (if needed) using [DistributedDataParallel](https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel).
 
 ## Training Process
 This benchmark focuses on the first paradigm above. The training process is executed as follows:
 
-1) The master creates embedding tables on each of the 8 Parameter Servers and holds an [RRef](https://pytorch.org/docs/main/rpc.html#rref) to it.
+1) The master creates embedding tables on each of the 8 Parameter Servers and holds an [RRef](https://pytorch.org/docs/stable/rpc.html#rref) to it.
 2) The master, then kicks off the training loop on the 8 trainers and passes the embedding table RRef to the trainers.
 3) The trainers create a `HybridModel` which performs embedding lookups in all 8 Parameter Servers using the embedding table RRef provided by the master and then executes the FC layer which is wrapped and replicated via DDP (DistributedDataParallel).
 4) The trainer executes the forward pass of the model and uses the loss to
-   execute the backward pass using [Distributed Autograd](https://pytorch.org/docs/main/rpc.html#distributed-autograd-framework).
+   execute the backward pass using [Distributed Autograd](https://pytorch.org/docs/stable/rpc.html#distributed-autograd-framework).
 5) As part of the backward pass, the gradients for the FC layer are computed
    first and synced to all trainers via allreduce in DDP.
 6) Next, Distributed Autograd propagates the gradients to the parameter servers,
    where the gradients for the embedding table are updated.
-7) Finally, the [Distributed Optimizer](https://pytorch.org/docs/main/rpc.html#module-torch.distributed.optim) is used to update all parameters.
+7) Finally, the [Distributed Optimizer](https://pytorch.org/docs/stable/rpc.html#module-torch.distributed.optim) is used to update all parameters.
 
 
 ## Example Benchmark output:

--- a/torch/distributed/benchmarks/README.md
+++ b/torch/distributed/benchmarks/README.md
@@ -7,22 +7,22 @@ This Benchmark is used to measure distributed training iteration time. It combin
 There are different training paradigms where combining these two techniques might be useful. For example:
 1) If we have a model with a sparse part (large embedding table) and a dense
    part (FC layers), we might want to set the embedding table on a parameter
-   server and replicate the FC layer across multiple trainers using [DistributedDataParallel](https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel). The [Distributed RPC framework](https://pytorch.org/docs/stable/rpc.html) comes handy to perform embedding lookups on the parameter servers.
-2) Enable hybrid parallelism as described in the [PipeDream](https://arxiv.org/abs/1806.03377) paper. We can use the [Distributed RPC framework](https://pytorch.org/docs/stable/rpc.html) to pipeline stages of the model across multiple workers and replicate each stage (if needed) using [DistributedDataParallel](https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel).
+   server and replicate the FC layer across multiple trainers using [DistributedDataParallel](https://docs.pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel). The [Distributed RPC framework](https://docs.pytorch.org/docs/stable/rpc.html) comes handy to perform embedding lookups on the parameter servers.
+2) Enable hybrid parallelism as described in the [PipeDream](https://arxiv.org/abs/1806.03377) paper. We can use the [Distributed RPC framework](https://docs.pytorch.org/docs/stable/rpc.html) to pipeline stages of the model across multiple workers and replicate each stage (if needed) using [DistributedDataParallel](https://docs.pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel).
 
 ## Training Process
 This benchmark focuses on the first paradigm above. The training process is executed as follows:
 
-1) The master creates embedding tables on each of the 8 Parameter Servers and holds an [RRef](https://pytorch.org/docs/stable/rpc.html#rref) to it.
+1) The master creates embedding tables on each of the 8 Parameter Servers and holds an [RRef](https://docs.pytorch.org/docs/stable/rpc.html#rref) to it.
 2) The master, then kicks off the training loop on the 8 trainers and passes the embedding table RRef to the trainers.
 3) The trainers create a `HybridModel` which performs embedding lookups in all 8 Parameter Servers using the embedding table RRef provided by the master and then executes the FC layer which is wrapped and replicated via DDP (DistributedDataParallel).
 4) The trainer executes the forward pass of the model and uses the loss to
-   execute the backward pass using [Distributed Autograd](https://pytorch.org/docs/stable/rpc.html#distributed-autograd-framework).
+   execute the backward pass using [Distributed Autograd](https://docs.pytorch.org/docs/stable/rpc.html#distributed-autograd-framework).
 5) As part of the backward pass, the gradients for the FC layer are computed
    first and synced to all trainers via allreduce in DDP.
 6) Next, Distributed Autograd propagates the gradients to the parameter servers,
    where the gradients for the embedding table are updated.
-7) Finally, the [Distributed Optimizer](https://pytorch.org/docs/stable/rpc.html#module-torch.distributed.optim) is used to update all parameters.
+7) Finally, the [Distributed Optimizer](https://docs.pytorch.org/docs/stable/rpc.html#module-torch.distributed.optim) is used to update all parameters.
 
 
 ## Example Benchmark output:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3019,7 +3019,7 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op: bool = False):
 @deprecated(
     "`torch.distributed.all_reduce_coalesced` will be deprecated. If you must "
     "use it, please revisit our documentation later at "
-    "https://pytorch.org/docs/stable/distributed.html#collective-functions",
+    "https://docs.pytorch.org/docs/stable/distributed.html#collective-functions",
     category=FutureWarning,
 )
 def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op: bool = False):
@@ -4167,7 +4167,7 @@ def _all_gather_base(output_tensor, input_tensor, group=None, async_op: bool = F
 @deprecated(
     "`torch.distributed.all_gather_coalesced` will be deprecated. If you must use it, "
     "please revisit our documentation later at "
-    "https://pytorch.org/docs/stable/distributed.html#collective-functions",
+    "https://docs.pytorch.org/docs/stable/distributed.html#collective-functions",
     category=FutureWarning,
 )
 def all_gather_coalesced(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3019,7 +3019,7 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op: bool = False):
 @deprecated(
     "`torch.distributed.all_reduce_coalesced` will be deprecated. If you must "
     "use it, please revisit our documentation later at "
-    "https://pytorch.org/docs/main/distributed.html#collective-functions",
+    "https://pytorch.org/docs/stable/distributed.html#collective-functions",
     category=FutureWarning,
 )
 def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op: bool = False):
@@ -4167,7 +4167,7 @@ def _all_gather_base(output_tensor, input_tensor, group=None, async_op: bool = F
 @deprecated(
     "`torch.distributed.all_gather_coalesced` will be deprecated. If you must use it, "
     "please revisit our documentation later at "
-    "https://pytorch.org/docs/main/distributed.html#collective-functions",
+    "https://pytorch.org/docs/stable/distributed.html#collective-functions",
     category=FutureWarning,
 )
 def all_gather_coalesced(

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -112,9 +112,9 @@ def fully_shard(
     sharded on dim-0, while the unsharded parameters will be like the original
     parameters on ``module`` (e.g. :class:`torch.Tensor` if originally
     :class:`torch.Tensor`). A module
-    `forward pre-hook <https://pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_forward_pre_hook>`_
+    `forward pre-hook <https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_forward_pre_hook>`_
     on ``module`` all-gathers the parameters, and a module
-    `forward hook <https://pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_forward_hook>`_
+    `forward hook <https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_forward_hook>`_
     on ``module`` frees them (if needed). Similar backward hooks all-gather
     parameters and later free parameters and reduce-scatter gradients.
 

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -112,9 +112,9 @@ def fully_shard(
     sharded on dim-0, while the unsharded parameters will be like the original
     parameters on ``module`` (e.g. :class:`torch.Tensor` if originally
     :class:`torch.Tensor`). A module
-    `forward pre-hook <https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_forward_pre_hook>`_
+    `forward pre-hook <https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_forward_pre_hook>`_
     on ``module`` all-gathers the parameters, and a module
-    `forward hook <https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_forward_hook>`_
+    `forward hook <https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_forward_hook>`_
     on ``module`` frees them (if needed). Similar backward hooks all-gather
     parameters and later free parameters and reduce-scatter gradients.
 

--- a/torch/distributed/pipelining/README.md
+++ b/torch/distributed/pipelining/README.md
@@ -2,6 +2,6 @@
 
 `torch.distributed.pipelining` is a package for implementing pipeline parallelism on your model.
 
-Our documentation is available [here](https://pytorch.org/docs/main/distributed.pipelining.html).
+Our documentation is available [here](https://pytorch.org/docs/stable/distributed.pipelining.html).
 
 ![pipeline_diagram_web](https://github.com/pytorch/PiPPy/assets/6676466/c93e2fe7-1cd4-49a2-9fd8-231ec9905e0c)

--- a/torch/distributed/pipelining/README.md
+++ b/torch/distributed/pipelining/README.md
@@ -2,6 +2,6 @@
 
 `torch.distributed.pipelining` is a package for implementing pipeline parallelism on your model.
 
-Our documentation is available [here](https://pytorch.org/docs/stable/distributed.pipelining.html).
+Our documentation is available [here](https://docs.pytorch.org/docs/stable/distributed.pipelining.html).
 
 ![pipeline_diagram_web](https://github.com/pytorch/PiPPy/assets/6676466/c93e2fe7-1cd4-49a2-9fd8-231ec9905e0c)

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -662,7 +662,7 @@ class OpDispatcher:
             raise RuntimeError(
                 f"{op_call}: got mixed torch.Tensor and DTensor, need to convert all"
                 " torch.Tensor to DTensor before calling distributed operators!"
-                " Please see https://docs.pytorch.org/docs/main/distributed.tensor.html#mixed-tensor-and-dtensor-operations"
+                " Please see https://docs.pytorch.org/docs/stable/distributed.tensor.html#mixed-tensor-and-dtensor-operations"
                 " for more details."
             )
         return replication_spec

--- a/torch/fx/README.md
+++ b/torch/fx/README.md
@@ -66,19 +66,19 @@ Here, we set up a simple Module that exercises different language features: fetc
 
 # Internal Structure
 
-## [Graph](https://pytorch.org/docs/main/fx.html#torch.fx.Graph) ##
+## [Graph](https://pytorch.org/docs/stable/fx.html#torch.fx.Graph) ##
 The `fx.Graph` is a core data structure in FX that represents the operations and their dependencies in a structured format. It consists of a List of `fx.Node` representing individual operations and their inputs and outputs. The Graph enables simple manipulation and analysis of the model structure, which is essential for implementing various transformations and optimizations.
 
 ## Node
 An `fx.Node` is a data structure that represents individual operations within an `fx.Graph`, it maps to callsites such as operators, methods and modules. Each `fx.Node` keeps track of its inputs, the previous and next nodes, the stacktrace so you can map back the node to a line of code in your python file and some optional metadata stored in a `meta` dict.
 
-## [GraphModule](https://pytorch.org/docs/main/fx.html#torch.fx.GraphModule) ##
+## [GraphModule](https://pytorch.org/docs/stable/fx.html#torch.fx.GraphModule) ##
 The `fx.GraphModule` is a subclass of `nn.Module` that holds the transformed Graph, the original module's parameter attributes and its source code. It serves as the primary output of FX transformations and can be used like any other `nn.Module`. `fx.GraphModule` allows for the execution of the transformed model, as it generates a valid forward method based on the Graph's structure.
 
 
 # Tracing
 
-## [Symbolic Tracer](https://pytorch.org/docs/main/fx.html#torch.fx.Tracer) ##
+## [Symbolic Tracer](https://pytorch.org/docs/stable/fx.html#torch.fx.Tracer) ##
 
 `Tracer` is the class that implements the symbolic tracing functionality of `torch.fx.symbolic_trace`. A call to `symbolic_trace(m)` is equivalent to `Tracer().trace(m)`. Tracer can be subclassed to override various behaviors of the tracing process. The different behaviors that can be overridden are described in the docstrings of the methods on the class.
 
@@ -103,7 +103,7 @@ During the call to `symbolic_trace`, the parameter `x` is transformed into a Pro
 
 If you're doing graph transforms, you can wrap your own Proxy method around a raw Node so that you can use the overloaded operators to add additional things to a Graph.
 
-## [TorchDynamo](https://pytorch.org/docs/main/torch.compiler_dynamo_deepdive.html) ##
+## [TorchDynamo](https://pytorch.org/docs/stable/torch.compiler_dynamo_deepdive.html) ##
 
 Tracing has limitations in that it can't deal with dynamic control flow and is limited to outputting a single graph at a time, so a better alternative is the new `torch.compile()` infrastructure where you can output multiple subgraphs in either an aten or torch IR using `torch.fx`. [This tutorial](https://colab.research.google.com/drive/1Zh-Uo3TcTH8yYJF-LLo5rjlHVMtqvMdf) gives more context on how this works.
 

--- a/torch/fx/README.md
+++ b/torch/fx/README.md
@@ -66,19 +66,19 @@ Here, we set up a simple Module that exercises different language features: fetc
 
 # Internal Structure
 
-## [Graph](https://pytorch.org/docs/stable/fx.html#torch.fx.Graph) ##
+## [Graph](https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Graph) ##
 The `fx.Graph` is a core data structure in FX that represents the operations and their dependencies in a structured format. It consists of a List of `fx.Node` representing individual operations and their inputs and outputs. The Graph enables simple manipulation and analysis of the model structure, which is essential for implementing various transformations and optimizations.
 
 ## Node
 An `fx.Node` is a data structure that represents individual operations within an `fx.Graph`, it maps to callsites such as operators, methods and modules. Each `fx.Node` keeps track of its inputs, the previous and next nodes, the stacktrace so you can map back the node to a line of code in your python file and some optional metadata stored in a `meta` dict.
 
-## [GraphModule](https://pytorch.org/docs/stable/fx.html#torch.fx.GraphModule) ##
+## [GraphModule](https://docs.pytorch.org/docs/stable/fx.html#torch.fx.GraphModule) ##
 The `fx.GraphModule` is a subclass of `nn.Module` that holds the transformed Graph, the original module's parameter attributes and its source code. It serves as the primary output of FX transformations and can be used like any other `nn.Module`. `fx.GraphModule` allows for the execution of the transformed model, as it generates a valid forward method based on the Graph's structure.
 
 
 # Tracing
 
-## [Symbolic Tracer](https://pytorch.org/docs/stable/fx.html#torch.fx.Tracer) ##
+## [Symbolic Tracer](https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Tracer) ##
 
 `Tracer` is the class that implements the symbolic tracing functionality of `torch.fx.symbolic_trace`. A call to `symbolic_trace(m)` is equivalent to `Tracer().trace(m)`. Tracer can be subclassed to override various behaviors of the tracing process. The different behaviors that can be overridden are described in the docstrings of the methods on the class.
 
@@ -86,7 +86,7 @@ In the default implementation of `Tracer().trace`, the tracer first creates Prox
 
 ## Proxy ##
 
-Proxy objects are Node wrappers used by the Tracer to record operations seen during symbolic tracing. The mechanism through which Proxy objects record computation is [`__torch_function__`](https://pytorch.org/docs/stable/notes/extending.html#extending-torch). If any custom Python type defines a method named `__torch_function__`, PyTorch will invoke that `__torch_function__` implementation when an instance of that custom type is passed to a function in the `torch` namespace. In FX, when operations on Proxy are dispatched to the `__torch_function__` handler, the `__torch_function__` handler records the operation in the Graph as a Node. The Node that was recorded in the Graph is then itself wrapped in a Proxy, facilitating further application of ops on that value.
+Proxy objects are Node wrappers used by the Tracer to record operations seen during symbolic tracing. The mechanism through which Proxy objects record computation is [`__torch_function__`](https://docs.pytorch.org/docs/stable/notes/extending.html#extending-torch). If any custom Python type defines a method named `__torch_function__`, PyTorch will invoke that `__torch_function__` implementation when an instance of that custom type is passed to a function in the `torch` namespace. In FX, when operations on Proxy are dispatched to the `__torch_function__` handler, the `__torch_function__` handler records the operation in the Graph as a Node. The Node that was recorded in the Graph is then itself wrapped in a Proxy, facilitating further application of ops on that value.
 
 Consider the following example:
 
@@ -103,7 +103,7 @@ During the call to `symbolic_trace`, the parameter `x` is transformed into a Pro
 
 If you're doing graph transforms, you can wrap your own Proxy method around a raw Node so that you can use the overloaded operators to add additional things to a Graph.
 
-## [TorchDynamo](https://pytorch.org/docs/stable/torch.compiler_dynamo_deepdive.html) ##
+## [TorchDynamo](https://docs.pytorch.org/docs/stable/torch.compiler_dynamo_deepdive.html) ##
 
 Tracing has limitations in that it can't deal with dynamic control flow and is limited to outputting a single graph at a time, so a better alternative is the new `torch.compile()` infrastructure where you can output multiple subgraphs in either an aten or torch IR using `torch.fx`. [This tutorial](https://colab.research.google.com/drive/1Zh-Uo3TcTH8yYJF-LLo5rjlHVMtqvMdf) gives more context on how this works.
 

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -307,7 +307,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -341,7 +341,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -361,7 +361,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -383,7 +383,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -407,7 +407,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -433,7 +433,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -587,7 +587,7 @@ class Transformer(Interpreter):
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -609,7 +609,7 @@ class Transformer(Interpreter):
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -307,7 +307,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -341,7 +341,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -361,7 +361,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -383,7 +383,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -407,7 +407,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -433,7 +433,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -587,7 +587,7 @@ class Transformer(Interpreter):
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -609,7 +609,7 @@ class Transformer(Interpreter):
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
+                `Node <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1193,7 +1193,7 @@ Examples::
     tensor([2])
 
 .. _condition number:
-    https://pytorch.org/docs/stable/linalg.html#torch.linalg.cond
+    https://docs.pytorch.org/docs/stable/linalg.html#torch.linalg.cond
 .. _full description of these drivers:
     https://www.netlib.org/lapack/lug/node27.html
 """,
@@ -1884,7 +1884,7 @@ Examples::
     tensor(3.0957e-06)
 
 .. _condition number:
-    https://pytorch.org/docs/stable/linalg.html#torch.linalg.cond
+    https://docs.pytorch.org/docs/stable/linalg.html#torch.linalg.cond
 .. _the resulting vectors will span the same subspace:
     https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD
 """,

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1193,7 +1193,7 @@ Examples::
     tensor([2])
 
 .. _condition number:
-    https://pytorch.org/docs/main/linalg.html#torch.linalg.cond
+    https://pytorch.org/docs/stable/linalg.html#torch.linalg.cond
 .. _full description of these drivers:
     https://www.netlib.org/lapack/lug/node27.html
 """,
@@ -1884,7 +1884,7 @@ Examples::
     tensor(3.0957e-06)
 
 .. _condition number:
-    https://pytorch.org/docs/main/linalg.html#torch.linalg.cond
+    https://pytorch.org/docs/stable/linalg.html#torch.linalg.cond
 .. _the resulting vectors will span the same subspace:
     https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD
 """,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -265,7 +265,7 @@ class NLLLoss(_WeightedLoss):
 @deprecated(
     "`NLLLoss2d` has been deprecated. "
     "Please use `NLLLoss` instead as a drop-in replacement and see "
-    "https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss for more details.",
+    "https://docs.pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss for more details.",
     category=FutureWarning,
 )
 class NLLLoss2d(NLLLoss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -265,7 +265,7 @@ class NLLLoss(_WeightedLoss):
 @deprecated(
     "`NLLLoss2d` has been deprecated. "
     "Please use `NLLLoss` instead as a drop-in replacement and see "
-    "https://pytorch.org/docs/main/nn.html#torch.nn.NLLLoss for more details.",
+    "https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss for more details.",
     category=FutureWarning,
 )
 class NLLLoss2d(NLLLoss):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2242,7 +2242,7 @@ class Module:
             # DeprecationWarning is ignored by default
             warnings.warn(
                 "Positional args are being deprecated, use kwargs instead. Refer to "
-                "https://pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.state_dict"
+                "https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.state_dict"
                 " for details.",
                 FutureWarning,
                 stacklevel=2,

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2242,7 +2242,7 @@ class Module:
             # DeprecationWarning is ignored by default
             warnings.warn(
                 "Positional args are being deprecated, use kwargs instead. Refer to "
-                "https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.state_dict"
+                "https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.state_dict"
                 " for details.",
                 FutureWarning,
                 stacklevel=2,

--- a/torch/onnx/README.md
+++ b/torch/onnx/README.md
@@ -2,5 +2,5 @@
 
 Torch->ONNX converter / exporter.
 
-- User-facing docs: https://pytorch.org/docs/stable/onnx.html
+- User-facing docs: https://docs.pytorch.org/docs/stable/onnx.html
 - Developer docs: https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter

--- a/torch/onnx/README.md
+++ b/torch/onnx/README.md
@@ -2,5 +2,5 @@
 
 Torch->ONNX converter / exporter.
 
-- User-facing docs: https://pytorch.org/docs/main/onnx.html
+- User-facing docs: https://pytorch.org/docs/stable/onnx.html
 - Developer docs: https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -460,7 +460,7 @@ class AliasInfo:
 #   the operator's output (when given the input, args, and kwargs) to the
 #   portion of the output to gradcheck. For example, consider an operator
 #   like torch.linalg.slogdet
-#   (https://pytorch.org/docs/main/generated/torch.linalg.slogdet.html).
+#   (https://pytorch.org/docs/stable/generated/torch.linalg.slogdet.html).
 #   This operator returns a tuple of two tensors, but the first tensor
 #   cannot be backwarded through. Its "output_process_fn_grad" filters
 #   this output tuple to just the second argument, which we can call backward

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -460,7 +460,7 @@ class AliasInfo:
 #   the operator's output (when given the input, args, and kwargs) to the
 #   portion of the output to gradcheck. For example, consider an operator
 #   like torch.linalg.slogdet
-#   (https://pytorch.org/docs/stable/generated/torch.linalg.slogdet.html).
+#   (https://docs.pytorch.org/docs/stable/generated/torch.linalg.slogdet.html).
 #   This operator returns a tuple of two tensors, but the first tensor
 #   cannot be backwarded through. Its "output_process_fn_grad" filters
 #   this output tuple to just the second argument, which we can call backward

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -226,7 +226,7 @@ class BackwardHook:
                 if self.input_tensors_index is None:
                     warnings.warn("Full backward hook is firing when gradients are computed "
                                   "with respect to module outputs since no inputs require gradients. See "
-                                  "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "  # noqa: B950
+                                  "https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "  # noqa: B950
                                   "for more details.",
                                   stacklevel=5)
                     grad_inputs = self._pack_with_none([], [], self.n_inputs)


### PR DESCRIPTION
Fixes #170374

What does this PR do?

Updates hardcoded pytorch.org/docs/main/... URLs in code/docs/tests to pytorch.org/docs/stable/... to avoid broken links for users reading released documentation.

Why?

/docs/main is not guaranteed stable and can break or move; /docs/stable is the intended target for user-facing docs references.

Testing

Link-only/doc-only updates (no functional changes). CI should cover.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @ezyang @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo