### PR TITLE
Add python3-dev to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         libpng-dev \
         python-is-python3 \
         python3 \
+        python3-dev \
         python3-pip \
         && rm -rf /var/lib/apt/lists/*
 # Copy Python packages from pytorch-installs stage


### PR DESCRIPTION
Fixes dev image:

Test:
```
apt-get install python3-dev
find / -name "Python.h" 2>/dev/null
/usr/include/python3.12/Python.h
```

Failing  Test:
```
python smoke_test.py --package torchonly --runtime-error-check disabled
torch: 2.10.0.dev20251213+cu129
ATen/Parallel:
	at::get_num_threads() : 4
	at::get_num_interop_threads() : 4
OpenMP 201511 (a.k.a. OpenMP 4.5)
	omp_get_max_threads() : 4
Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications
	mkl_get_max_threads() : 4
Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)
std::thread::hardware_concurrency() : 8
Environment variables:
	OMP_NUM_THREADS : [not set]
	MKL_NUM_THREADS : [not set]
ATen parallel backend: OpenMP

Skip version check for channel None as stable version is None
Testing smoke_test_conv2d
Testing smoke_test_linalg on cpu
Testing SDPA on cpu using type torch.float16
Testing smoke_test_compile for cpu and torch.float16
W1215 21:06:22.064000 886 torch/utils/cpp_extension.py:118] [0/0] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
/usr/local/lib/python3.12/dist-packages/torch/_inductor/cpp_builder.py:1198: UserWarning: Can't find Python.h in /usr/include/python3.12
  warnings.warn(f"Can't find Python.h in {str(include_dir)}")
```

Passing Test:
```
python smoke_test.py --package torchonly --runtime-error-check disabled
torch: 2.10.0.dev20251213+cu129
ATen/Parallel:
	at::get_num_threads() : 4
	at::get_num_interop_threads() : 4
OpenMP 201511 (a.k.a. OpenMP 4.5)
	omp_get_max_threads() : 4
Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications
	mkl_get_max_threads() : 4
Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)
std::thread::hardware_concurrency() : 8
Environment variables:
	OMP_NUM_THREADS : [not set]
	MKL_NUM_THREADS : [not set]
ATen parallel backend: OpenMP

Skip version check for channel None as stable version is None
Testing smoke_test_conv2d
Testing smoke_test_linalg on cpu
Testing SDPA on cpu using type torch.float16
Testing smoke_test_compile for cpu and torch.float16
W1215 21:04:14.211000 754 torch/utils/cpp_extension.py:118] [0/0] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
Testing smoke_test_compile for cpu and torch.float32
Testing smoke_test_compile for cpu and torch.float64
Picked CPU ISA VecAVX512 bit width 512
Testing smoke_test_compile with mode 'max-autotune' for torch.float32
cudagraph partition due to non gpu ops
cudagraph partition due to non gpu ops. Found from : 
   File "/workspace/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 57, in forward
    x = self.conv1(x)

cudagraph partition due to non gpu ops
cudagraph partition due to non gpu ops. Found from : 
   File "/workspace/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 58, in forward
    x = self.conv2(x)

cudagraph partition due to non gpu ops. Found from : 
   File "/workspace/pytorch/.ci/pytorch/smoke_test/smoke_test.py", line 61, in forward
    output = self.fc1(x)

Windows platform or CUDA is not available, skipping NVSHMEM test

```