### PR TITLE
[export] Deepcopy graph signature when unlifting

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -361,9 +361,16 @@ def _verify_exported_program_signature(exported_program) -> None:
     ]
 
     if len(input_node_names) != len(gs.input_specs):
+        input_spec_names = [
+            spec.arg.name for spec in gs.input_specs if hasattr(spec.arg, "name")
+        ]
+        missing_in_specs = set(input_node_names) - set(input_spec_names)
+        missing_in_graph = set(input_spec_names) - set(input_node_names)
         raise SpecViolationError(
             f"Number of graph inputs ({len(input_node_names)}) "
-            f"does not match number of inputs in the graph signature ({len(gs.input_specs)})"
+            f"does not match number of inputs in the graph signature ({len(gs.input_specs)})\n"
+            f"Placeholders missing input_specs: {missing_in_specs}\n"
+            f"Input_specs missing placeholders: {missing_in_graph}"
         )
 
     for input_spec, node in zip(gs.input_specs, input_node_names):
@@ -471,11 +478,17 @@ def _verify_exported_program_signature(exported_program) -> None:
     ]
 
     if len(output_nodes) != len(gs.output_specs):
+        output_spec_names = [
+            spec.arg.name if hasattr(spec.arg, "name") else str(spec.arg)
+            for spec in gs.output_specs
+        ]
+        missing_out_specs = set(output_nodes) - set(output_spec_names)
+        missing_out_graph = set(output_spec_names) - set(output_nodes)
         raise SpecViolationError(
             f"Number of output nodes {len(output_nodes)} is different "
-            "Than the number of outputs specified by the graph signature: \n"
-            f"Number of mutated buffers: {len(gs.buffers_to_mutate)}. \n"
-            f"Number of user outputs: {len(gs.user_outputs)}. \n"
+            f"Than the number of outputs specified by the graph signature: {len(gs.output_specs)}\n"
+            f"Nodes missing output_specs: {missing_out_specs}\n"
+            f"Output_specs missing nodes: {missing_out_graph}"
         )
 
     num_tokens = len(gs.output_tokens)

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -759,6 +759,9 @@ def _unlift_exported_program_lifted_states(
     new_gm = torch.fx.GraphModule(ep.graph_module, copy.deepcopy(ep.graph))
     new_gm.meta.update(ep.graph_module.meta)
     ep = copy.copy(ep)
+    ep._graph_signature = ExportGraphSignature(
+        ep._graph_signature.input_specs, ep._graph_signature.output_specs
+    )
     ep._graph_module = new_gm
 
     # TODO T206340015


### PR DESCRIPTION
Previously https://github.com/pytorch/pytorch/pull/167231 modified ep.module() such that it deepcopies ep before applying ep.module() so that ep.module() does not affect the original ep. However we didn't deepcopy the graph signature which caused some issues.

Differential Revision: D89209276


