### PR TITLE
Fill test_jsons_while_running when workflow ends for jobs without s3 permissions

### DIFF
--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -234,12 +234,14 @@ def upload_file_to_s3(
     )
 
 
-def unzip(p: Path) -> None:
+def unzip(p: Path) -> Path:
     """Unzip the provided zipfile to a similarly-named directory.
 
     Returns None if `p` is not a zipfile.
 
     Looks like: /tmp/test-reports.zip -> /tmp/unzipped-test-reports/
+
+    Returns the path to the unzipped directory.
     """
     assert p.is_file()
     unzipped_dir = p.with_name("unzipped-" + p.stem)
@@ -247,6 +249,8 @@ def unzip(p: Path) -> None:
 
     with zipfile.ZipFile(p, "r") as zip:
         zip.extractall(unzipped_dir)
+
+    return unzipped_dir
 
 
 def is_rerun_disabled_tests(

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -166,7 +166,9 @@ def get_tests(workflow_run_id: int, workflow_run_attempt: int) -> list[dict[str,
         return flattened
 
 
-def backfill_test_jsons_while_running(workflow_run_id: int, workflow_run_attempt: int) -> None:
+def backfill_test_jsons_while_running(
+    workflow_run_id: int, workflow_run_attempt: int
+) -> None:
     # The bucket name name is a bit misleading, usually the jsons should be
     # uploaded while the job is running, but that won't happen if the job
     # doesn't have permissions to write to the bucket or if there was an error
@@ -190,12 +192,19 @@ def backfill_test_jsons_while_running(workflow_run_id: int, workflow_run_attempt
         all_existing_jsons = []
         for unzipped_dir in unzipped_json_dirs:
             all_existing_jsons.extend(
-                [str(Path(json_report).relative_to(unzipped_dir)) for json_report in unzipped_dir.glob("**/*.json")]
+                [
+                    str(Path(json_report).relative_to(unzipped_dir))
+                    for json_report in unzipped_dir.glob("**/*.json")
+                ]
             )
 
         for unzipped_dir in unzipped_xml_dirs:
             for xml in unzipped_dir.glob("**/*.xml"):
-                corresponding_json = str(xml.with_suffix(".json").relative_to(unzipped_dir / "test" / "test-reports"))
+                corresponding_json = str(
+                    xml.with_suffix(".json").relative_to(
+                        unzipped_dir / "test" / "test-reports"
+                    )
+                )
                 if corresponding_json in all_existing_jsons:
                     print(f"Skipping upload for existing test json for {xml}")
                     continue
@@ -331,9 +340,7 @@ if __name__ == "__main__":
         remove_nan_inf(failed_tests_cases),
     )
 
-    backfill_test_jsons_while_running(
-        args.workflow_run_id, args.workflow_run_attempt
-    )
+    backfill_test_jsons_while_running(args.workflow_run_id, args.workflow_run_attempt)
 
     # Upload full test_run only for trusted refs (main or trunk/{sha} tags)
     if should_upload_full_test_run(args.head_branch, args.head_repository):

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -16,6 +16,7 @@ from tools.stats.upload_stats_lib import (
     get_job_id,
     remove_nan_inf,
     unzip,
+    upload_to_s3,
     upload_workflow_stats_to_s3,
 )
 
@@ -165,6 +166,58 @@ def get_tests(workflow_run_id: int, workflow_run_attempt: int) -> list[dict[str,
         return flattened
 
 
+def backfill_test_jsons_while_running(workflow_run_id: int, workflow_run_attempt: int) -> None:
+    # The bucket name name is a bit misleading, usually the jsons should be
+    # uploaded while the job is running, but that won't happen if the job
+    # doesn't have permissions to write to the bucket or if there was an error
+    with TemporaryDirectory() as temp_dir:
+        print("Using temporary directory:", temp_dir)
+        os.chdir(temp_dir)
+
+        # Download and extract all the reports (both GHA and S3)
+        s3_xmls = download_s3_artifacts(
+            "test-report", workflow_run_id, workflow_run_attempt
+        )
+
+        s3_jsons = download_s3_artifacts(
+            "test-jsons", workflow_run_id, workflow_run_attempt
+        )
+
+        # Unzip artifacts and save their locations
+        unzipped_xml_dirs = [unzip(path) for path in s3_xmls]
+        unzipped_json_dirs = [unzip(path) for path in s3_jsons]
+
+        all_existing_jsons = []
+        for unzipped_dir in unzipped_json_dirs:
+            all_existing_jsons.extend(
+                [str(Path(json_report).relative_to(unzipped_dir)) for json_report in unzipped_dir.glob("**/*.json")]
+            )
+
+        for unzipped_dir in unzipped_xml_dirs:
+            for xml in unzipped_dir.glob("**/*.xml"):
+                corresponding_json = str(xml.with_suffix(".json").relative_to(unzipped_dir / "test" / "test-reports"))
+                if corresponding_json in all_existing_jsons:
+                    print(f"Skipping upload for existing test json for {xml}")
+                    continue
+                # print(f"Uploading missing test json for {xml}")
+                job_id = get_job_id(xml)
+                test_cases = parse_xml_report(
+                    "testcase",
+                    xml,
+                    workflow_run_id,
+                    workflow_run_attempt,
+                    job_id,
+                )
+                json_file = xml.with_suffix(".json")
+                s3_key = (
+                    json_file.relative_to(unzipped_dir / "test" / "test-reports")
+                    .as_posix()
+                    .replace("/", "_")
+                )
+                s3_key = f"test_jsons_while_running/{workflow_run_id}/{job_id}/{s3_key}"
+                upload_to_s3("gha-artifacts", s3_key, remove_nan_inf(test_cases))
+
+
 def summarize_test_cases(test_cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Group test cases by classname, file, and job_id. We perform the aggregation
     manually instead of using the `test-suite` XML tag because xmlrunner does
@@ -276,6 +329,10 @@ if __name__ == "__main__":
         args.workflow_run_attempt,
         "failed_test_runs",
         remove_nan_inf(failed_tests_cases),
+    )
+
+    backfill_test_jsons_while_running(
+        args.workflow_run_id, args.workflow_run_attempt
     )
 
     # Upload full test_run only for trusted refs (main or trunk/{sha} tags)


### PR DESCRIPTION
The bucket name name is a bit misleading now, but usually the jsons should be uploaded while the job is running, but that won't happen if the job doesn't have permissions to write to the bucket or if there was an error

This makes it so that if any xmls aren't uploaded to s3, they do get uploaded eventually when the workflow finishes, which will trigger the s3 -> tests.all_test_runs ingestion

For jobs without permissions, maybe we can grant the permissions?  Does oidc allow for super specific path permissions?  Ex I want to just give it permission to upload to s3_path_prefix/workflow_id?  Then we could also upload while running for stuff like rocm and the tpu runners