### PR TITLE
[cd] Validate Docker release builds only when WITH_PUSH

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -174,6 +174,7 @@ jobs:
 
   validate:
     needs: build
+    if: ${{ env.WITH_PUSH == 'true' }}
     uses: pytorch/test-infra/.github/workflows/validate-docker-images.yml@main
     with:
       channel: nightly

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -174,7 +174,7 @@ jobs:
 
   validate:
     needs: build
-    if: ${{ env.WITH_PUSH == 'true' }}
+    if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) }}
     uses: pytorch/test-infra/.github/workflows/validate-docker-images.yml@main
     with:
       channel: nightly


### PR DESCRIPTION
Validation when run on PR validates previous nightly docker run rather then results of the Docker build on PR. 
Hence enable validation only when WITH_PUSH is true
