### PR TITLE
Inline job-filter action to avoid ci failures on PR that reference action on main

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -36,12 +36,21 @@ permissions:
 
 jobs:
   # See job-filter.yml for rules on adding job filter conditions
+  # action is inlined temporarily to avoid issues on the PRs
   job-filter:
     if: github.repository_owner == 'pytorch'
-    name: job-filter
-    uses: ./.github/workflows/job-filter.yml
-    with:
-      jobs-to-include: ${{ github.event.inputs.jobs-to-include || '' }}
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: ${{ steps.set.outputs.jobs }}
+    steps:
+      - id: set
+        run: |
+          jobs="${{ github.event.inputs.jobs-to-include || '' }}"
+          if [ -n "$jobs" ]; then
+            echo "jobs= ${jobs} " >> "$GITHUB_OUTPUT"
+          else
+            echo "jobs=" >> "$GITHUB_OUTPUT"
+          fi
 
   llm-td:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -33,12 +33,21 @@ permissions:
 
 jobs:
   # See job-filter.yml for rules on adding job filter conditions
+  # action is inlined temporarily to avoid issues on the PRs
   job-filter:
     if: github.repository_owner == 'pytorch'
-    name: job-filter
-    uses: ./.github/workflows/job-filter.yml
-    with:
-      jobs-to-include: ${{ github.event.inputs.jobs-to-include || '' }}
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: ${{ steps.set.outputs.jobs }}
+    steps:
+      - id: set
+        run: |
+          jobs="${{ github.event.inputs.jobs-to-include || '' }}"
+          if [ -n "$jobs" ]; then
+            echo "jobs= ${jobs} " >> "$GITHUB_OUTPUT"
+          else
+            echo "jobs=" >> "$GITHUB_OUTPUT"
+          fi
 
   llm-td:
     if: github.repository_owner == 'pytorch'


### PR DESCRIPTION
quoting @malfet:

> It would cause the same SEV-like event like Eli's change last week, as GitHub always rebases .yml files, but not its dependnecies
> I.e. everything will be green on HUD, but everyone PRs will be failing with job-filter.yml not found
> See https://github.com/pytorch/pytorch/issues/170320


this is a temporary bandaid until people rebase past the new reusable action