### PR TITLE
Fix recompilation from python scalar * 0-d tensor in inplace mul_

### DIFF
--- a/test/dynamo/test_recompiles.py
+++ b/test/dynamo/test_recompiles.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+import os
 from unittest.mock import patch
 
 import torch
@@ -164,6 +165,39 @@ class RecompileTests(torch._dynamo.test_case.TestCase):
         with_automatic = run_with_automatic()
         self.assertEqual(with_automatic.frame_count, 3)
         self.assertEqual(with_automatic.op_count, 3)
+
+    def test_no_recompile_python_scalar_times_tensorified_lr_inplace_mul(self):
+        torch._dynamo.reset()
+        counter = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+
+        def scaling_step(update: torch.Tensor, dummy_tensor: torch.Tensor, lr):
+            dummy_tensor.mul_(0.5 * lr)  # forces lr to participate in tensor math
+
+            r, c = update.size(-2), update.size(-1)
+            scaling_factor = max(1, r / c) ** 0.5  # Python float
+            update.mul_(scaling_factor * lr)  # bug trigger path
+            return update
+
+        update = torch.randn(128, 128)
+        dummy_tensor = torch.randn(324, 64)
+
+        with patch.dict(os.environ, {"TENSORIFY_PYTHON_SCALARS": "1"}):
+            opt = torch.compile(backend=counter, fullgraph=True)(scaling_step)
+            opt(update, dummy_tensor, 1e-4)  # first compile
+            first = counter.frame_count
+
+            # Allow at most one extra compile due to restart-analysis mechanics.
+            opt(update, dummy_tensor, 2e-4)
+            self.assertLessEqual(counter.frame_count, first + 1)
+
+            settled = counter.frame_count
+
+            # Now changing lr many times must not recompile.
+            for i in range(3, 30):
+                opt(update, dummy_tensor, 1e-4 * (i + 1))
+
+        self.assertEqual(counter.frame_count, settled)
+        torch._dynamo.reset()
 
     def test_automatic_dynamic_tensor_scalar_change(self):
         # Test the counterfactual, lots of recompiles without this config

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import operator
 import os
 from typing import Any, TYPE_CHECKING, Union
 
@@ -231,6 +232,40 @@ def tensorify_python_scalars(
                     expr_to_tensor_proxy[s], torch.float64
                 )
 
+            elif (
+                node is not None
+                and node.op == "call_method"
+                and node.target == "item"
+                and isinstance(node.args[0], fx.Node)
+                and node.args[0] in placeholders
+            ):
+                arg0 = node.args[0]
+                if "val" not in arg0.meta:
+                    continue
+
+                dtype = arg0.meta["val"].dtype
+                sym = node.meta.get("val")
+                if sym is None or not isinstance(sym, torch.SymFloat):
+                    continue
+
+                s = sym.node.expr
+
+                expr_to_sym_proxy[s] = MetaProxy(
+                    node, tracer=tracer, fake_mode=fake_mode
+                )
+
+                # only tensorify if the dtype is floating point
+                if not dtype.is_floating_point:
+                    continue
+
+                expr_to_tensor_proxy[s] = MetaProxy(
+                    arg0, tracer=tracer, fake_mode=fake_mode
+                )
+                # Upcast the float tensor to torch.float64 to avoid precision problem
+                expr_to_tensor_proxy[s] = torch.ops.prims.convert_element_type.default(
+                    expr_to_tensor_proxy[s], torch.float64
+                )
+
             # pyrefly: ignore [bad-argument-type]
             elif (sym_expr := _get_sym_val(node)) is not None:
                 if sym_expr not in expr_to_sym_proxy and not isinstance(
@@ -331,6 +366,55 @@ def tensorify_python_scalars(
                         metrics_context.set(
                             "tensorify_float_success", True, overwrite=True
                         )
+            elif (
+                node.op == "call_function"
+                and node.target is operator.mul
+                and isinstance((sym_val := node.meta.get("val")), torch.SymFloat)
+            ):
+                # Tensorify SymFloat produced by Python "<built-in function mul>"
+                # so it doesn't get specialized into a value-guard later.
+                did_transform = False
+
+                if node.users and all(
+                    isinstance(u.meta.get("val"), FakeTensor) for u in node.users
+                ):
+                    user_compute_dtypes = {
+                        get_computation_dtype(u.meta["val"].dtype)
+                        for u in node.users
+                    }
+                    if len(user_compute_dtypes) == 1:
+                        compute_dtype = next(iter(user_compute_dtypes))
+                        try:
+                            proxy = _sympy_interp(sym_val.node.expr)
+                        except NotImplementedError:
+                            proxy = None
+
+                        if proxy is not None:
+                            if (
+                                compute_dtype != torch.bool
+                                and proxy.node.meta["val"].dtype != compute_dtype
+                            ):
+                                proxy = torch.ops.prims.convert_element_type.default(
+                                    proxy, compute_dtype
+                                )
+
+                            for s in sym_val.node.expr.free_symbols:
+                                tensorified_symbols.add(s)
+
+                            node.replace_all_uses_with(proxy.node)
+                            graph.erase_node(node)
+                            did_transform = True
+
+                # Preserve existing diagnostics if we did not transform.
+                if not did_transform:
+                    for a in node.args:
+                        if (
+                            isinstance(a, fx.Node)
+                            and "val" in a.meta
+                            and isinstance(a.meta["val"], torch.SymFloat)
+                        ):
+                            failed_tensorify_ops.update(str(node.target))
+                            log.info("Failed to tensorify %s", str(node.target))
             else:
                 # pyrefly: ignore [missing-attribute]
                 for a in node.args:


### PR DESCRIPTION
Fixes #169634

Problem: torch.compile recompiles repeatedly when a python scalar multiplies a 0-d tensor tracked as tensorified, producing value guards on __as_tensor(lr).item().

Fix: Extend tensorify_python_scalars to (1) map placeholder .item() represented as call_method("item") and (2) tensorify operator.mul producing SymFloat when it feeds tensor consumers, preventing specialization into value guards.

Test: Add regression in test/dynamo/test_recompiles.py ensuring recompiles settle and do not grow with changing lr.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo