### PR TITLE
ci: Split out pallas tpu + gpu

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -16,6 +16,7 @@ ciflow_push_tags:
 - ciflow/inductor-cu126
 - ciflow/inductor-micro-benchmark
 - ciflow/inductor-micro-benchmark-cpu-x86
+- ciflow/inductor-pallas
 - ciflow/inductor-perf-compare
 - ciflow/inductor-perf-test-nightly-rocm-mi300
 - ciflow/inductor-perf-test-nightly-rocm-mi355
@@ -25,7 +26,6 @@ ciflow_push_tags:
 - ciflow/inductor-rocm
 - ciflow/inductor-rocm-mi200
 - ciflow/inductor-rocm-mi300
-- ciflow/inductor-tpu
 - ciflow/linux-aarch64
 - ciflow/mps
 - ciflow/nightly

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -25,6 +25,7 @@ ciflow_push_tags:
 - ciflow/inductor-rocm
 - ciflow/inductor-rocm-mi200
 - ciflow/inductor-rocm-mi300
+- ciflow/inductor-tpu
 - ciflow/linux-aarch64
 - ciflow/mps
 - ciflow/nightly

--- a/.github/workflows/inductor-pallas-tpu.yml
+++ b/.github/workflows/inductor-pallas-tpu.yml
@@ -1,0 +1,62 @@
+name: inductor-pallas-tpu
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - ciflow/inductor-tpu/*
+  pull_request:
+    paths:
+      - torch/_inductor/codegen/pallas.py
+      - test/inductor/test_pallas.py
+      - .github/workflows/inductor-pallas-tpu.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      opt_out_experiments: lf
+
+  linux-jammy-py3_12-inductor-pallas-tpu-build:
+    name: pallas-tpu-py3.12-inductor
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-py3.12-gcc11-pallas-tpu
+      docker-image-name: ci-image:pytorch-linux-jammy-tpu-py3.12-pallas
+      test-matrix: |
+        { include: [
+          { config: "inductor-pallas-tpu", shard: 1, num_shards: 1, runner: "linux.google.tpuv6e.1" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-py3_12-inductor-pallas-tpu-test:
+    permissions:
+      id-token: write
+      contents: read
+    name: pallas-tpu-py3.12-inductor
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-jammy-py3_12-inductor-pallas-tpu-build
+    with:
+      build-environment: ${{ needs.linux-jammy-py3_12-inductor-pallas-tpu-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-py3_12-inductor-pallas-tpu-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_12-inductor-pallas-tpu-build.outputs.test-matrix }}
+    secrets: inherit

--- a/.github/workflows/inductor-pallas.yml
+++ b/.github/workflows/inductor-pallas.yml
@@ -1,4 +1,4 @@
-name: inductor-pallas-tpu
+name: inductor-pallas
 
 on:
   push:
@@ -6,12 +6,13 @@ on:
       - main
       - release/*
     tags:
-      - ciflow/inductor-tpu/*
+      - ciflow/inductor/*
+      - ciflow/inductor-pallas/*
   pull_request:
     paths:
       - torch/_inductor/codegen/pallas.py
       - test/inductor/test_pallas.py
-      - .github/workflows/inductor-pallas-tpu.yml
+      - .github/workflows/inductor-pallas.yml
   workflow_dispatch:
 
 concurrency:
@@ -33,6 +34,35 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
       opt_out_experiments: lf
+
+  linux-jammy-py3_12-inductor-pallas-gpu-build:
+    name: pallas-gpu-py3.12-inductor
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-jammy-cuda12.8-py3.12-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-py3.12-pallas
+      cuda-arch-list: '9.0'
+      runner: linux.8xlarge.memory
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "inductor-pallas-gpu", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-py3_12-inductor-pallas-gpu-test:
+    permissions:
+      id-token: write
+      contents: read
+    name: pallas-gpu-py3.12-inductor
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-jammy-py3_12-inductor-pallas-gpu-build
+    with:
+      build-environment: ${{ needs.linux-jammy-py3_12-inductor-pallas-gpu-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-py3_12-inductor-pallas-gpu-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_12-inductor-pallas-gpu-build.outputs.test-matrix }}
+    secrets: inherit
 
   linux-jammy-py3_12-inductor-pallas-tpu-build:
     name: pallas-tpu-py3.12-inductor

--- a/.github/workflows/inductor-pallas.yml
+++ b/.github/workflows/inductor-pallas.yml
@@ -6,7 +6,6 @@ on:
       - main
       - release/*
     tags:
-      - ciflow/inductor/*
       - ciflow/inductor-pallas/*
   pull_request:
     paths:

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -108,32 +108,6 @@ jobs:
       test-matrix: ${{ needs.inductor-pallas-cpu-build.outputs.test-matrix }}
     secrets: inherit
 
-  inductor-pallas-gpu-build:
-    name: inductor-pallas-gpu-build
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: linux-jammy-cuda12.8-py3.12-gcc11
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-py3.12-pallas
-      cuda-arch-list: '9.0'
-      runner: linux.8xlarge.memory
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      test-matrix: |
-        { include: [
-          { config: "inductor-pallas-gpu", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
-        ]}
-    secrets: inherit
-
-  inductor-pallas-gpu-test:
-    name: inductor-pallas-gpu-test
-    uses: ./.github/workflows/_linux-test.yml
-    needs: inductor-pallas-gpu-build
-    with:
-      build-environment: ${{ needs.inductor-pallas-gpu-build.outputs.build-environment }}
-      docker-image: ${{ needs.inductor-pallas-gpu-build.outputs.docker-image }}
-      test-matrix: ${{ needs.inductor-pallas-gpu-build.outputs.test-matrix }}
-    secrets: inherit
-
   inductor-triton-cpu-build:
     name: inductor-triton-cpu-build
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -134,30 +134,6 @@ jobs:
       test-matrix: ${{ needs.inductor-pallas-gpu-build.outputs.test-matrix }}
     secrets: inherit
 
-  inductor-pallas-tpu-build:
-    name: inductor-pallas-tpu-build
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      build-environment: linux-jammy-py3.12-gcc11-pallas-tpu
-      docker-image-name: ci-image:pytorch-linux-jammy-tpu-py3.12-pallas
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      test-matrix: |
-        { include: [
-          { config: "inductor-pallas-tpu", shard: 1, num_shards: 1, runner: "linux.google.tpuv6e.1" },
-        ]}
-    secrets: inherit
-
-  inductor-pallas-tpu-test:
-    name: inductor-pallas-tpu-test
-    uses: ./.github/workflows/_linux-test.yml
-    needs: inductor-pallas-tpu-build
-    with:
-      build-environment: linux-jammy-py3.12-gcc11-pallas-tpu
-      docker-image: ${{ needs.inductor-pallas-tpu-build.outputs.docker-image }}
-      test-matrix: ${{ needs.inductor-pallas-tpu-build.outputs.test-matrix }}
-    secrets: inherit
-
   inductor-triton-cpu-build:
     name: inductor-triton-cpu-build
     uses: ./.github/workflows/_linux-build.yml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #170478

Splits out tpu and gpu pallas jobs into their own workflow and own ciflow path. This should
help us with the supply constraints on the TPU and GPU side until we can get
more capacity to run this more regularly.


Signed-off-by: Eli Uriegas <eliuriegas@meta.com>