### PR TITLE
[dtensor][partial] fixing torch.sum() on NormPartial

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1079,6 +1079,25 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(res.placements, [Shard(0), Replicate()])
         self.assertEqual(res.full_tensor(), expected_answer)
 
+    @with_comms
+    def test_norm_partial_matching_reduction_ops(self):
+        mesh = self.build_device_mesh()
+
+        x = torch.tensor(
+            [
+                [3.0, 4.0, 0.0, 0.0],  # norm = 5.0
+                [5.0, 12.0, 0.0, 0.0],  # norm = 13.0
+            ]
+        )
+
+        dt = distribute_tensor(x, mesh, [Shard(1)])  # shard features across devices
+
+        norm_list = torch.linalg.vector_norm(dt, dim=1)
+
+        res = torch.sum(norm_list)
+        expected_answer = 18.0
+        self.assertEqual(res, expected_answer)
+
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistMathOpsTest,

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -316,7 +316,18 @@ def common_reduction_strategy(
         for p in op_spec.output_spec.placements:
             # when the partial reduction op matches the global reduction op,
             # we can delay redistribution (i.e max, max)
-            if isinstance(p, Partial) and p.reduce_op != reduction_op:
+            propagate_partial = True
+
+            # ordering matters here since NormPartial is a subclass of Partial
+            if isinstance(p, _NormPartial):
+                if p.reduce_op == "sum":
+                    propagate_partial = False
+
+            elif isinstance(p, Partial):
+                if p.reduce_op != reduction_op:
+                    propagate_partial = False
+
+            if propagate_partial:
                 reduction_linear = False
                 break
 


### PR DESCRIPTION
**Summary:** In order to prevent unnecessary redistributions, we skip redistributing partials when the op matches the reduce_op. However, this also applies to _NormPartial, as it also has reduce_op for sum. As you can see below, this is incorrect which means we do need to redistribute. 

<img width="1437" height="1916" alt="image" src="https://github.com/user-attachments/assets/a1b46916-8463-41f4-9ce4-28c14654f151" />

It should be noted that for NormPartial (min/max), we can still use the same logic as Partial's for why we can skip redistribution. 


**Test Cases** 
pytest test/distributed/tensor/test_math_ops.py -k test_norm_partial_matching_reduction_ops

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170498



cc @wanchaol @tianyu-l @wz337 @XilunWu @d4l3k @pragupta @SherlockNoMad @ppwwyyxx