### PR TITLE
[debug mode] Support dispatching into subgraphs in DebugMode for InvokeSubgraph

### DIFF
--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -36,6 +36,7 @@ from torch.fx.experimental.proxy_tensor import (
 )
 from torch.fx.graph_module import GraphModule
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
+from torch.utils._debug_mode import DebugMode
 from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispatchMode
 
 
@@ -675,12 +676,42 @@ def _(subgraph, identifier, *operands):
     return autograd_fn_callable(*operands)
 
 
+@invoke_subgraph.py_impl(DebugMode)
+def _(debug_mode, subgraph, identifier, *operands):
+    # record HOP call
+    call = torch.utils._debug_mode._OpCall(
+        invoke_subgraph,
+        (identifier, *operands),
+        kwargs={},
+        call_depth=debug_mode.call_depth + 1,
+        stack=debug_mode.record_stack_trace,
+    )
+    debug_mode._record_call(call)
+
+    debug_mode.call_depth += 1
+    debug_mode._handle_annotate(f"[enter InvokeSubgraph HOP] {identifier}")
+
+    # If the HOP is dispatched from DebugMode, we should enable debug_mode
+    # for the subgraph call.
+    with debug_mode:
+        if getattr(subgraph, "_boxed_call", False):
+            result = subgraph(list(operands))
+        else:
+            result = subgraph(*operands)
+    debug_mode._handle_annotate(f"[exit InvokeSubgraph HOP] {identifier}")
+    debug_mode.call_depth -= 1
+    # record output of HOP
+    debug_mode._record_call_output(call, result)
+    return result
+
+
 @invoke_subgraph.py_impl(DispatchKey.CompositeExplicitAutograd)
 def _(subgraph, identifier, *operands):
     from torch.utils._python_dispatch import _get_current_dispatch_mode
 
     mode = _get_current_dispatch_mode()
     assert mode is None, "Mode should never be enabled for CPU/CUDA key"
+
     if getattr(subgraph, "_boxed_call", False):
         return subgraph(list(operands))
     else:

--- a/torch/utils/_debug_mode.py
+++ b/torch/utils/_debug_mode.py
@@ -956,8 +956,6 @@ class DebugMode(TorchDispatchMode):
         return result
 
     def __enter__(self):
-        self.reset()
-
         if self.record_torchfunction:
             torch._C._push_on_torch_function_stack(self)
 


### PR DESCRIPTION
Used to debug invoke_subgraph gradient accuracy in https://github.com/pytorch/pytorch/pull/170485

```
python test/distributed/tensor/debug/test_debug_mode.py -k test_invoke_subgraph
```

We need to 
1) clearly mark the beginning and end of invoke_subgraph
2) actually enable debug_mode for the subgraph call in invoke_subgraph


Example debug string:

```
    def test_nested_invoke_subgraph(self):
        # Test that DebugMode can trace the operations inside
        # invoke_subgraph HOP
        @torch.compiler.nested_compile_region
        def ggn(x):
            a = torch.cos(x)
            return a

        @torch.compiler.nested_compile_region
        def gn(x):
            x = x + 1
            x = ggn(x)
            a = torch.sin(x)
            return a

        def fn(x):
            foo1 = gn(x)
            y = foo1 * 2
            return y

            """\
    torch.ops.higher_order.invoke_subgraph(subgraph_1, t: f32[8, 8])  ->  ('t: f32[8, 8]',)
    [annotate] [enter InvokeSubgraph HOP] subgraph_1
      aten::add.Tensor(t: f32[8, 8], 1)  ->  t: f32[8, 8]
      torch.ops.higher_order.invoke_subgraph(subgraph_0, t: f32[8, 8])  ->  ('t: f32[8, 8]',)
      [annotate] [enter InvokeSubgraph HOP] subgraph_0
        aten::cos(t: f32[8, 8])  ->  t: f32[8, 8]
      [annotate] [exit InvokeSubgraph HOP] subgraph_0
      aten::sin(t: f32[8, 8])  ->  t: f32[8, 8]
    [annotate] [exit InvokeSubgraph HOP] subgraph_1
    aten::mul.Tensor(t: f32[8, 8], 2)  ->  t: f32[8, 8]""",  # noqa: B950

```