### PR TITLE
Fix optimizer example to use Adam instead of SGD in base class docs

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -899,7 +899,7 @@ class Optimizer:
         Example:
             >>> # xdoctest: +SKIP
             >>> model = torch.nn.Linear(10, 10)
-            >>> optim = torch.optim.SGD(model.parameters(), lr=3e-4)
+            >>> optim = torch.optim.Adam(model.parameters(), lr=3e-4)
             >>> scheduler1 = torch.optim.lr_scheduler.LinearLR(
             ...     optim,
             ...     start_factor=0.1,


### PR DESCRIPTION
## Description

Fixes #164932

The `load_state_dict` example in the base `Optimizer` class was using `torch.optim.SGD`, but this documentation is inherited by all optimizer classes (Adam, Adagrad, RMSprop, etc.). This caused confusion when viewing documentation for other optimizers, as they would show SGD-specific examples.

## Changes

Changed line 902 in `torch/optim/optimizer.py` from:
```python
>>> optim = torch.optim.SGD(model.parameters(), lr=3e-4)
```

to:
```python
>>> optim = torch.optim.Adam(model.parameters(), lr=3e-4)
```

Adam is a more commonly used optimizer and provides a better generic example that doesn't create confusion when inherited by other optimizer classes.

## Testing

This is a documentation-only change. The example code remains functionally equivalent - it still demonstrates the proper usage of `load_state_dict` with LR schedulers.

cc: @albanD