### PR TITLE
[ROCm] Fixed UT test_disable_external_correlation and test_dynamic_toggle for test_profiler

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2190,7 +2190,7 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
 
         self.assertTrue(any("aten" in e.name for e in p.events()))
 
-        self.assertTrue(any(device in e.name for e in p.events()))
+        self.assertTrue(any(device in e.name.lower() for e in p.events()))
 
         self.assertTrue(any("kernel" in e.name.lower() for e in p.events()))
 
@@ -2316,10 +2316,14 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
             if "cat" in event and event["cat"] in cuda_external_id_events:
                 if disable_external_correlation:
                     self.assertTrue("External id" not in event["args"])
-                elif event["name"] != "cudaDeviceSynchronize":
-                    self.assertTrue("External id" in event["args"])
-                    self.assertTrue(event["args"]["External id"] > 0)
-
+                else:
+                    excluded_events = (
+                        {"hipDeviceSynchronize"} if TEST_WITH_ROCM 
+                        else {"cudaDeviceSynchronize"})
+                    if event["name"] not in excluded_events:
+                        self.assertTrue("External id" in event["args"])
+                        self.assertTrue(event["args"]["External id"] > 0)
+ 
         def validate_json(prof, disable_external_correlation):
             with TemporaryFileName(mode="w+") as fname:
                 prof.export_chrome_trace(fname)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2318,8 +2318,10 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
                     self.assertTrue("External id" not in event["args"])
                 else:
                     excluded_events = (
-                        {"hipDeviceSynchronize"} if TEST_WITH_ROCM
-                        else {"cudaDeviceSynchronize"})
+                        {"hipDeviceSynchronize"}
+                        if TEST_WITH_ROCM
+                        else {"cudaDeviceSynchronize"}
+                    )
                     if event["name"] not in excluded_events:
                         self.assertTrue("External id" in event["args"])
                         self.assertTrue(event["args"]["External id"] > 0)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2318,12 +2318,12 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
                     self.assertTrue("External id" not in event["args"])
                 else:
                     excluded_events = (
-                        {"hipDeviceSynchronize"} if TEST_WITH_ROCM 
+                        {"hipDeviceSynchronize"} if TEST_WITH_ROCM
                         else {"cudaDeviceSynchronize"})
                     if event["name"] not in excluded_events:
                         self.assertTrue("External id" in event["args"])
                         self.assertTrue(event["args"]["External id"] > 0)
- 
+
         def validate_json(prof, disable_external_correlation):
             with TemporaryFileName(mode="w+") as fname:
                 prof.export_chrome_trace(fname)


### PR DESCRIPTION
Fixes #143373
Fixes #134479

Summary of fixes:
1. test_disable_external_correlation:
Updates the test for external correlation to correctly exclude hipDeviceSynchronize on ROCm and cudaDeviceSynchronize on CUDA platforms when checking for External ID presence in profiler events.

2. test_dynamic_toggle:
The pattern matches against lowercase event names, so this will correctly identify events containing "cuda", "xpu", or other device types in the profiler trace.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang