### PR TITLE
[DTensor] Provide user control of output gradients placements 

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -186,8 +186,9 @@ class RedistributeTest(DTensorTestBase):
             )
             out.backward(torch.ones_like(out))
 
-        self.assertEqual(comm_mode.get_total_counts(), 1)
-        self.assertEqual(comm_mode.get_comm_counts()[funcol.all_reduce], 1)
+        # redistribute forward is no-op, backward 
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(comm_mode.get_comm_counts()[funcol.all_reduce], 0)
 
     @with_comms
     def test_replicate_to_shard_forward_backward(self):

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -186,7 +186,7 @@ class RedistributeTest(DTensorTestBase):
             )
             out.backward(torch.ones_like(out))
 
-        # redistribute forward is no-op, backward 
+        # redistribute forward is no-op, backward
         self.assertEqual(comm_mode.get_total_counts(), 0)
         self.assertEqual(comm_mode.get_comm_counts()[funcol.all_reduce], 0)
 

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -137,9 +137,11 @@ class _FromTorchTensor(torch.autograd.Function):
         run_check: bool,
         shape: torch.Size | None = None,
         stride: tuple[int, ...] | None = None,
+        grad_placements: tuple[Placement, ...] | None = None,
     ) -> "DTensor":
         ctx.forward_input_placements = placements
         ctx.forward_input_device_mesh = device_mesh
+        ctx.grad_placements = grad_placements
 
         if shape and stride:
             tensor_shape, tensor_stride = shape, stride
@@ -202,20 +204,27 @@ class _FromTorchTensor(torch.autograd.Function):
     def backward(ctx, grad_output: "DTensor"):  # type: ignore[override]
         forward_input_placements = ctx.forward_input_placements
         forward_input_device_mesh = ctx.forward_input_device_mesh
+        grad_placements = ctx.grad_placements
 
-        # reshard to the placement when creating DistributedTensor
-        # so that the gradient layout matches, and we could return
-        # local gradients directly
-        if grad_output.placements != forward_input_placements:
-            current_spec = grad_output._spec
+        # When user provided grad_placements, we use it as the desired layout without any optimizations
+        if grad_placements is not None:
+            desired_grad_placements = grad_placements
+            target_spec = DTensorSpec(
+                forward_input_device_mesh,
+                desired_grad_placements,
+                tensor_meta=grad_output._spec.tensor_meta,
+            )
+        else:
+            desired_grad_placements = forward_input_placements
 
+            # We optimize input gradients placement by replacing partial to replicate
             # for backward shard -> partial, we do shard -> replicate
             # for backward replicate -> partial, we do replicate -> replicate / skip transformation
             # TODO: for backward partial -> partial, right now we keep it unchanged,
             # but this might need revisit
             normalized_placements: list[Placement] = []
             for current, target in zip(
-                current_spec.placements, forward_input_placements
+                grad_output._spec.placements, desired_grad_placements
             ):
                 if (
                     current.is_shard() or current.is_replicate()
@@ -229,6 +238,8 @@ class _FromTorchTensor(torch.autograd.Function):
                 tuple(normalized_placements),
                 tensor_meta=grad_output._spec.tensor_meta,
             )
+        if grad_output.placements != desired_grad_placements:
+            current_spec = grad_output._spec
             local_tensor = grad_output._local_tensor
             output = redistribute_local_tensor(
                 local_tensor,

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1043,8 +1043,12 @@ class Redistribute(torch.autograd.Function):
                 # for backward shard -> partial, we just do shard -> replicate
                 # for backward replicate -> partial, we skip the transformation
                 normalized_placements: list[Placement] = []
-                for current, target in zip(current_spec.placements, previous_spec.placements):
-                    if (current.is_shard() or current.is_replicate()) and target.is_partial():
+                for current, target in zip(
+                    current_spec.placements, previous_spec.placements
+                ):
+                    if (
+                        current.is_shard() or current.is_replicate()
+                    ) and target.is_partial():
                         normalized_placements.append(Replicate())
                     else:
                         normalized_placements.append(target)


### PR DESCRIPTION
As discussed in https://github.com/pytorch/pytorch/pull/170147(see comment [here](https://github.com/pytorch/pytorch/pull/170147#discussion_r2617225276) and [here](https://github.com/pytorch/pytorch/pull/170147#discussion_r2617409579)), we added a parameter `grad_placements` to `from_local` and `redistribute` forward, where user can control the placements of the output gradients in backward. 

1. If the user specify gradients placement, backward will output gradients with the exact same placements users provided;
 
2. If user has not passed in gradients placement, backward will output gradients with the same placements as the forward inputs, with the following optimizations applied:

  - optimizations for `redistribute` backward: 
    - if forward is no-op, backward is also no-op, meaning output gradients == input gradients 
    - if backward output gradient is partial, and input gradient is shard or replicate, redistribute output gradient to replicate.

 - optimizations for `from_local` backward:
   - if backward output gradient is partial, always redistribute it to replicate instead. 

## Test plan: 

```
python3 test/distributed/tensor/test_redistribute.py
python test/distributed/tensor/test_api.py 
```