### PR TITLE
don't check mat1 sizes when deciding whether to fuse bias

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -218,9 +218,6 @@ static bool isInputCompliesAddmmCudaLt(
     && ( // some shape/stride restrictions
       // Strangely, if mat2 has only 1 row or column, we get
       // CUBLAS_STATUS_INVALID_VALUE error from cublasLtMatmulAlgoGetHeuristic.
-      // NOTE: extension to mat1 because mat1/mat2 can be swapped based off
-      // their row-/col-majorness.
-      mat1_sizes[0] > 1 && mat1_sizes[1] > 1 &&
       mat2_sizes[0] > 1 && mat2_sizes[1] > 1
       // The last conditions is to skip 16b transA and non-trans-B having
       // leading dim >> rows when they are sliced from a large tensor


### PR DESCRIPTION
Checking mat1 sizes was added in #163955 but it's not needed. mat1 and mat2 can be swapped only if output is column-major but we've already checked that output is contiguous.
