### PR TITLE
OpenReg: add basic HostAllocator stats tracking

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHostAllocator.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHostAllocator.cpp
@@ -1,6 +1,209 @@
 #include "OpenRegHostAllocator.h"
 
+#include <c10/util/Exception.h>
+
+#include <mutex>
+#include <unordered_map>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace c10::openreg {
+
+namespace {
+
+constexpr size_t kDefaultPageSizeBytes = 4096;
+
+size_t getPageSizeBytes() {
+  static const size_t page_size_bytes = [] {
+#if defined(_WIN32)
+    SYSTEM_INFO system_info;
+    GetSystemInfo(&system_info);
+    const long page_size_long = static_cast<long>(system_info.dwPageSize);
+#else
+    const long page_size_long = sysconf(_SC_PAGESIZE);
+#endif
+    return page_size_long > 0 ? static_cast<size_t>(page_size_long)
+                              : kDefaultPageSizeBytes;
+  }();
+  return page_size_bytes;
+}
+
+size_t roundUpToPageSize(size_t nbytes) {
+  const size_t page_size = getPageSizeBytes();
+  return ((nbytes + page_size - 1) / page_size) * page_size;
+}
+
+class HostMemoryAllocator {
+ public:
+  HostMemoryAllocator() = default;
+
+  HostMemoryAllocator(const HostMemoryAllocator&) = delete;
+  HostMemoryAllocator& operator=(const HostMemoryAllocator&) = delete;
+
+  void* malloc(size_t nbytes) {
+    if (nbytes == 0) {
+      return nullptr;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+    const size_t aligned_nbytes = roundUpToPageSize(nbytes);
+
+    void* data = nullptr;
+    const auto ret = orMallocHost(&data, aligned_nbytes);
+
+    TORCH_CHECK(
+        ret == orSuccess && data != nullptr,
+        "Failed to allocate ",
+        aligned_nbytes,
+        " bytes on host.");
+
+    allocation_sizes_[data] = aligned_nbytes;
+
+    stats_.allocations.increase(1);
+    stats_.allocated_bytes.increase(aligned_nbytes);
+    stats_.active_requests.increase(1);
+    stats_.active_bytes.increase(aligned_nbytes);
+
+    stats_.num_host_alloc += 1;
+
+    return data;
+  }
+
+  void free(void* ptr) {
+    if (!ptr) {
+      return;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+    auto it = allocation_sizes_.find(ptr);
+    if (it != allocation_sizes_.end()) {
+      const size_t nbytes = it->second;
+      const auto ret = orFreeHost(ptr);
+      if (ret != orSuccess && ret != orErrorUnknown) {
+        TORCH_WARN(
+            "orFreeHost failed for OpenReg host pointer ",
+            ptr,
+            ". Return code: ",
+            ret);
+        return;
+      }
+
+      allocation_sizes_.erase(it);
+
+      stats_.allocations.decrease(1);
+      stats_.allocated_bytes.decrease(nbytes);
+      stats_.active_requests.decrease(1);
+      stats_.active_bytes.decrease(nbytes);
+
+      if (ret == orSuccess) {
+        stats_.num_host_free += 1;
+      }
+
+      return;
+    }
+
+    // Best-effort orFreeHost for untracked pointers; don't update stats.
+    const auto ret = orFreeHost(ptr);
+    if (ret != orSuccess && ret != orErrorUnknown) {
+      TORCH_WARN(
+          "orFreeHost failed for untracked OpenReg host pointer ",
+          ptr,
+          ". Return code: ",
+          ret);
+    }
+  }
+
+  at::HostStats getStats() const {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    return stats_;
+  }
+
+  void resetAccumulatedStats() {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+    stats_.allocations.reset_accumulated();
+    stats_.allocated_bytes.reset_accumulated();
+    stats_.active_requests.reset_accumulated();
+    stats_.active_bytes.reset_accumulated();
+
+    stats_.host_alloc_time.reset_accumulated();
+    stats_.host_free_time.reset_accumulated();
+
+    stats_.num_host_alloc = 0;
+    stats_.num_host_free = 0;
+  }
+
+  void resetPeakStats() {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+    stats_.allocations.reset_peak();
+    stats_.allocated_bytes.reset_peak();
+    stats_.active_requests.reset_peak();
+    stats_.active_bytes.reset_peak();
+
+    stats_.host_alloc_time.reset_peak();
+    stats_.host_free_time.reset_peak();
+  }
+
+ private:
+  mutable std::recursive_mutex mutex_;
+
+  at::HostStats stats_{};
+  std::unordered_map<void*, size_t> allocation_sizes_;
+};
+
+HostMemoryAllocator g_host_allocator;
+
+void deleteOpenRegHostMemory(void* ptr) {
+  g_host_allocator.free(ptr);
+}
+
+} // namespace
+
+at::DataPtr OpenRegHostAllocator::allocate(size_t nbytes) {
+  void* data = g_host_allocator.malloc(nbytes);
+  return {data, data, &deleteOpenRegHostMemory, at::Device(at::kCPU)};
+}
+
+at::DeleterFnPtr OpenRegHostAllocator::raw_deleter() const {
+  return &deleteOpenRegHostMemory;
+}
+
+void OpenRegHostAllocator::copy_data(
+    void* dest,
+    const void* src,
+    std::size_t count) const {
+  orMemcpy(dest, src, count, orMemcpyHostToHost);
+}
+
+bool OpenRegHostAllocator::record_event(
+    [[maybe_unused]] void* ptr,
+    [[maybe_unused]] void* ctx,
+    [[maybe_unused]] c10::Stream stream) {
+  return true;
+}
+
+void OpenRegHostAllocator::empty_cache() {
+  // No caching for OpenReg host allocations today.
+}
+
+at::HostStats OpenRegHostAllocator::get_stats() {
+  return g_host_allocator.getStats();
+}
+
+void OpenRegHostAllocator::reset_accumulated_stats() {
+  g_host_allocator.resetAccumulatedStats();
+}
+
+void OpenRegHostAllocator::reset_peak_stats() {
+  g_host_allocator.resetPeakStats();
+}
 
 OpenRegHostAllocator caching_host_allocator;
 REGISTER_HOST_ALLOCATOR(at::kPrivateUse1, &caching_host_allocator);

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHostAllocator.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHostAllocator.h
@@ -4,6 +4,7 @@
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
+#include <c10/core/Stream.h>
 
 #include <include/openreg.h>
 
@@ -11,40 +12,24 @@ namespace c10::openreg {
 struct OpenRegHostAllocator final : at::HostAllocator {
   OpenRegHostAllocator() = default;
 
-  static void ReportAndDelete(void* ptr) {
-    if (!ptr) {
-      return;
-    }
-    orFreeHost(ptr);
-  }
+  at::DataPtr allocate(size_t nbytes) override;
 
-  at::DataPtr allocate(size_t nbytes) override {
-    void* data = nullptr;
-    if (nbytes > 0) {
-      orMallocHost(&data, nbytes);
-      TORCH_CHECK(data, "Failed to allocator ", nbytes, " bytes on host.");
-    }
-    return {data, data, &ReportAndDelete, at::Device(at::kCPU)};
-  }
+  at::DeleterFnPtr raw_deleter() const override;
 
-  at::DeleterFnPtr raw_deleter() const override {
-    return &ReportAndDelete;
-  }
+  void copy_data(void* dest, const void* src, std::size_t count) const final;
 
-  void copy_data(void* dest, const void* src, std::size_t count) const final {
-    orMemcpy(dest, src, count, orMemcpyHostToHost);
-  }
+  bool record_event(
+      [[maybe_unused]] void* ptr,
+      [[maybe_unused]] void* ctx,
+      [[maybe_unused]] c10::Stream stream) override;
 
-  // ignore
-  bool record_event(void* ptr, void* ctx, c10::Stream stream) override {
-    return true;
-  }
-  void empty_cache() override {}
-  at::HostStats get_stats() override {
-    return at::HostStats();
-  }
-  void reset_accumulated_stats() override {}
-  void reset_peak_stats() override {}
+  void empty_cache() override;
+
+  at::HostStats get_stats() override;
+
+  void reset_accumulated_stats() override;
+
+  void reset_peak_stats() override;
 };
 
 } // namespace c10::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
@@ -465,6 +465,45 @@ class TestPinMemory(TestCase):
         )
         self.assertTrue(shared_tensor.is_pinned())
 
+    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    def test_pin_memory_openreg_basic(self):
+        t = torch.randn(10, dtype=torch.float32)
+        self.assertFalse(t.is_pinned())
+
+        pinned = t.pin_memory("openreg")
+        self.assertEqual(pinned.device.type, "cpu")
+        self.assertEqual(pinned.shape, t.shape)
+        self.assertEqual(pinned.dtype, t.dtype)
+        self.assertTrue(pinned.is_pinned("openreg"))
+
+    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    def test_pin_memory_openreg_varied_sizes(self):
+        # Use uint8 so `numel()` directly corresponds to bytes, which makes it
+        # easier to exercise the host allocator's page-size alignment logic.
+        sizes = [0, 1, 4095, 4096, 4097, 8192]
+        for size in sizes:
+            t = torch.empty(size, dtype=torch.uint8)
+            pinned = t.pin_memory("openreg")
+            self.assertEqual(pinned.numel(), size)
+            self.assertEqual(pinned.dtype, t.dtype)
+            self.assertEqual(pinned.device.type, "cpu")
+
+            # Zero-size tensors may not allocate any storage, but should still
+            # be safe to pin.
+            if size != 0:
+                self.assertTrue(pinned.is_pinned("openreg"))
+
+    @skipIfTorchDynamo("unsupported aten.is_pinned.default")
+    def test_pin_memory_openreg_repeated_cycles(self):
+        # Keep this test lightweight but exercise repeated alloc/free cycles
+        # through the OpenReg pinned allocator.
+        for i in range(50):
+            pinned = torch.empty(4096, dtype=torch.uint8).pin_memory("openreg")
+            self.assertTrue(pinned.is_pinned("openreg"))
+            del pinned
+            if i % 10 == 0:
+                gc.collect()
+
 
 class TestMultiDeviceAllocation(TestCase):
     """Test basic multi-device allocation functionality."""


### PR DESCRIPTION
  Track at::HostStats in OpenRegHostAllocator for pinned host allocations, mirroring
  the core counters used by the device allocator (active/allocated bytes, active
  requests, alloc/free counts). Keep host allocator behavior minimal: no caching and no
  timing stats.

  Add simple OpenReg pin_memory regression tests in test_memory.py to cover varied
  allocation sizes and repeated alloc/free cycles.

Fixes #ISSUE_NUMBER


cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD