### PR TITLE
[XPU] Migrate test_testing for xpu

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -40,6 +40,7 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -488,6 +489,8 @@ if __name__ == '__main__':
             dynamic_dispatch = opinfo.utils.dtypes_dispatch_hint(dynamic_dtypes)
             if self.device_type == 'cpu':
                 dtypes = op.dtypes
+            elif self.device_type == 'xpu':
+                dtypes = op.dtypesIfXPU
             else:  # device_type ='cuda'
                 dtypes = op.dtypesIfCUDA
 
@@ -1187,7 +1190,7 @@ class TestAssertCloseMultiDevice(TestCase):
                 fn(check_device=False)
 
 
-instantiate_device_type_tests(TestAssertCloseMultiDevice, globals(), only_for="cuda")
+instantiate_device_type_tests(TestAssertCloseMultiDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True)
 
 
 class TestAssertCloseErrorMessage(TestCase):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -40,7 +40,6 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
-
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -37,6 +37,7 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -493,6 +494,8 @@ if __name__ == '__main__':
             dynamic_dispatch = opinfo.utils.dtypes_dispatch_hint(dynamic_dtypes)
             if self.device_type == 'cpu':
                 dtypes = op.dtypes
+            elif self.device_type == 'xpu':
+                dtypes = op.dtypesIfXPU
             else:  # device_type ='cuda'
                 dtypes = op.dtypesIfCUDA
 
@@ -1026,7 +1029,7 @@ class TestAssertCloseMultiDevice(TestCase):
                 fn(check_device=False)
 
 
-instantiate_device_type_tests(TestAssertCloseMultiDevice, globals(), only_for="cuda")
+instantiate_device_type_tests(TestAssertCloseMultiDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True)
 
 
 class TestAssertCloseErrorMessage(TestCase):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -37,7 +37,6 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
-
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -9,7 +9,6 @@ import numpy as np
 import numpy.typing as npt
 
 import torch
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_dtype import (
     _dispatch_dtypes,
     all_types,
@@ -26,7 +25,11 @@ from torch.testing._internal.common_dtype import (
     integral_types,
     integral_types_and,
 )
-from torch.testing._internal.common_utils import torch_to_numpy_dtype_dict
+from torch.testing._internal.common_utils import (
+    TEST_CUDA,
+    TEST_XPU,
+    torch_to_numpy_dtype_dict,
+)
 
 
 COMPLETE_DTYPES_DISPATCH = (
@@ -49,7 +52,7 @@ EXTENSIBLE_DTYPE_DISPATCH = (
 )
 
 # Better way to acquire devices?
-DEVICES = ["cpu"] + (["cuda"] if TEST_CUDA else [])
+DEVICES = ["cpu"] + (["cuda"] if TEST_CUDA else []) + (["xpu"] if TEST_XPU else [])
 
 
 class _dynamic_dispatch_dtypes(_dispatch_dtypes):
@@ -59,13 +62,19 @@ class _dynamic_dispatch_dtypes(_dispatch_dtypes):
 
 def get_supported_dtypes(op, sample_inputs_fn, device_type):
     # Returns the supported dtypes for the given operator and device_type pair.
-    if device_type not in ["cpu", "cuda"]:
-        raise AssertionError(
-            f"Expected device_type in ['cpu', 'cuda'], got {device_type!r}"
-        )
+    if device_type not in ["cpu", "cuda", "xpu"]:
+        raise AssertionError(f"Expected device_type in ['cpu', 'cuda', 'xpu'], got {device_type!r}")
+
     if not TEST_CUDA and device_type == "cuda":
         warnings.warn(
             "WARNING: CUDA is not available, empty_dtypes dispatch will be returned!",
+            stacklevel=2,
+        )
+        return _dynamic_dispatch_dtypes(())
+
+    if not TEST_XPU and device_type == "xpu":
+        warnings.warn(
+            "WARNING: XPU is not available, empty_dtypes dispatch will be returned!",
             stacklevel=2,
         )
         return _dynamic_dispatch_dtypes(())

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -26,8 +26,7 @@ from torch.testing._internal.common_dtype import (
     integral_types_and,
 )
 from torch.testing._internal.common_utils import (
-    TEST_CUDA,
-    TEST_XPU,
+    TEST_ACCELERATOR,
     torch_to_numpy_dtype_dict,
 )
 
@@ -51,9 +50,6 @@ EXTENSIBLE_DTYPE_DISPATCH = (
     all_types_and,
 )
 
-# Better way to acquire devices?
-DEVICES = ["cpu"] + (["cuda"] if TEST_CUDA else []) + (["xpu"] if TEST_XPU else [])
-
 
 class _dynamic_dispatch_dtypes(_dispatch_dtypes):
     # Class to tag the dynamically generated types.
@@ -66,16 +62,9 @@ def get_supported_dtypes(op, sample_inputs_fn, device_type):
         raise AssertionError(
             f"Expected device_type in ['cpu', 'cuda', 'xpu'], got {device_type!r}"
         )
-    if not TEST_CUDA and device_type == "cuda":
+    if not TEST_ACCELERATOR and device_type in ("cuda", "xpu"):
         warnings.warn(
-            "WARNING: CUDA is not available, empty_dtypes dispatch will be returned!",
-            stacklevel=2,
-        )
-        return _dynamic_dispatch_dtypes(())
-
-    if not TEST_XPU and device_type == "xpu":
-        warnings.warn(
-            "WARNING: XPU is not available, empty_dtypes dispatch will be returned!",
+            "WARNING: Accelerator is not available, empty_dtypes dispatch will be returned!",
             stacklevel=2,
         )
         return _dynamic_dispatch_dtypes(())

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -63,8 +63,9 @@ class _dynamic_dispatch_dtypes(_dispatch_dtypes):
 def get_supported_dtypes(op, sample_inputs_fn, device_type):
     # Returns the supported dtypes for the given operator and device_type pair.
     if device_type not in ["cpu", "cuda", "xpu"]:
-        raise AssertionError(f"Expected device_type in ['cpu', 'cuda', 'xpu'], got {device_type!r}")
-
+        raise AssertionError(
+		    f"Expected device_type in ['cpu', 'cuda', 'xpu'], got {device_type!r}"
+        )
     if not TEST_CUDA and device_type == "cuda":
         warnings.warn(
             "WARNING: CUDA is not available, empty_dtypes dispatch will be returned!",

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -64,7 +64,7 @@ def get_supported_dtypes(op, sample_inputs_fn, device_type):
     # Returns the supported dtypes for the given operator and device_type pair.
     if device_type not in ["cpu", "cuda", "xpu"]:
         raise AssertionError(
-		    f"Expected device_type in ['cpu', 'cuda', 'xpu'], got {device_type!r}"
+            f"Expected device_type in ['cpu', 'cuda', 'xpu'], got {device_type!r}"
         )
     if not TEST_CUDA and device_type == "cuda":
         warnings.warn(


### PR DESCRIPTION
# Description
Fixes #114850, we will port dynamo, fsdp tests to Intel GPU
We could enable Intel GPU with following methods and try the best to keep the original code styles:

# Changes
1. Get device type with from accelerator and get device type helper method
2. Add dtypesIfXPU for dtypes test case.
3. Use common utils replace the cuda utils to import TEST_CUDA and TEST_XPU


# Notify
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @chenyang78 @mingfeima @sanchitintel @ashokei @jingxu10 @jerryzh168 @ipiszy @muchulee8 @aakhundov @coconutruben @gujinghui @fengyuan14 @guangyey