### PR TITLE
[ROCm] Fix TestExportOnFakeCuda.test_preserve_original_behavior

### DIFF
--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -212,7 +212,6 @@ for op in ops:
         self.assertEqual(r, "")
 
     @unittest.skipIf(not torch.backends.cuda.is_built(), "requires CUDA build")
-    @skipIfRocm
     def test_preserve_original_behavior(self):
         test_script = f"""\
 import torch


### PR DESCRIPTION
Fixes #168552

It seems 09454c3 have fixed it as well.
Hence just remove the skipIfRocm


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang