### PR TITLE
Fix _fused_dropout_decomposition zero divisor error

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1166,6 +1166,22 @@ class DecompOneOffTests(TestCase):
             torch._decomp.decompositions._weight_norm_interface(inp, inp2),
         )
 
+    @onlyCUDA
+    @skipIfCrossRef
+    def test_fused_dropout_p0(self, device):
+        input_tensor = torch.randn(10, 10, dtype=torch.float32, device=device)
+        p = 0.0
+        generator = None
+
+        fn = torch.ops.aten._fused_dropout
+        compile_fn = torch.compile(fn, backend="eager")
+
+        ref = fn(input_tensor, p, generator)
+        res = compile_fn(input_tensor, p, generator)
+
+        self.assertTrue(torch.allclose(ref[0], res[0], equal_nan=True))
+        self.assertTrue(torch.allclose(ref[1], res[1]))
+
     @onlyCPU
     @skipIfCrossRef
     @skipOps(

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2241,7 +2241,10 @@ def _batch_norm_no_update(
 def _fused_dropout_decomposition(input, p, generator=None):
     assert generator is None
     mask = (torch.rand_like(input) < p).to(dtype=torch.uint8)
-    res = mask.type_as(input) * input * (1.0 / p)
+    if p == 0.0:
+        res = torch.zeros_like(input)
+    else:
+        res = mask.type_as(input) * input * (1.0 / p)
     return (res, mask)
 
 


### PR DESCRIPTION
Fixes #170520

This pull request adds a new test for the fused dropout operation with probability zero and fixes the decomposition logic for this edge case. The changes ensure that when the dropout probability `p` is zero, the output tensor is correctly set to all zeros, improving correctness and test coverage.

cc @chauhang @penguinwu