### PR TITLE
Less aggressive assertions in sympy Mod

### DIFF
--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -506,10 +506,8 @@ class Mod(sympy.Function):
 
         # Evaluate if they are both literals.
         if q.is_Number and p.is_Number:
-            if p < 0:
-                raise AssertionError(p)
-            if q < 1:
-                raise AssertionError(q)
+            if p < 0 or q < 1:
+                return None
             return p % q
 
         # If q == 2, it's a matter of whether p is odd or even.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):


See: https://github.com/pytorch/pytorch/issues/163876. 

Evaluating `.is_constant` should not result in an error. `eval` is a simplification api and we should pessimize instead of throwing, if the current expected invariants are not met.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01