### PR TITLE
[Inductor] Finely overlap template fusion with async_compile

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -15,6 +15,7 @@ import textwrap
 import traceback
 import typing
 from collections import Counter, defaultdict
+from concurrent.futures import as_completed, Future
 from typing import Any, Generic, Optional, TYPE_CHECKING, TypeAlias, TypeVar, Union
 from typing_extensions import ParamSpec
 
@@ -96,6 +97,39 @@ cudagraphs_log = torch._logging.getArtifactLogger(__name__, "cudagraphs")
 PartitionType: TypeAlias = list["BaseSchedulerNode"]
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
+
+
+@dataclasses.dataclass
+class FusionResult:
+    should_fuse: Optional[bool] = None
+    callable_fn: Optional[Callable[[], bool]] = None
+    future: Optional[LambdaFuture] = None
+
+    def __post_init__(self):
+        assert (self.should_fuse is not None) ^ (self.callable_fn is not None), (
+            "Fusion result should contain either fusion decision or callable_fn, not both"
+        )
+
+    @classmethod
+    def fuse(cls, should_fuse: bool):
+        return FusionResult(should_fuse=should_fuse)
+
+    @classmethod
+    def from_callable(
+        cls, callable_fn: Callable[[], bool], future: Optional[LambdaFuture] = None
+    ):
+        return FusionResult(callable_fn=callable_fn, future=future)
+
+
+@dataclasses.dataclass
+class PendingFusion:
+    callable_fn: Callable[[], bool]
+    node1: BaseSchedulerNode
+    node2: BaseSchedulerNode
+    future: Optional[LambdaFuture] = None
+
+    def get_fusion_nodes(self) -> tuple[BaseSchedulerNode, BaseSchedulerNode]:
+        return (self.node1, self.node2)
 
 
 class MixOrderReduction:
@@ -2798,6 +2832,22 @@ def get_scheduler_node_symbol_uses(
     return free_symbol_uses
 
 
+def is_epilogue_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return node1.is_template() and config.epilogue_fusion and not node2.is_template()
+
+
+def is_prologue_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return node2.is_template() and config.prologue_fusion and not node1.is_template()
+
+
+def is_template_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return is_epilogue_fusion(node1, node2) or is_prologue_fusion(node1, node2)
+
+
+def template_fusion_pw_node(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return node2 if is_epilogue_fusion(node1, node2) else node1
+
+
 class Scheduler:
     """
     A Scheduler is a graph of BaseSchedulerNodes. It is responsible for
@@ -2864,6 +2914,9 @@ class Scheduler:
         # in codegen we only use buf0, never buf1
         self.mutation_renames: dict[str, str] = {}
 
+        self.seen_template_fusions: OrderedSet[
+            tuple[BaseSchedulerNode, BaseSchedulerNode]
+        ] = OrderedSet()
         # Must run first to correctly set dependencies, before all other passes that rely on
         # reading from .read_writes.reads or .unmet_dependencies
         self.nodes = comms.decide_global_ordering_of_comms(
@@ -3678,7 +3731,7 @@ class Scheduler:
         device = nodes[0].get_device()
         self.current_device = device
         backend = self.get_backend(device)
-        with dynamo_timed("benchmark_fused_nodes"):
+        with dynamo_timed("generate_kernel_code_from_nodes"):
             return backend.generate_kernel_code_from_nodes(
                 nodes, benchmark_kernel, hint_override=hint_override
             )
@@ -3692,7 +3745,7 @@ class Scheduler:
         """
         self.current_device = device
         backend = self.get_backend(device)
-        with dynamo_timed("benchmark_fused_nodes"):
+        with dynamo_timed("benchmark_codegened_module"):
             return backend.benchmark_codegened_module(module)
 
     def finalize_multi_template_buffers(self) -> None:
@@ -3812,7 +3865,7 @@ class Scheduler:
 
     def speedup_by_fusion(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
-    ) -> Union[bool, Callable[[], bool]]:
+    ) -> FusionResult:
         """
         If config.benchmark_fusion is False, always return True.
         Otherwise, return True if fusion can brings speedup.
@@ -3824,7 +3877,7 @@ class Scheduler:
             for n in (node1, node2)
         )
         if not config.benchmark_fusion and not is_multi_template:
-            return True
+            return FusionResult.fuse(True)
 
         if (
             node1.is_template()
@@ -3833,7 +3886,7 @@ class Scheduler:
             or node2.is_foreach()
         ):
             # TODO support benchmarking epilogue fusion
-            return True
+            return FusionResult.fuse(True)
 
         node_list_1 = node1.get_nodes()
         device = node_list_1[0].get_device()
@@ -3841,7 +3894,7 @@ class Scheduler:
 
         # don't support benchmark fusion for CPU C++ backend right now.
         if device.type == "cpu" and config.cpu_backend != "triton":
-            return True
+            return FusionResult.fuse(True)
 
         node_list_2 = node2.get_nodes()
         node_list_fused = list(itertools.chain(node_list_1, node_list_2))
@@ -3850,7 +3903,7 @@ class Scheduler:
         # due to how we generate random integer inputs.
         # Skip benchmarking them by allowing fusion.
         if self._any_atomic_add(node_list_fused):
-            return True
+            return FusionResult.fuse(True)
 
         from triton.compiler.errors import CompilationError
 
@@ -3967,7 +4020,7 @@ class Scheduler:
             else:
                 # By default, don't do prologue fusion. Generally slower
                 if not epilogue_fusion:
-                    return False
+                    return FusionResult.fuse(False)
 
                 ms2 = node2._get_estimated_runtime()
                 ms2_fused = _estimate_fused_epilogue_runtime(node1, node2, ms2)
@@ -4004,7 +4057,7 @@ class Scheduler:
                     future_choices.append((choice, *compile_kernel(node_list_fused)))
 
             if len(future_choices) == 0:
-                return False
+                return FusionResult.fuse(False)
 
             def benchmark_when_ready() -> bool:
                 min_ms_fused = float("inf")
@@ -4083,7 +4136,9 @@ class Scheduler:
                 else:
                     return False
 
-            return benchmark_when_ready
+            return FusionResult.from_callable(
+                benchmark_when_ready, future_choices[0][1]
+            )
 
         else:
             # Start parallel compilation for all three kernels
@@ -4163,11 +4218,242 @@ class Scheduler:
                         return True
                     raise
 
-            return benchmark_when_ready
+            return FusionResult.from_callable(
+                callable_fn=benchmark_when_ready, future=future_and_mod_l1_fused[0]
+            )
 
     def get_fused_node(self, node: BaseSchedulerNode) -> BaseSchedulerNode:
         "Look up the node in Scheduler name_to_fused_node"
         return self.name_to_fused_node[node.get_first_name()]
+
+    def fuse_two_nodes(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+    ) -> BaseSchedulerNode:
+        fusion_log.debug("fusing %s with %s", node1.get_name(), node2.get_name())
+
+        device = node1.get_device()
+        assert node2.get_device() == device
+        node3 = self.get_backend(device).fuse(node1, node2)
+        fused_nodes.remove(node1)
+        fused_nodes.remove(node2)
+        fused_nodes.add(node3)
+        self.name_to_fused_node.update({n.get_name(): node3 for n in node3.get_nodes()})
+        return node3
+
+    def fuse_if_speedup(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        speedup_fn: Callable[[], bool],
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+    ):
+        if (
+            self.can_fuse(node1, node2)
+            and not self.will_fusion_create_cycle(node1, node2)
+            and speedup_fn()
+        ):
+            self.fuse_two_nodes(node1, node2, fused_nodes)
+            return True
+
+        return False
+
+    def _evaluate_pending_template_fusions(
+        self,
+        template_fusion_candidates: dict[BaseSchedulerNode, list[PendingFusion]],
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+    ) -> None:
+        """
+        Evaluate pending template fusions for a set of fusion candidate nodes.
+        The fusion candidate nodes are pointwise nodes as potential epilogue
+        or prologue fusions
+        """
+
+        while template_fusion_candidates:
+            template_futures: list[Future] = []
+            future_to_pending_fusion: dict[
+                Future, tuple[PendingFusion, BaseSchedulerNode]
+            ] = {}
+            fusions_to_remove: OrderedSet[BaseSchedulerNode] = OrderedSet()
+            for candidate in template_fusion_candidates:
+                assert (
+                    candidate in template_fusion_candidates
+                    and len(template_fusion_candidates[candidate]) >= 1
+                )
+                pending_fusion = template_fusion_candidates[candidate].pop(0)
+
+                if len(template_fusion_candidates[candidate]) == 0:
+                    fusions_to_remove.add(candidate)
+
+                node1, node2 = pending_fusion.get_fusion_nodes()
+
+                if node2 == candidate:
+                    assert is_epilogue_fusion(node1, node2)
+                    template_node = node1
+                else:
+                    assert node1 == candidate
+                    assert is_prologue_fusion(node1, node2)
+                    template_node = node2
+
+                # template node fused with same class of pointwise (prologue/epilogue)
+                # move onto next candidate as not fusible
+                # TODO (PaulZhang12): Does not support fusions of templates with
+                # multiple potential epilogues
+                if self.get_fused_node(template_node) is not template_node:
+                    continue
+
+                if pending_fusion.future:
+                    f = pending_fusion.future.future
+                    assert f is not None
+                    template_futures.append(f)
+                    future_to_pending_fusion[f] = (pending_fusion, candidate)
+                else:
+                    # Non AsyncCompile path, perform fusion
+                    if self.fuse_if_speedup(
+                        node1, node2, pending_fusion.callable_fn, fused_nodes
+                    ):
+                        fusions_to_remove.add(candidate)
+
+            # Evaluate fusion candidates as async_compile completes
+            for f in as_completed(template_futures):
+                pending_fusion, cand = future_to_pending_fusion[f]
+                if self.fuse_if_speedup(
+                    self.get_fused_node(pending_fusion.node1),
+                    self.get_fused_node(pending_fusion.node2),
+                    pending_fusion.callable_fn,
+                    fused_nodes,
+                ):
+                    fusions_to_remove.add(cand)
+
+            for f in fusions_to_remove:
+                template_fusion_candidates.pop(f)
+
+    def _try_fusion_pairs(
+        self,
+        possible_fusion_pairs: list[tuple[BaseSchedulerNode, BaseSchedulerNode]],
+        pending_fusions: dict[BaseSchedulerNode, PendingFusion],
+        template_fusion_nodes: dict[BaseSchedulerNode, list[PendingFusion]],
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+        is_reorder_round: bool,
+    ):
+        def resolve_pending_fusions(
+            node1: BaseSchedulerNode,
+            node2: BaseSchedulerNode,
+        ) -> None:
+            while (
+                self.get_fused_node(node1) in pending_fusions
+                or self.get_fused_node(node2) in pending_fusions
+            ):
+                pending_fusion = pending_fusions.get(
+                    self.get_fused_node(node1),
+                    pending_fusions.get(self.get_fused_node(node2)),
+                )
+                assert pending_fusion is not None
+
+                node_key1, node_key2 = pending_fusion.get_fusion_nodes()
+                is_speedup = pending_fusion.callable_fn
+
+                pending_fusions.pop(node_key1, None)
+                pending_fusions.pop(node_key2, None)
+
+                assert self.get_fused_node(node_key1) is node_key1
+                assert self.get_fused_node(node_key2) is node_key2
+
+                if not is_speedup() or self.will_fusion_create_cycle(node1, node2):
+                    continue
+
+                self.fuse_two_nodes(node_key1, node_key2, fused_nodes)
+
+        for node1, node2 in possible_fusion_pairs:
+            # if either node is in a pending fusion, resolve it.
+            # since we iterate on potential fusions based on profitability
+            # the first potential fusion should take precedence.
+            resolve_pending_fusions(node1, node2)
+            node1 = self.get_fused_node(node1)
+            node2 = self.get_fused_node(node2)
+
+            if (
+                is_template_fusion(node1, node2)
+                and (node1, node2) in self.seen_template_fusions
+            ):
+                continue
+
+            if self.can_fuse(
+                node1, node2, is_reorder_round
+            ) and not self.will_fusion_create_cycle(node1, node2):
+                fusion_res = self.speedup_by_fusion(node1, node2)
+                if fusion_res.callable_fn is not None:
+                    pending_fusion = PendingFusion(
+                        callable_fn=fusion_res.callable_fn,
+                        node1=node1,
+                        node2=node2,
+                        future=fusion_res.future,
+                    )
+
+                    if is_template_fusion(node1, node2):
+                        assert (node1, node2) not in self.seen_template_fusions
+                        self.seen_template_fusions.add((node1, node2))
+
+                        template_pw_node = template_fusion_pw_node(node1, node2)
+                        if template_pw_node not in template_fusion_nodes:
+                            template_fusion_nodes[template_pw_node] = []
+                        template_fusion_nodes[template_pw_node].append(pending_fusion)
+                    else:
+                        pending_fusions[node1] = pending_fusion
+                        pending_fusions[node2] = pending_fusion
+
+                    continue
+
+                if not fusion_res.should_fuse:
+                    continue
+
+                self.fuse_two_nodes(node1, node2, fused_nodes)
+
+    def _finish_pending_fusions(
+        self,
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+        pending_fusions: dict[BaseSchedulerNode, PendingFusion],
+    ):
+        seen_pair_speedup_fn: OrderedSet[Callable[[], bool]] = OrderedSet()
+
+        # Resolve pending fusions for non templates in case of benchmark_kernel=True
+        for pending_fusion in pending_fusions.values():
+            node_key1, node_key2 = pending_fusion.get_fusion_nodes()
+            is_speedup_fn = pending_fusion.callable_fn
+
+            if is_speedup_fn in seen_pair_speedup_fn or is_template_fusion(
+                node_key1, node_key2
+            ):
+                continue
+
+            seen_pair_speedup_fn.add(is_speedup_fn)
+
+            assert self.get_fused_node(node_key1) is node_key1
+            assert self.get_fused_node(node_key2) is node_key2
+
+            self.fuse_if_speedup(node_key1, node_key2, is_speedup_fn, fused_nodes)
+
+    def _handle_template_overlap(
+        self,
+        possible_fusions: list[tuple[BaseSchedulerNode, BaseSchedulerNode]],
+        deferred_prologue_fusions: list[tuple[BaseSchedulerNode, BaseSchedulerNode]],
+    ):
+        # Potentially a prologue fusion might have the same template as an epilogue
+        # the prologue fusion therefore has to be evaluated on the potential
+        # fused template + epilogue
+        epilogue_template_nodes = OrderedSet(
+            [n1 for n1, n2 in possible_fusions if is_epilogue_fusion(n1, n2)]
+        )
+        new_possible_fusions = []
+        for n1, n2 in possible_fusions:
+            if is_prologue_fusion(n1, n2) and n1 in epilogue_template_nodes:
+                deferred_prologue_fusions.append((n1, n2))
+            else:
+                new_possible_fusions.append((n1, n2))
+
+        possible_fusions = new_possible_fusions
 
     def fuse_nodes_once(
         self,
@@ -4190,88 +4476,51 @@ class Scheduler:
 
         # These are potential fusions which we are async compiling,
         # and which we will benchmark profitability of.
+        # Maps node -> (is_speedup_fn, LambdaFuture, node1, node2)
+        # Only used in the case of benchmark_kernel=True
         pending_fusions: dict[
             BaseSchedulerNode,
-            tuple[Callable[[], bool], BaseSchedulerNode, BaseSchedulerNode],
+            PendingFusion,
         ] = {}
 
-        def fuse_two_nodes(
-            node1: BaseSchedulerNode, node2: BaseSchedulerNode
-        ) -> BaseSchedulerNode:
-            fusion_log.debug("fusing %s with %s", node1.get_name(), node2.get_name())
+        template_fusion_nodes: dict[BaseSchedulerNode, list[PendingFusion]] = {}
+        deferred_prologue_fusions: list[
+            tuple[BaseSchedulerNode, BaseSchedulerNode]
+        ] = []
 
-            device = node1.get_device()
-            assert node2.get_device() == device
-            node3 = self.get_backend(device).fuse(node1, node2)
-            fused_nodes.remove(node1)
-            fused_nodes.remove(node2)
-            fused_nodes.add(node3)
-            self.name_to_fused_node.update(
-                {n.get_name(): node3 for n in node3.get_nodes()}
+        possible_fusions = self.get_possible_fusions(
+            nodes,
+            is_reorder_round,
+        )
+
+        if (
+            (config.max_autotune_gemm or config.max_autotune)
+            and config.prologue_fusion
+            and config.epilogue_fusion
+        ):
+            self._handle_template_overlap(possible_fusions, deferred_prologue_fusions)
+
+        self._try_fusion_pairs(
+            possible_fusions,
+            pending_fusions,
+            template_fusion_nodes,
+            fused_nodes,
+            is_reorder_round,
+        )
+        self._finish_pending_fusions(fused_nodes, pending_fusions)
+
+        self._evaluate_pending_template_fusions(template_fusion_nodes, fused_nodes)
+        template_fusion_nodes.clear()
+
+        if deferred_prologue_fusions:
+            self._try_fusion_pairs(
+                deferred_prologue_fusions,
+                pending_fusions,
+                template_fusion_nodes,
+                fused_nodes,
+                is_reorder_round,
             )
-            return node3
-
-        def resolve_pending_fusions(
-            node1: BaseSchedulerNode, node2: BaseSchedulerNode
-        ) -> None:
-            while (
-                self.get_fused_node(node1) in pending_fusions
-                or self.get_fused_node(node2) in pending_fusions
-            ):
-                pending_fusion = pending_fusions.get(
-                    self.get_fused_node(node1),
-                    pending_fusions.get(self.get_fused_node(node2)),
-                )
-                assert pending_fusion is not None
-
-                is_speedup, node_key1, node_key2 = pending_fusion
-                pending_fusions.pop(node_key1, None)
-                pending_fusions.pop(node_key2, None)
-
-                assert self.get_fused_node(node_key1) is node_key1
-                assert self.get_fused_node(node_key2) is node_key2
-
-                if not is_speedup() or self.will_fusion_create_cycle(node1, node2):
-                    continue
-
-                fuse_two_nodes(node_key1, node_key2)
-
-        for node1, node2 in self.get_possible_fusions(nodes, is_reorder_round):
-            # if either node is in a pending fusion, resolve it.
-            # since we iterate on potential fusions based on profitability
-            # the first potential fusion should take precedence.
-            resolve_pending_fusions(node1, node2)
-            node1 = self.get_fused_node(node1)
-            node2 = self.get_fused_node(node2)
-
-            if self.can_fuse(
-                node1, node2, is_reorder_round
-            ) and not self.will_fusion_create_cycle(node1, node2):
-                speedup = self.speedup_by_fusion(node1, node2)
-                if callable(speedup):
-                    pending_fusions[node1] = (speedup, node1, node2)
-                    pending_fusions[node2] = (speedup, node1, node2)
-                    continue
-
-                if not speedup:
-                    continue
-
-                fuse_two_nodes(node1, node2)
-
-        seen_pair_speedup_fn: OrderedSet[Callable[[], bool]] = OrderedSet()
-        for is_speedup_fn, node_key1, node_key2 in pending_fusions.values():
-            if is_speedup_fn in seen_pair_speedup_fn:
-                continue
-
-            seen_pair_speedup_fn.add(is_speedup_fn)
-
-            assert self.get_fused_node(node_key1) is node_key1
-            assert self.get_fused_node(node_key2) is node_key2
-
-            if is_speedup_fn() and not self.will_fusion_create_cycle(
-                node_key1, node_key2
-            ):
-                fuse_two_nodes(node_key1, node_key2)
+            self._evaluate_pending_template_fusions(template_fusion_nodes, fused_nodes)
 
         nodes = sorted(fused_nodes, key=lambda x: x.min_order)
         nodes = self.topological_sort_schedule(nodes)


### PR DESCRIPTION
Differential Revision: D89255518

Currently during epilogue fusion evaluation, the epilogues that get benchmarked/statically analyzed are based on the order of nodes coming into the fusion. However, this does not take full advantage of the async compilation of templates with epilogues/prologues. 

We fix that by extracting the compile futures from the call to speedup_fn. We then take the futures that first complete, still maintaining the template fusion order, where epilogues/prologues that can be fused into multiple templates. We also cache epilogue/prologue fusions that have been evaluated previously, as repeated codegen IO for the template fusions are expensive.

Two main optimizations are introduced for max-autotune compile time in this PR:
1. Cache template fusions that have already been seen. While template fusions that have been previously seen already aren't benchmarked, the cost of writing each fusion to disk introduces overhead, especially with repeated ones over many rounds of fusion. 
2. Kick off all epilogue/prologue kernel compilation in parallel, which takes advantage of async_compile process pool for efficient parallelization. Evaluate epilogue and prologue fusions based on original fusion order for each epilogue/prologue candidate as compilation is done through evaluating the futures.

## **Compile time experiments all done with representative internal arch**
Baseline -> ~12s

**Standard Max-Autotune**
Max-autotune - 144s
Max-autotune - overlap template fusions -> 100s

**All with diode topk=1**
Max-autotune + no epilogue/prologue fusions -> ~18s
Max-autotune + benchmarking epilogues -> ~59s
Max-autotune + benchmarking epilogues + overlap template fusions -> ~29s
* without caching: 46s
* without overlapping: 54s

Max-autotune + static analyzing epilogues -> ~30s
Max-autotune + static analyzing epilogues + async pipelined autotuning -> 47s
Max-autotune + static analyzing epilogues + overlap template fusions + async pipelined autotuning -> ~18s

## **TorchInductor CI compile time**
Below is data collected from manually running torchbench locally on an H100 machine, as the CI compilation numbers can often be flaky/unreliable.


TIMM | compilation_latency | compilation_latency optimization | Compilation Latency Increase (s)
-- | -- | -- | --
adv_inception_v3 | 112.349167 | 112.760696 | 0.411529
beit_base_patch16_224 | 95.903498 | 97.692569 | 1.789071
convnextv2_nano.fcmae_ft_in22k_in1k | 118.273649 | 121.011309 | 2.73766
deit_base_distilled_patch16_224 | 80.767883 | 81.779595 | 1.011712
deit_tiny_patch16_224.fb_in1k | 70.213287 | 70.691566 | 0.478279
dm_nfnet_f0 | 115.08765 | 111.540226 | -3.547424
ghostnet_100 | 171.751849 | 169.028063 | -2.723786
inception_v3 | 168.096137 | 171.589615 | 3.493478
mobilenetv2_100 | 131.443499 | 134.202953 | 2.759454
mobilenetv3_large_100 | 232.691377 | 241.775705 | 9.084328
mobilevit_s | 162.556104 | 157.611769 | -4.944335
nfnet_l0 | 106.444117 | 103.529731 | -2.914386
repvgg_a2 | 89.10137 | 92.640802 | 3.539432
swin_base_patch4_window7_224 | 230.605837 | 232.994867 | 2.38903
tf_efficientnet_b0 | 131.88646 | 133.045255 | 1.158795
visformer_small | 87.243081 | 86.116177 | -1.126904
vit_base_patch16_siglip_256 | 0 | 0 | 0



HuggingFace | compilation_latency | compilation_latency optimization | Compilation Latency Increase (s)
-- | -- | -- | --
AlbertForMaskedLM | 91.178588 | 44.86694 | -46.311648
AllenaiLongformerBase | 128.938647 | 125.305844 | -3.632803
BartForCausalLM | 22.288702 | 21.940061 | -0.348641
BertForMaskedLM | 95.562674 | 89.870288 | -5.692386
BlenderbotForCausalLM | 102.171161 | 101.956513 | -0.214648
DebertaV2ForMaskedLM | 155.576169 | 153.626961 | -1.949208
DistilBertForMaskedLM | 81.940878 | 84.612052 | 2.671174
DistillGPT2 | 73.420599 | 70.765531 | -2.655068
ElectraForCausalLM | 42.653002 | 43.163519 | 0.510517
GPT2ForSequenceClassification | 101.844608 | 108.868427 | 7.023819
GoogleFnet | 75.241814 | 77.868139 | 2.626325
LayoutLMForMaskedLM | 95.432125 | 99.822281 | 4.390156
M2M100ForConditionalGeneration | 46.549122 | 46.859677 | 0.310555
MBartForCausalLM | 24.602922 | 24.559812 | -0.04311
MT5ForConditionalGeneration | 99.856653 | 102.516542 | 2.659889
MegatronBertForCausalLM | 128.070552 | 126.370065 | -1.700487
MobileBertForMaskedLM | 141.329823 | 134.774825 | -6.554998
OPTForCausalLM | 34.37166 | 33.30809 | -1.06357
PLBartForCausalLM | 31.595436 | 30.708169 | -0.887267
PegasusForCausalLM | 22.28014 | 21.993263 | -0.286877
Qwen/Qwen3-0.6B | 0 | 0 | 0
RobertaForCausalLM | 99.922612 | 96.397972 | -3.52464
T5ForConditionalGeneration | 72.263815 | 73.285807 | 1.021992
T5Small | 71.761801 | 73.808848 | 2.047047
TrOCRForCausalLM | 27.9683 | 28.123752 | 0.155452
XGLMForCausalLM | 29.021936 | 29.015994 | -0.005942
XLNetLMHeadModel | 153.020033 | 147.014865 | -6.005168
YituTechConvBert | 121.180943 | 121.468483 | 0.28754
google/gemma-2-2b | 0 | 0 | 0
meta-llama/Llama-3.2-1B | 0 | 0 | 0
openai/whisper-tiny | 0 | 0 | 0



## **Dashboard for Performance**

**Note: Compilation time for max-autotune is very noisy. Refer to above local results for more accurate compilation time overheads**
Inference:
<img width="1728" height="915" alt="Screenshot 2026-01-12 at 11 17 15 AM" src="https://github.com/user-attachments/assets/bbb7a689-298d-4b60-bc12-fb66ea20e266" />

Training:
<img width="1728" height="677" alt="Screenshot 2026-01-12 at 11 18 04 AM" src="https://github.com/user-attachments/assets/fe46a765-b04a-417e-84e7-2a1ae89c0c3f" />



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo