### PR TITLE
Touch `__init__.py` in `vendored_templates` for CuTeDSL Grouped MM template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1753,6 +1753,8 @@ def main() -> None:
         "_inductor/script.ld",
         "_inductor/kernel/flex/templates/*.jinja",
         "_inductor/kernel/templates/*.jinja",
+        # NOTE: for CuTeDSL grouped_gemm.py to be included.
+        "_inductor/kernel/vendored_templates/*.py",
         "_export/serde/*.yaml",
         "_export/serde/*.thrift",
         "share/cmake/ATen/*.cmake",

--- a/setup.py
+++ b/setup.py
@@ -647,6 +647,8 @@ def mirror_inductor_external_kernels() -> None:
         # Create the dirs involved in new_path if they don't exist
         if not new_path.exists():
             new_path.parent.mkdir(parents=True, exist_ok=True)
+            # Add `__init__.py` for find_packages to see `new_path.parent` as a submodule
+            (new_path.parent / "__init__.py").touch(exist_ok=True)
 
         # Copy the files from the orig location to the new location
         if orig_path.is_file():
@@ -1753,8 +1755,6 @@ def main() -> None:
         "_inductor/script.ld",
         "_inductor/kernel/flex/templates/*.jinja",
         "_inductor/kernel/templates/*.jinja",
-        # NOTE: for CuTeDSL grouped_gemm.py to be included.
-        "_inductor/kernel/vendored_templates/*.py",
         "_export/serde/*.yaml",
         "_export/serde/*.thrift",
         "share/cmake/ATen/*.cmake",

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -364,6 +364,7 @@ class TestPublicBindings(TestCase):
             "torch._inductor.codegen.cpp_gemm_template",
             "torch._inductor.codegen.cpp_micro_gemm",
             "torch._inductor.codegen.cpp_template_kernel",
+            "torch._inductor.kernel.vendored_templates.cutedsl_grouped_gemm",  # depends on cutlass_cppgen
             "torch._inductor.runtime.triton_helpers",
             "torch.ao.pruning._experimental.data_sparsifier.lightning.callbacks.data_sparsity",
             "torch.backends._coreml.preprocess",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2374,6 +2374,7 @@ class TestImports(TestCase):
                            "torch.distributed._tools.sac_ilp",  # depends on pulp
                            "torch.csrc",  # files here are devtools, not part of torch
                            "torch.include",  # torch include files after install
+                           "torch._inductor.kernel.vendored_templates.cutedsl_grouped_gemm",  # depends on cutlass
                            ]
         if IS_WINDOWS or IS_MACOS or IS_JETSON:
             # Distributed should be importable on Windows(except nn.api.), but not on Mac


### PR DESCRIPTION
This pull request makes a small improvement to the `mirror_inductor_external_kernels` function in `setup.py` to ensure that newly created directories are recognized as Python packages by `find_packages`.

* When creating a new directory for mirrored files, the code now adds an empty `__init__.py` file to the directory so that `find_packages` treats it as a submodule.Added inclusion of vendored_templates for CuTeDSL.

This is to fix `ModuleNotFoundError` of `torch._inductor.kernel.vendored_templates`

```
$ pytest -v -s -x test/inductor/test_cutedsl_grouped_mm.py
...
FAILED [2.2725s] test_cutedsl_grouped_mm.py::TestCuTeDSLGroupedGemm::test_grouped_gemm_assorted_layouts_layout_A_contiguous_layout_B_broadcasted - torch._inductor.exc.InductorError: ModuleNotFoundError: No module named 'torch._inductor.kernel.vendored_templates'
```

The error wouldn't be there if pytorch is installed in development mode.