### PR TITLE
[ROCm] Enable device properties for ROCm >= 6.4

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2254,6 +2254,7 @@ class _CudaDeviceProperties:
     memory_clock_rate: _int
     memory_bus_width: _int
     shared_memory_per_block: _int
+    shared_memory_per_multiprocessor: _int
 
 # Functions related to SDPA
 class _SDPAParams:

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1064,7 +1064,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
           "max_threads_per_block", &cudaDeviceProp::maxThreadsPerBlock)
       .def_readonly("warp_size", &cudaDeviceProp::warpSize)
       .def_readonly(
-      "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
+          "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
       .def_property_readonly(
           "clock_rate",
           [](const cudaDeviceProp&) {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1063,8 +1063,8 @@ static void registerCudaDeviceProperties(PyObject* module) {
       .def_readonly(
           "max_threads_per_block", &cudaDeviceProp::maxThreadsPerBlock)
       .def_readonly("warp_size", &cudaDeviceProp::warpSize)
-#ifndef USE_ROCM
-      // NVIDIA-only properties
+      .def_readonly(
+      "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
       .def_property_readonly(
           "clock_rate",
           [](const cudaDeviceProp&) {
@@ -1085,19 +1085,16 @@ static void registerCudaDeviceProperties(PyObject* module) {
           })
       .def_readonly("memory_bus_width", &cudaDeviceProp::memoryBusWidth)
       .def_readonly(
-          "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
+          "shared_memory_per_multiprocessor",
+          &cudaDeviceProp::sharedMemPerMultiprocessor)
+
+#ifndef USE_ROCM
+      // NVIDIA-only properties
       .def_readonly(
           "shared_memory_per_block_optin",
           &cudaDeviceProp::sharedMemPerBlockOptin)
-      .def_readonly(
-          "shared_memory_per_multiprocessor",
-          &cudaDeviceProp::sharedMemPerMultiprocessor)
 #endif
-#if USE_ROCM
-      // ROCm: expose shared_memory_per_block for shared memory based pruning
-      .def_readonly(
-          "shared_memory_per_block", &cudaDeviceProp::sharedMemPerBlock)
-#endif
+
       .def_readonly(
           "regs_per_multiprocessor", &cudaDeviceProp::regsPerMultiprocessor)
       // HIP-only property; reuse name attribute for CUDA builds


### PR DESCRIPTION
## Summary

Enables several `cudaDeviceProp` fields for ROCm builds version 6.4+, which were previously gated behind `#ifndef USE_ROCM`. These properties are now available in `hipDeviceProp_t` as of HIP 6.4.

## Changes

**Properties now available for ROCm >= 6.4:**
- `clock_rate` 
- `memory_clock_rate` 
- `memory_bus_width` 
- `shared_memory_per_multiprocessor` 

**Properties unchanged:**
- `shared_memory_per_block_optin` — Remains CUDA-only (NVIDIA-specific feature)

Also adds `shared_memory_per_multiprocessor` to the type stub file.

## Testing

Verified on ROCm 6.4 with AMD MI300 (gfx942) — all newly enabled properties return valid values via `torch.cuda.get_device_properties()`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang