### PR TITLE
Add FX node stack trace to dynamo's run_node error msg

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3756,9 +3756,16 @@ def run_node(
         except Unsupported:
             raise
         except Exception as e:
-            raise RuntimeError(make_error_message(e)).with_traceback(
+            exc = RuntimeError(make_error_message(e)).with_traceback(
                 e.__traceback__
-            ) from e
+            )
+            if getattr(node, "stack_trace", False):
+                # Augment exception msg with FX node's stack trace if there's one.
+                stack_trace = "\nFX node stack trace:\n" + node.stack_trace
+                old_msg = "" if len(exc.args) == 0 else str(exc.args[0])
+                new_msg = old_msg + stack_trace
+                exc.args = (new_msg,) + exc.args[1:]
+            raise exc
 
     raise AssertionError(op)
 


### PR DESCRIPTION
Example err message.
```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in function mul>(*(FakeTensor(..., size=(32, s27)), FakeTensor(..., size=(32,))), **{}): got RuntimeError('The size of tensor a (s27: hint = 2048) must match the size of tensor b (32) at non-singleton dimension 1)')

FX node stack trace:
  File ... line 216, in forward
    res = self._export_root(*args, **kwargs)
  File ... line 1304, in forward
    items = items.t() * scores
```
Differential Revision: D89304374




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo