### PR TITLE
Fixing hardcoded OMP thread counts in torch compile

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5610,7 +5610,7 @@ class WorkSharing:
                 # Thread count differs from system (user probably set it so hardcode)
                 use_dynamic = False
 
-            if use_dynamic:
+            if use_dynamic or config.cpp.dynamic_threads:
                 self.code.writeline("#pragma omp parallel")
             else:
                 self.code.writeline(f"#pragma omp parallel num_threads({threads})")

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5,6 +5,7 @@ import functools
 import itertools
 import math
 import operator
+import os
 import re
 import sys
 import warnings
@@ -5597,7 +5598,19 @@ class WorkSharing:
         if not self.in_parallel:
             self.num_threads = threads
             self.in_parallel = True
-            if config.cpp.dynamic_threads:
+            # Decide whether to use dynamic threading
+            use_dynamic = False
+            if config.cpp.threads >= 1:
+                # User explicitly set config.cpp.threads (hardcode it)
+                use_dynamic = False
+            elif threads == os.cpu_count():
+                # Thread count matches system CPU count (most likely default, use dynamic)
+                use_dynamic = True
+            else:
+                # Thread count differs from system (user probably set it so hardcode)
+                use_dynamic = False
+
+            if use_dynamic:
                 self.code.writeline("#pragma omp parallel")
             else:
                 self.code.writeline(f"#pragma omp parallel num_threads({threads})")

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -49,7 +49,12 @@ extern "C"
     constexpr int64_t num_threads = {{num_threads}};
     int64_t B_single_thread_block = (B / num_threads) * num_threads;
 
+    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == os.cpu_count()) %}
+    {%- if use_dynamic_threads %}
+    #pragma omp parallel for
+    {%- else %}
     #pragma omp parallel for num_threads({{num_threads}})
+    {%- endif %}
     {%- else %}
     int64_t B_single_thread_block = B;
     {%- endif %}

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -49,7 +49,7 @@ extern "C"
     constexpr int64_t num_threads = {{num_threads}};
     int64_t B_single_thread_block = (B / num_threads) * num_threads;
 
-    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == os.cpu_count()) %}
+    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == cpu_count) %}
     {%- if use_dynamic_threads %}
     #pragma omp parallel for
     {%- else %}

--- a/torch/_inductor/codegen/cpp_bmm_template.py
+++ b/torch/_inductor/codegen/cpp_bmm_template.py
@@ -49,7 +49,7 @@ extern "C"
     constexpr int64_t num_threads = {{num_threads}};
     int64_t B_single_thread_block = (B / num_threads) * num_threads;
 
-    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == cpu_count) %}
+    {%- set use_dynamic_threads = ((config.cpp.threads < 1) and (num_threads == cpu_count)) or config.cpp.dynamic_threads %}
     {%- if use_dynamic_threads %}
     #pragma omp parallel for
     {%- else %}

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -2,6 +2,7 @@
 import contextlib
 import logging
 import math
+import os
 from collections.abc import Callable
 from functools import lru_cache
 from typing import Any, cast, Optional, TypeVar, Union
@@ -207,7 +208,7 @@ GEMM_TEMPLATE = r"""
 {%- endif %}
 
 {%- if num_threads > 1 %}
-    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == os.cpu_count()) %}
+    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == cpu_count) %}
     {%- if use_dynamic_threads %}
     #pragma omp parallel
     {%- else %}
@@ -1609,6 +1610,7 @@ class CppGemmTemplate(CppTemplate):
             is_woq_int4=self.is_woq_int4(),
             q_group_size=q_group_size_node,
             qscale_and_zeros=qscale_and_zeros,
+            cpu_count=os.cpu_count(),
         )
         return options
 

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -208,7 +208,7 @@ GEMM_TEMPLATE = r"""
 {%- endif %}
 
 {%- if num_threads > 1 %}
-    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == cpu_count) %}
+    {%- set use_dynamic_threads = ((config.cpp.threads < 1) and (num_threads == cpu_count)) or config.cpp.dynamic_threads %}
     {%- if use_dynamic_threads %}
     #pragma omp parallel
     {%- else %}

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -207,7 +207,12 @@ GEMM_TEMPLATE = r"""
 {%- endif %}
 
 {%- if num_threads > 1 %}
+    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == os.cpu_count()) %}
+    {%- if use_dynamic_threads %}
+    #pragma omp parallel
+    {%- else %}
     #pragma omp parallel num_threads({{num_threads}})
+    {%- endif %}
     {
         {{ template.codegen_multi_threads_params()|indent(8, false) }}
 {%- else %}

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -46,7 +46,7 @@ extern "C" {{export_declaration}}
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOuts[0], config, L1_cache_size, L2_cache_size, X_list[0], W_list[0]
     ) }}
 {%- if num_threads > 1 %}
-    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == os.cpu_count()) %}
+    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == cpu_count) %}
     {%- if use_dynamic_threads %}
     #pragma omp parallel
     {%- else %}

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -47,7 +47,7 @@ extern "C" {{export_declaration}}
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOuts[0], config, L1_cache_size, L2_cache_size, X_list[0], W_list[0]
     ) }}
 {%- if num_threads > 1 %}
-    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == cpu_count) %}
+    {%- set use_dynamic_threads = ((config.cpp.threads < 1) and (num_threads == cpu_count)) or config.cpp.dynamic_threads %}
     {%- if use_dynamic_threads %}
     #pragma omp parallel
     {%- else %}

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 from collections.abc import Callable
 from typing import Any, cast, Optional, TypeVar
 from unittest.mock import patch
@@ -511,6 +512,7 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
             Y_list={"Y" + str(idx): Y for idx, Y in enumerate(Y_list)},
             Y_2d_list=Y_2d_list,
             multi_output_buffers=multi_output_buffers,
+            cpu_count=os.cpu_count(),
         )
         with contextlib.ExitStack() as stack:
             stack.enter_context(

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -46,7 +46,12 @@ extern "C" {{export_declaration}}
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOuts[0], config, L1_cache_size, L2_cache_size, X_list[0], W_list[0]
     ) }}
 {%- if num_threads > 1 %}
+    {%- set use_dynamic_threads = (config.cpp.threads < 1) and (num_threads == os.cpu_count()) %}
+    {%- if use_dynamic_threads %}
+    #pragma omp parallel
+    {%- else %}
     #pragma omp parallel num_threads({{num_threads}})
+    {%- endif %}
     {
         {{ template.codegen_multi_threads_params()|indent(8, false) }}
 {%- else %}


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/167459

Fixes hardcoded OpenMP thread counts in torch.compile cache by removing num_threads(X) from #pragma omp parallel directives.

1. However, I'm unsure if this the right approach. The fix seems straightforward (removing num_threads(X) ), but I want to confirm this won't cause any issues.
2. How should this be tested? I'd appreciate guidance on how to verify the generated cache code doesn't have hardcoded num_threads, and whether there are existing test patterns for similar cache-related fixes


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo