### PR TITLE
Lift a Fresh Tensor under Capture

### DIFF
--- a/aten/src/ATen/FunctionalInverses.cpp
+++ b/aten/src/ATen/FunctionalInverses.cpp
@@ -216,8 +216,8 @@ Tensor FunctionalInverses::detach_inverse(const Tensor& base, const Tensor& muta
     return mutated_view;
 }
 
-Tensor FunctionalInverses::lift_fresh_inverse(const Tensor& base, const Tensor& mutated_view, InverseReturnMode inverse_return_mode) {
-    return mutated_view;
+Tensor FunctionalInverses::lift_fresh_inverse(const Tensor& base, const Tensor& mutated_view, InverseReturnMode inverse_return_mode, Device device) {
+  return mutated_view;
 }
 
 Tensor FunctionalInverses::slice_Tensor_inverse(const Tensor& base, const Tensor& mutated_view, InverseReturnMode inverse_return_mode, int64_t dim, std::optional<c10::SymInt> start, std::optional<c10::SymInt> end, c10::SymInt step) {

--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -208,18 +208,18 @@ static at::Tensor lift_functionalize(const at::Tensor & self) {
   return at::functionalization::impl::to_functional_tensor(out);
 }
 
-static at::Tensor lift_fresh_functionalize(const at::Tensor & self) {
+static at::Tensor lift_fresh_functionalize(const at::Tensor & self, at::Device device) {
   // See Note [Exporting and compiling a graph with lift_fresh_copy]
   if (at::functionalization::impl::isFunctionalTensor(self)) {
     return self.view_as(self);
   }
 
   at::AutoDispatchSkipFunctionalize guard;
-  auto out = at::lift_fresh(self);
+  auto out = at::lift_fresh(self, device);
   return at::functionalization::impl::to_functional_tensor(out);
 }
 
-static at::Tensor lift_fresh_functionalize_copy(const at::Tensor & self) {
+static at::Tensor lift_fresh_functionalize_copy(const at::Tensor & self, at::Device device) {
   // Note [Exporting and compiling a graph with lift_fresh_copy]
   // If out is already a functional tensor, don't wrap it twice.
   // In theory this could be useful if we want to nest functionalization with itself,
@@ -236,7 +236,7 @@ static at::Tensor lift_fresh_functionalize_copy(const at::Tensor & self) {
   }
 
   at::AutoDispatchSkipFunctionalize guard;
-  auto out = at::lift_fresh_copy(self);
+  auto out = at::lift_fresh_copy(self, device);
   return at::functionalization::impl::to_functional_tensor(out);
 }
 

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -56,6 +56,14 @@ void CUDAGraph::register_generator_state(const at::Generator& generator) {
   cuda_gen->register_graph(this);
 }
 
+bool CUDAGraph::prev_only_lift_cpu_tensors() const {
+  return prev_only_lift_cpu_tensors_;
+}
+
+void CUDAGraph::set_prev_only_lift_cpu_tensors(bool value) {
+  prev_only_lift_cpu_tensors_ = value;
+}
+
 void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capture_mode) {
   TORCH_CHECK(!has_graph_exec_,
               "This CUDAGraph instance already owns a captured graph. "

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -26,6 +26,8 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // See Note [Explicit Registration of Generators to the CUDA Graph]
   void register_generator_state(c10::intrusive_ptr<at::CUDAGeneratorState> state);
   void register_generator_state(const at::Generator& generator);
+  bool prev_only_lift_cpu_tensors() const;
+  void set_prev_only_lift_cpu_tensors(bool value);
   void capture_begin(
       MempoolId_t pool = {0, 0},
       cudaStreamCaptureMode capture_mode = cudaStreamCaptureModeGlobal);
@@ -89,6 +91,7 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   c10::DeviceIndex capture_dev_{UNDEFINED_DEVICE};
 
   bool keep_graph_;
+  bool prev_only_lift_cpu_tensors_{false};
 };
 
 } // namespace cuda

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -4938,9 +4938,19 @@ at::Tensor lift(const at::Tensor& self) {
   return self;
 }
 
-// See notes in native_functions.yaml
-at::Tensor lift_fresh(const at::Tensor& self) {
+DEFINE_DISPATCH(lift_fresh_stub);
+namespace {
+at::Tensor lift_fresh_cpu(const at::Tensor& self, Device device) {
   return self;
+}
+} // namespace
+
+REGISTER_ALL_CPU_DISPATCH(lift_fresh_stub, &lift_fresh_cpu)
+
+// See notes in native_functions.yaml
+at::Tensor lift_fresh(const at::Tensor& self, Device device) {
+  return (device.type() == kCUDA) ? lift_fresh_stub(device.type(), self, device)
+                                  : lift_fresh_stub(kCPU, self, device);
 }
 
 // Autogen kernels for tensor list ops dont work on XLA. TODO(jakeszwe)

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -5,6 +5,9 @@
 
 namespace at::native {
 
+using lift_fresh_fn = at::Tensor (*)(const at::Tensor&, Device device);
+DECLARE_DISPATCH(lift_fresh_fn, lift_fresh_stub)
+
 TORCH_API at::Tensor clone_preserve_strides(const at::Tensor& self);
 
 inline bool cat_should_skip_tensor(const Tensor& t) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8239,12 +8239,12 @@
 # torch.tensor call; if you FX trace a lift_fresh, you are obligated
 # to convert this into a lift_fresh_copy (because FX will violate the
 # freshness invariant when tracing).
-- func: lift_fresh(Tensor(a) self) -> Tensor(a)
+- func: lift_fresh(Tensor(a) self, Device device) -> Tensor(a)
   dispatch:
     CompositeExplicitAutograd: lift_fresh
 
 # Like lift, but it clones the input.
-- func: lift_fresh_copy(Tensor self) -> Tensor
+- func: lift_fresh_copy(Tensor self, Device device) -> Tensor
   tags: view_copy
   dispatch:
     CompositeExplicitAutogradNonFunctional: lift_fresh_copy

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2092,6 +2092,21 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_torch_tensor(self):
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            a = torch.tensor([[1, 1], [1, 1]], device="cuda")
+            b = torch.tensor([[1, 1], [1, 1]], device="cuda")
+            c = a + b
+
+        g.replay()
+        self.assertEqual(c.sum().item(), 8.0)
+        g.replay()
+        self.assertEqual(c.sum().item(), 8.0)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graphsafe_set_get_rng_state(self):
         # Define a function to create generator states, with optional graph registration
         def create_states(generator):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1889,7 +1889,7 @@
   self: grad
   result: auto_linear
 
-- name: lift_fresh(Tensor(a) self) -> Tensor(a)
+- name: lift_fresh(Tensor(a) self, Device device) -> Tensor(a)
   self: grad
   result: auto_linear
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2291,7 +2291,7 @@ def _to_copy(
 # Questionable decompositions
 # This is only valid if we're running the graph without autograd, such as if the backward pass has been traced.
 # Note that this decomposition causes issues with in-place ops
-@register_decomposition([aten.detach, aten.lift, aten.lift_fresh])
+@register_decomposition([aten.detach, aten.lift])
 @out_wrapper()
 def nop_decomposition(x):
     return aten.alias(x)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2441,7 +2441,7 @@ class FakeTensorMode(TorchDispatchMode):
         # this is generated from torch.tensor(), which does not use the
         # dispatcher, to allow wrapper subclasses to wrap the new tensor
         if is_lift_func:
-            assert len(kwargs) == 0 and len(args) == 1, f"{args} {kwargs}"
+            assert len(kwargs) == 0 and len(args) == 2, f"{args} {kwargs}"
 
             if type(args[0]) is Tensor:
                 return converter.from_real_tensor(self, args[0])

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -174,7 +174,7 @@ inline Variable valueToTensor(
   // device
   if (device == at::kCPU && !scalar.isSymbolic()) {
     return at::lift_fresh(
-        at::indexing::scalarToTensor(scalar, options, device));
+        at::indexing::scalarToTensor(scalar, options, device), device);
   } else {
     return at::indexing::scalarToTensor(scalar, options, device);
   }

--- a/torch/csrc/cuda/Graph.cpp
+++ b/torch/csrc/cuda/Graph.cpp
@@ -37,19 +37,20 @@ void THCPGraph_init(PyObject* module) {
             c10::cuda::MempoolId_t pool = pool_opt.has_value()
                 ? pool_opt.value()
                 : c10::cuda::MempoolId_t{0, 0};
-                if (capture_error_mode == "global") {
-                  capture_mode = cudaStreamCaptureModeGlobal;
-                } else if (capture_error_mode == "thread_local") {
-                  capture_mode = cudaStreamCaptureModeThreadLocal;
-                } else if (capture_error_mode == "relaxed") {
-                  capture_mode = cudaStreamCaptureModeRelaxed;
-                } else {
-                  TORCH_CHECK(
-                    false,
-                    "Unknown capture error mode. Expected `global`, `thread_local`, or `relaxed`, got ",
-                    capture_error_mode);
-                  }
-            self.set_prev_only_lift_cpu_tensors(torch::utils::only_lift_cpu_tensors());
+            if (capture_error_mode == "global") {
+              capture_mode = cudaStreamCaptureModeGlobal;
+            } else if (capture_error_mode == "thread_local") {
+              capture_mode = cudaStreamCaptureModeThreadLocal;
+            } else if (capture_error_mode == "relaxed") {
+              capture_mode = cudaStreamCaptureModeRelaxed;
+            } else {
+              TORCH_CHECK(
+                  false,
+                  "Unknown capture error mode. Expected `global`, `thread_local`, or `relaxed`, got ",
+                  capture_error_mode);
+            }
+            self.set_prev_only_lift_cpu_tensors(
+                torch::utils::only_lift_cpu_tensors());
             torch::utils::set_only_lift_cpu_tensors(true);
             return self.capture_begin(pool, capture_mode);
           },
@@ -60,7 +61,8 @@ void THCPGraph_init(PyObject* module) {
           "capture_end",
           [](::at::cuda::CUDAGraph& self) {
             self.capture_end();
-            torch::utils::set_only_lift_cpu_tensors(self.prev_only_lift_cpu_tensors());
+            torch::utils::set_only_lift_cpu_tensors(
+                self.prev_only_lift_cpu_tensors());
           },
           py::call_guard<py::gil_scoped_release>())
       .def(

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -390,7 +390,9 @@ at::Tensor LazyNativeFunctions::lift(const at::Tensor& tensor) {
       !at::functionalization::impl::isFunctionalTensor(tensor));
   return at::functionalization::impl::to_functional_tensor(tensor);
 }
-at::Tensor LazyNativeFunctions::lift_fresh(const at::Tensor& tensor, at::Device device) {
+at::Tensor LazyNativeFunctions::lift_fresh(
+    const at::Tensor& tensor,
+    at::Device device) {
   TORCH_INTERNAL_ASSERT(
       !at::functionalization::impl::isFunctionalTensor(tensor));
   return at::functionalization::impl::to_functional_tensor(tensor);

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -390,7 +390,7 @@ at::Tensor LazyNativeFunctions::lift(const at::Tensor& tensor) {
       !at::functionalization::impl::isFunctionalTensor(tensor));
   return at::functionalization::impl::to_functional_tensor(tensor);
 }
-at::Tensor LazyNativeFunctions::lift_fresh(const at::Tensor& tensor) {
+at::Tensor LazyNativeFunctions::lift_fresh(const at::Tensor& tensor, at::Device device) {
   TORCH_INTERNAL_ASSERT(
       !at::functionalization::impl::isFunctionalTensor(tensor));
   return at::functionalization::impl::to_functional_tensor(tensor);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -475,7 +475,7 @@ Tensor internal_new_from_data(
     // to dispatch to it.
     // TODO: arguably it should have an autograd implementation that noops
     at::AutoDispatchBelowADInplaceOrView guard;
-    tensor = at::lift_fresh(tensor);
+    tensor = at::lift_fresh(tensor, device);
   }
   if (only_lift_cpu_tensors() && device.type() != DeviceType::CPU) {
     if (!device.has_index() &&

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -269,15 +269,17 @@ at::Tensor tensor_from_numpy(
       "given numpy array has byte order different from the native byte order. "
       "Conversion between byte orders is currently not supported.");
   Py_INCREF(obj);
-  return at::lift_fresh(at::from_blob(
-      data_ptr,
-      sizes,
-      strides,
-      [obj](void* data) {
-        pybind11::gil_scoped_acquire gil;
-        Py_DECREF(obj);
-      },
-      at::device(kCPU).dtype(torch_dtype)), kCPU);
+  return at::lift_fresh(
+      at::from_blob(
+          data_ptr,
+          sizes,
+          strides,
+          [obj](void* data) {
+            pybind11::gil_scoped_acquire gil;
+            Py_DECREF(obj);
+          },
+          at::device(kCPU).dtype(torch_dtype)),
+      kCPU);
 }
 
 int aten_to_numpy_dtype(const ScalarType scalar_type) {

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -277,7 +277,7 @@ at::Tensor tensor_from_numpy(
         pybind11::gil_scoped_acquire gil;
         Py_DECREF(obj);
       },
-      at::device(kCPU).dtype(torch_dtype)));
+      at::device(kCPU).dtype(torch_dtype)), kCPU);
 }
 
 int aten_to_numpy_dtype(const ScalarType scalar_type) {


### PR DESCRIPTION
Fixes #168991. When creating a CUDA tensor from a host constant inside CUDA graph capture, for example:

```python
with torch.cuda.graph(g):
    x = torch.tensor(-float("inf"), device="cuda")
```

currently fails with `cudaErrorStreamCaptureUnsupported`. This occurs because `torch.tensor(...)` internally performs a host-to-device copy that synchronizes the stream, which is illegal during CUDA stream capture. Since this pattern is common in real models, this limitation prevents cudagraphifying otherwise valid code paths.

The initial design behind this change is to reuse `lift_fresh`, which marks a tensor as “fresh” and serves as the semantic hook for constants (as introduced in earlier work by @ezyang). This operator is already used in `tensor_new.cpp`, but until now it only affected Dynamo and FX graphs. Building on @zou3519’s work for FX graphs, this PR reuses the `only_lift_cpu_tensors` mechanism by enabling it at CUDA graph `capture_begin` and restoring it at `capture_end`. When enabled, `only_lift_cpu_tensors` rewrites `torch.tensor(..., device="cuda")` from the sequence “create CPU tensor → move to CUDA via `.to()` → call `lift_fresh()`” into “create CPU tensor → call `lift_fresh()` → move to CUDA,” ensuring that constant semantics are made explicit before any device transfer.

This PR makes constant lifting (`lift_fresh`) aware of CUDA graph capture. It extends `lift_fresh` and `lift_fresh_copy` to accept an explicit `Device`, allowing the operator to know the intended destination device and enabling device-specific handling without changing higher-level semantics. A CUDA implementation of `lift_fresh` is added: when not capturing, behavior is unchanged and the operator simply returns `self`. When capturing, `lift_fresh` performs the one-time host-to-device copy on a side stream under relaxed capture mode so that the copy is not captured into the graph. The output of `lift_fresh` becomes a CUDA tensor that is treated as a graph constant and preserved in the graph pool, making the subsequent `.to("cuda")` a no-op in the captured graph. This approach avoids introducing illegal synchronization nodes, preserves existing semantics, and reuses established FX and functionalization infrastructure rather than adding new special cases.

**Reference**
- https://github.com/pytorch/pytorch/pull/81192
- https://github.com/pytorch/pytorch/pull/124413

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng