### PR TITLE
Gate deletion of clean-up steps in `build_common.sh`

### DIFF
--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -115,7 +115,10 @@ if [[ -z "$PYTORCH_ROOT" ]]; then
 fi
 pushd "$PYTORCH_ROOT"
 retry pip install -qUr requirements-build.txt
-python setup.py clean
+DO_SETUP_PY_CLEAN_BEFORE_BUILD=${DO_SETUP_PY_CLEAN_BEFORE_BUILD:-1}
+if [[ "$DO_SETUP_PY_CLEAN_BEFORE_BUILD" == "1" ]]; then
+    python setup.py clean
+fi
 retry pip install -qr requirements.txt
 case ${DESIRED_PYTHON} in
   cp31*)
@@ -444,10 +447,16 @@ if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
     fi
 fi
 
-# remove stuff before testing
-rm -rf /opt/rh
-if ls /usr/local/cuda* >/dev/null 2>&1; then
-    rm -rf /usr/local/cuda*
+# Optionally remove stuff before testing
+WIPE_RH_CUDA_AFTER_BUILD=${WIPE_RH_CUDA_AFTER_BUILD:-1}
+if [[ "${WIPE_RH_CUDA_AFTER_BUILD}" == "1" ]]; then
+    echo "Removing /opt/rh and /usr/local/cuda*"
+    rm -rf /opt/rh
+    if ls /usr/local/cuda* >/dev/null 2>&1; then
+        rm -rf /usr/local/cuda*
+    fi
+else
+    echo "Not removing /opt/rh and /usr/local/cuda*"
 fi
 
 


### PR DESCRIPTION
## Problem

The `.ci/manywheel/build.sh` script is helpful to us for building AArch64 CPU-only PyTorch wheels in a way that closely matches what PyTorch does. However, this approach occasionally requires debugging, for which incremental builds would be very valuable. When run, this script calls out to `.ci/manywheel/build_common.sh`, which performs two actions that inhibit incremental builds:
1. the `python setup.py clean` step is always run before installing the `pip` requirements, and;
2. the RHEL and CUDA toolsets are wiped at the end.
With the former, the `build/` directory is wiped. With the latter, running `ninja` in the build directory leads to `cmake` being invoked but, because it cannot find the original compiler, it dies, and thus the rebuild fails.

## Contribution

This PR adds gating to optionally disable both steps described above. Note that the default behaviour preserves what was previously done.

## Remark

Tracking the file back, it is unclear why wiping the toolsets was done in the first place; if you think it is better to remove those lines entirely let me know and I will amend the PR.