### PR TITLE
[DO NOT REVIEW] correct error msg for view

### DIFF
--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -732,6 +732,14 @@ class TestStridedSharding(DTensorTestBase):
         return 4
 
     @with_comms
+    def test_1d_mesh_view(self):
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        orig_shape = (8192, 2048)
+        global_inps = torch.randn(*orig_shape, device=self.device_type)
+        inps = distribute_tensor(global_inps, mesh, (Shard(0), ))
+        inps_viewed = inps.view(2, 4096, 2048)
+
+    @with_comms
     def test_1d_mesh_strided_sharding(self):
         mesh_1d = init_device_mesh(self.device_type, (self.world_size,))
         # Test 1: 1-d tensor over 1-d mesh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170606

the error msg seems to be clear on latest trunk

```
pytest -s test_utils.py -k test_1d_mesh_view
```

```
  File ".../lib/python3.12/site-packages/torch/distributed/tensor/_dispatch.py", line 214, in _propagate_op_sharding_dispatch_slow_path
    return self.sharding_propagator.propagate_op_sharding_non_cached(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/site-packages/torch/distributed/tensor/_sharding_prop.py", line 441, in propagate_op_sharding_non_cached
    op_strategy = self.op_strategy_funcs[op_schema.op](strategy_schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/site-packages/torch/distributed/tensor/_ops/_view_ops.py", line 727, in reshape_strategy
    input_tgt_placements, output_placements = propagate_shape_and_sharding(
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/site-packages/torch/distributed/tensor/_ops/_view_ops.py", line 653, in propagate_shape_and_sharding
    in_dim = get_in_dim_to_shard(cmd)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/site-packages/torch/distributed/tensor/_ops/_view_ops.py", line 625, in get_in_dim_to_shard
    raise RuntimeError(
RuntimeError: ('Attempted to split the sharded dimension 0 into multiple subdimensions. ', 'It cannot be performed without redistribution, which is disallowed by the current operator.')
```