### PR TITLE
[torchcomms] Add collective effect type for torchcomms op ordering

### DIFF
--- a/torch/_library/effects.py
+++ b/torch/_library/effects.py
@@ -6,6 +6,7 @@ import torch
 
 class EffectType(Enum):
     ORDERED = "Ordered"
+    COLLECTIVE = "Collective"  # For communication ops that mutate tensors in-place
 
 
 from torch._library.utils import RegistrationHandle


### PR DESCRIPTION
Summary: the main change is supporting mutating/aliasing ops

Test Plan:
Run torchcomms compile tests.
buck2 test mode/opt //caffe2/test:higher_order_ops -- -r "test_collective_effect"

Differential Revision: D89316567


