### PR TITLE
Fix bug with FakeTensorMode/skip_data ctx storage size in torch.load

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1847,7 +1847,6 @@ class FakeTensorPropTest(TestCase):
                 self.assertEqual(TwoTensor(result_a, result_b), sd_orig[key])
             else:
                 untyped_storage = t.untyped_storage()
-                # Verify nbytes is correct (not multiplied by element_size again)
                 self.assertEqual(
                     untyped_storage.nbytes(), sd_orig[key].untyped_storage().nbytes()
                 )

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1813,7 +1813,7 @@ class FakeTensorPropTest(TestCase):
         sd = model.state_dict()
         sd["tt"] = TwoTensor(torch.randn(2), torch.randn(2))
 
-        def _read_tensor_and_check(key, sd_loaded, all_bytes, device):
+        def _read_tensor_and_check(key, sd_loaded, sd_orig, all_bytes, device):
             dtype = torch.float32
             t = sd_loaded[key]
             self.assertEqual(t.device.type, device)
@@ -1821,6 +1821,14 @@ class FakeTensorPropTest(TestCase):
                 untyped_storage_a, untyped_storage_b = (
                     t.a.untyped_storage(),
                     t.b.untyped_storage(),
+                )
+                self.assertEqual(
+                    untyped_storage_a.nbytes(),
+                    sd_orig[key].a.untyped_storage().nbytes(),
+                )
+                self.assertEqual(
+                    untyped_storage_b.nbytes(),
+                    sd_orig[key].b.untyped_storage().nbytes(),
                 )
                 offset_a, offset_b = (
                     untyped_storage_a._checkpoint_offset,
@@ -1836,15 +1844,19 @@ class FakeTensorPropTest(TestCase):
                 result_b = torch.frombuffer(
                     all_bytes, dtype=dtype, count=nbytes_b, offset=offset_b
                 ).resize_(t.b.size())
-                self.assertEqual(TwoTensor(result_a, result_b), sd[key])
+                self.assertEqual(TwoTensor(result_a, result_b), sd_orig[key])
             else:
                 untyped_storage = t.untyped_storage()
+                # Verify nbytes is correct (not multiplied by element_size again)
+                self.assertEqual(
+                    untyped_storage.nbytes(), sd_orig[key].untyped_storage().nbytes()
+                )
                 offset = untyped_storage._checkpoint_offset
                 nbytes = untyped_storage.nbytes() // 4
                 result = torch.frombuffer(
                     all_bytes, dtype=dtype, count=nbytes, offset=offset
                 ).resize_(t.size())
-                self.assertEqual(result, sd[key])
+                self.assertEqual(result, sd_orig[key])
 
         with TemporaryFileName() as f, torch.serialization.safe_globals([TwoTensor]):
             # Create state_dict to be loaded later
@@ -1856,11 +1868,11 @@ class FakeTensorPropTest(TestCase):
             with fake_mode:
                 sd_loaded = torch.load(f)
             for k in sd:
-                _read_tensor_and_check(k, sd_loaded, all_bytes, "cpu")
+                _read_tensor_and_check(k, sd_loaded, sd, all_bytes, "cpu")
             with fake_mode:
                 sd_loaded = torch.load(f, map_location="cuda")
             for k in sd:
-                _read_tensor_and_check(k, sd_loaded, all_bytes, "cuda")
+                _read_tensor_and_check(k, sd_loaded, sd, all_bytes, "cuda")
 
         for k in sd:
             sd[k] = sd[k].to("cuda")
@@ -1874,11 +1886,11 @@ class FakeTensorPropTest(TestCase):
             with fake_mode:
                 sd_loaded = torch.load(f)
             for k in sd:
-                _read_tensor_and_check(k, sd_loaded, all_bytes, "cuda")
+                _read_tensor_and_check(k, sd_loaded, sd, all_bytes, "cuda")
             with fake_mode:
                 sd_loaded = torch.load(f, map_location="cpu")
             for k in sd:
-                _read_tensor_and_check(k, sd_loaded, all_bytes, "cpu")
+                _read_tensor_and_check(k, sd_loaded, sd, all_bytes, "cpu")
 
 
 make_propagate_real_tensors_cls(FakeTensorPropTest)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -949,6 +949,14 @@ class SerializationMixin:
             with safe_globals([TwoTensor]), skip_data():
                 sd_loaded = torch.load(f)
             self.assertNotEqual(sd_loaded, sd)
+            self.assertEqual(
+                sd_loaded['t_v2'].untyped_storage().nbytes(),
+                sd['t_v2'].untyped_storage().nbytes()
+            )
+            self.assertEqual(
+                sd_loaded['tt'].a.untyped_storage().nbytes(),
+                sd['tt'].a.untyped_storage().nbytes()
+            )
             for k in sd_loaded:
                 sd_loaded[k] = sd_loaded[k].zero_()
             self.assertEqual(sd_loaded, sd_zeroed)

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -240,6 +240,40 @@ class HeaderOnlyArrayRef {
   /// @}
 };
 
+// WARNING: Template instantiation will NOT be willing to do an implicit
+// conversions to get you to an c10::HeaderOnlyArrayRef, which is why we need so
+// many overloads.
+
+template <typename T>
+bool operator==(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return a1.equals(a2);
+}
+
+template <typename T>
+bool operator!=(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return !a1.equals(a2);
+}
+
+template <typename T>
+bool operator==(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
+}
+
+template <typename T>
+bool operator!=(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return !c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
+}
+
+template <typename T>
+bool operator==(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
+  return a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
+}
+
+template <typename T>
+bool operator!=(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
+  return !a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
+}
+
 } // namespace c10
 
 namespace torch::headeronly {

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -240,40 +240,6 @@ class HeaderOnlyArrayRef {
   /// @}
 };
 
-// WARNING: Template instantiation will NOT be willing to do an implicit
-// conversions to get you to an c10::HeaderOnlyArrayRef, which is why we need so
-// many overloads.
-
-template <typename T>
-bool operator==(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return a1.equals(a2);
-}
-
-template <typename T>
-bool operator!=(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return !a1.equals(a2);
-}
-
-template <typename T>
-bool operator==(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
-}
-
-template <typename T>
-bool operator!=(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return !c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
-}
-
-template <typename T>
-bool operator==(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
-  return a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
-}
-
-template <typename T>
-bool operator!=(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
-  return !a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
-}
-
 } // namespace c10
 
 namespace torch::headeronly {


### PR DESCRIPTION
`numel` was already `nbytes`, but we erroneously multiplied this by `torch._utils._element_size(dtype)` size again

https://github.com/pytorch/pytorch/blob/3b52fc255f659beac8608d0627fd9bcf3cea426f/torch/serialization.py#L2115-L2118

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170619
* __->__ #170618

