### PR TITLE
ci: Switch inductor-pallas to autolabel

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -131,6 +131,7 @@
 - torch/_inductor/codegen/pallas.py
 - test/inductor/test_pallas.py
 - test/inductor/pallas_expected_failures/**
+- .github/workflows/inductor-pallas.yml
 
 "ciflow/b200":
 - test/test_matmul_cuda.py

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -127,6 +127,11 @@
 "ciflow/vllm":
 - .github/ci_commit_pins/vllm.txt
 
+"ciflow/inductor-pallas":
+- torch/_inductor/codegen/pallas.py
+- test/inductor/test_pallas.py
+- test/inductor/pallas_expected_failures/**
+
 "ciflow/b200":
 - test/test_matmul_cuda.py
 - test/test_scaled_matmul_cuda.py

--- a/.github/workflows/inductor-pallas.yml
+++ b/.github/workflows/inductor-pallas.yml
@@ -7,11 +7,6 @@ on:
       - release/*
     tags:
       - ciflow/inductor-pallas/*
-  pull_request:
-    paths:
-      - torch/_inductor/codegen/pallas.py
-      - test/inductor/test_pallas.py
-      - .github/workflows/inductor-pallas.yml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #170620

The pull_request trigger path and ciflow path caused jobs to get
triggered twice creating some confusion so wanted to switch this over
to utilize the same autolabel path as everything else.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>