### PR TITLE
[WIP][annotate] Fix annotation for invoke_subgraphs

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1489,7 +1489,10 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         # preserve_node_meta context manager is setup. This is important to pass
         # on the metadata to the create_proxy nodes.
         stack = ExitStack()
-        stack.enter_context(torch.fx.traceback.annotate(self.target_values))
+        annotation_dict, combine_fn = self.target_values
+        stack.enter_context(
+            torch.fx.traceback.annotate(annotation_dict, combine_fn=combine_fn)
+        )
         stack.enter_context(torch.fx.traceback.preserve_node_meta())
         self.set_cleanup_hook(tx, lambda: stack.close())
         return variables.ConstantVariable.create(None)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5136,15 +5136,21 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
     ) -> VariableTracker:
         # This flattens the kwargs into lifted args
         assert self._HOP_NAME is not None
-        (
-            p_args,
-            p_kwargs,
-            example_value,
-            body_r,
-            body_gmod,
-            body_name,
-            body_graph_output_vts,
-        ) = self.create_wrapped_node(tx, args[0], args[1:], kwargs, self._HOP_NAME)
+
+        # NB: annotation in invoke_subgraph
+        # The subgraph should not inherit the annotation from parent context.
+        # We trace the subgraph once and the subgraph can be used in different calls,
+        # so the parent annotation is not well-defined.
+        with torch.fx.traceback.set_current_annotation({}):
+            (
+                p_args,
+                p_kwargs,
+                example_value,
+                body_r,
+                body_gmod,
+                body_name,
+                body_graph_output_vts,
+            ) = self.create_wrapped_node(tx, args[0], args[1:], kwargs, self._HOP_NAME)
 
         if len(p_kwargs) > 0:
             unimplemented(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -390,9 +390,15 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             torch.fx.traceback.annotate,
             torch.fx.traceback.annotate.__wrapped__,  # type: ignore[attr-defined]
         ):
-            assert len(args) <= 1 and len(kwargs) == 0
+            assert len(args) == 1
+            annotation_dict = args[0].as_python_constant()
+            combine_fn = (
+                kwargs["combine_fn"].as_python_constant()
+                if "combine_fn" in kwargs
+                else None
+            )
             return FxTracebackAnnotateVariable(
-                args[0].as_python_constant(), source=self.source
+                (annotation_dict, combine_fn), source=self.source
             )
         elif inspect.isclass(self.value) and issubclass(self.value, torch.Stream):
             from torch._dynamo.variables.builder import wrap_fx_proxy_cls

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -9,6 +9,7 @@ import dataclasses
 from typing import Any, Optional
 
 import torch
+import torch.fx.traceback as fx_traceback
 import torch.utils._pytree as pytree
 import torch.utils.dlpack
 from torch._dispatch.python import enable_python_dispatcher
@@ -249,12 +250,15 @@ def aot_dispatch_base_graph(
         updated_flat_args_subclasses_desugared_descs
     )
 
-    fw_module = _create_graph(
-        fn_to_trace,
-        updated_flat_args_subclasses_desugared,
-        updated_flat_args_subclasses_desugared_descs,
-        aot_config=aot_config,
-    )
+    # need preserve_node_meta so we have annotation from fx.traceback.annotate
+    # on the graph
+    with fx_traceback.preserve_node_meta():
+        fw_module = _create_graph(
+            fn_to_trace,
+            updated_flat_args_subclasses_desugared,
+            updated_flat_args_subclasses_desugared_descs,
+            aot_config=aot_config,
+        )
 
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
         # We update metadata to consider any assigned buffers as buffer mutations.

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -269,6 +269,24 @@ def set_stack_trace(stack: list[str]):
         current_meta["stack_trace"] = "".join(stack)
 
 
+@compatibility(is_backward_compatible=False)
+@contextmanager
+def set_current_annotation(annotation_dict: dict):
+    global current_meta
+    if should_preserve_node_meta:
+        saved_custom = current_meta.get("custom")
+        try:
+            if "custom" in current_meta:
+                current_meta["custom"] = annotation_dict
+
+            yield
+        finally:
+            if saved_custom:
+                current_meta["custom"] = saved_custom
+    else:
+        yield
+
+
 def _replace_combine_fn(old, new):
     """
     Combine the old and new annotations by replacing the old annotation with the new one.


### PR DESCRIPTION
To make annotation consistent with invoke_subgraphs, we also make the following claim:

**Anything inside "nested_compile_region" will NOT inherit the annotation from anything outside of the region.**

This is because the nested region can be called from different code paths, and a single graph cannot inherit multiple parent annotations. So, we treat each "nested_compile_region" as the compile-root for annotation. 


For example, for the following annotation, the nodes in `bar` will only have the `bar` annotation, not `g` or `foo`.

```
@torch.compiler.nested_compile_region
def bar()
 with annotate({"mod_name": "bar"}, combine_fn=combine):
		....

def f():
 with annotate({"mod_name": "foo"}, combine_fn=combine):
	bar()

def g():
  with annotate({"mod_name": "g"}, combine_fn=combine):
	f()
	bar()
```


**We also fix the a problem with `seq_nr` node meta on invoke subgraph node and its subgraph nodes.**

We currently rely on “seq_nr” node meta to map nodes between forward and backward graphs. We use this mapping to copy node meta on the corresponding forward graph node to the backward graph node. 

The seq_nr on the joint graph of the nested region is only correct when it’s first traced here.  For all other re-traced graphs, the seq_nr for all nodes in the graph is the same. As a result, we need two special handlings: 
  - Do the copy-metadata pass right after we traced the first backward graph (which is actually a joint graph because how invoke_subgraph works)

   - Exclude these subgraphs from the final copy-metadata pass on the overall graph 


The seq_nr on the invoke_subraph node (the node itself, not the subgraph nodes) needs the seq_nr at the time of InvokeSubgraphAutogradOp.apply to match the seq_nr on the backward invoke_subgraph node


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98