### PR TITLE
[XPU] fix UT cases of COW issue

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -351,7 +351,7 @@ class Attr {
             DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1);
 
         binary_m = at::native::onednn::make_onednn_memory(
-            md, engine, binary.data_ptr());
+            md, engine, binary.const_data_ptr());
 
         args.insert(
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binary_m});

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -223,8 +223,8 @@ sycl::event matmul(
   dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
   // STEP4: create memory
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
+  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.const_data_ptr());
   auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
 
   auto expected_m1_md = matmul_pd.src_desc();
@@ -250,7 +250,7 @@ sycl::event matmul(
   args.insert({DNNL_ARG_WEIGHTS, m2_m});
   args.insert({DNNL_ARG_DST, dst_m});
   if (with_bias) {
-    auto bias_m = make_onednn_memory(bias_md, engine, b.data_ptr());
+    auto bias_m = make_onednn_memory(bias_md, engine, b.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, bias_m});
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -531,7 +531,7 @@ sycl::event scaled_matmul(
   };
 
   auto scratchpad =
-      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void*)nullptr);
+      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, const_cast<void*>nullptr);
 
   // 3. Setup Args for exec
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -531,7 +531,7 @@ sycl::event scaled_matmul(
   };
 
   auto scratchpad =
-      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, const_cast<void*>nullptr);
+      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void*)nullptr);
 
   // 3. Setup Args for exec
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -531,7 +531,7 @@ sycl::event scaled_matmul(
   };
 
   auto scratchpad =
-      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void *)nullptr);
+      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void*)nullptr);
 
   // 3. Setup Args for exec
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -531,7 +531,7 @@ sycl::event scaled_matmul(
   };
 
   auto scratchpad =
-      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, nullptr);
+      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void *)nullptr);
 
   // 3. Setup Args for exec
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -18,6 +18,11 @@ dnnl::memory make_onednn_memory(
       ptr == nullptr ? DNNL_MEMORY_ALLOCATE : ptr);
 }
 
+dnnl::memory make_onednn_memory(
+    dnnl::memory::desc md, dnnl::engine& engine, const void* ptr) {
+  return make_onednn_memory(md, engine, (void*)ptr);
+}
+
 dnnl::memory::format_tag get_dnnl_default_format(
     int ndims,
     bool is_channels_last,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -19,7 +19,9 @@ dnnl::memory make_onednn_memory(
 }
 
 dnnl::memory make_onednn_memory(
-    dnnl::memory::desc md, dnnl::engine& engine, const void* ptr) {
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    const void* ptr) {
   return make_onednn_memory(md, engine, (void*)ptr);
 }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -22,7 +22,7 @@ dnnl::memory make_onednn_memory(
     dnnl::memory::desc md,
     dnnl::engine& engine,
     const void* ptr) {
-  return make_onednn_memory(md, engine, const_cast<void*>ptr);
+  return make_onednn_memory(md, engine, const_cast<void*>(ptr));
 }
 
 dnnl::memory::format_tag get_dnnl_default_format(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -22,7 +22,7 @@ dnnl::memory make_onednn_memory(
     dnnl::memory::desc md,
     dnnl::engine& engine,
     const void* ptr) {
-  return make_onednn_memory(md, engine, (void*)ptr);
+  return make_onednn_memory(md, engine, const_cast<void*>ptr);
 }
 
 dnnl::memory::format_tag get_dnnl_default_format(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
@@ -18,6 +18,11 @@ dnnl::memory make_onednn_memory(
     dnnl::engine& engine,
     void* ptr);
 
+TORCH_XPU_API dnnl::memory make_onednn_memory(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    const void* ptr);
+
 // Keep non-static and non-inline
 bool set_onednn_verbose(int level);
 


### PR DESCRIPTION
Fixed UT cases: 
test_cow_input_addmm_xpu_float32
test_cow_input_matmul_xpu_float32
test_cow_input_addmm_decomposed_xpu_float32

The COW feature need the OP code use the const ptr type to make oneDNN memory() as input parameter.
In legacy, all parameters in mat_mul are non-const ptr types. It lead to the COW feature is disabled.
In this PR, the input parameters: m1(src), m2(weights), b(bias) are constructed as oneDNN memory by const ptr type.
It will make the COW feature is enabled.

oneDNN don't provide the construct function with const ptr in API.
But it promises the input parameters won't be modified in the API. Please refer to: https://uxlfoundation.github.io/oneDNN/dev_guide_matmul.html#execution-arguments.

In the PR, we remove the const before construct oneDNN memory() for input parameters src,weights and bias. 
It won't impact the code security according to oneDNN API guide.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01