### PR TITLE
Automatically verify that external inputs to a cuda graph are alive before replay.

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3808,6 +3808,83 @@ with torch.cuda.graph(g):
                 .strip()
             )
 
+    def test_cuda_graph_detect_killed_input(self):
+        input_to_kill = torch.zeros(1024, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph, capture_error_mode="relaxed", debug_options={"input_liveness"}
+        ):
+            input_to_kill += 1
+
+        graph.replay()
+
+        del input_to_kill
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Tensor captured for CUDA graph was freed before graph replay",
+        ):
+            graph.replay()
+
+    def test_cuda_graph_detect_killed_input_ignore_non_capture_stream(self):
+        input_to_kill = torch.zeros(1024, device="cuda")
+
+        extra_work_tensor = torch.zeros(1024, device="cuda")
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph, capture_error_mode="relaxed", debug_options={"input_liveness"}
+        ):
+            input_to_kill += 1
+            with torch.cuda.stream(torch.cuda.Stream()):
+                extra_work_tensor.fill_(42)
+
+        del extra_work_tensor
+        # Should not throw an exception
+        graph.replay()
+
+    def test_cuda_graph_detected_killed_input_overriden(self):
+        input_tensor = torch.zeros(1024, device="cuda")
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph, capture_error_mode="relaxed", debug_options={"input_liveness"}
+        ):
+            # This creates a new torch.Tensor object referring,
+            # distinct from the one originally bound to input_tensor
+            input_tensor = input_tensor + 1
+
+        del extra_work_tensor
+        # Should not throw an exception
+        graph.replay()
+
+    def test_cuda_graph_detected_killed_input_ignore_temporaries(self):
+        input_tensor = torch.zeros(1024, device="cuda")
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph, capture_error_mode="relaxed", debug_options={"input_liveness"}
+        ):
+            temp = input_tensor + 1
+            # temp is an input to this
+            out = temp + 1
+            del temp
+
+        # Should not throw an exception
+        graph.replay()
+
+    # TODO: Figure out what to do if we have an allocated tensor from
+    # a previous graph get deleted by a future graph, if all graphs
+    # share a memory pool. This should be "safe", right? We could
+    # potentially introspect the private pool. If an input is from
+    # this graph's private pool, then there is no need to give an
+    # error when the preceding graph is run, right?
+
+    # TODO: Also think about what to do when there are several graphs
+    # sharing a memory pool In this case, they should not reference
+    # each others' outputs as inputs, so it is probably pretty safe to
+    # ignore that.
+
     def test_batch_norm_gather_stats(self):
         input = torch.randn(1, 3, 3, 3, device="cuda")
         mean, invstd = torch.batch_norm_gather_stats(

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import gc
+import traceback
 import typing
+import weakref
 from collections.abc import Callable
 from typing import Optional, overload, TYPE_CHECKING, TypeAlias, Union
 from typing_extensions import ParamSpec, Self, TypeVar
@@ -140,6 +142,27 @@ class CUDAGraph(torch._C._CUDAGraph):
 
     def replay(self) -> None:
         r"""Replay the CUDA work captured by this graph."""
+        death_records = getattr(self, "tensor_inputs_death_records", None)
+        if death_records:
+            entries = []
+            for rec in death_records:
+                entries.append(
+                    f"Function: {rec['func']}\n"
+                    f"Argument: {rec['arg']}\n"
+                    "Python backtrace at creation:\n"
+                    f"{rec['creation_python']}"
+                    "C++ backtrace at creation:\n"
+                    f"{rec['creation_cpp']}"
+                    "Python backtrace at death:\n"
+                    f"{rec['death_python']}"
+                )
+            message = (
+                "Tensor captured for CUDA graph was freed before graph replay.\n"
+                + "\n---\n".join(entries)
+            )
+            # Clear after reporting to avoid duplicate reports on subsequent calls.
+            death_records.clear()
+            raise ValueError(message)
         super().replay()
 
     def reset(self) -> None:
@@ -182,6 +205,105 @@ class CUDAGraph(torch._C._CUDAGraph):
         """  # noqa: B950
         return super().raw_cuda_graph_exec()
 
+    def __del__(self) -> None:
+        if hasattr(self, "tensor_inputs_used"):
+            # If we were tracking tensor liveness for this graph, drop the weakrefs.
+            try:
+                self.tensor_inputs_used.clear()
+            except Exception:
+                pass
+        if hasattr(self, "tensor_inputs_death_records"):
+            try:
+                self.tensor_inputs_death_records.clear()
+            except Exception:
+                pass
+
+
+# Avoid a circular dependency
+def create_collect_inputs_dispatch_mode(cuda_graph):
+    from torch.utils._python_dispatch import TorchDispatchMode
+
+    class CollectInputsDispatchMode(TorchDispatchMode):
+        def __init__(self, graph):
+            self.supports_higher_order_operators = True
+            self.graph = graph
+            # This is hacky, but we keep the weakrefs alive as long as
+            # the cuda graph is alive by making them an instance
+            # variable on the cuda graph we are doing stream capture
+            # to.
+            self.graph.tensor_inputs_used = set()
+            self.graph.tensor_inputs_death_records = []
+            self.tensor_inputs_used_during_capture = weakref.WeakKeyDictionary()
+            super().__init__()
+
+        def __torch_dispatch__(self, func, types, args, kwargs=None):
+            resolved_kwargs = {} if kwargs is None else kwargs
+
+            # Record the tensors used by this op only if they are part
+            # of the graph
+            if not torch.cuda.is_current_stream_capturing():
+                return func(*args, **resolved_kwargs)
+
+            # Avoid a circular dependency
+            from torch.utils.cpp_backtrace import get_cpp_backtrace
+
+            python_backtrace = "".join(traceback.format_stack()[:-1])
+            cpp_backtrace = get_cpp_backtrace()
+
+            func_name = getattr(func, "__name__", str(func))
+
+            def make_death_callback(arg_desc: str):
+                creation_py = python_backtrace
+                creation_cpp = cpp_backtrace
+
+                def death_callback(_):
+                    try:
+                        death_py = "".join(traceback.format_stack()[:-1])
+                        self.graph.tensor_inputs_death_records.append(
+                            {
+                                "func": func_name,
+                                "arg": arg_desc,
+                                "creation_python": creation_py,
+                                "creation_cpp": creation_cpp,
+                                "death_python": death_py,
+                            }
+                        )
+                    except Exception:
+                        # Best-effort; avoid raising from GC callback.
+                        pass
+
+                return death_callback
+
+            for idx, arg in enumerate(args):
+                for maybe_tensor in torch.utils._pytree.tree_iter(arg):
+                    if isinstance(maybe_tensor, torch.Tensor):
+                        self.tensor_inputs_used_during_capture[maybe_tensor] = (
+                            make_death_callback(f"args[{idx}]")
+                        )
+
+            for name, arg in resolved_kwargs.items():
+                for maybe_tensor in torch.utils._pytree.tree_iter(arg):
+                    if isinstance(maybe_tensor, torch.Tensor):
+                        self.tensor_inputs_used_during_capture[maybe_tensor] = (
+                            make_death_callback(f"kwargs['{name}']")
+                        )
+
+            return func(*args, **resolved_kwargs)
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            super().__exit__(exc_type, exc_val, exc_tb)
+            # Inputs that happened to die during stream capture will
+            # have already been removed from
+            # self.tensor_inputs_used_during_capture
+            for (
+                tensor,
+                death_callback,
+            ) in self.tensor_inputs_used_during_capture.items():
+                self.graph.tensor_inputs_used.add(weakref.ref(tensor, death_callback))
+            self.tensor_inputs_used_during_capture = None
+
+    return CollectInputsDispatchMode(cuda_graph)
+
 
 class graph:
     r"""Context-manager that captures CUDA work into a :class:`torch.cuda.CUDAGraph` object for later replay.
@@ -221,6 +343,7 @@ class graph:
         pool: Optional[_POOL_HANDLE] = None,
         stream: Optional[torch.cuda.Stream] = None,
         capture_error_mode: str = "global",
+        debug_options: Optional[set] = None,
     ):
         # Lazy-init of default_capture_stream helps avoid circular-import errors.
         # Not thread safe, but graphs already have the general (explicitly documented)
@@ -238,6 +361,10 @@ class graph:
         self.stream_ctx = torch.cuda.stream(self.capture_stream)
         self.cuda_graph = cuda_graph
         self.capture_error_mode = capture_error_mode
+        self.debug_options = debug_options or set()
+
+        if "input_liveness" in self.debug_options:
+            self.collect_inputs = create_collect_inputs_dispatch_mode(cuda_graph)
 
     def __enter__(self) -> None:
         # Free as much memory as we can for the graph
@@ -263,8 +390,12 @@ class graph:
             # pyrefly: ignore [bad-keyword-argument]
             capture_error_mode=self.capture_error_mode,
         )
+        if "input_liveness" in self.debug_options:
+            self.collect_inputs.__enter__()
 
     def __exit__(self, *args: object) -> None:
+        if "input_liveness" in self.debug_options:
+            self.collect_inputs.__exit__(*args)
         self.cuda_graph.capture_end()
         self.stream_ctx.__exit__(*args)
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()


### PR DESCRIPTION
This is a draft. I have no plans to work towards merging this until I figure out some kinks. Feedback welcome.

A common bug when using cuda graphs is the failure to keep your inputs alive. Unfortunately, you cannot force an invalid memory access since pytorch's CUDACachingAllocator reuses existing allocations. Even if you could, that would not be guaranteed to work since cudaMalloc itself can reuse allocations and the increase in memory usage may result in your workload being urunnable.

I used to think that we would need type information for the raw cuda kernels' parameters in order to do such a check. However, TorchDispatchModes also gives us more or less what we need, in a more interpretable way, because people reason about pytorch ops, not their underlying kernels. People need to be careful while using this. If you add cuda kernels to your cuda graph outside of a pytorch op (e.g., via DLPack), this debug tool will not be able to detect that your input is dead.

This rough draft has pointed out some engineering issues:

- Importing TorchDispatchMode into torch/cuda/graphs.py causes a circular dependency. I'm not sure what the proper fix is.

- We need a way to query the memory pool ID of the cuda graph that the current stream is capturing to. This is to ignore the death of inputs to graph 2 that were outputs from graph 1, where graph 1 and 2 share a pool *and* 1 was captued before 2. This is easy to add. I did something similar for my old work on adding suport for torch.cond() inside cuda graph. See the TODO in test_cuda.py

- This does not handle pinned host memory tensors, but it should.

- This does not filter out ops that do not create cuda work, but it should. Note that it is currently up to debate whether or not we should warn on CPU-only work that happens during a cuda graph. My guess is no, since there are a few situations where this is okay.

- The interface should be worked out better such that other ideas in issue #167885 can be straighforwardly implemented with this interface.

Fixes #167885
