### PR TITLE
Use accscalar_t for interpolation accumulators in CUDA UpSample kernel

### DIFF
--- a/aten/src/ATen/native/cuda/UpSample.cuh
+++ b/aten/src/ATen/native/cuda/UpSample.cuh
@@ -350,8 +350,8 @@ __device__ __forceinline__ accscalar_t interpolate_aa_single_dim(
     const scalar_t* src,
     const scalar_t* weights,
     int size) {
-  scalar_t t = static_cast<accscalar_t>(*src);
-  scalar_t wts = static_cast<accscalar_t>(weights[0]);
+  accscalar_t t = static_cast<accscalar_t>(*src);
+  accscalar_t wts = static_cast<accscalar_t>(weights[0]);
   accscalar_t output = t * wts;
 
   int j = 1;


### PR DESCRIPTION
**What this PR does**

- Updates the local variables in `aten/src/ATen/native/cuda/UpSample.cuh` (around lines 352–354) to use `accscalar_t` instead of `scalar_t` for intermediate computations:
  - `t` is now declared as `accscalar_t`
  - `wts` is now declared as `accscalar_t`
- Keeps the original data loading from `scalar_t` but immediately casts to `accscalar_t` for the subsequent arithmetic.

**Why this change is needed**

- `accscalar_t` is the designated accumulator type for interpolation kernels and is often wider / higher precision than `scalar_t` (e.g., accumulate `float16` in `float32`), which improves numerical stability.
- Using `accscalar_t` for these intermediate variables prevents unnecessary narrowing and reduces the risk of precision loss or overflow during weight application and accumulation.
- This change aligns this CUDA upsampling helper with the rest of the interpolation code path, which already uses `accscalar_t` for accumulation to ensure consistent behavior across devices and dtypes.