### PR TITLE
[ROCm][CI] Revert login-ecr changes to .github/workflows/docker-cache-rocm.yml

### DIFF
--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -70,8 +70,18 @@ jobs:
           JSON_STRINGIFIED="${{ toJSON(needs.download-docker-builds-artifacts.outputs) }}"
           echo "Outputs of download-docker-builds-artifacts job: ${JSON_STRINGIFIED}"
 
-      - name: Login to ECR
-        uses: ./.github/actions/ecr-login
+      - name: configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        continue-on-error: false
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Generate ghrc.io tag
         id: ghcr-io-tag


### PR DESCRIPTION
Revert docker-cache-rocm.yml to state before [0265bb7](https://github.com/pytorch/pytorch/commit/0265bb7#diff-cd757c82fa75682f03d7ec1f8d65628f72d2a7d34492d61fa3f3e3f416dce7e9) (wasn't covered as part of reverting ROCm-impacting changes in https://github.com/pytorch/pytorch/pull/170260)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang