### PR TITLE
AOTAutograd should generate same hash on different processes with identical inputs

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import enum
 import functools
+import hashlib
 import logging
 import re
 import sys
@@ -1126,6 +1127,16 @@ def tracing(
         _TLS.tracing_context = old_context
 
 
+def _stable_hash(obj: Any) -> int:
+    """
+    Compute a stable hash that is consistent across Python processes.
+
+    Python's built-in hash() uses PYTHONHASHSEED for strings, which varies
+    across processes. This function uses repr() + sha256 for stable hashing.
+    """
+    return int.from_bytes(hashlib.sha256(repr(obj).encode()).digest()[:8], "big")
+
+
 @overload
 def dataclass_with_cached_hash(cls: type[T], **kwargs: Any) -> type[T]: ...
 
@@ -1140,13 +1151,24 @@ def dataclass_with_cached_hash(
 def dataclass_with_cached_hash(
     cls: type[T] | None = None, **kwargs: Any
 ) -> type[T] | Callable[[type[T]], type[T]]:
+    """
+    Decorator that creates a frozen dataclass with cached, **stable** hashing.
+
+    This decorator wraps dataclasses.dataclass and overrides __hash__ to:
+    1. Use a stable hash function that is consistent across Python processes
+       (unlike Python's built-in hash() which varies with PYTHONHASHSEED)
+    2. Cache the hash value for performance
+
+    This is important for serialization/deserialization scenarios where
+    hash consistency across processes is required.
+    """
+
     def wrap(cls_inner: type[T]) -> type[T]:
         new_cls = dataclasses.dataclass(cls_inner, **kwargs)
-        old_hash = cls_inner.__hash__
 
-        def __hash__(self) -> int:
+        def __hash__(self: Any) -> int:
             if not hasattr(self, "_hash"):
-                object.__setattr__(self, "_hash", old_hash(self))
+                object.__setattr__(self, "_hash", _stable_hash(self))
             return self._hash
 
         new_cls.__hash__ = __hash__
@@ -1162,18 +1184,6 @@ def dataclass_with_cached_hash(
 # TODO(voz): Consider a toplevel torch/_source.py
 @dataclass_with_cached_hash(frozen=True)
 class Source:
-    def __getstate__(self) -> dict[str, Any]:
-        # Exclude _hash from pickle to ensure deterministic serialization.
-        # _hash is cached by @dataclass_with_cached_hash and uses Python's
-        # hash() which varies across processes due to PYTHONHASHSEED when used
-        # on string.
-        return {k: v for k, v in self.__dict__.items() if k != "_hash"}
-
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        # Restore state without _hash (it will be recomputed on demand)
-        for k, v in state.items():
-            object.__setattr__(self, k, v)
-
     def is_dict_key(self) -> bool:
         return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170683

Mostly done by Claude. 
When we call hash on dynamo sources that contains strings, we can't guarantee stability as python hash() function returns different hash on each processes. In Dynamo, there is a logic to cache the hash which is causing problem because now we are storing the hash instead of computing on the fly. The solution is to opt into stable hashing. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo