### PR TITLE
[torchcomms] opaque object support

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -9,7 +9,11 @@ from typing import Optional
 import torch
 import torch.utils._pytree as pytree
 from torch._dynamo.test_case import run_tests, TestCase
-from torch._dynamo.testing import AotEagerAndRecordGraphs, CompileCounter
+from torch._dynamo.testing import (
+    AotEagerAndRecordGraphs,
+    CompileCounter,
+    InductorAndRecordGraphs,
+)
 from torch._dynamo.utils import counters as dynamo_counters
 from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
@@ -65,6 +69,13 @@ class RNGState:
     def __init__(self, seed):
         self.seed = seed
         self.rng = random.Random(self.seed)
+
+
+class OpaqueMultiplier:
+    """Opaque object that holds a multiplier value for backward tests."""
+
+    def __init__(self, multiplier: float):
+        self.multiplier = multiplier
 
 
 class Counter:
@@ -988,6 +999,135 @@ def forward(self, arg0_1):
         opt_f = torch.compile(foo, fullgraph=True, backend="inductor")
         x = torch.randn(3, 3)
         self.assertEqual(opt_f(x), foo(x))
+
+    def test_opaque_obj_saved_for_backward(self):
+        """Test that opaque objects are correctly saved and passed to backward."""
+        register_opaque_type(OpaqueMultiplier, typ="reference")
+        opaque_type = get_opaque_type_name(OpaqueMultiplier)
+
+        # Define the main op that uses the opaque object
+        torch.library.define(
+            "_TestOpaqueObject::mul_with_scale",
+            f"({opaque_type} scale_obj, Tensor x) -> Tensor",
+            tags=torch.Tag.pt2_compliant_tag,
+            lib=self.lib,
+        )
+
+        # Define an op to get the multiplier as a tensor from the opaque object
+        torch.library.define(
+            "_TestOpaqueObject::get_multiplier_tensor",
+            f"({opaque_type} scale_obj, Tensor tensor) -> Tensor",
+            tags=torch.Tag.pt2_compliant_tag,
+            lib=self.lib,
+        )
+
+        @torch.library.impl(
+            "_TestOpaqueObject::mul_with_scale",
+            "CompositeExplicitAutograd",
+            lib=self.lib,
+        )
+        def mul_with_scale_impl(
+            scale_obj: OpaqueMultiplier, x: torch.Tensor
+        ) -> torch.Tensor:
+            return x * scale_obj.multiplier
+
+        @torch.library.register_fake("_TestOpaqueObject::mul_with_scale", lib=self.lib)
+        def mul_with_scale_fake(
+            scale_obj: OpaqueMultiplier, x: torch.Tensor
+        ) -> torch.Tensor:
+            return torch.empty_like(x)
+
+        @torch.library.impl(
+            "_TestOpaqueObject::get_multiplier_tensor",
+            "CompositeExplicitAutograd",
+            lib=self.lib,
+        )
+        def get_multiplier_tensor_impl(
+            scale_obj: OpaqueMultiplier, tensor: torch.Tensor
+        ) -> torch.Tensor:
+            return tensor * scale_obj.multiplier
+
+        @torch.library.register_fake(
+            "_TestOpaqueObject::get_multiplier_tensor", lib=self.lib
+        )
+        def get_multiplier_tensor_fake(
+            scale_obj: OpaqueMultiplier, tensor: torch.Tensor
+        ) -> torch.Tensor:
+            return torch.empty_like(tensor)
+
+        def mul_setup_context(ctx, inputs, output):
+            ctx.scale_obj = inputs[0]
+
+        def mul_backward(ctx, grad) -> tuple[torch.Tensor, None]:
+            scale = torch.ops._TestOpaqueObject.get_multiplier_tensor(
+                ctx.scale_obj, grad
+            )
+            return None, scale
+
+        torch.library.register_autograd(
+            "_TestOpaqueObject::mul_with_scale",
+            mul_backward,
+            setup_context=mul_setup_context,
+            lib=self.lib,
+        )
+
+        def foo(scale_obj, x):
+            result = torch.ops._TestOpaqueObject.mul_with_scale(scale_obj, x)
+            result = result * 2
+            return result
+
+        def compile_and_run_with_backend(backend):
+            scale_obj = OpaqueMultiplier(2.5)
+            x = torch.randn(3, 3, requires_grad=True)
+
+            opt_f = torch.compile(foo, fullgraph=True, backend=backend)
+            out = opt_f(scale_obj, x)
+            expected = x * 2.5 * 2
+            self.assertTrue(torch.allclose(out, expected))
+
+            upstream_grad = torch.ones_like(out) * 5
+            out.backward(upstream_grad)
+            self.assertIsNotNone(x.grad)
+            expected_grad = torch.ones_like(x) * 5 * 5
+            self.assertTrue(torch.allclose(x.grad, expected_grad))
+
+        backend = InductorAndRecordGraphs()
+        compile_and_run_with_backend(backend)
+        self.assertTrue(len(backend.graphs) > 0)
+        fw_graph = backend.graphs[0]
+        self.assertExpectedInline(
+            fw_graph.code.strip(),
+            """\
+def forward(self, L_x_ : torch.Tensor, L_scale_obj_ : test_opaque_obj_v2_OpaqueMultiplier):
+    l_x_ = L_x_
+    l_scale_obj_ = L_scale_obj_
+    result = torch.ops._TestOpaqueObject.mul_with_scale(l_scale_obj_, l_x_);  l_scale_obj_ = l_x_ = None
+    result_1 = result * 2;  result = None
+    return (result_1,)""",
+        )
+
+        backend = AotEagerAndRecordGraphs()
+        compile_and_run_with_backend(backend)
+        self.assertTrue(len(backend.fw_graphs) > 0)
+        fw_graph = backend.fw_graphs[0]
+        self.assertExpectedInline(
+            fw_graph.code.strip(),
+            """\
+def forward(self, primals_1, primals_2):
+    mul_with_scale = torch.ops._TestOpaqueObject.mul_with_scale.default(primals_2, primals_1);  primals_1 = None
+    mul = torch.ops.aten.mul.Tensor(mul_with_scale, 2);  mul_with_scale = None
+    return (mul, primals_2)""",
+        )
+        self.assertTrue(len(backend.bw_graphs) > 0)
+        bw_graph = backend.bw_graphs[0]
+        self.assertExpectedInline(
+            bw_graph.code.strip(),
+            """\
+def forward(self, primals_2, tangents_1):
+    mul_1 = torch.ops.aten.mul.Tensor(tangents_1, 2);  tangents_1 = None
+    get_multiplier_tensor = torch.ops._TestOpaqueObject.get_multiplier_tensor.default(primals_2, mul_1);  primals_2 = mul_1 = None
+    return (get_multiplier_tensor, None)""",
+        )
 
 
 instantiate_parametrized_tests(TestOpaqueObject)

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -21,6 +21,8 @@ from collections.abc import Callable
 from contextlib import nullcontext
 from typing import Any, Optional, TYPE_CHECKING, Union
 
+from torch._library.fake_class_registry import FakeScriptObject
+
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -1711,6 +1713,7 @@ def _aot_stage2a_partition(
             fw_outs_saved_for_bw = fw_outs[num_inner_fwd_outputs:]
             num_fw_outs_saved_for_bw = len(fw_outs_saved_for_bw)
             symint_outs_saved_for_bw = []
+            opaque_outs_saved_for_bw = []
             for idx, node in enumerate(fw_outs_saved_for_bw):
                 if is_sym_node(node):
                     symint_outs_saved_for_bw.append(node)
@@ -1727,10 +1730,22 @@ def _aot_stage2a_partition(
                     }
                     if dynamic_dims:
                         fw_metadata.dynamic_saved_tensors_idxs[idx] = dynamic_dims
+                elif (
+                    isinstance(node, torch.fx.Node)
+                    and "val" in getattr(node, "meta", {})
+                    and isinstance(node.meta["val"], FakeScriptObject)
+                ):
+                    # Opaque objects (like FakeScriptObject) saved for backward
+                    opaque_outs_saved_for_bw.append(node)
 
             num_symints_saved_for_bw = len(symint_outs_saved_for_bw)
+            num_opaque_objects_saved_for_bw = len(opaque_outs_saved_for_bw)
             fw_metadata.num_symints_saved_for_bw = num_symints_saved_for_bw
+            fw_metadata.num_opaque_objects_saved_for_bw = (
+                num_opaque_objects_saved_for_bw
+            )
             inner_meta.num_symints_saved_for_bw = num_symints_saved_for_bw
+            inner_meta.num_opaque_objects_saved_for_bw = num_opaque_objects_saved_for_bw
             if torch._functorch.config.donated_buffer:
                 fw_metadata.bw_donated_idxs = collect_bw_donated_buffer_idxs(
                     fw_module,

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -26,6 +26,7 @@ from torch._functorch._activation_checkpointing.ac_logging_utils import (
     create_structured_trace_for_min_cut_info,
 )
 from torch._inductor import config as inductor_config
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.utils import is_builtin
 from torch._logging import trace_structured
 from torch._subclasses.fake_tensor import extract_tensor_metadata
@@ -2012,8 +2013,12 @@ def solve_min_cut(
         if is_sym_node(node):
             weight = float(sym_node_size(node))
         elif is_non_tensor_node:
+            # FakeScriptObjects (opaque objects) should have weight 0.0 so they can be
+            # properly partitioned between forward and backward, like BackwardState.
             weight = (
-                0.0 if isinstance(node.meta.get("val"), BackwardState) else math.inf
+                0.0
+                if isinstance(node.meta.get("val"), (BackwardState, FakeScriptObject))
+                else math.inf
             )
         else:
             weight = get_node_weight(node, node_info.static_lifetime_input_nodes)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -27,7 +27,11 @@ from torch._dynamo.utils import counters, dynamo_timed
 from torch._inductor.codegen.debug_utils import DebugPrinterManager
 from torch._inductor.codegen.multi_kernel import MultiKernelState
 from torch._inductor.runtime.runtime_utils import cache_dir
-from torch._library.opaque_object import get_opaque_obj_repr, is_opaque_value_type
+from torch._library.opaque_object import (
+    get_opaque_obj_repr,
+    is_opaque_type,
+    is_opaque_value_type,
+)
 from torch._logging import trace_structured
 from torch.fx.experimental.symbolic_shapes import (
     CallMethodKey,
@@ -2178,6 +2182,8 @@ class PythonWrapperCodegen(CodeGen):
         self.writeline(f"{node.get_name()} = None")
 
     def benchmark_compiled_module(self, output):
+        """Generate code for benchmarking the compiled module."""
+
         def add_fake_input(name, shape, stride, device, dtype):
             output.writeline(
                 f"{name} = rand_strided("
@@ -2194,9 +2200,15 @@ class PythonWrapperCodegen(CodeGen):
                 output.writeline(f"{name} = None")
                 return
 
-            import pickle
+            if is_opaque_type(type(value)):
+                output.writeline(
+                    f'raise TypeError("Unsupported opaque type: {type(value)} for variable {name}")'
+                )
+                return
 
             assert isinstance(value, torch.ScriptObject)
+
+            import pickle
 
             output.writeline(f"{name} = pickle.loads({pickle.dumps(value)!r})")
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9415,7 +9415,7 @@ class NonTensorObj(IRNode):
 @ir_dataclass
 class TorchBindObject(NonTensorObj):
     name: str
-    value: Union[FakeScriptObject, torch.ScriptObject]
+    value: Union[FakeScriptObject, torch.ScriptObject, Any]
 
     def get_name(self) -> str:
         return self.name
@@ -9423,7 +9423,7 @@ class TorchBindObject(NonTensorObj):
     def codegen_reference(self, writer: Optional[IndentedBuffer] = None) -> str:
         return self.name
 
-    def get_value(self) -> Union[FakeScriptObject, torch.ScriptObject]:
+    def get_value(self) -> Union[FakeScriptObject, torch.ScriptObject, Any]:
         return self.value
 
     def get_real_obj(self) -> torch.ScriptObject:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -59,6 +59,7 @@ import torch.utils._pytree as pytree
 from torch import SymBool, SymFloat, SymInt
 from torch._C._functorch import get_unwrapped, is_batchedtensor
 from torch._guards import ShapeGuard, SLoc, Source, TracingContext
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._logging import dtrace_structured, LazyString, structured, trace_structured
 from torch._subclasses.meta_utils import is_sparse_any
 from torch._utils_internal import signpost_event
@@ -939,6 +940,8 @@ def _iterate_exprs(val: IterateExprs) -> Iterator[sympy.Basic]:
         pass
     # see Note: [Generator arguments in AOTDispatcher]
     elif isinstance(val, torch.Generator):
+        pass
+    elif isinstance(val, FakeScriptObject):
         pass
     else:
         raise AssertionError(f"cannot extract sympy expressions from {val} {type(val)}")


### PR DESCRIPTION
Summary: support for opaqueobjects for torchcomms joint-graph tracing. allows custom objects (like TorchComm, TorchCommWindow, ReduceOp) to flow through torch.compile without issue. there are some caveats, like if the objects aren't  able to be lifted as graph inputs, then they should be pickleable.

Test Plan: Run torchcomms compile tests

Differential Revision: D89317993




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela