### PR TITLE
[DOCS] Write specific docsting for `torch.Tensor.Permute`

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3753,7 +3753,18 @@ add_docstr_all(
     r"""
 permute(*dims) -> Tensor
 
-See :func:`torch.permute`
+Returns a view of the tensor with its dimensions permuted.
+
+Args:
+    dims (torch.Size, int..., tuple of int or list of int): a sequence of integers defining
+        the shape of the output tensor.
+
+Example:
+    >>> x = torch.randn(2, 3, 5)
+    >>> x.size()
+    torch.Size([2, 3, 5])
+    >>> x.permute(2, 0, 1).size()
+    torch.Size([5, 2, 3])
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3756,8 +3756,7 @@ permute(*dims) -> Tensor
 Returns a view of the tensor with its dimensions permuted.
 
 Args:
-    dims (torch.Size, int..., tuple of int or list of int): a sequence of integers defining
-        the shape of the output tensor.
+    dims (torch.Size, int..., tuple of int or list of int): the desired ordering of dimensions.
 
 Example:
     >>> x = torch.randn(2, 3, 5)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8541,7 +8541,7 @@ Returns a view of the original tensor :attr:`input` with its dimensions permuted
 
 Args:
     {input}
-    dims (tuple of int): The desired ordering of dimensions
+    dims (torch.Size, tuple of int or list of int): the desired ordering of dimensions.
 
 Example:
     >>> x = torch.randn(2, 3, 5)


### PR DESCRIPTION
So that the difference in the input arguments is properly reflected.

This is because `torch.permute` does not accept variadic arguments as the `dims` arguments, unlike the `torch.Tensor.permute` method.
