### PR TITLE
[dynamo] fullgraph: error when Dynamo skips / captures no graph

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -131,6 +131,11 @@ class SkipFrame(TorchDynamoException):
     pass
 
 
+class FullGraphCompileError(TorchDynamoException):
+    # Raised when torch.compile(..., fullgraph=True) is requested but Dynamo does not produce a graph.
+    pass
+
+
 class TorchRuntimeError(TorchDynamoException):
     pass
 


### PR DESCRIPTION
**Follow-up to #168284 (PR2): enforce `fullgraph=True` semantics.** When `torch.compile(..., fullgraph=True)` does not produce compiled code for the compiled function frame (i.e., no `guarded_code` / no FX graph), raise `torch._dynamo.exc.FullGraphCompileError` instead of silently running eager.

### Motivation

`fullgraph=True` is intended to mean “compile everything or error.” Today there are skip/fallback paths (e.g., TorchDispatchMode) where Dynamo can return a skip result and run eager without raising, violating that contract. This change makes those cases fail closed.

### What this changes

1. **Centralize enforcement in one place:** for `fullgraph=True` runs, if the `ConvertFrameReturn` for the **compiled function frame** has no `guarded_code`, raise `FullGraphCompileError`.
2. Introduce a small internal exception class `torch._dynamo.exc.FullGraphCompileError` (subclass of `TorchDynamoException`) to represent this **non-graph-break tracing failure** (avoids using `Unsupported`).

### Tests

Add regression: `test_fullgraph_errors_if_skipped_due_to_torch_dispatch_mode`, covering both values of `inline_torch_dispatch_torch_compile` to ensure a deterministic “skip → eager fallback” now errors under `fullgraph=True`.

### Issue links

Follow-up to #168284.
Related context: #161790, #162415.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos