### PR TITLE
Remove _scaled_mm layout check on Blackwells

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -372,8 +372,10 @@ _scaled_gemm(
           const std::optional<Tensor>& alpha = std::nullopt) {
   cublasCommonArgs args(mat1, mat2, out, scale_a, scale_b, std::nullopt, scaling_choice_a, scaling_choice_b);
   const auto out_dtype_ = args.result->scalar_type();
-  TORCH_CHECK(args.transa == 't' && args.transb == 'n', "Only multiplication of row-major and column-major matrices is supported by cuBLASLt");
-
+  // H100 only supports row-major x column-major, but all permutaitons are supported on Blackwells
+  if (_scaled_mm_allowed_device(true, false)) {
+    TORCH_CHECK(args.transa == 't' && args.transb == 'n', "Only multiplication of row-major and column-major matrices is supported by cuBLASLt");
+  }
 // ROCM enables the TunableOp path only
 // but can fallback to at::cuda::blas::scaled_gemm
 #ifdef USE_ROCM

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import math
 import re
+import itertools
 import tempfile
 import unittest
 from typing import Optional
@@ -695,11 +696,17 @@ class TestFP8Matmul(TestCase):
                               x_dtype: torch.dtype = e4m3_type,
                               y_dtype: torch.dtype = e4m3_type,
                               out_dtype: Optional[torch.dtype] = None,
+                              x_cm: bool = True,
+                              y_cm: bool = False,
                               size: int = 16) -> None:
         if not _device_supports_scaled_mm_fp8(device):
             raise unittest.SkipTest(f8_msg)
         x_fp8 = torch.rand(size, size, device=device).to(x_dtype)
-        y_fp8 = torch.eye(size, device=device, dtype=y_dtype).t()
+        y_fp8 = torch.eye(size, device=device, dtype=y_dtype)
+        if not x_cm:
+            x_fp8 = x_fp8.t()
+        if not y_cm:
+            y_fp8 = y_fp8.t()
         out_fp32 = torch.mm(x_fp8.to(torch.float), y_fp8.to(torch.float))
         scale_a = torch.tensor(1.0, device=device)
         scale_b = torch.tensor(1.0, device=device)
@@ -724,6 +731,11 @@ class TestFP8Matmul(TestCase):
         self._test_tautological_mm(device, size=64, out_dtype=torch.float16)
         self._test_tautological_mm(device, size=96, out_dtype=torch.float32)
         self._test_tautological_mm(device, size=80, out_dtype=torch.bfloat16)
+
+        # Check that all possible matrix layouts are supported on Blackwell
+        if torch.cuda.is_available() and torch.cuda.get_device_properties(0).major == 10:
+            for (x_cm, y_cm) in itertools.product([True, False], repeat=2):
+                self._test_tautological_mm(device, size=64, out_dtype=torch.bfloat16, x_cm=x_cm, y_cm=y_cm)
 
         with self.assertRaises(
             AssertionError if (torch.version.hip or "xpu" in device or "cpu" in device)


### PR DESCRIPTION
As it supports all permutations as one can see by running
```python
import torch

M, N, K = 512, 512, 1024
A_tensor = torch.full([M, K], 1.0, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
B_tensor = torch.full([K, N], 1.0, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
AT_tensor = torch.full([K, M], 1.0, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
BT_tensor = torch.full([N, K], 1.0, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
scale_a = torch.ones([M, K // 32], device="cuda", dtype=torch.float8_e8m0fnu)
scale_b = torch.ones([N, K // 32], device="cuda", dtype=torch.float8_e8m0fnu)

out = torch._scaled_mm(A_tensor, BT_tensor.t(), scale_a, scale_b, out_dtype=torch.bfloat16)
out = torch._scaled_mm(AT_tensor.t(), B_tensor, scale_a, scale_b, out_dtype=torch.bfloat16)
out = torch._scaled_mm(A_tensor, B_tensor, scale_a, scale_b, out_dtype=torch.bfloat16)
out = torch._scaled_mm(AT_tensor.t(), BT_tensor.t(), scale_a, scale_b, out_dtype=torch.bfloat16)
```
