### PR TITLE
[XPU] Fix SyclExtension Windows build for oneAPI 2025.3+ breaking change

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -947,6 +947,20 @@ class BuildExtension(build_ext):
         def win_hip_flags(cflags):
             return (COMMON_HIPCC_FLAGS + COMMON_HIP_FLAGS + cflags + _get_rocm_arch_flags(cflags))
 
+        def win_filter_msvc_include_dirs(pp_opts) -> list[str]:
+            """Filter out MSVC include dirs from pp_opts for oneAPI 2025.3+."""
+            # oneAPI 2025.3+ changed include path ordering to match MSVC behavior.
+            # Filter out MSVC headers to avoid conflicting declarations with oneAPI's std headers.
+            icpx_version = int(_get_icpx_version())
+            if icpx_version >= 20250300:
+                vc_tools_dir = os.path.normcase(os.environ.get('VCToolsInstallDir', ''))
+                if vc_tools_dir:
+                    pp_opts = [
+                        path for path in pp_opts
+                        if vc_tools_dir not in os.path.normcase(path)
+                    ]
+            return pp_opts
+
         def win_wrap_single_compile(sources,
                                     output_dir=None,
                                     macros=None,
@@ -1070,18 +1084,6 @@ class BuildExtension(build_ext):
                     "cannot have both SYCL and CUDA files in the same extension"
                 )
 
-            # oneAPI 2025.3+ changed include path ordering to match MSVC behavior.
-            # Filter out MSVC headers to avoid conflicting declarations with oneAPI's std headers.
-            if with_sycl:
-                icpx_version = int(_get_icpx_version())
-                if icpx_version >= 20250300:
-                    vc_tools_dir = os.path.normcase(os.environ.get('VCToolsInstallDir', ''))
-                    if vc_tools_dir:
-                        pp_opts = [
-                            path for path in pp_opts
-                            if vc_tools_dir not in os.path.normcase(path)
-                        ]
-
             # extra_postargs can be either:
             # - a dict mapping cxx/nvcc to extra flags
             # - a list of extra flags.
@@ -1128,7 +1130,7 @@ class BuildExtension(build_ext):
             sycl_post_cflags = None
             sycl_dlink_post_cflags = None
             if with_sycl:
-                sycl_cflags = common_cflags + pp_opts + _COMMON_SYCL_FLAGS
+                sycl_cflags = common_cflags + win_filter_msvc_include_dirs(pp_opts) + _COMMON_SYCL_FLAGS
                 if isinstance(extra_postargs, dict):
                     sycl_post_cflags = extra_postargs['sycl']
                 else:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1070,6 +1070,8 @@ class BuildExtension(build_ext):
                     "cannot have both SYCL and CUDA files in the same extension"
                 )
 
+            # oneAPI 2025.3+ changed include path ordering to match MSVC behavior.
+            # Filter out MSVC headers to avoid conflicting declarations with oneAPI's std headers.
             if with_sycl:
                 icpx_version = int(_get_icpx_version())
                 if icpx_version >= 20250300:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1070,6 +1070,16 @@ class BuildExtension(build_ext):
                     "cannot have both SYCL and CUDA files in the same extension"
                 )
 
+            if with_sycl:
+                icpx_version = int(_get_icpx_version())
+                if icpx_version >= 20250300:
+                    vc_tools_dir = os.path.normcase(os.environ.get('VCToolsInstallDir', ''))
+                    if vc_tools_dir:
+                        pp_opts = [
+                            path for path in pp_opts
+                            if vc_tools_dir not in os.path.normcase(path)
+                        ]
+
             # extra_postargs can be either:
             # - a dict mapping cxx/nvcc to extra flags
             # - a list of extra flags.


### PR DESCRIPTION
## Summary
Fixes SyclExtension compilation on Windows when using oneAPI 2025.3 or higher.

## Problem
oneAPI 2025.3 introduced a breaking change in how include paths are ordered to align with MSVC behavior. This causes build failures when compiling SyclExtension on Windows.

The issue occurs because MSVC include directories are explicitly passed on the compiler command line. With the new include path ordering in oneAPI 2025.3, this causes the wrong std headers included.

These MSVC directories are already added as correctly-ordered implicit include paths by the compiler, so they should not need to be passed explicitly on the command line. Passing them explicitly disrupts the intended include order.

## Solution
When building SYCL extensions on Windows with oneAPI version >= 2025.3, filter out Microsoft Visual Studio paths from the compiler's include directories.

The fix is version-gated to only apply for oneAPI 2025.3+ to avoid affecting users on older oneAPI versions.

Fixes:
https://github.com/intel/torch-xpu-ops/issues/2574

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @chenyang78