### PR TITLE
[DTensor] matmul with strided shard input

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -155,7 +155,7 @@ class DistMatrixOpsTest(DTensorTestBase):
         mesh = self.build_device_mesh()
         batch_size, seq_len, contract_dim, out_dim = 2, 4, 3, 7
         global_inps_viewed = torch.arange(batch_size * seq_len * contract_dim, device="cuda").float().view(batch_size * seq_len, contract_dim)
-        inps_viewed = distribute_tensor(global_inps_viewed, mesh, (Replicate(),)).redistribute(mesh, (_StridedShard(dim=0, split_factor=2),))
+        inps_viewed = distribute_tensor(global_inps_viewed, mesh, (_StridedShard(dim=0, split_factor=2),), src_data_rank=None)
         global_weight = torch.arange(contract_dim * out_dim).float().view(contract_dim, out_dim)
         weight = distribute_tensor(global_weight, mesh, (Replicate(), ))
         out = torch.mm(inps_viewed, weight)

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -16,6 +16,9 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
+from torch.distributed.tensor.placement_types import (
+    _StridedShard,
+)
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
 from torch.testing._internal.common_device_type import E4M3_MAX_POS, e4m3_type
@@ -145,6 +148,19 @@ class DistMatrixOpsTest(DTensorTestBase):
         shard_specs_comb = list(itertools.product(placement_specs, placement_specs))
         for spec in shard_specs_comb:
             test_placement_comb([spec[0]], [spec[1]])
+
+
+    @with_comms
+    def test_mm_with_strided_input(self):
+        mesh = self.build_device_mesh()
+        batch_size, seq_len, contract_dim, out_dim = 2, 4, 3, 7
+        global_inps_viewed = torch.arange(batch_size * seq_len * contract_dim, device="cuda").float().view(batch_size * seq_len, contract_dim)
+        inps_viewed = distribute_tensor(global_inps_viewed, mesh, (Replicate(),)).redistribute(mesh, (_StridedShard(dim=0, split_factor=2),))
+        global_weight = torch.arange(contract_dim * out_dim).float().view(contract_dim, out_dim)
+        weight = distribute_tensor(global_weight, mesh, (Replicate(), ))
+        out = torch.mm(inps_viewed, weight)
+        expected_placements = (_StridedShard(dim=0, split_factor=2),)
+        self.assertEqual(out.placements, expected_placements)
 
     @with_comms
     @skip_unless_torch_gpu

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -356,6 +356,13 @@ def redistribute_cost(
     # TODO(zpcore): test placements with _StridedShard.
     if current_spec.placements == target_spec.placements:
         return cost
+
+    # TODO(zpcore): Support _StridedShard redistribution. Remove the temporary
+    # fix, which is to prevent StridedShard erroring out.
+    if current_spec.shard_order is None or target_spec.shard_order is None:
+        return float("inf")
+
+
     if _are_we_tracing():
         transform_infos = _gen_transform_infos_non_cached(current_spec, target_spec)
     else:

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -26,6 +26,9 @@ from torch.distributed.tensor._ops.utils import (
     prod,
     register_op_strategy,
 )
+from torch.distributed.tensor._ops.single_dim_strategy import (
+    register_single_dim_strategy,
+)
 from torch.distributed.tensor._utils import (
     compute_local_shape_and_global_offset,
     compute_local_stride,
@@ -350,7 +353,7 @@ def gen_single_dim_einsum_strategies(
 
 # TODO enable in a separate PR along with more extensive validation.
 # currently just used in test_single_dim_strategy.py to help validate the single-dim expansion infra
-# @register_single_dim_strategy(aten.mm.default)
+@register_single_dim_strategy(aten.mm.default)
 def mm_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
 ) -> list[list[Placement | _ShardingPlaceholder]]:

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -5,7 +5,7 @@ import itertools
 import operator
 from collections.abc import Callable, Iterable, Sequence
 from typing import cast, Optional, TypeAlias, TypeVar, Union
-
+import logging
 import torch
 from torch._prims_common import DimsSequenceType, DimsType
 from torch.distributed.tensor._api import DTensor
@@ -29,6 +29,9 @@ from torch.distributed.tensor.placement_types import (
     Shard,
 )
 
+
+
+logger = logging.getLogger(__name__)
 
 def _get_registration_wrapper(
     registration_fn,
@@ -393,15 +396,24 @@ def expand_to_full_mesh_op_strategy(
     strategy_combs = itertools.product(*all_mesh_dim_strategies)
 
     all_strategies = []
+    skipped_non_shard_order = []
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
+        non_ordered_shard = False
         for specs in zip(*strategy_comb):
             if specs[0] is not None:
                 # TODO: we should fill in tensor_meta here.  If nothing else, it helps the filter strategy callback
                 # pyrefly: ignore [bad-argument-type]
-                spec_list.append(DTensorSpec(mesh, specs))
+                spec = DTensorSpec(mesh, specs)
+                if spec.shard_order is None or len(spec.shard_order) == 0:
+                    non_ordered_shard = True
+                    break
+                spec_list.append(spec)
             else:
                 spec_list.append(None)
+        if non_ordered_shard:
+            skipped_non_shard_order.append(strategy_comb)
+            continue
 
         input_specs: list[DTensorSpec] = [
             s for s in spec_list[input_index:] if isinstance(s, DTensorSpec)
@@ -455,6 +467,12 @@ def expand_to_full_mesh_op_strategy(
             redistribute_cost=redistribute_cost,
         )
         all_strategies.append(strategy)
+    if skipped_non_shard_order:
+        logger.warning(
+            "Skipped %d non-ordered shard order combinations: %s",
+            len(skipped_non_shard_order),
+            skipped_non_shard_order,
+        )
     return OpStrategy(all_strategies)
 
 

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -396,7 +396,7 @@ def expand_to_full_mesh_op_strategy(
     strategy_combs = itertools.product(*all_mesh_dim_strategies)
 
     all_strategies = []
-    skipped_non_shard_order = []
+    # skipped_non_shard_order = []
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
         non_ordered_shard = False
@@ -405,15 +405,15 @@ def expand_to_full_mesh_op_strategy(
                 # TODO: we should fill in tensor_meta here.  If nothing else, it helps the filter strategy callback
                 # pyrefly: ignore [bad-argument-type]
                 spec = DTensorSpec(mesh, specs)
-                if spec.shard_order is None or len(spec.shard_order) == 0:
-                    non_ordered_shard = True
-                    break
+                # if spec.shard_order is None or len(spec.shard_order) == 0:
+                #     non_ordered_shard = True
+                #     break
                 spec_list.append(spec)
             else:
                 spec_list.append(None)
-        if non_ordered_shard:
-            skipped_non_shard_order.append(strategy_comb)
-            continue
+        # if non_ordered_shard:
+        #     skipped_non_shard_order.append(strategy_comb)
+        #     continue
 
         input_specs: list[DTensorSpec] = [
             s for s in spec_list[input_index:] if isinstance(s, DTensorSpec)
@@ -467,12 +467,12 @@ def expand_to_full_mesh_op_strategy(
             redistribute_cost=redistribute_cost,
         )
         all_strategies.append(strategy)
-    if skipped_non_shard_order:
-        logger.warning(
-            "Skipped %d non-ordered shard order combinations: %s",
-            len(skipped_non_shard_order),
-            skipped_non_shard_order,
-        )
+    # if skipped_non_shard_order:
+    #     logger.warning(
+    #         "Skipped %d non-ordered shard order combinations: %s",
+    #         len(skipped_non_shard_order),
+    #         skipped_non_shard_order,
+    #     )
     return OpStrategy(all_strategies)
 
 

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -749,7 +749,12 @@ def _gen_transform_infos_non_cached(
     dst_shard_order = dst_spec.shard_order
     # DTensorSpec should automatically generate shard_order, and it can be () if
     # no shard.
-    assert src_shard_order is not None and dst_shard_order is not None
+    try:
+        assert src_shard_order is not None and dst_shard_order is not None
+    except:
+        drp = get_redistribute_planner(device_mesh, len(src_spec.shape))
+        transform_infos = drp.generate_greedy_transform_infos(src_spec, dst_spec)
+        return transform_infos
     # Determine which transform strategy to use:
     # 1. Non-standard device order → always use graph-based
     # 2. Global flag or explicit parameter True → use graph-based


### PR DESCRIPTION
test matmul with strided shard input on top of single-dim infra

```
pytest -s test/distributed/tensor/test_matrix_ops.py -k test_mm_with_strided_input
```

```
  File "/data/users/weif/pytorch/test/distributed/tensor/test_matrix_ops.py", line 178, in test_mm_with_strided_input
    self.assertEqual(out.placements, expected_placements)
  File "/data/users/weif/pytorch/torch/testing/_internal/common_utils.py", line 4284, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Object comparison failed: _StridedShard(dim=0, sf=16) != _StridedShard(dim=0, sf=4)
```




Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #170716



Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: