### PR TITLE
`torch._scaled_mm`: better default output dtype for MXFP8

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -653,7 +653,10 @@ _scaled_mm_cuda(const Tensor& mat_a, const Tensor& mat_b,
           const std::optional<at::Tensor>& scale_result,
           std::optional<c10::ScalarType> out_dtype,
           bool use_fast_accum) {
-  const auto out_dtype_ = out_dtype.value_or(mat_a.scalar_type());
+  // Result of MXFP8 matmuls must be at least 16-bit type, otherwise operation fails with
+  // CUBLAS_STATUS_INVALID_VALUE when calling `cublasLtMatmulAlgoGetHeuristic(...
+  auto default_dtype = c10::isFloat8Type(mat_a.scalar_type()) && scale_a.scalar_type() == kFloat8_e8m0fnu ? kBFloat16 : mat_a.scalar_type();
+  const auto out_dtype_ = out_dtype.value_or(default_dtype);
   Tensor out = at::empty({0}, mat_a.options().dtype(out_dtype_));
 
   return _scaled_mm_out_cuda(mat_a, mat_b, scale_a, scale_b, bias, scale_result, out_dtype, use_fast_accum, out);


### PR DESCRIPTION
Looks like it must be a 16-bit datatype, as attempting to find algo that outputs e4m3 results inCUBLAS_STATUS_INVALID_VALUE runtime error

Test plan
```python
import torch

M, N, K = 512, 512, 1024
A_tensor = torch.full([M, K], 1.0, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
BT_tensor = torch.full([N, K], 1.0, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
scale_a = torch.ones([M, K // 32], device="cuda", dtype=torch.float8_e8m0fnu)
scale_b = torch.ones([N, K // 32], device="cuda", dtype=torch.float8_e8m0fnu)
torch._scaled_mm(A_tensor, BT_tensor.t(), scale_a, scale_b)
```
