### PR TITLE
Fix WeakKeyDictionaryScriptObjectTestCase.test_pop AttributeError

### DIFF
--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -585,13 +585,7 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         super().setUp()
         if IS_MACOS:
             raise unittest.SkipTest("non-portable load_library call used in test")
-
-    def __init__(self, *args, **kw):
-        unittest.TestCase.__init__(self, *args, **kw)
-        try:
-            load_torchbind_test_lib()
-        except unittest.SkipTest:
-            return  # Skip in setup
+        load_torchbind_test_lib()
 
         self.reference = self._reference().copy()
 


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'WeakKeyDictionaryScriptObjectTestCase' object has no attribute 'inmapping'` in `WeakKeyDictionaryScriptObjectTestCase.test_pop`.

## Test Details

- **Test:** `WeakKeyDictionaryScriptObjectTestCase.test_pop`
- **Repro:** `python test/test_weak.py -v WeakKeyDictionaryScriptObjectTestCase.test_pop`

## Problem

The test class had a design flaw where `unittest.SkipTest` exceptions were caught and suppressed in `__init__()`. This prevented proper test skipping while also preventing initialization of required attributes (`self.inmapping`, `self.reference`, `self.other`). When tests executed without these attributes, they failed with `AttributeError`.

## Solution

Moved both torchbind library loading and attribute initialization from `__init__()` to `setUp()`. This allows the unittest framework to properly handle `SkipTest` exceptions and ensures all attributes are initialized when tests run. Tests now correctly skip when the torchbind library is unavailable