### PR TITLE
[dynamo] do not include source hashes in pickle

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -22,6 +22,7 @@ from torch._dynamo.bytecode_transformation import transform_code_object
 from torch._dynamo.exc import PackageError
 from torch._dynamo.guards import CheckFunctionManager, CompileId
 from torch._dynamo.package import CompilePackage
+from torch._dynamo.source import LocalSource
 from torch._dynamo.symbolic_convert import (
     ExceptionStack,
     InstructionTranslator,
@@ -1839,6 +1840,17 @@ class TestGuardSerialization(TestGuardSerializationBase):
             {"x": x, "backend": torch.nn.attention.SDPBackend.CUDNN_ATTENTION},
             False,
         )
+
+    def test_source_serialization(self):
+        # Test that "equal" sources with different hashes serialize to the same result
+        src1 = LocalSource("x")
+        src2 = LocalSource("x")
+
+        # Force different cached hashes to test that serialization excludes _hash
+        object.__setattr__(src1, "_hash", 12345)
+        object.__setattr__(src2, "_hash", 67890)
+
+        self.assertEqual(pickle.dumps(src1), pickle.dumps(src2))
 
 
 class SimpleModule(torch.nn.Module):

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1149,7 +1149,16 @@ def dataclass_with_cached_hash(
                 object.__setattr__(self, "_hash", old_hash(self))
             return self._hash
 
+        def __reduce__(self):
+            # Exclude _hash from pickling to ensure deterministic cache keys.
+            # The _hash is a cached value that can be nondeterministically computed
+            # (e.g., based on id() of objects), so it should not affect pickling.
+            fields = dataclasses.fields(self)
+            field_values = tuple(getattr(self, f.name) for f in fields)
+            return (self.__class__, field_values)
+
         new_cls.__hash__ = __hash__
+        new_cls.__reduce__ = __reduce__
         return new_cls  # type: ignore[return-value]
 
     if cls is None:


### PR DESCRIPTION
Summary:
Reported in S603290: We were causing aot autograd cache misses because sources were being pickled with cached hashes, which could differ between different runs.

The fix was to exclude the `_hash` field of affected sources.

Test Plan: Added dynamo unit test, verified tlparses of multiple runs of `buck run mode/opt caffe2/benchmarks/dynamo:torchbench -- --training --backend=inductor --repeat 1 --performance --cold-start-latency  --only nanogpt` hit the aot autograd cache.

Differential Revision: D89420622




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo