### PR TITLE
Fix Wdeprecated-copy-with-dtor warnings

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -277,6 +277,8 @@ static bool NumericalCheck(ScalarType dtype, void* c, void* other_c, int64_t siz
 template <typename T>
 struct GemmParams : OpParams {
   GemmParams() = default;
+  GemmParams& operator=(const GemmParams&) = default;
+  ~GemmParams() override = default;
 
   std::string BLASSignature() const override {
     std::string alpha_str = to_string_opmath<T>(alpha);
@@ -319,8 +321,7 @@ struct GemmParams : OpParams {
   }
 
   GemmParams* DeepCopy(bool duplicate_inputs) const {
-    GemmParams* copy = new GemmParams;
-    *copy = *this;
+    GemmParams* copy = new GemmParams(*this);
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
     size_t c_size = GetSizeC();
@@ -374,6 +375,13 @@ private:
 
 template <typename T>
 struct GemmAndBiasParams : OpParams {
+  GemmAndBiasParams() = default;
+  GemmAndBiasParams(const GemmAndBiasParams&) = default;
+  GemmAndBiasParams(GemmAndBiasParams&&) noexcept = default;
+  GemmAndBiasParams& operator=(const GemmAndBiasParams&) = default;
+  GemmAndBiasParams& operator=(GemmAndBiasParams&&) noexcept = default;
+  ~GemmAndBiasParams() override = default;
+
   std::string BLASSignature() const override {
     std::string alpha_str = to_string_opmath<T>(alpha);
     std::string activation_str = to_string_epilogue(activation);
@@ -415,8 +423,7 @@ struct GemmAndBiasParams : OpParams {
   }
 
   GemmAndBiasParams* DeepCopy(bool duplicate_inputs) const {
-    GemmAndBiasParams* copy = new GemmAndBiasParams;
-    *copy = *this;
+    GemmAndBiasParams* copy = new GemmAndBiasParams(*this);
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
     size_t c_size = GetSizeC();
@@ -471,6 +478,13 @@ private:
 
 template <typename T, typename C_Dtype = T>
 struct GemmStridedBatchedParams : OpParams {
+  GemmStridedBatchedParams() = default;
+  GemmStridedBatchedParams(const GemmStridedBatchedParams&) = default;
+  GemmStridedBatchedParams(GemmStridedBatchedParams&&) noexcept = default;
+  GemmStridedBatchedParams& operator=(const GemmStridedBatchedParams&) = default;
+  GemmStridedBatchedParams& operator=(GemmStridedBatchedParams&&) noexcept = default;
+  ~GemmStridedBatchedParams() override = default;
+
   std::string BLASSignature() const override {
     std::string alpha_str = to_string_opmath<T>(alpha);
     std::string beta_str = to_string_opmath<T>(beta);
@@ -512,8 +526,7 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   GemmStridedBatchedParams* DeepCopy(bool duplicate_inputs) const {
-    GemmStridedBatchedParams* copy = new GemmStridedBatchedParams;
-    *copy = *this;
+    GemmStridedBatchedParams* copy = new GemmStridedBatchedParams(*this);
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
     size_t c_size = GetSizeC();
@@ -574,6 +587,11 @@ private:
 template <typename T>
 struct ScaledGemmParams : OpParams {
   ScaledGemmParams() = default;
+  ScaledGemmParams(const ScaledGemmParams&) = default;
+  ScaledGemmParams(ScaledGemmParams&&) noexcept = default;
+  ScaledGemmParams& operator=(const ScaledGemmParams&) = default;
+  ScaledGemmParams& operator=(ScaledGemmParams&&) noexcept = default;
+  ~ScaledGemmParams() override = default;
 
   std::string BLASSignature() const override {
     // Excluding use_fast_accum and use_rowise booleans for now
@@ -633,8 +651,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   ScaledGemmParams* DeepCopy(bool duplicate_inputs) const {
-    ScaledGemmParams* copy = new ScaledGemmParams;
-    *copy = *this;
+    ScaledGemmParams* copy = new ScaledGemmParams(*this);
     c10::DeviceIndex device = 0;
     AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
     size_t c_size = GetSizeC();

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -277,6 +277,7 @@ static bool NumericalCheck(ScalarType dtype, void* c, void* other_c, int64_t siz
 template <typename T>
 struct GemmParams : OpParams {
   GemmParams() = default;
+  GemmParams(const GemmParams&) = default;
   GemmParams& operator=(const GemmParams&) = default;
   ~GemmParams() override = default;
 

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -421,6 +421,8 @@ class TunableOp {
 };
 
 struct OpParams {
+  OpParams() = default;
+  OpParams(const OpParams&) = default;
   virtual ~OpParams() = default;
   virtual std::string Signature() const = 0;
   virtual std::string BLASSignature() const = 0;

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -463,7 +463,7 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       getCatGrid(batchCounter, catGrid);
     }
 #endif
-    int32_t trailingSize;
+    int32_t trailingSize = 0;
     int nDimsLocal = nDims;
     TensorSizeStride<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> kernelOutputParam;
     if (isInOutAligned) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -515,6 +515,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // NOTE: timeout in ProcessGroupNCCL::Options denote the timeout for
     // operations. This is only used when blockingWait_ is enabled.
     explicit Options(bool is_high_priority_stream = false);
+    Options(const Options&) = default;
+    Options(Options&&) noexcept = default;
+    Options& operator=(const Options&) = delete;
+    Options& operator=(Options&&) noexcept = delete;
+    ~Options() override = default;
 
     // return intrusive_ptr of the object
     static c10::intrusive_ptr<Options> create(


### PR DESCRIPTION
This PR fixes errors like
```
definition of implicit copy constructor for 'Options' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]
     42 |     ~Options() override = default;
```