### PR TITLE
Partitioner Hook for Custom Runtime Estimation

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2461,6 +2461,10 @@ def estimate_runtime(node):
             node.target(*args, **kwargs)
         counted_flops = mode.get_total_flops()
         return max(counted_flops, 1)
+
+    elif callable(RUNTIME_MODE):
+        return RUNTIME_MODE(node)
+
     else:
         raise RuntimeError(f"Not aware of runtime estimator: {RUNTIME_MODE}")
 


### PR DESCRIPTION
Summary:
## Summary

This diff adds a hook in PyTorch's partitioner to support **custom callable runtime estimators**.

### Motivation

The existing `RUNTIME_MODE` parameter only accepts predefined string modes (e.g., `"flops"`). To enable custom runtime estimation strategies—such as history-based estimation from MAST traces—we need the partitioner to accept user-provided callables.

Test Plan:
### E2E Testing

OmniFM LWB (96 B200; AC budget 0.3)
- Baseline + Custom Kernels + FLOPS Runtime Estimation: aps-LWB_omnifmv4_1124_autoac_flop-49be42744e 164k p90 QPS (+5%), 90% peak memory
- Baseline + Custom Kernels + History Based(**Custom**) Runtime Estimation: aps-LWB_omnifmv4_1124_autoac_lookup-aca6abaaa5 167k p90 QPS (+7%), 91% peak memory

Injecting custom runtime estimation, improves QPS results by ~2%.

Differential Revision: D88714606


