### PR TITLE
[ROCm] implement mxfp4 global scale

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2087,7 +2087,11 @@ void scaled_gemm(
       user_alpha.copy_(a);
       // Tell cublasLt we're using device-side pointers for alpha/beta
       auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
+      // On ROCm, HIPBLASLT_MATMUL_DESC_POINTER_MODE is not working as expected.
+      // Till the issue is fixed, comment the code
+#ifndef USE_ROCM
       computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
+#endif
       alpha_ptr = user_alpha.data_ptr<float>();
       beta_ptr = at::cuda::detail::get_cublas_device_zero();
     } else {

--- a/aten/src/ATen/cuda/CUDAScaledBlas.cpp
+++ b/aten/src/ATen/cuda/CUDAScaledBlas.cpp
@@ -239,9 +239,39 @@ bool check_mxfp8_recipe(c10::ScalarType type_a,
 
 /**
  * Both inputs must be fp4
- * A, B must have 1 scale each, {Blockwise_1x32, e8m0}
+ * A, B must have 2 scale each, {Blockwise_1x32, e8m0}
  */
 bool check_mxfp4_recipe(c10::ScalarType type_a,
+                        std::vector<ScalingType>& recipe_a,
+                        ArrayRef<Tensor>& scales_a,
+                        c10::ScalarType type_b,
+                        std::vector<ScalingType>& recipe_b,
+                        ArrayRef<Tensor>& scales_b) {
+  // both types must be fp4
+  if (type_a != ScalarType::Float4_e2m1fn_x2 || type_b != ScalarType::Float4_e2m1fn_x2) {
+    return false;
+  }
+
+  // 2 scales, 2 recipes for each input
+  if (scales_a.size() != 2 || recipe_a.size() != 2 || scales_b.size() != 2 || recipe_b.size() != 2) {
+    return false;
+  }
+
+  // Need {Blockwise_1x32, e8m0} for A & B
+  if (recipe_a[0] != ScalingType::BlockWise1x32) return false;
+  if (scales_a[0].scalar_type() != ScalarType::Float8_e8m0fnu) return false;
+  if (recipe_b[0] != ScalingType::BlockWise1x32) return false;
+  if (scales_b[0].scalar_type() != ScalarType::Float8_e8m0fnu) return false;
+
+  return true;
+}
+
+
+/**
+ * Both inputs must be fp4
+ * A, B must have 1 scale each, {Blockwise_1x32, e8m0}
+ */
+bool check_mxfp4_recipe_single_scale(c10::ScalarType type_a,
                         std::vector<ScalingType>& recipe_a,
                         ArrayRef<Tensor>& scales_a,
                         c10::ScalarType type_b,

--- a/aten/src/ATen/cuda/CUDAScaledBlas.h
+++ b/aten/src/ATen/cuda/CUDAScaledBlas.h
@@ -100,6 +100,7 @@ enum class ScaledGemmImplementation {
   NVFP4_NVFP4 = 7,
   NVFP4_NVFP4_SINGLE_SCALE = 8,
   MXFP4_MXFP4 = 9,
+  MXFP4_MXFP4_SINGLE_SCALE = 10,
 };
 
 /**
@@ -164,6 +165,13 @@ bool check_mxfp8_recipe(c10::ScalarType,
                         ArrayRef<Tensor>&);
 
 bool check_mxfp4_recipe(c10::ScalarType,
+                        std::vector<ScalingType>&,
+                        ArrayRef<Tensor>&,
+                        c10::ScalarType,
+                        std::vector<ScalingType>&,
+                        ArrayRef<Tensor>&);
+
+bool check_mxfp4_recipe_single_scale(c10::ScalarType,
                         std::vector<ScalingType>&,
                         ArrayRef<Tensor>&,
                         c10::ScalarType,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/168822

Modify _scaled_mxfp4_mxfp4 to handle global scale along with blockwise scale.
Modify test_blockwise_nvfp4_with_global_scale to handle mxfp4 along with nvfp4.
Test command:
PYTORCH_TEST_WITH_ROCM=1 python test/test_scaled_matmul_cuda.py -v -k test_blockwise_nvfp4_mxfp4_with_global_scale



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang