### PR TITLE
Support torch.accelerator.get_device_capability on XPU

### DIFF
--- a/c10/xpu/impl/XPUGuardImpl.h
+++ b/c10/xpu/impl/XPUGuardImpl.h
@@ -48,7 +48,6 @@ struct XPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
 
   DeviceCapability getDeviceCapability(Device d) const override {
     DeviceCapability cap;
-    cap.capability_data.capability_bits = 0;
     cap.capability_data.capability_bits = (1ULL << kIndex_Byte) |
         (1ULL << kIndex_Char) | (1ULL << kIndex_Short) | (1ULL << kIndex_Int) |
         (1ULL << kIndex_Long) | (1ULL << kIndex_Float) |

--- a/c10/xpu/impl/XPUGuardImpl.h
+++ b/c10/xpu/impl/XPUGuardImpl.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <c10/core/DeviceCapability.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/GPUTrace.h>

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -141,6 +141,16 @@ class TestXpu(TestCase):
         )  # xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
         self.assertEqual(len(device_properties.uuid.bytes), 16)
 
+    def test_get_device_capability(self):
+        device_capability = torch.xpu.get_device_capability()
+        acc_capability = torch.accelerator.get_device_capability()
+        supported_dtypes = acc_capability["supported_dtypes"]
+        if device_capability["has_fp16"]:
+            self.assertIn(torch.float16, supported_dtypes)
+        if device_capability["has_fp64"]:
+            self.assertIn(torch.double, supported_dtypes)
+        self.assertIn(torch.int, supported_dtypes)
+
     @unittest.skipIf(IS_WINDOWS, "not applicable to Windows (only fails with fork)")
     def test_wrong_xpu_fork(self):
         stderr = TestCase.runWithPytorchAPIUsageStderr(

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -149,7 +149,11 @@ class TestXpu(TestCase):
             self.assertIn(torch.float16, supported_dtypes)
         if device_capability["has_fp64"]:
             self.assertIn(torch.double, supported_dtypes)
+        self.assertIn(torch.bool, supported_dtypes)
         self.assertIn(torch.int, supported_dtypes)
+        self.assertIn(torch.float, supported_dtypes)
+        if torch.xpu.is_bf16_supported(including_emulation=True):
+            self.assertIn(torch.bfloat16, supported_dtypes)
 
     @unittest.skipIf(IS_WINDOWS, "not applicable to Windows (only fails with fork)")
     def test_wrong_xpu_fork(self):

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -145,13 +145,13 @@ class TestXpu(TestCase):
         device_capability = torch.xpu.get_device_capability()
         acc_capability = torch.accelerator.get_device_capability()
         supported_dtypes = acc_capability["supported_dtypes"]
+        self.assertIn(torch.bool, supported_dtypes)
+        self.assertIn(torch.int, supported_dtypes)
+        self.assertIn(torch.float, supported_dtypes)
         if device_capability["has_fp16"]:
             self.assertIn(torch.float16, supported_dtypes)
         if device_capability["has_fp64"]:
             self.assertIn(torch.double, supported_dtypes)
-        self.assertIn(torch.bool, supported_dtypes)
-        self.assertIn(torch.int, supported_dtypes)
-        self.assertIn(torch.float, supported_dtypes)
         if torch.xpu.is_bf16_supported(including_emulation=True):
             self.assertIn(torch.bfloat16, supported_dtypes)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170752
* __->__ #170747

# Motivation
This PR adds support for `torch.accelerator.get_device_capability` on XPU. At the current stage, it reports a limited set of basic scalar data types, taking potential software emulation into account where native hardware support may not be available.
