### PR TITLE
[Inductor][Triton][FP8] Support (BlockWise128x128, BlockWise1x128) scaling in Inductor

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -827,8 +827,9 @@ class TestFP8Lowering(TestCase):
     @parametrize("shape", ((16, 256, 256), (1024, 512, 1024), (32768, 4096, 4096)))
     @parametrize("use_fast_accum", (False, True))
     @parametrize(
-        "scaling_block_sizes", ((1, 128, 128, 128), (1, 128, 1, 128))
-    )  # (BlockWise1x128, BlockWise128x128), (BlockWise1x128, BlockWise1x128)
+        "scaling_block_sizes",
+        ((1, 128, 128, 128), (1, 128, 1, 128), (128, 128, 1, 128)),
+    )  # (BlockWise1x128, BlockWise128x128), (BlockWise1x128, BlockWise1x128), (BlockWise128x128, BlockWise1x128)
     def test_main_loop_scaling(
         self,
         shape: tuple[int, int, int],

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -754,6 +754,7 @@ scaling_pairs = [
     (ScalingType.RowWise, ScalingType.RowWise),
     (ScalingType.BlockWise1x128, ScalingType.BlockWise128x128),
     (ScalingType.BlockWise1x128, ScalingType.BlockWise1x128),
+    (ScalingType.BlockWise128x128, ScalingType.BlockWise1x128),
 ]
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6489,6 +6489,13 @@ def _check_scaled_mm_sizes(
             ):
                 # (BlockWise1x128, BlockWise1x128)
                 pass  # do nothing, but do not error
+            elif (
+                scale_a.size(0) == ceil_div(m, 128)
+                and scale_a.size(1) == scale_b.size(0) == ceil_div(_k, 128)
+                and scale_b.size(1) == n
+            ):
+                # (BlockWise128x128, BlockWise1x128)
+                pass  # do nothing, but do not error
             else:
                 # does not match any valid scaling type
                 torch._check(
@@ -6500,6 +6507,8 @@ def _check_scaled_mm_sizes(
                         f"For (BlockWise1x128, BlockWise128x128), scale_a should be ({m}, {ceil_div(_k, 128)}), "
                         + f"scale_b should be ({ceil_div(_k, 128)}, {ceil_div(n, 128)}). "
                         f"For (BlockWise1x128, BlockWise1x128), scale_a should be ({m}, {ceil_div(_k, 128)}), "
+                        + f"scale_b should be ({ceil_div(_k, 128)}, {n}). "
+                        f"For (BlockWise128x128, BlockWise1x128), scale_a should be ({ceil_div(m, 128)}, {ceil_div(_k, 128)}), "
                         + f"scale_b should be ({ceil_div(_k, 128)}, {n}). "
                         f"Got scale_a.size()=({scale_a.size(0)}, {scale_a.size(1)}) "
                         f"and scale_b.size()=({scale_b.size(0)}, {scale_b.size(1)})"


### PR DESCRIPTION
Summary:
Support `(BlockWise128x128, BlockWise1x128)` scaling in Inductor Triton for FP8 GEMMs:
- Activation `(M, K)` computes scaling values for each `128x128` block
- Weight `(N, K)` computes scaling values for each `1x128` tile

NOTE: Block-wise scaling in ATen is only supported in CUDA 12.9+; use OSS PyTorch.

Test Plan:
```
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 TRITON_PRINT_AUTOTUNING=1 TORCHINDUCTOR_MAX_AUTOTUNE_GEMM=1 ENABLE_PERSISTENT_TMA_MATMUL=1 TORCH_LOGS=+inductor python3 run.py --op fp8_gemm --only torch_fp8_gemm,pt2_fp8_gemm --metrics accuracy,tflops,latency --m 2048 --n 2048 --k 2048 --scaling-pair BlockWise128x128,BlockWise1x128
```

Differential Revision: D89438745




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo