### PR TITLE
[ROCm] Enable MIOpen backend for CTC Loss

### DIFF
--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -33,6 +33,8 @@
 #include <ATen/ops/tensor.h>
 #include <ATen/ops/where.h>
 #include <ATen/ops/zeros.h>
+#include <ATen/ops/_use_miopen_ctc_loss.h>
+#include <ATen/ops/miopen_ctc_loss.h>
 #endif
 
 #include <type_traits>
@@ -489,26 +491,39 @@ Tensor get_clamped_target_length(
   return target_lengths.clamp_min(1);
 }
 
-// this wrapper function dispatches to the native and cudnn implementations and hides the alpha/grad from the user (by just returning the loss)
-// the gradient is implemented for _cudnn_ctc_loss (just in derivatives.yaml) and _ctc_loss and this function has automatic gradients
+// this wrapper function dispatches to the native and cudnn/miopen implementations and hides the alpha/grad from the user (by just returning the loss)
+// the gradient is implemented for _cudnn_ctc_loss, miopen_ctc_loss (just in derivatives.yaml) and _ctc_loss and this function has automatic gradients
 // it also handles the reduction if desired
 template <typename LengthsType>
 Tensor ctc_loss_impl(const Tensor& log_probs_, const Tensor& targets, LengthsType input_lengths, LengthsType target_lengths, int64_t BLANK, int64_t reduction, bool zero_infinity) {
   auto is_batched = log_probs_.dim() == 3;
   Tensor log_probs = is_batched ? log_probs_ : log_probs_.unsqueeze(1);
+
+  Tensor res;
+
+  // cuDNN CTC Loss (returns false on non-CUDA builds)
   bool use_cudnn =
       (log_probs.device().type() == at::kCUDA) &&
       at::_use_cudnn_ctc_loss(
           log_probs, targets, input_lengths, target_lengths, BLANK);
 
-  Tensor res;
+  // MIOpen CTC Loss (returns false on non-ROCm builds)
+  Tensor targets_cpu = targets.device().type() == at::kCPU
+      ? targets.to(at::kInt)
+      : targets.to(Device(at::kCPU), at::kInt);
+  bool use_miopen = (log_probs.device().type() == at::kCUDA) &&
+      at::_use_miopen_ctc_loss(log_probs, targets_cpu, input_lengths, target_lengths, BLANK);
+
   if (use_cudnn) {
     // non-deterministic ctc loss on cudnn disabled due to inconsistent results
     // see: https://github.com/pytorch/pytorch/issues/21680
     res = std::get<0>(at::_cudnn_ctc_loss(log_probs, targets, input_lengths, target_lengths, BLANK, /*deterministic=*/true, zero_infinity));
+  } else if (use_miopen) {
+    // MIOpen CTC Loss only supports deterministic algorithm
+    res = std::get<0>(at::miopen_ctc_loss(log_probs, targets_cpu, input_lengths, target_lengths, BLANK, /*deterministic=*/true, zero_infinity));
   } else {
-    // if the targets are on CPU (which you need for CuDNN, let's move them to
-    // GPU as a service for the user)
+    // if the targets are on CPU (which you need for cuDNN/MIOpen), move them to
+    // GPU as a service for the user
     res = std::get<0>(at::_ctc_loss(
         log_probs,
         targets.to(log_probs.device(), kLong),
@@ -537,13 +552,22 @@ Tensor ctc_loss(const Tensor& log_probs_, const Tensor& targets, IntArrayRef inp
 
 // Convenience function accepting Tensors
 Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, const Tensor& input_lengths, const Tensor& target_lengths, int64_t BLANK, int64_t reduction, bool zero_infinity) {
-  // we don't want to convert to IntArrayRef if we can dispatch to cuDNN (this allows graph-capturable ctc_loss)
+  // we don't want to convert to IntArrayRef if we can dispatch to cuDNN/MIOpen (this allows graph-capturable ctc_loss)
+  // cuDNN CTC Loss (returns false on non-CUDA builds)
   bool use_cudnn =
       (log_probs.device().type() == at::kCUDA) &&
       at::_use_cudnn_ctc_loss(
           log_probs, targets, input_lengths, target_lengths, BLANK);
+  // MIOpen CTC Loss (returns false on non-ROCm builds)
+  Tensor targets_check = targets.device().type() == at::kCPU
+      ? targets.to(at::kInt)
+      : targets.to(Device(at::kCPU), at::kInt);
+  bool use_miopen = (log_probs.device().type() == at::kCUDA) &&
+      at::_use_miopen_ctc_loss(
+          log_probs, targets_check, input_lengths, target_lengths, BLANK);
+  bool use_accelerated = use_cudnn || use_miopen;
   if (at::areAnyTensorSubclassLike(
-          {log_probs, targets, input_lengths, target_lengths}) || use_cudnn) {
+          {log_probs, targets, input_lengths, target_lengths}) || use_accelerated) {
     // Composite Compliant path for TensorSubclasses
     return ctc_loss_impl(log_probs, targets, input_lengths, target_lengths, BLANK, reduction, zero_infinity);
   }

--- a/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
+++ b/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
@@ -150,6 +150,9 @@ std::tuple<Tensor, Tensor> miopen_ctc_loss(
     bool zero_infinity) {
   (void)zero_infinity; // only used for backward
 
+  // Validate non-empty tensor before MIOpen call
+  TORCH_CHECK(log_probs_t.numel() > 0, "log_probs tensor must not be empty");
+
   const CheckedFrom c = "miopen_ctc_loss";
   const TensorArg log_probs{log_probs_t, "log_probs", 1};
   const TensorArg targets{targets_t, "targets", 2};

--- a/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
+++ b/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
@@ -1,0 +1,286 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+#include <ATen/Config.h>
+#include <ATen/TensorUtils.h>
+#include <c10/util/Exception.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/miopen_ctc_loss.h>
+#include <ATen/ops/miopen_ctc_loss_native.h>
+#endif
+
+// TODO: Remove the condition on AT_ROCM_ENABLED entirely,
+// don't build this file as part of CPU build.
+#include <ATen/cuda/CUDAConfig.h>
+
+#if !AT_ROCM_ENABLED()
+
+namespace at::native {
+
+bool _use_miopen_ctc_loss(
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    int64_t BLANK) {
+  return false;
+}
+
+bool _use_miopen_ctc_loss_tensor(
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    int64_t BLANK) {
+  return false;
+}
+
+std::tuple<Tensor, Tensor> miopen_ctc_loss(
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    int64_t blank,
+    bool deterministic,
+    bool zero_infinity) {
+  TORCH_CHECK(false, "miopen_ctc_loss: ATen not compiled with MIOpen support");
+}
+
+std::tuple<Tensor, Tensor> miopen_ctc_loss_tensor(
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    int64_t blank,
+    bool deterministic,
+    bool zero_infinity) {
+  TORCH_CHECK(false, "miopen_ctc_loss: ATen not compiled with MIOpen support");
+}
+
+} // namespace at::native
+
+#else // AT_ROCM_ENABLED()
+
+#include <ATen/miopen/miopen-wrapper.h>
+#include <ATen/miopen/Descriptors.h>
+#include <ATen/miopen/Handle.h>
+
+#include <ATen/hip/HIPContext.h>
+#include <c10/hip/HIPStream.h>
+#include <c10/hip/HIPException.h>
+#include <c10/util/irange.h>
+
+namespace at::native {
+
+bool _use_miopen_ctc_loss(
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    int64_t BLANK) {
+  auto& ctx = at::globalContext();
+
+  bool use_miopen = ctx.userEnabledCuDNN() && (BLANK == 0) &&
+      (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
+      (targets.scalar_type() == at::kInt) &&
+      (targets.device().type() == at::kCPU) && (targets.is_contiguous()) &&
+      (log_probs.device().type() == at::kCUDA) && (log_probs.dim() == 3);
+
+  if (use_miopen) {
+    // we don't know that input_lengths and target_lengths have the same size
+    // (they should, but we didn't check yet)
+    int64_t max_input_length = log_probs.size(0);
+    for (const auto input_length : input_lengths) {
+      use_miopen = use_miopen && ((input_length == max_input_length) ? 1 : 0);
+    }
+    for (const auto b : c10::irange(target_lengths.size())) {
+      // target length < 256 is documented, but we see illegal memory accesses
+      // when target lengths > input lengths for MIOpen (same as cuDNN)
+      use_miopen = use_miopen && (target_lengths[b] < 256) &&
+          (target_lengths[b] <= input_lengths[b]);
+    }
+  }
+  return use_miopen;
+}
+
+bool _use_miopen_ctc_loss_tensor(
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    int64_t BLANK) {
+  auto& ctx = at::globalContext();
+
+  bool use_miopen = ctx.userEnabledCuDNN() && (BLANK == 0) &&
+      (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
+      (targets.scalar_type() == at::kInt) &&
+      (log_probs.device().type() == at::kCUDA) && (targets.is_contiguous()) &&
+      (log_probs.dim() == 3) && (input_lengths.scalar_type() == at::kInt) &&
+      (target_lengths.scalar_type() == at::kInt);
+
+  if (use_miopen) {
+    Tensor ilc = input_lengths.to(Device(at::kCPU), at::kLong).contiguous();
+    Tensor tlc = target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
+    IntArrayRef il(ilc.const_data_ptr<int64_t>(), ilc.numel());
+    IntArrayRef tl(tlc.const_data_ptr<int64_t>(), tlc.numel());
+    for (const auto b : c10::irange(tl.size())) {
+      // target length < 256 is documented, but we see illegal memory accesses
+      // when target lengths > input lengths for MIOpen (same as cuDNN)
+      use_miopen = use_miopen && (tl[b] < 256) && (tl[b] <= il[b]);
+      if (!use_miopen) {
+        return use_miopen;
+      }
+    }
+  }
+  return use_miopen;
+}
+
+std::tuple<Tensor, Tensor> miopen_ctc_loss(
+    const Tensor& log_probs_t,
+    const Tensor& targets_t,
+    IntArrayRef input_lengths_,
+    IntArrayRef target_lengths_,
+    int64_t BLANK,
+    bool deterministic,
+    bool zero_infinity) {
+  (void)zero_infinity; // only used for backward
+
+  const CheckedFrom c = "miopen_ctc_loss";
+  const TensorArg log_probs{log_probs_t, "log_probs", 1};
+  const TensorArg targets{targets_t, "targets", 2};
+
+  checkDim(c, log_probs, 3);
+  checkScalarType(c, log_probs, kFloat);
+  checkDim(c, targets, 1);
+  checkScalarType(c, targets, kInt);
+  checkContiguous(c, targets);
+  checkBackend(c, {*log_probs}, Backend::CUDA);
+  checkBackend(c, {*targets}, Backend::CPU);
+
+  const auto batch_size = log_probs->size(1);
+  const auto input_length = log_probs->size(0);
+  const auto num_labels = log_probs->size(2);
+
+  TORCH_CHECK(
+      static_cast<int64_t>(input_lengths_.size()) == batch_size,
+      "input_lengths needs to have size to match batch_size");
+  TORCH_CHECK(
+      static_cast<int64_t>(target_lengths_.size()) == batch_size,
+      "target_lengths needs to have size to match batch_size");
+  TORCH_CHECK(BLANK == 0, "blank must be label 0 for miopen_ctc_loss");
+
+  std::vector<int> input_lengths(input_lengths_.begin(), input_lengths_.end());
+  std::vector<int> target_lengths(target_lengths_.begin(), target_lengths_.end());
+
+  miopenHandle_t handle = getMiopenHandle();
+  miopenCTCLossDescriptor_t ctc_desc;
+  MIOPEN_CHECK(miopenCreateCTCLossDescriptor(&ctc_desc));
+
+  // MIOpen expects probabilities, apply_softmax=true converts log_probs via exp()
+  MIOPEN_CHECK(miopenSetCTCLossDescriptor(
+      ctc_desc, miopenFloat, static_cast<int>(BLANK), /*apply_softmax=*/true));
+
+  int dims[3] = {
+      static_cast<int>(input_length),
+      static_cast<int>(batch_size),
+      static_cast<int>(num_labels)};
+  int strides[3] = {
+      static_cast<int>(batch_size * num_labels),
+      static_cast<int>(num_labels),
+      1};
+
+  miopenTensorDescriptor_t probs_desc, grads_desc;
+  MIOPEN_CHECK(miopenCreateTensorDescriptor(&probs_desc));
+  MIOPEN_CHECK(miopenCreateTensorDescriptor(&grads_desc));
+  MIOPEN_CHECK(miopenSetTensorDescriptor(probs_desc, miopenFloat, 3, dims, strides));
+  MIOPEN_CHECK(miopenSetTensorDescriptor(grads_desc, miopenFloat, 3, dims, strides));
+
+  Tensor costs = at::empty({batch_size}, log_probs->options());
+  Tensor grad = at::empty_like(log_probs_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  // MIOpen requires labels and lengths on GPU
+  Tensor labels_gpu = targets_t.to(Device(at::kCUDA), at::kInt);
+  Tensor label_lengths_gpu = at::empty(
+      {static_cast<int64_t>(target_lengths.size())},
+      at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+  Tensor input_lengths_gpu = at::empty(
+      {static_cast<int64_t>(input_lengths.size())},
+      at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+
+  C10_HIP_CHECK(hipMemcpy(
+      label_lengths_gpu.data_ptr<int>(),
+      target_lengths.data(),
+      target_lengths.size() * sizeof(int),
+      hipMemcpyHostToDevice));
+  C10_HIP_CHECK(hipMemcpy(
+      input_lengths_gpu.data_ptr<int>(),
+      input_lengths.data(),
+      input_lengths.size() * sizeof(int),
+      hipMemcpyHostToDevice));
+
+  size_t workspace_size;
+  (void)deterministic; // MIOpen only supports deterministic algorithm
+  MIOPEN_CHECK(miopenGetCTCLossWorkspaceSize(
+      handle,
+      probs_desc,
+      grads_desc,
+      labels_gpu.data_ptr<int>(),
+      label_lengths_gpu.data_ptr<int>(),
+      input_lengths_gpu.data_ptr<int>(),
+      MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC,
+      ctc_desc,
+      &workspace_size));
+
+  Tensor workspace = at::empty(workspace_size, log_probs->options().dtype(kByte));
+
+  MIOPEN_CHECK(miopenCTCLoss(
+      handle,
+      probs_desc,
+      log_probs_t.data_ptr(),
+      labels_gpu.data_ptr<int>(),
+      label_lengths_gpu.data_ptr<int>(),
+      input_lengths_gpu.data_ptr<int>(),
+      costs.data_ptr(),
+      grads_desc,
+      grad.data_ptr(),
+      MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC,
+      ctc_desc,
+      workspace.data_ptr(),
+      workspace_size));
+
+  MIOPEN_CHECK(miopenDestroyTensorDescriptor(probs_desc));
+  MIOPEN_CHECK(miopenDestroyTensorDescriptor(grads_desc));
+  MIOPEN_CHECK(miopenDestroyCTCLossDescriptor(ctc_desc));
+
+  return std::make_tuple(costs, grad);
+}
+
+std::tuple<Tensor, Tensor> miopen_ctc_loss_tensor(
+    const Tensor& log_probs_t,
+    const Tensor& targets_t,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    int64_t BLANK,
+    bool deterministic,
+    bool zero_infinity) {
+  Tensor ilc = input_lengths.to(Device(at::kCPU), at::kLong).contiguous();
+  Tensor tlc = target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
+  IntArrayRef il(ilc.const_data_ptr<int64_t>(), ilc.numel());
+  IntArrayRef tl(tlc.const_data_ptr<int64_t>(), tlc.numel());
+
+  Tensor targets_cpu = targets_t.device().type() == at::kCPU
+      ? targets_t
+      : targets_t.to(Device(at::kCPU));
+
+  return at::native::miopen_ctc_loss(
+      log_probs_t, targets_cpu, il, tl, BLANK, deterministic, zero_infinity);
+}
+
+} // namespace at::native
+
+#endif // AT_ROCM_ENABLED()

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4212,6 +4212,27 @@
     CUDA: miopen_rnn_backward
   autogen: miopen_rnn_backward.out
 
+- func: _use_miopen_ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank) -> bool
+  device_check: NoCheck  # Tensor arguments allowed to be on different devices, see also miopen_ctc_loss
+  dispatch:
+    CUDA: _use_miopen_ctc_loss
+
+- func: _use_miopen_ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank) -> bool
+  device_check: NoCheck  # Tensor arguments allowed to be on different devices, see also miopen_ctc_loss
+  dispatch:
+    CUDA: _use_miopen_ctc_loss_tensor
+
+- func: miopen_ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
+  device_check: NoCheck  # log_probs is expected to be on CUDA while targets is expected to be on CPU
+  dispatch:
+    CUDA: miopen_ctc_loss
+  autogen: miopen_ctc_loss.out
+
+- func: miopen_ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
+  device_check: NoCheck  # log_probs is expected to be on CUDA while targets is expected to be on CPU
+  dispatch:
+    CUDA: miopen_ctc_loss_tensor
+
 - func: mm(Tensor self, Tensor mat2) -> Tensor
   structured_delegate: mm.out
   variants: function, method

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -652,6 +652,8 @@ aten::_upsample_nearest_exact3d_backward
 aten::_upsample_nearest_exact3d_backward.grad_input
 aten::_use_cudnn_ctc_loss
 aten::_use_cudnn_ctc_loss.Tensor
+aten::_use_miopen_ctc_loss
+aten::_use_miopen_ctc_loss.Tensor
 aten::_validate_compressed_sparse_indices
 aten::_values
 aten::_values_copy
@@ -968,6 +970,9 @@ aten::miopen_convolution_add_relu
 aten::miopen_convolution_relu
 aten::miopen_convolution_transpose
 aten::miopen_convolution_transpose.out
+aten::miopen_ctc_loss
+aten::miopen_ctc_loss.Tensor
+aten::miopen_ctc_loss.out
 aten::miopen_depthwise_convolution
 aten::miopen_depthwise_convolution.out
 aten::miopen_rnn

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -895,6 +895,8 @@ meta_dispatch_device_expected_failures['cuda'] = {
     aten._unique2.default: {f16},  # aten::_unique2
     aten._use_cudnn_ctc_loss.default: {f32, f64},  # aten::_use_cudnn_ctc_loss
     aten._use_cudnn_ctc_loss.Tensor: {f32, f64},  # aten::_use_cudnn_ctc_loss.Tensor
+    aten._use_miopen_ctc_loss.default: {f32, f64},  # aten::_use_miopen_ctc_loss
+    aten._use_miopen_ctc_loss.Tensor: {f32, f64},  # aten::_use_miopen_ctc_loss.Tensor
     aten.cudnn_grid_sampler.default: {f16, f32, f64},  # aten::cudnn_grid_sampler
     aten.geqrf.default: {f32, f64},  # aten::geqrf
     aten.linalg_eigvalsh.out: {f32, f64},  # aten::linalg_eigvalsh.out

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11923,7 +11923,6 @@ class TestNNDeviceType(NNTestCase):
             gradcheck(ctc_after_softmax, [x])
 
     @onlyCUDA
-    @skipCUDAIfRocm(msg="skipped Cudnn test on ROCm")
     def test_ctc_loss_cudnn(self, device):
         batch_size = 16
         input_length = 30
@@ -11942,12 +11941,14 @@ class TestNNDeviceType(NNTestCase):
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cpu', torch.int32),
                                                   input_lengths, target_lengths, reduction='none')
-        self.assertTrue("Cudnn" in str(loss_cudnn.grad_fn))
+        # ROCm uses MIOpen (MiopenCtcLossBackward), CUDA uses cuDNN (CudnnCtcLossBackward)
+        grad_fn_str = str(loss_cudnn.grad_fn)
+        self.assertTrue("Miopen" in grad_fn_str or "Cudnn" in grad_fn_str,
+                        f"Expected MiopenCtcLossBackward or CudnnCtcLossBackward, got {grad_fn_str}")
         grad_cudnn, = torch.autograd.grad(loss_cudnn, log_probs, grad_out)
         self.assertEqual(grad_cudnn, grad_native, atol=1e-4, rtol=0)
 
     @onlyCUDA
-    @skipCUDAIfRocm(msg="skipped Cudnn test on ROCm")
     def test_ctc_loss_cudnn_tensor_cuda(self):
         batch_size = 16
         input_length = 30
@@ -11970,12 +11971,14 @@ class TestNNDeviceType(NNTestCase):
                                                   input_lengths.to('cuda', torch.int32),
                                                   target_lengths.to('cuda', torch.int32),
                                                   reduction='none')
-        self.assertTrue("Cudnn" in str(loss_cudnn.grad_fn))
+        # ROCm uses MIOpen (MiopenCtcLossBackward), CUDA uses cuDNN (CudnnCtcLossBackward)
+        grad_fn_str = str(loss_cudnn.grad_fn)
+        self.assertTrue("Miopen" in grad_fn_str or "Cudnn" in grad_fn_str,
+                        f"Expected MiopenCtcLossBackward or CudnnCtcLossBackward, got {grad_fn_str}")
         grad_cudnn, = torch.autograd.grad(loss_cudnn, log_probs, grad_out)
         self.assertEqual(grad_cudnn, grad_native, atol=1e-4, rtol=0)
 
     @onlyCUDA
-    @skipCUDAIfRocm(msg="skipped Cudnn test on ROCm")
     def test_ctc_loss_cudnn_tensor_cpu_length_cuda(self):
         # batch size
         N = 50

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2817,6 +2817,12 @@
 - name: miopen_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state, Tensor reserve, bool[4] output_mask) -> (Tensor, Tensor, Tensor, Tensor[])
   dropout_state: non_differentiable
 
+- name: miopen_ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
+  log_probs: _miopen_ctc_loss_backward(grad, result0, result1, zero_infinity)
+
+- name: miopen_ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
+  log_probs: _miopen_ctc_loss_backward(grad, result0, result1, zero_infinity)
+
 - name: mkldnn_rnn_layer(Tensor input, Tensor weight0, Tensor weight1, Tensor weight2, Tensor weight3, Tensor hx_, Tensor cx_, bool reverse, int[] batch_sizes, int mode, int hidden_size, int num_layers, bool has_biases, bool bidirectional, bool batch_first, bool train) -> (Tensor, Tensor, Tensor, Tensor)
   output_differentiability: [True, True, True, False]
   input, weight0, weight1, weight2, weight3, hx_, cx_: "GradMode::is_enabled() ? mkldnn_rnn_layer_differentiable_backward(input, weight0, weight1, weight2, weight3, hx_, cx_, result0, result1, result2, grads[0], grads[1], grads[2], reverse, mode, hidden_size, num_layers, has_biases, train, bidirectional, batch_sizes, batch_first, result3) : mkldnn_rnn_layer_backward(input, weight0, weight1, weight2, weight3, hx_, cx_, result0, result1, result2, grads[0], grads[1], grads[2], reverse, mode, hidden_size, num_layers, has_biases, train, bidirectional, batch_sizes, batch_first, result3)"

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5344,6 +5344,15 @@ Tensor _cudnn_ctc_loss_backward(
   }
 }
 
+Tensor _miopen_ctc_loss_backward(
+    const Tensor& grad_out,
+    const Tensor& loss,
+    const Tensor& raw_grad,
+    bool zero_infinity) {
+  // MIOpen CTC Loss backward is identical to cuDNN
+  return _cudnn_ctc_loss_backward(grad_out, loss, raw_grad, zero_infinity);
+}
+
 bool any_variable_defined(const variable_list& variables) {
   for (const auto& variable : variables) {
     if (variable.defined()) {

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -604,6 +604,11 @@ at::Tensor _cudnn_ctc_loss_backward(
     const at::Tensor& loss,
     const at::Tensor& raw_grad,
     bool zero_infinity);
+at::Tensor _miopen_ctc_loss_backward(
+    const at::Tensor& grad_out,
+    const at::Tensor& loss,
+    const at::Tensor& raw_grad,
+    bool zero_infinity);
 at::Tensor elu_double_backward(
     const Tensor& grad,
     const Tensor& grad_output,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -193,6 +193,7 @@ def get_ignored_functions() -> set[Callable]:
         torch.cudnn_convolution_add_relu,
         torch.cudnn_grid_sampler,
         torch.cudnn_is_acceptable,
+        torch.miopen_ctc_loss,
         torch.empty,
         torch.empty_permuted,
         torch.empty_strided,

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -69,6 +69,8 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "_nnz",  # returns an int
     "_use_cudnn_ctc_loss",  # returns a boolean
     "_use_cudnn_ctc_loss.Tensor",  # returns a boolean
+    "_use_miopen_ctc_loss",  # returns a boolean
+    "_use_miopen_ctc_loss.Tensor",  # returns a boolean
     "_validate_compressed_sparse_indices",  # no return
     "allclose",  # returns a boolean
     "dense_dim",  # returns an int


### PR DESCRIPTION
Fixes #168808
Fixes: #168809

Summary
This PR enables MIOpen CTC Loss support on the ROCm platform. Previously, CTC Loss was disabled on ROCm because AT_CUDNN_ENABLED() evaluates to false, causing tests to skip.

Implementation Details
To ensure strict separation between backends (as requested), I have implemented the MIOpen CTC Loss support in a dedicated source file instead of modifying the CuDNN path.

Source Location: Moved the implementation to aten/src/ATen/native/miopen/LossCTC_miopen.cpp.
Dispatch: Updated aten/src/ATen/native/LossCTC.cpp to correctly dispatch to the MIOpen backend on ROCm.
Registration: Registered _ctc_loss and _ctc_loss_backward in native_functions.yaml and derivatives.yaml.

Key differences handled:
- Memory Location: MIOpen requires labels and lengths to be on GPU device memory, whereas cuDNN accepts them on CPU. Added necessary hipMemcpy handling.
- Softmax: MIOpen's apply_softmax_layer=true is used to align with PyTorch's expected probability distribution behavior.

Test Plan
Verified locally on MI308. The following tests now PASS (previously skipped):
- test_ctc_loss_cudnn
- test_ctc_loss_cudnn_tensor_cuda

<img width="800" height="294" alt="image" src="https://github.com/user-attachments/assets/ce41aa92-ec45-455c-a3ea-c6bec8c927d0" />

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang