### PR TITLE
Fix-bucketize-export-crash

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -18026,6 +18026,32 @@ def forward(self, x, y):
             str(ep.graph)
         )
 
+    def test_bucketize_scalar_export(self):
+        class BucketizeScalar(torch.nn.Module):
+            def __init__(self, scalar_value, out_int32=False):
+                super().__init__()
+                self.scalar_value = scalar_value
+                self.out_int32 = out_int32
+
+            def forward(self, boundaries):
+                return torch.bucketize(
+                    self.scalar_value, boundaries, out_int32=self.out_int32
+                )
+
+        test_cases = [
+            (5, torch.tensor([1, 3, 7, 9]), False, torch.int64),
+            (2.5, torch.tensor([1.0, 2.0, 3.0, 4.0]), False, torch.int64),
+            (5, torch.tensor([1, 3, 7, 9]), True, torch.int32),
+        ]
+
+        for scalar_value, boundaries, out_int32, expected_dtype in test_cases:
+            model = BucketizeScalar(scalar_value, out_int32)
+            exported = export(model, (boundaries,))
+            eager_result = model(boundaries)
+            export_result = exported.module()(boundaries)
+            self.assertEqual(eager_result, export_result)
+            self.assertEqual(export_result.dtype, expected_dtype)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -27,6 +27,7 @@ from torch._prims_common import (
     IntLike,
     make_contiguous_strides_for,
     Number,
+    NumberType,
     suggest_memory_format,
     TensorLike,
 )
@@ -7478,7 +7479,13 @@ def meta_bucketize(self, boundaries, *, out_int32=False, right=False):
 
 
 @register_meta([aten.bucketize.Scalar, aten.bucketize.Scalar_out])
-def meta_bucketize_scalar(self, boundaries, *, out_int32=False, right=False):
+def meta_bucketize_scalar(
+    self: NumberType,
+    boundaries: Tensor,
+    *,
+    out_int32: bool = False,
+    right: bool = False,
+):
     return boundaries.new_empty(
         (),
         dtype=torch.int32 if out_int32 else torch.int64,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7477,6 +7477,14 @@ def meta_bucketize(self, boundaries, *, out_int32=False, right=False):
     )
 
 
+@register_meta([aten.bucketize.Scalar, aten.bucketize.Scalar_out])
+def meta_bucketize_scalar(self, boundaries, *, out_int32=False, right=False):
+    return boundaries.new_empty(
+        (),
+        dtype=torch.int32 if out_int32 else torch.int64,
+    )
+
+
 @register_meta([aten.histc])
 @out_wrapper()
 def meta_histc(input, bins=100, min=0, max=0):


### PR DESCRIPTION
Fixes #169977


Summary:

- Fixes torch.export compatibility with scalar bucketize.
- Matches eager mode behaviour