### PR TITLE
[ROCm] remove ROCm specific skip for test_python_ref_executor

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -754,6 +754,7 @@ class TestCommon(TestCase):
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref_executor(self, device, dtype, op, executor):
         from copy import copy
+
         from torch._prims.executor import make_traced
 
         op = copy(op)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -753,14 +753,7 @@ class TestCommon(TestCase):
     @parametrize("executor", ["aten"])
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref_executor(self, device, dtype, op, executor):
-        if (
-            TEST_WITH_ROCM
-            and (op.name == "_refs.fft.ihfftn" or op.name == "_refs.fft.ihfft2")
-            and dtype == torch.float16
-        ):
-            self.skipTest("Skipped on ROCm")
         from copy import copy
-
         from torch._prims.executor import make_traced
 
         op = copy(op)


### PR DESCRIPTION
Fixes #168816

Remove ROCm specific skip for this unit test due to two reasons
- These two ops have been marked to skip GPU devices anyway
- Unit tests can pass according to our evaluation

See the comments on the issue for further details: https://github.com/pytorch/pytorch/issues/168816#issuecomment-3668731034


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang