### PR TITLE
[ROCm] [CI] Fix deterministic scan kernel edge case and enable test

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -303,7 +303,7 @@ __global__ void final_scan_kernel(const T* d_in, T* d_out, T* agg, int64_t nelem
   T agg_data;
   agg_data = threadIdx.x >= blockIdx.x ? T(0) : agg[threadIdx.x];
   // In case there are fewer threads than previous block aggregates to be read, add more aggregates (should be at most 2-3 aggregates per thread)
-  for (int i=threadIdx.x + blockDim.x; i<blockIdx.x; i+=blockDim.x) {
+  for (unsigned int i=threadIdx.x + blockDim.x; i<blockIdx.x; i+=blockDim.x) {
     agg_data += agg[i];
   }
 

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -302,11 +302,11 @@ __global__ void final_scan_kernel(const T* d_in, T* d_out, T* agg, int64_t nelem
   // load agg and reduce my starting value
   T agg_data;
   agg_data = threadIdx.x >= blockIdx.x ? T(0) : agg[threadIdx.x];
-  // if there are fewer threads than previous values to be read,
-  // read another value
-  if (threadIdx.x + blockDim.x < blockIdx.x) {
-    agg_data += agg[threadIdx.x + blockDim.x];
+  // In case there are fewer threads than previous block aggregates to be read, add more aggregates (should be at most 2-3 aggregates per thread)
+  for (int i=threadIdx.x + blockDim.x; i<blockIdx.x; i+=blockDim.x) {
+    agg_data += agg[i];
   }
+
   T aggregate = BlockReduceT(temp_storage.reduce).Sum(agg_data);
   __syncthreads();
   BlockPrefixCallbackOp prefix_op(aggregate);
@@ -442,8 +442,6 @@ inline void inclusive_deterministic_scan(const scalar_t *  input, scalar_t * out
 
   const int iters_per_cta = (grid_size + num_sms - 1)/num_sms;
   grid_size = std::min(num_sms, grid_size);
-  // simple reduction in scan kernel handles at most 2 items per thread
-  TORCH_INTERNAL_ASSERT(2 * BLOCK_THREADS >= grid_size);
   auto& allocator = *c10::cuda::CUDACachingAllocator::get();
   auto agg = allocator.allocate(grid_size * sizeof(scalar_t));
   calc_block_sums<BLOCK_THREADS, ITEMS_PER_THREAD, false>

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1728,7 +1728,6 @@ class TestTorchDeviceType(TestCase):
             'embedding_bag_backward_cuda_max',
             torch.device(device).type == 'cuda')
 
-    @skipIfRocmArch(MI300_ARCH)
     @skipIfTorchInductor("https://github.com/pytorch/pytorch/issues/113707")
     @onlyCUDA
     def test_deterministic_cumsum(self, device):

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -12,21 +12,10 @@ import warnings
 from collections.abc import Callable
 from enum import Enum
 from typing import Literal, NamedTuple, TypeAlias
+from typing_extensions import NotRequired, TypedDict
 
 import torch
 from torch import Tensor
-
-
-try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
-
-try:
-    from typing import NotRequired
-except ImportError:
-    from typing_extensions import NotRequired
-
 from torch._higher_order_ops.flex_attention import flex_attention as flex_attention_hop
 from torch._higher_order_ops.utils import setup_compilation_env
 from torch._prims_common import DeviceLikeType


### PR DESCRIPTION
Fixes #168862
 
Previously the test would break on MI300x on this assertion 
```cpp
TORCH_INTERNAL_ASSERT(2 * BLOCK_THREADS >= grid_size);
```
because the MI300x has 304 SMs, so the grid_size would get set to at least 304 while the number of threads within a block would be 128 for 16-byte types (2 * 128 = 256 which is not >= 304). 

It seems like the reason for this assertion was because the kernel performed a simple reduction for the block aggregates: each thread held a block's aggregate, and if there were less threads per block than the number of blocks, then each thread would add up 2 aggregates (hence the assertion as a safe guard). Changing the conditional to a loop should incur very minimal overhead since it's executed at most one more time per thread than the old behavior. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang