### PR TITLE
[DeviceMesh] Fix error in fake-mode + TORCH_DISTRIBUTED_DEBUG

### DIFF
--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -311,7 +311,8 @@ class _MeshLayout(Layout):
 
         complement_layout = self.complement(rank_map.numel())
 
-        return rank_map.as_strided(
-            flatten(complement_layout.sizes) + flatten(self.sizes),
-            flatten(complement_layout.strides) + flatten(self.strides),
-        ).reshape(-1, *self.top_level_sizes)
+        with torch._subclasses.fake_tensor.unset_fake_temporarily():
+            return rank_map.as_strided(
+                flatten(complement_layout.sizes) + flatten(self.sizes),
+                flatten(complement_layout.strides) + flatten(self.strides),
+            ).reshape(-1, *self.top_level_sizes)

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -311,8 +311,7 @@ class _MeshLayout(Layout):
 
         complement_layout = self.complement(rank_map.numel())
 
-        with torch._subclasses.fake_tensor.unset_fake_temporarily():
-            return rank_map.as_strided(
-                flatten(complement_layout.sizes) + flatten(self.sizes),
-                flatten(complement_layout.strides) + flatten(self.strides),
-            ).reshape(-1, *self.top_level_sizes)
+        return rank_map.as_strided(
+            flatten(complement_layout.sizes) + flatten(self.sizes),
+            flatten(complement_layout.strides) + flatten(self.strides),
+        ).reshape(-1, *self.top_level_sizes)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -305,18 +305,19 @@ else:
 
         @property
         def mesh(self) -> torch.Tensor:
-            """Returns the tensor representing the layout of devices."""
-            full_mesh = self._layout.remap_to_tensor(self._rank_map)
-            if full_mesh.size(0) == 1:
-                return full_mesh[0]
-            my_coords = (full_mesh == get_rank()).nonzero()
-            if my_coords.size(0) > 0:
-                return full_mesh[my_coords[0, 0]]
-            raise RuntimeError(
-                "In order to get the mesh Tensor of a DeviceMesh it needs to "
-                "either have all its original dimensions (e.g., no slicing) "
-                "or it needs to contain the local rank"
-            )
+            with torch._subclasses.fake_tensor.unset_fake_temporarily():
+                """Returns the tensor representing the layout of devices."""
+                full_mesh = self._layout.remap_to_tensor(self._rank_map)
+                if full_mesh.size(0) == 1:
+                    return full_mesh[0]
+                my_coords = (full_mesh == get_rank()).nonzero()
+                if my_coords.size(0) > 0:
+                    return full_mesh[my_coords[0, 0]]
+                raise RuntimeError(
+                    "In order to get the mesh Tensor of a DeviceMesh it needs to "
+                    "either have all its original dimensions (e.g., no slicing) "
+                    "or it needs to contain the local rank"
+                )
 
         @property
         def mesh_dim_names(self) -> tuple[str, ...] | None:

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -305,8 +305,8 @@ else:
 
         @property
         def mesh(self) -> torch.Tensor:
+            """Returns the tensor representing the layout of devices."""
             with torch._subclasses.fake_tensor.unset_fake_temporarily():
-                """Returns the tensor representing the layout of devices."""
                 full_mesh = self._layout.remap_to_tensor(self._rank_map)
                 if full_mesh.size(0) == 1:
                     return full_mesh[0]


### PR DESCRIPTION
When setting `TORCH_DISTRIBUTED_DEBUG=DETAIL` I got this error:
```py
Traceback (most recent call last):
  File "train.py", line 1463, in <module>
    main(exit_stack)
  File "train.py", line 400, in main
    loss = model(inp)
           ^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1774, in _wrapped_call_impl
    return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 943, in compile_wrapper
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_dynamo/output_graph.py", line 2437, in _call_user_compiler
    raise BackendCompilerFailed(
  File "/my_conda_env/lib/python3.11/site-packages/torch/_dynamo/output_graph.py", line 2412, in _call_user_compiler
    compiled_fn = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_dynamo/repro/after_dynamo.py", line 156, in __call__
    compiled_gm = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/__init__.py", line 2435, in __call__
    return compile_fx(model_, inputs_, config_patches=self.config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_inductor/compile_fx.py", line 2477, in compile_fx
    return compile_fx(
           ^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_inductor/compile_fx.py", line 2528, in compile_fx
    return _maybe_wrap_and_compile_fx_main(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_inductor/compile_fx.py", line 2605, in _maybe_wrap_and_compile_fx_main
    return _compile_fx_main(
           ^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_inductor/compile_fx.py", line 2800, in _compile_fx_main
    return aot_autograd(
           ^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_dynamo/backends/common.py", line 123, in __call__
    cg = aot_module_simplified(gm, example_inputs, **self.kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_functorch/aot_autograd.py", line 1115, in aot_module_simplified
    compiled_fn, _ = aot_stage2_compile(
                     ^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 355, in aot_stage2_compile
    return aot_stage2_autograd(aot_state, aot_graph_capture)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 2002, in aot_stage2_autograd
    fw_module_str, bw_module_str = _log_fw_bw_graphs(
                                   ^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 1499, in _log_fw_bw_graphs
    str(fw_metadata),
    ^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/dataclasses.py", line 240, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
  File "/my_conda_env/lib/python3.11/dataclasses.py", line 240, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
  File "/my_conda_env/lib/python3.11/dataclasses.py", line 240, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
  File "/my_conda_env/lib/python3.11/site-packages/torch/distributed/device_mesh.py", line 518, in __repr__
    device_mesh_repr += f", Mesh: {self.mesh.tolist()}"
                                   ^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/distributed/device_mesh.py", line 308, in mesh
    full_mesh = self._layout.remap_to_tensor(self._rank_map)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/distributed/_mesh_layout.py", line 306, in remap_to_tensor
    return rank_map.as_strided(
           ^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/utils/_stats.py", line 29, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 1397, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 2155, in dispatch
    return self._cached_dispatch_impl(func, types, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 1510, in _cached_dispatch_impl
    return self._dispatch_impl(func, types, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 2451, in _dispatch_impl
    (flat_args, flat_arg_fake_tensors) = self.validate_and_convert_non_fake_tensors(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 2909, in validate_and_convert_non_fake_tensors
    validated_args = [validate(a) for a in flat_args]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 2909, in <listcomp>
    validated_args = [validate(a) for a in flat_args]
                      ^^^^^^^^^^^
  File "/my_conda_env/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py", line 2897, in validate
    raise AssertionError(
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
AssertionError: Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode with 'allow_non_fake_inputs'. Found in aten.as_strided.default(...)

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```