### PR TITLE
Remove PyUnicode_READY  for Python < 3.10

### DIFF
--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -84,12 +84,6 @@ THPObjectPtr _unicode_dispatch(PyObject* str) {
     return THPObjectPtr();
   }
 
-  // Remove this when we're 3.10+
-  if (PyUnicode_READY(str) != 0) {
-    // Returns -1 with an exception set on failure
-    return THPObjectPtr();
-  }
-
   auto length = PyUnicode_GET_LENGTH(str);
 
   switch (PyUnicode_KIND(str)) {


### PR DESCRIPTION
This PR removes `PyUnicode_READY` which does nothing on Python 3.10+.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo