### PR TITLE
Support torch.compile inside FakeTensorMode

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9500,6 +9500,17 @@ def ___make_guard_fn():
         opt_out = opt_model(x)
         self.assertTrue(same(orig_out, opt_out))
 
+    def test_compile_with_userland_fake_tensor_mode(self):
+        # Test that torch.compile works when called inside a user's FakeTensorMode.
+        # The user's fake tensors should be "refakified" to Dynamo's fake mode.
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            model = torch.nn.Linear(4, 4)
+            inp = torch.rand(4, 4)
+            loss = torch.compile(model, backend="aot_eager")(inp).sum()
+            loss.backward()
+
     def test_scalar_tensor_is_equivalent_to_symint_argument(self):
         class GumbelTopKSampler(torch.nn.Module):
             def __init__(self, T, k):

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -101,18 +101,6 @@ def process_inputs(
 def construct_fake_mode(
     flat_args: list[Any], aot_config: AOTConfig
 ) -> tuple[FakeTensorMode, Optional[ShapeEnv]]:
-    # First, try to get the fake mode from the tracing context.  This is the
-    # authoritative source when Dynamo is driving compilation, since it creates
-    # a fresh FakeTensorMode for the backend.  We intentionally do NOT use
-    # detect_fake_mode here because that also checks the fake modes of input
-    # tensors, which may have been created from a different (userland)
-    # FakeTensorMode.  Those tensors will be "refakified" in process_inputs.
-    if tracing_context := torch._guards.TracingContext.try_get():
-        fake_mode = tracing_context.fake_mode
-        if fake_mode is not None:
-            return (fake_mode, fake_mode.shape_env)
-
-    # Fall back to detecting from inputs if there's no tracing context
     fake_mode = detect_fake_mode(flat_args)
     if fake_mode is None:
         shape_env = ShapeEnv() if aot_config.dynamic_shapes else None

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1281,12 +1281,15 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
         get_plain_tensors,
     )
 
-    fake_modes = []
-
+    # If TracingContext has a fake_mode, use it authoritatively.
+    # This is the case when Dynamo is driving compilation - any fake tensors
+    # from other modes in the inputs will be refakified by the caller.
     if context := TracingContext.try_get():
         fake_mode = context.fake_mode
         if fake_mode is not None:
-            fake_modes.append((fake_mode, "tracing context", 0))
+            return fake_mode
+
+    fake_modes = []
 
     from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #170777
* __->__ #170773

Dynamo is fine, AOTAutograd is the problem; it needs to be willing to
refakeify inputs.  This is incomplete because there will likely be more
problems when we get to Inductor.

Authored with claude code but I have carefully reviewed.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo