### PR TITLE
[CI] Do not auto-add  'ciflow/rocm' when CUDA files are modified

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -155,15 +155,16 @@
 - test/inductor/test_max_autotune.py
 - third_party/fbgemm
 
-"ciflow/rocm":
-- test/test_matmul_cuda.py
-- test/test_scaled_matmul_cuda.py
-- test/inductor/test_fp8.py
-- aten/src/ATen/native/cuda/*Blas.cpp
-- aten/src/ATen/cuda/CUDA*Blas.*
-- torch/_inductor/kernel/mm.py
-- test/inductor/test_max_autotune.py
-- third_party/fbgemm
+# NS: Disbaled because of the runner availability
+# "ciflow/rocm":
+# - test/test_matmul_cuda.py
+# - test/test_scaled_matmul_cuda.py
+# - test/inductor/test_fp8.py
+# - aten/src/ATen/native/cuda/*Blas.cpp
+# - aten/src/ATen/cuda/CUDA*Blas.*
+# - torch/_inductor/kernel/mm.py
+# - test/inductor/test_max_autotune.py
+# - third_party/fbgemm
 
 "ciflow/mps":
 - aten/src/ATen/mps/**


### PR DESCRIPTION
Commented out the 'ciflow/rocm' section due to runner availability issues.

See 
<img width="800" height="227" alt="image" src="https://github.com/user-attachments/assets/48481a19-677d-4ab8-abde-544d286143f6" />



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang