### PR TITLE
Make inductor_compiled_code bug out when FakeTensorMode is on

### DIFF
--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -1072,6 +1072,21 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
 
+    def test_fake_tensor_mode_raises_error(self):
+        """Test that running compiled code inside FakeTensorMode raises a clear error"""
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            model = torch.nn.Linear(4, 4)
+            inp = torch.rand(4, 4)
+
+            with inductor_config.patch({"wrap_inductor_compiled_regions": True}):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Inductor compiled code cannot be run with FakeTensor inputs",
+                ):
+                    torch.compile(model)(inp)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -7,7 +7,11 @@ from typing import Any, Optional
 import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
-from torch._higher_order_ops.utils import redirect_to_mode, reenter_make_fx
+from torch._higher_order_ops.utils import (
+    redirect_to_mode,
+    reenter_make_fx,
+    register_fake,
+)
 from torch._logging import warning_once
 from torch._ops import HigherOrderOperator
 from torch.fx import GraphModule
@@ -71,10 +75,6 @@ def inductor_compiled_code_impl(func, inputs):
 redirect_to_mode(inductor_compiled_code, DebugMode)
 redirect_to_mode(inductor_compiled_code, _CachingTorchDispatchMode)
 redirect_to_mode(inductor_compiled_code, _CachedTorchDispatchMode)
-
-
-# Register with FakeTensorMode to raise a clear error
-from torch._higher_order_ops.utils import register_fake
 
 
 @register_fake(inductor_compiled_code)

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -73,6 +73,19 @@ redirect_to_mode(inductor_compiled_code, _CachingTorchDispatchMode)
 redirect_to_mode(inductor_compiled_code, _CachedTorchDispatchMode)
 
 
+# Register with FakeTensorMode to raise a clear error
+from torch._higher_order_ops.utils import register_fake
+
+
+@register_fake(inductor_compiled_code)
+def inductor_compiled_code_fake(func, inputs):
+    raise RuntimeError(
+        "Inductor compiled code cannot be run with FakeTensor inputs. "
+        "This can happen when torch.compile is called inside a FakeTensorMode. "
+        "Consider using backend='eager' or backend='aot_eager' instead."
+    )
+
+
 class WrapWithSetGradEnabled(HigherOrderOperator):
     def __init__(self) -> None:
         super().__init__("wrap_with_set_grad_enabled")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #170777
* #170773

This doesn't help when you don't have wrap_inductor_compiled_regions
setup but when it's on you get a nice error instead of IMA.

Authored with claude code

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo