### PR TITLE
[DTensor] Fix OpInfo.schema type and add asserts

### DIFF
--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -644,7 +644,13 @@ class OpInfo:
     compute_mesh: DeviceMesh
 
     # compete runtime operator infos
-    schema: OpSchema
+    # NOTE: schema can be None due to C++ fast path optimization. When the C++
+    # dispatch layer (dispatchDTensorOp in python_variable.cpp) finds a cached
+    # sharding decision, it skips creating the full OpSchema to reduce CPU overhead.
+    # In this case, OpInfo is created with create_schema=False, setting schema to None.
+    # The operator information is still available through output_sharding.redistribute_schema
+    # when redistribution is needed.
+    schema: OpSchema | None
     flat_args_schema: list[object]
     local_args: Sequence[object]
     local_kwargs: dict[str, object]

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -407,6 +407,13 @@ class ShardingPropagator:
         # Ideally, this function would be deleted, but there are a handful of
         # one off call sites here that aren't cleaned up.
 
+        # NOTE: schema should always be populated when calling this function,
+        # as it's only called after unwrap_to_op_info (create_schema=True).
+        assert op_info.schema is not None, (
+            "op_info.schema should not be None in propagate. "
+            "This function should only be called after unwrap_to_op_info."
+        )
+
         # We cannot use an lru cache if we know that inputs will have dynamic shapes,
         # because SymInts are not hashable.
         # This is generally ok because this only happens during tracing in torch.compile,

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -892,7 +892,7 @@ def _sdpa_handler(
 ) -> object:
     # extract local tensor and sharding infos to a OpInfo
     op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
-    logger.debug("Dispatching op_call: %s", op_info.schema)
+    logger.debug("Dispatching op_call: %s", op_info.schema or op_call)
 
     # sharding propagation
     # TODO: remove the context parallel strategy from the default propagation

--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -112,6 +112,9 @@ def _propagate_tensor_meta(
     kwargs: dict[str, object],
 ) -> TensorMeta:
     op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    assert op_info.schema is not None, (
+        "op_info.schema should not be None after unwrap_to_op_info"
+    )
     tensor_meta = DTensor._op_dispatcher.sharding_propagator.propagate_tensor_meta(
         op_info.schema
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170790
* #170584

After the C++ optimizations for DTensor dispatch, there are now cases
where an OpInfo schema is not created for performance reasons, namely
when the cache is hit.

This PR updates the python typing info to reflect the change and adds
comments explaining the reasoning.