### PR TITLE
ci: Ensure we pin onnx-ir

### DIFF
--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -20,6 +20,7 @@ pip_install \
 
 pip_install coloredlogs packaging
 pip_install onnxruntime==1.23.1
+pip_install onnx-ir==0.1.12
 pip_install onnxscript==0.5.4
 
 # Cache the transformers model to be used later by ONNX tests. We need to run the transformers

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -352,6 +352,11 @@ onnxscript==0.5.4
 #Pinned versions:
 #test that import:
 
+onnx-ir==0.1.12
+#Description: In-memory IR for ONNX, dependency of onnxscript. Pinned to avoid breaking changes in newer versions.
+#Pinned versions: 0.1.12
+#test that import:
+
 parameterized==0.8.1
 #Description: Parameterizes unittests, both the tests themselves and the entire testing class
 #Pinned versions:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #170792

The newest version of onnx-ir actually introduces a regression that's
showing up when we re-build the docker images. Pin for now.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>