### PR TITLE
[ROCm][CI] Remove MI300 docker image caching

### DIFF
--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux.rocm.gfx942.docker-cache, linux.rocm.mi250.docker-cache]
+        runner: [linux.rocm.mi250.docker-cache]
         docker-image: [
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"


### PR DESCRIPTION
Docker image caching is not effective on the current MI300 CI cluster because the shared/persistent storage is not performant, which makes the docker caching step super slow.


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang