### PR TITLE
[annotate] propagate anotation to runtime asserts

### DIFF
--- a/test/dynamo/test_dynamo_runtime_assert.py
+++ b/test/dynamo/test_dynamo_runtime_assert.py
@@ -1,0 +1,98 @@
+# Owner(s): ["module: dynamo"]
+import time
+
+import torch
+import torch._dynamo.test_case
+import torch._dynamo.testing
+import torch._dynamo.utils
+
+
+class DenseBlock(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.linear = torch.nn.Linear(dim, dim)
+        self.norm = torch.nn.LayerNorm(dim)
+        self.gate = torch.nn.Linear(dim, dim)
+
+    def forward(self, x):
+        return self.norm(self.linear(x)) * torch.sigmoid(self.gate(x))
+
+
+class DenseArch(torch.nn.Module):
+    def __init__(self, dim, num_layers):
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([DenseBlock(dim) for _ in range(num_layers)])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+class RecModel(torch.nn.Module):
+    """Simplified recommendation model with many nested submodules."""
+
+    def __init__(self, num_events=10, num_layers=6, num_embeddings=12, dim=128):
+        super().__init__()
+        self.shared_arch = DenseArch(dim, num_layers)
+        self.event_submodels = torch.nn.ModuleDict(
+            {
+                f"event_{i}": torch.nn.Sequential(
+                    DenseArch(dim, num_layers),
+                    torch.nn.Linear(dim, 1),
+                )
+                for i in range(num_events)
+            }
+        )
+        self.embeddings = torch.nn.ModuleList(
+            [torch.nn.Embedding(1000, dim) for _ in range(num_embeddings)]
+        )
+
+    def forward(self, x):
+        x = self.shared_arch(x)
+        outputs = []
+        for submodel in self.event_submodels.values():
+            outputs.append(submodel(x))
+        return torch.cat(outputs, dim=-1)
+
+
+class RuntimeAssertCompileTimeTests(torch._dynamo.test_case.TestCase):
+    """Regression test for _set_node_metadata_hook overhead in
+    insert_deferred_runtime_asserts (S603290).
+
+    With inline_inbuilt_nn_modules=False, call_module nodes cause _copy_attr
+    to install full module subtrees into the GraphModule, making gm.modules()
+    large. If the pass wraps every loop iteration with _set_node_metadata_hook
+    (which iterates gm.modules() on enter AND exit), the cost becomes
+    O(nodes * modules) — catastrophic for large models.
+    """
+
+    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
+    def test_insert_runtime_assert_pass_time(self):
+        # Large model so overhead from O(nodes*modules) would be measurable.
+        model = RecModel(num_events=30, num_layers=10, num_embeddings=20, dim=128)
+        x = torch.randn(8, 128)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(model, backend="eager")
+        t0 = time.perf_counter()
+        compiled(x)
+        total_s = time.perf_counter() - t0
+
+        pass_times = torch._dynamo.utils.compilation_time_metrics.get(
+            "insert_deferred_runtime_asserts", []
+        )
+        pass_s = sum(pass_times)
+
+        self.assertLess(
+            pass_s / total_s,
+            0.05,
+            f"insert_deferred_runtime_asserts took {pass_s * 1000:.1f}ms out of "
+            f"{total_s * 1000:.1f}ms ({pass_s / total_s * 100:.1f}% of compile time)",
+        )
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/test/dynamo/test_fx_annotate.py
+++ b/test/dynamo/test_fx_annotate.py
@@ -299,6 +299,36 @@ class AnnotateTests(torch._dynamo.test_case.TestCase):
         x = torch.randn(10, requires_grad=True)
         self.assertEqual(fn(x), opt_fn(x))
 
+    def test_annotation_on_runtime_asserts(self):
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                with torch.fx.traceback.annotate({"moo": 0}):
+                    x = torch.cat([x, x])
+                    b = y.item()
+                    torch._check(b >= x.shape[0])
+                    return x * b
+
+        backend = AotEagerAndRecordGraphs()
+
+        inputs = (torch.randn(3), torch.tensor(6))
+        model = M()
+        torch._dynamo.mark_dynamic(inputs[0], 0)
+        torch.compile(model, fullgraph=True, backend=backend)(*inputs)
+        dynamo_metadata = fx_traceback._get_custom_metadata(backend.graphs[0])
+        self.assertExpectedInline(
+            str(dynamo_metadata),
+            """\
+('placeholder', 's77', {'moo': 0})
+('placeholder', 'l_x_', {'moo': 0})
+('placeholder', 'l_y_', {'moo': 0})
+('call_function', 'x', {'moo': 0})
+('call_method', 'item', {'moo': 0})
+('call_function', 'mul_1', {'moo': 0})
+('call_function', 'ge', {'moo': 0})
+('call_function', '_check', {'moo': 0})
+('call_function', 'mul', {'moo': 0})""",  # noqa: B950
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_export/passes/_node_metadata_hook.py
+++ b/torch/_export/passes/_node_metadata_hook.py
@@ -87,6 +87,8 @@ def _node_metadata_hook(
         ),
     )
 
+    node.meta["custom"] = node.meta.get("custom", arg_meta.get("custom", {}))
+
 
 @contextlib.contextmanager
 def _set_node_metadata_hook(gm: torch.fx.GraphModule, f):

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -161,38 +161,39 @@ def insert_deferred_runtime_asserts(
         elif "val" in node.meta:
             break
 
+    # Note: DO NOT register one _set_node_metadata_hook(_node_metadata_hook)
+    # for each nodes in the graph.
+    # _set_node_metadata_hook is expensive and this can cause compile
+    # time to regress significantly.
     def _node_metadata_hook(
         node: torch.fx.Node,
         stack_trace: Optional[str] = None,
         nn_module_stack: Optional[dict[str, Any]] = None,
         custom: Optional[dict[str, Any]] = None,
+        skip_val: bool = False,
     ) -> None:
-        fake_args = pytree.tree_map(
-            lambda arg: (
-                _get_example_value(arg) if isinstance(arg, torch.fx.Node) else arg
-            ),
-            node.args,
-        )
-        try:
-            target = node.target
-            if node.op == "call_method":
-                if not isinstance(node.target, str):
-                    raise AssertionError(
-                        f"Expected str target, got {type(node.target)}"
-                    )
-                target = getattr(fake_args[0], node.target)
-                fake_args = fake_args[1:]
-            node.meta[val_key] = target(*fake_args)  # type: ignore[operator]
-        except NotImplementedError:
-            # This can happen when attempting to reify a symbol with an unsupported call_function node,
-            # e.g. with NestedTensors + sym_size.int via match_symbol().
-            # This seems to be fine, as the node gets CSE'd and deleted later in favor of a SymInt graph input.
-            pass
-        except torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode:
-            # This can happen when node args are symints
-            # e.g. test/dynamo/test_export.py -k test_export_preserve_constraints_as_metadata_tensor
-            # aten.sym_constrain_range_for_size(u0)
-            pass
+        if not skip_val:
+            fake_args = pytree.tree_map(
+                lambda arg: (
+                    _get_example_value(arg) if isinstance(arg, torch.fx.Node) else arg
+                ),
+                node.args,
+            )
+            try:
+                target = node.target
+                if node.op == "call_method":
+                    if not isinstance(node.target, str):
+                        raise AssertionError(
+                            f"Expected str target, got {type(node.target)}"
+                        )
+                    target = getattr(fake_args[0], node.target)
+                    fake_args = fake_args[1:]
+                node.meta[val_key] = target(*fake_args)  # type: ignore[operator]
+            except NotImplementedError:
+                # This can happen when attempting to reify a symbol with an unsupported call_function node,
+                # e.g. with NestedTensors + sym_size.int via match_symbol().
+                # This seems to be fine, as the node gets CSE'd and deleted later in favor of a SymInt graph input.
+                pass
         if stack_trace is not None:
             node.meta["stack_trace"] = stack_trace
         if nn_module_stack is not None:
@@ -268,17 +269,28 @@ def insert_deferred_runtime_asserts(
             else:
                 # Convert the sympy expression into a sequence of FX
                 # nodes
-                res = _sympy_interp(expr_to_proxy, ra.expr).node
-
-                graph.call_function(
-                    torch.ops.aten._assert_scalar.default,
-                    # TODO: use ra.msg here, but it's pretty
-                    # useless right now
-                    (
-                        res,
-                        f"Runtime assertion failed for expression {ra.expr} on node '{res}'",
+                with _set_node_metadata_hook(
+                    gm,
+                    functools.partial(
+                        _node_metadata_hook,
+                        stack_trace=node.meta.get("stack_trace"),
+                        nn_module_stack=node.meta.get("nn_module_stack"),
+                        # nodes added in `apply_runtime_assertion_pass` will have the same annotation
+                        # as the input node to the assertion
+                        custom=node.meta.get("custom"),
                     ),
-                )
+                ):
+                    res = _sympy_interp(expr_to_proxy, ra.expr).node
+
+                    graph.call_function(
+                        torch.ops.aten._assert_scalar.default,
+                        # TODO: use ra.msg here, but it's pretty
+                        # useless right now
+                        (
+                            res,
+                            f"Runtime assertion failed for expression {ra.expr} on node '{res}'",
+                        ),
+                    )
                 added_asserts.add(ra.expr)
 
     nodes = list(graph.nodes)
@@ -286,19 +298,8 @@ def insert_deferred_runtime_asserts(
         # Placeholders can match symbols, but when we destructure them
         # with size we have to make sure we insert the nodes after all
         # the placeholders
-        with (
-            graph.inserting_before(
-                nodes[i + 1] if node not in placeholders else first_non_placeholder
-            ),
-            _set_node_metadata_hook(
-                gm,
-                functools.partial(
-                    _node_metadata_hook,
-                    stack_trace=node.meta.get("stack_trace"),
-                    nn_module_stack=node.meta.get("nn_module_stack"),
-                    custom=node.meta.get("custom"),
-                ),
-            ),
+        with graph.inserting_before(
+            nodes[i + 1] if node not in placeholders else first_non_placeholder
         ):
             # Unfortunately, this logic still must remain because manual
             # make_fx calls may not explicitly bind all symbolic ints as
@@ -318,7 +319,18 @@ def insert_deferred_runtime_asserts(
                         )
                         and s not in expr_to_proxy
                     ):
-                        expr_to_proxy[s] = fx.Proxy(cb(), tracer=tracer)
+                        with _set_node_metadata_hook(
+                            gm,
+                            functools.partial(
+                                _node_metadata_hook,
+                                stack_trace=node.meta.get("stack_trace"),
+                                nn_module_stack=node.meta.get("nn_module_stack"),
+                                # nodes added in `apply_runtime_assertion_pass` will have the same annotation
+                                # as the input node to the assertion
+                                custom=node.meta.get("custom"),
+                            ),
+                        ):
+                            expr_to_proxy[s] = fx.Proxy(cb(), tracer=tracer)
 
                         log.debug("expr_to_proxy[%s] = %s", s, expr_to_proxy[s])
 
@@ -413,10 +425,21 @@ def insert_deferred_runtime_asserts(
                     if _is_intermediate_tensor_sym_call(
                         node
                     ):  # reify from input shapes
-                        expr_to_proxy[sym_expr] = _sympy_interp(
-                            expr_to_proxy,
-                            sym_expr,
-                        )  # type: ignore[arg-type]
+                        with _set_node_metadata_hook(
+                            gm,
+                            functools.partial(
+                                _node_metadata_hook,
+                                stack_trace=node.meta.get("stack_trace"),
+                                nn_module_stack=node.meta.get("nn_module_stack"),
+                                # nodes added in `apply_runtime_assertion_pass` will have the same annotation
+                                # as the input node to the assertion
+                                custom=node.meta.get("custom"),
+                            ),
+                        ):
+                            expr_to_proxy[sym_expr] = _sympy_interp(
+                                expr_to_proxy,
+                                sym_expr,
+                            )  # type: ignore[arg-type]
                         # won't try DCE-ing tensor compute here
                     hash_node = expr_to_proxy[sym_expr].node  # type: ignore[arg-type]
                     node.replace_all_uses_with(hash_node)
@@ -536,7 +559,20 @@ def insert_deferred_runtime_asserts(
                             raise AssertionError(f"unrecognized keypath {keypath}")
 
                     if s not in expr_to_proxy:
-                        expr_to_proxy[s] = fx.Proxy(go(node, keypath), tracer=tracer)
+                        with _set_node_metadata_hook(
+                            gm,
+                            functools.partial(
+                                _node_metadata_hook,
+                                stack_trace=node.meta.get("stack_trace"),
+                                nn_module_stack=node.meta.get("nn_module_stack"),
+                                # nodes added in `apply_runtime_assertion_pass` will have the same annotation
+                                # as the input node to the assertion
+                                custom=node.meta.get("custom"),
+                            ),
+                        ):
+                            expr_to_proxy[s] = fx.Proxy(
+                                go(node, keypath), tracer=tracer
+                            )
                         log.debug("expr_to_proxy[%s] = %s", s, expr_to_proxy[s])
 
             for i0 in defs:
@@ -608,26 +644,37 @@ def insert_deferred_runtime_asserts(
                         # TODO(pianpwk): calling sym_constrain_range_for_size or adding bound asserts
                         # raises AOTAutograd errors on cast_symbool_to_symint_guardless
 
-                        if (min_val := convert(vr.lower)) is not None:
-                            ge = _sympy_interp(expr_to_proxy, i0 >= min_val).node
-                            graph.call_function(
-                                torch.ops.aten._assert_scalar.default,
-                                (
-                                    ge,
-                                    f"Runtime assertion failed for expression {i0 >= min_val} on node '{ge}'",
-                                ),
-                            )
-                            added_asserts.add(i0 >= min_val)
-                        if (max_val := convert(vr.upper)) is not None:
-                            le = _sympy_interp(expr_to_proxy, i0 <= max_val).node
-                            graph.call_function(
-                                torch.ops.aten._assert_scalar.default,
-                                (
-                                    le,
-                                    f"Runtime assertion failed for expression {i0 <= max_val} on node '{le}'",
-                                ),
-                            )
-                            added_asserts.add(i0 <= max_val)
+                        with _set_node_metadata_hook(
+                            gm,
+                            functools.partial(
+                                _node_metadata_hook,
+                                stack_trace=node.meta.get("stack_trace"),
+                                nn_module_stack=node.meta.get("nn_module_stack"),
+                                # nodes added in `apply_runtime_assertion_pass` will have the same annotation
+                                # as the input node to the assertion
+                                custom=node.meta.get("custom"),
+                            ),
+                        ):
+                            if (min_val := convert(vr.lower)) is not None:
+                                ge = _sympy_interp(expr_to_proxy, i0 >= min_val).node
+                                graph.call_function(
+                                    torch.ops.aten._assert_scalar.default,
+                                    (
+                                        ge,
+                                        f"Runtime assertion failed for expression {i0 >= min_val} on node '{ge}'",
+                                    ),
+                                )
+                                added_asserts.add(i0 >= min_val)
+                            if (max_val := convert(vr.upper)) is not None:
+                                le = _sympy_interp(expr_to_proxy, i0 <= max_val).node
+                                graph.call_function(
+                                    torch.ops.aten._assert_scalar.default,
+                                    (
+                                        le,
+                                        f"Runtime assertion failed for expression {i0 <= max_val} on node '{le}'",
+                                    ),
+                                )
+                                added_asserts.add(i0 <= max_val)
 
                 constrained_unbacked_symbols.add(i0)
                 add_runtime_asserts(ras)


### PR DESCRIPTION
A reland of https://github.com/pytorch/pytorch/pull/169497

Added a unit test for models with a lot of submodules, which test that the runtime assert pass should not take a large fraction of total compilation time.

```
 python test/dynamo/test_dynamo_runtime_assert.py 
```

This diff fixes a compile-time performance regression ([S603290](https://www.internalfb.com/google_autolink/S603290)) in insert_deferred_runtime_asserts and propagates custom annotations to runtime assert nodes.
The _set_node_metadata_hook context manager is expensive because it iterates over gm.modules() on both enter and exit. Previously, it was called for every node in the graph loop, even when no runtime assertions were created, resulting in O(nodes × modules) cost. For models with many submodules (e.g., recommendation models with inline_inbuilt_nn_modules=False), this dominated compile time.
The fix moves _set_node_metadata_hook calls to only the specific points where new assertion nodes are actually being created, eliminating the overhead for all nodes that don't generate assertions.
Additionally, the custom metadata field from torch.fx.traceback.annotate is now propagated to runtime assert nodes, enabling annotation-based traceability on generated checks.
Reland of https://github.com/pytorch/pytorch/pull/169497.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo