### PR TITLE
[ROCm][CI] Remove ciflow/rocm and ciflow/inductor-rocm triggers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -155,7 +155,7 @@
 - test/inductor/test_max_autotune.py
 - third_party/fbgemm
 
-"ciflow/rocm":
+"ciflow/rocm-mi300":
 - test/test_matmul_cuda.py
 - test/test_scaled_matmul_cuda.py
 - test/inductor/test_fp8.py

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -23,7 +23,6 @@ ciflow_push_tags:
 - ciflow/inductor-perf-test-nightly-x86-zen
 - ciflow/inductor-perf-test-nightly-xpu
 - ciflow/inductor-periodic
-- ciflow/inductor-rocm
 - ciflow/inductor-rocm-mi200
 - ciflow/inductor-rocm-mi300
 - ciflow/linux-aarch64
@@ -36,7 +35,6 @@ ciflow_push_tags:
 - ciflow/pull
 - ciflow/quantization-periodic
 - ciflow/riscv64
-- ciflow/rocm
 - ciflow/rocm-mi200
 - ciflow/rocm-mi300
 - ciflow/rocm-mi355

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -22,7 +22,6 @@ LABEL_CIFLOW_BINARIES = "ciflow/binaries"
 LABEL_CIFLOW_PERIODIC = "ciflow/periodic"
 LABEL_CIFLOW_BINARIES_LIBTORCH = "ciflow/binaries_libtorch"
 LABEL_CIFLOW_BINARIES_WHEEL = "ciflow/binaries_wheel"
-LABEL_CIFLOW_ROCM = "ciflow/rocm"
 
 
 @dataclass

--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -6,7 +6,6 @@ on:
       - main
       - release/*
     tags:
-      - ciflow/inductor-rocm/*
       - ciflow/inductor-rocm-mi300/*
   workflow_dispatch:
 

--- a/.github/workflows/rocm-mi300.yml
+++ b/.github/workflows/rocm-mi300.yml
@@ -6,7 +6,6 @@ on:
       - main
       - release/*
     tags:
-      - ciflow/rocm/*
       - ciflow/rocm-mi300/*
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Use only the arch-specific one to prevent double triggering the workflows if both ciflow labels are added. For eg. `ciflow/rocm` was being added by default for any PRs matching "rocm" in the title (until that was replaced with `ciflow/rocm-mi300` in https://github.com/pytorch/test-infra/pull/7578). If a dev would add `ciflow/rocm-mi300` on the same PR, it would double-trigger the same workflow rocm-mi300.yml.


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang