### PR TITLE
Speedup grouped_mm a bit

### DIFF
--- a/aten/src/ATen/native/cuda/GroupMM.cu
+++ b/aten/src/ATen/native/cuda/GroupMM.cu
@@ -133,7 +133,7 @@ void bf16bf16_grouped_gemm_impl_sm90_sm100(
           cutlass::epilogue::collective::EpilogueTileAuto,
           DtypeAccum,
           DtypeAccum,
-          DtypeOutput,
+          void, // Indicate there is no beta scaling to save register
           LayoutOutput*,
           AlignmentOutput,
           DtypeOutput,
@@ -283,7 +283,7 @@ void bf16bf16_grouped_gemm_impl_sm90_sm100(
        (const DtypeB**)inputB_ptrs,
        stride_B},
       {{},
-       (const DtypeOutput**)output_ptrs,
+       nullptr,
        stride_output,
        output_ptrs,
        stride_output}};


### PR DESCRIPTION
By indicating that ElementC type is void, that avoids some redundant IO/compute and slightly improves perf

Idea stolen from [CUTLASS unit tests](https://github.com/NVIDIA/cutlass/blob/b84e9802d84b16bcb4e92338fcf0a04785df9236/test/unit/gemm/device/sm100_tensorop_gemm/f16_f16_void_f32.cu#L143)
Observe perf improvements for 4 group 32768x7168x4096 operation from 1237 to 1313 TFlops