### PR TITLE
[inductor][triton_kernel_wrap] Return TensorBox values when Triton compile failed in `identify_mutated_tensors()`

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -114,6 +114,35 @@ class KernelTests(torch._inductor.test_case.TestCase):
         # not crash
 
     @requires_gpu
+    def test_triton_kernel_ill_formed(self):
+        @triton.jit
+        def ill_formed_kernel(kernel):
+            off_n = tl.program_id(0)
+            seq_len_a = 5
+            if off_n < seq_len_a:
+                out_row_idx = off_n + seq_len_a
+            else:
+                out_row_idx = (off_n + seq_len_a).to(tl.int64)
+            tl.store(kernel, out_row_idx)
+
+        @torch.compile(backend="inductor")
+        def f(x):
+            grid = (x.numel(),)
+            ill_formed_kernel[grid](kernel=x)
+
+        catch_error = False
+        try:
+            t1 = torch.rand(5, device=GPU_TYPE)
+            f(t1)
+        except torch._inductor.exc.InductorError as e:
+            if isinstance(e.inner_exception, triton.compiler.errors.CompilationError):
+                catch_error = True
+        finally:
+            # we assert user custom Triton kernel compile error can be captured
+            # after torch.compile
+            self.assertTrue(catch_error)
+
+    @requires_gpu
     def test_triton_kernel_higher_order_func(self):
         from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -984,6 +984,8 @@ def identify_mutated_tensors(
             ordered_tensor_names[i] for i, mutated in enumerate(mutations) if mutated
         ]
     except Exception:
+        import torch._inductor.ir
+
         log.warning(
             "Encountered an exception in identify_mutated_tensors, assuming every input is mutated",
             exc_info=True,
@@ -996,7 +998,11 @@ def identify_mutated_tensors(
                 log.debug("===\t%s\t===", name)
                 for ret, ops in fn.items():
                     log.debug("%s\t=>\t%s", ret, ops)
-        return [key for key, value in kwargs.items() if isinstance(value, Tensor)]
+        return [
+            key
+            for key, value in kwargs.items()
+            if isinstance(value, (Tensor, torch._inductor.ir.TensorBox))
+        ]
 
 
 ###############################################################################


### PR DESCRIPTION
Summary:
Following-up on https://fb.workplace.com/groups/385893200869952/posts/831929169599684/

Return mutated tensorboxs when the Triton compile failed.

At https://www.internalfb.com/code/fbsource/[e1ad4b70c1c0e165fa662e47f19a2b1316007f70]/fbcode/caffe2/torch/_inductor/ir.py?lines=7135, the IR node UserDefinedTritonKernel is calling `identify_mutated_tensors()` to identify mutated tensors.

In `identify_mutated_tensors()`, when the Triton compile failed, it is conservatively saving all Tensors into mutable list.

However, when constructing the UserDefinedTritonKernel IR node in GraphLowering, the GraphLowering node contains TensorBox instead of Tensors. In this case, we need to conservatively place TensorBox values into mutable_args, otherwise, the ill-formed Triton kernel will be removed by dead code elimination, causing it to silently ignore Triton kernel call in the generated code.

Ignoring user-custom Triton kernel call silently is dangerous, for example, when we benchmark the model, it will return unrealisticly fast performance, since the kernel is silently eliminated.

Test Plan:
Depend on D87983277:

```
TORCH_TRACE=~/tlparse_logs TORCH_LOGS=+inductor,output_code buck2 run -c fbcode.nvcc_arch=b200a -c fbcode.platform010_cuda_version=12.8 mode/opt //pytorch/tritonbench/benchmarks:split_2d_jagged
```

Before this Diff: finishes without error

After (crash is expected):

```
V1218 10:36:04.238000 3240180 /data/users/xzhao9/fbsource/fbcode/caffe2/torch/_inductor/graph.py:2468] [0/0] [__output_code]     compiled_module_main('None', benchmark_compiled_module)
V1218 10:36:04.238000 3240180 /data/users/xzhao9/fbsource/fbcode/caffe2/torch/_inductor/graph.py:2468] [0/0] [__output_code] 
V1218 10:36:04.239000 3240180 /data/users/xzhao9/fbsource/fbcode/caffe2/torch/_inductor/graph.py:2479] [0/0] [__output_code] Output code written to: /var/tmp/torchinductor_xzhao9/xd/cxd3vqy2cj63ylrkneemz3ddwkqwc3bcbmavjlgri5t7dipsjt5o.py
  0%|                                                                                                                                                                                     | 0/1 [00:09<?, ?it/s]
WARNING:tritonbench.utils.triton_op:Caught exception on backend triton_kernel, terminating early with partial results
Traceback (most recent call last):
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/tritonbench/utils/triton_op.py", line 1147, in run
    y_vals: Dict[str, BenchmarkOperatorMetrics] = functools.reduce(
                                                  ^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/tritonbench/utils/triton_op.py", line 1128, in _reduce_benchmarks
    acc[bm_name] = self._do_bench(
                   ^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/tritonbench/utils/triton_op.py", line 1712, in _do_bench
    metrics.latency = do_bench_wrapper(
                      ^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/tritonbench/components/do_bench/run.py", line 734, in do_bench_wrapper
    raise e
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/tritonbench/components/do_bench/run.py", line 724, in do_bench_wrapper
    times=bench_fn(
          ^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/triton/testing.py", line 149, in do_bench
    fn()
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/pytorch/tritonbench/benchmarks/split_2d_jagged/run.py", line 633, in _impl
    return model(*inputs)
           ^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_dynamo/eval_frame.py", line 441, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/nn/modules/module.py", line 1789, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_dynamo/eval_frame.py", line 940, in compile_wrapper
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/compile_fx.py", line 1017, in _compile_fx_inner
    raise InductorError(e, currentframe()).with_traceback(
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/compile_fx.py", line 1001, in _compile_fx_inner
    mb_compiled_graph = fx_codegen_and_compile(
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/compile_fx.py", line 1768, in fx_codegen_and_compile
    return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/compile_fx.py", line 1548, in codegen_and_compile
    compiled_module = graph.compile_to_module()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/graph.py", line 2415, in compile_to_module
    return self._compile_to_module()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/graph.py", line 2425, in _compile_to_module
    mod = self._compile_to_module_lines(wrapper_code)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/graph.py", line 2500, in _compile_to_module_lines
    mod = PyCodeCache.load_by_key_path(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/codecache.py", line 3673, in load_by_key_path
    mod = _reload_python_module(key, path, set_sys_modules=in_toplevel)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/compile_tasks.py", line 35, in _reload_python_module
    exec(code, mod.__dict__, mod.__dict__)
  File "/var/tmp/torchinductor_xzhao9/xd/cxd3vqy2cj63ylrkneemz3ddwkqwc3bcbmavjlgri5t7dipsjt5o.py", line 173, in <module>
    async_compile.wait(globals())
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/async_compile.py", line 649, in wait
    self._wait_futures(scope)
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/async_compile.py", line 669, in _wait_futures
    kernel = result.result()
             ^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/codecache.py", line 4416, in result
    return self.result_fn()
           ^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/async_compile.py", line 438, in get_result
    raise e.with_name(kernel_name) from e
torch._inductor.exc.InductorError: SubprocException: An exception occurred in a subprocess:

Name=triton_split_2d_jagged_kernel
Traceback (most recent call last):
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/compile_worker/subproc_pool.py", line 457, in do_job
    result = job()
             ^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/compile_tasks.py", line 68, in _worker_compile_triton
    kernel.precompile(warm_cache_only=True)
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/triton_heuristics.py", line 427, in precompile
    self._precompile_worker()
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/triton_heuristics.py", line 458, in _precompile_worker
    compile_results.append(self._precompile_config(c))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/triton_heuristics.py", line 804, in _precompile_config
    binary = triton.compile(*compile_args, **compile_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/triton/compiler/compiler.py", line 356, in compile
    module = src.make_ir(options, codegen_fns, module_map, context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/triton/compiler/compiler.py", line 83, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
triton.compiler.errors.CompilationError: at 103:4:
        input_row_idx = seq_start + off_n
        # Compute input pointer - optimized for coalesced memory access
        # Memory layout: [L, D] with stride_id for row dimension
        # offs_d provides consecutive offsets within the row for coalescing
        in_ptrs = In + input_row_idx.to(tl.int64) * stride_id + offs_d
        # Load with mask - only load valid feature dimensions
        v = tl.load(in_ptrs, mask=mask_d, other=0.0)
    # Store to appropriate output based on position
    # Branch on off_n to route data to output A or B
    # Note: This branch is data-dependent but necessary for the split operation
    # Modern GPUs handle this efficiently through predication
    if off_n < seq_len_a:
    ^
AssertionError('Mismatched type for out_row_idx between then block (int32) and else block (fp32)')


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

WARNING:tritonbench.utils.triton_op:Failing input: --input-id 0 --num-inputs 1 --input-sample-mode first-k
🧪 ERROR: Test failed with exception: SubprocException: An exception occurred in a subprocess:

Name=triton_split_2d_jagged_kernel
Traceback (most recent call last):
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/compile_worker/subproc_pool.py", line 457, in do_job
    result = job()
             ^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/compile_tasks.py", line 68, in _worker_compile_triton
    kernel.precompile(warm_cache_only=True)
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/triton_heuristics.py", line 427, in precompile
    self._precompile_worker()
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/triton_heuristics.py", line 458, in _precompile_worker
    compile_results.append(self._precompile_config(c))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/torch/_inductor/runtime/triton_heuristics.py", line 804, in _precompile_config
    binary = triton.compile(*compile_args, **compile_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/triton/compiler/compiler.py", line 356, in compile
    module = src.make_ir(options, codegen_fns, module_map, context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/a21c0b3b7f7e8816/pytorch/tritonbench/benchmarks/__split_2d_jagged__/split_2d_jagged-inplace#link-tree/triton/compiler/compiler.py", line 83, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
triton.compiler.errors.CompilationError: at 103:4:
        input_row_idx = seq_start + off_n
        # Compute input pointer - optimized for coalesced memory access
        # Memory layout: [L, D] with stride_id for row dimension
        # offs_d provides consecutive offsets within the row for coalescing
        in_ptrs = In + input_row_idx.to(tl.int64) * stride_id + offs_d
        # Load with mask - only load valid feature dimensions
        v = tl.load(in_ptrs, mask=mask_d, other=0.0)
    # Store to appropriate output based on position
    # Branch on off_n to route data to output A or B
    # Note: This branch is data-dependent but necessary for the split operation
    # Modern GPUs handle this efficiently through predication
    if off_n < seq_len_a:
    ^
AssertionError('Mismatched type for out_row_idx between then block (int32) and else block (fp32)')


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

```

Reviewed By: oulgen

Differential Revision: D88754383




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo