### PR TITLE
[ONNX] Exportable module

### DIFF
--- a/docs/source/onnx_export.md
+++ b/docs/source/onnx_export.md
@@ -242,6 +242,8 @@ Each initialized value, input, output has the following metadata:
 .. autofunction:: torch.onnx.export
 .. autoclass:: torch.onnx.ONNXProgram
     :members:
+.. autoclass:: torch.onnx.ExportableModule
+    :members:
 .. autofunction:: torch.onnx.is_in_onnx_export
 .. autoclass:: torch.onnx.OnnxExporterError
     :members:

--- a/test/onnx/exporter/test_exportable_module.py
+++ b/test/onnx/exporter/test_exportable_module.py
@@ -218,9 +218,8 @@ class TestExportableModule(common_utils.TestCase):
             def forward(self, x):
                 return x * 2
 
-        model = IncompleteExportableModel()
-        with self.assertRaises(NotImplementedError):
-            model.example_arguments()
+        with self.assertRaises(TypeError):
+            IncompleteExportableModel()
 
     def test_forward_with_complex_inputs(self):
         """Test ExportableModule with more complex input types."""

--- a/test/onnx/exporter/test_exportable_module.py
+++ b/test/onnx/exporter/test_exportable_module.py
@@ -1,0 +1,242 @@
+# Owner(s): ["module: onnx"]
+"""Unit tests for ExportableModule."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch.onnx._internal.exporter import _exportable_module
+from torch.testing._internal import common_utils
+
+
+class SimpleExportableModel(_exportable_module.ExportableModule):
+    """A simple concrete implementation of ExportableModule for testing."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
+        return (torch.randn(2, 10),), None
+
+
+class ExportableModelWithKwargs(_exportable_module.ExportableModule):
+    """ExportableModule with keyword arguments."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 5)
+
+    def forward(self, x, scale: float = 1.0):
+        return self.linear(x) * scale
+
+    def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
+        return (torch.randn(2, 10),), {"scale": 2.0}
+
+
+class ExportableModelWithDynamicShapes(_exportable_module.ExportableModule):
+    """ExportableModule with dynamic shapes."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
+        return (torch.randn(2, 10),), None
+
+    def dynamic_shapes(self):
+        return {"x": {0: "batch_size"}}
+
+
+class ExportableModelWithNames(_exportable_module.ExportableModule):
+    """ExportableModule with input and output names."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
+        return (torch.randn(2, 10),), None
+
+    def input_names(self):
+        return ["input_tensor"]
+
+    def output_names(self):
+        return ["output_tensor"]
+
+
+class ExportableModelMultipleOutputs(_exportable_module.ExportableModule):
+    """ExportableModule with multiple outputs."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(10, 5)
+        self.linear2 = torch.nn.Linear(10, 3)
+
+    def forward(self, x):
+        return self.linear1(x), self.linear2(x)
+
+    def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
+        return (torch.randn(2, 10),), None
+
+    def output_names(self):
+        return ["output1", "output2"]
+
+
+class TestExportableModule(common_utils.TestCase):
+    """Tests for ExportableModule abstract class and its implementations."""
+
+    def test_abstract_class_cannot_be_instantiated(self):
+        """Test that ExportableModule cannot be instantiated directly."""
+        with self.assertRaises(TypeError):
+            _exportable_module.ExportableModule()
+
+    def test_simple_exportable_model(self):
+        """Test basic ExportableModule implementation."""
+        model = SimpleExportableModel()
+        self.assertIsInstance(model, torch.nn.Module)
+        self.assertIsInstance(model, _exportable_module.ExportableModule)
+
+        # Test example_arguments
+        args, kwargs = model.example_arguments()
+        self.assertIsInstance(args, tuple)
+        self.assertEqual(len(args), 1)
+        self.assertIsNone(kwargs)
+
+        # Test forward pass
+        output = model(*args)
+        self.assertEqual(output.shape, (2, 5))
+
+    def test_exportable_model_with_kwargs(self):
+        """Test ExportableModule with keyword arguments."""
+        model = ExportableModelWithKwargs()
+
+        args, kwargs = model.example_arguments()
+        self.assertIsInstance(args, tuple)
+        self.assertIsInstance(kwargs, dict)
+        self.assertEqual(kwargs["scale"], 2.0)
+
+        # Test forward pass with kwargs
+        output = model(*args, **kwargs)
+        self.assertEqual(output.shape, (2, 5))
+
+    def test_dynamic_shapes_default(self):
+        """Test that dynamic_shapes returns None by default."""
+        model = SimpleExportableModel()
+        self.assertIsNone(model.dynamic_shapes())
+
+    def test_dynamic_shapes_custom(self):
+        """Test custom dynamic_shapes implementation."""
+        model = ExportableModelWithDynamicShapes()
+        dynamic_shapes = model.dynamic_shapes()
+        self.assertIsNotNone(dynamic_shapes)
+        self.assertIsInstance(dynamic_shapes, dict)
+        self.assertIn("x", dynamic_shapes)
+
+    def test_input_names_default(self):
+        """Test that input_names returns None by default."""
+        model = SimpleExportableModel()
+        self.assertIsNone(model.input_names())
+
+    def test_output_names_default(self):
+        """Test that output_names returns None by default."""
+        model = SimpleExportableModel()
+        self.assertIsNone(model.output_names())
+
+    def test_input_output_names_custom(self):
+        """Test custom input_names and output_names implementation."""
+        model = ExportableModelWithNames()
+
+        input_names = model.input_names()
+        self.assertIsNotNone(input_names)
+        self.assertEqual(len(input_names), 1)
+        self.assertEqual(input_names[0], "input_tensor")
+
+        output_names = model.output_names()
+        self.assertIsNotNone(output_names)
+        self.assertEqual(len(output_names), 1)
+        self.assertEqual(output_names[0], "output_tensor")
+
+    def test_multiple_outputs(self):
+        """Test ExportableModule with multiple outputs."""
+        model = ExportableModelMultipleOutputs()
+
+        args, kwargs = model.example_arguments()
+        output1, output2 = model(*args)
+        self.assertEqual(output1.shape, (2, 5))
+        self.assertEqual(output2.shape, (2, 3))
+
+        output_names = model.output_names()
+        self.assertEqual(len(output_names), 2)
+        self.assertEqual(output_names[0], "output1")
+        self.assertEqual(output_names[1], "output2")
+
+    def test_to_onnx_calls_export(self):
+        """Test that to_onnx correctly calls torch.onnx.export."""
+        model = SimpleExportableModel()
+
+        # This test verifies that to_onnx returns an ONNXProgram
+        # The actual export functionality is tested elsewhere
+        try:
+            onnx_program = model.to_onnx(dynamo=True, fallback=False)
+            self.assertIsNotNone(onnx_program)
+            self.assertIsInstance(onnx_program, torch.onnx.ONNXProgram)
+        except Exception as e:
+            # If export fails for environmental reasons, skip this test
+            # The important part is that the method exists and calls export
+            if "dynamo" not in str(e).lower():
+                raise
+
+    def test_exportable_module_is_nn_module(self):
+        """Test that ExportableModule is a proper nn.Module."""
+        model = SimpleExportableModel()
+
+        # Test that it has standard nn.Module methods
+        self.assertTrue(hasattr(model, "parameters"))
+        self.assertTrue(hasattr(model, "named_parameters"))
+        self.assertTrue(hasattr(model, "state_dict"))
+        self.assertTrue(hasattr(model, "load_state_dict"))
+
+        # Test that parameters work correctly
+        params = list(model.parameters())
+        self.assertGreater(len(params), 0)
+
+    def test_example_arguments_must_be_implemented(self):
+        """Test that example_arguments must be implemented by subclasses."""
+
+        class IncompleteExportableModel(_exportable_module.ExportableModule):
+            def forward(self, x):
+                return x * 2
+
+        model = IncompleteExportableModel()
+        with self.assertRaises(NotImplementedError):
+            model.example_arguments()
+
+    def test_forward_with_complex_inputs(self):
+        """Test ExportableModule with more complex input types."""
+
+        class ComplexInputModel(_exportable_module.ExportableModule):
+            def forward(self, x, y):
+                return x + y
+
+            def example_arguments(self):
+                return (torch.randn(2, 3), torch.randn(2, 3)), None
+
+        model = ComplexInputModel()
+        args, kwargs = model.example_arguments()
+        output = model(*args)
+        self.assertEqual(output.shape, (2, 3))
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+
 __all__ = [
     # Modules
     "errors",
@@ -25,8 +26,8 @@ from torch._C._onnx import (  # Deprecated members that are excluded from __all_
 )
 
 from . import errors, ops
-from ._internal.exporter._onnx_program import ONNXProgram
 from ._internal.exporter._exportable_module import ExportableModule
+from ._internal.exporter._onnx_program import ONNXProgram
 from ._internal.torchscript_exporter import (  # Deprecated members that are excluded from __all__
     symbolic_helper,
     symbolic_opset10,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 
 # Set namespace for exposed private names
 ONNXProgram.__module__ = "torch.onnx"
+ExportableModule.__module__ = "torch.onnx"
 OnnxExporterError.__module__ = "torch.onnx"
 
 # TODO(justinchuby): Remove these two properties

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-
 __all__ = [
     # Modules
     "errors",
@@ -12,6 +11,7 @@ __all__ = [
     # Base error
     "OnnxExporterError",
     "ONNXProgram",
+    "ExportableModule",
 ]
 
 from typing import Any, TYPE_CHECKING
@@ -26,6 +26,7 @@ from torch._C._onnx import (  # Deprecated members that are excluded from __all_
 
 from . import errors, ops
 from ._internal.exporter._onnx_program import ONNXProgram
+from ._internal.exporter._exportable_module import ExportableModule
 from ._internal.torchscript_exporter import (  # Deprecated members that are excluded from __all__
     symbolic_helper,
     symbolic_opset10,
@@ -278,7 +279,9 @@ def export(
     .. versionchanged:: 2.9
         *dynamo* is now True by default.
     """
-    if dynamo is True or isinstance(model, torch.export.ExportedProgram):
+    if dynamo is True or isinstance(
+        model, (torch.export.ExportedProgram, ExportableModule)
+    ):
         from torch.onnx._internal.exporter import _compat
 
         if isinstance(args, torch.Tensor):

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -17,6 +17,7 @@ from torch.onnx._internal.exporter import (
     _constants,
     _core,
     _dynamic_shapes,
+    _exportable_module,
     _onnx_program,
     _registration,
 )
@@ -84,6 +85,17 @@ def export_compat(
                 UserWarning,
                 stacklevel=3,
             )
+
+    if isinstance(model, _exportable_module.ExportableModule):
+        # Skip argument extraction if args or kwargs are provided
+        if not args and not kwargs:
+            args, kwargs = model.example_arguments()
+            if input_names is None:
+                input_names = model.input_names()
+            if output_names is None:
+                output_names = model.output_names()
+            if dynamic_shapes is None:
+                dynamic_shapes = model.dynamic_shapes()
 
     if isinstance(model, torch.export.ExportedProgram):
         # We know the model is already exported program, so the args, kwargs, and dynamic_shapes

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -23,7 +23,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
             def forward(self, x):
                 return x * 2
 
-
         class MyExportableModule(torch.onnx.ExportableModule):
             def __init__(self):
                 super().__init__()

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -43,7 +43,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
             def dynamic_shapes(self):
                 return ({0: "batch_size"},)
 
-
         exportable_module = MyExportableModule()
         onnx_program = exportable_module.to_onnx()
         # The model can also be supplied directly to torch.onnx.export

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -19,9 +19,11 @@ class ExportableModule(torch.nn.Module, abc.ABC):
     to create a module that can be exported to ONNX format.
 
     Example::
+
         class Model(torch.nn.Module):
             def forward(self, x):
                 return x * 2
+
 
         class MyExportableModule(torch.onnx.ExportableModule):
             def __init__(self):
@@ -43,6 +45,7 @@ class ExportableModule(torch.nn.Module, abc.ABC):
             def dynamic_shapes(self):
                 return ({0: "batch_size"},)
 
+
         exportable_module = MyExportableModule()
         onnx_program = exportable_module.to_onnx()
         # The model can also be supplied directly to torch.onnx.export
@@ -58,11 +61,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         arguments should be representative of the expected input shapes and types
         during inference.
 
-        Returns:
-            A tuple containing:
-                - A tuple of positional arguments to pass to the forward method
-                - A dictionary of keyword arguments (or None if no kwargs are needed)
-
         Example::
 
             def example_arguments(self):
@@ -75,6 +73,12 @@ class ExportableModule(torch.nn.Module, abc.ABC):
                 return (torch.randn(1, 3, 224, 224), torch.randn(1, 512)), {
                     "temperature": 1.0
                 }
+
+        Returns:
+            A tuple containing:
+
+            - A tuple of positional arguments to pass to the forward method
+            - A dictionary of keyword arguments (or None if no kwargs are needed)
         """
         raise NotImplementedError
 
@@ -84,13 +88,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         Override this method to specify which dimensions of the input tensors
         should be treated as dynamic during ONNX export. This allows the exported
         model to accept inputs with varying sizes along the specified dimensions.
-
-        Returns:
-            Dynamic shape specification compatible with ``torch.export.export``.
-            Return None if all input dimensions should be static. The format can be:
-                - A dictionary mapping input names to dimension specifications
-                - A tuple/list of dimension specifications corresponding to inputs
-                - Any format accepted by the ``dynamic_shapes`` parameter of ``torch.export.export``
 
         Example::
 
@@ -108,6 +105,14 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
         Note:
             The default implementation returns None, indicating all dimensions are static.
+
+        Returns:
+            Dynamic shape specification compatible with ``torch.export.export``.
+            Return None if all input dimensions should be static. The format can be:
+
+            - A dictionary mapping input names to dimension specifications
+            - A tuple/list of dimension specifications corresponding to inputs
+            - Any format accepted by the ``dynamic_shapes`` parameter of ``torch.export.export``
         """
         return None
 
@@ -117,11 +122,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         Override this method to provide custom names for the input tensors in the
         exported ONNX model. These names will be used as identifiers in the ONNX
         graph and can be useful for debugging and model inspection.
-
-        Returns:
-            A sequence of strings representing input names, or None to use default names.
-            The number of names should match the number of positional arguments in the
-            forward method.
 
         Example::
 
@@ -135,6 +135,11 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
         Note:
             The default implementation returns None, which results in auto-generated names.
+
+        Returns:
+            A sequence of strings representing input names, or None to use default names.
+            The number of names should match the number of positional arguments in the
+            forward method.
         """
         return None
 
@@ -144,11 +149,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         Override this method to provide custom names for the output tensors in the
         exported ONNX model. These names will be used as identifiers in the ONNX
         graph and can be useful for debugging and model inspection.
-
-        Returns:
-            A sequence of strings representing output names, or None to use default names.
-            The number of names should match the number of outputs from the forward method.
-            For models returning multiple outputs, provide a name for each output.
 
         Example::
 
@@ -162,6 +162,11 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
         Note:
             The default implementation returns None, which results in auto-generated names.
+
+        Returns:
+            A sequence of strings representing output names, or None to use default names.
+            The number of names should match the number of outputs from the forward method.
+            For models returning multiple outputs, provide a name for each output.
         """
         return None
 
@@ -173,6 +178,8 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         names defined by the module. Additional export options can be specified via
         keyword arguments.
 
+        See Also: ``torch.onnx.export`` for complete documentation of export options.
+
         Args:
             **kwargs: Additional keyword arguments to pass to ``torch.onnx.export``.
                 Common options include:
@@ -182,9 +189,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
         Returns:
             An ONNXProgram object containing the exported model and metadata.
-
-        See Also:
-            ``torch.onnx.export`` for complete documentation of export options.
         """
         result = torch.onnx.export(self, **kwargs)
         assert result is not None

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import abc
 from typing import Any, TYPE_CHECKING
+
 import torch
+
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -20,6 +22,7 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         class Model(torch.nn.Module):
             def forward(self, x):
                 return x * 2
+
 
         class MyExportableModule(torch.onnx.ExportableModule):
             def __init__(self):
@@ -40,6 +43,7 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
             def dynamic_shapes(self):
                 return ({0: "batch_size"},)
+
 
         exportable_module = MyExportableModule()
         onnx_program = exportable_module.to_onnx()

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -1,0 +1,27 @@
+"""Abstract interface for ONNX exportable modules."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, TYPE_CHECKING
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class ExportableModule(torch.nn.Module, abc.ABC):
+    """Abstract interface for ONNX exportable modules."""
+
+    @abc.abstractmethod
+    def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
+        raise NotImplementedError
+
+    def dynamic_shapes(self):
+        return None
+
+    def input_names(self) -> Sequence[str] | None:
+        return None
+
+    def output_names(self) -> Sequence[str] | None:
+        return None

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -25,3 +25,17 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
     def output_names(self) -> Sequence[str] | None:
         return None
+
+    def to_onnx(self, **kwargs: Any) -> torch.onnx.ONNXProgram:
+        example_args, example_kwargs = self.example_arguments()
+        result = torch.onnx.export(
+            self,
+            example_args,
+            kwargs=example_kwargs,
+            input_names=self.input_names(),
+            output_names=self.output_names(),
+            dynamic_shapes=self.dynamic_shapes(),
+            **kwargs,
+        )
+        assert result is not None
+        return result

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -48,7 +48,7 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         exportable_module = MyExportableModule()
         onnx_program = exportable_module.to_onnx()
         # The model can also be supplied directly to torch.onnx.export
-        exportable_module = torch.onnx.export(exportable_module)
+        onnx_program = torch.onnx.export(exportable_module)
     """
 
     @abc.abstractmethod

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -56,7 +56,7 @@ class ExportableModule(torch.nn.Module, abc.ABC):
     def example_arguments(self) -> tuple[tuple[Any], dict[str, Any] | None]:
         raise NotImplementedError
 
-    def dynamic_shapes(self):
+    def dynamic_shapes(self) -> Any:
         return None
 
     def input_names(self) -> Sequence[str] | None:

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -180,6 +180,7 @@ class ExportableModule(torch.nn.Module, abc.ABC):
                 Common options include:
 
                 - ``opset_version`` (int): The ONNX opset version to target
+                - ``optimize`` (bool): Whether to apply optimizations to the exported model
 
         Returns:
             An ONNXProgram object containing the exported model and metadata.

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -178,7 +178,8 @@ class ExportableModule(torch.nn.Module, abc.ABC):
         Args:
             **kwargs: Additional keyword arguments to pass to ``torch.onnx.export``.
                 Common options include:
-                    - ``opset_version`` (int): The ONNX opset version to target
+
+                - ``opset_version`` (int): The ONNX opset version to target
 
         Returns:
             An ONNXProgram object containing the exported model and metadata.

--- a/torch/onnx/_internal/exporter/_exportable_module.py
+++ b/torch/onnx/_internal/exporter/_exportable_module.py
@@ -17,15 +17,11 @@ class ExportableModule(torch.nn.Module, abc.ABC):
     to create a module that can be exported to ONNX format.
 
     Example::
-        import torch
-
-
         class Model(torch.nn.Module):
             def forward(self, x):
                 return x * 2
 
-
-        class MyExportableModule(ExportableModule):
+        class MyExportableModule(torch.onnx.ExportableModule):
             def __init__(self):
                 super().__init__()
                 self.model = Model()
@@ -44,7 +40,6 @@ class ExportableModule(torch.nn.Module, abc.ABC):
 
             def dynamic_shapes(self):
                 return ({0: "batch_size"},)
-
 
         exportable_module = MyExportableModule()
         onnx_program = exportable_module.to_onnx()


### PR DESCRIPTION
This pull request introduces the new `ExportableModule` abstract interface for ONNX exportable modules, integrates it into the ONNX export workflow, and provides comprehensive unit tests for its functionality. The changes improve the extensibility and usability of ONNX export by allowing models to define example arguments, dynamic shapes, and input/output names. 

Example:

```py
class Model(torch.nn.Module):
    def forward(self, x):
        return x * 2


class MyExportableModule(torch.onnx.ExportableModule):
    def __init__(self):
        super().__init__()
        self.model = Model()

    def forward(self, x):
        return self.model(x)

    def example_arguments(self):
        return (torch.randn(2, 3, 224, 224),), None

    def input_names(self):
        return ("input",)

    def output_names(self):
        return ("output",)

    def dynamic_shapes(self):
        return ({0: "batch_size"},)


exportable_module = MyExportableModule()
onnx_program = exportable_module.to_onnx()
# The model can also be supplied directly to torch.onnx.export
onnx_program = torch.onnx.export(exportable_module)
```

Fix https://github.com/pytorch/pytorch/issues/165354

cc @titaiwangms