### PR TITLE
Try to avoid sympy with 32 bit indices

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1858,9 +1858,10 @@ class SIMDScheduling(BaseScheduling):
 
         # Only install guards for 32-bit indexing as there is no correctness
         # issue with using 64-bit for everything
-        V.graph.sizevars.check_leq(numel, int_max)  # type: ignore[arg-type]
-        for size in buf_sizes:
-            V.graph.sizevars.check_leq(size, int_max)  # type: ignore[arg-type]
+        for i in (numel, *buf_sizes):
+            # `check_leq` is quite expensive, so for constant values we try to bail out early.
+            if not (isinstance(i, sympy.Integer) and int(i) <= int_max):
+                V.graph.sizevars.check_leq(i, int_max)
         return True
 
     def codegen_node_schedule(self, kernel_features: SIMDKernelFeatures):


### PR DESCRIPTION
Summary: Manipulating SymPy expressions is quite expensive, and it's very common the the symints are just constants. It's also about 100x faster to to check the fast path compared to the full symbolic expression parsing. This saves another 5% off of `GraphLowering.run` for the diode max-autotune case.

Test Plan: Same as prior

Differential Revision: D89199581




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo