### PR TITLE
ProcessGroupGloo: fix CUDA tensor stream handling with futures

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4795,7 +4795,12 @@ class DistributedTest:
 
             # Test a simple linear as well as a ResNet model.
             models_to_test = [
-                nn.Sequential(nn.Linear(3, 3), nn.Linear(3, 3), nn.Linear(3, 3)).cuda()
+                nn.Sequential(nn.Linear(3, 3), nn.Linear(3, 3), nn.Linear(3, 3)).cuda(),
+                # run model of at least 1M parameters to hit potential race conditions in
+                # stream semantics
+                nn.Sequential(
+                    nn.Linear(3, 1024), nn.Linear(1024, 1024), nn.Linear(1024, 3)
+                ).cuda(),
             ]
             if HAS_TORCHVISION:
                 models_to_test.append(torchvision.models.resnet50().cuda())
@@ -4837,7 +4842,7 @@ class DistributedTest:
                     for i in range(8):
                         inp = (
                             torch.randn(1, 3, 1000, 1000, device="cuda")
-                            if j == 1
+                            if j == 2
                             else torch.randn(10, 3, device="cuda")
                         )
                         model(inp).sum().backward()


### PR DESCRIPTION
Fixes #155714

There's a very subtle bug in Gloo where CUDA future streams aren't preserved correctly leading to silent corruption when using Gloo with a CUDA model using the DDP reducer.

Test plan:

```python
import os

RANK = int(os.environ["RANK"])
WORLD_SIZE = int(os.environ["WORLD_SIZE"])
os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["LOCAL_RANK"]

import torch
import torch.distributed as dist

torch.manual_seed(0)

dist.init_process_group("gloo")

N = 10
expected = torch.sum(torch.arange(0, WORLD_SIZE, dtype=torch.float)).item()
t = torch.full((1000000,), RANK, device="cuda", dtype=torch.float)
tensors = [
    t.clone()
    for _ in range(N)
]

futs = []
for tensor in tensors:
    work = dist.all_reduce(tensor, async_op=True)
    futs.append(work.get_future())

# create high priority stream to do the CPU copy and preempt the default stream
stream = torch.cuda.Stream(priority=-1)

for fut, tensor in zip(futs, tensors):
    with torch.cuda.stream(stream):
        fut.wait()
        val = tensor[-1].item()
        assert val == expected, f"Expected {expected}, got {val}"
```

```
torchrun --nnodes 1 --nproc_per_node=gpu ~/scripts/gloo_future_stream.py
```

```
BACKEND=gloo WORLD_SIZE=4 TEMP_DIR=/tmp/foo pytest test/distributed/test_distributed_spawn.py -v -s -x  -k 'test_ddp_apply_optim_in_backward'
```