### PR TITLE
Address LocalTensor test flakines

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1186,11 +1186,9 @@ class LocalTensorMode(TorchDispatchMode):
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
 
-        self.enable_()
-
     def __enter__(self) -> "LocalTensorMode":
-        self.enable_()
         get_local_tensor_mode_list().append(self)
+        self.enable_()
 
         # _distribute_region will compute correct per-shard offsets
         # but we want all ranks to start with the same state
@@ -1210,8 +1208,12 @@ class LocalTensorMode(TorchDispatchMode):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        self.disable_()
-        get_local_tensor_mode_list().pop()
+        local_tensor_mode_list = get_local_tensor_mode_list()
+        local_tensor_mode_list.pop()
+        if not local_tensor_mode_list:
+            self.disable_()
+        if len(local_tensor_mode_list) > 0 and local_tensor_mode_list[-1]._disable:
+            local_tensor_mode_list[-1].disable_()
         super().__exit__(exc_type, exc_val, exc_tb)
 
     def __torch_dispatch__(

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1210,8 +1210,7 @@ class LocalTensorMode(TorchDispatchMode):
     ) -> None:
         local_tensor_mode_list = get_local_tensor_mode_list()
         local_tensor_mode_list.pop()
-        if not local_tensor_mode_list:
-            self.disable_()
+        self.disable_()
         if len(local_tensor_mode_list) > 0:
             if local_tensor_mode_list[-1]._disable:
                 local_tensor_mode_list[-1].disable_()

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1212,8 +1212,11 @@ class LocalTensorMode(TorchDispatchMode):
         local_tensor_mode_list.pop()
         if not local_tensor_mode_list:
             self.disable_()
-        if len(local_tensor_mode_list) > 0 and local_tensor_mode_list[-1]._disable:
-            local_tensor_mode_list[-1].disable_()
+        if len(local_tensor_mode_list) > 0:
+            if local_tensor_mode_list[-1]._disable:
+                local_tensor_mode_list[-1].disable_()
+            else:
+                local_tensor_mode_list[-1].enable_()
         super().__exit__(exc_type, exc_val, exc_tb)
 
     def __torch_dispatch__(

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -770,6 +770,9 @@ class LocalDTensorOpTestBase(DTensorOpTestBase):
     def _spawn_processes(self) -> None:
         pass
 
+    def _spawn_threads(self) -> None:
+        pass
+
     def run_test(self, test_name: str, parent_pipe) -> None:
         getattr(self, test_name)()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170815

Suspect when exiting inner (nested) LocalTensorMode it may accidenally disable
outer LocalTensor mode and then lead to failed asserts that not expect a mismatch
between patched DeviceMesh and lack of LocalTensorMode.