### PR TITLE
[ONNX] Remove two unused constants

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -51,10 +51,6 @@ if TYPE_CHECKING:
 ONNXProgram.__module__ = "torch.onnx"
 OnnxExporterError.__module__ = "torch.onnx"
 
-# TODO(justinchuby): Remove these two properties
-producer_name = "pytorch"
-producer_version = _C_onnx.PRODUCER_VERSION
-
 
 def export(
     model: torch.nn.Module

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4474,11 +4474,6 @@ class TestCase(expecttest.TestCase):
             expected = re.sub(r'CppOp\[(.+?)\]', 'CppOp[]', expected)
             s = re.sub(r'CppOp\[(.+?)\]', 'CppOp[]', s)
 
-        # Adjust for producer_version
-        expected = expected.replace(
-            'producer_version: "CURRENT_VERSION"',
-            f'producer_version: "{torch.onnx.producer_version}"'
-        )
         if expecttest.ACCEPT:
             if expected != s:
                 return accept_output("updated output")


### PR DESCRIPTION
The two constants producer_name and producer_version are unused and scheduled for removal since a few years ago.

cc @titaiwangms