### PR TITLE
[DTensor] Hook up output tensor_meta to expand util

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -105,8 +105,21 @@ class TestExpandPlaceholder(TestCase):
                 kwargs_schema={},
                 schema_info=RuntimeSchemaInfo(1, needs_pytree=True),
             )
+
+            # Compute output tensor_meta for cat operation
+            # Cat concatenates along the specified dim, so output shape is input shapes
+            # with concat dim size summed
+            first_input = inputs[0]
+            output_shape = list(first_input.shape)
+            output_shape[dim] = sum(inp.shape[dim] for inp in inputs)
+            output_meta = TensorMeta(
+                shape=torch.Size(output_shape),
+                stride=first_input.stride(),
+                dtype=first_input.dtype,
+            )
+
             expanded_strategy_fn = _expand_single_dim_strategy_to_mesh(
-                mesh, op_schema, cat_single_dim_strategy
+                mesh, op_schema, cat_single_dim_strategy, output_meta
             )
             strategy = expanded_strategy_fn(
                 torch.ops.aten.cat.default, op_schema.args_meta, op_schema.kwargs_meta
@@ -184,9 +197,18 @@ class TestExpandPlaceholder(TestCase):
         1. Single-dim matmul strategies (S0,R -> S0 and R,S1->S1) are correctly expanded to 3D
         2. The implicit full-replication rule is included
         3. _ShardingPlaceholder is correctly replaced with actual Shard placements
+        4. tensor_meta is properly populated for output and input specs
         """
         mesh = DeviceMesh("cpu", mesh=torch.arange(8).reshape(2, 2, 2))
-        left_meta, right_meta = _get_mm_metas()
+        M, K, N = 64, 32, 64
+        left_meta, right_meta = _get_mm_metas(M, K, N)
+
+        # Compute expected output tensor_meta for matmul: (M, K) @ (K, N) -> (M, N)
+        output_meta = TensorMeta(
+            shape=torch.Size([M, N]),
+            stride=(N, 1),
+            dtype=torch.float32,
+        )
 
         # Create DTensorSpec for inputs with Shard placements using helper
         # Left input sharded on dim 0 across first mesh dim, replicated on others
@@ -211,7 +233,7 @@ class TestExpandPlaceholder(TestCase):
 
         # Expand the strategy to the full mesh
         expanded_strategy_fn = _expand_single_dim_strategy_to_mesh(
-            mesh, op_schema, mm_single_dim_strategy
+            mesh, op_schema, mm_single_dim_strategy, output_meta
         )
         strategy = expanded_strategy_fn(
             torch.ops.aten.matmul.default, op_schema.args_meta, op_schema.kwargs_meta
@@ -228,6 +250,28 @@ class TestExpandPlaceholder(TestCase):
             output_spec = op_spec.output_spec
             input_specs = op_spec.input_specs
             assert input_specs is not None
+
+            # Verify tensor_meta is populated for output spec
+            self.assertIsNotNone(
+                output_spec.tensor_meta, "Output spec should have tensor_meta populated"
+            )
+            self.assertEqual(output_spec.tensor_meta.shape, torch.Size([M, N]))
+            self.assertEqual(output_spec.tensor_meta.dtype, torch.float32)
+
+            # Verify tensor_meta is populated for input specs
+            self.assertIsNotNone(
+                input_specs[0].tensor_meta,
+                "Left input spec should have tensor_meta populated",
+            )
+            self.assertEqual(input_specs[0].tensor_meta.shape, torch.Size([M, K]))
+            self.assertEqual(input_specs[0].tensor_meta.dtype, torch.float32)
+
+            self.assertIsNotNone(
+                input_specs[1].tensor_meta,
+                "Right input spec should have tensor_meta populated",
+            )
+            self.assertEqual(input_specs[1].tensor_meta.shape, torch.Size([K, N]))
+            self.assertEqual(input_specs[1].tensor_meta.dtype, torch.float32)
 
             # Check if this is the all-replicate strategy
             if (

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -10,7 +10,7 @@ import torch
 from torch._prims_common import DimsSequenceType, DimsType
 from torch.distributed.tensor._api import DTensor
 from torch.distributed.tensor._collective_utils import redistribute_cost
-from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import (
     OpSchema,
     OpSpec,
@@ -354,6 +354,7 @@ def expand_to_full_mesh_op_strategy(
     op_schema: OpSchema,
     single_mesh_dim_strategies: list[PlacementList],
     *,
+    output_tensor_meta: TensorMeta | Sequence[TensorMeta | None] | None = None,
     input_index: int = 1,
     inplace_op: bool = False,
     is_valid_strategy_cb: Callable[
@@ -363,7 +364,7 @@ def expand_to_full_mesh_op_strategy(
 ) -> OpStrategy:
     """
     Convenience function to allow writing a sharding strategy considering only a single mesh dimension,
-    and have it expanded combinatorically to all mesh dimensions.
+    and have it expanded combinatorially to all mesh dimensions.
 
     Args:
         mesh (DeviceMesh): the device mesh to expand the strategy to
@@ -371,6 +372,7 @@ def expand_to_full_mesh_op_strategy(
         single_mesh_dim_strategies (list[PlacementList]): the sharding strategies to expand. The outer list is over
             different strategies.  The inner PlacementList is over the outputs and inputs of the op. If input_index is 1,
             a PlacementList looks like [output_placement, input_placement1, input_placement2, ...].
+        output_tensor_meta: tensor metadata for the output(s), used to populate DTensorSpec.tensor_meta field
         input_index: the number of outputs of the op, defaults to 1
         inplace_op: whether the op is inplace or not, defaults to False
         is_valid_strategy_cb: a callback function to filter out invalid sharding rules, defaults to None.
@@ -392,24 +394,41 @@ def expand_to_full_mesh_op_strategy(
 
     strategy_combs = itertools.product(*all_mesh_dim_strategies)
 
+    args_strategy = op_schema.args_strategy
+    kwargs_strategy = op_schema.kwargs_strategy
+    input_args_strategy = args_strategy + kwargs_strategy
     all_strategies = []
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
+        spec_index = 0
         for specs in zip(*strategy_comb):
             if specs[0] is not None:
-                # TODO: we should fill in tensor_meta here.  If nothing else, it helps the filter strategy callback
+                # Populate tensor_meta field for both output and input specs,
+                # including for tuple output cases
+                tensor_meta = None
+                if spec_index < input_index:
+                    if output_tensor_meta is not None:
+                        if isinstance(output_tensor_meta, TensorMeta):
+                            tensor_meta = output_tensor_meta
+                        elif isinstance(output_tensor_meta, (tuple, list)):
+                            if spec_index < len(output_tensor_meta):
+                                tensor_meta = output_tensor_meta[spec_index]
+                else:
+                    input_strategy_index = spec_index - input_index
+                    if input_strategy_index < len(input_args_strategy):
+                        tensor_meta = input_args_strategy[
+                            input_strategy_index
+                        ].tensor_meta
+
                 # pyrefly: ignore [bad-argument-type]
-                spec_list.append(DTensorSpec(mesh, specs))
+                spec_list.append(DTensorSpec(mesh, specs, tensor_meta=tensor_meta))
+                spec_index += 1
             else:
                 spec_list.append(None)
 
         input_specs: list[DTensorSpec] = [
             s for s in spec_list[input_index:] if isinstance(s, DTensorSpec)
         ]
-
-        args_strategy = op_schema.args_strategy
-        kwargs_strategy = op_schema.kwargs_strategy
-        input_args_strategy = args_strategy + kwargs_strategy
 
         if len(input_specs) != len(input_args_strategy):
             raise AssertionError(

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -479,10 +479,17 @@ class ShardingPropagator:
             if single_dim_strategy is not None:
                 mesh = try_find_mesh_from_args(op_schema.op, op_schema.args_schema)
                 assert isinstance(mesh, DeviceMesh), "Expected to find a valid mesh"
+                # if we run into a case where we register a single-dim rule for an op that can't propagate tensor meta,
+                # we could loosen this assert, but it's better to fix gaps in tensor meta prop. We want to end up
+                # with the invariant that all DTensorSpec have a valid tensormeta, but many existing sharding rules
+                # skip this.  We try to enforce it for all newly added single-dim rules.
+                assert out_tensor_meta is not None, (
+                    f"_propagate_tensor_meta_non_cached returned None for {op_schema}, but tensor_meta is required"
+                )
                 # expand to generate the full set of strategy combinations, each one
                 # with a redistribute cost, and then find the min strategy over those costs.
                 _expanded_strategy_fn = _expand_single_dim_strategy_to_mesh(
-                    mesh, strategy_schema, single_dim_strategy
+                    mesh, strategy_schema, single_dim_strategy, out_tensor_meta
                 )
                 op_strategy = _expanded_strategy_fn(
                     op_schema.op, strategy_schema.args_meta, strategy_schema.kwargs_meta


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #168115
* __->__ #170827
* #170359
* #167677
* #170615

Enforce tensor_meta is not none for new single-dim rules.

Allow tensor_meta to continue to be None for existing rules for now. We
should consider in the future asserting tensor_meta is required in
DTensorSpec, but for now we just try to limit the bleeding.