### PR TITLE
[ROCm] Enable multiple NestedTensor tests on ROCm

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7184,6 +7184,8 @@ torch.cuda.synchronize()
     @skipIfTorchDynamo("SDPA test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @onlyCUDA
+    # efficient_attention_forward meta kernel shape mismatch on CDNA - see issue #171568
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH)
     @dtypes(
         *(
             [torch.float16, torch.bfloat16, torch.float32]
@@ -7214,7 +7216,7 @@ torch.cuda.synchronize()
     )
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @onlyCUDA
-    # AssertionError, wrong number of dimensions3 for op torch.ops.aten._flash_attention_forward.default
+    # flash_attention_forward meta kernel shape mismatch on CDNA - see issue #171568
     @skipIfRocmArch(MI200_ARCH + MI300_ARCH)
     @skipIfTorchDynamo()
     def test_sdpa_autocast(self, device):
@@ -7718,10 +7720,7 @@ torch.cuda.synchronize()
 
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
-    # AssertionError
-    # expected size 1==4, stride 27==96 at dim=0
-    # expected size 3==3, stride 9==32 at dim=1
-    # expected size 9==32, stride 1==1 at dim=2
+    # efficient_attention_forward meta kernel shape mismatch on CDNA - see issue #171568
     @skipIfRocmArch(MI200_ARCH + MI300_ARCH)
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_compile_preserves_metadata_cache(self, device, dtype):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -60,7 +60,6 @@ from torch.testing._internal.common_utils import (
     skipIfSlowGradcheckEnv,
     skipIfTorchDynamo,
     subtest,
-    TEST_WITH_ROCM,
     xfailIfTorchDynamo,
     xfailIfWindows,
 )
@@ -6571,11 +6570,6 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         ):
             a.copy_(b)
 
-    # This can't happen in the opinfo tests due to subprocess creation
-    @unittest.skipIf(
-        TEST_WITH_ROCM,
-        "In ROCm, kernel asserts are disabled due to performance overhead",
-    )
     def test_index_put_error(self, device):
         import subprocess
 
@@ -6729,12 +6723,7 @@ torch.cuda.synchronize()
         check_results(fn, compiled_fn, generate_inp(20))
         self.assertEqual(compile_counter.frame_count, frame_count_2)
 
-    # Note 1: Math fallback doesn't work with bfloat16 on CUDA
-    # Note 2: ROCm doesn't support flash attention or mem_efficient attention for NT
-    @unittest.skipIf(
-        TEST_WITH_ROCM,
-        "ROCm doesn't support flash attention or mem_efficient attention for NT",
-    )
+    # Note: Math fallback doesn't work with bfloat16 on CUDA
     @tf32_on_and_off(0.005)
     @dtypes(
         *(
@@ -7004,9 +6993,7 @@ torch.cuda.synchronize()
 
     @skipIfTorchDynamo("SDPA test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    # Guarding with sqrt() doesn't work on ROCm?
     @xfailIfWindows
-    @skipCUDAIfRocm
     @onlyCUDA
     @dtypes(
         *(
@@ -7193,8 +7180,6 @@ torch.cuda.synchronize()
     @decorateIf(xfailIfWindows, lambda params: params["dtype"] == torch.float32)
     @skipIfTorchDynamo("SDPA test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    # mha_varlen_fwd not supported on ROCm
-    @skipCUDAIfRocm
     @onlyCUDA
     @dtypes(
         *(
@@ -7225,7 +7210,6 @@ torch.cuda.synchronize()
         "Platform doesn't support flash or mem-efficient attention",
     )
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     @onlyCUDA
     @skipIfTorchDynamo()
     def test_sdpa_autocast(self, device):
@@ -7308,7 +7292,6 @@ torch.cuda.synchronize()
         "Platform doesn't support flash or mem-efficient attention",
     )
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     @onlyCUDA
     @skipIfTorchDynamo()
     def test_sdpa_flop_counter(self, device):
@@ -7731,7 +7714,6 @@ torch.cuda.synchronize()
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     def test_compile_preserves_metadata_cache(self, device, dtype):
         # shape (B, *, D)
         nt = random_nt_from_dims(
@@ -7758,7 +7740,6 @@ torch.cuda.synchronize()
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     def test_compile_with_dynamic_max_seq_len(self, device, dtype):
         # shape (B, *, D)
         # max seq len: 18
@@ -7791,7 +7772,6 @@ torch.cuda.synchronize()
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     def test_compile_with_dynamic_min_seq_len(self, device, dtype):
         # shape (B, *, D)
         # min seq len: 7
@@ -7824,7 +7804,6 @@ torch.cuda.synchronize()
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     def test_compile_with_propagated_dynamic_max_seq_len(self, device, dtype):
         # shape (B, *, D)
         # max seq len: 18
@@ -7951,7 +7930,6 @@ torch.cuda.synchronize()
     @torch._dynamo.utils.disable_cache_limit()
     @skipIfTorchDynamo("SDPA test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     @dtypes(torch.float32, torch.double, torch.half)
     @parametrize("nt_dim", [2, 3, 4])
     @parametrize("requires_grad", [False, True])
@@ -8053,7 +8031,6 @@ torch.cuda.synchronize()
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipCUDAIfRocm
     def test_compile_padded_dense_conversion_preserves_metadata_cache(
         self, device, dtype
     ):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -53,10 +53,13 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_FBCODE,
     markDynamoStrictTest,
+    MI200_ARCH,
+    MI300_ARCH,
     NestedTensorTestCase,
     parametrize,
     run_tests,
     serialTest,
+    skipIfRocmArch,
     skipIfSlowGradcheckEnv,
     skipIfTorchDynamo,
     subtest,
@@ -7719,7 +7722,7 @@ torch.cuda.synchronize()
     # expected size 1==4, stride 27==96 at dim=0
     # expected size 3==3, stride 9==32 at dim=1
     # expected size 9==32, stride 1==1 at dim=2
-    @skipIfRocmArch(MI200_ARCH, MI300_ARCH) 
+    @skipIfRocmArch(MI200_ARCH, MI300_ARCH)
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_compile_preserves_metadata_cache(self, device, dtype):
         # shape (B, *, D)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7211,6 +7211,8 @@ torch.cuda.synchronize()
     )
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @onlyCUDA
+    # AssertionError, wrong number of dimensions3 for op torch.ops.aten._flash_attention_forward.default
+    @skipIfRocmArch(MI200_ARCH, MI300_ARCH)
     @skipIfTorchDynamo()
     def test_sdpa_autocast(self, device):
         def fn_nt(values32, values16, offsets):
@@ -7713,6 +7715,11 @@ torch.cuda.synchronize()
 
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
+    # AssertionError
+    # expected size 1==4, stride 27==96 at dim=0
+    # expected size 3==3, stride 9==32 at dim=1
+    # expected size 9==32, stride 1==1 at dim=2
+    @skipIfRocmArch(MI200_ARCH, MI300_ARCH) 
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_compile_preserves_metadata_cache(self, device, dtype):
         # shape (B, *, D)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7215,7 +7215,7 @@ torch.cuda.synchronize()
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @onlyCUDA
     # AssertionError, wrong number of dimensions3 for op torch.ops.aten._flash_attention_forward.default
-    @skipIfRocmArch(MI200_ARCH, MI300_ARCH)
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH)
     @skipIfTorchDynamo()
     def test_sdpa_autocast(self, device):
         def fn_nt(values32, values16, offsets):
@@ -7722,7 +7722,7 @@ torch.cuda.synchronize()
     # expected size 1==4, stride 27==96 at dim=0
     # expected size 3==3, stride 9==32 at dim=1
     # expected size 9==32, stride 1==1 at dim=2
-    @skipIfRocmArch(MI200_ARCH, MI300_ARCH)
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH)
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_compile_preserves_metadata_cache(self, device, dtype):
         # shape (B, *, D)


### PR DESCRIPTION
This PR enables several NestedTensor tests (SDPA, compile, and error index) that now pass on ROCm 7.1.

Three tests that use flash/efficient attention with torch.compile are skipped on CDNA architectures (MI200/MI300) due to a meta kernel shape mismatch tracked in #171568.

Fixes #168785
Fixes #168786
Fixes #168787
Fixes #168790
Fixes #168793
Fixes #168794
Fixes #168795
Fixes #168796
Fixes #168797

Note: #168788 (test_sdpa_backwards) is NOT fixed on CDNA - it requires the same meta kernel fix as #171568.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang