### PR TITLE
[Inductor] Account for shared memory from addmm, persistent in gemm config pruning

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -507,9 +507,11 @@ max_autotune_report_choices_stats = (
     os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_REPORT_CHOICES_STATS", "1") == "1"
 )
 
-# Prune configs that require more shared memory than the hardware limit
+# Prune configs that have a theoretical maximum shared memory usage than the hardware limit
+# Will over-prune - pruning some valid configs with theoretical shared memory usage higher
+# than real shared memory usage, ensuring that invalid configs are not possibly autotuned
 max_autotune_prune_choices_based_on_shared_mem = (
-    os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_PRUNE_CHOICES_BASED_ON_SHARED_MEM", "1")
+    os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_PRUNE_CHOICES_BASED_ON_SHARED_MEM", "0")
     == "1"
 )
 

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -790,11 +790,51 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         return scaled_configs
 
+    # Estimate theoretical maximum shared memory
+    def get_shared_memory_estimation(
+        self,
+        gemm_config: BaseConfig,
+        dtype_size: int,
+        has_sm_layout_conversion: bool,
+        layout_conversion_byte_size: int,
+    ):
+        shared_mem_loads = dtype_size * (
+            gemm_config.block_m * gemm_config.block_k
+            + gemm_config.block_n * gemm_config.block_k
+        )
+
+        # Extra bytes to account for barriers in boundary conditions
+        extra_bytes = 128
+
+        # In persistent tma case, the layout conversion from mma -> blocked layout
+        # is not free and takes additional shared memory, while next loads are prefetched
+        # For addmm, the conversion is in the acc dtype, as it is needed before the bias addition
+        # For mm, the conversion is in the output dtype, as it happens before the store
+        if has_sm_layout_conversion:
+            element_bits = layout_conversion_byte_size * 8
+            # 8 bytes of padding for fp16/bf16
+            max_padding = 128 // element_bits
+            block_n = max_padding + gemm_config.block_n
+            shared_mem_epilogue = (
+                layout_conversion_byte_size * gemm_config.block_m * block_n
+            )
+        else:
+            shared_mem_epilogue = 0
+
+        return (
+            shared_mem_loads * gemm_config.num_stages
+            + shared_mem_epilogue
+            + extra_bytes
+        )
+
     def _get_exceeding_shared_memory_checker(
         self,
+        has_sm_layout_conversion: bool,
+        layout_conversion_byte_size: int,
     ) -> Optional[Callable[[BaseConfig, int], bool]]:
         """
         Returns a function that checks whether a given configuration exceeds the available shared memory for the device.
+        based on the config's theoretical maximum shared memory used.
         If the device does not report available shared memory, returns None.
         """
 
@@ -814,11 +854,13 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         # TODO make a BaseDeviceConfigHeuristics to handle different device configuration in its own implementation.
         def exceeds(gemm_config: BaseConfig, dtype_size: int) -> bool:
-            shared_mem_accum = dtype_size * (
-                gemm_config.block_m * gemm_config.block_k
-                + gemm_config.block_n * gemm_config.block_k
+            estimation = self.get_shared_memory_estimation(
+                gemm_config,
+                dtype_size,
+                has_sm_layout_conversion,
+                layout_conversion_byte_size,
             )
-            return shared_mem_accum * gemm_config.num_stages > sm_available
+            return estimation > sm_available
 
         return exceeds
 
@@ -826,31 +868,26 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         self,
         configs: list[BaseConfig],
         dtype_size: int,
+        has_sm_layout_conversion: bool = False,
+        layout_conversion_byte_size: int = 0,
     ) -> list[BaseConfig]:
         if dtype_size <= 0:
             return configs
 
-        is_exceeding_shared_memory = self._get_exceeding_shared_memory_checker()
+        is_exceeding_shared_memory = self._get_exceeding_shared_memory_checker(
+            has_sm_layout_conversion, layout_conversion_byte_size
+        )
         if is_exceeding_shared_memory is None:
             return configs
 
         return [c for c in configs if not is_exceeding_shared_memory(c, dtype_size)]
 
-    def _prune_exhaustive_configs(
+    def _prune_reg_spill_configs(
         self,
         configs: list[BaseConfig],
-        dtype_size: int,
     ) -> list[BaseConfig]:
-        is_exceeding_shared_memory = self._get_exceeding_shared_memory_checker()
-
         pruned_configs = []
         for gemm_config in configs:
-            # Will use more shared memory than available
-            if is_exceeding_shared_memory and is_exceeding_shared_memory(
-                gemm_config, dtype_size
-            ):
-                continue
-
             NUM_REG = 255
             acc_regs = math.ceil(
                 gemm_config.block_m * gemm_config.block_n / (gemm_config.num_warps * 32)
@@ -883,6 +920,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         ] = lambda m, n, k: False,
         dtype_size: int = 0,
         op_name: str = "mm",  # For preprocessing overrides e.g. on CPU
+        **kwargs,
     ) -> Generator[TritonConfig, None, None]:
         configs = self._filter_configs(configs)
         scaled_configs = self._scale_mm_configs(
@@ -890,14 +928,18 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         )
 
         # Filter out configs that require more shared memory than is available.
+        # Theoretical upper bound, will over-prune configs. Off by default for maximum
+        # performance
         if config.max_autotune_prune_choices_based_on_shared_mem:
             scaled_configs = self._prune_exceeding_max_shared_mem_configs(
-                scaled_configs, dtype_size
+                scaled_configs,
+                dtype_size,
+                kwargs.get("has_sm_layout_conversion", False),
+                kwargs.get("layout_conversion_byte_size", 0),
             )
 
         if config.max_autotune_gemm_search_space == "EXHAUSTIVE":
-            assert dtype_size > 0, "dtype_size must be provided for exhaustive search"
-            scaled_configs = self._prune_exhaustive_configs(scaled_configs, dtype_size)
+            scaled_configs = self._prune_reg_spill_configs(scaled_configs)
         return self._finalize_mm_configs(scaled_configs)
 
     def triton_config(
@@ -1032,6 +1074,7 @@ class CPUConfigHeuristic(BaseConfigHeuristic):
         ] = lambda m, n, k: False,
         dtype_size: int = 0,
         op_name: str = "mm",  # For preprocessing overrides e.g. on CPU
+        **kwargs,
     ) -> Generator[TritonConfig, None, None]:
         """
         CPU-specific preprocessing that applies CPU-specific scaling (0.5) and exclusion logic.
@@ -1050,6 +1093,7 @@ class CPUConfigHeuristic(BaseConfigHeuristic):
             exclude=cpu_exclude_fn,
             dtype_size=dtype_size,
             op_name=op_name,
+            **kwargs,
         )
 
 
@@ -1778,6 +1822,7 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         """
         Convert config lists to template kwargs.
@@ -1802,7 +1847,14 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         configs = self._get_config_generator()
 
         # Generate and process configs
-        for c in configs(m, n, k, dtype_size=dtype.itemsize, op_name=op_name):
+        for c in configs(
+            m,
+            n,
+            k,
+            dtype_size=dtype.itemsize,
+            op_name=op_name,
+            **kwargs,
+        ):
             template_kwargs = self._convert_config_to_template_kwargs(
                 c,
                 m,
@@ -1883,15 +1935,20 @@ class MMPlusMMTemplateConfigMixin(MMTemplateConfigMixin):
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         assert isinstance(kernel_inputs, MMKernelInputs), "Expect MMKernelInputs"
         m, n, k = kernel_inputs.mnk_symbolic()
-        for kwargs in super()._get_template_configs_impl(kernel_inputs, op_name):
+        for template_kwargs in super()._get_template_configs_impl(
+            kernel_inputs, op_name, **kwargs
+        ):
             # Apply BLOCK_K constraint specific to mm_plus_mm
             # see https://github.com/triton-lang/triton/issues/1298
             # BLOCK_K = K causes llvm error
-            if V.graph.sizevars.statically_known_lt(kwargs.get("BLOCK_K", k), k):
-                yield kwargs
+            if V.graph.sizevars.statically_known_lt(
+                template_kwargs.get("BLOCK_K", k), k
+            ):
+                yield template_kwargs
 
 
 class TMAWorkspaceMixin(MMTemplateConfigMixin):
@@ -1921,6 +1978,15 @@ class TMAWorkspaceMixin(MMTemplateConfigMixin):
         return super()._filter_configs(configs)
 
 
+def get_shared_memory_checker_opts(op_name: str, dtype_size: int):
+    return {
+        "has_sm_layout_conversion": True,
+        # addmm requires the acc dtype for layout conversion due to adding bias
+        # mm just input dtype
+        "layout_conversion_byte_size": 4 if op_name == "addmm" else dtype_size,
+    }
+
+
 # TMA-specific mixin for TMA templates
 class TMATemplateConfigMixin(TMAWorkspaceMixin, MMTemplateConfigMixin):
     """
@@ -1932,6 +1998,7 @@ class TMATemplateConfigMixin(TMAWorkspaceMixin, MMTemplateConfigMixin):
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         """
         Generate TMA template configs by calling super and adding TMA-specific options.
@@ -1949,10 +2016,14 @@ class TMATemplateConfigMixin(TMAWorkspaceMixin, MMTemplateConfigMixin):
             "tma_store": config.triton.enable_template_tma_store,
             "transpose_discontiguous_tensor_descriptors_override": True,
         }
+
         # Get base template configs from superclass
         for template_kwargs in super()._get_template_configs_impl(
             kernel_inputs,
             op_name,
+            **get_shared_memory_checker_opts(
+                op_name, dtype_size=kernel_inputs.dtype().itemsize
+            ),
         ):
             yield {**template_kwargs, **tma_opts}
 
@@ -1963,6 +2034,7 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         """
         Generate TMA template configs by calling super and adding TMA-specific options.
@@ -1971,6 +2043,7 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
         for template_kwargs in super()._get_template_configs_impl(
             kernel_inputs,
             op_name,
+            **kwargs,
         ):
             # Some Triton versions requires num_warps >= 4 for WS
             # to avoid compilation issues. Triton disables WS if num_warps < 4
@@ -2036,6 +2109,7 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         """
         Generate scaled MM template configs with scaled MM-specific options.
@@ -2079,7 +2153,7 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
 
         # Get base template configs from superclass
         for template_kwargs in super()._get_template_configs_impl(
-            kernel_inputs, op_name
+            kernel_inputs, op_name, **kwargs
         ):
             # Add scaled MM-specific options (moved from mm_common.scaled_mm_options)
             # Override accumulator type for scaled MM
@@ -2167,6 +2241,7 @@ class ScaledTMAConfigMixin(TMAWorkspaceMixin, BaseScaledMMConfigMixin):
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         """
         Generate scaled TMA template configs with both scaled MM and TMA-specific options.
@@ -2175,6 +2250,7 @@ class ScaledTMAConfigMixin(TMAWorkspaceMixin, BaseScaledMMConfigMixin):
         for template_kwargs in super()._get_template_configs_impl(
             kernel_inputs,
             op_name,
+            **kwargs,
         ):
             # Add TMA-specific options for device TMA scaled MM
             template_kwargs["TMA_SIZE"] = TMA_DESCRIPTOR_SIZE
@@ -2373,6 +2449,7 @@ class CUDAScaledTMAMainLoopScalingTemplateConfigHeuristic(
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
+        **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         """
         Generate main loop scaling kernel inputs.
@@ -2390,6 +2467,7 @@ class CUDAScaledTMAMainLoopScalingTemplateConfigHeuristic(
         for template_kwargs in super()._get_template_configs_impl(
             kernel_inputs,
             op_name,
+            **kwargs,
         ):
             # Add scaling-specific options for main loop scaling variants
 


### PR DESCRIPTION
Differential Revision: D89510915

TMA persistent template generally results in more shared memory from realizing the epilogue, due to layout conversions in shared memory for the epilogue while other loads are happening. Example for addmm persistent: https://pastebin.com/y1ezWP88

Addmm does the layout conversion in the acc dtype (fp32) for adding onto the bias afterwards while mm does it in the output dtype before calling tl.store.

The shared memory checker previously did not prune enough, which ended up providing out of memory configs potentially when the flag was on. This PR makes a few changes to the logic:
* Disables shared memory checker by default
* Instead of under-pruning, where pruning only occurred when the shared memory of the loads were greater than the shared memory available, a poor heuristic as pipelining assumptions, etc. did not always hold true due to optimizations, we now over-prune, where the theoretical maximum shared memory is taken and if it is larger than the shared memory available, pruning occurs. This results in a few good configs being pruned, but ensures that all potentially out of memory configs no longer exist
* Exhaustive autotuning does not use the shared memory checker due to potentially pruning good configs




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo