### PR TITLE
Fix Wcpp warnings

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -409,7 +409,7 @@ function(torch_compile_options libname)
         -Wno-error=unused-parameter
       )
       if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        list(APPEND private_compile_options -Werror=unused-but-set-variable)
+        list(APPEND private_compile_options -Werror=unused-but-set-variable -Werror=cpp)
       endif()
     endif()
   endif()

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -28,7 +28,6 @@
 #include <c10/util/irange.h>
 
 #include <algorithm>
-#include <ciso646>
 #include <functional>
 #include <numeric>
 #include <utility>


### PR DESCRIPTION
This PR turns `Wcpp` into an error and fixes g++ warnings like
```
  /usr/include/c++/15.2.1/ciso646:49:6: warning: #warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros" [-Wcpp]
     49 | #    warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros"
        |      ^~~~~~~
```