### PR TITLE
[BugFix] Fix operator precedence bug in check_channel signal pad validation 

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -164,7 +164,7 @@ void check_channel(int channel, int world_size) {
       channel,
       ")");
   const size_t num_channels = c10d::symmetric_memory::get_signal_pad_size() /
-      sizeof(uint32_t) * world_size;
+      (sizeof(uint32_t) * world_size);
   TORCH_CHECK(
       static_cast<size_t>(channel) < num_channels,
       "The maximum supported channel for barrier(), put_signal() and wait_signal() is ",


### PR DESCRIPTION
The num_channels calculation had an operator precedence bug where division and multiplication were evaluated left-to-right, causing incorrect results:   
                                                                                                                                                                                                                                            
Original (incorrect):
num_channels = (get_signal_pad_size() / sizeof(uint32_t)) * world_size = (9,216 / 4) * 8 = 18,432 channels                                                                                                                              
                                                                                                                                                                   
Fixed (correct):
num_channels = get_signal_pad_size() / (sizeof(uint32_t) * world_size) = 9,216 / 32        = 288 channels

https://github.com/pytorch/pytorch/blob/f8858743d408b12265d9ca0bbb9f817d323ac737/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp#L12-L21

https://github.com/pytorch/pytorch/blob/f8858743d408b12265d9ca0bbb9f817d323ac737/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu#L193-L194

Maybe cause memory corruption or buffer overflow

cc @malfet @cyyever