### PR TITLE
[ROCm] Enable 13 stale-skipped tests in test_cuda.py

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4136,7 +4136,7 @@ class TestCudaMallocAsync(TestCase):
         finally:
             torch.cuda.memory._record_memory_history(None)
 
-    @skipIfRocm
+    @skipIfRocm(msg="ROCTracer does not capture Python stack frames in profiler output")
     def test_memory_profiler_viz(self):
         with torch.profiler.profile(
             with_stack=True, profile_memory=True, record_shapes=True
@@ -4906,7 +4906,6 @@ print(value, end="")
     def test_temperature(self):
         self.assertTrue(0 <= torch.cuda.temperature() <= 150)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "flaky for AMD gpu")
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_device_memory_used(self):
         """
@@ -5085,7 +5084,10 @@ def reconstruct_from_tensor_metadata(metadata):
     return t
 
 
-@unittest.skipIf(not TEST_CUDA or TEST_CUDAMALLOCASYNC or TEST_WITH_ROCM, "NYI")
+@unittest.skipIf(
+    not TEST_CUDA or TEST_CUDAMALLOCASYNC,
+    "CUDA required, not supported with CUDAMallocAsync",
+)
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestBlockStateAbsorption(TestCase):
     @property

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1823,10 +1823,6 @@ except RuntimeError as e:
             self.assertEqual(stash[0], torch.full_like(a, 6))
             self.assertEqual(stash[1], torch.full_like(a, 6))
 
-    @unittest.skipIf(
-        TEST_WITH_ROCM,
-        "In ROCm, kernel asserts are disabled due to performance overhead",
-    )
     def test_fixed_cuda_assert_async(self):
         with self.assertRaisesRegex(
             RuntimeError, "Boolean value of Tensor with no values is ambiguous"
@@ -1924,7 +1920,6 @@ torch.cuda.synchronize()
     # Test is flaky on Windows (https://github.com/pytorch/pytorch/issues/57401)
     @unittest.skipIf(IS_WINDOWS, "Test is flaky on Windows (see issue 57401)")
     @unittest.skipIf(not TEST_CUDNN, "CUDNN not available")
-    @skipIfRocm
     def test_cudnn_multiple_threads_same_device(self):
         # This function is intended to test the lazy creation and reuse of per-thread
         # cudnn handles on each device in aten/src/ATen/cudnn/Handles.cpp.


### PR DESCRIPTION
This PR enables 13 tests in test_cuda.py that were skipped for ROCm but now pass.

## Changes

### TestBlockStateAbsorption (11 tests)
Remove `TEST_WITH_ROCM` from the class-level skip. Memory checkpoint pool state functionality works correctly on ROCm with the native caching allocator.

### test_fixed_cuda_assert_async
Remove `@skipIfRocm` - kernel asserts now work on ROCm.

### test_cudnn_multiple_threads_same_device  
Remove `@skipIfRocm` - MIOpen per-thread handles work correctly.

### Additional changes (not issue fixes)

**test_device_memory_used**: Remove "flaky for AMD gpu" skip. The test works correctly when amdsmi is installed. The amdsmi package is publicly available from ROCm and can be pip-installed; PyTorch's `_HAS_PYNVML` check properly detects it.

**test_memory_profiler_viz**: Improved skip message to clarify that ROCTracer does not capture Python stack frames the same way as CUPTI (this is a real limitation, not a stale skip).

## Testing
All tests verified on ROCm 7.1.25424 (RX 7700S).

Fixes #168713
Fixes #168714
Fixes #168725
Fixes #168726
Fixes #168727
Fixes #168728
Fixes #168729
Fixes #168730
Fixes #168731
Fixes #168732
Fixes #168733
Fixes #168734
Fixes #168735

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang