### PR TITLE
[ROCm] remove rocm specific skip logic for test_python_ref_torch_fallback

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -739,8 +739,6 @@ class TestCommon(TestCase):
         # In this test, refs call into the torch namespace (after the initial invocation)
         # For example, a ref with torch.foo in it will call torch.foo instead of refs.foo
         # Direct calls to refs and prims are not translated
-        if TEST_WITH_ROCM and op.name == "_refs.fft.ihfftn" and dtype == torch.float16:
-            self.skipTest("Skipped on ROCm")
         if op.full_name == "_refs.div.floor_rounding" and dtype == torch.bfloat16:
             self.skipTest(
                 "Skipped _refs.div.floor_rounding with bfloat16"

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -717,6 +717,7 @@ python_ref_db: list[OpInfo] = [
             ),
             # AssertionError: Reference result was farther (0.09746177145360499) from the precise
             # computation than the torch result was (0.09111555632069855)
+            # See https://github.com/pytorch/pytorch/pull/170856 for more details.
             DecorateInfo(
                 unittest.skip("Skipped!"),
                 "TestCommon",


### PR DESCRIPTION
Fixes #168815

Remove ROCm specific skip for this unit test because
- test_python_ref_torch_fallback__refs_fft_ihfftn_cuda_float16 has been marked to skip GPU devices anyway

Which is implemented by the code below:
https://github.com/pytorch/pytorch/blob/c8a37a2d5ee91d61bad92e80e608a38286f079a6/torch/testing/_internal/opinfo/definitions/fft.py#L721

- This test instance fails on both CUDA and ROCm GPUs, but the limitation is coming from the precision of float16 itself. More specifically:

aten has normalization options for both fft_r2c and fft_c2c, so the op trace will be fft_r2c(+norm) -> conj -> ffc_c2c(+norm). However, _ref uses prims which does not utilizes the normalization option in aten (see the code below).
https://github.com/pytorch/pytorch/blob/c8a37a2d5ee91d61bad92e80e608a38286f079a6/torch/_prims/__init__.py#L2857

In this case, a seperate _apply_norm function fuses the normalization factors from all dimensions together, which is applied at last. So, the op trace will be:  fft_r2c(no norm) -> conj -> ffc_c2c(no norm) -> fused norm, this introduces numerical variance when fp16 is involved. That's perhaps the reason why it was marked to skip GPUs in the first place.
https://github.com/pytorch/pytorch/blob/c8a37a2d5ee91d61bad92e80e608a38286f079a6/torch/_refs/fft.py#L434


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang