### PR TITLE
[inductor] Fix test_equivalent_template_code for ROCm

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -296,11 +296,22 @@ if HAS_GPU_AND_TRITON:
         def test_equivalent_template_code(self):
             code, code2 = self._equivalent_output_code_impl(256)
             for out_code in [code, code2]:
-                FileCheck().check(get_func_call()).check_count(
-                    "empty_strided", 1, exactly=True
-                ).check("triton_tem_fused_addmm_relu_t_0").check_count(
-                    ".reset()" if config.cpp_wrapper else "del", 3, exactly=True
-                ).check("" if config.cpp_wrapper else "return").run(out_code[0])
+                if torch.version.hip:
+                    # ROCm generates separate kernels for addmm and relu
+                    FileCheck().check(get_func_call()).check_count(
+                        "empty_strided", 1, exactly=True
+                    ).check("triton_tem_fused_addmm_t_0").check(
+                        "triton_poi_fused_addmm_relu_1"
+                    ).check_count(
+                        ".reset()" if config.cpp_wrapper else "del", 3, exactly=True
+                    ).check("" if config.cpp_wrapper else "return").run(out_code[0])
+                else:
+                    # CUDA fuses addmm and relu into a single kernel
+                    FileCheck().check(get_func_call()).check_count(
+                        "empty_strided", 1, exactly=True
+                    ).check("triton_tem_fused_addmm_relu_t_0").check_count(
+                        ".reset()" if config.cpp_wrapper else "del", 3, exactly=True
+                    ).check("" if config.cpp_wrapper else "return").run(out_code[0])
 
         @fresh_cache()
         @config.patch(max_autotune_gemm_backends="ATEN")


### PR DESCRIPTION
Fixes #166601

1. Test expected 1 fused kernel: 'triton_tem_fused_addmm_relu_t_0' but ROCm generates 2 kernels: 'triton_tem_fused_addmm_t_0' and  'triton_poi_fused_addmm_relu_1', as a fix added platform detection.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben