### PR TITLE
[xpu][fix]Warn fast_accum not supported in xpu instead of runtime error

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -133,6 +133,12 @@ Tensor& _scaled_gemm(
     const bool use_fast_accum,
     Tensor& out,
     const std::optional<Tensor>& alpha = std::nullopt) {
+  bool _use_fast_accum = use_fast_accum;
+  if (use_fast_accum) {
+    _use_fast_accum = false;
+    TORCH_WARN(
+        "fast_accum is not supported in XPU for now. Setting use_fast_accum to false.");
+  }
   // TODO: scale_result and alpha is not defined or used!
   std::optional<Tensor> scaled_result = std::nullopt;
   at::native::onednn::scaled_matmul(
@@ -145,7 +151,7 @@ Tensor& _scaled_gemm(
       scaling_choice_b,
       bias,
       scaled_result,
-      use_fast_accum);
+      _use_fast_accum);
 
   return out;
 }
@@ -190,7 +196,12 @@ Tensor& _scaled_mm_out_xpu(
     bool use_fast_accum,
     Tensor& out) {
   // Note: fast_accum is not supported in XPU for now.
-  TORCH_CHECK(!use_fast_accum, "fast_accum is not supported in XPU for now.");
+  bool _use_fast_accum = use_fast_accum;
+  if (use_fast_accum) {
+    _use_fast_accum = false;
+    TORCH_WARN(
+        "fast_accum is not supported in XPU for now. Setting use_fast_accum to false.");
+  }
 
   TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix");
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
@@ -313,7 +324,7 @@ Tensor& _scaled_mm_out_xpu(
       scaling_choice_a,
       scaling_choice_b,
       bias,
-      use_fast_accum,
+      _use_fast_accum,
       out);
 }
 

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -133,11 +133,11 @@ Tensor& _scaled_gemm(
     const bool use_fast_accum,
     Tensor& out,
     const std::optional<Tensor>& alpha = std::nullopt) {
-  bool _use_fast_accum = use_fast_accum;
+  // Note: XPU does not support fast_accum for now, we will warn and always pass
+  // false to the call.
   if (use_fast_accum) {
-    _use_fast_accum = false;
     TORCH_WARN(
-        "fast_accum is not supported in XPU for now. Setting use_fast_accum to false.");
+        "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
   // TODO: scale_result and alpha is not defined or used!
   std::optional<Tensor> scaled_result = std::nullopt;
@@ -151,7 +151,7 @@ Tensor& _scaled_gemm(
       scaling_choice_b,
       bias,
       scaled_result,
-      _use_fast_accum);
+      false /* use_fast_accum */);
 
   return out;
 }
@@ -195,12 +195,11 @@ Tensor& _scaled_mm_out_xpu(
     std::optional<c10::ScalarType> out_dtype,
     bool use_fast_accum,
     Tensor& out) {
-  // Note: fast_accum is not supported in XPU for now.
-  bool _use_fast_accum = use_fast_accum;
+  // Note: XPU does not support fast_accum for now, we will warn and always pass
+  // false to the call.
   if (use_fast_accum) {
-    _use_fast_accum = false;
     TORCH_WARN(
-        "fast_accum is not supported in XPU for now. Setting use_fast_accum to false.");
+        "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
 
   TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix");
@@ -324,7 +323,7 @@ Tensor& _scaled_mm_out_xpu(
       scaling_choice_a,
       scaling_choice_b,
       bias,
-      _use_fast_accum,
+      false /* use_fast_accum */,
       out);
 }
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2606
Currently, XPU does not support fast_accum, this PR will let it directly set the `use_fast_accum` to false and don't break the overall run.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey