### PR TITLE
Fix CPUReproTests.test_disabled_amp on ARM

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1772,7 +1772,7 @@ test_linux_aarch64() {
        inductor/test_split_cat_fx_passes inductor/test_compile inductor/test_torchinductor \
        inductor/test_torchinductor_codegen_dynamic_shapes inductor/test_torchinductor_dynamic_shapes inductor/test_memory \
        inductor/test_triton_cpu_backend inductor/test_triton_extension_backend inductor/test_mkldnn_pattern_matcher inductor/test_cpu_cpp_wrapper \
-       inductor/test_cpu_select_algorithm \
+       inductor/test_cpu_select_algorithm  inductor/test_cpu_repro \
        --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" --verbose
 }
 

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -305,7 +305,7 @@ class CPUReproTests(TestCase):
     def test_conv2d_autocast(self):
         v = torch.randn(1, 3, 28, 18, dtype=torch.float32)
         mod = torch.nn.Sequential(torch.nn.Conv2d(3, 64, 3, 3)).eval()
-        with torch.no_grad(), torch.cpu.amp.autocast():
+        with torch.no_grad(), torch.amp.autocast("cpu"):
             self.common(
                 mod,
                 (v,),
@@ -588,7 +588,7 @@ class CPUReproTests(TestCase):
         for amp_enabled in amp_enabled_configs:
             mod = M(in_channel, out_channel).eval()
             v = torch.randn(5, in_channel, 15, 15)
-            with torch.no_grad(), torch.cpu.amp.autocast(enabled=amp_enabled):
+            with torch.no_grad(), torch.amp.autocast("cpu", enabled=amp_enabled):
                 self.common(
                     mod,
                     (v,),
@@ -650,7 +650,7 @@ class CPUReproTests(TestCase):
                 batch_first,
             ).eval()
             maybe_autocast = (
-                torch.cpu.amp.autocast()
+                torch.amp.autocast("cpu")
                 if dtype == torch.bfloat16
                 else contextlib.nullcontext()
             )
@@ -5218,13 +5218,13 @@ class CPUReproTests(TestCase):
         context = contextlib.nullcontext if not is_inference else torch.no_grad
         with (
             config.patch({"fallback_random": True}),
-            torch.cpu.amp.autocast(),
+            torch.amp.autocast("cpu"),
             context(),
             sdpa_kernel(SDPBackend.MATH),
         ):
-            torch.manual_seed(0)
+            torch.manual_seed(23)
             eager = mod(*inputs)
-            torch.manual_seed(0)
+            torch.manual_seed(23)
             self.assertEqual(compiler_mode(*inputs), eager)
 
     def test_fused_node(self):
@@ -5447,7 +5447,7 @@ class CPUReproTests(TestCase):
             convert_element_type_default_14,
         )
 
-        with torch.cpu.amp.autocast():
+        with torch.amp.autocast("cpu"):
             mod = M().to(torch.bfloat16).eval()
             self.common(mod, inputs, atol=1e-3, rtol=1e-3)
 


### PR DESCRIPTION
Fixes #142134 

## Implementation
By resetting the random number seed in `torch.manual_seed( )`

## Result
`CPUReproTests.test_disabled_amp` passed on ARM

cc: @robert-hardwick @aditew01 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo