### PR TITLE
Batched SDPA op fix

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -478,8 +478,12 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   bool supports_sdpa_vector = (query_seq_len <= 8) && (query_seq_len <= k_.size(2)) &&
       ((!mask_.has_value()) || (mask_.value().dtype() == at::kBool)) && sdpa_vector_supported_head_dim;
 
+  // kernel path fails correctness for bs > 1.
+  // Issue: https://github.com/pytorch/pytorch/issues/170837
+  auto batch_size = query.size(0);
+
   // boolean to decide if we can use kernel paths
-  bool supports_fast_sdpa = !is_causal && supports_sdpa_vector;
+  bool supports_fast_sdpa = !is_causal && supports_sdpa_vector && batch_size == 1;
 
   // if none of the fast paths apply, fall back to the generic mps graph solution
   if (!supports_fast_sdpa) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9994,6 +9994,28 @@ class TestSDPA(TestCaseMPS):
         # 1 kB different maximum allowed value
         torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=1e-3, rtol=1e-3)
 
+    def test_sdpa_batch_size_and_non_contiguous(self):
+        dtype = torch.float32
+        for contiguous in [True, False]:
+            for batch_size in [1, 2]:
+                B, H, S, D = batch_size, 12, 7, 64
+
+                if contiguous:
+                    q = torch.randn(B, H, S, D, dtype=dtype)
+                    k = torch.randn(B, H, S, D, dtype=dtype)
+                    v = torch.randn(B, H, S, D, dtype=dtype)
+                else:
+                    q = torch.randn(B, S, H * D, dtype=dtype).view(B, S, H, D).transpose(1, 2)
+                    k = torch.randn(B, S, H * D, dtype=dtype).view(B, S, H, D).transpose(1, 2)
+                    v = torch.randn(B, S, H * D, dtype=dtype).view(B, S, H, D).transpose(1, 2)
+
+                out_cpu = F.scaled_dot_product_attention(q, k, v)
+                out_mps = F.scaled_dot_product_attention(q.to("mps"), k.to("mps"), v.to("mps")).cpu()
+
+                diff = (out_cpu - out_mps).abs().max().item()
+                torch.testing.assert_close(out_cpu, out_mps)
+
+
     def generate_qkv(self, batch: int, NH: int, q_len: int, s_len: int, head_dim: int, layout: str, dtype: torch.dtype):
         if layout == "contiguous":
             q = torch.randn(batch, NH, q_len, head_dim, dtype=dtype, device="mps")


### PR DESCRIPTION
Fixes #170837

The issue happens when the batch dimension is not 1 and the inputs are not contiguous and the computation gets dispatched to the SDPA metal kernels instead of the MPSGraph implementation.

Adjusts the conditions to dispatch computations with batched inputs to the MPSGraph implementation. Adds a regression test to test_mps.py.