### PR TITLE
[ROCM][CI] Update ECR login action to use pytorch repository

### DIFF
--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -113,7 +113,7 @@ runs:
         echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --network=host" >> "${GITHUB_ENV}"
 
     - name: Login to ECR
-      uses: ./.github/actions/ecr-login
+      uses: pytorch/pytorch/.github/actions/ecr-login
 
     - name: Preserve github env variables for use in docker
       shell: bash

--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -113,7 +113,7 @@ runs:
         echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --network=host" >> "${GITHUB_ENV}"
 
     - name: Login to ECR
-      uses: pytorch/pytorch/.github/actions/ecr-login
+      uses: pytorch/pytorch/.github/actions/ecr-login@main
 
     - name: Preserve github env variables for use in docker
       shell: bash


### PR DESCRIPTION
There are currently failures in other repos such as ao: https://github.com/pytorch/ao/actions/runs/20368607833/job/58529516014
This is due to the ecr-login change that was introduced here:
https://github.com/pytorch/pytorch/pull/170700
The change has been tested here:
https://github.com/pytorch/ao/actions/runs/20375969656/job/58554421109?pr=3519

The PR simply explicitly references the pytorch repo rather than the current repo.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang