### PR TITLE
Fix DTensor support for torch.linalg.pinv operation

### DIFF
--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -539,6 +539,7 @@ def foreach_max_strategy(op_schema: OpSchema) -> TupleStrategy:
     [
         aten._linalg_svd.default,
         aten.linalg_qr.default,
+        aten.linalg_pinv.atol_rtol_tensor,
         # TODO: The diagonal ops can have an improved sharding strategy for
         # shard placements that does not require redistributing to replicate.
         aten.diagonal_copy.default,


### PR DESCRIPTION
## Summary
Fixes test failure in `TestMultiThreadedDTensorOpsCPU.test_dtensor_op_db_linalg_pinv_singular_cpu_float32` by adding DTensor sharding strategy support for `torch.linalg.pinv()`.

## Test Information
- **Test**: `TestMultiThreadedDTensorOpsCPU.test_dtensor_op_db_linalg_pinv_singular_cpu_float32`
- **Repro**: `python test/distributed/tensor/test_dtensor_ops.py -v TestMultiThreadedDTensorOpsCPU.test_dtensor_op_db_linalg_pinv_singular_cpu_float32`

## Problem
The test was failing with `NotImplementedError: Operator aten.linalg_pinv.atol_rtol_tensor does not have a sharding strategy registered`. When DTensor operations encountered `torch.linalg.pinv()`, the dispatcher couldn't find a registered sharding strategy, causing the operation to fail.

## Solution
Added `aten.linalg_pinv.atol_rtol_tensor` to the `linalg_replicate_strategy` in `torch/distributed/tensor/_ops/_math_ops.py`. This strategy replicates inputs across all devices before computation, which is appropriate for complex linear algebra operations like pseudo-inverse (similar to SVD and QR decomposition which already use this strategy)

cc @nWEIdia 