### PR TITLE
ci: Switch to zstd compression for docker

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -405,7 +405,8 @@ fi
 docker buildx build \
        ${no_cache_flag} \
        ${progress_flag} \
-       --output "type=docker,compression=${COMPRESSION},compression-level=${COMPRESSION_LEVEL},force-compression=true,name=${tmp_tag}" \
+       --load \
+       --output "type=docker,compression=${COMPRESSION},compression-level=${COMPRESSION_LEVEL},force-compression=true" \
        --build-arg "BUILD_ENVIRONMENT=${image}" \
        --build-arg "LLVMDEV=${LLVMDEV:-}" \
        --build-arg "VISION=${VISION:-}" \
@@ -441,6 +442,7 @@ docker buildx build \
        --build-arg "SKIP_LLVM_SRC_BUILD_INSTALL=${SKIP_LLVM_SRC_BUILD_INSTALL:-}" \
        --build-arg "INSTALL_MINGW=${INSTALL_MINGW:-}" \
        -f $(dirname ${DOCKERFILE})/Dockerfile \
+       -t "$tmp_tag" \
        "$@" \
        .
 

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -113,6 +113,12 @@ jobs:
       - name: Login to ECR
         uses: ./.github/actions/ecr-login
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          version: latest
+          driver-opts: image=moby/buildkit:v0.19.0
+
       - name: Build docker image
         id: build-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #170932
* __->__ #170883

Apparently this is way quicker to decompress so wanted to try it out

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>