### PR TITLE
Skip flex attention CPU tests on platforms without AVX2 support

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1305,7 +1305,9 @@ class TestFlexAttention(InductorTestCase):
         )
 
     @supported_platform
-    @skipCPUIf(not torch.cpu._is_avx2_supported(), "CPU flex attention requires AVX2 support")
+    @skipCPUIf(
+        not torch.cpu._is_avx2_supported(), "CPU flex attention requires AVX2 support"
+    )
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1305,6 +1305,7 @@ class TestFlexAttention(InductorTestCase):
         )
 
     @supported_platform
+    @skipCPUIf(not torch.cpu._is_avx2_supported(), "CPU flex attention requires AVX2 support")
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)


### PR DESCRIPTION
### Problem

The test `TestFlexAttentionCPU.test_builtin_score_mods_dynamic` was failing on ARM machines (Nvidia GB200) without AVX2 support with:
```
NotImplementedError: torch.compile on current platform is not supported for CPU.
```

**Repro command:**
```bash
python test/inductor/test_flex_attention.py TestFlexAttentionCPU.test_builtin_score_mods_dynamic_score_mask_mod2_cpu_float32
```

### Root Cause

The existing `@supported_platform` decorator checks if *any* platform (CPU, CUDA, or XPU) supports flex attention. When CUDA is available, tests are instantiated for both CUDA and CPU devices. However, the CPU variant requires AVX2 instruction set support, which is not available on ARM architectures. The platform-level decorator cannot distinguish between device-specific requirements, so CPU tests ran even when AVX2 was unavailable.

https://github.com/pytorch/pytorch/blob/4fda5a6e3dcf874f1fbc5d7452fbd035588f62b2/test/inductor/test_flex_attention.py#L1307-L1315

### Solution

Added `@skipCPUIf(not torch.cpu._is_avx2_supported(), "CPU flex attention requires AVX2 support")` decorator to the affected test. This device-specific decorator:
- Skips only the CPU test variant when AVX2 is not supported
- Allows CUDA/XPU tests to continue running normally on the same machine
- Properly enforces the CPU-specific hardware requirement for compiled flex attention

This ensures tests run only on compatible hardware while maintaining test coverage on supported platforms.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo