### PR TITLE
Fix test_comprehensive_to_sparse_cpu_int32 by adding missing expected failures

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -248,8 +248,12 @@ inductor_expected_failures_single_sample["cpu"] = {
     ("sparse.mm", "reduce"): {f32, f64, f16},
     "sparse.sampled_addmm": {f32, f64},
     "to_sparse": {
+        b8,
+        f16,
         f32,
         f64,
+        i32,
+        i64,
     },  # NYI: could not find kernel for aten.view.default at dispatch key DispatchKey.SparseCPU
     "view_as_complex": {f16},
 }


### PR DESCRIPTION
## Summary
Fixes `TestInductorOpInfoCPU.test_comprehensive_to_sparse_cpu_int32` test failure by adding missing dtypes to the CPU expected failures list for `to_sparse` operations.

## Test Failure
- **Test**: `TestInductorOpInfoCPU.test_comprehensive_to_sparse_cpu_int32`
- **Repro**: `python test/inductor/test_torchinductor_opinfo.py -k test_comprehensive_to_sparse_cpu_int32`

## Problem
The test failed because `torch.compile` does not support operations that return sparse tensors with `fullgraph=True`. While CUDA and XPU configurations correctly marked `to_sparse` with integer dtypes (`b8`, `i32`, `i64`) as expected failures in commit 79a37055e79, the CPU configuration was not updated, causing tests with these dtypes to fail unexpectedly.

## Solution
Updated the CPU expected failures list in `test/inductor/test_torchinductor_opinfo.py` to include `b8`, `f16`, `i32`, and `i64` dtypes for `to_sparse`, making it consistent with CUDA and XPU configurations. This properly marks these known limitations as expected failures rather than test failures

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo