### PR TITLE
Add id fields to issue templates for URL pre-filling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,6 +7,7 @@ body:
     value: >
       #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/pytorch/pytorch/issues?q=is%3Aissue+sort%3Acreated-desc+). Note: Please write your bug report in English to ensure it can be understood and addressed by the development team. If you are filing a bug for torch.compile, please use the [torch.compile issue template](https://github.com/pytorch/pytorch/issues/new?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen&template=pt2-bug-report.yml).
 - type: textarea
+  id: bug-description
   attributes:
     label: 🐛 Describe the bug
     description: |
@@ -42,6 +43,7 @@ body:
   validations:
     required: true
 - type: textarea
+  id: versions
   attributes:
     label: Versions
     description: |

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -7,6 +7,7 @@ body:
     value: >
       #### Note: Please report your documentation issue in English to ensure it can be understood and addressed by the development team.
 - type: textarea
+  id: doc-issue
   attributes:
     label: 📚 The doc issue
     description: >
@@ -14,6 +15,7 @@ body:
   validations:
     required: true
 - type: textarea
+  id: suggested-fix
   attributes:
     label: Suggest a potential alternative/fix
     description: >

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -7,6 +7,7 @@ body:
     value: >
       #### Note: Please write your feature request in English to ensure it can be understood and addressed by the development team.
 - type: textarea
+  id: feature-motivation
   attributes:
     label: 🚀 The feature, motivation and pitch
     description: >
@@ -14,11 +15,13 @@ body:
   validations:
     required: true
 - type: textarea
+  id: alternatives
   attributes:
     label: Alternatives
     description: >
       A description of any alternative solutions or features you've considered, if any.
 - type: textarea
+  id: additional-context
   attributes:
     label: Additional context
     description: >

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -27,6 +27,7 @@ body:
         If the above requirements are met, add the label "topic: fuzzer" to your issue.
 
   - type: textarea
+    id: bug-description
     attributes:
       label: 🐛 Describe the bug
       description: |
@@ -45,6 +46,7 @@ body:
       required: false
 
   - type: textarea
+    id: error-logs
     attributes:
       label: Error logs
       description: |
@@ -55,6 +57,7 @@ body:
       required: false
 
   - type: textarea
+    id: versions
     attributes:
       label: Versions
       description: |

--- a/.github/ISSUE_TEMPLATE/release-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/release-feature-request.yml
@@ -4,10 +4,11 @@ labels: ["release-feature-request"]
 
 body:
 - type: textarea
+  id: feature-title
   attributes:
     label: New Feature for Release
     description: >
-      Example: “A torch.special module, analogous to SciPy's special module.”
+      Example: "A torch.special module, analogous to SciPy's special module."
 - type: input
   id: contact
   attributes:
@@ -27,6 +28,7 @@ body:
   validations:
     required: true
 - type: textarea
+  id: out-of-tree-repo
   attributes:
     label: Out-Of-Tree Repo
     description: >
@@ -34,6 +36,7 @@ body:
   validations:
     required: false
 - type: textarea
+  id: description
   attributes:
     label: Description and value to the user
     description: >
@@ -41,11 +44,13 @@ body:
   validations:
     required: false
 - type: textarea
+  id: links
   attributes:
     label: Link to design doc, GitHub issues, past submissions, etc
   validations:
     required: false
 - type: textarea
+  id: feedback
   attributes:
     label: What feedback adopters have provided
     description: >
@@ -65,6 +70,7 @@ body:
   validations:
     required: true
 - type: textarea
+  id: tutorial-context
   attributes:
     label: Additional context for tutorials
     description: >
@@ -82,6 +88,7 @@ body:
   validations:
     required: true
 - type: textarea
+  id: marketing-assistance
   attributes:
     label: Are you requesting other marketing assistance with this feature?
     description: >
@@ -89,6 +96,7 @@ body:
   validations:
     required: false
 - type: textarea
+  id: release-version
   attributes:
     label: Release Version
     description: >
@@ -96,6 +104,7 @@ body:
   validations:
     required: false
 - type: textarea
+  id: platform-coverage
   attributes:
     label: OS / Platform / Compute Coverage
     description: >
@@ -103,6 +112,7 @@ body:
   validations:
     required: false
 - type: textarea
+  id: testing-support
   attributes:
     label: Testing Support (CI, test cases, etc..)
     description: >


### PR DESCRIPTION
## Summary

Adds `id` attributes to all textarea and input fields in GitHub issue templates (.github/ISSUE_TEMPLATE/*.yml).

## Purpose

Enables programmatic issue creation with pre-filled form fields via URL query parameters. This allows automation tools and scripts to generate URLs that pre-populate issue forms, while still requiring human review and submission.

## Changes

- **bug-report.yml**: Added `bug-description` and `versions` IDs
- **pt2-bug-report.yml**: Added `bug-description`, `error-logs`, and `versions` IDs
- **documentation.yml**: Added `doc-issue` and `suggested-fix` IDs
- **feature-request.yml**: Added `feature-motivation`, `alternatives`, and `additional-context` IDs
- **release-feature-request.yml**: Added IDs to all textarea fields

## Reference

[GitHub Docs: Syntax for GitHub's form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema) - See section on `id` attribute for URL query parameter prefills.