### PR TITLE
[annotation] add torch.fx.traceback.annotate_scope API

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1650,6 +1650,8 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.assertGreater(len(all_new_nodes), 0, "Should have created new nodes")
 
             for node in all_new_nodes:
+                if "_pt2_compiled_region" in node.meta.get("custom"):
+                    del node.meta["custom"]["_pt2_compiled_region"]
                 self.assertEqual(
                     node.meta.get("nn_module_stack"), test_metadata["nn_module_stack"]
                 )

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -13,6 +13,7 @@ from torch._C import (
 )
 from torch._dynamo.testing import normalize_gm
 from torch._dynamo.utils import counters
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.overrides import (
     _get_current_function_mode_stack,
     BaseTorchFunctionMode,
@@ -808,7 +809,6 @@ class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
         When force_compile_during_fx_trace=True, the invoke_subgraph backend should
         emit an invoke_subgraph HOP in the traced graph instead of inlining the subgraph.
         """
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         torch._dynamo.reset()  # Clear any cached graphs
 
@@ -858,7 +858,6 @@ class outer_fn(torch.nn.Module):
         don't cause guard failures, both calls should reference the same subgraph.
         """
         from torch._guards import tracing, TracingContext
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         torch._dynamo.reset()
 
@@ -1062,7 +1061,6 @@ class GraphModule(torch.nn.Module):
         failures (e.g., different bool values), each compilation should result
         in a separate invoke_subgraph with a different identifier.
         """
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         torch._dynamo.reset()
 
@@ -1119,7 +1117,6 @@ class outer_fn(torch.nn.Module):
         Verifies that the invoke_subgraph HOP correctly handles functions
         that take more than 2 tensor inputs.
         """
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         torch._dynamo.reset()
 
@@ -1166,7 +1163,6 @@ class outer_fn(torch.nn.Module):
         Verifies that the invoke_subgraph HOP correctly handles functions
         that return multiple tensors.
         """
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         torch._dynamo.reset()
 
@@ -1216,7 +1212,6 @@ class outer_fn(torch.nn.Module):
         Verifies that the invoke_subgraph HOP correctly handles functions
         that have both multiple tensor inputs and multiple tensor outputs.
         """
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         torch._dynamo.reset()
 
@@ -1320,6 +1315,117 @@ class outer_fn(torch.nn.Module):
             compile_counter.frame_count,
             1,
             f"Expected 1 compilation, got {compile_counter.frame_count}",
+        )
+
+    @torch._dynamo.config.patch(force_compile_during_fx_trace=True)
+    def test_annotate_rqn(self):
+        """Test annotate_rqn with nested function calls.
+
+        Demonstrates that when inner_fn is called multiple times within
+        outer_fn's scope, each call's operations get the correct nested
+        rqn annotation.
+        """
+        import torch.fx.traceback as fx_traceback
+        from torch._guards import tracing, TracingContext
+
+        torch._dynamo.reset()
+
+        def simple_fn(x):
+            with fx_traceback.annotate_rqn("inner"):
+                return x * 2
+
+        compiled_fn = torch.compile(simple_fn, backend="invoke_subgraph")
+
+        def outer_fn(x, y):
+            # Call the same compiled function twice
+            with fx_traceback.annotate_rqn("outer_1"):
+                a = compiled_fn(x)
+            with fx_traceback.annotate_rqn("outer_2"):
+                b = compiled_fn(y)
+            return a + b
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        # Set up TracingContext so invoke_subgraph cache works
+        tracing_ctx = TracingContext(fake_mode=None)
+        with tracing(tracing_ctx), fx_traceback.preserve_node_meta():
+            traced = make_fx(
+                outer_fn, tracing_mode="fake", _disable_torch_fn_metadata_mode=True
+            )(x, y)
+
+        # Only 1 subgraph is produced
+        self.assertEqual(len(list(traced.modules())), 2)
+
+        custom_metadata = fx_traceback._get_annotated_rqn_metadata(traced)
+        # The torch.ops.higher_order.invoke_subgraph and get_attr nodes have correct outer anntoation
+        self.assertExpectedInline(
+            str(custom_metadata),
+            """\
+('get_attr', 'repeated_subgraph0', 'outer_1')
+[('call_function', 'mul', 'inner')]
+('call_function', 'invoke_subgraph', 'outer_1')
+('call_function', 'getitem', 'outer_1')
+('get_attr', 'repeated_subgraph0_1', 'outer_2')
+[('call_function', 'mul', 'inner')]
+('call_function', 'invoke_subgraph_1', 'outer_2')
+('call_function', 'getitem_1', 'outer_2')""",
+        )
+
+    @torch._dynamo.config.patch(force_compile_during_fx_trace=True)
+    def test_annotate_rqn_fn(self):
+        """Test annotate_rqn_fn with nested function calls.
+
+        Demonstrates that when inner_fn is called multiple times within
+        outer_fn's scope, each call's operations get the correct nested
+        rqn annotation.
+        """
+        import torch.fx.traceback as fx_traceback
+        from torch._guards import tracing, TracingContext
+
+        torch._dynamo.reset()
+
+        def simple_fn(x):
+            return x * 2
+
+        simple_fn_annotated = fx_traceback.annotate_rqn_fn("inner")(simple_fn)
+
+        compiled_fn = torch.compile(simple_fn_annotated, backend="invoke_subgraph")
+
+        def outer_fn(x, y):
+            # Call the same compiled function twice
+            with fx_traceback.annotate_rqn("outer_1"):
+                a = compiled_fn(x)
+            with fx_traceback.annotate_rqn("outer_2"):
+                b = compiled_fn(y)
+            return a + b
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        # Set up TracingContext so invoke_subgraph cache works
+        tracing_ctx = TracingContext(fake_mode=None)
+        with tracing(tracing_ctx), fx_traceback.preserve_node_meta():
+            traced = make_fx(
+                outer_fn, tracing_mode="fake", _disable_torch_fn_metadata_mode=True
+            )(x, y)
+
+        # Only 1 subgraph is produced
+        self.assertEqual(len(list(traced.modules())), 2)
+
+        custom_metadata = fx_traceback._get_annotated_rqn_metadata(traced)
+        # The torch.ops.higher_order.invoke_subgraph and get_attr nodes have correct outer anntoation
+        self.assertExpectedInline(
+            str(custom_metadata),
+            """\
+('get_attr', 'repeated_subgraph0', 'outer_1')
+[('call_function', 'mul', 'inner')]
+('call_function', 'invoke_subgraph', 'outer_1')
+('call_function', 'getitem', 'outer_1')
+('get_attr', 'repeated_subgraph0_1', 'outer_2')
+[('call_function', 'mul', 'inner')]
+('call_function', 'invoke_subgraph_1', 'outer_2')
+('call_function', 'getitem_1', 'outer_2')""",
         )
 
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -646,11 +646,14 @@ class TestExport(TestCase):
         # should not be copied to other nodes
         counter = 0
         for node in new_ep.graph.nodes:
-            if "custom" in node.meta:
+            if node.target == torch.ops.aten.linear.default:
+                self.assertTrue("custom" in node.meta)
                 counter += 1
                 self.assertTrue(node.meta["custom"]["quantization_tag"] == "foo")
-                self.assertTrue(node.target == torch.ops.aten.linear.default)
-
+            else:
+                # other annotation such as '_torchdynamo_disable' might be added
+                if "custom" in node.meta:
+                    self.assertTrue("quantization_tag" not in node.meta["custom"])
         self.assertEqual(counter, 1)
 
     @skipIfCrossRef

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5073,9 +5073,7 @@ class <lambda>(torch.nn.Module):
             add: "f32[2, 2]" = torch.ops.aten.add.Tensor(sin, 5);  sin = None
 
             cos: "f32[2, 2]" = torch.ops.aten.cos.default(add);  add = None
-
             sum_1: "f32[]" = torch.ops.aten.sum.default(arg1_1);  arg1_1 = None
-
             add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
             return (add_1,)
 
@@ -5086,7 +5084,6 @@ class <lambda>(torch.nn.Module):
             body_graph_0 = self.body_graph_0
             map_impl = torch.ops.higher_order.map_impl(body_graph_0, [cos], [arg1_1]);  body_graph_0 = None
             getitem: "f32[2, 2]" = map_impl[0];  map_impl = None
-
             sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
 
             add: "f32[2, 2]" = torch.ops.aten.add.Tensor(cos, sum_1);  sum_1 = None
@@ -5094,7 +5091,6 @@ class <lambda>(torch.nn.Module):
             body_graph_1 = self.body_graph_1
             map_impl_1 = torch.ops.higher_order.map_impl(body_graph_1, [cos], [arg1_1]);  body_graph_1 = cos = arg1_1 = None
             getitem_1: "f32[2, 2]" = map_impl_1[0];  map_impl_1 = None
-
             sum_2: "f32[]" = torch.ops.aten.sum.default(getitem_1);  getitem_1 = None
 
             add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(add, sum_2);  add = sum_2 = None

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -160,6 +160,15 @@ def invoke_subgraph_inner_compiler(
     from torch._dynamo import disable
     from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_infer
 
+    # See NB annotation in invoke_subgraph
+    compiled_region_rqn = torch.fx.traceback._get_compile_rqn_annotation()
+    torch.fx.traceback._remove_rqn_metadata_prefix(subgraph, compiled_region_rqn)
+
+    for node in subgraph.graph.nodes:
+        # remove the compiled RQN annotation key because it's different for each trace
+        if torch.fx.traceback.COMPILE_RQN_ANNOTATION_KEY in node.meta.get("custom", {}):
+            del node.meta["custom"][torch.fx.traceback.COMPILE_RQN_ANNOTATION_KEY]
+
     @disable
     @torch._dynamo.allow_in_graph
     def invoke_subgraph_wrapper_unboxed(*operands: Any) -> Any:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -999,6 +999,13 @@ class _TorchDynamoContext:
                     torch._C._functorch.get_dynamic_layer_stack_depth()
                 )
 
+                # Set up compile region annotation BEFORE enabling the callback
+                # to avoid contextlib frames being traced by Dynamo
+                current_rqn = torch.fx.traceback.get_current_rqn()
+                saved_compile_region = torch.fx.traceback._enter_annotation(
+                    {torch.fx.traceback.COMPILE_RQN_ANNOTATION_KEY: current_rqn}
+                )
+
                 _maybe_set_eval_frame(_callback_from_stance(callback))
 
                 try:
@@ -1031,6 +1038,7 @@ class _TorchDynamoContext:
                     set_skip_guard_eval_unsafe(prior_skip_guard_eval_unsafe)
                     for cleanup in cleanups:
                         cleanup()
+                    torch.fx.traceback._exit_annotation(saved_compile_region)
             finally:
                 _maybe_set_eval_frame(prior)
 

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1098,6 +1098,16 @@
       ]
     }
   ],
+  "GB7894": [
+    {
+      "Gb_type": "annotation context manager torch.fx.traceback.{fn_name} escaped from compiled region",
+      "Context": "str(self)",
+      "Explanation": "Dynamo doesn't support graph break on torch.fx.traceback.{fn_name}.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0096": [
     {
       "Gb_type": "Should not compile partial graph (STORE_ATTR)",

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -28,6 +28,8 @@ from .ctx_manager import (
     DynamoConfigPatchVariable,
     ErrorOnGraphBreakVariable,
     FSDPParamGroupUseTrainingStateVariable,
+    FxTracebackAnnotateBaseVariable,
+    FxTracebackAnnotateRqnVariable,
     FxTracebackAnnotateVariable,
     GenericContextWrappingVariable,
     GradIncrementNestingCtxManagerVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -141,6 +141,8 @@ supported_ctx_manager_classes = dict.fromkeys(
         torch.cuda.amp.autocast_mode.autocast,
         torch.fx.traceback.annotate,
         torch.fx.traceback.annotate.__wrapped__,  # type: ignore[attr-defined]
+        torch.fx.traceback.annotate_rqn,
+        torch.fx.traceback.annotate_rqn.__wrapped__,  # type: ignore[attr-defined]
         # We'll let Dynamo inline into the contextlib part of these context
         # manager instances, all the way till it invokes the wrapped function
         # itself (at which point we wrap it back to special context manager
@@ -466,6 +468,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             DisabledSavedTensorsHooksVariable,
             DualLevelContextManager,
             FSDPParamGroupUseTrainingStateVariable,
+            FxTracebackAnnotateRqnVariable,
             FxTracebackAnnotateVariable,
             GradIncrementNestingCtxManagerVariable,
             GradInplaceRequiresGradCtxManagerVariable,
@@ -507,6 +510,14 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
         ):
             assert len(args) <= 1 and len(kwargs) == 0
             return FxTracebackAnnotateVariable(
+                args[0].as_python_constant(), source=self.source
+            )
+        elif self.value in (
+            torch.fx.traceback.annotate_rqn,
+            torch.fx.traceback.annotate_rqn.__wrapped__,  # type: ignore[attr-defined]
+        ):
+            assert len(args) <= 1 and len(kwargs) == 0
+            return FxTracebackAnnotateRqnVariable(
                 args[0].as_python_constant(), source=self.source
             )
         elif inspect.isclass(self.value) and issubclass(self.value, torch.Stream):

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import Any, Optional
 
 import torch
+import torch.fx.traceback as fx_traceback
 import torch.utils._pytree as pytree
 import torch.utils.dlpack
 from torch._dispatch.python import enable_python_dispatcher
@@ -259,12 +260,15 @@ def aot_dispatch_base_graph(
         updated_flat_args_subclasses_desugared_descs
     )
 
-    fw_module = _create_graph(
-        fn_to_trace,
-        updated_flat_args_subclasses_desugared,
-        updated_flat_args_subclasses_desugared_descs,
-        aot_config=aot_config,
-    )
+    # need preserve_node_meta so we have annotation from fx.traceback.annotate
+    # on the graph
+    with fx_traceback.preserve_node_meta():
+        fw_module = _create_graph(
+            fn_to_trace,
+            updated_flat_args_subclasses_desugared,
+            updated_flat_args_subclasses_desugared_descs,
+            aot_config=aot_config,
+        )
 
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
         # We update metadata to consider any assigned buffers as buffer mutations.

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -22,6 +22,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import py_sym_types
+from torch.fx.traceback import ANNOTATION_META_KEYS
 
 
 _T = TypeVar("_T")
@@ -633,10 +634,11 @@ def _copy_metadata_to_bw_nodes_in_subgraph(
         if fwd_node is not None:
             node.meta["fwd_nn_module_stack"] = fwd_node.meta.get("nn_module_stack")
             node.meta["fwd_source_fn_stack"] = fwd_node.meta.get("source_fn_stack")
-            # TODO: better to change to a specific field of custom?
-            custom = fwd_node.meta.get("custom")
-            if custom is not None:
-                node.meta["custom"] = copy.deepcopy(custom)
+            # Copy annotation metadata keys
+            for key in ANNOTATION_META_KEYS:
+                value = fwd_node.meta.get(key)
+                if value is not None:
+                    node.meta[key] = copy.deepcopy(value)
 
 
 def copy_fwd_metadata_to_bw_nodes(fx_g: torch.fx.GraphModule) -> None:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -655,11 +655,18 @@ class CodeGen:
                 annotation_trunc = {}
                 if annotation:
                     for key, value in annotation.items():
+                        if key == torch.fx.traceback.COMPILE_RQN_ANNOTATION_KEY:
+                            continue
                         value_str = str(value)
                         if len(value_str) > 40:
                             annotation_trunc[key] = value_str[:40] + "..."
                         else:
                             annotation_trunc[key] = value
+                # Handle annotated_rqn with label
+                annotated_rqn = node.meta.get("annotated_rqn", None)
+                if annotated_rqn:
+                    annotation_trunc["RQN"] = annotated_rqn
+                if annotation_trunc:
                     annotation_str = f" Annotation: {annotation_trunc}"
 
                 stack_trace_str = "No stacktrace found for following nodes"

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -118,8 +118,11 @@ _COPY_META_FIELDS = [
     "from_node",
     "quantization_tag",  # TODO deprecated
     "_numeric_debug_handle",  # TODO deprecated
-    "custom",
     "partitioner_tag",
+    # There are from torch.fx.traceback.ANNOTATION_META_KEYS.
+    # we cannot import here due to circular import
+    "custom",
+    "annotated_rqn",
 ]
 
 
@@ -211,8 +214,9 @@ class TracerBase:
             replay_node: Node = fx_traceback.get_current_replay_node()
             if replay_node is not None:
                 node.meta["is_functional_regenerated"] = True
-                if "custom" in replay_node.meta:
-                    node.meta["custom"] = replay_node.meta.get("custom")
+                for key in fx_traceback.ANNOTATION_META_KEYS:
+                    if key in replay_node.meta:
+                        node.meta[key] = replay_node.meta.get(key)
                 if "stack_trace" in replay_node.meta:
                     node.stack_trace = replay_node.meta.get("stack_trace")
 

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 import traceback
+import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum
@@ -20,6 +21,8 @@ log = logging.getLogger(__name__)
 __all__ = [
     "annotate",
     "annotate_fn",
+    "annotate_rqn",
+    "annotate_rqn_fn",
     "preserve_node_meta",
     "has_preserved_node_meta",
     "set_stack_trace",
@@ -33,6 +36,8 @@ __all__ = [
     "get_graph_provenance_json",
     "set_current_replay_node",
     "get_current_replay_node",
+    "get_current_rqn",
+    "reset_current_annotation",
 ]
 
 current_meta: dict[str, Any] = {}
@@ -41,6 +46,20 @@ current_replay_node: Optional[Node] = None
 should_preserve_node_meta = False
 # Preserve the "seq_nr" node meta field
 _should_preserve_node_meta = False
+
+
+# If you change the key here, you should also change
+# _COPY_META_FIELDS in torch/fx/proxy.py
+
+# RQN stands for relative qualified name. The qualified name is relative to a root.
+RQN_ANNOTATION_KEY = "annotated_rqn"
+COMPILE_RQN_ANNOTATION_KEY = "_pt2_compiled_region"
+RQN_DELIMITER = "."
+
+# List of metadata keys used for annotations
+# These keys are propagated through various compilation passes
+ANNOTATION_META_KEYS = ["custom", RQN_ANNOTATION_KEY]
+
 
 GRADIENT_ACC_SPECIAL_STACK = (
     "Gradient addition node due to multiple use of tensor around:"
@@ -291,6 +310,39 @@ def set_stack_trace(stack: list[str]):
         current_meta["stack_trace"] = "".join(stack)
 
 
+def _enter_annotation(annotation_dict: dict) -> tuple[bool, dict]:
+    """
+    Core function to enter an annotation context.
+    Returns (had_custom, old_custom) for restoration.
+    """
+    global current_meta
+
+    has_custom = "custom" in current_meta
+    old_custom = copy.copy(current_meta.get("custom", {}))
+
+    if not has_custom:
+        current_meta["custom"] = {}
+
+    new_custom = copy.copy(current_meta["custom"])
+    new_custom.update(annotation_dict)
+    current_meta["custom"] = new_custom
+
+    return (has_custom, old_custom)
+
+
+def _exit_annotation(saved_state: tuple[bool, dict]) -> None:
+    """
+    Core function to exit an annotation context.
+    """
+    global current_meta
+
+    has_custom, old_custom = saved_state
+    if has_custom:
+        current_meta["custom"] = old_custom
+    else:
+        del current_meta["custom"]
+
+
 @compatibility(is_backward_compatible=False)
 @contextmanager
 def annotate(annotation_dict: dict):
@@ -307,6 +359,10 @@ def annotate(annotation_dict: dict):
 
     This is intended for advanced users who need to attach additional metadata to the fx nodes
     (e.g., for debugging, analysis, or external tooling) during export tracing.
+
+    When nested, annotations with the same keys are overridden by the innermost context,
+    while annotations with different keys are merged. Upon exiting each nested context,
+    the annotations are restored to their previous state.
 
     Note:
         This API is **not backward compatible** and may evolve in future releases.
@@ -325,25 +381,61 @@ def annotate(annotation_dict: dict):
         >>> with annotate({"source": "custom_pass", "tag": 42}):
         ...     pass  # Your computation here
     """
-
-    global current_meta
-
-    has_custom = "custom" in current_meta
-    old_custom = copy.copy(current_meta.get("custom", {}))
-
+    saved_state = _enter_annotation(annotation_dict)
     try:
-        if not has_custom:
-            current_meta["custom"] = {}
-
-        # Update with all key-value pairs from the input dict
-        current_meta["custom"].update(annotation_dict)
         yield
     finally:
-        if has_custom:
-            # Restore the original custom dict
-            current_meta["custom"] = old_custom
+        _exit_annotation(saved_state)
+
+
+@compatibility(is_backward_compatible=False)
+@contextmanager
+def annotate_rqn(rqn: str):
+    """
+    Temporarily adds a relatively qualified name (RQN) annotation to the current tracing context.
+    FX nodes will have the annotation in node.metadata["annotated_rqn"].
+
+    When nested, RQN annotations are automatically concatenated with dots ('.') to create
+    a hierarchical path (e.g., "model.encoder.layer1").
+
+    Note:
+        This API is **not backward compatible** and may evolve in future releases.
+
+    Note:
+        This API is not compatible with fx.symbolic_trace or jit.trace. It's intended
+        to be used with PT2 family of tracers, e.g. torch.export and dynamo.
+
+    Args:
+        rqn (str): Relatively qualified name to inject into FX trace metadata. Avoid using dots ('.').
+
+    Example:
+        >>> with annotate_rqn("model"):
+        ...     with annotate_rqn("encoder"):
+        ...         x = y + z  # annotated_rqn="model.encoder"
+    """
+    if RQN_DELIMITER in rqn:
+        warnings.warn(
+            f"annotate_rqn {rqn} contains '{RQN_DELIMITER}'. "
+            f"'{RQN_DELIMITER}' is used as the delimiter. "
+            f"Consider using a different rqn annotation."
+        )
+    global current_meta
+
+    has_scope_annotation = RQN_ANNOTATION_KEY in current_meta
+    old_rqn = current_meta.get(RQN_ANNOTATION_KEY, "")
+
+    try:
+        if not has_scope_annotation:
+            current_meta[RQN_ANNOTATION_KEY] = rqn
         else:
-            del current_meta["custom"]
+            current_meta[RQN_ANNOTATION_KEY] = old_rqn + RQN_DELIMITER + rqn
+        yield
+    finally:
+        if has_scope_annotation:
+            # Restore the original custom dict
+            current_meta[RQN_ANNOTATION_KEY] = old_rqn
+        else:
+            del current_meta[RQN_ANNOTATION_KEY]
 
 
 @compatibility(is_backward_compatible=False)
@@ -381,6 +473,66 @@ def annotate_fn(annotation_dict: dict):
         return wrapper
 
     return decorator
+
+
+@compatibility(is_backward_compatible=False)
+def annotate_rqn_fn(rqn: str):
+    """
+    A decorator that wraps a function with the annotate_rqn context manager.
+    Use this when you want to annotate an entire function with a relatively qualified name
+    instead of a specific code block.
+
+    Note:
+        This API is **not backward compatible** and may evolve in future releases.
+
+    Note:
+        This API is not compatible with fx.symbolic_trace or jit.trace. It's intended
+        to be used with PT2 family of tracers, e.g. torch.export and dynamo.
+
+    Args:
+        rqn (str): A relatively qualified name string to inject into the FX trace metadata
+            for all operations in the function.
+
+    Example:
+        All operations in my_function will have annotated_rqn metadata.
+
+        >>> @annotate_rqn_fn("my_module.my_function")
+        ... def my_function(x):
+        ...     return x + 1
+    """
+    from functools import wraps
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with annotate_rqn(rqn):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@compatibility(is_backward_compatible=False)
+@contextmanager
+def reset_current_annotation():
+    global current_meta
+    saved_rqn = current_meta.get(RQN_ANNOTATION_KEY)
+    saved_custom = current_meta.get("custom", {})
+    try:
+        if RQN_ANNOTATION_KEY in current_meta:
+            del current_meta[RQN_ANNOTATION_KEY]
+
+        if "custom" in current_meta:
+            current_meta["custom"] = {}
+
+        yield
+    finally:
+        if saved_rqn:
+            current_meta[RQN_ANNOTATION_KEY] = saved_rqn
+
+        if saved_custom:
+            current_meta["custom"] = saved_custom
 
 
 @compatibility(is_backward_compatible=False)
@@ -459,6 +611,11 @@ def get_current_meta() -> dict[str, Any]:
 
 
 @compatibility(is_backward_compatible=False)
+def get_current_rqn() -> str:
+    return current_meta.get(RQN_ANNOTATION_KEY, "")
+
+
+@compatibility(is_backward_compatible=False)
 @contextmanager
 def set_current_replay_node(node):
     """
@@ -513,20 +670,47 @@ def get_graph_provenance_json(graph: Graph) -> dict[str, Any]:
         return {}
 
 
-def _get_custom_metadata(gm: GraphModule) -> str:
-    if not isinstance(gm, GraphModule):
-        raise AssertionError(f"Expected GraphModule, got {type(gm)}")
+def _get_annotation_metadata(
+    gm: GraphModule, key: str, ignore_compile_rqn_annotation_key: bool = True
+) -> str:
+    """
+    Generic helper to extract annotation metadata for a given key from a GraphModule.
+
+    Args:
+        gm: The GraphModule to extract metadata from
+        key: The metadata key to extract (e.g., "custom", "annotated_rqn")
+        ignore_compile_rqn_annotation_key: If True (default), exclude the internal
+            COMPILE_RQN_ANNOTATION_KEY from the output when key is "custom"
+
+    Returns:
+        A string representation of all nodes with the specified metadata key
+    """
+    assert isinstance(gm, GraphModule)
 
     def helper(gm: GraphModule):
-        custom_metadata = []
+        metadata = []
         for node in gm.graph.nodes:
-            if hasattr(node, "meta") and node.meta.get("custom", None):
-                custom_metadata.append((node.op, node.name, node.meta["custom"]))
+            if hasattr(node, "meta") and node.meta.get(key, None):
+                node_meta = node.meta[key]
+                # Filter out COMPILE_RQN_ANNOTATION_KEY if requested
+                if (
+                    ignore_compile_rqn_annotation_key
+                    and key == "custom"
+                    and isinstance(node_meta, dict)
+                ):
+                    node_meta = {
+                        k: v
+                        for k, v in node_meta.items()
+                        if k != COMPILE_RQN_ANNOTATION_KEY
+                    }
+                    if not node_meta:
+                        continue
+                metadata.append((node.op, node.name, node_meta))
             if node.op == "get_attr" and isinstance(
                 getattr(gm, node.target), GraphModule
             ):
-                custom_metadata.append(helper(getattr(gm, node.target)))
-        return custom_metadata
+                metadata.append(helper(getattr(gm, node.target)))
+        return metadata
 
     return "\n".join(str(x) for x in helper(gm))
 
@@ -561,3 +745,50 @@ def _get_ordered_seq_nr_groups(
                     seq_nr_dict[seq_nr].append(node.name)
     # Sort by seq_nr and return list of sorted lists
     return [sorted(seq_nr_dict[k]) for k in sorted(seq_nr_dict.keys())]
+
+
+def _get_custom_metadata(gm: GraphModule) -> str:
+    """
+    Extract custom annotation metadata from a GraphModule.
+    This function maintains backward compatibility.
+
+    Args:
+        gm: The GraphModule to extract metadata from
+
+    Returns:
+        A string representation of all nodes with custom metadata
+    """
+    return _get_annotation_metadata(gm, "custom")
+
+
+def _get_annotated_rqn_metadata(gm: GraphModule) -> str:
+    """
+    Extract annotated_rqn metadata from a GraphModule.
+
+    Args:
+        gm: The GraphModule to extract metadata from
+
+    Returns:
+        A string representation of all nodes with annotated_rqn metadata
+    """
+    return _get_annotation_metadata(gm, "annotated_rqn")
+
+
+def _remove_rqn_metadata_prefix(subgraph: GraphModule, prefix: str):
+    """
+    Remove `prefix` from the prefix of node's RQN metadata along with the first delimiter.
+    """
+    if prefix:
+        for node in subgraph.graph.nodes:
+            if RQN_ANNOTATION_KEY in node.meta:
+                rqn = node.meta[RQN_ANNOTATION_KEY]
+                new_rqn = rqn.removeprefix(prefix).removeprefix(RQN_DELIMITER)
+                node.meta[RQN_ANNOTATION_KEY] = new_rqn
+
+
+def _get_compile_rqn_annotation():
+    """
+    Get the current RQN annotation for the current compilation.
+    """
+    global current_meta, COMPILE_RQN_ANNOTATION_KEY
+    return current_meta.get("custom", {}).get(COMPILE_RQN_ANNOTATION_KEY, "")


### PR DESCRIPTION
This PR introduces a new API `torch.fx.traceback.annotate_rqn` for annotating the module hierarchy of code chunks during PT2 tracing. It also ensures this API composes correctly with the `invoke_subgraph` torch.compile backend, where compiled regions do not inherit the parent rqn.

RQN stands for "relative qualified name", it's a name that's relative to some root (in contrast to FQN, fully qualified name, where it's an absolute path). For example, it can be relative to the torch.compile root or the invoke_subgraph root. 

```
 python test/dynamo/test_modes.py -k test_annotate_rqn
 python test/functorch/test_aot_joint_with_descriptors.py -k rqn
```

Some existing unittest's gm blank spacing changes because of the `with fx_traceback.preserve_node_meta()` context manager added in the graph_capture.py. Now more nodes should have correct stack trace on them. 


### 1. New `annotate_rqn` API (`torch/fx/traceback.py`)

A new context manager that allows users to annotate FX graph nodes with hierarchical rqn information. 

- Nested rqn's are automatically concatenated with `.` delimiter
- Annotations appear in `node.meta["annotated_rqn"]`
- Displayed in `gm.print_readable()` output

### 2. Integration with `invoke_subgraph` Backend (`torch/_dynamo/backends/debugging.py`)

When using the `invoke_subgraph` compile backend:
- Compiled regions get their own isolated rqn (don't inherit parent rqn)
- The parent rqn is tracked via `_pt2_compiled_region` in custom metadata in `torch/_dynamo/eval_frame.py`.
- Subgraph nodes only show their internal rqn annotations

Note that currently the API only works with the `invoke_subgraph` torch.compile backend.

It doesn't work with `aot_export_joint_with_descriptors` yet. Meaning, if you annotate_rqn on invoke_subgraph region, the traced subgraph will contain rqn of the first parent call. To make annotate_rqn work with `aot_export_joint_with_descriptors` , we need https://github.com/pytorch/pytorch/pull/172919  


### 3. Supporting Infrastructure

- **`torch/fx/proxy.py`**: Updated metadata copying to update (not override) custom dict, filtering internal keys
- **`torch/_dynamo/variables/ctx_manager.py`**: Added `FxTracebackAnnotateScopeVariable` for Dynamo tracing
- **`torch/fx/graph.py`**: Updated `print_readable()` to display rqn annotations
- **`torch/_functorch/_aot_autograd/graph_capture.py`**: Wrapped graph creation with `preserve_node_meta()`



##Examples

### Example 1: Nested Module Hierarchy

```python
import torch
import torch.nn as nn
import torch.fx.traceback as fx_traceback

class Bar(nn.Module):
    def forward(self, x):
        with fx_traceback.annotate_rqn("bar"):
            return x * 1

class Foo(nn.Module):
    def __init__(self):
        super().__init__()
        self.bar = Bar()

    def forward(self, x):
        with fx_traceback.annotate_rqn("foo"):
            y = self.bar(x)
            return y * 2

class MyMod(nn.Module):
    def __init__(self):
        super().__init__()
        self.foo = Foo()

    def forward(self, x):
        with fx_traceback.annotate_rqn("my_mod"):
            x = x / 2
            y = self.foo(x)
        return y - 1

model = MyMod()
compiled = torch.compile(model, backend=capture_backend)
compiled(torch.randn(4, 3))
```

**`gm.print_readable()` output:**
```
class GraphModule(torch.nn.Module):
    def forward(self, L_x_: "f32[4, 3]"):
        l_x_ = L_x_

        # RQN: 'my_mod' File: .../forward, code: x = x / 2
        x: "f32[4, 3]" = l_x_ / 2;  l_x_ = None

        # RQN: 'my_mod.foo.bar' File: .../forward, code: return x * 1
        y: "f32[4, 3]" = x * 1;  x = None

        # RQN: 'my_mod.foo' File: .../forward, code: return y * 2
        y_1: "f32[4, 3]" = y * 2;  y = None

        # File: .../forward, code: return y - 1
        sub: "f32[4, 3]" = y_1 - 1;  y_1 = None
        return (sub,)
```


### Example 2: Compose with `invoke_subgraph` Backend

```python
import torch
import torch.fx.traceback as fx_traceback
from torch.fx.experimental.proxy_tensor import make_fx

def simple_fn(x):
    with fx_traceback.annotate_rqn("inner"):
        return x * 2

compiled_fn = torch.compile(simple_fn, backend="invoke_subgraph")

def outer_fn(x, y):
    with fx_traceback.annotate_rqn("outer_1"):
        a = compiled_fn(x)
    with fx_traceback.annotate_rqn("outer_2"):
        b = compiled_fn(y)
    return a + b

# Trace with make_fx
traced = make_fx(outer_fn, tracing_mode="fake")(x, y)
```

**`traced.print_readable()` output:**
```
class outer_fn(torch.nn.Module):
    def forward(self, x_1: "f32[3, 3]", y_1: "f32[3, 3]"):
        # RQN: 'outer_1'
        repeated_subgraph0 = self.repeated_subgraph0
        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0, 'invoke_subgraph_0', x_1)
        getitem: "f32[3, 3]" = invoke_subgraph[0]

        # RQN: 'outer_2'
        repeated_subgraph0_1 = self.repeated_subgraph0
        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0_1, 'invoke_subgraph_0', y_1)
        getitem_1: "f32[3, 3]" = invoke_subgraph_1[0]

        add: "f32[3, 3]" = torch.ops.aten.add.Tensor(getitem, getitem_1)
        return add

    class repeated_subgraph0(torch.nn.Module):
        def forward(self, arg0_1: "f32[3, 3]"):
            # RQN: 'inner' File: .../simple_fn, code: return x * 2
            mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg0_1, 2)
            return (mul,)
```

**Key behavior:**
- The outer graph shows `outer_1` and `outer_2` rqns
- The subgraph shows only `inner` rqn (not `outer_1.inner` or `outer_2.inner`)
- This ensures compiled regions have independent rqn hierarchies

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela