### PR TITLE
[FakeTensor] Override fake impl for diagonal_scatter to accepts mixed devices

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7727,12 +7727,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
 
     # https://github.com/pytorch/pytorch/issues/151670
     @requires_cuda
-<<<<<<< HEAD
     def test_diagonal_scatter_single_elem_cpu_with_cuda_tensor(self):
-=======
-    @parametrize("backend", ["eager", "inductor"])
-    def test_single_elem_cpu_with_cuda_tensor(self, backend: str):
->>>>>>> d9edf67ff04 (update test names to be more descriptive)
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7751,6 +7751,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         self.assertEqual(model(*inputs), compiled_model(*inputs))
 
 
+
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     def test_sub_alpha_scalar_repro(self, device):
         @torch.compile(backend="aot_eager")

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7727,7 +7727,12 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
 
     # https://github.com/pytorch/pytorch/issues/151670
     @requires_cuda
+<<<<<<< HEAD
     def test_diagonal_scatter_single_elem_cpu_with_cuda_tensor(self):
+=======
+    @parametrize("backend", ["eager", "inductor"])
+    def test_single_elem_cpu_with_cuda_tensor(self, backend: str):
+>>>>>>> d9edf67ff04 (update test names to be more descriptive)
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7751,7 +7751,6 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         self.assertEqual(model(*inputs), compiled_model(*inputs))
 
 
-
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     def test_sub_alpha_scalar_repro(self, device):
         @torch.compile(backend="aot_eager")

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7725,6 +7725,31 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
 
         self.assertEqual(model(*inputs), compiled_model(*inputs))
 
+    # https://github.com/pytorch/pytorch/issues/151670
+    @requires_cuda
+    def test_diagonal_scatter_single_elem_cpu_with_cuda_tensor(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                y = torch.ones(x.size(0))
+                x = torch.diagonal_scatter(x, y)
+                return x
+
+        model = Model()
+
+        x = torch.rand(1, 2)
+        inputs = [x]
+
+        device = "cuda"
+        model = model.to(device)
+        inputs = [x.to(device) for x in inputs]
+
+        compiled_model = torch.compile(model, backend="eager")
+
+        self.assertEqual(model(*inputs), compiled_model(*inputs))
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     def test_sub_alpha_scalar_repro(self, device):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -268,6 +268,8 @@ class FakeTensorTest(TestCase):
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_add_one_dim_single_elem_cpu_with_cuda_tensor(self):
+        if torch._functorch.config.fake_tensor_propagate_real_tensors:
+            self.skipTest("Propagate real tensor not supported")
         with FakeTensorMode():
             x = torch.randn([1])
             y = torch.randn(10, device="cuda")

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -247,7 +247,7 @@ class FakeTensorTest(TestCase):
             torch.nextafter(fake_x, fake_y)
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_one_dim_cpu_with_cuda_tensor(self):
+    def test_one_dim_single_elem_cpu_with_cuda_tensor(self):
         with FakeTensorMode():
             base = torch.zeros((1, 2), device="cuda")
             src = torch.tensor([1.0])
@@ -257,7 +257,7 @@ class FakeTensorTest(TestCase):
             self.assertTrue(isinstance(out, FakeTensor))
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_n_dim_single_elem_cpu_with_cuda_tensor(self):
+    def test_three_dim_single_elem_cpu_with_cuda_tensor(self):
         with FakeTensorMode():
             x = torch.randn((1, 1, 1))
             y = torch.randn(10, device="cuda")

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -247,7 +247,7 @@ class FakeTensorTest(TestCase):
             torch.nextafter(fake_x, fake_y)
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_one_dim_one_elem(self):
+    def test_one_dim_cpu_with_cuda_tensor(self):
         with FakeTensorMode():
             base = torch.zeros((1, 2), device="cuda")
             src = torch.tensor([1.0])

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -256,7 +256,6 @@ class FakeTensorTest(TestCase):
             self.assertEqual(out.device, base.device)
             self.assertTrue(isinstance(out, FakeTensor))
 
-
     def test_nan_to_num(self):
         with FakeTensorMode():
             for dtype in [torch.float16, torch.float32]:

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -256,6 +256,16 @@ class FakeTensorTest(TestCase):
             self.assertEqual(out.device, base.device)
             self.assertTrue(isinstance(out, FakeTensor))
 
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_n_dim_single_elem_cpu_with_cuda_tensor(self):
+        with FakeTensorMode():
+            x = torch.randn((1, 1, 1))
+            y = torch.randn(10, device="cuda")
+            out = x + y
+            self.assertEqual(out.shape, (1, 1, 10))
+            self.assertEqual(out.device, y.device)
+            self.assertTrue(isinstance(out, FakeTensor))
+
     def test_nan_to_num(self):
         with FakeTensorMode():
             for dtype in [torch.float16, torch.float32]:

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -247,7 +247,7 @@ class FakeTensorTest(TestCase):
             torch.nextafter(fake_x, fake_y)
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_one_dim_single_elem_cpu_with_cuda_tensor(self):
+    def test_diagonal_scatter_one_dim_single_elem_cpu_with_cuda_tensor(self):
         with FakeTensorMode():
             base = torch.zeros((1, 2), device="cuda")
             src = torch.tensor([1.0])
@@ -257,14 +257,15 @@ class FakeTensorTest(TestCase):
             self.assertTrue(isinstance(out, FakeTensor))
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
-    def test_three_dim_single_elem_cpu_with_cuda_tensor(self):
+    def test_add_one_dim_single_elem_cpu_with_cuda_tensor(self):
         with FakeTensorMode():
-            x = torch.randn((1, 1, 1))
+            x = torch.randn([1])
             y = torch.randn(10, device="cuda")
-            out = x + y
-            self.assertEqual(out.shape, (1, 1, 10))
-            self.assertEqual(out.device, y.device)
-            self.assertTrue(isinstance(out, FakeTensor))
+
+            with self.assertRaisesRegex(
+                RuntimeError, "Unhandled FakeTensor Device Propagation for.*"
+            ) as exc:
+                x + y
 
     def test_nan_to_num(self):
         with FakeTensorMode():

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -257,6 +257,16 @@ class FakeTensorTest(TestCase):
             self.assertTrue(isinstance(out, FakeTensor))
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_diagonal_scatter_two_dim_cpu_with_cuda_tensor(self):
+        with FakeTensorMode():
+            base = torch.zeros((3, 3, 3))
+            src = torch.ones((3, 3), device="cuda")
+            out = torch.diagonal_scatter(base, src)
+            self.assertEqual(out.shape, (3, 3, 3))
+            self.assertEqual(out.device, base.device)
+            self.assertTrue(isinstance(out, FakeTensor))
+
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_add_one_dim_single_elem_cpu_with_cuda_tensor(self):
         with FakeTensorMode():
             x = torch.randn([1])

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -246,6 +246,17 @@ class FakeTensorTest(TestCase):
         ) as exc:
             torch.nextafter(fake_x, fake_y)
 
+    @unittest.skipIf(not RUN_CUDA, "requires cuda")
+    def test_one_dim_one_elem(self):
+        with FakeTensorMode():
+            base = torch.zeros((1, 2), device="cuda")
+            src = torch.tensor([1.0])
+            out = torch.diagonal_scatter(base, src, dim1=0, dim2=1)
+            self.assertEqual(out.shape, (1, 2))
+            self.assertEqual(out.device, base.device)
+            self.assertTrue(isinstance(out, FakeTensor))
+
+
     def test_nan_to_num(self):
         with FakeTensorMode():
             for dtype in [torch.float16, torch.float32]:

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1071,6 +1071,7 @@ def embedding_bag(fake_mode, func, *args, **kwargs):
 @register_op_impl(aten.copy.default)
 @register_op_impl(aten.copy_.default)
 @register_op_impl(aten.slice_scatter.default)
+@register_op_impl(aten.diagonal_scatter.default)
 def multi_device_op_default(fake_mode, func, *args, **kwargs):
     return run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -44,6 +44,7 @@ from torch._subclasses.meta_utils import (
     MetaConverter,
 )
 from torch._utils import render_call
+from torch.fx.experimental.symbolic_shapes import guard_or_false
 from torch.fx.immutable_collections import immutable_dict
 from torch.fx.operator_schemas import normalize_function
 from torch.multiprocessing.reductions import StorageWeakRef
@@ -925,7 +926,7 @@ class FakeTensor(Tensor):
             return device.type == "cpu"
 
         def cpu_single_element(t: Tensor) -> bool:
-            return check_cpu_device(t.device) and torch.numel(t) == 1
+            return check_cpu_device(t.device) and guard_or_false(t.numel() == 1)
 
         def merge_devices(t: object) -> None:
             nonlocal common_device

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -904,14 +904,12 @@ class FakeTensor(Tensor):
     ) -> tuple[torch.device, bool]:
         # Returns: (common_device, has_scalar_only_inputs)
 
-        from torch.fx.experimental.symbolic_shapes import guard_or_false
-
-        # cpu - single element tensors can be called in cuda kernels,
-        # so overwrite the common_device if the only existing device
-        # comes from a cpu single element tensor
+        # cpu - zero-dim tensors can be called in cuda kernels,
+        # so overwrite the common_device if it the only existing
+        # device comes from a cpu zero-dim tensor
         common_device = None
         has_scalar_only_inputs = False
-        is_cpu_single_element = None
+        is_cpu_zero_dim = None
 
         # list of ops which can have args(tensor/tensorList) in mixed device
         mixed_device_fns = ordered_set(
@@ -919,52 +917,46 @@ class FakeTensor(Tensor):
         )
 
         # list of ops not using zero dim cpu tensor logic to align with the eager mode.
-        bypass_single_element_cpu_tensor_check_ops = ordered_set(
+        bypass_zero_dim_cpu_tensor_check_ops = ordered_set(
             aten.nextafter.default,
         )
 
         def check_cpu_device(device: torch.device) -> bool:
             return device.type == "cpu"
 
-        def cpu_single_element(t: Tensor) -> bool:
-            return check_cpu_device(t.device) and guard_or_false(t.numel() == 1)
+        def cpu_zero_dim(t: Tensor) -> bool:
+            return check_cpu_device(t.device) and t.dim() == 0
 
         def merge_devices(t: object) -> None:
             nonlocal common_device
-            nonlocal is_cpu_single_element
+            nonlocal is_cpu_zero_dim
             if not isinstance(t, FakeTensor):
                 return
 
             if common_device is None:
                 common_device = t.device
-                is_cpu_single_element = cpu_single_element(t)
+                is_cpu_zero_dim = cpu_zero_dim(t)
                 return
 
-            t_is_cpu_single_element = cpu_single_element(t)
+            t_is_cpu_zero_dim = cpu_zero_dim(t)
             if t.device == common_device:
-                if is_cpu_single_element:
-                    is_cpu_single_element = t_is_cpu_single_element
+                if is_cpu_zero_dim:
+                    is_cpu_zero_dim = t_is_cpu_zero_dim
                 return
 
-            is_bypass_single_element_cpu_tensor_check_op = (
-                func in bypass_single_element_cpu_tensor_check_ops
+            is_bypass_zero_dim_cpu_tensor_check_op = (
+                func in bypass_zero_dim_cpu_tensor_check_ops
             )
 
             # mismatching devices !
-            # if current tensor is cpu single element, defer to existing device
-            if (
-                t_is_cpu_single_element
-                and not is_bypass_single_element_cpu_tensor_check_op
-            ):
+            # if current tensor is cpu 0 dim, defer to existing device
+            if t_is_cpu_zero_dim and not is_bypass_zero_dim_cpu_tensor_check_op:
                 return
 
-            # current device is from cpu single element tensor, overwrite
-            if (
-                is_cpu_single_element
-                and not is_bypass_single_element_cpu_tensor_check_op
-            ):
+            # current device is from cpu 0 dim tensor, overwrite
+            if is_cpu_zero_dim and not is_bypass_zero_dim_cpu_tensor_check_op:
                 common_device = t.device
-                is_cpu_single_element = t_is_cpu_single_element
+                is_cpu_zero_dim = t_is_cpu_zero_dim
                 return
 
             # if still device mismatches we will check ops which can work
@@ -984,13 +976,13 @@ class FakeTensor(Tensor):
                 if not common_has_preferred and t_has_preferred:
                     # Switch to the preferred device type
                     common_device = t.device
-                    is_cpu_single_element = t_is_cpu_single_element
+                    is_cpu_zero_dim = t_is_cpu_zero_dim
                     return
                 elif common_has_preferred and not t_has_preferred:
                     # Keep the existing preferred device type
                     return
 
-            # mismatching devices of non - single element tensors, throw
+            # mismatching devices of non-zero dim tensors, throw
             # This might be valid behavior and need to be explicitly modeled, e.g. reshape_as
             raise RuntimeError(
                 f"Unhandled FakeTensor Device Propagation for {func}, found two different devices {common_device}, {t.device}"

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -950,14 +950,14 @@ class FakeTensor(Tensor):
             )
 
             # mismatching devices !
-            # if current tensor is cpu single value, defer to existing device
+            # if current tensor is cpu single element, defer to existing device
             if (
                 t_is_cpu_single_element
                 and not is_bypass_single_element_cpu_tensor_check_op
             ):
                 return
 
-            # current device is from cpu single value tensor, overwrite
+            # current device is from cpu single element tensor, overwrite
             if (
                 is_cpu_single_element
                 and not is_bypass_single_element_cpu_tensor_check_op
@@ -989,7 +989,7 @@ class FakeTensor(Tensor):
                     # Keep the existing preferred device type
                     return
 
-            # mismatching devices of non - single value tensors, throw
+            # mismatching devices of non - single element tensors, throw
             # This might be valid behavior and need to be explicitly modeled, e.g. reshape_as
             raise RuntimeError(
                 f"Unhandled FakeTensor Device Propagation for {func}, found two different devices {common_device}, {t.device}"

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -44,7 +44,6 @@ from torch._subclasses.meta_utils import (
     MetaConverter,
 )
 from torch._utils import render_call
-from torch.fx.experimental.symbolic_shapes import guard_or_false
 from torch.fx.immutable_collections import immutable_dict
 from torch.fx.operator_schemas import normalize_function
 from torch.multiprocessing.reductions import StorageWeakRef
@@ -904,6 +903,8 @@ class FakeTensor(Tensor):
         func: OpOverload, flat_args: Sequence[object]
     ) -> tuple[torch.device, bool]:
         # Returns: (common_device, has_scalar_only_inputs)
+
+        from torch.fx.experimental.symbolic_shapes import guard_or_false
 
         # cpu - single element tensors can be called in cuda kernels,
         # so overwrite the common_device if the only existing device


### PR DESCRIPTION
**Context**
torch.diagonal_scatter accepts tensors on mixed devices (e.g. cuda and cpu). We see this behavior in eager mode, however, we get errors when we try to do this in inductor mode. We should faithfully emulate this behavior. 

This PR registers a fake tensor implementation for aten.diagonal_scatter.default that enables multi-device.

**Repro**
```
import torch
from torch._subclasses.fake_tensor import FakeTensorMode

#test 1: we want this to succeed
with FakeTensorMode():
    base = torch.zeros((1, 2), device="cuda")
    src = torch.tensor([1.0])
    result = torch.diagonal_scatter(base, src, dim1=0, dim2=1)
```
- Error Message: `RuntimeError: Unhandled FakeTensor Device Propagation for aten.add.Tensor, found two different devices cpu, cuda:0`
- Expected Behavior: Successful execution.

```
import torch
from torch._subclasses.fake_tensor import FakeTensorMode

#test2: we expect this to fail
with FakeTensorMode():
    x = torch.randn([1])
    y = torch.randn(10, device="cuda")
    x + y
```
- Error Message: `RuntimeError: Unhandled FakeTensor Device Propagation for aten.add.Tensor, found two different devices cpu, cuda:0`
- Expected Behavior: Error message is correct.

**Solution**
Register a fake tensor implementation for aten.diagonal_scatter.default that enables multi-device.

**Testing**
This PR adds several tests for
1. A reproduction of the original reported issue using torch.diagonal_scatter. This tests that the model output of eager mode and torch.compile(backend="eager") are the same.
2. A FakeTensorMode torch.diagonal_scatter test where the base tensor (on cuda) is shape (1, 2) and the src tensor is shape (1).
3. A mixed device test using torch.add that is expected to fail but ensures we have not accidentally modified overall behavior.
4. A FakeTensorMode torch.diagonal_scatter test where the base tensor (on cuda) is shape(3, 3, 3) and the src tnesor is shape (3, 3).

```
$ python test/dynamo/test_repros.py ReproTests.test_diagonal_scatter_single_elem_cpu_with_cuda_tensor

----------------------------------------------------------------------
Ran 1 test in 0.254s

OK
```
```
$ python test/test_fake_tensor.py FakeTensorTest.test_diagonal_scatter_one_dim_single_elem_cpu_with_cuda_tensor FakeTensorTest.test_add_one_dim_single_elem_cpu_with_cuda_tensor FakeTensorTest.test_diagonal_scatter_two_dim_cpu_with_cuda_tensor

----------------------------------------------------------------------
Ran 3 tests in 0.016s

OK
```

ghstack-source-id: 7adfd4bbb55c77c8df1ca9c7248fb4589f31c5cd
Pull-Request: https://github.com/pytorch/pytorch/pull/170898

Fixes #151670


cc @eellison @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @bdhirsh @bobrenjc93 @mingfeima @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 