### PR TITLE
Fix Windows ABI filename bug #170542

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1153,9 +1153,10 @@ class BuildExtension(build_ext):
         if self.no_python_abi_suffix:
             # The parts will be e.g. ["my_extension", "cpython-37m-x86_64-linux-gnu", "so"].
             ext_filename_parts = ext_filename.split('.')
-            # Omit the second to last element.
-            without_abi = ext_filename_parts[:-2] + ext_filename_parts[-1:]
-            ext_filename = '.'.join(without_abi)
+            if len(ext_filename_parts) > 2:
+                # Omit the second to last element.
+                without_abi = ext_filename_parts[:-2] + ext_filename_parts[-1:]
+                ext_filename = '.'.join(without_abi)
         return ext_filename
 
     def _check_abi(self) -> tuple[str, TorchVersion]:


### PR DESCRIPTION
Fixes #170542 
# Title
[Windows] Fix filename mangling in cpp_extension when no_python_abi_suffix=True

# Summary
I ran into a build issue on Windows (specifically related to #170542) where `cpp_extension.py` was generating incorrect filenames when `no_python_abi_suffix` is set to `True`.

It seems that on Windows, `get_ext_filename` often returns a simple path like `package\lib.pyd` (without an ABI string). The current logic tries to strip the ABI suffix unconditionally. When the ABI suffix isn't present, the string manipulation ends up mangling the filename (e.g., stripping the library name entirely and returning just `.pyd`).

This PR adds a check to ensure we only attempt to strip the ABI suffix if it's actually part of the filename. This fixes the build error for extensions with nested packages on Windows.


# Test Plan
I created a reproduction script that mocks `setuptools` behavior on Windows (where dots are replaced by separators and the extension is just `.pyd`).

**Results:**
Ran the reproduction script with the fix applied:
```text
[Test Case 1: Missing ABI] Input: 'mylib' -> Output: 'mylib.pyd'
[Test Case 2: Nested Pkg] Input: 'torchaudio.lib.libtorchaudio' -> Output: 'torchaudio\lib\libtorchaudio.pyd'
[Test Case 3: Normal ABI] Input: 'mylib' -> Output: 'mylib.so'
----------------------------------------------------------------------
Ran 3 tests in 0.622s

OK
```
### Verification Script
Here is the script code in a block if you need to share it as a file or Gist.

```python
import unittest
import unittest.mock
import sys
import os
from setuptools.dist import Distribution
from torch.utils.cpp_extension import BuildExtension

class TestWindowsABIFilename(unittest.TestCase):
    
    def setUp(self):
        self.dist = Distribution()
        self.cmd = BuildExtension(self.dist)
        self.cmd.no_python_abi_suffix = True

    def test_bug_case_missing_abi(self):
        """Standard simple extension on Windows (no ABI)."""
        def mock_parent_behavior(ext_name):
            # Reality: dots become path separators
            return ext_name.replace('.', os.sep) + ".pyd"

        with unittest.mock.patch('setuptools.command.build_ext.build_ext.get_ext_filename', 
                                 side_effect=mock_parent_behavior):
            
            input_name = "mylib"
            result = self.cmd.get_ext_filename(input_name)
            
            print(f"\n[Test Case 1: Missing ABI] Input: '{input_name}' -> Output: '{result}'")
            self.assertNotEqual(result, "pyd", "❌ FAILED: Filename mangled to 'pyd'")
            self.assertTrue(result.endswith("mylib.pyd"), "✅ SUCCESS")

    def test_bug_case_nested_package(self):
        """
        The specific Issue #170542 case.
        Input: 'torchaudio.lib.libtorchaudio'
        Real Setuptools Output: 'torchaudio\lib\libtorchaudio.pyd'
        """
        def mock_parent_behavior(ext_name):
            # Reality: dots become path separators!
            return ext_name.replace('.', os.sep) + ".pyd"

        with unittest.mock.patch('setuptools.command.build_ext.build_ext.get_ext_filename', 
                                 side_effect=mock_parent_behavior):
            
            input_name = "torchaudio.lib.libtorchaudio"
            result = self.cmd.get_ext_filename(input_name)
            
            print(f"[Test Case 2: Nested Pkg] Input: '{input_name}' -> Output: '{result}'")
            
            # This failed before because the mock was wrong. Now it should pass.
            self.assertIn("libtorchaudio", result, "❌ FAILED: The library name was lost.")
            self.assertTrue(result.endswith(".pyd"), "❌ FAILED: Extension is wrong.")

    def test_regression_normal_case(self):
        """Linux case where ABI is present and SHOULD be stripped."""
        def mock_parent_behavior(ext_name):
            return ext_name + ".cp310-linux_x86_64.so"

        with unittest.mock.patch('setuptools.command.build_ext.build_ext.get_ext_filename', 
                                 side_effect=mock_parent_behavior):
            
            input_name = "mylib"
            result = self.cmd.get_ext_filename(input_name)
            
            print(f"[Test Case 3: Normal ABI] Input: '{input_name}' -> Output: '{result}'")
            self.assertEqual(result, "mylib.so", "❌ REGRESSION: Failed to strip ABI.")

if __name__ == "__main__":
    unittest.main(verbosity=0)
```