### PR TITLE
[Inductor] Support appending fb-only CUDA options in triton template

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -14,6 +14,16 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._triton import has_datacenter_blackwell_tma_device
 
 
+def has_tlx() -> bool:
+    """Check if TLX (Triton Language eXtensions) is available."""
+    try:
+        import triton.language.extra.tlx  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 torch.set_float32_matmul_precision("high")
 
 
@@ -295,74 +305,69 @@ class TestMaxAutotuneBlackwell(TestCase):
         not has_datacenter_blackwell_tma_device() or not config.is_fbcode(),
         "Need Blackwell with device-side TMA support in Triton",
     )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("template", ("blackwell_gemm_clc", "blackwell_gemm_2cta"))
     @parametrize("dynamic", (False, True))
     @parametrize("epilogue_subtile", (False, True))
     def test_tlx_mm(
         self,
+        template: str,
         dynamic: bool,
         epilogue_subtile: bool,
     ):
-        try:
-            import triton.language.extra.tlx  # noqa: F401
+        a_transposed: bool = False
+        b_transposed: bool = False
 
-            # TODO. remove try/except once TLX is available by default
+        def mm(a, b):
+            # TMA requires 16-byte alignment: here we repeat the dims
+            # by the factor of 8, as float16 is 2-byte. All dims are
+            # repeated due to the possible transpositions below.
+            # a = a.repeat(8, 8)
+            # b = b.repeat(8, 8)
+            if a_transposed:
+                a = a.T
+            if b_transposed:
+                b = b.T
 
-            template = "blackwell_gemm_clc"
-            a_transposed: bool = False
-            b_transposed: bool = False
+            return torch.mm(a, b)
 
-            def mm(a, b):
-                # TMA requires 16-byte alignment: here we repeat the dims
-                # by the factor of 8, as float16 is 2-byte. All dims are
-                # repeated due to the possible transpositions below.
-                # a = a.repeat(8, 8)
-                # b = b.repeat(8, 8)
-                if a_transposed:
-                    a = a.T
-                if b_transposed:
-                    b = b.T
+        def next_multiple_16(a: int) -> int:
+            return ((a + 15) // 16) * 16
 
-                return torch.mm(a, b)
+        M, N, K = 4096, 4096, 4096
+        a_shape = (K, M) if a_transposed else (M, K)
+        a_stride = (
+            (next_multiple_16(M), 1) if a_transposed else (next_multiple_16(K), 1)
+        )
+        a = torch.empty_strided(a_shape, a_stride, dtype=torch.float16).to(GPU_TYPE)
+        a[:] = torch.randn(a_shape, dtype=torch.float16)
+        a = a.to(GPU_TYPE)
+        b_shape = (N, K) if b_transposed else (K, N)
+        b_stride = (
+            (next_multiple_16(K), 1) if a_transposed else (next_multiple_16(N), 1)
+        )
+        b = torch.empty_strided(b_shape, b_stride, dtype=torch.float16)
+        b[:] = torch.randn(b_shape, dtype=torch.float16)
+        b = b.to(GPU_TYPE)
 
-            def next_multiple_16(a: int) -> int:
-                return ((a + 15) // 16) * 16
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "enable_caching_generated_triton_templates": False,
+                "triton.enable_tlx_templates": True,
+                "max_autotune": True,
+                "test_configs.autotune_choice_name_regex": template,
+                "triton.enable_epilogue_subtiling": epilogue_subtile,
+            }
+        ):
+            c_actual, code = run_and_get_code(torch.compile(mm, dynamic=dynamic), a, b)
+            c_expected = mm(a, b)
 
-            M, N, K = 4096, 4096, 4096
-            a_shape = (K, M) if a_transposed else (M, K)
-            a_stride = (
-                (next_multiple_16(M), 1) if a_transposed else (next_multiple_16(K), 1)
-            )
-            a = torch.empty_strided(a_shape, a_stride, dtype=torch.float16).to(GPU_TYPE)
-            a[:] = torch.randn(a_shape, dtype=torch.float16)
-            a = a.to(GPU_TYPE)
-            b_shape = (N, K) if b_transposed else (K, N)
-            b_stride = (
-                (next_multiple_16(K), 1) if a_transposed else (next_multiple_16(N), 1)
-            )
-            b = torch.empty_strided(b_shape, b_stride, dtype=torch.float16)
-            b[:] = torch.randn(b_shape, dtype=torch.float16)
-            b = b.to(GPU_TYPE)
+        torch.testing.assert_close(c_actual, c_expected)
 
-            with config.patch(
-                {
-                    "triton.enable_tlx_templates": True,
-                    "max_autotune": True,
-                    "test_configs.autotune_choice_name_regex": template,
-                    "triton.enable_epilogue_subtiling": epilogue_subtile,
-                }
-            ):
-                c_actual, code = run_and_get_code(
-                    torch.compile(mm, dynamic=dynamic), a, b
-                )
-                c_expected = mm(a, b)
-
-            torch.testing.assert_close(c_actual, c_expected)
-
-            FileCheck().check("triton_tem_fused_mm").check(
-                "tlx.async_descriptor_load"
-            ).run(code[0])
-        except ImportError:
-            pass
+        FileCheck().check("triton_tem_fused_mm").check("tlx.async_descriptor_load").run(
+            code[0]
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -28,7 +28,11 @@ from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._ordered_set import OrderedSet
 
 from ..triton_bundler import TritonBundler
-from ..utils import prefix_is_reduction, triton_version_uses_attrs_dict
+from ..utils import (
+    fb_only_cuda_options,
+    prefix_is_reduction,
+    triton_version_uses_attrs_dict,
+)
 from . import triton_helpers
 from .autotune_cache import AutotuneCache
 from .benchmarking import benchmarker
@@ -711,6 +715,7 @@ class CachingAutotuner(KernelInterface):
             compile_meta["num_buffers_warp_spec"] = getattr(
                 cfg, "num_buffers_warp_spec", 0
             )
+
         compile_meta["debug"] = self.inductor_meta.get(
             "assert_indirect_indexing", True
         ) and not self.inductor_meta.get("is_hip", False)
@@ -718,6 +723,10 @@ class CachingAutotuner(KernelInterface):
         # device type will be "hip" rather than "cuda" here
         compile_meta["device_type"] = self.device_props.type
         compile_meta["cc"] = self.device_props.cc
+
+        for k in fb_only_cuda_options():
+            if v := getattr(cfg, k, None):
+                compile_meta[k] = v
 
         return compile_meta
 
@@ -754,6 +763,10 @@ class CachingAutotuner(KernelInterface):
                     "launch_pdl": compile_meta.get("launch_pdl", False),  # True
                 }
             )
+            for k in fb_only_cuda_options():
+                if v := getattr(cfg, k, None):
+                    options[k] = v
+
         if self.device_props.type == "hip":
             if "waves_per_eu" in compile_meta:
                 options["waves_per_eu"] = compile_meta["waves_per_eu"]
@@ -3570,6 +3583,7 @@ def template(
     num_buffers_warp_spec=0,
     filename=None,
     inductor_meta=None,
+    **kwargs,
 ):
     """
     Compile a triton template
@@ -3588,6 +3602,11 @@ def template(
                 "num_buffers_warp_spec": num_buffers_warp_spec,
             }
         )
+
+    for k in fb_only_cuda_options():
+        if v := triton_meta.get(k, None):
+            config_args[k] = v
+
     return cached_autotune(
         None,
         [triton.Config({}, **config_args)],

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -82,6 +82,7 @@ from .utils import (
     ceildiv,
     do_bench_using_profiling,
     FakeIndentedBuffer,
+    fb_only_cuda_options,
     get_dtype_size,
     is_gpu,
     Placeholder,
@@ -661,6 +662,10 @@ class TritonTemplateKernel(TritonKernel):
         if kpack:
             triton_meta["kpack"] = kpack
 
+        for k in fb_only_cuda_options():
+            if v := self.meta.get(k, None):
+                triton_meta[k] = v
+
         self.triton_meta = triton_meta
 
         inductor_meta = {
@@ -689,6 +694,13 @@ class TritonTemplateKernel(TritonKernel):
             num_consumer_groups={self.num_consumer_groups},
             num_buffers_warp_spec={self.num_buffers_warp_spec},
         """
+
+        for k in fb_only_cuda_options():
+            if v := self.meta.get(k, None):
+                template_args += f"""
+                    {k}={v},
+                """
+                self.triton_meta[k] = v
 
         return f"""
             @triton_heuristics.template(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -33,6 +33,7 @@ from collections.abc import (
     MutableSet,
 )
 from datetime import datetime
+from functools import lru_cache
 from io import StringIO
 from typing import (
     Any,
@@ -4222,3 +4223,18 @@ COLLECTIVE_OPS = OrderedSet(
 def is_collective_op(op_name: str) -> bool:
     """Check if an operation is a collective operation."""
     return op_name in COLLECTIVE_OPS
+
+
+@lru_cache
+def fb_only_cuda_options() -> list[str]:
+    if config.is_fbcode():
+        try:
+            from torch._inductor.fb.tlx_templates.registry import fb_only_cuda_options
+
+            return fb_only_cuda_options
+
+        except ImportError:
+            return []
+
+    else:
+        return []


### PR DESCRIPTION
Summary:
For example, add `ctas_per_cga`  parameter to support CUDA-native cluster launch semantics (TLX way), distinguishing it from Triton's existing `num_ctas` approach. (introduced by https://github.com/facebookexperimental/triton/pull/741)

**Two cluster launch semantics:**

1. **Triton's way** (`num_ctas`): Grid is multiplied by cluster_dims to get total CTAs.
   - `cluster_dims = (2, 1, 1)` → `num_ctas = 2`
   - Grid (2, 1) × cluster (2, 1, 1) = 4 total CTAs

2. **TLX/CUDA way** (`ctas_per_cga`): Grid equals total CTAs, ctas_per_cga regroups them into clusters.
   - `ctas_per_cga = (2, 1, 1)` → `num_ctas = 1`
   - Grid (2, 1) = 2 total CTAs, grouped into clusters of 2

Differential Revision: D89576223




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo