### PR TITLE
Rename _get_cuda_runtime_library to _get_cuda_library

### DIFF
--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -31,7 +31,7 @@ def _get_hip_runtime_library() -> ctypes.CDLL:
     return lib
 
 
-def _get_cuda_runtime_library() -> ctypes.CDLL:
+def _get_cuda_library() -> ctypes.CDLL:
     if sys.platform == "win32":
         return ctypes.CDLL("nvcuda.dll")
     else:  # Unix-based systems
@@ -43,7 +43,7 @@ def _get_gpu_runtime_library() -> ctypes.CDLL:
     if torch.version.hip:
         return _get_hip_runtime_library()
     else:
-        return _get_cuda_runtime_library()
+        return _get_cuda_library()
 
 
 # Helper: check CUDA errors


### PR DESCRIPTION
The rename was unintentional.

cc @msaroufim 