### PR TITLE
Reinstate format-string args in CUDA_KERNEL_ASSERT_VERBOSE call in IndexKernelUtils.cu

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernelUtils.cu
+++ b/aten/src/ATen/native/cuda/IndexKernelUtils.cu
@@ -13,7 +13,7 @@ __global__ void vectorized_gather_kernel(char * out, char * inp, index_t * idx, 
     if (allow_neg_indices) {
         ind = (ind < 0) ? ind + ind_dim_size : ind;
     }
-    CUDA_KERNEL_ASSERT_VERBOSE(ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds");
+    CUDA_KERNEL_ASSERT_VERBOSE(ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds", "Expected 0 <= index < ind_dim_size(%ld), but got index = %ld", ind_dim_size, ind);
     // off is guaranteed to be within int32 limits
     for (int32_t off = (blockDim.x * blockIdx.y + threadIdx.x) * Alignment; off < slice_size; off += blockDim.x * gridDim.y * Alignment) {
       auto vec = at::native::memory::ld_vec<Alignment>(inp + ind * inp_stride + off);


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/166974 unintentionally removed the extra format-string args to `CUDA_KERNEL_ASSERT_VERBOSE`. This change adds them back.

Test Plan:
As a quick sanity check, check that we don't reintrodue the grid config issue that https://github.com/pytorch/pytorch/pull/166974 was fixing.

Python driver
```
# D86262085.py
import torch

src = torch.randint(0, 20, (4, 87, 1056, 736), device="cuda")
indices = torch.tensor([True, False, False, True], device="cuda")
res = src[indices]
res_cpu = src.cpu()[indices.cpu()]

if not torch.equal(res.cpu(), res_cpu):
    raise Exception("different results on GPU and CPU")
print("Success")
```

Output:
```
$ buck2 run //scripts/mjk/ai_training:D86262085
[...]
Success
```

**NOTE**: I'd also like to double check that we get the correct debug output here, but I confess I don't understand the alignment checks in `fast_gather_kernel_eligible`, so I wasn't able to craft an example that triggered the "fast path". I triggered the check at ScatterGatherKernel.cu:164 instead.

Differential Revision: D89575112


