### PR TITLE
Skip CUDA device in test_qat_embeddingbag_linear quantization test

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -9647,8 +9647,8 @@ class TestQuantizeFxModels(QuantizationTestCase):
     def test_qat_embeddingbag_linear(self):
         for device in get_supported_device_types():
             # Quantization backends (qnnpack, fbgemm, onednn) only support CPU tensors
-            # Skip CUDA device for quantization tests
-            if device == 'cuda':
+            # Skip other device for quantization tests (e.g. CUDA)
+            if device != 'cpu':
                 continue
 
             class EmbeddingBagLinear(torch.nn.Module):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -9646,6 +9646,11 @@ class TestQuantizeFxModels(QuantizationTestCase):
     @override_qengines
     def test_qat_embeddingbag_linear(self):
         for device in get_supported_device_types():
+            # Quantization backends (qnnpack, fbgemm, onednn) only support CPU tensors
+            # Skip CUDA device for quantization tests
+            if device == 'cuda':
+                continue
+
             class EmbeddingBagLinear(torch.nn.Module):
                 def __init__(self) -> None:
                     super().__init__()


### PR DESCRIPTION
## Summary

Skips CUDA device in `TestQuantizeFxModels.test_qat_embeddingbag_linear`.

**Test:** `TestQuantizeFxModels.test_qat_embeddingbag_linear`  
**Repro:** `python test/test_quantization.py TestQuantizeFxModels.test_qat_embeddingbag_linear -v`

## Problem

The test at `test/quantization/fx/test_quantize_fx.py:9647` started failing after https://github.com/pytorch/pytorch/pull/167043 added `.to(device)` to migrate models and tensors to CUDA. When the test runs with CUDA device and QNNPACK backend, `convert_fx()` fails at line 9672 during weight quantization. The failure occurs in `torch.quantize_per_tensor()` which calls `at::new_qtensor()` in `aten/src/ATen/quantized/Quantizer.cpp:130`, where a `TORCH_CHECK` explicitly rejects CUDA tensors for CPU-only quantization backends (QNNPACK, FBGEMM, ONEDNN).

## Solution

Skips CUDA device in the test loop by adding a `continue` statement when `device == 'cuda'`. This change at `test/quantization/fx/test_quantize_fx.py:9653` ensures the test only runs on CPU, which is the only supported platform for all current quantization backends. The test now passes successfully, restoring the original working behavior from before that PR.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv