### PR TITLE
Skip test_compare_cpu for _scaled_mm_v2 (CUDA-only operator)

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16574,6 +16574,8 @@ op_db: list[OpInfo] = [
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),
+            # _scaled_mm_v2 is CUDA-only, no CPU implementation
+            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_compare_cpu'),
             # "add_stub" not implemented for 'Float8_e4m3fn'
             # "ufunc_add_CUDA" not implemented for 'Float8_e4m3fn'
             # https://github.com/pytorch/pytorch/issues/107256


### PR DESCRIPTION
## Summary

Skips test failure: `TestCommonCUDA.test_compare_cpu_torch__scaled_mm_v2_cuda_float8_e4m3fn`

**Repro command:**
```bash
PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py -v TestCommonCUDA.test_compare_cpu_torch__scaled_mm_v2_cuda_float8_e4m3fn
```

## Problem

The `test_compare_cpu` test was attempting to validate `torch._scaled_mm_v2` by comparing results between CPU and CUDA backends. However, `_scaled_mm_v2` is a **CUDA-only operator** designed for hardware-accelerated float8 matrix multiplication on NVIDIA GPUs with tensor core support. It has no CPU implementation by design, causing the test to fail with `NotImplementedError: Could not run 'aten::_scaled_mm_v2' with arguments from the 'CPU' backend`.

## Solution

Added a skip decorator to the `_scaled_mm_v2` OpInfo definition in `torch/testing/_internal/common_methods_invocations.py` to exclude it from the `test_compare_cpu` test. This follows the existing pattern for other tests that don't apply to this CUDA-only operator.

```python
DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_compare_cpu'),
```