### PR TITLE
[DTensor] Register sharding strategy for aten._is_any_true

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -739,6 +739,29 @@ class TestMultiThreadedDTensorOps(DTensorOpTestBase, TestDTensorOps):
 
     def test_one_hot(self):
         self.run_one_hot()
+        
+    def test_dtensor_anomaly_detection_nan(self):
+        self.mesh = init_device_mesh(DEVICE_TYPE, (self.world_size,))
+
+        x = torch.randn(4, 4, requires_grad=True, device=DEVICE_TYPE)
+        dx = distribute_tensor(x, self.mesh, [Replicate()])
+
+        with torch.autograd.detect_anomaly(check_nan=True):
+            y = dx * 2
+            loss = y.sum()
+            loss.backward()
+
+        x_nan = torch.randn(4, 4, requires_grad=True, device=DEVICE_TYPE)
+        with torch.no_grad():
+             x_nan[0][0] = float('nan')
+
+        dx_nan = distribute_tensor(x_nan, self.mesh, [Replicate()])
+
+        with self.assertRaisesRegex(RuntimeError, "returned nan values"):
+            with torch.autograd.detect_anomaly(check_nan=True):
+                y = dx_nan * dx_nan
+                loss = y.sum()
+                loss.backward()
 
 
 class TestLocalDTensorOps(TestDTensorOps):

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -311,6 +311,7 @@ LINEAR_REDUCTION_OP_MAP = {
     aten.sum.dim_IntList: "sum",
     prims.sum.default: "sum",
     aten.any.default: "sum",
+    aten._is_any_true.default: "sum",
     aten.any.dim: "sum",
     aten.any.dims: "sum",
     aten.any.out: "sum",


### PR DESCRIPTION
# Title
[DTensor] Register sharding strategy for aten._is_any_true to fix anomaly detection

# Summary
Fixes #170936

When running `torch.autograd.detect_anomaly(check_nan=True)` on a `DTensor`, the backward pass previously crashed with:
`NotImplementedError: Operator aten._is_any_true.default does not have a sharding strategy registered.`

The anomaly detector uses `aten._is_any_true` to check for NaNs across the tensor. This PR registers `aten._is_any_true.default` in `_math_ops.py` using the `"sum"` reduction strategy. This acts as a logical OR across ranks (if any rank sees a NaN, the global result is True), matching the behavior of `aten.any.default`.

# Test Plan
I verified this locally on CPU with a two-part test script:
1. **Regression Test:** Confirmed the code no longer crashes with `NotImplementedError`.
2. **Functional Test:** Injected a NaN on Rank 0 and confirmed that `detect_anomaly` successfully catches it (proving the reduction logic works).

**Verification Script:**
```python
import torch
import torch.distributed as dist
import torch.multiprocessing as mp
from torch.distributed._tensor import DTensor, Replicate, Shard, DeviceMesh
import os

def run_tests(rank, world_size):
    os.environ["MASTER_ADDR"] = "127.0.0.1"
    os.environ["MASTER_PORT"] = "29500"
    dist.init_process_group("gloo", rank=rank, world_size=world_size)
    mesh = DeviceMesh("cpu", list(range(world_size)))
    
    # [Test 1] Regression Check: Should not crash
    try:
        x = torch.randn(4, 4, requires_grad=True)
        dx = DTensor.from_local(x, mesh, [Replicate()])
        with torch.autograd.detect_anomaly(check_nan=True):
            y = dx * 2
            loss = y.sum()
            loss.backward()
        if rank == 0: print("✅ [Test 1] Regression Passed (No Crash)")
    except Exception as e:
        if rank == 0: print(f"❌ [Test 1] Failed: {e}")

    # [Test 2] Functional Check: Should catch NaN
    local_x = torch.randn(4, 4, requires_grad=True)
    if rank == 0:
        with torch.no_grad(): local_x[0][0] = float('nan')
    dx_nan = DTensor.from_local(local_x, mesh, [Shard(0)])
    
    try:
        with torch.autograd.detect_anomaly(check_nan=True):
            y = dx_nan * dx_nan 
            loss = y.sum()
            loss.backward()
    except RuntimeError as e:
        if "nan" in str(e).lower() or "anomaly" in str(e).lower():
            if rank == 0: print("✅ [Test 2] Functional Passed (NaN Caught)")

    dist.destroy_process_group()

if __name__ == "__main__":
    mp.spawn(run_tests, args=(2,), nprocs=2, join=True)
```
**Output:**
```
✅ [Test 1] Regression Passed (No Crash)
✅ [Test 2] Functional Passed (NaN Caught)
```