### PR TITLE
tools/testing: Fix ShardedTest ordering when time is None

### DIFF
--- a/tools/test/test_test_run.py
+++ b/tools/test/test_test_run.py
@@ -163,6 +163,13 @@ class TestShardedTest(unittest.TestCase):
 
         self.assertListEqual(sharded_test.get_pytest_args(), expected_args)
 
+    def test_lt_with_none_time_is_unordered(self) -> None:
+        left = ShardedTest("foo", 1, 1)
+        right = ShardedTest("foo", 1, 1)
+
+        self.assertFalse(left < right)
+        self.assertFalse(right < left)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/testing/test_run.py
+++ b/tools/testing/test_run.py
@@ -293,7 +293,9 @@ class ShardedTest:
         if self.num_shards != other.num_shards:
             return self.num_shards < other.num_shards
 
-        # None is the smallest value
+        # None is the smallest value, but equal None values shouldn't be ordered.
+        if self.time is None and other.time is None:
+            return False
         if self.time is None:
             return True
         if other.time is None:


### PR DESCRIPTION
## Summary
`ShardedTest.__lt__` treats `None` as the smallest value for `time`. When both `self.time` and `other.time` are `None`, the current implementation returns `True`, which makes identical `ShardedTest` instances compare as both `==` and `<`. This violates a consistent ordering and can lead to unpredictable sorting behavior.

## Changes
- Update `ShardedTest.__lt__` to return `False` when both times are `None`, while keeping `None` ordered before any numeric time.
- Add a unit test covering the `(None, None)` comparison edge case.

## Test Plan
- `python3 -m unittest tools.test.test_test_run.TestShardedTest`


cc @mruberry