### PR TITLE
[1/N][Optimize] Convert `not all(...)` patterns to `any(...)` patterns for code readability and performance.

### DIFF
--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -558,7 +558,7 @@ def validate_function_matches_schema(
 ) -> None:
     sig = inspect.signature(func)
 
-    if not all(supported_param(p) for _, p in sig.parameters.items()):
+    if any(not supported_param(p) for _, p in sig.parameters.items()):
         raise ValueError(
             f"custom_op(..., manual_schema)(func): positional-only args, "
             f"varargs, and kwargs are not supported. Please rewrite `func` "

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -110,7 +110,7 @@ def _convert_out_params(f):
             out_kwargs = tuple(kwargs.pop(o, None) for o in out_names)
             # Either all of the out kwargs are set or none of them
             is_none = out_kwargs[0] is None
-            if not all((o is None) == is_none for o in out_kwargs):
+            if any((o is None) != is_none for o in out_kwargs):
                 raise AssertionError(
                     f"all out kwargs must be set or none of them, got {out_kwargs}"
                 )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2552,9 +2552,9 @@ class OutputGraph(OutputGraphCommon):
             # TODO: This will bail here if you ever end up with a more complicated
             # computation function, like sum(list_of_ints), even though it
             # should be DCE'able
-            if not all(is_symnode_arg(a) for a in node.args):
+            if any(not is_symnode_arg(a) for a in node.args):
                 return False
-            if not all(is_symnode_arg(a) for a in node.kwargs.values()):
+            if any(not is_symnode_arg(a) for a in node.kwargs.values()):
                 return False
             return True
 

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -177,7 +177,7 @@ def set_intersection(set1, *others, cls=set):
     if len(others) == 0:
         return set1.copy()
 
-    if not all(isinstance(s, Iterable) for s in others):
+    if any(not isinstance(s, Iterable) for s in others):
         raise TypeError(f"set.difference expected an iterable, got {type(others)}")
 
     for s in others:
@@ -209,7 +209,7 @@ def set_union(set1, *others, cls=None):
     if len(others) == 0:
         return set1.copy()
 
-    if not all(isinstance(s, Iterable) for s in others):
+    if any(not isinstance(s, Iterable) for s in others):
         raise TypeError(f"set.union expected an iterable, got {type(others)}")
 
     for s in others:
@@ -238,7 +238,7 @@ def set_difference(set1, *others, cls=set):
     if len(others) == 0:
         return set1.copy()
 
-    if not all(isinstance(s, Iterable) for s in others):
+    if any(not isinstance(s, Iterable) for s in others):
         raise TypeError(f"set.difference expected an iterable, got {type(others)}")
 
     for s in others:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1037,8 +1037,9 @@ class BuiltinVariable(VariableTracker):
                 args: Sequence[VariableTracker],
                 kwargs: dict[str, VariableTracker],
             ) -> VariableTracker:
-                if fn is AssertionError and not all(
-                    x.is_python_constant() and isinstance(x.as_python_constant(), str)
+                if fn is AssertionError and any(
+                    not x.is_python_constant()
+                    or not isinstance(x.as_python_constant(), str)
                     for x in args
                 ):
                     unimplemented(

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -792,7 +792,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         flattened = self._flatten_type_spec(raw_value)
         if not flattened:
             return None
-        if not all(isinstance(typ, type) for typ in flattened):
+        if any(not isinstance(typ, type) for typ in flattened):
             return None
         return tuple(dict.fromkeys(flattened))
 
@@ -1064,7 +1064,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
             if self._is_generator_just_started() and len(args):
                 # can't send non-None value to a just-started generator
                 # Test: GeneratorCPythonTests.test_send_non_none_to_new_gen
-                if not all(arg.is_constant_none() for arg in args):
+                if any(not arg.is_constant_none() for arg in args):
                     raise_observed_exception(TypeError, tx)
             tracer = self.inline_tracer
             tracer.push_many(args)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -583,7 +583,7 @@ def collect_intermediate_outputs(
 
 
 def _check_all_tensorvariable(args: Sequence[VariableTracker]) -> None:
-    if not all(type(a.realize()) is TensorVariable for a in args):
+    if any(type(a.realize()) is not TensorVariable for a in args):
         unimplemented(
             gb_type="HOP: non torch.Tensor leaf",
             context=f"args types: {[type(a.realize()) for a in args]}",
@@ -2698,8 +2698,9 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
             for node in fx.graph.nodes:
                 # Check that the combine_fn is pointwise, if combine_mode='pointwise'
-                if not all(
-                    is_pointwise_use(use) or use.op == "output" for use in node.users
+                if any(
+                    not is_pointwise_use(use) and use.op != "output"
+                    for use in node.users
                 ):
                     raise RuntimeError(
                         "For combine_mode='pointwise', the combine_fn needs to be pointwise"

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -570,7 +570,7 @@ class RangeVariable(BaseListVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         if name == "__iter__":
-            if not all(var.is_python_constant() for var in self.items):
+            if any(not var.is_python_constant() for var in self.items):
                 # Can't represent a `range_iterator` without well defined bounds
                 return variables.misc.DelayGraphBreakVariable(
                     msg="Cannot create range_iterator: bounds (start, stop, step) must be fully defined as concrete constants.",
@@ -931,7 +931,7 @@ class ListVariable(CommonListMethodsVariable):
             else:
                 keys = [key_fn_var.call_function(tx, [x], {}) for x in self.items]
 
-            if not all(k.is_python_constant() for k in keys):
+            if any(not k.is_python_constant() for k in keys):
                 first_non_constant_key = None
                 for k in keys:
                     if not k.is_python_constant():

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -664,8 +664,9 @@ class NNModuleVariable(VariableTracker):
             return invoke_and_store_as_constant(tx, fn, name, args, kwargs)
 
         def assert_all_args_kwargs_const() -> None:
-            if not all(
-                x.is_python_constant() for x in itertools.chain(args, kwargs.values())
+            if any(
+                not x.is_python_constant()
+                for x in itertools.chain(args, kwargs.values())
             ):
                 unimplemented(
                     gb_type="non-const argument in nn.Module method",

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1620,7 +1620,7 @@ def aot_export_joint_simple(
         raise RuntimeError(
             f"aot_export_joint_simple requires inputs to be a single list/tuple. in_spec={str(in_spec)}"
         )
-    if not all(child.is_leaf() for child in in_spec.children()):
+    if any(not child.is_leaf() for child in in_spec.children()):
         raise RuntimeError(
             f"aot_export_joint_simple requires individual inputs not to be pytrees. in_spec={str(in_spec)}"
         )
@@ -1628,7 +1628,7 @@ def aot_export_joint_simple(
         raise RuntimeError(
             f"aot_export_joint_simple requires outputs to be a single list/tuple. out_spec={str(out_spec)}"
         )
-    if not all(child.is_leaf() for child in out_spec.children()):
+    if any(not child.is_leaf() for child in out_spec.children()):
         raise RuntimeError(
             f"aot_export_joint_simple requires individual outputs not to be pytrees. out_spec={str(out_spec)}"
         )

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -127,7 +127,7 @@ def functional_call(
     if isinstance(parameter_and_buffer_dicts, dict):
         parameters_and_buffers = parameter_and_buffer_dicts
     elif isinstance(parameter_and_buffer_dicts, Sequence):
-        if not all(isinstance(d, dict) for d in parameter_and_buffer_dicts):
+        if any(not isinstance(d, dict) for d in parameter_and_buffer_dicts):
             raise ValueError(
                 "Expected all elements of parameter_and_buffer_dicts to be dictionaries"
             )
@@ -230,7 +230,7 @@ def stack_module_state(
             "stack_module_state: Expected all models to have the same training/eval mode."
         )
     model0_typ = type(models[0])
-    if not all(type(m) is model0_typ for m in models):
+    if any(type(m) is not model0_typ for m in models):
         raise RuntimeError(
             "stack_module_state: Expected all models to be of the same class."
         )

--- a/torch/_functorch/make_functional.py
+++ b/torch/_functorch/make_functional.py
@@ -536,7 +536,7 @@ def combine_state_for_ensemble(
             "have the same training/eval mode."
         )
     model0_typ = type(models[0])
-    if not all(type(m) is model0_typ for m in models):
+    if any(type(m) is not model0_typ for m in models):
         raise RuntimeError(
             "combine_state_for_ensemble: Expected all models to be of the same class."
         )

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1907,7 +1907,7 @@ def solve_min_cut(
         if node.op == "placeholder":
             return True
 
-        return not all(is_fusible(node, user) for user in node.users)
+        return any(not is_fusible(node, user) for user in node.users)
 
     def get_node_weight(node, static_lifetime_input_nodes) -> float:
         if (

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -209,7 +209,7 @@ def associative_scan(
             raise ValueError(
                 f"Combine_mode must either 'pointwise' or 'generic', but got {cm}"
             )
-        if cm == "pointwise" and not all(l.device.type in ("cuda", "xpu") for l in lxs):
+        if cm == "pointwise" and any(l.device.type not in ("cuda", "xpu") for l in lxs):
             raise ValueError(
                 "For combine_mode='pointwise', all input tensors need to be on CUDA or XPU"
             )

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -36,7 +36,7 @@ class HintsWrapper(HigherOrderOperator):
         if not isinstance(args, tuple):
             args = tuple(args)
 
-        if not all(isinstance(t, (torch.Tensor, int, float, bool)) for t in args):
+        if any(not isinstance(t, (torch.Tensor, int, float, bool)) for t in args):
             raise RuntimeError(
                 f"args must be a tuple of tensors, ints, floats, or bools, got {args}"
             )

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -91,7 +91,7 @@ def map(
     """
     flat_xs, xs_spec = pytree.tree_flatten(xs)
     flat_args, args_spec = pytree.tree_flatten(args)
-    if not all(isinstance(t, torch.Tensor) for t in flat_xs):
+    if any(not isinstance(t, torch.Tensor) for t in flat_xs):
         raise RuntimeError(f"Mapped xs can only consist of tensors. Got xs {flat_xs}.")
 
     shapes = [xs.shape for xs in flat_xs]

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -687,10 +687,10 @@ def create_fw_bw_graph(fn, use_output_and_grad_bw, fw_inputs, fw_outputs):
 
 def _unstack_pytree(xs):
     flat_xs, inspec = pytree.tree_flatten(xs)
-    if not all(isinstance(xs, torch.Tensor) for xs in flat_xs):
+    if any(not isinstance(xs, torch.Tensor) for xs in flat_xs):
         raise RuntimeError(f"Leaves of xs must be Tensor {flat_xs}")
 
-    if not all(xs.shape[0] == flat_xs[0].shape[0] for xs in flat_xs):
+    if any(xs.shape[0] != flat_xs[0].shape[0] for xs in flat_xs):
         raise RuntimeError(
             f"Leaves of xs must have same leading dimension size {[xs.shape for xs in flat_xs]}"
         )

--- a/torch/_inductor/aoti_eager.py
+++ b/torch/_inductor/aoti_eager.py
@@ -184,8 +184,8 @@ def aoti_compile_with_persistent_cache(
     """
     assert not dynamic, "Only support static shape for now"
     flattened_inputs = list(args) + list(kwargs.values())
-    if not all(
-        isinstance(
+    if any(
+        not isinstance(
             input,
             (
                 supported_scalar_types(),
@@ -204,8 +204,8 @@ def aoti_compile_with_persistent_cache(
         raise NotImplementedError(err_msg)
 
     for input in flattened_inputs:
-        if isinstance(input, list) and not all(
-            isinstance(item, torch.Tensor) for item in input
+        if isinstance(input, list) and any(
+            not isinstance(item, torch.Tensor) for item in input
         ):
             err_msg = f"_impl_with_aoti_compile encounters unsupported input types: {flattened_inputs}"
             log.exception(err_msg)

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -376,11 +376,9 @@ class InductorChoices:
             lower = bounds.lower
             upper = bounds.upper
 
-            if not all(
-                (
-                    (isinstance(bound, int) or bound.is_constant())
-                    and bound != torch.utils._sympy.numbers.IntInfinity()
-                )
+            if any(
+                (not isinstance(bound, int) and not bound.is_constant())
+                or bound == torch.utils._sympy.numbers.IntInfinity()
                 for bound in (lower, upper)
             ):
                 return False

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4879,9 +4879,9 @@ class CppScheduling(BaseScheduling):
 
     def _get_outer_loop_fusion_depth(self, node1, node2):
         DISABLE_OUTER_LOOP_FUSION = 0
-        if not all(
+        if any(
             type(node)
-            in (OuterLoopFusedSchedulerNode, FusedSchedulerNode, SchedulerNode)
+            not in (OuterLoopFusedSchedulerNode, FusedSchedulerNode, SchedulerNode)
             for node in (node1, node2)
         ):
             return DISABLE_OUTER_LOOP_FUSION
@@ -5349,9 +5349,9 @@ class CppScheduling(BaseScheduling):
 
             assert template_buffer.get_name() in outputs_by_name
             users = outputs_by_name[template_buffer.get_name()].users
-            return not all(
-                isinstance(user.node, BaseSchedulerNode)
-                and user.node.node in epilogue_nodes
+            return any(
+                not isinstance(user.node, BaseSchedulerNode)
+                or user.node.node not in epilogue_nodes
                 for user in users
             )
 

--- a/torch/_inductor/codegen/cuda/cuda_kernel.py
+++ b/torch/_inductor/codegen/cuda/cuda_kernel.py
@@ -105,10 +105,10 @@ class CUDAKernel(Kernel):
             # And if they come from the same node, whichever symbol we use is fine.
             # if in runtime the logic changes, this would trigger guard
             first_match = matches[0]
-            if not all(
-                match.node == first_match.node
-                and match.attr == first_match.attr
-                and match.dim == first_match.dim
+            if any(
+                match.node != first_match.node
+                or match.attr != first_match.attr
+                or match.dim != first_match.dim
                 for match in matches
             ):
                 raise AssertionError("All matching layout args should be identical")

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1337,8 +1337,8 @@ class SIMDScheduling(BaseScheduling):
                 #    its tiling is incompatible with native matmul tiling (z,y,x,r).
                 #    This means _split_iteration_ranges will fail, so these nodes should not be fused.
                 tiling = self.select_tiling(node1.get_nodes(), numel1, rnumel1)
-                if not all(
-                    SIMDKernel.is_compatible(
+                if any(
+                    not SIMDKernel.is_compatible(
                         tiling.values(), n2.get_ranges(), reduction_numel=rnumel1
                     )
                     for n2 in node2.get_nodes()
@@ -1414,8 +1414,8 @@ class SIMDScheduling(BaseScheduling):
         if not node1.is_reduction() and node2.is_reduction():
             assert rnumel1 == 1 and rnumel2 != 1
             if numel1 == numel2 * rnumel2:
-                if not all(
-                    SIMDKernel.is_compatible((numel2, rnumel2), n.get_ranges())
+                if any(
+                    not SIMDKernel.is_compatible((numel2, rnumel2), n.get_ranges())
                     for n in node1.get_nodes()
                 ):
                     why("nodes numel/rnumel incompatibility")
@@ -1853,7 +1853,7 @@ class SIMDScheduling(BaseScheduling):
                     if buf.has_tensor_output()
                 ]
 
-        if not all(expr_fits_within_32bit(size) for size in buf_sizes):
+        if any(not expr_fits_within_32bit(size) for size in buf_sizes):
             return False
 
         # Only install guards for 32-bit indexing as there is no correctness

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -189,11 +189,11 @@ class SIMDKernelFeatures:
         ]
         for node in pointwise_nodes:
             # An index can be an integer when loading a random seed.
-            if not all(
-                not isinstance(dep, MemoryDep)
-                or dep.is_contiguous()
-                or isinstance(dep.index, (sympy.Integer, int))
-                or dep.stride1_for_last_dim()
+            if any(
+                isinstance(dep, MemoryDep)
+                and not dep.is_contiguous()
+                and not isinstance(dep.index, (sympy.Integer, int))
+                and not dep.stride1_for_last_dim()
                 for dep in itertools.chain(
                     node.read_writes.reads, node.read_writes.writes
                 )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2557,8 +2557,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     @property
     def has_store_with_contiguous_rdim(self) -> bool:
-        return not all(
-            is_buffer_removed(name) for name in self.stores_with_contiguous_rdim
+        return any(
+            not is_buffer_removed(name) for name in self.stores_with_contiguous_rdim
         )
 
     def dtype_to_str(self, dtype: torch.dtype) -> str:
@@ -3585,7 +3585,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if (
                 is_sympy_integer_like(index)
                 and value.shape is not None
-                and not all(str(x) == "1" for x in value.shape)
+                and any(str(x) != "1" for x in value.shape)
             ):
                 value_shape = ", ".join(map(str, value.shape))
                 indexing_str += f".broadcast_to({value_shape})"
@@ -3596,7 +3596,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if (
                 is_sympy_integer_like(index)
                 and value.shape is not None
-                and not all(str(x) == "1" for x in value.shape)
+                and any(str(x) != "1" for x in value.shape)
             ):
                 value_shape = ", ".join(map(str, value.shape))
                 indexing_str += f".broadcast_to({value_shape})"
@@ -4465,7 +4465,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if (
                 is_sympy_integer_like(index)
                 and value.shape is not None
-                and not all(str(x) == "1" for x in value.shape)
+                and any(str(x) != "1" for x in value.shape)
             ):
                 value_shape = ", ".join(map(str, value.shape))
                 indexing_str += f".broadcast_to({value_shape})"

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -369,7 +369,7 @@ def is_b2b_gemm_good_on(
     checks whether the sizes are good for b2b_gemm
     """
     # basic checks
-    if not all(["val" in A_node.meta, "val" in B_node.meta, "val" in C_node.meta]):
+    if any("val" not in node.meta for node in (A_node, B_node, C_node)):
         return False
     fake_tensors = (
         A_node.meta["val"],
@@ -386,7 +386,7 @@ def is_b2b_gemm_good_on(
         fake_tensors, "is_xpu"
     ):
         return False
-    if not all([len(A.shape) == 2, len(B.shape) == 2, len(C.shape) == 2]):
+    if any(len(shape) != 2 for shape in (A.shape, B.shape, C.shape)):
         return False
     if not ((A.shape[1] == B.shape[0]) and (B.shape[1] == C.shape[0])):
         return False

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -143,21 +143,21 @@ def addmm_patterns_init():
         if "w3" in match.kwargs:
             weight_inputs.append("w3")
 
-        if not all(
-            match.kwargs[wgt].target is torch.ops.prims.convert_element_type.default
+        if any(
+            match.kwargs[wgt].target is not torch.ops.prims.convert_element_type.default
             for wgt in weight_inputs
         ):
             return False
 
-        if not all(
+        if any(
             next(iter(match.kwargs[wgt]._input_nodes.keys())).meta["val"].dtype
-            is torch.int8
+            is not torch.int8
             for wgt in weight_inputs
         ):
             return False
 
-        if not all(
-            match.kwargs[wgt].meta["val"].dtype is torch.bfloat16
+        if any(
+            match.kwargs[wgt].meta["val"].dtype is not torch.bfloat16
             for wgt in weight_inputs
         ):
             return False
@@ -185,9 +185,9 @@ def addmm_patterns_init():
         for equal_shape_group in equal_shape_inputs:
             inps = [match.kwargs[name] for name in equal_shape_group]
 
-            if not all(
-                inp.op == "get_attr"
-                and inp.meta["val"].shape == inps[0].meta["val"].shape
+            if any(
+                inp.op != "get_attr"
+                or inp.meta["val"].shape != inps[0].meta["val"].shape
                 for inp in inps
             ):
                 return False

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -37,7 +37,7 @@ def _is_backward(graph: torch.fx.Graph) -> bool:
         if node.op != "placeholder":
             break
         placeholders.append(node)
-    return not all(node.name.startswith("primal") for node in placeholders)
+    return any(not node.name.startswith("primal") for node in placeholders)
 
 
 def _compute_mm_arithmetic_intensity(M: int, N: int, K: int) -> float:

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -137,7 +137,7 @@ def can_pad(
     if not check_dtype(mat1, mat2):
         return False
 
-    if not all(valid_shape_and_stride(t) for t in (mat1, mat2, input)):
+    if any(not valid_shape_and_stride(t) for t in (mat1, mat2, input)):
         return False
 
     # Check for zero dimensions - not safe to pad

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1024,13 +1024,13 @@ def _is_input_output_same_scale_zp(check_node):
         )
         assert len(quant_nodes) == 1, "expect only 1 add node at output quant pattern"
         zero_points.append(quant_nodes[0].args[2])
-        if not all(zero_point == zero_points[0] for zero_point in zero_points):
+        if any(zero_point != zero_points[0] for zero_point in zero_points):
             return False
 
         # Step 2: Check inputs/output scale
         scales = [node.args[1] for node in dequant_nodes]
         scales.append(quant_nodes[0].args[1])
-        if not all(math.isclose(scale, scales[0], rel_tol=1e-5) for scale in scales):  # type: ignore[arg-type]
+        if any(not math.isclose(scale, scales[0], rel_tol=1e-5) for scale in scales):  # type: ignore[arg-type]
             return False
 
         return True
@@ -1114,8 +1114,8 @@ def _is_valid_concat_linear_int8_woq_optimization_pattern():
         if not config.cpp.enable_concat_linear:
             return False
         assert all(k in match.kwargs for k in ("x", "w1", "w2", "w3", "scales"))
-        if not all(
-            hasattr(match.kwargs[key], "meta")
+        if any(
+            not hasattr(match.kwargs[key], "meta")
             for key in ["x", "w1", "w2", "w3", "scales"]
         ):
             return False
@@ -1152,8 +1152,8 @@ def _is_valid_concat_linear_int8_woq_optimization_pattern():
 def _is_valid_woq_optimization_pattern():
     def fn(match):
         assert all(k in match.kwargs for k in ("x", "weight", "scales"))
-        if not all(
-            hasattr(match.kwargs[key], "meta") for key in ["x", "weight", "scales"]
+        if any(
+            not hasattr(match.kwargs[key], "meta") for key in ["x", "weight", "scales"]
         ):
             return False
         x = match.kwargs["x"].meta["val"]

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -763,7 +763,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         ) is not None:
             mutated_args = node.args[inplaceable_op.mutated_arg]
 
-            if not all((arg, node) in copy_args_to_copy_nodes for arg in mutated_args):
+            if any((arg, node) not in copy_args_to_copy_nodes for arg in mutated_args):
                 continue
 
             if can_inplace(node, mutated_args):

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -307,7 +307,7 @@ class IndexPropagation(DefaultHandler):
             for a in itertools.chain(args, kwargs.values())
             if isinstance(a, IndexPropVar)
         ]
-        if not all(v.is_symbolic for v in var_arguments):
+        if any(not v.is_symbolic for v in var_arguments):
             return self.fallback(name, args, kwargs)
 
         return self.propagate_sympy(name, args, kwargs)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3844,8 +3844,8 @@ class Layout(OutputSpec):
 
         # Skip padding the strides for dynamic shapes based on config.pad_dynamic_shape
         # Checking both shape and strides, as there are cases where only one is dynamic
-        is_dynamic = not all(
-            isinstance(s, (int, sympy.Integer))
+        is_dynamic = any(
+            not isinstance(s, (int, sympy.Integer))
             for s in itertools.chain(in_strides, size)
         )
         if not config.pad_dynamic_shapes and is_dynamic:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -501,7 +501,7 @@ def _register_lowering(
             args = list(args[0])
 
         if any(
-            (fn not in fallbacks or in_namespace(fn, "_c10d_functional"))
+            (fn not in fallbacks and not in_namespace(fn, "_c10d_functional"))
             for fn in aten_fn
         ):
             # explicitly assert for "out=" ops for better error messages

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -500,8 +500,9 @@ def _register_lowering(
             unpacked = True
             args = list(args[0])
 
-        if not all(
-            (fn in fallbacks or in_namespace(fn, "_c10d_functional")) for fn in aten_fn
+        if any(
+            (fn not in fallbacks or in_namespace(fn, "_c10d_functional"))
+            for fn in aten_fn
         ):
             # explicitly assert for "out=" ops for better error messages
             assert not any(x == "out" for x in kwargs), "out= ops aren't yet supported"
@@ -3983,8 +3984,8 @@ def index_put_impl_(self, indices, values, accumulate, check, may_realize=False)
                 )
             return False
 
-        if ir.try_get_name(self) in values.get_read_names() and not all(
-            indice_slice_from_randperm(indice) for indice in indices
+        if ir.try_get_name(self) in values.get_read_names() and any(
+            not indice_slice_from_randperm(indice) for indice in indices
         ):
             # Fix issue: https://github.com/pytorch/pytorch/issues/138908
             # When self and values have memory overlapping, indices may

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -173,7 +173,7 @@ def _prepare_convolution_fusion_create(
     # won't change the stride of this tensor since stride for dimensions of size 1 is ignored. While in Conv kernel,
     # this tensor is considered as channels first and the output will be in contiguous format.
     # To align the behavior of the Conv kernel, we set the output_stride in such case to be contiguous instead of channels last.
-    dynamic_shapes = not all(isinstance(i, int) for i in (output_size))
+    dynamic_shapes = any(not isinstance(i, int) for i in (output_size))
     if (
         dynamic_shapes or get_device_type(x) == "xpu"
     ) and is_contiguous_storage_and_layout(x):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -306,12 +306,12 @@ class MixOrderReduction:
         # other_ndoe. If that ascess is non-contiugous, generating
         # mix-order reduction can be inefficient especially when we
         # force XBLOCK to be 1
-        # if not all(
-        #     cls.is_contiguous_load(buf, contiguous_node) for buf in common_reads
+        # if any(
+        #     not cls.is_contiguous_load(buf, contiguous_node) for buf in common_reads
         # ):
         #     return False
-        if not all(
-            cls.is_contiguous_load(dep.name, contiguous_node)
+        if any(
+            not cls.is_contiguous_load(dep.name, contiguous_node)
             for dep in contiguous_node.read_writes.reads
         ):
             return False
@@ -5104,7 +5104,7 @@ class Scheduler:
             for node in prologue_nodes[:-1]:
                 node_outs = node.get_outputs()
                 for out in node_outs:
-                    if not all(user.node in prologue_nodes for user in out.users):
+                    if any(user.node not in prologue_nodes for user in out.users):
                         why("template prologue can only fuse nodes with a single use")
                         return False
 
@@ -5294,11 +5294,11 @@ class Scheduler:
             if not relevant_reads:
                 continue
             num_concurrent_reads += 1
-            if not all(
-                isinstance(read, MemoryDep)
-                and not free_symbol_is_type(read.index, SymT.TMP)
-                and read.index == write.index
-                and read.size == write.size
+            if any(
+                not isinstance(read, MemoryDep)
+                or free_symbol_is_type(read.index, SymT.TMP)
+                or read.index != write.index
+                or read.size != write.size
                 for read in relevant_reads
             ):
                 return False

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -793,8 +793,8 @@ def analyze_memory_coalescing(
             # n1 can can be split beyond range
 
             MIN_TILING_BLOCK = 8
-            if not all(
-                V.graph.sizevars.statically_known_lt(MIN_TILING_BLOCK, block)
+            if any(
+                not V.graph.sizevars.statically_known_lt(MIN_TILING_BLOCK, block)
                 for block in (tiling_factor, var_ranges[v] // tiling_factor)
             ):
                 continue

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3412,7 +3412,7 @@ def inferred_fake_kernel_from_real_out(
     # This is a general limitation on custom ops that we impose for PT2
     # to avoid baking non-symbolic float/int outputs into the graph.
     real_flat_out, spec = pytree.tree_flatten(real_out)
-    if not all(isinstance(t, torch.Tensor) for t in real_flat_out):
+    if any(not isinstance(t, torch.Tensor) for t in real_flat_out):
         raise RuntimeError(
             f"propagate_real_tensors: we don't support operators that return "
             f"non-Tensors. Got {op._schema}"

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1697,7 +1697,7 @@ class Tensor(torch._C.TensorBase):
         if kwargs is None:
             kwargs = {}
 
-        if not all(issubclass(cls, t) for t in types):
+        if any(not issubclass(cls, t) for t in types):
             return NotImplemented
 
         with _C.DisableTorchFunctionSubclass():

--- a/torch/_vmap_internals.py
+++ b/torch/_vmap_internals.py
@@ -176,8 +176,8 @@ def _validate_outputs(outputs: Any, func: Callable) -> None:
 def _check_out_dims_is_int_or_int_tuple(out_dims: out_dims_t, func: Callable) -> None:
     if isinstance(out_dims, int):
         return
-    if not isinstance(out_dims, tuple) or not all(
-        isinstance(out_dim, int) for out_dim in out_dims
+    if not isinstance(out_dims, tuple) or any(
+        not isinstance(out_dim, int) for out_dim in out_dims
     ):
         raise ValueError(
             f"vmap({_get_name(func)}, ..., out_dims={out_dims}): `out_dims` must be "

--- a/torch/ao/quantization/quantize_jit.py
+++ b/torch/ao/quantization/quantize_jit.py
@@ -68,7 +68,7 @@ def fuse_conv_bn_jit(model, inplace=False):
 def _prepare_jit(model, qconfig_dict, inplace=False, quant_type=QuantType.STATIC):
     _check_is_script_module(model)
     _check_forward_method(model)
-    if not all(isinstance(x, str) for x in qconfig_dict):
+    if any(not isinstance(x, str) for x in qconfig_dict):
         raise ValueError("qconfig_dict should only contain names(str) as keys.")
     scripted_qconfig_dict = script_qconfig_dict(qconfig_dict)
     model = fuse_conv_bn_jit(model, inplace)
@@ -90,7 +90,7 @@ def _prepare_ondevice_jit(
     quant_type=QuantType.STATIC,
 ):
     _check_is_script_module(model)
-    if not all(isinstance(x, str) for x in qconfig_dict):
+    if any(not isinstance(x, str) for x in qconfig_dict):
         raise ValueError("qconfig_dict should only contain names(str) as keys.")
     scripted_qconfig_dict = script_qconfig_dict(qconfig_dict)
     method_graph = model._c._get_method(method_name).graph


### PR DESCRIPTION
Apply De Morgan's Law optimization to PyTorch codebase by converting `not all(...)` patterns to `any(...)` patterns for improved code readability and performance.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela