### PR TITLE
[ROCm] Fix foreach profiler check and cholesky_solve nondeterminism

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -81,7 +81,9 @@ class ForeachFuncWrapper:
 
         # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
         # https://github.com/pytorch/pytorch/issues/148681. TODO: ADD IT BACK!!!
-        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)]
+        # Also skip on ROCm where rocTracer has similar kernel detection issues
+        # https://github.com/pytorch/pytorch/issues/97167
+        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)] or TEST_WITH_ROCM
         if (
             is_cuda
             and not skip_profiler_check

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13059,6 +13059,9 @@ op_db: list[OpInfo] = [
            check_batched_gradgrad=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
+           # ROCm hipSOLVER has nondeterministic backward for complex types
+           # https://github.com/pytorch/pytorch/issues/164193
+           gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            gradcheck_wrapper=lambda *args, **kwargs: gradcheck_wrapper_triangular_input(*args, idx=1, **kwargs),
            decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack]),
     OpInfo('chunk',


### PR DESCRIPTION
## What this does

Fixes two ROCm test failures by applying the same patterns used elsewhere in the codebase.

### Fix 1: Skip profiler check in foreach tests

The foreach tests verify kernel execution by checking profiler output. On ROCm, rocTracer sometimes misses kernels even when they run correctly - same issue NVIDIA has with CUPTI on CUDA 12.6/12.8.

We already skip this check for those CUDA versions, so this extends it to ROCm.

### Fix 2: Add tolerance for cholesky_solve gradcheck

hipSOLVER's backward pass for complex types has slight numerical variation between runs, which fails gradcheck's reentrant test. Adding `GRADCHECK_NONDET_TOL` (1e-12) fixes it - same approach used for `addmm`, `mm`, etc.

## Tests now passing

- `test_foreach_copy_with_multi_dtypes` (5 dtype combinations)
- `test_fn_gradgrad_cholesky_solve_cuda_complex128`

Fixes #164193

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet