### PR TITLE
[Fix] Fix unreachable AssertionError in DispatchKey.Python logic

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -945,12 +945,12 @@ class OpOverload(OperatorBase, Generic[_P, _T]):
 
                 # TODO: We also need to handle tensor subclasses here
                 # TODO(voz): We should walk all the nodes here / turn it into a list, topmode is ok for now.
-                curr_mode = type(_get_current_dispatch_mode())
-                if curr_mode is None:
+                raw_mode = _get_current_dispatch_mode()
+                if raw_mode is None:
                     raise AssertionError(
                         "Illegal invocation of dispatch on DispatchKey.Python without a mode."
                     )
-
+                curr_mode = type(raw_mode)
                 if curr_mode not in self.python_key_table:
                     if isinstance(self, TorchBindOpOverload):
                         with (


### PR DESCRIPTION
The current implementation mistakenly checks `type(_get_current_dispatch_mode()) is None`. Since `type(None)` evaluates to `<class 'NoneType'>`, this identity check always returns `False`, making the `AssertionError` unreachable even when no dispatch mode is active.

cc @cyyever 