### PR TITLE
Fix PDL codegen assertion by using `writeline` instead of `cse.generate`

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_cuda import (
     IS_SM90,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MX_GEMM,
+    SM90OrLater,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -1427,6 +1428,38 @@ class TestFP8Lowering(TestCase):
                 bias,
             )
         self.assertTrue("Invalid scaling configuration." in str(cm.exception))
+
+    @unittest.skipIf(not SM90OrLater, "PDL requires SM 9.0+")
+    @onlyOn(["cuda", "xpu"])
+    def test_scaled_mm_pdl_handles_none_bias(self, device):
+        dtype_float8 = _fix_fp8_dtype_for_rocm(torch.float8_e4m3fn, device)
+        M, K, N = 32, 64, 32
+
+        # A row-major, B column-major view (transpose of contiguous)
+        a = torch.randn(M, K, device=device, dtype=torch.float16).to(dtype_float8)
+        b = torch.randn(N, K, device=device, dtype=torch.float16).to(dtype_float8).t()
+        scale_a = torch.tensor(1.0, device=device)
+        scale_b = torch.tensor(1.0, device=device)
+        scale_r = torch.tensor(1.0, device=device)
+
+        def linear(a, b, sa, sb, sr):
+            return torch._scaled_mm(a, b, sa, sb, None, sr, out_dtype=torch.bfloat16)
+
+        expected = linear(a, b, scale_a, scale_b, scale_r)
+
+        patch_cfg = {
+            "triton.enable_pdl": True,
+            "triton.use_tensor_descriptor": False,
+            "max_autotune_gemm": True,
+            "max_autotune_gemm_backends": "ATEN,TRITON",
+            "max_autotune_gemm_search_space": "EXHAUSTIVE",
+        }
+
+        with config.patch(patch_cfg):
+            compiled = torch.compile(linear, mode="max-autotune")
+            actual = compiled(a, b, scale_a, scale_b, scale_r)
+
+        self.assertEqual(expected, actual, rtol=5e-2, atol=0.07)
 
 
 instantiate_device_type_tests(TestFP8Types, globals(), allow_xpu=True)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3346,9 +3346,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             current_load_index = self._load_index
             launch_if_last_load = DelayMaybeLine(
                 lambda: current_load_index == self._load_index,
-                f"0; {GDC_LAUNCH} # gdc launch for {result_var}",
+                f"{GDC_LAUNCH} # gdc launch for {result_var}",
             )
-            self.cse.generate(launch_buffer, launch_if_last_load, dtype=torch.int32)
+            launch_buffer.writeline(launch_if_last_load)
 
     def partial_accumulate(
         self, name: str, reduction_type, val, extra_meta: dict[str, Any]


### PR DESCRIPTION
The `_handle_pdl_after_load` method could be incorrectly using `cse.generate()` to emit the `gdc_launch_dependents()` PDL instruction. This caused an assertion failure when `shape=None` was passed to [`TritonCSEVariable`](https://github.com/pytorch/pytorch/blob/6493f23b9931ff9661a36cfb3752d1b528467805/torch/_inductor/codegen/triton.py#L1010-L1022):

  AssertionError: TritonCSEVariable must have shape

This was triggered when combining FP8 (`_scaled_mm`) with PDL and exhaustive GEMM autotuning (e.g., TorchTitan on GB200).

The root issue is that `cse.generate()` could have been being misused here:
- The CSE variable (`tmp = 0; gdc_launch...`) was never used downstream
- Each PDL launch has a unique cache key, so no CSE benefit exists
- It's purely a side-effect instruction, not a cacheable computation

The fix changes to `launch_buffer.writeline()` directly, which:
- Avoids creating an unnecessary CSE variable (no shape/dtype needed)
- Produces cleaner generated code (no `tmp = 0;` prefix)
- Maintains the strict `TritonCSEVariable` shape assertion

Note: The `tmp = 0` assignments were eliminated by Triton's frontend anyway (DCE), so the final PTX/SASS is unchanged. This fix addresses the assertion failure at the Inductor codegen level.

Test Plan:
- Added `test_scaled_mm_pdl_handles_none_bias` to test/inductor/test_fp8.py

For the following script
```python
import torch
import torch._inductor.config as config

config.triton.enable_pdl = True

def fn(a, b):
    return a + b

x = torch.randn(1024, device="cuda")
y = torch.randn(1024, device="cuda")
compiled = torch.compile(fn)
_ = compiled(x, y)
```

the current main generates:
```python
@triton.jit
def triton_poi_fused_add_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK: tl.constexpr):
    xnumel = 1024
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex
    tl.extra.cuda.gdc_wait()
    tmp0 = tl.load(in_ptr0 + (x0), xmask)
    tmp2 = tl.load(in_ptr1 + (x0), xmask)
    tmp3 = 0; tl.extra.cuda.gdc_launch_dependents() # gdc launch for tmp2
    tmp4 = tmp0 + tmp2
    tl.store(out_ptr0 + (x0), tmp4, xmask)
```

and this branch:
```python
@triton.jit
def triton_poi_fused_add_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK: tl.constexpr):
    xnumel = 1024
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex
    tl.extra.cuda.gdc_wait()
    tmp0 = tl.load(in_ptr0 + (x0), xmask)
    tmp1 = tl.load(in_ptr1 + (x0), xmask)
    tl.extra.cuda.gdc_launch_dependents()  # gdc launch for tmp1
    tmp2 = tmp0 + tmp1
    tl.store(out_ptr0 + (x0), tmp2, xmask)
```

but both lead to the following TTIR:
```
%0 = tt.elementwise_inline_asm "griddepcontrol.wait; // dummy $0" {pure = false} -> i32
%tmp0 = tt.load %ptr0, %mask : tensor<128x!tt.ptr<f32>>
%tmp1 = tt.load %ptr1, %mask : tensor<128x!tt.ptr<f32>>
%1 = tt.elementwise_inline_asm "griddepcontrol.launch_dependents; // dummy $0" {pure = false} -> i32
%tmp2 = arith.addf %tmp0, %tmp1 : tensor<128xf32>
tt.store %out_ptr, %tmp2, %mask
```

Fixes #170980


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo