### PR TITLE
[ROCm] Display ROCm version in torch.__config__.show()

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -204,7 +204,6 @@ std::string show_config() {
   }
   ss << '\n';
 
-  // TODO: do HIP
   // TODO: do XLA
   // TODO: do MPS
 

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -440,6 +440,10 @@ std::string CUDAHooks::showConfig() const {
     oss << '\n';
   }
   oss << "  - NVCC architecture flags: " << NVCC_FLAGS_EXTRA << '\n';
+#else
+  // ROCm version info
+  oss << "  - ROCm " << (ROCM_VERSION / 10000) << '.'
+      << (ROCM_VERSION / 100 % 100) << '.' << (ROCM_VERSION % 100) << '\n';
 #endif
 
 #if !defined(USE_ROCM)


### PR DESCRIPTION
## Summary

Display ROCm version in `torch.__config__.show()` output, matching the existing CUDA version display.

**Before:** No ROCm version shown
**After:** `- ROCm 6.1.0` (or similar)

## Changes

- `CUDAHooks.cpp`: Add ROCm version formatting using `ROCM_VERSION` macro
- `Version.cpp`: Remove outdated TODO comment

## Test Plan

- [ ] `torch.__config__.show()` displays ROCm version on ROCm builds
- [ ] No output change on CUDA-only builds

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)