### PR TITLE
[ROCm] Add HIP tensor serialization support in JIT

### DIFF
--- a/torch/csrc/jit/serialization/pickler_helper.cpp
+++ b/torch/csrc/jit/serialization/pickler_helper.cpp
@@ -12,11 +12,10 @@ WriteableTensorData getWriteableTensorData(
   WriteableTensorData result;
   result.tensor_ = tensor;
   result.size_ = tensor.storage().nbytes();
-  // TODO HIP support
   if (tensor.storage().device_type() != DeviceType::CPU && to_cpu) {
-    // NB: This new tensor is created to support cuda tensors.
-    // Storages can be mutated when converting tensors from cuda to cpu,
-    // and we need a cpu tensor to copy data from.
+    // NB: This new tensor is created to support CUDA and HIP tensors.
+    // Storages can be mutated when converting tensors from CUDA/HIP to CPU,
+    // and we need a CPU tensor to copy data from.
     result.tensor_ =
         at::empty({0}, tensor.options())
             .set_(

--- a/torch/csrc/jit/serialization/pickler_helper.h
+++ b/torch/csrc/jit/serialization/pickler_helper.h
@@ -107,7 +107,7 @@ struct WriteableTensorData {
 };
 
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor
-// if it was CUDA and to_cpu is True.
+// if it was CUDA/HIP and to_cpu is True.
 TORCH_API WriteableTensorData
 getWriteableTensorData(const at::Tensor& tensor, bool to_cpu = true);
 

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -604,14 +604,14 @@ PickleOpCode Unpickler::readInstruction() {
         tensor = at::empty({0}, options).set_(storage);
       }
 
-      if (device.is_cuda() || device.is_xpu() || device.is_meta() ||
-          device.is_mtia() || device.is_hpu() || device.is_mps() ||
-          device.is_privateuseone()) {
+      if (device.is_cuda() || device.is_hip() || device.is_xpu() ||
+          device.is_meta() || device.is_mtia() || device.is_hpu() ||
+          device.is_mps() || device.is_privateuseone()) {
         tensor = tensor.to(device, tensor.scalar_type());
       } else if (device.type() != DeviceType::CPU) {
         TORCH_CHECK(
             false,
-            "supported devices include CPU, CUDA, HPU and ",
+            "supported devices include CPU, CUDA, HIP, HPU and ",
             c10::get_privateuse1_backend(),
             " however got ",
             DeviceTypeName(device.type(), false));


### PR DESCRIPTION
## Summary

Enable proper serialization/deserialization of HIP tensors in TorchScript.

## Problem

HIP tensors fail to deserialize with error:
```
supported devices include CPU, CUDA, HPU... however got HIP
```

## Solution

Add `device.is_hip()` to the supported device check in unpickler.

## Changes

- `unpickler.cpp`: Add HIP to supported device list
- `pickler_helper.cpp/h`: Update comments to reflect CUDA/HIP support

## Test Plan

- [ ] `torch.jit.save()`/`torch.jit.load()` works with HIP tensors
- [ ] No regression on CUDA tensor serialization

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)