### PR TITLE
[ROCm] Add Inductor optimizations with architecture-aware defaults

### DIFF
--- a/torch/_inductor/template_heuristics/decompose_k.py
+++ b/torch/_inductor/template_heuristics/decompose_k.py
@@ -30,15 +30,14 @@ class EmptyDecomposeKConfigHeuristics(TemplateConfigHeuristics):
     "xpu",
     op_name="mm",
 )
-# on CUDA, we don't support hip for decompose_k yet
+# Decompose-K is enabled on both NVIDIA CUDA and AMD ROCm.
+# For ROCm, the feature can be controlled via config.rocm.use_decompose_k
+# (defaults to True, set TORCHINDUCTOR_ROCM_USE_DECOMPOSE_K=0 to disable).
 @register_template_heuristic(
     decompose_k_subgraph_template.uid,
     "cuda",
-    register=torch.version.hip is None,
     op_name="mm",
 )
-# TODO(coconutruben): enable decompose k on AMD by removing the register bool
-# and benchmarking it for performance and stability
 # TODO(coconutruben): enable decompose k on other devices (xpu, cpu, mps, mtia)
 # by either adding specific register_template_heuristic tags, or setting the
 # device to None (enabled on all devices)


### PR DESCRIPTION
## Summary

Enable key Inductor optimizations for ROCm with architecture-aware defaults and robust edge case handling.

## Features

### 1. Decompose-K Optimization
Split large K dimensions across thread blocks for better parallelism.
- Controlled via `config.rocm.use_decompose_k` (default: enabled)
- Env var: `TORCHINDUCTOR_ROCM_USE_DECOMPOSE_K=0` to disable

### 2. Architecture-Aware Pipeline Stages
Optimal software pipelining depth per GPU architecture:
- **CDNA3 (MI300, gfx942/950)**: 3 stages
- **CDNA2 (MI200, gfx90a)**: 2 stages
- **Other**: 2 stages (conservative)

Env var: `TORCHINDUCTOR_ROCM_NUM_STAGES=N` to override

### 3. Layout Optimization
NHWC (channels-last) enabled for CDNA3+ architectures where MIOpen has good support.

### 4. Multi-arch AOTI
Fat binary support for ROCm using clang-offload-bundler.

## Edge Case Fixes

- **Division by zero**: Guard in `get_k_splits()` when m=0 or n=0
- **Env var parsing**: Safe parsing with validation and warnings
- **Exception handling**: Specific exceptions with debug logging

## Test Plan

- [x] 11 new unit tests for edge cases
- [ ] ROCm CI passes
- [ ] No regression on CUDA CI

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jansel @Chillee @eellison

🤖 Generated with [Claude Code](https://claude.com/claude-code)