### PR TITLE
Fix #150119: Handle ROCm device strings in foreach pointwise test

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -149,7 +149,7 @@ def get_transform_func(num_tensors, dtype, device, is_fastpath):
 class TestForeach(TestCase):
     @property
     def is_cuda(self):
-        return self.device_type == "cuda"
+        return self.device_type == ("hip" if TEST_WITH_ROCM else "cuda")
 
     def _get_funcs(self, op):
         return (


### PR DESCRIPTION
## Summary
Fixes #150119 by updating the foreach test property `is_cuda` to properly handle ROCm device strings.

## Problem
The `is_cuda` property in `test/test_foreach.py` was hardcoded to check for `"cuda"` device type, but on ROCm systems it should check for `"hip"` device type. This caused foreach operation tests to fail on ROCm systems.

## Solution
Updated the `is_cuda` property to conditionally check for the appropriate device type:
- Uses `"hip"` when `TEST_WITH_ROCM` is true (ROCm systems)
- Uses `"cuda"` otherwise (CUDA systems)

## Changes
- Modified `test/test_foreach.py` line 152 to use conditional device type checking

## Testing
This fix enables proper ROCm compatibility for foreach operations testing by ensuring the device type check matches the actual device type used on ROCm systems.

## Labels
Please add the following labels:
- `module: rocm`
- `topic: tests` 
- `bug`
- `cla signed`

## Notes
- Single focused commit addressing only issue #150119

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang