### PR TITLE
Fix #150120: Handle ROCm device strings in foreach multi-device test

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -679,7 +679,7 @@ class TestForeach(TestCase):
             foreach_op_(tensors1, tensors2)
 
         # different devices
-        if self.device_type == "cuda" and torch.cuda.device_count() > 1:
+        if self.device_type == ("hip" if TEST_WITH_ROCM else "cuda") and torch.cuda.device_count() > 1:
             tensor1 = torch.zeros(10, 10, device="cuda:0", dtype=dtype)
             tensor2 = torch.ones(10, 10, device="cuda:1", dtype=dtype)
             with self.assertRaisesRegex(


### PR DESCRIPTION
## Summary
Fixes #150120 by updating the foreach multi-device test to properly handle ROCm device strings.

## Problem
The foreach multi-device test in `test/test_foreach.py` was hardcoded to check for `"cuda"` device type when testing operations across different devices, but on ROCm systems it should check for `"hip"` device type. This caused multi-device foreach operation tests to fail on ROCm systems.

## Solution
Updated the multi-device test condition to conditionally check for the appropriate device type:
- Uses `"hip"` when `TEST_WITH_ROCM` is true (ROCm systems)
- Uses `"cuda"` otherwise (CUDA systems)

## Changes
- Modified `test/test_foreach.py` line 682 to use conditional device type checking

## Testing
This fix enables proper ROCm compatibility for foreach multi-device operations testing by ensuring the device type check matches the actual device type used on ROCm systems.

## Labels
Please add the following labels:
- `module: rocm`
- `topic: tests` 
- `bug`
- `cla signed`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang