### PR TITLE
[ROCm][Strix Halo] Fix for cpp_extension ROCm detection

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2623,10 +2623,14 @@ def _get_build_directory(name: str, verbose: bool) -> str:
     root_extensions_directory = os.environ.get('TORCH_EXTENSIONS_DIR')
     if root_extensions_directory is None:
         root_extensions_directory = get_default_build_root()
-        cu_str = ('cpu' if torch.version.cuda is None else
-                  f'cu{torch.version.cuda.replace(".", "")}')
+        if torch.version.cuda is not None:
+            accelerator = f'cu{torch.version.cuda.replace(".", "")}'
+        elif torch.version.hip is not None:
+            accelerator = f'rocm{torch.version.hip.replace(".", "")}'
+        else:
+            accelerator = 'cpu'
         python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
-        build_folder = f'{python_version}_{cu_str}'
+        build_folder = f'{python_version}_{accelerator}'
 
         root_extensions_directory = os.path.join(
             root_extensions_directory, build_folder)


### PR DESCRIPTION
## Summary

Fixes incorrect build directory naming for ROCm installations in `torch/utils/cpp_extension.py`.

**Problem**: The code only checked for CUDA, treating all non-CUDA builds as CPU:
```python
cu_str = ('cpu' if torch.version.cuda is None else f'cu{...}')
```

This caused ROCm kernels to be placed in CPU directories, leading to conflicts when environments are shared via NFS across systems with different hardware.

**Solution**: Add proper ROCm/HIP detection:
```python
if torch.version.cuda is not None:
    accelerator = f'cu{torch.version.cuda.replace(".", "")}'
elif torch.version.hip is not None:
    accelerator = f'rocm{torch.version.hip.replace(".", "")}'
else:
    accelerator = 'cpu'
```

## Example

| Platform | Before | After |
|----------|--------|-------|
| CUDA 12.4 | `py311_cu124` | `py311_cu124` |
| ROCm 6.2 | `py311_cpu` ❌ | `py311_rocm62` ✅ |
| CPU | `py311_cpu` | `py311_cpu` |

Fixes #170778

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang