### PR TITLE
[ROCm][Strix Halo] Fix for rocm_env.sh file existence check

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
 set -ex -o pipefail
 
 # for ROCm environment variables
-if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
   # shellcheck disable=SC1091
   source /etc/rocm_env.sh
 fi


### PR DESCRIPTION
## Summary

Fixes CI script failure when `/etc/rocm_env.sh` doesn't exist on ROCm installations.

**Problem**: `.ci/pytorch/common.sh` unconditionally sources `/etc/rocm_env.sh` when `BUILD_ENVIRONMENT` contains "rocm":
```bash
if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
  source /etc/rocm_env.sh  # Fails if file doesn't exist
fi
```

**Error**: `.ci/pytorch/common.sh: line 11: /etc/rocm_env.sh: No such file or directory`

**Solution**: Add file existence check:
```bash
if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
  source /etc/rocm_env.sh
fi
```

This allows the script to work on ROCm installations that don't have `/etc/rocm_env.sh`.

Fixes #170983

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang