### PR TITLE
Fix training IR opaque export handling

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -435,11 +435,14 @@ def _decompose_and_get_gm_with_new_signature_constants(
         for node in mod.graph.nodes:
             if node.op == "placeholder":
                 if isinstance(node.meta["val"], CustomObjArgument):
-                    real_script_obj = None
-                    if node.meta["val"].fake_val is None:
-                        real_script_obj = ep.constants[node.meta["val"].name]
+                    custom_obj = node.meta["val"]
+                    fake_val = custom_obj.fake_val
+                    if fake_val is None:
+                        real_script_obj = ep.constants[custom_obj.name]
+                    elif isinstance(fake_val, FakeScriptObject):
+                        real_script_obj = fake_val.real_obj
                     else:
-                        real_script_obj = node.meta["val"].fake_val.real_obj
+                        real_script_obj = fake_val
                     retracing_args.append(real_script_obj)
                 else:
                     retracing_args.append(node.meta["val"])


### PR DESCRIPTION
## Summary
- ensure retracing handles opaque custom inputs when the fake val does not provide a 
- avoid assuming every  carries a  so the new ROCm failure is resolved

## Testing
- not run (importing torch currently fails because torch/version.py is not generated in this source tree)
