### PR TITLE
Fix spelling typos in test files

### DIFF
--- a/test/jit/test_tensor_creation_ops.py
+++ b/test/jit/test_tensor_creation_ops.py
@@ -27,7 +27,7 @@ class TestTensorCreationOps(JitTestCase):
 
         self.checkScript(randperm, (3,))
 
-    def test_randperm_specifed_dtype(self):
+    def test_randperm_specified_dtype(self):
         def randperm(x: int):
             perm = torch.randperm(x, dtype=torch.float)
             # Have to perform assertion here because TorchScript returns dtypes

--- a/test/quantization/bc/test_backward_compatibility.py
+++ b/test/quantization/bc/test_backward_compatibility.py
@@ -235,7 +235,7 @@ class TestSerialization(TestCase):
             input_tensor: torch.Tensor,
         ) -> torch.nn.Module:
             example_inputs = (input_tensor,)
-            # do the quantizaton transforms and save result
+            # do the quantization transforms and save result
             qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
             mp = quantize_fx.prepare_fx(m, {"": qconfig}, example_inputs=example_inputs)
             mp(input_tensor)


### PR DESCRIPTION
## Summary
Fix spelling typos in test files:

- `test_randperm_specifed_dtype` → `test_randperm_specified_dtype` in `test/jit/test_tensor_creation_ops.py`
- `quantizaton` → `quantization` in `test/quantization/bc/test_backward_compatibility.py`

## Test plan
- No functional changes, only spelling corrections
- The function name fix updates the test method name to correct spelling

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @pytorch/quantization