### PR TITLE
[ROCm][Strix Halo] Fix for HIP_OFFLOAD initialization

### DIFF
--- a/.ci/docker/common/install_ucc.sh
+++ b/.ci/docker/common/install_ucc.sh
@@ -61,6 +61,7 @@ function install_ucc() {
     else
       amdgpu_targets=`rocm_agent_enumerator | grep -v gfx000 | sort -u | xargs`
     fi
+    HIP_OFFLOAD=""
     for arch in $amdgpu_targets; do
       HIP_OFFLOAD="$HIP_OFFLOAD --offload-arch=$arch"
     done


### PR DESCRIPTION
## Summary
Fix uninitialized variable in UCC installation script for ROCm builds.

**Bug:** In `install_ucc.sh`, the `HIP_OFFLOAD` variable was appended to in a loop (line 65-66) without being initialized first. In bash, appending to an uninitialized variable can include unexpected content from the environment or result in malformed configure flags.

**Fix:** Initialize `HIP_OFFLOAD=""` before the loop to ensure clean flag construction.

## Test Plan
Code inspection - follows bash best practices for variable initialization before use.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)