### PR TITLE
[Misc] Fix typo in SYCL error message: 'dected' -> 'detected'

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -182,7 +182,7 @@ def _join_sycl_home(*paths) -> str:
     only once we need to get any SYCL-specific path.
     """
     if SYCL_HOME is None:
-        raise OSError('SYCL runtime is not dected. Please setup the pytorch '
+        raise OSError('SYCL runtime is not detected. Please setup the pytorch '
                       'prerequisites for Intel GPU following the instruction in '
                       'https://github.com/pytorch/pytorch?tab=readme-ov-file#intel-gpu-support '
                       'or install intel-sycl-rt via pip.')


### PR DESCRIPTION
## Summary
Fix typo in error message for SYCL runtime detection.

**Bug:** The word "detected" was misspelled as "dected" in the OSError message in `_join_sycl_home()`.

## Test Plan
N/A - typo fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)