### PR TITLE
[ROCm][Strix Halo] Fix for MIOpen db directory check

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -155,10 +155,12 @@ EOF
     fi
 
     # ROCm 6.0 had a regression where journal_mode was enabled on the kdb files resulting in permission errors at runtime
-    for kdb in /opt/rocm/share/miopen/db/*.kdb
-    do
-        sqlite3 $kdb "PRAGMA journal_mode=off; PRAGMA VACUUM;"
-    done
+    if [ -d /opt/rocm/share/miopen/db ]; then
+        for kdb in /opt/rocm/share/miopen/db/*.kdb
+        do
+            sqlite3 $kdb "PRAGMA journal_mode=off; PRAGMA VACUUM;"
+        done
+    fi
 
     # ROCm 6.3 had a regression where initializing static code objects had significant overhead
     # CI no longer builds for ROCm 6.3, but


### PR DESCRIPTION
## Summary
Add directory existence check before iterating over MIOpen .kdb files.

**Bug:** The loop at lines 158-161 iterates over `/opt/rocm/share/miopen/db/*.kdb` without checking if the directory exists. In bash, if the directory doesn't exist, the glob pattern expands to the literal string `"/opt/rocm/share/miopen/db/*.kdb"`, causing `sqlite3` to fail with a confusing "unable to open database file" error.

**Fix:** Add `if [ -d /opt/rocm/share/miopen/db ]` check before the loop.

## Test Plan
Code inspection - follows the pattern used elsewhere in ROCm CI scripts.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)