### PR TITLE
[Bugfix] Fix incorrect @staticmethod signatures in GEMM template

### DIFF
--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -475,7 +475,9 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
 
     @staticmethod
     @abstractmethod
-    def _has_tma_epilogue(self) -> bool:
+    def _has_tma_epilogue(
+        op: "cutlass_library.gemm_op.GemmOperation",  # type: ignore[name-defined]  # noqa: F821
+    ) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -1732,7 +1734,9 @@ class CUTLASS2xGemmTemplate(CUTLASSGemmTemplate):
         return [cutlass_lib.GemmKind.Universal, cutlass_lib.GemmKind.Sparse]
 
     @staticmethod
-    def _has_tma_epilogue(self) -> bool:
+    def _has_tma_epilogue(
+        op: "cutlass_library.gemm_op.GemmOperation",  # type: ignore[name-defined]  # noqa: F821
+    ) -> bool:
         return False
 
     def _get_template(self) -> str:


### PR DESCRIPTION
## Summary
Fix two `@staticmethod` methods that incorrectly had `self` as a parameter in the CUTLASS GEMM template code.

**Bug:** The following methods were decorated with `@staticmethod` but had `self` as the first parameter:
1. `CUTLASSGemmTemplate._has_tma_epilogue` (abstract base class, line 478)
2. `CUTLASS2xGemmTemplate._has_tma_epilogue` (concrete implementation, line 1735)

Since static methods don't receive `self` automatically, the first positional argument passed to these methods (the `op` parameter from calls like `self._has_tma_epilogue(op)`) would be incorrectly bound to the `self` parameter.

**Fix:** Use the correct signature that matches `CUTLASS3xGemmTemplate._has_tma_epilogue`:
```python
@staticmethod
def _has_tma_epilogue(
    op: "cutlass_library.gemm_op.GemmOperation",
) -> bool:
```

## Test Plan
- Code inspection confirms the fix aligns with the existing `CUTLASS3xGemmTemplate._has_tma_epilogue` signature
- The method is called as `self._has_tma_epilogue(op)` in multiple places (lines 956, 1096, 1143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo