### PR TITLE
Fix GELU docstring parameter type annotation in ONNX exporter

### DIFF
--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -31,7 +31,7 @@ def aten_gelu_opset20(
     self: TReal,
     approximate: str = "none",
 ) -> TReal:
-    """gelu(Tensor self, *, bool approximate=False) -> Tensor"""
+    """gelu(Tensor self, *, str approximate="none") -> Tensor"""
     return op20.Gelu(self, approximate=approximate)
 
 


### PR DESCRIPTION

### Summary

This change fixes an incorrect parameter type in the docstring for the GELU operator used by the ONNX exporter.
### What was wrong

The docstring for `aten_gelu_opset20` did not match the actual function signature:

* The docstring listed `approximate` as a `bool` with a default of `False`
* The function actually expects a `str` with a default value of `"none"`

This mismatch could be confusing when reading the code or using IDE tooltips.

### What changed

* Updated the docstring to reflect the correct type: `str`
* Corrected the default value from `False` to `"none"`
* Ensured the documented signature matches the real function signature exactly

### Impact

* Improves documentation accuracy for the ONNX GELU operator
* Better IDE hints and code completion
* Reduces potential confusion for developers reading or extending the exporter
* Documentation-only fix with no functional impact

### Files changed

* `torch/onnx/_internal/exporter/_torchlib/ops/nn.py`
  *(1 line)*

### Verification
* Docstring now matches the function signature
* No lint or formatting issues introduced
* No behavior changes



cc @justinchuby @titaiwangms