### PR TITLE
Fix missing closing bracket in ONNX attention docstring

### DIFF
--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -198,7 +198,7 @@ def _attention_repeat_kv_for_group_query(
     Returns:
         Tuple of (expanded_key, expanded_value) where:
             - expanded_key: Tensor of shape [B, q_num_heads, kv_S, E]
-            - expanded_value: Tensor of shape [B, q_num_heads, kv_S, E
+            - expanded_value: Tensor of shape [B, q_num_heads, kv_S, E]
     """
 
     assert (


### PR DESCRIPTION
Found a small typo in the docstring - there was a missing closing bracket on line 201 that was bugging me when I was reading through the code.

The tensor shape documentation was incomplete:
`- expanded_value: Tensor of shape [B, q_num_heads, kv_S, E`

Just added the missing `]` to fix it:
`- expanded_value: Tensor of shape [B, q_num_heads, kv_S, E]`

Simple fix but makes the docs cleaner and easier to read. No code changes, just fixing the documentation formatting.

cc @justinchuby @titaiwangms