### PR TITLE
Add missing docstring to _is_orthogonal function

### DIFF
--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -12,6 +12,15 @@ __all__ = ["orthogonal", "spectral_norm", "weight_norm"]
 
 
 def _is_orthogonal(Q, eps=None):
+    """Check if a matrix is orthogonal.
+    
+    Args:
+        Q: Matrix to check
+        eps: Tolerance for the check (optional)
+        
+    Returns:
+        True if the matrix is orthogonal, False otherwise
+    """
     n, k = Q.size(-2), Q.size(-1)
     Id = torch.eye(k, dtype=Q.dtype, device=Q.device)
     # A reasonable eps, but not too large


### PR DESCRIPTION
I was looking through the parametrizations code and noticed that the `_is_orthogonal` function didn't have any docstring, while all the other functions around it were properly documented.

Added a simple docstring to explain what the function does - it checks if a matrix is orthogonal by verifying that Q.H @ Q is close to the identity matrix.

Just keeping the documentation consistent across the codebase. Nothing fancy, just wanted to help future developers (and myself) understand what this function is for at a glance.