### PR TITLE
Add docstring to _WeightNorm forward method

### DIFF
--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -324,6 +324,15 @@ class _WeightNorm(Module):
         self.dim = dim
 
     def forward(self, weight_g, weight_v):
+        """Apply weight normalization using magnitude and direction components.
+        
+        Args:
+            weight_g: Weight magnitude
+            weight_v: Weight direction  
+            
+        Returns:
+            Normalized weight tensor
+        """
         return torch._weight_norm(weight_v, weight_g, self.dim)
 
     def right_inverse(self, weight):


### PR DESCRIPTION
Noticed that the forward method in the _WeightNorm class didn't have any documentation while going through the weight normalization code.

The method takes weight_g (magnitude) and weight_v (direction) parameters and applies weight normalization, but there was no docstring explaining this.

Added a simple docstring to make it clear what the method does and what the parameters are for. Should help anyone working with weight normalization understand the code better.
