### PR TITLE
Add docstring to _WeightNorm right_inverse method

### DIFF
--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -328,10 +328,8 @@ class _WeightNorm(Module):
 
     def right_inverse(self, weight):
         """Decompose weight back into magnitude and direction components.
-        
         Args:
             weight: Normalized weight tensor to decompose
-            
         Returns:
             Tuple of (weight_g, weight_v) where weight_g is the magnitude 
             and weight_v is the direction component

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -327,6 +327,15 @@ class _WeightNorm(Module):
         return torch._weight_norm(weight_v, weight_g, self.dim)
 
     def right_inverse(self, weight):
+        """Decompose weight back into magnitude and direction components.
+        
+        Args:
+            weight: Normalized weight tensor to decompose
+            
+        Returns:
+            Tuple of (weight_g, weight_v) where weight_g is the magnitude 
+            and weight_v is the direction component
+        """
         weight_g = torch.norm_except_dim(weight, 2, self.dim)
         weight_v = weight
 


### PR DESCRIPTION
While looking at the _WeightNorm class, I noticed that the right_inverse method was also missing documentation, just like the forward method I fixed earlier.

This method does the opposite of forward - it takes a normalized weight tensor and decomposes it back into the magnitude (weight_g) and direction (weight_v) components that were used to create it.

Added a docstring to explain what it does and what it returns. Now both methods in the class are properly documented!