### PR TITLE
Add docstring to SpectralNorm reshape_weight_to_matrix method

### DIFF
--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -51,10 +51,8 @@ class SpectralNorm:
 
     def reshape_weight_to_matrix(self, weight: torch.Tensor) -> torch.Tensor:
         """Reshape weight tensor to a 2D matrix for spectral normalization.
-        
         Args:
             weight: Weight tensor to reshape
-            
         Returns:
             2D weight matrix with the specified dimension moved to front
         """

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -50,6 +50,14 @@ class SpectralNorm:
         self.eps = eps
 
     def reshape_weight_to_matrix(self, weight: torch.Tensor) -> torch.Tensor:
+        """Reshape weight tensor to a 2D matrix for spectral normalization.
+        
+        Args:
+            weight: Weight tensor to reshape
+            
+        Returns:
+            2D weight matrix with the specified dimension moved to front
+        """
         weight_mat = weight
         if self.dim != 0:
             # permute dim to front


### PR DESCRIPTION
Found another method without documentation while looking through the spectral normalization code.

The reshape_weight_to_matrix method does something important - it takes a weight tensor and reshapes it into a 2D matrix by moving the specified dimension to the front and then flattening. This is needed for the spectral normalization algorithm to work properly.

But there was no docstring explaining this, so I added one. Now developers can understand what this method does without having to read through the implementation details.
