### PR TITLE
Add docstring to _reparametrize_module context manager

### DIFF
--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -104,7 +104,6 @@ def _reparametrize_module(
     stack_weights: bool = False,
 ):
     """Context manager for temporarily replacing module parameters and buffers.
-    
     Args:
         module: The module to reparametrize
         parameters_and_buffers: Dict mapping parameter names to new values

--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -103,6 +103,18 @@ def _reparametrize_module(
     strict: bool = False,
     stack_weights: bool = False,
 ):
+    """Context manager for temporarily replacing module parameters and buffers.
+    
+    Args:
+        module: The module to reparametrize
+        parameters_and_buffers: Dict mapping parameter names to new values
+        tie_weights: Whether to respect tied weights in the module
+        strict: Whether parameter names must match exactly 
+        stack_weights: Whether to stack weights
+        
+    Yields:
+        The module with temporarily replaced parameters and buffers
+    """
     if tie_weights:
         untied_parameters_and_buffers = _untie_named_tensors_map(
             module, parameters_and_buffers


### PR DESCRIPTION
I was going through the stateless utils and noticed that the `_reparametrize_module` function didn't have any documentation.

It's a context manager that does something pretty important - temporarily replacing module parameters and buffers - but you'd have to read the whole implementation to figure that out.

Added a docstring explaining what it does and what the parameters mean. Should make the code more readable for anyone working with stateless functional calls.
