### PR TITLE
Add docstring to _get_composite_method function

### DIFF
--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -97,6 +97,21 @@ class BasePruningMethod(ABC):
         """
 
         def _get_composite_method(cls, module, name, *args, **kwargs):
+            """Get or create a composite pruning method for a module parameter.
+            
+            Checks if a pruning method has already been applied to the specified
+            parameter. If so, retrieves the existing method to compose with the new one.
+            
+            Args:
+                cls: The pruning method class
+                module: The module containing the parameter to prune
+                name: Name of the parameter to prune
+                *args: Arguments for the new pruning method
+                **kwargs: Keyword arguments for the new pruning method
+                
+            Returns:
+                The composed pruning method (new or combined with existing)
+            """
             # Check if a pruning method has already been applied to
             # `module[name]`. If so, store that in `old_method`.
             old_method = None

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -98,17 +98,14 @@ class BasePruningMethod(ABC):
 
         def _get_composite_method(cls, module, name, *args, **kwargs):
             """Get or create a composite pruning method for a module parameter.
-            
             Checks if a pruning method has already been applied to the specified
             parameter. If so, retrieves the existing method to compose with the new one.
-            
             Args:
                 cls: The pruning method class
                 module: The module containing the parameter to prune
                 name: Name of the parameter to prune
                 *args: Arguments for the new pruning method
                 **kwargs: Keyword arguments for the new pruning method
-                
             Returns:
                 The composed pruning method (new or combined with existing)
             """


### PR DESCRIPTION
I was looking through the pruning utilities and found another function that only had inline comments scattered around instead of a proper docstring.

The `_get_composite_method` function does something pretty important - it checks if a pruning method has already been applied to a parameter and handles composing it with new pruning methods. But you had to piece together what it does from reading all the comments in the code.

Converted those comments into a proper docstring that clearly explains what the function does, what parameters it takes, and what it returns. Makes the pruning code easier to understand for developers.
