### PR TITLE
Add docstring to _check_and_unexpand_args function

### DIFF
--- a/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
@@ -60,6 +60,20 @@ def forward_helper(func, expanded_args, expanded_kwargs):
 
 
 def _check_and_unexpand_args(func, expanded_args, expanded_kwargs):
+    """Check arguments and convert ExpandedWeights back to regular tensors.
+    
+    Validates that the input is a proper tensor (not an ExpandedWeight) and
+    converts any ExpandedWeight arguments back to their original tensor form
+    for function execution.
+    
+    Args:
+        func: The function to be called
+        expanded_args: Arguments that may contain ExpandedWeights to convert
+        expanded_kwargs: Keyword arguments that may contain ExpandedWeights
+        
+    Returns:
+        Tuple of (unexpanded_args, unexpanded_kwargs) with regular tensors
+    """
     # input must be the first argument passed
     input = expanded_args[0]
     if isinstance(input, ExpandedWeight):

--- a/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
@@ -61,11 +61,9 @@ def forward_helper(func, expanded_args, expanded_kwargs):
 
 def _check_and_unexpand_args(func, expanded_args, expanded_kwargs):
     """Check arguments and convert ExpandedWeights back to regular tensors.
-    
     Validates that the input is a proper tensor (not an ExpandedWeight) and
     converts any ExpandedWeight arguments back to their original tensor form
     for function execution.
-    
     Args:
         func: The function to be called
         expanded_args: Arguments that may contain ExpandedWeights to convert


### PR DESCRIPTION
Found another function in the expanded weights utilities that only had inline comments instead of a proper docstring.

The `_check_and_unexpand_args` function does some important validation and conversion work - it checks that the input is a proper tensor (not an ExpandedWeight) and converts any ExpandedWeight arguments back to regular tensors so functions can work with them normally.

But you had to read through all the inline comments and error messages to understand what it does. Added a proper docstring explaining its purpose, parameters, and return values to make the code more maintainable.