### PR TITLE
Add docstring to _no_grad_uniform_ helper function

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -69,6 +69,20 @@ _FanMode = Literal["fan_in", "fan_out"]
 def _no_grad_uniform_(
     tensor: Tensor, a: float, b: float, generator: torch.Generator | None = None
 ) -> Tensor:
+    """Fill tensor with uniformly distributed values in no-grad context.
+    
+    Helper function that applies uniform_ initialization within a no_grad context
+    to avoid gradient computation during initialization.
+    
+    Args:
+        tensor: Tensor to be filled with uniform values
+        a: Lower bound of uniform distribution
+        b: Upper bound of uniform distribution  
+        generator: Optional random number generator
+        
+    Returns:
+        The input tensor filled with uniform values
+    """
     with torch.no_grad():
         return tensor.uniform_(a, b, generator=generator)
 


### PR DESCRIPTION
The helper function was missing documentation. Added a docstring explaining that it fills tensors with uniform values within a no_grad context to avoid gradient computation during initialization.

Improves code documentation for neural network initialization utilities.

