### PR TITLE
Add compact docstring to _no_grad_normal_ helper function

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -79,6 +79,7 @@ def _no_grad_normal_(
     std: float,
     generator: torch.Generator | None = None,
 ) -> Tensor:
+    """Fill tensor with normal distribution values in no-grad context."""
     with torch.no_grad():
         return tensor.normal_(mean, std, generator=generator)
 


### PR DESCRIPTION
Added a concise single-line docstring explaining the function's purpose without excessive spacing. The function fills tensors with normal distribution values within a no_grad context during initialization.


