### PR TITLE
Add compact docstring to is_batch_first utility function

### DIFF
--- a/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
@@ -6,6 +6,7 @@ from .expanded_weights_impl import ExpandedWeight
 
 
 def is_batch_first(expanded_args_and_kwargs):
+    """Check consistent batch_first setting across ExpandedWeight arguments."""
     batch_first = None
     # pyrefly: ignore [bad-assignment]
     for arg in expanded_args_and_kwargs:


### PR DESCRIPTION
Small codebase fix: Added single-line docstring to a focused 13-line utility function that checks batch_first consistency across ExpandedWeight arguments.

