### PR TITLE
Fix string concatenation bug in gaussian_nll_loss error handling

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3320,7 +3320,7 @@ def gaussian_nll_loss(
 
     # Check validity of reduction mode
     if reduction != "none" and reduction != "mean" and reduction != "sum":
-        raise ValueError(reduction + " is not valid")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
 
     # Clamp for stability
     var = var.clone()


### PR DESCRIPTION
Found and fixed a runtime bug in gaussian_nll_loss that could crash users with TypeError.

**The Bug:**
The function used unsafe string concatenation for error messages, which would crash if the reduction parameter wasn't a string type.

**Before (buggy code):**
if reduction != "none" and reduction != "mean" and reduction != "sum":
    raise ValueError(reduction + " is not valid")  # ← Crashes on non-strings!

