### PR TITLE
Fix dead code and string concatenation bugs in poisson_nll_loss

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9838,6 +9838,17 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.soft_margin_loss(input, input.sign().detach(), reduction=reduction))
 
     @onlyNativeDeviceTypes
+    def test_poisson_nll_loss_invalid_reduction_error_message(self, device):
+        input = torch.randn(3, 5, device=device).abs()
+        target = torch.poisson(input)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"'invalid' is not a valid reduction mode\. Expected 'none', 'mean', or 'sum'\.",
+        ):
+            F.poisson_nll_loss(input, target, reduction="invalid")
+
+    @onlyNativeDeviceTypes
     def test_smooth_l1_loss_vs_huber_loss(self, device):
         def _make_test_tensor(shape, contiguous=True):
             if contiguous:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9844,7 +9844,7 @@ class TestNNDeviceType(NNTestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            r"'invalid' is not a valid reduction mode\. Expected 'none', 'mean', or 'sum'\.",
+            "'invalid' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.",
         ):
             F.poisson_nll_loss(input, target, reduction="invalid")
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3237,8 +3237,7 @@ def poisson_nll_loss(
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
     if reduction != "none" and reduction != "mean" and reduction != "sum":
-        ret = input
-        raise ValueError(reduction + " is not a valid value for reduction")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
 
     ret = torch.poisson_nll_loss(
         input, target, log_input, full, eps, _Reduction.get_enum(reduction)


### PR DESCRIPTION

### Summary

This change fixes two small but real bugs in the error handling of `poisson_nll_loss` that could cause confusing behavior or crashes for users.

### What was fixed

**1. Removed dead code**

There was an unused variable assignment right before an error was raised. Since the value was never used, it served no purpose and was removed to keep the code clean and correct.

**2. Made error messages safer**

The error message used string concatenation, which could crash if `reduction` was not a string. This has been replaced with an f-string that works safely for all input types and clearly shows the valid options.

### What changed

* Removed unnecessary code that was never used
* Replaced unsafe string concatenation with a safer f-string
* Improved the error message by listing the valid `reduction` values
* Prevents accidental `TypeError` when users pass an invalid type

### Impact

* More robust and predictable error handling
* Clearer error messages for users
* Small functional fix with no behavior changes beyond better errors


