### PR TITLE
Fix dead code and string concatenation bugs in multilabel_soft_margin_loss

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9792,6 +9792,18 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.soft_margin_loss(input, input.sign().detach(), reduction=reduction))
 
     @onlyNativeDeviceTypes
+    def test_multilabel_soft_margin_loss_invalid_reduction_error_message(self, device):
+        """Test that multilabel_soft_margin_loss raises ValueError with proper error message for invalid reduction."""
+        input = torch.randn(3, 5, device=device)
+        target = torch.zeros_like(input).to(torch.int64)
+        
+        with self.assertRaisesRegex(
+            ValueError,
+            r"'invalid' is not a valid reduction mode\. Expected 'none', 'mean', or 'sum'\."
+        ):
+            F.multilabel_soft_margin_loss(input, target, reduction='invalid')
+
+    @onlyNativeDeviceTypes
     def test_smooth_l1_loss_vs_huber_loss(self, device):
         def _make_test_tensor(shape, contiguous=True):
             if contiguous:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4191,8 +4191,7 @@ def multilabel_soft_margin_loss(
     elif reduction == "sum":
         ret = loss.sum()
     else:
-        ret = input
-        raise ValueError(reduction + " is not valid")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
     return ret
 
 


### PR DESCRIPTION

Fixed two small bugs in `multilabel_soft_margin_loss` error handling.

* Removed unused code that ran right before raising an error
* Replaced unsafe string concatenation with safe f-string formatting
* Improved the error message by clearly listing valid `reduction` values
* Prevents crashes when `reduction` is not a string

