### PR TITLE
[Typing] Add ArrayLike type alias to improve type hints for tensor factory functions

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1020,6 +1020,7 @@
   ],
   "torch.types": [
     "Any",
+    "ArrayLike",
     "Device",
     "FileLike",
     "List",

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1065,7 +1065,7 @@ def gen_pyi(
                 defs(
                     "asarray",
                     [
-                        "obj: Any",
+                        "obj: ArrayLike",
                         "*",
                         "dtype: _dtype | None = None",
                         "device: DeviceLikeType | None = None",
@@ -1094,7 +1094,7 @@ def gen_pyi(
             "as_tensor": [
                 defs(
                     "as_tensor",
-                    ["data: Any", "dtype: _dtype | None = None", DEVICE_PARAM],
+                    ["data: ArrayLike", "dtype: _dtype | None = None", DEVICE_PARAM],
                     "Tensor",
                 )
             ],
@@ -1108,7 +1108,7 @@ def gen_pyi(
             # These functions are explicitly disabled by
             # SKIP_PYTHON_BINDINGS because they are hand bound.
             # Correspondingly, we must hand-write their signatures.
-            "tensor": [defs("tensor", ["data: Any", *FACTORY_PARAMS], "Tensor")],
+            "tensor": [defs("tensor", ["data: ArrayLike", *FACTORY_PARAMS], "Tensor")],
             "sparse_coo_tensor": [
                 defs(
                     "sparse_coo_tensor",
@@ -1524,7 +1524,9 @@ def gen_pyi(
                 defs("new_ones", ["self", "size: _size", *FACTORY_PARAMS], "Tensor")
             ],
             "new_tensor": [
-                defs("new_tensor", ["self", "data: Any", *FACTORY_PARAMS], "Tensor")
+                defs(
+                    "new_tensor", ["self", "data: ArrayLike", *FACTORY_PARAMS], "Tensor"
+                )
             ],
             "__new__": [defs("__new__", ["cls", "*args", "**kwargs"], "Self")],
             # new and __init__ have the same signatures differ only in return type

--- a/torch/types.py
+++ b/torch/types.py
@@ -83,18 +83,18 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 # Protocol for nested sequences (matches numpy._typing._NestedSequence)
 @runtime_checkable
-class NestedSequence(Protocol[_T_co]):
+class _NestedSequence(Protocol[_T_co]):
     """A protocol for representing nested sequences of elements."""
 
     def __len__(self, /) -> int: ...
-    def __getitem__(self, index: int, /) -> "_T_co | NestedSequence[_T_co]": ...
+    def __getitem__(self, index: int, /) -> "_T_co | _NestedSequence[_T_co]": ...
     def __contains__(self, x: object, /) -> bool: ...
-    def __iter__(self, /) -> "Iterator[_T_co | NestedSequence[_T_co]]": ...
+    def __iter__(self, /) -> "Iterator[_T_co | _NestedSequence[_T_co]]": ...
 
 
 # Protocol for objects that support the array protocol (__array__ method)
 @runtime_checkable
-class SupportsArray(Protocol):
+class _SupportsArray(Protocol):
     """A protocol for objects that can be converted to arrays via __array__."""
 
     def __array__(self) -> Any: ...
@@ -104,15 +104,15 @@ class SupportsArray(Protocol):
 # This includes:
 #   - Tensor: PyTorch tensors
 #   - numpy.ndarray: NumPy arrays (via import)
-#   - SupportsArray: Objects with __array__ method (e.g., custom array types)
-#   - NestedSequence: Nested lists/tuples of numbers
+#   - _SupportsArray: Objects with __array__ method (e.g., custom array types)
+#   - _NestedSequence: Nested lists/tuples of numbers
 #   - Scalar types: bool, int, float, complex
 #   - bytes/bytearray: For certain dtype conversions
 ArrayLike: TypeAlias = Union[
     Tensor,
     "numpy.ndarray[Any, Any]",  # noqa: F821  # pyrefly: ignore[unknown-name]  # numpy is optional
-    SupportsArray,
-    NestedSequence[Union[bool, int, float, complex]],
+    _SupportsArray,
+    _NestedSequence[Union[bool, int, float, complex]],
     bool,
     int,
     float,

--- a/torch/types.py
+++ b/torch/types.py
@@ -108,18 +108,18 @@ class SupportsArray(Protocol):
 #   - NestedSequence: Nested lists/tuples of numbers
 #   - Scalar types: bool, int, float, complex
 #   - bytes/bytearray: For certain dtype conversions
-ArrayLike: TypeAlias = (
-    Tensor
-    | "numpy.ndarray[Any, Any]"  # type: ignore[name-defined]  # numpy may not be installed
-    | SupportsArray
-    | NestedSequence[bool | int | float | complex]
-    | bool
-    | int
-    | float
-    | complex
-    | bytes
-    | bytearray
-)
+ArrayLike: TypeAlias = Union[
+    Tensor,
+    "numpy.ndarray[Any, Any]",  # noqa: F821  # pyrefly: ignore[unknown-name]  # numpy is optional
+    SupportsArray,
+    NestedSequence[Union[bool, int, float, complex]],
+    bool,
+    int,
+    float,
+    complex,
+    bytes,
+    bytearray,
+]
 
 # Meta-type for "device-like" things.  Not to be confused with 'device' (a
 # literal device object).  This nomenclature is consistent with PythonArgParser.


### PR DESCRIPTION
## Summary
Adds a public `ArrayLike` type alias to `torch.types` to replace `Any` in tensor factory functions like `torch.tensor()`, `torch.as_tensor()`, and `torch.asarray()`.

## Related Issues
Related to #51156 - This PR adds type-level support for array-like inputs, including objects that implement the __array__ interface via a SupportsArray protocol

## Motivation
- Functions like `torch.tensor(data: Any)` provide poor IDE/type-checker feedback
- NumPy has `numpy.typing.ArrayLike` but PyTorch had no equivalent
- This improves developer experience with better autocompletion and type checking

## Changes
1. **[torch/types.py](cci:7://file:///Users/florian/Projects/cursor/pytorch2/torch/types.py:0:0-0:0)**: Added `ArrayLike`, [NestedSequence](cci:2://file:///Users/florian/Projects/cursor/pytorch2/torch/types.py:84:0-91:75), and [SupportsArray](cci:2://file:///Users/florian/Projects/cursor/pytorch2/torch/types.py:95:0-99:35) types
2. **[tools/pyi/gen_pyi.py](cci:7://file:///Users/florian/Projects/cursor/pytorch2/tools/pyi/gen_pyi.py:0:0-0:0)**: Updated stub generation to use `ArrayLike` instead of `Any`

## Type Definition
```python
ArrayLike = (
    Tensor | numpy.ndarray | SupportsArray | 
    NestedSequence[bool | int | float | complex] |
    bool | int | float | complex | bytes | bytearray
)