### PR TITLE
Fix string concatenation bug in RNN mode validation

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -164,7 +164,7 @@ class RNNBase(Module):
         elif mode == "RNN_RELU":
             gate_size = hidden_size
         else:
-            raise ValueError("Unrecognized RNN mode: " + mode)
+            raise ValueError(f"Unrecognized RNN mode: '{mode}'. Expected 'LSTM', 'GRU', 'RNN_TANH', or 'RNN_RELU'.")
 
         self._flat_weights_names = []
         self._all_weights = []


### PR DESCRIPTION
Fixed unsafe string concatenation in RNNBase.__init__ error handling:

- Replaced unsafe string concatenation with f-string formatting
- Prevents TypeError when mode parameter is not a string
- Provides clearer error message listing all valid RNN modes
- Improves user experience with better error guidance

This prevents runtime crashes when invalid mode types are passed to RNN, LSTM, or GRU constructors.
