### PR TITLE
[ROCm] Display ROCm version in torch.__config__.show()

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -204,7 +204,6 @@ std::string show_config() {
   }
   ss << '\n';
 
-  // TODO: do HIP
   // TODO: do XLA
   // TODO: do MPS
 

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -440,6 +440,10 @@ std::string CUDAHooks::showConfig() const {
     oss << '\n';
   }
   oss << "  - NVCC architecture flags: " << NVCC_FLAGS_EXTRA << '\n';
+#else
+  // ROCm version info
+  oss << "  - ROCm " << (ROCM_VERSION / 10000) << '.'
+      << (ROCM_VERSION / 100 % 100) << '.' << (ROCM_VERSION % 100) << '\n';
 #endif
 
 #if !defined(USE_ROCM)


### PR DESCRIPTION
## What this does

Shows the ROCm version when you run `torch.__config__.show()`.

Currently on ROCm builds, you see the HIP runtime version but not the ROCm version itself. This adds it:

```
  - HIP Runtime 6.2.43482
  - ROCm 6.2.0           <-- new
```

Useful for debugging and checking compatibility.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet