### PR TITLE
Fix string concatenation bug in Module.__getattr__ error message

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -732,7 +732,7 @@ class Module:
             mod = getattr(mod, item)
 
             if not isinstance(mod, torch.nn.Module):
-                raise AttributeError("`" + item + "` is not an nn.Module")
+                raise AttributeError(f"`{item}` is not an nn.Module")
 
         return mod
 


### PR DESCRIPTION
This PR fixes a potential TypeError in the get_submodule method error handling.

**Problem:**
The current code uses unsafe string concatenation which can crash if the `item` parameter is not a string type:
raise AttributeError("`" + item + "` is not an nn.Module")

**Solution:**
Replaced with f-string formatting for safety and better readability:
raise AttributeError(f"`{item}` is not an nn.Module")This ensures the error message is always properly formatted regardless of the input type.