### PR TITLE
Fix multiple string concatenation bugs in loss function error messages

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3237,8 +3237,7 @@ def poisson_nll_loss(
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
     if reduction != "none" and reduction != "mean" and reduction != "sum":
-        ret = input
-        raise ValueError(reduction + " is not a valid value for reduction")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
 
     ret = torch.poisson_nll_loss(
         input, target, log_input, full, eps, _Reduction.get_enum(reduction)
@@ -3320,7 +3319,7 @@ def gaussian_nll_loss(
 
     # Check validity of reduction mode
     if reduction != "none" and reduction != "mean" and reduction != "sum":
-        raise ValueError(reduction + " is not valid")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
 
     # Clamp for stability
     var = var.clone()
@@ -4191,8 +4190,7 @@ def multilabel_soft_margin_loss(
     elif reduction == "sum":
         ret = loss.sum()
     else:
-        ret = input
-        raise ValueError(reduction + " is not valid")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
     return ret
 
 


### PR DESCRIPTION
Fixed some bugs in error messages that could crash the program.

**The problem:**
Three functions had bad error messages. They tried to join strings like this:
raise ValueError(reduction + " is not valid")This works when `reduction` is text, but breaks if someone gives it a number or None. Instead of a nice error, the program just crashes.

**What I changed:**
- **poisson_nll_loss**: Fixed the string bug and removed a useless line
- **gaussian_nll_loss**: Fixed the same string bug
- **multilabel_soft_margin_loss**: Fixed string bug and removed useless code

**Why it's better:**
Now all three use safe string formatting and give clear messages:
raise ValueError(f"'{reduction}' is not valid. Use 'none', 'mean', or 'sum'.")If someone uses the wrong value, they get a helpful message instead of a crash. The message tells them exactly what they can use.

**Impact:**
- No more crashes from bad error handling
- Users get better, clearer error messages  
- Code is cleaner and safer