### PR TITLE
Fix error message consistency in triplet_margin_with_distance_loss

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5642,7 +5642,7 @@ def triplet_margin_with_distance_loss(
 
     # Check validity of reduction mode
     if reduction not in ("mean", "sum", "none"):
-        raise ValueError(f"{reduction} is not a valid value for reduction")
+        raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")
 
     # Check validity of margin
     if margin <= 0:


### PR DESCRIPTION
Fixed the error message format to match other loss functions for better consistency.

**What I changed:**
The function had an error message that wasn't quite the same format as other loss functions:
raise ValueError(f"{reduction} is not a valid value for reduction")

**Made it consistent:**
raise ValueError(f"'{reduction}' is not a valid reduction mode. Expected 'none', 'mean', or 'sum'.")

**Why it's better:**
- Quotes make the error clearer when debugging
- Shows exactly what values are allowed
- Same format as all other loss functions
- Better user experience when fixing errors