### PR TITLE
[WIP][Dynamo] Refactor error handling in Dynamo to replace `UserError` with `Unsupported` for consistency

### DIFF
--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -365,7 +365,7 @@ def export_for_aoti_minifier(
     #
     # If skip_export_error=True, then the errors in export will not be raised, and the minifier
     # will keep exploring and ignore this graph.
-    from torch._dynamo.exc import UserError, UserErrorType
+    from torch._dynamo.exc import Unsupported, UserErrorType
 
     try:
         ep = torch.export.export(gm, tuple_inputs, strict=strict)
@@ -374,7 +374,7 @@ def export_for_aoti_minifier(
     except Exception as e:
         if skip_export_error:
             return None
-        if isinstance(e, UserError) and e.error_type == UserErrorType.INVALID_OUTPUT:
+        if isinstance(e, Unsupported) and e.error_type == UserErrorType.INVALID_OUTPUT:
             # graph output is not allowed by export when strict=True
             return None
         if isinstance(e, RuntimeError):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -806,7 +806,7 @@ def generic_jump(
                     eval_result = value.evaluate_expr(self.output)
                 else:
                     eval_result = guard_bool(value.sym_num != 0)
-            except exc.UserError as e:
+            except exc.Unsupported as e:
                 if self.should_compile_partial_graph():
                     return jump_graph_break(self, inst, value, extra_msg=f"\n{e}")
                 raise

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3484,7 +3484,6 @@ def get_fake_value(
         TorchRuntimeError,
         unimplemented,
         Unsupported,
-        UserError,
         UserErrorType,
     )
 
@@ -3634,13 +3633,24 @@ def get_fake_value(
         elif isinstance(
             cause, torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode
         ):
-            raise UserError(  # noqa: B904
-                UserErrorType.CONSTRAINT_VIOLATION,
-                str(cause),
-                case_name="constrain_as_size_example",
+            unimplemented(
+                gb_type="user_error",
+                context="torch._dynamo.utils: constrain_as_size_example",
+                explanation=str(cause),
+                hints=[],
+                from_exc=None,
+                error_type=UserErrorType.CONSTRAINT_VIOLATION,
+                exportdb_case_name="constrain_as_size_example",
             )
         elif isinstance(cause, ValueRangeError):
-            raise UserError(UserErrorType.CONSTRAINT_VIOLATION, e.args[0]) from e
+            unimplemented(
+                gb_type="user_error",
+                context="torch._dynamo.utils: constraint violation",
+                explanation=e.args[0],
+                hints=[],
+                from_exc=e,
+                error_type=UserErrorType.CONSTRAINT_VIOLATION,
+            )
         elif isinstance(cause, TypeError) and "argument" in str(cause):
             unimplemented(
                 gb_type="TypeError when making fake tensor call",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -48,7 +48,6 @@ from ..exc import (
     raise_observed_exception,
     unimplemented,
     Unsupported,
-    UserError,
     UserErrorType,
 )
 from ..guards import GuardBuilder, install_guard
@@ -2894,11 +2893,14 @@ class BuiltinVariable(VariableTracker):
         try:
             py_type = obj.python_type()
         except NotImplementedError as error:
-            raise UserError(
-                UserErrorType.INVALID_INPUT,
-                str(error),
-                case_name="unknown_python_type",
-            ) from None
+            unimplemented(
+                gb_type="user_error",
+                context="torch._dynamo.variables.builtin: unknown_python_type",
+                explanation=str(error),
+                hints=[],
+                from_exc=None,
+                error_type=UserErrorType.INVALID_INPUT,
+            )
 
         source = obj.source and TypeSource(obj.source)
         if (

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -30,7 +30,6 @@ from ..exc import (
     ObservedUserStopIteration,
     raise_observed_exception,
     unimplemented,
-    UserError,
 )
 from .base import ValueMutationNew, VariableTracker
 from .constant import ConstantVariable
@@ -458,10 +457,13 @@ class ZipVariable(IteratorVariable):
                         # all iterables exhausted, raise original error
                         raise
                 handle_observed_exception(tx)
-                raise UserError(
-                    ValueError,  # type: ignore[arg-type]
-                    "zip() has one argument of len differing from others",
-                ) from None
+                unimplemented(
+                    gb_type="user_error",
+                    context="torch._dynamo.variables.iter",
+                    explanation="zip() has one argument of len differing from others",
+                    hints=[],
+                    from_exc=None,
+                )
             raise
 
         tx.output.side_effects.mutation(self)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -47,7 +47,6 @@ from .._trace_wrapped_higher_order_op import trace_wrapped
 from ..exc import (
     unimplemented,
     UnknownPropertiesDuringBackwardTrace,
-    UserError,
     UserErrorType,
 )
 from ..external_utils import call_hook_from_backward_state
@@ -1630,10 +1629,14 @@ class SymNodeVariable(VariableTracker):
             if torch.fx.experimental._config.no_data_dependent_graph_break:
                 raise
 
-            raise UserError(  # noqa: B904
-                UserErrorType.ANTI_PATTERN,
-                f"Consider annotating your code using torch._check*(). {str(e)}",
-                case_name="constrain_as_size_example",
+            unimplemented(
+                gb_type="user_error",
+                context="torch._dynamo.variables.tensor: constrain_as_size_example",
+                explanation=f"Consider annotating your code using torch._check*(). {str(e)}",
+                hints=[],
+                from_exc=None,
+                error_type=UserErrorType.ANTI_PATTERN,
+                exportdb_case_name="constrain_as_size_example",
             )
 
     def call_method(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2977,12 +2977,15 @@ def _aoti_flatten_inputs(
     )
 
     if any(isinstance(x[1], torch.ScriptObject) for x in flat_args_with_path):
-        from torch._dynamo.exc import UserError, UserErrorType
-
-        raise UserError(
-            UserErrorType.INVALID_INPUT,
-            "TorchBind objects found in inputs. TorchBind object inputs are not supported in AOTInductor. "
-            "TorchBind objects can only be attributes.",
+        from torch._dynamo.exc import unimplemented, UserErrorType
+        msg = "TorchBind objects found in inputs. TorchBind object inputs are not supported in AOTInductor. TorchBind objects can only be attributes."
+        unimplemented(
+            gb_type="user_error",
+            context="torch._inductor.compile_fx._aoti_flatten_inputs",
+            explanation=msg,
+            hints=[],
+            from_exc=None,
+            error_type=UserErrorType.INVALID_INPUT
         )
 
     # Replace non-tensor (constant) inputs with Nones, since these are not being


### PR DESCRIPTION
Fixes part of #170558

Since `UserErrorType` is widely used for many purposes, I add it to `Unsuported` before removing `UserError`. Correct me if there is a problem.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @williamwen42 