### PR TITLE
[ROCm] Fix broken loop logic in test_raw_amdsmi_device_uuids

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4968,10 +4968,8 @@ print(value, end="")
         uuids = [s.strip() for s in uuids]
         raw_uuids = torch.cuda._raw_device_uuid_amdsmi()
         for uuid in uuids:
-            matching = True
-            if not any(uuid in raw_id for raw_id in raw_uuids):
-                matching = False
-        self.assertEqual(True, matching)
+            self.assertTrue(any(uuid in raw_id for raw_id in raw_uuids),
+                           f"UUID {uuid} not found in {raw_uuids}")
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")


### PR DESCRIPTION
## What this does

Fixes a bug in the UUID verification test where only the last UUID was actually checked.

## The bug

```python
for uuid in uuids:
    matching = True  # reset every iteration!
    if not any(uuid in raw_id for raw_id in raw_uuids):
        matching = False
self.assertEqual(True, matching)  # only reflects last UUID
```

If the first 3 UUIDs were missing but the last one matched, the test would pass.

## The fix

```python
for uuid in uuids:
    self.assertTrue(any(uuid in raw_id for raw_id in raw_uuids),
                   f"UUID {uuid} not found in {raw_uuids}")
```

Now each UUID is checked immediately, and failures show which one was missing.

Fixes #169881

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet