### PR TITLE
[ROCm][Strix Halo] Fix for undefined MIOPEN_CMAKE_DB_FLAGS

### DIFF
--- a/.ci/docker/common/install_miopen.sh
+++ b/.ci/docker/common/install_miopen.sh
@@ -109,7 +109,6 @@ mkdir -p build
 cd build
 PKG_CONFIG_PATH=/usr/local/lib/pkgconfig CXX=${ROCM_INSTALL_PATH}/llvm/bin/clang++ cmake .. \
     ${MIOPEN_CMAKE_COMMON_FLAGS} \
-    ${MIOPEN_CMAKE_DB_FLAGS} \
     -DCMAKE_PREFIX_PATH="${ROCM_INSTALL_PATH}"
 make MIOpen -j $(nproc)
 


### PR DESCRIPTION
## Summary
Remove reference to undefined variable in MIOpen build script.

## Problem
The cmake command in `install_miopen.sh` references `${MIOPEN_CMAKE_DB_FLAGS}`, but this variable is never defined in the script. It expands to empty, making it a no-op.

## Changes
- Remove the unused `${MIOPEN_CMAKE_DB_FLAGS}` from the cmake command

## Test Plan
- This is a code cleanup - removes dead/undefined variable reference
- No functional change since the variable was always empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang