### PR TITLE
[ROCm] Remove obsolete HIP NaN handling workarounds

### DIFF
--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -408,9 +408,9 @@ inline __device__ float gpuAtomicMul (float * address, float val) {
 
 template <typename T>
 __host__ __device__ T safe_max(T a, T b) {
-  #if defined(__HIPCC__)
-  // TODO: remove this special case for HIP when issue is fixed:
-  //       https://github.com/ROCm/hip/issues/2209
+  #if defined(__HIPCC__) && ROCM_VERSION < 60002
+  // Workaround for ROCm < 6.0.2 where std::max doesn't propagate NaN correctly
+  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
     T max = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::max<T>(a, b));
   #else
     T max = at::_isnan(b) ? b : std::max<T>(a, b);
@@ -468,9 +468,9 @@ inline __device__ float gpuAtomicMax(float * address, float val) {
 
 template <typename T>
 __host__ __device__ T safe_min(T a, T b) {
-  #if defined(__HIPCC__)
-  // TODO: remove this special case for HIP when issue is fixed:
-  //       https://github.com/ROCm/hip/issues/2209
+  #if defined(__HIPCC__) && ROCM_VERSION < 60002
+  // Workaround for ROCm < 6.0.2 where std::min doesn't propagate NaN correctly
+  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
     T min = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::min<T>(a, b));
   #else
     T min = at::_isnan(b) ? b : std::min<T>(a, b);

--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -408,14 +408,7 @@ inline __device__ float gpuAtomicMul (float * address, float val) {
 
 template <typename T>
 __host__ __device__ T safe_max(T a, T b) {
-  #if defined(__HIPCC__) && ROCM_VERSION < 60002
-  // Workaround for ROCm < 6.0.2 where std::max doesn't propagate NaN correctly
-  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
-    T max = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::max<T>(a, b));
-  #else
-    T max = at::_isnan(b) ? b : std::max<T>(a, b);
-  #endif
-
+  T max = at::_isnan(b) ? b : std::max<T>(a, b);
   return max;
 }
 
@@ -468,14 +461,7 @@ inline __device__ float gpuAtomicMax(float * address, float val) {
 
 template <typename T>
 __host__ __device__ T safe_min(T a, T b) {
-  #if defined(__HIPCC__) && ROCM_VERSION < 60002
-  // Workaround for ROCm < 6.0.2 where std::min doesn't propagate NaN correctly
-  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
-    T min = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::min<T>(a, b));
-  #else
-    T min = at::_isnan(b) ? b : std::min<T>(a, b);
-  #endif
-
+  T min = at::_isnan(b) ? b : std::min<T>(a, b);
   return min;
 }
 

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -24,24 +24,12 @@
 #if defined(__CUDACC__) || defined(__HIPCC__)
 template <typename scalar_t>
 inline C10_DEVICE scalar_t max_propagate_nan(scalar_t a, scalar_t b) {
-#if defined(__HIPCC__) && ROCM_VERSION < 60002
-  // Workaround for ROCm < 6.0.2 where std::max doesn't propagate NaN correctly
-  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
-  scalar_t max = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::max(a, b));
-#else
   scalar_t max = at::_isnan(b) ? b : std::max(a, b);
-#endif
   return max;
 }
 template <typename scalar_t>
 inline C10_DEVICE scalar_t min_propagate_nan(scalar_t a, scalar_t b) {
-#if defined(__HIPCC__) && ROCM_VERSION < 60002
-  // Workaround for ROCm < 6.0.2 where std::min doesn't propagate NaN correctly
-  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
-  scalar_t min = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::min(a, b));
-#else
   scalar_t min = at::_isnan(b) ? b : std::min(a, b);
-#endif
   return min;
 }
 #define MAX(X, Y) max_propagate_nan(X,Y)

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -24,9 +24,9 @@
 #if defined(__CUDACC__) || defined(__HIPCC__)
 template <typename scalar_t>
 inline C10_DEVICE scalar_t max_propagate_nan(scalar_t a, scalar_t b) {
-#if defined(__HIPCC__)
-  // TODO: remove this special case for HIP when issue is fixed:
-  //       https://github.com/ROCm/hip/issues/2209
+#if defined(__HIPCC__) && ROCM_VERSION < 60002
+  // Workaround for ROCm < 6.0.2 where std::max doesn't propagate NaN correctly
+  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
   scalar_t max = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::max(a, b));
 #else
   scalar_t max = at::_isnan(b) ? b : std::max(a, b);
@@ -35,9 +35,9 @@ inline C10_DEVICE scalar_t max_propagate_nan(scalar_t a, scalar_t b) {
 }
 template <typename scalar_t>
 inline C10_DEVICE scalar_t min_propagate_nan(scalar_t a, scalar_t b) {
-#if defined(__HIPCC__)
-  // TODO: remove this special case for HIP when issue is fixed:
-  //       https://github.com/ROCm/hip/issues/2209
+#if defined(__HIPCC__) && ROCM_VERSION < 60002
+  // Workaround for ROCm < 6.0.2 where std::min doesn't propagate NaN correctly
+  // See: https://github.com/ROCm/hip/issues/2209 (fixed in ROCm 6.0.2)
   scalar_t min = at::_isnan(a) ? a : (at::_isnan(b) ? b : std::min(a, b));
 #else
   scalar_t min = at::_isnan(b) ? b : std::min(a, b);


### PR DESCRIPTION
## What this does

Removes HIP-specific NaN handling workarounds that applied to old ROCm versions.

The special cases in `safe_max`, `safe_min`, `max_propagate_nan`, and `min_propagate_nan` were added to work around a bug where `std::min`/`std::max` didn't propagate NaN correctly on HIP.

That [HIP bug](https://github.com/ROCm/hip/issues/2209) was closed in ROCm 6.0.2. 

## Why this matters

- Cleaner code on modern ROCm
- Keeps backward compatibility with older versions

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet