### PR TITLE
[ROCm] Update outdated ROCm 5.5 skip comments

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14438,7 +14438,7 @@ op_db: list[OpInfo] = [
            sample_inputs_func=sample_inputs_masked_select,
            error_inputs_func=error_inputs_masked_select,
            skips=(
-               # Compiler issue on ROCm. Might need to skip until ROCm5.5
+               # ROCm: non-standard bool values test - needs validation on modern ROCm
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
            )),
@@ -19304,7 +19304,7 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
                # AssertionError: JIT Test does not execute any logic
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
-               # Might need to skip until ROCm5.5
+               # ROCm: multi-device test - needs validation on modern ROCm
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_multiple_devices',
                             dtypes=[torch.float32, torch.int64], active_if=TEST_WITH_ROCM),
            )),
@@ -20453,7 +20453,7 @@ op_db: list[OpInfo] = [
                # TODO: implement csr.to_sparse(sample_dim) where sampled_dim is 1.
                DecorateInfo(unittest.skip("csr.to_sparse(1) not implemented. Skipped!"),
                             'TestSparseCSR', 'test_sparse_csr_consistency'),
-               # Compiler issue on ROCm. Might need to skip until ROCm5.5
+               # ROCm: non-standard bool values test - needs validation on modern ROCm
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
            )
@@ -20696,7 +20696,7 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
                # Can't find schemas for this operator for some reason
                DecorateInfo(unittest.expectedFailure, 'TestOperatorSignatures', 'test_get_torch_func_signature_exhaustive'),
-               # Compiler issue on ROCm. Might need to skip until ROCm5.5
+               # ROCm: non-standard bool values test - needs validation on modern ROCm
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
            )),
@@ -21325,7 +21325,7 @@ op_db: list[OpInfo] = [
         supports_autograd=False,
         sample_inputs_func=sample_inputs_argwhere,
         skips=(
-            # Compiler issue on ROCm. Might need to skip until ROCm5.5
+            # ROCm: non-standard bool values test - needs validation on modern ROCm
             DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                          dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
         ),


### PR DESCRIPTION
## What this does

Updates comments that still mentioned "ROCm5.5" to say the skips need validation on modern ROCm.

These are just comment updates - the test skips themselves stay in place until someone can verify the tests pass on current ROCm versions.

## Affected tests

- `masked_select` - test_non_standard_bool_values
- `randint` - test_multiple_devices  
- `sparse_sampled_addmm` - test_non_standard_bool_values
- `nonzero` - test_non_standard_bool_values
- `argwhere` - test_non_standard_bool_values

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet