### PR TITLE
Fix _ExperimentalConfig pickle serialization

### DIFF
--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -430,6 +430,7 @@ void initPythonBindings(PyObject* module) {
                 py_metrics,
                 p.profiler_measure_per_kernel,
                 p.verbose,
+                py_perf_events,
                 p.enable_cuda_sync_events,
                 p.adjust_profiler_step,
                 p.disable_external_correlation,
@@ -437,26 +438,23 @@ void initPythonBindings(PyObject* module) {
                 p.capture_overload_names,
                 p.record_python_gc_info,
                 p.expose_kineto_event_metadata,
-                p.custom_profiler_config,
-                p.performance_events);
+                p.custom_profiler_config);
           },
           [](const py::tuple& t) { // __setstate__
-            TORCH_CHECK(t.size() < 5, "Expected at least 5 values in state");
+            TORCH_CHECK(t.size() >= 12, "Expected at least 12 values in state");
 
             py::list py_metrics = t[0].cast<py::list>();
-            std::vector<std::string> metrics{py_metrics.size()};
-
+            std::vector<std::string> metrics;
+            metrics.reserve(py_metrics.size());
             for (const auto& py_metric : py_metrics) {
               metrics.push_back(py::str(py_metric));
             }
 
+            py::list py_perf_events = t[3].cast<py::list>();
             std::vector<std::string> performance_events;
-            if (t.size() == 5) {
-              py::list py_perf_events = t[4].cast<py::list>();
-              performance_events.resize(py_perf_events.size());
-              for (const auto& py_perf_event : py_perf_events) {
-                performance_events.push_back(py::str(py_perf_event));
-              }
+            performance_events.reserve(py_perf_events.size());
+            for (const auto& py_perf_event : py_perf_events) {
+              performance_events.push_back(py::str(py_perf_event));
             }
 
             return ExperimentalConfig(
@@ -464,8 +462,14 @@ void initPythonBindings(PyObject* module) {
                 t[1].cast<bool>(),
                 t[2].cast<bool>(),
                 std::move(performance_events),
-                t[3].cast<bool>(),
-                t[4].cast<bool>());
+                t[4].cast<bool>(),
+                t[5].cast<bool>(),
+                t[6].cast<bool>(),
+                t[7].cast<bool>(),
+                t[8].cast<bool>(),
+                t[9].cast<bool>(),
+                t[10].cast<bool>(),
+                t[11].cast<std::string>());
           }));
 
   py::class_<ProfilerConfig>(m, "ProfilerConfig")


### PR DESCRIPTION
Summary:
The pickle implementation for `_ExperimentalConfig` had multiple bugs that caused `deepcopy` to fail with "Expected at least 5 values in state" error. This prevented code using `_ExperimentalConfig` from being deepcopied, such as QAT training workflows in d2go.

The issues were:
- Inverted size check in `__setstate__` (`< 5` instead of `>= 12`)
- `__getstate__` serialized 12 fields but `__setstate__` only deserialized 5
- Field ordering didn't match the constructor parameter order

Differential Revision: D89671186


