### PR TITLE
Enable op-level profiling in sigmoid runtime for Kineto traces

### DIFF
--- a/torch/nativert/executor/ExecutorConfig.h
+++ b/torch/nativert/executor/ExecutorConfig.h
@@ -13,6 +13,9 @@ struct ExecutorConfig {
   bool runConstFolding = false;
   bool doExecutionFrameCleanup = true;
   bool tryFreeUnmanagedValuesAfterUse = true;
+  // When enabled, emit RECORD_FUNCTION for each op during execution
+  // to enable profiling with Kineto/PyTorch profiler
+  bool enableOpProfiling = false;
   // allows up to max number of concurrent threads.
   int64_t maxNumConcurrentThreads = 8;
   // allows up to max number of parallel ops.

--- a/torch/nativert/executor/SerialGraphExecutor.cpp
+++ b/torch/nativert/executor/SerialGraphExecutor.cpp
@@ -1,3 +1,4 @@
+#include <ATen/record_function.h>
 #include <torch/nativert/executor/ExecutionPlanner.h>
 #include <torch/nativert/executor/ExecutorConfig.h>
 #include <torch/nativert/executor/SerialGraphExecutor.h>
@@ -17,6 +18,11 @@ std::vector<c10::IValue> SerialGraphExecutor::executeWithPrefilledFrame(
   executionFrame.withManagedMemory([&](const LayoutManager* layout_manager) {
     // Execute kernels for all nodes except prim.Input and prim.Output
     for (NodeIndex nodeIdx = 1; nodeIdx < nodeKernels_.size() - 1; ++nodeIdx) {
+      if (executorConfig_.enableOpProfiling) {
+        RECORD_FUNCTION(
+            nodeKernels_[nodeIdx]->node()->target(),
+            c10::ArrayRef<const c10::IValue>{});
+      }
       nodeKernels_[nodeIdx]->compute(executionFrame);
 
 #ifndef NDEBUG


### PR DESCRIPTION
Summary:
When running sigmoid runtime with load_net_predictor in Benchmark mode with  --benchmarkEnableProfiling, Kineto profiles only showed low-level ATen ops (e.g., aten::as_strided) rather than the actual sigmoid graph ops.

This change adds RECORD_FUNCTION instrumentation to the SerialGraphExecutor, which emits profiling markers for each op when profiling is enabled. The profiling is automatically activated when running load_net_predictor with --benchmarkEnableProfiling true, making individual ops visible in Kineto traces.

Test Plan:
Tested locally:
- Built and ran load_net_predictor with --loadMode=Benchmark --benchmarkEnableProfiling true
- Verified that individual sigmoid ops now appear in the Kineto profile with their target names

https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html?url=https://interncache-all.fbcdn.net/manifold/gpu_traces/tree/traces/clientAPI/0/1765901743/devvm31861.atn0/libkineto_activities_419373.json.gz#!/viewer?url=https%3A%2F%2Finterncache-all.fbcdn.net%2Fmanifold%2Fgpu_traces%2Ftree%2Ftraces%2FclientAPI%2F0%2F1765901743%2Fdevvm31861.atn0%2Flibkineto_activities_419373.json.gz

- Confirmed BenchmarkByOp mode continues to work as before
- Added a unit test

Differential Revision:
D89596722

Privacy Context Container: L1297311


