### PR TITLE
[export] Use bytecode to flatten graph inputs.

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -782,21 +782,15 @@ def forward(self, x):
             gm = dynamo_graph_capture_for_export(foo)(*trace_inputs)
             test_inputs = make_inputs()
             self.assertExpectedInline(
-                gm._in_shuffle_graph.code.strip("\r\n "),
-                """\
-def forward(self, arg0_1, arg1_1, arg2_1):
-    return (arg1_1, arg2_1)""",
-            )
-            self.assertExpectedInline(
                 gm.code.strip("\r\n "),
                 """\
 def forward(self, args_0):
-    _tree_leaf_0, _tree_leaf_1, _tree_leaf_2, = pytree.tree_leaves((self, args_0,))
-    L_bar_x , L_bar_y , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2)
+    _fn_args = (args_0, )
+    L_bar_x , L_bar_y , = self._dynamo_bytecode_flatten(*_fn_args)
     l_bar_x = L_bar_x
     l_bar_y = L_bar_y
     add = l_bar_x + l_bar_y;  l_bar_x = l_bar_y = None
-    return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2, add), self._out_spec)""",
+    return self._dynamo_bytecode_unflatten((add,), _fn_args)""",
             )
             self.assertEqual(gm(*test_inputs), foo(*test_inputs))
         finally:
@@ -819,25 +813,18 @@ def forward(self, args_0):
         inps = (torch.randn(10, 32),)
         ep = dynamo_graph_capture_for_export(MyModel())(*inps)
         self.assertExpectedInline(
-            ep._in_shuffle_graph.code.strip("\r\n "),
-            """\
-def forward(self, arg0_1, arg1_1):
-    _tensor_constant0 = self._tensor_constant0
-    return (arg1_1, _tensor_constant0)""",
-        )
-        self.assertExpectedInline(
             ep.code.strip("\r\n "),
             """\
 def forward(self, args_0):
-    _tree_leaf_0, _tree_leaf_1, = pytree.tree_leaves((self, args_0,))
-    L_x_ , L_outer_ , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1)
+    _fn_args = (args_0, )
+    L_x_ , L_outer_ , = self._dynamo_bytecode_flatten(*_fn_args)
     l_x_ = L_x_
     l_outer_ = L_outer_
     z = l_x_ + l_outer_;  l_x_ = l_outer_ = None
     y = z[(slice(None, -1, None), slice(None, None, None))];  z = None
     stacked = torch.stack([y, y, y], dim = 0);  y = None
     reshaped = stacked.reshape(-1, 3, 32);  stacked = None
-    return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, reshaped), self._out_spec)""",
+    return self._dynamo_bytecode_unflatten((reshaped,), _fn_args)""",
         )
         self.assertEqual(ep(*inps), MyModel()(*inps))
 
@@ -916,12 +903,12 @@ def forward(self, args_0):
             gm.code.strip("\r\n "),
             """\
 def forward(self, args_0):
-    _tree_leaf_0, _tree_leaf_1, = pytree.tree_leaves((self, args_0,))
-    L_args_0_ , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1)
+    _fn_args = (args_0, )
+    L_args_0_ , = self._dynamo_bytecode_flatten(*_fn_args)
     l_args_0_ = L_args_0_
     add = l_args_0_ + 1
     mul = l_args_0_ * 2;  l_args_0_ = None
-    return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, mul, add), self._out_spec)""",
+    return self._dynamo_bytecode_unflatten((mul, add,), _fn_args)""",
         )
         self.assertEqual(gm(*test_inputs), foo(*test_inputs))
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -9775,7 +9775,6 @@ def forward(self, b_a_buffer, x):
         self.assertTrue(torch.allclose(ep.module()(xs), module_out))
 
     @requires_cuda_and_triton
-    @testing.expectedFailureStrictV2
     def test_export_associative_scan_lifted_buffers(self):
         if "cpp_runtime_nonstrict" in self.id():
             self.skipTest("TODO Unexpected success in OSS but not in fbcode.")
@@ -10020,7 +10019,6 @@ def forward(self, b_a_buffer, x):
         self.assertEqual(len(ep.graph_signature.input_specs), 4)
         self.assertTrue(torch.allclose(ep.module()(*inp), transform.module()(*inp)))
 
-    @testing.expectedFailureStrictV2
     def test_tensor_attribute_zero_args(self):
         class Foo(torch.nn.Module):
             def __init__(self, value):
@@ -10340,7 +10338,6 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
             # expected 4, but got 7
             ep_v2.module()(*test_inp)
 
-    @testing.expectedFailureStrictV2
     def test_constant_output(self):
         class ModuleConstant(torch.nn.Module):
             def __init__(self) -> None:
@@ -16484,13 +16481,10 @@ def forward(self, x):
     submod_6 = self.submod_1
     to = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_6, mod_embedding_weight);  submod_6 = mod_embedding_weight = None
     getitem = to[0];  to = None
-    submod_7 = self.submod_3
-    wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_7);  submod_7 = wrap_with_set_grad_enabled = None
-    submod_8 = self.submod_4
-    view_as = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_8, detach, getitem);  submod_8 = detach = getitem = None
-    getitem_1 = view_as[0];  view_as = None
+    set_ = torch.ops.aten.set_.source_Tensor(detach, getitem);  detach = getitem = None
+    view_as = torch.ops.aten.view_as.default(set_, set_);  set_ = None
     ones = torch.ops.aten.ones.default([4], dtype = torch.int64, device = device(type='cuda', index=0), pin_memory = False)
-    embedding = torch.ops.aten.embedding.default(getitem_1, ones);  getitem_1 = ones = None
+    embedding = torch.ops.aten.embedding.default(view_as, ones);  view_as = ones = None
     sum_1 = torch.ops.aten.sum.default(embedding);  embedding = None
     sum_2 = torch.ops.aten.sum.default(args_0);  args_0 = None
     sum_3 = torch.ops.aten.sum.default(sum_1);  sum_1 = None

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1103,6 +1103,11 @@ def get_traced_fn(mod: Any) -> tuple[FunctionType, Optional[object]]:
             # pyrefly: ignore [missing-attribute]
             resolved_forward = resolved_forward.__func__
 
+        resolved_call = mod.__call__
+        if hasattr(resolved_call, "__self__"):
+            # pyrefly: ignore [missing-attribute]
+            resolved_call = resolved_call.__func__
+
         # Mirrored from NNModuleVariable.call_function:
         # https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/variables/nn_module.py#L1035
         if (
@@ -1114,7 +1119,8 @@ def get_traced_fn(mod: Any) -> tuple[FunctionType, Optional[object]]:
             and len(mod._backward_hooks) == 0
             and len(torch.nn.modules.module._global_backward_pre_hooks) == 0
             and len(torch.nn.modules.module._global_backward_hooks) == 0
-            and resolved_forward != torch.nn.Module.forward
+            and resolved_forward != torch.nn.Module.forward  # has forward impl
+            and resolved_call == torch.nn.Module.__call__  # no custom __call__ impl
         ):
             # We cannot trace __call__ by default because it will break
             # the legacy dynamo export. If we want to revisit this,

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 import sys
 import traceback
+import types
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
@@ -28,7 +29,7 @@ from torch.fx.experimental.symbolic_shapes import (
     ShapeEnv,
     StatelessSymbolicContext,
 )
-from torch.fx.graph import _ExportCodeGen, _PyTreeCodeGen, _PyTreeInfo
+from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 from torch.fx.node import Argument, Target
 from torch.utils._pytree import TreeSpec
 
@@ -627,6 +628,269 @@ def normalize_graph_module(gm: torch.fx.GraphModule) -> None:
             node.meta["val"] = node.meta["example_value"]
 
 
+class InputProcessor:
+    def __init__(
+        self,
+        root: object,
+        num_args: int,
+        kwarg_names: list[str],
+    ) -> None:
+        self.root = root
+        self.num_args = num_args
+        self.kwarg_names = kwarg_names
+
+    def __call__(
+        self, inputs: tuple[object, ...]
+    ) -> tuple[tuple[object, ...], dict[str, object]]:
+        args = inputs
+        kwargs = {}
+        if len(args) > self.num_args:
+            kwargs = dict(zip(self.kwarg_names, args[self.num_args :]))
+            args = args[: self.num_args]
+        if self.root is not None:
+            if isinstance(self.root, torch.fx.GraphModule):
+                assert isinstance(self.root.graph._codegen, _DynamoBytecodeCodeGen)
+                assert hasattr(
+                    self.root.graph._codegen.dynamo_bytecode_flatten, "input_processor"
+                )
+                assert (
+                    self.root.graph._codegen.dynamo_bytecode_flatten.input_processor
+                    is self
+                )
+            args = (self.root, *args)
+        return args, kwargs
+
+
+class Yield(Exception):
+    pass
+
+
+class DynamoBytecodeFlatten:
+    def __init__(
+        self,
+        input_processor: InputProcessor,
+        out: CaptureOutput,
+        f_globals: dict[str, object],
+    ) -> None:
+        self.input_processor = input_processor
+        self.out = out
+        self.f_globals = f_globals
+        self.gm_inputs: tuple[Any, ...] | None = None
+
+    def __call__(self, *inputs: object) -> object:
+        def backend_dummy(*example_inputs: object) -> None:
+            self.gm_inputs = example_inputs
+            raise Yield
+
+        args, kwargs = self.input_processor(inputs)
+        try:
+            self.out.forward_callable(
+                compiled_fn=backend_dummy, extra_globals=self.f_globals
+            )(*args, **kwargs)
+        except Yield:
+            assert self.gm_inputs is not None
+            return self.gm_inputs
+        raise RuntimeError
+
+
+class DynamoBytecodeUnflatten:
+    def __init__(
+        self,
+        input_processor: InputProcessor,
+        out: CaptureOutput,
+        f_globals: dict[str, object],
+    ) -> None:
+        self.input_processor = input_processor
+        self.out = out
+        self.f_globals = f_globals
+
+    def __call__(
+        self, flat_outs: Sequence[object], inputs: tuple[object, ...]
+    ) -> object:
+        def backend_dummy(*example_inputs: object) -> Sequence[object]:
+            return flat_outs
+
+        args, kwargs = self.input_processor(inputs)
+        with torch._C._DisableTorchDispatch():
+            results = self.out.forward_callable(
+                compiled_fn=backend_dummy, extra_globals=self.f_globals
+            )(*args, **kwargs)
+        return results
+
+
+def create_fx_graph_from_captured_output(
+    out: CaptureOutput, mod: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> torch.fx.GraphModule:
+    assert out.backend_input is not None
+    backend_input = out.backend_input
+
+    _, root = torch._dynamo.convert_frame.get_traced_fn(mod)
+
+    flat_real_args = pytree.tree_leaves((args, kwargs))
+    torch._dynamo.eval_frame.check_user_input_output(
+        flat_real_args, UserErrorType.INVALID_INPUT
+    )
+    f_globals = out.graph_capture_output.f_globals
+
+    graph_module = backend_input.graph_module
+    if isinstance(root, torch.nn.Module):
+        graph_module._parameters = root._parameters.copy()
+        graph_module._buffers = root._buffers.copy()
+        assert all(not hasattr(graph_module, m) for m in root._modules)
+        graph_module._modules.update(root._modules)
+        graph_module._non_persistent_buffers_set = (
+            root._non_persistent_buffers_set.copy()
+        )
+        if sys.version_info >= (3, 14):
+            import annotationlib  # added in 3.14
+
+            annotations = annotationlib.get_annotations(torch.nn.Module)
+        else:
+            annotations = getattr(torch.nn.Module, "__annotations__", None)
+        for name, value in root.__dict__.items():
+            if annotations and name not in annotations:
+                graph_module.__dict__[name] = value
+        graph_module._forward_hooks = root._forward_hooks.copy()
+        graph_module._forward_pre_hooks = root._forward_pre_hooks.copy()
+        graph_module._backward_hooks = root._backward_hooks.copy()
+        graph_module._backward_pre_hooks = root._backward_pre_hooks.copy()
+        if graph_module._forward_hooks or graph_module._forward_pre_hooks:
+            # Even forward hooks are traced through, they still capture a bunch
+            # of state through closure. We need to make sure these data are
+            # accessible through the captured module (but the hooks should be
+            # disabled).
+            assert getattr(graph_module, "_wrapped_call", None) is not None
+            assert isinstance(
+                graph_module._wrapped_call, torch.fx.graph_module._WrappedCall
+            )
+            assert graph_module._wrapped_call.cls_call is None
+
+            def dynamo_wrapped_call(self, *args: object, **kwargs: object) -> object:
+                assert "forward" not in self.__dict__
+
+                fwd_hooks = self._forward_hooks
+                fwd_pre_hooks = self._forward_pre_hooks
+                original_forward = type(self).forward
+
+                def patched_forward(self, *args: object, **kwargs: object) -> object:
+                    self._forward_hooks = fwd_hooks
+                    self._forward_pre_hooks = fwd_pre_hooks
+                    return original_forward(self, *args, **kwargs)
+
+                try:
+                    self.forward = types.MethodType(patched_forward, self)
+                    self._forward_hooks = {}
+                    self._forward_pre_hooks = {}
+                    # pyrefly: ignore [invalid-argument]
+                    return super(type(self), self).__call__(*args, **kwargs)
+                finally:
+                    self.__dict__.pop("forward")
+                    self._forward_hooks = fwd_hooks
+                    self._forward_pre_hooks = fwd_pre_hooks
+
+            graph_module._wrapped_call.cls_call = dynamo_wrapped_call
+
+    root = graph_module if isinstance(root, torch.nn.Module) else root
+    input_processor = InputProcessor(root, len(args), list(kwargs.keys()))
+    dynamo_bytecode_flatten = DynamoBytecodeFlatten(input_processor, out, f_globals)
+    dynamo_bytecode_unflatten = DynamoBytecodeUnflatten(input_processor, out, f_globals)
+
+    graph_module.graph._codegen = _DynamoBytecodeCodeGen(
+        argument_names(inspect.signature(mod), args, kwargs),
+        dynamo_bytecode_flatten,
+        dynamo_bytecode_unflatten,
+    )  # type: ignore[attr-defined]
+    normalize_graph_module(graph_module)
+    assert not hasattr(graph_module, "_dynamo_bytecode_flatten")
+    assert not hasattr(graph_module, "_dynamo_bytecode_unflatten")
+    # pyrefly: ignore [bad-argument-type]
+    graph_module._dynamo_bytecode_flatten = dynamo_bytecode_flatten
+    # pyrefly: ignore [bad-argument-type]
+    graph_module._dynamo_bytecode_unflatten = dynamo_bytecode_unflatten
+    delattr(graph_module, "_param_name_to_source")
+    graph_module.recompile()
+    graph_module.meta["module_call_specs"] = (
+        out.graph_capture_output.output_graph.export_metadata.module_call_spec
+    )
+    assert out.backend_input is not None
+    graph_module.meta["fake_mode"] = out.backend_input.fake_mode  # type: ignore[attr-defined]
+    graph_module.meta["fake_mode"].allow_non_fake_inputs = True
+    tracing_context = TracingContext(graph_module.meta["fake_mode"])
+    tracing_context.tensor_to_context = out.backend_input.tensor_to_context  # type: ignore[attr-defined]
+    graph_module.meta["tracing_context"] = tracing_context
+
+    return graph_module
+
+
+class _DynamoBytecodeCodeGen(torch.fx.graph.CodeGen):
+    def __init__(
+        self,
+        orig_arg_names: list[str],
+        dynamo_bytecode_flatten: Callable,
+        dynamo_bytecode_unflatten: Callable,
+    ) -> None:
+        super().__init__()
+        self.orig_arg_names = orig_arg_names
+        self.dynamo_bytecode_flatten = dynamo_bytecode_flatten
+        self.dynamo_bytecode_unflatten = dynamo_bytecode_unflatten
+        self.wrap_tuple = False
+        self._inputs: tuple[Any, ...] | None = None
+
+    def process_inputs(self, *inputs: Any) -> Any:
+        self._inputs = inputs
+        results = self.dynamo_bytecode_flatten(*inputs)
+        return results
+
+    def process_outputs(self, outputs: Any) -> Any:
+        results = self.dynamo_bytecode_unflatten(outputs, self._inputs)
+        if self.wrap_tuple:
+            results = (results,)
+        self._inputs = None
+        return results
+
+    def gen_fn_def(
+        self,
+        free_vars: list[str],
+        maybe_return_annotation: str,
+        *,
+        expanded_def: bool = False,
+    ) -> str:
+        fn_args = self.orig_arg_names
+        has_orig_self = (fn_args[0] == "self") if len(fn_args) > 0 else False
+        if has_orig_self:
+            free_vars.insert(0, "self")
+        fn_definition = super().gen_fn_def(
+            fn_args[:], maybe_return_annotation, expanded_def=expanded_def
+        )
+
+        if len(free_vars) > 0:  # pytree has placeholders in it
+            fn_definition += self.gen_var_bindings(fn_args, free_vars, expanded_def)
+        return fn_definition
+
+    def gen_var_bindings(
+        self, fn_args: list[str], free_vars: list[str], expanded_def: bool
+    ) -> str:
+        without_annotation = [x.split(":")[0].split("#")[0] for x in free_vars]
+        if len(fn_args) == 0:
+            fn_signature = ""
+        elif len(fn_args) == 1:
+            fn_signature = f"{fn_args[0]}, "
+        else:
+            fn_signature = f"{', '.join(fn_args)}"
+        return f"""
+    _fn_args = ({fn_signature})
+    {", ".join(without_annotation)}, = self._dynamo_bytecode_flatten(*_fn_args)"""
+
+    def generate_output(
+        self, output_args: torch.fx.node.Argument, *, descs: object | None = None
+    ) -> str:
+        # pyrefly: ignore [not-iterable]
+        returned = f"self._dynamo_bytecode_unflatten(({', '.join([str(a) for a in output_args])},), _fn_args)"
+        if self.wrap_tuple:
+            returned = f"({returned},)"
+        return f"return {returned}"
+
+
 def dynamo_graph_capture_for_export(
     mod: Callable[..., Any],
     constraints: Optional[list[Constraint]] = None,
@@ -645,62 +909,7 @@ def dynamo_graph_capture_for_export(
                 constraints=constraints,
             )
 
-        # TODO filter out side effects.
-        pyt = pytreeify(out, mod, args, kwargs)
-
-        graph_module = pyt.graph_module
-        tree_leaf_names = [
-            graph_module.graph._graph_namespace.create_name(f"_tree_leaf_{i}", None)
-            for i in range(pyt.num_flat_args)
-        ]
-        graph_module.graph._codegen = _ExportCodeGen(
-            _PyTreeInfo(
-                # TODO we should be able to use the names from dynamo graph directly.
-                argument_names(inspect.signature(mod), args, kwargs),
-                pyt.in_spec,
-                pyt.out_spec,
-            ),
-            pyt.in_shuffle_graph,
-            pyt.out_shuffle_graph,
-            tree_leaf_names,
-            graph_module if isinstance(pyt.root, torch.nn.Module) else pyt.root,
-        )  # type: ignore[attr-defined]
-        normalize_graph_module(graph_module)
-        if pyt.root is not None:
-            graph_module._parameters = pyt.root._parameters.copy()
-            graph_module._buffers = pyt.root._buffers.copy()
-            assert all(not hasattr(graph_module, m) for m in pyt.root._modules)
-            graph_module._modules.update(pyt.root._modules)
-            graph_module._non_persistent_buffers_set = (
-                pyt.root._non_persistent_buffers_set.copy()
-            )
-            if sys.version_info >= (3, 14):
-                import annotationlib  # added in 3.14
-
-                annotations = annotationlib.get_annotations(torch.nn.Module)
-            else:
-                annotations = getattr(torch.nn.Module, "__annotations__", None)
-            for name, value in pyt.root.__dict__.items():
-                if annotations and name not in annotations:
-                    graph_module.__dict__[name] = value
-        graph_module._in_spec = pyt.in_spec
-        graph_module._out_spec = pyt.out_spec
-        assert not hasattr(graph_module, "_in_shuffle_graph")
-        assert not hasattr(graph_module, "_out_shuffle_graph")
-        graph_module._in_shuffle_graph = pyt.in_shuffle_graph
-        graph_module._out_shuffle_graph = pyt.out_shuffle_graph
-        delattr(graph_module, "_param_name_to_source")
-        graph_module.recompile()
-        graph_module.meta["module_call_specs"] = (
-            out.graph_capture_output.output_graph.export_metadata.module_call_spec
-        )
-        assert out.backend_input is not None
-        graph_module.meta["fake_mode"] = out.backend_input.fake_mode  # type: ignore[attr-defined]
-        graph_module.meta["fake_mode"].allow_non_fake_inputs = True
-        tracing_context = TracingContext(graph_module.meta["fake_mode"])
-        tracing_context.tensor_to_context = out.backend_input.tensor_to_context  # type: ignore[attr-defined]
-        graph_module.meta["tracing_context"] = tracing_context
-        return graph_module
+        return create_fx_graph_from_captured_output(out, mod, args, kwargs)
 
     return inner
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -149,6 +149,7 @@ class ATenExportArtifact:
     gm: torch.fx.GraphModule
     sig: ExportGraphSignature
     constants: dict[str, _ConstantAttributeType]
+    inferred_out_spec: TreeSpec
 
 
 @dataclasses.dataclass(frozen=True)
@@ -280,24 +281,43 @@ def _extract_fake_inputs(gm, args, kwargs):
         else:
             fake_vals.append(node.meta.get("example_value"))
 
-    if in_shuffle_graph := getattr(gm, "_in_shuffle_graph", None):
-        flat_args = pytree.tree_leaves((args, kwargs))
-        node_map = {
-            node: i
-            for i, node in enumerate(
-                next(iter(reversed(in_shuffle_graph.graph.nodes))).args[0]
-            )
-            if node.op == "placeholder"
-        }
-        new_fake_inps: list[Any] = []
-        for i, node in enumerate(
-            in_shuffle_graph.graph.find_nodes(op="placeholder")[1:]
-        ):
-            if node in node_map:
-                new_fake_inps.append(fake_inps[node_map[node]])
+    if dynamo_bytecode_flatten := getattr(gm, "_dynamo_bytecode_flatten", None):
+        # In _extract_fake_inputs, the goal is to make real inputs into
+        # fake (and symbolic) inputs. The way currently it's implemented
+        # is by looking at the node.meta["val"] of the placeholder nodes.
+        # This doesn't work when the graph is Dynamo flattened, because now
+        # plceholder nodes doesn't have the ordering like pytree inputs do.
+        # Instead, we need to look at how the inputs are shuffled, and map
+        # the inputs to their actual fake inputs and symbolic inputs.
+        # Since inputs can also contain symints, we cannot simply use the
+        # FakeTensorMode memo to look up tensors only there.
+
+        fake_inps = []
+        positions = {}
+        idx = 0
+
+        def mark_inputs(x):
+            # x can be a tensor or symbolic integer or a normal constant.
+            nonlocal idx
+            fake_inps.append(x)
+            if isinstance(x, torch.Tensor):
+                ret = x
             else:
-                new_fake_inps.append(flat_args[i])
-        fake_inps = new_fake_inps
+                ret = object()
+            if id(ret) not in positions:
+                positions[id(ret)] = idx
+            idx += 1
+            return ret
+
+        dummy_args = pytree.tree_map(mark_inputs, args + tuple(kwargs.values()))
+        shuffled_args = dynamo_bytecode_flatten(*dummy_args)
+
+        for node, shuffled_arg in zip(
+            gm.graph.find_nodes(op="placeholder"), shuffled_args
+        ):
+            if id(shuffled_arg) in positions:
+                fake_inps[positions[id(shuffled_arg)]] = node.meta.get("val")
+
     # We get both because now we might have a combination of symint and tensor
     # inputs, and we want to check that the shape env is consistent between
     # both. Unfortunately we can't see what fake mode is attached to the shape
@@ -645,6 +665,7 @@ def _produce_aten_artifact(
         gm,
         export_graph_signature,
         constants,
+        inferred_out_spec=graph_signature.out_spec,
     )
 
 
@@ -1562,30 +1583,36 @@ def _strict_export(
                 )
 
     # Fix the graph output signature to be tuple if scalar
-
-    # gm_torch_level.graph._codegen is made a _PyTreeCodeGen in rewrite_signature in eval_frame.py
-    assert isinstance(gm_torch_level.graph._codegen, torch.fx.graph._PyTreeCodeGen)
-
+    wrap_tuple = False
     # Calling gm_torch_level._out_spec is not safe because gm_torch_level might be
     # a _LazyGraphModule, which does not populate _out_spec when calling recompile().
     # TODO: Fix recompile() in  _LazyGraphModule. T207713214
-    out_spec = orig_out_spec = gm_torch_level.graph._codegen.pytree_info.out_spec
+    if isinstance(gm_torch_level.graph._codegen, torch.fx.graph._PyTreeCodeGen):
+        out_spec = orig_out_spec = gm_torch_level.graph._codegen.pytree_info.out_spec
+        orig_arg_names = gm_torch_level.graph._codegen.pytree_info.orig_args  # type: ignore[attr-defined]
 
-    # Used to get rid of lint type error.
-    assert out_spec is not None
-    assert orig_out_spec is not None
+        assert out_spec is not None
+        if out_spec.type not in (list, tuple):
+            # aot_export expect the return type to always be a tuple.
+            out_spec = pytree.treespec_tuple([out_spec])
+            wrap_tuple = True
+        gm_torch_level.graph._codegen.pytree_info = _PyTreeInfo(
+            orig_arg_names,
+            gm_torch_level._in_spec,
+            out_spec,
+        )
+    elif isinstance(
+        gm_torch_level.graph._codegen,
+        torch._dynamo.functional_export._DynamoBytecodeCodeGen,
+    ):
+        # Since we're using bytecode codegen, we need to separately apply tuple
+        # output instead of modifying pytree spec inplace.
+        orig_arg_names = gm_torch_level.graph._codegen.orig_arg_names
+        out_spec = orig_out_spec = None
+        wrap_tuple = gm_torch_level.graph._codegen.wrap_tuple = True
+    else:
+        raise RuntimeError(f"Unknown codegen type: {gm_torch_level.graph._codegen}")
 
-    # aot_export expect the return type to always be a tuple.
-    if out_spec.type not in (list, tuple):
-        out_spec = pytree.treespec_tuple([out_spec])
-
-    orig_arg_names = gm_torch_level.graph._codegen.pytree_info.orig_args  # type: ignore[attr-defined]
-
-    gm_torch_level.graph._codegen.pytree_info = _PyTreeInfo(
-        orig_arg_names,
-        gm_torch_level._in_spec,
-        out_spec,
-    )
     gm_torch_level.recompile()
 
     _normalize_nn_module_stack(gm_torch_level, type(mod))
@@ -1658,10 +1685,16 @@ def _strict_export(
     # 5. Rename constants nodes in graph module from buffers to constants
     _rename_constants_nodes(gm, export_graph_signature)
 
+    if orig_out_spec is None:
+        out_spec = aten_export_artifact.inferred_out_spec
+        if wrap_tuple:
+            out_spec = out_spec.children()[0]
+    else:
+        out_spec = orig_out_spec
     return ExportArtifact(
         aten=aten_export_artifact,
         in_spec=orig_in_spec,
-        out_spec=orig_out_spec,
+        out_spec=out_spec,
         fake_mode=dynamo_fake_mode,
         module_call_specs=gm_torch_level.meta["module_call_specs"],
     )


### PR DESCRIPTION
Summary:
Previously for dynamo_graph_capture_for_export, we use make_fx() to trace through the dynamo bytecode so that the GraphModule looks like the following:
```
tree_leaves = pytree_flatten(*args)
graph_inputs = self.in_shuffle_graph(*tree_leaves)
graph_outputs = graph(*graph_inputs)
tree_outs = outputs = self.out_shuffle_graph(*graph_outputs)
return pytree.tree_unflatten(tree_outs)
```

After a bunch of experiments, we think the make_fx step is not necessaery, and to further close the gap between strict export and dynamo, we propose the new impl to do the following using torch.fx codegen:

```
graph_inputs = self._dynamo_bytecode_flatten(*args)
graph_outs = graph(*graph_inputs)
return self._dynamo_bytecode_unflatten(*graph_outs)
```
The `_dynamo_bytecode_flatten` and `_dynamo_bytecode_unflatten` wrappers are constructed in the way that the behavior will be 100% identical to directly running bytecode.

This is important for also making precompile reusing the same piece of logic that torch.export uses.

Test Plan: test:test_export -- -r _strict_export_v2

Differential Revision: D89673950




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo