### PR TITLE
[BE][Typing][Dynamo] Type torch/_dynamo/variables/misc.py

### DIFF
--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1557,6 +1557,12 @@
     {
       "Gb_type": "Unsupported function call (delayed)",
       "Context": "source: {self.source}",
+      "Explanation": "Dynamo determined that a graph break should occur when calling `{name}`. Reason: {self.msg}",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Unsupported function call (delayed)",
+      "Context": "source: {self.source}",
       "Explanation": "Dynamo determined that a graph break should occur when calling `{self.source.name}`. Reason: {self.msg}",
       "Hints": []
     }

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -413,7 +413,7 @@ class SideEffects:
 
     def track_object_new(
         self,
-        cls_source: Source,
+        cls_source: Source | None,
         user_cls: Any,
         variable_cls: Any,
         options: dict[str, Any],

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1002,7 +1002,7 @@ class BuiltinVariable(VariableTracker):
     ) -> Callable[
         [
             "InstructionTranslator",
-            Sequence[VariableTracker],
+            tuple[VariableTracker, ...],
             dict[str, VariableTracker],
         ],
         VariableTracker | None,
@@ -1027,7 +1027,7 @@ class BuiltinVariable(VariableTracker):
 
             def create_exception_class_object(
                 tx: "InstructionTranslator",
-                args: Sequence[VariableTracker],
+                args: tuple[VariableTracker, ...],
                 kwargs: dict[str, VariableTracker],
             ) -> VariableTracker:
                 if fn is AssertionError and not all(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4199,7 +4199,7 @@ class AutogradFunctionApplyVariable(VariableTracker):
     _ALLOW_FALLBACK_TO_EAGER = True
 
     def __init__(
-        self, fwd_fn: Any, bwd_fn: Any, parent_source: Source, **kwargs: Any
+        self, fwd_fn: Any, bwd_fn: Any, parent_source: Source | None, **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
         self.fwd_fn = fwd_fn
@@ -4374,8 +4374,11 @@ class AutogradFunctionApplyVariable(VariableTracker):
             proxy = tx.output.create_proxy(
                 "call_function", torch.autograd.function.FunctionCtx, (), {}
             )
+            # type: ignore[attr-defined]
             set_example_value(proxy.node, ctx.value)
+            # type: ignore[attr-defined]
             ctx.proxy = proxy
+        # pyrefly: ignore[bad-return]
         return ctx
 
     def trace_forward_graph(

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -29,8 +29,7 @@ import types
 from collections.abc import Callable, Sequence
 from random import Random
 from types import BuiltinFunctionType
-from typing import Any, Literal, NoReturn, TYPE_CHECKING, Union
-from typing_extensions import TypeIs
+from typing import Any, Literal, NoReturn, TYPE_CHECKING, TypeGuard, Union
 
 import torch._C
 import torch._numpy as tnp
@@ -549,7 +548,7 @@ class ExceptionVariable(VariableTracker):
     def __init__(
         self,
         exc_type: Any,
-        args: Sequence[VariableTracker],
+        args: tuple[VariableTracker, ...],
         init_kwargs: dict[str, VariableTracker] | None = None,
         source: Source | None = None,
         mutation_type: MutationType | None = None,
@@ -1247,6 +1246,7 @@ class AutogradEngineVariable(UserDefinedObjectVariable):
 
 
 class LambdaVariable(VariableTracker):
+    # TODO: change to Ts = TypeVarTuple("Ts") for py 3.11+
     def __init__(self, fn: Callable[..., VariableTracker], **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.fn = fn
@@ -1929,7 +1929,7 @@ class DebuggingVariable(VariableTracker):
     @staticmethod
     def is_reorderable_logging_function(
         obj: Any,
-    ) -> TypeIs[types.FunctionType | types.BuiltinFunctionType]:
+    ) -> TypeGuard[types.FunctionType | types.BuiltinFunctionType]:
         return (
             callable(obj)
             and isinstance(obj, (types.FunctionType, types.BuiltinFunctionType))

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 """
 This module contains miscellaneous variable tracker implementations for various Python types
 and features used in Dynamo's symbolic execution. These classes help track and propagate
@@ -22,18 +20,24 @@ import enum
 import functools
 import inspect
 import itertools
+import logging
 import random
 import re
 import sys
 import traceback
 import types
-import warnings
-from collections.abc import Sequence
-from typing import Optional, TYPE_CHECKING, Union
+from collections.abc import Callable, Sequence
+from random import Random
+from types import BuiltinFunctionType
+from typing import Any, Literal, NoReturn, TYPE_CHECKING, Union
+from typing_extensions import TypeIs
 
 import torch._C
 import torch._numpy as tnp
 import torch.utils._pytree as pytree
+from torch._dynamo.variables.base import MutationType
+from torch._dynamo.variables.lists import TupleVariable
+from torch._guards import Source
 
 from .. import config, graph_break_hints, trace_rules, variables
 from ..bytecode_transformation import (
@@ -88,7 +92,12 @@ class SuperVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def __init__(self, typevar, objvar=None, **kwargs) -> None:
+    def __init__(
+        self,
+        typevar: VariableTracker,
+        objvar: VariableTracker | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         # typevar is the first argument to super(). In the case where no argument
         # is provided to super(), it is the __class__ object where
@@ -100,7 +109,7 @@ class SuperVariable(VariableTracker):
         # cls for a classmethod)
         self.objvar = objvar
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(lambda: codegen(variables.BuiltinVariable(super)))
         codegen(self.typevar)
         if self.objvar is not None:
@@ -109,7 +118,9 @@ class SuperVariable(VariableTracker):
         else:
             codegen.extend_output(create_call_function(1, False))
 
-    def _resolved_getattr_and_source(self, tx: "InstructionTranslator", name):
+    def _resolved_getattr_and_source(
+        self, tx: "InstructionTranslator", name: str
+    ) -> tuple[Any, AttrSource | None]:
         if not self.objvar:
             unimplemented(
                 gb_type="1-arg super not implemented",
@@ -121,6 +132,7 @@ class SuperVariable(VariableTracker):
                     "Use two-argument super(type, object_or_type).",
                 ],
             )
+        assert self.objvar is not None
         search_type = self.typevar.as_python_constant()
 
         # The rest of this function does two things:
@@ -131,11 +143,11 @@ class SuperVariable(VariableTracker):
         # Find the class object, where the function lives.
         # When objvar is "self", use type(self), when objvar is "cls", use it as-is
         type_to_use = self.objvar.python_type()
-        type_to_use_source = (
+        type_to_use_source: Source | None = (
             TypeSource(self.objvar.source) if self.objvar.source else None
         )
         if issubclass(type_to_use, type):
-            type_to_use = self.objvar.value
+            type_to_use = self.objvar.value  # type: ignore[attr-defined]
             type_to_use_source = self.objvar.source
 
         source = None
@@ -174,7 +186,7 @@ class SuperVariable(VariableTracker):
             ],
         )
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         # Check if getattr is a constant. If not, delay the actual work by
         # wrapping the result in GetAttrVariable. Mostly super is called with a
         # method, so most of the work is delayed to call_function.
@@ -183,7 +195,7 @@ class SuperVariable(VariableTracker):
         # special when it comes to finding sources. Compared to other VTs, super
         # requires the attr name to walk the mro and find the actual source (and
         # not just AttrSource).
-        value, source = self._resolved_getattr_and_source(self, name)
+        value, source = self._resolved_getattr_and_source(tx, name)
         if not variables.ConstantVariable.is_literal(value):
             return GetAttrVariable(self, name)
         if source:
@@ -193,11 +205,12 @@ class SuperVariable(VariableTracker):
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
-        inner_fn, source = self._resolved_getattr_and_source(self, name)
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        inner_fn, source = self._resolved_getattr_and_source(tx, name)
+        assert self.objvar is not None
         # This essentially simulates CPython's `super_getattro`:
         # https://github.com/python/cpython/blob/a1c52d1265c65bcf0d9edf87e143843ad54f9b8f/Objects/typeobject.c#L11138-L11168
         # where `inner_fn` is the VT for `res = _super_lookup_descr(...)`.
@@ -239,8 +252,9 @@ class SuperVariable(VariableTracker):
         ):
             user_cls = inner_fn.__self__
             if hasattr(user_cls, "__module__") and user_cls.__module__ == "builtins":
-                user_cls_vt = variables.BuiltinVariable(user_cls)
+                user_cls_vt: VariableTracker = variables.BuiltinVariable(user_cls)
             else:
+                assert source is not None
                 user_cls_source = source.member
                 user_cls_vt = variables.UserDefinedClassVariable(
                     user_cls, source=user_cls_source
@@ -270,9 +284,11 @@ class SuperVariable(VariableTracker):
                 if self.objvar.source:
                     cls_source = TypeSource(self.objvar.source)
                 cls_variable = VariableTracker.build(
-                    tx, self.objvar.value_type, cls_source
+                    tx,
+                    self.objvar.value_type,  # type: ignore[attr-defined]
+                    cls_source,
                 )
-
+            assert source is not None
             fn_vt = VariableTracker.build(
                 tx, inner_fn.__func__, source=AttrSource(source, "__func__")
             )
@@ -287,6 +303,7 @@ class SuperVariable(VariableTracker):
         elif is_standard_setattr(inner_fn) and isinstance(
             self.objvar, UserDefinedObjectVariable
         ):
+            # type: ignore[arg-type]
             return self.objvar.method_setattr_standard(tx, *args, **kwargs)
         elif inner_fn is object.__delattr__:
             attr = args[0]
@@ -316,7 +333,7 @@ class SuperVariable(VariableTracker):
                         *graph_break_hints.DYNAMO_BUG,
                     ],
                 )
-
+            assert isinstance(attr, str)
             tx.output.side_effects.store_attr(
                 self.objvar, attr, variables.DeletedVariable()
             )
@@ -344,7 +361,7 @@ class SuperVariable(VariableTracker):
         elif inner_fn is object.__getattribute__:
             # object.__getattribute__ has no side-effects. We can directly call
             # __getattribute__ to access the attribute.
-            attr_name = args[0].value
+            attr_name = args[0].value  # type: ignore[attr-defined]
             if tx.output.side_effects.has_pending_mutation_of_attr(
                 self.objvar, attr_name
             ):
@@ -355,8 +372,10 @@ class SuperVariable(VariableTracker):
                     raise_observed_exception(AttributeError, tx)
                 return result
 
+            attr_value = None
             try:
                 # NB - use object.__getattribute__ to prevent running any user code
+                # type: ignore[attr-defined]
                 attr_value = object.__getattribute__(self.objvar.value, attr_name)
             except AttributeError:
                 raise_observed_exception(AttributeError, tx)
@@ -373,7 +392,8 @@ class SuperVariable(VariableTracker):
             #  * (func, types, args, kwargs)
             func = args[0]
             tf_kwargs = {}
-            tf_args = args[2].items
+            tf_args = args[2].items  # type: ignore[attr-defined]
+            # type: ignore[attr-defined]
             for hash_key_vt, value_vt in args[3].items.items():
                 key_str = hash_key_vt.vt.as_python_constant()
                 tf_kwargs[key_str] = value_vt
@@ -409,11 +429,11 @@ class SuperVariable(VariableTracker):
 
 
 class FrameSummaryVariable(VariableTracker):
-    def __init__(self, frame_summary: traceback.FrameSummary, **kwargs) -> None:
+    def __init__(self, frame_summary: traceback.FrameSummary, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.frame_summary = frame_summary
 
-    def var_getattr(self, tx, name):
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name == "lineno":
             return variables.ConstantVariable.create(self.frame_summary.lineno)
         elif name == "filename":
@@ -429,8 +449,8 @@ class TracebackVariable(VariableTracker):
     def __init__(
         self,
         frame_summary: FrameSummaryVariable,
-        tb_next,
-        **kwargs,
+        tb_next: Union["TracebackVariable", ConstantVariable],
+        **kwargs: Any,
     ) -> None:
         # The traceback holds four attributes:
         #  - tb_frame
@@ -449,7 +469,7 @@ class TracebackVariable(VariableTracker):
         cls,
         frame_summary: traceback.FrameSummary,
         tb_next: Union["TracebackVariable", ConstantVariable],
-    ):
+    ) -> "TracebackVariable":
         return cls(FrameSummaryVariable(frame_summary), tb_next=tb_next)
 
     @staticmethod
@@ -458,21 +478,21 @@ class TracebackVariable(VariableTracker):
             istype(obj, ConstantVariable) and obj.is_constant_none()
         )
 
-    def extract_tb(self) -> list[traceback.FrameSummary]:
+    def extract_tb(self) -> list[traceback.FrameSummary | FrameSummaryVariable]:
         if istype(self.tb_next, ConstantVariable):
             return [self.frame_summary]
         return [self.frame_summary] + self.tb_next.extract_tb()
 
     def has_reference_cycle(self, tb: "TracebackVariable") -> bool:
         # checks if `tb` is in the chain of tb_next starting from `self`
-        curr_tb = self
+        curr_tb: TracebackVariable | ConstantVariable = self
         while istype(curr_tb, TracebackVariable):
             if curr_tb is tb:
                 return True
             curr_tb = curr_tb.tb_next
         return False
 
-    def python_type(self):
+    def python_type(self) -> type[types.TracebackType]:
         return types.TracebackType
 
     def call_setattr(
@@ -480,11 +500,12 @@ class TracebackVariable(VariableTracker):
         tx: "InstructionTranslator",
         name_var: VariableTracker,
         val: VariableTracker,
-    ):
+    ) -> VariableTracker:
         name = name_var.as_python_constant()
         if name == "tb_next":
             if not self.is_valid_traceback(val):
                 raise_observed_exception(TypeError, tx)
+            assert isinstance(val, TracebackVariable)
             if self.has_reference_cycle(val) or (
                 istype(val, TracebackVariable) and val.has_reference_cycle(self)
             ):
@@ -512,9 +533,9 @@ class TracebackVariable(VariableTracker):
         self,
         tx: "InstructionTranslator",
         name: str,
-        args: Sequence[VariableTracker],
+        args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
-    ):
+    ) -> VariableTracker:
         if name == "__eq__":
             # Two traceback variables are only equal if they are the same object
             return variables.ConstantVariable.create(self is args[0])
@@ -526,7 +547,12 @@ class TracebackVariable(VariableTracker):
 class ExceptionVariable(VariableTracker):
     # The ExceptionVariable corresponds to the BaseException class in Python
     def __init__(
-        self, exc_type, args, init_kwargs=None, source=None, mutation_type=None
+        self,
+        exc_type: Any,
+        args: Sequence[VariableTracker],
+        init_kwargs: dict[str, VariableTracker] | None = None,
+        source: Source | None = None,
+        mutation_type: MutationType | None = None,
     ) -> None:
         super().__init__(source=source, mutation_type=mutation_type)
         self.exc_type = exc_type
@@ -541,22 +567,22 @@ class ExceptionVariable(VariableTracker):
         # When raising a new exception while another exception is already being
         # handled, the new exception's __context__ attribute is automatically
         # set to the handled exception.
-        self.__context__ = ConstantVariable(None)
+        self.__context__: VariableTracker = ConstantVariable(None)
         # Set when user raised an exception from another:
         # raise ... from ...
-        self.__cause__ = ConstantVariable(None)
+        self.__cause__: VariableTracker = ConstantVariable(None)
         # Boolean flag that controls whether the __context__ attribute is set
-        self.__suppress_context__ = ConstantVariable(False)
+        self.__suppress_context__: VariableTracker = ConstantVariable(False)
         # Contains the call stack where the exception was raised.
-        self.__traceback__ = ConstantVariable(None)
+        self.__traceback__: VariableTracker = ConstantVariable(None)
         # The user stack at the time this exception was first raised.
         # Used to preserve the original exception location when re-raising.
         self.python_stack = None
 
-    def set_context(self, context: "ExceptionVariable"):
+    def set_context(self, context: "ExceptionVariable") -> None:
         self.__context__ = context
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(
             lambda: codegen.load_import_from("builtins", self.exc_type.__name__)
         )
@@ -577,7 +603,7 @@ class ExceptionVariable(VariableTracker):
         codegen_attr("__cause__")
         codegen_attr("__suppress_context__")
 
-    def python_type(self):
+    def python_type(self) -> type:
         return self.exc_type
 
     def call_setattr(
@@ -585,12 +611,13 @@ class ExceptionVariable(VariableTracker):
         tx: "InstructionTranslator",
         name_var: VariableTracker,
         val: VariableTracker,
-    ):
-        def raise_error(msg):
+    ) -> VariableTracker:
+        def raise_error(msg: str) -> NoReturn:
             raise_observed_exception(TypeError, tx, args=[ConstantVariable(msg)])
 
         name = name_var.as_python_constant()
         if name == "__context__":
+            assert isinstance(val, ExceptionVariable)
             self.set_context(val)
         elif name == "__cause__":
             if val.is_constant_none() or isinstance(
@@ -634,7 +661,13 @@ class ExceptionVariable(VariableTracker):
             )
         return variables.ConstantVariable(None)
 
-    def call_method(self, tx, name, args, kwargs):
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if name == "__setattr__":
             return self.call_setattr(tx, *args)
         elif name == "with_traceback":
@@ -654,10 +687,10 @@ class ExceptionVariable(VariableTracker):
         elif name == "__traceback__":
             return self.__traceback__
         elif name == "args":
-            return variables.ListVariable(self.args, source=self.source)
+            return variables.ListVariable(list(self.args), source=self.source)
         return super().var_getattr(tx, name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.exc_type})"
 
     __repr__ = __str__
@@ -674,21 +707,22 @@ class DelayGraphBreakVariable(UnknownVariable):
     Used to insert a dummy variable in the stack to do the graph break at CALL_FUNCTION.
     """
 
-    def __init__(self, msg=None, **kwargs):
+    def __init__(self, msg: str | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.msg = msg
 
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        name = "" if self.source is None else self.source.name
         unimplemented(
             gb_type="Unsupported function call (delayed)",
             context=f"source: {self.source}",
             explanation="Dynamo determined that a graph break should occur "
-            f"when calling `{self.source.name}`. Reason: {self.msg}",
+            f"when calling `{name}`. Reason: {self.msg}",
             hints=[],
         )
 
@@ -699,12 +733,13 @@ class ComptimeVariable(VariableTracker):
     Dynamo compile time
     """
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         raise NotImplementedError("comptime is special form")
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         from ..comptime import comptime
 
+        assert self.source is not None
         # To support the comptime.print_graph convenience accessors
         return VariableTracker.build(
             tx, getattr(comptime, name), source=AttrSource(self.source, name)
@@ -713,9 +748,9 @@ class ComptimeVariable(VariableTracker):
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         from ..comptime import ComptimeContext
 
         # TODO: support an expression form as well
@@ -742,6 +777,7 @@ class ComptimeVariable(VariableTracker):
                 code,
                 fn.f_globals,
                 fn.fn_name.as_python_constant(),
+                # type: ignore[attr-defined]
                 tuple(fn.defaults.items) if fn.defaults else None,
                 # We could automatically promote free variables into
                 # ComptimeVar but this is confusing if you access
@@ -764,28 +800,29 @@ class CellVariable(VariableTracker):
     # Note that all mutation to the cell (i.e., its content) will be buffered in
     # SideEffects, rather than being reflected here. One can think of
     # `CellVariable` as a special case for `UserDefinedObjectVariable`.
-    pre_existing_contents: Optional[VariableTracker]
+    pre_existing_contents: VariableTracker | None
 
     # This is set when this cell can be referenced via `LOAD/STORE_DEREF` in the
     # root frame via this name (e.g., the name is in `co_cellvars/co_freevars`).
-    local_name: Optional[str] = None
+    local_name: str | None = None
 
     def __init__(
-        self, pre_existing_contents: Optional[VariableTracker] = None, **kwargs
+        self, pre_existing_contents: VariableTracker | None = None, **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
         self.pre_existing_contents = pre_existing_contents
 
 
 class NewGlobalVariable(VariableTracker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
 
-def produce_trampoline_autograd_apply(fn_cls):
-    def trampoline_autograd_apply(*args, **kwargs):
+def produce_trampoline_autograd_apply(fn_cls: Any) -> Callable[..., Any]:
+    def trampoline_autograd_apply(*args: Any, **kwargs: Any) -> Any:
         return fn_cls.apply(*args, **kwargs)
 
+    # type: ignore[attr-defined]
     trampoline_autograd_apply._origin = produce_trampoline_autograd_apply
     return trampoline_autograd_apply
 
@@ -798,16 +835,22 @@ class AutogradFunctionVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def __init__(self, fn_cls, **kwargs) -> None:
+    def __init__(self, fn_cls: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.fn_cls = fn_cls
 
-    def call_apply(self, tx: "InstructionTranslator", args, kwargs):
+    def call_apply(
+        self,
+        tx: "InstructionTranslator",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         requires_grad = False
 
-        def visit(vt):
+        def visit(vt: VariableTracker) -> None:
             nonlocal requires_grad
             if vt.is_tensor():
+                # type: ignore[attr-defined]
                 if vt.requires_grad is not False:
                     requires_grad = True
             if isinstance(vt, variables.NNModuleVariable):
@@ -818,10 +861,6 @@ class AutogradFunctionVariable(VariableTracker):
 
         if requires_grad and torch.is_grad_enabled():
             source = self.source
-            if config.capture_autograd_function is False:
-                warnings.warn(
-                    "The config.capture_autograd_function flag is deprecated, it's now always true."
-                )
 
             from torch._functorch.autograd_function import (
                 autograd_function_forward_rewritten,
@@ -878,7 +917,6 @@ class AutogradFunctionVariable(VariableTracker):
                     tx.import_source(self.fn_cls.__module__), self.fn_cls.__name__
                 )
             apply_source = source and AttrSource(source, member="apply")
-
             val = AutogradFunctionApplyVariable(
                 forward_fn,
                 self.fn_cls.backward,
@@ -903,7 +941,7 @@ class AutogradFunctionVariable(VariableTracker):
         args = [ctx, *args]
         if isinstance(fn, types.FunctionType):
             sig = inspect.signature(fn)
-            if len(args) - 1 == len(sig._parameters):
+            if len(args) - 1 == len(sig.parameters):
                 args = args[1:]  # Don't use context
             fn_vt = VariableTracker.build(tx, fn, source=source)
             return fn_vt.call_function(tx, args, kwargs)
@@ -926,25 +964,36 @@ class AutogradFunctionVariable(VariableTracker):
                 ],
             )
 
-    def call_backward(self, tx: "InstructionTranslator", args, kwargs):
+    def call_backward(
+        self,
+        tx: "InstructionTranslator",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         fn = self.fn_cls.backward
+        # type: ignore[attr-defined]
         assert type(args[0].value) is torch._dynamo.external_utils.FakeBackwardCFunction
         assert isinstance(fn, types.FunctionType)
-
+        assert self.source is not None
         fn_source = AttrSource(self.source, "backward")
         fn_vt = VariableTracker.build(tx, fn, source=fn_source)
         return fn_vt.call_function(tx, args, kwargs)
 
-    def call_function(self, tx: "InstructionTranslator", args, kwargs):
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> "AutogradFunctionVariable":
         return AutogradFunctionVariable(self.fn_cls)
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ):
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         from .builder import wrap_fx_proxy
 
         if name == "apply":
@@ -974,16 +1023,18 @@ class AutogradFunctionVariable(VariableTracker):
 
             if isinstance(obj, staticmethod):
                 func = obj.__get__(self.fn_cls)
+                traced = trace_rules.lookup(func)
+                assert traced is not None
                 if source is not None:
                     return (
-                        trace_rules.lookup(func)
-                        .create_with_source(func, source=source)
-                        .call_function(tx, args, kwargs)
+                        # type: ignore[attr-defined]
+                        traced.create_with_source(func, source=source).call_function(
+                            tx, args, kwargs
+                        )
                     )
                 else:
-                    return trace_rules.lookup(func)(func).call_function(
-                        tx, args, kwargs
-                    )
+                    # type: ignore[misc]
+                    return traced(func).call_function(tx, args, kwargs)
             elif isinstance(obj, classmethod):
                 return variables.UserMethodVariable(
                     obj.__func__, self, source=source
@@ -1022,13 +1073,13 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
 
     def __init__(
         self,
-        value,
-        value_type=None,
-        inference=False,
-        saved_tensors=None,
-        needs_input_grad=None,
-        non_differentiable=None,
-        **kwargs,
+        value: Any,
+        value_type: type | None = None,
+        inference: bool = False,
+        saved_tensors: Any | None = None,
+        needs_input_grad: tuple[bool, ...] | None = None,
+        non_differentiable: Any | None = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(value=value, value_type=value_type, **kwargs)
         self.inference = inference
@@ -1037,9 +1088,14 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         self.non_differentiable = non_differentiable
 
     @staticmethod
-    def create(tx: "InstructionTranslator", args=None, kwargs=None):
+    def create(
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker] | None = None,
+        kwargs: dict[str, VariableTracker] | None = None,
+    ) -> VariableTracker:
         needs_input_grad = None
         if args and not kwargs:
+            # type: ignore[attr-defined]
             needs_input_grad = tuple(x.is_tensor() and x.requires_grad for x in args)
         out = tx.output.side_effects.track_object_new(
             None,
@@ -1054,7 +1110,8 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
         )
         return out
 
-    def as_proxy(self):
+    def as_proxy(self) -> Any:
+        # type: ignore[attr-defined]
         if self.proxy is None:
             unimplemented(
                 gb_type="proxy not set",
@@ -1063,15 +1120,16 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
                 "to be initialized with a proxy.",
                 hints=[*graph_break_hints.DYNAMO_BUG],
             )
+        # type: ignore[attr-defined]
         return self.proxy
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if name == "__setattr__":
             return super().call_method(tx, name, args, kwargs)
         elif name == "mark_non_differentiable":
@@ -1102,7 +1160,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
                     "`save_for_backward` only supported on a newly constructed `torch.autograd.function.FunctionCtx`.",
                 ],
             )
-
+        assert self.saved_tensors is not None
         if not self.inference:
             if kwargs or not self.source:
                 raise_type_error_exc(
@@ -1117,10 +1175,10 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             self.saved_tensors.tensors.append(arg)
         return variables.ConstantVariable.create(None)
 
-    def var_getattr(self, tx: "InstructionTranslator", name):
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name in ["save_for_backward", "mark_non_differentiable"]:
             return LambdaVariable(
-                lambda *args, **kwargs: self.call_method(tx, name, args, kwargs)
+                lambda *args, **kwargs: self.call_method(tx, name, list(args), kwargs)
             )
         if name == "saved_tensors" and self.saved_tensors is not None:
             return variables.TupleVariable(list(self.saved_tensors.tensors))
@@ -1129,6 +1187,7 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
                 return variables.ConstantVariable.create(self.needs_input_grad)
             if self.source:
                 source = AttrSource(self.source, "needs_input_grad")
+                # type: ignore[attr-defined]
                 return VariableTracker.build(tx, self.value.needs_input_grad, source)
 
         return super().var_getattr(tx, name)
@@ -1141,19 +1200,19 @@ class AutogradEngineVariable(UserDefinedObjectVariable):
 
     def __init__(
         self,
-        value,
-        value_type=None,
-        **kwargs,
+        value: torch._C._ImperativeEngine,
+        value_type: type[torch._C._ImperativeEngine] | None = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(value=value, value_type=value_type, **kwargs)
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if name == "queue_callback":
             if torch._dynamo.compiled_autograd.in_compiled_autograd_region:
                 assert tx.one_graph or tx.error_on_graph_break, (
@@ -1188,16 +1247,16 @@ class AutogradEngineVariable(UserDefinedObjectVariable):
 
 
 class LambdaVariable(VariableTracker):
-    def __init__(self, fn, **kwargs) -> None:
+    def __init__(self, fn: Callable[..., VariableTracker], **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.fn = fn
 
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         return self.fn(*args, **kwargs)
 
 
@@ -1208,7 +1267,13 @@ class GetAttrVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def __init__(self, obj, name, py_type=None, **kwargs) -> None:
+    def __init__(
+        self,
+        obj: VariableTracker,
+        name: str,
+        py_type: type | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         assert isinstance(obj, VariableTracker)
         assert isinstance(name, str)
@@ -1216,7 +1281,7 @@ class GetAttrVariable(VariableTracker):
         self.name = name
         self.py_type = py_type  # In some cases we know the type (ex. tensor methods)
 
-    def python_type(self):
+    def python_type(self) -> type:
         if self.py_type is not None:
             return self.py_type
         else:
@@ -1226,20 +1291,20 @@ class GetAttrVariable(VariableTracker):
         return f"{self.__class__.__name__}({self.obj}, {self.name})"
 
     @staticmethod
-    def create_getattr_proxy(base_proxy: torch.fx.Proxy, attr):
+    def create_getattr_proxy(base_proxy: torch.fx.Proxy, attr: str) -> Any:
         return getattr(base_proxy, attr)
 
-    def as_proxy(self):
+    def as_proxy(self) -> Any:
         return GetAttrVariable.create_getattr_proxy(self.obj.as_proxy(), self.name)
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> Any:
         constant = self.obj.as_python_constant()
         try:
             return getattr(constant, self.name)
         except AttributeError:
             raise NotImplementedError(f"{self} is not a constant") from None
 
-    def const_getattr(self, tx: "InstructionTranslator", name):
+    def const_getattr(self, tx: "InstructionTranslator", name: str) -> Any:
         if not isinstance(self.obj, variables.NNModuleVariable):
             raise NotImplementedError
         step1 = tx.output.get_submodule(self.obj.module_key)
@@ -1250,22 +1315,22 @@ class GetAttrVariable(VariableTracker):
             raise NotImplementedError
         return inspect.getattr_static(step2, name)
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen(self.obj)
         codegen.extend_output(codegen.create_load_attrs(self.name))
 
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
-        return self.obj.call_method(tx, self.name, args, kwargs)
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return self.obj.call_method(tx, self.name, list(args), kwargs)
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
+        name: str,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
@@ -1330,7 +1395,7 @@ class GetAttrVariable(VariableTracker):
 
         return super().call_method(tx, name, args, kwargs)
 
-    def get_forwarded_dict(self, tx):
+    def get_forwarded_dict(self, tx: "InstructionTranslator") -> VariableTracker:
         assert (
             self.name == "__dict__"
             and isinstance(self.obj, variables.UserDefinedClassVariable)
@@ -1341,17 +1406,16 @@ class GetAttrVariable(VariableTracker):
 
 
 class MethodWrapperVariable(VariableTracker):
-    def __init__(self, method_wrapper, **kwargs) -> None:
+    def __init__(self, method_wrapper: types.MethodWrapperType, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.method_wrapper = method_wrapper
-        self._builtin_fns = {}
 
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if is_tensor_base_attr_getter(self.method_wrapper) and isinstance(
             args[0], variables.TensorVariable
         ):
@@ -1359,7 +1423,7 @@ class MethodWrapperVariable(VariableTracker):
                 raise_type_error_exc(
                     tx, "tensor attribute getter takes exactly one argument"
                 )
-
+            # type: ignore[arg-type, attr-defined]
             return args[0].var_getattr(tx, self.method_wrapper.__self__.__name__)
 
         # method-wrapper variables are common in __init__ calls. For example,
@@ -1375,7 +1439,11 @@ class MethodWrapperVariable(VariableTracker):
             fn_obj = type(self_obj).__init__
             if fn_obj is object.__init__:
                 return variables.BuiltinVariable(object).call_method(
-                    tx, wrapper_name, [self_obj, *args], kwargs
+                    tx,
+                    wrapper_name,
+                    # type: ignore[arg-type, list-item]
+                    [self_obj, *args],
+                    kwargs,
                 )
         elif (
             sys.version_info >= (3, 14)
@@ -1412,38 +1480,38 @@ class MethodWrapperVariable(VariableTracker):
 
         return super().call_function(tx, args, kwargs)
 
-    def is_python_constant(self):
+    def is_python_constant(self) -> Literal[True]:
         return True
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> types.MethodWrapperType:
         return self.method_wrapper
 
-    def is_python_hashable(self):
+    def is_python_hashable(self) -> Literal[True]:
         return True
 
-    def get_python_hash(self):
+    def get_python_hash(self) -> int:
         return hash(self.as_python_constant())
 
-    def is_python_equal(self, other):
+    def is_python_equal(self, other: VariableTracker) -> bool:
         return self.as_python_constant() == other.as_python_constant()
 
 
 class GetSetDescriptorVariable(VariableTracker):
-    def __init__(self, desc, **kwargs) -> None:
+    def __init__(self, desc: types.GetSetDescriptorType, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.desc = desc
 
-    def var_getattr(self, tx: "InstructionTranslator", name):
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name == "__get__" and self.source:
             source = AttrSource(self.source, "__get__")
             return VariableTracker.build(tx, self.desc.__get__, source)
         else:
             return super().var_getattr(tx, name)
 
-    def is_python_constant(self):
+    def is_python_constant(self) -> Literal[True]:
         return True
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> types.GetSetDescriptorType:
         return self.desc
 
 
@@ -1454,28 +1522,31 @@ class PythonModuleVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def __init__(self, value: types.ModuleType, **kwargs) -> None:
+    def __init__(self, value: types.ModuleType, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
         self.is_torch = self.value is torch or self.value.__name__.startswith("torch.")
 
-    def python_type(self):
+    def python_type(self) -> type[types.ModuleType]:
         return types.ModuleType
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> types.ModuleType:
         return self.value
 
     def __repr__(self) -> str:
         return f"PythonModuleVariable({self.value})"
 
-    def call_obj_hasattr(self, tx: "InstructionTranslator", name):
+    def call_obj_hasattr(
+        self, tx: "InstructionTranslator", name: str
+    ) -> ConstantVariable:
         result = hasattr(self.value, name)
         return variables.ConstantVariable.create(result)
 
-    def var_getattr(self, tx: "InstructionTranslator", name):
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if tx.output.side_effects.has_pending_mutation_of_attr(self, name):
             return tx.output.side_effects.load_attr(self, name)
 
+        attr_value = None
         if self.is_torch or name not in self.value.__dict__:
             try:
                 attr_value = getattr(self.value, name)
@@ -1489,17 +1560,17 @@ class PythonModuleVariable(VariableTracker):
 
 
 class TypingVariable(VariableTracker):
-    def __init__(self, value, **kwargs) -> None:
+    def __init__(self, value: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         # Create a new typing variable, e.g., `List[int]`
         if name == "__getitem__" and len(args) == 1:
             new_typing = self.value[args[0].as_python_constant()]
@@ -1514,14 +1585,14 @@ class TypingVariable(VariableTracker):
             ],
         )
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str):
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         from .builder import SourcelessBuilder, VariableBuilder
 
         if name in cmp_name_to_op_mapping:
             return variables.GetAttrVariable(self, name)
 
         if tx.output.side_effects.has_pending_mutation_of_attr(self, name):
-            return tx.side_effects.load_attr(self, name)
+            return tx.output.side_effects.load_attr(self, name)
 
         value = getattr(self.value, name)
         if self.source:
@@ -1530,7 +1601,7 @@ class TypingVariable(VariableTracker):
         else:
             return SourcelessBuilder.create(tx, value)
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> Any:
         return self.value
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
@@ -1561,18 +1632,18 @@ class TypingVariable(VariableTracker):
         #
         codegen.append_output(codegen.create_load_const(self.value))
 
-    def is_python_hashable(self):
+    def is_python_hashable(self) -> Literal[True]:
         return True
 
-    def get_python_hash(self):
+    def get_python_hash(self) -> int:
         return hash(self.as_python_constant())
 
-    def is_python_equal(self, other):
+    def is_python_equal(self, other: VariableTracker) -> bool:
         return self.as_python_constant() == other.as_python_constant()
 
 
 @functools.lru_cache(maxsize=1)
-def get_np_to_tnp_map():
+def get_np_to_tnp_map() -> dict[types.BuiltinFunctionType, types.FunctionType]:
     """
     This generates a mapping from numpy modules to their torch._numpy
     modules equivalents.
@@ -1593,7 +1664,7 @@ def get_np_to_tnp_map():
 
 
 @functools.lru_cache(maxsize=1)
-def get_tnp_to_np_map():
+def get_tnp_to_np_map() -> dict[types.FunctionType, types.BuiltinFunctionType]:
     """
     This is just the reverse mapping of get_np_to_tnp_map() - mapping from
     torch._numpy modules to numpy equivalents.
@@ -1609,18 +1680,18 @@ class NumpyVariable(VariableTracker):
 
     constant_fold_functions = (tnp.issubdtype,)
 
-    def __init__(self, value, **kwargs) -> None:
+    def __init__(self, value: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
     @classmethod
-    def can_constant_fold_through(cls, fn):
+    def can_constant_fold_through(cls, fn: types.FunctionType) -> bool:
         mod = fn.__module__.split(".")
         assert len(mod) >= 2 and mod[:2] == ["torch", "_numpy"]
         return fn in cls.constant_fold_functions
 
     @classmethod
-    def get_constant_collection_for_func(cls, fn):
+    def get_constant_collection_for_func(cls, fn: types.FunctionType) -> Any:
         mod = fn.__module__.split(".")
         assert len(mod) >= 2 and mod[:2] == ["torch", "_numpy"]
         return np_constant_collections_map.get(fn)
@@ -1628,9 +1699,9 @@ class NumpyVariable(VariableTracker):
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if not config.trace_numpy:
             unimplemented(
                 gb_type="attempted to trace numpy function with config.trace_numpy=False",
@@ -1657,6 +1728,7 @@ class NumpyVariable(VariableTracker):
             )
 
         # We are dealing with a function that produces a const collection type (np.dtype, np.iinfo/np.finfo)
+        assert func is not None
         if (
             collection_variable_typ := self.get_constant_collection_for_func(func)
         ) is not None:
@@ -1718,10 +1790,10 @@ class NumpyVariable(VariableTracker):
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         unimplemented(
             gb_type="attempted to trace numpy.* function as a method",
             context=f"numpy function: {self.value}, args: {args}, kwargs: {kwargs}",
@@ -1731,10 +1803,10 @@ class NumpyVariable(VariableTracker):
             ],
         )
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> BuiltinFunctionType:
         return self.value
 
-    def as_proxy(self):
+    def as_proxy(self) -> Any:
         if config.trace_numpy:
             # Can replace with EnumType once we drop 3.10 support
             if isinstance(self.value, enum.EnumMeta):
@@ -1748,25 +1820,25 @@ class NumpyVariable(VariableTracker):
 
         return super().as_proxy()
 
-    def is_python_hashable(self):
+    def is_python_hashable(self) -> Literal[True]:
         return True
 
-    def get_python_hash(self):
+    def get_python_hash(self) -> int:
         return hash(self.as_python_constant())
 
-    def is_python_equal(self, other):
+    def is_python_equal(self, other: VariableTracker) -> bool:
         return self.as_python_constant() == other.as_python_constant()
 
 
 # Used to keep track of NULLs pushed on the stack for Python 3.11 function calls
 class NullVariable(VariableTracker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
     def __repr__(self) -> str:
         return "NullVariable"
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         if sys.version_info < (3, 11):
             unimplemented(
                 gb_type="cannot reconstruct NullVariable in Python < 3.11",
@@ -1792,7 +1864,12 @@ class StringFormatVariable(VariableTracker):
     _nonvar_fields = {"format_string", *VariableTracker._nonvar_fields}
 
     @classmethod
-    def create(cls, format_string, sym_args, sym_kwargs):
+    def create(
+        cls,
+        format_string: str,
+        sym_args: Sequence[VariableTracker],
+        sym_kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if all(
             x.is_python_constant()
             for x in itertools.chain(sym_args, sym_kwargs.values())
@@ -1805,7 +1882,13 @@ class StringFormatVariable(VariableTracker):
             )
         return cls(format_string, list(sym_args), dict(sym_kwargs))
 
-    def __init__(self, format_string, sym_args, sym_kwargs, **kwargs) -> None:
+    def __init__(
+        self,
+        format_string: str,
+        sym_args: Sequence[VariableTracker],
+        sym_kwargs: dict[str, VariableTracker],
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         assert isinstance(format_string, str)
         self.format_string = format_string
@@ -1815,7 +1898,7 @@ class StringFormatVariable(VariableTracker):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.format_string!r}, {self.sym_args!r}, {self.sym_kwargs!r})"
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(
             lambda: codegen.extend_output(
                 [
@@ -1825,7 +1908,7 @@ class StringFormatVariable(VariableTracker):
             ),
             call_function_ex=True,
         )
-        codegen(variables.TupleVariable(self.sym_args))
+        codegen(variables.TupleVariable(list(self.sym_args)))
         kwargs = {
             variables.ConstantVariable.create(k): v for k, v in self.sym_kwargs.items()
         }
@@ -1839,19 +1922,27 @@ class DebuggingVariable(VariableTracker):
     registered to config.reorderable_logging_functions.
     """
 
-    def __init__(self, value, **kwargs) -> None:
+    def __init__(self, value: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
     @staticmethod
-    def is_reorderable_logging_function(obj):
+    def is_reorderable_logging_function(
+        obj: Any,
+    ) -> TypeIs[types.FunctionType | types.BuiltinFunctionType]:
         return (
             callable(obj)
             and isinstance(obj, (types.FunctionType, types.BuiltinFunctionType))
             and obj in torch._dynamo.config.reorderable_logging_functions
         )
 
-    def call_function(self, tx: "InstructionTranslator", args, kwargs):
+    # type: ignore[override]
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> None:
         if tx.export:
             # For export cases, we can just make debugging functions no-ops
             return
@@ -1869,11 +1960,12 @@ class DebuggingVariable(VariableTracker):
 
         tx.debug_locals.append((self, list(args)))
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        assert self.source is not None
         return self.source.reconstruct(codegen)
 
     @staticmethod
-    def can_reorder_logs(fn, args, kwargs) -> True:
+    def can_reorder_logs(fn: Any, args: Sequence[Any], kwargs: dict[str, Any]) -> bool:
         """
         Run some additional checks for what sort of function calls can we
         actually reorder.
@@ -1898,11 +1990,16 @@ class IgnoredFunctionVariable(VariableTracker):
     Represents a call to an arbitrary function that should be ignored.
     """
 
-    def __init__(self, value, **kwargs):
+    def __init__(self, value: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
-    def call_function(self, tx, args, kwargs):
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         return variables.ConstantVariable.create(None)
 
 
@@ -1911,17 +2008,17 @@ class LoggingLoggerVariable(VariableTracker):
     Represents a call to any logging.Logger methods.
     """
 
-    def __init__(self, value, **kwargs) -> None:
+    def __init__(self, value: logging.Logger, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         if tx.export:
             # For export cases, we can just make logging functions no-ops.
             return variables.ConstantVariable.create(None)
@@ -1955,15 +2052,17 @@ class ConstantLikeVariable(VariableTracker):
             generic as np_generic,
         )
     except ImportError:
+        # type: ignore[misc, assignment]
         np_floating = type("invalid_type", (), {})
+        # type: ignore[misc, assignment]
         np_dtype = type("invalid_type", (), {})
 
-    def __init__(self, value, **kwargs) -> None:
+    def __init__(self, value: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
     @property
-    def _error_prefix(self):
+    def _error_prefix(self) -> str:
         """Dynamically compute the prefix from the value's type"""
         t = type(self.value)
 
@@ -1973,16 +2072,17 @@ class ConstantLikeVariable(VariableTracker):
 
         return f"{t.__module__}.{t.__qualname__}"
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> Any:
         return self.value
 
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
+        name: str,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        cargs, ckwargs = [], {}
         try:
             # we only support constant propagation for methods
             cargs = [x.as_python_constant() for x in args]
@@ -2030,14 +2130,14 @@ class ConstantLikeVariable(VariableTracker):
 class TorchVersionVariable(ConstantLikeVariable):
     _error_prefix = "torch.__version__"
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("value", torch.__version__)
         assert kwargs["value"] is torch.__version__
         super().__init__(**kwargs)
 
 
 class NumpyDTypeVariable(ConstantLikeVariable):
-    def as_proxy(self):
+    def as_proxy(self) -> str:
         """Similar to how numpy dtype descriptors (e.g. np.float32 ) are handled by NumpyVariable:
 
         np.dtype() objects are serialized as strings, torch._numpy wrappers will normalize to the torch dtype.
@@ -2056,10 +2156,15 @@ np_constant_collections_map = {
 class RandomClassVariable(VariableTracker):
     """random.Random"""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-    def call_function(self, tx: "InstructionTranslator", args, kwargs):
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> "RandomVariable":
         if len(args) > 1 or kwargs:
             unimplemented(
                 gb_type="random.Random() with improper arguments",
@@ -2097,9 +2202,9 @@ class RandomVariable(VariableTracker):
 
     def __init__(
         self,
-        rand: Optional[random.Random] = None,
-        seed: Optional[VariableTracker] = None,
-        **kwargs,
+        rand: random.Random | None = None,
+        seed: VariableTracker | None = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if rand is not None:
@@ -2110,14 +2215,14 @@ class RandomVariable(VariableTracker):
             seed = seed.as_python_constant() if seed is not None else None
             self.random = random.Random(seed)
 
-    def python_type(self):
+    def python_type(self) -> type[random.Random]:
         return random.Random
 
-    def as_python_constant(self):
+    def as_python_constant(self) -> random.Random:
         return self.random
 
     @staticmethod
-    def is_supported_random_obj(val):
+    def is_supported_random_obj(val: Random) -> bool:
         if type(val) is not random.Random:
             return False
         for name in itertools.chain(
@@ -2136,7 +2241,7 @@ class RandomVariable(VariableTracker):
         return True
 
     @staticmethod
-    def check_state(state):
+    def check_state(state: tuple[int, tuple[int, ...], float | None]) -> None:
         assert type(state) is tuple
         assert type(state[0]) is int
         assert type(state[1]) is tuple
@@ -2144,7 +2249,7 @@ class RandomVariable(VariableTracker):
         assert state[2] is None or type(state[2]) is float
 
     @staticmethod
-    def wrap_state(state):
+    def wrap_state(state: tuple[int, tuple[int, ...], float | None]) -> TupleVariable:
         RandomVariable.check_state(state)
         return variables.TupleVariable(
             [
@@ -2157,7 +2262,9 @@ class RandomVariable(VariableTracker):
         )
 
     @staticmethod
-    def unwrap_state(state):
+    def unwrap_state(
+        state: VariableTracker,
+    ) -> tuple[int, tuple[int, ...], float | None]:
         state_obj = state.as_python_constant()
         RandomVariable.check_state(state_obj)
         return state_obj
@@ -2165,7 +2272,7 @@ class RandomVariable(VariableTracker):
     def call_method(
         self,
         tx: "InstructionTranslator",
-        name,
+        name: str,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
@@ -2186,7 +2293,7 @@ class RandomVariable(VariableTracker):
             tx.output.side_effects.mutation(self)
             state = self.random.getstate()
 
-            def call_random_meth(*args, **kwargs):
+            def call_random_meth(*args: Any, **kwargs: Any) -> Any:
                 r = random.Random()
                 r.setstate(state)
                 return getattr(r, name)(*args, **kwargs)
@@ -2201,7 +2308,7 @@ class RandomVariable(VariableTracker):
             return call_random_fn(tx, call_random_meth, args, kwargs)
         return super().call_method(tx, name, args, kwargs)
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(
             lambda: codegen.extend_output(
                 [
@@ -2222,8 +2329,13 @@ class RandomVariable(VariableTracker):
 
 class WeakRefVariable(VariableTracker):
     @staticmethod
-    def build(tx, weakref_value, **options):
-        source = options.get("source")
+    def build(
+        tx: "InstructionTranslator",
+        weakref_value: Any,
+        source: Source | None,
+        **options: Any,
+    ) -> "WeakRefVariable":
+        assert source is not None
         callback = weakref_value.__callback__
         callback_source = source and AttrSource(source, "__callback__")
         callback_vt = VariableTracker.build(tx, callback, callback_source)
@@ -2233,7 +2345,9 @@ class WeakRefVariable(VariableTracker):
         options["source"] = source
         return WeakRefVariable(referent_vt, callback_vt, **options)
 
-    def __init__(self, referent_vt, callback_vt, **options):
+    def __init__(
+        self, referent_vt: VariableTracker, callback_vt: VariableTracker, **options: Any
+    ):
         super().__init__(**options)
         self.referent_vt = referent_vt
         self.callback_vt = callback_vt
@@ -2241,23 +2355,25 @@ class WeakRefVariable(VariableTracker):
     def call_function(
         self,
         tx: "InstructionTranslator",
-        args: "list[VariableTracker]",
-        kwargs: "dict[str, VariableTracker]",
-    ) -> "VariableTracker":
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
         return self.referent_vt
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(lambda: codegen.load_import_from("weakref", "ref"))
         codegen(self.referent_vt)
         codegen(self.callback_vt)
         codegen.extend_output(create_call_function(2, False))
 
-    def is_python_hashable(self):
+    def is_python_hashable(self) -> bool:
         return self.referent_vt.is_python_hashable()
 
-    def get_python_hash(self):
+    def get_python_hash(self) -> int:
         # weakref relies on the referent's hash
         return self.referent_vt.get_python_hash()
 
-    def is_python_equal(self, other):
+    def is_python_equal(self, other: VariableTracker) -> bool:
+        if not isinstance(other, WeakRefVariable):
+            return False
         return self.referent_vt.is_python_equal(other.referent_vt)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2168,7 +2168,7 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
             and inspect.ismethoddescriptor(method)
             and len(kwargs) == 0
         ):
-            self.exc_vt.args = args
+            self.exc_vt.args = tuple(args)
             # pyrefly: ignore[missing-attribute]
             self.value.args = args
             return variables.ConstantVariable(None)
@@ -2190,7 +2190,7 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
         return self.exc_vt.__context__
 
     @property
-    def args(self) -> Sequence[VariableTracker]:
+    def args(self) -> tuple[VariableTracker, ...]:
         return self.exc_vt.args
 
     def set_context(self, context: "variables.ExceptionVariable") -> None:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -263,7 +263,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return ConstantVariable.create(self.value.__qualname__)
         elif name == "__dict__":
             options = {"source": source}
-            return variables.GetAttrVariable(self, name, **options)
+            return variables.GetAttrVariable(self, name, None, **options)
         elif name == "__mro__":
             attr_source = self.source and TypeMROSource(self.source)
             return VariableTracker.build(tx, self.value.__mro__, attr_source)
@@ -296,7 +296,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return super().var_getattr(tx, name)
 
         if name in cmp_name_to_op_mapping and not isinstance(obj, types.FunctionType):
-            return variables.GetAttrVariable(self, name, source=source)
+            return variables.GetAttrVariable(self, name, None, source=source)
 
         if isinstance(obj, staticmethod):
             return VariableTracker.build(tx, obj.__get__(self.value), source)
@@ -1535,7 +1535,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         if name == "__dict__":
             options_dict = {"source": source}
-            return variables.GetAttrVariable(self, name, **options_dict)
+            return variables.GetAttrVariable(self, name, None, **options_dict)
 
         # TODO(anijain2305) - Investigate if we need specialization for more
         # dunder attrs. inspect.getattr_static does not return correct value for
@@ -1792,7 +1792,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 or is_cython_function(subobj)
             ):
                 options = {"source": source}
-                return variables.GetAttrVariable(self, name, **options)
+                return variables.GetAttrVariable(self, name, None, **options)
             if source:
                 if is_accessible_from_type_mro:
                     source = self.get_source_by_walking_mro(name)
@@ -2186,10 +2186,11 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
 
     @property
     def __context__(self) -> "ConstantVariable":
+        # type: ignore[return-value]
         return self.exc_vt.__context__
 
     @property
-    def args(self) -> tuple[VariableTracker, ...]:
+    def args(self) -> Sequence[VariableTracker]:
         return self.exc_vt.args
 
     def set_context(self, context: "variables.ExceptionVariable") -> None:


### PR DESCRIPTION
Provides type coverage to torch/_dynamo/variables/misc.py

Coverage report:
`mypy torch/_dynamo/variables/tensor.py --linecount-report /tmp/coverage_log`

Compare before to after - we go from 0 lines and 0 funcs covered to 2379 lines and 137 funcs covered


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo