### PR TITLE
Always flush stdio when printing debug message in aoti DebugPrintManager

### DIFF
--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -104,32 +104,35 @@ class DebugPrinterManager:
     ):
         if self.debug_printer_level == IntermediateValueDebuggingLevel.OFF:
             return
-        if self.debug_printer_level == IntermediateValueDebuggingLevel.SAVE_ONLY:
-            # by default save all the tensor values before launch
-            self.codegen_intermediate_tensor_value_save(
-                self.args_to_print_or_save,
-                self.kernel_name,
-                before_launch,
-                arg_signatures=self.arg_signatures,
-            )
-        if self.debug_printer_level == IntermediateValueDebuggingLevel.PRINT_ONLY:
-            # by default print all the tensor values before launch
-            self.codegen_intermediate_tensor_value_print(
-                self.args_to_print_or_save,
-                self.kernel_name,
-                before_launch,
-                arg_signatures=self.arg_signatures,
-            )
-        if (
-            self.debug_printer_level
-            == IntermediateValueDebuggingLevel.PRINT_KERNEL_NAMES_ONLY
-        ):
-            # Print all kernel names to the console only
-            self.codegen_intermediate_tensor_value_print(
-                [],
-                self.kernel_name,
-                before_launch,
-            )
+        try:
+            if self.debug_printer_level == IntermediateValueDebuggingLevel.SAVE_ONLY:
+                # by default save all the tensor values before launch
+                self.codegen_intermediate_tensor_value_save(
+                    self.args_to_print_or_save,
+                    self.kernel_name,
+                    before_launch,
+                    arg_signatures=self.arg_signatures,
+                )
+            if self.debug_printer_level == IntermediateValueDebuggingLevel.PRINT_ONLY:
+                # by default print all the tensor values before launch
+                self.codegen_intermediate_tensor_value_print(
+                    self.args_to_print_or_save,
+                    self.kernel_name,
+                    before_launch,
+                    arg_signatures=self.arg_signatures,
+                )
+            if (
+                self.debug_printer_level
+                == IntermediateValueDebuggingLevel.PRINT_KERNEL_NAMES_ONLY
+            ):
+                # Print all kernel names to the console only
+                self.codegen_intermediate_tensor_value_print(
+                    [],
+                    self.kernel_name,
+                    before_launch,
+                )
+        finally:
+            V.graph.wrapper_code.writeline('fflush(stdout);')
 
     @functools.lru_cache  # noqa: B019
     def _get_debug_filtered_kernel_names(self) -> list[str]:


### PR DESCRIPTION
Summary:
We observed aftering executing the aoti generated c++ wrapper with errors, the debugging messages would be truncated because the stdout is not flushed. This makes it difficult to locate the problematic kernel if we rely on the debug messages "before_kernel_xxx" and "after_kernel_xxx".
This diffs add fflush(stdout); at the end of the printing context manager.

Test Plan: Tested in local and it helped find the kernel that caused errors.

Differential Revision: D89572453




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo