### PR TITLE
[ROCm] Simplify has_hipsolver() version check

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1810,9 +1810,8 @@ def has_cusolver():
 
 
 def has_hipsolver():
-    rocm_version = _get_torch_rocm_version()
-    # hipSOLVER is disabled on ROCM < 5.3
-    return rocm_version >= (5, 3)
+    # hipSOLVER is available on all supported ROCm versions (6.0+)
+    return torch.version.hip is not None
 
 
 # Skips a test on CUDA/ROCM if cuSOLVER/hipSOLVER is not available


### PR DESCRIPTION
## What this does

Removes old version-checking code that's no longer needed.

The `has_hipsolver()` function used to check if ROCm was at least version 5.3 before saying hipSOLVER was available. But since PyTorch now requires ROCm 6.0+ anyway (see RELEASE.md), this check always passes. So we can just return `TEST_WITH_ROCM` directly.

## Why this is safe

- ROCm 6.0 is the minimum supported version
- hipSOLVER has been included since ROCm 5.3
- Every supported ROCm version has hipSOLVER
- No behavior change, just less code

## Before (9 lines)
```python
def has_hipsolver():
    if not TEST_WITH_ROCM:
        return False
    rocm_version = str(torch.version.hip)
    rocm_version = rocm_version.split("-")[0]
    rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
    return rocm_version_tuple >= (5, 3)
```

## After (2 lines)
```python
def has_hipsolver():
    return TEST_WITH_ROCM
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet