### PR TITLE
[ROCm] Update MIN_ROCM_VERSION to 6.0 in verify_dynamo.py

### DIFF
--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -7,7 +7,7 @@ import warnings
 
 
 MIN_CUDA_VERSION = "11.6"
-MIN_ROCM_VERSION = "5.4"
+MIN_ROCM_VERSION = "6.0"
 MIN_PYTHON_VERSION = (3, 10)
 
 


### PR DESCRIPTION
## What this does

Updates the minimum ROCm version constant from 5.4 to 6.0.

The `MIN_ROCM_VERSION` in `verify_dynamo.py` was still set to 5.4, but PyTorch now requires ROCm 6.0+ (check RELEASE.md).

## Why this is safe

This constant only affects warning messages in the verification script. If someone runs an old ROCm version, they'll see a more accurate warning now.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet