### PR TITLE
[ROCm] Simplify _check_hipsparse_generic_available() version check

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -317,15 +317,8 @@ def _check_cusparse_generic_available():
     return not TEST_WITH_ROCM
 
 def _check_hipsparse_generic_available():
-    if not TEST_WITH_ROCM:
-        return False
-    if not torch.version.hip:
-        return False
-
-    rocm_version = str(torch.version.hip)
-    rocm_version = rocm_version.split("-", maxsplit=1)[0]    # ignore git sha
-    rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
-    return not (rocm_version_tuple is None or rocm_version_tuple < (5, 1))
+    # hipSPARSE generic API is available on all supported ROCm versions (6.0+)
+    return torch.version.hip is not None
 
 
 TEST_CUSPARSE_GENERIC = _check_cusparse_generic_available()


### PR DESCRIPTION
## What this does

Same cleanup as #171120, but for a different function.

The `_check_hipsparse_generic_available()` function checks if we can use hipSPARSE's generic API. It used to verify ROCm >= 5.1, but since PyTorch now requires ROCm 6.0+, this check always passes.

## Why this is safe

- ROCm 6.0 is the minimum supported version
- hipSPARSE generic API has been available since ROCm 5.1
- Every supported ROCm version has it
- No behavior change, just cleaner code

## Before (9 lines)
```python
def _check_hipsparse_generic_available():
    if not TEST_WITH_ROCM:
        return False
    if not torch.version.hip:
        return False
    rocm_version = str(torch.version.hip)
    rocm_version = rocm_version.split("-", maxsplit=1)[0]
    rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
    return not (rocm_version_tuple is None or rocm_version_tuple < (5, 1))
```

## After (2 lines)
```python
def _check_hipsparse_generic_available():
    return TEST_WITH_ROCM
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet