### PR TITLE
[ROCm][Strix Halo] Fix for PermissionError in nvcc check - #167839

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -266,7 +266,7 @@ def _cuda_system_info_comment() -> str:
         cuda_version_lines = cuda_version_out.decode().split("\n")
         comment = "".join([f"# {s} \n" for s in cuda_version_lines if s != ""])
         model_str += f"{comment}\n"
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except (FileNotFoundError, PermissionError, subprocess.CalledProcessError):
         model_str += "# nvcc not found\n"
 
     gpu_names = Counter(


### PR DESCRIPTION
## Summary
On ROCm docker images, `nvcc` may exist but not be executable, causing a `PermissionError` that crashes dynamo debugging. This PR adds `PermissionError` to the exception handling in `_cuda_system_info_comment()` to gracefully handle this case.

## Problem
When running PyTorch on ROCm docker images, the dynamo debugging code attempts to run `nvcc --version` to collect CUDA info. If nvcc exists but is not executable (common in ROCm environments), a `PermissionError` is raised which crashes the entire inference pipeline.

Stack trace from issue:
```
File "/opt/venv/lib/python3.10/site-packages/torch/_dynamo/repro/after_aot.save_graph_repro"
...
PermissionError: [Errno 13] Permission denied: 'nvcc'
```

## Solution
Add `PermissionError` to the exception tuple in line 269 of `torch/_dynamo/debug_utils.py`:
```python
except (FileNotFoundError, PermissionError, subprocess.CalledProcessError):
    model_str += "# nvcc not found\n"
```

## Test Plan
This is a simple defensive fix that handles an edge case. The behavior is identical to the existing `FileNotFoundError` handling - it simply returns "# nvcc not found\n" instead of crashing.

Fixes #167839

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @janeyx99