### PR TITLE
[ROCm] Update outdated ROCm version references to 6.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -828,7 +828,7 @@ def get_latest_nightly_version(variant: str = "cpu") -> str:
 def download_and_extract_nightly_wheel(version: str) -> None:
     """Download and extract nightly PyTorch wheel for USE_NIGHTLY=VERSION builds."""
 
-    # Extract variant from version (e.g., cpu, cu121, cu118, rocm5.7)
+    # Extract variant from version (e.g., cpu, cu121, cu118, rocm6.2)
     variant = extract_variant_from_version(version)
     nightly_index_url = f"https://download.pytorch.org/whl/nightly/{variant}/"
 

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -419,7 +419,7 @@ class UsageLogger:
         elif self._has_amdsmi:
             # Iterate over the available GPUs
             for handle in self._gpu_handles:
-                # see https://rocm.docs.amd.com/projects/amdsmi/en/docs-5.7.0/py-interface_readme_link.html
+                # see https://rocm.docs.amd.com/projects/amdsmi/en/latest/how-to/amdsmi-py-lib.html
                 engine_usage = amdsmi.amdsmi_get_gpu_activity(handle)
                 gpu_uuid = amdsmi.amdsmi_get_gpu_device_uuid(handle)
                 gpu_utilization = engine_usage["gfx_activity"]

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1307,7 +1307,7 @@ def _get_amdsmi_handler(device: Device = None):
         amdsmi.amdsmi_init()
     except amdsmi.AmdSmiException as e:
         raise RuntimeError(
-            "amdsmi driver can't be loaded, requires >=ROCm5.6 installation"
+            "amdsmi driver can't be loaded, requires >=ROCm6.0 installation"
         ) from e
     device = _get_amdsmi_device_index(device)
     handle = amdsmi.amdsmi_get_processor_handles()[device]


### PR DESCRIPTION
## What this does

Updates three places where the code still mentions old ROCm versions (5.6, 5.7) to match the current minimum requirement of ROCm 6.0.

## Changes

1. **torch/cuda/__init__.py** - Error message said "requires >=ROCm5.6", now says "requires >=ROCm6.0"

2. **tools/stats/monitor.py** - Documentation link pointed to old ROCm 5.7.0 docs, now points to latest

3. **setup.py** - Example comment said "rocm5.7", now says "rocm6.2" (a current version)

## Why this matters

When users hit an error or read comments, they should see accurate version info. These were just outdated strings that slipped through.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet