### PR TITLE
[Test] Add FakeTensor test for ConvTranspose2d zero-size output

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1160,6 +1160,24 @@ class FakeTensorTest(TestCase):
         self.assertEqual(out[1].dtype, eye.dtype)
         self.assertEqual(out[2].dtype, eye.dtype)
 
+    def test_conv_transpose_zero_size_output(self):
+        # https://github.com/pytorch/pytorch/issues/171093
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("requires cuda")
+
+        with FakeTensorMode():
+            # ConvTranspose2d that produces zero-size output
+            # Output size = (input_size - 1) * stride - 2 * padding + kernel_size
+            #             = (2 - 1) * 2 - 2 * 2 + 2 = 0
+            #             = [1, 1, 0, 0]
+            conv = torch.nn.ConvTranspose2d(3, 1, 2, 2, 2, bias=False).cuda()
+            x = torch.randn(1, 3, 2, 2, device="cuda")
+
+            # This should NOT raise "Output size is too small" on CUDA with cuDNN
+            # logic in meta_registrations.py: if not is_cudnn: check(...)
+            out = conv(x)
+            self.assertEqual(out.shape, torch.Size([1, 1, 0, 0]))
+
 
 instantiate_parametrized_tests(FakeTensorTest)
 


### PR DESCRIPTION
Adds a regression test to 

test_fake_tensor.py
 verify zero-size output behavior for ConvTranspose2d in FakeTensorMode, as requested in [review](https://github.com/pytorch/pytorch/pull/171127).

The actual fix was already merged into main, so this PR just adds the missing test coverage to prevent regression.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo