### PR TITLE
[CUDA][cuBLAS] bump tolerances for `addmm_alignment`

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -258,7 +258,7 @@ class TestMatmulCuda(InductorTestCase):
         torch.backends.cuda.matmul.allow_fp16_accumulation = orig_fp16_accumulate
 
     @onlyCUDA
-    @toleranceOverride({torch.float16: xtol(atol=1e-3, rtol=2e-3)})
+    @toleranceOverride({torch.float16: xtol(atol=1e-3, rtol=3e-3)})
     @dtypes(torch.float16)
     def test_cublas_addmm_alignment(self, dtype):
         device = 'cuda'


### PR DESCRIPTION
Seems to fail otherwise on 5090 with 0.0% mismatches

cc @csarofeen @ptrblck @xwang233 @nWEIdia