### PR TITLE
[ROCm] Make grouped GEMM CK opt‑in via env and default to fallback path

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -85,6 +85,10 @@ std::string precision2str(Float32Precision prec) {
   TORCH_CHECK(false, "Invalid enum Float32Precision(", static_cast<int>(prec), ")");
 }
 
+#ifdef USE_ROCM
+static constexpr const auto rocm_allow_group_gemm_ck = "ROCM_ALLOW_GROUP_GEMM_CK";
+#endif
+
 Context::Context() = default;
 
 // TODO: This could be bad juju if someone calls globalContext() in the
@@ -227,6 +231,13 @@ bool Context::allowTF32OneDNN() const {
   TORCH_WARN("TF32 acceleration on top of oneDNN is available for Intel GPUs. The current Torch version does not have Intel GPU Support.");
   #endif
 }
+
+#ifdef USE_ROCM
+bool Context::rocmAllowGroupGemmCk() const {
+    const auto allow_group_gemm_ck = c10::utils::check_env(rocm_allow_group_gemm_ck) == true;
+    return allow_group_gemm_ck;
+}
+#endif
 
 bool Context::userEnabledFlashSDP() const {
   return enabled_flashSDP;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -382,6 +382,7 @@ class TORCH_API Context {
       bool allow_splitk = true);
   bool allowFP16AccumulationCuBLAS() const;
   void setAllowFP16AccumulationCuBLAS(bool /*b*/);
+  bool rocmAllowGroupGemmCk() const;
 
   // Matmuls can use a so-called "persistent" kernel which launches one CUDA
   // block for each SM on the GPU, and each block then iterates over multiple

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -6,6 +6,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Context.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/NamedTensor.h>
 #include <ATen/Dispatch.h>
@@ -667,33 +668,33 @@ std::optional<c10::ScalarType> out_dtype) {
   );
 #ifndef USE_ROCM
   bool use_fast_path = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true) && a_b_and_out_are_bf16;
-#else
-  // _scaled_mm_allowed_device is used here within _grouped_mm_cuda which seems incorrect since scale is not used.
-  // the _grouped_mm_fallback should be safe for any ROCm GPU since it's just calling typical mm/bmm
-  bool use_fast_path = false;
-  // On non CK system(w/ ROCm), make sure use_fast_path is false
-#if defined(USE_ROCM_CK_GEMM)
-  if (at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950"})) {
-    use_fast_path = true;
-  }
-#endif //USE_ROCM_CK_GEMM
-#endif
   const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
   if (use_fast_path) {
     // fast path, no d2h sync needed
-#ifndef USE_ROCM
     at::cuda::detail::bf16bf16_grouped_mm(mat_a, mat_b, offs, bias, out);
-#else
-#if defined(USE_ROCM_CK_GEMM)
-    at::hip::detail::group_gemm_ck(mat_a, mat_b, offs, bias, out);
-#else
-    TORCH_WARN("ROCm: Group Gemm through CK not selected.");
-#endif //USE_ROCM_CK_GEMM
-#endif
   } else {
     _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
   }
+#else
+  // On ROCm fast path routes to group_gemm_ck and slow path to _grouped_mm_fallback.
+  // Keep use_fast_path as false till ck kernel perf is optimal.
+  // To enable CK path, use env variable ROCM_ALLOW_GROUP_GEMM_CK=1.
+  bool use_fast_path = false;
+  // ifdef USE_ROCM_CK_GEMM is required since ROCm systems w/o CK should not call ck path.
+#if defined(USE_ROCM_CK_GEMM)
+  if (at::globalContext().rocmAllowGroupGemmCk() && at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950"})) {
+    use_fast_path = true;
+  }
+#endif //USE_ROCM_CK_GEMM
+  const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
+  Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+  if (use_fast_path) {
+    at::hip::detail::group_gemm_ck(mat_a, mat_b, offs, bias, out);
+  } else {
+    _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
+  }
+#endif //ifndef USE_ROCM
   return out;
 }
 

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: linear algebra"]
 
 import contextlib
+import os
 import time
 import unittest
 from itertools import product
@@ -9,6 +10,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn.functional as F
+from torch.profiler import profile, ProfilerActivity
 
 from torch.quantization._quantized_conversions import (
     pack_int4_to_int8,
@@ -29,6 +31,7 @@ from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
     onlyCUDA,
+    skipCUDAIfNotRocm,
     tol as xtol,
     toleranceOverride,
 )
@@ -82,6 +85,22 @@ def blas_library_context(backend):
         yield
     finally:
         torch.backends.cuda.preferred_blas_library(prev_backend)
+
+@contextlib.contextmanager
+def rocm_group_gemm_ck_env(value):
+    var = "ROCM_ALLOW_GROUP_GEMM_CK"
+    old = os.environ.get(var, None)
+    try:
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = old
 
 class TestMatmulCuda(InductorTestCase):
     def setUp(self):
@@ -679,6 +698,44 @@ class TestMatmulCuda(InductorTestCase):
             C = f(A, B.transpose(-2, -1), offs=offs)
             self.assertEqual(C, C_ref)
 
+    @skipCUDAIfNotRocm
+    def test_grouped_gemm_rocm_ck_flag(self):
+        CK_HINT = "kernel_grouped_gemm_xdl_splitk"
+        HIPBLASLT_HINT = "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs"
+
+        def uses_ck(kernels: set[str]) -> bool:
+            return any(CK_HINT in k for k in kernels)
+
+        def uses_hipblaslt(kernels: set[str]) -> bool:
+            return any(HIPBLASLT_HINT in k for k in kernels)
+
+        def run_grouped_mm():
+            device = "cuda"
+            dtype = torch.bfloat16
+            # row-major 3d-3d
+            G, M, N, K = 4, 16, 32, 64
+            a = torch.randn(G, M, K, device=device, dtype=dtype)
+            b = torch.randn(G, N, K, device=device, dtype=dtype)
+            # 3d-3d grouped GEMM: [G, M, K] @ [G, K, N]
+            out = F.grouped_mm(a, b.transpose(-2, -1), out_dtype=dtype)
+            return out
+
+        def collect_kernel_names():
+            kernels = set()
+            with profile(
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                record_shapes=False,
+                with_stack=False,
+            ) as prof:
+                run_grouped_mm()
+            for evt in prof.key_averages(group_by_input_shape=False):
+                kernels.add(evt.key)
+            return kernels
+
+        with rocm_group_gemm_ck_env(None):
+            self.assertTrue(uses_hipblaslt(collect_kernel_names()))
+        with rocm_group_gemm_ck_env("1"):
+            self.assertTrue(uses_ck(collect_kernel_names()))
 
     @onlyCUDA
     @parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])


### PR DESCRIPTION
On ROCm fast path routes to group_gemm_ck and slow path to _grouped_mm_fallback.
By default, fast path = False route is activated since CK path is not performant yet. 
To activate CK path, use ROCM_ALLOW_GROUP_GEMM_CK=1 env variable.

Cherry pick of https://github.com/pytorch/pytorch/pull/170159 to release/2.10 branch.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang