### PR TITLE
[vLLM] Fail the benchmark when there is no results

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -474,8 +474,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results
-        # DEBUG, TO BE REVERT ONCE https://github.com/pytorch/test-infra/pull/7620 LANDS
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-7619
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
         if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.check-tpu.outputs.has_tpu != 'true'
         with:
           benchmark-results-dir: test/test-reports

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -474,6 +474,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results
+        # DEBUG, TO BE REVERT ONCE https://github.com/pytorch/test-infra/pull/7620 LANDS
         uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-7619
         if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.check-tpu.outputs.has_tpu != 'true'
         with:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -474,7 +474,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-761
         if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.check-tpu.outputs.has_tpu != 'true'
         with:
           benchmark-results-dir: test/test-reports

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -474,7 +474,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-761
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-7619
         if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.check-tpu.outputs.has_tpu != 'true'
         with:
           benchmark-results-dir: test/test-reports

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -207,8 +207,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results to OSS benchmark database for the dashboard
-        # DEBUG, TO BE REVERTED ONCE https://github.com/pytorch/test-infra/pull/7620 lands
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-7619
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
         with:
           benchmark-results-dir: vllm-project/vllm/benchmarks/results
           benchmark-name: 'PyTorch x vLLM benchmark'

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -101,6 +101,7 @@ jobs:
             dist/torch-*.whl \
             dist/vision/torchvision-*.whl \
             dist/audio/torchaudio-*.whl \
+            dist/ao/torchao-*.whl \
             dist/vllm/vllm-*.whl \
             --extra-index-url https://download.pytorch.org/whl/cu129 \
             --index-strategy unsafe-best-match

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -202,9 +202,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results to OSS benchmark database for the dashboard
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-7619
         with:
           benchmark-results-dir: vllm-project/vllm/benchmarks/results
           benchmark-name: 'PyTorch x vLLM benchmark'
           dry-run: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          if-no-files-found: error

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -101,10 +101,14 @@ jobs:
             dist/torch-*.whl \
             dist/vision/torchvision-*.whl \
             dist/audio/torchaudio-*.whl \
-            dist/ao/torchao-*.whl \
             dist/vllm/vllm-*.whl \
             --extra-index-url https://download.pytorch.org/whl/cu129 \
             --index-strategy unsafe-best-match
+
+          # We can build and install torchao from its pinned commit in PyTorch
+          # too, but that pin is too old and nothing seems to use it. Let's
+          # install torchao from pypi then
+          uv pip install torchao==0.15.0 --torch-backend=cu129
 
       - name: Print some debug information
         env:
@@ -203,6 +207,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload the benchmark results to OSS benchmark database for the dashboard
+        # DEBUG, TO BE REVERTED ONCE https://github.com/pytorch/test-infra/pull/7620 lands
         uses: pytorch/test-infra/.github/actions/upload-benchmark-results@reland-7619
         with:
           benchmark-results-dir: vllm-project/vllm/benchmarks/results

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build PyTorch
         shell: bash
         env:
-          BUILD_ADDITIONAL_PACKAGES: 'vision audio torchao'
+          BUILD_ADDITIONAL_PACKAGES: 'vision audio'
         run: |
           set -eux
           bash .ci/pytorch/build.sh

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build PyTorch
         shell: bash
         env:
-          BUILD_ADDITIONAL_PACKAGES: 'vision audio ao'
+          BUILD_ADDITIONAL_PACKAGES: 'vision audio torchao'
         run: |
           set -eux
           bash .ci/pytorch/build.sh


### PR DESCRIPTION
Once https://github.com/pytorch/test-infra/pull/7620 lands, we can fail vLLM benchmark when there is no results.  It's necessary to track vLLM benchmark failures this way because I frequently see `vllm bench serve` failing instead of just performance regression.

This also installs torchao 0.15.0 from pypi.  I tried to use the pinned torchao commit from PyTorch, but it's too old, so I assume no one is using it at the moment.  I can ask someone from core to update the pinned torchao commit later if we need it.  Otherwise, getting the package from pypi is easier.