### PR TITLE
[CI] Update job-filter dependencies for cross-compile-linux-test job

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -86,7 +86,7 @@ jobs:
     secrets: inherit
 
   linux-jammy-cuda12_8-py3_10-gcc11-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda12.8-py3.10-gcc11 ') }}
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda12.8-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test ') }}
     name: linux-jammy-cuda12.8-py3.10-gcc11
     uses: ./.github/workflows/_linux-build.yml
     needs:
@@ -282,7 +282,7 @@ jobs:
     secrets: inherit
 
   win-vs2022-cuda12_8-py3-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' win-vs2022-cuda12.8-py3 ') }}
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' win-vs2022-cuda12.8-py3 ') || contains(needs.job-filter.outputs.jobs, ' cross-compile-linux-test ') }}
     name: win-vs2022-cuda12.8-py3
     uses: ./.github/workflows/_win-build.yml
     needs:


### PR DESCRIPTION
noticed that this job doesn't trigger when job-filter is specified, because dependencies are not met:

https://github.com/pytorch/pytorch/actions/workflows/trunk.yml?query=branch%3Atrunk%2F2a9a1cc632b8ce1000b131fe2f45d74a5abdc51a


(in the long term I'll add a linter for that)