### PR TITLE
[inductor] Update `codegen.cutlass_utils` to support `torch.float8_e5m2`

### DIFF
--- a/torch/_inductor/codegen/cuda/cuda_template.py
+++ b/torch/_inductor/codegen/cuda/cuda_template.py
@@ -361,6 +361,7 @@ class CUTLASSTemplate(CUDATemplate):
         torch.bool: "bool",
         torch.bfloat16: "cutlass::bfloat16_t",
         torch.float8_e4m3fn: "cutlass::float_e4m3_t",
+        torch.float8_e5m2: "cutlass::float_e5m2_t",
     }
 
     _DTYPE_TO_CUTLASS_SPARSE_META = {

--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -366,6 +366,11 @@ def get_accumulator_dtype(
     if len(input_torch_dtypes) != 2:
         return None
 
+    if OrderedSet(input_torch_dtypes) == OrderedSet(
+        [torch.float8_e5m2, torch.float8_e4m3fn]
+    ):
+        return torch.float
+
     torch_dtype = None
     if input_torch_dtypes[0] == input_torch_dtypes[1]:
         torch_dtype = input_torch_dtypes[0]
@@ -388,8 +393,6 @@ def get_accumulator_dtype(
         torch.float,
         torch.float8_e4m3fn,
         torch.float8_e5m2,
-    ) or OrderedSet([dtype0, dtype1]) == OrderedSet(
-        [torch.float8_e5m2, torch.float8_e4m3fn]
     ):
         accumulator_dtype = torch.float
     elif torch_dtype == torch.int8:


### PR DESCRIPTION
This pull request adds support for the `torch.float8_e5m2` data type to the CUTLASS backend in TorchInductor, enabling mixed FP8 (e4m3fn x e5m2) matrix multiplication and ensuring correct type handling throughout the codebase. The main changes include updating type mappings, alignment logic, and accumulator selection, as well as introducing a new test for mixed FP8 dtypes.

### FP8 (e5m2) Support in CUTLASS Backend

* Added `torch.float8_e5m2` to the set of supported CUTLASS input types (`XW_DTYPES`) and updated the mapping to corresponding CUTLASS and CUDA types (`cutlass::float_e5m2_t`, `__nv_fp8_e5m2`).
* Updated the `dtype_match` function to handle `torch.float8_e5m2` correctly when matching with CUTLASS data types.
* Modified alignment logic in `get_alignments` to include `torch.float8_e5m2` alongside `torch.float8_e4m3fn`.
* Enhanced accumulator type selection in `get_accumulator_dtype` to support mixed FP8 types and ensure correct accumulator dtype for `torch.float8_e5m2`.

### Testing

* Added a new test, `test_cutlass_backend_fp8_scaled_mm_mixed_dtypes`, to verify CUTLASS backend functionality with mixed FP8 dtypes (`e4m3fn` x `e5m2`).

Fixes #171165.

Used GPT-5.2

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos