### PR TITLE
Fix dead code in RNNCell error handling

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1637,7 +1637,6 @@ class RNNCell(RNNCellBase):
                 self.bias_hh,
             )
         else:
-            ret = input  # TODO: remove when jit supports exception flow
             raise RuntimeError(f"Unknown nonlinearity: {self.nonlinearity}")
 
         if not is_batched:


### PR DESCRIPTION
**Problem:**
The code assigned `ret = input` before raising a RuntimeError for unknown nonlinearity, but this assignment was never used since the exception is raised immediately after.

**Solution:**
Removed the unused assignment, cleaning up the code and addressing the TODO comment about removing this workaround.

**Impact:**
- Eliminates confusing dead code
- Cleaner exception handling
- Addresses existing TODO comment

