### PR TITLE
Fix wrong exception types in RNN forward method

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -733,10 +733,10 @@ class RNN(RNNBase):
                 hx = self.permute_hidden(hx, sorted_indices)
 
         if hx is None:
-            raise AssertionError("hx must not be None")
+            raise RuntimeError("hx must not be None")
         self.check_forward_args(input, hx, batch_sizes)
         if self.mode != "RNN_TANH" and self.mode != "RNN_RELU":
-            raise AssertionError(f"mode must be RNN_TANH or RNN_RELU, got {self.mode}")
+            raise ValueError(f"mode must be RNN_TANH or RNN_RELU, got {self.mode}")
         if batch_sizes is None:
             if self.mode == "RNN_TANH":
                 result = _VF.rnn_tanh(


### PR DESCRIPTION
Replace AssertionError with proper exception types:
- hx must not be None' now raises RuntimeError (user-facing error)
- Invalid mode check now raises ValueError (validation error)

AssertionError should only be used for internal invariants, not user-facing validation errors.


