### PR TITLE
Fix dead code in reduction enum error handling

### DIFF
--- a/torch/nn/_reduction.py
+++ b/torch/nn/_reduction.py
@@ -19,7 +19,6 @@ def get_enum(reduction: str) -> int:
     elif reduction == "sum":
         ret = 2
     else:
-        ret = -1  # TODO: remove once JIT exceptions support control flow
         raise ValueError(f"{reduction} is not a valid value for reduction")
     return ret
 


### PR DESCRIPTION
Remove unused assignment 'ret = -1' that precedes ValueError. The variable is never used since the exception is raised immediately.



