### PR TITLE
Fix wrong exception type in embedding padding_idx validation

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2545,10 +2545,10 @@ def embedding(
     if padding_idx is not None:
         if padding_idx > 0:
             if padding_idx >= weight.size(0):
-                raise AssertionError("Padding_idx must be within num_embeddings")
+                raise ValueError("Padding_idx must be within num_embeddings")
         elif padding_idx < 0:
             if padding_idx < -weight.size(0):
-                raise AssertionError("Padding_idx must be within num_embeddings")
+                raise ValueError("Padding_idx must be within num_embeddings")
             padding_idx = weight.size(0) + padding_idx
     else:
         padding_idx = -1


### PR DESCRIPTION
Replace AssertionError with ValueError for padding_idx validation.

AssertionError should be used for internal invariants, while ValueError is appropriate for user-provided parameter validation. The padding_idx parameter is user-facing and should raise ValueError when out of bounds.


