### PR TITLE
Fix wrong exception type in TensorDataset.__init__

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -199,7 +199,7 @@ class TensorDataset(Dataset[tuple[Tensor, ...]]):
 
     def __init__(self, *tensors: Tensor) -> None:
         if all(tensors[0].size(0) != tensor.size(0) for tensor in tensors):
-            raise AssertionError("Size mismatch between tensors")
+            raise ValueError("Size mismatch between tensors")
         self.tensors = tensors
 
     def __getitem__(self, index):


### PR DESCRIPTION
Changed AssertionError to ValueError for tensor size validation in TensorDataset.

AssertionError is for internal code checks, not user input validation. When users provide tensors with different sizes to TensorDataset, they should get ValueError instead.

This makes error handling consistent with other PyTorch APIs that validate user input.

