### PR TITLE
Add CUTLASS backend support for torch.float8_e5m2 dtype

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -634,9 +634,7 @@ class TestCutlassBackend(TestCase):
         a8 = torch.randn(m, k, device="cuda", dtype=torch.float16).to(
             torch.float8_e4m3fn
         )
-        b8 = torch.randn(k, n, device="cuda", dtype=torch.float16).to(
-            torch.float8_e5m2
-        )
+        b8 = torch.randn(k, n, device="cuda", dtype=torch.float16).to(torch.float8_e5m2)
         # _scaled_mm requires mat2 to be column-major
         b8 = b8.t().contiguous().t()
 

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -634,7 +634,9 @@ class TestCutlassBackend(TestCase):
         a8 = torch.randn(m, k, device="cuda", dtype=torch.float16).to(
             torch.float8_e4m3fn
         )
-        b8 = torch.randn(k, n, device="cuda", dtype=torch.float16).to(torch.float8_e5m2)
+        b8 = torch.randn(k, n, device="cuda", dtype=torch.float16).to(
+            torch.float8_e5m2
+        )
         # _scaled_mm requires mat2 to be column-major
         b8 = b8.t().contiguous().t()
 

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -391,21 +391,17 @@ def get_accumulator_dtype(
     if input_torch_dtypes[0] == input_torch_dtypes[1]:
         torch_dtype = input_torch_dtypes[0]
     else:
-        fp8_types = {torch.float8_e4m3fn, torch.float8_e5m2}
-        if set(input_torch_dtypes).issubset(fp8_types):
-            torch_dtype = torch.float8_e4m3fn  # Mixed FP8 types use float32 accumulator
+        size0 = torch.tensor([], dtype=input_torch_dtypes[0]).element_size()
+        size1 = torch.tensor([], dtype=input_torch_dtypes[1]).element_size()
+        if size0 > size1:
+            dtype0, dtype1 = input_torch_dtypes
         else:
-            size0 = torch.tensor([], dtype=input_torch_dtypes[0]).element_size()
-            size1 = torch.tensor([], dtype=input_torch_dtypes[1]).element_size()
-            if size0 > size1:
-                dtype0, dtype1 = input_torch_dtypes
-            else:
-                dtype1, dtype0 = input_torch_dtypes
-            if dtype0 in [torch.half, torch.bfloat16] and dtype1 in [
-                torch.int8,
-                torch.uint8,
-            ]:
-                torch_dtype = dtype0
+            dtype1, dtype0 = input_torch_dtypes
+        if dtype0 in [torch.half, torch.bfloat16] and dtype1 in [
+            torch.int8,
+            torch.uint8,
+        ]:
+            torch_dtype = dtype0
 
     if torch_dtype in (
         torch.float16,

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -328,6 +328,10 @@ def torch_dtype_to_cutlass_type(
         return cutlass_library.library.DataType.f16
     elif torch_dtype == torch.bfloat16:
         return cutlass_library.library.DataType.bf16
+    elif torch_dtype == torch.float8_e4m3fn:
+        return cutlass_library.library.DataType.e4m3
+    elif torch_dtype == torch.float8_e5m2:
+        return cutlass_library.library.DataType.e5m2
     else:
         raise NotImplementedError(f"Unsupported data type: {torch_dtype=}")
 
@@ -387,17 +391,21 @@ def get_accumulator_dtype(
     if input_torch_dtypes[0] == input_torch_dtypes[1]:
         torch_dtype = input_torch_dtypes[0]
     else:
-        size0 = torch.tensor([], dtype=input_torch_dtypes[0]).element_size()
-        size1 = torch.tensor([], dtype=input_torch_dtypes[1]).element_size()
-        if size0 > size1:
-            dtype0, dtype1 = input_torch_dtypes
+        fp8_types = {torch.float8_e4m3fn, torch.float8_e5m2}
+        if set(input_torch_dtypes).issubset(fp8_types):
+            torch_dtype = torch.float8_e4m3fn  # Mixed FP8 types use float32 accumulator
         else:
-            dtype1, dtype0 = input_torch_dtypes
-        if dtype0 in [torch.half, torch.bfloat16] and dtype1 in [
-            torch.int8,
-            torch.uint8,
-        ]:
-            torch_dtype = dtype0
+            size0 = torch.tensor([], dtype=input_torch_dtypes[0]).element_size()
+            size1 = torch.tensor([], dtype=input_torch_dtypes[1]).element_size()
+            if size0 > size1:
+                dtype0, dtype1 = input_torch_dtypes
+            else:
+                dtype1, dtype0 = input_torch_dtypes
+            if dtype0 in [torch.half, torch.bfloat16] and dtype1 in [
+                torch.int8,
+                torch.uint8,
+            ]:
+                torch_dtype = dtype0
 
     if torch_dtype in (
         torch.float16,


### PR DESCRIPTION
Add CUTLASS backend support for torch.float8_e5m2 dtype

Fixes assertion error in torch._scaled_mm with mixed FP8 dtypes during
FP8 training backward pass. When using torch.compile with CUTLASS backend,
torch._scaled_mm failed when called with mixed FP8 dtypes (float8_e4m3fn
and float8_e5m2).

The CUTLASS backend was missing support for torch.float8_e5m2. This adds:

CUTLASS backend (cutlass_utils.py):
- Added torch.float8_e5m2 to XW_DTYPES (supported input types)
- Added CUDA type mapping (__nv_fp8_e5m2)
- Added CUTLASS library DataType mapping (DataType.e5m2)
- Added dtype matching logic for e5m2
- Added accumulator dtype inference (uses float32 like e4m3fn)
- Added alignment support [16, 8, 4, 2] elements
- Fixed get_accumulator_dtype to handle mixed FP8 types

TMA compatibility (utils.py):
- Added torch.float8_e5m2 to TMA-compatible dtypes check
- Added e5m2 to FP8 special case requiring inner dimension >= 32

This enables mixed FP8 precision operations (e4m3fn x e5m2) in
CUTLASS-accelerated kernels, particularly for FP8 training backward passes.

Fixes #171165

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo