### PR TITLE
[ROCm][Windows] Add -std=c++17 to HIP_HIPCC_FLAGS

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1033,6 +1033,7 @@ if(USE_ROCM)
       list(APPEND HIP_CXX_FLAGS -DUSE_ROCM_CK_GEMM)
     endif()
     list(APPEND HIP_HIPCC_FLAGS --offload-compress)
+    list(APPEND HIP_HIPCC_FLAGS -std=c++17)
     # Pass device library path for theRock nightly builds
     if(DEFINED ENV{HIP_DEVICE_LIB_PATH})
       list(APPEND HIP_HIPCC_FLAGS --rocm-device-lib-path=$ENV{HIP_DEVICE_LIB_PATH})


### PR DESCRIPTION
To fix build error with C++17 when building *.hip files.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @ScottTodd 
