### PR TITLE
[Inductor] Fix Triton kernel name mangling in WrapperCodeGen

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2300,6 +2300,11 @@ class PythonWrapperCodegen(CodeGen):
         gpu: bool = True,
         cpp_definition: Optional[str] = None,
     ):
+        # Fix for https://github.com/pytorch/pytorch/issues/170398
+        # Escape kernel names that start with double underscores to avoid name mangling
+        if kernel_name.startswith("__"):
+            kernel_name = "triton_" + kernel_name
+
         self.writeline(
             KernelDefinitionLine(
                 self,
@@ -2864,6 +2869,10 @@ class PythonWrapperCodegen(CodeGen):
         triton: Defines whether the backend uses Triton for codegen. Otherwise it uses the CUDA language when gpu=True,
                 and C++ when gpu=False.
         """
+        # Fix for https://github.com/pytorch/pytorch/issues/170398
+        # Escape kernel names that start with double underscores to avoid name mangling
+        if kernel_name.startswith("__"):
+            kernel_name = "triton_" + kernel_name
 
         # Store buffers corresponding to each call arg.
         # This is used to generate example args for autotuning later on.


### PR DESCRIPTION
### **Fixes #170398**
## Summary
This PR fixes a regression in `torch.compile` where Triton kernels generated with names starting with double underscores (e.g., `__mm_kernel_0`) cause a `NameError` when executed within a class context (such as the `Runner` class).

## The Bug
As identified in issue #170398, when a kernel variable is named `__mm_kernel_0`, Python's class-private name mangling transforms it into `_Runner__mm_kernel_0` at runtime if the execution occurs inside a class. Because the kernel definition itself remains `__mm_kernel_0`, this mismatch leads to the following error:

`NameError: name '_Runner__mm_kernel_0' is not defined`

## The Fix
I have updated `torch/_inductor/codegen/wrapper.py` to sanitize generated kernel names. Both `define_kernel` and `generate_kernel_call` now check for kernel names starting with `__` and prefix them with `triton_` (transforming `__mm_kernel_0` into `triton___mm_kernel_0`). This safely bypasses Python's name mangling behavior and ensures the definition and the call site match.

## Test Plan
The fix has been verified against the reproduction script provided in the original issue. I am relying on the existing CI suite to confirm there are no regressions across different GPU environments.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo