### PR TITLE
Fix TestNN upsampling_bfloat16 test failure & enable test_nn on Arm

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1749,7 +1749,7 @@ test_executorch() {
 }
 
 test_linux_aarch64() {
-  python test/run_test.py --include test_modules test_mkldnn test_mkldnn_fusion test_openmp test_torch test_dynamic_shapes \
+  python test/run_test.py --include test_modules test_nn test_mkldnn test_mkldnn_fusion test_openmp test_torch test_dynamic_shapes \
         test_transformers test_multiprocessing test_numpy_interop test_autograd test_binary_ufuncs test_complex test_spectral_ops \
         test_foreach test_reductions test_unary_ufuncs test_tensor_creation_ops test_ops profiler/test_memory_profiler \
         distributed/elastic/timer/api_test distributed/elastic/timer/local_timer_example distributed/elastic/timer/local_timer_test \


### PR DESCRIPTION
## Description
As in the title, this patch fix a test failure of `TestNN upsampling_bfloat16 test failure` on Arm and thereby enabling `TestNN` on the same platform.
## Test
```
python test/test_nn.py TestNN.test_upsampling_bfloat16
```
## Environment
AWS c8g. 16xlarge with Ubuntu 24.04.1

cc: @robert-hardwick @aditew01 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @mruberry @snadampal @milpuz01 @nikhil-arm @fadara01 @nWEIdia