### PR TITLE
Set a separate build env for each inductor build

### DIFF
--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      build-environment: linux-jammy-py3.12-gcc11
+      build-environment: linux-jammy-py3.12-gcc11-halide
       docker-image-name: ci-image:pytorch-linux-jammy-py3.12-halide
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
@@ -89,7 +89,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      build-environment: linux-jammy-py3.12-gcc11
+      build-environment: linux-jammy-py3.12-gcc11-pallas
       docker-image-name: ci-image:pytorch-linux-jammy-py3.12-pallas
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
@@ -113,7 +113,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
-      build-environment: linux-jammy-py3.12-gcc11
+      build-environment: linux-jammy-py3.12-gcc11-triton-cpu
       docker-image-name: ci-image:pytorch-linux-jammy-py3.12-triton-cpu
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |


### PR DESCRIPTION
The pallas tests are failing flakily https://hud.pytorch.org/hud/pytorch/pytorch/426deda9c50d98084cb39dae39dbc43b77b5cb61/1?per_page=100&name_filter=pallas&mergeEphemeralLF=true

If you look at the builds for the failing ones, they all reuse the old wheel, but the succeeding ones rebuild the wheel.  

There are 3 builds in the inductor unittest workflow that set the same build environment.  The build environment controls where in s3 the built binary gets stored and retrieved.

My guess is that the 3 builds are slightly different, but because they all upload to the same place, an incorrect one gets pulled by the reuse wheel step, but when a rebuild happens, since the test job runs right after the build job, which would have uploaded the correct wheel, it much less likely to pull a binary from a different build.

This PR makes each of the build environment names different so they upload the binary to different places, which should make it impossible to pull the wrong binary.

Even if this is not the cause, it's probably a good idea to do this anyway