### PR TITLE
[MPS][BE] Do not use deprecated `isIntegralType` method

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -29,7 +29,7 @@ static void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp
   if (!exp_scalar.isComplex() && exp_scalar.to<float>() == 2.0) {
     return lib.exec_unary_kernel(iter, "sqr");
   }
-  if (c10::isIntegralType(iter.common_dtype())) {
+  if (c10::isIntegralType(iter.common_dtype(), true)) {
     return lib.exec_unary_kernel(iter, "pow_scalar", exp_scalar, kInt);
   }
   if (!exp_scalar.isComplex() && exp_scalar.to<float>() == -1.0) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #171200

Fixes following compilation warning
```
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/mps/operations/UnaryKernel.mm:32:12: warning: 'isIntegralType' is deprecated: isIntegralType is deprecated. Please use the overload with 'includeBool' parameter instead. [-Wdeprecated-declarations]
```