### PR TITLE
[Inductor] Fix unbacked-symint stride ordering, add regression tests

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -177,6 +177,54 @@ from user code:
     it = iter(items)""",
         )
 
+    def test_noncontiguous_out_tensor_graph_break(self):
+        def fn(x):
+            out = torch.empty_like(x).transpose(0, 1)
+            return torch.ops.aten.add.out(x, 1, out=out)
+
+        self.assertExpectedInlineMunged(
+            Unsupported,
+            lambda: torch.compile(fn, backend="eager", fullgraph=True)(
+                torch.randn(2, 2)
+            ),
+            """\
+Attempted to call op with non-contiguous `out=` tensor
+  Explanation: Dynamo does not support this.
+  Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
+
+  Developer debug context: self.value=aten.add.out, args=[TensorVariable(), ConstantVariable(int: 1)], kwargs={'out': TensorVariable()}
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0242.html
+
+from user code:
+   File "test_error_messages.py", line N, in fn
+    return torch.ops.aten.add.out(x, 1, out=out)""",
+        )
+
+    def test_noncontiguous_out_list_graph_break(self):
+        def fn(x):
+            out = x.t()
+            return torch.ops.aten._foreach_add.Scalar_out((x,), 1, out=(out,))
+
+        self.assertExpectedInlineMunged(
+            Unsupported,
+            lambda: torch.compile(fn, backend="eager", fullgraph=True)(
+                torch.randn(2, 2)
+            ),
+            """\
+Attempted to call op with non-contiguous `out=` list of tensors
+  Explanation: Dynamo does not support this.
+  Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
+
+  Developer debug context: self.value=aten._foreach_add.Scalar_out, args=[TupleVariable(length=1), ConstantVariable(int: 1)], kwargs={'out': TupleVariable(length=1)}
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0241.html
+
+from user code:
+   File "test_error_messages.py", line N, in fn
+    return torch.ops.aten._foreach_add.Scalar_out((x,), 1, out=(out,))""",
+        )
+
     def test_super_call_function(self):
         def fn(it):
             return [x + 1 for x in it()]
@@ -888,6 +936,32 @@ Data-dependent branching
 from user code:
    File "test_error_messages.py", line N, in fn
     if x.sum() > 0:""",
+        )
+
+    def test_data_dependent_branching_tensor_all(self):
+        def fn(attention_mask):
+            if attention_mask.all():
+                return attention_mask + 1
+            return attention_mask - 1
+
+        self.assertExpectedInlineMunged(
+            Unsupported,
+            lambda: torch.compile(fn, backend="eager", fullgraph=True)(
+                torch.ones(2, 2, dtype=torch.bool)
+            ),
+            """\
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+
+from user code:
+   File "test_error_messages.py", line N, in fn
+    if attention_mask.all():""",
         )
 
     # Test that the bytecode source attribution is correct with VariableTracker

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -61,6 +61,7 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     IS_SANDCASTLE,
     parametrize,
+    scoped_load_inline,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
@@ -2465,6 +2466,7 @@ class TestFxGraphCacheHashing(TestCase):
                 pickler.dumps(torch.randn(3, 3)),
                 pickler.dumps(torch.randn(3, 4)),
             )
+
             self.assertNotEqual(
                 pickler.dumps(torch.randn(3, 3)),
                 pickler.dumps(torch.randn(4, 3)),
@@ -2537,6 +2539,43 @@ class TestFxGraphCacheHashing(TestCase):
                     pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:0")),
                     pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
                 )
+
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    @scoped_load_inline
+    def test_pybind_function_in_graph_cache_key(self, load_inline):
+        reset()
+        cpp_source = """
+#include <torch/extension.h>
+
+torch::Tensor foobar(torch::Tensor x) {
+  return x + 1;
+}
+        """
+
+        module = load_inline(
+            name="test_pybind_cache_key",
+            cpp_sources=cpp_source,
+            functions="foobar",
+            verbose=False,
+        )
+        torch.compiler.allow_in_graph(module.foobar)
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def f(x):
+            return module.foobar(x)
+
+        x = torch.ones(2, 2)
+        try:
+            out = f(x)
+        except Exception as exc:
+            msg = str(exc)
+            self.assertNotIn("pybind11_detail_function_record", msg)
+            self.assertNotIn("pickle", msg)
+            if isinstance(exc, torch._dynamo.exc.Unsupported):
+                return
+            raise
+
+        self.assertEqual(out, x + 1)
 
     def test_hash_kwargs(self):
         """

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -288,6 +288,25 @@ class TestInductorDynamic(TestCase):
         opt_r = opt_f(splits)
         self.assertEqual(r, opt_r)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_symbool_guard_does_not_become_graph_input(self, device):
+        def f(x):
+            n = x.sum().item()
+            torch._check(n > 0)
+            return (x * 2).sum()
+
+        compiled_f = torch.compile(f, fullgraph=True, dynamic=True)
+        x = torch.ones(4, device=device, requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_(True)
+
+        y = compiled_f(x)
+        y_ref = f(x_ref)
+        y.backward()
+        y_ref.backward()
+
+        self.assertEqual(y, y_ref)
+        self.assertEqual(x.grad, x_ref.grad)
+
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
     def test_nonzero_size_factory_nobreak(self, device):
         def f(x, b):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1885,9 +1885,7 @@ class GraphLowering(torch.fx.Interpreter):
                             result = ir.ExternKernel.require_stride_order(
                                 result,
                                 ir.get_stride_order(
-                                    make_channels_last_strides_for(
-                                        n.meta["val"].shape
-                                    ),
+                                    make_channels_last_strides_for(n.meta["val"].shape),
                                     self._shape_env,
                                 ),
                             )

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1873,7 +1873,9 @@ class GraphLowering(torch.fx.Interpreter):
                         if user.target in need_fixed_layout:
                             result = ir.ExternKernel.require_stride_order(
                                 result,
-                                ir.get_stride_order(n.meta["val"].stride()),
+                                ir.get_stride_order(
+                                    n.meta["val"].stride(), self._shape_env
+                                ),
                                 allow_padding=True,
                             )
                         if (
@@ -1883,7 +1885,10 @@ class GraphLowering(torch.fx.Interpreter):
                             result = ir.ExternKernel.require_stride_order(
                                 result,
                                 ir.get_stride_order(
-                                    make_channels_last_strides_for(n.meta["val"].shape)
+                                    make_channels_last_strides_for(
+                                        n.meta["val"].shape
+                                    ),
+                                    self._shape_env,
                                 ),
                             )
                     if user.op == "output":


### PR DESCRIPTION
I found some issues while testing some new dependencies for another project. One of the issues was a bug in torch, addressed by "fix unbacked-symint stride ordering". This PR contains that fix and adds a test for it. I also added some tests which confirmed other issues were downstream.

## Summary

- Fix Inductor stride-ordering to pass a ShapeEnv, avoiding data-dependent guards when unbacked symints appear in strides.
- Add Dynamo error-message regression tests for non-contiguous out= tensor/list and attention_mask.all() data-dependent branching (gb0242/gb0241/gb0170).
- Add Inductor regression tests for SymBool guards as graph inputs and unbacked symint backward dependencies.
- Add fx graph cache hashing regression test for pybind function objects.

cc @ezyang @penguinwu @bobrenjc93 @aditvenk @laithsakka @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @mlazos