### PR TITLE
follow fn calls in find_triton_kernels

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -1117,6 +1117,68 @@ class AOTAutogradCacheTests(InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_triton_op_recursive_function_kernel_detection(self):
+        """
+        Test that triton kernels hidden behind helper function calls are detected.
+
+        This tests the recursive function analysis capability where:
+            def helper():
+                capture_triton(my_kernel)[grid](...)
+
+            @triton_op(...)
+            def my_op(x):
+                helper()  # kernel is inside helper, not directly in my_op
+
+        The recursive analysis in get_inner_triton_kernels should trace
+        into helper functions to find the triton kernels.
+        """
+        from torch._library import capture_triton
+        from torch._library.triton import triton_ops_to_kernels
+
+        @triton.jit
+        def nested_kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            tl.store(x_ptr + offsets, x + 100, mask=mask)
+
+        def helper_that_calls_kernel(y, n_elements):
+            """Helper function that contains the triton kernel call."""
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+            capture_triton(nested_kernel)[grid](y, n_elements, BLOCK_SIZE=256)
+
+        @torch._library.triton_op("test::recursive_func_triton_op", mutates_args=())
+        def recursive_func_triton_op(x: torch.Tensor) -> torch.Tensor:
+            y = x.clone()
+            n_elements = y.numel()
+            # The kernel is hidden inside helper_that_calls_kernel
+            helper_that_calls_kernel(y, n_elements)
+            return y
+
+        kernels = triton_ops_to_kernels.get("test::recursive_func_triton_op", [])
+        self.assertGreater(
+            len(kernels),
+            0,
+            "Recursive function analysis should detect the kernel in helper function",
+        )
+
+        kernel_names = [getattr(k, "__name__", str(k)) for k in kernels]
+        self.assertIn(
+            "nested_kernel",
+            kernel_names,
+            f"nested_kernel should be detected, got: {kernel_names}",
+        )
+
+        a = torch.randn(5, device=GPU_TYPE)
+        expected = a.clone() + 100
+        result = torch.ops.test.recursive_func_triton_op(a)
+        self.assertEqual(result, expected)
+
+    @requires_cuda_and_triton
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     @unittest.expectedFailure  # Currently ops that call other ops does not properly invalidate cache
     def test_triton_op_cache_multiple_ops_invalidation(self):
         @triton.jit

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -208,7 +208,7 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
 
             # not in globals/nonlocals/builtins, check if it's a local assignment
             if name not in collector.assignments:
-                logger.warning(f"{name} not in collector.assignments")
+                logger.warning("%s not in collector.assignments", name)
                 return []
 
             # trace through assignments - collect all names referenced in RHS

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -33,6 +33,9 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
 
     It also recursively analyzes called functions to find triton kernels hidden
     behind helper function calls.
+
+    That said, it is best effort. There are cases (e.g., recursion > MAX_RECURSION_DEPTH)
+    that are not accounted for, so keep that in mind.
     """
 
     # prevent infinite recursion
@@ -256,8 +259,10 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
                     if kernel_id not in seen_ids:
                         seen_ids.add(kernel_id)
                         resolved.append(kernel)
-            except Exception as e:
-                logger.debug("failed to analyze called function %s: %s", func_name, e)
+            except Exception:
+                logger.debug(
+                    "failed to analyze called function %s", func_name, exc_info=True
+                )
 
         return resolved
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #171218
* __->__ #171202

Summary:
follow-up to https://github.com/pytorch/pytorch/pull/171118, handling the todo about tracing through function calls

Test Plan:
python -m pytest test/dynamo/test_aot_autograd_cache.py::AOTAutogradCacheTests -k "test_triton_op" -v

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo