### PR TITLE
Add missing thrust include.

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -26,6 +26,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
 #include <thrust/generate.h>
+#include <thrust/pair.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>


### PR DESCRIPTION
This is included implicitly, but we use it directly; if thrust were to ever clean up its header inclusions we would need to include pair.