### PR TITLE
[ROCm] Handle AMDSMI exception in clock_rate() for MI300X

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1376,7 +1376,12 @@ def _get_amdsmi_power_draw(device: Device = None) -> int:
 
 def _get_amdsmi_clock_rate(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    clock_info = amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)
+    try:
+        clock_info = amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)
+    except amdsmi.AmdSmiLibraryException:
+        # Some GPU architectures (e.g., MI300X) may return
+        # AMDSMI_STATUS_UNEXPECTED_DATA for clock info queries
+        return 0
     if "cur_clk" in clock_info:  # ROCm 6.2 deprecation
         clock_rate = clock_info["cur_clk"]
     else:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1378,9 +1378,10 @@ def _get_amdsmi_clock_rate(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
     try:
         clock_info = amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)
-    except amdsmi.AmdSmiLibraryException:
+    except amdsmi.AmdSmiLibraryException as e:
         # Some GPU architectures (e.g., MI300X) may return
         # AMDSMI_STATUS_UNEXPECTED_DATA for clock info queries
+        warnings.warn(f"Unable to get clock info via AMDSMI: {e}", stacklevel=2)
         return 0
     if "cur_clk" in clock_info:  # ROCm 6.2 deprecation
         clock_rate = clock_info["cur_clk"]


### PR DESCRIPTION
## Summary

On AMD Instinct MI300X GPUs, calling `amdsmi_get_clock_info()` raises `AmdSmiLibraryException` with `AMDSMI_STATUS_UNEXPECTED_DATA` error code (43). This causes `torch.cuda.clock_rate()` to crash instead of returning gracefully.

**Before this fix:**
```python
>>> torch.cuda.clock_rate()
amdsmi.amdsmi_exception.AmdSmiLibraryException: Error code: 43 | AMDSMI_STATUS_UNEXPECTED_DATA
```

**After this fix:**
```python
>>> torch.cuda.clock_rate()
0
```

## Changes

Added exception handling to `_get_amdsmi_clock_rate()` to catch `AmdSmiLibraryException` and return 0, consistent with how other "N/A" cases are handled in the same function.

## Testing

Tested on AMD Instinct MI300X (gfx942) via AMD Developer Cloud:
- PyTorch: 2.5.0a0+gitcedc116
- ROCm: 6.2.41133
- GPU: AMD Instinct MI300X VF (192GB)

## Related

This fix may enable re-enabling `test_clock_speed` in `test/test_cuda.py` which is currently skipped for MI300 architecture with `@skipIfRocmArch(MI300_ARCH)`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang