### PR TITLE
[ROCm] Handle AMDSMI exception in utilization() and memory_usage() for MI300X

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1344,12 +1344,22 @@ def _get_amdsmi_device_memory_used(device: Device = None) -> int:
 
 def _get_amdsmi_memory_usage(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_gpu_activity(handle)["umc_activity"]
+    try:
+        return amdsmi.amdsmi_get_gpu_activity(handle)["umc_activity"]
+    except amdsmi.AmdSmiLibraryException:
+        # Some GPU architectures (e.g., MI300X) may return
+        # AMDSMI_STATUS_UNEXPECTED_DATA for activity queries
+        return 0
 
 
 def _get_amdsmi_utilization(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_gpu_activity(handle)["gfx_activity"]
+    try:
+        return amdsmi.amdsmi_get_gpu_activity(handle)["gfx_activity"]
+    except amdsmi.AmdSmiLibraryException:
+        # Some GPU architectures (e.g., MI300X) may return
+        # AMDSMI_STATUS_UNEXPECTED_DATA for activity queries
+        return 0
 
 
 def _get_amdsmi_temperature(device: Device = None) -> int:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1346,9 +1346,10 @@ def _get_amdsmi_memory_usage(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
     try:
         return amdsmi.amdsmi_get_gpu_activity(handle)["umc_activity"]
-    except amdsmi.AmdSmiLibraryException:
+    except amdsmi.AmdSmiLibraryException as e:
         # Some GPU architectures (e.g., MI300X) may return
         # AMDSMI_STATUS_UNEXPECTED_DATA for activity queries
+        warnings.warn(f"Unable to get memory usage via AMDSMI: {e}", stacklevel=2)
         return 0
 
 
@@ -1356,9 +1357,10 @@ def _get_amdsmi_utilization(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
     try:
         return amdsmi.amdsmi_get_gpu_activity(handle)["gfx_activity"]
-    except amdsmi.AmdSmiLibraryException:
+    except amdsmi.AmdSmiLibraryException as e:
         # Some GPU architectures (e.g., MI300X) may return
         # AMDSMI_STATUS_UNEXPECTED_DATA for activity queries
+        warnings.warn(f"Unable to get GPU utilization via AMDSMI: {e}", stacklevel=2)
         return 0
 
 


### PR DESCRIPTION
## Summary

On AMD Instinct MI300X GPUs, calling `amdsmi_get_gpu_activity()` raises `AmdSmiLibraryException` with `AMDSMI_STATUS_UNEXPECTED_DATA` error code (43). This causes `torch.cuda.utilization()` to crash instead of returning gracefully.

**Before this fix:**
```python
>>> torch.cuda.utilization()
amdsmi.amdsmi_exception.AmdSmiLibraryException: Error code: 43 | AMDSMI_STATUS_UNEXPECTED_DATA
```

**After this fix:**
```python
>>> torch.cuda.utilization()
0
```

## Changes

Added exception handling to both `_get_amdsmi_utilization()` and `_get_amdsmi_memory_usage()` to catch `AmdSmiLibraryException` and return 0, consistent with how other error cases are handled.

Both functions use `amdsmi_get_gpu_activity()` internally, so both are protected for safety.

## Testing

Tested on AMD Instinct MI300X (gfx942) via AMD Developer Cloud:
- PyTorch: 2.5.0a0+gitcedc116
- ROCm: 6.2.41133
- GPU: AMD Instinct MI300X VF (192GB)

**Test results on MI300X:**
- `torch.cuda.temperature()` → 52 ✓
- `torch.cuda.power_draw()` → "N/A" (handled separately)
- `torch.cuda.utilization()` → CRASH (fixed by this PR)
- `torch.cuda.memory_usage()` → 285 ✓ (still protected for safety)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang