### PR TITLE
Switch from flat colexigraph to structred indexing

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -6,7 +6,11 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 
 import torch
-from torch._inductor.kernel.flex.flex_flash_attention import ensure_flash_available
+from torch._inductor.kernel.flex.flex_flash_attention import (
+    _hierarchical_indexer_cute,
+    ensure_flash_available,
+    HierarchicalIndex,
+)
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.nn.attention.flex_attention import (
@@ -802,8 +806,6 @@ class TestHierarchicalIndex(InductorTestCase):
     def test_hierarchical_index_preserves_args(self):
         from sympy import Symbol
 
-        from torch._inductor.kernel.flex.flex_flash_attention import HierarchicalIndex
-
         b = Symbol("b")
         q_idx = Symbol("q_idx")
         idx = HierarchicalIndex(b, q_idx)
@@ -814,10 +816,6 @@ class TestHierarchicalIndex(InductorTestCase):
     def test_hierarchical_indexer_single_dim_no_wrap(self):
         from sympy import Symbol
 
-        from torch._inductor.kernel.flex.flex_flash_attention import (
-            _hierarchical_indexer_cute,
-        )
-
         indexer = _hierarchical_indexer_cute(size=[10])
         q_idx = Symbol("q_idx")
 
@@ -825,11 +823,6 @@ class TestHierarchicalIndex(InductorTestCase):
 
     def test_hierarchical_indexer_multi_dim_wraps(self):
         from sympy import Symbol
-
-        from torch._inductor.kernel.flex.flex_flash_attention import (
-            _hierarchical_indexer_cute,
-            HierarchicalIndex,
-        )
 
         indexer = _hierarchical_indexer_cute(size=[4, 128])
         b = Symbol("b")
@@ -842,11 +835,6 @@ class TestHierarchicalIndex(InductorTestCase):
 
     def test_hierarchical_indexer_3d_and_4d(self):
         from sympy import Symbol
-
-        from torch._inductor.kernel.flex.flex_flash_attention import (
-            _hierarchical_indexer_cute,
-            HierarchicalIndex,
-        )
 
         b, h, q_idx, kv_idx = (
             Symbol("b"),
@@ -868,8 +856,6 @@ class TestHierarchicalIndex(InductorTestCase):
     def test_isinstance_detection_for_load(self):
         from sympy import Symbol
 
-        from torch._inductor.kernel.flex.flex_flash_attention import HierarchicalIndex
-
         b = Symbol("b")
         q_idx = Symbol("q_idx")
 
@@ -878,10 +864,6 @@ class TestHierarchicalIndex(InductorTestCase):
 
     def test_hierarchical_indexer_rank_mismatch(self):
         from sympy import Symbol
-
-        from torch._inductor.kernel.flex.flex_flash_attention import (
-            _hierarchical_indexer_cute,
-        )
 
         indexer = _hierarchical_indexer_cute(size=[2, 4])
         b = Symbol("b")
@@ -926,7 +908,7 @@ class TestHierarchicalIndex(InductorTestCase):
         )
         code_str = "\n".join(code)
 
-        expected_pattern = "in_ptr0[tmp0, tmp1]"
+        expected_pattern = "in_ptr4[tmp3, tmp4]"
         self.assertIn(
             expected_pattern,
             code_str,
@@ -971,7 +953,7 @@ class TestHierarchicalIndex(InductorTestCase):
         )
         code_str = "\n".join(code)
 
-        expected_pattern = "in_ptr0[tmp0, tmp1, tmp2]"
+        expected_pattern = "in_ptr4[tmp4, tmp5, tmp6]"
         self.assertIn(
             expected_pattern,
             code_str,
@@ -1016,7 +998,7 @@ class TestHierarchicalIndex(InductorTestCase):
         )
         code_str = "\n".join(code)
 
-        expected_pattern = "in_ptr0[tmp0, tmp1, tmp2, tmp3]"
+        expected_pattern = "in_ptr4[tmp5, tmp6, tmp7, tmp8]"
         self.assertIn(
             expected_pattern,
             code_str,

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -12,7 +12,6 @@ from sympy import Expr, Integer
 
 import torch
 from torch.fx import GraphModule
-from torch.utils._sympy.functions import Identity
 
 from ...ir import FixedLayout, ShapeAsConstantBuffer, Subgraph, TensorBox
 from ...lowering import empty_strided
@@ -48,37 +47,31 @@ flash_attention_backward_cutedsl_template = CuteDSLTemplate(
 )
 
 
-def _fixed_indexer_cute(
+class HierarchicalIndex(sympy.Function):
+    """Preserve multi-dimensional indices for CuteDSL indexing."""
+
+    @classmethod
+    def eval(cls, *args):
+        return None
+
+
+def _hierarchical_indexer_cute(
     size: Sequence[int],
-    stride: Optional[Sequence[int]] = None,
+    stride: Sequence[int] | None = None,
     offset: Expr = Integer(0),
 ) -> Callable[[Sequence[Expr]], Expr]:
-    """
-    Colexicographic indexer for CuteDSL - matches CuTe's coordinate interpretation.
+    """Return an indexer that preserves multi-dimensional indices for CuteDSL."""
 
-    CuTe interprets linear indices in colexicographic (column-major) order,
-    whereas Inductor's default _fixed_indexer uses lexicographic (row-major) order.
-
-    For size=[4, 128] with index=[b, q_idx]:
-    - Lexicographic:    b*128 + q_idx*1
-    - Colexicographic:  b*1 + q_idx*2
-
-    CuTe then applies the tensor's actual memory strides to get the correct offset.
-    """
-
-    def indexer(index: Sequence[Expr]) -> Expr:
-        assert offset == Integer(0), "Offset not supported for colexicographic indexing"
-        if not index:
+    def indexer(indices: Sequence[Expr]) -> Expr:
+        assert offset == Integer(0), "Offset not supported for hierarchical indexing"
+        assert len(indices) == len(size), (
+            f"Rank mismatch: got {len(indices)} indices for tensor of rank {len(size)}"
+        )
+        if not indices:
             return Integer(0)
-
-        result = index[0]
-        runner = size[0]
-
-        for idx, sz in zip(index[1:], size[1:], strict=True):
-            result = result + runner * Identity(idx)
-            runner = runner * sz
-
-        return result
+        if len(indices) == 1:
+            return indices[0]
+        return HierarchicalIndex(*indices)
 
     return indexer
 
@@ -86,17 +79,17 @@ def _fixed_indexer_cute(
 @contextmanager
 def patch_fixed_layout_indexer_for_cutedsl():
     """
-    Temporarily swap FixedLayout.make_indexer so CuteDSL sees colexicographic indexing.
+    Temporarily swap FixedLayout.make_indexer so CuteDSL sees hierarchical indexing.
 
     Note [CuteDSL indexer patch]:
     Flex flash attention only supports a limited set of IR ops (pointwise, reads, no stores),
-    so temporarily changing the indexing order is safe for the kernels we emit today.
+    so temporarily changing the indexing behavior is safe for the kernels we emit today.
     TODO(dynamic shapes): Reconfirm once flex flash attention supports dynamic shapes.
     """
     original_make_indexer = FixedLayout.make_indexer
 
     def cutedsl_make_indexer(self):
-        return _fixed_indexer_cute(self.size, self.stride, self.offset)
+        return _hierarchical_indexer_cute(self.size, self.stride, self.offset)
 
     FixedLayout.make_indexer = cutedsl_make_indexer  # type: ignore[assignment]
     try:
@@ -111,7 +104,7 @@ def wrap_choice_render_with_cutedsl_indexer(choice: Any) -> None:
 
     See Note [CuteDSL indexer patch]:
     CuteDSL handles tensor strides internally, so template rendering must use
-    colexicographic indexing.
+    hierarchical indexing.
     """
     original_make_kernel_render = choice.make_kernel_render
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #171222

Running the old reproer, here: https://github.com/pytorch/torchtitan/pull/2171


Before this PR

```Py
❯ python issue_repro_2d_indexing.py
Config: B=8, S=8192, H=2, D=128
Documents per sequence: [7, 11, 8, 7, 6, 7, 6, 11]

Block mask sparsity: 86.19%
kv_num_blocks equal: True
kv_indices equal: True
Attention output max diff: 0.00e+00

Benchmark results:
  2D [b, idx]     FLASH :  1468.33 μs
  2D [b, idx]     TRITON:   386.17 μs
  1D [b*S+idx]    FLASH :   467.82 μs
  1D [b*S+idx]    TRITON:   388.35 μs

```



After this PR
``` Py

Config: B=8, S=8192, H=2, D=128
Documents per sequence: [7, 11, 8, 7, 6, 7, 6, 11]

Block mask sparsity: 86.19%
kv_num_blocks equal: True
kv_indices equal: True
Attention output max diff: 0.00e+00

Benchmark results:
  2D [b, idx]     FLASH :   440.89 μs
  2D [b, idx]     TRITON:   386.76 μs
  1D [b*S+idx]    FLASH :   441.16 μs
  1D [b*S+idx]    TRITON:   390.21 μs

```


Thanks for the advice @Aneureka

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng