### PR TITLE
[DTensor] LRU cachable OpStrategy

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -903,9 +903,26 @@ DEFINE_CACHING_PYTHON_IMPORT_GETTER(
         .attr("_op_schema")
         .attr("OutputSharding"))
 
+DEFINE_CACHING_PYTHON_IMPORT_GETTER(
+    get_op_strategy_class,
+    py::module::import("torch.distributed.tensor")
+        .attr("_op_schema")
+        .attr("OpStrategy"))
+
+DEFINE_CACHING_PYTHON_IMPORT_GETTER(
+    get_tuple_strategy_class,
+    py::module::import("torch.distributed.tensor")
+        .attr("_op_schema")
+        .attr("TupleStrategy"))
+
 static bool arg_type_tensor_or_tensor_list_like(py::handle arg) {
   const auto dtensor_spec_class = get_dtensor_spec_class();
-  if (py::isinstance(arg, dtensor_spec_class)) {
+  const auto op_strategy_class = get_op_strategy_class();
+  const auto tuple_strategy_class = get_tuple_strategy_class();
+
+  if (py::isinstance(arg, dtensor_spec_class) ||
+      py::isinstance(arg, op_strategy_class) ||
+      py::isinstance(arg, tuple_strategy_class)) {
     return true;
   }
   if (!PyList_Check(arg.ptr())) {
@@ -913,7 +930,9 @@ static bool arg_type_tensor_or_tensor_list_like(py::handle arg) {
   }
   py::list arg_list = py::reinterpret_borrow<py::list>(arg);
   for (const auto e : arg_list) {
-    if (!e.is_none() && !py::isinstance(e, dtensor_spec_class)) {
+    if (!e.is_none() && !py::isinstance(e, dtensor_spec_class) &&
+        !py::isinstance(e, op_strategy_class) &&
+        !py::isinstance(e, tuple_strategy_class)) {
       return false;
     }
   }

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -182,6 +182,23 @@ class OpSpec:
         output_spec_str = _pretty_print_spec(self.output_specs)
         return f"{input_specs_str}{output_spec_str}"
 
+    def __hash__(self) -> int:
+        output_hash = hash(
+            self.output_specs
+            if isinstance(self.output_specs, DTensorSpec)
+            else tuple(self.output_specs)
+        )
+        input_hash = hash(tuple(self.input_specs)) if self.input_specs else 0
+        return hash((output_hash, input_hash))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OpSpec):
+            return False
+        return (
+            self.output_specs == other.output_specs
+            and self.input_specs == other.input_specs
+        )
+
 
 class StrategyType:
     """
@@ -235,6 +252,12 @@ class OpStrategy(StrategyType):
         assert self.strategies[0].output_spec.tensor_meta is not None
         return self.strategies[0].output_spec.tensor_meta
 
+    def __hash__(self) -> int:
+        return hash(tuple(self.strategies))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, OpStrategy) and self.strategies == other.strategies
+
 
 class TupleStrategy(StrategyType):
     """
@@ -280,6 +303,12 @@ class TupleStrategy(StrategyType):
             [f"{str(strat)}" for idx, strat in enumerate(self.children)]
         )
         return f"TupleStrategy({child_strategies_str})"
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.children))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, TupleStrategy) and self.children == other.children
 
 
 try:

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -1,6 +1,7 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 from collections.abc import Callable, Sequence
+from functools import lru_cache
 from typing import Any, cast, Optional, TypeAlias, TypeVar, Union
 
 import torch
@@ -180,6 +181,7 @@ def _expand_single_dim_strategy_to_mesh(
     # Note: circular import, failed to untangle with #168221, reverted
     from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
 
+    @lru_cache
     def _create_expanded_strategy(
         op_schema: OpSchema,
         output_tensor_meta: TensorMeta | Sequence[TensorMeta | None],
@@ -299,7 +301,6 @@ def _expand_single_dim_strategy_to_mesh(
                 output_tensor_meta,  # type: ignore[arg-type]
                 tensorlist_i,
             )
-            # TODO: enrich OpSchema._comparison_key so we can lru_cache this (for starters, it doesn't include placements)
             per_index_strategy = _create_expanded_strategy(
                 per_index_schema, per_index_output_meta
             )


### PR DESCRIPTION
extends `OpSchema._comparison_key` to include StrategyType information, so we can LRU cache single-dim strategy expansion, without false positive cache hits 
