### PR TITLE
Fixes determinant gradient for 1 x 1 matrices

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1048,7 +1048,7 @@ class TestLinalg(TestCase):
     def test_det_backward(self):
         # Regression test for #80761.
         input = torch.tensor([[0.]], dtype=torch.float64, requires_grad=True)
-        self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=(input)))
+        self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=input))
 
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1045,9 +1045,9 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.double, torch.cdouble)
-    def test_det_backward(self):
+    def test_det_backward(self, device, dtype):
         # Regression test for #80761.
-        input = torch.tensor([[0.]], dtype=self.dtype, requires_grad=True)
+        input = torch.tensor([[0.]], device=device, dtype=self.dtype, requires_grad=True)
         self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=input))
 
     @skipCUDAIfNoMagma

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1047,7 +1047,7 @@ class TestLinalg(TestCase):
     @dtypes(torch.double, torch.cdouble)
     def test_det_backward(self, device, dtype):
         # Regression test for #80761.
-        input = torch.tensor([[0.]], device=device, dtype=self.dtype, requires_grad=True)
+        input = torch.tensor([[0.]], device=device, dtype=dtype, requires_grad=True)
         self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=input))
 
     @skipCUDAIfNoMagma

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1044,6 +1044,14 @@ class TestLinalg(TestCase):
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
+    @dtypes(torch.double, torch.cdouble)
+    def test_det_backward(self):
+        # Regression test for #80761.
+        input = torch.tensor([[0.]], dtype=torch.float64, requires_grad=True)
+        self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=(input)))
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-4, torch.complex64: 1e-4})
     def test_eigh(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1047,7 +1047,7 @@ class TestLinalg(TestCase):
     @dtypes(torch.double, torch.cdouble)
     def test_det_backward(self):
         # Regression test for #80761.
-        input = torch.tensor([[0.]], dtype=torch.float64, requires_grad=True)
+        input = torch.tensor([[0.]], dtype=self.dtype, requires_grad=True)
         self.assertTrue(torch.autograd.gradcheck(torch.det, inputs=input))
 
     @skipCUDAIfNoMagma

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4317,6 +4317,14 @@ Tensor linalg_det_backward(
     return {};
   }
 
+  // Special case handling for 1 x 1 matrix, to ensure mathematically correct.
+  // d(det)/dA = 1, so gradient = grad * ones_like(A)
+  // See #80761
+  if (A.sym_size(-2) == 1 && A.sym_size(-1) == 1) {
+  // For batched 1x1 matrices, broadcast grad to match A's shape
+  return grad.unsqueeze(-1).unsqueeze(-1).expand_as(A);
+}
+
   // The gradient G is the matrix solving
   // A.mH G = det(A).conj() * grad * I
   auto d_diag = grad * det.conj();

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4321,9 +4321,9 @@ Tensor linalg_det_backward(
   // d(det)/dA = 1, so gradient = grad * ones_like(A)
   // See #80761
   if (A.sym_size(-2) == 1 && A.sym_size(-1) == 1) {
-  // For batched 1x1 matrices, broadcast grad to match A's shape
-  return grad.unsqueeze(-1).unsqueeze(-1).expand_as(A);
-}
+    // For batched 1x1 matrices, broadcast grad to match A's shape
+    return grad.unsqueeze(-1).unsqueeze(-1).expand_as(A);
+  }
 
   // The gradient G is the matrix solving
   // A.mH G = det(A).conj() * grad * I


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/80761, by adding special case handling for 1 x 1 matrices, to ensure gradient of the determinant is 1 for all input values. Also adds a regression test.

Note, as a separate issue, it might also be worth special casing 0 x 0 matrices as well to ensure gradient is 0 for the determinant function, since `d(det(A))/dA_ij = C_ij`, where `C_ij` is the cofactor matrix, and `C_ij` is implicitly assumed to be 1 for 0 x 0 matrices in the recursive determinant expression `det(A) = sum_k A_ik C_ik`- hence gradient of a constant is 0. This would also be consistent with other torch matrix operation gradients on 0 x 0 matrices:

```
# All other operations return tensor([], size=(0, 0))
torch.sum(empty_matrix).backward()    → grad: tensor([], size=(0, 0)) ✓
torch.trace(empty_matrix).backward()  → grad: tensor([], size=(0, 0)) ✓
torch.det(empty_matrix).backward()    → grad: None                     ✗
```


