### PR TITLE
Fix ROCm device string in test_remove_noop_view_dtype for inductor tests

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6739,9 +6739,9 @@ class CommonTemplate:
 
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
-def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}"):
-        add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
-        add_9: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(add, 1);  add = None
+def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}"):
+        add: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
+        add_9: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}" = torch.ops.aten.add.Tensor(add, 1);  add = None
         return (add_9,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,
@@ -6762,10 +6762,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         torch._dynamo.mark_dynamic(x, 1)
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
-def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "f32[s77, s27, 2][2*s27, 2, 1]{str(x.device)}"):
-        add: "f32[s77, s27, 2][2*s27, 2, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg2_1, 1);  arg2_1 = None
-        slice_1: "f32[s77, s27, 1][2*s27, 2, 1]{str(x.device)}" = torch.ops.aten.slice.Tensor(add, -1, 0, -1);  add = None
-        add_9: "f32[s77, s27, 1][s27, 1, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(slice_1, 1);  slice_1 = None
+def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "f32[s77, s27, 2][2*s27, 2, 1]{device_str}"):
+        add: "f32[s77, s27, 2][2*s27, 2, 1]{device_str}" = torch.ops.aten.add.Tensor(arg2_1, 1);  arg2_1 = None
+        slice_1: "f32[s77, s27, 1][2*s27, 2, 1]{device_str}" = torch.ops.aten.slice.Tensor(add, -1, 0, -1);  add = None
+        add_9: "f32[s77, s27, 1][s27, 1, 1]{device_str}" = torch.ops.aten.add.Tensor(slice_1, 1);  slice_1 = None
         return (add_9,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,
@@ -6791,10 +6791,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "f32[s77, s27,
 
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
-def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}"):
-        empty: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.empty.memory_format([arg0_1, arg1_1, arg2_1], dtype = torch.float32, layout = torch.strided, device = {repr(x.device)}, pin_memory = False);  arg0_1 = arg1_1 = arg2_1 = empty = None
-        add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
-        add_13: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(add, 1);  add = None
+def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}"):
+        empty: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}" = torch.ops.aten.empty.memory_format([arg0_1, arg1_1, arg2_1], dtype = torch.float32, layout = torch.strided, device = {repr(x.device)}, pin_memory = False);  arg0_1 = arg1_1 = arg2_1 = empty = None
+        add: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
+        add_13: "f32[s77, s27, s53][s27*s53, s53, 1]{device_str}" = torch.ops.aten.add.Tensor(add, 1);  add = None
         return (add_13,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,
@@ -14346,8 +14346,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         x = torch.randn((2, 3, 2), device=self.device)
         expected_graph1 = f"""\
-def forward(self, arg0_1: "f32[2, 3, 2][6, 2, 1]{str(x.device)}"):
-        permute: "f32[2, 2, 3][6, 1, 2]{str(x.device)}" = torch.ops.aten.permute.default(arg0_1, [0, 2, 1]);  arg0_1 = None
+def forward(self, arg0_1: "f32[2, 3, 2][6, 2, 1]{device_str}"):
+        permute: "f32[2, 2, 3][6, 1, 2]{device_str}" = torch.ops.aten.permute.default(arg0_1, [0, 2, 1]);  arg0_1 = None
         return (permute,)"""  # noqa: B950
 
         post_grad_graph = get_post_grad_graph(f, (x,))
@@ -14362,8 +14362,8 @@ def forward(self, arg0_1: "f32[2, 3, 2][6, 2, 1]{str(x.device)}"):
         # dynamic shape
         x = torch.randn((4, 3, 2), device=self.device)
         expected_graph2 = f"""\
-def forward(self, arg0_1: "Sym(s77)", arg1_1: "f32[s77, 3, 2][6, 2, 1]{str(x.device)}"):
-        permute: "f32[s77, 2, 3][6, 1, 2]{str(x.device)}" = torch.ops.aten.permute.default(arg1_1, [0, 2, 1]);  arg1_1 = None
+def forward(self, arg0_1: "Sym(s77)", arg1_1: "f32[s77, 3, 2][6, 2, 1]{device_str}"):
+        permute: "f32[s77, 2, 3][6, 1, 2]{device_str}" = torch.ops.aten.permute.default(arg1_1, [0, 2, 1]);  arg1_1 = None
         return (permute,)"""  # noqa: B950
         post_grad_graph = get_post_grad_graph(f, (x,))
         self.assertExpectedInline(
@@ -14388,8 +14388,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "f32[s77, 3, 2][6, 2, 1]{str(x.dev
 
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
-def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "u8[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}"):
-        permute: "u8[s77, s53, s27][s27*s53, 1, s53]{str(x.device)}" = torch.ops.aten.permute.default(arg3_1, [0, 2, 1]);  arg3_1 = None
+def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "u8[s77, s27, s53][s27*s53, s53, 1]{device_str}"):
+        permute: "u8[s77, s53, s27][s27*s53, 1, s53]{device_str}" = torch.ops.aten.permute.default(arg3_1, [0, 2, 1]);  arg3_1 = None
         return (permute,)"""  # noqa: B950
         self.assertExpectedInline(
             post_grad_graph,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14387,6 +14387,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "f32[s77, 3, 2][6, 2, 1]{device_st
         torch._dynamo.mark_dynamic(x, 2)
 
         post_grad_graph = get_post_grad_graph(f, (x,))
+        device_str = "hip" if TEST_WITH_ROCM else "cuda"
         expected_graph = f"""\
 def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "u8[s77, s27, s53][s27*s53, s53, 1]{device_str}"):
         permute: "u8[s77, s53, s27][s27*s53, 1, s53]{device_str}" = torch.ops.aten.permute.default(arg3_1, [0, 2, 1]);  arg3_1 = None


### PR DESCRIPTION
Fixes #151541

## Problem
The `test_remove_noop_view_dtype` test was failing on ROCm because it used `str(x.device)` in the expected IR graph strings. On ROCm systems, this evaluates to `'cuda:0'`, but the Inductor IR code generator uses `'hip'`.

## Solution
Replaced `{str(x.device)}` with a conditional `{device_str}` variable that evaluates to `"hip"` on ROCm and `"cuda"` on CUDA systems. This matches the pattern used in other recent fixes for similar issues.

## Changes
- Modified `test_remove_noop_view_dtype` in `test/inductor/test_torchinductor.py`
- Also applied the same fix to `test_remove_noop_view_default` which had the same issue.

## Labels
Please add the following labels:

module: rocm
module: inductor


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben