### PR TITLE
Skip foreach addcmul complex64 on ROCm (Issue #164822)

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11450,6 +11450,14 @@ foreach_pointwise_op_db: list[ForeachFuncInfo] = [
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_inplace", dtypes=(torch.bool,)),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_symbolic_meta_inplace_all_strides",
                          dtypes=integral_types() + complex_types_and(torch.bool)),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestForeach",
+                "test_pointwise_op_with_tensor_of_scalarlist_overload",
+                device_type="cuda",
+                dtypes=(torch.complex64,),
+                active_if=TEST_WITH_ROCM,
+            ),
         ),
     ),
     ForeachFuncInfo(


### PR DESCRIPTION
## Description
This PR addresses Issue #164822 by skipping the `test_pointwise_op_with_tensor_of_scalarlist_overload` test for the `addcmul` operator when using `complex64` dtype on ROCm.

## Motivation
The `foreach_addcmul` operator with `complex64` inputs is currently failing on ROCm hardware. This is a known issue that requires investigation into the underlying kernel implementation. To ensure the stability of the test suite and allow other tests to pass, we are skipping this specific test case on ROCm.

## Changes
- Modified `torch/testing/_internal/common_methods_invocations.py` to add a `unittest.skip` decorator to the `addcmul` OpInfo.
- The skip is conditional on `TEST_WITH_ROCM` and applies only to `complex64` dtype for the `test_pointwise_op_with_tensor_of_scalarlist_overload` test.

## Testing
- Verified that the skip is correctly applied by checking the code changes.
- This change only affects test configuration and does not modify runtime code.

## Related Issues
- Fixes #164822

topic: tests

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang