### PR TITLE
[ROCm] Fix logic error in test_raw_amdsmi_device_uuids

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4968,10 +4968,11 @@ print(value, end="")
         uuids = subprocess.check_output(cmd, shell=True, text=True).strip().split("\n")
         uuids = [s.strip() for s in uuids]
         raw_uuids = torch.cuda._raw_device_uuid_amdsmi()
+        matching = True
         for uuid in uuids:
-            matching = True
             if not any(uuid in raw_id for raw_id in raw_uuids):
                 matching = False
+                break
         self.assertEqual(True, matching)
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")


### PR DESCRIPTION
## Summary

Fix a logic bug in `test_raw_amdsmi_device_uuids` where the `matching` variable was incorrectly reset inside the loop.

## Problem

```python
for uuid in uuids:
    matching = True  # BUG: Reset on each iteration!
    if not any(uuid in raw_id for raw_id in raw_uuids):
        matching = False
self.assertEqual(True, matching)  # Only checks last UUID
```

The `matching = True` was inside the loop, so if the last UUID matched, the test would pass even if earlier UUIDs failed.

## Solution

```python
matching = True  # Move outside loop
for uuid in uuids:
    if not any(uuid in raw_id for raw_id in raw_uuids):
        matching = False
        break  # Early exit on first failure
self.assertEqual(True, matching)
```

## Test Plan

- Logic verified by code review
- No functional change to passing cases
- Flaky failures will now be caught consistently

Fixes: https://github.com/pytorch/pytorch/issues/169881

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang