### PR TITLE
[xpu][test]port binary_ufunc test file for Intel GPU

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -981,7 +981,7 @@ class TestBinaryUfuncs(TestCase):
             dtype == torch.half
             and torch.device(device).type not in ["cuda", "xpu"]
             or dtype == torch.bfloat16
-            and torch.device(device).type not in ["cpu", "xpu"]
+            and device != "cpu"
         )
         d_ref = d_true.float() if rounding_unsupported else d_true
         self.assertEqual(d_trunc, d_ref.trunc().to(dtype))
@@ -1290,75 +1290,34 @@ class TestBinaryUfuncs(TestCase):
     @dtypes(torch.double)
     def test_binary_op_mem_overlap(self, device, dtype):
         ops = [
-            ("add", True, True, "cpu"),
-            ("add", True, True, "cuda"),
-            ("add", True, True, "xpu"),
-            ("mul", True, True, "cpu"),
-            ("mul", True, True, "cuda"),
-            ("mul", True, True, "xpu"),
-            ("sub", True, True, "cpu"),
-            ("sub", True, True, "cuda"),
-            ("sub", True, True, "xpu"),
-            ("div", True, True, "cpu"),
-            ("div", True, True, "cuda"),
-            ("div", True, True, "xpu"),
-            ("pow", True, True, "cpu"),
-            ("pow", True, True, "cuda"),
-            ("pow", True, True, "xpu"),
-            ("fmod", True, True, "cpu"),
-            ("fmod", True, True, "cuda"),
-            ("fmod", True, True, "xpu"),
-            ("atan2", True, True, "cpu"),
-            ("atan2", True, True, "cuda"),
-            ("aten2", True, True, "xpu"),
-            ("hypot", True, True, "cpu"),
-            ("hypot", True, True, "cuda"),
-            ("hypot", True, True, "xpu"),
-            ("igamma", True, True, "cpu"),
-            ("igamma", True, True, "cuda"),
-            ("igamma", True, True, "xpu"),
-            ("igammac", True, True, "cpu"),
-            ("igammac", True, True, "cuda"),
-            ("igammac", True, True, "xpu"),
-            ("nextafter", True, True, "cpu"),
-            ("nextafter", True, True, "cuda"),
-            ("nextafter", True, True, "xpu"),
-            ("le", True, True, "cpu"),
-            ("le", True, True, "cuda"),
-            ("le", True, True, "xpu"),
-            ("lt", True, True, "cpu"),
-            ("lt", True, True, "cuda"),
-            ("lt", True, True, "xpu"),
-            ("ge", True, True, "cpu"),
-            ("ge", True, True, "cuda"),
-            ("ge", True, True, "xpu"),
-            ("gt", True, True, "cpu"),
-            ("gt", True, True, "cuda"),
-            ("gt", True, True, "xpu"),
-            ("eq", True, True, "cpu"),
-            ("eq", True, True, "cuda"),
-            ("eq", True, True, "xpu"),
-            ("ne", True, True, "cpu"),
-            ("ne", True, True, "cuda"),
-            ("ne", True, True, "xpu"),
-            ("logical_and", True, True, "cpu"),
-            ("logical_and", True, True, "cuda"),
-            ("logical_and", True, True, "xpu"),
-            ("logical_or", True, True, "cpu"),
-            ("logical_or", True, True, "cuda"),
-            ("logical_or", True, True, "xpu"),
-            ("logical_xor", True, True, "cpu"),
-            ("logical_xor", True, True, "cuda"),
-            ("logical_xor", True, True, "xpu"),
+            ("add", True, True, ["cpu", "cuda", "xpu"]),
+            ("mul", True, True, ["cpu", "cuda", "xpu"]),
+            ("sub", True, True, ["cpu", "cuda", "xpu"]),
+            ("div", True, True, ["cpu", "cuda", "xpu"]),
+            ("pow", True, True, ["cpu", "cuda", "xpu"]),
+            ("fmod", True, True, ["cpu", "cuda", "xpu"]),
+            ("atan2", True, True, ["cpu", "cuda", "xpu"]),
+            ("hypot", True, True, ["cpu", "cuda", "xpu"]),
+            ("igamma", True, True, ["cpu", "cuda", "xpu"]),
+            ("igammac", True, True, ["cpu", "cuda", "xpu"]),
+            ("nextafter", True, True, ["cpu", "cuda", "xpu"]),
+            ("le", True, True, ["cpu", "cuda", "xpu"]),
+            ("lt", True, True, ["cpu", "cuda", "xpu"]),
+            ("ge", True, True, ["cpu", "cuda", "xpu"]),
+            ("gt", True, True, ["cpu", "cuda", "xpu"]),
+            ("eq", True, True, ["cpu", "cuda", "xpu"]),
+            ("ne", True, True, ["cpu", "cuda", "xpu"]),
+            ("logical_and", True, True, ["cpu", "cuda", "xpu"]),
+            ("logical_or", True, True, ["cpu", "cuda", "xpu"]),
+            ("logical_xor", True, True, ["cpu", "cuda", "xpu"]),
         ]
-
         for (
             fn,
             has_input_output_mem_overlap_check,
             has_internal_mem_overlap_check,
-            dev,
+            devs,
         ) in ops:
-            if dev != device:
+            if torch.device(device).type not in devs:
                 continue
             out_op = getattr(torch, fn)
             inplace_op = getattr(torch.Tensor, fn + "_")

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3469,6 +3469,7 @@ class TestBinaryUfuncs(TestCase):
         assert m.dim() == 0, "m is intentionally a scalar"
         self.assertEqual(torch.pow(2, m), 2**m)
 
+    @skipXPU
     def test_ldexp(self, device):
         # random values
         mantissas = torch.randn(64, device=device)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14479,13 +14479,11 @@ op_db: list[OpInfo] = [
                     dtypes=floating_and_complex_types_and(torch.bfloat16, torch.float16),
                     dtypesIfCUDA=floating_and_complex_types_and(torch.bfloat16, torch.float16, torch.complex32),
                     dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
-                    # XPU issue, see https://github.com/intel/torch-xpu-ops/issues/2376
                     dtypesIfXPU=floating_types_and(torch.bfloat16, torch.float16),
                     supports_forward_ad=True,
                     supports_fwgrad_bwgrad=True,
                     supports_rhs_python_scalar=False,
                     skips=(
-                        # XPU issue, see https://github.com/intel/torch-xpu-ops/issues/2376
                         DecorateInfo(unittest.skip("Skipped!"), 'TestBinaryUfuncs', 'test_type_promotion',
                                      device_type='xpu'),
                     )),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12381,6 +12381,10 @@ op_db: list[OpInfo] = [
                                      'TestBinaryUfuncs',
                                      'test_type_promotion',
                                      device_type='cuda'),
+                        DecorateInfo(unittest.expectedFailure,
+                                     'TestBinaryUfuncs',
+                                     'test_type_promotion',
+                                     device_type='xpu'),
                         # dispatch to lazy test failed
                         DecorateInfo(unittest.expectedFailure, 'TestLazyOpInfo', 'test_dispatched_to_lazy'),
                         # test error disabled since rhs non-tensor python scalar is supported
@@ -12400,6 +12404,10 @@ op_db: list[OpInfo] = [
                                      'TestBinaryUfuncs',
                                      'test_type_promotion',
                                      device_type='cuda'),
+                        DecorateInfo(unittest.expectedFailure,
+                                     'TestBinaryUfuncs',
+                                     'test_type_promotion',
+                                     device_type='xpu'),
                         # dispatch to lazy test failed
                         DecorateInfo(unittest.expectedFailure, 'TestLazyOpInfo', 'test_dispatched_to_lazy'),
                         # test error disabled since rhs non-tensor python scalar is supported
@@ -14471,9 +14479,16 @@ op_db: list[OpInfo] = [
                     dtypes=floating_and_complex_types_and(torch.bfloat16, torch.float16),
                     dtypesIfCUDA=floating_and_complex_types_and(torch.bfloat16, torch.float16, torch.complex32),
                     dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+                    # XPU issue, see https://github.com/intel/torch-xpu-ops/issues/2376
+                    dtypesIfXPU=floating_types_and(torch.bfloat16, torch.float16),
                     supports_forward_ad=True,
                     supports_fwgrad_bwgrad=True,
-                    supports_rhs_python_scalar=False),
+                    supports_rhs_python_scalar=False,
+                    skips=(
+                        # XPU issue, see https://github.com/intel/torch-xpu-ops/issues/2376
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestBinaryUfuncs', 'test_type_promotion',
+                                     device_type='xpu'),
+                    )),
     OpInfo('logaddexp2',
            dtypes=floating_types_and(torch.bfloat16, torch.half),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
@@ -14900,6 +14915,7 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_jit_alias_remapping'),
             # TODO: FIXME: RuntimeError: "max_elementwise_cuda" not implemented for 'ComplexFloat'
             DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion', device_type='cuda'),
+            DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion', device_type='xpu'),
         )),
     BinaryUfuncInfo(
         'maximum',
@@ -14912,6 +14928,7 @@ op_db: list[OpInfo] = [
         skips=(
             # TODO: FIXME: RuntimeError: "max_elementwise_cuda" not implemented for 'ComplexFloat'
             DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion', device_type='cuda'),
+            DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion', device_type='xpu'),
         )),
     BinaryUfuncInfo(
         'min',
@@ -14932,6 +14949,10 @@ op_db: list[OpInfo] = [
                          'TestBinaryUfuncs',
                          'test_type_promotion',
                          device_type='cuda'),
+            DecorateInfo(unittest.expectedFailure,
+                         'TestBinaryUfuncs',
+                         'test_type_promotion',
+                         device_type='xpu'),
         )),
     BinaryUfuncInfo(
         'minimum',
@@ -14947,6 +14968,10 @@ op_db: list[OpInfo] = [
                          'TestBinaryUfuncs',
                          'test_type_promotion',
                          device_type='cuda'),
+            DecorateInfo(unittest.expectedFailure,
+                         'TestBinaryUfuncs',
+                         'test_type_promotion',
+                         device_type='xpu'),
         ),
     ),
     BinaryUfuncInfo('logical_and',
@@ -14984,6 +15009,8 @@ op_db: list[OpInfo] = [
                         # RuntimeError: "bitwise_and_cuda" not implemented for 'Half'
                         DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs',
                                      'test_type_promotion', device_type='cuda'),
+                        DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs',
+                                     'test_type_promotion', device_type='xpu'),
                     )),
     BinaryUfuncInfo('bitwise_or',
                     ref=np.bitwise_or,
@@ -14999,6 +15026,10 @@ op_db: list[OpInfo] = [
                                      'TestBinaryUfuncs',
                                      'test_type_promotion',
                                      device_type='cuda'),
+                        DecorateInfo(unittest.expectedFailure,
+                                     'TestBinaryUfuncs',
+                                     'test_type_promotion',
+                                     device_type='xpu'),
                     )),
     BinaryUfuncInfo('bitwise_xor',
                     ref=np.bitwise_xor,
@@ -15014,6 +15045,10 @@ op_db: list[OpInfo] = [
                                      'TestBinaryUfuncs',
                                      'test_type_promotion',
                                      device_type='cuda'),
+                        DecorateInfo(unittest.expectedFailure,
+                                     'TestBinaryUfuncs',
+                                     'test_type_promotion',
+                                     device_type='xpu'),
                     )),
     BinaryUfuncInfo('heaviside',
                     ref=lambda a, b: (


### PR DESCRIPTION
we port test_binary_ufuncs for Intel GPU in this pr.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

Use torch.accelerator for general gpu
Skip the case if running on xpu which has known issues
extend case that running on cuda to cuda and xpu.