### PR TITLE
[DTensor] register_sharding supports custom static argnum and kwargkey

### DIFF
--- a/test/distributed/tensor/experimental/test_register_sharding.py
+++ b/test/distributed/tensor/experimental/test_register_sharding.py
@@ -144,6 +144,37 @@ class TestRegisterSharding(DTensorTestBase):
         self.assertEqual(result[0].full_tensor(), expected_values)
         self.assertEqual(result[1].full_tensor(), expected_indices)
 
+    @with_comms
+    def test_register_sharding_with_static_argument_info(self):
+        mesh = self.build_device_mesh()
+        x = torch.randn(4, 4, device=self.device_type)
+        x_dt = distribute_tensor(x, mesh, [Replicate()])
+
+        @register_sharding(aten.min.dim_min, static_argnum=1, static_kwargkey=['out'])
+        def min_dim_strategy(x, dim, keepdim, min, min_indices):
+            all_replicate = (
+                [Replicate(), Replicate()],
+                [Replicate(), None, None, Replicate(), Replicate()],
+            )
+            return [all_replicate]
+
+        value = torch.randn(4, 1, device=self.device_type)
+        indices = torch.randn(4, 1, device=self.device_type).long()
+        value_dt = distribute_tensor(value, mesh, [Replicate()])
+        indices_dt = distribute_tensor(indices, mesh, [Replicate()])
+
+        result = torch.min(x_dt, dim=1, keepdim=True, out=(value_dt, indices_dt))
+
+        schema_info = DTensor._op_dispatcher.sharding_propagator.op_to_schema_info[
+            aten.min.dim_min
+        ]
+        self.assertEqual(schema_info.static_argnum, 1)
+        self.assertEqual(schema_info.static_kwargkey, ['out'])
+
+        expected_values, expected_indices = torch.min(x, dim=1, keepdim=True)
+        self.assertEqual(result[0].full_tensor(), expected_values)
+        self.assertEqual(result[1].full_tensor(), expected_indices)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
`register_sharding` supports customizing static argnum and kwargkey for more flexible usage scenarios
