### PR TITLE
[OpenReg][distributed] Add OCCL ProcessGroup stub validation + distributed smoke tests

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB_RECURSE SOURCE_FILES
 
 add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
 
-target_link_libraries(${LIBRARY_NAME} PRIVATE torch_cpu_library openreg)
+target_link_libraries(${LIBRARY_NAME} PRIVATE torch_cpu_library torch_python_library openreg)
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS ${LIBRARY_NAME}

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -1,0 +1,346 @@
+#include <stdexcept>
+
+#include <ATen/core/Tensor.h>
+#include <c10/util/Exception.h>
+#include <c10/util/string_view.h>
+#include <torch/headeronly/core/DeviceType.h>
+
+#include "ProcessGroupOCCL.hpp"
+namespace {
+
+void checkTensorDevice(
+    const at::Tensor& tensor,
+    c10::string_view opName,
+    c10::string_view argName) {
+  if (!tensor.defined()) {
+    return;
+  }
+
+  TORCH_CHECK(
+      tensor.device().type() == c10::DeviceType::PrivateUse1,
+      "ProcessGroupOCCL only supports OpenReg (PrivateUse1) tensors. Got ",
+      tensor.device().type(),
+      " for argument '",
+      argName,
+      "' in ",
+      opName,
+      ".");
+}
+
+void checkTensorList(
+    const std::vector<at::Tensor>& tensors,
+    c10::string_view opName,
+    c10::string_view argName) {
+  for (const auto& tensor : tensors) {
+    checkTensorDevice(tensor, opName, argName);
+  }
+}
+
+void checkTensorListOfLists(
+    const std::vector<std::vector<at::Tensor>>& tensorLists,
+    c10::string_view opName,
+    c10::string_view argName) {
+  for (const auto& tensors : tensorLists) {
+    checkTensorList(tensors, opName, argName);
+  }
+}
+
+} // namespace
+
+/**
+    @brief Currently, a no-op OCCL ProcessGroup stub for registration, tests and educational purposes.
+
+    This translation unit provides a minimal ProcessGroup backend named "OCCL" (short
+    for OpenReg Collective Communications Library) that only validates input shapes/devices
+    and immediately returns a completed Work object without performing any actual communication.
+    It is intended for:
+        - Out-of-tree custom CCL backend registration and linkage tests
+        - API surface validation and call-site integration
+
+    All collective point-to-point and synchronization calls are implemented as
+    immediate, successful completions (unless a precondition check fails and an
+    exception is thrown). As a result, these calls do not exchange data, do not
+    synchronize ranks, and do not modify input/output tensors. OCCL is for testing
+    and educational purposes only; it does not provide any real distributed functionality.
+
+    ------------------------------------------------------------------------------
+    Class: ProcessGroupOCCL::DummyWork
+
+    @brief An immediately-completed Work instance.
+
+    - Construction marks an internal c10::ivalue::Future as completed.
+    - isCompleted(): always true after construction.
+    - isSuccess(): true unless an error was explicitly set (not expected here).
+    - wait(timeout): returns immediately; the Future is already complete.
+    - synchronize(): no-op; there is no associated device or stream work.
+    - abort(): attempts to set an error only if the Future is not completed;
+                         has no effect in the current implementation since the Future is
+                         completed in the constructor.
+    - getFuture(): returns the already-completed Future.
+
+    Notes:
+    - No background progress, streams, or device synchronization is involved.
+    - Intended solely as a lightweight placeholder Work for API conformance.
+
+    ------------------------------------------------------------------------------
+    Class: ProcessGroupOCCL
+
+    @brief A stub ProcessGroup backend whose collectives validate inputs and then
+                 return a DummyWork that is already complete.
+
+    General behavior across all methods below:
+    - Input validation: Methods call internal helpers (e.g., checkTensorList,
+        checkTensorListOfLists, checkTensorDevice) to validate that inputs are
+        defined, have expected dtypes/devices, and adhere to basic invariants.
+        This is for building connection with out-of-tree accelerator backend (OpenReg)
+        and as a guard for blocking any changes from upstream that will break the compatibility.
+    - No communication: No data movement or cross-rank coordination occurs.
+    - Options ignored: All options/attributes (e.g., reduce ops, tags, counts,
+        timeouts) are accepted but not used to affect behavior.
+    - Immediate completion: A ProcessGroupOCCL::DummyWork is returned, whose
+        future is already completed successfully.
+    - No side-effects: Output tensors are not populated or modified.
+
+    Limitations and caveats:
+    - Does not guarantee any semantic property of real collectives (e.g., data
+        equivalence across ranks, synchronization, ordering).
+    - Barrier does not synchronize ranks; it simply returns a completed Work.
+    - Safe for use in unit tests only where communication effects are not required.
+
+    ------------------------------------------------------------------------------
+    Factory:
+
+    @fn createProcessGroupOCCL(const c10::intrusive_ptr<c10d::Store>& store, int rank, int size, const std::chrono::duration<float>& timeout)
+            Constructs a ProcessGroupOCCL using the given rank and size. The store and
+            timeout are accepted for API parity but are not used to affect behavior.
+            - @param store: Process group store (ignored).
+            - @param rank: This process rank.
+            - @param size: World size.
+            - @param timeout: Operation timeout hint (ignored).
+            - @return A new ProcessGroupOCCL instance.
+
+    ------------------------------------------------------------------------------
+    Usage notes:
+    - Suitable for tests that only check callability/flow, not correctness of
+        distributed results.
+    - Do not rely on returned outputs or synchronization semantics.
+    - In production, replace with a real backend (e.g., NCCL, Gloo, MPI).
+*/
+namespace c10d {
+
+// WorkOCCL -----------------------------------------------------------------
+
+ProcessGroupOCCL::DummyWork::DummyWork()
+    : Work(-1, OpType::UNKNOWN),
+      future_(c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get())) {
+  if (!future_->completed()) {
+    future_->markCompleted(c10::IValue());
+  }
+  finish();
+}
+
+ProcessGroupOCCL::DummyWork::~DummyWork() = default;
+
+bool ProcessGroupOCCL::DummyWork::isCompleted() {
+  return future_->completed();
+}
+
+bool ProcessGroupOCCL::DummyWork::isSuccess() const {
+  return !future_->hasError();
+}
+
+bool ProcessGroupOCCL::DummyWork::wait(std::chrono::milliseconds /* timeout */) {
+  future_->wait();
+  return !future_->hasError();
+}
+
+void ProcessGroupOCCL::DummyWork::synchronize() {
+
+}
+
+void ProcessGroupOCCL::DummyWork::abort() {
+  if (!future_->completed()) {
+    future_->setError(std::make_exception_ptr(std::runtime_error("OCCL work aborted")));
+  }
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupOCCL::DummyWork::getFuture() {
+  return future_;
+}
+
+// Options ------------------------------------------------------------------
+
+ProcessGroupOCCL::Options::Options(std::chrono::milliseconds timeout)
+    : Backend::Options(OCCL_BACKEND_NAME, timeout) {}
+
+// ProcessGroupOCCL ---------------------------------------------------------
+
+ProcessGroupOCCL::ProcessGroupOCCL(int rank, int size)
+    : Backend(rank, size), options_(Options::create()) {}
+
+ProcessGroupOCCL::~ProcessGroupOCCL() = default;
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::broadcast(
+    std::vector<at::Tensor>& tensors,
+    const BroadcastOptions& /* opts */) {
+  checkTensorList(tensors, "broadcast", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::allreduce(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& /* opts */) {
+  checkTensorList(tensors, "allreduce", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::allreduce_sparse(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& /* opts */) {
+  checkTensorList(tensors, "allreduce_sparse", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::allreduce_coalesced(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceCoalescedOptions& /* opts */) {
+  checkTensorList(tensors, "allreduce_coalesced", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce(
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& /* opts */) {
+  checkTensorList(tensors, "reduce", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::_reduce_scatter_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    const ReduceScatterOptions& /* opts */) {
+  checkTensorDevice(outputTensor, "_reduce_scatter_base", "outputTensor");
+  checkTensorDevice(inputTensor, "_reduce_scatter_base", "inputTensor");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::_allgather_base(
+    at::Tensor& output_tensor,
+    at::Tensor& input_tensor,
+    const AllgatherOptions& /* opts */) {
+  checkTensorDevice(output_tensor, "_allgather_base", "output_tensor");
+  checkTensorDevice(input_tensor, "_allgather_base", "input_tensor");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather(
+    std::vector<std::vector<at::Tensor>>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const AllgatherOptions& /* opts */) {
+  checkTensorListOfLists(outputs, "allgather", "outputs");
+  checkTensorList(inputs, "allgather", "inputs");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather_coalesced(
+    std::vector<std::vector<at::Tensor>>& output_lists,
+    std::vector<at::Tensor>& input_list,
+    const AllgatherOptions& /* opts */) {
+  checkTensorListOfLists(output_lists, "allgather_coalesced", "output_lists");
+  checkTensorList(input_list, "allgather_coalesced", "input_list");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather_into_tensor_coalesced(
+    std::vector<at::Tensor>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const AllgatherOptions& /* opts */) {
+  checkTensorList(outputs, "allgather_into_tensor_coalesced", "outputs");
+  checkTensorList(inputs, "allgather_into_tensor_coalesced", "inputs");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::gather(
+    std::vector<std::vector<at::Tensor>>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const GatherOptions& /* opts */) {
+  checkTensorListOfLists(outputs, "gather", "outputs");
+  checkTensorList(inputs, "gather", "inputs");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::scatter(
+    std::vector<at::Tensor>& outputs,
+    std::vector<std::vector<at::Tensor>>& inputs,
+    const ScatterOptions& /* opts */) {
+  checkTensorList(outputs, "scatter", "outputs");
+  checkTensorListOfLists(inputs, "scatter", "inputs");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter(
+    std::vector<at::Tensor>& outputs,
+    std::vector<std::vector<at::Tensor>>& inputs,
+    const ReduceScatterOptions& /* opts */) {
+  checkTensorList(outputs, "reduce_scatter", "outputs");
+  checkTensorListOfLists(inputs, "reduce_scatter", "inputs");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter_tensor_coalesced(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const ReduceScatterOptions& /* opts */) {
+  checkTensorList(outputTensors, "reduce_scatter_tensor_coalesced", "outputTensors");
+  checkTensorList(inputTensors, "reduce_scatter_tensor_coalesced", "inputTensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::alltoall_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    std::vector<int64_t>& /* outputCounts */,
+    std::vector<int64_t>& /* inputCounts */,
+    const AllToAllOptions& /* opts */) {
+  checkTensorDevice(outputTensor, "alltoall_base", "outputTensor");
+  checkTensorDevice(inputTensor, "alltoall_base", "inputTensor");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::send(
+    std::vector<at::Tensor>& tensors,
+    int /* dstRank */,
+    int /* tag */) {
+  checkTensorList(tensors, "send", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::recv(
+    std::vector<at::Tensor>& tensors,
+    int /* srcRank */,
+    int /* tag */) {
+  checkTensorList(tensors, "recv", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::recvAnysource(
+    std::vector<at::Tensor>& tensors,
+    int /* tag */) {
+  checkTensorList(tensors, "recvAnysource", "tensors");
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<Work> ProcessGroupOCCL::barrier(
+    const BarrierOptions& /* opts */) {
+  return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
+}
+
+c10::intrusive_ptr<ProcessGroupOCCL> createProcessGroupOCCL(
+    const c10::intrusive_ptr<c10d::Store>& store,
+    int rank,
+    int size,
+    const std::chrono::duration<float>& timeout) {
+  return c10::make_intrusive<ProcessGroupOCCL>(rank, size);
+}
+
+} // namespace c10d

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -1,3 +1,4 @@
+#if USE_DISTRIBUTED
 #include <stdexcept>
 
 #include <ATen/core/Tensor.h>
@@ -364,3 +365,4 @@ c10::intrusive_ptr<ProcessGroupOCCL> createProcessGroupOCCL(
 }
 
 } // namespace c10d
+#endif // USE_DISTRIBUTED

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.cpp
@@ -8,60 +8,76 @@
 #include "ProcessGroupOCCL.hpp"
 namespace {
 
-void checkTensorDevice(
-    const at::Tensor& tensor,
-    c10::string_view opName,
-    c10::string_view argName) {
-  if (!tensor.defined()) {
-    return;
-  }
+#define CHECK_TENSOR(tensor)                                                    \
+  do {                                                                          \
+    if (tensor.defined()) {                                                     \
+      TORCH_CHECK(                                                              \
+          tensor.device().type() == c10::DeviceType::PrivateUse1,               \
+          "ProcessGroupOCCL only supports OpenReg (PrivateUse1) tensors. Got ", \
+          tensor.device().type(),                                               \
+          " for argument '",                                                    \
+          #tensor,                                                              \
+          "' in ",                                                              \
+          __func__,                                                             \
+          ".");                                                                 \
+    }                                                                           \
+  } while (0)
 
-  TORCH_CHECK(
-      tensor.device().type() == c10::DeviceType::PrivateUse1,
-      "ProcessGroupOCCL only supports OpenReg (PrivateUse1) tensors. Got ",
-      tensor.device().type(),
-      " for argument '",
-      argName,
-      "' in ",
-      opName,
-      ".");
-}
+#define CHECK_TENSOR_LIST(tensorList)                                             \
+  do {                                                                            \
+    for (const auto& tensor : tensorList) {                                       \
+      if (tensor.defined()) {                                                     \
+        TORCH_CHECK(                                                              \
+            tensor.device().type() == c10::DeviceType::PrivateUse1,               \
+            "ProcessGroupOCCL only supports OpenReg (PrivateUse1) tensors. Got ", \
+            tensor.device().type(),                                               \
+            " for argument '",                                                    \
+            #tensorList,                                                          \
+            "' in ",                                                              \
+            __func__,                                                             \
+            ".");                                                                 \
+      }                                                                           \
+    }                                                                             \
+  } while (0)
 
-void checkTensorList(
-    const std::vector<at::Tensor>& tensors,
-    c10::string_view opName,
-    c10::string_view argName) {
-  for (const auto& tensor : tensors) {
-    checkTensorDevice(tensor, opName, argName);
-  }
-}
-
-void checkTensorListOfLists(
-    const std::vector<std::vector<at::Tensor>>& tensorLists,
-    c10::string_view opName,
-    c10::string_view argName) {
-  for (const auto& tensors : tensorLists) {
-    checkTensorList(tensors, opName, argName);
-  }
-}
+#define CHECK_TENSOR_LIST_OF_LISTS(tensorListOfLists)                               \
+  do {                                                                              \
+    for (const auto& tensor_list : tensorListOfLists) {                             \
+      for (const auto& tensor : tensor_list) {                                      \
+        if (tensor.defined()) {                                                     \
+          TORCH_CHECK(                                                              \
+              tensor.device().type() == c10::DeviceType::PrivateUse1,               \
+              "ProcessGroupOCCL only supports OpenReg (PrivateUse1) tensors. Got ", \
+              tensor.device().type(),                                               \
+              " for argument '",                                                    \
+              #tensorListOfLists,                                                   \
+              "' in ",                                                              \
+              __func__,                                                             \
+              ".");                                                                 \
+        }                                                                           \
+      }                                                                             \
+    }                                                                               \
+  } while (0)
 
 } // namespace
 
 /**
-    @brief Currently, a no-op OCCL ProcessGroup stub for registration, tests and educational purposes.
+    @brief Currently, a no-op OCCL ProcessGroup stub for registration, tests and
+   educational purposes.
 
-    This translation unit provides a minimal ProcessGroup backend named "OCCL" (short
-    for OpenReg Collective Communications Library) that only validates input shapes/devices
-    and immediately returns a completed Work object without performing any actual communication.
-    It is intended for:
+    This translation unit provides a minimal ProcessGroup backend named "OCCL"
+   (short for OpenReg Collective Communications Library) that only validates
+   input shapes/devices and immediately returns a completed Work object without
+   performing any actual communication. It is intended for:
         - Out-of-tree custom CCL backend registration and linkage tests
         - API surface validation and call-site integration
 
     All collective point-to-point and synchronization calls are implemented as
     immediate, successful completions (unless a precondition check fails and an
     exception is thrown). As a result, these calls do not exchange data, do not
-    synchronize ranks, and do not modify input/output tensors. OCCL is for testing
-    and educational purposes only; it does not provide any real distributed functionality.
+    synchronize ranks, and do not modify input/output tensors. OCCL is for
+   testing and educational purposes only; it does not provide any real
+   distributed functionality.
 
     ------------------------------------------------------------------------------
     Class: ProcessGroupOCCL::DummyWork
@@ -74,8 +90,8 @@ void checkTensorListOfLists(
     - wait(timeout): returns immediately; the Future is already complete.
     - synchronize(): no-op; there is no associated device or stream work.
     - abort(): attempts to set an error only if the Future is not completed;
-                         has no effect in the current implementation since the Future is
-                         completed in the constructor.
+                         has no effect in the current implementation since the
+   Future is completed in the constructor.
     - getFuture(): returns the already-completed Future.
 
     Notes:
@@ -85,15 +101,16 @@ void checkTensorListOfLists(
     ------------------------------------------------------------------------------
     Class: ProcessGroupOCCL
 
-    @brief A stub ProcessGroup backend whose collectives validate inputs and then
-                 return a DummyWork that is already complete.
+    @brief A stub ProcessGroup backend whose collectives validate inputs and
+   then return a DummyWork that is already complete.
 
     General behavior across all methods below:
     - Input validation: Methods call internal helpers (e.g., checkTensorList,
         checkTensorListOfLists, checkTensorDevice) to validate that inputs are
         defined, have expected dtypes/devices, and adhere to basic invariants.
-        This is for building connection with out-of-tree accelerator backend (OpenReg)
-        and as a guard for blocking any changes from upstream that will break the compatibility.
+        This is for building connection with out-of-tree accelerator backend
+   (OpenReg) and as a guard for blocking any changes from upstream that will
+   break the compatibility.
     - No communication: No data movement or cross-rank coordination occurs.
     - Options ignored: All options/attributes (e.g., reduce ops, tags, counts,
         timeouts) are accepted but not used to affect behavior.
@@ -105,14 +122,16 @@ void checkTensorListOfLists(
     - Does not guarantee any semantic property of real collectives (e.g., data
         equivalence across ranks, synchronization, ordering).
     - Barrier does not synchronize ranks; it simply returns a completed Work.
-    - Safe for use in unit tests only where communication effects are not required.
+    - Safe for use in unit tests only where communication effects are not
+   required.
 
     ------------------------------------------------------------------------------
     Factory:
 
-    @fn createProcessGroupOCCL(const c10::intrusive_ptr<c10d::Store>& store, int rank, int size, const std::chrono::duration<float>& timeout)
-            Constructs a ProcessGroupOCCL using the given rank and size. The store and
-            timeout are accepted for API parity but are not used to affect behavior.
+    @fn createProcessGroupOCCL(const c10::intrusive_ptr<c10d::Store>& store, int
+   rank, int size, const std::chrono::duration<float>& timeout) Constructs a
+   ProcessGroupOCCL using the given rank and size. The store and timeout are
+   accepted for API parity but are not used to affect behavior.
             - @param store: Process group store (ignored).
             - @param rank: This process rank.
             - @param size: World size.
@@ -149,22 +168,23 @@ bool ProcessGroupOCCL::DummyWork::isSuccess() const {
   return !future_->hasError();
 }
 
-bool ProcessGroupOCCL::DummyWork::wait(std::chrono::milliseconds /* timeout */) {
+bool ProcessGroupOCCL::DummyWork::wait(
+    std::chrono::milliseconds /* timeout */) {
   future_->wait();
   return !future_->hasError();
 }
 
-void ProcessGroupOCCL::DummyWork::synchronize() {
-
-}
+void ProcessGroupOCCL::DummyWork::synchronize() {}
 
 void ProcessGroupOCCL::DummyWork::abort() {
   if (!future_->completed()) {
-    future_->setError(std::make_exception_ptr(std::runtime_error("OCCL work aborted")));
+    future_->setError(
+        std::make_exception_ptr(std::runtime_error("OCCL work aborted")));
   }
 }
 
-c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupOCCL::DummyWork::getFuture() {
+c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupOCCL::DummyWork::
+    getFuture() {
   return future_;
 }
 
@@ -183,35 +203,35 @@ ProcessGroupOCCL::~ProcessGroupOCCL() = default;
 c10::intrusive_ptr<Work> ProcessGroupOCCL::broadcast(
     std::vector<at::Tensor>& tensors,
     const BroadcastOptions& /* opts */) {
-  checkTensorList(tensors, "broadcast", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::allreduce(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& /* opts */) {
-  checkTensorList(tensors, "allreduce", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::allreduce_sparse(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& /* opts */) {
-  checkTensorList(tensors, "allreduce_sparse", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::allreduce_coalesced(
     std::vector<at::Tensor>& tensors,
     const AllreduceCoalescedOptions& /* opts */) {
-  checkTensorList(tensors, "allreduce_coalesced", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce(
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& /* opts */) {
-  checkTensorList(tensors, "reduce", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -219,8 +239,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::_reduce_scatter_base(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& /* opts */) {
-  checkTensorDevice(outputTensor, "_reduce_scatter_base", "outputTensor");
-  checkTensorDevice(inputTensor, "_reduce_scatter_base", "inputTensor");
+  CHECK_TENSOR(outputTensor);
+  CHECK_TENSOR(inputTensor);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -228,8 +248,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::_allgather_base(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& /* opts */) {
-  checkTensorDevice(output_tensor, "_allgather_base", "output_tensor");
-  checkTensorDevice(input_tensor, "_allgather_base", "input_tensor");
+  CHECK_TENSOR(output_tensor);
+  CHECK_TENSOR(input_tensor);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -237,8 +257,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& /* opts */) {
-  checkTensorListOfLists(outputs, "allgather", "outputs");
-  checkTensorList(inputs, "allgather", "inputs");
+  CHECK_TENSOR_LIST_OF_LISTS(outputs);
+  CHECK_TENSOR_LIST(inputs);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -246,8 +266,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather_coalesced(
     std::vector<std::vector<at::Tensor>>& output_lists,
     std::vector<at::Tensor>& input_list,
     const AllgatherOptions& /* opts */) {
-  checkTensorListOfLists(output_lists, "allgather_coalesced", "output_lists");
-  checkTensorList(input_list, "allgather_coalesced", "input_list");
+  CHECK_TENSOR_LIST_OF_LISTS(output_lists);
+  CHECK_TENSOR_LIST(input_list);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -255,8 +275,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::allgather_into_tensor_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& /* opts */) {
-  checkTensorList(outputs, "allgather_into_tensor_coalesced", "outputs");
-  checkTensorList(inputs, "allgather_into_tensor_coalesced", "inputs");
+  CHECK_TENSOR_LIST(outputs);
+  CHECK_TENSOR_LIST(inputs);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -264,8 +284,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::gather(
     std::vector<std::vector<at::Tensor>>& outputs,
     std::vector<at::Tensor>& inputs,
     const GatherOptions& /* opts */) {
-  checkTensorListOfLists(outputs, "gather", "outputs");
-  checkTensorList(inputs, "gather", "inputs");
+  CHECK_TENSOR_LIST_OF_LISTS(outputs);
+  CHECK_TENSOR_LIST(inputs);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -273,8 +293,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::scatter(
     std::vector<at::Tensor>& outputs,
     std::vector<std::vector<at::Tensor>>& inputs,
     const ScatterOptions& /* opts */) {
-  checkTensorList(outputs, "scatter", "outputs");
-  checkTensorListOfLists(inputs, "scatter", "inputs");
+  CHECK_TENSOR_LIST(outputs);
+  CHECK_TENSOR_LIST_OF_LISTS(inputs);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -282,8 +302,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter(
     std::vector<at::Tensor>& outputs,
     std::vector<std::vector<at::Tensor>>& inputs,
     const ReduceScatterOptions& /* opts */) {
-  checkTensorList(outputs, "reduce_scatter", "outputs");
-  checkTensorListOfLists(inputs, "reduce_scatter", "inputs");
+  CHECK_TENSOR_LIST(outputs);
+  CHECK_TENSOR_LIST_OF_LISTS(inputs);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -291,8 +311,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::reduce_scatter_tensor_coalesced(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ReduceScatterOptions& /* opts */) {
-  checkTensorList(outputTensors, "reduce_scatter_tensor_coalesced", "outputTensors");
-  checkTensorList(inputTensors, "reduce_scatter_tensor_coalesced", "inputTensors");
+  CHECK_TENSOR_LIST(outputTensors);
+  CHECK_TENSOR_LIST(inputTensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -302,8 +322,8 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::alltoall_base(
     std::vector<int64_t>& /* outputCounts */,
     std::vector<int64_t>& /* inputCounts */,
     const AllToAllOptions& /* opts */) {
-  checkTensorDevice(outputTensor, "alltoall_base", "outputTensor");
-  checkTensorDevice(inputTensor, "alltoall_base", "inputTensor");
+  CHECK_TENSOR(outputTensor);
+  CHECK_TENSOR(inputTensor);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -311,7 +331,7 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::send(
     std::vector<at::Tensor>& tensors,
     int /* dstRank */,
     int /* tag */) {
-  checkTensorList(tensors, "send", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
@@ -319,14 +339,14 @@ c10::intrusive_ptr<Work> ProcessGroupOCCL::recv(
     std::vector<at::Tensor>& tensors,
     int /* srcRank */,
     int /* tag */) {
-  checkTensorList(tensors, "recv", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupOCCL::recvAnysource(
     std::vector<at::Tensor>& tensors,
     int /* tag */) {
-  checkTensorList(tensors, "recvAnysource", "tensors");
+  CHECK_TENSOR_LIST(tensors);
   return c10::make_intrusive<ProcessGroupOCCL::DummyWork>();
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <chrono>
+
+#include <c10/util/intrusive_ptr.h>
+#include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/Store.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
+#include <torch/csrc/distributed/c10d/Utils.hpp>
+#include <torch/csrc/distributed/c10d/Work.hpp>
+
+#include <include/Macros.h>
+
+namespace c10d {
+
+//
+// ProcessGroupTest implements dummy bindings for c10d.
+//
+
+constexpr const char* OCCL_BACKEND_NAME = "occl";
+
+class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
+ public:
+  class DummyWork : public Work {
+   public:
+    DummyWork();
+
+    virtual ~DummyWork();
+    bool isCompleted() override;
+    bool isSuccess() const override;
+    bool wait(std::chrono::milliseconds timeout) override;
+    void synchronize() override;
+    void abort() override;
+    c10::intrusive_ptr<c10::ivalue::Future> getFuture() override;
+
+   protected:
+    friend class ProcessGroupOCCL;
+
+   private:
+    c10::intrusive_ptr<c10::ivalue::Future> future_;
+  };
+
+  struct TORCH_API Options : public Backend::Options {
+    explicit Options(
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout);
+
+    // return intrusive_ptr of the object
+    static c10::intrusive_ptr<Options> create(
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout) {
+      return c10::make_intrusive<Options>(timeout);
+    }
+  };
+
+  explicit ProcessGroupOCCL(int rank = -1, int size = -1);
+  virtual ~ProcessGroupOCCL();
+  const std::string getBackendName() const override {
+    return std::string(OCCL_BACKEND_NAME);
+  }
+
+  bool supportsSplitting() const override {
+    return false;
+  }
+
+  c10::intrusive_ptr<Backend::Options> getBackendOptions() override {
+    return c10::static_intrusive_pointer_cast<Backend::Options>(options_);
+  }
+
+  c10::intrusive_ptr<Work> broadcast(
+    std::vector<at::Tensor>& tensors,
+    const BroadcastOptions& opts = BroadcastOptions()) override;
+
+  c10::intrusive_ptr<Work> allreduce(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& opts = AllreduceOptions()) override;
+
+  c10::intrusive_ptr<Work> allreduce_sparse(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& opts = AllreduceOptions()) override;
+
+  c10::intrusive_ptr<Work> allreduce_coalesced(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceCoalescedOptions& opts =
+      AllreduceCoalescedOptions()) override;
+
+  c10::intrusive_ptr<Work> reduce(
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& opts = ReduceOptions()) override;
+
+  c10::intrusive_ptr<Work> _reduce_scatter_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> _allgather_base(
+    at::Tensor& output_tensor,
+    at::Tensor& input_tensor,
+    const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  c10::intrusive_ptr<Work> allgather(
+    std::vector<std::vector<at::Tensor>>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  c10::intrusive_ptr<Work> allgather_coalesced(
+    std::vector<std::vector<at::Tensor>>& output_lists,
+    std::vector<at::Tensor>& input_list,
+    const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+    std::vector<at::Tensor>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  c10::intrusive_ptr<Work> gather(
+    std::vector<std::vector<at::Tensor>>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const GatherOptions& opts = GatherOptions()) override;
+
+  c10::intrusive_ptr<Work> scatter(
+    std::vector<at::Tensor>& outputs,
+    std::vector<std::vector<at::Tensor>>& inputs,
+    const ScatterOptions& opts = ScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> reduce_scatter(
+    std::vector<at::Tensor>& outputs,
+    std::vector<std::vector<at::Tensor>>& inputs,
+    const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> alltoall_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    std::vector<int64_t>& outputCounts,
+    std::vector<int64_t>& inputCounts,
+    const AllToAllOptions& opts = AllToAllOptions()) override;
+
+  c10::intrusive_ptr<Work> send(
+    std::vector<at::Tensor>& tensors,
+    int dstRank,
+    int tag) override;
+
+  c10::intrusive_ptr<Work> recv(
+    std::vector<at::Tensor>& tensors,
+    int srcRank,
+    int tag) override;
+
+  c10::intrusive_ptr<Work> recvAnysource(
+    std::vector<at::Tensor>& tensors,
+    int tag) override;
+
+  c10::intrusive_ptr<Work> barrier(
+    const BarrierOptions& opts = BarrierOptions()) override;
+
+ protected:
+  const c10::intrusive_ptr<Options> options_;
+};
+OPENREG_EXPORT c10::intrusive_ptr<ProcessGroupOCCL> createProcessGroupOCCL(
+    const c10::intrusive_ptr<c10d::Store>& store,
+    int rank,
+    int size,
+    const std::chrono::duration<float>& timeout);
+
+} // namespace c10d

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#if USE_DISTRIBUTED
 #include <chrono>
 
 #include <c10/util/intrusive_ptr.h>
@@ -40,7 +40,7 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     c10::intrusive_ptr<c10::ivalue::Future> future_;
   };
 
-  struct TORCH_API Options : public Backend::Options {
+  struct OPENREG_EXPORT Options : public Backend::Options {
     explicit Options(
         std::chrono::milliseconds timeout = kBackendDefaultTimeout);
 
@@ -165,3 +165,4 @@ OPENREG_EXPORT c10::intrusive_ptr<ProcessGroupOCCL> createProcessGroupOCCL(
     const std::chrono::duration<float>& timeout);
 
 } // namespace c10d
+#endif // USE_DISTRIBUTED

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
@@ -1,0 +1,101 @@
+# Owner(s): ["module: PrivateUse1"]
+
+import os
+import sys
+import tempfile
+
+
+os.environ["BACKEND"] = "occl"
+os.environ["WORLD_SIZE"] = "2"
+
+# Provide a TEMP_DIR compatible with Barrier helpers if not already present.
+if "TEMP_DIR" not in os.environ:
+    _tmp_dir = tempfile.TemporaryDirectory()
+    os.environ["TEMP_DIR"] = _tmp_dir.name
+    os.makedirs(os.path.join(_tmp_dir.name, "barrier"), exist_ok=True)
+    os.makedirs(os.path.join(_tmp_dir.name, "test_dir"), exist_ok=True)
+    os.makedirs(os.path.join(_tmp_dir.name, "init_dir"), exist_ok=True)
+    os.environ["INIT_METHOD"] = (
+        f"file://{os.path.join(_tmp_dir.name, 'init_dir', 'shared_init_file')}"
+    )
+
+
+import torch
+import torch.distributed as dist
+from torch.distributed.distributed_c10d import _get_default_group
+from torch.testing._internal.common_distributed import (
+    cleanup_temp_dir,
+    initialize_temp_directories,
+    MultiProcessTestCase,
+)
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.distributed.distributed_test import (
+    Barrier,
+    DistributedTest,
+    TestDistBackend,
+)
+
+
+if not (dist.is_available() and "occl" in dist.Backend.backend_list):
+    print("torch.distributed OCCL backend unavailable, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+
+class TestProcessGroupOCCL(TestDistBackend, DistributedTest._DistTestBase):
+    # OCCL collectives are dummy; we only validate registration and basic API.
+
+    def setUp(self):
+        # Bypass TestDistBackend.setUp (which expects many inherited tests) and
+        # perform the minimal MultiProcessTestCase setup plus temp dir wiring.
+        MultiProcessTestCase.setUp(self)
+        initialize_temp_directories()
+        Barrier.init()
+        self.skip_return_code_checks = []
+        # Spawn subprocesses for multi-process execution when running as main.
+        if self.rank == self.MAIN_PROCESS_RANK:
+            self._spawn_processes()
+
+    def tearDown(self):
+        cleanup_temp_dir()
+        super().tearDown()
+
+    def test_occl_backend_registration_and_default_group(self) -> None:
+        # Backend is registered and available in the backend list.
+        self.assertTrue(dist.is_available())
+        self.assertIn("occl", dist.Backend.backend_list)
+
+        # Default group should already be initialized for OCCL.
+        self.assertTrue(dist.is_initialized())
+        self.assertEqual(dist.get_backend(), "occl")
+
+        pg = _get_default_group()
+        self.assertEqual(dist.get_backend(pg), "occl")
+        self.assertEqual(dist.get_world_size(), 2)
+        self.assertEqual(dist.get_rank(), self.rank)
+
+    def test_occl_allreduce(self) -> None:
+        pg = _get_default_group()
+        device = torch.device("openreg")
+
+        tensors = [torch.rand(1, device=device)]
+        fut = pg.allreduce(tensors).get_future()
+        fut.wait()
+        self.assertTrue(fut.done())
+
+        # OCCL is currently a dummy backend and all communication methods return None.
+        res = fut.value()
+        self.assertEqual(res, None)
+
+
+# Drop inherited torch distributed backend tests; we only need the OCCL smoke test.
+_allowed_tests = {
+    "test_occl_backend_registration_and_default_group",
+    "test_occl_allreduce",
+}
+for _name in dir(TestProcessGroupOCCL):
+    if _name.startswith("test_") and _name not in _allowed_tests:
+        setattr(TestProcessGroupOCCL, _name, None)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
@@ -4,6 +4,14 @@ import os
 import sys
 import tempfile
 
+import torch
+import torch.distributed as dist
+
+
+if not (dist.is_available() and "occl" in dist.Backend.backend_list):
+    print("torch.distributed OCCL backend unavailable, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
 
 os.environ["BACKEND"] = "occl"
 os.environ["WORLD_SIZE"] = "2"
@@ -20,8 +28,6 @@ if "TEMP_DIR" not in os.environ:
     )
 
 
-import torch
-import torch.distributed as dist
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.testing._internal.common_distributed import (
     cleanup_temp_dir,
@@ -34,11 +40,6 @@ from torch.testing._internal.distributed.distributed_test import (
     DistributedTest,
     TestDistBackend,
 )
-
-
-if not (dist.is_available() and "occl" in dist.Backend.backend_list):
-    print("torch.distributed OCCL backend unavailable, skipping tests", file=sys.stderr)
-    sys.exit(0)
 
 
 class TestProcessGroupOCCL(TestDistBackend, DistributedTest._DistTestBase):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py
@@ -1,16 +1,15 @@
 # Owner(s): ["module: PrivateUse1"]
 
 import os
-import sys
 import tempfile
+import unittest
 
 import torch
 import torch.distributed as dist
 
 
 if not (dist.is_available() and "occl" in dist.Backend.backend_list):
-    print("torch.distributed OCCL backend unavailable, skipping tests", file=sys.stderr)
-    sys.exit(0)
+    raise unittest.SkipTest("torch.distributed OCCL backend unavailable")
 
 
 os.environ["BACKEND"] = "occl"

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
@@ -17,6 +17,14 @@ torch.utils.rename_privateuse1_backend("openreg")
 torch._register_device_module("openreg", torch_openreg.openreg)
 torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
 
+if torch.distributed.is_available():
+    try:
+        torch.distributed.Backend.register_backend(
+            "occl", torch_openreg._C._createProcessGroupOCCL, devices=["openreg"]
+        )
+    except Exception as e:
+        raise RuntimeError("Failed to register 'occl' process group backend.") from e
+
 
 # LITERALINCLUDE START: AUTOLOAD
 def _autoload():

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/csrc/Module.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/csrc/Module.cpp
@@ -10,7 +10,9 @@
 #include <pybind11/chrono.h>
 #include <pybind11/pybind11.h>
 
+#if USE_DISTRIBUTED
 #include <distributed/c10d/ProcessGroupOCCL.hpp>
+#endif
 #include <runtime/OpenRegFunctions.h>
 
 static PyObject* _initExtension(PyObject* self, PyObject* noargs) {
@@ -118,10 +120,11 @@ extern "C" OPENREG_EXPORT PyObject* initOpenRegModule(void) {
 
   namespace py = pybind11;
   py::module m = py::reinterpret_borrow<py::module>(mod);
-  // Expose the OCCL process group to Python. The intrusive_ptr template arg
-  // tells pybind11 how to manage lifetime of C++ shared state when returned
-  // to Python, and we list Backend as a base so Python recognizes the
-  // inheritance hierarchy.
+  // Expose the OCCL process group to Python only when distributed is enabled.
+  // The intrusive_ptr template arg tells pybind11 how to manage lifetime of
+  // C++ shared state when returned to Python, and we list Backend as a base
+  // so Python recognizes the inheritance hierarchy.
+#if USE_DISTRIBUTED
   py::class_<c10d::ProcessGroupOCCL, c10d::Backend, c10::intrusive_ptr<c10d::ProcessGroupOCCL>>( // NOLINT(bugprone-unused-raii)
       m,
       "ProcessGroupOCCL");
@@ -134,6 +137,7 @@ extern "C" OPENREG_EXPORT PyObject* initOpenRegModule(void) {
       py::arg("rank"),
       py::arg("size"),
       py::arg("timeout"));
+#endif
 
   return mod;
 }


### PR DESCRIPTION
## Summary
This PR improves the OpenReg out-of-tree distributed backend integration tests and stubs:

- Strengthens `ProcessGroupOCCL` (OCCL) as a no-op c10d backend by validating that inputs are OpenReg / `PrivateUse1` tensors across all entrypoints.
- Updates the stub `Work` implementation to be future-backed (uses `Work::getFuture()`), avoiding deprecated success APIs and matching modern c10d patterns.
- Refactors the OpenReg distributed test to use PyTorch’s standard distributed test harness (`TestDistBackend` / `DistributedTest._DistTestBase`) and adds extra coverage for backend registration + process group creation.

OCCL is intentionally a dummy backend and does not perform real communication; tests focus on initialization, registration, and basic API callability.

## Motivation
OpenReg (PrivateUse1) backends are often developed out-of-tree. This PR ensures:

- Pefrom as an example for out-of-tree CCL backend integration.
- Early, clear failures when non-OpenReg tensors are accidentally passed to OCCL collectives.
- The backend follows current c10d `Work` semantics (future-based completion).
- The extension test suite exercises the same initialization and spawning patterns used by upstream distributed tests.

## Test plan
- `python test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_distributed.py -v`

## Notes
- The OCCL backend remains a no-op stub; returned futures complete immediately and collectives do not modify tensors.
