### PR TITLE
[inductor] Fix nan_asserts for FP8 types

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16534,8 +16534,8 @@ if RUN_GPU:
                 self.assertRegex(code, r"return_vars = (.*)")
                 self.assertIn("for var in return_vars:", code)
                 self.assertIn("if isinstance(var, torch.Tensor):", code)
-                self.assertRegex(code, r"assert not .*\.isnan\(\)\.any\(\).item\(\)")
-                self.assertRegex(code, r"assert not .*\.isinf\(\)\.any\(\).item\(\)")
+                self.assertRegex(code, r"assert not .*\.float\(\)\.isnan\(\)\.any\(\).item\(\)")
+                self.assertRegex(code, r"assert not .*\.float\(\)\.isinf\(\)\.any\(\).item\(\)")
 
         @config.patch("nan_asserts", True)
         def test_nan_checker_fail(self):
@@ -16548,6 +16548,19 @@ if RUN_GPU:
                 AssertionError if not config.cpp_wrapper else RuntimeError
             ):
                 torch.compile(f)(x)
+
+        @config.patch("nan_asserts", True)
+        def test_nan_checker_fp8(self):
+            """Test that nan_asserts works with FP8 types (issue #149002)."""
+
+            def f(x):
+                return x.half() + 1
+
+            x = torch.randn(10, device=GPU_TYPE).to(torch.float8_e4m3fn)
+            # This should not raise RuntimeError about isinf not implemented for FP8
+            actual = torch.compile(f, fullgraph=True)(x)
+            ref = f(x)
+            self.assertTrue(torch.allclose(ref, actual))
 
 
 if RUN_CPU:

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -259,9 +259,10 @@ class MultiKernel:
                     continue
                 seen.add(arg)
                 if isinstance(precompile_arg, TensorArg):
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # Use .float() to handle FP8 types which don't support isnan/isinf
+                    line = f"assert not {arg}.float().isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {arg}.float().isinf().any().item()"
                     wrapper.writeline(line)
 
     @property

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5616,9 +5616,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         f'AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_check_inf_and_nan("{arg}", {arg}));'
                     )
                 else:
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # Use .float() to handle FP8 types which don't support isnan/isinf
+                    line = f"assert not {arg}.float().isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not {arg}.float().isinf().any().item()"
                     wrapper.writeline(line)
 
     def create_cse_var(self, *args, **kwargs) -> TritonCSEVariable:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1364,9 +1364,10 @@ class PythonWrapperCodegen(CodeGen):
             if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
                 continue
 
-            line = f"assert not {name}.isnan().any().item()"
+            # Use .float() to handle FP8 types which don't support isnan/isinf
+            line = f"assert not {name}.float().isnan().any().item()"
             self.prefix.writeline(line)
-            line = f"assert not {name}.isinf().any().item()"
+            line = f"assert not {name}.float().isinf().any().item()"
             self.prefix.writeline(line)
 
     def write_async_compile_wait(self) -> None:
@@ -1519,8 +1520,9 @@ class PythonWrapperCodegen(CodeGen):
                 self.wrapper_call.do_indent()
                 self.wrapper_call.writeline("if isinstance(var, torch.Tensor):")
                 self.wrapper_call.do_indent()
-                self.wrapper_call.writeline("assert not var.isnan().any().item()")
-                self.wrapper_call.writeline("assert not var.isinf().any().item()")
+                # Use .float() to handle FP8 types which don't support isnan/isinf
+                self.wrapper_call.writeline("assert not var.float().isnan().any().item()")
+                self.wrapper_call.writeline("assert not var.float().isinf().any().item()")
                 self.wrapper_call.do_unindent(2)
 
             self.wrapper_call.writeline("return (" + ", ".join(output_refs) + ", )")


### PR DESCRIPTION
## Summary
- Fix RuntimeError when using `config.nan_asserts = True` with FP8 tensors
- Upcast FP8 tensors to float before calling `isnan()`/`isinf()`

## Changes
- `torch/_inductor/codegen/wrapper.py`: Use `.float()` before nan/inf checks
- `torch/_inductor/codegen/triton.py`: Same fix
- `torch/_inductor/codegen/multi_kernel.py`: Same fix
- `test/inductor/test_torchinductor.py`: Add test for FP8 nan_asserts

## Test plan
- Added `test_nan_checker_fp8` test case
- Existing nan_asserts tests updated to match new code pattern

Fixes #149002

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo