### PR TITLE
[PrivateUse1][Profiler] Refactor `RegisterPRIVATEUSE1Observer` constructor and macro for clarity

### DIFF
--- a/torch/csrc/profiler/standalone/privateuse1_observer.h
+++ b/torch/csrc/profiler/standalone/privateuse1_observer.h
@@ -34,13 +34,11 @@ extern TORCH_API struct PushPRIVATEUSE1CallbacksStub
     pushPRIVATEUSE1CallbacksStub;
 
 struct RegisterPRIVATEUSE1Observer {
-  RegisterPRIVATEUSE1Observer(
-      PushPRIVATEUSE1CallbacksStub& stub,
-      CallBackFnPtr value) {
-    stub.set_privateuse1_dispatch_ptr(value);
+  RegisterPRIVATEUSE1Observer(CallBackFnPtr cb) {
+    pushPRIVATEUSE1CallbacksStub.set_privateuse1_dispatch_ptr(cb);
   }
 };
 
-#define REGISTER_PRIVATEUSE1_OBSERVER(name, fn) \
-  static RegisterPRIVATEUSE1Observer name##__register(name, fn);
+#define REGISTER_PRIVATEUSE1_OBSERVER(cb) \
+  static RegisterPRIVATEUSE1Observer privateuse1_callbacks_stub_register(cb);
 } // namespace torch::profiler::impl


### PR DESCRIPTION
## Summary  
This PR refactors the registration macro for PrivateUse1 callback stubs.  

## Motivation  
The previous macro included a redundant input argument, `name`, which represented an instance of `PushPRIVATEUSE1CallbacksStub` used for registering the stub:  
https://github.com/pytorch/pytorch/blob/4a0c83f1ca2a64bec76db4e3f1aa332beb6c6423/torch/csrc/profiler/standalone/privateuse1_observer.h#L33-L45  

However, there is already a static instance, `pushPRIVATEUSE1CallbackStub`, which is the sole entity being invoked:  
https://github.com/pytorch/pytorch/blob/4a0c83f1ca2a64bec76db4e3f1aa332beb6c6423/torch/csrc/autograd/profiler_kineto.cpp#L778-L780  

As a result, the `name` parameter introduces unnecessary ambiguity and confusion.  

cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise @mwootton @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD @fffrog