### PR TITLE
[ROCm][AMDSMI] Fix exception handling and test logic bugs

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4968,11 +4968,12 @@ print(value, end="")
         uuids = subprocess.check_output(cmd, shell=True, text=True).strip().split("\n")
         uuids = [s.strip() for s in uuids]
         raw_uuids = torch.cuda._raw_device_uuid_amdsmi()
+        matching = True
         for uuid in uuids:
-            matching = True
             if not any(uuid in raw_id for raw_id in raw_uuids):
                 matching = False
-        self.assertEqual(True, matching)
+                break  # Exit early on first mismatch
+        self.assertTrue(matching, "Mismatch detected between rocminfo and amdsmi UUIDs")
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1310,7 +1310,13 @@ def _get_amdsmi_handler(device: Device = None):
             "amdsmi driver can't be loaded, requires >=ROCm5.6 installation"
         ) from e
     device = _get_amdsmi_device_index(device)
-    handle = amdsmi.amdsmi_get_processor_handles()[device]
+    try:
+        handle = amdsmi.amdsmi_get_processor_handles()[device]
+    except (amdsmi.AmdSmiException, IndexError) as e:
+        raise RuntimeError(
+            f"Failed to get AMDSMI handle for device index {device}. "
+            "This may occur if the index is out of range or the driver is unresponsive."
+        ) from e
     return handle
 
 


### PR DESCRIPTION
## Summary

This PR addresses two AMDSMI-related issues that affect ROCm users:

### 1. Exception Handling Fix (`torch/cuda/__init__.py`)

**Problem:** The `_get_amdsmi_handler()` function calls `amdsmi.amdsmi_get_processor_handles()[device]` but only catches `AmdSmiException`. If the device index is out of range, an uncaught `IndexError` is raised with no meaningful error message.

**Fix:** Add `IndexError` to the exception handler and provide a descriptive error message that helps users diagnose the issue.

```python
except (amdsmi.AmdSmiException, IndexError) as e:
    raise RuntimeError(
        f"Failed to get AMDSMI handle for device index {device}. "
        "This may occur if the index is out of range or the driver is unresponsive."
    ) from e
```

### 2. Test Logic Fix (`test/test_cuda.py`)

**Problem:** In `test_raw_amdsmi_device_uuids()`, the `matching` variable is reset to `True` at the start of each loop iteration. This causes the test to only validate the **last** UUID, not all of them. A test with 8 GPUs could pass even if 7 UUIDs are wrong.

**Before (buggy):**
```python
for uuid in uuids:
    matching = True  # Reset each iteration!
    if not any(uuid in raw_id for raw_id in raw_uuids):
        matching = False
self.assertEqual(True, matching)  # Only checks last UUID
```

**After (fixed):**
```python
matching = True  # Set once before loop
for uuid in uuids:
    if not any(uuid in raw_id for raw_id in raw_uuids):
        matching = False
        break  # Exit early on first mismatch
self.assertTrue(matching, "Mismatch detected between rocminfo and amdsmi UUIDs")
```

## Test Plan

- Verified syntax correctness of both changes
- The test logic fix ensures all UUIDs are validated, not just the last one
- The exception handling fix provides better error messages for out-of-range device indices

## Platforms Affected

- AMD Instinct MI300X (gfx942)
- AMD Strix Halo (gfx1151)
- All ROCm platforms using AMDSMI

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet