### PR TITLE
[ROCm] Add warning when cpp_extension fails to auto-detect architecture

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2603,6 +2603,12 @@ def _get_rocm_arch_flags(cflags: list[str] | None = None) -> list[str]:
             archs = archFlags.split()
         else:
             archs = []
+            logger.warning(
+                "Failed to auto-detect ROCm architecture. Extensions will be compiled "
+                "without architecture-specific optimizations. Set PYTORCH_ROCM_ARCH "
+                "environment variable to specify target architectures "
+                "(e.g., export PYTORCH_ROCM_ARCH='gfx90a;gfx942')."
+            )
     else:
         archs = _archs.replace(' ', ';').split(';')
     flags = [f'--offload-arch={arch}' for arch in archs]


### PR DESCRIPTION
## Summary

Adds a warning when ROCm architecture auto-detection fails in `torch.utils.cpp_extension`.

### The Problem

When building a C++ extension on ROCm without setting `PYTORCH_ROCM_ARCH`, the code attempts to auto-detect the architecture via `torch._C._cuda_getArchFlags()`. If this returns empty (e.g., if PyTorch wasn't compiled with specific ROCm arch flags), the code **silently** compiles extensions without any `--offload-arch` flags:

```python
if archFlags:
    archs = archFlags.split()
else:
    archs = []  # Silent failure!
```

This leads to:
1. Extensions compiled without architecture-specific optimizations
2. Potential runtime issues when running on GPUs with different architectures
3. User confusion about why their extensions perform poorly or fail

### The Fix

Add a warning when `archs` is empty, guiding users to set `PYTORCH_ROCM_ARCH`:

```python
logger.warning(
    "Failed to auto-detect ROCm architecture. Extensions will be compiled "
    "without architecture-specific optimizations. Set PYTORCH_ROCM_ARCH "
    "environment variable to specify target architectures "
    "(e.g., export PYTORCH_ROCM_ARCH='gfx90a;gfx942')."
)
```

### Comparison with CUDA

The CUDA path (`_get_cuda_arch_flags`) has robust auto-detection:
- Uses `torch.cuda.device_count()` and `torch.cuda.get_device_capability()`
- Logs detected architectures
- Validates against supported architectures

This PR improves the ROCm path to at least warn users when detection fails.

## Test Plan

- Manual testing: Build an extension on ROCm without PYTORCH_ROCM_ARCH set
- Expected: Warning message is printed

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)