### PR TITLE
[Inductor] Fix missing kernel hash for templated kernels

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -360,6 +360,13 @@ class CachingAutotuner(KernelInterface):
             base_name = os.path.basename(self.filename)
             if ".py" in base_name:
                 self.kernel_hash = os.path.splitext(base_name)[0]
+        else:
+            fn_name = getattr(fn, "__name__", "unknown_kernel")
+            try:
+                code_hash = hashlib.sha256(fn.__code__.co_code).hexdigest()[:16]
+            except AttributeError:
+                code_hash = str(hash(fn))
+            self.kernel_hash = f"{fn_name}_{code_hash}"
 
         self.precompile_time_taken_ns = 0
         self.autotune_time_taken_ns = 0


### PR DESCRIPTION
Fixes #171184 

[Inductor] Fix missing kernel hash for templated kernels in CachingAutotuner



### Summary
This PR fixes an issue where `CachingAutotuner` failed to generate a `kernel_hash` for templated kernels (where `filename` is `None`). This resulted in missing `bestconfig` and launch parameter dumps for those kernels, complicating debugging for AMD/H100 workflows.

**The Fix:**
I updated the `__init__` logic in `CachingAutotuner`.
- If `filename` is provided, the behavior remains unchanged (hash is derived from the filename).
- If `filename` is `None`, it now falls back to generating a deterministic hash using the function name and bytecode (`fn.__code__.co_code`).
- Added a robust fallback (`str(hash(fn))`) for objects without bytecode (e.g., mocks or partials) to prevent regressions in edge cases.

### Test Plan
I verified the fix locally using a unit test script that covers standard cases, missing filenames with bytecode, and objects without bytecode.

**Verification Script:**
<details>
<summary>Click to expand test script</summary>

```python
import unittest
import torch
import hashlib
from unittest.mock import MagicMock
from torch._inductor.runtime.triton_heuristics import CachingAutotuner

class TestCachingAutotunerHash(unittest.TestCase):
    def setUp(self):
        self.mock_config = MagicMock()
        self.mock_config.pre_hook = None
        self.triton_meta = {"device": MagicMock()}

    def _get_autotuner(self, fn, filename):
        return CachingAutotuner(
            fn=fn,
            triton_meta=self.triton_meta,
            configs=[self.mock_config],
            save_cache_hook=False,
            mutated_arg_names=[],
            optimize_mem=False,
            heuristic_type="pointwise",
            filename=filename
        )

    def test_standard_filename(self):
        """Case 1: Standard behavior where filename is provided."""
        fn = MagicMock()
        fn.__name__ = "standard_kernel"
        filename = "/tmp/torchinductor_user/standard_kernel_xyz123.py"
        
        tuner = self._get_autotuner(fn, filename)
        self.assertEqual(tuner.kernel_hash, "standard_kernel_xyz123")

    def test_filename_none_with_bytecode(self):
        """Case 2 (The Bug): Filename is None, but function has bytecode."""
        def real_function_logic(x):
            return x + 1

        tuner = self._get_autotuner(real_function_logic, filename=None)
        self.assertIsNotNone(tuner.kernel_hash)
        self.assertNotEqual(tuner.kernel_hash, "")
        self.assertIn("real_function_logic", tuner.kernel_hash)

    def test_filename_none_no_bytecode(self):
        """Case 3: Filename is None, and function has no bytecode."""
        # Define a callable class that has a name but NO __code__ attribute
        class MockKernel:
            def __init__(self, name):
                self.__name__ = name
            def __call__(self): pass

        fn = MockKernel("mock_kernel_obj")
        tuner = self._get_autotuner(fn, filename=None)
        
        self.assertIsNotNone(tuner.kernel_hash)
        self.assertNotEqual(tuner.kernel_hash, "")
        self.assertIn("mock_kernel_obj", tuner.kernel_hash)

    def test_hash_uniqueness(self):
        """Case 4: Different functions should produce different hashes."""
        def func_a(x): return x + 1
        def func_b(x): return x * 2

        tuner_a = self._get_autotuner(func_a, filename=None)
        tuner_b = self._get_autotuner(func_b, filename=None)

        self.assertNotEqual(tuner_a.kernel_hash, tuner_b.kernel_hash)

if __name__ == "__main__":
    unittest.main()
```
**Output:**
```
Ran 4 tests in 0.003s
OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo