### PR TITLE
sixlib precompile workarounds

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -957,6 +957,10 @@ class MockFXGraphCacheOutput(OutputCode):
         # Serialize the FX graph via GraphPickler and clear gm to avoid std pickle issues.
         if self.gm is not None:
             from torch.fx._graph_pickler import GraphPickler
+            for node in self.gm.graph.nodes:
+                node.meta.pop("source_fn_stack", None)
+                node.meta.pop("nn_module_stack", None)
+                node.meta.pop("fwd_source_fn_stack", None)
             self._serialized_graph_module = GraphPickler.dumps(self.gm)
             self.gm = None
 

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -35,6 +35,7 @@ def _ops_filter_safe(name: str) -> bool:
         (
             "torch.ops.aten",
             "torch.ops.fbgemm",
+            "torch.ops",
         )
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #171279
* __->__ #171278
* #171277
* #171276
* #170999
* #170998
* #170961



cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo