### PR TITLE
[Dynamo][Triton] handle wrap_triton as a no-op in Dynamo tracing

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4221,6 +4221,7 @@ class GraphModule(torch.nn.Module):
 
         self.assertEqual(result, torch.sin(x))
 
+
 def udf_mul(x, y):
     return x * y
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4221,7 +4221,6 @@ class GraphModule(torch.nn.Module):
 
         self.assertEqual(result, torch.sin(x))
 
-
 def udf_mul(x, y):
     return x * y
 

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -3314,6 +3314,17 @@
       ]
     }
   ],
+  "GB6735": [
+    {
+      "Gb_type": "torch.library.wrap_triton call with > 1 args",
+      "Context": "args={args}, kwargs={kwargs}",
+      "Explanation": "Attempted to call `torch.library.wrap_triton` with > 1 args. Dynamo does not support this.",
+      "Hints": [
+        "Remove the torch.library.wrap_triton call or its additional args.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0315": [
     {
       "Gb_type": "torch.associative_scan: improper xs",

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -374,6 +374,7 @@ manual_torch_name_rule_map: dict[
     "torch._C._autograd._unsafe_set_version_counter": TorchInGraphFunctionVariable,
     "torch.xpu.get_rng_state": SkipFunctionVariable,
     "torch.xpu.set_rng_state": SkipFunctionVariable,
+    "torch.library.wrap_triton": TorchInGraphFunctionVariable,
     # avoid skipping user defined modules in distributed unit tests
     "torch/testing/_internal/common_fsdp.py#forward": UserFunctionVariable,
     f"torch/testing/_internal/common_fsdp.py#{TORCH_DYNAMO_RESUME_IN_PREFIX}": UserFunctionVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -688,7 +688,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
 
         @register(torch.library.wrap_triton)
-        def handle_wrap_triton(self, tx: "InstructionTranslator", *args, **kwargs):
+        def handle_wrap_triton(self, tx: "InstructionTranslator", *args: VariableTracker, **kwargs: VariableTracker) -> VariableTracker:
             if len(args) == 1:
                 # torch.library.wrap_triton is a no-op in dynamo
                 return args[0]

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -688,7 +688,12 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
 
         @register(torch.library.wrap_triton)
-        def handle_wrap_triton(self, tx: "InstructionTranslator", *args: VariableTracker, **kwargs: VariableTracker) -> VariableTracker:
+        def handle_wrap_triton(
+            self,
+            tx: "InstructionTranslator",
+            *args: VariableTracker,
+            **kwargs: VariableTracker,
+        ) -> VariableTracker:
             if len(args) == 1:
                 # torch.library.wrap_triton is a no-op in dynamo
                 return args[0]

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -687,6 +687,22 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 ],
             )
 
+        @register(torch.library.wrap_triton)
+        def handle_wrap_triton(self, tx: "InstructionTranslator", *args, **kwargs):
+            if len(args) == 1:
+                # torch.library.wrap_triton is a no-op in dynamo
+                return args[0]
+
+            unimplemented(
+                gb_type="torch.library.wrap_triton call with > 1 args",
+                context=f"args={args}, kwargs={kwargs}",
+                explanation="Attempted to call `torch.library.wrap_triton` with > 1 args. Dynamo does not support this.",
+                hints=[
+                    "Remove the torch.library.wrap_triton call or its additional args.",
+                    *graph_break_hints.SUPPORTABLE,
+                ],
+            )
+
         @register(*REWRITE_OPS_TO_TENSOR_SIZE_METHOD)
         def handle_tensor_size_rewrites(self, tx: "InstructionTranslator", input):
             assert input.is_tensor()


### PR DESCRIPTION
**Context**
`wrap_triton` should be handled as a no-op by Dynamo. Currently, it is under a module marked to be skipped by Dynamo, so `wrap_triton` generates a graph break. This PR adds a custom handler that returns the provided argument to `wrap_triton` (the user-defined custom kernel). 

**Repro**
```
import torch
import triton
import triton.language as tl

@triton.jit
def sin_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: "tl.constexpr"):
    pid = tl.program_id(axis=0)
    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
    mask = offsets < n_elements
    x = tl.load(x_ptr + offsets, mask=mask)
    tl.store(y_ptr + offsets, tl.sin(x), mask=mask)

def fn(x: torch.Tensor) -> torch.Tensor:
    out = torch.empty_like(x)
    n_elements = x.numel()

    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)

    wrapped = torch.library.wrap_triton(sin_kernel)
    wrapped[grid](x, out, n_elements, BLOCK_SIZE=128)
    return out

compiled = torch.compile(fn, fullgraph=True, backend="eager")
x = torch.randn(1024, device="cuda")
result = compiled(x)
print(torch.allclose(result, torch.sin(x)))
```
- Error message
```
Graph Break Reason: Attempted to call function marked as skipped
...
```
- Expected behavior: Print `True`

**Solution**
1. Mark torch.library.wrap_triton as a function to be included in the FX graph in trace_rules.py.
2. Add a custom handler for torch.library.wrap_triton in torch.py that returns the argument provided to the function. This is a no-op.

**Testing**
This PR adds 1 new test. Run the test with
```
python test/dynamo/test_functions.py FunctionTests.test_wrap_triton_handled_during_tracing
```

**Other Notes**
1. If you `wrapped = torch.library.wrap_triton(sin_kernel)` outside the definition of `fn`, this throws a different error. This error is Dynamo error unsupported context manager 'lock'. The hint alludes that typically context managers cannot be created outside the compiled region and used in the compiled region. Therefore, this error seems to be expected behavior `wrap_triton` creates a lock context manager, so we cannot call it outside the compiled region and use the object TraceableTritonKernelWrapper it produces inside the compiled region since many of its functions use the same lock.
2. The graph produced after this change is the exact same as the graph produced if we had no call to `wrap_triton` at all. This is not necessarily an issue but just something interesting to call out.
<img width="645" height="95" alt="Screenshot 2025-12-24 at 11 34 09 PM" src="https://github.com/user-attachments/assets/1d24383d-be01-447d-93c8-f95c6d0c819f" />


Fixes #154365


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @ydwu4