### PR TITLE
Fix typo in variable name from 'statetful_sd' to 'stateful_sd'

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -173,17 +173,17 @@ def load(
         # the same order.
         keys = sorted(state_dict.keys())
 
-        statetful_sd = {}
+        stateful_sd = {}
         for key in keys:
             if key not in state_dict:
                 continue
             elem = state_dict[key]
-            statetful_sd[key] = (
+            stateful_sd[key] = (
                 elem.state_dict() if isinstance(elem, Stateful) else elem
             )
 
         _load_state_dict(
-            state_dict=statetful_sd,
+            state_dict=stateful_sd,
             storage_reader=storage_reader,
             process_group=process_group,
             no_dist=no_dist,
@@ -196,10 +196,10 @@ def load(
             if isinstance(elem, Stateful):
                 # If the state_dict is a Stateful object,
                 # DCP does an in-place load in the original state dict.
-                elem.load_state_dict(statetful_sd[key])
+                elem.load_state_dict(stateful_sd[key])
             else:
                 # Otherwise, replace the state_dict with the loaded state_dict.
-                state_dict[key] = statetful_sd[key]
+                state_dict[key] = stateful_sd[key]
 
 
 def _load_state_dict(

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -178,9 +178,7 @@ def load(
             if key not in state_dict:
                 continue
             elem = state_dict[key]
-            stateful_sd[key] = (
-                elem.state_dict() if isinstance(elem, Stateful) else elem
-            )
+            stateful_sd[key] = elem.state_dict() if isinstance(elem, Stateful) else elem
 
         _load_state_dict(
             state_dict=stateful_sd,


### PR DESCRIPTION
Fix the typo in the variable name by correcting `statetful_sd` to `stateful_sd` — the original misspelling had caused confusion in code interpretation and maintenance.