### PR TITLE
[Enhancement] support @classmethod to get code source

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -30,6 +30,7 @@ from torch.testing._internal.inductor_utils import (
 def compute_loss_helper(x):
     return reduce_to_scalar_loss(x)
 
+
 class _tempTensorSamplerForQualName:
     def __init__(self, val, mask, prob):
         self.val = val
@@ -83,6 +84,7 @@ class _tempNetForQualName(torch.nn.Module):
         x += y.sum()
         x = self.instance_method_with_args(x)
         return x
+
 
 @functorch_config.patch("bundled_autograd_cache", True)
 @torch._dynamo.config.patch({"strict_precompile": True})

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -16,6 +16,7 @@ import functools
 import hashlib
 import importlib
 import inspect
+import itertools
 import json
 import logging
 import os
@@ -332,8 +333,11 @@ def _get_code_source(code: types.CodeType) -> tuple[str, str]:
                         return res
 
             if inspect.isclass(obj):
-                for name, value in obj.__dict__.items():
-                    value = getattr(obj, name)
+                for name in itertools.chain(obj.__dict__.keys(), dir(obj)):
+                    try:
+                        value = getattr(obj, name)
+                    except AttributeError:
+                        continue
                     if not (
                         inspect.isfunction(value)
                         or inspect.isclass(value)


### PR DESCRIPTION
Hi everyone, I found a bug under my cases and tried to reproduce with a minimal test case. 

Without the changes on `torch/_dynamo/package.py`, the error would be like
```
======================================================================
ERROR: test_classmethod_qualname_device_cuda (__main__.TestPackage.test_classmethod_qualname_device_cuda)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/torch/testing/_internal/common_utils.py", line 3331, in wrapper
    method(*args, **kwargs)
  File "/data/torch/testing/_internal/common_utils.py", line 586, in instantiated_test
    test(self, **param_kwargs)
  File "/opt/conda/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/test/dynamo/test_package.py", line 739, in test_classmethod_qualname
    compiled_fn(x)
  File "/data/torch/_dynamo/eval_frame.py", line 974, in compile_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/test/dynamo/test_package.py", line 73, in forward
    sampler = _tempTensorSamplerForQualName.from_tensor(x)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/torch/_dynamo/convert_frame.py", line 2225, in __call__
    result = self._torchdynamo_orig_backend(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/torch/_dynamo/convert_frame.py", line 1960, in __call__
    result = self._inner_convert(
             ^^^^^^^^^^^^^^^^^^^^
  File "/data/torch/_dynamo/convert_frame.py", line 709, in __call__
    result = _compile(
             ^^^^^^^^^
  File "/data/torch/_dynamo/convert_frame.py", line 1608, in _compile
    with (
  File "/opt/conda/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/data/torch/_dynamo/package.py", line 686, in code_context
    self._add_user_function(code)
  File "/data/torch/_dynamo/package.py", line 668, in _add_user_function
    function_name, code_source = _get_code_source(code)
                                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/torch/_dynamo/package.py", line 321, in _get_code_source
    _raise_resolution_error(code, toplevel)
  File "/data/torch/_dynamo/package.py", line 232, in _raise_resolution_error
    raise PackageError(
torch._dynamo.exc.PackageError: Cannot resolve a fully qualified name for <code object from_tensor at 0x7fb3b9de81b0, file "/data/test/dynamo/test_package.py", line 39>. Lookup scope: <bound method _tempTensorSamplerForQualName.from_tensor of <class '__main__._tempTensorSamplerForQualName'>> 
```

It is caused by extra user code compilation, which could contain @classmethod but is not supported to fetch a __qualname__ yet. 
(Ref to comment http://github.com/pytorch/pytorch/blob/0a792e137d51c033c760eee26eccd323a62b9e70/torch/_dynamo/package.py#L697-L700. )

In the test case, I used non-recommended context as I cannot reproduce the *extra user code compilation* in other ways. Suggestions are welcome. 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo