### PR TITLE
[ROCm] Enable test_addmm_sizes on MI300 by relaxing TF32 tolerance

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7542,11 +7542,10 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     def test_addmm_gelu(self, device, dtype):
         self._test_addmm_impl(torch._addmm_activation, "gelu", device, dtype)
 
-    @skipIfRocmArch(MI300_ARCH)
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(*floating_and_complex_types())
-    @tf32_on_and_off(0.005)
-    @reduced_f32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
+    @reduced_f32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_addmm_sizes(self, device, dtype):
         for m in [0, 1, 25]:
             for n in [0, 1, 10]:


### PR DESCRIPTION
## Summary
Enables `test_addmm_sizes` in `test_linalg.py` for MI300 architectures by relaxing the TF32 tolerance.

## Details
The `test_addmm_sizes` test was previously skipped on MI300 (`gfx942`) via `@skipIfRocmArch(MI300_ARCH)`.
When running on MI300X, the test fails with a maximum error of approx `0.0062` due to aggressive TF32 optimizations (current tolerance is `0.005`).

This PR:
1. Removes the `MI300_ARCH` skip for `test_addmm_sizes`.
2. Relaxes the `@tf32_on_and_off` tolerance to `0.01` **only for ROCm**, preserving the strict check for CUDA.
3. Relaxes the `@reduced_f32_on_and_off` tolerance similarly.

CUDA behavior and tolerances are unchanged.

This follows the pattern in `test_linalg.py` (e.g., `precisionOverride`) where tolerances are conditionalized for hardware backends.

## Verification
- Verified locally on AMD Instinct MI300X.
- Test `test_addmm_sizes` passes with the new tolerance.

Fixes part of #169392

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang