### PR TITLE
Make finite fp8 datatypes not overflow immediatly to NaN on conversion

### DIFF
--- a/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float8.h
@@ -97,7 +97,8 @@ static inline void cvtfp8e4m3_fp32(const __m128i& a, __m512& o) {
 static inline __m128i cvtfp32_fp8e4m3(const __m512& src) {
   // cvt 16x32 from fp32 to fp8 e4m3
   const __m512i sign_mask = _mm512_set1_epi32(0x80000000);
-  const __m512i fp8_max = _mm512_set1_epi32(UINT32_C(1087) << 20);
+  const __m512i fp32_inf = _mm512_set1_epi32(UINT32_C(255) << 23);
+  const __m512i fp8_max = _mm512_set1_epi32(UINT32_C(543) << 21);
   const __m512i denorm_thresh = _mm512_set1_epi32(UINT32_C(121) << 23);
   const __m512i denorm_mask = _mm512_set1_epi32(UINT32_C(141) << 23);
   const __m512i bias_part1 = _mm512_set1_epi32((uint32_t)(7 - 127) << 23);
@@ -110,14 +111,21 @@ static inline __m128i cvtfp32_fp8e4m3(const __m512& src) {
   // Prepare result containers
   __m512i result = _mm512_setzero_si512();
 
-  // Step 1: Handle case of overflow
-  // (f_bits >= fp8_max): set result = 0x7f
-  __mmask16 overflow_mask = _mm512_cmpge_epu32_mask(f_bits, fp8_max);
-  if (overflow_mask) {
-    result = _mm512_mask_set1_epi32(result, overflow_mask, 0x7f);
+  // Step 1: Handle case of NaN
+  // (f_bits > fp32_inf): set result = 0x7F
+  __mmask16 nan_mask = _mm512_cmpgt_epu32_mask(f_bits, fp32_inf);
+  if (nan_mask) {
+    result = _mm512_mask_set1_epi32(result, nan_mask, 0x7F);
   }
 
-  // Step 2: Handle small numbers (denormals)
+  // Step 2: Handle clamping
+  // (f_bits >= fp8_max): set result = 0x7E
+  __mmask16 overflow_mask = _mm512_cmpge_epu32_mask(f_bits, fp8_max);
+  if (overflow_mask) {
+    result = _mm512_mask_set1_epi32(result, overflow_mask, 0x7E);
+  }
+
+  // Step 3: Handle small numbers (denormals)
   // Small numbers (f_bits < denorm_thresh)
   __mmask16 denorm_thresh_mask = _mm512_cmplt_epu32_mask(f_bits, denorm_thresh);
 
@@ -130,7 +138,7 @@ static inline __m128i cvtfp32_fp8e4m3(const __m512& src) {
     result = _mm512_mask_mov_epi32(result, denorm_thresh_mask, small_result);
   }
 
-  // Step 3: Handle normal numbers
+  // Step 4: Handle normal numbers
   __mmask16 normal_mask = ~(overflow_mask | denorm_thresh_mask);
 
   if (normal_mask) {

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -174,14 +174,16 @@ def simulate_fp8_precision(input, variant):
     is_odd = (mantissa_val_rounded & last_unrounded_bit) != 0
     mantissa_val_rounded += (ties & is_odd) * last_unrounded_bit
 
-    # Re-compose mantissa and exponent
-    vals = (mantissa_val_rounded * 2.0 ** (-23 + exponent)).to(dtype)
+    # Re-compose mantissa, exponent, and sign
+    vals = (mantissa_val_rounded * 2.0 ** (-23 + exponent)).to(dtype) * signs
 
-    # Replace overflows with inf/NaN as appropriate (no saturation)
-    have_inf = variant in FLOAT8_DTYPES_WITH_INF
-    vals[vals > torch.finfo(variant).max] = torch.inf if have_inf else torch.nan
-
-    return vals * signs
+    # Replace overflows with inf/max as appropriate
+    has_inf = variant in FLOAT8_DTYPES_WITH_INF
+    max_v = torch.finfo(variant).max
+    min_v = torch.finfo(variant).min
+    vals[vals > max_v] = torch.inf if has_inf else max_v
+    vals[vals < min_v] = torch.neg_inf if has_inf else min_v
+    return vals
 
 
 def _round_e8m0_rne(biased_exponent, lsb, g, r, s):

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -182,7 +182,7 @@ def simulate_fp8_precision(input, variant):
     max_v = torch.finfo(variant).max
     min_v = torch.finfo(variant).min
     vals[vals > max_v] = torch.inf if has_inf else max_v
-    vals[vals < min_v] = torch.neg_inf if has_inf else min_v
+    vals[vals < min_v] = -torch.inf if has_inf else min_v
     return vals
 
 

--- a/torch/headeronly/util/Float8_e4m3fn.h
+++ b/torch/headeronly/util/Float8_e4m3fn.h
@@ -169,12 +169,19 @@ inline C10_HOST_DEVICE float fp8e4m3fn_to_fp32_value(uint8_t input) {
  */
 inline C10_HOST_DEVICE uint8_t fp8e4m3fn_from_fp32_value(float f) {
   /*
-   * Binary representation of 480.0f, which is the first value
-   * not representable in fp8e4m3fn range:
-   * 0 1111 111 - fp8e4m3fn
-   * 0 10000111 11100000000000000000000 - fp32
+   * Representation of +inf in fp32 format, which is the last
+   * non-NaN fp32 value:
+   * 0 11111111 00000000000000000000000 - fp32
    */
-  constexpr uint32_t fp8_max = UINT32_C(1087) << 20;
+  constexpr uint32_t fp32_inf = UINT32_C(255) << 23;
+
+  /*
+   * Representation of 448.0f in fp32 format, which is the last
+   * non-NaN fp8e4m3fn value
+   * 0 1111 110 - fp8e4m3fn
+   * 0 10000111 11000000000000000000000 - fp32
+   */
+  constexpr uint32_t fp8_max = UINT32_C(543) << 21;
 
   /*
    * A mask for converting fp32 numbers lower than fp8e4m3fn normal range
@@ -193,7 +200,7 @@ inline C10_HOST_DEVICE uint8_t fp8e4m3fn_from_fp32_value(float f) {
    *      +---+----------------------------------+
    *      | S |0000000 00000000 00000000 00000000|
    *      +---+----------------------------------+
-   * Bits  31                 0-31
+   * Bits  31                30-0
    */
   const uint32_t sign = f_bits & UINT32_C(0x80000000);
 
@@ -202,29 +209,30 @@ inline C10_HOST_DEVICE uint8_t fp8e4m3fn_from_fp32_value(float f) {
    */
   f_bits ^= sign;
 
-  if (f_bits >= fp8_max) {
+  if (f_bits >= fp32_inf) {
     // NaN - all exponent and mantissa bits set to 1
-    result = 0x7f;
+    result = 0x7F;
+  } else if (f_bits >= fp8_max) {
+    // Input number is 448 or larger and thus needs to be clamped
+    // Largest fp8e4m3fn normal number is 448
+    result = 0x7E;
+  } else if (f_bits < (UINT32_C(121) << 23)) {
+    // Input number is smaller than 2^(-6), which is the smallest
+    // fp8e4m3fn normal number
+    f_bits = fp32_to_bits(fp32_from_bits(f_bits) + fp32_from_bits(denorm_mask));
+    result = static_cast<uint8_t>(f_bits - denorm_mask);
   } else {
-    if (f_bits < (UINT32_C(121) << 23)) {
-      // Input number is smaller than 2^(-6), which is the smallest
-      // fp8e4m3fn normal number
-      f_bits =
-          fp32_to_bits(fp32_from_bits(f_bits) + fp32_from_bits(denorm_mask));
-      result = static_cast<uint8_t>(f_bits - denorm_mask);
-    } else {
-      // resulting mantissa is odd
-      uint8_t mant_odd = (f_bits >> 20) & 1;
+    // resulting mantissa is odd
+    uint8_t mant_odd = (f_bits >> 20) & 1;
 
-      // update exponent, rounding bias part 1
-      f_bits += ((uint32_t)(7 - 127) << 23) + 0x7FFFF;
+    // update exponent, rounding bias part 1
+    f_bits += ((uint32_t)(7 - 127) << 23) + 0x7FFFF;
 
-      // rounding bias part 2
-      f_bits += mant_odd;
+    // rounding bias part 2
+    f_bits += mant_odd;
 
-      // take the bits!
-      result = static_cast<uint8_t>(f_bits >> 20);
-    }
+    // take the bits!
+    result = static_cast<uint8_t>(f_bits >> 20);
   }
 
   result |= static_cast<uint8_t>(sign >> 24);

--- a/torch/headeronly/util/Float8_e4m3fn.h
+++ b/torch/headeronly/util/Float8_e4m3fn.h
@@ -177,11 +177,11 @@ inline C10_HOST_DEVICE uint8_t fp8e4m3fn_from_fp32_value(float f) {
 
   /*
    * Representation of 448.0f in fp32 format, which is the last
-   * non-NaN fp8e4m3fn value
+   * non-NaN fp8e4m3fn value:
    * 0 1111 110 - fp8e4m3fn
    * 0 10000111 11000000000000000000000 - fp32
    */
-  constexpr uint32_t fp8_max = UINT32_C(543) << 21;
+  constexpr uint32_t fp8_max = UINT32_C(0x21F) << 21;
 
   /*
    * A mask for converting fp32 numbers lower than fp8e4m3fn normal range

--- a/torch/headeronly/util/Float8_e5m2fnuz.h
+++ b/torch/headeronly/util/Float8_e5m2fnuz.h
@@ -69,13 +69,19 @@ namespace detail {
  */
 inline C10_HOST_DEVICE uint8_t fp8e5m2fnuz_from_fp32_value(float f) {
   /*
-   * Binary representation of 65536.0f, which is the first value not
-   * representable (i.e. the first value which would overflow in to the sign
-   * bit, resulting in a NaN) in fp8e4m3fnuz range:
-   * 1 00000 00 - fp8e5m2fnuz
-   * 0 10001111 00000000000000000000000 - fp32
+   * Representation of +inf in fp32 format, which is the last
+   * non-NaN fp32 value
+   * 0 11111111 00000000000000000000000 - fp32
    */
-  constexpr uint32_t fnuz_max = UINT32_C(0x8F) << 23;
+  constexpr uint32_t fp32_inf = UINT32_C(0xFF) << 23;
+  
+  /*
+   * Binary representation of 57344.0f, which is the last
+   * non-NaN fp8e5m2fnuz value:
+   * 0 11111 11 - fp8e5m2fnuz
+   * 0 10001110 11000000000000000000000 - fp32
+   */
+  constexpr uint32_t fnuz_max = UINT32_C(0x23B) << 21;
 
   /*
    * A mask for converting fp32 numbers lower than fp8e5m2fnuz normal range
@@ -93,7 +99,7 @@ inline C10_HOST_DEVICE uint8_t fp8e5m2fnuz_from_fp32_value(float f) {
    *      +---+----------------------------------+
    *      | S |0000000 00000000 00000000 00000000|
    *      +---+----------------------------------+
-   * Bits  31                 0-31
+   * Bits  31                30-0
    */
   const uint32_t sign = f_bits & UINT32_C(0x80000000);
 
@@ -102,12 +108,14 @@ inline C10_HOST_DEVICE uint8_t fp8e5m2fnuz_from_fp32_value(float f) {
    */
   f_bits ^= sign;
 
-  if (f_bits >= fnuz_max) {
+  if (f_bits >= fp32_inf) {
     // NaN -- sign bit set to 1, rest 0s
     return 0x80;
-  }
-
-  if (f_bits < (UINT32_C(0x70) << 23) /* 2^-15 in float32 */) {
+  } else if (f_bits >= fnuz_max) {
+    // Input number is 57344 or larger and thus needs to be clamped
+    // Largest fp8e5m2fnuz normal number is 57344
+    result = 0x7F;
+  } else if (f_bits < (UINT32_C(0x70) << 23) /* 2^-15 in float32 */) {
     // Input exponent is less than -15, the smallest e5m2fnuz exponent, so the
     // number will become subnormal.
     f_bits = fp32_to_bits(fp32_from_bits(f_bits) + fp32_from_bits(denorm_mask));

--- a/torch/headeronly/util/Float8_e5m2fnuz.h
+++ b/torch/headeronly/util/Float8_e5m2fnuz.h
@@ -74,7 +74,7 @@ inline C10_HOST_DEVICE uint8_t fp8e5m2fnuz_from_fp32_value(float f) {
    * 0 11111111 00000000000000000000000 - fp32
    */
   constexpr uint32_t fp32_inf = UINT32_C(0xFF) << 23;
-  
+
   /*
    * Binary representation of 57344.0f, which is the last
    * non-NaN fp8e5m2fnuz value:


### PR DESCRIPTION
As mentioned in issue #154028 
Previous PR attempt #160488 got messed up due to incorrect branch root.
Edit: I also apparently didn't realize I could merge with just one approval, but this PR should fix all 3 fp8 finite/NaN-only types instead of just fp8e4m3fn as the previous one did.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01