### PR TITLE
[Doc] Fix missing space in set_stream docstring

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -791,7 +791,7 @@ def _set_stream_by_id(stream_id, device_index, device_type):
 
 
 def set_stream(stream: Stream):
-    r"""Set the current stream.This is a wrapper API to set the stream.
+    r"""Set the current stream. This is a wrapper API to set the stream.
         Usage of this function is discouraged in favor of the ``stream``
         context manager.
 

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -243,7 +243,7 @@ def empty_cache() -> None:
 
 
 def set_stream(stream: Stream):
-    r"""Set the current stream.This is a wrapper API to set the stream.
+    r"""Set the current stream. This is a wrapper API to set the stream.
         Usage of this function is discouraged in favor of the ``stream``
         context manager.
 

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -376,7 +376,7 @@ def _set_stream_by_id(stream_id, device_index, device_type) -> None:
 
 
 def set_stream(stream: Stream) -> None:
-    r"""Set the current stream.This is a wrapper API to set the stream.
+    r"""Set the current stream. This is a wrapper API to set the stream.
         Usage of this function is discouraged in favor of the ``stream``
         context manager.
 


### PR DESCRIPTION
Fix a minor typo in the `set_stream` docstring.

No functional changes.