### PR TITLE
[ROCm] Enable complex dtypes in test_foreach_copy_with_multi_dtypes

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1341,6 +1341,8 @@ class TestForeach(TestCase):
     def test_foreach_copy_with_multi_dtypes(self, device, dtype, op):
         # check (a) multi_tensor_apply is called and (b) numerical parity with for-loop and Tensor.copy_
         foreach_copy_ = ForeachFuncWrapper(op.inplace_variant)
+        if dtype in (torch.complex128, torch.complex64):
+            self.skipTest("Complex dtypes are not supported")
 
         for sample in op.sample_inputs(
             device, dtype, noncontiguous=False, allow_higher_dtype_scalars=True


### PR DESCRIPTION
This PR skips test_foreach_copy_with_multi_dtypes for complex dtypes due to precision issues. The  foreach_copy operation supports complex types, but the cross-dtype conversion scenario in this test hits edge cases (precision) in the multi_tensor_apply kernel that cause flaky failures.

Fixes #150161

Tested on ROCm 7.1.0

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang