### PR TITLE
[Bugfix] fix issue #167836

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6241,6 +6241,18 @@ class TestTorchDeviceType(TestCase):
         actual = t_non_contig.masked_scatter_(mask_contig, source)
         self.assertEqual(actual, expected)
 
+    def test_tolist_with_grad(self, device):
+        def f(x):
+            result = x.tolist()
+            for l, r in zip(result, [1.0, 2.0, 3.0]):
+                assert l == r
+            return sum(x)
+
+        x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True, device=device)
+        grad_f = torch.func.grad(f)
+        result = grad_f(x)
+        self.assertEqual(result.tolist() , [1.0, 1.0, 1.0])
+
 
 # Tests that compare a device's computation with the (gold-standard) CPU's.
 class TestDevicePrecision(TestCase):
@@ -10692,7 +10704,6 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
             x.item()  # No warning
 
             self.assertEqual(len(w), 0)
-
 
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests

--- a/torch/csrc/utils/tensor_list.cpp
+++ b/torch/csrc/utils/tensor_list.cpp
@@ -59,6 +59,7 @@ PyObject* tensor_to_list(const Tensor& tensor) {
   if (!data.device().is_cpu()) {
     pybind11::gil_scoped_release no_gil;
     data = data.toBackend(Backend::CPU);
+    data = recursive_unwrap(data);
   }
   TORCH_CHECK(
       tensor.numel() == 0 || data.const_data_ptr(),


### PR DESCRIPTION
Fixes #167836

I found the reason. The `.to(backend)` would also wrap the actually created tensor under the wrap-for-grad context. So the fix is quite simple. 

As for the unit test for it, I have no idea about where to put it. Could anyone give some suggestions? Thanks! 

Ref, the unit test.
```
import torch


def test_tolist_with_grad():
    def f(x):
        result = x.tolist()
        for l, r in zip(result, [1.0, 2.0, 3.0]):
            assert l == r
        return sum(x)

    x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True, device="mps")
    grad_f = torch.func.grad(f)
    result = grad_f(x)
    assert result.tolist() == [1.0, 1.0, 1.0]


if __name__ == "__main__":
    test_tolist_with_grad()
```
