### PR TITLE
[ROCm] Masquerade HIP memory allocation as CUDA for profiler analysis

### DIFF
--- a/c10/hip/HIPCachingAllocatorAmend.h
+++ b/c10/hip/HIPCachingAllocatorAmend.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <c10/hip/HIPCachingAllocator.h>
+
+namespace c10 {
+namespace hip {
+// Wrapper for c10::reportMemoryUsageToProfiler that converts
+// c10::DeviceType::HIP device to c10::DeviceType::CUDA. In ROCm builds, memory
+// allocations are made on HIP devices. However, the PyTorch profiler records
+// and associates TensorMetadata based on DeviceType::CUDA. Without this
+// conversion, allocation events reported as HIP would not be matched with their
+// corresponding usage in the profiler analysis.
+inline void reportMemoryUsageToProfilerMasqueradingAsCUDA(
+    void* ptr,
+    int64_t alloc_size,
+    size_t total_allocated,
+    size_t total_reserved,
+    Device device) {
+  if (device.type() == c10::DeviceType::HIP)
+    device = c10::Device(c10::DeviceType::CUDA, device.index());
+  c10::reportMemoryUsageToProfiler(
+      ptr, alloc_size, total_allocated, total_reserved, device);
+}
+} // namespace hip
+} // namespace c10

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4143,7 +4143,6 @@ class TestCudaMallocAsync(TestCase):
         finally:
             torch.cuda.memory._record_memory_history(None)
 
-    @skipIfRocm(msg="ROCTracer does not capture Python stack frames in profiler output")
     def test_memory_profiler_viz(self):
         with torch.profiler.profile(
             with_stack=True, profile_memory=True, record_shapes=True

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -9401,6 +9401,10 @@ CAFFE2_SPECIFIC_MAPPINGS = collections.OrderedDict(
         ("cuda::OptionalCUDAStreamGuard", ("hip::OptionalHIPStreamGuard", API_CAFFE2)),
         ("c10/cuda/CUDAGuard.h", ("c10/hip/HIPGuard.h", API_CAFFE2)),
         ("gloo/cuda", ("gloo/hip", API_CAFFE2)),
+        # replace CUDACachingAllocator.h with amended version that redirects profiler-related calls
+        # to masquerade as c10::DeviceType::CUDA
+        ("c10/cuda/CUDACachingAllocator.h", ("c10/hip/HIPCachingAllocatorAmend.h", API_CAFFE2)),
+        ("c10::reportMemoryUsageToProfiler", ("c10::hip::reportMemoryUsageToProfilerMasqueradingAsCUDA", API_CAFFE2)),
     ]
 )
 


### PR DESCRIPTION
Fixes #168721

In ROCm builds, memory allocations are reported with DeviceType::HIP, while the PyTorch profiler associates TensorMetadata with DeviceType::CUDA. This mismatch prevents allocation events and usage being correctly correlated.

Add c10/hip/HIPCachingAllocatorAmend.h to implement a wrapper around c10::reportMemoryUsageToProfiler that converts HIP to CUDA. Update cuda_to_hip_mappings.py to replace c10/cuda/CUDACachingAllocator.h with the wrapper header that redirects profiler-related calls. Enable test_memory_profiler_viz test for ROCm.

Tested:
- test_cuda.py::TestCudaMallocAsync.test_memory_profiler_viz

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang