### PR TITLE
[Inductor] fix: `CompiledFxGraph` object has no attribute `compiled_fn_runner`

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -600,7 +600,7 @@ class CompiledFxGraph(OutputCode):
         self._wrap_compiled_regions = config.wrap_inductor_compiled_regions
 
     def __del__(self) -> None:
-        if self.compiled_fn_runner is not None:
+        if getattr(self, "compiled_fn_runner", None) is not None:
             # For torch._inductor.config.graph_partition = True,
             # self.compiled_fn_runner.partitions hold cudagraphified functions
             # which prevents deallocation. When CompiledFxGraph is deleted,


### PR DESCRIPTION
When `CompiledFxGraph` failed to initialize (e.g. FileNotFoundError), we probably can have the situation when `self.compiled_fn_runner` is not set and then `__del__` is called, which will cause further error:

```log
W1226 20:52:17.069000 2606954 torch/_inductor/codecache.py:1021] Traceback (most recent call last):
W1226 20:52:17.069000 2606954 torch/_inductor/codecache.py:1021]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 1017, in iterate_over_candidates
W1226 20:52:17.069000 2606954 torch/_inductor/codecache.py:1021]     with open(os.path.join(subdir, path), "rb") as f:
W1226 20:52:17.069000 2606954 torch/_inductor/codecache.py:1021]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
W1226 20:52:17.069000 2606954 torch/_inductor/codecache.py:1021] FileNotFoundError: [Errno 2] No such file or directory: '/root/tmp/torchinductor_root/fxgraph/bb/fbbmcyjnbceqsez56zyy5k6jmbsvzlmnkziia5l73b2tylkfh2lu/.2606952.140423205942848.tmp'
W1226 20:52:17.200000 2606956 torch/_inductor/codecache.py:1021] fx graph cache unable to load compiled graph
W1226 20:52:17.200000 2606956 torch/_inductor/codecache.py:1021] Traceback (most recent call last):
W1226 20:52:17.200000 2606956 torch/_inductor/codecache.py:1021]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 1017, in iterate_over_candidates
W1226 20:52:17.200000 2606956 torch/_inductor/codecache.py:1021]     with open(os.path.join(subdir, path), "rb") as f:
W1226 20:52:17.200000 2606956 torch/_inductor/codecache.py:1021]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
W1226 20:52:17.200000 2606956 torch/_inductor/codecache.py:1021] FileNotFoundError: [Errno 2] No such file or directory: '/root/tmp/torchinductor_root/fxgraph/z2/fz27ss7ga3my7ijxiudii7cyld2xx3wxrq3dhrr77wjlgzjz7gf6/.2606959.140223538198080.tmp'
Exception ignored in: <function CompiledFxGraph.__del__ at 0x7ed2ef5784a0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/output_code.py", line 582, in __del__
    if self.compiled_fn_runner is not None:
       ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'CompiledFxGraph' object has no attribute 'compiled_fn_runner'
```

While such kind of exceptions will be ignored, it's still very annoying to get them printed in the console. This PR addresses this issue by checking if self has the `compiled_fn_runner` first so that no such error will be thrown.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> - A Lab for Experiential Intelligence.</sub>