### PR TITLE
[BE][Typing][Dynamo] Type torch/_dynamo/variables/builder.py

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -500,10 +500,12 @@ def substitute_in_graph(
                 guard_type = GuardBuilder.MODULE_MATCH
             else:
                 guard_type = GuardBuilder.ID_MATCH
+            guards = self.install_guards(guard_type)
+            assert guards is not None
             return PolyfilledFunctionVariable(
                 value,
                 source=self.source,
-                **self.install_guards(guard_type),
+                **guards,
             )
 
         id_dispatch_map[id(original_fn)] = id_dispatch_map[id(wrapped)] = dispatch_fn

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1961,6 +1961,14 @@
   "GB0181": [
     {
       "Gb_type": "dtype mismatch between tensor and its gradient",
+      "Context": "tensor dtype: {value.dtype}; grad dtype: {grad_str}",
+      "Explanation": "Inconsistent dtype between tensor and its gradient. This can happen in FSDP and crashes meta tensor creation.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "dtype mismatch between tensor and its gradient",
       "Context": "tensor dtype: {value.dtype}; grad dtype: {safe_grad(value).dtype}",
       "Explanation": "Inconsistent dtype between tensor and its gradient. This can happen in FSDP and crashes meta tensor creation.",
       "Hints": [

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4687,7 +4687,7 @@ def unique(seq: Sequence[T]) -> Generator[T, None, None]:
 
 
 def make_dupe_guard(
-    obj_source: Source, dupe_source: Source
+    obj_source: Source, dupe_source: Source | None
 ) -> Optional[functools.partial[Any]]:
     # Note - we may end up in a situation where we invoke something like
     # def fn(x, y)

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2368,6 +2368,7 @@ class OutputGraph(OutputGraphCommon):
                 cg.pop_top()
 
             for idx, arg in enumerate(self.graphargs):
+                assert arg.source is not None
                 self.export_metadata.graph_input_idx_to_local_source[idx] = arg.source
 
             cg.make_call_generated_code(name)
@@ -2487,6 +2488,7 @@ class OutputGraph(OutputGraphCommon):
 
     def example_inputs(self) -> list[torch.Tensor]:
         result = [arg.example for arg in self.graphargs]
+        # pyrefly: ignore[bad-return]
         return result
 
     def remove_unused_get_attr_nodes(self) -> None:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -400,7 +400,9 @@ class ExportMetaData:
     # maps graph input index to its' source which is later
     # used in export to map to correct user input. In its' flat form,
     # just looks like GetItem(base=LocalSource("foo", idx=0))
-    graph_input_idx_to_local_source: dict[int, Source] = dc_field(default_factory=dict)
+    graph_input_idx_to_local_source: dict[int, Source | None] = dc_field(
+        default_factory=dict
+    )
     # maps user output idx to what type of output it is. There are 3 options:
     # 1) graph out
     # 2) user input
@@ -2368,7 +2370,6 @@ class OutputGraph(OutputGraphCommon):
                 cg.pop_top()
 
             for idx, arg in enumerate(self.graphargs):
-                assert arg.source is not None
                 self.export_metadata.graph_input_idx_to_local_source[idx] = arg.source
 
             cg.make_call_generated_code(name)

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -405,6 +405,8 @@ class SideEffects:
         item: Any,
         variable: VariableTracker,
     ) -> VariableTracker:
+        # TODO: Modify this API so that we preserve type info of
+        # variable
         return self._track_obj(
             item,
             variable,

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1184,7 +1184,7 @@ def is_from_global_source(source: Source) -> bool:
     return get_global_source_name(source) is not None
 
 
-def get_global_source_name(source: Source) -> Optional[str]:
+def get_global_source_name(source: Source | None) -> str | None:
     if isinstance(source, ChainedSource):
         return get_global_source_name(source.base)
     if not isinstance(source, GlobalSource):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5201,6 +5201,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             else:
                 fglobals_value = _import_module(module_name)
             # Dont use lazy vt because we will do a setattr afterwards
+            # TODO: fix InstructionTranslator -> InstructionTranslatorBase
+            # pyrefly: ignore[bad-argument-type]
             fglobals_vt = VariableBuilder(self, module_source)(fglobals_value)
             global_source = AttrSource(module_source, name)
         else:
@@ -5210,6 +5212,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             globals_source = GlobalSource(globals_name)
             fglobals_value = self.f_globals  # type: ignore[assignment]
             # Dont use lazy vt because we will do a setattr afterwards
+            # pyrefly: ignore[bad-argument-type]
             fglobals_vt = VariableBuilder(self, globals_source)(fglobals_value)
             global_source = DictGetItemSource(globals_source, name)  # type: ignore[assignment]
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3600,7 +3600,7 @@ def _automatic_dynamic(
         outer_context = _automatic_dynamic(
             e, tx, source, static_shapes, outer_only=True
         )
-        assert isinstance(outer_context, SubclassSymbolicContext)
+        assert isinstance(outer_context, StatefulSymbolicContext)
 
         # Get symbolic contexts for inner tensors
         inner_contexts = {}  # mapping from attr -> symbolic context

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 """
 This module contains classes and utilities for building variable trackers in Dynamo.
 Variable trackers are used to convert Python values into symbolic representations
@@ -37,7 +35,8 @@ import sys
 import types
 import weakref
 from collections.abc import Callable, MutableMapping
-from typing import Any, NamedTuple, Optional, TYPE_CHECKING, Union
+from types import ModuleType
+from typing import Any, NamedTuple, NoReturn, TYPE_CHECKING, Union
 
 import sympy
 
@@ -59,7 +58,12 @@ from torch._higher_order_ops.flat_apply import flat_apply
 from torch._higher_order_ops.torchbind import call_torchbind
 from torch._library.opaque_object import is_opaque_type, is_opaque_value_type
 from torch._ops import HigherOrderOperator, OpOverload, OpOverloadPacket
-from torch._subclasses.fake_tensor import FakeTensor, is_fake, maybe_get_fake_mode
+from torch._subclasses.fake_tensor import (
+    FakeTensor,
+    FakeTensorMode,
+    is_fake,
+    maybe_get_fake_mode,
+)
 from torch._subclasses.meta_utils import is_sparse_any, safe_grad
 from torch._utils_internal import justknobs_check
 from torch.fx.experimental._backward_state import BackwardState
@@ -299,24 +303,32 @@ from .user_defined import (
 try:
     import numpy as np
 except ModuleNotFoundError:
-    np = None
+    np: ModuleType = None  # type: ignore[assignment]
 
 
 if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
-    from torch._dynamo.symbolic_convert import InstructionTranslator
+    from torch._dynamo.symbolic_convert import (
+        InstructionTranslator,
+        InstructionTranslatorBase,
+    )
 
 
 log = logging.getLogger(__name__)
 static_inputs_log = torch._logging.getArtifactLogger(
     __name__, "cudagraph_static_inputs"
 )
+from typing import TypeVar
 
+
+# Placeholder for a VariableTracker to be used in proxy
+# creation so that we don't type erase
+VariableTrackerType = TypeVar("VariableTrackerType")
 
 DimList = list
 
 
-def safe_has_grad(t):
+def safe_has_grad(t: object) -> bool:
     with torch._logging.hide_warnings(torch._logging._internal.safe_grad_filter):
         return hasattr(t, "grad")
 
@@ -327,11 +339,11 @@ class _missing:
 
 @dataclasses.dataclass
 class GraphArg:
-    source: Source
+    source: Source | None
     # TODO: storing a SymInt here but not a FakeTensor is a pretty strange
     # thing to do.  Probably should have example (which stores an int) and
     # fake_example
-    _example: Union[TensorWeakRef, torch.SymInt]
+    _example: Any
     # When True, this indicates that this GraphArg is a Python quantity (e.g.,
     # a float or int) which we pass to the FX graph as a Tensor.  This
     # controls how we codegen calls into the Dynamo graph: we will call
@@ -349,7 +361,7 @@ class GraphArg:
     # often are, but not necessarily.  ezyang(May 2024) plans to fix this
     # soon.
     pass_arg_as_tensor: bool
-    fake_tensor: Optional[torch._subclasses.fake_tensor.FakeTensor]
+    fake_tensor: torch._subclasses.fake_tensor.FakeTensor | None
     # UnspecializedPythonVariable often masquerades as a tensor.
     # We MUST NOT generate shape guard code
     # that actually tries to access tensor properties on these values.
@@ -359,9 +371,9 @@ class GraphArg:
     # Sometimes, the Tensor we pass to example is freshly allocated (smh).
     # Then we cannot only keep a weak reference to it.  This lets you
     # stash a strong reference too.
-    example_strong_ref: Optional[torch.Tensor] = None
+    example_strong_ref: torch.Tensor | torch.SymInt | None = None
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         # Use object.__setattr__ to bypass Dynamo's STORE_ATTR interception.
         # This is needed because when PYTORCH_TEST_WITH_DYNAMO=1, even internal
         # GraphArg creation can be traced, and with replay_side_effects=False,
@@ -369,7 +381,7 @@ class GraphArg:
         object.__setattr__(self, name, value)
 
     @property
-    def example(self):
+    def example(self) -> torch.Tensor | torch.SymInt | BackwardState | None:
         if isinstance(self._example, TensorWeakRef):
             r = self._example()
             assert r is not None
@@ -377,20 +389,28 @@ class GraphArg:
         else:
             return self._example
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self._example, torch.Tensor):
             self._example = TensorWeakRef(self._example)
             assert is_fake(self.fake_tensor)
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen(self.source)
 
-    def erase(self):
+    def erase(self) -> None:
         self._example = None
         self.example_strong_ref = None
 
-    def __eq__(self, other):
-        return self.source.name == other.source.name
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GraphArg):
+            return False
+        assert isinstance(other, GraphArg)
+        if self.source is None:
+            return other.source is None
+        else:
+            if other.source is None:
+                return False
+            return self.source.name == other.source.name
 
 
 class BackwardStateGraphArg(GraphArg):
@@ -403,7 +423,7 @@ class BackwardStateGraphArg(GraphArg):
             is_tensor=False,
         )
 
-    def reconstruct(self, codegen: "PyCodegen"):
+    def reconstruct(self, codegen: "PyCodegen") -> None:
         assert codegen.tx.output.backward_state_var
         codegen.add_push_null(
             lambda: codegen.load_import_from(BackwardState.__module__, "BackwardState")
@@ -435,7 +455,7 @@ class VariableBuilder:
 
     def __init__(
         self,
-        tx,
+        tx: "InstructionTranslator",
         source: Source,
     ) -> None:
         assert source is not None, (
@@ -447,7 +467,7 @@ class VariableBuilder:
         self.source = source
         self.name = source.name
 
-    def __call__(self, value):
+    def __call__(self, value: object) -> VariableTracker:
         if value in self.tx.output.side_effects:
             side_effect_result = self.tx.output.side_effects[value]
             dup_guard = make_dupe_guard(self.source, side_effect_result.source)
@@ -476,7 +496,7 @@ class VariableBuilder:
         if vt.source is None:
             vt.source = self.source
 
-        def _is_deduplicable_sym_variable(value, vt):
+        def _is_deduplicable_sym_variable(value: Any, vt: VariableTracker) -> bool:
             # Constants like 0, 1, 2, etc. can be unspecialized as SymNodeVariables sometimes, but we
             # should NOT track them. If we use a single SymNodeVariable instance to track them
             # across multiple uses, then guards created for one usage will incorrectly apply to
@@ -498,7 +518,7 @@ class VariableBuilder:
         self.tx.output.variable_tracker_cache.add(value, self.source, vt)
         return vt
 
-    def _can_lift_attrs_to_inputs(self, vt):
+    def _can_lift_attrs_to_inputs(self, vt: VariableTracker) -> bool:
         return type(vt) in {
             TensorVariable,
             TensorWithTFOverrideVariable,
@@ -506,10 +526,10 @@ class VariableBuilder:
             NumpyNdarrayVariable,
         }
 
-    def get_source(self):
+    def get_source(self) -> Source:
         return self.source
 
-    def install_guards(self, *guards):
+    def install_guards(self, *guards: Callable[..., Any]) -> dict[str, Any] | None:
         source = self.get_source()
         try:
             tmp = [source.make_guard(guard) for guard in guards]
@@ -519,12 +539,12 @@ class VariableBuilder:
         return {}
 
     @classmethod
-    def _type_dispatch(cls):
+    def _type_dispatch(cls) -> dict[object, Callable[..., Any]]:
         return cls._type_dispatch_impl(config.trace_numpy)
 
     @classmethod
     @functools.cache
-    def _type_dispatch_impl(cls, trace_numpy):
+    def _type_dispatch_impl(cls, trace_numpy: bool) -> dict[object, Callable[..., Any]]:
         # NB: Careful not to close over self to avoid ref cycle from lru_cache
         entries = [
             (
@@ -562,16 +582,18 @@ class VariableBuilder:
 
         return result
 
-    def wrap_regex_pattern(self, value: re.Pattern):
+    def wrap_regex_pattern(self, value: re.Pattern) -> ConstantLikeVariable:
         # TODO(jansel): something like a REPR_MATCH might be more robust here
         self.install_guards(GuardBuilder.ID_MATCH)
         return ConstantLikeVariable(value)
 
-    def wrap_weakref(self, value: weakref.ReferenceType):
+    def wrap_weakref(self, value: weakref.ReferenceType) -> WeakRefVariable:
         self.install_guards(GuardBuilder.TYPE_MATCH)
         return WeakRefVariable.build(self.tx, value, source=self.source)
 
-    def wrap_removable_handle(self, value):
+    def wrap_removable_handle(
+        self, value: torch.utils.hooks.RemovableHandle
+    ) -> NoReturn:
         # This means that the removable handle was created in some other frame.
         # Our current infra requires the hook to be registered and removed in
         # the same frame. So graph break.
@@ -584,13 +606,13 @@ class VariableBuilder:
             hints=[],
         )
 
-    def wrap_jit_function(self, value):
+    def wrap_jit_function(self, value: Any) -> WrapperUserFunctionVariable:
         self.install_guards(GuardBuilder.TYPE_MATCH)
         return WrapperUserFunctionVariable(
             value, "_torchdynamo_inline", source=self.source
         )
 
-    def wrap_mapping_proxy(self, value):
+    def wrap_mapping_proxy(self, value: Any) -> VariableTracker:
         self.install_guards(GuardBuilder.TYPE_MATCH)
         # This might be suboptimal compared to dict guards. But mappingproxy is
         # not very common, so its ok to guard on all keys.
@@ -651,7 +673,7 @@ class VariableBuilder:
 
         return result
 
-    def _wrap(self, value):
+    def _wrap(self, value: Any) -> VariableTracker:
         # import here to avoid circular dependencies
         from torch.utils._triton import (
             has_triton,
@@ -676,15 +698,15 @@ class VariableBuilder:
                 pass
 
         # default implementations, in case we don't have triton (or the wrong triton version)
-        def create_1d_tma_descriptor():
+        def create_1d_tma_descriptor() -> None:
             pass
 
-        def create_2d_tma_descriptor():
+        def create_2d_tma_descriptor() -> None:
             pass
 
         class TensorDescriptor:
             @staticmethod
-            def from_tensor():
+            def from_tensor() -> None:
                 pass
 
         if has_triton_experimental_host_tma():
@@ -736,7 +758,10 @@ class VariableBuilder:
                 for name in namedtuple_fields(type(value))
             ]
             result = NamedTupleVariable(
-                output, tuple_cls=type(value), source=self.source
+                # type: ignore[arg-type]
+                output,
+                tuple_cls=type(value),
+                source=self.source,
             )
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif istype(value, (dict, collections.defaultdict, collections.OrderedDict)):
@@ -768,7 +793,9 @@ class VariableBuilder:
 
             # We need all the keys to be hashable. We do this within the
             # _HashableTracker class in dicts.py
-            def build_key_value(i, k, v):
+            def build_key_value(
+                i: Any, k: Any, v: Any
+            ) -> tuple[LazyVariableTracker, LazyVariableTracker]:
                 base = self.get_source()
                 if all_const:
                     key = ConstantVariable.create(k)
@@ -793,7 +820,7 @@ class VariableBuilder:
             if istype(value, collections.defaultdict):
                 factory_source = AttrSource(self.source, "default_factory")
                 result = DefaultDictVariable(
-                    result,
+                    result,  # type: ignore[arg-type]
                     type(value),
                     default_factory=VariableBuilder(self.tx, factory_source)(
                         value.default_factory
@@ -802,7 +829,9 @@ class VariableBuilder:
                 )
             else:
                 result = ConstDictVariable(
-                    result, user_cls=type(value), source=self.source
+                    result,  # type: ignore[arg-type]
+                    user_cls=type(value),
+                    source=self.source,
                 )
 
             return self.tx.output.side_effects.track_mutable(value, result)
@@ -993,6 +1022,7 @@ class VariableBuilder:
         elif isinstance(value, torch.autograd.function.FunctionCtx):
             actual_saved_tensors = None
             try:
+                # type: ignore[attr-defined]
                 actual_saved_tensors = value.saved_tensors
             except RuntimeError:
                 pass
@@ -1064,6 +1094,7 @@ class VariableBuilder:
         elif callable(value) and trace_rules.lookup_callable(value) is not None:
             if trace_rules.is_callable_allowed(value):
                 self.tx.output.has_user_defined_allowed_in_graph = True
+            # type: ignore[attr-defined]
             return trace_rules.lookup_callable(value).create_with_source(
                 value, source=self.source
             )
@@ -1083,6 +1114,7 @@ class VariableBuilder:
             self.install_guards(GuardBuilder.ID_MATCH)
             stream_source = AttrSource(self.source, "stream")
             stream_var = VariableBuilder(self.tx, stream_source)(value.stream)
+            # type: ignore[arg-type]
             return StreamContextVariable.create(self.tx, stream_var)
         elif isinstance(value, torch.Stream):
             # This refers to the device-agnostic torch.Stream
@@ -1174,13 +1206,13 @@ class VariableBuilder:
                 node = self.tx.output.root_tracer.dynamic_scalar_nodes[id(value)]
             else:
                 sym = self.tx.output.shape_env.create_unspecified_symbol(
-                    value.real,
+                    value.real,  # type: ignore[attr-defined]
                     source=source,
                     dynamic_dim=DimDynamic.DYNAMIC,
                 )
                 node = self.tx.output.shape_env.create_symintnode(
                     sym,
-                    hint=value.real,
+                    hint=value.real,  # type: ignore[attr-defined]
                     source=source,
                 )
 
@@ -1219,6 +1251,7 @@ class VariableBuilder:
                 if isinstance(value, torch.SymInt)
                 else ConvertIntSource(self.source)
             )
+            new_symint = None
             if value.node.has_hint():
                 new_symint = (
                     self.tx.output.shape_env.create_unspecified_symint_and_symbol(
@@ -1243,7 +1276,7 @@ class VariableBuilder:
                         explanation="Unbacked SymInt input is not supported yet.",
                         hints=[*graph_break_hints.SUPPORTABLE],
                     )
-
+            assert new_symint is not None
             sym_node_proxy = self.tx.output.root_tracer.create_graph_input(
                 re.sub(r"[^a-zA-Z0-9]+", "_", self.name),
                 type(new_symint),
@@ -1344,6 +1377,7 @@ class VariableBuilder:
             # so source needs to be updated as well.
             if attr_name is not None:
                 self.source = AttrSource(self.source, attr_name)
+            # type: ignore[attr-defined]
             return trace_rules.lookup(value).create_with_source(
                 value, source=self.source
             )
@@ -1363,6 +1397,7 @@ class VariableBuilder:
         elif isinstance(value, (types.ModuleType, replay_record.DummyModule)):
             self.install_guards(GuardBuilder.MODULE_MATCH)
             result = PythonModuleVariable(
+                # type: ignore[arg-type]
                 value,
                 source=self.source,
             )
@@ -1418,6 +1453,7 @@ class VariableBuilder:
                 torch.nn.Buffer,
             ):
                 # TODO(jansel): combine this case with the one above
+                # type: ignore[attr-defined]
                 return trace_rules.lookup(value).create_with_source(
                     value, source=self.source
                 )
@@ -1464,6 +1500,7 @@ class VariableBuilder:
                 ScriptObjectQualifiedNameSource,
             )
 
+            # type: ignore[arg-type]
             if torch._library.fake_class_registry.tracing_with_real(value):
                 proxy = self.tx.output.root_tracer.create_graph_input(
                     re.sub(r"[^a-zA-Z0-9]+", "_", self.name),
@@ -1476,7 +1513,12 @@ class VariableBuilder:
                 # setting example to be real value because these example values will be used
                 # as example_inputs for user compiler.
                 proxy.node.meta["grapharg"] = GraphArg(
-                    self.source, value, False, None, False, value
+                    self.source,
+                    value,
+                    False,
+                    None,
+                    False,
+                    value,  # type: ignore[arg-type]
                 )
                 return TorchScriptObjectVariable.create(
                     proxy,
@@ -1490,7 +1532,7 @@ class VariableBuilder:
                     # Value-type: guard on equality (will use __eq__)
                     self.install_guards(GuardBuilder.CONSTANT_MATCH)
                     return TorchScriptObjectVariable.create(
-                        value,
+                        value,  # type: ignore[arg-type]
                         value,
                         source=self.source,
                     )
@@ -1537,7 +1579,12 @@ class VariableBuilder:
             # setting example to be real value because these example values will be used
             # as example_inputs for user compiler.
             proxy.node.meta["grapharg"] = GraphArg(
-                self.source, value, False, None, False, fake_script_obj
+                self.source,
+                value,  # type: ignore[arg-type]
+                False,
+                None,
+                False,
+                fake_script_obj,  # type: ignore[arg-type]
             )
             return TorchScriptObjectVariable.create(
                 proxy,
@@ -1607,7 +1654,9 @@ class VariableBuilder:
             ]
 
             tuple_vt = TupleVariable(
-                output, source=self.source, mutation_type=ValueMutationExisting()
+                output,  # type: ignore[arg-type]
+                source=self.source,
+                mutation_type=ValueMutationExisting(),
             )
             result = UserDefinedTupleVariable(
                 value, tuple_vt=tuple_vt, source=self.source
@@ -1627,7 +1676,9 @@ class VariableBuilder:
                 for i in range(list.__len__(value))
             ]
             list_vt = ListVariable(
-                output, source=self.source, mutation_type=ValueMutationExisting()
+                output,  # type: ignore[arg-type]
+                source=self.source,
+                mutation_type=ValueMutationExisting(),
             )
             result = UserDefinedListVariable(value, list_vt=list_vt, source=self.source)
             return self.tx.output.side_effects.track_object_existing(value, result)
@@ -1645,7 +1696,8 @@ class VariableBuilder:
             ]
             if isinstance(value, set):
                 set_vt_cls = SetVariable
-            elif isinstance(value, frozenset):
+            else:
+                assert isinstance(value, frozenset)
                 set_vt_cls = FrozensetVariable
 
             set_vt = set_vt_cls(
@@ -1713,7 +1765,7 @@ class VariableBuilder:
         else:
             return self.wrap_user_defined(value)
 
-    def wrap_user_defined(self, value: Any):
+    def wrap_user_defined(self, value: Any) -> VariableTracker:
         self.install_guards(GuardBuilder.TYPE_MATCH)
         result = UserDefinedObjectVariable(value, source=self.source)
         if not SideEffects.cls_supports_mutation_side_effects(type(value)):
@@ -1721,7 +1773,9 @@ class VariableBuilder:
             return result
         return self.tx.output.side_effects.track_object_existing(value, result)
 
-    def wrap_listlike(self, value: Union[tuple, list, odict_values, NamedTuple]):
+    def wrap_listlike(
+        self, value: Union[tuple, list, odict_values, NamedTuple]
+    ) -> VariableTracker:
         for item in value:
             if item is value:
                 unimplemented(
@@ -1792,6 +1846,7 @@ class VariableBuilder:
             # Apply relevant logic from `VariableTracker.build(value[i])`
             # (except for the `create_graph_input` stuff).
             guards = []
+            # type: ignore[attr-defined]
             for i, tensor_variable in enumerate(list_variable.items):
                 source_i = GetItemSource(base=source, index=i, index_is_slice=False)
                 # access unpacked tensor from this list instead of from a lifted arg
@@ -1835,13 +1890,13 @@ class VariableBuilder:
             # https://github.com/pytorch/pytorch/issues/153701.
             for vt in output:
                 vt.realize()
-
+        # type: ignore[arg-type]
         result = BaseListVariable.cls_for_instance(value)(output, source=self.source)
         if istype(value, (list, collections.deque)):
             return self.tx.output.side_effects.track_mutable(value, result)
         return result
 
-    def wrap_tuple_iterator(self, value: tuple_iterator):
+    def wrap_tuple_iterator(self, value: tuple_iterator) -> VariableTracker:
         self.install_guards(GuardBuilder.TUPLE_ITERATOR_LEN)
         output = [
             VariableBuilder(self.tx, TupleIteratorGetItemSource(self.get_source(), i))(
@@ -1852,7 +1907,7 @@ class VariableBuilder:
         result = TupleIteratorVariable(output, source=self.source)
         return self.tx.output.side_effects.track_mutable(value, result)
 
-    def wrap_range_iterator(self, value: range_iterator):
+    def wrap_range_iterator(self, value: range_iterator) -> VariableTracker:
         self.install_guards(GuardBuilder.RANGE_ITERATOR_MATCH)
         # Get all the values from the range iterator; no need to install guards
         # on items since `RANGE_ITERATOR_MATCH` guarantees the same items.
@@ -1860,7 +1915,7 @@ class VariableBuilder:
         result = ListIteratorVariable(items, source=self.source)
         return self.tx.output.side_effects.track_mutable(value, result)
 
-    def wrap_slice_range(self, value: Union[slice, range]):
+    def wrap_slice_range(self, value: slice | range) -> SliceVariable | RangeVariable:
         items = [
             VariableBuilder(self.tx, AttrSource(self.get_source(), k))(
                 getattr(value, k)
@@ -1873,7 +1928,7 @@ class VariableBuilder:
         else:
             return RangeVariable(items, source=self.source)
 
-    def mark_static_input(self, value: torch.Tensor, guard: bool):
+    def mark_static_input(self, value: torch.Tensor, guard: bool) -> None:
         from ..decorators import mark_static_address
 
         static_inputs_log.debug(
@@ -1885,11 +1940,13 @@ class VariableBuilder:
         # As long as this runs before AOT this is sound
         if value in self.tx.output.side_effects:
             var = self.tx.output.side_effects[value]
+            # type: ignore[attr-defiend]
             var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
+                # type: ignore[attr-defiend]
                 value._dynamo_static_input_type
             )
 
-    def wrap_module(self, value: torch.nn.Module):
+    def wrap_module(self, value: torch.nn.Module) -> VariableTracker:
         from ..eval_frame import OptimizedModule
 
         if len(value.__dict__) == 0:
@@ -1971,6 +2028,7 @@ class VariableBuilder:
             # Note [Tracing a torch.compiled function]
             # when make_fx tracing a compiled function, we need
             if isinstance(value, torch.fx.experimental.proxy_tensor._AttrProxy):
+                # type: ignore[attr-defined]
                 value = value.get_base()
                 self.source = AttrProxySource(self.source)
 
@@ -1983,10 +2041,12 @@ class VariableBuilder:
                 # exception
                 if (
                     callable(value.named_parameters)
+                    # type: ignore[attr-defined]
                     and value.named_parameters.__func__
                     is og_module_named_parameters_fn_ptr
                 ):
                     try:  # catch TypeErrors in named_parameters() from unserializable nn modules
+                        # type: ignore[attr-defined]
                         for _, p in value.named_parameters():
                             self.mark_static_input(p, guard=freezing)
                     except TypeError as e:
@@ -1994,9 +2054,11 @@ class VariableBuilder:
 
                 if (
                     callable(value.named_buffers)
+                    # type: ignore[attr-defined]
                     and value.named_buffers.__func__ is og_module_named_buffers_fn_ptr
                 ):
                     try:  # catch TypeErrors in named_parameters() from unserializable nn modules
+                        # type: ignore[attr-defined]
                         for _, b in value.named_buffers():
                             self.mark_static_input(b, guard=freezing)
                     except TypeError as e:
@@ -2049,7 +2111,7 @@ class VariableBuilder:
                 # Guards are added inside register_attr_or_module
             )
 
-    def wrap_literal(self, value):
+    def wrap_literal(self, value: object) -> VariableTracker:
         if type(value) is int:
             # allowlist has higher precedence over specialization control.
             if is_dynamic_source(self.source.name):
@@ -2104,14 +2166,14 @@ class VariableBuilder:
                 return self.tx.output.side_effects.track_mutable(value, result)
             return result
 
-    def assert_not_wrapped_by_this_graph(self, value: torch.Tensor):
+    def assert_not_wrapped_by_this_graph(self, value: torch.Tensor) -> None:
         if is_fake(value) and maybe_get_fake_mode(value) is self.tx.fake_mode:
             raise InternalTorchDynamoError(
                 "Cannot wrap a Tensor that has already been",
                 "wrapped by this instance of Dynamo",
             )
 
-    def wrap_tensor(self, value: torch.Tensor):
+    def wrap_tensor(self, value: torch.Tensor) -> VariableTracker:
         source = self.get_source()
 
         # We cannot already be tracking the tensor, which implies
@@ -2233,11 +2295,14 @@ class VariableBuilder:
         if (
             safe_has_grad(value)
             and safe_grad(value) is not None
+            # type: ignore[attr-defined]
             and value.dtype != safe_grad(value).dtype
         ):
+            safe_grad_val = safe_grad(value)
+            grad_str = str(safe_grad_val.dtype) if safe_grad_val is not None else "None"
             unimplemented(
                 gb_type="dtype mismatch between tensor and its gradient",
-                context=f"tensor dtype: {value.dtype}; grad dtype: {safe_grad(value).dtype}",
+                context=f"tensor dtype: {value.dtype}; grad dtype: {grad_str}",
                 explanation="Inconsistent dtype between tensor and its gradient. "
                 "This can happen in FSDP and crashes meta tensor creation.",
                 hints=[*graph_break_hints.SUPPORTABLE],
@@ -2367,6 +2432,7 @@ class VariableBuilder:
         tensor_proxy.node.meta["tensor_dict"] = _extract_tensor_dict(value)
 
         # Note: this information is conveyed via subclass_type now
+        # type: ignore[attr-defined]
         fake_tensor_value = tensor_variable.proxy.node.meta["example_value"]
         if maybe_get_fake_mode(fake_tensor_value) is not self.tx.fake_mode:
             raise InternalTorchDynamoError("Wrapped Tensor must be this graph's fake")
@@ -2375,7 +2441,7 @@ class VariableBuilder:
         tensor_proxy.node.meta["grapharg"] = grapharg
         return tensor_variable
 
-    def wrap_numpy_ndarray(self, value):
+    def wrap_numpy_ndarray(self, value: Any) -> VariableTracker:
         assert np is not None
         assert isinstance(value, np.ndarray)
 
@@ -2391,7 +2457,7 @@ class VariableBuilder:
                 # One can not easily make nditer elements writable,
                 # but warning is not the end of the world
                 assert isinstance(value.base, np.nditer)
-
+        tensor_value = None
         with torch_function_mode_stack_state_mgr.temp_restore_stack():
             try:
                 tensor_value = _util._try_convert_to_tensor(value)
@@ -2408,6 +2474,7 @@ class VariableBuilder:
                     hints=[],
                     from_exc=e,
                 )
+        assert tensor_value is not None
 
         # We do this because we want the full behavior of guarding the numpy ndarray as if it were
         # a tensor. It's a little annoying to make a VT to throw out, but there's so many side effects here
@@ -2433,10 +2500,12 @@ class VariableBuilder:
             tx=self.tx,
             proxy=proxy,
             example_value=example_value,
+            subclass_type=None,
             **options,
         )
 
         self.tx.output.input_source_to_var[source] = numpy_ndarray_variable
+        # type: ignore[attr-defined]
         example_value = numpy_ndarray_variable.proxy.node.meta["example_value"]
 
         # pass_arg_as_tensor should be true because we are wrapping a np.ndarray as argument input, and it needs to be
@@ -2459,10 +2528,10 @@ class VariableBuilder:
 
     def wrap_symint(
         self,
-        value,
-        dynamism: Optional[DimDynamic] = None,
-        context: Optional[SymIntSymbolicContext] = None,
-    ):
+        value: int,
+        dynamism: DimDynamic | None = None,
+        context: SymIntSymbolicContext | None = None,
+    ) -> VariableTracker:
         assert type(value) is int
 
         if self.name in self.tx.output.unspec_variable_map:
@@ -2518,6 +2587,7 @@ class VariableBuilder:
             elif (
                 isinstance(base_source, LocalSource)
                 and base_source.dynamism is not None
+                # pyrefly: ignore[no-matching-overload]
                 and dict(base_source.dynamism).get(normalized_source_name, {0: False})[
                     0
                 ]
@@ -2562,6 +2632,7 @@ class VariableBuilder:
         assert isinstance(sym_expr, sympy.Symbol), f"{sym_expr} is not a basic Symbol."
         self.tx.output.root_tracer.bound_symbols[sym_expr] = proxy
         unspec_var = SymNodeVariable.create(self.tx, proxy, wrapped_value, **options)
+        # type: ignore[assignment]
         self.tx.output.unspec_variable_map[self.name] = unspec_var
 
         if not is_constant_source(self.get_source()):
@@ -2576,7 +2647,7 @@ class VariableBuilder:
 
         return unspec_var
 
-    def wrap_symfloat(self, value):
+    def wrap_symfloat(self, value: float) -> VariableTracker:
         # SymFloat wrapping is special.  We first wrap it in the same way we
         # do an unspecialized primitive, and then we item() it into a
         # SymFloat.  Removal of the item() call is left to a later FX pass,
@@ -2589,6 +2660,7 @@ class VariableBuilder:
         frame_state_entry = process_automatic_dynamic(
             self.tx,
             self.source.name,
+            # type: ignore[arg-type]
             FrameStateSizeEntry.make_scalar(value),
             is_unspecialized_nn_module=self.source.guard_source.is_unspecialized_nn_module(),
         )
@@ -2662,6 +2734,7 @@ class VariableBuilder:
             tx=self.tx,
             proxy=proxy,
             example_value=example_value,
+            subclass_type=None,
             **options,
         )
         assert isinstance(unspec_var, UnspecializedPythonVariable)
@@ -2676,6 +2749,7 @@ class VariableBuilder:
         assert is_fake(example_value)
 
         fake_tensor_value = example_value
+        # type: ignore[attr-defined]
         assert fake_tensor_value.fake_mode is self.tx.fake_mode, (
             f"fake mode ({fake_tensor_value.fake_mode}) from fake tensor metadata doesn't match mode"
             "({self.tx.fake_mode}) from InstructionTranslator"
@@ -2696,6 +2770,7 @@ class VariableBuilder:
             self.get_source(),
             wrapped_value,
             pass_arg_as_tensor=True,
+            # type: ignore[arg-type]
             fake_tensor=fake_tensor_value,
             is_tensor=False,
             example_strong_ref=wrapped_value,
@@ -2710,13 +2785,14 @@ class VariableBuilder:
                 *proxy_args_kwargs([unspec_var], {}),
             ),
         )
+        # type: ignore[attr-defined]
         self.tx.output.tracked_fakes.append(TrackedFake(r.sym_num, self.source, None))
 
         get_metrics_context().set("tensorify_float_attempt", True, overwrite=True)
 
         return r
 
-    def wrap_unspecialized_primitive(self, value):
+    def wrap_unspecialized_primitive(self, value: Any) -> VariableTracker:
         if self.name in self.tx.output.unspec_variable_map:
             return self.tx.output.unspec_variable_map[self.name]
 
@@ -2743,8 +2819,10 @@ class VariableBuilder:
             tx=self.tx,
             proxy=proxy,
             example_value=example_value,
+            subclass_type=None,
             **options,
         )
+        # type: ignore[assignment]
         self.tx.output.unspec_variable_map[self.name] = unspec_var
         if not is_constant_source(self.get_source()):
             if self.tx.export and not isinstance(self.get_source(), LocalSource):
@@ -2756,10 +2834,12 @@ class VariableBuilder:
                 # TODO: when can this happen?
                 example_value = unspec_var.as_python_constant()
             else:
+                # type: ignore[attr-defined]
                 example_value = unspec_var.proxy.node.meta["example_value"]
             assert is_fake(example_value)
 
             fake_tensor_value = example_value
+            # type: ignore[attr-defined]
             assert fake_tensor_value.fake_mode is self.tx.fake_mode, (
                 f"fake mode ({fake_tensor_value.fake_mode}) from fake tensor metadata doesn't match mode"
                 "({self.tx.fake_mode}) from InstructionTranslator"
@@ -2769,6 +2849,7 @@ class VariableBuilder:
                 self.get_source(),
                 wrapped_value,
                 pass_arg_as_tensor=True,
+                # type: ignore[arg-type]
                 fake_tensor=fake_tensor_value,
                 is_tensor=False,
                 example_strong_ref=wrapped_value,
@@ -2776,7 +2857,8 @@ class VariableBuilder:
         return unspec_var
 
 
-def _dataclasses_fields_lambda(obj):
+def _dataclasses_fields_lambda(obj: VariableTracker) -> TupleVariable:
+    value = None
     if isinstance(obj, UserDefinedObjectVariable):
         value = obj.value
     else:
@@ -2786,7 +2868,9 @@ def _dataclasses_fields_lambda(obj):
             explanation=f"Dataclass fields handling fails for {obj}. Expected it to be a user-defined object.",
             hints=[],
         )
+    assert value is not None
     items = []
+    # type: ignore[arg-type]
     for field in dataclasses.fields(value):
         source = None
         if obj.source:
@@ -2796,7 +2880,7 @@ def _dataclasses_fields_lambda(obj):
     return TupleVariable(items)
 
 
-def _clone_input(value, fake_mode):
+def _clone_input(value: Any, fake_mode: FakeTensorMode | None) -> Any:
     if isinstance(value, torch.Tensor):
         # tensor subclasses will not be converted to FakeTensors and need to be cloned
         if not (
@@ -2815,7 +2899,11 @@ def _clone_input(value, fake_mode):
 
 
 def wrap_fx_proxy(
-    tx, proxy, example_value=None, subclass_type=None, **options
+    tx: "InstructionTranslatorBase",
+    proxy: Any,
+    example_value: Any | None = None,
+    subclass_type: type | None = None,
+    **options: Any,
 ) -> VariableTracker:
     kwargs = {
         "tx": tx,
@@ -2825,14 +2913,19 @@ def wrap_fx_proxy(
         **options,
     }
     if subclass_type is None:
+        # pyrefly: ignore[bad-argument-type]
         return wrap_fx_proxy_cls(target_cls=TensorVariable, **kwargs)
     else:
+        # pyrefly: ignore[bad-argument-type]
         result = wrap_fx_proxy_cls(target_cls=TensorWithTFOverrideVariable, **kwargs)
+        # type: ignore[attr-defined]
         result.install_global(tx)
         return result
 
 
-def cache_real_value_when_export(tx, proxy, example_value):
+def cache_real_value_when_export(
+    tx: "InstructionTranslatorBase", proxy: Any, example_value: Any
+) -> None:
     if tx.export:
         # The legacy behavior for real value cache with subclasses was
         # to perform a clone WITHOUT preserving the subclass.  It's
@@ -2888,10 +2981,15 @@ def cache_real_value_when_export(tx, proxy, example_value):
 # SOMETHING INTO THE GRAPH.  This is sort of obvious, because you can't call
 # this function without a proxy.
 def wrap_fx_proxy_cls(
-    target_cls, tx, proxy, example_value=None, subclass_type=None, **options
-):
+    target_cls: type[VariableTrackerType],
+    tx: "InstructionTranslatorBase",
+    proxy: Any,
+    example_value: Any | None = None,
+    subclass_type: type | None = None,
+    **options: Any,
+) -> VariableTrackerType:
     if example_value is None:
-        out = _wrap_fx_proxy(
+        out: VariableTrackerType = _wrap_fx_proxy(
             target_cls, tx, proxy, example_value, subclass_type, **options
         )
     elif isinstance(example_value, torch.Tensor):
@@ -2902,6 +3000,7 @@ def wrap_fx_proxy_cls(
         # This will skip tracing an op and recursively reinvoke wrap_fx_proxy_cls on supported
         # data structures. In essence this just handles tracing some other value which may
         # contain Fake Tensors or is otherwise proxyable.
+        # pyrefly: ignore[bad-assignment]
         out = handle_traced_output(
             example_value, tx, proxy, options, subclass_type, target_cls
         )
@@ -2922,8 +3021,13 @@ def wrap_fx_proxy_cls(
 
 # This is 1 above (wrapping a preexisting tensor)
 def _wrap_fx_preexisting_tensor(
-    target_cls, tx, proxy, tensor, subclass_type=None, **options
-):
+    target_cls: type[VariableTrackerType],
+    tx: "InstructionTranslatorBase",
+    proxy: torch.fx.Proxy,
+    tensor: torch.Tensor,
+    subclass_type: type | None = None,
+    **options: Any,
+) -> VariableTrackerType:
     from ..symbolic_convert import InstructionTranslatorBase
 
     assert isinstance(tensor, torch.Tensor), (
@@ -2957,6 +3061,7 @@ def _wrap_fx_preexisting_tensor(
                 # to perform a clone WITHOUT preserving the subclass.  It's
                 # not entirely clear this is what you actually want though.
                 with torch._C.DisableTorchFunctionSubclass():
+                    # type: ignore[attr-defined]
                     proxy.tracer.real_value_cache[proxy.node] = _clone_input(
                         tensor, tx.fake_mode
                     )
@@ -2970,6 +3075,7 @@ def _wrap_fx_preexisting_tensor(
             }
             assert "source" in options and options["source"] is not None
             kwargs["source"] = options["source"]
+            # pyrefly: ignore[missing-argument, bad-argument-type]
             tensor = wrap_to_fake_tensor_and_record(tensor, tx=tx, **kwargs)
 
         if tensor.device.type != "meta" and (
@@ -2987,8 +3093,13 @@ def _wrap_fx_preexisting_tensor(
 
 # This is 2 in the above comment (wrapping the output of a traced op)
 def _wrap_fx_proxy(
-    target_cls, tx, proxy, example_value=None, subclass_type=None, **options
-):
+    target_cls: type[VariableTrackerType],
+    tx: "InstructionTranslatorBase",
+    proxy: torch.fx.Proxy,
+    example_value: Any | None = None,
+    subclass_type: type | None = None,
+    **options: Any,
+) -> VariableTrackerType:
     from ..symbolic_convert import InstructionTranslatorBase
 
     assert isinstance(tx, InstructionTranslatorBase)
@@ -3004,13 +3115,27 @@ def _wrap_fx_proxy(
         # cases properly below.
         example_value = get_fake_value(proxy.node, tx, allow_non_graph_fake=True)
 
+    # pyrefly: ignore[bad-return]
     return handle_traced_output(
-        example_value, tx, proxy, options, subclass_type, target_cls
+        # type: ignore[arg-type]
+        example_value,
+        tx,
+        proxy,
+        options,
+        subclass_type,
+        target_cls,
     )
 
 
-# This handles wrapping of the output of an op traced into the graph
-def handle_traced_output(example_value, tx, proxy, options, subclass_type, target_cls):
+# This handles wrapping of the output of an op traced into the graphs
+def handle_traced_output(
+    example_value: Any,
+    tx: "InstructionTranslatorBase",
+    proxy: torch.fx.Proxy,
+    options: dict[str, Any],
+    subclass_type: type | None,
+    target_cls: type[VariableTrackerType],
+) -> VariableTracker:
     import torch._functorch.vmap
     import torch._subclasses.fake_tensor
     import torch._utils
@@ -3040,6 +3165,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
         # NOTE we pass a dummy object as the `item` argument to avoid
         # constructing a dummy _tensor_ object. The object isn't used for
         # newly constructed VTs anyways.
+        assert isinstance(var, VariableTracker)
         tx.output.side_effects._track_obj(
             proxy, var, mutation_type_cls=AttributeMutationNew
         )
@@ -3047,6 +3173,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
     elif (
         hasattr(proxy.node.target, "__name__")
         and proxy.node.target.__name__ == "set_state"
+        # type: ignore[attr-defined]
         and isinstance(proxy.node.target.__self__, torch._C.Generator)
         or proxy.node.target is torch.random.set_rng_state
     ):
@@ -3094,6 +3221,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
                 # WARNING: this assumes the same target_cls as this tuple/list call
                 unpacked.append(
                     wrap_fx_proxy_cls(
+                        # pyrefly: ignore[bad-argument-type]
                         target_cls=target_cls,
                         tx=tx,
                         proxy=proxy_i,
@@ -3134,6 +3262,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
         index = None
         if proxy.node.target is get_external_object_by_index:
             index = proxy.node.args[0]
+        # type: ignore[arg-type]
         return StreamVariable(proxy, example_value, index, **options)
     elif (
         isinstance(example_value, torch.Event)
@@ -3146,6 +3275,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
         if proxy.node.target is get_external_object_by_index:
             index = proxy.node.args[0]
         set_example_value(proxy.node, example_value)
+        # type: ignore[arg-type]
         return EventVariable(proxy, example_value, index, **options)
     elif (
         inspect.isclass(proxy.node.target)
@@ -3236,7 +3366,7 @@ def handle_traced_output(example_value, tx, proxy, options, subclass_type, targe
         )
 
 
-def infer_subclass_type(value):
+def infer_subclass_type(value: Any) -> type | None:
     if type(value) in (
         torch.Tensor,
         torch.nn.Parameter,
@@ -3265,7 +3395,12 @@ def infer_subclass_type(value):
         return type(value)
 
 
-def get_specialized_props(target_cls, tx, example_value, subclass_type):
+def get_specialized_props(
+    target_cls: Any,
+    tx: "InstructionTranslatorBase",
+    example_value: Any,
+    subclass_type: type | None,
+) -> dict[str, Any]:
     specialized_props = target_cls.specialize(example_value)
     # TODO: not sure about this fake mode test
     if (
@@ -3286,8 +3421,13 @@ def get_specialized_props(target_cls, tx, example_value, subclass_type):
 
 
 def construct_tensor_variable(
-    target_cls, tx, proxy, example_value, subclass_type, options
-):
+    target_cls: type[VariableTrackerType],
+    tx: "InstructionTranslatorBase",
+    proxy: torch.fx.Proxy,
+    example_value: Any,
+    subclass_type: type | None,
+    options: dict[str, Any],
+) -> VariableTrackerType:
     """
     Actually construct a tensor variable after all the pre-processing from
     wrapping a pre-existing or newly created tensor value.
@@ -3307,7 +3447,7 @@ def construct_tensor_variable(
     return target_cls(proxy, **options)
 
 
-def get_automatic_dynamic_shapes_mark_as():
+def get_automatic_dynamic_shapes_mark_as() -> DimDynamic:
     if config.automatic_dynamic_shapes_mark_as == "dynamic":
         return DimDynamic.DYNAMIC
     elif config.automatic_dynamic_shapes_mark_as == "unbacked":
@@ -3320,8 +3460,8 @@ def get_automatic_dynamic_shapes_mark_as():
         )
 
 
-_DYNAMIC_SOURCES: Optional[set[str]] = None
-_DYNAMIC_SOURCES_CONFIG_HASH: Optional[int] = None
+_DYNAMIC_SOURCES: set[str] | None = None
+_DYNAMIC_SOURCES_CONFIG_HASH: int | None = None
 
 
 def get_dynamic_sources() -> set[str]:
@@ -3358,7 +3498,7 @@ def is_dynamic_source(source_name: str) -> bool:
 
 
 def record_automatic_dynamic(
-    tx: "InstructionTranslator", name: str, e: torch.Tensor
+    tx: "InstructionTranslatorBase", name: str, e: torch.Tensor
 ) -> FrameStateSizeEntry:
     # This mimics stride inference algorithm in _create_symbolic_sizes_strides_storage_offset
     ex_size = e.size()
@@ -3378,12 +3518,16 @@ def record_automatic_dynamic(
         stride = []
 
     return process_automatic_dynamic(
-        tx, name, FrameStateSizeEntry.make_tensor(tuple(ex_size), tuple(stride))
+        # type: ignore[arg-type]ks
+        tx,
+        name,
+        # type: ignore[arg-type]
+        FrameStateSizeEntry.make_tensor(tuple(ex_size), tuple(stride)),
     )
 
 
-_UNBACKED_SOURCES: Optional[set[str]] = None
-_UNBACKED_SOURCES_CONFIG_HASH: Optional[int] = None
+_UNBACKED_SOURCES: set[str] | None = None
+_UNBACKED_SOURCES_CONFIG_HASH: int | None = None
 
 
 def get_unbacked_sources() -> set[str]:
@@ -3422,7 +3566,11 @@ def is_unbacked_source(source_name: str) -> bool:
 # Performs automatic dynamic dim determination.
 # Returns a SymbolicContext
 def _automatic_dynamic(
-    e, tx, source, static_shapes, outer_only=False
+    e: Any,
+    tx: "InstructionTranslatorBase",
+    source: Source,
+    static_shapes: bool,
+    outer_only: bool = False,
 ) -> SymbolicContext:
     # strided NT not supported
     if e.is_nested and not isinstance(
@@ -3442,7 +3590,7 @@ def _automatic_dynamic(
     )
 
     # Get base context if the tensor is a view
-    view_base_context: Optional[SymbolicContext] = None
+    view_base_context: SymbolicContext | None = None
     if e._is_view():
         base_source = AttrSource(source, "_base")
         view_base_context = _automatic_dynamic(e._base, tx, base_source, static_shapes)
@@ -3452,6 +3600,7 @@ def _automatic_dynamic(
         outer_context = _automatic_dynamic(
             e, tx, source, static_shapes, outer_only=True
         )
+        assert isinstance(outer_context, SubclassSymbolicContext)
 
         # Get symbolic contexts for inner tensors
         inner_contexts = {}  # mapping from attr -> symbolic context
@@ -3482,6 +3631,7 @@ def _automatic_dynamic(
             constraint_strides=[None] * e.dim(),
             view_base_context=view_base_context,
             tensor_source=source,
+            # type: ignore[assignment]
             shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
         )
 
@@ -3500,6 +3650,7 @@ def _automatic_dynamic(
             constraint_strides=[None] * e.dim(),
             view_base_context=view_base_context,
             tensor_source=source,
+            # type: ignore[assignment]
             shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
         )
 
@@ -3529,7 +3680,8 @@ def _automatic_dynamic(
 
     from torch.export.dynamic_shapes import _RelaxedConstraint
 
-    if tx.output.export_constraints:
+    if tx.output.export_constraints is not None:
+        # type: ignore[iterable]
         for constraint in tx.output.export_constraints:
             if isinstance(constraint, _RelaxedConstraint):
                 continue
@@ -3566,6 +3718,7 @@ def _automatic_dynamic(
         if marked_dynamic or (
             isinstance(base_source, LocalSource)
             and base_source.dynamism is not None
+            # pyrefly: ignore[no-matching-overload]
             and dict(base_source.dynamism).get(normalized_source_name, {i: False})[i]
         ):
             # TODO: This can be batched
@@ -3683,14 +3836,20 @@ def _automatic_dynamic(
         specialize_on=specialize_on,
         view_base_context=view_base_context,
         tensor_source=source,
+        # type: ignore[arg-type]
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
     )
 
 
 # See note [Tensor Fakification and Symbol Caching]
 def wrap_to_fake_tensor_and_record(
-    e, tx, *, source: Optional[Source], is_tensor: bool, parent_context=None
-):
+    e: Any,
+    tx: "InstructionTranslatorBase",
+    *,
+    source: Source | None,
+    is_tensor: bool,
+    parent_context: Any | None = None,
+) -> Any:
     if (
         type(e) in (torch.Tensor, torch.nn.Parameter, FakeTensor)
         or isinstance(e, torch.Tensor)
@@ -3731,9 +3890,10 @@ def wrap_to_fake_tensor_and_record(
         # we use enable_python_dispatcher mainly to tweak the DispatchKeyState so that subclass authors
         # can check it to know if they are running in an eager context or not
         with enable_python_dispatcher():
+            assert tx.fake_mode is not None
             fake_e = wrap_fake_exception(
                 lambda: tx.fake_mode.from_tensor(
-                    e,
+                    e,  # type: ignore[arg-type]
                     source=source,
                     symbolic_context=symbolic_context,
                 )
@@ -3812,8 +3972,9 @@ class SourcelessBuilder:
         raise AssertionError("Use SourcelessBuilder.create()")
 
     @staticmethod
-    def create(tx: "InstructionTranslator", value) -> VariableTracker:
+    def create(tx: "InstructionTranslator", value: Any) -> VariableTracker:
         value_type = type(value)
+        # type: ignore[attr-defined]
         fast_handler = SourcelessBuilder._type_handlers.get(value_type)
         if fast_handler:
             return fast_handler(tx, value)
@@ -3821,6 +3982,7 @@ class SourcelessBuilder:
         if isinstance(value, VariableTracker):
             # This is always valid to call, and useful for recursive calls.
             return value
+        # type: ignore[attr-defined]
         elif isinstance(value, dataclasses._HAS_DEFAULT_FACTORY_CLASS):
             return UserDefinedObjectVariable(value)
         elif ConstantVariable.is_literal(value):
@@ -3828,14 +3990,17 @@ class SourcelessBuilder:
         elif callable(value) and trace_rules.lookup_callable(value) is not None:
             if trace_rules.is_callable_allowed(value):
                 tx.output.has_user_defined_allowed_in_graph = True
+            # pyrefly: ignore[not-callable, bad-argument-count]
             return trace_rules.lookup_callable(value)(value)
         elif callable(value) and UserDefinedClassVariable.is_supported_new_method(
             value
         ):
             # NamedTuple._make uses an alias of tuple.__new__
+            # pyrefly: ignore[not-callable, bad-argument-count, missing-attribute]
             obj = trace_rules.lookup_callable(value.__self__)(value.__self__)
             return GetAttrVariable(obj, "__new__")
         elif is_function_or_wrapper(value):
+            # pyrefly: ignore[not-callable, bad-argument-count]
             return trace_rules.lookup(value)(value)
         elif isinstance(
             value, (enum.Enum, torch.DispatchKey, torch._C._functorch.TransformType)
@@ -3898,14 +4063,18 @@ class SourcelessBuilder:
         )
 
     @staticmethod
-    def wrap_constant_literal(value):
+    def wrap_constant_literal(value) -> VariableTracker:
         assert ConstantVariable.is_literal(value)
         return ConstantVariable.create(value=value)
 
     @staticmethod
-    def make_type_handlers():
+    def make_type_handlers() -> dict[
+        type, Callable[["InstructionTranslator", Any], VariableTracker]
+    ]:
         create = SourcelessBuilder.create
-        handlers = {}
+        handlers: dict[
+            type, Callable[[InstructionTranslator, Any], VariableTracker]
+        ] = {}
         for t in common_constant_types:
             handlers[t] = lambda tx, value: ConstantVariable(value)
         handlers[set] = lambda tx, value: SetVariable(
@@ -3959,7 +4128,7 @@ class SourcelessBuilder:
             )
         )
 
-        def passthrough(tx: "InstructionTranslator", value):
+        def passthrough(tx: "InstructionTranslator", value: Any) -> Any:
             return value
 
         for cls in VariableTrackerMeta.all_subclasses:
@@ -3981,7 +4150,7 @@ class SourcelessUserDefinedObjectBuilder:
         raise AssertionError("Use SourcelessUserDefinedObjectBuilder.create()")
 
     @staticmethod
-    def create(tx: "InstructionTranslator", value) -> VariableTracker:
+    def create(tx: "InstructionTranslator", value: Any) -> VariableTracker:
         value_type = type(value)
         if issubclass(value_type, MutableMapping):
             return MutableMappingVariable(value, mutation_type=ValueMutationNew())

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2725,6 +2725,7 @@ class DynamoTritonHOPifier(TritonHOPifier):
     ) -> VariableTracker:
         from .builder import VariableBuilder
 
+        assert tx is not None
         wrapped_user_obj = VariableBuilder(
             tx, AttrSource(variable.kernel_source, f"{name}")
         )._wrap(user_obj)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2260,9 +2260,9 @@ class TrackedFake:
     Used by shape guard computation.
     """
 
-    fake: Union[FakeTensor, SymInt]
+    fake: FakeTensor | SymInt | SymFloat
     source: Source
-    symbolic_context: Optional[SymbolicContext]
+    symbolic_context: SymbolicContext | None
 
     def __hash__(self) -> int:
         return hash((self.fake, self.source.name))


### PR DESCRIPTION
Provides type coverage to torch/_dynamo/variables/builder.py

Coverage report:
`mypy torch/_dynamo/variables/builder.py --linecount-report /tmp/coverage_log`

Compare before to after - we go from 0 lines and 0 funcs covered to 4159 lines and 65 funcs covered

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @jataylo