### PR TITLE
[DO NOT LAND] Async autotune test for dashboard

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -823,39 +823,6 @@ class DistTensorOpsTest(DTensorTestBase):
         self.assertEqual(sharded_dtensor.grad.full_tensor(), global_tensor.grad)
 
     @with_comms
-    def test_slice_full_size_on_sharded_dim(self):
-        """
-        Test for the issue #170427 where slicing with a size that equals or
-        exceeds the full dimension size should work correctly on sharded
-        dimensions.
-
-        So when slicing [:, :N] where N >= dim_size on a tensor sharded on that
-        dimension, the operation may be optimized to use aten.alias.default,
-        which must have a proper sharding strategy registered.
-        """
-        mesh = self.build_device_mesh()
-
-        global_tensor = torch.randn(2, 4)
-        sharded_dtensor = distribute_tensor(global_tensor, mesh, [Shard(1)])
-
-        result1 = sharded_dtensor[:, :2]  # partial slice
-        self.assertEqual(result1.full_tensor(), global_tensor[:, :2])
-
-        result2 = sharded_dtensor[:, 2:]  # partial slice from middle
-        self.assertEqual(result2.full_tensor(), global_tensor[:, 2:])
-
-        # This used to fail with: NotImplementedError: Operator aten.alias.default
-        # does not have a sharding strategy registered
-        result3 = sharded_dtensor[:, :4]  # full dimension slice
-        self.assertEqual(result3.full_tensor(), global_tensor[:, :4])
-
-        result4 = sharded_dtensor[:, :8]  # beyond dimension size
-        self.assertEqual(result4.full_tensor(), global_tensor[:, :8])
-
-        result5 = sharded_dtensor[:2, :]  # full slice on dim 0
-        self.assertEqual(result5.full_tensor(), global_tensor[:2, :])
-
-    @with_comms
     def test_split_on_partial(self):
         self.run_subtests(
             {

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -15,6 +15,7 @@ import textwrap
 import traceback
 import typing
 from collections import Counter, defaultdict
+from concurrent.futures import as_completed
 from typing import Any, Generic, Optional, TYPE_CHECKING, TypeAlias, TypeVar, Union
 from typing_extensions import ParamSpec
 
@@ -96,6 +97,39 @@ compute_dependencies_log = torch._logging.getArtifactLogger(
 PartitionType: TypeAlias = list["BaseSchedulerNode"]
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
+
+
+@dataclasses.dataclass
+class FusionResult:
+    should_fuse: Optional[bool] = None
+    callable_fn: Optional[Callable[[], bool]] = None
+    future: Optional[LambdaFuture] = None
+
+    def __post_init__(self):
+        assert (self.should_fuse is not None) ^ (self.callable_fn is not None), (
+            "Fusion result should contain either fusion decision or callable_fn, not both"
+        )
+
+    @classmethod
+    def fuse(cls, should_fuse: bool):
+        return FusionResult(should_fuse=should_fuse)
+
+    @classmethod
+    def from_callable(
+        cls, callable_fn: Callable[[], bool], future: Optional[LambdaFuture] = None
+    ):
+        return FusionResult(callable_fn=callable_fn, future=future)
+
+
+@dataclasses.dataclass
+class PendingFusion:
+    callable_fn: Callable[[], bool]
+    node1: BaseSchedulerNode
+    node2: BaseSchedulerNode
+    future: Optional[LambdaFuture] = None
+
+    def get_fusion_nodes(self) -> tuple[BaseSchedulerNode, BaseSchedulerNode]:
+        return (self.node1, self.node2)
 
 
 class MixOrderReduction:
@@ -2795,6 +2829,34 @@ def get_scheduler_node_symbol_uses(
     return free_symbol_uses
 
 
+def is_epilogue_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return node1.is_template() and config.epilogue_fusion and not node2.is_template()
+
+
+def is_prologue_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return node2.is_template() and config.prologue_fusion and not node1.is_template()
+
+
+def is_template_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
+    return is_epilogue_fusion(node1, node2) or is_prologue_fusion(node1, node2)
+
+
+def _should_defer_template_fusion(
+    fused_node1: BaseSchedulerNode,
+    fused_node2: BaseSchedulerNode,
+    pending_fusions: dict[BaseSchedulerNode, list[PendingFusion]],
+):
+    if is_template_fusion(fused_node1, fused_node2):
+        pending_fusion = (
+            pending_fusions[fused_node2]
+            if is_epilogue_fusion(fused_node1, fused_node2)
+            else pending_fusions[fused_node1]
+        )
+        return len(pending_fusion) > 0 and pending_fusion[0].future
+
+    return False
+
+
 class Scheduler:
     """
     A Scheduler is a graph of BaseSchedulerNodes. It is responsible for
@@ -2859,6 +2921,9 @@ class Scheduler:
         # in codegen we only use buf0, never buf1
         self.mutation_renames: dict[str, str] = {}
 
+        self.seen_template_fusions: OrderedSet[
+            tuple[BaseSchedulerNode, BaseSchedulerNode]
+        ] = OrderedSet()
         # Must run first to correctly set dependencies, before all other passes that rely on
         # reading from .read_writes.reads or .unmet_dependencies
         self.nodes = comms.decide_global_ordering_of_comms(
@@ -3673,7 +3738,7 @@ class Scheduler:
         device = nodes[0].get_device()
         self.current_device = device
         backend = self.get_backend(device)
-        with dynamo_timed("benchmark_fused_nodes"):
+        with dynamo_timed("generate_kernel_code_from_nodes"):
             return backend.generate_kernel_code_from_nodes(
                 nodes, benchmark_kernel, hint_override=hint_override
             )
@@ -3687,7 +3752,7 @@ class Scheduler:
         """
         self.current_device = device
         backend = self.get_backend(device)
-        with dynamo_timed("benchmark_fused_nodes"):
+        with dynamo_timed("benchmark_codegened_module"):
             return backend.benchmark_codegened_module(module)
 
     def finalize_multi_template_buffers(self) -> None:
@@ -3807,7 +3872,7 @@ class Scheduler:
 
     def speedup_by_fusion(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
-    ) -> Union[bool, Callable[[], bool]]:
+    ) -> FusionResult:
         """
         If config.benchmark_fusion is False, always return True.
         Otherwise, return True if fusion can brings speedup.
@@ -3819,7 +3884,7 @@ class Scheduler:
             for n in (node1, node2)
         )
         if not config.benchmark_fusion and not is_multi_template:
-            return True
+            return FusionResult.fuse(True)
 
         if (
             node1.is_template()
@@ -3828,7 +3893,7 @@ class Scheduler:
             or node2.is_foreach()
         ):
             # TODO support benchmarking epilogue fusion
-            return True
+            return FusionResult.fuse(True)
 
         node_list_1 = node1.get_nodes()
         device = node_list_1[0].get_device()
@@ -3836,7 +3901,7 @@ class Scheduler:
 
         # don't support benchmark fusion for CPU C++ backend right now.
         if device.type == "cpu" and config.cpu_backend != "triton":
-            return True
+            return FusionResult.fuse(True)
 
         node_list_2 = node2.get_nodes()
         node_list_fused = list(itertools.chain(node_list_1, node_list_2))
@@ -3845,7 +3910,7 @@ class Scheduler:
         # due to how we generate random integer inputs.
         # Skip benchmarking them by allowing fusion.
         if self._any_atomic_add(node_list_fused):
-            return True
+            return FusionResult.fuse(True)
 
         from triton.compiler.errors import CompilationError
 
@@ -3962,7 +4027,7 @@ class Scheduler:
             else:
                 # By default, don't do prologue fusion. Generally slower
                 if not epilogue_fusion:
-                    return False
+                    return FusionResult.fuse(False)
 
                 ms2 = node2._get_estimated_runtime()
                 ms2_fused = _estimate_fused_epilogue_runtime(node1, node2, ms2)
@@ -3999,7 +4064,7 @@ class Scheduler:
                     future_choices.append((choice, *compile_kernel(node_list_fused)))
 
             if len(future_choices) == 0:
-                return False
+                return FusionResult.fuse(False)
 
             def benchmark_when_ready() -> bool:
                 min_ms_fused = float("inf")
@@ -4078,7 +4143,9 @@ class Scheduler:
                 else:
                     return False
 
-            return benchmark_when_ready
+            return FusionResult.from_callable(
+                benchmark_when_ready, future_choices[0][1]
+            )
 
         else:
             # Start parallel compilation for all three kernels
@@ -4158,11 +4225,116 @@ class Scheduler:
                         return True
                     raise
 
-            return benchmark_when_ready
+            return FusionResult.from_callable(
+                callable_fn=benchmark_when_ready, future=future_and_mod_l1_fused[0]
+            )
 
     def get_fused_node(self, node: BaseSchedulerNode) -> BaseSchedulerNode:
         "Look up the node in Scheduler name_to_fused_node"
         return self.name_to_fused_node[node.get_first_name()]
+
+    def fuse_two_nodes(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+    ) -> BaseSchedulerNode:
+        fusion_log.error("fusing %s with %s", node1.get_name(), node2.get_name())
+
+        device = node1.get_device()
+        assert node2.get_device() == device
+        node3 = self.get_backend(device).fuse(node1, node2)
+        fused_nodes.remove(node1)
+        fused_nodes.remove(node2)
+        fused_nodes.add(node3)
+        self.name_to_fused_node.update({n.get_name(): node3 for n in node3.get_nodes()})
+        return node3
+
+    def evaluate_pending_template_fusions(
+        self,
+        fusion_nodes: OrderedSet[BaseSchedulerNode],
+        seen_pair_speedup_fn: OrderedSet[Callable[[], bool]],
+        fused_nodes: OrderedSet[BaseSchedulerNode],
+        pending_fusions: dict[BaseSchedulerNode, list[PendingFusion]],
+    ) -> None:
+        """
+        Evaluate pending template fusions for a set of fusion candidate nodes.
+        fusion_type is either "epilogue" or "prologue" for logging purposes.
+        """
+        finished_fusions: OrderedSet[BaseSchedulerNode] = OrderedSet()
+
+        def fuse_if_speedup(node1, node2, speedup_fn):
+            if (
+                self.can_fuse(node1, node2)
+                and speedup_fn()
+                and not self.will_fusion_create_cycle(node1, node2)
+            ):
+                self.fuse_two_nodes(node1, node2, fused_nodes)
+                non_template_node = node2 if is_epilogue_fusion(node1, node2) else node1
+                pending_fusions.pop(non_template_node, None)
+                finished_fusions.add(non_template_node)
+
+        while len(fusion_nodes) > len(finished_fusions):
+            template_futures = []
+            future_to_pending_fusion = {}
+
+            remaining_nodes = fusion_nodes - finished_fusions
+            for fusion_node in remaining_nodes:
+                # Pointwise node already fused
+                if fusion_node not in pending_fusions:
+                    finished_fusions.add(fusion_node)
+                    continue
+
+                assert len(pending_fusions[fusion_node]) >= 1
+
+                pending_fusion = pending_fusions[fusion_node].pop(0)
+                node1, node2 = pending_fusion.get_fusion_nodes()
+
+                assert self.get_fused_node(node1) is node1
+                if is_epilogue_fusion(node1, node2):
+                    assert self.get_fused_node(node2) is node2
+                    template_node = node1
+                else:
+                    # In prologue fusion cases, the template node can change
+                    # from fusion with an epilogue
+                    node2 = self.get_fused_node(node2)
+                    template_node = node2
+
+                # Above the fusion potential gets popped. If fusion_node has no other
+                # fusion candidates, delete from pending_fusions
+                if len(pending_fusions[fusion_node]) == 0:
+                    pending_fusions.pop(fusion_node)
+                    finished_fusions.add(fusion_node)
+
+                # speedup already evaluated, don't fuse as wasn't fused prior or
+                # the template node has already been fused
+                if (
+                    pending_fusion.callable_fn in seen_pair_speedup_fn
+                    or template_node not in fused_nodes
+                ):
+                    continue
+
+                seen_pair_speedup_fn.add(pending_fusion.callable_fn)
+
+                future = pending_fusion.future
+
+                if future:
+                    f = future.future
+                    assert f is not None
+                    template_futures.append(f)
+                    future_to_pending_fusion[f] = pending_fusion
+                else:
+                    # Non AsyncCompile path, perform fusion
+                    fuse_if_speedup(node1, node2, pending_fusion.callable_fn)
+
+            # Evaluate fusion candidates as async_compile completes
+            for f in as_completed(template_futures):
+                pending_fusion = future_to_pending_fusion[f]
+                fuse_if_speedup(
+                    self.get_fused_node(pending_fusion.node1),
+                    self.get_fused_node(pending_fusion.node2),
+                    pending_fusion.callable_fn,
+                )
 
     def fuse_nodes_once(
         self,
@@ -4185,30 +4357,20 @@ class Scheduler:
 
         # These are potential fusions which we are async compiling,
         # and which we will benchmark profitability of.
-        pending_fusions: dict[
-            BaseSchedulerNode,
-            tuple[Callable[[], bool], BaseSchedulerNode, BaseSchedulerNode],
-        ] = {}
+        # Maps node -> (is_speedup_fn, LambdaFuture, node1, node2)
+        pending_fusions = collections.defaultdict(list[PendingFusion])
 
-        def fuse_two_nodes(
-            node1: BaseSchedulerNode, node2: BaseSchedulerNode
-        ) -> BaseSchedulerNode:
-            fusion_log.debug("fusing %s with %s", node1.get_name(), node2.get_name())
-
-            device = node1.get_device()
-            assert node2.get_device() == device
-            node3 = self.get_backend(device).fuse(node1, node2)
-            fused_nodes.remove(node1)
-            fused_nodes.remove(node2)
-            fused_nodes.add(node3)
-            self.name_to_fused_node.update(
-                {n.get_name(): node3 for n in node3.get_nodes()}
-            )
-            return node3
+        epilogue_fusion_nodes: OrderedSet[BaseSchedulerNode] = OrderedSet()
+        prologue_fusion_nodes: OrderedSet[BaseSchedulerNode] = OrderedSet()
 
         def resolve_pending_fusions(
             node1: BaseSchedulerNode, node2: BaseSchedulerNode
         ) -> None:
+            if _should_defer_template_fusion(
+                self.get_fused_node(node1), self.get_fused_node(node2), pending_fusions
+            ):
+                return
+
             while (
                 self.get_fused_node(node1) in pending_fusions
                 or self.get_fused_node(node2) in pending_fusions
@@ -4217,9 +4379,11 @@ class Scheduler:
                     self.get_fused_node(node1),
                     pending_fusions.get(self.get_fused_node(node2), None),
                 )
-                assert pending_fusion is not None
+                assert len(pending_fusion) == 1
 
-                is_speedup, node_key1, node_key2 = pending_fusion
+                node_key1, node_key2 = pending_fusion[0].get_fusion_nodes()
+                is_speedup = pending_fusion[0].callable_fn
+
                 pending_fusions.pop(node_key1, None)
                 pending_fusions.pop(node_key2, None)
 
@@ -4229,7 +4393,28 @@ class Scheduler:
                 if not is_speedup() or self.will_fusion_create_cycle(node1, node2):
                     continue
 
-                fuse_two_nodes(node_key1, node_key2)
+                self.fuse_two_nodes(node_key1, node_key2, fused_nodes)
+
+        def evaluate_lazy_fusions(node1, node2, fusion_res: FusionResult):
+            assert fusion_res.callable_fn is not None
+
+            if is_template_fusion(node1, node2):
+                assert (node1, node2) not in self.seen_template_fusions
+                self.seen_template_fusions.add((node1, node2))
+
+                if is_epilogue_fusion(node1, node2):
+                    epilogue_fusion_nodes.add(node2)
+                else:
+                    prologue_fusion_nodes.add(node1)
+
+            pending_fusion = PendingFusion(
+                callable_fn=fusion_res.callable_fn,
+                node1=node1,
+                node2=node2,
+                future=fusion_res.future,
+            )
+            pending_fusions[node1].append(pending_fusion)
+            pending_fusions[node2].append(pending_fusion)
 
         for node1, node2 in self.get_possible_fusions(nodes, is_reorder_round):
             # if either node is in a pending fusion, resolve it.
@@ -4239,24 +4424,40 @@ class Scheduler:
             node1 = self.get_fused_node(node1)
             node2 = self.get_fused_node(node2)
 
+            if (
+                is_template_fusion(node1, node2)
+                and (node1, node2) in self.seen_template_fusions
+            ):
+                continue
+
             if self.can_fuse(
                 node1, node2, is_reorder_round
             ) and not self.will_fusion_create_cycle(node1, node2):
-                speedup = self.speedup_by_fusion(node1, node2)
-                if callable(speedup):
-                    pending_fusions[node1] = (speedup, node1, node2)
-                    pending_fusions[node2] = (speedup, node1, node2)
+                fusion_res = self.speedup_by_fusion(node1, node2)
+                if fusion_res.callable_fn is not None:
+                    evaluate_lazy_fusions(node1, node2, fusion_res)
                     continue
 
-                if not speedup:
+                if not fusion_res.should_fuse:
                     continue
 
-                fuse_two_nodes(node1, node2)
+                self.fuse_two_nodes(node1, node2, fused_nodes)
 
+        # Evaluate epilogue fusions first (generally higher priority/more gain),
+        # then prologue fusions
         seen_pair_speedup_fn: OrderedSet[Callable[[], bool]] = OrderedSet()
-        for is_speedup_fn, node_key1, node_key2 in pending_fusions.values():
-            if is_speedup_fn in seen_pair_speedup_fn:
+
+        # Resolve pending fusions for non templates
+        for pending_fusion in pending_fusions.values():
+            node_key1, node_key2 = pending_fusion[0].get_fusion_nodes()
+            is_speedup_fn = pending_fusion[0].callable_fn
+
+            if is_speedup_fn in seen_pair_speedup_fn or is_template_fusion(
+                node_key1, node_key2
+            ):
                 continue
+
+            assert len(pending_fusion) == 1
 
             seen_pair_speedup_fn.add(is_speedup_fn)
 
@@ -4266,7 +4467,15 @@ class Scheduler:
             if is_speedup_fn() and not self.will_fusion_create_cycle(
                 node_key1, node_key2
             ):
-                fuse_two_nodes(node_key1, node_key2)
+                self.fuse_two_nodes(node_key1, node_key2, fused_nodes)
+
+        # Evaluate epilogue template fusions first, and then prologue
+        self.evaluate_pending_template_fusions(
+            epilogue_fusion_nodes, seen_pair_speedup_fn, fused_nodes, pending_fusions
+        )
+        self.evaluate_pending_template_fusions(
+            prologue_fusion_nodes, seen_pair_speedup_fn, fused_nodes, pending_fusions
+        )
 
         nodes = sorted(fused_nodes, key=lambda x: x.min_order)
         nodes = self.topological_sort_schedule(nodes)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171329

This reverts commit 3827373922750b72f6fbd094aab57e531f6b87da.

Reverted https://github.com/pytorch/pytorch/pull/170521 on behalf of https://github.com/pytorch-auto-revert due to Reverted automatically by pytorch's autorevert, to avoid this behaviour add the tag autorevert: disable ([comment](https://github.com/pytorch/pytorch/pull/170521#issuecomment-3679340251))

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo