### PR TITLE
Add Doc of nonzero_static

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3629,50 +3629,7 @@ add_docstr_all(
     r"""
 nonzero_static(input, *, size, fill_value=-1) -> Tensor
 
-Returns a 2-D tensor where each row is the index for a non-zero value.
-The returned Tensor has the same `torch.dtype` as `torch.nonzero()`.
-
-Args:
-    input (Tensor): the input tensor to count non-zero elements.
-
-Keyword args:
-    size (int): the size of non-zero elements expected to be included in the out
-        tensor. Pad the out tensor with `fill_value` if the `size` is larger
-        than total number of non-zero elements, truncate out tensor if `size`
-        is smaller. The size must be a non-negative integer.
-    fill_value (int, optional): the value to fill the output tensor with when `size` is larger
-        than the total number of non-zero elements. Default is `-1` to represent
-        invalid index.
-
-Example:
-
-    # Example 1: Padding
-    >>> input_tensor = torch.tensor([[1, 0], [3, 2]])
-    >>> static_size = 4
-    >>> t = torch.nonzero_static(input_tensor, size=static_size)
-    tensor([[  0,   0],
-            [  1,   0],
-            [  1,   1],
-            [  -1, -1]], dtype=torch.int64)
-
-    # Example 2: Truncating
-    >>> input_tensor = torch.tensor([[1, 0], [3, 2]])
-    >>> static_size = 2
-    >>> t = torch.nonzero_static(input_tensor, size=static_size)
-    tensor([[  0,   0],
-            [  1,   0]], dtype=torch.int64)
-
-    # Example 3: 0 size
-    >>> input_tensor = torch.tensor([10])
-    >>> static_size = 0
-    >>> t = torch.nonzero_static(input_tensor, size=static_size)
-    tensor([], size=(0, 1), dtype=torch.int64)
-
-    # Example 4: 0 rank input
-    >>> input_tensor = torch.tensor(10)
-    >>> static_size = 2
-    >>> t = torch.nonzero_static(input_tensor, size=static_size)
-    tensor([], size=(2, 0), dtype=torch.int64)
+See :func:`torch.nonzero_static`
 """,
 )
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8399,43 +8399,38 @@ add_docstr(
 nonzero_static(input, *, size, fill_value=-1) -> LongTensor
 
 Returns a 2-D tensor where each row is the index for a non-zero value.
-The returned tensor has the same dtype and semantics as :func:`torch.nonzero` (indices of type ``torch.int64``).
-
+The returned Tensor has the same `torch.dtype` as `torch.nonzero()`.
 Args:
-    input (Tensor): the input tensor.
-
+    input (Tensor): the input tensor to count non-zero elements.
 Keyword args:
-    size (int): the number of non-zero elements to include in the output. If :attr:`size` is larger than
-        the number of non-zero elements, pads extra rows with :attr:`fill_value`. If smaller, truncates the result.
-        Must be a non-negative integer.
-    fill_value (int, optional): the value used to pad rows when :attr:`size` exceeds the number of non-zero elements.
-        The default is ``-1`` to represent an invalid index.
-
-Example::
-
+    size (int): the size of non-zero elements expected to be included in the out
+        tensor. Pad the out tensor with `fill_value` if the `size` is larger
+        than total number of non-zero elements, truncate out tensor if `size`
+        is smaller. The size must be a non-negative integer.
+    fill_value (int, optional): the value to fill the output tensor with when `size` is larger
+        than the total number of non-zero elements. Default is `-1` to represent
+        invalid index.
+Example:
     # Example 1: Padding
     >>> input_tensor = torch.tensor([[1, 0], [3, 2]])
     >>> static_size = 4
     >>> t = torch.nonzero_static(input_tensor, size=static_size)
-    tensor([[ 0,  0],
-            [ 1,  0],
-            [ 1,  1],
-            [-1, -1]])
-
+    tensor([[  0,   0],
+            [  1,   0],
+            [  1,   1],
+            [  -1, -1]], dtype=torch.int64)
     # Example 2: Truncating
     >>> input_tensor = torch.tensor([[1, 0], [3, 2]])
     >>> static_size = 2
     >>> t = torch.nonzero_static(input_tensor, size=static_size)
-    tensor([[0, 0],
-            [1, 0]])
-
-    # Example 3: Zero size
+    tensor([[  0,   0],
+            [  1,   0]], dtype=torch.int64)
+    # Example 3: 0 size
     >>> input_tensor = torch.tensor([10])
     >>> static_size = 0
     >>> t = torch.nonzero_static(input_tensor, size=static_size)
     tensor([], size=(0, 1), dtype=torch.int64)
-
-    # Example 4: Zero-rank input
+    # Example 4: 0 rank input
     >>> input_tensor = torch.tensor(10)
     >>> static_size = 2
     >>> t = torch.nonzero_static(input_tensor, size=static_size)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8394,6 +8394,56 @@ Example::
 )
 
 add_docstr(
+    torch.nonzero_static,
+    r"""
+nonzero_static(input, *, size, fill_value=-1) -> LongTensor
+
+Returns a 2-D tensor where each row is the index for a non-zero value.
+The returned tensor has the same dtype and semantics as :func:`torch.nonzero` (indices of type ``torch.int64``).
+
+Args:
+    input (Tensor): the input tensor.
+
+Keyword args:
+    size (int): the number of non-zero elements to include in the output. If :attr:`size` is larger than
+        the number of non-zero elements, pads extra rows with :attr:`fill_value`. If smaller, truncates the result.
+        Must be a non-negative integer.
+    fill_value (int, optional): the value used to pad rows when :attr:`size` exceeds the number of non-zero elements.
+        The default is ``-1`` to represent an invalid index.
+
+Example::
+
+    # Example 1: Padding
+    >>> input_tensor = torch.tensor([[1, 0], [3, 2]])
+    >>> static_size = 4
+    >>> t = torch.nonzero_static(input_tensor, size=static_size)
+    tensor([[ 0,  0],
+            [ 1,  0],
+            [ 1,  1],
+            [-1, -1]])
+
+    # Example 2: Truncating
+    >>> input_tensor = torch.tensor([[1, 0], [3, 2]])
+    >>> static_size = 2
+    >>> t = torch.nonzero_static(input_tensor, size=static_size)
+    tensor([[0, 0],
+            [1, 0]])
+
+    # Example 3: Zero size
+    >>> input_tensor = torch.tensor([10])
+    >>> static_size = 0
+    >>> t = torch.nonzero_static(input_tensor, size=static_size)
+    tensor([], size=(0, 1), dtype=torch.int64)
+
+    # Example 4: Zero-rank input
+    >>> input_tensor = torch.tensor(10)
+    >>> static_size = 2
+    >>> t = torch.nonzero_static(input_tensor, size=static_size)
+    tensor([], size=(2, 0), dtype=torch.int64)
+""",
+)
+
+add_docstr(
     torch.numel,
     r"""
 numel(input: Tensor) -> int


### PR DESCRIPTION
PyTorch doc website has no entry for `nonzero_static`:
https://docs.pytorch.org/docs/stable/search.html?q=nonzero_static#

This is because the doc string was not defined in `_torch_docs.py`.