### PR TITLE
[Inductor][CuTeDSL] Check cutlass instead of cutlass.cute for CuTeDSL detection

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1959,7 +1959,7 @@ def ensure_cute_available() -> bool:
     in the same interpreter to retry the import.
     """
     try:
-        return importlib.util.find_spec("cutlass.cute") is not None
+        return importlib.util.find_spec("cutlass") is not None
     except ImportError:
         return False
 


### PR DESCRIPTION
Summary: Instead of checking if `cutlass.cute` is importable, we should just check for `cutlass`. The module intiialization for `cutlass.cute` messes with PyTorch's garbage collection and causes us to fail some CudaGraph Tree related tests.

Test Plan: `buck test fbcode//mode/opt fbcode//caffe2/test/inductor:cudagraph_trees -c fbcode.nvcc_arch=b200a -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 -- --exact 'fbcode//caffe2/test/inductor:cudagraph_trees - test_graph_partition_dynamic_scalar_inputs (caffe2.test.inductor.test_cudagraph_trees.CudaGraphTreeTests)'`

Differential Revision: D89820584




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo