### PR TITLE
[ROCm] Fix UUID visible devices parsing

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4988,9 +4988,10 @@ import torch
 import os
 print(f"{torch.cuda.device_count()}")
         """
-        cmd = "rocminfo | grep -o 'Uuid:.*GPU-.*' | sed 's/Uuid://'"
+        # Use rocm-smi to get device UUIDs that match amdsmi's asic_serial format
+        cmd = "rocm-smi --showuniqueid | grep -oP '0x[0-9a-fA-F]+' | sed 's/0x/GPU-/'"
         uuids = subprocess.check_output(cmd, shell=True, text=True).strip().split("\n")
-        uuids = [s.strip() for s in uuids]
+        uuids = [s.strip() for s in uuids if s.strip()]
 
         custom_envs = []
         for uuid in uuids:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4995,10 +4995,18 @@ print(f"{torch.cuda.device_count()}")
         custom_envs = []
         for uuid in uuids:
             custom_envs.append(
-                {"CUDA_VISIBLE_DEVICES": f"{uuid}", "HIP_VISIBLE_DEVICES": None}
+                {
+                    "CUDA_VISIBLE_DEVICES": f"{uuid}",
+                    "HIP_VISIBLE_DEVICES": None,
+                    "ROCR_VISIBLE_DEVICES": None,
+                }
             )
             custom_envs.append(
-                {"HIP_VISIBLE_DEVICES": f"{uuid}", "CUDA_VISIBLE_DEVICES": None}
+                {
+                    "HIP_VISIBLE_DEVICES": f"{uuid}",
+                    "CUDA_VISIBLE_DEVICES": None,
+                    "ROCR_VISIBLE_DEVICES": None,
+                }
             )
 
         for env_config in custom_envs:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -986,7 +986,7 @@ def _transform_uuid_to_ordinals(candidates: list[str], uuids: list[str]) -> list
     def uuid_to_ordinal(candidate: str, uuids: list[str]) -> int:
         best_match = -1
         for idx, uuid in enumerate(uuids):
-            if not uuid.startswith(candidate):
+            if not (uuid.startswith(candidate) or candidate.startswith(uuid)):
                 continue
             # Ambiguous candidate
             if best_match != -1:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1000,6 +1000,7 @@ def _transform_uuid_to_ordinals(candidates: list[str], uuids: list[str]) -> list
             candidate = candidate.replace(
                 "GPU-", "", 1
             )  # Remove GPU-prefix to match amdsmi asic serial
+            candidate = candidate.lower()
         idx = uuid_to_ordinal(candidate, uuids)
         # First invalid ordinal stops parsing
         if idx < 0:


### PR DESCRIPTION
Fixes #169878

Normalize ROCm UUID casing for visible-devices parsing and isolate the test subprocess environment by clearing `ROCR_VISIBLE_DEVICES`.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang