### PR TITLE
[ROCm][cuda] Initialize nll_loss2d total_weight for reduction=None

### DIFF
--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -253,6 +253,11 @@ void nll_loss2d_forward_out_cuda_template(
   total_weight.resize_({});
 
   if (reduction == at::Reduction::None) {
+    // total_weight is part of the forward API return. For reduction=None it is
+    // semantically unused, but must be well-defined (CPU sets it to 0). Leaving
+    // it uninitialized can cause flaky comparisons in decomposition tests.
+    total_weight.zero_();
+
     int64_t batch_size = input.size(0);
     int64_t H = input.size(2);
     int64_t W = input.size(3);


### PR DESCRIPTION
Fixes #118355
Fixes #117732

Initialize `total_weight` in `nll_loss2d_forward` for `reduction=None` on CUDA/ROCm (avoid returning uninitialized output) and add a small decomp regression test.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang