### PR TITLE
[ROCm] Stabilize micro_pipeline_tp tests by isolating Inductor config

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -70,6 +70,7 @@ class MicroPipelineTPTest(TestCase):
             reorder_for_compute_comm_overlap=False,
         )
         self._inductor_config_patch.__enter__()
+        self.addCleanup(self._inductor_config_patch.__exit__, None, None, None)
 
         self.rank = 0
         self.world_size = 2
@@ -85,7 +86,6 @@ class MicroPipelineTPTest(TestCase):
 
     def tearDown(self):
         dist.destroy_process_group()
-        self._inductor_config_patch.__exit__(None, None, None)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
@@ -519,6 +519,7 @@ class MicroPipelineTP4GPUTest(TestCase):
             reorder_for_compute_comm_overlap=False,
         )
         self._inductor_config_patch.__enter__()
+        self.addCleanup(self._inductor_config_patch.__exit__, None, None, None)
 
         self.rank = 0
         self.world_size = 4
@@ -534,7 +535,6 @@ class MicroPipelineTP4GPUTest(TestCase):
 
     def tearDown(self):
         dist.destroy_process_group()
-        self._inductor_config_patch.__exit__(None, None, None)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()

--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -63,7 +63,13 @@ def _fp8_all_gather(
 @instantiate_parametrized_tests
 class MicroPipelineTPTest(TestCase):
     def setUp(self):
-        torch._inductor.config._micro_pipeline_tp = True
+        # Avoid test-order flakes: these are global Inductor configs that other
+        # tests may patch without restoring.
+        self._inductor_config_patch = torch._inductor.config.patch(
+            _micro_pipeline_tp=True,
+            reorder_for_compute_comm_overlap=False,
+        )
+        self._inductor_config_patch.__enter__()
 
         self.rank = 0
         self.world_size = 2
@@ -79,6 +85,7 @@ class MicroPipelineTPTest(TestCase):
 
     def tearDown(self):
         dist.destroy_process_group()
+        self._inductor_config_patch.__exit__(None, None, None)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
@@ -505,7 +512,13 @@ class MicroPipelineTPTest(TestCase):
 @instantiate_parametrized_tests
 class MicroPipelineTP4GPUTest(TestCase):
     def setUp(self):
-        torch._inductor.config._micro_pipeline_tp = True
+        # Avoid test-order flakes: these are global Inductor configs that other
+        # tests may patch without restoring.
+        self._inductor_config_patch = torch._inductor.config.patch(
+            _micro_pipeline_tp=True,
+            reorder_for_compute_comm_overlap=False,
+        )
+        self._inductor_config_patch.__enter__()
 
         self.rank = 0
         self.world_size = 4
@@ -521,6 +534,7 @@ class MicroPipelineTP4GPUTest(TestCase):
 
     def tearDown(self):
         dist.destroy_process_group()
+        self._inductor_config_patch.__exit__(None, None, None)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()


### PR DESCRIPTION
Fixes #153223

Scope micro_pipeline_tp Inductor config changes using `torch._inductor.config.patch(...)` and ensure cleanup via `addCleanup` to avoid test-order flakes.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang