### PR TITLE
[XPU][inductor] Make epilogue fusion FileCheck accept add/mul order

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3723,8 +3723,10 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                     FileCheck().check("triton_tem_fused_add_mm_mul").run(code[0])
                 else:
                     # Aten wins in unfused case
-                    FileCheck().check_not("triton_tem").check(
-                        "triton_poi_fused_add_mul"
+                    # Pointwise epilogue may appear as either `add`->`mul` or
+                    # `mul`->`add` depending on fusion / canonicalization.
+                    FileCheck().check_not("triton_tem").check_regex(
+                        "triton_poi_fused_(add_mul|mul_add)"
                     ).run(code[0])
 
                 if not config.cpp_wrapper:


### PR DESCRIPTION
Fixes #170854
Fixes #170923

Make the epilogue-fusion FileCheck accept either add→mul or mul→add kernel naming to avoid brittle order dependence.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben