### PR TITLE
[dynamo] Remove SkipCodeRecursiveException and RecompileLimitExceeded, add frame_exec_strategy attribute

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2126,7 +2126,9 @@ Dynamo recompile limit exceeded
   Hint: To monitor recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider increasing torch._dynamo.config.recompile_limit to an appropriate value.
   Hint: See https://pytorch.org/docs/main/compile/programming_model.recompilation.html for tips on dealing with recompilations.
 
-  Developer debug context: Limit type: recompile_limit""",
+  Developer debug context: Limit type: recompile_limit
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0039.html""",
             )
 
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2090,6 +2090,45 @@ from user code:
     torch._dynamo.graph_break()""",
             )
 
+    @make_logging_test()
+    @torch._dynamo.config.patch(recompile_limit=1)
+    def test_recompile_limit_hit_message(self, records):
+        @torch.compile(backend="eager", dynamic=False)
+        def fn(x, n):
+            return x + n
+
+        def outer(x):
+            for i in range(2):
+                x = fn(x, i)
+            return x
+
+        outer(torch.ones(3))
+
+        self.assertExpectedInline(
+            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            """\
+torch._dynamo hit config.recompile_limit (1)
+   function: 'fn' (test_error_messages.py:N)
+   last reason: 0/0: n == 0                                                   # return x + n  # test/dynamo/test_error_messages.py:N in fn
+To log all recompilation reasons, use TORCH_LOGS="recompiles".
+To diagnose recompilation issues, see https://pytorch.org/docs/main/compile/programming_model.recompilation.html""",
+        )
+
+        torch.compiler.reset()
+
+        with torch._dynamo.error_on_graph_break(True):
+            self.assertExpectedInlineMunged(
+                Unsupported,
+                lambda: outer(torch.ones(3)),
+                """\
+Dynamo recompile limit exceeded
+  Explanation: Dynamo attempted to recompile the code object too many times, exceeding the recompile_limit cache size limit (currently set to 1). Excessive recompilations can degrade performance due to the compilation overhead of each recompilation.
+  Hint: To monitor recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider increasing torch._dynamo.config.recompile_limit to an appropriate value.
+  Hint: See https://pytorch.org/docs/main/compile/programming_model.recompilation.html for tips on dealing with recompilations.
+
+  Developer debug context: Limit type: recompile_limit""",
+            )
+
 
 class NestedGraphBreakLoggingTests(
     LoggingTestCase, torch._dynamo.test_case.TestCaseWithNestedGraphBreaks

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2104,12 +2104,19 @@ from user code:
 
         outer(torch.ones(3))
 
+        def post_munge(s):
+            return re.sub(
+                r"# \S+/test_error_messages\.py", "# test_error_messages.py", s
+            )
+
         self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+            post_munge(
+                munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0)
+            ),
             """\
 torch._dynamo hit config.recompile_limit (1)
    function: 'fn' (test_error_messages.py:N)
-   last reason: 0/0: n == 0                                                   # return x + n  # test/dynamo/test_error_messages.py:N in fn
+   last reason: 0/0: n == 0                                                   # return x + n  # test_error_messages.py:N in fn
 To log all recompilation reasons, use TORCH_LOGS="recompiles".
 To diagnose recompilation issues, see https://pytorch.org/docs/main/compile/programming_model.recompilation.html""",
         )

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2118,7 +2118,7 @@ torch._dynamo hit config.recompile_limit (1)
    function: 'fn' (test_error_messages.py:N)
    last reason: 0/0: n == 0                                                   # return x + n  # test_error_messages.py:N in fn
 To log all recompilation reasons, use TORCH_LOGS="recompiles".
-To diagnose recompilation issues, see https://pytorch.org/docs/main/compile/programming_model.recompilation.html""",
+To diagnose recompilation issues, see https://docs.pytorch.org/docs/main/user_guide/torch_compiler/compile/programming_model.recompilation.html""",
         )
 
         torch.compiler.reset()
@@ -2131,7 +2131,7 @@ To diagnose recompilation issues, see https://pytorch.org/docs/main/compile/prog
 Dynamo recompile limit exceeded
   Explanation: Dynamo attempted to recompile the code object too many times, exceeding the recompile_limit cache size limit (currently set to 1). Excessive recompilations can degrade performance due to the compilation overhead of each recompilation.
   Hint: To monitor recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider increasing torch._dynamo.config.recompile_limit to an appropriate value.
-  Hint: See https://pytorch.org/docs/main/compile/programming_model.recompilation.html for tips on dealing with recompilations.
+  Hint: See https://docs.pytorch.org/docs/main/user_guide/torch_compiler/compile/programming_model.recompilation.html for tips on dealing with recompilations.
 
   Developer debug context: Limit type: recompile_limit
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1690,10 +1690,10 @@ def _compile(
 
             def raise_unimplemented_cache_limit_exceeded():
                 unimplemented(
-                    gb_type="Dynamo cache limit exceeded",
+                    gb_type="Dynamo recompile limit exceeded",
                     context=f"Limit type: {limit_type}",
                     explanation="Dynamo attempted to recompile the code object too many times, "
-                    f"exceeding the {limit_type} cache size limit. "
+                    f"exceeding the {limit_type} cache size limit (currently set to {getattr(config, limit_type)}). "
                     "Excessive recompilations can degrade "
                     "performance due to the compilation overhead of each recompilation.",
                     hints=[

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -62,7 +62,6 @@ from torch._guards import compile_context, CompileContext, CompileId, tracing
 from torch._logging import structured
 from torch._utils_internal import (
     compile_time_strobelight_meta,
-    justknobs_check,
     maybe_upload_prof_stats_to_manifold,
     signpost_event,
 )
@@ -1694,7 +1693,7 @@ def _compile(
                     gb_type="Dynamo cache limit exceeded",
                     context=f"Limit type: {limit_type}",
                     explanation="Dynamo attempted to recompile the code object too many times, "
-                    f"exceeding the {limit_type} cache size limit."
+                    f"exceeding the {limit_type} cache size limit. "
                     "Excessive recompilations can degrade "
                     "performance due to the compilation overhead of each recompilation.",
                     hints=[
@@ -2066,7 +2065,10 @@ class ConvertFrame:
                 log.warning(error_msg, exc_info=True)
 
             # Check if the exception has a specific frame execution strategy
-            if isinstance(e, exc.TorchDynamoException) and e.frame_exec_strategy is not None:
+            if (
+                isinstance(e, exc.TorchDynamoException)
+                and e.frame_exec_strategy is not None
+            ):
                 return ConvertFrameReturn(frame_exec_strategy=e.frame_exec_strategy)
 
         return ConvertFrameReturn()

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -81,7 +81,7 @@ class TorchDynamoException(RuntimeError):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._torch_dynamo_tracer_output: Optional[DynamoTracerOutput] = None
-        self.frame_exec_strategy: Optional[FrameExecStrategy] = None
+        self.frame_exec_strategy: FrameExecStrategy | None = None
 
 
 class InternalTorchDynamoError(TorchDynamoException):

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
     from .output_graph import DynamoTracerOutput
     from .symbolic_convert import InstructionTranslatorBase
-    from .types import DynamoFrameType
+    from .types import DynamoFrameType, FrameExecStrategy
 
 
 def exportdb_error_message(case_name: str) -> str:
@@ -67,9 +67,20 @@ graph_breaks_log = torch._logging.getArtifactLogger(__name__, "graph_breaks")
 
 
 class TorchDynamoException(RuntimeError):
+    """Base exception class for all TorchDynamo-specific exceptions.
+
+    Attributes:
+        _torch_dynamo_tracer_output: Optional tracer output attached to the exception
+        frame_exec_strategy: Optional frame execution strategy to control how convert_frame
+            should handle this exception. When set, convert_frame will use this strategy
+            instead of the default behavior. This allows exceptions to signal specific
+            execution strategies (e.g., SKIP, RUN_ONLY) without requiring separate
+            exception types for control flow.
+    """
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._torch_dynamo_tracer_output: Optional[DynamoTracerOutput] = None
+        self.frame_exec_strategy: Optional[FrameExecStrategy] = None
 
 
 class InternalTorchDynamoError(TorchDynamoException):
@@ -267,14 +278,6 @@ class UserError(Unsupported):
         super().__init__(msg, case_name if case_name else "UserError")
         self.error_type = error_type
         self.message = msg
-
-
-class SkipCodeRecursiveException(TorchDynamoException):
-    pass
-
-
-class RecompileLimitExceeded(Unsupported):
-    pass
 
 
 # debug exception thrown when tracing torch._dynamo.step_unsupported()

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -77,6 +77,7 @@ class TorchDynamoException(RuntimeError):
             execution strategies (e.g., SKIP, RUN_ONLY) without requiring separate
             exception types for control flow.
     """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._torch_dynamo_tracer_output: Optional[DynamoTracerOutput] = None

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -388,9 +388,9 @@
   ],
   "GB0039": [
     {
-      "Gb_type": "Dynamo cache limit exceeded",
+      "Gb_type": "Dynamo recompile limit exceeded",
       "Context": "Limit type: {limit_type}",
-      "Explanation": "Dynamo attempted to recompile the code object too many times, exceeding the {limit_type} cache size limit. Excessive recompilations can degrade performance due to the compilation overhead of each recompilation.",
+      "Explanation": "Dynamo attempted to recompile the code object too many times, exceeding the {limit_type} cache size limit (currently set to {getattr(config, limit_type)}). Excessive recompilations can degrade performance due to the compilation overhead of each recompilation.",
       "Hints": [
         "To monitor recompilations, enable TORCH_LOGS=recompiles. ",
         "If recompilations are expected, consider ",

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -390,6 +390,17 @@
     {
       "Gb_type": "Dynamo cache limit exceeded",
       "Context": "Limit type: {limit_type}",
+      "Explanation": "Dynamo attempted to recompile the code object too many times, exceeding the {limit_type} cache size limit. Excessive recompilations can degrade performance due to the compilation overhead of each recompilation.",
+      "Hints": [
+        "To monitor recompilations, enable TORCH_LOGS=recompiles. ",
+        "If recompilations are expected, consider ",
+        "increasing torch._dynamo.config.{limit_type} to an appropriate value.",
+        "See {troubleshooting_url} for tips on dealing with recompilations."
+      ]
+    },
+    {
+      "Gb_type": "Dynamo cache limit exceeded",
+      "Context": "Limit type: {limit_type}",
       "Explanation": "Dynamo attempted to recompile the code object too many times, exceeding the {limit_type} cache size limit.Giving up on compiling as the compile time tradeoff is likely not worth the performance gain.",
       "Hints": []
     }

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -169,9 +169,7 @@ counters: collections.defaultdict[str, Counter[str]] = collections.defaultdict(
     collections.Counter
 )
 optimus_scuba_log: dict[str, Any] = {}
-troubleshooting_url = (
-    "https://pytorch.org/docs/main/compile/programming_model.recompilation.html"
-)
+troubleshooting_url = "https://docs.pytorch.org/docs/main/user_guide/torch_compiler/compile/programming_model.recompilation.html"
 nnmodule_doc_url = "https://pytorch.org/docs/main/torch.compiler_nn_module.html"
 nnmodule_doc_url_msg = f"See {nnmodule_doc_url} for more information and limitations."
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #171486
* __->__ #171358
* #170587

Replace exception-based control flow pattern with attribute-based approach for
SkipCodeRecursiveException and RecompileLimitExceeded.

Instead of using specific exception types for control flow, add a frame_exec_strategy
attribute to TorchDynamoException that allows exceptions to optionally specify how
convert_frame should handle them.

Benefits:
- Cleaner separation of concerns (exceptions for errors, attributes for control flow)
- More flexible - any exception can specify a frame execution strategy
- Easier to extend - no need for new exception types for new strategies
- Better type safety with isinstance(e, exc.TorchDynamoException) check

Changes:
- torch/_dynamo/exc.py:
  * Add frame_exec_strategy attribute to TorchDynamoException with documentation
  * Remove SkipCodeRecursiveException and RecompileLimitExceeded classes
- torch/_dynamo/convert_frame.py:
  * Remove imports of removed exception classes
  * Replace isinstance checks with frame_exec_strategy attribute check
  * Set frame_exec_strategy on Unsupported exception in recompile limit handler

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo