### PR TITLE
[Inductor][NV Universal GEMM]  Fix autotuning for GEMM inputs that are views of the same buffer

### DIFF
--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -6,7 +6,7 @@ This module generates Python code that calls cutlass_api to execute GEMM operati
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from torch._inductor.codegen.common import IndentedBuffer, Kernel
 from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import CuteDSLOpOverrides
@@ -156,20 +156,28 @@ class NVUniversalGemmKernel(Kernel):
         """
         wrapper = V.graph.wrapper_code
 
-        call_args = []
-        arg_types = []
+        call_args: list[str] = []
+        arg_types: list[Any] = []
+        raw_args: list[Union[Buffer, ReinterpretView, None]] = []
 
         for _, input_node in self._template_input_args:
             reinterpret_view = self._get_reinterpret_view(input_node)
             if reinterpret_view is not None:
                 call_args.append(reinterpret_view.codegen_reference())
+                # Pass the ReinterpretView as raw_arg so autotune_at_compile_time
+                # can use it to generate example tensors
+                raw_args.append(reinterpret_view)
             else:
                 call_args.append(input_node.get_name())
+                raw_args.append(input_node)
             arg_types.append(V.graph.get_dtype(input_node.get_name()))
 
         output_name = self.output_node.get_name()
         call_args.append(output_name)
         arg_types.append(V.graph.get_dtype(output_name))
+        raw_args.append(None)  # Output buffer is findable by name
 
         # Generate the kernel call using triton=True for Python-based kernels
-        wrapper.generate_kernel_call(name, call_args, triton=True, arg_types=arg_types)
+        wrapper.generate_kernel_call(
+            name, call_args, triton=True, arg_types=arg_types, raw_args=raw_args
+        )

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3010,6 +3010,9 @@ class PythonWrapperCodegen(CodeGen):
                 assert len(raw_args) == len(call_args), (
                     "call_args and raw_args do not match"
                 )
+                # If raw_args is provided but raw_keys is not, fill with None
+                if raw_keys is None:
+                    raw_keys = [None] * len(call_args)
 
             reused_args = {}
             for i, (arg, arg_type, raw_key, raw_arg) in enumerate(
@@ -3022,7 +3025,7 @@ class PythonWrapperCodegen(CodeGen):
                     key, arg = arg.split("=")
 
                 triton_input: Optional[str] = None
-                if autotune_args and raw_key in autotune_args:
+                if autotune_args and raw_key is not None and raw_key in autotune_args:
                     triton_input = self.get_autotuning_input_name(  # type: ignore[attr-defined]
                         autotune_args[raw_key]
                     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #171556
* #171360
* #171205
* __->__ #171363
* #171362
* #170623

When GEMM inputs are views of the same underlying buffer (common in fused QKV attention patterns where Q, K, V are slices of a single fused tensor), compile-time autotuning ends up building only one example tensor:
  - The NV Universal GEMM wrapper hands `generate_kernel_call()` only argument names. For `ReinterpretView` nodes, `get_name()` is the base buffer name, not a unique view identifier.
  - If both A and B matrices are views of the same tensor (e.g., `fused_qkv`), they share that name.
  - When the autotuner later fabricates example tensors, it sees duplicate names and generates a single tensor instead of
    two distinct views.
  - Benchmarks then run with the wrong shapes/strides, causing failures.


By passing the `ReinterpretView` itself as r`aw_arg` (instead of just the underlying buffer name), `autotune_at_compile_time` can:
  - Access each view’s layout information (size, stride, offset).
  - Generate separate example tensors per view, even when they share storage.
  - Ensure every tensor used during benchmarking reflects the correct view layout.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo