### PR TITLE
[ROCm] Enable TestCudaMallocAsync.test_clock_speed on ROCm MI300

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5611,7 +5611,6 @@ print(value, end="")
         self.assertTrue(torch.cuda.power_draw() >= 0)
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
-    @skipIfRocmArch(MI300_ARCH)
     def test_clock_speed(self):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 


### PR DESCRIPTION
Remove the skip rule on MI300_ARCH.
With amdsmi installed, the test passed on ROCm MI300X locally. 

Fixes #168723

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang