### PR TITLE
fix(nn): Validate target values in one_hot against num_classes

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -48,16 +48,16 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     }
 
     // non-empty tensor
-    if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
-        self.device().type() != at::kPrivateUse1 && self.device().type() != at::kXLA) {
+    if (self.device().type() != at::kCUDA &&
+        self.device().type() != at::kPrivateUse1) {
       // for cuda, rely on device assert thrown by scatter
       TORCH_CHECK(self.min().item().toLong() >= 0, "Class values must be non-negative.");
     }
     if (num_classes == -1) {
         num_classes = self.max().item().toLong() + 1;
     } else {
-        if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
-            self.device().type() != at::kPrivateUse1 && self.device().type() != at::kXLA) {
+        if (self.device().type() != at::kCUDA &&
+            self.device().type() != at::kPrivateUse1) {
           // rely on device asserts from scatter to avoid sync here
           TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
         } else {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9630,12 +9630,7 @@ class TestNNDeviceType(NNTestCase):
 
     def test_one_hot(self, device):
         # cuda throws device assert for invalid data
-        # xla & mps ignore out of bound indices
-        if (
-            self.device_type != 'cuda'
-            and self.device_type != 'xla'
-            and self.device_type != 'mps'
-        ):
+        if self.device_type != 'cuda':
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
 


### PR DESCRIPTION
When using `torch.nn.functional.one_hot` with target tensor values larger than the specified num_classes, the function previously performed silent truncation - computing encoding up to max(target) + 1 then truncating to num_classes columns. This returned zeros for out-of-bounds indices without any warning.

Now it raises RuntimeError when any class value >= num_classes on CPU/MPS devices, preventing unexpected silent data loss.

[Release Notes]
-  `torch.nn.functional.one_hot` now raises an error when target values are >= num_classes instead of silently truncating (CPU/MPS only).

Fixes #163504


cc @malfet @kulinseth @DenisVieriu97 @jhavukainen @aditvenk