### PR TITLE
[ROCm] Enable test_register_effectful_custom_op for ROCm

### DIFF
--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -36,7 +36,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     TEST_CUDA,
-    TEST_WITH_ROCM,
     TestCase,
 )
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
@@ -301,7 +300,6 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         res.sum().backward()
 
     @unittest.skipIf(IS_WINDOWS, "triton")
-    @unittest.skipIf(TEST_WITH_ROCM, "triton")
     @unittest.skipIf(not SM80OrLater, "triton")
     @unittest.skipIf(not TEST_CUDA, "triton")
     @skipIfNoDynamoSupport


### PR DESCRIPTION
Fixes #168555
Fixes #168556

## Summary
This PR enables the `test_register_effectful_custom_op` test to run on ROCm platforms by removing the ROCm-specific skip condition.

### Changes Made
`test/higher_order_ops/test_with_effects.py`

   - Removed `@unittest.skipIf(TEST_WITH_ROCM, "triton")` decorator from the test method
   - This allows the test to run on ROCm platforms


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang