### PR TITLE
Add cross-platform temp directory utilities

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/tensor_layout_mini_benchmark.py
+++ b/benchmarks/dynamo/microbenchmarks/tensor_layout_mini_benchmark.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import torch
 from torch._inductor import ir
 from torch._inductor.runtime.benchmarking import benchmarker
@@ -48,7 +51,7 @@ def bench_conv(with_stack=True):
         test_out = test_fn()
         torch.cuda.synchronize()
 
-    p.export_chrome_trace("/tmp/chrome.json")
+    p.export_chrome_trace(os.path.join(tempfile.gettempdir(), "chrome.json"))
     assert torch.allclose(baseline_out, test_out, atol=1e-3, rtol=1e-3), (
         baseline_out[0][0][0][:32],
         test_out[0][0][0][:32],

--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -2,6 +2,7 @@ import csv
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -172,7 +173,9 @@ for name, name2, log in chunker(entries, 3):
 
     # Temporary file names are meaningless, report it's generated code in this
     # case
-    if "/tmp/" in component:
+    normalized_component = os.path.normpath(component)
+    temp_dir = os.path.normpath(tempfile.gettempdir())
+    if temp_dir in normalized_component:
         component = "generated code"
         context = ""
 

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import warnings
 from collections import namedtuple
 from os.path import abspath, exists
@@ -51,7 +52,7 @@ def _reassign_parameters(model):
 def setup_torchbench_cwd():
     original_dir = abspath(os.getcwd())
 
-    os.environ["KALDI_ROOT"] = "/tmp"  # avoids some spam
+    os.environ["KALDI_ROOT"] = tempfile.gettempdir()  # avoids some spam
     for torchbench_dir in (
         "./torchbenchmark",
         "../torchbenchmark",

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
@@ -387,7 +387,7 @@ class TestCheckpointProcess(TestCase):
 
         # Attempting to write should raise an error
         with self.assertRaises(RuntimeError) as cm:
-            future = checkpoint_process.write(self.test_state_dict, "/tmp/test")
+            future = checkpoint_process.write(self.test_state_dict, os.path.join(tempfile.gettempdir(), "test"))
             future.result()
 
         self.assertIn("Child process terminated unexpectedly", str(cm.exception))

--- a/test/distributed/checkpoint/_experimental/test_checkpointer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpointer.py
@@ -603,7 +603,7 @@ class TestAsyncCheckpointerSpecific(TestCase):
 
         try:
             # This should not raise immediately
-            stage_future, write_future = checkpointer.save("/tmp/test", self.state_dict)
+            stage_future, write_future = checkpointer.save(os.path.join(tempfile.gettempdir(), "test"), self.state_dict)
 
             # But waiting for the write future should raise the error
             with self.assertRaises(RuntimeError) as cm:

--- a/test/distributed/checkpoint/test_compatibility.py
+++ b/test/distributed/checkpoint/test_compatibility.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import tempfile
 from unittest.mock import patch
 
 import torch
@@ -47,16 +48,17 @@ class TestDCPCompatbility(TestCase):
             TensorProperties as stp,
         )
 
-        with patch("torch.distributed.checkpoint.metadata.TensorProperties", stp):
-            dcp.save(
-                {"a": torch.zeros(4, 4)},
-                dcp.FileSystemWriter("/tmp/dcp_testing"),
-            )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("torch.distributed.checkpoint.metadata.TensorProperties", stp):
+                dcp.save(
+                    {"a": torch.zeros(4, 4)},
+                    dcp.FileSystemWriter(tmpdir),
+                )
 
-        dcp.load(
-            {"a": torch.zeros(4, 4)},
-            dcp.FileSystemReader("/tmp/dcp_testing"),
-        )
+            dcp.load(
+                {"a": torch.zeros(4, 4)},
+                dcp.FileSystemReader(tmpdir),
+            )
 
     @with_temp_dir
     def test_storage_meta(self) -> None:

--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -571,7 +571,7 @@ class LocalElasticAgentTest(unittest.TestCase):
     def run_agent_local_watchdog_setup_enabled(self):
         # Set the env for watchdog
         watchdog_env_name = TORCHELASTIC_TIMER_FILE
-        watchdog_file_path = "/tmp/watchdog_timer_" + str(uuid.uuid4())
+        watchdog_file_path = os.path.join(tempfile.gettempdir(), f"watchdog_timer_{uuid.uuid4()}")
         os.environ[watchdog_env_name] = watchdog_file_path
         # Run the agent
         node_conf = Conf(

--- a/test/distributed/elastic/timer/file_based_local_timer_test.py
+++ b/test/distributed/elastic/timer/file_based_local_timer_test.py
@@ -8,6 +8,7 @@
 import multiprocessing as mp
 import os
 import signal
+import tempfile
 import time
 import unittest
 import unittest.mock as mock
@@ -39,7 +40,7 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
         def setUp(self):
             super().setUp()
             self.max_interval = 0.01
-            self.file_path = f"/tmp/test_file_path_{os.getpid()}_{uuid.uuid4()}"
+            self.file_path = os.path.join(tempfile.gettempdir(), f"test_file_path_{os.getpid()}_{uuid.uuid4()}")
             self.server = timer.FileTimerServer(
                 self.file_path, "test", self.max_interval
             )
@@ -206,7 +207,7 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
     class FileTimerServerTest(TestCase):
         def setUp(self):
             super().setUp()
-            self.file_path = f"/tmp/test_file_path_{os.getpid()}_{uuid.uuid4()}"
+            self.file_path = os.path.join(tempfile.gettempdir(), f"test_file_path_{os.getpid()}_{uuid.uuid4()}")
             self.max_interval = 0.01
             self.server = timer.FileTimerServer(
                 self.file_path, "test", self.max_interval

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -769,10 +769,10 @@ class RendezvousFileTest(TestCase):
             gen = dist.rendezvous("file://?rank=0&world_size=1")
             next(gen)
         with self.assertRaisesRegex(ValueError, "rank parameter missing"):
-            gen = dist.rendezvous("file:///tmp/foo?world_size=1")
+            gen = dist.rendezvous(f"file://{tempfile.gettempdir()}/foo?world_size=1")
             next(gen)
         with self.assertRaisesRegex(ValueError, "size parameter missing"):
-            gen = dist.rendezvous("file:///tmp/foo?rank=0")
+            gen = dist.rendezvous(f"file://{tempfile.gettempdir()}/foo?rank=0")
             next(gen)
 
     def test_nominal(self):

--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import os
+import tempfile
 
 import torch
 from torch import nn
@@ -164,7 +165,7 @@ class AutoChunkerTest(TestCase):
                 for step in range(5):
                     with torch.profiler.record_function(f"Step {step}"):
                         opt_f(x, y)
-            path = "/tmp/trace.json"
+            path = os.path.join(tempfile.gettempdir(), "trace.json")
             print(f"Write the chrome trace to {path}")
             p.export_chrome_trace(path)
 

--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError, wait
 from contextlib import contextmanager
 from functools import wraps
@@ -104,7 +105,7 @@ class ConfigTest(TestCase):
     FOO_JK_NAME: str = "foo_jk_name"
     FOO_OSS_DEFAULT: bool = False
     FOO_ENV_VAR_OVERRIDE: str = "foo_env_var_override"
-    FOO_ENV_VAR_OVERRIDE_LOCK_FPATH: str = f"/tmp/testing/{FOO_ENV_VAR_OVERRIDE}.lock"
+    FOO_ENV_VAR_OVERRIDE_LOCK_FPATH: str = os.path.join(tempfile.gettempdir(), "testing", f"{FOO_ENV_VAR_OVERRIDE}.lock")
     FOO_ENV_VAR_OVERRIDE_LOCK: FileLock = FileLock(FOO_ENV_VAR_OVERRIDE_LOCK_FPATH)
 
     @classmethod
@@ -1352,7 +1353,7 @@ class InterfacesTest(TestMixin, TestCase):
         the Memoizer initializes with an empty cache without crashing.
         """
         # Setup: Configure path to non-existent file
-        non_existent_path = "/tmp/this_file_does_not_exist_12345.json"
+        non_existent_path = os.path.join(tempfile.gettempdir(), "this_file_does_not_exist_12345.json")
 
         with patch.object(
             config, "CACHE_DUMP_FILE_PATH", return_value=non_existent_path

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import sys
+import tempfile
 
 import torch
 import torch.distributed as dist
@@ -38,7 +39,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         """
         dist.init_process_group(
             backend="nccl",
-            init_method=f"file:///tmp/test_equiv_allreduce_{self.id()}",
+            init_method=f"file://{tempfile.gettempdir()}/test_equiv_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
         )
@@ -120,7 +121,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         """
         dist.init_process_group(
             backend="nccl",
-            init_method=f"file:///tmp/test_vllm_allreduce_{self.id()}",
+            init_method=f"file://{tempfile.gettempdir()}/test_vllm_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
         )

--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -2,6 +2,7 @@
 import copy
 import functools
 import os
+import tempfile
 import unittest
 
 import torch
@@ -167,7 +168,7 @@ class TestCaseBase(TestCase):
                     f_rhs(*args, **kwargs)
             device_interface.synchronize()
 
-        profile_path = "/tmp/chrome.json"
+        profile_path = os.path.join(tempfile.gettempdir(), "chrome.json")
         p.export_chrome_trace(profile_path)
         print(f"Chrome trace is written to {profile_path}")
 

--- a/test/test_tempdir.py
+++ b/test/test_tempdir.py
@@ -1,0 +1,94 @@
+import os
+import tempfile
+from unittest import mock
+
+from torch._tempdir import get_pytorch_tmpdir, get_temp_path
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestTempDir(TestCase):
+    def test_default_uses_system_temp(self):
+        """Verify fallback to tempfile.gettempdir() when PYTORCH_TMPDIR unset."""
+        # Remove only PYTORCH_TMPDIR, preserve system temp env vars (TMPDIR, TEMP, TMP)
+        env_without_pytorch_tmpdir = {
+            k: v for k, v in os.environ.items() if k != "PYTORCH_TMPDIR"
+        }
+        with mock.patch.dict(os.environ, env_without_pytorch_tmpdir, clear=True):
+            result = get_pytorch_tmpdir()
+            # Should match system temp resolution which respects TMPDIR/TEMP/TMP
+            self.assertEqual(result, tempfile.gettempdir())
+
+    def test_respects_pytorch_tmpdir_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                result = get_pytorch_tmpdir()
+                self.assertEqual(result, tmpdir)
+
+    def test_raises_if_pytorch_tmpdir_does_not_exist(self):
+        # Use a path that's unlikely to exist on any platform
+        nonexistent = os.path.join(tempfile.gettempdir(), "nonexistent_12345_xyz")
+        with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": nonexistent}):
+            with self.assertRaises(RuntimeError) as ctx:
+                get_pytorch_tmpdir()
+            self.assertIn("does not exist", str(ctx.exception))
+
+    def test_raises_if_pytorch_tmpdir_is_not_directory(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            temp_file = f.name
+        try:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": temp_file}):
+                with self.assertRaises(RuntimeError) as ctx:
+                    get_pytorch_tmpdir()
+                self.assertIn("not a directory", str(ctx.exception))
+        finally:
+            os.unlink(temp_file)
+
+    def test_get_temp_path_creates_subdirectory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                subdir_path = get_temp_path(subdirectory="test_subdir")
+                self.assertTrue(os.path.isdir(subdir_path))
+
+    def test_get_temp_path_with_subdirectory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                result = get_temp_path(subdirectory="subdir")
+                self.assertEqual(result, os.path.join(tmpdir, "subdir"))
+
+    def test_get_temp_path_with_filename(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                result = get_temp_path(filename="file.txt")
+                self.assertEqual(result, os.path.join(tmpdir, "file.txt"))
+
+    def test_get_temp_path_with_subdirectory_and_filename(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                result = get_temp_path(subdirectory="subdir", filename="file.txt")
+                self.assertEqual(result, os.path.join(tmpdir, "subdir", "file.txt"))
+                # Verify subdirectory was created
+                self.assertTrue(os.path.isdir(os.path.join(tmpdir, "subdir")))
+
+    def test_get_temp_path_nested_subdirectory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                # Use os.path.join for cross-platform nested paths
+                nested = os.path.join("level1", "level2", "level3")
+                result = get_temp_path(subdirectory=nested)
+                expected = os.path.join(tmpdir, "level1", "level2", "level3")
+                self.assertEqual(result, expected)
+                self.assertTrue(os.path.isdir(expected))
+
+    def test_get_temp_path_idempotent_directory_creation(self):
+        """Verify calling get_temp_path multiple times doesn't raise errors."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PYTORCH_TMPDIR": tmpdir}):
+                # Call twice with same subdirectory
+                result1 = get_temp_path(subdirectory="repeated_subdir")
+                result2 = get_temp_path(subdirectory="repeated_subdir")
+                self.assertEqual(result1, result2)
+                self.assertTrue(os.path.isdir(result1))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -60,6 +60,7 @@ from torch._dynamo.distributed import get_compile_pg
 from torch._dynamo.symbolic_convert import TensorifyState
 from torch._guards import compile_context, CompileContext, CompileId, tracing
 from torch._logging import structured
+from torch._tempdir import get_temp_path
 from torch._utils_internal import (
     compile_time_strobelight_meta,
     justknobs_check,
@@ -473,7 +474,7 @@ def cprofile_wrapper(func: Callable[_P, _T]) -> Callable[_P, _T]:
         trace_id = CompileContext.current_trace_id()
         assert trace_id, "Trace id is None"
         profile_path = Path(
-            f"/tmp/{func.__name__}_{str(trace_id).replace('/', '_')}.profile"
+            get_temp_path(filename=f"{func.__name__}_{str(trace_id).replace('/', '_')}.profile")
         )
         prof = cProfile.Profile()
         try:

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -9,6 +9,7 @@ from typing import Optional, TYPE_CHECKING
 
 import torch
 from torch import dtype as torch_dtype
+from torch._tempdir import get_temp_path
 
 from .. import config
 from ..virtualized import V
@@ -210,15 +211,14 @@ class DebugPrinterManager:
                     f'aoti_torch_save_tensor_handle({arg}, "{arg}", "{launch_prefix}", "{kernel_name}");'
                 )
             else:
-                cwd = os.getcwd()
-                saved_dir = cwd + "/tmp/jit_inductor/"
+                saved_dir = get_temp_path(subdirectory="jit_inductor")
                 if not os.path.exists(saved_dir):
                     log.info(
                         "Creating directory to save inductor intermediate tensor values."
                     )
                     os.makedirs(saved_dir)
                 # Save the model to the directory
-                saved_path = saved_dir + f"{launch_prefix}_{kernel_name}_{arg}.pt"
+                saved_path = os.path.join(saved_dir, f"{launch_prefix}_{kernel_name}_{arg}.pt")
                 log.info(
                     "Saved intermediate tensor %s for %s to %s",
                     arg,

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -16,6 +16,7 @@ from typing_extensions import final, override, Self
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
 import torch.fx
 from torch._inductor.codecache import BypassFxGraphCache, FxGraphCache
+from torch._tempdir import get_temp_path
 from torch._inductor.metrics import CachedMetricsDeltas, CachedMetricsHelper
 from torch._inductor.output_code import (
     CompiledFxGraph,
@@ -662,19 +663,20 @@ class _DebugFileFxCompile(_SerializedFxCompile):
         idx = _DebugFileFxCompile.file_index
         _DebugFileFxCompile.file_index += 1
 
-        name = f"/tmp/aorenste/pytorch_compile_fx_tmp_input_{idx}.bin"
+        name = get_temp_path(subdirectory="pytorch_compile_fx_debug", filename=f"input_{idx}.bin")
+        os.makedirs(os.path.dirname(name), exist_ok=True)
         with open(name, "wb") as f:
             f.write(pickled_input.value)
         print(f"Wrote to {name}")
 
         if False:
-            name = f"/tmp/aorenste/pytorch_compile_fx_tmp_actual_{idx}.bin"
+            name = get_temp_path(subdirectory="pytorch_compile_fx_debug", filename=f"actual_{idx}.bin")
             actual = self._run_in_child(pickled_input)
             with open(name, "wb") as f:
                 f.write(actual.value)
             return actual
         elif False:
-            name = f"/tmp/aorenste/pytorch_compile_fx_tmp_output_{idx}.bin"
+            name = get_temp_path(subdirectory="pytorch_compile_fx_debug", filename=f"output_{idx}.bin")
             with open(name, "rb") as f:
                 result = _WireProtocolPickledOutput(f.read())
                 print(f"Read from {name}")

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -25,6 +25,7 @@ from torch._dynamo.utils import get_debug_dir
 from torch._inductor import utils
 from torch._logging import getArtifactLogger
 from torch._logging._internal import trace_structured
+from torch._tempdir import get_temp_path
 from torch._utils_internal import signpost_event
 from torch.fx.graph_module import GraphModule
 from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
@@ -1190,7 +1191,7 @@ def save_args_for_compile_fx_inner(*args: Any, **kwargs: Any) -> None:
     with the saved arguments using load_args_and_run_compile_fx_inner.
     """
 
-    folder = "/tmp/inductor_saved_args"
+    folder = get_temp_path(subdirectory="inductor_saved_args")
     if not os.path.exists(folder):
         os.mkdir(folder)
 

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -1192,8 +1192,7 @@ def save_args_for_compile_fx_inner(*args: Any, **kwargs: Any) -> None:
     """
 
     folder = get_temp_path(subdirectory="inductor_saved_args")
-    if not os.path.exists(folder):
-        os.mkdir(folder)
+    os.makedirs(folder, exist_ok=True)
 
     def handle_tensor(x: Any) -> Any:
         """

--- a/torch/_tempdir.py
+++ b/torch/_tempdir.py
@@ -1,0 +1,83 @@
+"""
+Centralized temp directory utilities for PyTorch.
+
+Provides cross-platform temp directory resolution to support Windows,
+restricted environments, and custom storage configurations where /tmp
+is unavailable or undesirable.
+"""
+import os
+import tempfile
+from typing import Optional
+
+# Reason: Separate env var from system TMPDIR allows PyTorch-specific
+# override without affecting other applications in the same process
+_PYTORCH_TMPDIR_ENV = "PYTORCH_TMPDIR"
+
+
+def get_pytorch_tmpdir() -> str:
+    """
+    Get the base temp directory for PyTorch operations.
+
+    The directory specified via the ``PYTORCH_TMPDIR`` environment variable
+    must already exist, be a directory, and be writable by the current
+    process. If it is not set, this falls back to ``tempfile.gettempdir()``.
+
+    Returns:
+        str: Path to temp directory.
+
+    Raises:
+        RuntimeError: If ``PYTORCH_TMPDIR`` is set to a path that does not
+            exist, is not a directory, or is not writable/executable.
+    """
+    # Reason: Fallback to tempfile.gettempdir() ensures cross-platform
+    # compatibility (Windows, Linux, macOS) without hardcoding paths
+    env_value = os.environ.get(_PYTORCH_TMPDIR_ENV)
+    if not env_value:
+        return tempfile.gettempdir()
+
+    # Reason: Validate custom temp directory upfront to provide clear error
+    # messages instead of opaque downstream I/O failures
+    if not os.path.exists(env_value):
+        raise RuntimeError(
+            f"{_PYTORCH_TMPDIR_ENV} is set to '{env_value}', "
+            "but this path does not exist."
+        )
+    if not os.path.isdir(env_value):
+        raise RuntimeError(
+            f"{_PYTORCH_TMPDIR_ENV} is set to '{env_value}', "
+            "but this path is not a directory."
+        )
+    if not os.access(env_value, os.W_OK | os.X_OK):
+        raise RuntimeError(
+            f"{_PYTORCH_TMPDIR_ENV} is set to '{env_value}', "
+            "but this directory is not writable/executable."
+        )
+    return env_value
+
+
+def get_temp_path(
+    subdirectory: Optional[str] = None, filename: Optional[str] = None
+) -> str:
+    """
+    Get a temp path with optional subdirectory and filename.
+
+    Args:
+        subdirectory: Optional subdirectory under temp root.
+        filename: Optional filename to append.
+
+    Returns:
+        str: Full path to temp location. The directory component of the
+            path (temp root plus optional subdirectory) is created if it
+            does not already exist.
+    """
+    base = get_pytorch_tmpdir()
+    if subdirectory:
+        base = os.path.normpath(os.path.join(base, subdirectory))
+
+    # Reason: Create directory automatically so callers can safely create
+    # files at the returned path without additional os.makedirs() calls
+    os.makedirs(base, exist_ok=True)
+
+    if filename:
+        return os.path.join(base, filename)
+    return base

--- a/torch/distributed/_symmetric_memory/_nvshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_nvshmem_triton.py
@@ -5,6 +5,7 @@ import sysconfig
 from typing import Any
 
 import torch.distributed as dist
+from torch._tempdir import get_pytorch_tmpdir
 from torch.utils._triton import has_triton
 
 
@@ -1209,7 +1210,7 @@ if has_triton():
         def on_exit() -> None:
             logger.info("PTX files:")
             for kernel in triton_kernels:
-                with tempfile.NamedTemporaryFile(dir="/tmp", delete=False) as f:
+                with tempfile.NamedTemporaryFile(dir=get_pytorch_tmpdir(), delete=False) as f:
                     f.write(kernel.asm["ptx"].encode("utf-8"))
                     logger.info(f"+- {kernel.name}: {f.name}")  # noqa: G004
 

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -18,6 +18,7 @@ from string import Template
 from typing import Any, TYPE_CHECKING
 
 import torch.distributed.elastic.timer as timer
+from torch._tempdir import get_temp_path
 from torch.distributed.elastic import events
 from torch.distributed.elastic.agent.server.api import (
     RunResult,
@@ -170,7 +171,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         watchdog_file_path = os.getenv(watchdog_file_env_name)
         if watchdog_enabled is not None and str(watchdog_enabled) == "1":
             if watchdog_file_path is None:
-                watchdog_file_path = "/tmp/watchdog_timer_" + str(uuid.uuid4())
+                watchdog_file_path = get_temp_path(filename=f"watchdog_timer_{uuid.uuid4()}")
             logger.info("Starting a FileTimerServer with %s ...", watchdog_file_path)
             if not envs:
                 logger.warning(


### PR DESCRIPTION
Replace hardcoded `/tmp` paths with centralized temp directory utilities to support Windows, restricted environments, and custom storage configurations.

Changes:
- Add `torch/_tempdir.py` with `get_pytorch_tmpdir()` and `get_temp_path()`
- Support `PYTORCH_TMPDIR` environment variable override
- Fall back to `tempfile.gettempdir()` for cross-platform compatibility
- Update inductor debug, dynamo profiler, and distributed components
- Update test files to use `tempfile.gettempdir()`

Fixes 171385


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela