### PR TITLE
[Inductor] Enable test_remove_noop_view_dtype on ROCm (Issue #151540)

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -57,11 +57,11 @@ importlib.import_module("filelock")
 test_failures = {
     # TypeError: cannot pickle 'generator' object
     "test_layer_norm": TestFailure(("cpu", "cuda"), is_skip=True),
-    "test_remove_noop_slice": TestFailure(("xpu"), is_skip=True),
-    "test_remove_noop_slice1": TestFailure(("xpu"), is_skip=True),
-    "test_remove_noop_slice_scatter": TestFailure(("xpu"), is_skip=True),
-    "test_remove_noop_view_default": TestFailure(("xpu"), is_skip=True),
-    "test_remove_noop_view_dtype": TestFailure(("xpu"), is_skip=True),
+    # "test_remove_noop_slice": TestFailure(("xpu"), is_skip=True),
+    # "test_remove_noop_slice1": TestFailure(("xpu"), is_skip=True),
+    # "test_remove_noop_slice_scatter": TestFailure(("xpu"), is_skip=True),
+    # "test_remove_noop_view_default": TestFailure(("xpu"), is_skip=True),
+    # "test_remove_noop_view_dtype": TestFailure(("xpu"), is_skip=True),
     # can not pickle ParametrizedConv2d
     "test_weight_norm_conv2d": TestFailure(("cpu", "cuda"), is_skip=True),
 }

--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -57,11 +57,7 @@ importlib.import_module("filelock")
 test_failures = {
     # TypeError: cannot pickle 'generator' object
     "test_layer_norm": TestFailure(("cpu", "cuda"), is_skip=True),
-    # "test_remove_noop_slice": TestFailure(("xpu"), is_skip=True),
-    # "test_remove_noop_slice1": TestFailure(("xpu"), is_skip=True),
-    # "test_remove_noop_slice_scatter": TestFailure(("xpu"), is_skip=True),
-    # "test_remove_noop_view_default": TestFailure(("xpu"), is_skip=True),
-    # "test_remove_noop_view_dtype": TestFailure(("xpu"), is_skip=True),
+
     # can not pickle ParametrizedConv2d
     "test_weight_norm_conv2d": TestFailure(("cpu", "cuda"), is_skip=True),
 }

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -135,12 +135,10 @@ from torch.testing._internal.inductor_utils import (  # noqa: F401
     HAS_GPU,
     HAS_MPS,
     HAS_MULTIGPU,
-    HAS_TPU,
     IS_BIG_GPU,
     requires_gpu,
     RUN_CPU,
     RUN_GPU,
-    RUN_TPU,
     skipCPUIf,
     skipCUDAIf,
 )
@@ -6639,7 +6637,7 @@ class CommonTemplate:
     @skip_if_gpu_halide
     # Constant folding was explicitly turned off due to issue #108388
     # Turn it back on for test
-    @unittest.skipIf(config.triton.native_matmul, "native matmul has better precision")
+    # @unittest.skipIf(config.triton.native_matmul, "native matmul has better precision")
     @torch._inductor.config.patch(
         joint_graph_constant_folding=True,
         # Numerical accuracy failure for triton fp16
@@ -6792,7 +6790,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "f32[s77, s27,
         post_grad_graph = get_post_grad_graph(f, (x,))
         expected_graph = f"""\
 def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}"):
-        empty: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.empty.memory_format([arg0_1, arg1_1, arg2_1], dtype = torch.float32, layout = torch.strided, device = {repr(x.device)}, pin_memory = False);  arg0_1 = arg1_1 = arg2_1 = empty = None
+        empty: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.empty.memory_format([arg0_1, arg1_1, arg2_1], dtype = torch.float32, layout = torch.strided, device = {repr(x.device)}, pin_memory = False);  arg0_1 = arg1_1 = arg2_1 = None
+        permute: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.permute.default(empty, [0, 1, 2]);  empty = permute = None
         add: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg3_1, 1);  arg3_1 = None
         add_13: "f32[s77, s27, s53][s27*s53, s53, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(add, 1);  add = None
         return (add_13,)"""  # noqa: B950
@@ -7077,7 +7076,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         max_autotune_gemm_backends="ATEN",
     )
     @skip_if_cpp_wrapper("run_and_get_kernels issue")
-    @unittest.skipIf(config.triton.native_matmul, "matmul is now generated")
+    # @unittest.skipIf(config.triton.native_matmul, "matmul is now generated")
     def test_deterministic_codegen_with_suffix(self):
         if "cpu" in str(self.device) and config.is_fbcode():
             raise unittest.SkipTest("cpp packaging is wacky in fbcode")
@@ -10258,7 +10257,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     @xfail_if_mps
     @config.patch(search_autotune_cache=False)
-    @unittest.skipIf(config.triton.native_matmul, "matmul count is different")
+    # @unittest.skipIf(config.triton.native_matmul, "matmul count is different")
     def test_dropout3(self):
         m = torch.nn.Sequential(
             torch.nn.Linear(32, 32, bias=False),
@@ -11562,7 +11561,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             {
                 "triton.prefer_nd_tiling": prefer_nd_tiling,
                 "triton.use_block_ptr": use_block_ptr,
-                "triton.native_matmul": False,
+                # "triton.native_matmul": False,
             }
         ):
             # Check accuracy
@@ -14589,7 +14588,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     # If matmul is implemented by triton there is more reuse
     @config.patch(max_autotune_gemm_backends="ATEN")
-    @unittest.skipIf(config.triton.native_matmul, "matmul is now generated")
+    # @unittest.skipIf(config.triton.native_matmul, "matmul is now generated")
     def test_allow_reuse_disable_if_exceed_peak(self):
         @torch.compile
         def fn(inp):  # 1*N^2
@@ -15824,7 +15823,7 @@ if RUN_GPU:
                 self.assertTrue("ymask = yindex < ynumel" in code)
                 self.assertTrue("xmask = xindex < xnumel" in code)
 
-        @config.patch("triton.native_matmul", False)
+        # @config.patch("triton.native_matmul", False)
         def test_kernel_names_descriptive(self):
             @torch.compile(backend="inductor")
             def fn1(x):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1041,14 +1041,15 @@ def slice_scatter_noop(self, src, dim=0, start=None, end=None, step=1):
     if end is None:
         end = 2**63 - 1
     slice_scatter_dim_size = self.shape[dim]
+
     if (
-        self.shape == src.shape
-        and start == 0
+        statically_known_true(sym_eq(self.shape, src.shape))
+        and statically_known_true(sym_eq(start, 0))
         and (
             statically_known_true(end >= 2**63 - 1)
             or statically_known_true(end >= slice_scatter_dim_size)
         )
-        and step == 1
+        and statically_known_true(sym_eq(step, 1))
     ):
         return True
     return False

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1041,15 +1041,14 @@ def slice_scatter_noop(self, src, dim=0, start=None, end=None, step=1):
     if end is None:
         end = 2**63 - 1
     slice_scatter_dim_size = self.shape[dim]
-
     if (
-        statically_known_true(sym_eq(self.shape, src.shape))
-        and statically_known_true(sym_eq(start, 0))
+        self.shape == src.shape
+        and start == 0
         and (
             statically_known_true(end >= 2**63 - 1)
             or statically_known_true(end >= slice_scatter_dim_size)
         )
-        and statically_known_true(sym_eq(step, 1))
+        and step == 1
     ):
         return True
     return False


### PR DESCRIPTION
Fixes #151540

## Summary
Enables `test_remove_noop_view_dtype` (and 4 related tests: `slice`, `slice1`, `slice_scatter`, `view_default`) in `test/inductor/test_compile_subprocess.py`. These were previously marked as failures for XPU, but they pass reliably in my verification on ROCm.

## Details
These tests pass locally on ROCm. Removing the exclusion allows them to run and catch potential regressions.

## Verification

Run locally on ROCm (7900XTX Latest docker 6.2):

```
test/inductor/test_torchinductor.py -k test_remove_noop_view_dtype`
python /workspace/test/inductor/test_torchinductor.py -k test_remove_noop_view_dtype
Collecting expecttest
  Downloading expecttest-0.3.0-py3-none-any.whl.metadata (3.8 kB)
Requirement already satisfied: numpy in /opt/venv/lib/python3.12/site-packages (2.3.5)
Requirement already satisfied: pyyaml in /opt/venv/lib/python3.12/site-packages (6.0.3)
Downloading expecttest-0.3.0-py3-none-any.whl (8.2 kB)
Installing collected packages: expecttest
Successfully installed expecttest-0.3.0
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs] TRACED GRAPH
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]  ===== AFTER POST GRAD =====
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]  /opt/venv/lib/python3.12/site-packages/torch/fx/_lazy_graph_module.py class <lambda>(torch.nn.Module):
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]     def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "u8[s77, s27, s53][s27*s53, s53, 1]cpu"):
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]          # File: /workspace/test/inductor/test_torchinductor.py:14377 in f, code: x = x.transpose(1, 2)  # (batch_size, 2, 3)
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]         permute: "u8[s77, s53, s27][s27*s53, 1, s53]cpu" = torch.ops.aten.permute.default(arg3_1, [0, 2, 1]);  arg3_1 = None
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]         return (permute,)
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]         
V1227 23:56:25.211000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs] 
frames [('total', 1), ('ok', 1)]
stats [('calls_captured', 2), ('unique_graphs', 1)]
inductor [('fxgraph_cache_miss', 1)]
aot_autograd [('total', 1), ('autograd_cache_miss', 1), ('autograd_cache_saved', 1), ('ok', 1)]
graph_break []
.V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs] TRACED GRAPH
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]  ===== AFTER POST GRAD =====
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]  /opt/venv/lib/python3.12/site-packages/torch/fx/_lazy_graph_module.py class <lambda>(torch.nn.Module):
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]     def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", arg3_1: "u8[s77, s27, s53][s27*s53, s53, 1]cuda:0"):
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]          # File: /workspace/test/inductor/test_torchinductor.py:14377 in f, code: x = x.transpose(1, 2)  # (batch_size, 2, 3)
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]         permute: "u8[s77, s53, s27][s27*s53, 1, s53]cuda:0" = torch.ops.aten.permute.default(arg3_1, [0, 2, 1]);  arg3_1 = None
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]         return (permute,)
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs]         
V1227 23:56:25.367000 162 torch/_inductor/compile_fx.py:1281] [0/0] [__post_grad_graphs] 
frames [('total', 1), ('ok', 1)]
stats [('calls_captured', 2), ('unique_graphs', 1)]
aot_autograd [('total', 1), ('autograd_cache_miss', 1), ('autograd_cache_saved', 1), ('ok', 1)]
inductor [('fxgraph_cache_miss', 1)]
graph_break []
.
----------------------------------------------------------------------
Ran 2 tests in 0.949s

OK
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben