### PR TITLE
Fix F.pdist contiguity requirement in Inductor lowerings

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2922,7 +2922,7 @@ make_fallback(aten._scaled_dot_product_attention_math_for_mps)  # @malfet
 # 1) Easy
 make_fallback(aten.uniform, warn=False)
 make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_torch.py)
-make_fallback(aten._pdist_forward)  # Has decomp. Needs benchmarks
+make_fallback(aten._pdist_forward, require_contiguous)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
 if torch.xpu.is_available():
@@ -2993,7 +2993,7 @@ make_fallback(aten.upsample_linear1d_backward)
 make_fallback(aten.upsample_bicubic2d_backward, require_contiguous)
 make_fallback(aten.upsample_trilinear3d_backward)
 make_fallback(aten.grid_sampler_2d_backward)
-make_fallback(aten._pdist_backward)
+make_fallback(aten._pdist_backward, require_contiguous)
 
 
 # 5) Impossible (missing triton/CPU features)


### PR DESCRIPTION
Fixed #170939

**Summary:**
This PR fixes a `RuntimeError: _pdist_forward requires contiguous input` that occurs when using `torch.compile` with `torch.nn.functional.pdist` on non-contiguous inputs (e.g., after a permute). The underlying `aten._pdist_forward` and `aten._pdist_backward` kernels require contiguous tensors, but the Inductor fallbacks were not enforcing this constraint.

**Changes:**
- Wrapped `aten._pdist_forward` and `aten._pdist_backward` in `torch/_inductor/lowering.py` with `require_contiguous`.

**Test Plan:**
Verified on **Radeon RX 7900 XTX** with **Docker 29.1.3** (`rocm/pytorch:latest`).
Ran reproduction script:
```python
import torch
@torch.compile
def f(x):
    return torch.nn.functional.pdist(x.transpose(0, 1))

x = torch.randn(10, 10, device="cuda")
f(x) # Previously failed, now passes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo