### PR TITLE
Fix dtype in TensorOptions docs example

### DIFF
--- a/docs/cpp/source/notes/tensor_creation.rst
+++ b/docs/cpp/source/notes/tensor_creation.rst
@@ -160,7 +160,7 @@ device 1:
 
   auto options =
     torch::TensorOptions()
-      .dtype(torch::kFloat32)
+      .dtype(torch::kFloat64)
       .layout(torch::kStrided)
       .device(torch::kCUDA, 1)
       .requires_grad(true);
@@ -175,7 +175,7 @@ properties:
 
   torch::Tensor tensor = torch::full({3, 4}, /*value=*/123, options);
 
-  assert(tensor.dtype() == torch::kFloat32);
+  assert(tensor.dtype() == torch::kFloat64);
   assert(tensor.layout() == torch::kStrided);
   assert(tensor.device().type() == torch::kCUDA); // or device().is_cuda()
   assert(tensor.device().index() == 1);


### PR DESCRIPTION
Fixes #167467

## Summary
The documentation comment states "64-bit float" but the example code used `kFloat32` (32-bit float). This PR corrects the code to use `kFloat64` to match the description.

## Changes
- Changed `.dtype(torch::kFloat32)` to `.dtype(torch::kFloat64)` in the TensorOptions example
- Updated corresponding assertion from `torch::kFloat32` to `torch::kFloat64`

## Test Plan
Documentation-only change. Verified the code example now matches its description.