### PR TITLE
Add documentation for torch.pi and torch.e constants

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -320,8 +320,10 @@ Constants
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ======================================= ===========================================
+``e``                                       The mathematical constant *e* = 2.718281..., Euler's number. Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
 ``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
+``pi``                                      The mathematical constant *π* = 3.141592..., the ratio of a circle's circumference to its diameter. Alias for :attr:`math.pi`.
 ======================================= ===========================================
 
 Pointwise Ops


### PR DESCRIPTION
Fixes #167535

## Summary
Added documentation for `torch.pi` and `torch.e` mathematical constants that were previously undocumented.

## Changes
- Added `torch.e` to Constants section with description: "The mathematical constant *e* = 2.718281..., Euler's number. Alias for :attr:`math.e`."
- Added `torch.pi` to Constants section with description: "The mathematical constant *π* = 3.141592..., the ratio of a circle's circumference to its diameter. Alias for :attr:`math.pi`."

## Test Plan
Documentation-only change. The constants are already available in PyTorch and work as expected:
```python
import torch
print(torch.pi)  # 3.141592653589793
print(torch.e)   # 2.718281828459045
```