### PR TITLE
Fix addcdiv documentation to match actual behavior

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -460,8 +460,8 @@ add_docstr(
     r"""
 addcdiv(input, tensor1, tensor2, *, value=1, out=None) -> Tensor
 
-Performs the element-wise division of :attr:`tensor1` by :attr:`tensor2`,
-multiplies the result by the scalar :attr:`value` and adds it to :attr:`input`.
+Multiplies :attr:`tensor1` by the scalar :attr:`value`, divides the result by :attr:`tensor2`,
+and adds it to :attr:`input`.
 
 .. warning::
     Integer division with addcdiv is no longer supported, and in a future


### PR DESCRIPTION
Fixes #170869

## Summary
The documentation description for `torch.addcdiv` stated that it "divides tensor1 by tensor2, then multiplies by value", which implied the order `(tensor1/tensor2) * value`. However, the actual implementation computes `(value * tensor1) / tensor2`.

This PR updates the description to accurately reflect the operation order.

## Changes
- Updated description from "Performs the element-wise division of tensor1 by tensor2, multiplies the result by the scalar value and adds it to input"
- To: "Multiplies tensor1 by the scalar value, divides the result by tensor2, and adds it to input"
- The formula `out = input + value × (tensor1 / tensor2)` remains correct and unchanged

## Test Plan
Documentation-only change. The formula and implementation were already correct, only the prose description needed clarification.