### PR TITLE
Fix inconsistent xavier_uniform_ initialization in MultiheadAttention

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1233,7 +1233,7 @@ class MultiheadAttention(Module):
 
     def _reset_parameters(self) -> None:
         if self._qkv_same_embed_dim:
-            xavier_uniform_(self.in_proj_weight)
+            xavier_uniform_(self.in_proj_weight, gain=math.sqrt(2))
         else:
             xavier_uniform_(self.q_proj_weight)
             xavier_uniform_(self.k_proj_weight)


### PR DESCRIPTION
Fixes #166378

## Summary
The default initialization of Q, K, and V matrices in `nn.MultiheadAttention` was inconsistent between the packed and unpacked cases.

When `_qkv_same_embed_dim=True`, `in_proj_weight` is a packed tensor of shape `(3*embed_dim, embed_dim)`. Calling `xavier_uniform_` on this tensor uses `fan_out=3*embed_dim`, which produces different initialization values compared to calling `xavier_uniform_` separately on Q, K, V projections.

## Changes
- Added `gain=math.sqrt(2)` parameter to `xavier_uniform_(self.in_proj_weight)` call
- This makes the packed initialization statistically equivalent to the unpacked case

## Mathematical Justification  
Xavier initialization scales values by `sqrt(2 / (fan_in + fan_out))`.

**Packed case (before fix):**
- fan_out = 3 * embed_dim
- Scale = sqrt(2 / (embed_dim + 3*embed_dim)) = sqrt(1 / (2*embed_dim))

**Unpacked case:**
- fan_out = embed_dim (for each of Q, K, V)
- Scale = sqrt(2 / (embed_dim + embed_dim)) = sqrt(1 / embed_dim)

**With gain=sqrt(2):**
- Packed scale = sqrt(2) * sqrt(1 / (2*embed_dim)) = sqrt(1 / embed_dim) ✓

## Test Plan
Existing MultiheadAttention tests should pass. The change only affects initialization, not forward pass behavior.

cc @drisspg @liangel-02 @howardzhang-cv