### PR TITLE
[ROCm] Enabled test cases for ROCm

### DIFF
--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -1,13 +1,11 @@
 # Owner(s): ["module: dynamo"]
 
-import unittest
 from unittest.mock import Mock
 
 import torch
 from torch._dynamo.callback import callback_handler, CallbackArgs, CallbackTrigger
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._guards import CompileId
-from torch.testing._internal.common_utils import TEST_WITH_ROCM
 from torch.testing._internal.triton_utils import HAS_CUDA_AND_TRITON, requires_gpu
 
 
@@ -63,9 +61,6 @@ class CallbackTests(TestCase):
             callback_handler._CompilationCallbackHandler__pending_callbacks_counter, 0
         )
 
-    @unittest.skipIf(
-        TEST_WITH_ROCM, "ROCm outputs a different number of autotuning logs"
-    )
     @requires_gpu
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_triggers(self) -> None:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2315,8 +2315,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(model_parallel.module.param_normal.shape, torch.Size([2, 3]))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
-    # Skip the test for ROCm as per https://github.com/pytorch/pytorch/issues/53190
-    @skipIfRocm
     def test_broadcast_double_backwards_gpu(self):
         tensors = (torch.randn(4, 4, device='cuda', requires_grad=True, dtype=torch.double),
                    torch.randn(4, 4, device='cuda', requires_grad=True, dtype=torch.double),

--- a/test/test_out_dtype_op.py
+++ b/test/test_out_dtype_op.py
@@ -8,7 +8,7 @@ import torch._inductor.decomposition
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
-    run_tests, TestCase, IS_WINDOWS, TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, TEST_CUDA
+    run_tests, TestCase, IS_WINDOWS, IS_FBCODE, IS_REMOTE_GPU, TEST_CUDA
 )
 from torch.testing._internal.common_quantization import skipIfNoDynamoSupport
 from torch.testing import FileCheck
@@ -163,7 +163,6 @@ class TestOutDtypeOp(TestCase):
             loss.backward()
 
     @unittest.skipIf(IS_WINDOWS, "_int_mm unavailable")
-    @unittest.skipIf(TEST_WITH_ROCM, "_int_mm unavailable")
     @unittest.skipIf(not SM80OrLater, "_int_mm unavailable")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @unittest.skipIf(_get_torch_cuda_version() >= (11, 7), "_int_mm unavailable")


### PR DESCRIPTION
Fixes #168538
Fixes #168539
Fixes #168817
Fixes #168818
Fixes #168799

## [ROCm] Enabled test cases for ROCm

### Summary
This PR enables several previously-skipped test cases to run on ROCm by removing `@skipIfRocm` and `TEST_WITH_ROCM` decorators/conditions.

### Changes

#### 1. `test/dynamo/test_callback.py`
- Removed `@unittest.skipIf(TEST_WITH_ROCM, "ROCm outputs a different number of autotuning logs")` decorator from `test_triggers()`
- Removed unused imports: `unittest` and `TEST_WITH_ROCM`

#### 2. `test/test_out_dtype_op.py`
- Removed `@unittest.skipIf(TEST_WITH_ROCM, "_int_mm unavailable")` decorator from a test
- Removed `TEST_WITH_ROCM` from imports

#### 3. `test/test_nn.py`
- Removed `@skipIfRocm` decorator from `test_broadcast_double_backwards_gpu()`
- Previously skipped due to https://github.com/pytorch/pytorch/issues/53190

### Testing
- Verified all enabled tests pass on ROCm.
- `PYTORCH_TEST_WITH_ROCM=1 pytest test/test_nn.py -k test_broadcast_double_backwards_gpu -v`
- `PYTORCH_TEST_WITH_ROCM=1 pytest test/test_out_dtype_op.py -k test_out_dtype_inductor_decomp -v`
- `PYTORCH_TEST_WITH_ROCM=1 pytest test/dynamo/test_callback.py -k test_triggers -v`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela