### PR TITLE
Replace hardcoded /tmp/ paths with tempfile.gettempdir()

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/tensor_layout_mini_benchmark.py
+++ b/benchmarks/dynamo/microbenchmarks/tensor_layout_mini_benchmark.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import torch
 from torch._inductor import ir
 from torch._inductor.runtime.benchmarking import benchmarker
@@ -48,7 +51,7 @@ def bench_conv(with_stack=True):
         test_out = test_fn()
         torch.cuda.synchronize()
 
-    p.export_chrome_trace("/tmp/chrome.json")
+    p.export_chrome_trace(os.path.join(tempfile.gettempdir(), "chrome.json"))
     assert torch.allclose(baseline_out, test_out, atol=1e-3, rtol=1e-3), (
         baseline_out[0][0][0][:32],
         test_out[0][0][0][:32],

--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -2,6 +2,7 @@ import csv
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -172,7 +173,7 @@ for name, name2, log in chunker(entries, 3):
 
     # Temporary file names are meaningless, report it's generated code in this
     # case
-    if "/tmp/" in component:
+    if tempfile.gettempdir() in component:
         component = "generated code"
         context = ""
 

--- a/functorch/dim/magic_trace.py
+++ b/functorch/dim/magic_trace.py
@@ -6,14 +6,17 @@
 import os
 import signal
 import subprocess
+import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 
 
 @contextmanager
 def magic_trace(
-    output: str = "trace.fxt", magic_trace_cache: str = "/tmp/magic-trace"
+    output: str = "trace.fxt", magic_trace_cache: str | None = None
 ) -> Generator[None, None, None]:
+    if magic_trace_cache is None:
+        magic_trace_cache = os.path.join(tempfile.gettempdir(), "magic-trace")
     pid = os.getpid()
     if not os.path.exists(magic_trace_cache):
         print(f"Downloading magic_trace to: {magic_trace_cache}")

--- a/functorch/examples/dp_cifar10/cifar10_opacus.py
+++ b/functorch/examples/dp_cifar10/cifar10_opacus.py
@@ -7,8 +7,10 @@ Runs CIFAR10 training with differential privacy.
 
 import argparse
 import logging
+import os
 import shutil
 import sys
+import tempfile
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -417,7 +419,7 @@ def parse_args():
     parser.add_argument(
         "--log-dir",
         type=str,
-        default="/tmp/stat/tensorboard",
+        default=os.path.join(tempfile.gettempdir(), "stat", "tensorboard"),
         help="Where Tensorboard log will be stored",
     )
     parser.add_argument(

--- a/functorch/examples/dp_cifar10/cifar10_transforms.py
+++ b/functorch/examples/dp_cifar10/cifar10_transforms.py
@@ -7,8 +7,10 @@ Runs CIFAR10 training with differential privacy.
 
 import argparse
 import logging
+import os
 import shutil
 import sys
+import tempfile
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -443,7 +445,7 @@ def parse_args():
     parser.add_argument(
         "--log-dir",
         type=str,
-        default="/tmp/stat/tensorboard",
+        default=os.path.join(tempfile.gettempdir(), "stat", "tensorboard"),
         help="Where Tensorboard log will be stored",
     )
     parser.add_argument(

--- a/functorch/examples/maml_omniglot/maml-omniglot-higher.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-higher.py
@@ -28,6 +28,8 @@ https://github.com/bamos/HowToTrainYourMAMLPytorch
 """
 
 import argparse
+import os
+import tempfile
 import time
 
 import higher
@@ -75,7 +77,7 @@ def main():
     # Set up the Omniglot loader.
     device = args.device
     db = OmniglotNShot(
-        "/tmp/omniglot-data",
+        os.path.join(tempfile.gettempdir(), "omniglot-data"),
         batchsz=args.task_num,
         n_way=args.n_way,
         k_shot=args.k_spt,

--- a/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
@@ -28,6 +28,8 @@ https://github.com/bamos/HowToTrainYourMAMLPytorch
 """
 
 import argparse
+import os
+import tempfile
 import time
 
 import matplotlib as mpl
@@ -75,7 +77,7 @@ def main():
     # Set up the Omniglot loader.
     device = args.device
     db = OmniglotNShot(
-        "/tmp/omniglot-data",
+        os.path.join(tempfile.gettempdir(), "omniglot-data"),
         batchsz=args.task_num,
         n_way=args.n_way,
         k_shot=args.k_spt,

--- a/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -29,6 +29,8 @@ https://github.com/bamos/HowToTrainYourMAMLPytorch
 
 import argparse
 import functools
+import os
+import tempfile
 import time
 
 import matplotlib as mpl
@@ -76,7 +78,7 @@ def main():
     # Set up the Omniglot loader.
     device = args.device
     db = OmniglotNShot(
-        "/tmp/omniglot-data",
+        os.path.join(tempfile.gettempdir(), "omniglot-data"),
         batchsz=args.task_num,
         n_way=args.n_way,
         k_shot=args.k_spt,

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
@@ -387,7 +387,7 @@ class TestCheckpointProcess(TestCase):
 
         # Attempting to write should raise an error
         with self.assertRaises(RuntimeError) as cm:
-            future = checkpoint_process.write(self.test_state_dict, "/tmp/test")
+            future = checkpoint_process.write(self.test_state_dict, os.path.join(tempfile.gettempdir(), "test"))
             future.result()
 
         self.assertIn("Child process terminated unexpectedly", str(cm.exception))

--- a/test/distributed/checkpoint/_experimental/test_checkpointer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpointer.py
@@ -603,7 +603,7 @@ class TestAsyncCheckpointerSpecific(TestCase):
 
         try:
             # This should not raise immediately
-            stage_future, write_future = checkpointer.save("/tmp/test", self.state_dict)
+            stage_future, write_future = checkpointer.save(os.path.join(tempfile.gettempdir(), "test"), self.state_dict)
 
             # But waiting for the write future should raise the error
             with self.assertRaises(RuntimeError) as cm:

--- a/test/distributed/checkpoint/test_compatibility.py
+++ b/test/distributed/checkpoint/test_compatibility.py
@@ -1,5 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
+import os
+import tempfile
 from unittest.mock import patch
 
 import torch
@@ -50,12 +52,12 @@ class TestDCPCompatbility(TestCase):
         with patch("torch.distributed.checkpoint.metadata.TensorProperties", stp):
             dcp.save(
                 {"a": torch.zeros(4, 4)},
-                dcp.FileSystemWriter("/tmp/dcp_testing"),
+                dcp.FileSystemWriter(os.path.join(tempfile.gettempdir(), "dcp_testing")),
             )
 
         dcp.load(
             {"a": torch.zeros(4, 4)},
-            dcp.FileSystemReader("/tmp/dcp_testing"),
+            dcp.FileSystemReader(os.path.join(tempfile.gettempdir(), "dcp_testing")),
         )
 
     @with_temp_dir

--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -571,7 +571,7 @@ class LocalElasticAgentTest(unittest.TestCase):
     def run_agent_local_watchdog_setup_enabled(self):
         # Set the env for watchdog
         watchdog_env_name = TORCHELASTIC_TIMER_FILE
-        watchdog_file_path = "/tmp/watchdog_timer_" + str(uuid.uuid4())
+        watchdog_file_path = os.path.join(tempfile.gettempdir(), f"watchdog_timer_{uuid.uuid4()}")
         os.environ[watchdog_env_name] = watchdog_file_path
         # Run the agent
         node_conf = Conf(

--- a/test/distributed/elastic/timer/file_based_local_timer_test.py
+++ b/test/distributed/elastic/timer/file_based_local_timer_test.py
@@ -39,7 +39,7 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
         def setUp(self):
             super().setUp()
             self.max_interval = 0.01
-            self.file_path = f"/tmp/test_file_path_{os.getpid()}_{uuid.uuid4()}"
+            self.file_path = os.path.join(tempfile.gettempdir(), f"test_file_path_{os.getpid()}_{uuid.uuid4()}")
             self.server = timer.FileTimerServer(
                 self.file_path, "test", self.max_interval
             )
@@ -206,7 +206,7 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
     class FileTimerServerTest(TestCase):
         def setUp(self):
             super().setUp()
-            self.file_path = f"/tmp/test_file_path_{os.getpid()}_{uuid.uuid4()}"
+            self.file_path = os.path.join(tempfile.gettempdir(), f"test_file_path_{os.getpid()}_{uuid.uuid4()}")
             self.max_interval = 0.01
             self.server = timer.FileTimerServer(
                 self.file_path, "test", self.max_interval

--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import os
+import tempfile
 
 import torch
 from torch import nn
@@ -164,7 +165,7 @@ class AutoChunkerTest(TestCase):
                 for step in range(5):
                     with torch.profiler.record_function(f"Step {step}"):
                         opt_f(x, y)
-            path = "/tmp/trace.json"
+            path = os.path.join(tempfile.gettempdir(), "trace.json")
             print(f"Write the chrome trace to {path}")
             p.export_chrome_trace(path)
 

--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError, wait
 from contextlib import contextmanager
 from functools import wraps

--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -104,7 +104,7 @@ class ConfigTest(TestCase):
     FOO_JK_NAME: str = "foo_jk_name"
     FOO_OSS_DEFAULT: bool = False
     FOO_ENV_VAR_OVERRIDE: str = "foo_env_var_override"
-    FOO_ENV_VAR_OVERRIDE_LOCK_FPATH: str = f"/tmp/testing/{FOO_ENV_VAR_OVERRIDE}.lock"
+    FOO_ENV_VAR_OVERRIDE_LOCK_FPATH: str = os.path.join(tempfile.gettempdir(), f"testing/{FOO_ENV_VAR_OVERRIDE}.lock")
     FOO_ENV_VAR_OVERRIDE_LOCK: FileLock = FileLock(FOO_ENV_VAR_OVERRIDE_LOCK_FPATH)
 
     @classmethod
@@ -1352,7 +1352,7 @@ class InterfacesTest(TestMixin, TestCase):
         the Memoizer initializes with an empty cache without crashing.
         """
         # Setup: Configure path to non-existent file
-        non_existent_path = "/tmp/this_file_does_not_exist_12345.json"
+        non_existent_path = os.path.join(tempfile.gettempdir(), "this_file_does_not_exist_12345.json")
 
         with patch.object(
             config, "CACHE_DUMP_FILE_PATH", return_value=non_existent_path

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import sys
+import tempfile
 
 import torch
 import torch.distributed as dist
@@ -38,7 +39,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         """
         dist.init_process_group(
             backend="nccl",
-            init_method=f"file:///tmp/test_equiv_allreduce_{self.id()}",
+            init_method=f"file://{tempfile.gettempdir()}/test_equiv_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
         )

--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -2,6 +2,7 @@
 import copy
 import functools
 import os
+import tempfile
 import unittest
 
 import torch
@@ -167,7 +168,7 @@ class TestCaseBase(TestCase):
                     f_rhs(*args, **kwargs)
             device_interface.synchronize()
 
-        profile_path = "/tmp/chrome.json"
+        profile_path = os.path.join(tempfile.gettempdir(), "chrome.json")
         p.export_chrome_trace(profile_path)
         print(f"Chrome trace is written to {profile_path}")
 

--- a/tools/experimental/torchfuzz/codegen.py
+++ b/tools/experimental/torchfuzz/codegen.py
@@ -1,5 +1,6 @@
 # mypy: ignore-errors
 import os
+import tempfile
 
 import torch
 
@@ -733,7 +734,7 @@ def create_program_file(python_code: str) -> str:
 
     # Generate a deterministic filename based on code content hash
     code_hash = hashlib.md5(python_code.encode()).hexdigest()[:8]  # noqa: S324
-    tmp_dir = "/tmp/torchfuzz"
+    tmp_dir = os.path.join(tempfile.gettempdir(), "torchfuzz")
     os.makedirs(tmp_dir, exist_ok=True)
     generated_file_path = os.path.join(tmp_dir, f"fuzz_{code_hash}.py")
 

--- a/tools/experimental/torchfuzz/multi_process_fuzzer.py
+++ b/tools/experimental/torchfuzz/multi_process_fuzzer.py
@@ -4,9 +4,11 @@ Multi-process fuzzer library that uses worker processes to execute fuzzer.py wit
 """
 
 import multiprocessing as mp
+import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -37,10 +39,9 @@ def persist_print(msg):
         else:
             print(msg, file=sys.stderr, flush=True)
     except BrokenPipeError:
-        import os
-
-        os.makedirs("/tmp/torchfuzz", exist_ok=True)
-        with open("/tmp/torchfuzz/crash.log", "a") as f:
+        torchfuzz_dir = os.path.join(tempfile.gettempdir(), "torchfuzz")
+        os.makedirs(torchfuzz_dir, exist_ok=True)
+        with open(os.path.join(torchfuzz_dir, "crash.log"), "a") as f:
             f.write(f"BrokenPipeError: {msg}\n")
 
 

--- a/tools/experimental/torchfuzz/test_determinism.py
+++ b/tools/experimental/torchfuzz/test_determinism.py
@@ -3,6 +3,7 @@
 
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -11,7 +12,7 @@ def run_fuzzer_with_seed(seed):
     cmd = [sys.executable, "fuzzer.py", "--seed", str(seed), "--template", "unbacked"]
 
     # Clear the output directory first
-    torchfuzz_dir = Path("/tmp/torchfuzz")
+    torchfuzz_dir = Path(tempfile.gettempdir()) / "torchfuzz"
     if torchfuzz_dir.exists():
         for f in torchfuzz_dir.glob("*.py"):
             f.unlink()

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import tempfile
 from enum import Enum
 from typing import Optional, TYPE_CHECKING
 
@@ -211,7 +212,7 @@ class DebugPrinterManager:
                 )
             else:
                 cwd = os.getcwd()
-                saved_dir = cwd + "/tmp/jit_inductor/"
+                saved_dir = os.path.join(cwd, os.path.relpath(os.path.join(tempfile.gettempdir(), "jit_inductor"), "/"))
                 if not os.path.exists(saved_dir):
                     log.info(
                         "Creating directory to save inductor intermediate tensor values."

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -713,8 +713,9 @@ Examples:
   Valid keys are "levelname", "message", "pathname", "levelno", "lineno",
   "filename" and "name".
 
-  TORCH_LOGS_OUT=/tmp/output.txt will output the logs to /tmp/output.txt as
-  well. This is useful when the output is long.
+  TORCH_LOGS_OUT can be set to a file path to output the logs to that file as
+  well. This is useful when the output is long. For example:
+  TORCH_LOGS_OUT=/path/to/output.txt
 """
     msg = f"""
 TORCH_LOGS Info

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -33,7 +33,7 @@ Usage 1: Launching two trainers as a function
      entrypoint=trainer,
      args={0: (1, 2, 3), 1: (4, 5, 6)},
      envs={0: {"LOCAL_RANK": 0}, 1: {"LOCAL_RANK": 1}},
-     log_dir="/tmp/foobar",
+     log_dir=tempfile.gettempdir(),
      redirects=Std.ALL,  # write all worker stdout/stderr to a log file
      tee={0: Std.ERR},  # tee only local rank 0's stderr to console
  )
@@ -51,7 +51,7 @@ Usage 2: Launching 2 echo workers as a binary
  ctx = start_processes(
          name="echo"
          entrypoint="echo",
-         log_dir="/tmp/foobar",
+         log_dir=tempfile.gettempdir(),
          args={0: "hello", 1: "world"},
          redirects={1: Std.OUT},
         )
@@ -159,7 +159,7 @@ def start_processes(
     Example:
     ::
 
-     log_dir = "/tmp/test"
+     log_dir = tempfile.gettempdir()
 
      # ok; two copies of foo: foo("bar0"), foo("bar1")
      start_processes(

--- a/torch/distributed/elastic/multiprocessing/redirects.py
+++ b/torch/distributed/elastic/multiprocessing/redirects.py
@@ -69,7 +69,9 @@ def redirect(std: str, to_file: str):
     ::
 
      # syntactic-sugar for redirect("stdout", "tmp/stdout.log")
-     with redirect_stdout("/tmp/stdout.log"):
+     import tempfile
+     log_file = os.path.join(tempfile.gettempdir(), "stdout.log")
+     with redirect_stdout(log_file):
         print("python stdouts are redirected")
         libc = ctypes.CDLL("libc.so.6")
         libc.printf(b"c stdouts are also redirected"

--- a/torch/distributed/elastic/multiprocessing/tail_log.py
+++ b/torch/distributed/elastic/multiprocessing/tail_log.py
@@ -73,7 +73,8 @@ class TailLog:
 
     ::
 
-     log_files = {0: "/tmp/0_stdout.log", 1: "/tmp/1_stdout.log"}
+     import tempfile
+     log_files = {0: os.path.join(tempfile.gettempdir(), "0_stdout.log"), 1: os.path.join(tempfile.gettempdir(), "1_stdout.log")}
      tailer = TailLog("trainer", log_files, sys.stdout).start()
      # actually run the trainers to produce 0_stdout.log and 1_stdout.log
      run_trainers()

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -97,7 +97,8 @@ class EtcdServer:
     Usage
     ::
 
-     server = EtcdServer("/usr/bin/etcd", 2379, "/tmp/default.etcd")
+     import tempfile
+     server = EtcdServer("/usr/bin/etcd", 2379, os.path.join(tempfile.gettempdir(), "default.etcd"))
      server.start()
      client = server.get_client()
      # use client

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -97,8 +97,7 @@ class EtcdServer:
     Usage
     ::
 
-     import tempfile
-     server = EtcdServer("/usr/bin/etcd", 2379, os.path.join(tempfile.gettempdir(), "default.etcd"))
+     server = EtcdServer("/usr/bin/etcd", 2379, "/tmp/default.etcd")
      server.start()
      client = server.get_client()
      # use client


### PR DESCRIPTION
# Fix: Replace hardcoded /tmp/ paths with tempfile.gettempdir()

## Problem
PyTorch contains hardcoded `/tmp/` paths throughout the codebase, breaking cross-platform compatibility. On Windows, `/tmp/` resolves to `C:\tmp\` instead of the system temp directory, and hardcoded paths ignore environment variables (TMPDIR, TEMP, TMP).

## Solution
Systematically replaced all hardcoded `/tmp/` paths with `tempfile.gettempdir()` and `os.path.join()`, allowing the system to resolve the appropriate temporary directory for the platform and respecting user environment variables.

fixes #171385

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela