### PR TITLE
[nn] Fix F.pad losing int64 precision for values > 2^53

### DIFF
--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -204,7 +204,7 @@ static std::string_view padding_mode_string(padding_mode m) {
 }
 
 
-Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mode_int, std::optional<double> value) {
+Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mode_int, const std::optional<Scalar>& value) {
   const auto input_dim = self.dim();
   TORCH_CHECK(pad.size() % 2 == 0, "Padding length must be divisible by 2");
   TORCH_CHECK(static_cast<int64_t>(pad.size()) <= input_dim * 2,
@@ -212,9 +212,9 @@ Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mod
   auto mode = static_cast<at::padding_mode>(mode_int);
 
   if (mode == at::padding_mode::constant) {
-    return at::constant_pad_nd_symint(self, pad, value.value_or(0.0));
+    return at::constant_pad_nd_symint(self, pad, value.value_or(0));
   }
-  TORCH_CHECK(!value.has_value() || *value == 0,
+  TORCH_CHECK(!value.has_value() || value->equal(0),
               "Padding mode \"", padding_mode_string(mode),
               "\" doesn't take in value argument");
 
@@ -251,7 +251,7 @@ Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mod
   C10_THROW_ERROR(NotImplementedError, error_msg.str());
 }
 
-Tensor pad_symint(const Tensor &self, c10::SymIntArrayRef pad, std::string_view mode, std::optional<double> value) {
+Tensor pad_symint(const Tensor &self, c10::SymIntArrayRef pad, std::string_view mode, const std::optional<Scalar>& value) {
   const auto mode_enum = [&] {
     if (mode == "reflect") {
       return at::padding_mode::reflect;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12890,12 +12890,12 @@
   dispatch:
     CompositeImplicitAutograd: _pad_circular_symint
 
-- func: _pad_enum(Tensor self, SymInt[] pad, int mode, float? value=None) -> Tensor
+- func: _pad_enum(Tensor self, SymInt[] pad, int mode, Scalar? value=None) -> Tensor
   python_module: nn
   dispatch:
     CompositeImplicitAutograd: _pad_enum_symint
 
-- func: pad(Tensor self, SymInt[] pad, str mode="constant", float? value=None) -> Tensor
+- func: pad(Tensor self, SymInt[] pad, str mode="constant", Scalar? value=None) -> Tensor
   python_module: nn
   dispatch:
     CompositeImplicitAutograd: pad_symint

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7638,6 +7638,37 @@ class TestConstantPadNd(TestCase):
         nhwc_padded = torch.constant_pad_nd(nhwc_tensor, [1, 2], 0.5)
         self.assertTrue(nhwc_padded.is_contiguous(memory_format=torch.channels_last))
 
+    def test_pad_int64_precision(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/170798
+        # Padding value should preserve int64 precision for values > 2^53
+        v = 2**53 + 1
+        result = torch.nn.functional.pad(
+            input=torch.tensor([v], dtype=torch.int64),
+            pad=(0, 1),
+            value=v,
+        )
+        self.assertEqual(result[0].item(), v)
+        self.assertEqual(result[1].item(), v)
+
+        # Also test with int64 max value
+        v_max = torch.iinfo(torch.int64).max
+        result_max = torch.nn.functional.pad(
+            input=torch.tensor([v_max], dtype=torch.int64),
+            pad=(1, 1),
+            value=v_max,
+        )
+        self.assertEqual(result_max[0].item(), v_max)
+        self.assertEqual(result_max[1].item(), v_max)
+        self.assertEqual(result_max[2].item(), v_max)
+
+        # Test with constant_pad_nd directly
+        result_direct = torch.constant_pad_nd(
+            torch.tensor([v], dtype=torch.int64),
+            [0, 1],
+            v,
+        )
+        self.assertEqual(result_direct[1].item(), v)
+
 
 class TestAddRelu(TestCase):
     def test_add_relu(self):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5349,7 +5349,7 @@ def pad(
     input: Tensor,
     pad: list[int],
     mode: str = "constant",
-    value: Optional[float] = None,
+    value: Optional[int | float] = None,
 ) -> Tensor:
     r"""
     pad(input, pad, mode="constant", value=None) -> Tensor


### PR DESCRIPTION
## Summary
Fixes #170798

The `pad` and `_pad_enum` functions used `float` (Python) / `double` (C++) for the padding value parameter, causing precision loss when padding int64 tensors with values larger than 2^53 (the limit of float64 mantissa).

### The Bug
```python
v = 2**53 + 1
torch.nn.functional.pad(
    input=torch.tensor([v], dtype=torch.int64),
    pad=(0, 1),
    value=v,
)
# Expected: tensor([9007199254740993, 9007199254740993])
# Actual:   tensor([9007199254740993, 9007199254740992])  # WRONG!
```

### The Fix
- Changed parameter type from `float?` to `Scalar?` in `native_functions.yaml` for both `pad` and `_pad_enum`
- Updated C++ implementation to use `std::optional<Scalar>` instead of `std::optional<double>`
- Updated Python type hint from `Optional[float]` to `Optional[int | float]`

## Test Plan
- Added regression test `test_pad_int64_precision` in `test/test_nn.py` that verifies:
  - Values > 2^53 are preserved correctly
  - int64 max value is handled correctly
  - Both `F.pad` and `torch.constant_pad_nd` work correctly

```bash
python test/test_nn.py TestConstantPadNd.test_pad_int64_precision
```

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki

🤖 Generated with [Claude Code](https://claude.com/claude-code)