### PR TITLE
[vLLM] Run PyTorch x vLLM compilation unit tests on B200

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -31,7 +31,7 @@ jobs:
       build-external-packages: "vllm"
       build-environment: linux-jammy-cuda12.9-py3.12-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.9-cudnn9-py3.12-gcc11-vllm
-      cuda-arch-list: '8.0 8.9 9.0'
+      cuda-arch-list: '8.0 8.9 9.0 10.0'
       runner: linux.24xlarge.memory
       test-matrix: |
         { include: [

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -41,6 +41,7 @@ jobs:
           { config: "vllm_regression_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_multi_model_processor_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_pytorch_compilation_unit_tests", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "vllm_pytorch_compilation_unit_tests", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
           { config: "vllm_lora_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu" },
           { config: "vllm_multi_model_test_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu"},
           { config: "vllm_language_model_test_extended_generation_28_failure_test", shard: 1, num_shards: 1, runner: "linux.g6.4xlarge.experimental.nvidia.gpu"},

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - ciflow/vllm/*
   workflow_dispatch:
-  schedule:
-    - cron: '0 */8 * * *'  # every 8 hours at minute 0 (UTC)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Per @BoyuanFeng request, we already have compilation unit tests, including `test_fusion_attn`, running on PyTorch CI L4 runner.  The test is defined here https://github.com/pytorch/pytorch/blob/main/.ci/lumen_cli/cli/lib/core/vllm/vllm_test_library.yaml#L92. So, let's try to run this on B200 where there are still some capacity.