### PR TITLE
Emit profiler events for compilation events

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -364,6 +364,23 @@ def forward(self, arg0_1):
             ],
         )
 
+    def test_chromium_event_timed_profiling(self):
+        # chromium_event_timed should emit profiler events so they appear in
+        # the stock profiler, not just in tlparse traces.
+        from torch._dynamo.utils import chromium_event_timed
+
+        with torch.profiler.profile(with_stack=False) as prof:
+            with chromium_event_timed("test_chromium_event"):
+                x = torch.rand((2, 2))
+                _ = x.sin()
+
+        self.assertTrue(
+            any(
+                "test_chromium_event (chromium_event_timed)" in evt.name
+                for evt in prof.events()
+            )
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -35,7 +35,6 @@ from torch._dynamo.external_utils import (
 )
 from torch._dynamo.source import GetItemSource, LocalSource
 from torch._dynamo.utils import (
-    compile_time_record_function,
     counters,
     get_chromium_event_logger,
     lazy_format_graph_code,
@@ -323,7 +322,9 @@ class AutogradCompilerInstance:
         self.nan_checker = NaNChecker(accumulate_grad) if check_nans else None
         self.start_time_ns = time.time_ns()
         # Start profiler event so compiled_autograd appears in stock profiler
-        self._profiler_record_function = None
+        self._profiler_record_function: (
+            torch._C._profiler._RecordFunctionFast | None
+        ) = None
         if torch.autograd.profiler._is_profiler_enabled:
             self._profiler_record_function = torch._C._profiler._RecordFunctionFast(
                 "compiled_autograd"

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2127,8 +2127,7 @@ def chromium_event_timed(
     Context manager that creates a chromium start and end event. Chromium event
     logging is integrated with dynamo_timed, so you probably want to use that
     instead. Use this context manager only if you want to avoid dynamo_timed.
-
-    Also emits profiler events so these appear in the stock profiler.
+    NOTE: Also emits profiler events so these appear in the stock profiler.
     """
     chromium_event_log = get_chromium_event_logger()
     chromium_start_time = time.time_ns()
@@ -2138,10 +2137,14 @@ def chromium_event_timed(
         {},
         log_pt2_compile_event,
     )
+    record_function = compile_time_record_function(
+        f"{event_name} (chromium_event_timed)"
+    )
+    record_function.__enter__()
     try:
-        with compile_time_record_function(f"{event_name} (chromium_event_timed)"):
-            yield
+        yield
     finally:
+        record_function.__exit__(None, None, None)
         chromium_event_log.log_event_end(
             event_name,
             time.time_ns(),

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2127,6 +2127,8 @@ def chromium_event_timed(
     Context manager that creates a chromium start and end event. Chromium event
     logging is integrated with dynamo_timed, so you probably want to use that
     instead. Use this context manager only if you want to avoid dynamo_timed.
+
+    Also emits profiler events so these appear in the stock profiler.
     """
     chromium_event_log = get_chromium_event_logger()
     chromium_start_time = time.time_ns()
@@ -2137,7 +2139,8 @@ def chromium_event_timed(
         log_pt2_compile_event,
     )
     try:
-        yield
+        with compile_time_record_function(f"{event_name} (chromium_event_timed)"):
+            yield
     finally:
         chromium_event_log.log_event_end(
             event_name,


### PR DESCRIPTION
## Summary
- **chromium_event_timed**: Now uses `compile_time_record_function` to emit profiler events alongside chromium events
- **compiled_autograd**: Added `_RecordFunctionFast` around the `begin_capture`/`end_capture` span so `compiled_autograd` compilation appears in the profiler
- Added test for `chromium_event_timed` profiler event emission

## Motivation
Previously, compilation events were only logged via `trace_structured` for tlparse/Perfetto, but they would not appear in `torch.profiler.profile()` output. This makes debugging and profiling compilation overhead difficult since users need to use tlparse to see compilation events.

This change makes compilation events visible in the stock PyTorch profiler by adding `RecordFunction` calls alongside the existing chromium event logging.

## Test plan
- Added `test_chromium_event_timed_profiling` test that verifies the new profiler event appears in the profiler output
- The `compiled_autograd` profiler event can be tested by running a backward pass with profiling enabled

Fixes #171220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @xmfan @aditvenk