### PR TITLE
[ROCm] Skip alias check for empty tensors in fake tensor crossref

### DIFF
--- a/torch/_subclasses/fake_utils.py
+++ b/torch/_subclasses/fake_utils.py
@@ -50,7 +50,20 @@ def output_alias_each_other(outputs):
     return False
 
 
+def _all_tensor_leaves_empty(obj) -> bool:
+    return all(t.numel() == 0 for t in tree_flatten_only(torch.Tensor, obj))
+
+
 def _check_alias_info(context, real_out, real_in, fake_out, fake_in):
+    # Skip alias checks for empty tensors - aliasing is unobservable.
+    if (
+        _all_tensor_leaves_empty(real_out)
+        and _all_tensor_leaves_empty(real_in)
+        and _all_tensor_leaves_empty(fake_out)
+        and _all_tensor_leaves_empty(fake_in)
+    ):
+        return
+
     r_aliasing = outputs_alias_inputs(real_out, real_in)
     f_aliasing = outputs_alias_inputs(fake_out, fake_in)
     if r_aliasing != f_aliasing:


### PR DESCRIPTION
Fixes #159150
Fixes #159151

Skip alias consistency checks in FakeTensor validation when all tensor leaves are empty. Aliasing semantics are unobservable for empty tensors, so mismatches between real and fake outputs should not cause validation failures.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang