### PR TITLE
[ROCm] Allow swap_tensors when tensor has weak references

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -2,7 +2,6 @@
 
 import copyreg
 import os.path as _osp
-import weakref
 
 import torch
 from torch.utils import (
@@ -40,11 +39,6 @@ def swap_tensors(t1, t2):
 
     This will not work if t1 and t2 have different slots.
     """
-    # Ensure there are no weakrefs
-    if weakref.getweakrefs(t1):
-        raise RuntimeError("Cannot swap t1 because it has weakref associated with it")
-    if weakref.getweakrefs(t2):
-        raise RuntimeError("Cannot swap t2 because it has weakref associated with it")
     t1_slots = set(copyreg._slotnames(t1.__class__))  # type: ignore[attr-defined]
     t2_slots = set(copyreg._slotnames(t2.__class__))  # type: ignore[attr-defined]
     if t1_slots != t2_slots:


### PR DESCRIPTION
Fixes #165387

Allow `torch.utils.swap_tensors` to proceed when a tensor has weak references. Weak references do not prevent the swap operation and the weakref callback will fire naturally when the original tensor is collected.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang