### PR TITLE
[ROCm] Use DEVICE pointer mode for hipSPARSE csrgeam2

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1079,8 +1079,8 @@ void add_out_sparse_csr(
         auto beta_dev = at::empty_strided({1}, {1}, scalar_opts);
         alpha_dev.fill_(alpha_);
         beta_dev.fill_(beta_);
-        const scalar_t* alpha_ptr = alpha_dev.data_ptr<scalar_t>();
-        const scalar_t* beta_ptr = beta_dev.data_ptr<scalar_t>();
+        const scalar_t* alpha_ptr = alpha_dev.const_data_ptr<scalar_t>();
+        const scalar_t* beta_ptr = beta_dev.const_data_ptr<scalar_t>();
 #else
         TORCH_CUDASPARSE_CHECK(
             cusparseSetPointerMode(handle, CUSPARSE_POINTER_MODE_HOST));

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1072,7 +1072,7 @@ void add_out_sparse_csr(
 #if AT_ROCM_ENABLED()
         // ROCm: HOST pointer mode broken for csrgeam2, use DEVICE mode
         TORCH_CUDASPARSE_CHECK(
-            cusparseSetPointerMode(handle, CUSPARSE_POINTER_MODE_DEVICE));
+            cusparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
         auto scalar_opts =
             C_values.options().dtype(C.scalar_type()).layout(kStrided);
         auto alpha_dev = at::empty_strided({1}, {1}, scalar_opts);


### PR DESCRIPTION
Fixes #167783

Use DEVICE pointer mode for alpha/beta in hipSPARSE csrgeam2 to work around a library bug where HOST mode produces incorrect results.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang