### PR TITLE
[ROCm] Enable upsample launch failure test

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11361,8 +11361,8 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out_ref, out)
 
     @unittest.expectedFailure
-    @skipIfRocm
     @onlyCUDA
+    @skipCUDAIfRocm  # ROCm succeeds where CUDA fails - see test_upsamplingNearest2d_launch_rocm
     def test_upsamplingNearest2d_launch_fail(self, device):
         m = nn.Upsample(scale_factor=2)
         # launch grid_y == 2**16 (larger than maximum y-dimension limit 65535)


### PR DESCRIPTION
Fixes #168807

Replace `@skipIfRocm` with `@skipCUDAIfRocm` for `test_upsamplingNearest2d_launch_fail`. The test expects a CUDA launch failure for large grid sizes, but ROCm handles this case differently and succeeds.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang