### PR TITLE
[ROCm] Enable cross entropy out-of-bounds assertion test

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12384,7 +12384,6 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(grad_long, grad_byte)
 
     @onlyCUDA
-    @skipIfRocm
     @dtypes(torch.float16, torch.float32)
     def test_cross_entropy_loss_2d_out_of_bounds_class_index(self, device, dtype):
         # Test for issue #117532
@@ -12420,7 +12419,11 @@ class TestThatContainsCUDAAssert(TestCase):
 if __name__ == '__main__':
     run_tests()
         """)
-        self.assertIn('CUDA error: device-side assert triggered', stderr)
+        # CUDA says "device-side assert triggered", ROCm says "unspecified launch failure"
+        has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
+        has_hip_assert = 'HIP error' in stderr and 'launch failure' in stderr
+        self.assertTrue(has_cuda_assert or has_hip_assert,
+                        f"Expected CUDA/HIP device-side assert, got: {stderr}")
 
 
 


### PR DESCRIPTION
Fixes #168812

Enable `test_cross_entropy_loss_2d_out_of_bounds_class_index` on ROCm. The test triggers a device-side assertion, and ROCm reports this via HIP error messages rather than CUDA error messages. The fix checks for the platform-appropriate error string.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang