### PR TITLE
Fix Inductor view_copy decomposition to handle dtype size changes

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3152,6 +3152,13 @@ class CommonTemplate:
             ),
         )
 
+    def test_view_copy_dtype_change(self):
+        def fn(x, dtype):
+            return torch.ops.aten.view_copy(x, dtype=dtype)
+
+        x = torch.randint(2, 32, (8, 16), dtype=torch.int32, device=self.device)
+        self.common(fn, (x, torch.int64))
+
     def test_torch_device_split(self):
         def fn(x):
             return x.split(2)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -604,7 +604,7 @@ def view_copy_dtype(
     self: torch.Tensor,
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    return self.to(dtype).clone()
+    return self.clone().view(dtype)
 
 
 def _get_shape_permutation_like(


### PR DESCRIPTION

Fixes #171366 

The previous decomposition for `aten.view_copy.dtype` was implemented as `self.to(dtype).clone()`. This was incorrect because `.to(dtype)` performs a value cast (preserving shape), whereas `view_copy` expects bitcast semantics (reshaping based on element size).

For example, viewing an `int32` tensor of shape `[8, 16]` as `int64` should result in `[8, 8]`. The old implementation returned `[8, 16]`.

This PR changes the decomposition to `self.clone().view(dtype)`, which correctly handles the bitcast and shape inference.

- Verified locally with the reproduction script from the issue.
- Eager and Inductor shapes now match.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos