### PR TITLE
Replace hard-coded /tmp paths with tempfile.gettempdir()

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import warnings
 from collections import namedtuple
 from os.path import abspath, exists
@@ -51,7 +52,7 @@ def _reassign_parameters(model):
 def setup_torchbench_cwd():
     original_dir = abspath(os.getcwd())
 
-    os.environ["KALDI_ROOT"] = "/tmp"  # avoids some spam
+    os.environ["KALDI_ROOT"] = tempfile.gettempdir()  # avoids some spam
     for torchbench_dir in (
         "./torchbenchmark",
         "../torchbenchmark",

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6641,7 +6641,7 @@ class TestGreenContext(TestCase):
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestGDS(TestCase):
     def _get_tmp_dir_fs_type(self):
-        my_path = os.path.realpath("/tmp")
+        my_path = os.path.realpath(tempfile.gettempdir())
         root_type = ""
         for part in psutil.disk_partitions():
             if part.mountpoint == "/":

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -184,6 +184,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
     from torch.utils.weak import WeakIdKeyDictionary
+
     from .backends.registry import CompilerFn
     from .package import CompilePackage
     from .repro.after_dynamo import WrapBackendDebug

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -82,6 +82,7 @@ from torch.utils._python_dispatch import (
     is_in_any_mode_without_ignore_compile_internals,
 )
 from torch.utils._traceback import CapturedTraceback, format_traceback_short
+
 from . import config, decorators, exc, graph_break_hints, trace_rules
 from .bytecode_analysis import remove_dead_code, remove_pointless_jumps
 from .bytecode_transformation import (

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -39,6 +39,7 @@ import pstats
 import random
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -473,7 +474,10 @@ def cprofile_wrapper(func: Callable[_P, _T]) -> Callable[_P, _T]:
         trace_id = CompileContext.current_trace_id()
         assert trace_id, "Trace id is None"
         profile_path = Path(
-            f"/tmp/{func.__name__}_{str(trace_id).replace('/', '_')}.profile"
+            os.path.join(
+                tempfile.gettempdir(),
+                f"{func.__name__}_{str(trace_id).replace('/', '_')}.profile"
+            )
         )
         prof = cProfile.Profile()
         try:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -82,7 +82,6 @@ from torch.utils._python_dispatch import (
     is_in_any_mode_without_ignore_compile_internals,
 )
 from torch.utils._traceback import CapturedTraceback, format_traceback_short
-
 from . import config, decorators, exc, graph_break_hints, trace_rules
 from .bytecode_analysis import remove_dead_code, remove_pointless_jumps
 from .bytecode_transformation import (
@@ -184,7 +183,6 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
     from torch.utils.weak import WeakIdKeyDictionary
-
     from .backends.registry import CompilerFn
     from .package import CompilePackage
     from .repro.after_dynamo import WrapBackendDebug
@@ -476,7 +474,7 @@ def cprofile_wrapper(func: Callable[_P, _T]) -> Callable[_P, _T]:
         profile_path = Path(
             os.path.join(
                 tempfile.gettempdir(),
-                f"{func.__name__}_{str(trace_id).replace('/', '_')}.profile"
+                f"{func.__name__}_{str(trace_id).replace('/', '_')}.profile",
             )
         )
         prof = cProfile.Profile()

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -26,6 +26,7 @@ from torch._inductor.output_code import (
 )
 from torch._subclasses import FakeTensorMode
 from torch.utils._ordered_set import OrderedSet
+
 from . import config
 from .compile_fx import _CompileFxKwargs, _InProcessFxCompile, FxCompile, log
 from .debug import DebugContext

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -7,6 +7,7 @@ import logging
 import os
 import queue
 import sys
+import tempfile
 import warnings
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -662,19 +663,19 @@ class _DebugFileFxCompile(_SerializedFxCompile):
         idx = _DebugFileFxCompile.file_index
         _DebugFileFxCompile.file_index += 1
 
-        name = f"/tmp/aorenste/pytorch_compile_fx_tmp_input_{idx}.bin"
+        name = os.path.join(tempfile.gettempdir(), f"pytorch_compile_fx_tmp_input_{idx}.bin")
         with open(name, "wb") as f:
             f.write(pickled_input.value)
         print(f"Wrote to {name}")
 
         if False:
-            name = f"/tmp/aorenste/pytorch_compile_fx_tmp_actual_{idx}.bin"
+            name = os.path.join(tempfile.gettempdir(), f"pytorch_compile_fx_tmp_actual_{idx}.bin")
             actual = self._run_in_child(pickled_input)
             with open(name, "wb") as f:
                 f.write(actual.value)
             return actual
         elif False:
-            name = f"/tmp/aorenste/pytorch_compile_fx_tmp_output_{idx}.bin"
+            name = os.path.join(tempfile.gettempdir(), f"pytorch_compile_fx_tmp_output_{idx}.bin")
             with open(name, "rb") as f:
                 result = _WireProtocolPickledOutput(f.read())
                 print(f"Read from {name}")

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -26,7 +26,6 @@ from torch._inductor.output_code import (
 )
 from torch._subclasses import FakeTensorMode
 from torch.utils._ordered_set import OrderedSet
-
 from . import config
 from .compile_fx import _CompileFxKwargs, _InProcessFxCompile, FxCompile, log
 from .debug import DebugContext
@@ -663,19 +662,25 @@ class _DebugFileFxCompile(_SerializedFxCompile):
         idx = _DebugFileFxCompile.file_index
         _DebugFileFxCompile.file_index += 1
 
-        name = os.path.join(tempfile.gettempdir(), f"pytorch_compile_fx_tmp_input_{idx}.bin")
+        name = os.path.join(
+            tempfile.gettempdir(), f"pytorch_compile_fx_tmp_input_{idx}.bin"
+        )
         with open(name, "wb") as f:
             f.write(pickled_input.value)
         print(f"Wrote to {name}")
 
         if False:
-            name = os.path.join(tempfile.gettempdir(), f"pytorch_compile_fx_tmp_actual_{idx}.bin")
+            name = os.path.join(
+                tempfile.gettempdir(), f"pytorch_compile_fx_tmp_actual_{idx}.bin"
+            )
             actual = self._run_in_child(pickled_input)
             with open(name, "wb") as f:
                 f.write(actual.value)
             return actual
         elif False:
-            name = os.path.join(tempfile.gettempdir(), f"pytorch_compile_fx_tmp_output_{idx}.bin")
+            name = os.path.join(
+                tempfile.gettempdir(), f"pytorch_compile_fx_tmp_output_{idx}.bin"
+            )
             with open(name, "rb") as f:
                 result = _WireProtocolPickledOutput(f.read())
                 print(f"Read from {name}")

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -33,6 +33,7 @@ from torch.fx.passes.tools_common import legalize_graph
 from torch.types import FileLike
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
+
 from . import config, ir  # noqa: F811, this is needed
 from .ir import ExternKernel
 from .scheduler import (

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -10,9 +10,9 @@ import logging
 import os
 import os.path
 import pickle
-import tempfile
 import pstats
 import shutil
+import tempfile
 import traceback
 from collections.abc import Callable, Iterator, Sequence
 from typing import Any, IO, Optional, Union
@@ -33,7 +33,6 @@ from torch.fx.passes.tools_common import legalize_graph
 from torch.types import FileLike
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
-
 from . import config, ir  # noqa: F811, this is needed
 from .ir import ExternKernel
 from .scheduler import (

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -10,6 +10,7 @@ import logging
 import os
 import os.path
 import pickle
+import tempfile
 import pstats
 import shutil
 import traceback
@@ -1190,7 +1191,7 @@ def save_args_for_compile_fx_inner(*args: Any, **kwargs: Any) -> None:
     with the saved arguments using load_args_and_run_compile_fx_inner.
     """
 
-    folder = "/tmp/inductor_saved_args"
+    folder = os.path.join(tempfile.gettempdir(), "inductor_saved_args")
     if not os.path.exists(folder):
         os.mkdir(folder)
 

--- a/torch/distributed/_symmetric_memory/_nvshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_nvshmem_triton.py
@@ -1209,7 +1209,7 @@ if has_triton():
         def on_exit() -> None:
             logger.info("PTX files:")
             for kernel in triton_kernels:
-                with tempfile.NamedTemporaryFile(dir="/tmp", delete=False) as f:
+                with tempfile.NamedTemporaryFile(delete=False) as f:
                     f.write(kernel.asm["ptx"].encode("utf-8"))
                     logger.info(f"+- {kernel.name}: {f.name}")  # noqa: G004
 

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -12,6 +12,7 @@ import json
 import os
 import signal
 import socket
+import tempfile
 import time
 import uuid
 from string import Template
@@ -170,7 +171,9 @@ class LocalElasticAgent(SimpleElasticAgent):
         watchdog_file_path = os.getenv(watchdog_file_env_name)
         if watchdog_enabled is not None and str(watchdog_enabled) == "1":
             if watchdog_file_path is None:
-                watchdog_file_path = "/tmp/watchdog_timer_" + str(uuid.uuid4())
+                watchdog_file_path = os.path.join(
+                    tempfile.gettempdir(), "watchdog_timer_" + str(uuid.uuid4())
+                )
             logger.info("Starting a FileTimerServer with %s ...", watchdog_file_path)
             if not envs:
                 logger.warning(


### PR DESCRIPTION
Fixes #171385

Summary
Replaced hardcoded `/tmp` paths with `tempfile.gettempdir()` in production code and key test files to allow users to configure temp directory location via environment variables (e.g., `TMPDIR`).

 Motivation
Users need to specify custom temp directory locations when:
- `/tmp` has limited storage or quota restrictions
- Running on Windows (where `/tmp` doesn't exist)
- Using containerized environments with custom temp directories

Changes
Modified 7 files to use `tempfile.gettempdir()`:
- `torch/_inductor/debug.py` - Inductor saved args
- `torch/_dynamo/convert_frame.py` - cProfile outputs  
- `torch/_inductor/compile_fx_ext.py` - Debug serialization files
- `torch/distributed/elastic/agent/server/local_elastic_agent.py` - Watchdog timers
- `torch/distributed/_symmetric_memory/_nvshmem_triton.py` - NVSHMEM PTX files
- `benchmarks/dynamo/torchbench.py` - KALDI_ROOT env var
- `test/test_cuda.py` - GDS filesystem tests

 Scope
Note: This PR focuses on production code and critical test files (~7 files). The codebase has ~96 `/tmp` references across 53 files, but many are in:
- Comments/docstrings (documentation examples)
- Example scripts (functorch examples)
- Less critical test files

These were intentionally excluded to keep the PR focused and minimize risk of breaking existing workflows. Follow-up PRs can address remaining instances if needed.

Backward Compatibility
Fully backward compatible - when `TMPDIR` is not set, `tempfile.gettempdir()` defaults to `/tmp` on Unix/Linux systems, maintaining existing behavior.

Testing
- Verified with `git diff` that only intended changes were made
- All modified paths now respect system temp directory configuration
- Users can test with: `export TMPDIR=/custom/path`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela