### PR TITLE
[XPU] Add XPUGraph make_graphed_callables feature

### DIFF
--- a/docs/source/xpu.aliases.md
+++ b/docs/source/xpu.aliases.md
@@ -21,6 +21,20 @@ The following are aliases to their counterparts in ``torch.xpu`` in the nested n
 ```
 
 ```{eval-rst}
+.. automodule:: torch.xpu.graphs
+.. currentmodule:: torch.xpu.graphs
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    is_current_stream_capturing
+    graph_pool_handle
+    XPUGraph
+    graph
+    make_graphed_callables
+```
+
+```{eval-rst}
 .. automodule:: torch.xpu.streams
 .. currentmodule:: torch.xpu.streams
 .. autosummary::

--- a/docs/source/xpu.md
+++ b/docs/source/xpu.md
@@ -62,6 +62,20 @@
     Stream
 ```
 
+## Graphs
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    is_current_stream_capturing
+    graph_pool_handle
+    XPUGraph
+    graph
+    make_graphed_callables
+```
+
 ```{eval-rst}
 .. automodule:: torch.xpu.memory
 ```

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -43,7 +43,7 @@ TEST_MULTIXPU = torch.xpu.device_count() > 1
 cpu_device = torch.device("cpu")
 xpu_device = torch.device("xpu")
 
-any_common_cpu_xpu_one = OpDTypes.any_common_cpu_xpu_one
+any_common_cpu_xpu_one = OpDTypes.any_common_cpu_cuda_one
 _xpu_computation_op_list = [
     "fill",
     "zeros",
@@ -1165,18 +1165,6 @@ if __name__ == "__main__":
             z[0] = z[0] + 1.0
             self.assertEqual(z, x)
 
-    def test_graph_is_current_stream_capturing(self):
-        self.assertFalse(torch.xpu.is_current_stream_capturing())
-
-        if TEST_XPU:
-            s = torch.xpu.Stream()
-            with torch.xpu.stream(s):
-                g = torch.xpu.XPUGraph()
-                self.assertFalse(torch.xpu.is_current_stream_capturing())
-                g.capture_begin()
-                self.assertTrue(torch.xpu.is_current_stream_capturing())
-                g.capture_end()    
-
     @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
     def test_graph_capture_simple(self):
         s = torch.xpu.Stream()
@@ -1195,83 +1183,6 @@ if __name__ == "__main__":
         g.replay()
 
         self.assertEqual(b.sum().item(), 11000.0)
-
-    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
-    def test_graphsafe_set_get_rng_state(self):
-        # Define a function to create generator states, with optional graph registration
-        def create_states(generator):
-            """Initializes generator states and registers them with a XPU graph if provided."""
-            # Ensure the XPU generator is initialized
-            torch.rand(1, device="xpu")
-            generator.manual_seed(0)
-
-            # Save the current state of the generator
-            old_state = generator.graphsafe_get_state()
-            # Create and save a cloned state of the generator
-            new_state = generator.clone_state()
-            # Return the original generator and its two states
-            return generator, old_state, new_state
-
-        def register_states_to_graph(generator_state, graph):
-            _, old_state, new_state = generator_state
-            graph.register_generator_state(old_state)
-            graph.register_generator_state(new_state)
-
-        # Define a function to perform specific RNG actions using the generator's states
-        def perform_random_generation_steps(generator_state):
-            generator, old_state, new_state = generator_state
-            random_values = []
-
-            # Generate random numbers with the new generator state
-            generator.graphsafe_set_state(new_state)
-            random_values.append(torch.rand(5, device="xpu", generator=generator))
-
-            # Generate random numbers twice with the old generator state
-            generator.graphsafe_set_state(old_state)
-            random_values.extend(
-                [torch.rand(5, device="xpu", generator=generator) for _ in range(2)]
-            )
-
-            return random_values
-
-        # Define a function to retrieve the final offsets of the original and new generator states
-        def get_final_offsets_of_states(generator_state):
-            _, old_state, new_state = generator_state
-            old_state_offset = old_state.get_offset()
-            new_state_offset = new_state.get_offset()
-            return old_state_offset, new_state_offset
-
-        # Set up and test a new XPU generator
-        generator = torch.Generator(device="xpu")
-        generator_state = create_states(generator)
-
-        # Set up and test the default XPU generator with a XPU Graph
-        g = torch.xpu.XPUGraph()
-        s = torch.xpu.Stream()
-        default_generator = torch.xpu.default_generators[0]
-        default_generator_state = create_states(default_generator)
-        register_states_to_graph(default_generator_state, g)
-
-        # Perform random number generation within a XPU graph
-        with torch.xpu.stream(s):
-            g.capture_begin()
-            graphed_random_values = perform_random_generation_steps(
-                default_generator_state
-            )
-            g.capture_end()
-
-        # Synchronize the streams and replay the graph
-        torch.xpu.current_stream().wait_stream(s)
-        for _ in range(3):
-            random_values = perform_random_generation_steps(generator_state)
-            g.replay()
-            offset = get_final_offsets_of_states(generator_state)
-            graph_offset = get_final_offsets_of_states(default_generator_state)
-
-            # Compare the final offsets of states for both generators to ensure consistency
-            self.assertEqual(offset, graph_offset)
-            # Compare the states generated outside and inside the graph
-            self.assertEqual(random_values, graphed_random_values)
 
     @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
     def test_memory_stats_of_multiple_generators_and_graphs(self):
@@ -1385,23 +1296,6 @@ if __name__ == "__main__":
 
         g.reset()
         del g
-
-    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
-    def test_graph_timing(self):
-        torch.xpu.empty_cache()
-        x = torch.randn(10240000, device="xpu")
-        y = torch.rand_like(x)
-        g = torch.xpu.XPUGraph()
-        start_event = torch.xpu.Event(enable_timing=True, external=True)
-        end_event = torch.xpu.Event(enable_timing=True, external=True)
-        with torch.xpu.graph(g):
-            start_event.record()
-            z = x + y
-            end_event.record()
-        torch.xpu.synchronize()
-        g.replay()
-        torch.xpu.synchronize()
-        self.assertTrue(start_event.elapsed_time(end_event) > 0)
 
     @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
     def test_graph_warn_if_has_zero_nodes(self):
@@ -1530,7 +1424,119 @@ if __name__ == "__main__":
         for op, kwargs in ops_with_kwargs:
             run(op, kwargs)
 
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_graph_rng_distributions(self):
+        size = 10000
+        input = torch.rand((size,), device="xpu", dtype=torch.float)
+        alloc = torch.empty((size,), device="xpu", dtype=torch.float)
 
+        # Torch ops to test with sample args (tuple) and kwargs (dict)
+        torch_with_args = (
+            ("bernoulli", (input.clone(),), {}),
+            ("normal", (input.clone() + 1, 1.0), {}),
+            ("poisson", (input.clone(),), {}),
+            ("rand", (size,), {"device": "xpu", "dtype": torch.float}),
+            ("randint", (0, 3, (size,)), {"device": "xpu", "dtype": torch.float}),
+            ("randn", (size,), {"device": "xpu", "dtype": torch.float}),
+        )
+
+        # Tensor methods to test with sample args (tuple)
+        tensor_with_args = (
+            ("bernoulli_", (input.clone(),)),
+            ("cauchy_", ()),
+            ("exponential_", ()),
+            ("geometric_", (0.3,)),
+            ("log_normal_", ()),
+            ("normal_", ()),
+            ("random_", ()),
+            ("uniform_", ()),
+        )
+
+        def run(module, op, args, kwargs):
+            torch.xpu.manual_seed(5)
+
+            # Each path runs a dummy op to increment the state a bit before creating controls.
+            if module == "torch":
+                dummy = getattr(torch, op)(*args, **kwargs)
+                control1 = getattr(torch, op)(*args, **kwargs)
+                control2 = getattr(torch, op)(*args, **kwargs)
+            else:
+                dummy = alloc.clone()
+                control1 = alloc.clone()
+                control2 = alloc.clone()
+                getattr(dummy, op)(*args)
+                getattr(control1, op)(*args)
+                getattr(control2, op)(*args)
+
+            stream = torch.xpu.Stream()
+            stream.wait_stream(torch.xpu.current_stream())
+            with torch.xpu.stream(stream):
+                torch.xpu.manual_seed(5)
+
+                g = torch.xpu.XPUGraph()
+                torch.xpu.empty_cache()
+                if module == "torch":
+                    g.capture_begin()
+                    t1 = getattr(torch, op)(*args, **kwargs)
+                    t2 = getattr(torch, op)(*args, **kwargs)
+                    g.capture_end()
+                else:
+                    t1 = alloc.clone()
+                    t2 = alloc.clone()
+                    g.capture_begin()
+                    getattr(t1, op)(*args)
+                    getattr(t2, op)(*args)
+                    g.capture_end()
+            torch.xpu.current_stream().wait_stream(stream)
+
+            try:
+                self.assertNotEqual(control1, t1)
+                self.assertNotEqual(control2, t2)
+            except Exception as e:
+                raise RuntimeError("Failed on " + module + "." + op) from e
+
+            # Set a new seed to check if graph would use it
+            for seed in [6, 314, 271]:
+                torch.xpu.manual_seed(seed)
+                # Runs a dummy op prelude, as for controls, to make sure replay()
+                # picks up the dummy op's state increment.
+                if module == "torch":
+                    dummy = getattr(torch, op)(*args, **kwargs)
+                    control1 = getattr(torch, op)(*args, **kwargs)
+                    control2 = getattr(torch, op)(*args, **kwargs)
+                else:
+                    getattr(dummy, op)(*args)
+                    getattr(control1, op)(*args)
+                    getattr(control2, op)(*args)
+
+                torch.xpu.manual_seed(seed)
+                if module == "torch":
+                    dummy = getattr(torch, op)(*args, **kwargs)
+                else:
+                    getattr(dummy, op)(*args)
+
+                t1.copy_(alloc)
+                t2.copy_(alloc)
+
+                # Runs RNG ops that fill t1 and t2.
+                g.replay()
+
+                try:
+                    self.assertEqual(control1, t1)
+                    self.assertEqual(control2, t2)
+                except Exception as e:
+                    raise RuntimeError("Failed on " + module + "." + op) from e
+
+            # We hold references to all tensors used across streams up til this sync,
+            # so no need to call record_stream on those tensors.
+            torch.xpu.synchronize()
+
+        for op_with_args in torch_with_args:
+            run("torch", *op_with_args)
+
+        for meth_with_args in tensor_with_args:
+            # Adds an empty dict for kwargs, which none of the Tensor methods use
+            run("Tensor", *(meth_with_args + ({},)))
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuOps(TestCase):

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1386,6 +1386,24 @@ if __name__ == "__main__":
         g.reset()
         del g
 
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_graph_timing(self):
+        torch.xpu.empty_cache()
+        x = torch.randn(10240000, device="xpu")
+        y = torch.rand_like(x)
+        g = torch.xpu.XPUGraph()
+        start_event = torch.xpu.Event(enable_timing=True, external=True)
+        end_event = torch.xpu.Event(enable_timing=True, external=True)
+        with torch.xpu.graph(g):
+            start_event.record()
+            z = x + y
+            end_event.record()
+        torch.xpu.synchronize()
+        g.replay()
+        torch.xpu.synchronize()
+        self.assertTrue(start_event.elapsed_time(end_event) > 0)
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
     def test_graph_warn_if_has_zero_nodes(self):
         with warnings.catch_warnings(record=True) as caught:
             g = torch.xpu.XPUGraph()
@@ -1396,6 +1414,123 @@ if __name__ == "__main__":
         self.assertTrue(
             any("The XPU Graph is empty" in str(w.message) for w in caught)
         )
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_graph_capture_oom(self):
+        oom_regex = ("out of memory")
+        with self.assertRaisesRegex(RuntimeError, oom_regex):
+            with torch.xpu.graph(torch.xpu.XPUGraph()):
+                torch.zeros(2**40, device="xpu")
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_repeat_graph_capture_oneDNN_memory(self):
+        (x, y, z) = 1024, 512, 64
+        a = torch.rand((x, y), device="xpu")
+        b = torch.rand((y, z), device="xpu")
+
+        # warmup
+        torch.mm(a, b)
+
+        free_bytes_before, total_bytes = torch.xpu.mem_get_info()
+        used_gb_before = (total_bytes - free_bytes_before) / 1e9
+
+        for _ in range(100):
+            torch_graph = torch.xpu.XPUGraph()
+            with torch.xpu.graph(torch_graph):
+                torch.mm(a, b)
+            torch_graph.replay()
+
+        free_bytes_after, _ = torch.xpu.mem_get_info()
+        used_gb_after = (total_bytes - free_bytes_after) / 1e9
+
+        self.assertFalse(used_gb_before + 0.1 < used_gb_after)
+
+    def test_graph_rng_functional(self):
+        ops_with_kwargs = (
+            (torch.nn.functional.dropout, {"p": 0.1}),
+            (torch.nn.functional.rrelu, {"training": True}),
+        )
+        size = 10000
+
+        def run(op, kwargs):
+            a = torch.randn((size,), device="xpu", dtype=torch.float)
+
+            # Control
+            torch.xpu.manual_seed(5)
+            eager_out = a
+            for _ in range(6):
+                eager_out = op(eager_out, **kwargs)
+
+            graph_in = a.clone()
+            stream = torch.xpu.Stream()
+            stream.wait_stream(torch.xpu.current_stream())
+            with torch.xpu.stream(stream):
+                torch.xpu.manual_seed(5)
+
+                g = torch.xpu.XPUGraph()
+                torch.xpu.empty_cache()
+                g.capture_begin()
+                graph_out = graph_in
+                for _ in range(2):
+                    graph_out = op(graph_out, **kwargs)
+                g.capture_end()
+            torch.xpu.current_stream().wait_stream(stream)
+
+            # Runs a graphed->eager->graphed sequence of RNG ops.
+            # replay() plays 2 invocations of the op, so the sequence has 6
+            # invocations total, matching Control.
+            # replay() reads from graph_in and writes to graph_out.
+            g.replay()
+            out = op(graph_out, **kwargs)
+            out = op(out, **kwargs)
+            graph_in.copy_(out)
+            g.replay()
+
+            # If replay() updated RNG state correctly, graph_out
+            # should now hold data equal to eager_out.
+            try:
+                self.assertEqual(eager_out, graph_out)
+            except Exception as e:
+                raise RuntimeError("Failed on ", op) from e
+
+            # Do the same operations varying seeds
+            seeds = [6, 128, 9999]
+
+            for seed in seeds:
+                torch.xpu.manual_seed(seed)
+                graph_in.copy_(a)
+                for _ in range(3):
+                    g.replay()
+
+                # If the random seed was not updated then the graph would
+                # generate the same output as in previous check.
+                try:
+                    self.assertNotEqual(eager_out, graph_out)
+                except Exception as e:
+                    raise RuntimeError("Failed on ", op) from e
+
+                # Now repeat the same operations in non-graphed mode.
+                torch.xpu.manual_seed(seed)
+                for _ in range(3):
+                    eager_out.copy_(a)
+                    eager_out = op(eager_out, **kwargs)
+                    eager_out = op(eager_out, **kwargs)
+
+                # In the end, graph_out and eager_out must be equal
+                # as they went under the same set of operations.
+                try:
+                    self.assertEqual(eager_out, graph_out)
+                except Exception as e:
+                    raise RuntimeError("Failed on ", op) from e
+
+            # We hold references to all tensors used across streams up til this sync,
+            # so no need to call record_stream on those tensors.
+            torch.xpu.synchronize()
+
+        for op, kwargs in ops_with_kwargs:
+            run(op, kwargs)
+
+
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuOps(TestCase):

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1305,13 +1305,11 @@ if __name__ == "__main__":
             with torch.xpu.stream(s):
                 g.capture_begin()
                 g.capture_end()
-        self.assertTrue(
-            any("The XPU Graph is empty" in str(w.message) for w in caught)
-        )
+        self.assertTrue(any("The XPU Graph is empty" in str(w.message) for w in caught))
 
     @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
     def test_graph_capture_oom(self):
-        oom_regex = ("out of memory")
+        oom_regex = "out of memory"
         with self.assertRaisesRegex(RuntimeError, oom_regex):
             with torch.xpu.graph(torch.xpu.XPUGraph()):
                 torch.zeros(2**40, device="xpu")
@@ -1537,6 +1535,7 @@ if __name__ == "__main__":
         for meth_with_args in tensor_with_args:
             # Adds an empty dict for kwargs, which none of the Tensor methods use
             run("Tensor", *(meth_with_args + ({},)))
+
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuOps(TestCase):

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -12,6 +12,7 @@ import tempfile
 import threading
 import time
 import unittest
+import warnings
 
 import torch
 import torch.xpu._gpu_trace as gpu_trace
@@ -42,7 +43,7 @@ TEST_MULTIXPU = torch.xpu.device_count() > 1
 cpu_device = torch.device("cpu")
 xpu_device = torch.device("xpu")
 
-any_common_cpu_xpu_one = OpDTypes.any_common_cpu_cuda_one
+any_common_cpu_xpu_one = OpDTypes.any_common_cpu_xpu_one
 _xpu_computation_op_list = [
     "fill",
     "zeros",
@@ -1164,6 +1165,237 @@ if __name__ == "__main__":
             z[0] = z[0] + 1.0
             self.assertEqual(z, x)
 
+    def test_graph_is_current_stream_capturing(self):
+        self.assertFalse(torch.xpu.is_current_stream_capturing())
+
+        if TEST_XPU:
+            s = torch.xpu.Stream()
+            with torch.xpu.stream(s):
+                g = torch.xpu.XPUGraph()
+                self.assertFalse(torch.xpu.is_current_stream_capturing())
+                g.capture_begin()
+                self.assertTrue(torch.xpu.is_current_stream_capturing())
+                g.capture_end()    
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_graph_capture_simple(self):
+        s = torch.xpu.Stream()
+
+        with torch.xpu.stream(s):
+            a = torch.full((1000,), 1, device="xpu")
+            g = torch.xpu.XPUGraph()
+            torch.xpu.empty_cache()
+            g.capture_begin()
+            b = a
+            for _ in range(10):
+                b = b + 1
+            g.capture_end()
+        torch.xpu.current_stream().wait_stream(s)
+
+        g.replay()
+
+        self.assertEqual(b.sum().item(), 11000.0)
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_graphsafe_set_get_rng_state(self):
+        # Define a function to create generator states, with optional graph registration
+        def create_states(generator):
+            """Initializes generator states and registers them with a XPU graph if provided."""
+            # Ensure the XPU generator is initialized
+            torch.rand(1, device="xpu")
+            generator.manual_seed(0)
+
+            # Save the current state of the generator
+            old_state = generator.graphsafe_get_state()
+            # Create and save a cloned state of the generator
+            new_state = generator.clone_state()
+            # Return the original generator and its two states
+            return generator, old_state, new_state
+
+        def register_states_to_graph(generator_state, graph):
+            _, old_state, new_state = generator_state
+            graph.register_generator_state(old_state)
+            graph.register_generator_state(new_state)
+
+        # Define a function to perform specific RNG actions using the generator's states
+        def perform_random_generation_steps(generator_state):
+            generator, old_state, new_state = generator_state
+            random_values = []
+
+            # Generate random numbers with the new generator state
+            generator.graphsafe_set_state(new_state)
+            random_values.append(torch.rand(5, device="xpu", generator=generator))
+
+            # Generate random numbers twice with the old generator state
+            generator.graphsafe_set_state(old_state)
+            random_values.extend(
+                [torch.rand(5, device="xpu", generator=generator) for _ in range(2)]
+            )
+
+            return random_values
+
+        # Define a function to retrieve the final offsets of the original and new generator states
+        def get_final_offsets_of_states(generator_state):
+            _, old_state, new_state = generator_state
+            old_state_offset = old_state.get_offset()
+            new_state_offset = new_state.get_offset()
+            return old_state_offset, new_state_offset
+
+        # Set up and test a new XPU generator
+        generator = torch.Generator(device="xpu")
+        generator_state = create_states(generator)
+
+        # Set up and test the default XPU generator with a XPU Graph
+        g = torch.xpu.XPUGraph()
+        s = torch.xpu.Stream()
+        default_generator = torch.xpu.default_generators[0]
+        default_generator_state = create_states(default_generator)
+        register_states_to_graph(default_generator_state, g)
+
+        # Perform random number generation within a XPU graph
+        with torch.xpu.stream(s):
+            g.capture_begin()
+            graphed_random_values = perform_random_generation_steps(
+                default_generator_state
+            )
+            g.capture_end()
+
+        # Synchronize the streams and replay the graph
+        torch.xpu.current_stream().wait_stream(s)
+        for _ in range(3):
+            random_values = perform_random_generation_steps(generator_state)
+            g.replay()
+            offset = get_final_offsets_of_states(generator_state)
+            graph_offset = get_final_offsets_of_states(default_generator_state)
+
+            # Compare the final offsets of states for both generators to ensure consistency
+            self.assertEqual(offset, graph_offset)
+            # Compare the states generated outside and inside the graph
+            self.assertEqual(random_values, graphed_random_values)
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_memory_stats_of_multiple_generators_and_graphs(self):
+        # Function to clear XPU cache and collect garbage
+        def clear_xpu_cache():
+            gc.collect()
+            torch.xpu.empty_cache()
+
+        # capture and execute a random number generation within a XPU graph.
+        def simple_graph_task(graph):
+            s = torch.xpu.Stream()
+            with torch.xpu.stream(s):
+                graph.capture_begin()
+                torch.rand(1, device="xpu")
+                graph.capture_end()
+            torch.xpu.current_stream().wait_stream(s)
+            graph.replay()
+
+        def get_memory_stats():
+            stats = torch.xpu.memory_stats()
+            num_blocks = stats["active.all.current"]
+            total_size = stats["active_bytes.all.current"]
+            return num_blocks, total_size
+
+        def test(num_graphs, num_generators):
+            baseline = get_memory_stats()
+            baseline_num_blocks, baseline_total_size = baseline
+
+            # Allocate XPU graphs
+            graphs = [torch.xpu.XPUGraph() for _ in range(num_graphs)]
+
+            # Allocate and manage generator states
+            default_generator = torch.xpu.default_generators[0]
+            generators = [default_generator.graphsafe_get_state()]
+
+            # Starts from 1 as one state is already added
+            for _ in range(1, num_generators):
+                generators.append(default_generator.clone_state())
+
+            for graph in graphs:
+                for generator_state in generators:
+                    graph.register_generator_state(generator_state)
+                simple_graph_task(graph)
+
+            # Assert conditions after graph tasks
+            num_blocks, total_size = get_memory_stats()
+            # The allocated blocks should only be proportional to the number of generators
+            expected_blocks_diff = 2 * num_generators
+            expected_size_diff = 2 * 512 * num_generators  # Each block's size is 512
+
+            self.assertEqual(
+                (num_blocks - baseline_num_blocks),
+                expected_blocks_diff,
+                "Unexpected number of active blocks.",
+            )
+            self.assertEqual(
+                (total_size - baseline_total_size),
+                expected_size_diff,
+                "Unexpected total memory size.",
+            )
+
+            # Cleanup graphs and clear XPU cache
+            while graphs:
+                graph = graphs.pop()
+                del graph
+            clear_xpu_cache()
+
+            # Assert that memory stats return to baseline after cleanup
+            self.assertEqual(
+                get_memory_stats(),
+                baseline,
+                "Memory stats do not match baseline after cleanup.",
+            )
+
+        # Running the test function with different parameters
+        test(1, 1)
+        test(3, 2)
+        test(10, 20)
+
+    @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
+    def test_graph_capture_reset_recapture(self):
+        s = torch.xpu.Stream()
+
+        with torch.xpu.stream(s):
+            a = torch.full((1000,), 1, device="xpu")
+            g = torch.xpu.XPUGraph()
+            torch.xpu.empty_cache()
+            g.capture_begin()
+            b = a
+            for _ in range(10):
+                b = b + 1
+            g.capture_end()
+        torch.xpu.current_stream().wait_stream(s)
+
+        g.replay()
+
+        self.assertEqual(b.sum().item(), 11000.0)
+
+        g.reset()
+
+        with torch.xpu.stream(s):
+            g.capture_begin()
+            b.fill_(2.0)
+            for _ in range(10):
+                b = b + 2
+            g.capture_end()
+        torch.xpu.current_stream().wait_stream(s)
+
+        g.replay()
+        self.assertEqual(b.sum().item(), 22000.0)
+
+        g.reset()
+        del g
+
+    def test_graph_warn_if_has_zero_nodes(self):
+        with warnings.catch_warnings(record=True) as caught:
+            g = torch.xpu.XPUGraph()
+            s = torch.xpu.Stream()
+            with torch.xpu.stream(s):
+                g.capture_begin()
+                g.capture_end()
+        self.assertTrue(
+            any("The XPU Graph is empty" in str(w.message) for w in caught)
+        )
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuOps(TestCase):

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -11,11 +11,7 @@ import threading
 import traceback
 from collections.abc import Callable
 from functools import lru_cache
-<<<<<<< HEAD
-from typing import Any, Optional
-=======
-from typing import Any, NewType, Optional, Union
->>>>>>> 5b3b93c1d59 ([XPU] Implement XPUGraph capture and replay)
+from typing import Any, NewType, Optional
 
 import torch
 import torch._C

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -11,7 +11,11 @@ import threading
 import traceback
 from collections.abc import Callable
 from functools import lru_cache
+<<<<<<< HEAD
 from typing import Any, Optional
+=======
+from typing import Any, NewType, Optional, Union
+>>>>>>> 5b3b93c1d59 ([XPU] Implement XPUGraph capture and replay)
 
 import torch
 import torch._C
@@ -19,6 +23,7 @@ from torch._utils import _dummy_type, _LazySeedTracker
 from torch.types import Device
 
 from ._utils import _get_device_index
+from .graphs import graph, XPUGraph
 from .streams import Event, Stream
 
 
@@ -548,11 +553,13 @@ from .random import (
 )
 
 
+_POOL_HANDLE = NewType("_POOL_HANDLE", tuple[int, int])
 __all__ = [
     "Event",
     "Stream",
     "StreamContext",
     "XPUPluggableAllocator",
+    "XPUGraph",
     "can_device_access_peer",
     "change_current_allocator",
     "current_device",
@@ -571,6 +578,7 @@ __all__ = [
     "get_rng_state",
     "get_rng_state_all",
     "get_stream_from_external",
+    "graph",
     "init",
     "initial_seed",
     "is_available",

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -19,7 +19,13 @@ from torch._utils import _dummy_type, _LazySeedTracker
 from torch.types import Device
 
 from ._utils import _get_device_index
-from .graphs import graph, XPUGraph
+from .graphs import (
+    XPUGraph,
+    graph,
+    graph_pool_handle,
+    is_current_stream_capturing,
+    make_graphed_callables,
+)
 from .streams import Event, Stream
 
 
@@ -579,8 +585,10 @@ __all__ = [
     "initial_seed",
     "is_available",
     "is_bf16_supported",
+    "is_current_stream_capturing",
     "is_initialized",
     "is_tf32_supported",
+    "make_graphed_callables",
     "manual_seed",
     "manual_seed_all",
     "max_memory_allocated",

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -13,7 +13,7 @@ from .._utils import _dummy_type
 
 __all__ = [
     "graph_pool_handle",
-    "CUDAGraph",
+    "XPUGraph",
     "graph",
 ]
 

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -21,18 +21,18 @@ __all__ = [
 if not hasattr(torch._C, "_XpuStreamBase"):
     # Define dummy base classes
     torch._C.__dict__["_XPUGraph"] = _dummy_type("_XPUGraph")
-    torch._C.__dict__["_graph_pool_handle"] = _dummy_type("_graph_pool_handle")
+    torch._C.__dict__["_xpu_graph_pool_handle"] = _dummy_type("_xpu_graph_pool_handle")
 
 from torch._C import (  # noqa: F401
     _XPUGraph,
-    _graph_pool_handle,
+    _xpu_graph_pool_handle,
 )
 
 def graph_pool_handle() -> _POOL_HANDLE:
     r"""Return an opaque token representing the id of a graph memory pool.
 
     """
-    return torch.xpu._POOL_HANDLE(_graph_pool_handle())
+    return torch.xpu._POOL_HANDLE(_xpu_graph_pool_handle())
 
 class XPUGraph(torch._C._XPUGraph):
     r"""Wrapper around a XPU graph.

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -92,6 +92,41 @@ class XPUGraph(torch._C._XPUGraph):
         r"""Delete the graph currently held by this instance."""
         super().reset()
 
+    def pool(self) -> _POOL_HANDLE:
+        r"""Return an opaque token representing the id of this graph's memory pool.
+
+        This id can optionally be passed to another graph's ``capture_begin``,
+        which hints the other graph may share the same memory pool.
+        """
+        return super().pool()
+
+    def enable_debug_mode(self) -> None:
+        r"""Enable debugging mode for XPUGraph.debug_dump."""
+        return super().enable_debug_mode()
+
+    def debug_dump(self, debug_path: str) -> None:
+        r"""
+        Arguments:
+            debug_path (required): Path to dump the graph to.
+
+        Calls a debugging function to dump the graph if the debugging is
+        enabled via XPUGraph.enable_debug_mode()
+        """
+        return super().debug_dump(debug_path)
+
+    def raw_xpu_graph(self) -> int:
+        r"""Returns the underlying xpuGraph_t. ``keep_graph`` must be True.
+
+        XPU doesn't provide APIs to manipulate this object.
+        """  # noqa: B950
+        return super().raw_xpu_graph()
+
+    def raw_xpu_graph_exec(self) -> int:
+        r"""Returns the underlying xpuGraphExec_t. ``instantiate`` must have been called if ``keep_graph`` is True, or ``capture_end`` must have been called if ``keep_graph`` is False. If you call ``instantiate()`` after ``raw_xpu_graph_exec()``, the previously returned xpuGraphExec_t will be destroyed. It is your responsibility not to use this object after destruction.
+
+        XPU doesn't provide APIs to manipulate this object.
+        """  # noqa: B950
+        return super().raw_xpu_graph_exec()
 
 class graph:
     r"""Context-manager that captures XPU work into a :class:`torch.xpu.XPUGraph` object for later replay.

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -56,7 +56,7 @@ class XPUGraph(torch._C._XPUGraph):
 
     def capture_begin(
         self, pool: Optional[_POOL_HANDLE] = None) -> None:
-        r"""Begin capturing XPU work on the current sycl queue.
+        r"""Begin capturing XPU work on the current xpu stream.
 
         Typically, you shouldn't call ``capture_begin`` yourself.
         Use :class:`~torch.xpu.graph`, which call ``capture_begin`` internally.

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Optional, overload, TYPE_CHECKING, TypeAlias, Union
+from typing_extensions import ParamSpec, Self, TypeVar
+
+import torch
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from torch.xpu import _POOL_HANDLE
+
+from .._utils import _dummy_type
+
+__all__ = [
+    "graph_pool_handle",
+    "CUDAGraph",
+    "graph",
+]
+
+
+if not hasattr(torch._C, "_XpuStreamBase"):
+    # Define dummy base classes
+    torch._C.__dict__["_XPUGraph"] = _dummy_type("_XPUGraph")
+    torch._C.__dict__["_graph_pool_handle"] = _dummy_type("_graph_pool_handle")
+
+from torch._C import (  # noqa: F401
+    _XPUGraph,
+    _graph_pool_handle,
+)
+
+def graph_pool_handle() -> _POOL_HANDLE:
+    r"""Return an opaque token representing the id of a graph memory pool.
+
+    """
+    return torch.xpu._POOL_HANDLE(_graph_pool_handle())
+
+class XPUGraph(torch._C._XPUGraph):
+    r"""Wrapper around a XPU graph.
+
+    Arguments:
+        keep_graph (bool, optional): If ``keep_graph=False``, the
+            executable command graph will be instantiated on GPU at the end of
+            ``capture_end`` and the underlying modifiable command graph will be
+            destroyed. Note that the executable command graph will not be
+            instantiated at the end of ``capture_end`` in this
+            case. Instead, it will be instantiated via an explicit called
+            to ``instantiate`` or automatically on the first call to
+            ``replay`` if ``instantiate`` was not already called. Calling
+            ``instantiate`` manually before ``replay`` is recommended to
+            prevent increased latency on the first call to ``replay``.
+
+    """
+
+    def __new__(cls, keep_graph: bool = False) -> Self:
+        return super().__new__(cls, keep_graph)
+
+    def capture_begin(
+        self, pool: Optional[_POOL_HANDLE] = None) -> None:
+        r"""Begin capturing XPU work on the current sycl queue.
+
+        Typically, you shouldn't call ``capture_begin`` yourself.
+        Use :class:`~torch.xpu.graph`, which call ``capture_begin`` internally.
+
+        Arguments:
+            pool (optional): Token (returned by :func:`~torch.xpu.graph_pool_handle` or
+                :meth:`other_Graph_instance.pool()<torch.xpu.XPUGraph.pool>`) that hints this graph may share memory
+                with the indicated pool.
+        """
+        super().capture_begin(pool=pool)
+
+    def capture_end(self) -> None:
+        r"""End XPU graph capture on the current stream.
+
+        After ``capture_end``, ``replay`` may be called on this instance.
+
+        Typically, you shouldn't call ``capture_end`` yourself.
+        Use :class:`~torch.xpu.graph`, which call ``capture_end`` internally.
+        """
+        super().capture_end()
+
+    def instantiate(self) -> None:
+        r"""Instantiate the XPU graph. Will be called by
+        ``capture_end`` if ``keep_graph=False``, or by ``replay`` if
+        ``keep_graph=True`` and ``instantiate`` has not already been
+        explicitly called. Does not destroy the xpu modify command graph returned
+        by ``raw_xpu_graph``.
+        """
+        super().instantiate()
+
+    def replay(self) -> None:
+        r"""Replay the XPU work captured by this graph."""
+        super().replay()
+
+    def reset(self) -> None:
+        r"""Delete the graph currently held by this instance."""
+        super().reset()
+
+class graph:
+    r"""Context-manager that captures XPU work into a :class:`torch.xpu.XPUGraph` object for later replay.
+
+    Arguments:
+        xpu_graph (torch.xpu.XPUGraph): Graph object used for capture.
+        pool (optional): Opaque token (returned by a call to :func:`~torch.xpu.graph_pool_handle()` or
+            :meth:`other_Graph_instance.pool()<torch.xpu.XPUGraph.pool>`) hinting this graph's capture
+            may share memory from the specified pool.
+        stream (torch.xpu.Stream, optional): If supplied, will be set as the current stream in the context.
+            If not supplied, ``graph`` sets its own internal side stream as the current stream in the context.
+
+    .. note::
+        For effective memory sharing, if you pass a ``pool`` used by a previous capture and the previous capture
+        used an explicit ``stream`` argument, you should pass the same ``stream`` argument to this capture.
+
+    """  # noqa: B950
+
+    default_capture_stream: Optional[torch.xpu.Stream] = None
+
+    def __init__(
+        self,
+        xpu_graph: XPUGraph,
+        pool: Optional[_POOL_HANDLE] = None,
+        stream: Optional[torch.xpu.Stream] = None,
+    ):
+        # Lazy-init of default_capture_stream helps avoid circular-import errors.
+        # Not thread safe, but graphs already have the general (explicitly documented)
+        # restriction that only one capture may be underway at a time in the process.
+        if self.__class__.default_capture_stream is None:
+            self.__class__.default_capture_stream = torch.xpu.Stream()
+
+        self.pool: Union[tuple[()], tuple[_POOL_HANDLE]] = (
+            () if pool is None else (pool,)
+        )
+        self.capture_stream = (
+            stream if stream is not None else self.__class__.default_capture_stream
+        )
+        assert self.capture_stream is not None
+        self.stream_ctx = torch.xpu.stream(self.capture_stream)
+        self.xpu_graph = xpu_graph
+
+    def __enter__(self) -> None:
+        # Free as much memory as we can for the graph
+        torch.xpu.synchronize()
+
+        torch.xpu.empty_cache()
+        self.stream_ctx.__enter__()
+
+        self.xpu_graph.capture_begin(*self.pool)
+
+    def __exit__(self, *args: object) -> None:
+        self.xpu_graph.capture_end()
+        self.stream_ctx.__exit__(*args)

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -13,19 +13,40 @@ from .._utils import _dummy_type
 
 
 __all__ = [
+    "is_current_stream_capturing",
     "graph_pool_handle",
     "XPUGraph",
     "graph",
 ]
 
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 if not hasattr(torch._C, "_XpuStreamBase"):
     # Define dummy base classes
     torch._C.__dict__["_XPUGraph"] = _dummy_type("_XPUGraph")
     torch._C.__dict__["_xpu_graph_pool_handle"] = _dummy_type("_xpu_graph_pool_handle")
+    torch._C.__dict__["_xpu_isCurrentStreamCapturing"] = _dummy_type(
+        "_xpu_isCurrentStreamCapturing"
+    )
 
+<<<<<<< HEAD
 from torch._C import _xpu_graph_pool_handle, _XPUGraph  # noqa: F401
 
+=======
+from torch._C import (  # noqa: F401
+    _xpu_isCurrentStreamCapturing,
+    _XPUGraph,
+    _xpu_graph_pool_handle,
+)
+>>>>>>> 59a95865977 ([XPU] Add XPUGraph make_graphed_callables feature)
+
+def is_current_stream_capturing() -> bool:
+    r"""Return True if XPU graph capture is underway on the current XPU stream, False otherwise.
+
+    If a XPU context does not exist on the current device, returns False without initializing the context.
+    """
+    return _xpu_isCurrentStreamCapturing()
 
 def graph_pool_handle() -> _POOL_HANDLE:
     r"""Return an opaque token representing the id of a graph memory pool."""
@@ -182,3 +203,323 @@ class graph:
     def __exit__(self, *args: object) -> None:
         self.xpu_graph.capture_end()
         self.stream_ctx.__exit__(*args)
+
+_ModuleOrCallable: TypeAlias = Union["torch.nn.Module", Callable[..., object]]
+
+
+@overload
+def make_graphed_callables(
+    callables: _ModuleOrCallable,
+    sample_args: tuple[Tensor, ...],
+    num_warmup_iters: int = 3,
+    allow_unused_input: bool = False,
+    pool: Optional[_POOL_HANDLE] = None,
+) -> _ModuleOrCallable: ...
+
+
+@overload
+def make_graphed_callables(
+    callables: tuple[_ModuleOrCallable, ...],
+    sample_args: tuple[tuple[Tensor, ...], ...],
+    num_warmup_iters: int = 3,
+    allow_unused_input: bool = False,
+    pool: Optional[_POOL_HANDLE] = None,
+) -> tuple[_ModuleOrCallable, ...]: ...
+
+
+def make_graphed_callables(
+    callables: Union[_ModuleOrCallable, tuple[_ModuleOrCallable, ...]],
+    sample_args: Union[tuple[Tensor, ...], tuple[tuple[Tensor, ...], ...]],
+    num_warmup_iters: int = 3,
+    allow_unused_input: bool = False,
+    pool: Optional[_POOL_HANDLE] = None,
+) -> Union[_ModuleOrCallable, tuple[_ModuleOrCallable, ...]]:
+    r"""Accept callables (functions or :class:`nn.Module<torch.nn.Module>`\ s) and returns graphed versions.
+
+    Each graphed callable's forward pass runs its source callable's
+    forward XPU work as a XPU graph inside a single autograd node.
+
+    The graphed callable's forward pass also appends
+    a backward node to the autograd graph. During backward, this node runs the
+    callable's backward work as a XPU graph.
+
+    Therefore, each graphed callable should be a drop-in replacement for its source callable
+    in an autograd-enabled training loop.
+
+    See :ref:`Partial-network capture<partial-network-capture>` for detailed use and constraints.
+
+    If you pass a tuple of several callables, their captures will use the same memory pool.
+
+    Arguments:
+        callables (torch.nn.Module or Python function, or tuple of these): Callable or callables to graph.
+            If you pass a tuple of callables, their order in the tuple must be the same order they'll run
+            in the live workload.
+        sample_args (tuple of Tensors, or tuple of tuples of Tensors): Samples args for each callable.
+            If a single callable was passed, ``sample_args`` must be a single tuple of argument Tensors.
+            If a tuple of callables was passed, ``sample_args`` must be tuple of tuples of argument Tensors.
+        num_warmup_iters (int): The number of warmup iterations. Currently, ``DataDistributedParallel`` needs
+            11 iterations for warm up. Default: ``3``.
+        allow_unused_input (bool): If False, specifying inputs that were not used when computing outputs
+            (and therefore their grad is always zero) is an error. Defaults to False.
+        pool (optional): Token (returned by :func:`~torch.xpu.graph_pool_handle` or
+            :meth:`other_Graph_instance.pool()<torch.xpu.XPUGraph.pool>`) that hints this graph may share memory
+            with the indicated pool.
+    .. note::
+        The ``requires_grad`` state of each Tensor in ``sample_args`` must match the state
+        that's expected for the corresponding real input in the training loop.
+
+    .. warning::
+        This API is in beta and may change in future releases.
+
+    .. warning::
+        ``sample_args`` for each callable must contain only Tensors. Other types are not allowed.
+
+    .. warning::
+        Returned callables do not support higher order differentiation (e.g., double backward).
+
+    .. warning::
+        In any :class:`~torch.nn.Module` passed to :func:`~make_graphed_callables`, only parameters
+        may be trainable. Buffers must have ``requires_grad=False``.
+
+    .. warning::
+        After you pass a :class:`torch.nn.Module` through :func:`~make_graphed_callables`,
+        you may not add or remove any of that Module's parameters or buffers.
+
+    .. warning::
+        :class:`torch.nn.Module`\s passed to :func:`~torch.xpu.make_graphed_callables` must not have module hooks
+        registered on them at the time they are passed. However, registering hooks on modules *after* passing them
+        through :func:`~torch.xpu.make_graphed_callables` is allowed.
+
+    .. warning::
+        When running a graphed callable, you must pass its arguments in the same order and format
+        they appeared in that callable's ``sample_args``.
+
+    .. warning::
+        The automatic mixed precision is supported in :func:`~torch.xpu.make_graphed_callables` only with disabled
+        caching. The context manager `torch.amp.autocast()` must have `cache_enabled=False`.
+    """
+    if torch.is_autocast_enabled() and torch.is_autocast_cache_enabled():
+        raise RuntimeError(
+            "make_graphed_callables does not support the autocast caching. Please set `cache_enabled=False`."
+        )
+
+    just_one_callable = False
+
+    _sample_args: tuple[tuple[Tensor, ...], ...]
+    if not isinstance(callables, tuple):
+        just_one_callable = True
+        callables = (callables,)
+        _sample_args = (typing.cast(tuple[Tensor, ...], sample_args),)
+    else:
+        _sample_args = typing.cast(tuple[tuple[Tensor, ...], ...], sample_args)
+
+    flatten_sample_args = []
+
+    for c, args in zip(callables, _sample_args):
+        if isinstance(c, torch.nn.Module):
+            assert (
+                len(c._backward_hooks) == 0
+                and len(c._forward_hooks) == 0
+                and len(c._forward_pre_hooks) == 0
+            ), (
+                "Modules must not have hooks registered at the time they are passed. However, registering hooks "
+                + "on modules after passing them through make_graphed_callables is allowed."
+            )
+            assert all(b.requires_grad is False for b in c.buffers()), (
+                "In any :class:`~torch.nn.Module` passed to "
+                + ":func:`~make_graphed_callables`, only parameters may be trainable. All buffers must have "
+                + "``requires_grad=False``."
+            )
+        flatten_arg = torch.utils._pytree.arg_tree_leaves(*args)
+        flatten_sample_args.append(tuple(flatten_arg))
+        assert all(isinstance(arg, torch.Tensor) for arg in flatten_arg), (
+            "In the beta API, sample_args "
+            + "for each callable must contain only Tensors. Other types are not allowed."
+        )
+
+    # If a callable is an nn.Module, its graph's full input surface is the args the user explicitly
+    # passes to forward (ie, its sample_args) AND the module's parameter attributes.
+    per_callable_len_user_args = [len(args) for args in flatten_sample_args]
+    per_callable_module_params = [
+        tuple(c.parameters()) if isinstance(c, torch.nn.Module) else ()
+        for c in callables
+    ]
+    per_callable_static_input_surfaces = [
+        flatten_sample_args[i] + per_callable_module_params[i]
+        for i in range(len(callables))
+    ]
+
+    fwd_graphs = [torch.xpu.XPUGraph() for _ in range(len(callables))]
+    bwd_graphs = [torch.xpu.XPUGraph() for _ in range(len(callables))]
+
+    mempool = graph_pool_handle() if pool is None else pool
+
+    # Warmup
+    torch.xpu.synchronize()
+    with torch.xpu.stream(torch.xpu.Stream()):
+        for func, args, static_input_surface in zip(
+            callables, _sample_args, per_callable_static_input_surfaces
+        ):
+            grad_inputs, outputs, outputs_grad = None, None, None
+            for _ in range(num_warmup_iters):
+                outputs = torch.utils._pytree.tree_leaves(func(*args))
+                outputs_grad = tuple(o for o in outputs if o.requires_grad)
+                if len(outputs_grad) > 0:
+                    grad_inputs = torch.autograd.grad(
+                        outputs=outputs_grad,
+                        inputs=tuple(
+                            i for i in static_input_surface if i.requires_grad
+                        ),
+                        grad_outputs=tuple(
+                            torch.empty_like(o) for o in outputs if o.requires_grad
+                        ),
+                        only_inputs=True,
+                        allow_unused=allow_unused_input,
+                    )
+            for v in [outputs, outputs_grad, grad_inputs]:
+                del v
+
+    torch.xpu.synchronize()
+
+    # Capture forward graphs
+    per_callable_static_outputs = []
+    per_callable_output_unflatten_spec = []
+    for func, args, fwd_graph in zip(callables, _sample_args, fwd_graphs):
+        # each graph uses the same mempool
+        with torch.xpu.graph(fwd_graph, pool=mempool):
+            func_outputs = func(*args)
+
+        flatten_outputs, spec = torch.utils._pytree.tree_flatten(func_outputs)
+        per_callable_static_outputs.append(tuple(flatten_outputs))
+        per_callable_output_unflatten_spec.append(spec)
+
+    # Capture backward graphs in reverse order
+    per_callable_static_grad_outputs = []
+    per_callable_static_grad_inputs = []
+    for static_input_surface, static_outputs, bwd_graph in zip(
+        reversed(per_callable_static_input_surfaces),
+        reversed(per_callable_static_outputs),
+        reversed(bwd_graphs),
+    ):
+        static_grad_outputs = tuple(
+            torch.empty_like(o) if o.requires_grad else None for o in static_outputs
+        )
+
+        outputs_grad = tuple(o for o in static_outputs if o.requires_grad)
+        grad_inputs = None
+        if len(outputs_grad) > 0:
+            with torch.xpu.graph(bwd_graph, pool=mempool):
+                grad_inputs = torch.autograd.grad(
+                    outputs=outputs_grad,
+                    inputs=tuple(i for i in static_input_surface if i.requires_grad),
+                    grad_outputs=tuple(o for o in static_grad_outputs if o is not None),
+                    only_inputs=True,
+                    allow_unused=allow_unused_input,
+                )
+
+        static_grad_inputs = []
+        grad_idx = 0
+        for arg in static_input_surface:
+            if arg.requires_grad and grad_inputs is not None:
+                static_grad_inputs.append(grad_inputs[grad_idx])
+                grad_idx += 1
+            else:
+                static_grad_inputs.append(None)  # type: ignore[arg-type]
+        static_grad_inputs = tuple(static_grad_inputs)  # type: ignore[assignment]
+
+        per_callable_static_grad_outputs.append(static_grad_outputs)
+        per_callable_static_grad_inputs.append(static_grad_inputs)
+
+    # Reverses the most recent two lists
+    per_callable_static_grad_outputs.reverse()
+    per_callable_static_grad_inputs.reverse()
+
+    def make_graphed_autograd_function(
+        fwd_graph: XPUGraph,
+        bwd_graph: XPUGraph,
+        module_params: tuple[torch.nn.Parameter, ...],
+        len_user_args: int,
+        output_unflatten_spec: torch.utils._pytree.TreeSpec,
+        static_input_surface: tuple[Tensor, ...],
+        static_outputs: tuple[Tensor, ...],
+        static_grad_outputs: tuple[Optional[Tensor], ...],
+        static_grad_inputs: tuple[Tensor, ...],
+    ) -> Callable[..., object]:
+        class Graphed(torch.autograd.Function):
+            @staticmethod
+            # pyrefly: ignore [bad-override]
+            def forward(ctx: object, *inputs: Tensor) -> tuple[Tensor, ...]:
+                # At this stage, only the user args may (potentially) be new tensors.
+                for i in range(len_user_args):
+                    if static_input_surface[i].data_ptr() != inputs[i].data_ptr():
+                        static_input_surface[i].copy_(inputs[i])
+                fwd_graph.replay()
+                assert isinstance(static_outputs, tuple)
+                return tuple(o.detach() for o in static_outputs)
+
+            @staticmethod
+            @torch.autograd.function.once_differentiable
+            # pyrefly: ignore [bad-override]
+            def backward(ctx: object, *grads: Tensor) -> tuple[Tensor, ...]:
+                assert len(grads) == len(static_grad_outputs)
+                for g, grad in zip(static_grad_outputs, grads):
+                    if g is not None:
+                        if g.data_ptr() != grad.data_ptr():
+                            g.copy_(grad)
+                bwd_graph.replay()
+
+                assert isinstance(static_grad_inputs, tuple)
+                return tuple(
+                    # pyrefly: ignore [bad-argument-type]
+                    b.detach() if b is not None else b
+                    for b in static_grad_inputs
+                )
+
+        def functionalized(*user_args: object) -> object:
+            # Runs the new autograd function which replays the XPU graphs
+            flatten_user_args = torch.utils._pytree.arg_tree_leaves(*user_args)
+            out = Graphed.apply(*(tuple(flatten_user_args) + module_params))
+            return torch.utils._pytree.tree_unflatten(out, output_unflatten_spec)
+
+        return functionalized
+
+    ret: list[_ModuleOrCallable] = []
+    for i, func in enumerate(callables):
+        graphed = make_graphed_autograd_function(
+            fwd_graphs[i],
+            bwd_graphs[i],
+            per_callable_module_params[i],
+            per_callable_len_user_args[i],
+            per_callable_output_unflatten_spec[i],
+            per_callable_static_input_surfaces[i],
+            per_callable_static_outputs[i],
+            per_callable_static_grad_outputs[i],
+            per_callable_static_grad_inputs[i],
+        )
+
+        if isinstance(func, torch.nn.Module):
+
+            def make_graphed_forward(
+                func: torch.nn.Module,
+                graph_training_state: bool,
+                graphed: Callable[_P, _R],
+                orig_fwd: Callable[_P, _R],
+            ) -> Callable[_P, _R]:
+                def new_fwd(*user_args: _P.args, **user_kwargs: _P.kwargs) -> _R:
+                    if func.training == graph_training_state:
+                        return graphed(*user_args, **user_kwargs)
+                    else:
+                        return orig_fwd(*user_args, **user_kwargs)
+                return new_fwd
+
+            func.forward = make_graphed_forward(
+                func, func.training, graphed, func.forward
+            )
+            ret.append(func)
+        else:
+            ret.append(graphed)
+
+    if just_one_callable:
+        return ret[0]
+
+    return tuple(ret)

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -30,16 +30,8 @@ if not hasattr(torch._C, "_XpuStreamBase"):
         "_xpu_isCurrentStreamCapturing"
     )
 
-<<<<<<< HEAD
 from torch._C import _xpu_graph_pool_handle, _XPUGraph  # noqa: F401
 
-=======
-from torch._C import (  # noqa: F401
-    _xpu_isCurrentStreamCapturing,
-    _XPUGraph,
-    _xpu_graph_pool_handle,
-)
->>>>>>> 59a95865977 ([XPU] Add XPUGraph make_graphed_callables feature)
 
 def is_current_stream_capturing() -> bool:
     r"""Return True if XPU graph capture is underway on the current XPU stream, False otherwise.


### PR DESCRIPTION
XPUGraph PR submission plan, following this [RFC](https://github.com/pytorch/pytorch/issues/162143).

- [x] 1, enhance XPUGenerator to cover XPUGeneratorState and philoxState
- [x] 2, the implementation of MemPool in XPU device allocator
- [x] 3, the implementations of capture_begin/capture_end/instantiate for XPUGraph
- [x] 4, the implementations of replay/debug_dump/reset for XPUGraph, XPUGraph python APIs: graph_pool_handle/graph
- [ ] 5, XPUGraph python APIs: capture/replay
- [ ] ->6, Add XPUGraph make_graphed_callables feature
