### PR TITLE
[inductor] Fix Conv1d stride mismatch with non-contiguous input (#158930)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4799,6 +4799,20 @@ class CommonTemplate:
 
         self.common(ConvModel(), (torch.randn([32, 100, 1]),), check_lowp=False)
 
+    def test_conv1d_grouped_with_transpose(self):
+        # fix https://github.com/pytorch/pytorch/issues/158930
+        class TransposeConv(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv1d(1024, 1024, kernel_size=3, groups=1024, padding=2)
+
+            def forward(self, x):
+                x = x.transpose(1, 2)
+                x = self.conv(x)[..., :1]
+                return x
+
+        self.common(TransposeConv(), (torch.randn([32, 1, 1024]),), check_lowp=False)
+
     def test_conv1d_depthwise(self):
         class ConvModel(nn.Module):
             def __init__(self):


### PR DESCRIPTION
Fixes #158930

## Summary
Fix `torch.compile` stride assertion failure when a transpose operation precedes a grouped Conv1d.

## Problem
When compiling a model with `transpose` followed by grouped `Conv1d`:
```
x = x.transpose(1, 2)
x = self.conv(x) # Conv1d with groups=1024
```

## Root Cause
In `conv_layout`, the fake mode convolution's `output.stride()` incorrectly preserves the non-contiguous input strides in the output layout. However, ATen Conv1d always produces contiguous output regardless of input strides.

## Fix
For Conv1d (`ndim == 1`), explicitly use contiguous strides instead of relying on `output.stride()` from fake mode. Conv2d/Conv3d retain the existing behavior to support channels-last memory formats.

## Test Plan
Verified all compile modes pass with the fix:
- `default` ✅
- `reduce-overhead` ✅  
- `max-autotune` ✅
- `max-autotune-no-cudagraphs` ✅

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @desertfire @jansel