### PR TITLE
[Perf] Remove redundant copy in `evaluate_function` for Autograd

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1092,7 +1092,7 @@ void Engine::evaluate_function(
   auto& exec_info_ = graph_task->exec_info_;
   if (!exec_info_.empty()) {
     auto& fn_info = exec_info_.at(func);
-    const variable_list* inputs_for_captures = &inputs.buffer;
+    variable_list& inputs_for_captures = &inputs.buffer;
     variable_list new_inputs;
     if (!fn_info.needed_) {
       // We always want to call tensor pre-hooks, but want to avoid calling it

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1110,7 +1110,7 @@ void Engine::evaluate_function(
       std::lock_guard<std::mutex> lock(graph_task->mutex_);
       for (const auto& capture : *capture_vec) {
         auto& captured_grad = graph_task->captured_vars_[capture.output_idx_];
-        captured_grad = (*inputs_for_captures)[capture.input_idx_];
+        captured_grad = inputs_for_captures[capture.input_idx_];
         // NOTE [Deprecated capture hooks]
         for (const auto& hook :
              capture.DO_NOT_USE_DEPRECATED_get_capture_hooks()) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1092,7 +1092,8 @@ void Engine::evaluate_function(
   auto& exec_info_ = graph_task->exec_info_;
   if (!exec_info_.empty()) {
     auto& fn_info = exec_info_.at(func);
-    variable_list new_inputs = inputs.buffer;
+    const variable_list* inputs_for_captures = &inputs.buffer;
+    variable_list new_inputs;
     if (!fn_info.needed_) {
       // We always want to call tensor pre-hooks, but want to avoid calling it
       // twice. needed_ = True indicates that we will call tensor pre-hooks
@@ -1101,6 +1102,7 @@ void Engine::evaluate_function(
       // See NOTE [Hooks ordering] for more context.
       new_inputs = call_tensor_pre_hooks(
           *func, InputBuffer::variables(std::move(inputs)));
+      inputs_for_captures = &new_inputs;
     }
     if (auto* capture_vec = fn_info.captures_.get()) {
       auto opt_parent_stream = (*func).stream();
@@ -1108,7 +1110,7 @@ void Engine::evaluate_function(
       std::lock_guard<std::mutex> lock(graph_task->mutex_);
       for (const auto& capture : *capture_vec) {
         auto& captured_grad = graph_task->captured_vars_[capture.output_idx_];
-        captured_grad = new_inputs[capture.input_idx_];
+        captured_grad = (*inputs_for_captures)[capture.input_idx_];
         // NOTE [Deprecated capture hooks]
         for (const auto& hook :
              capture.DO_NOT_USE_DEPRECATED_get_capture_hooks()) {


### PR DESCRIPTION
`variable_list new_inputs = inputs.buffer;`

This will do a copy anyway, which could be optimized using pointer, this PR fixes the issue.