### PR TITLE
[Perf] Optimize `getActiveCallbacksImpl` to return earlier if no callbacks available

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -282,6 +282,10 @@ void CacheEntry::update(const std::vector<RecordFunctionCallback>& callbacks) {
 }
 
 void CacheEntry::getActiveCallbacksImpl() {
+  // skip if no callbacks registered for this scope.
+  if (C10_LIKELY(callbacks_.empty())) {
+    return;
+  }
   // We rebuild the active set when `sampling_countdown_` reaches zero, so if it
   // reaches zero at the start of this function something has gone wrong.
   TORCH_INTERNAL_ASSERT(sampling_countdown_ > 0, sampling_countdown_);


### PR DESCRIPTION
`getStepCallbacksUnlessEmpty` will be called each time in op dispatch, which eventually calls `getActiveCallbacksImpl`

If no callbacks available, we will still go through the counting down logic

```C++
  // We rebuild the active set when `sampling_countdown_` reaches zero, so if it
  // reaches zero at the start of this function something has gone wrong.
  TORCH_INTERNAL_ASSERT(sampling_countdown_ > 0, sampling_countdown_);

  if (C10_UNLIKELY(!(--sampling_countdown_))) {
    // Use inferred steps to update sampled callbacks.
    for (auto& i : callbacks_) {
      if (i.tries_left_ > 0) {
        TORCH_INTERNAL_ASSERT(i.tries_left_ >= steps_for_this_update_);
        i.tries_left_ -= steps_for_this_update_;
      }
    }

    // Determine which callbacks to run and for how long.
    rebuildActiveCallbacks();

    // Resample any sampled callbacks that ran this call.
    for (auto& i : callbacks_) {
      if (!i.tries_left_) {
        i.tries_left_ = sampleTries(i.callback_.samplingProb());
      }
    }
  }
```

This PR fixes the issue and return earlier, which is small but since dispatcher is used in the hot path, so could got benefits in the performance.


cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise @mwootton