### PR TITLE
Remove MB < PP check for Gpipe

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -539,12 +539,6 @@ class PipelineScheduleSingle(_PipelineSchedule):
         self._stage_forward_initialized = False
         self._stage_backward_initialized = False
 
-        if n_microbatches < self._num_stages:
-            raise ValueError(
-                f"Number of microbatches ({n_microbatches}) must be greater than \
-or equal to the number of stages ({self._num_stages})."
-            )
-
         self.pipeline_order: dict[int, list[_Action | None]] | None = (
             self._get_pipeline_order()
         )
@@ -811,6 +805,31 @@ class Schedule1F1B(PipelineScheduleSingle):
     The 1F1B schedule.
     Will perform one forward and one backward on the microbatches in steady state.
     """
+
+    def __init__(
+        self,
+        stage: _PipelineStageBase,
+        n_microbatches: int,
+        loss_fn: Callable | None = None,
+        args_chunk_spec: tuple[TensorChunkSpec, ...] | None = None,
+        kwargs_chunk_spec: dict[str, TensorChunkSpec] | None = None,
+        output_merge_spec: dict[str, Any] | tuple[Any] | None = None,
+        scale_grads: bool = True,
+    ):
+        super().__init__(
+            stage=stage,
+            n_microbatches=n_microbatches,
+            loss_fn=loss_fn,
+            args_chunk_spec=args_chunk_spec,
+            kwargs_chunk_spec=kwargs_chunk_spec,
+            output_merge_spec=output_merge_spec,
+            scale_grads=scale_grads,
+        )
+        if n_microbatches < self._num_stages:
+            raise ValueError(
+                f"Number of microbatches ({n_microbatches}) must be greater than \
+or equal to the number of stages ({self._num_stages})."
+            )
 
     def _step_microbatches(
         self,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/171312

Move the microbatches < pipeline stages check only for 1F1B, since we don't want to restrict Gpipe

We can remove this check when we consolidate the single stage schedules to use ScheduleExecutionRuntime, which we will do when we upstream graph PP
