### PR TITLE
emscripten support

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -341,7 +341,7 @@ class TORCH_API TensorBase {
                 "nbytes is not defined for sparse tensors.  If you want the size of the constituent " \
                 "tensors, add the nbytes of the indices and values.  If you want the size of the  " \
                 "equivalent dense tensor, multiply numel() by element_size()");
-    return impl_->sym_numel() * impl_->itemsize();
+    return impl_->sym_numel() * c10::SymInt(impl_->itemsize());
   }
 
   int64_t numel() const {

--- a/aten/src/ATen/native/AutogradComposite.cpp
+++ b/aten/src/ATen/native/AutogradComposite.cpp
@@ -46,7 +46,7 @@ Tensor _new_zeros_with_same_feature_meta(
   auto other_sizes = other.sym_sizes();
   auto other_strides = other.sym_strides();
   auto other_storage_offset = other.storage_offset();
-  auto other_storage_numel = other.storage().sym_nbytes() / other.itemsize();
+  auto other_storage_numel = other.storage().sym_nbytes() / c10::SymInt(other.itemsize());
 
   if (self_num_batch_dims == 0) {
     auto new_tensor = at::zeros_symint({other_storage_numel}, other.options());
@@ -88,7 +88,7 @@ Tensor _new_zeros_with_same_feature_meta(
 }
 
 bool _has_same_storage_numel(const at::Tensor& base, const at::Tensor& other) {
-  return base.storage().sym_nbytes() / base.itemsize() == other.storage().sym_nbytes() / other.itemsize();
+  return base.storage().sym_nbytes() / c10::SymInt(base.itemsize()) == other.storage().sym_nbytes() / c10::SymInt(other.itemsize());
 }
 
 Tensor _lazy_clone(Tensor const& self) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -4842,7 +4842,7 @@ at::Tensor clone_preserve_strides(const at::Tensor& self) {
   if (at::has_internal_overlap(self) == at::MemOverlap::Yes) {
     return self.clone();
   }
-  auto dtype_size = self.dtype().itemsize();
+  auto dtype_size = c10::SymInt(self.dtype().itemsize());
   auto nbytes = self.storage().sym_nbytes();
   TORCH_INTERNAL_ASSERT(nbytes % dtype_size == 0);
   auto numel = nbytes / dtype_size;

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -401,7 +401,7 @@ Tensor qembeddingbag_byte_prepack_meta(const Tensor& weight) {
   const auto cols_dim = weight.ndimension() - 1;
   const auto& embedding_cols = weight_sizes[cols_dim];
   // Add 8 bytes per column to store FP32 scale and zero_point per row.
-  const auto output_columns = embedding_cols + 2 * sizeof(float);
+  const auto output_columns = embedding_cols + 2 * c10::SymInt(sizeof(float));
 
   // Adjust output dimensions to account for FP32 scale and zero_points.
   auto output_shape = weight_sizes.vec();

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
@@ -169,7 +169,7 @@ Tensor qembeddingbag_byte_unpack_meta(const Tensor& packed_weight) {
   const auto input_columns = packed_weight_sizes[col_dim];
   // The last 2 values are used to store the FP32 scale and zero_point values
   // per row.
-  const auto output_columns = input_columns - 2 * sizeof(float);
+  const auto output_columns = input_columns - 2 * c10::SymInt(sizeof(float));
 
   auto output_shape = packed_weight_sizes.vec();
   output_shape[col_dim] = output_columns;

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2219,7 +2219,7 @@ Tensor split_backward(
   auto num_splits = grads.size();
   std::vector<c10::SymInt> split_sizes(num_splits, split_size);
   split_sizes[num_splits - 1] =
-      split_size - (split_size * num_splits - dim_size);
+      split_size - (split_size * c10::SymInt(num_splits) - dim_size);
   return split_with_sizes_backward(grads, split_sizes, dim, sym_sizes, options);
 }
 


### PR DESCRIPTION
This PR addresses compilation errors encountered when building PyTorch with emcc (WebAssembly). 

```
/home/ice/pytorch_wasm/aten/src/ATen/core/TensorBase.h:344:31: error: use of overloaded operator '*' is ambiguous (with
      operand types 'c10::SymInt' and 'size_t' (aka 'unsigned long'))
  344 |     return impl_->sym_numel() * impl_->itemsize();
      |            ~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
```
Ambiguous SymInt Operator Overloads: On Wasm32 architecture, size_t is 32-bit. This causes ambiguous operator overload errors when performing arithmetic between c10::SymInt and size_t (e.g., impl_->itemsize()), as the compiler cannot determine the correct implicit conversion. This patch resolves the ambiguity by explicitly casting the operands to c10::SymInt.

You can use the following script to compile libtorch

```
git clone https://github.com/emscripten-core/emsdk.git
cd emsdk
./emsdk install latest
./emsdk activate latest
source ./emsdk_env.sh
cd ..

git clone https://github.com/futz12/pytorch_wasm
cd pytorch_wasm
git submodule sync && git submodule update --init --recursive

cmake -Bbuild_host \
    -DBUILD_CUSTOM_PROTOBUF=ON \
    -DPROTOBUF_PROTOC_EXECUTABLE="" \
    -DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=""
cmake --build build_host --config Release -j4 --target protoc
sudo cp ./build_host/bin/protoc* /usr/local/bin/
rm -rf build_host

emcmake cmake -Bbuild_wasm \
    -DCMAKE_BUILD_TYPE=Release \
    -DUSE_KINETO=OFF \
    -DUSE_CUDA=OFF \
    -DUSE_MPI=OFF \
    -DUSE_OPENMP=OFF \
    -DUSE_MKLDNN=OFF \
    -DBUILD_TEST=OFF \
    -DBUILD_BINARY=OFF \
    -DBUILD_SHARED_LIBS=OFF \
    -DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=/usr/local/bin/protoc \
    -DPROTOBUF_PROTOC_EXECUTABLE=/usr/local/bin/protoc \
    -DONNX_CUSTOM_PROTOC_EXECUTABLE=/usr/local/bin/protoc
cmake --build build_wasm --config Release -j4 --target torch_cpu c10
```



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01