### PR TITLE
[FlexFlash] dynamic shapes

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1150,7 +1150,7 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
             self._flash_triton_dynamic(q, k, v)
 
     def test_captured_float_fails_with_dynamic(self):
-        """Test that captured Python float fails with dynamic=True (unbacked_bindings)."""
+        """Test that captured Python float fails with dynamic=True."""
         val = 2.0  # Captured float
 
         def score_mod(score, _b, _h, _q, _k):
@@ -1159,13 +1159,15 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
         compiled_fn = torch.compile(flex_attention, dynamic=True)
         q, k, v = create_test_tensors(seq_len=256, device="cuda", dtype=torch.float16)
 
-        with self.assertRaisesRegex(Exception, r"unbacked_bindings"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"captures a dynamic scalar \(SymInt/SymFloat\)"
+        ):
             compiled_fn(
                 q, k, v, score_mod=score_mod, kernel_options={"BACKEND": "FLASH"}
             )
 
     def test_captured_int_fails_with_dynamic(self):
-        """Captured Python int should fail with dynamic=True (index_expr-style error)."""
+        """Captured Python int should fail with dynamic=True."""
         val = 2  # Captured int
 
         def score_mod(score, _b, _h, _q, _k):
@@ -1174,7 +1176,9 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
         compiled_fn = torch.compile(flex_attention, dynamic=True)
         q, k, v = create_test_tensors(seq_len=256, device="cuda", dtype=torch.float16)
 
-        with self.assertRaisesRegex(Exception, r"(index_expr|unbacked_bindings)"):
+        with self.assertRaisesRegex(
+            RuntimeError, r"captures a dynamic scalar \(SymInt/SymFloat\)"
+        ):
             compiled_fn(
                 q, k, v, score_mod=score_mod, kernel_options={"BACKEND": "FLASH"}
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #171465


# Summary

Add a bunch of tests around dynamic shapes and create better error message for captured symbols in score-mod / mask mods since we need to do somehting similiar to aux_tensors to support this 


<img width="365" height="325" alt="image" src="https://github.com/user-attachments/assets/bcaeeead-7932-49a8-a455-7382dd549786" />


Since b200 ci is down

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo