### PR TITLE
[ROCm][CI] Enable upload of S3 artifacts for inductor-perf-nightly-rocm* workflows

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -24,6 +24,8 @@ on:
       - inductor-cu124
       - inductor-rocm-mi200
       - inductor-rocm-mi300
+      - inductor-perf-nightly-rocm-mi300
+      - inductor-perf-nightly-rocm-mi355
       - mac-mps
       - linux-aarch64
     types:


### PR DESCRIPTION
Fixes issue where `inductor-perf-nightly-rocm` workflows are not uploading any artifacts to S3 from the ROCm runners, thus not showing up in the HUD page e.g. https://hud.pytorch.org/pytorch/pytorch/commit/b8782c62b12676b2bfdce0819032d4ff1063505c#inductor-perf-nightly-rocm-mi300
as compared to
https://hud.pytorch.org/pytorch/pytorch/commit/e37e8cd47c45b62ed1d3cc65a1d91bd17f76fa82#inductor-perf-nightly-h100
which uploads various artifacts such as `test-jsons` and `test-reports`.

The underlying reason for why this is needed is that the CUDA runners are able to use IAM instance profiles and directly upload to S3 as part of the workflow run, whereas ROCm runners do not have IAM instance profiles available and need to rely on this post-workflow step to upload the GHA artifacts to S3.

CUDA example: https://github.com/pytorch/pytorch/actions/runs/20550393401/job/59028077488#step:8:46
```
Checking for IAM instance profile
  Checking EC2 metadata endpoint for IAM instance profile...
  Attempting IMDSv2...
  IMDSv2 token obtained, checking IAM info...
  IAM instance profile detected:
```

ROCm example: https://github.com/pytorch/pytorch/actions/runs/20561972469/job/59054928030#step:3:527
```
Checking for IAM instance profile
  Checking EC2 metadata endpoint for IAM instance profile...
  Attempting IMDSv2...
  IMDSv2 not available, trying IMDSv1...
  No IAM instance profile found (not on EC2, or no profile attached)
```

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang