### PR TITLE
[inductor] pass additional template/choice metadata to callers

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6722,6 +6722,7 @@ class ExternKernelOut(ExternKernel):
         cpp_kernel_name: Optional[str] = None,
         ordered_kwargs_for_cpp_kernel: Sequence[Any] = (),
         op_overload: Optional[_OpOverloads] = None,
+        choice_uid: Optional[str] = None,
     ) -> None:
         unwrapped_inputs = self.unwrap_storage(inputs)
         assert isinstance(unwrapped_inputs, Sequence), type(unwrapped_inputs)
@@ -6737,6 +6738,7 @@ class ExternKernelOut(ExternKernel):
             ordered_kwargs_for_cpp_kernel,
             op_overload,
         )
+        self.choice_uid = choice_uid
         self.name = V.graph.register_buffer(self)
         V.graph.register_operation(self)
 
@@ -6778,6 +6780,7 @@ class ExternKernelAlloc(ExternKernel):
         cpp_kernel_name: Optional[str] = None,
         ordered_kwargs_for_cpp_kernel: Sequence[Any] = (),
         op_overload: Optional[_OpOverloads] = None,
+        choice_uid: Optional[str] = None,
     ) -> None:
         unwrapped_inputs = self.unwrap_storage(inputs)
         assert all(isinstance(i, IRNode) for i in unwrapped_inputs)
@@ -6793,6 +6796,7 @@ class ExternKernelAlloc(ExternKernel):
             ordered_kwargs_for_cpp_kernel,
             op_overload,
         )
+        self.choice_uid = choice_uid
         # We need output buffers for generating kernel arguments in the
         # abi-compatible mode, where we retrieve outputs by pass each individual
         # output through the abi-compatible interface.

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2158,6 +2158,7 @@ class TritonTemplate(KernelTemplate):
             workspace_arg=workspace_arg,
             allowed_prologue_inps=result.prologue_supported_inputs,
             hint_override=hint_override,
+            template_name=self.name,
         )
 
 
@@ -2270,10 +2271,12 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         workspace_arg: Optional[WorkspaceArg] = None,
         allowed_prologue_inps: Optional[OrderedSet[str]] = None,
         hint_override: Optional[int] = None,
+        template_name: Optional[str] = None,
     ) -> None:
         super().__init__(name, input_nodes, layout, description)
         self.make_kernel_render = make_kernel_render
         self.bmreq: TritonBenchmarkRequest = bmreq
+        self.template_name = template_name
         if log_info is None:
             log_info = {}
         self.log_info: dict[str, Any] = log_info
@@ -2471,6 +2474,7 @@ class ExternKernelCaller(ChoiceCaller):
                 ordered_kwargs_for_cpp_kernel=self.choice.ordered_kwargs_for_cpp_kernel,
                 op_overload=self.choice.op_overload,
                 kwargs=self.kwargs,
+                choice_uid=self.choice.uid,
             )
 
         return ir.TensorBox.create(inner)


### PR DESCRIPTION
Summary: this additional metadata is helpful for lookup table -esque things (like deconstructing a choice caller into the originating choice)

Test Plan: CI

Differential Revision: D89897130




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo