### PR TITLE
[inductor] fixed template config override

### DIFF
--- a/torch/_inductor/template_heuristics/__init__.py
+++ b/torch/_inductor/template_heuristics/__init__.py
@@ -3,4 +3,4 @@
 from . import aten, base, contiguous_mm, decompose_k, registry, tlx, triton
 
 # expose the entry function
-from .registry import get_template_heuristic
+from .registry import get_template_heuristic, with_fixed_template_config


### PR DESCRIPTION
Summary: this piggybacks off of `override_template_heuristics` to enable a simpler method of overriding specifically Triton template configs to a single config

Test Plan:
```
buck test fbcode//mode/opt caffe2/test/inductor:max_autotune -- test_with_fixed_template_config
```

Differential Revision: D89901599




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo