### PR TITLE
Fix EMA equation indices in documentation

### DIFF
--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -547,10 +547,10 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
 {func}`torch.optim.swa_utils.get_ema_multi_avg_fn` returns a function that applies the following EMA equation to the weights:
 
 ```{math}
-W^\textrm{EMA}_{t+1} = \alpha W^\textrm{EMA}_{t} + (1 - \alpha) W^\textrm{model}_t
+W^\textrm{EMA}_{t} = \alpha W^\textrm{EMA}_{t-1} + (1 - \alpha) W^\textrm{model}_t
 ```
 
-where alpha is the EMA decay.
+where alpha is the EMA decay and $W^\textrm{EMA}_0 = W^\textrm{model}_0$.
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these


### PR DESCRIPTION
Fixes #155551

## Summary
Fixed inconsistent indexing in the EMA (Exponential Moving Average) equation documentation for `get_ema_multi_avg_fn()`.

## Problem
The previous equation was:
```math
W^EMA_{t+1} = α W^EMA_t + (1-α) W^model_t
```

This was confusing because the left side shows EMA at time t+1, but the model weight on the right side is at time t (not t+1), creating an inconsistency in the time indices.

## Solution
The corrected equation is now:
```math
W^EMA_t = α W^EMA_{t-1} + (1-α) W^model_t
```

This properly shows that:
- The current EMA at time t is computed from:
  - The previous EMA at time t-1 (weighted by α)
  - The current model weights at time t (weighted by 1-α)

This matches the actual implementation in the code:
```python
p_ema.copy_(p_ema * decay + p_model * (1 - decay))
```

Also added the initialization condition: $W^{EMA}_0 = W^{model}_0$

## Testing
Documentation change only - no code changes required.