### PR TITLE
[nativert] Add MtiaTritonKernelManager for MTIA Triton kernel execution

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -646,6 +646,10 @@ libtorch_nativert_sources = [
     "torch/nativert/kernels/ETCallDelegateKernel.cpp",
 ]
 
+libtorch_nativert_mtia_sources = [
+    "torch/nativert/executor/triton/fb/MtiaTritonKernelManager.cpp",
+]
+
 libtorch_nativert_cuda_sources = [
     "torch/nativert/executor/triton/CudaTritonKernelManager.cpp",
     "torch/nativert/executor/AOTInductorModelContainerCudaShim.cpp",
@@ -787,6 +791,8 @@ libtorch_cuda_distributed_sources = libtorch_cuda_distributed_base_sources + lib
 libtorch_cuda_sources = libtorch_cuda_core_sources + libtorch_cuda_distributed_sources + [
     "torch/csrc/cuda/nccl.cpp",
 ] + libtorch_nativert_cuda_sources
+
+libtorch_mtia_sources = libtorch_nativert_mtia_sources
 
 torch_cpp_srcs = [
     "torch/csrc/api/src/cuda.cpp",  # this just forwards stuff, no real CUDA

--- a/test/cpp/nativert/CMakeLists.txt
+++ b/test/cpp/nativert/CMakeLists.txt
@@ -41,6 +41,7 @@ set(NATIVERT_TEST_SRCS
   ${TORCH_ROOT}/torch/nativert/graph/passes/pass_manager/PassManager.cpp
   ${TORCH_ROOT}/torch/nativert/kernels/KernelHandlerRegistry.cpp
   ${TORCH_ROOT}/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
+  ${TORCH_ROOT}/torch/nativert/executor/triton/fb/MtiaTritonKernelManager.cpp
   ${TORCH_ROOT}/torch/nativert/kernels/TritonKernel.cpp
   ${TORCH_ROOT}/torch/nativert/executor/DelegateExecutor.cpp
   ${TORCH_ROOT}/torch/nativert/executor/AOTInductorDelegateExecutor.cpp

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -58,8 +58,8 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TemporaryFileName,
-    TestCase,
     TEST_WITH_ROCM,
+    TestCase,
 )
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
@@ -722,7 +722,8 @@ def forward(self, x):
                 )
 
     @unittest.skipIf(
-        not torch.cuda.is_available() or not has_triton() or TEST_WITH_ROCM, "requires cuda and triton, ROCm doesn't support bool tl.cosntexpr."
+        not torch.cuda.is_available() or not has_triton() or TEST_WITH_ROCM,
+        "requires cuda and triton, ROCm doesn't support bool tl.cosntexpr.",
     )
     def test_triton_constexpr_matching(self) -> None:
         """Test that constexpr values are properly matched during serialization.

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -778,10 +778,7 @@ def forward(self, x):
         # Verify the triton node was serialized
         triton_node = None
         for node in serialized.exported_program.graph_module.graph.nodes:
-            if (
-                node.target
-                == "torch.ops.higher_order.triton_kernel_wrapper_functional"
-            ):
+            if node.target == "torch.ops.higher_order.triton_kernel_wrapper_functional":
                 triton_node = node
                 break
         self.assertIsNotNone(triton_node)

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -59,6 +59,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TemporaryFileName,
     TestCase,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
@@ -721,7 +722,7 @@ def forward(self, x):
                 )
 
     @unittest.skipIf(
-        not torch.cuda.is_available() or not has_triton(), "requires cuda and triton"
+        not torch.cuda.is_available() or not has_triton() or TEST_WITH_ROCM, "requires cuda and triton, ROCm doesn't support bool tl.cosntexpr."
     )
     def test_triton_constexpr_matching(self) -> None:
         """Test that constexpr values are properly matched during serialization.

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -888,7 +888,9 @@ class GraphModuleSerializer(metaclass=Final):
 
                 if hasattr(kernel_cache_metadata, "shared"):
                     if isinstance(kernel_cache_metadata.shared, bool):
-                        kwargs_new["shared_memory_bytes"] = int(kernel_cache_metadata.shared)
+                        kwargs_new["shared_memory_bytes"] = int(
+                            kernel_cache_metadata.shared
+                        )
                     else:
                         kwargs_new["shared_memory_bytes"] = kernel_cache_metadata.shared
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -600,20 +600,41 @@ def get_triton_kernel_and_cache_entry(node: torch.fx.Node):
             if actual_kernel.arg_names[idx] in constexpr_vals
         ]
 
+        # Normalize expected values for comparison with parsed constexpr values.
+        # The kernel signature key stores constexprs as strings (e.g., "True", "1.5", "42"),
+        # which we parse back to Python types. To ensure proper comparison, we normalize
+        # the expected values: booleans, ints, and floats are kept as-is since they can
+        # be compared directly with parsed values. Other types (like dtype or string
+        # constants) are converted to strings to match the parsed format.
+        normalized_expected = []
+        for val in expected_values:
+            if isinstance(val, (bool, int, float)):
+                normalized_expected.append(val)
+            else:
+                normalized_expected.append(str(val))
+
         matching_entries = []
         for sig_key, cache_entry in cache.items():
             constexpr_matches = re.findall(r"\('constexpr',\s*([^)]+)\)", sig_key)
             if constexpr_matches:
+                # Parse constexpr string values back to Python types for comparison.
+                # Booleans are stored as "True"/"False" strings, numbers as their string
+                # representation. Values that can't be parsed as numbers are kept as strings
+                # (e.g., dtype names like "torch.float32").
                 constexpr_values = []
                 for match in constexpr_matches:
                     if match in ("True", "False"):
                         constexpr_values.append(match == "True")
-                    elif "." in match or "e" in match or "E" in match:
-                        constexpr_values.append(float(match))
                     else:
-                        constexpr_values.append(int(match))
+                        try:
+                            constexpr_values.append(float(match))
+                        except ValueError:
+                            try:
+                                constexpr_values.append(int(match))
+                            except ValueError:
+                                constexpr_values.append(match)
 
-                if constexpr_values == expected_values:
+                if constexpr_values == normalized_expected:
                     matching_entries.append((sig_key, cache_entry))
     else:
         matching_entries = list(cache.items())
@@ -866,7 +887,42 @@ class GraphModuleSerializer(metaclass=Final):
                     )
 
                 if hasattr(kernel_cache_metadata, "shared"):
-                    kwargs_new["shared_memory_bytes"] = kernel_cache_metadata.shared
+                    if isinstance(kernel_cache_metadata.shared, bool):
+                        kwargs_new["shared_memory_bytes"] = int(kernel_cache_metadata.shared)
+                    else:
+                        kwargs_new["shared_memory_bytes"] = kernel_cache_metadata.shared
+
+                # MTIA-specific parameters for triton kernel compilation
+                if hasattr(kernel_cache_metadata, "tile_width"):
+                    kwargs_new["tile_width"] = kernel_cache_metadata.tile_width
+                if hasattr(kernel_cache_metadata, "tile_height"):
+                    kwargs_new["tile_height"] = kernel_cache_metadata.tile_height
+                if hasattr(kernel_cache_metadata, "base_pe"):
+                    kwargs_new["base_pe"] = kernel_cache_metadata.base_pe
+
+                # Kernel parameter metadata for MTIA fatbin compilation
+                kwargs_new["kernel_param_names"] = [
+                    p.name for p in kernel.params if not p.is_constexpr
+                ]
+                # Use inferred signature types from the compiled kernel's ASTSource
+                # when available. The signature is populated at runtime with actual
+                # types like "i32", "*fp32" based on the values passed to the kernel
+                # (see specialize_impl in jit.py). Fall back to static annotations
+                # for architectures that don't rely on precise type information.
+                compiled_signature = getattr(
+                    getattr(kernel_cache_entry, "src", None), "signature", None
+                )
+                if compiled_signature is not None:
+                    kwargs_new["kernel_param_types"] = [
+                        str(compiled_signature.get(p.name, p.annotation))
+                        for p in kernel.params
+                        if not p.is_constexpr
+                    ]
+                else:
+                    # Default behavior: use static annotations (may be empty)
+                    kwargs_new["kernel_param_types"] = [
+                        str(p.annotation) for p in kernel.params if not p.is_constexpr
+                    ]
 
                 ex_node = Node(
                     target=self.serialize_operator(node.target),

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -556,7 +556,7 @@ def get_triton_kernel_and_cache_entry(node: torch.fx.Node):
 
     if hasattr(actual_kernel, "device_caches"):
         caches = actual_kernel.device_caches
-        assert len(caches.keys()) >= 1
+        assert len(caches.keys()) == 1
         cache = next(iter(caches.values()))[0]
     elif hasattr(actual_kernel, "cache"):
         # old path, still used for cpu triton builds

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1669,9 +1669,9 @@ class GraphModuleSerializer(metaclass=Final):
             ],
             in_spec=self.serialize_treespec(module_call_signature.in_spec),
             out_spec=self.serialize_treespec(module_call_signature.out_spec),
-            forward_arg_names=names
-            if (names := module_call_signature.forward_arg_names)
-            else None,
+            forward_arg_names=(
+                names if (names := module_call_signature.forward_arg_names) else None
+            ),
         )
 
     def serialize_module_call_graph(
@@ -3150,9 +3150,9 @@ class GraphModuleDeserializer(metaclass=Final):
             ],
             in_spec=treespec_loads(module_call_signature.in_spec),
             out_spec=treespec_loads(module_call_signature.out_spec),
-            forward_arg_names=names
-            if (names := module_call_signature.forward_arg_names)
-            else None,
+            forward_arg_names=(
+                names if (names := module_call_signature.forward_arg_names) else None
+            ),
         )
 
     def deserialize_module_call_graph(

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -556,7 +556,7 @@ def get_triton_kernel_and_cache_entry(node: torch.fx.Node):
 
     if hasattr(actual_kernel, "device_caches"):
         caches = actual_kernel.device_caches
-        assert len(caches.keys()) == 1
+        assert len(caches.keys()) >= 1
         cache = next(iter(caches.values()))[0]
     elif hasattr(actual_kernel, "cache"):
         # old path, still used for cpu triton builds

--- a/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
@@ -59,8 +59,10 @@ class CudaTritonKernelManager final : public TritonKernelManager {
   CudaTritonKernelManager& operator=(CudaTritonKernelManager&& other) noexcept;
 
   void launch(const LaunchParams& launch_params, void** args) final;
-  std::unique_ptr<KernelInputs> create_inputs(size_t num_args, size_t num_attrs)
-      const final {
+  std::unique_ptr<KernelInputs> create_inputs(
+      size_t num_args,
+      size_t num_attrs,
+      const KernelInputParams& /*params*/) const final {
     return std::unique_ptr<KernelInputs>(
         new CudaKernelInputs(num_args, num_attrs));
   }

--- a/torch/nativert/kernels/TritonKernel.cpp
+++ b/torch/nativert/kernels/TritonKernel.cpp
@@ -37,7 +37,7 @@ TritonKernel::TritonKernel(
   size_t num_double_attrs = 0;
   for (const auto& attr : node_->attributes()) {
     if (attr.name.empty() && std::holds_alternative<double>(attr.value)) {
-        ++num_double_attrs;
+      ++num_double_attrs;
     }
   }
   float_attrs_.reserve(num_double_attrs);
@@ -138,8 +138,7 @@ TritonKernel::TritonKernel(
         tmp_dir + kernel_name + ".so",
         tmp_dir + kernel_name + ".launcher.so");
     TORCH_CHECK(
-        loader_ != nullptr,
-        "couldn't find CPU loader -- is this a cpu build?");
+        loader_ != nullptr, "couldn't find CPU loader -- is this a cpu build?");
   } else if (reader->hasRecord(kernel_prefix + "/" + kernel_name + ".bin")) {
     loader_ = TritonKernelManagerRegistry()->Create(
         at::kMTIA, symbol_name, tmp_dir + kernel_name + ".bin", "");
@@ -161,7 +160,8 @@ void TritonKernel::computeInternal(ExecutionFrame& executionFrame) const {
 
   auto* loader = const_cast<TritonKernelManager*>(loader_.get());
 
-  auto inputs = loader->create_inputs(num_inputs, num_attrs, kernel_input_params_);
+  auto inputs =
+      loader->create_inputs(num_inputs, num_attrs, kernel_input_params_);
 
   for (const auto i : c10::irange(num_inputs)) {
     inputs->add_tensor_arg(input(i, executionFrame).toTensor());

--- a/torch/nativert/kernels/TritonKernel.h
+++ b/torch/nativert/kernels/TritonKernel.h
@@ -28,6 +28,7 @@ class TritonKernel : public OpKernel {
   std::vector<float> float_attrs_;
   std::vector<int64_t> output_indices_;
   LaunchParams launch_params_;
+  KernelInputParams kernel_input_params_;
 };
 
 } // namespace torch::nativert


### PR DESCRIPTION
Summary:
This adds MTIA device support for executing Triton kernels in nativert. The key changes are:

- Add MtiaTritonKernelManager that compiles Triton ELF binaries to MTIA fatbin format and launches kernels via the MTIA runtime
- Extend LaunchParams with MTIA-specific parameters (tile_width, tile_height, base_pe) and kernel parameter metadata
- Add MtiaKernelInputs class that uses KernelArgManager to convert at::Tensor to TensorView* for MTIA runtime
- Update TritonKernel to parse MTIA-specific attributes and support .bin files for MTIA kernels
- Extend serialize.py to include MTIA kernel metadata (tile dimensions, base_pe, param names/types)
- Add build configuration for libtorch_mtia with MTIA dependencies

(The early implementation to support triton in NativeRT: D81724234)

Test Plan: Built and tested with MTIA Triton kernel execution on MTIA device.

Reviewed By: minjang

Differential Revision: D89666786


