### PR TITLE
[xpu][fix] Fix test_wrap_triton_handled_during_tracing on XPU

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4216,7 +4216,7 @@ class GraphModule(torch.nn.Module):
 
         compiled = torch.compile(fn, fullgraph=True, backend="eager")
 
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=device_type)
         result = compiled(x)
 
         self.assertEqual(result, torch.sin(x))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171512

# Motivation
This PR aims to fix the failure introduced from https://github.com/pytorch/pytorch/pull/171289 on XPU backend.
Currently, some UTs under `test/dynamo/` are device-agnostic. So the cuda-specific code will raise the following error on XPU backend.
```python
AssertionError: Torch not compiled with CUDA enabled
```

# Additional Context
Fix https://github.com/pytorch/pytorch/issues/171508 and https://github.com/pytorch/pytorch/issues/171509

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo