### PR TITLE
[docs] Clarify Flatten usage with nn.Sequential

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4518,6 +4518,9 @@ flattened shape is input's data copied. See :meth:`torch.Tensor.view` for detail
 
 .. note::
     Flattening a zero-dimensional tensor will return a one-dimensional view.
+    
+    When using :class:`~torch.nn.Sequential`, prefer :class:`~torch.nn.Flatten`
+    to insert a flattening step into the module pipeline.
 
 Args:
     {input}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4518,9 +4518,6 @@ flattened shape is input's data copied. See :meth:`torch.Tensor.view` for detail
 
 .. note::
     Flattening a zero-dimensional tensor will return a one-dimensional view.
-    
-    When using :class:`~torch.nn.Sequential`, prefer :class:`~torch.nn.Flatten`
-    to insert a flattening step into the module pipeline.
 
 Args:
     {input}

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -13,7 +13,8 @@ class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor.
 
-    For use with :class:`~nn.Sequential`, see :meth:`torch.flatten` for details.
+    For use with :class:`~nn.Sequential`, use this module to insert a flattening
+    step into the module pipeline. For functional details, see :func:`torch.flatten`.
 
     Shape:
         - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,'


### PR DESCRIPTION
Fixes #171401

### Summary
Add a short documentation note clarifying that when using `torch.nn.Sequential`, `torch.nn.Flatten` is preferred to insert a flattening step in the module pipeline.