### PR TITLE
[inductor][lut] propagate KTC annotation to output nodes

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -2592,17 +2592,20 @@ class DeferredRecordingTest(TestMixin, TestCase):
         memoizer = Memoizer()
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred_obj = interfaces.DeferredRecording()
-                return deferred_obj
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred_obj = interfaces.DeferredRecording()
+                    return deferred_obj
 
-            return encode
+                return encode
+
+            return deferred_encoder
 
         call_count = 0
 
-        @memoizer.record(custom_result_encoder=deferred_encoder)
+        @memoizer.record(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -2638,15 +2641,18 @@ class DeferredRecordingTest(TestMixin, TestCase):
         memoizer = Memoizer()
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred_obj = interfaces.DeferredRecording()
-                return deferred_obj
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred_obj = interfaces.DeferredRecording()
+                    return deferred_obj
 
-            return encode
+                return encode
 
-        @memoizer.record(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.record(custom_result_encoder=deferred_encoder_factory)
         def compute_record(x: int) -> int:
             return x * 2
 
@@ -2680,22 +2686,25 @@ class DeferredRecordingTest(TestMixin, TestCase):
         memoizer = Memoizer()
         cache_populated = Event()
 
-        def future_encoder(*args: object, **kwargs: object) -> object:
-            def encode(future_result: Future[int]) -> interfaces.DeferredRecording:
-                deferred = interfaces.DeferredRecording()
+        def future_encoder_factory(fn) -> object:
+            def future_encoder(*args: object, **kwargs: object) -> object:
+                def encode(future_result: Future[int]) -> interfaces.DeferredRecording:
+                    deferred = interfaces.DeferredRecording()
 
-                def on_complete(completed_future: Future[int]) -> None:
-                    actual_result = completed_future.result()
-                    deferred.finalize(actual_result)
+                    def on_complete(completed_future: Future[int]) -> None:
+                        actual_result = completed_future.result()
+                        deferred.finalize(actual_result)
 
-                future_result.add_done_callback(on_complete)
-                return deferred
+                    future_result.add_done_callback(on_complete)
+                    return deferred
 
-            return encode
+                return encode
+
+            return future_encoder
 
         with ThreadPoolExecutor() as executor:
 
-            @memoizer.record(custom_result_encoder=future_encoder)
+            @memoizer.record(custom_result_encoder=future_encoder_factory)
             def compute_async(x: int) -> Future[int]:
                 return executor.submit(lambda: x * 2)
 
@@ -2743,13 +2752,16 @@ class DeferredRecordingTest(TestMixin, TestCase):
         # Setup
         memoizer = Memoizer()
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                return interfaces.DeferredRecording()
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    return interfaces.DeferredRecording()
 
-            return encode
+                return encode
 
-        @memoizer.record(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.record(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             return x * 2
 
@@ -2787,15 +2799,18 @@ class DeferredRecordingTest(TestMixin, TestCase):
         persistent = PersistentMemoizer(sub_dir=self.sub_dir())
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred_obj = interfaces.DeferredRecording()
-                return deferred_obj
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred_obj = interfaces.DeferredRecording()
+                    return deferred_obj
 
-            return encode
+                return encode
 
-        @persistent.record(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @persistent.record(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             return x * 2
 
@@ -2836,15 +2851,18 @@ class DeferredRecordingTest(TestMixin, TestCase):
         persistent = PersistentMemoizer(sub_dir=self.sub_dir())
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred_obj = interfaces.DeferredRecording()
-                return deferred_obj
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred_obj = interfaces.DeferredRecording()
+                    return deferred_obj
 
-            return encode
+                return encode
 
-        @persistent.record(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @persistent.record(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             return x * 2
 
@@ -2880,15 +2898,18 @@ class DeferredRecordingTest(TestMixin, TestCase):
         deferred_objects: list[interfaces.DeferredRecording] = []
         call_count = 0
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                deferred = interfaces.DeferredRecording()
-                deferred_objects.append(deferred)
-                return deferred
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    deferred = interfaces.DeferredRecording()
+                    deferred_objects.append(deferred)
+                    return deferred
 
-            return encode
+                return encode
 
-        @persistent.memoize(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @persistent.memoize(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -2924,15 +2945,18 @@ class DeferredRecordingTest(TestMixin, TestCase):
         memoizer = Memoizer()
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred_obj = interfaces.DeferredRecording()
-                return deferred_obj
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred_obj = interfaces.DeferredRecording()
+                    return deferred_obj
 
-            return encode
+                return encode
 
-        @memoizer.record(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.record(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> None:
             return None
 
@@ -2959,17 +2983,20 @@ class DeferredRecordingTest(TestMixin, TestCase):
         memoizer = Memoizer()
         deferred_objects: dict[int, interfaces.DeferredRecording] = {}
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            x = args[0]
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                x = args[0]
 
-            def encode(result: object) -> interfaces.DeferredRecording:
-                deferred = interfaces.DeferredRecording()
-                deferred_objects[x] = deferred
-                return deferred
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    deferred = interfaces.DeferredRecording()
+                    deferred_objects[x] = deferred
+                    return deferred
 
-            return encode
+                return encode
 
-        @memoizer.record(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.record(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             return x * 2
 
@@ -2989,6 +3016,189 @@ class DeferredRecordingTest(TestMixin, TestCase):
             cache_hit = memoizer._cache.get(cache_key)
             self.assertIsNotNone(cache_hit)
             self.assertEqual(cache_hit.value.encoded_result, expected)
+
+    # ============= Result Encoder/Decoder Factory Tests =============
+
+    @set_caching_module_enabled(True)
+    def test_encoder_factory_receives_underlying_function(self) -> None:
+        """Test that the encoder factory receives the underlying function.
+
+        Verifies that when custom_result_encoder is provided, the factory
+        receives the unwrapped function as the first parameter, allowing
+        the encoder to call it if needed.
+        """
+        # Setup: create a memoizer and track what fn is passed to the factory
+        memoizer = Memoizer()
+        received_fn: list[object] = []
+
+        def encoder_factory(fn: object) -> object:
+            received_fn.append(fn)
+
+            def params_to_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> object:
+                    return result
+
+                return encode
+
+            return params_to_encoder
+
+        @memoizer.record(custom_result_encoder=encoder_factory)
+        def compute(x: int) -> int:
+            return x * 2
+
+        # Execute: call the memoized function
+        result = compute(5)
+
+        # Assert: encoder factory received a function (the unwrapped compute)
+        self.assertEqual(len(received_fn), 1)
+        self.assertTrue(callable(received_fn[0]))
+        self.assertEqual(result, 10)
+
+        # Verify that calling the received fn works correctly
+        underlying_fn = received_fn[0]
+        self.assertEqual(underlying_fn(7), 14)
+
+    @set_caching_module_enabled(True)
+    def test_encoder_factory_fn_bypasses_memoization(self) -> None:
+        """Test that calling fn from the encoder bypasses memoization.
+
+        Verifies that the fn passed to the encoder factory is the unwrapped
+        function, so calling it does not trigger caching side effects.
+        """
+        # Setup: create a memoizer and count direct vs memoized calls
+        memoizer = Memoizer()
+        direct_call_count = 0
+        received_fn: list[object] = []
+
+        def encoder_factory(fn: object) -> object:
+            received_fn.append(fn)
+
+            def params_to_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> object:
+                    return result
+
+                return encode
+
+            return params_to_encoder
+
+        @memoizer.record(custom_result_encoder=encoder_factory)
+        def compute(x: int) -> int:
+            nonlocal direct_call_count
+            direct_call_count += 1
+            return x * 2
+
+        # Execute: call the memoized function once
+        compute(5)
+        self.assertEqual(direct_call_count, 1)
+
+        # Now call the underlying fn directly multiple times
+        underlying_fn = received_fn[0]
+        underlying_fn(5)
+        underlying_fn(5)
+        underlying_fn(5)
+
+        # Assert: direct calls happened but no new cache entries
+        self.assertEqual(direct_call_count, 4)  # 1 memoized + 3 direct
+        # Cache should only have the one entry from the memoized call
+        cache_entries = len(memoizer._cache._memory)
+        self.assertEqual(cache_entries, 1)
+
+    @set_caching_module_enabled(True)
+    def test_decoder_factory_receives_underlying_function(self) -> None:
+        """Test that the decoder factory receives the underlying function.
+
+        Verifies that when custom_result_decoder is provided, the factory
+        receives the unwrapped function as the first parameter, allowing
+        the decoder to call it as a fallback if needed.
+        """
+        # Setup: create a memoizer and track what fn is passed to the factory
+        memoizer = Memoizer()
+        received_fn: list[object] = []
+
+        # First, populate the cache with a value
+        cache_key = interfaces._BaseMemoizer._make_key(None, 5)
+        cache_entry = interfaces.CacheEntry(
+            encoded_params={"args": (5,), "kwargs": {}},
+            encoded_result={"encoded_value": 10},
+        )
+        memoizer._cache.insert(cache_key, cache_entry)
+
+        def decoder_factory(fn: object) -> object:
+            received_fn.append(fn)
+
+            def params_to_decoder(*args: object, **kwargs: object) -> object:
+                def decode(encoded_result: object) -> int:
+                    return encoded_result["encoded_value"]
+
+                return decode
+
+            return params_to_decoder
+
+        @memoizer.replay(custom_result_decoder=decoder_factory)
+        def compute(x: int) -> int:
+            return x * 2
+
+        # Execute: replay the cached value
+        result = compute(5)
+
+        # Assert: decoder factory received a function (the unwrapped compute)
+        self.assertEqual(len(received_fn), 1)
+        self.assertTrue(callable(received_fn[0]))
+        self.assertEqual(result, 10)
+
+        # Verify that calling the received fn works correctly
+        underlying_fn = received_fn[0]
+        self.assertEqual(underlying_fn(7), 14)
+
+    @patch_on_disk_cache_base_dir
+    @set_caching_module_enabled(True)
+    def test_persistent_memoizer_decoder_receives_fn(self) -> None:
+        """Test that PersistentMemoizer decoder factory receives fn.
+
+        Verifies that the two-level cache correctly passes the fn parameter
+        to the decoder factory when replaying from disk cache.
+        """
+        import pickle
+
+        # Setup: create a persistent memoizer
+        persistent = PersistentMemoizer(sub_dir=self.sub_dir())
+        received_fn: list[object] = []
+
+        # Populate the disk cache with a value
+        cache_key = interfaces._BaseMemoizer._make_key(None, 5)
+        cache_entry = interfaces.CacheEntry(
+            encoded_params={"args": (5,), "kwargs": {}},
+            encoded_result={"encoded_value": 10},
+        )
+        pickled_entry = pickle.dumps(cache_entry)
+        persistent._disk_cache.insert(cache_key, pickled_entry)
+
+        def decoder_factory(fn: object) -> object:
+            received_fn.append(fn)
+
+            def params_to_decoder(*args: object, **kwargs: object) -> object:
+                def decode(encoded_result: object) -> int:
+                    return encoded_result["encoded_value"]
+
+                return decode
+
+            return params_to_decoder
+
+        @persistent.replay(custom_result_decoder=decoder_factory)
+        def compute(x: int) -> int:
+            return x * 2
+
+        # Execute: replay from disk cache
+        result = compute(5)
+
+        # Assert: decoder factory received the underlying function
+        self.assertEqual(len(received_fn), 1)
+        self.assertTrue(callable(received_fn[0]))
+        self.assertEqual(result, 10)
+
+        # Verify fn works correctly
+        underlying_fn = received_fn[0]
+        self.assertEqual(underlying_fn(7), 14)
 
     @set_caching_module_enabled(True)
     def test_deferred_recording_double_finalize_raises(self) -> None:
@@ -3124,19 +3334,22 @@ class DeferredRecordingTest(TestMixin, TestCase):
         original_result: list[int] = []
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: int) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                original_result.append(result)
-                deferred = interfaces.DeferredRecording(
-                    make_interim_result=lambda: result
-                )
-                deferred_obj = deferred
-                return deferred
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: int) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    original_result.append(result)
+                    deferred = interfaces.DeferredRecording(
+                        make_interim_result=lambda: result
+                    )
+                    deferred_obj = deferred
+                    return deferred
 
-            return encode
+                return encode
 
-        @memoizer.memoize(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.memoize(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -3173,18 +3386,21 @@ class DeferredRecordingTest(TestMixin, TestCase):
         shared_object = {"value": "shared"}
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: object) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred = interfaces.DeferredRecording(
-                    make_interim_result=lambda: shared_object
-                )
-                deferred_obj = deferred
-                return deferred
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: object) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred = interfaces.DeferredRecording(
+                        make_interim_result=lambda: shared_object
+                    )
+                    deferred_obj = deferred
+                    return deferred
 
-            return encode
+                return encode
 
-        @memoizer.memoize(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.memoize(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> object:
             return shared_object
 
@@ -3213,27 +3429,30 @@ class DeferredRecordingTest(TestMixin, TestCase):
         call_count = 0
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def future_encoder(*args: object, **kwargs: object) -> object:
-            def encode(future_result: Future[int]) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred = interfaces.DeferredRecording(
-                    make_interim_result=lambda: future_result
-                )
+        def future_encoder_factory(fn) -> object:
+            def future_encoder(*args: object, **kwargs: object) -> object:
+                def encode(future_result: Future[int]) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred = interfaces.DeferredRecording(
+                        make_interim_result=lambda: future_result
+                    )
 
-                def on_complete(completed_future: Future[int]) -> None:
-                    actual_result = completed_future.result()
-                    deferred.finalize(actual_result)
+                    def on_complete(completed_future: Future[int]) -> None:
+                        actual_result = completed_future.result()
+                        deferred.finalize(actual_result)
 
-                future_result.add_done_callback(on_complete)
-                deferred_obj = deferred
-                return deferred
+                    future_result.add_done_callback(on_complete)
+                    deferred_obj = deferred
+                    return deferred
 
-            return encode
+                return encode
+
+            return future_encoder
 
         with ThreadPoolExecutor() as executor:
             barrier = Event()
 
-            @memoizer.memoize(custom_result_encoder=future_encoder)
+            @memoizer.memoize(custom_result_encoder=future_encoder_factory)
             def compute_async(x: int) -> Future[int]:
                 nonlocal call_count
                 call_count += 1
@@ -3244,17 +3463,19 @@ class DeferredRecordingTest(TestMixin, TestCase):
 
                 return executor.submit(work)
 
-            # First call: executes function, returns Future
-            future1 = compute_async(5)
-            self.assertEqual(call_count, 1)
+            try:
+                # First call: executes function, returns Future
+                future1 = compute_async(5)
+                self.assertEqual(call_count, 1)
 
-            # Second call: should return same Future without re-execution
-            future2 = compute_async(5)
-            self.assertEqual(call_count, 1)  # No additional call
-            self.assertIs(future1, future2)  # Same Future object
-
-            # Release the barrier
-            barrier.set()
+                # Second call: should return same Future without re-execution
+                future2 = compute_async(5)
+                self.assertEqual(call_count, 1)  # No additional call
+                self.assertIs(future1, future2)  # Same Future object
+            finally:
+                # Release the barrier - must be in finally to prevent test hang
+                # if any assertion fails before this point
+                barrier.set()
 
             # Wait for Future to complete
             result = future1.result(timeout=5)
@@ -3275,18 +3496,21 @@ class DeferredRecordingTest(TestMixin, TestCase):
         deferred_obj: interfaces.DeferredRecording | None = None
         call_count = 0
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: int) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred = interfaces.DeferredRecording(
-                    make_interim_result=lambda: result
-                )
-                deferred_obj = deferred
-                return deferred
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: int) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred = interfaces.DeferredRecording(
+                        make_interim_result=lambda: result
+                    )
+                    deferred_obj = deferred
+                    return deferred
 
-            return encode
+                return encode
 
-        @memoizer.memoize(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.memoize(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -3324,18 +3548,21 @@ class DeferredRecordingTest(TestMixin, TestCase):
         call_count = 0
         deferred_obj: interfaces.DeferredRecording | None = None
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: int) -> interfaces.DeferredRecording:
-                nonlocal deferred_obj
-                deferred = interfaces.DeferredRecording(
-                    make_interim_result=lambda: result
-                )
-                deferred_obj = deferred
-                return deferred
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: int) -> interfaces.DeferredRecording:
+                    nonlocal deferred_obj
+                    deferred = interfaces.DeferredRecording(
+                        make_interim_result=lambda: result
+                    )
+                    deferred_obj = deferred
+                    return deferred
 
-            return encode
+                return encode
 
-        @persistent.memoize(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @persistent.memoize(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -3379,17 +3606,20 @@ class DeferredRecordingTest(TestMixin, TestCase):
         # Keep strong references to deferred recordings to prevent GC
         deferred_objs: list[interfaces.DeferredRecording] = []
 
-        def deferred_encoder(*args: object, **kwargs: object) -> object:
-            def encode(result: int) -> interfaces.DeferredRecording:
-                deferred = interfaces.DeferredRecording(
-                    make_interim_result=lambda: result
-                )
-                deferred_objs.append(deferred)
-                return deferred
+        def deferred_encoder_factory(fn) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: int) -> interfaces.DeferredRecording:
+                    deferred = interfaces.DeferredRecording(
+                        make_interim_result=lambda: result
+                    )
+                    deferred_objs.append(deferred)
+                    return deferred
 
-            return encode
+                return encode
 
-        @memoizer.memoize(custom_result_encoder=deferred_encoder)
+            return deferred_encoder
+
+        @memoizer.memoize(custom_result_encoder=deferred_encoder_factory)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1
@@ -3588,16 +3818,19 @@ class DeferredRecordingTest(TestMixin, TestCase):
         # Keep strong references to deferred recordings to prevent GC
         deferred_objs: list[interfaces.DeferredRecording] = []
 
-        def deferred_encoder_no_interim(*args: object, **kwargs: object) -> object:
-            def encode(result: int) -> interfaces.DeferredRecording:
-                # Explicitly not setting make_interim_result
-                deferred = interfaces.DeferredRecording()
-                deferred_objs.append(deferred)
-                return deferred
+        def deferred_encoder_factory_no_interim(fn: object) -> object:
+            def deferred_encoder(*args: object, **kwargs: object) -> object:
+                def encode(result: int) -> interfaces.DeferredRecording:
+                    # Explicitly not setting make_interim_result
+                    deferred = interfaces.DeferredRecording()
+                    deferred_objs.append(deferred)
+                    return deferred
 
-            return encode
+                return encode
 
-        @memoizer.memoize(custom_result_encoder=deferred_encoder_no_interim)
+            return deferred_encoder
+
+        @memoizer.memoize(custom_result_encoder=deferred_encoder_factory_no_interim)
         def compute(x: int) -> int:
             nonlocal call_count
             call_count += 1

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -610,12 +610,14 @@ class CppTemplateCaller(ir.ChoiceCaller):
         return {"backend": "CPP", "op_type": "unknown"}
 
     def output_node(self) -> ir.TensorBox:
-        return ir.TensorBox.create(
-            ir.CppTemplateBuffer(
-                layout=self.layout,
-                inputs=self.input_nodes,
-                make_kernel_render=self.make_kernel_render,
-                template=self.template,
-                choice=self,
-            )
+        buffer = ir.CppTemplateBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            make_kernel_render=self.make_kernel_render,
+            template=self.template,
+            choice=self,
         )
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            buffer.annotations["ktc"] = self.annotations["ktc"]
+        return ir.TensorBox.create(buffer)

--- a/torch/_inductor/codegen/cuda/cuda_kernel.py
+++ b/torch/_inductor/codegen/cuda/cuda_kernel.py
@@ -674,13 +674,15 @@ class CUDATemplateCaller(ChoiceCaller):
 
     def output_node(self) -> TensorBox:
         self.bmreq.update_workspace_size()
-        return TensorBox.create(
-            CUDATemplateBuffer(
-                layout=self.layout,
-                inputs=self.input_nodes,
-                make_kernel_render=self.make_kernel_render,
-                workspace_size=self.bmreq.workspace_size,
-                supports_epilogue_fusion=self.supports_epilogue_fusion,
-                template=self.template,
-            )
+        buffer = CUDATemplateBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            make_kernel_render=self.make_kernel_render,
+            workspace_size=self.bmreq.workspace_size,
+            supports_epilogue_fusion=self.supports_epilogue_fusion,
+            template=self.template,
         )
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            buffer.annotations["ktc"] = self.annotations["ktc"]
+        return TensorBox.create(buffer)

--- a/torch/_inductor/codegen/cutedsl/cutedsl_template.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_template.py
@@ -162,15 +162,17 @@ class CuteDSLTemplateCaller(ChoiceCaller):
 
     def output_node(self) -> TensorBox:
         """Create the output node for this template choice."""
-        return TensorBox.create(
-            CuteDSLTemplateBuffer(
-                layout=self.layout,
-                inputs=self.input_nodes,
-                make_kernel_render=self.make_kernel_render,
-                template=self.template,
-                mutated_inputs=self.mutated_inputs,
-            )
+        buffer = CuteDSLTemplateBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            make_kernel_render=self.make_kernel_render,
+            template=self.template,
+            mutated_inputs=self.mutated_inputs,
         )
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            buffer.annotations["ktc"] = self.annotations["ktc"]
+        return TensorBox.create(buffer)
 
     def call_name(self) -> str:
         """Return the kernel call name."""

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -139,14 +139,16 @@ class NVUniversalGemmCaller(ChoiceCaller):
     def output_node(self) -> TensorBox:
         from torch._inductor.ir import NVUniversalGemmBuffer
 
-        return TensorBox.create(
-            NVUniversalGemmBuffer(
-                layout=self.layout,
-                inputs=self.input_nodes,
-                kernel=self.kernel,
-                accumulator_type=self.accumulator_type,
-            )
+        buffer = NVUniversalGemmBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            kernel=self.kernel,
+            accumulator_type=self.accumulator_type,
         )
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            buffer.annotations["ktc"] = self.annotations["ktc"]
+        return TensorBox.create(buffer)
 
     def call_name(self) -> str:
         return self.name

--- a/torch/_inductor/codegen/rocm/rocm_kernel.py
+++ b/torch/_inductor/codegen/rocm/rocm_kernel.py
@@ -278,12 +278,14 @@ class ROCmTemplateCaller(ChoiceCaller):
 
     def output_node(self) -> TensorBox:
         self.bmreq.update_workspace_size()
-        return TensorBox.create(
-            ROCmTemplateBuffer(
-                layout=self.layout,
-                inputs=self.input_nodes,
-                make_kernel_render=self.make_kernel_render,
-                workspace_size=self.bmreq.workspace_size,
-                template=self.template,
-            )
+        buffer = ROCmTemplateBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            make_kernel_render=self.make_kernel_render,
+            workspace_size=self.bmreq.workspace_size,
+            template=self.template,
         )
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            buffer.annotations["ktc"] = self.annotations["ktc"]
+        return TensorBox.create(buffer)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -550,6 +550,8 @@ class IRNode:
     # traces back to where the IRNode is created in Inductor
     traceback: Optional[list[str]] = dataclasses.field(init=False)
     origin_node: Optional[torch.fx.Node] = dataclasses.field(init=False)
+    # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
+    annotations: dict[str, Any] = dataclasses.field(init=False)
 
     @staticmethod
     @contextlib.contextmanager
@@ -587,6 +589,8 @@ class IRNode:
             "traceback", traceback.format_stack() if config.debug_ir_traceback else None
         )
         self._post_init_setattr("origin_node", None)
+        # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
+        self._post_init_setattr("annotations", {})
 
     def get_read_names(self) -> OrderedSet[str]:
         return OrderedSet(dep.name for dep in self.get_reads())
@@ -5049,6 +5053,8 @@ class TemplateBuffer(OperationBuffer):
         self.make_kernel_render = make_kernel_render
         self.name = V.graph.register_buffer(self)
         V.graph.register_operation(self)
+        # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
+        self.annotations: dict[str, Any] = {}
 
     def get_read_writes(self) -> dependencies.ReadWrites:
         return self.extract_read_writes(normalize=True)
@@ -5851,6 +5857,8 @@ class ExternKernel(InputsKernel):
         self.unbacked_bindings = {}
         self.mutation_outputs = []
         self.fx_node = V.graph.current_node
+        # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
+        self.annotations: dict[str, Any] = {}
 
     def get_outputs(self) -> list[Buffer]:
         return [self, *self.mutation_outputs]

--- a/torch/_inductor/runtime/caching/interfaces.py
+++ b/torch/_inductor/runtime/caching/interfaces.py
@@ -12,12 +12,14 @@ import json
 import logging
 import pickle
 import shutil
+import threading
+import weakref
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from hashlib import sha256
 from os import PathLike
 from pathlib import Path
-from typing import cast, TypedDict
+from typing import cast, Generic, TypedDict
 from typing_extensions import ParamSpec, TypeVar
 
 from filelock import FileLock
@@ -84,6 +86,128 @@ class CacheEntry:
 
     encoded_params: object
     encoded_result: object
+
+
+@dataclass
+class DeferredRecording(Generic[_EncodedR]):
+    """Signals that recording should happen at a later time.
+
+    When returned from a custom_result_encoder, the memoizer will:
+    1. Skip immediate caching
+    2. Register a completion callback on this object
+
+    The encoder is responsible for calling `finalize(encoded_result)`
+    when the actual result is ready to be cached. This is useful when
+    the function returns a value whose final encoded form is not yet
+    available (e.g., an object containing a pending computation),
+    allowing the expensive work to remain hidden while still enabling caching.
+
+    This class handles the race condition where the computation might complete
+    before the memoizer has registered its callback. If finalize() is called
+    first, the result is stored and the callbacks are invoked when registered.
+
+    Multiple callbacks can be registered - they will all be invoked when
+    finalize() is called (or immediately if already completed). Callbacks are
+    guaranteed to be invoked in registration order.
+
+    This class is thread-safe: concurrent calls to finalize() and
+    register_callback() are properly synchronized.
+
+    WARNING: Callbacks are executed while holding the internal lock to ensure
+    ordering guarantees. Callbacks MUST NOT call back into this DeferredRecording
+    instance (e.g., calling finalize() or register_callback() from within a
+    callback) as this will cause a deadlock.
+
+    Example usage in an encoder:
+        def my_encoder(*args, **kwargs):
+            def encode(result: _R) -> DeferredRecording[_EncodedR]:
+                deferred: DeferredRecording[_EncodedR] = DeferredRecording()
+
+                def on_complete():
+                    encoded_result: _EncodedR = _encode_result(result)
+                    deferred.finalize(encoded_result)
+
+                result.add_completion_callback(on_complete)
+                return deferred
+
+            return encode
+
+    Attributes:
+        _callbacks: List of callbacks to invoke when finalize() is called.
+                   Set to None after finalize() is called to indicate completion.
+        _encoded_result: The encoded result passed to finalize().
+        _lock: Lock for thread-safe access to mutable state.
+    """
+
+    _callbacks: list[Callable[[_EncodedR], None]] | None = field(
+        default_factory=list, repr=False
+    )
+    _encoded_result: _EncodedR | None = field(default=None, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def finalize(self, encoded_result: _EncodedR) -> None:
+        """Finalize the deferred recording with the encoded result.
+
+        This method should be called by the encoder (typically via a completion
+        callback) when the actual result is ready to be cached.
+
+        All registered callbacks are invoked with the encoded result in
+        registration order. If no callbacks are registered yet, the result is
+        stored and callbacks will be invoked when registered.
+
+        This method is thread-safe.
+
+        WARNING: Callbacks are executed while holding the internal lock.
+        Do not call finalize() or register_callback() from within a callback,
+        as this will cause a deadlock.
+
+        Args:
+            encoded_result: The encoded result to cache.
+        """
+        with self._lock:
+            if self._callbacks is None:
+                raise RuntimeError(
+                    "finalize() called multiple times on DeferredRecording"
+                )
+
+            # Store the result and get callbacks to invoke
+            self._encoded_result = encoded_result
+            callbacks_to_invoke = self._callbacks
+            self._callbacks = None
+
+            # Execute callbacks inside the lock to ensure ordering:
+            # - All pre-finalize callbacks execute in registration order
+            # - Any callback registered during/after finalize will see
+            #   _callbacks=None and execute immediately (also under lock)
+            for callback in callbacks_to_invoke:
+                callback(encoded_result)
+
+    def register_callback(self, callback: Callable[[_EncodedR], None]) -> None:
+        """Register a completion callback.
+
+        This method is called by memoizers to register callbacks that
+        will insert cache entries. Multiple callbacks can be registered.
+
+        If finalize() has already been called (e.g., the computation was fast),
+        the callback is invoked immediately with the stored result.
+
+        This method is thread-safe. Callbacks are guaranteed to be invoked
+        in registration order.
+
+        WARNING: Callbacks are executed while holding the internal lock.
+        Do not call finalize() or register_callback() from within a callback,
+        as this will cause a deadlock.
+
+        Args:
+            callback: The function to call with the encoded result.
+        """
+        with self._lock:
+            if self._callbacks is None:
+                # Already finalized - invoke immediately while holding lock
+                # to maintain ordering with respect to other callbacks
+                callback(cast(_EncodedR, self._encoded_result))
+            else:
+                self._callbacks.append(callback)
 
 
 class _BaseMemoizer:
@@ -265,6 +389,13 @@ class Memoizer(_BaseMemoizer):
         )
         # Optional sub_key for nested cache structure
         self._sub_key: str | None = sub_key
+        # Track pending deferred recordings by cache key.
+        # Uses WeakValueDictionary to prevent memory leaks: if the DeferredRecording
+        # is no longer referenced elsewhere (e.g., the async computation was cancelled
+        # or failed and garbage collected), the entry is automatically removed.
+        self._pending_deferred: weakref.WeakValueDictionary[str, DeferredRecording] = (
+            weakref.WeakValueDictionary()
+        )
         # Register atexit handler to dump cache on program exit
         if config.IS_DUMP_MEMOIZER_CACHE_ENABLED():
             atexit.register(self._dump_to_disk)
@@ -280,6 +411,31 @@ class Memoizer(_BaseMemoizer):
         the fresh_cache() context manager via clear_on_fresh_cache registration.
         """
         self._cache._memory.clear()
+
+    def _finalize_deferred_recording(
+        self,
+        cache_key: str,
+        encoded_params: object,
+        encoded_result: _EncodedR,
+    ) -> None:
+        """Finalize a deferred recording by inserting the cache entry.
+
+        This method is called when a DeferredRecording's finalize() method is invoked.
+        It creates the cache entry and inserts it into the in-memory cache.
+
+        Args:
+            cache_key: The cache key for the entry.
+            encoded_params: The encoded function parameters.
+            encoded_result: The final encoded result to cache.
+        """
+        # Remove from pending tracking
+        self._pending_deferred.pop(cache_key, None)
+        # Insert into cache
+        cache_entry = CacheEntry(
+            encoded_params=encoded_params,
+            encoded_result=encoded_result,
+        )
+        self._cache.insert(cache_key, cache_entry)
 
     @functools.cached_property
     def _shared_cache_filepath(self) -> Path:
@@ -567,6 +723,7 @@ class Memoizer(_BaseMemoizer):
             if not config.IS_CACHING_MODULE_ENABLED():
                 return fn
 
+            @functools.wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 """Call the original function and cache the result.
 
@@ -599,6 +756,20 @@ class Memoizer(_BaseMemoizer):
                     encoded_result = encoder_fn(result)
                 else:
                     encoded_result = result
+
+                # Check for deferred recording
+                if isinstance(encoded_result, DeferredRecording):
+                    # Track the pending deferred recording
+                    self._pending_deferred[cache_key] = encoded_result
+                    # Register the callback - handles race condition if pending already completed
+                    encoded_result.register_callback(
+                        functools.partial(
+                            self._finalize_deferred_recording,
+                            cache_key,
+                            encoded_params,
+                        )
+                    )
+                    return result  # Return without caching
 
                 # Store CacheEntry in cache
                 cache_entry = CacheEntry(
@@ -655,11 +826,13 @@ class Memoizer(_BaseMemoizer):
             # If caching is disabled, always raise KeyError (cache miss)
             if not config.IS_CACHING_MODULE_ENABLED():
 
+                @functools.wraps(fn)
                 def always_miss(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                     raise KeyError("Caching is disabled")
 
                 return always_miss
 
+            @functools.wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 """Retrieve the cached result without calling the function.
 
@@ -760,6 +933,10 @@ class PersistentMemoizer(_BaseMemoizer):
         with custom encoding/decoding logic. Results are stored in both
         the in-memory cache and the on-disk cache.
 
+        This method delegates to the underlying Memoizer for memory caching,
+        then adds disk persistence. For deferred recordings, it registers
+        an additional callback to persist to disk when the recording completes.
+
         Args:
             custom_params_encoder: Optional encoder for function parameters.
                                   If None, parameters are pickled directly.
@@ -797,6 +974,7 @@ class PersistentMemoizer(_BaseMemoizer):
                 custom_params_encoder, custom_result_encoder
             )(fn)
 
+            @functools.wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 """Call the original function and cache the result in both caches.
 
@@ -813,21 +991,53 @@ class PersistentMemoizer(_BaseMemoizer):
                 # Also store in disk cache
                 cache_key = self._make_key(custom_params_encoder, *args, **kwargs)
 
-                # Get the cache entry from memory cache
-                # We know it must be there since memory_record_fn just cached it
-                cached_hit = self._memoizer._cache.get(cache_key)
-                assert cached_hit, "Cache entry must exist in memory cache"
-                cache_entry = cast(CacheEntry, cached_hit.value)
+                # Check if this was a deferred recording
+                pending = self._memoizer._pending_deferred.get(cache_key)
+                if pending is not None:
+                    pending = cast(DeferredRecording[_EncodedR], pending)
+                    # Deferred recording - register our own callback for disk persistence
+                    # By the time our callback runs, Memoizer's callback will have
+                    # already inserted the cache entry, so we just read and persist it
+                    pending.register_callback(
+                        functools.partial(self._persist_to_disk, cache_key)
+                    )
+                    return result
 
-                # Store the full CacheEntry in disk cache for easier debugging
-                pickled_entry: bytes = pickle.dumps(cache_entry)
-                self._disk_cache.insert(cache_key, pickled_entry)
+                # Persist the cache entry to disk
+                self._persist_to_disk(cache_key)
 
                 return result
 
             return inner
 
         return wrapper
+
+    def _persist_to_disk(
+        self,
+        cache_key: str,
+        _callback_result: object = None,
+    ) -> None:
+        """Persist a cache entry to disk.
+
+        This method handles disk persistence for both immediate and deferred recordings:
+        - For immediate recordings: called directly after memory caching
+        - For deferred recordings: registered as a callback that runs after the
+          Memoizer's callback has inserted the entry into memory
+
+        Args:
+            cache_key: The cache key for the entry.
+            _callback_result: Unused. When called as a callback from DeferredRecording,
+                             this receives the encoded result, but we ignore it and
+                             read the full CacheEntry from the Memoizer's cache instead.
+        """
+        # Always read from memory cache - Memoizer's callback has already inserted it
+        cached_hit = self._memoizer._cache.get(cache_key)
+        assert cached_hit, "Cache entry must exist in memory cache"
+        cache_entry = cast(CacheEntry, cached_hit.value)
+
+        # Store the full CacheEntry in disk cache for easier debugging
+        pickled_entry: bytes = pickle.dumps(cache_entry)
+        self._disk_cache.insert(cache_key, pickled_entry)
 
     def replay(
         self,
@@ -872,6 +1082,7 @@ class PersistentMemoizer(_BaseMemoizer):
             # If caching is disabled, always raise KeyError (cache miss)
             if not config.IS_CACHING_MODULE_ENABLED():
 
+                @functools.wraps(fn)
                 def always_miss(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                     raise KeyError("Caching is disabled")
 
@@ -882,6 +1093,7 @@ class PersistentMemoizer(_BaseMemoizer):
                 custom_params_encoder, custom_result_decoder
             )(fn)
 
+            @functools.wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 """Retrieve the cached result without calling the function.
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2317,15 +2317,17 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         )
 
     def output_node(self):
-        return ir.TensorBox.create(
-            ir.TritonTemplateBuffer(
-                layout=self.layout,
-                inputs=self.input_nodes,
-                make_kernel_render=self.make_kernel_render,
-                mutated_inputs=self.mutated_inputs,
-                allowed_prologue_inps=self.allowed_prologue_inps,
-            )
+        buffer = ir.TritonTemplateBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            make_kernel_render=self.make_kernel_render,
+            mutated_inputs=self.mutated_inputs,
+            allowed_prologue_inps=self.allowed_prologue_inps,
         )
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            buffer.annotations["ktc"] = self.annotations["ktc"]
+        return ir.TensorBox.create(buffer)
 
     def info_dict(self) -> dict[str, Union[PrimitiveInfoType, list[PrimitiveInfoType]]]:
         """Information returned here is logged to the autotune log file when that is enabled."""
@@ -2473,6 +2475,9 @@ class ExternKernelCaller(ChoiceCaller):
                 kwargs=self.kwargs,
             )
 
+        # Pass KTC annotation to the buffer for encoding
+        if "ktc" in self.annotations:
+            inner.annotations["ktc"] = self.annotations["ktc"]
         return ir.TensorBox.create(inner)
 
     def info_dict(self) -> dict[str, Union[PrimitiveInfoType, list[PrimitiveInfoType]]]:


### PR DESCRIPTION
Summary:
# Diff Summary: Propagate KTC Annotation to Output Nodes

## Overview

This change propagates **Kernel Template Choice (KTC) annotations** from template choice objects to their corresponding output buffer nodes across all template backends in the PyTorch Inductor codebase.

## Motivation

### Problem

When a kernel template choice wins the autotuning process and produces a single output node (i.e., not a `MultiTemplateBuffer`), there was previously no straightforward way to trace back from the buffer to the original KTC that generated it.

### Solution

By passing the KTC annotation directly to the buffer at creation time, we enable:

1. **Simpler reverse engineering** of which KTC was responsible for the winning choice in single output node scenarios
2. **Automatic lookup table generation** — the annotation metadata allows tooling to automatically build lookup tables that map kernel configurations to optimal choices without requiring complex graph traversal or heuristic matching

## Files Changed

| File | Template Type |
|------|---------------|
| `codegen/cpp_template_kernel.py` | CPP Template |
| `codegen/cuda/cuda_kernel.py` | CUDA Template |
| `codegen/cutedsl/cutedsl_template.py` | CuteDSL Template |
| `codegen/nv_universal_gemm/nv_universal_gemm.py` | NV Universal GEMM |
| `codegen/rocm/rocm_kernel.py` | ROCm Template |
| `select_algorithm.py` | Triton Template + Extern Kernel |

> **Note:** Changes are mirrored in both `fbcode/caffe2/torch/_inductor/` and `xplat/caffe2/torch/_inductor/` directories.

## Implementation Pattern

The same refactoring pattern is applied consistently across all `output_node()` methods:

### Before

```python
def output_node(self) -> TensorBox:
    return TensorBox.create(
        SomeTemplateBuffer(
            layout=self.layout,
            inputs=self.input_nodes,
            # ... other params
        )
    )
```

### After

```python
def output_node(self) -> TensorBox:
    buffer = SomeTemplateBuffer(
        layout=self.layout,
        inputs=self.input_nodes,
        # ... other params
    )
    # Pass annotations to the buffer for encoding
    buffer.annotations = self.annotations
    return TensorBox.create(buffer)
```

## Key Benefits

| Benefit | Description |
|---------|-------------|
| **Traceability** | Direct link from buffer → KTC annotation without graph analysis |
| **Lookup Table Generation** | Enables automated tools to build choice → performance lookup tables |
| **Caching Integration** | Supports the `PersistentMemoizer` caching infrastructure for `tuned_mm` and `tuned_addmm` |
| **Consistency** | All template backends now follow the same annotation propagation pattern |

## Context in Stack

This commit is part of a larger effort to implement persistent caching for autotuned kernels (specifically `tuned_mm` and `tuned_addmm`). The annotation propagation is a prerequisite for the encoders/decoders to correctly serialize and deserialize winning template choices.

---

*Commit: `[inductor][lut] propagate KTC annotation to output nodes`*

Test Plan: CI

Differential Revision: D89922817




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben