### PR TITLE
[ROCm] Enabled and fixed test_circular_dependencies on ROCm 

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
-    TEST_WITH_ROCM, decorateIf, skipIfRocm
+    TEST_WITH_ROCM, decorateIf
 )
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -2362,7 +2362,6 @@ class TestImports(TestCase):
 
     # The test is flaky on ROCm/XPU and has been open and close multiple times
     # https://github.com/pytorch/pytorch/issues/110040
-    @skipIfRocm
     def test_circular_dependencies(self) -> None:
         """ Checks that all modules inside torch can be imported
         Prevents regression reported in https://github.com/pytorch/pytorch/issues/77441 """
@@ -2377,6 +2376,7 @@ class TestImports(TestCase):
                            "torch._inductor.codegen.cuda",  # depends on cutlass
                            "torch._inductor.codegen.cutedsl",  # depends on cutlass
                            "torch.distributed.benchmarks",  # depends on RPC and DDP Optim
+                           "torch.distributed.debug._frontend",  # depends on tabulate
                            "torch.distributed.examples",  # requires CUDA and torchvision
                            "torch.distributed.tensor.examples",  # example scripts
                            "torch.distributed._tools.sac_ilp",  # depends on pulp


### PR DESCRIPTION
Fixes #168860
Fixes #168859

# Enable test_circular_dependencies on ROCm

## Summary

This PR enables the `test_circular_dependencies` test to run on ROCm by removing the `@skipIfRocm` decorator and fixing the underlying import issue that was causing the test to fail.

## Background

The `test_circular_dependencies` test was previously skipped on ROCm due to flakiness (see [pytorch/pytorch#110040](https://github.com/pytorch/pytorch/issues/110040)). This test is critical as it validates that all PyTorch modules can be imported without circular dependency issues

## Changes Made

### 1. Removed ROCm Skip Decorator
@skipIfRocm

### 2. Added Missing Module to Ignore List
Added `torch.distributed.debug._frontend` to the ignored modules list as it has an optional dependency on the `tabulate` package which may not be available in all test environments.

### 3. Cleaned Up Imports
Removed unused `skipIfRocm` import from the test file.

## Root Cause

The test was failing on ROCm because the `torch.distributed.debug._frontend` module attempted to import `tabulate`, which is an optional dependency that may not be installed in all environments. This was causing import failures that manifested as circular dependency issues.

## Testing

### Test Command
```bash
pytest test/test_testing.py::TestImports::test_circular_dependencies -v
```

### Test Results
Test now passes on ROCm.






cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang