### PR TITLE
[pallas backend] Add automatic padding to align tensor sizes to WARPGROUP_SIZE (128)

### DIFF
--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -1395,7 +1395,7 @@ if test_torchinductor.RUN_GPU and has_cuda_pallas():
     class PallasTestsCUDA(PallasTestsMixin, TestCase):
         DEVICE = "cuda"
 
-    # make_pallas(test_torchinductor.SweepInputsGPUTest)
+    make_pallas(test_torchinductor.SweepInputsGPUTest)
     # make_pallas(test_torchinductor.GPUTests)
 
 if test_torchinductor.RUN_TPU and has_tpu_pallas():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #171539
* #171531
* #171485
* #171475

Mosaic requires tiles of size 128, and there's no way to mask since jnp.arange is not supported. I'm told padding is the only way. Until I find a better alternative, pad to 128.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo