### PR TITLE
Improve NUMA binding docs

### DIFF
--- a/docs/source/elastic/numa.rst
+++ b/docs/source/elastic/numa.rst
@@ -1,10 +1,12 @@
 .. _numa-api:
 
-NUMA Binding Utilities
-======================
+NUMA Binding
+============
 
 .. automodule:: torch.numa
    :members:
 
 .. automodule:: torch.numa.binding
    :members:
+   :undoc-members:
+   :member-order: bysource

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -38,7 +38,7 @@ from torch.distributed.elastic.multiprocessing.subprocess_handler import (
     SubprocessHandler,
 )
 from torch.distributed.elastic.multiprocessing.tail_log import TailLog
-from torch.numa.binding import maybe_wrap_with_numa_binding, NumaOptions
+from torch.numa.binding import _maybe_wrap_with_numa_binding, NumaOptions
 
 
 IS_WINDOWS = sys.platform == "win32"
@@ -698,7 +698,7 @@ def _wrap(
         os.environ[k] = v
 
     with stdout_cm, stderr_cm:
-        fn = maybe_wrap_with_numa_binding(
+        fn = _maybe_wrap_with_numa_binding(
             fn, gpu_index=local_rank, numa_options=numa_options
         )
         ret = record(fn)(*args_)

--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
@@ -11,7 +11,7 @@ import sys
 from subprocess import Popen
 from typing import Any
 
-from torch.numa.binding import maybe_wrap_command_args_with_numa_binding, NumaOptions
+from torch.numa.binding import _maybe_wrap_command_args_with_numa_binding, NumaOptions
 
 
 __all__ = ["SubprocessHandler"]
@@ -50,7 +50,7 @@ class SubprocessHandler:
         env_vars.update(env)
 
         args_str = (entrypoint, *[str(e) for e in args])
-        args_str = maybe_wrap_command_args_with_numa_binding(
+        args_str = _maybe_wrap_command_args_with_numa_binding(
             args_str,
             gpu_index=local_rank_id,
             numa_options=numa_options,

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -277,6 +277,19 @@ Membership Changes
    a new ``WorkerGroup`` is formed, and all workers are started with a new ``RANK`` and
    ``WORLD_SIZE``.
 
+NUMA Binding
+------------
+
+On multi-GPU systems with NUMA (Non-Uniform Memory Access) architecture, you can improve
+performance by binding worker processes to CPUs near their assigned GPUs. Use the
+``--numa-binding`` flag:
+
+::
+
+    torchrun --numa-binding=node --nproc-per-node=8 train.py
+
+See :ref:`numa-api` for more details.
+
 Important Notices
 -----------------
 
@@ -657,23 +670,8 @@ def get_args_parser() -> ArgumentParser:
         type=str,
         choices=[mode.value for mode in _AffinityMode],
         default=None,
-        help="""
-        If provided, we will affinitize the worker processes based on NUMA nodes
-        for better performance. (E.g., preferring to allocate memory locally and run on CPUs on the
-        same NUMA node.)
-
-        NOTE: This is currently only supported for GPUs, and we assume
-        that the LOCAL_RANK process corresponds to the GPU with index LOCAL_RANK. If this is not
-        accurate for your workload, this feature may be a pessimization.
-
-        Available options are:
-          - node: Processes are bound to cpu cores within a NUMA node. This is a good starting point,
-          but other options may perform even slightly better in some cases.
-          - socket: Processes are bound to cpu cores within a socket.
-          - exclusive: Processes are bound to exclusive sets of cpu cores within a NUMA node.
-          - core-complex: Processes are bound to cpu cores in a core-complex.
-          NOTE: The core-complex option might not achieve optimal performance on architectures
-          featuring a single L3 cache per socket.""",
+        help="Bind worker processes to CPUs near their assigned GPUs for better performance. "
+        "See torch/numa/binding.py for available modes and details.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
NUMA binding has now been in a stable state for a while, so I took the time to polish the docs! See issue #158775.

# Test Plan
```
$ make html
```
and viewed in browser.

Here is the section on the torchrun webpage:
<img width="1728" height="949" alt="Screenshot 2025-12-30 at 2 08 08 PM" src="https://github.com/user-attachments/assets/f41e5e0a-2516-4fcc-afbd-9fa414a8a605" />

Here is the NUMA binding page itself:
<img width="1728" height="952" alt="Screenshot 2025-12-30 at 2 08 36 PM" src="https://github.com/user-attachments/assets/970b158b-5109-4e43-8fbe-c5c43e575ff0" />
<img width="1728" height="952" alt="Screenshot 2025-12-30 at 2 08 56 PM" src="https://github.com/user-attachments/assets/01bf706f-02a6-4132-a74e-4b4b27d0aa6f" />
<img width="1728" height="957" alt="Screenshot 2025-12-30 at 2 08 49 PM" src="https://github.com/user-attachments/assets/22c03f74-98ab-48fa-9bb4-882e33985ef7" />

cc @raghavhrishi 
