### PR TITLE
[pallas backend] Refactor load and store functions.

### DIFF
--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -1147,6 +1147,7 @@ class PallasKernel(SIMDKernel):
             return False
 
         # Skip for reduction variables
+        # pyrefly: ignore [missing-argument]
         if any(entry.is_reduction for _, entry in var_items):
             return False
 
@@ -1370,6 +1371,7 @@ class PallasKernel(SIMDKernel):
         """Compute total reduction numel."""
         result = 1
         for tree in self.range_trees:
+            # pyrefly: ignore [missing-argument]
             if tree.is_reduction:
                 numel = self._safe_int(tree.numel)
                 if numel is None:
@@ -2077,6 +2079,7 @@ class PallasKernel(SIMDKernel):
             var = used_iter_vars[0]
             var_name = str(var)
             is_reduction_var = (
+                # pyrefly: ignore [missing-argument]
                 var in self.range_tree_nodes and self.range_tree_nodes[var].is_reduction
             )
 
@@ -2435,7 +2438,9 @@ class PallasKernel(SIMDKernel):
 
         # Count the number of pointwise and reduction dimensions
         n_reduction_dims = sum(
-            1 for var, entry in self.range_tree_nodes.items() if entry.is_reduction
+            1
+            for var, entry in self.range_tree_nodes.items()
+            if entry.is_reduction  # pyrefly: ignore [missing-argument]
         )
 
         if reduction_type == "xor_sum":
@@ -2468,7 +2473,7 @@ class PallasKernel(SIMDKernel):
                     reduction_vars = [
                         var
                         for var, entry in self.range_tree_nodes.items()
-                        if entry.is_reduction
+                        if entry.is_reduction  # pyrefly: ignore [missing-argument]
                     ]
                     if reduction_vars:
                         r_var = reduction_vars[0]
@@ -2481,7 +2486,7 @@ class PallasKernel(SIMDKernel):
                         pw_vars = [
                             var
                             for var, entry in self.range_tree_nodes.items()
-                            if not entry.is_reduction
+                            if not entry.is_reduction  # pyrefly: ignore [missing-argument]
                         ]
                         if pw_vars:
                             pw_var = pw_vars[0]

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -958,13 +958,8 @@ class PallasKernel(SIMDKernel):
 
         # Simplify the index
         index = V.graph.sizevars.simplify(index)
-        free_symbols = index.free_symbols
-
-        # Get iteration variables from range_tree_nodes
-        iter_vars = OrderedSet(self.range_tree_nodes.keys())
-
         # Find which iteration variable(s) are used
-        used_vars = free_symbols & iter_vars
+        used_vars = self._get_used_iter_vars(index)
 
         if len(used_vars) == 0:
             # No iteration variables, this is a constant index
@@ -1041,9 +1036,8 @@ class PallasKernel(SIMDKernel):
         The iteration variables (x0, x1, x2, x3) are already defined as jnp.arange arrays
         in the kernel. We just need to convert the sympy expression to JAX code.
         """
-        # Get iteration variables
-        iter_vars = OrderedSet(self.range_tree_nodes.keys())
         free_symbols = index.free_symbols
+        iter_vars = self._get_iter_vars()
 
         # Check that all free symbols are iteration variables (no indirect vars)
         used_vars = free_symbols & iter_vars
@@ -1066,19 +1060,25 @@ class PallasKernel(SIMDKernel):
         """
         return self._generate_strided_index(index)
 
+    def _get_iter_vars(self) -> OrderedSet:
+        """Get the set of iteration variable symbols."""
+        return OrderedSet(self.range_tree_nodes.keys())
+
+    def _get_used_iter_vars(self, index: sympy.Expr) -> OrderedSet:
+        """Get iteration variables used in an index expression."""
+        return index.free_symbols & self._get_iter_vars()
+
     def _has_iteration_vars(self, index: sympy.Expr) -> bool:
-        """Check if index expression contains iteration variables (x0, x1, etc.)."""
-        free_symbols = index.free_symbols
-        iter_vars = OrderedSet(self.range_tree_nodes.keys())
-        return bool(free_symbols & iter_vars)
+        """Check if index expression contains iteration variables."""
+        return bool(self._get_used_iter_vars(index))
+
+    def _get_indirect_vars(self, index: sympy.Expr) -> list[sympy.Symbol]:
+        """Get list of indirect variable symbols (tmp*) in an index expression."""
+        return [s for s in index.free_symbols if str(s).startswith("tmp")]
 
     def _has_indirect_vars(self, index: sympy.Expr) -> bool:
-        """Check if index expression contains indirect variables (tmp0, tmp1, etc.)."""
-        free_symbols = index.free_symbols
-        for sym in free_symbols:
-            if str(sym).startswith("tmp"):
-                return True
-        return False
+        """Check if index expression contains indirect variables."""
+        return len(self._get_indirect_vars(index)) > 0
 
     def _get_expected_output_shape(self) -> list:
         """Get the expected output shape from iteration variables.
@@ -1092,12 +1092,9 @@ class PallasKernel(SIMDKernel):
         var_items = list(self.range_tree_nodes.items())
         broadcast_vars = []
         for var_sym, entry in var_items:
-            try:
-                length = int(entry.length) if hasattr(entry.length, "__int__") else None
-                if length is not None:
-                    broadcast_vars.append(length)
-            except (TypeError, ValueError):
-                pass
+            length = self._safe_int(entry.length)
+            if length is not None:
+                broadcast_vars.append(length)
 
         if len(broadcast_vars) <= 1:
             return broadcast_vars
@@ -1115,146 +1112,127 @@ class PallasKernel(SIMDKernel):
         2. Square buffers: index coefficient pattern indicates transposed access
            (first iteration var has larger coefficient than second)
         """
-        try:
-            buf_obj = V.graph.get_buffer(name)
-            buf_size = buf_obj.get_size()
-            buf_stride = buf_obj.get_layout().stride
+        buf_obj = V.graph.get_buffer(name)
+        if buf_obj is None:
+            return False
 
-            # Only handle 2D buffers
-            if len(buf_size) != 2:
-                return False
+        buf_size = buf_obj.get_size()
 
-            size0 = int(buf_size[0]) if hasattr(buf_size[0], "__int__") else None
-            size1 = int(buf_size[1]) if hasattr(buf_size[1], "__int__") else None
-            if size0 is None or size1 is None or size0 <= 1 or size1 <= 1:
-                return False
+        # Only handle 2D buffers
+        if len(buf_size) != 2:
+            return False
 
-            # Check buffer stride - if column-major, don't transpose on load
-            s0 = int(buf_stride[0]) if hasattr(buf_stride[0], "__int__") else None
-            s1 = int(buf_stride[1]) if hasattr(buf_stride[1], "__int__") else None
-            if s0 is not None and s1 is not None and s0 < s1:
-                return False
+        layout = getattr(buf_obj, "get_layout", lambda: None)()
+        if layout is None:
+            return False
 
-            # Get iteration variable info
-            var_items = list(self.range_tree_nodes.items())
-            if len(var_items) < 2:
-                return False
+        buf_stride = getattr(layout, "stride", None)
+        if buf_stride is None or len(buf_stride) != 2:
+            return False
 
-            # Skip for reduction variables
-            has_reduction_var = any(
-                entry.prefix.startswith("r") for _, entry in var_items
-            )
-            if has_reduction_var:
-                return False
+        size0 = self._safe_int(buf_size[0])
+        size1 = self._safe_int(buf_size[1])
+        if size0 is None or size1 is None or size0 <= 1 or size1 <= 1:
+            return False
 
-            iter_sizes = []
-            for var, entry in var_items:
-                length = entry.length
-                if hasattr(length, "__int__"):
-                    iter_sizes.append(int(length))
+        # Check buffer stride - if column-major, don't transpose on load
+        s0 = self._safe_int(buf_stride[0])
+        s1 = self._safe_int(buf_stride[1])
+        if s0 is not None and s1 is not None and s0 < s1:
+            return False
 
-            if len(iter_sizes) < 2:
-                return False
+        # Get iteration variable info
+        var_items = list(self.range_tree_nodes.items())
+        if len(var_items) < 2:
+            return False
 
-            # For 2D: iter_sizes[0] is inner, iter_sizes[1] is outer
-            expected_rows = iter_sizes[1]
-            expected_cols = iter_sizes[0]
+        # Skip for reduction variables
+        if any(entry.is_reduction for _, entry in var_items):
+            return False
 
-            # For non-square buffers: if shape is (cols, rows) instead of (rows, cols)
-            if size0 != size1:
-                if size0 == expected_cols and size1 == expected_rows:
-                    return True
-                return False
+        iter_sizes = []
+        for var, entry in var_items:
+            length = self._safe_int(entry.length)
+            if length is not None:
+                iter_sizes.append(length)
 
-            # For square buffers: only transpose if output is also column-major
-            # This distinguishes actual transpose operations from broadcasting
-            # Check by looking at the output buffer name (should end with the store target)
-            # We can't directly check output_buffers here, so check the store_mode
-            # on the kernel - if it's column-major output, it's transpose
+        if len(iter_sizes) < 2:
+            return False
 
-            # Get output buffer info from kernel args (may not be populated yet)
-            # Fall back to checking if we have column-major stores expected
-            output_is_column_major = False
-            try:
-                # Check all registered output buffers
-                for out_name in getattr(self.args, "output_buffers", {}).values():
-                    out_buf = V.graph.get_buffer(out_name)
-                    out_stride = out_buf.get_layout().stride
-                    if len(out_stride) >= 2:
-                        out_s0 = (
-                            int(out_stride[0])
-                            if hasattr(out_stride[0], "__int__")
-                            else None
-                        )
-                        out_s1 = (
-                            int(out_stride[1])
-                            if hasattr(out_stride[1], "__int__")
-                            else None
-                        )
-                        if (
-                            out_s0 is not None
-                            and out_s1 is not None
-                            and out_s0 < out_s1
-                        ):
-                            output_is_column_major = True
-                            break
-            except Exception:
-                pass
+        # For 2D: iter_sizes[0] is inner, iter_sizes[1] is outer
+        expected_rows = iter_sizes[1]
+        expected_cols = iter_sizes[0]
 
-            # Only use coefficient analysis if output is column-major
-            if not output_is_column_major:
-                return False
+        # For non-square buffers: if shape is (cols, rows) instead of (rows, cols)
+        if size0 != size1:
+            return size0 == expected_cols and size1 == expected_rows
 
-            first_var = var_items[0][0]
-            second_var = var_items[1][0]
+        # For square buffers: only transpose if output is also column-major
+        # This distinguishes actual transpose operations from broadcasting
+        output_is_column_major = self._has_column_major_output()
+        if not output_is_column_major:
+            return False
 
-            index = V.graph.sizevars.simplify(index)
+        first_var = var_items[0][0]
+        second_var = var_items[1][0]
+        index = V.graph.sizevars.simplify(index)
 
-            def get_coefficient(var):
-                if index == var:
-                    return 1
-                if index.is_Add:
-                    for term in index.args:
-                        coeff = get_coefficient_from_term(term, var)
-                        if coeff is not None:
-                            return coeff
-                return get_coefficient_from_term(index, var)
+        def get_coefficient_from_term(term, var):
+            if term == var:
+                return 1
+            if term.is_Mul:
+                coeff = 1
+                has_var = False
+                for factor in term.args:
+                    if factor == var:
+                        has_var = True
+                    elif factor.is_number:
+                        coeff *= int(factor)
+                if has_var:
+                    return coeff
+            return None
 
-            def get_coefficient_from_term(term, var):
-                if term == var:
-                    return 1
-                if term.is_Mul:
-                    coeff = 1
-                    has_var = False
-                    for factor in term.args:
-                        if factor == var:
-                            has_var = True
-                        elif factor.is_number:
-                            coeff *= int(factor)
-                    if has_var:
+        def get_coefficient(var):
+            if index == var:
+                return 1
+            if index.is_Add:
+                for term in index.args:
+                    coeff = get_coefficient_from_term(term, var)
+                    if coeff is not None:
                         return coeff
-                return None
+            return get_coefficient_from_term(index, var)
 
-            coeff_first = get_coefficient(first_var)
-            coeff_second = get_coefficient(second_var)
+        coeff_first = get_coefficient(first_var)
+        coeff_second = get_coefficient(second_var)
 
-            if coeff_first is not None and coeff_second is not None:
-                # Transposed access: first var (inner dim) has larger coefficient
-                return coeff_first > coeff_second
+        if coeff_first is not None and coeff_second is not None:
+            # Transposed access: first var (inner dim) has larger coefficient
+            return coeff_first > coeff_second
 
-            return False
+        return False
 
-        except Exception:
-            return False
+    def _has_column_major_output(self) -> bool:
+        """Check if any output buffer has column-major stride layout."""
+        output_buffers = getattr(self.args, "output_buffers", {})
+        # output_buffers maps buffer_name -> param_name, we need buffer_name
+        for buf_name in output_buffers:
+            out_buf = V.graph.get_buffer(buf_name)
+            if out_buf is None:
+                continue
+            layout = getattr(out_buf, "get_layout", lambda: None)()
+            if layout is None:
+                continue
+            out_stride = getattr(layout, "stride", None)
+            if out_stride is None or len(out_stride) < 2:
+                continue
+            out_s0 = self._safe_int(out_stride[0])
+            out_s1 = self._safe_int(out_stride[1])
+            if out_s0 is not None and out_s1 is not None and out_s0 < out_s1:
+                return True
+        return False
 
     def _get_index_expr(self, index: sympy.Expr) -> tuple[str, bool]:
-        """
-        Get the index expression string and whether it needs flattening.
-
-        Returns:
-            Tuple of (index_str, needs_flatten) where needs_flatten indicates
-            if the buffer should be flattened before indexing (for mixed indexing).
-        """
+        """Get the index expression string and whether it needs flattening."""
         has_indirect = self._has_indirect_vars(index)
         has_iter_vars = self._has_iteration_vars(index)
 
@@ -1306,19 +1284,21 @@ class PallasKernel(SIMDKernel):
         all_buffer_names.update(V.graph.name_to_buffer.keys())
 
         # Get shapes and sizes for all buffers
+        # Use try/except to handle special layouts (MultiOutputLayout, NoneLayout, etc.)
+        # that don't support get_size()
         buf_info = []
         for buf_name in all_buffer_names:
             try:
                 buf = V.graph.get_buffer(buf_name)
+                if buf is None:
+                    continue
                 size = buf.get_size()
-                shape = tuple(int(s) if hasattr(s, "__int__") else s for s in size)
+                shape = tuple(self._safe_int(s) or s for s in size)
                 # Calculate flattened size
                 total_size = 1
                 for s in size:
-                    if hasattr(s, "__int__"):
-                        total_size *= int(s)
-                    else:
-                        total_size *= s
+                    int_s = self._safe_int(s)
+                    total_size *= int_s if int_s is not None else s
                 buf_info.append((buf_name, shape, total_size))
             except Exception:
                 pass
@@ -1362,313 +1342,676 @@ class PallasKernel(SIMDKernel):
             self.tensor_masks[buf_name] = mask_var
         return self.tensor_masks[buf_name]
 
+    def _ensure_masked_ops_initialized(self) -> None:
+        """Initialize masked ops strategy on first load/store if not yet determined."""
+        if self.use_masked_ops is None:
+            self.use_masked_ops = self._determine_masked_ops_for_kernel()
+
+    @staticmethod
+    def _safe_int(val: Any) -> Optional[int]:
+        """Convert value to int, returning None on failure."""
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return None
+
+    def _compute_prefix_numel(self, prefixes: OrderedSet) -> Optional[int]:
+        """Compute total numel for given prefixes (e.g., pointwise prefixes)."""
+        result = 1
+        for p in prefixes:
+            if p in self.numels:
+                numel = self._safe_int(self.numels[p])
+                if numel is None:
+                    return None
+                result *= numel
+        return result
+
+    def _compute_reduction_numel(self) -> Optional[int]:
+        """Compute total reduction numel."""
+        result = 1
+        for tree in self.range_trees:
+            if tree.is_reduction:
+                numel = self._safe_int(tree.numel)
+                if numel is None:
+                    return None
+                result *= numel
+        return result
+
+    def _get_buffer_info(self, name: str) -> tuple[Any, Any, Any, list, bool]:
+        """Get buffer metadata (buf_obj, buf_size, buf_numel, actual_strides, is_contiguous)."""
+        buf_obj = V.graph.get_buffer(name)
+        buf_size = buf_obj.get_size()
+        buf_numel = 1
+        for s in buf_size:
+            sval = self._safe_int(s)
+            buf_numel *= sval if sval is not None else s
+
+        # Get buffer strides and check contiguity
+        actual_strides: list = []
+        is_contiguous = True
+
+        layout = getattr(buf_obj, "get_layout", lambda: None)()
+        buf_stride = getattr(layout, "stride", None) if layout else None
+
+        if buf_stride is not None:
+            for i in range(len(buf_size)):
+                actual_stride = self._safe_int(buf_stride[i])
+                actual_strides.append(actual_stride)
+
+            # Check contiguity
+            if len(buf_size) == 1:
+                if actual_strides[0] is not None and actual_strides[0] != 1:
+                    is_contiguous = False
+            elif len(buf_size) > 1:
+                expected_stride = 1
+                for i in range(len(buf_size) - 1, -1, -1):
+                    actual_stride = actual_strides[i]
+                    if actual_stride is None or actual_stride != expected_stride:
+                        is_contiguous = False
+                    dim_size = self._safe_int(buf_size[i])
+                    if dim_size is not None:
+                        expected_stride *= dim_size
+
+        return buf_obj, buf_size, buf_numel, actual_strides, is_contiguous
+
+    def _compute_output_numel_from_index(
+        self, index: sympy.Expr
+    ) -> tuple[int, OrderedSet]:
+        """Compute expected output numel and used vars from iteration variables in index."""
+        used_vars = self._get_used_iter_vars(index)
+
+        used_range_lengths = []
+        for var in used_vars:
+            if var in self.range_tree_nodes:
+                entry = self.range_tree_nodes[var]
+                length_val = self._safe_int(entry.length)
+                if length_val is not None:
+                    used_range_lengths.append(length_val)
+
+        output_numel = 1
+        for l in used_range_lengths:
+            output_numel *= l
+
+        return output_numel, used_vars
+
+    def _get_index_coefficients(
+        self, index: sympy.Expr, used_vars: OrderedSet
+    ) -> OrderedSet:
+        """
+        Extract coefficients of iteration variables from index expression.
+        """
+        coefficients: OrderedSet = OrderedSet()
+        for var in used_vars:
+            var_expr = BlockPatternMatcher.get_subexpr_involving_symbol(index, var)
+            stride = BlockPatternMatcher.match_affine_block_expr(var_expr, var)
+            if stride is None:
+                stride = 1  # Variable without explicit coefficient has stride 1
+            coef = self._safe_int(stride)
+            coefficients.add(coef if coef is not None else stride)
+        return coefficients
+
+    def _check_gather_pattern(
+        self,
+        buf_size: list,
+        actual_strides: list,
+        is_contiguous: bool,
+        coefficients: OrderedSet,
+    ) -> bool:
+        """
+        Check if access pattern requires gather (non-standard striding).
+        """
+        expected_strides = [1]  # 1D buffers have stride 1
+
+        if len(buf_size) > 1:
+            expected_stride = 1
+            expected_strides = []
+            for i in range(len(buf_size) - 1, -1, -1):
+                expected_strides.insert(0, expected_stride)
+                dim_size = self._safe_int(buf_size[i])
+                if dim_size is not None:
+                    expected_stride *= dim_size
+
+        if is_contiguous:
+            # Buffer is contiguous - check if access coefficients match expected strides
+            expected_stride_set = OrderedSet(expected_strides)
+            for coef in coefficients:
+                if coef not in expected_stride_set:
+                    return True
+        else:
+            # Buffer is NOT contiguous (strided input)
+            # Check if coefficients match actual buffer strides
+            actual_stride_set = OrderedSet(s for s in actual_strides if s is not None)
+            for coef in coefficients:
+                if coef not in actual_stride_set:
+                    return True
+
+        return False
+
+    def _needs_strided_indexing(
+        self,
+        name: str,
+        index: sympy.Expr,
+        index_str: str,
+        needs_flatten: bool,
+    ) -> tuple[str, bool]:
+        """
+        Check if buffer access needs strided indexing due to size mismatch or gather patterns.
+
+        This handles cases like:
+        - Pooling operations where input/output have different sizes
+        - im2col-like gather patterns
+        - Transposed or strided buffer access
+        """
+        # Only applies when full array access is indicated
+        if index_str != "..." or needs_flatten:
+            return index_str, needs_flatten
+
+        buf = V.graph.get_buffer(name)
+        if buf is None:
+            return index_str, needs_flatten
+
+        buf_obj, buf_size, buf_numel, actual_strides, is_contiguous = (
+            self._get_buffer_info(name)
+        )
+        output_numel, used_vars = self._compute_output_numel_from_index(index)
+        all_iter_vars = self._get_iter_vars()
+        coefficients = self._get_index_coefficients(index, used_vars)
+
+        # Check for gather pattern
+        has_non_unit_strides = self._check_gather_pattern(
+            buf_size, actual_strides, is_contiguous, coefficients
+        )
+
+        # Check for im2col-like pattern (more iter vars used than buffer dims)
+        buf_effective_dims = sum(1 for s in buf_size if self._safe_int(s) != 1)
+        not_all_vars_used = (
+            len(used_vars) < len(all_iter_vars)
+            and len(used_vars) > 0
+            and buf_effective_dims > 1
+            and len(used_vars) > len(buf_size)
+        )
+
+        # Check various conditions for skipping strided indexing
+        is_tpu = torch._inductor.config._debug_cpu_to_tpu_pallas
+        is_known_non_contiguous = not is_contiguous and all(
+            s is not None for s in actual_strides
+        )
+        has_symbolic_coef = any(not isinstance(c, int | float) for c in coefficients)
+        skip_for_non_contiguous = (
+            is_known_non_contiguous and not is_tpu and buf_numel == output_numel
+        )
+
+        # Determine if strided indexing is needed
+        if (
+            output_numel > 0
+            and (buf_numel != output_numel or not_all_vars_used or has_non_unit_strides)
+            and len(used_vars) > 0
+            and not skip_for_non_contiguous
+            and not has_symbolic_coef
+        ):
+            return self._generate_strided_index(index), True
+
+        return index_str, needs_flatten
+
+    def _adjust_index_for_buffer_shape(
+        self,
+        name: str,
+        index: sympy.Expr,
+        index_str: str,
+        needs_flatten: bool,
+    ) -> tuple[str, bool]:
+        """
+        Adjust index expression based on buffer shape (0-dim scalar, multi-dim, etc.).
+        """
+        if needs_flatten or index_str == "...":
+            return index_str, needs_flatten
+
+        buf_obj = V.graph.get_buffer(name)
+        if buf_obj is None:
+            return index_str, needs_flatten
+
+        buf_size = buf_obj.get_size()
+
+        # 0-dimensional (scalar) buffer - use [...] to access it
+        if len(buf_size) == 0:
+            return "...", needs_flatten
+
+        # Multi-dimensional buffer with constant/scalar index
+        if len(buf_size) > 1:
+            has_iter_vars = self._has_iteration_vars(index)
+            if not has_iter_vars:
+                return index_str, True  # Use flattened access
+            elif "::" in index_str:
+                # Strided slice patterns need flattened indexing for multi-dim
+                return self._generate_strided_index(index), True
+
+        # GPU doesn't support gather from slice patterns on 1D buffers
+        if self.is_gpu and "::" in index_str:
+            return self._generate_strided_index(index), True
+
+        return index_str, needs_flatten
+
+    def _build_load_expr(
+        self,
+        buf: str,
+        name: str,
+        index: sympy.Expr,
+        index_str: str,
+        needs_flatten: bool,
+        use_masked: bool,
+    ) -> str:
+        """
+        Build the load expression based on indexing mode.
+        """
+        if use_masked:
+            # GPU masked load: flatten tensor and apply per-tensor mask
+            mask_var = self._get_or_create_mask(name)
+            return f"pltriton.load({buf}.at[pl.ds(block_size)], mask={mask_var})"
+        elif needs_flatten:
+            # Flatten then index for non-contiguous access (gather operation)
+            if self.is_gpu:
+                # GPU: use pltriton.load with explicit offsets
+                return f"pltriton.load({buf}.at[{index_str}])"
+            else:
+                # CPU: use JAX array indexing
+                has_minmax = index.has(sympy.Min) or index.has(sympy.Max)
+                idx = f"({index_str}).astype(jnp.int64)" if has_minmax else index_str
+                return f"{buf}[...].flatten()[{idx}]"
+        else:
+            # Direct indexing for contiguous access
+            load_expr = f"{buf}[{index_str}]"
+
+            # Check for transposed access
+            if index_str == "..." and self._is_transposed_access(name, index):
+                load_expr = f"jnp.transpose({load_expr})"
+                self.has_transposed_load = True
+
+            return load_expr
+
+    def _maybe_squeeze_intermediate_buffer(self, name: str, load_expr: str) -> str:
+        """
+        Squeeze (N,1) intermediate buffers when kernel has 1D graph inputs.
+
+        This avoids wrong broadcasting: (N,) op (N,1) -> (N,N) instead of (N,)
+        """
+        if not name.startswith("buf"):
+            return load_expr
+
+        # Check if any input buffer is a 1D graph input
+        has_1d_input = any(
+            not buf_name.startswith("buf")
+            and (buf_obj := V.graph.get_buffer(buf_name)) is not None
+            and len(buf_obj.get_size()) == 1
+            for buf_name in self.args.input_buffers
+        )
+
+        if has_1d_input:
+            buf_obj = V.graph.get_buffer(name)
+            if buf_obj is not None:
+                buf_size = buf_obj.get_size()
+                if len(buf_size) == 2 and buf_size[-1] == 1:
+                    return f"jnp.squeeze({load_expr}, axis=-1)"
+
+        return load_expr
+
+    def _check_im2col_pattern(
+        self, index: sympy.Expr, index_str: str, needs_flatten: bool
+    ) -> tuple[str, bool]:
+        """
+        Check for im2col-like patterns where store uses block variables but load doesn't.
+
+        For cat/expand patterns, both load and store prepared indices share block vars.
+        For im2col patterns, store compresses to block vars but load doesn't.
+        """
+        if index_str != "..." or needs_flatten:
+            return index_str, needs_flatten
+
+        prepared_index = self.prepare_indexing(index)
+        iter_vars = self._get_iter_vars()
+        store_orig_vars = self._get_used_iter_vars(index)
+        store_prep_vars = (
+            prepared_index.free_symbols
+            if hasattr(prepared_index, "free_symbols")
+            else OrderedSet()
+        ) & iter_vars
+        new_vars = store_prep_vars - store_orig_vars
+
+        # Only trigger if store introduces new block vars
+        if not new_vars or len(store_orig_vars) <= 1:
+            return index_str, needs_flatten
+
+        # Check if loads are compatible with broadcast or cat pattern
+        has_im2col_pattern = False
+        for buf_name, load_index in self.load_index_exprs.items():
+            load_orig_vars = self._get_used_iter_vars(load_index)
+            if not load_orig_vars:
+                continue
+
+            # Load has iteration variables
+            if load_orig_vars != store_orig_vars:
+                continue
+
+            # Same vars - check if load gets compressed too
+            prep_load = self.prepare_indexing(load_index)
+            load_prep_vars = (
+                prep_load.free_symbols
+                if hasattr(prep_load, "free_symbols")
+                else OrderedSet()
+            ) & iter_vars
+
+            # If store compresses but load doesn't, check for strided input vs im2col
+            if load_orig_vars != load_prep_vars or store_prep_vars == store_orig_vars:
+                continue
+
+            # Check if load coefficients match buffer strides
+            if not self._check_load_is_strided_input(
+                buf_name, load_index, load_orig_vars
+            ):
+                has_im2col_pattern = True
+                break
+
+        if has_im2col_pattern:
+            return self._generate_strided_index(prepared_index), True
+
+        return index_str, needs_flatten
+
+    def _check_load_is_strided_input(
+        self, buf_name: str, load_index: sympy.Expr, load_orig_vars: OrderedSet
+    ) -> bool:
+        """
+        Check if load coefficients match buffer strides (strided input vs im2col).
+        """
+        buf = V.graph.get_buffer(buf_name)
+        if buf is None:
+            return False
+
+        layout = getattr(buf, "get_layout", lambda: None)()
+        if layout is None:
+            return False
+
+        buf_strides = getattr(layout, "stride", None)
+        if buf_strides is None:
+            return False
+
+        buf_sizes = buf.get_size()
+
+        # Get load coefficients
+        load_coeffs = []
+        for var in load_orig_vars:
+            var_expr = BlockPatternMatcher.get_subexpr_involving_symbol(load_index, var)
+            coef = BlockPatternMatcher.match_affine_block_expr(var_expr, var)
+            if coef is not None:
+                int_coef = self._safe_int(coef)
+                load_coeffs.append(int_coef if int_coef is not None else coef)
+
+        # Check if coefficients match buffer strides
+        # Only include strides for non-trivial dimensions (size > 1)
+        buf_stride_set = OrderedSet()
+        for i, s in enumerate(buf_strides):
+            dim_size = self._safe_int(buf_sizes[i])
+            if dim_size is None or dim_size > 1:
+                int_s = self._safe_int(s)
+                buf_stride_set.add(int_s if int_s is not None else s)
+
+        return OrderedSet(load_coeffs) == buf_stride_set
+
+    def _check_store_needs_transpose(self, name: str) -> bool:
+        """
+        Check if output needs transpose for column-major storage.
+
+        Transpose on store is needed when:
+        - Output has column-major stride (s0 < s1)
+        - But input(s) have row-major stride
+        - And we haven't already transposed on load
+        """
+        if self.has_transposed_load:
+            return False
+
+        buf = V.graph.get_buffer(name)
+        if buf is None:
+            return False
+
+        layout = getattr(buf, "get_layout", lambda: None)()
+        if layout is None:
+            return False
+
+        buf_stride = getattr(layout, "stride", None)
+        if buf_stride is None:
+            return False
+
+        buf_size = buf.get_size()
+        if len(buf_stride) != 2 or len(buf_size) != 2:
+            return False
+
+        size0 = self._safe_int(buf_size[0])
+        size1 = self._safe_int(buf_size[1])
+        s0 = self._safe_int(buf_stride[0])
+        s1 = self._safe_int(buf_stride[1])
+
+        # Check if output is column-major with valid dimensions
+        if not (
+            s0 is not None
+            and s1 is not None
+            and s0 < s1
+            and size0 is not None
+            and size1 is not None
+            and size0 > 1
+            and size1 > 1
+        ):
+            return False
+
+        # Check if any input is column-major (if so, no transpose needed)
+        for inp_name in self.args.input_buffers:
+            inp_buf = V.graph.get_buffer(inp_name)
+            if inp_buf is None:
+                continue
+            inp_layout = getattr(inp_buf, "get_layout", lambda: None)()
+            if inp_layout is None:
+                continue
+            inp_stride = getattr(inp_layout, "stride", None)
+            if inp_stride is None or len(inp_stride) != 2:
+                continue
+            inp_s0 = self._safe_int(inp_stride[0])
+            inp_s1 = self._safe_int(inp_stride[1])
+            if inp_s0 is not None and inp_s1 is not None and inp_s0 < inp_s1:
+                return False  # Input is also column-major
+
+        return True
+
+    def _build_full_array_store_expr(
+        self, out: str, value: CSEVariable, needs_transpose: bool
+    ) -> str:
+        """
+        Build store expression for full array assignment.
+
+        Handles scalar broadcast, shape matching, and optional transpose.
+        """
+        if needs_transpose:
+            return (
+                f"{out}[...] = ("
+                f"jnp.full({out}.shape, {value}) if jnp.asarray({value}).ndim == 0 "
+                f"else jnp.transpose(jnp.asarray({value})))"
+            )
+        else:
+            return (
+                f"{out}[...] = ("
+                f"jnp.full({out}.shape, {value}) if jnp.asarray({value}).ndim == 0 "
+                f"else (jnp.broadcast_to(jnp.asarray({value}), {out}.shape) "
+                f"if jnp.asarray({value}).size != {out}.size "
+                f"else jnp.asarray({value}).reshape({out}.shape)))"
+            )
+
+    def _build_store_expr(
+        self,
+        out: str,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        index_str: str,
+        needs_flatten: bool,
+        use_masked: bool,
+    ) -> str:
+        """
+        Build the store expression based on indexing mode.
+        """
+        if use_masked:
+            # GPU masked store: flatten tensor and apply per-tensor mask
+            mask_var = self._get_or_create_mask(name)
+            return (
+                f"pltriton.store({out}.at[pl.ds(block_size)], {value}, mask={mask_var})"
+            )
+
+        if index_str == "...":
+            # Full array store with shape matching
+            needs_transpose = self._check_store_needs_transpose(name)
+            return self._build_full_array_store_expr(out, value, needs_transpose)
+
+        if needs_flatten:
+            # Block variable indexing (e.g., im2col) - use flattened scatter
+            if self.is_gpu:
+                return f"pltriton.store({out}.at[{index_str}], jnp.asarray({value}))"
+            else:
+                return (
+                    f"{out}[...] = {out}[...].flatten().at[({index_str}).flatten()].set("
+                    f"jnp.asarray({value}).flatten()).reshape({out}.shape)"
+                )
+
+        # Direct indexed assignment
+        has_indirect = self._has_indirect_vars(index)
+        buf = V.graph.get_buffer(name)
+
+        if buf is not None:
+            buf_size = buf.get_size()
+            if len(buf_size) > 1 and not self._has_iteration_vars(index):
+                # Multi-dim output with constant index - use [...] for full assignment
+                return self._build_full_array_store_expr(out, value, False)
+
+        if has_indirect:
+            # Indirect indexed store (scatter): broadcast scalar value
+            return (
+                f"{out}[{index_str}] = ("
+                f"jnp.full({index_str}.shape, {value}) "
+                f"if jnp.asarray({value}).ndim == 0 else {value})"
+            )
+
+        return f"{out}[{index_str}] = {value}"
+
+    def _build_scatter_store_expr(
+        self,
+        out: str,
+        value: CSEVariable,
+        scatter_info: dict[str, Any],
+        name: str,
+        mode: Any,
+    ) -> str:
+        """Build store expression for scatter operations (indirect indexing)."""
+        is_point_scatter = scatter_info.get("is_point_scatter", False)
+
+        # Mark this output parameter as needing to be readable (for aliasing)
+        self.outputs_need_read.add(out)
+        alias_param = f"{out}_alias"
+
+        # Use .add() for atomic_add mode, .set() otherwise
+        scatter_op = "add" if mode == "atomic_add" else "set"
+
+        if is_point_scatter:
+            # Single-element scatter
+            indirect_var = scatter_info["indirect_var"]
+            indirect_dim = scatter_info["indirect_dim"]
+            output_shape = scatter_info["output_shape"]
+
+            # Build index tuple with 0s for other dimensions
+            index_parts = []
+            for dim in range(len(output_shape)):
+                if dim == indirect_dim:
+                    index_parts.append(indirect_var)
+                else:
+                    index_parts.append("0")
+
+            index_tuple = ", ".join(index_parts)
+            return f"{out}[...] = {alias_param}[...].at[{index_tuple}].{scatter_op}({value})"
+
+        # Scatter with iteration variables
+        indirect_var = scatter_info["indirect_var"]
+        dims_before = scatter_info["dims_before"]
+        dims_after = scatter_info["dims_after"]
+
+        # Determine if element-wise or slice-based scatter
+        buf = V.graph.get_buffer(name)
+        output_ndim = len(buf.get_size()) if buf is not None else 0
+
+        num_iter_vars_in_store = len(dims_before) + len(dims_after)
+        total_kernel_iter_vars = len(self.range_tree_nodes)
+        remaining_dims = output_ndim - 1  # dims other than indirect
+
+        is_element_wise = (
+            num_iter_vars_in_store == remaining_dims
+            and num_iter_vars_in_store == total_kernel_iter_vars
+        )
+
+        if is_element_wise:
+            # Element-wise scatter: use iteration variable names
+            index_parts = [var_name for var_name, size in dims_before]
+
+            # Reshape indirect var for broadcasting if needed
+            n_leading = len(dims_before)
+            n_trailing = len(dims_after)
+            if n_leading > 0 and n_trailing > 0:
+                leading_ones = "None, " * n_leading
+                trailing_nones = ", None" * n_trailing
+                indirect_reshaped = f"{indirect_var}[{leading_ones}...{trailing_nones}]"
+            else:
+                indirect_reshaped = indirect_var
+            index_parts.append(indirect_reshaped)
+
+            index_parts.extend(var_name for var_name, size in dims_after)
+        else:
+            # Slice-based scatter: use : for iteration dimensions
+            index_parts = [":" for _ in dims_before]
+            index_parts.append(indirect_var)
+            index_parts.extend(":" for _ in dims_after)
+
+        index_tuple = ", ".join(index_parts)
+        return (
+            f"{out}[...] = {alias_param}[...].at[{index_tuple}].{scatter_op}({value})"
+        )
+
     @typing_extensions.override
     def load(self, name: str, index: sympy.Expr) -> CSEVariable:
         buf = self.args.input(name)
         dtype = V.graph.get_dtype(name)
 
-        def _safe_int(val):
-            try:
-                return int(val)
-            except (TypeError, ValueError):
-                return None
-
         # Track the load index expression for argmax/argmin axis detection
         self.load_index_exprs[name] = index
 
-        # Determine masked ops strategy on first load/store if not yet determined
-        if self.use_masked_ops is None:
-            self.use_masked_ops = self._determine_masked_ops_for_kernel()
+        self._ensure_masked_ops_initialized()
 
+        # Get base index expression
         index_str, needs_flatten = self._get_index_expr(index)
 
-        # Check for buffer size mismatch when using full array access
-        # This happens with pooling operations where input/output have different sizes
-        # In this case, we need to use strided indexing even though _get_index_str
-        # returned "..." (because the index expression is strided)
-        if index_str == "..." and not needs_flatten:
-            try:
-                buf_obj = V.graph.get_buffer(name)
-                buf_size = buf_obj.get_size()
-                buf_numel = 1
-                for s in buf_size:
-                    sval = _safe_int(s)
-                    buf_numel *= sval if sval is not None else s
+        # Check for buffer size mismatch requiring strided indexing
+        index_str, needs_flatten = self._needs_strided_indexing(
+            name, index, index_str, needs_flatten
+        )
 
-                # Get iteration variables used in the index expression
-                iter_vars = OrderedSet(self.range_tree_nodes.keys())
-                used_vars = index.free_symbols & iter_vars
+        # Adjust index for buffer shape (scalar, multi-dim, etc.)
+        index_str, needs_flatten = self._adjust_index_for_buffer_shape(
+            name, index, index_str, needs_flatten
+        )
 
-                # Compute the expected output size from iteration variables USED in the index
-                # Only multiply ranges of variables that appear in the index expression
-                used_range_lengths = []
-                for var in used_vars:
-                    if var in self.range_tree_nodes:
-                        entry = self.range_tree_nodes[var]
-                        length_val = _safe_int(entry.length)
-                        if length_val is not None:
-                            used_range_lengths.append(length_val)
+        # Determine if masked operations should be used
+        use_masked = (
+            index_str == "..." and not needs_flatten and self.use_masked_ops is True
+        )
 
-                # Multiply ranges of used variables to get expected output size
-                output_numel = 1
-                for l in used_range_lengths:
-                    output_numel *= l
+        # Build the load expression
+        load_expr = self._build_load_expr(
+            buf, name, index, index_str, needs_flatten, use_masked
+        )
 
-                # Check if index has gather-pattern strides (im2col-like)
-                # For expression like 4*x3 + 224*x4 + y0 + 56*y1 + 3136*y2:
-                # - If buffer is contiguous and index coefficients don't match buffer strides,
-                #   this is a gather pattern that needs explicit indexing
-                # - If index coefficients match buffer strides (like 1 + 10*x for 10xN buffer),
-                #   it's standard strided access and [...] is correct after .contiguous()
-                has_non_unit_strides = False
-                is_originally_contiguous = True
-                actual_buf_strides: list = []
-                coefficients: OrderedSet = OrderedSet()
-                try:
-                    buf_stride = buf_obj.get_layout().stride
-                    # Check if original buffer is contiguous (stride matches size)
-                    is_originally_contiguous = True
-                    expected_strides = [1]  # 1D buffers have stride 1
-                    actual_buf_strides = []  # Track actual buffer strides
-
-                    # First, collect all actual buffer strides
-                    for i in range(len(buf_size)):
-                        actual_stride = _safe_int(buf_stride[i])
-                        actual_buf_strides.append(actual_stride)
-
-                    # For 1D buffers, check if stride is 1
-                    if len(buf_size) == 1:
-                        if (
-                            actual_buf_strides[0] is not None
-                            and actual_buf_strides[0] != 1
-                        ):
-                            is_originally_contiguous = False
-                    elif len(buf_size) > 1:
-                        expected_stride = 1
-                        expected_strides = []  # Reset for multi-dim
-                        for i in range(len(buf_size) - 1, -1, -1):
-                            expected_strides.insert(0, expected_stride)
-                            actual_stride = actual_buf_strides[i]
-                            if (
-                                actual_stride is None
-                                or actual_stride != expected_stride
-                            ):
-                                is_originally_contiguous = False
-                                # Don't break - continue to compute expected_strides
-                            dim_size = _safe_int(buf_size[i])
-                            if dim_size is not None:
-                                expected_stride *= dim_size
-
-                    # Get index coefficients
-                    coefficients = OrderedSet()
-                    for var in used_vars:
-                        var_expr = BlockPatternMatcher.get_subexpr_involving_symbol(
-                            index, var
-                        )
-                        stride = BlockPatternMatcher.match_affine_block_expr(
-                            var_expr, var
-                        )
-                        if stride is None:
-                            stride = (
-                                1  # Variable without explicit coefficient has stride 1
-                            )
-                        coef = _safe_int(stride)
-                        coefficients.add(coef if coef is not None else stride)
-
-                    if is_originally_contiguous:
-                        # Buffer is contiguous - check if access coefficients match expected strides
-                        # If any coefficient is not in expected strides, it's a gather
-                        expected_stride_set = OrderedSet(expected_strides)
-                        for coef in coefficients:
-                            if coef not in expected_stride_set:
-                                has_non_unit_strides = True
-                                break
-                    else:
-                        # Buffer is NOT contiguous (strided input)
-                        # For TPU path (no .contiguous() call), check if index coefficients
-                        # match actual buffer strides - if so, the striding is already in the
-                        # data layout and we should use [...] not strided indexing
-                        is_tpu = torch._inductor.config._debug_cpu_to_tpu_pallas
-                        if is_tpu:
-                            # If all coefficients match actual buffer strides, no gather needed
-                            actual_stride_set = OrderedSet(
-                                s for s in actual_buf_strides if s is not None
-                            )
-                            for coef in coefficients:
-                                if coef not in actual_stride_set:
-                                    has_non_unit_strides = True
-                                    break
-                        else:
-                            # CPU/CUDA path calls .contiguous(), so buffer becomes contiguous
-                            # For simple strided views, if coefficients match ACTUAL buffer strides,
-                            # .contiguous() handles the striding and we should use [...] access.
-                            # Only use strided indexing if coefficients don't match actual strides
-                            # (indicating a gather pattern, not a simple strided view)
-                            actual_stride_set = OrderedSet(
-                                s for s in actual_buf_strides if s is not None
-                            )
-                            for coef in coefficients:
-                                if coef not in actual_stride_set:
-                                    has_non_unit_strides = True
-                                    break
-                except Exception:
-                    pass
-
-                # Use strided indexing if:
-                # 1. Buffer size differs from expected output size AND
-                # 2. There are iteration variables in the index (meaning we're accessing a subset)
-                # OR
-                # 3. Not all iteration variables are used (im2col-like patterns)
-                #    This handles cases like im2col where load uses 5 vars but store uses 2
-                #    The element counts may match but broadcast shapes won't align
-                # OR
-                # 4. Buffer is contiguous but index has non-unit strides (gather pattern)
-                # Note: inputs are made contiguous before passing to JAX, so we don't need
-                # to worry about transposed tensors here - the index expression directly
-                # corresponds to which elements to load from the contiguous buffer.
-                # Only consider "not all vars used" for truly multi-dim buffers.
-                # For 1D buffers or 2D broadcast buffers (with a dimension of size 1),
-                # using a subset of iteration vars is normal.
-                # Also check that the buffer has more dimensions than used vars,
-                # which indicates a gather pattern rather than simple broadcast.
-                buf_effective_dims = sum(1 for s in buf_size if _safe_int(s) != 1)
-                # For im2col patterns: the index uses MORE vars than buffer has dims
-                # This means multiple iteration vars map to fewer buffer dimensions
-                # which is a gather pattern. For normal access (including broadcast),
-                # used_vars <= buf_dims.
-                not_all_vars_used = (
-                    len(used_vars) < len(iter_vars)
-                    and len(used_vars) > 0
-                    and buf_effective_dims > 1
-                    and len(used_vars) > len(buf_size)  # More vars than dims = gather
-                )
-                # Avoid strided indexing when the original layout was non-contiguous;
-                # CPU/CUDA will make inputs contiguous at runtime.
-                is_tpu = torch._inductor.config._debug_cpu_to_tpu_pallas
-
-                # Check if buffer is KNOWN to be non-contiguous (static mismatch)
-                is_known_non_contiguous = not is_originally_contiguous and all(
-                    s is not None for s in actual_buf_strides
-                )
-
-                # Check if index has symbolic coefficients (can't use _generate_strided_index)
-                # This happens when the same kernel is called with different input shapes
-                has_symbolic_coef = any(
-                    not isinstance(c, int | float) for c in coefficients
-                )
-
-                # Only skip strided indexing for non-contiguous buffers when size matches
-                # (i.e., just a strided view, not a slice). For slices (size mismatch),
-                # we need strided indexing regardless of buffer contiguity.
-                skip_for_non_contiguous = (
-                    is_known_non_contiguous and not is_tpu and buf_numel == output_numel
-                )
-
-                if (
-                    output_numel > 0
-                    and (
-                        buf_numel != output_numel
-                        or not_all_vars_used
-                        or has_non_unit_strides
-                    )
-                    and len(used_vars) > 0
-                    and not skip_for_non_contiguous
-                    and not has_symbolic_coef
-                ):
-                    index_str = self._generate_strided_index(index)
-                    needs_flatten = True
-            except (TypeError, ValueError, AttributeError):
-                pass
-
-        # Build load expression using string concatenation
-        use_masked = index_str == "..." and not needs_flatten and self.use_masked_ops
-
-        # Check if we need flattened access for constant indices on multi-dim buffers
-        # This is needed for point scatter where a constant index should return a scalar
-        if not needs_flatten and index_str != "...":
-            try:
-                buf_obj = V.graph.get_buffer(name)
-                buf_size = buf_obj.get_size()
-                # If buffer is 0-dimensional (scalar), use [...] to access it
-                # JAX/Pallas doesn't support indexing scalars with [0]
-                if len(buf_size) == 0:
-                    index_str = "..."
-                # If buffer is multi-dimensional and index is a constant/scalar expression,
-                # use flattened access to get a single element
-                elif len(buf_size) > 1:
-                    has_iter_vars = self._has_iteration_vars(index)
-                    if not has_iter_vars:
-                        needs_flatten = True
-                    elif "::" in index_str:
-                        # For multi-dim buffers with strided slice patterns (like "::2"),
-                        # the slice applies to the first dimension only, which doesn't
-                        # match the semantics of the index expression (which operates on
-                        # the flattened buffer). Use flattened indexing instead.
-                        index_str = self._generate_strided_index(index)
-                        needs_flatten = True
-                # GPU (Mosaic backend) doesn't support gather from slice patterns
-                # For 1D buffers with offset slices (like "1::1"), use explicit indexing
-                elif self.is_gpu and "::" in index_str:
-                    index_str = self._generate_strided_index(index)
-                    needs_flatten = True
-            except Exception:
-                pass
-
-        if use_masked:
-            # GPU masked load: flatten tensor and use direct ref access
-            mask_var = self._get_or_create_mask(name)
-            load_expr = f"jnp.where({mask_var}, {buf}[pl.ds(block_size)], 0.0)"
-        elif needs_flatten:
-            # Flatten then index for non-contiguous access (gather operation)
-            if self.is_gpu:
-                # GPU: use direct ref access with explicit offsets
-                # (Pallas GPU/Mosaic doesn't support gather primitive)
-                load_expr = f"{buf}[...].flatten()[{index_str}]"
-            else:
-                # CPU: use JAX array indexing
-                # Cast to int64 if Min/Max ops may have introduced floats
-                has_minmax = index.has(sympy.Min) or index.has(sympy.Max)
-                idx = f"({index_str}).astype(jnp.int64)" if has_minmax else index_str
-                load_expr = f"{buf}[...].flatten()[{idx}]"
-        else:
-            # Direct indexing for contiguous access
-            load_expr = f"{buf}[{index_str}]"
-            # Check for transposed access using index expression coefficients
-            # For a 2D buffer with strides [S, 1], normal access is S*outer + inner
-            # Transposed access is outer + S*inner (coefficients are swapped)
-            if index_str == "...":
-                try:
-                    needs_transpose = self._is_transposed_access(name, index)
-                    if needs_transpose:
-                        load_expr = f"jnp.transpose({load_expr})"
-                        self.has_transposed_load = True
-                except Exception:
-                    pass
-            # Squeeze (N,1) intermediate buffers when kernel has 1D graph inputs
-            # to avoid wrong broadcasting: (N,) op (N,1) -> (N,N) instead of (N,)
-            # Check on demand since input_buffers may not be fully populated at __init__ time
-            is_intermediate_buffer = name.startswith("buf")
-            if is_intermediate_buffer:
-                # Check if any input buffer is a 1D graph input
-                has_1d_input = False
-                for buf_name in self.args.input_buffers:
-                    if not buf_name.startswith("buf"):
-                        try:
-                            buf_obj = V.graph.get_buffer(buf_name)
-                            buf_size = buf_obj.get_size()
-                            if len(buf_size) == 1:
-                                has_1d_input = True
-                                break
-                        except Exception:
-                            pass
-                if has_1d_input:
-                    try:
-                        buf_obj = V.graph.get_buffer(name)
-                        buf_size = buf_obj.get_size()
-                        if len(buf_size) == 2 and buf_size[-1] == 1:
-                            load_expr = f"jnp.squeeze({load_expr}, axis=-1)"
-                    except Exception:
-                        pass
+        # Handle intermediate buffer squeezing for correct broadcasting
+        if not needs_flatten and index_str == "...":
+            load_expr = self._maybe_squeeze_intermediate_buffer(name, load_expr)
 
         return self.cse.generate(
             self.compute,
@@ -1695,10 +2038,7 @@ class PallasKernel(SIMDKernel):
         the same shape, they are paired element-wise (not outer product), and
         the combined result dimension appears at the FRONT of the output.
         """
-        # Get iteration variables
-        iter_vars = OrderedSet(self.range_tree_nodes.keys())
-        free_symbols = index.free_symbols
-        used_iter_vars_set = free_symbols & iter_vars
+        used_iter_vars_set = self._get_used_iter_vars(index)
 
         if len(used_iter_vars_set) == 0:
             return self.kexpr(index)
@@ -1723,7 +2063,7 @@ class PallasKernel(SIMDKernel):
 
         # Rename symbolic sizes to kernel parameter names
         index_str = self.kexpr(self.rename_indexing(index))
-        indirect_var_syms = [s for s in free_symbols if str(s).startswith("tmp")]
+        indirect_var_syms = self._get_indirect_vars(index)
         indirect_vars = [str(sym) for sym in indirect_var_syms]
 
         # Get coefficients for indirect vars to determine output ordering
@@ -1736,9 +2076,9 @@ class PallasKernel(SIMDKernel):
         if len(used_iter_vars) == 1 and len(indirect_vars) == 1:
             var = used_iter_vars[0]
             var_name = str(var)
-            is_reduction_var = var in self.range_tree_nodes and self.range_tree_nodes[
-                var
-            ].prefix.startswith("r")
+            is_reduction_var = (
+                var in self.range_tree_nodes and self.range_tree_nodes[var].is_reduction
+            )
 
             if is_reduction_var:
                 # Reduction var: simple element-wise gather
@@ -1764,8 +2104,7 @@ class PallasKernel(SIMDKernel):
         paired_indirect = False
         if len(indirect_vars) > 1:
             # Count unused iteration variables (defined but not in index expression)
-            all_iter_vars = OrderedSet(self.range_tree_nodes.keys())
-            unused_iter_vars = all_iter_vars - used_iter_vars_set
+            unused_iter_vars = self._get_iter_vars() - used_iter_vars_set
             # Element-wise pairing: one unused iter var for the shared paired dimension
             # Outer product: multiple unused iter vars (one for each indirect var dimension)
             paired_indirect = len(unused_iter_vars) == 1
@@ -1890,19 +2229,11 @@ class PallasKernel(SIMDKernel):
         out = self.args.output(name)
         self.store_buffer_names.add(name)
 
-        # Determine masked ops strategy on first load/store if not yet determined
-        if self.use_masked_ops is None:
-            self.use_masked_ops = self._determine_masked_ops_for_kernel()
+        self._ensure_masked_ops_initialized()
 
         # Check if this is a scalar output (reduction to scalar)
-        # Only shape () is a true scalar, not (1,) which is a 1-element tensor
-        try:
-            buf = V.graph.get_buffer(name)
-            output_shape = buf.get_size()
-            is_scalar = len(output_shape) == 0
-        except Exception:
-            output_shape = ()
-            is_scalar = False
+        buf = V.graph.get_buffer(name)
+        is_scalar = buf is not None and len(buf.get_size()) == 0
 
         if is_scalar:
             # For scalar outputs, use [...] to assign the entire scalar
@@ -1912,532 +2243,139 @@ class PallasKernel(SIMDKernel):
             scatter_info = self._detect_scatter_pattern(index, name)
 
             if scatter_info is not None:
-                is_point_scatter = scatter_info.get("is_point_scatter", False)
-
-                # Mark this output parameter as needing to be readable (for aliasing)
-                self.outputs_need_read.add(out)
-                alias_param = f"{out}_alias"
-
-                # Use .add() for atomic_add mode (accumulate=True), .set() otherwise
-                scatter_op = "add" if mode == "atomic_add" else "set"
-
-                if is_point_scatter:
-                    # Single-element scatter: out[fixed_dims..., indirect, fixed_dims...] = scalar
-                    indirect_var = scatter_info["indirect_var"]
-                    indirect_dim = scatter_info["indirect_dim"]
-                    output_shape = scatter_info["output_shape"]
-
-                    # Build index tuple with 0s for other dimensions, indirect_var for scatter dim
-                    # For a (2, 3) array with scatter at dim=1: out.at[0, indirect_var].set(val)
-                    index_parts = []
-                    for dim in range(len(output_shape)):
-                        if dim == indirect_dim:
-                            index_parts.append(indirect_var)
-                        else:
-                            index_parts.append("0")
-
-                    index_tuple = ", ".join(index_parts)
-                    store_expr = f"{out}[...] = {alias_param}[...].at[{index_tuple}].{scatter_op}({value})"
-                else:
-                    # Scatter with iteration variables
-                    indirect_var = scatter_info["indirect_var"]
-                    dims_before = scatter_info["dims_before"]
-                    dims_after = scatter_info["dims_after"]
-
-                    # Determine if this is element-wise or slice-based scatter:
-                    # - Element-wise: each iter var corresponds to one output dimension
-                    #   e.g., scatter(x, 0, ind, src) with x:(196,992), ind:(1,992), src:(1,992)
-                    #   Here x0 with range 992 matches output dim 1 exactly
-                    # - Slice-based: iter vars together cover multiple output dimensions
-                    #   e.g., index_put(a, [b], c) with a:(800,256,7,7), b:(601,), c:(601,256,7,7)
-                    #   Here x0 with range 12544=256*7*7 covers dims 1,2,3 together
-                    #
-                    # Heuristic: if # iter vars in store == # remaining dims, it's element-wise
-                    # BUT: if there are more iter vars in the kernel than in the store index,
-                    # then some iter vars are embedded in the indirect var, requiring slice scatter
-                    try:
-                        buf = V.graph.get_buffer(name)
-                        output_ndim = len(buf.get_size())
-                    except Exception:
-                        output_ndim = 0
-
-                    num_iter_vars_in_store = len(dims_before) + len(dims_after)
-                    # Total iteration variables in the kernel
-                    total_kernel_iter_vars = len(self.range_tree_nodes)
-                    # indirect takes 1 dim, iter vars should cover the rest
-                    remaining_dims = output_ndim - 1  # dims other than indirect
-
-                    # Element-wise scatter requires:
-                    # 1. num iter vars in store == remaining dims
-                    # 2. All kernel iter vars appear in store (none embedded in indirect)
-                    is_element_wise = (
-                        num_iter_vars_in_store == remaining_dims
-                        and num_iter_vars_in_store == total_kernel_iter_vars
-                    )
-
-                    if is_element_wise:
-                        # Element-wise scatter: use iteration variable names
-                        # For 2D output with 1 iter var: no reshaping needed (both 1D)
-                        # For 3D+ with multiple iter vars: reshape indirect var for broadcasting
-                        # e.g., for 3D output with indirect at dim 1 and iter vars at dims 0,2:
-                        #   iter vars are reshaped to (n,1,1) and (1,1,m)
-                        #   indirect_var shape (k,) needs to become (1, k, 1)
-                        index_parts = []
-                        for var_name, size in dims_before:
-                            index_parts.append(var_name)
-
-                        # Reshape indirect var only if needed for broadcasting with
-                        # multi-dimensional iter vars (i.e., more than 1 iter var)
-                        n_leading = len(dims_before)
-                        n_trailing = len(dims_after)
-                        if n_leading > 0 and n_trailing > 0:
-                            # Middle dimension: needs reshaping for both before and after
-                            leading_ones = "None, " * n_leading
-                            trailing_nones = ", None" * n_trailing
-                            indirect_reshaped = (
-                                f"{indirect_var}[{leading_ones}...{trailing_nones}]"
-                            )
-                        else:
-                            # First or last dimension: no reshaping needed
-                            indirect_reshaped = indirect_var
-                        index_parts.append(indirect_reshaped)
-
-                        for var_name, size in dims_after:
-                            index_parts.append(var_name)
-                    else:
-                        # Slice-based scatter: use : for iteration dimensions
-                        index_parts = []
-                        for var_name, size in dims_before:
-                            index_parts.append(":")
-                        index_parts.append(indirect_var)
-                        for var_name, size in dims_after:
-                            index_parts.append(":")
-
-                    index_tuple = ", ".join(index_parts)
-                    store_expr = f"{out}[...] = {alias_param}[...].at[{index_tuple}].{scatter_op}({value})"
+                store_expr = self._build_scatter_store_expr(
+                    out, value, scatter_info, name, mode
+                )
             else:
+                # Get base index expression
                 index_str, needs_flatten = self._get_index_expr(index)
 
-                # Check for im2col-like patterns where store uses block variables
-                # but load doesn't. For cat/expand:
-                # - Load uses x0, store uses x0+128*x1 → x2
-                # - Both load and store prepared indices share the same block vars
-                # - OR: Load has no vars (broadcasts), store has block vars
-                # For im2col:
-                # - Load uses 4*x3+224*x4+... (NOT compressed, coefficients irregular)
-                # - Store uses x3+14*x4+... → x6+196*y5 (compressed, coefficients form products)
-                # - Store prepared uses block vars, load prepared doesn't
-                if index_str == "..." and not needs_flatten:
-                    try:
-                        prepared_index = self.prepare_indexing(index)
-                        iter_vars = OrderedSet(self.range_tree_nodes.keys())
-                        store_orig_vars = index.free_symbols & iter_vars
-                        store_prep_vars = (
-                            prepared_index.free_symbols
-                            if hasattr(prepared_index, "free_symbols")
-                            else OrderedSet()
-                        ) & iter_vars
-                        new_vars = store_prep_vars - store_orig_vars
-                        # Only trigger if store introduces new block vars
-                        if new_vars and len(store_orig_vars) > 1:
-                            # Check if loads are compatible with broadcast or cat pattern
-                            # cat: load orig vars ⊂ store orig vars (load uses subset)
-                            # im2col: load orig vars = store orig vars but load doesn't compress
-                            has_im2col_pattern = False
-                            for buf_name, load_index in self.load_index_exprs.items():
-                                load_orig_vars = load_index.free_symbols & iter_vars
-                                if load_orig_vars:
-                                    # Load has iteration variables
-                                    # cat: load vars are strict subset of store vars
-                                    # im2col: load vars equal store vars but load doesn't compress
-                                    if load_orig_vars == store_orig_vars:
-                                        # Same vars - check if load gets compressed too
-                                        prep_load = self.prepare_indexing(load_index)
-                                        load_prep_vars = (
-                                            prep_load.free_symbols
-                                            if hasattr(prep_load, "free_symbols")
-                                            else OrderedSet()
-                                        ) & iter_vars
-                                        # If store compresses but load doesn't, check if it's
-                                        # a simple strided input (coefficients match buffer strides)
-                                        # vs true im2col (irregular coefficients)
-                                        if (
-                                            load_orig_vars == load_prep_vars
-                                            and store_prep_vars != store_orig_vars
-                                        ):
-                                            # Check if load coefficients match buffer strides
-                                            # For strided inputs, coefficients = buffer strides
-                                            # For im2col, coefficients are irregular
-                                            is_strided_input = False
-                                            try:
-                                                buf = V.graph.get_buffer(buf_name)
-                                                buf_strides = buf.get_layout().stride
-                                                buf_sizes = buf.get_size()
-                                                # Get load coefficients
-                                                load_coeffs = []
-                                                for var in load_orig_vars:
-                                                    var_expr = BlockPatternMatcher.get_subexpr_involving_symbol(
-                                                        load_index, var
-                                                    )
-                                                    coef = BlockPatternMatcher.match_affine_block_expr(
-                                                        var_expr, var
-                                                    )
-                                                    if coef is not None:
-                                                        load_coeffs.append(
-                                                            int(coef)
-                                                            if hasattr(coef, "__int__")
-                                                            else coef
-                                                        )
-                                                # Check if coefficients match buffer strides
-                                                # Only include strides for non-trivial dimensions (size > 1)
-                                                # since dimensions with size 1 don't have iteration vars
-                                                buf_stride_set = OrderedSet()
-                                                for i, s in enumerate(buf_strides):
-                                                    dim_size = (
-                                                        int(buf_sizes[i])
-                                                        if hasattr(
-                                                            buf_sizes[i], "__int__"
-                                                        )
-                                                        else None
-                                                    )
-                                                    if dim_size is None or dim_size > 1:
-                                                        buf_stride_set.add(
-                                                            int(s)
-                                                            if hasattr(s, "__int__")
-                                                            else s
-                                                        )
-                                                if (
-                                                    OrderedSet(load_coeffs)
-                                                    == buf_stride_set
-                                                ):
-                                                    is_strided_input = True
-                                            except Exception:
-                                                pass
-                                            if not is_strided_input:
-                                                has_im2col_pattern = True
-                                                break
-                            if has_im2col_pattern:
-                                index_str = self._generate_strided_index(prepared_index)
-                                needs_flatten = True
-                    except Exception:
-                        pass
-
-                # Build store expression using string concatenation
-                use_masked = (
-                    index_str == "..." and not needs_flatten and self.use_masked_ops
+                # Check for im2col-like patterns
+                index_str, needs_flatten = self._check_im2col_pattern(
+                    index, index_str, needs_flatten
                 )
 
-                if use_masked:
-                    # GPU masked store: use jnp.where with direct ref access
-                    mask_var = self._get_or_create_mask(name)
-                    store_expr = f"{out}[pl.ds(block_size)] = jnp.where({mask_var}, {value}, {out}[pl.ds(block_size)])"
-                elif index_str == "...":
-                    # When storing the full array, we need to match the output shape.
-                    # This handles:
-                    # - Mixed indexing producing flat results needing reshape
-                    # - Squeeze operations where value has more dims than output
-                    # - Scalar values that need to be broadcast to the output shape
-                    # - Expand/broadcast operations (e.g., cat((x, x), 0) -> expand)
-                    # - Transpose for column-major outputs when computation is row-major
-                    # - If shapes already match, operations are no-ops.
-                    # Use jnp.full for scalars, broadcast_to for broadcast-compatible shapes,
-                    # and reshape for same-size different-shape arrays.
+                # Determine if masked operations should be used
+                use_masked = (
+                    index_str == "..."
+                    and not needs_flatten
+                    and self.use_masked_ops is True
+                )
 
-                    # Check if output needs transpose:
-                    # - Output has column-major stride (s0 < s1)
-                    # - But input(s) have row-major stride
-                    # - This indicates an explicit transpose operation in the IR
-                    # If inputs were also column-major, no transpose needed (.copy handles it)
-                    # Also skip if we already transposed on load (avoid double transpose)
-                    needs_transpose = False
-                    if not self.has_transposed_load:
-                        try:
-                            buf = V.graph.get_buffer(name)
-                            buf_stride = buf.get_layout().stride
-                            buf_size = buf.get_size()
-                            if len(buf_stride) == 2 and len(buf_size) == 2:
-                                size0 = (
-                                    int(buf_size[0])
-                                    if hasattr(buf_size[0], "__int__")
-                                    else None
-                                )
-                                size1 = (
-                                    int(buf_size[1])
-                                    if hasattr(buf_size[1], "__int__")
-                                    else None
-                                )
-                                s0 = (
-                                    int(buf_stride[0])
-                                    if hasattr(buf_stride[0], "__int__")
-                                    else None
-                                )
-                                s1 = (
-                                    int(buf_stride[1])
-                                    if hasattr(buf_stride[1], "__int__")
-                                    else None
-                                )
-                                # Output is column-major
-                                if (
-                                    s0 is not None
-                                    and s1 is not None
-                                    and s0 < s1
-                                    and size0 is not None
-                                    and size1 is not None
-                                    and size0 > 1
-                                    and size1 > 1
-                                ):
-                                    # Check if any input is column-major
-                                    any_input_column_major = False
-                                    for inp_name in self.args.input_buffers:
-                                        try:
-                                            inp_buf = V.graph.get_buffer(inp_name)
-                                            inp_stride = inp_buf.get_layout().stride
-                                            if len(inp_stride) == 2:
-                                                inp_s0 = (
-                                                    int(inp_stride[0])
-                                                    if hasattr(inp_stride[0], "__int__")
-                                                    else None
-                                                )
-                                                inp_s1 = (
-                                                    int(inp_stride[1])
-                                                    if hasattr(inp_stride[1], "__int__")
-                                                    else None
-                                                )
-                                                if (
-                                                    inp_s0 is not None
-                                                    and inp_s1 is not None
-                                                    and inp_s0 < inp_s1
-                                                ):
-                                                    any_input_column_major = True
-                                                    break
-                                        except Exception:
-                                            pass
-                                    # Transpose only if output is column-major but no inputs are
-                                    if not any_input_column_major:
-                                        needs_transpose = True
-                        except Exception:
-                            pass
-
-                    if needs_transpose:
-                        store_expr = (
-                            f"{out}[...] = ("
-                            f"jnp.full({out}.shape, {value}) if jnp.asarray({value}).ndim == 0 "
-                            f"else jnp.transpose(jnp.asarray({value})))"
-                        )
-                    else:
-                        store_expr = (
-                            f"{out}[...] = ("
-                            f"jnp.full({out}.shape, {value}) if jnp.asarray({value}).ndim == 0 "
-                            f"else (jnp.broadcast_to(jnp.asarray({value}), {out}.shape) "
-                            f"if jnp.asarray({value}).size != {out}.size "
-                            f"else jnp.asarray({value}).reshape({out}.shape)))"
-                        )
-                elif needs_flatten:
-                    # Block variable indexing (e.g., im2col) - use flattened scatter
-                    # The index_str contains an expression like "x6 + 196*y5" which computes
-                    # flat indices. Both the index and value need to be flattened.
-                    if self.is_gpu:
-                        # GPU: use direct ref access with explicit offsets
-                        # (Pallas GPU/Mosaic doesn't support scatter primitive)
-                        # Value shape must match index shape
-                        store_expr = (
-                            f"{out}[...] = {out}[...].flatten().at[({index_str}).flatten()].set("
-                            f"jnp.asarray({value}).flatten()).reshape({out}.shape)"
-                        )
-                    else:
-                        # CPU: use JAX array .at[].set()
-                        store_expr = (
-                            f"{out}[...] = {out}[...].flatten().at[({index_str}).flatten()].set("
-                            f"jnp.asarray({value}).flatten()).reshape({out}.shape)"
-                        )
-                else:
-                    # Direct indexed assignment
-                    # Check if we need special handling for constant indices on multi-dim outputs
-                    # e.g., storing a scalar to a (1,1,1) output with index 0
-                    has_indirect = self._has_indirect_vars(index)
-                    try:
-                        buf = V.graph.get_buffer(name)
-                        buf_size = buf.get_size()
-                        if len(buf_size) > 1 and not self._has_iteration_vars(index):
-                            # Multi-dim output with constant index - use [...] for full assignment
-                            # This handles cases like out_ptr0[0] where output is (1,1,1)
-                            store_expr = (
-                                f"{out}[...] = ("
-                                f"jnp.full({out}.shape, {value}) if jnp.asarray({value}).ndim == 0 "
-                                f"else (jnp.broadcast_to(jnp.asarray({value}), {out}.shape) "
-                                f"if jnp.asarray({value}).size != {out}.size "
-                                f"else jnp.asarray({value}).reshape({out}.shape)))"
-                            )
-                        elif has_indirect:
-                            # Indirect indexed store (scatter): arr[indices] = value
-                            # When value is scalar but indices is an array, JAX requires
-                            # the value to match the indexed result shape. Broadcast scalar.
-                            store_expr = (
-                                f"{out}[{index_str}] = ("
-                                f"jnp.full({index_str}.shape, {value}) "
-                                f"if jnp.asarray({value}).ndim == 0 else {value})"
-                            )
-                        else:
-                            store_expr = f"{out}[{index_str}] = {value}"
-                    except Exception:
-                        store_expr = f"{out}[{index_str}] = {value}"
+                # Build the store expression
+                store_expr = self._build_store_expr(
+                    out, name, index, value, index_str, needs_flatten, use_masked
+                )
 
         self.stores.writeline(store_expr)
         # Track which output param this store uses for filtering in codegen_kernel
         self.store_with_output.append((out, store_expr))
 
+    def _get_index_coefficient(self, index: sympy.Expr, var: sympy.Symbol) -> int:
+        """Get integer coefficient of a variable in an index expression."""
+        coeff = index.coeff(var)
+        if coeff == 0:
+            coeff = sympy.diff(index, var)
+        try:
+            return int(coeff)
+        except (TypeError, ValueError):
+            return 0
+
     def _detect_scatter_pattern(
         self, index: sympy.Expr, output_name: str = ""
-    ) -> Optional[dict]:
-        """
-        Detect if the index expression represents a scatter operation.
-
-        Scatter patterns occur when:
-        1. There's an indirect variable (tmp*) in the index
-        2. Optionally, iteration variables cover other dimensions
-
-        Returns:
-            dict with keys:
-                - 'indirect_var': name of indirect variable
-                - 'indirect_dim': which dimension it indexes (0-based from output shape)
-                - 'dims_before': list of (var_name, size) for dims before indirect
-                - 'dims_after': list of (var_name, size) for dims after indirect
-                - 'is_point_scatter': True if single-element scatter (no iter vars)
-                - 'output_shape': shape of output buffer (for point scatter)
-            or None if not a scatter pattern
-        """
-        has_indirect = self._has_indirect_vars(index)
-        has_iter_vars = self._has_iteration_vars(index)
-
-        if not has_indirect:
+    ) -> Optional[dict[str, Any]]:
+        """Detect scatter operation pattern. Returns scatter info dict or None."""
+        indirect_syms = self._get_indirect_vars(index)
+        if len(indirect_syms) != 1:
             return None
 
-        # Get iteration and indirect variables
-        iter_vars = OrderedSet(self.range_tree_nodes.keys())
-        free_symbols = index.free_symbols
-        used_iter_vars = free_symbols & iter_vars
-        indirect_var_syms = [s for s in free_symbols if str(s).startswith("tmp")]
-
-        if len(indirect_var_syms) != 1:
-            # Only handle single indirect variable for now
-            return None
-
-        indirect_sym = indirect_var_syms[0]
+        indirect_sym = indirect_syms[0]
         indirect_var = str(indirect_sym)
-
-        # Get coefficient of each variable
-        def get_coefficient(var):
-            coeff = index.coeff(var)
-            if coeff == 0:
-                coeff = sympy.diff(index, var)
-            try:
-                return int(coeff)
-            except (TypeError, ValueError):
-                return 0
-
-        indirect_coeff = get_coefficient(indirect_sym)
+        indirect_coeff = self._get_index_coefficient(index, indirect_sym)
         if indirect_coeff == 0:
             return None
 
-        # Handle point scatter (no iteration variables)
-        # This is single-element scatter where indirect var indexes one dimension
-        if not has_iter_vars:
-            # Try to get output shape to determine which dimension indirect indexes
-            output_shape = None
-            if output_name:
-                try:
-                    buf = V.graph.get_buffer(output_name)
-                    output_shape = [int(s) for s in buf.get_size()]
-                except Exception:
-                    pass
+        # Point scatter: no iteration variables, just indirect indexing
+        if not self._has_iteration_vars(index):
+            return self._detect_point_scatter(output_name, indirect_var, indirect_coeff)
 
-            if output_shape is None or len(output_shape) < 2:
-                return None
+        # Regular scatter: has both indirect and iteration variables
+        return self._detect_iter_scatter(index, indirect_var, indirect_coeff)
 
-            # Determine which dimension the indirect var indexes based on coefficient
-            # coefficient = product of sizes of all following dimensions
-            # For a (2, 3) array: dim 0 has coeff 3, dim 1 has coeff 1
-            cumulative_size = 1
-            indirect_dim = len(output_shape) - 1  # default to last dim
-            for dim in range(len(output_shape) - 1, -1, -1):
-                if indirect_coeff == cumulative_size:
-                    indirect_dim = dim
-                    break
-                cumulative_size *= output_shape[dim]
+    def _detect_point_scatter(
+        self, output_name: str, indirect_var: str, indirect_coeff: int
+    ) -> Optional[dict[str, Any]]:
+        """Detect single-element scatter pattern."""
+        if not output_name:
+            return None
+        try:
+            buf = V.graph.get_buffer(output_name)
+            output_shape = [int(s) for s in buf.get_size()]
+        except Exception:
+            return None
 
-            return {
-                "indirect_var": indirect_var,
-                "indirect_dim": indirect_dim,
-                "dims_before": [],
-                "dims_after": [],
-                "is_point_scatter": True,
-                "output_shape": output_shape,
-            }
+        if len(output_shape) < 2:
+            return None
 
-        # Collect all variables with their coefficients
+        # Find which dimension indirect var indexes based on coefficient
+        cumulative = 1
+        indirect_dim = len(output_shape) - 1
+        for dim in range(len(output_shape) - 1, -1, -1):
+            if indirect_coeff == cumulative:
+                indirect_dim = dim
+                break
+            cumulative *= output_shape[dim]
+
+        return {
+            "indirect_var": indirect_var,
+            "indirect_dim": indirect_dim,
+            "dims_before": [],
+            "dims_after": [],
+            "is_point_scatter": True,
+            "output_shape": output_shape,
+        }
+
+    def _detect_iter_scatter(
+        self, index: sympy.Expr, indirect_var: str, indirect_coeff: int
+    ) -> Optional[dict[str, Any]]:
+        """Detect scatter pattern with iteration variables."""
+        used_iter_vars = self._get_used_iter_vars(index)
+
+        # Collect (var_name, coefficient, length) for each variable
         all_vars = []
         for var in used_iter_vars:
-            coeff = get_coefficient(var)
+            coeff = self._get_index_coefficient(index, var)
             if coeff > 0 and var in self.range_tree_nodes:
-                try:
-                    length = int(self.range_tree_nodes[var].length)
-                    all_vars.append((str(var), coeff, length))
-                except (TypeError, ValueError):
+                length = self._safe_int(self.range_tree_nodes[var].length)
+                if length is None:
                     return None
+                all_vars.append((str(var), coeff, length))
 
-        # Add indirect variable
-        all_vars.append((indirect_var, indirect_coeff, -1))  # -1 marks as indirect
-
-        # Sort by coefficient descending (larger coeff = earlier dimension)
+        all_vars.append((indirect_var, indirect_coeff, -1))
         all_vars.sort(key=lambda x: x[1], reverse=True)
 
-        # Find position of indirect variable
-        indirect_pos = None
-        for i, (name, coeff, length) in enumerate(all_vars):
-            if name == indirect_var:
-                indirect_pos = i
-                break
-
+        # Find indirect variable position
+        indirect_pos = next(
+            (i for i, (name, _, _) in enumerate(all_vars) if name == indirect_var),
+            None,
+        )
         if indirect_pos is None:
             return None
 
-        # Split into before and after
-        dims_before = [
-            (name, length) for name, coeff, length in all_vars[:indirect_pos]
-        ]
-        dims_after = [
-            (name, length) for name, coeff, length in all_vars[indirect_pos + 1 :]
-        ]
-
-        # Verify coefficient structure for iteration variables only
-        # The indirect variable's coefficient should equal product of all following iter var sizes
-        # Each iter var's coefficient should equal product of all following iter var sizes
-        iter_vars_after = [
-            (name, coeff, length)
-            for name, coeff, length in all_vars[indirect_pos + 1 :]
-        ]
-
-        expected_coeff = 1
-        for name, coeff, length in reversed(iter_vars_after):
-            if coeff != expected_coeff:
+        # Verify coefficients form valid stride pattern
+        expected = 1
+        for _, coeff, length in reversed(all_vars[indirect_pos + 1 :]):
+            if coeff != expected:
                 return None
-            expected_coeff *= length
-
-        # Indirect var coeff should equal expected_coeff (product of all following iter var sizes)
-        if indirect_coeff != expected_coeff:
+            expected *= length
+        if indirect_coeff != expected:
             return None
-
-        # For vars before indirect, continue the coefficient check
-        # accounting for the indirect dimension's size in the output buffer
-        # We need to get the output buffer's size for the indirect dimension
-        # For now, we just verify the relative ordering is correct
-        # by checking each var's coeff is larger than the next
 
         return {
             "indirect_var": indirect_var,
             "indirect_dim": indirect_pos,
-            "dims_before": dims_before,
-            "dims_after": dims_after,
+            "dims_before": [(n, l) for n, _, l in all_vars[:indirect_pos]],
+            "dims_after": [(n, l) for n, _, l in all_vars[indirect_pos + 1 :]],
             "is_point_scatter": False,
             "output_shape": None,
         }
@@ -2491,44 +2429,13 @@ class PallasKernel(SIMDKernel):
         pointwise_prefixes = OrderedSet(["x", "y", "z"])
         has_pointwise = any(p in self.numels for p in pointwise_prefixes)
 
-        # Get the individual pointwise dimension sizes from range_tree_nodes
-        pointwise_sizes = []
-        for var, entry in sorted(
-            self.range_tree_nodes.items(), key=lambda x: str(x[0])
-        ):
-            if not entry.prefix.startswith("r"):
-                try:
-                    pointwise_sizes.append(int(entry.length))
-                except (TypeError, ValueError):
-                    pointwise_sizes = None
-                    break
-
         # Get the pointwise and reduction numels
-        pointwise_numel = 1
-        for p in pointwise_prefixes:
-            if p in self.numels:
-                numel = self.numels[p]
-                try:
-                    pointwise_numel *= int(numel)
-                except (TypeError, ValueError):
-                    pointwise_numel = None
-                    break
-
-        reduction_numel = 1
-        for p in self.numels:
-            if p.startswith("r"):
-                numel = self.numels[p]
-                try:
-                    reduction_numel *= int(numel)
-                except (TypeError, ValueError):
-                    reduction_numel = None
-                    break
+        pointwise_numel: Optional[int] = self._compute_prefix_numel(pointwise_prefixes)
+        reduction_numel: Optional[int] = self._compute_reduction_numel()
 
         # Count the number of pointwise and reduction dimensions
         n_reduction_dims = sum(
-            1
-            for var, entry in self.range_tree_nodes.items()
-            if entry.prefix.startswith("r")
+            1 for var, entry in self.range_tree_nodes.items() if entry.is_reduction
         )
 
         if reduction_type == "xor_sum":
@@ -2561,28 +2468,26 @@ class PallasKernel(SIMDKernel):
                     reduction_vars = [
                         var
                         for var, entry in self.range_tree_nodes.items()
-                        if entry.prefix.startswith("r")
+                        if entry.is_reduction
                     ]
                     if reduction_vars:
                         r_var = reduction_vars[0]
                         # Get the coefficient (stride) of the reduction variable
                         r_coeff = load_index.coeff(r_var)
-                        try:
-                            r_stride = int(r_coeff) if r_coeff != 0 else 1
-                        except (TypeError, ValueError):
+                        r_stride = self._safe_int(r_coeff) if r_coeff != 0 else 1
+                        if r_stride is None:
                             r_stride = 1
                         # Get pointwise variable
                         pw_vars = [
                             var
                             for var, entry in self.range_tree_nodes.items()
-                            if not entry.prefix.startswith("r")
+                            if not entry.is_reduction
                         ]
                         if pw_vars:
                             pw_var = pw_vars[0]
                             pw_coeff = load_index.coeff(pw_var)
-                            try:
-                                pw_stride = int(pw_coeff) if pw_coeff != 0 else 1
-                            except (TypeError, ValueError):
+                            pw_stride = self._safe_int(pw_coeff) if pw_coeff != 0 else 1
+                            if pw_stride is None:
                                 pw_stride = 1
                             # Higher stride = earlier (outer) axis
                             # For 2D: axis 0 has stride = dim1_size, axis 1 has stride = 1
@@ -2869,14 +2774,7 @@ def _pallas_partial_reduce(reduce_fn, v, pw_numel, red_numel):
                 broadcast_vars = []
                 total_var_idx = None
                 for idx, (var_sym, entry) in enumerate(var_items):
-                    try:
-                        length_val = (
-                            int(entry.length)
-                            if hasattr(entry.length, "__int__")
-                            else None
-                        )
-                    except (TypeError, ValueError):
-                        length_val = None
+                    length_val = self._safe_int(entry.length)
                     if length_val is not None and length_val == reshape_target_numel:
                         total_var_idx = idx
                     else:
@@ -2890,10 +2788,7 @@ def _pallas_partial_reduce(reduce_fn, v, pw_numel, red_numel):
                     # Rename symbolic lengths to use kernel parameter names
                     renamed_length = self.rename_indexing(length)
                     length_str = self.kexpr(renamed_length)
-                    try:
-                        length_val = int(length) if hasattr(length, "__int__") else None
-                    except (TypeError, ValueError):
-                        length_val = None
+                    length_val = self._safe_int(length)
 
                     # For symbolic lengths, only reshape if we have a valid target shape
                     # Without a target, we can't determine correct dimensions


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #171546

This refactoring extracts common logic from the load() and store() methods
into reusable helper functions, improving code readability and maintainability.

New helper methods added:
- _get_iter_vars(), _get_used_iter_vars(), _get_indirect_vars(): Variable extraction
- _safe_int(): Safe integer conversion
- _get_buffer_info(): Buffer metadata retrieval
- _compute_output_numel_from_index(): Output size computation
- _get_index_coefficients(), _check_gather_pattern(): Index analysis
- _needs_strided_indexing(), _adjust_index_for_buffer_shape(): Indexing decisions
- _build_load_expr(), _build_store_expr(): Expression building
- _detect_scatter_pattern(), _detect_point_scatter(), _detect_iter_scatter(): Scatter detection
- _check_im2col_pattern(), _check_load_is_strided_input(): Pattern matching
- _check_store_needs_transpose(), _build_full_array_store_expr(): Store helpers
- _maybe_squeeze_intermediate_buffer(): Broadcasting fixes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo