### PR TITLE
[inductor][caching] auto generated lut for tuned_addmm

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -1297,9 +1297,11 @@ class InterfacesTest(TestMixin, TestCase):
             test_filepath = tmp_file.name
             dump_data = {
                 "cache_size": 2,
-                "cache_entries": {
-                    "key1": {"params": {"x": 1}, "result": 10},
-                    "key2": {"params": {"x": 2}, "result": 20},
+                "collections": {
+                    "null": {
+                        "key1": {"params": {"x": 1}, "result": 10},
+                        "key2": {"params": {"x": 2}, "result": 20},
+                    },
                 },
             }
             json.dump(dump_data, tmp_file)
@@ -1401,7 +1403,7 @@ class InterfacesTest(TestMixin, TestCase):
         """Test that PersistentMemoizer loads cache from sub_dir nested structure.
 
         Verifies that when sub_dir is set, the PersistentMemoizer loads entries
-        from the nested cache_entries[sub_dir] structure.
+        from the nested collections[sub_dir] structure.
         """
         import json
         import os
@@ -1415,7 +1417,7 @@ class InterfacesTest(TestMixin, TestCase):
             test_filepath = tmp_file.name
             dump_data = {
                 "cache_size": 2,
-                "cache_entries": {
+                "collections": {
                     "test_subdir": {
                         "nested_key1": {"params": {"x": 1}, "result": 100},
                         "nested_key2": {"params": {"x": 2}, "result": 200},
@@ -1459,7 +1461,7 @@ class InterfacesTest(TestMixin, TestCase):
         """Test that PersistentMemoizer loads from root when sub_dir is empty.
 
         Verifies that when sub_dir is empty string, entries are loaded from
-        the root cache_entries level (not from any nested structure).
+        collections["null"] (the root collection).
         """
         import json
         import os
@@ -1470,11 +1472,15 @@ class InterfacesTest(TestMixin, TestCase):
             mode="w", suffix=".json", delete=False
         ) as tmp_file:
             test_filepath = tmp_file.name
+            # Note: "null" is the JSON representation of Python None
+            # When sub_dir is empty string (""), the Memoizer's sub_key is None
             dump_data = {
                 "cache_size": 3,
-                "cache_entries": {
-                    "root_key1": {"params": {"x": 1}, "result": 10},
-                    "root_key2": {"params": {"x": 2}, "result": 20},
+                "collections": {
+                    "null": {
+                        "root_key1": {"params": {"x": 1}, "result": 10},
+                        "root_key2": {"params": {"x": 2}, "result": 20},
+                    },
                     "some_subdir": {
                         "nested_key": {"params": {"x": 3}, "result": 30},
                     },
@@ -1527,10 +1533,16 @@ class InterfacesTest(TestMixin, TestCase):
             test_filepath = tmp_file.name
             # Simulate a cache entry for compute(5) -> 10
             cache_key = interfaces._BaseMemoizer._make_key(None, 5)
+            # Note: "null" is the JSON representation of Python None (no sub_key)
             dump_data = {
                 "cache_size": 1,
-                "cache_entries": {
-                    cache_key: {"params": {"args": (5,), "kwargs": {}}, "result": 10},
+                "collections": {
+                    "null": {
+                        cache_key: {
+                            "params": {"args": (5,), "kwargs": {}},
+                            "result": 10,
+                        },
+                    },
                 },
             }
             json.dump(dump_data, tmp_file)
@@ -1588,12 +1600,15 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("cache_entries", data)
+        self.assertIn("collections", data)
         self.assertIn("cache_size", data)
         self.assertEqual(data["cache_size"], 2)
 
+        # Note: "null" is the JSON representation of Python None (no sub_key)
+        self.assertIn("null", data["collections"])
+
         # Verify entries have correct format
-        for entry in data["cache_entries"].values():
+        for entry in data["collections"]["null"].values():
             self.assertIn("params", entry)
             self.assertIn("result", entry)
 
@@ -1603,7 +1618,7 @@ class InterfacesTest(TestMixin, TestCase):
         """Test that _dump_to_disk uses sub_key for nested structure.
 
         Verifies that when a Memoizer is initialized with a sub_key,
-        the cache entries are stored under cache_entries[sub_key].
+        the cache entries are stored under collections[sub_key].
         """
         # Setup: create a memoizer with sub_key and cache a value
         sub_key = "test_sub_key"
@@ -1622,11 +1637,11 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("cache_entries", data)
-        self.assertIn(sub_key, data["cache_entries"])
+        self.assertIn("collections", data)
+        self.assertIn(sub_key, data["collections"])
 
         # The sub_key should contain the cache entries
-        sub_entries = data["cache_entries"][sub_key]
+        sub_entries = data["collections"][sub_key]
         self.assertEqual(len(sub_entries), 1)
 
         # Verify entry format
@@ -1670,7 +1685,8 @@ class InterfacesTest(TestMixin, TestCase):
             data = json.load(f)
 
         self.assertEqual(data["cache_size"], 2)
-        self.assertEqual(len(data["cache_entries"]), 2)
+        # Note: "null" is the JSON representation of Python None (no sub_key)
+        self.assertEqual(len(data["collections"]["null"]), 2)
 
     @patch_on_disk_cache_base_dir
     @set_caching_module_enabled(True)
@@ -1722,7 +1738,7 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("cache_entries", data)
+        self.assertIn("collections", data)
         self.assertEqual(data["cache_size"], 1)
 
     @patch_on_disk_cache_base_dir
@@ -1749,8 +1765,8 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        # Get the single entry
-        entries = data["cache_entries"]
+        # Get the single entry (under "null" since no sub_key was set)
+        entries = data["collections"]["null"]
         self.assertEqual(len(entries), 1)
 
         entry = next(iter(entries.values()))
@@ -1789,12 +1805,12 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer1._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("feature_a", data["cache_entries"])
-        self.assertIn("feature_b", data["cache_entries"])
+        self.assertIn("feature_a", data["collections"])
+        self.assertIn("feature_b", data["collections"])
 
         # Verify each sub_key has one entry with correct result
-        feature_a_entries = data["cache_entries"]["feature_a"]
-        feature_b_entries = data["cache_entries"]["feature_b"]
+        feature_a_entries = data["collections"]["feature_a"]
+        feature_b_entries = data["collections"]["feature_b"]
 
         self.assertEqual(len(feature_a_entries), 1)
         self.assertEqual(len(feature_b_entries), 1)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -606,6 +606,11 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
 
 
 @register_lowering(aten.addmm, type_promotion_kind=None)
+@memoizers.tuned_addmm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_addmm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_addmm_result_decoder,
+)
 def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     """
     Lowering for autotuning aten.addmm with different backends (Aten, Triton, CUTLASS, etc.)

--- a/torch/_inductor/runtime/caching/__init__.py
+++ b/torch/_inductor/runtime/caching/__init__.py
@@ -1,4 +1,4 @@
-from . import config, encoders, memoizers
+from . import config, decoders, encoders, memoizers
 from .context import IsolationSchema, SelectedCompileContext, SelectedRuntimeContext
 from .exceptions import (
     CacheError,
@@ -27,6 +27,7 @@ __all__ = [
     "UserError",
     "ValueDecodingError",
     "ValueEncodingError",
+    "decoders",
     "encoders",
     "memoizers",
 ]

--- a/torch/_inductor/runtime/caching/decoders.py
+++ b/torch/_inductor/runtime/caching/decoders.py
@@ -1,0 +1,59 @@
+# pyre-strict
+
+"""
+Custom decoder functions for use with PersistentMemoizer.
+
+This module provides reusable decoder functions that reconstruct function results
+from cached data for deterministic cache replay.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import ParamSpec, TypeVar
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# Type alias for the encoded result
+TunedKernelEncodedResultDict = dict[str, object]
+
+# Type variable for function parameters
+_P = ParamSpec("_P")
+# Type variable for return type
+_R = TypeVar("_R")
+
+
+def tuned_kernel_result_decoder(
+    fn: Callable[_P, _R],
+) -> Callable[_P, Callable[[TunedKernelEncodedResultDict], _R]]:
+    """Factory factory that returns a params-to-decoder factory for tuned kernel results.
+
+    This is a placeholder implementation that doesn't actually decode cached results.
+    It just re-executes the underlying function.
+
+    Args:
+        fn: The underlying unwrapped function (passed by the memoizer)
+
+    Returns:
+        A factory that takes (*args, **kwargs) and returns a decoder function
+    """
+
+    def params_to_decoder(
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Callable[[TunedKernelEncodedResultDict], _R]:
+        """Factory that returns a decoder function for the given params."""
+
+        def decode_result(encoded: TunedKernelEncodedResultDict) -> _R:
+            return fn(*args, **kwargs)
+
+        return decode_result
+
+    return params_to_decoder
+
+
+# Operation-specific decoders (all use placeholder for now)
+tuned_mm_result_decoder = tuned_kernel_result_decoder

--- a/torch/_inductor/runtime/caching/decoders.py
+++ b/torch/_inductor/runtime/caching/decoders.py
@@ -57,3 +57,4 @@ def tuned_kernel_result_decoder(
 
 # Operation-specific decoders (all use placeholder for now)
 tuned_mm_result_decoder = tuned_kernel_result_decoder
+tuned_addmm_result_decoder = tuned_kernel_result_decoder

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -1,13 +1,10 @@
-# pyre-strict
-
 """
-Custom encoder functions for use with PersistentMemoizer.
+Custom encoder functions
 
 This module provides reusable encoder functions that convert function parameters
 into JSON-serializable dictionaries for caching purposes.
 """
 
-from typing import cast
 from typing_extensions import TypedDict
 
 import torch
@@ -64,8 +61,7 @@ def should_pad_params_encoder(
         mat2_exclude_padding_time=should_exclude_padding_time(match, "mat2"),
         tf32=False
         if mat1.dtype != torch.float32
-        else cast(
-            bool,
-            torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32,
+        else bool(
+            torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32
         ),
     )

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -5,12 +5,98 @@ This module provides reusable encoder functions that convert function parameters
 into JSON-serializable dictionaries for caching purposes.
 """
 
-from typing_extensions import TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import ParamSpec, TypedDict
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import torch
 from torch import Tensor
-from torch._inductor.pattern_matcher import Match
-from torch._inductor.runtime.caching.utils import _encode_tensor, EncodedTensor
+from torch._inductor.runtime.caching.interfaces import DeferredRecording
+
+
+if TYPE_CHECKING:
+    from torch._inductor.ir import (
+        Buffer,
+        IRNode,
+        Layout,
+        MultiTemplateBuffer,
+        TemplateBuffer,
+        TensorBox,
+    )
+    from torch._inductor.kernel_inputs import MMKernelInputs
+    from torch._inductor.kernel_template_choice import KernelTemplateChoice
+    from torch._inductor.pattern_matcher import Match
+    from torch._inductor.select_algorithm import ChoiceCaller
+
+
+# Type variable for function parameters
+_P = ParamSpec("_P")
+
+
+# =============================================================================
+# Encoded Types
+# =============================================================================
+
+
+class EncodedTensor(TypedDict):
+    """TypedDict for encoded tensor metadata."""
+
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: str
+
+
+class EncodedNode(TypedDict):
+    """TypedDict for encoded input node information (dtype, shape, stride)."""
+
+    dtype: str
+    shape: list[int]
+    stride: list[int]
+
+
+class EncodedChoice(TypedDict, total=False):
+    """TypedDict for an encoded choice from a KernelTemplateChoice.
+
+    Fields:
+        template_id: identifies which template (e.g., "aten::mm", "mm")
+        params: serialized params from ktc.params.to_serializeable_dict()
+        rank: optional rank for multi-choice encoding (lower is better)
+    """
+
+    template_id: str
+    params: dict[str, str]
+    rank: int
+
+
+class TunedKernelEncodedParams(TypedDict, total=False):
+    """TypedDict for encoded tuned kernel parameters (mm, addmm, etc.).
+
+    This structure mirrors the key format from LookupTableChoices._generate_kernel_inputs_key:
+    - nodes: list of (dtype, shape, stride) for each input node
+    - scalars: optional dict of scalar key=value pairs (e.g., alpha, beta for addmm)
+    """
+
+    nodes: list[EncodedNode]
+    scalars: dict[str, float | int]
+
+
+class TunedKernelEncodedResult(TypedDict, total=False):
+    """TypedDict for encoded tuned kernel result (mm, addmm, etc.).
+
+    The `_type` field determines which other fields are present:
+    - "single_choice": `choice` is present
+    - "multi_template_buffer": `choices` is present
+    - "unknown": encoding failed, decoder should recompute
+    """
+
+    _type: str
+    choice: EncodedChoice
+    choices: list[EncodedChoice]
 
 
 class ShouldPadEncodedParams(TypedDict):
@@ -23,6 +109,237 @@ class ShouldPadEncodedParams(TypedDict):
     mat1_exclude_padding_time: bool
     mat2_exclude_padding_time: bool
     tf32: bool
+
+
+# =============================================================================
+# Encoder Helper Functions
+# =============================================================================
+
+
+def _encode_tensor(t: Tensor) -> EncodedTensor:
+    """Encode a tensor's metadata into a JSON-serializable dict."""
+    return EncodedTensor(
+        shape=tuple(t.shape),
+        stride=tuple(t.stride()),
+        dtype=str(t.dtype),
+    )
+
+
+def _encode_kernel_inputs(kernel_inputs: MMKernelInputs) -> TunedKernelEncodedParams:
+    """Encode MMKernelInputs into a human-readable dict."""
+    dtypes = kernel_inputs.dtypes()
+    shapes = kernel_inputs.shapes_hinted()
+    strides = kernel_inputs.strides_hinted()
+
+    nodes: list[EncodedNode] = [
+        EncodedNode(
+            dtype=str(dtype),
+            shape=list(shape),
+            stride=list(stride),
+        )
+        for dtype, shape, stride in zip(dtypes, shapes, strides)
+    ]
+
+    result = TunedKernelEncodedParams(nodes=nodes)
+
+    if kernel_inputs._scalars:
+        result["scalars"] = dict(kernel_inputs._scalars)
+
+    return result
+
+
+def _encode_choice_from_ktc(
+    ktc: KernelTemplateChoice,
+    rank: int | None = None,
+) -> EncodedChoice | None:
+    """Encode a choice from a KernelTemplateChoice."""
+    if not hasattr(ktc, "template") or ktc.template is None:
+        return None
+    if not hasattr(ktc, "params") or ktc.params is None:
+        return None
+
+    # Convert params values to strings to ensure JSON serializability
+    # (e.g., torch.dtype objects are not JSON serializable)
+    raw_params = ktc.params.to_serializeable_dict()
+    serializable_params = {k: str(v) for k, v in raw_params.items()}
+
+    result = EncodedChoice(
+        template_id=ktc.template.uid,
+        params=serializable_params,
+    )
+
+    if rank is not None:
+        result["rank"] = rank
+
+    return result
+
+
+def _encode_choice_from_caller_or_node(
+    obj: ChoiceCaller | TemplateBuffer | IRNode,
+    rank: int | None = None,
+) -> EncodedChoice | None:
+    """Encode a choice from a ChoiceCaller or buffer node by extracting its KTC annotation.
+
+    This function is general and works with any object that has an annotations dict
+    containing a "ktc" key. This includes:
+    - ChoiceCaller instances (from autotune_select_algorithm)
+    - TemplateBuffer nodes (from output_node())
+    - Other IRNode types with annotations
+
+    Args:
+        obj: A ChoiceCaller, TemplateBuffer, IRNode, or any object with annotations["ktc"]
+        rank: Optional rank for multi-choice encoding (lower is better)
+
+    Returns:
+        EncodedChoice if encoding succeeded, None otherwise
+    """
+    annotations = getattr(obj, "annotations", None)
+    if not annotations or "ktc" not in annotations:
+        return None
+
+    ktc = annotations["ktc"]
+    return _encode_choice_from_ktc(ktc, rank=rank)
+
+
+def _encode_multi_template_buffer(
+    buffer: MultiTemplateBuffer,
+    fn: Callable[..., TensorBox],
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> DeferredRecording[TensorBox, TunedKernelEncodedResult]:
+    """Encode a MultiTemplateBuffer using deferred recording.
+
+    This function wraps the buffer's choice_timings method to capture timing
+    results and encode them when the timings are computed.
+
+    Memory management:
+    To avoid a reference cycle that would keep the DeferredRecording alive
+    as long as the buffer exists, we use a mutable holder for the deferred
+    reference and clear it after finalization.
+
+    Interim result handling:
+    When make_interim_result creates a new buffer, we need to map the cached
+    timings to the new buffer's ChoiceCaller objects. Since each call to the
+    underlying function produces different ChoiceCaller objects, we use their
+    hash to match corresponding choices between the original and new buffers.
+    """
+    from torch._inductor.ir import MultiTemplateBuffer, StorageBox, TensorBox
+
+    deferred: DeferredRecording[TensorBox, TunedKernelEncodedResult] = (
+        DeferredRecording()
+    )
+
+    original_choice_timings = buffer.choice_timings  # type: ignore[union-attr]
+    finalized = False
+
+    # Store deferred in a mutable holder so we can clear it after finalization.
+    deferred_holder: list[
+        DeferredRecording[TensorBox, TunedKernelEncodedResult] | None
+    ] = [deferred]
+
+    # Cache timing results by ChoiceCaller hash_key for mapping to new buffers in interim results.
+    # When make_interim_result creates a new buffer, its ChoiceCallers are different objects
+    # but have the same hash_key as the corresponding original ChoiceCallers.
+    cached_timings_by_hash: dict[str, float] | None = None
+
+    def wrapped_choice_timings(
+        hint_override: int | None = None,
+    ) -> dict[ChoiceCaller, float]:
+        nonlocal finalized, cached_timings_by_hash
+        timings_result = original_choice_timings(hint_override)
+
+        if hint_override is None and not finalized:
+            finalized = True
+
+            # Cache timings by hash_key for use by interim results
+            cached_timings_by_hash = {
+                caller.hash_key(): timing for caller, timing in timings_result.items()
+            }
+
+            # Get deferred from holder and clear it to break the reference cycle.
+            deferred_obj = deferred_holder[0]
+            deferred_holder[0] = None
+            assert deferred_obj is not None
+
+            sorted_choices = sorted(timings_result.items(), key=lambda x: x[1])
+            encoded_choices: list[EncodedChoice] = []
+            encoding_failed = False
+
+            for rank, (choice_caller, _timing) in enumerate(sorted_choices):
+                encoded = _encode_choice_from_caller_or_node(choice_caller, rank=rank)
+                if encoded is None:
+                    encoding_failed = True
+                    break
+                encoded_choices.append(encoded)
+
+            if encoding_failed or not encoded_choices:
+                encoded_result = TunedKernelEncodedResult(_type="unknown")
+            else:
+                encoded_result = TunedKernelEncodedResult(
+                    _type="multi_template_buffer",
+                    choices=encoded_choices,
+                )
+
+            deferred_obj.finalize(encoded_result)
+
+        return timings_result
+
+    buffer.choice_timings = wrapped_choice_timings  # type: ignore[union-attr]
+
+    def make_interim_result() -> TensorBox:
+        new_result = fn(*args, **kwargs)
+
+        if isinstance(new_result, TensorBox) and isinstance(
+            new_result.data, StorageBox
+        ):
+            new_buffer = new_result.data.data
+            if isinstance(new_buffer, MultiTemplateBuffer):
+                # Save the new buffer's original choice_timings for fallback
+                new_choice_timings = new_buffer.choice_timings  # type: ignore[union-attr]
+
+                def mapped_choice_timings(
+                    hint_override: int | None = None,
+                ) -> dict[ChoiceCaller, float]:
+                    # Check if cached timings are available (set when original choice_timings completes)
+                    if cached_timings_by_hash is not None:
+                        # Get the new buffer's choices by calling its original choice_timings.
+                        # This returns dict[ChoiceCaller, float] - we need the keys.
+                        new_timings = new_choice_timings(hint_override)
+
+                        # Safety check: verify all choices have cached timings.
+                        # If any choice's hash_key is missing, fall back to actual timings.
+                        all_choices_cached = all(
+                            choice.hash_key() in cached_timings_by_hash
+                            for choice in new_timings
+                        )
+
+                        if all_choices_cached:
+                            # Map cached timings to new buffer's choices by hash_key.
+                            # Each ChoiceCaller has a hash_key that identifies the choice,
+                            # so we can match new ChoiceCallers to their cached timings.
+                            return {
+                                choice: cached_timings_by_hash[choice.hash_key()]
+                                for choice in new_timings
+                            }
+                        else:
+                            # Some choices weren't cached - use the actual timings we just computed
+                            return new_timings
+                    else:
+                        # Cached timings not ready yet, fall back to actual timing computation
+                        return new_choice_timings(hint_override)
+
+                new_buffer.choice_timings = mapped_choice_timings  # type: ignore[union-attr]
+
+        return new_result
+
+    deferred.make_interim_result = make_interim_result
+
+    return deferred
+
+
+# =============================================================================
+# Encoders
+# =============================================================================
 
 
 def should_pad_params_encoder(
@@ -65,3 +382,123 @@ def should_pad_params_encoder(
             torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32
         ),
     )
+
+
+def tuned_mm_params_encoder(
+    mat1: Buffer,
+    mat2: Buffer,
+    out_dtype: torch.dtype | None = None,
+    *,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_mm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_mm:
+    1. First calls mm_args to realize the matrices (just like tuned_mm does)
+    2. Creates MMKernelInputs with the realized matrices
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each input node
+    - scalars: any scalar values (not used in basic mm, but used in addmm)
+
+    Args:
+        mat1: First matrix buffer
+        mat2: Second matrix buffer
+        out_dtype: Optional output dtype
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_mm
+    _m, _n, _k, _layout, mat1_realized, mat2_realized = mm_args(
+        mat1, mat2, layout=layout, out_dtype=out_dtype
+    )
+
+    # Create MMKernelInputs with the realized matrices
+    kernel_inputs = MMKernelInputs([mat1_realized, mat2_realized], out_dtype=out_dtype)
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_kernel_result_encoder(
+    fn: Callable[_P, TensorBox],
+) -> Callable[
+    _P,
+    Callable[
+        [TensorBox],
+        TunedKernelEncodedResult
+        | DeferredRecording[TensorBox, TunedKernelEncodedResult],
+    ],
+]:
+    """Factory factory that returns a params-to-encoder factory for tuned kernel results.
+
+    This is a generic result encoder that works with any tuned kernel function
+    (tuned_mm, tuned_addmm, etc.). It encodes choices using the KernelTemplateChoice
+    (KTC) annotations on ChoiceCallers and/or the buffer's annotations dict.
+
+    Encoding strategy:
+    1. MultiTemplateBuffer → deferred recording (choice_timings is expensive)
+       - When choice_timings completes, encode each ChoiceCaller via its KTC annotation
+    2. Single output node (TemplateBuffer or ExternKernelOut) → extract KTC from
+       buffer.annotations["ktc"]
+    3. Unknown types → return "unknown" for recomputation on decode
+
+    Args:
+        fn: The underlying unwrapped function (passed by the memoizer)
+
+    Returns:
+        A factory that takes (*args, **kwargs) and returns an encoder function
+    """
+
+    def params_to_encoder(
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Callable[
+        [TensorBox],
+        TunedKernelEncodedResult
+        | DeferredRecording[TensorBox, TunedKernelEncodedResult],
+    ]:
+        """Factory that returns an encoder function for the given params."""
+
+        def encode_result(
+            result: TensorBox,
+        ) -> (
+            TunedKernelEncodedResult
+            | DeferredRecording[TensorBox, TunedKernelEncodedResult]
+        ):
+            # Import at runtime to avoid circular imports
+            from torch._inductor.ir import (
+                MultiTemplateBuffer,
+                StorageBox,
+                TensorBox as TensorBoxType,
+            )
+
+            # Cases 1-2: TensorBox containing a StorageBox
+            if isinstance(result, TensorBoxType) and isinstance(
+                result.data, StorageBox
+            ):
+                buffer = result.data.data
+
+                # Case 1: MultiTemplateBuffer - use deferred recording
+                if isinstance(buffer, MultiTemplateBuffer):
+                    return _encode_multi_template_buffer(buffer, fn, args, kwargs)
+
+                # Case 2: Single output node - encode via annotations["ktc"] if available
+                encoded = _encode_choice_from_caller_or_node(buffer)
+                if encoded is not None:
+                    return TunedKernelEncodedResult(
+                        _type="single_choice",
+                        choice=encoded,
+                    )
+
+            # Fallback for unknown types - mark as unknown
+            return TunedKernelEncodedResult(_type="unknown")
+
+        return encode_result
+
+    return params_to_encoder

--- a/torch/_inductor/runtime/caching/exceptions.py
+++ b/torch/_inductor/runtime/caching/exceptions.py
@@ -1,5 +1,3 @@
-# pyre-strict
-
 """Exception classes for PyTorch Inductor runtime caching.
 
 This module defines a hierarchy of exceptions used throughout the caching system.

--- a/torch/_inductor/runtime/caching/locks.py
+++ b/torch/_inductor/runtime/caching/locks.py
@@ -1,4 +1,4 @@
-"""Lock acquisition utilities for caching system with timeout support.
+"""Lock acquisition utilities
 
 This module provides safe and unsafe lock acquisition functions for both threading.Lock
 and FileLock objects, with configurable timeout behaviors. It supports three timeout modes:

--- a/torch/_inductor/runtime/caching/memoizers.py
+++ b/torch/_inductor/runtime/caching/memoizers.py
@@ -8,3 +8,6 @@ should_pad_memoizer = PersistentMemoizer(sub_dir=Path("should_pad"))
 
 # Memoizer for tuned_mm in kernel/mm
 tuned_mm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_mm"))
+
+# Memoizer for tuned_addmm in kernel/mm
+tuned_addmm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_addmm"))

--- a/torch/_inductor/runtime/caching/memoizers.py
+++ b/torch/_inductor/runtime/caching/memoizers.py
@@ -5,3 +5,6 @@ from .interfaces import PersistentMemoizer
 
 # Memoizer for _should_pad in pad_mm
 should_pad_memoizer = PersistentMemoizer(sub_dir=Path("should_pad"))
+
+# Memoizer for tuned_mm in kernel/mm
+tuned_mm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_mm"))

--- a/torch/_inductor/runtime/caching/utils.py
+++ b/torch/_inductor/runtime/caching/utils.py
@@ -6,9 +6,7 @@ throughout the caching system.
 
 from collections.abc import Callable
 from functools import lru_cache, wraps
-from typing_extensions import ParamSpec, TypedDict, TypeVar
-
-from torch import Tensor
+from typing_extensions import ParamSpec, TypeVar
 
 
 # Type specification for function parameters
@@ -40,27 +38,3 @@ def _lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
             return fn(*args, **kwargs)
 
     return wrapper
-
-
-class EncodedTensor(TypedDict):
-    """TypedDict for encoded tensor metadata."""
-
-    shape: tuple[int, ...]
-    stride: tuple[int, ...]
-    dtype: str
-
-
-def _encode_tensor(t: Tensor) -> EncodedTensor:
-    """Encode a tensor's metadata into a JSON-serializable dict.
-
-    Args:
-        t: PyTorch tensor to encode
-
-    Returns:
-        Dict containing shape, stride, and dtype information
-    """
-    return EncodedTensor(
-        shape=tuple(t.shape),
-        stride=tuple(t.stride()),
-        dtype=str(t.dtype),
-    )

--- a/torch/_inductor/runtime/caching/utils.py
+++ b/torch/_inductor/runtime/caching/utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for caching operations in PyTorch Inductor runtime.
+"""Utility functions
 
 This module provides helper functions for LRU caching decorators used
 throughout the caching system.
@@ -33,9 +33,9 @@ def _lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
     cached_fn = lru_cache(maxsize=64, typed=True)(fn)
 
     @wraps(fn)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # type: ignore[type-var]
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
-            return cached_fn(*args, **kwargs)  # type: ignore[arg-type]
+            return cached_fn(*args, **kwargs)
         except TypeError:
             return fn(*args, **kwargs)
 


### PR DESCRIPTION
Summary:
This diff extends the PersistentMemoizer caching infrastructure to tuned_addmm.
The encoders and decoders reuse the same patterns established for tuned_mm.

Key changes:
- Added tuned_addmm_memoizer for caching tuned_addmm results
- Added tuned_addmm_params_encoder for encoding addmm parameters (inp, mat1, mat2, alpha, beta)
- Added tuned_addmm_result_decoder placeholder (reuses tuned_kernel_result_decoder)
- Applied memoize decorator to tuned_addmm function

Test Plan:
```
buck test fbcode//mode/opt caffe2/test/inductor:caching
```

Differential Revision: D89942696




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben