### PR TITLE
[ROCm] Fix HIP version parsing, BF16 exception handling, and AMDSMI return types

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -211,7 +211,7 @@ def _check_bf16_tensor_supported(device: Device):
     try:
         torch.tensor([1.0], dtype=torch.bfloat16, device=device)
         return True
-    except Exception:
+    except RuntimeError:
         return False
 
 
@@ -1365,11 +1365,11 @@ def _get_amdsmi_power_draw(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
     socket_power = amdsmi.amdsmi_get_power_info(handle)["average_socket_power"]
     if socket_power != "N/A":
-        return socket_power
+        return int(socket_power)
     else:
         socket_power = amdsmi.amdsmi_get_power_info(handle)["current_socket_power"]
         if socket_power != "N/A":
-            return socket_power
+            return int(socket_power)
         else:
             return 0
 
@@ -1382,7 +1382,7 @@ def _get_amdsmi_clock_rate(device: Device = None) -> int:
     else:
         clock_rate = clock_info["clk"]
     if clock_rate != "N/A":
-        return clock_rate
+        return int(clock_rate)
     else:
         return 0
 

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -19,7 +19,8 @@ def _get_hip_runtime_library() -> ctypes.CDLL:
         lib = ctypes.CDLL(str(rocm_sdk.find_libraries("amdhip64")[0]))
     except (ImportError, IndexError):
         if sys.platform == "win32":
-            lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
+            hip_major = torch.version.hip.split(".")[0]
+            lib = ctypes.CDLL(f"amdhip64_{hip_major}.dll")
         else:  # Unix-based systems
             lib = ctypes.CDLL("libamdhip64.so")
 
@@ -67,9 +68,8 @@ def _get_hiprtc_library() -> ctypes.CDLL:
         lib = ctypes.CDLL(str(rocm_sdk.find_libraries("hiprtc")[0]))
     except (ImportError, IndexError):
         if sys.platform == "win32":
-            version_str = "".join(
-                ["0", torch.version.hip[0], "0", torch.version.hip[2]]
-            )
+            parts = torch.version.hip.split(".")
+            version_str = f"0{parts[0]}0{parts[1]}"
             lib = ctypes.CDLL(f"hiprtc{version_str}.dll")
         else:
             lib = ctypes.CDLL("libhiprtc.so")


### PR DESCRIPTION
## Summary

Fix three ROCm-related bugs in `torch.cuda`:

### 1. HIP Version String Parsing (`torch/cuda/_utils.py`)

**Bug:** Used character indexing (`hip[0]`, `hip[2]`) which breaks for multi-digit version components.

```python
# Before (buggy):
lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
version_str = "".join(["0", torch.version.hip[0], "0", torch.version.hip[2]])
# For "6.10.0" → hip[2] = '.' (wrong!)

# After (fixed):
hip_major = torch.version.hip.split('.')[0]
lib = ctypes.CDLL(f"amdhip64_{hip_major}.dll")
parts = torch.version.hip.split('.')
version_str = f"0{parts[0]}0{parts[1]}"
```

### 2. BF16 Tensor Support Check (`torch/cuda/__init__.py`)

**Bug:** Caught all exceptions including OOM, driver errors, etc.

```python
# Before: except Exception:
# After: except RuntimeError:
```

### 3. AMDSMI Power/Clock Functions (`torch/cuda/__init__.py`)

**Bug:** Functions declared `-> int` but returned string values from AMDSMI.

```python
# Before: return socket_power  # Returns string
# After: return int(socket_power)  # Returns int as declared
```

## Test Plan

- CI validation on ROCm hardware
- Windows HIP DLL loading (version parsing fix)
- AMDSMI function return type correctness

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.com/claude-code)