### PR TITLE
[Inductor][NV Universal GEMM] Add BMM support

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -22,6 +22,7 @@ from ..utils import (
     use_ck_gemm_template,
     use_cpp_bmm_template,
     use_cutlass_template,
+    use_nv_universal_gemm_template,
     use_triton_template,
 )
 from ..virtualized import ops, V
@@ -218,6 +219,16 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
 
     if use_ck_gemm_template(layout, m, n, k):
         CKGemmTemplate.add_ck_gemm_choices(choices, layout, kernel_inputs.nodes())
+
+    if (
+        # TODO(nikhilap) There is a bug in cutlass_api, their compatibility check does not catch this failure cases
+        batch_stride_largest_or_zero
+        and is_nonzero
+        and use_nv_universal_gemm_template(layout, m, n, k, mat1, mat2)
+    ):
+        from ..codegen.nv_universal_gemm import add_nv_universal_gemm_choices
+
+        add_nv_universal_gemm_choices(choices, layout, kernel_inputs)
 
     return autotune_select_algorithm(name, choices, kernel_inputs.nodes(), layout)
 

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -336,3 +336,18 @@ class MMKernelInputs(KernelInputs):
         assert k == k_check, f"K dimensions don't match: {k} vs {k_check}"
 
         return (m, n, k)
+
+    def batch_hinted(self) -> int:
+        """
+        Get the hinted batch size for batched matrix multiplication.
+        Returns 1 for non-batched (2D) operations.
+
+        Returns:
+            The batch size as an integer
+        """
+        hinted_shapes = self.shapes_hinted()
+        mat1_shape = hinted_shapes[self._mat1_idx]
+
+        if len(mat1_shape) >= 3:
+            return mat1_shape[-3]  # Batch from third-to-last dimension
+        return 1  # Non-batched operation

--- a/torch/_inductor/template_heuristics/nv_universal_gemm.py
+++ b/torch/_inductor/template_heuristics/nv_universal_gemm.py
@@ -123,6 +123,7 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
             return kernels[:count]
 
         m, n, k = inputs.mnk_hinted()
+        batch_size = inputs.batch_hinted()
         dtype_a = inputs.dtype(inputs._mat1_idx)
         strides = inputs.strides_hinted()
         layout_a = "row" if strides[inputs._mat1_idx][-1] == 1 else "col"
@@ -144,6 +145,7 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
             count,
             OrderedSet(config_to_kernels.keys()),
             accumulator_type,
+            batch_size,
         )
 
         if not heuristic_configs:
@@ -245,6 +247,7 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
         count: int,
         valid_configs: OrderedSet[ConfigKey],
         accumulator_type: torch.dtype = torch.float32,
+        batch_size: int = 1,
     ) -> list[HeuristicConfig]:
         """
         Get kernel configurations recommended by nvMatmulHeuristics.
@@ -291,8 +294,9 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
 
         lh.loadInternalDiscoverySet(layout, precision=precision)
 
-        # TODO(nikhilap) support different batch sizes
-        problem = lh.makeNvMatmulHeuristicsProblem(m, n, k, layout, batch_size=1)
+        problem = lh.makeNvMatmulHeuristicsProblem(
+            m, n, k, layout, batch_size=batch_size
+        )
         raw_configs = lh.getEx(problem, count, backend, precision=precision)
         lh.destroyBackend(backend)
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2104,8 +2104,8 @@ def use_nv_universal_gemm_template(
         5. Max autotune or max autotune gemm is enabled
         6. We are not using dynamic shapes
         7. A and B base pointers are 16B aligned
-        8. n and k are divisible by 16
-        9. Non-unit strides are divisible by 16
+        8. m, n and k are divisible by 16
+        9. Non-innermost strides are divisible by 16 (row-major layout)
         10. Not in AOT Inductor mode (requires runtime JIT compilation)
     """
     if not ensure_cute_available():
@@ -2140,6 +2140,7 @@ def use_nv_universal_gemm_template(
         return False
 
     # TODO(nikhilap) There is a bug in cutlass_api, their compatibility check does not catch these failure cases
+    # N and K must be divisible by 16 for all cases
     if not V.graph.sizevars.statically_known_true(sympy.Eq(n % 16, 0)):
         return False
     if not V.graph.sizevars.statically_known_true(sympy.Eq(k % 16, 0)):
@@ -2147,16 +2148,26 @@ def use_nv_universal_gemm_template(
 
     a_layout = mat_a.get_layout()
     b_layout = mat_b.get_layout()
+    a_strides = list(a_layout.stride)
+    b_strides = list(b_layout.stride)
 
-    for stride in a_layout.stride:
-        if stride != 1:
-            if not V.graph.sizevars.statically_known_true(sympy.Eq(stride % 16, 0)):
+    # For 3D tensors (BMM), additional restrictions apply:
+    # - M must be > 1
+    # - strides[1] must not be 1
+    is_batched = len(a_strides) == 3
+    if is_batched:
+        if not V.graph.sizevars.statically_known_true(sympy.Gt(m, 1)):
+            return False
+        for strides in [a_strides, b_strides]:
+            if strides[1] == 1:
                 return False
 
-    for stride in b_layout.stride:
-        if stride != 1:
-            if not V.graph.sizevars.statically_known_true(sympy.Eq(stride % 16, 0)):
-                return False
+    # Check non-unit strides are divisible by 16 (both 2D and 3D)
+    for strides in [a_strides, b_strides]:
+        for stride in strides:
+            if stride != 1:
+                if not V.graph.sizevars.statically_known_true(sympy.Eq(stride % 16, 0)):
+                    return False
 
     return True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #171907
* __->__ #171556
* #171360
* #171205
* #171363
* #171362
* #170623

See: https://github.com/pytorch/pytorch/issues/165785

`TORCH_LOGS="+autotuning" TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 TRITON_ALWAYS_COMPILE=1 TRITON_PRINT_AUTOTUNING=1  CUDA_VISIBLE_DEVICES=7 python run.py --op bmm --only aten,pt2_nv_universal_bmm --cudagraph  --metrics tflops,accuracy --force  --num-inputs 1 --dtype fp16`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo