### PR TITLE
Avoid unnecessary recompilation in pad_mm when checking is_mm_compute_bound

### DIFF
--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -5,6 +5,7 @@ import typing
 from collections.abc import Callable, Sequence
 from typing import Any
 
+import sympy
 import torch
 import torch._inductor.runtime.runtime_utils
 from torch import Tensor
@@ -289,8 +290,7 @@ def is_mm_compute_bound(M: int, K: int, N: int, dtype: torch.dtype) -> bool:
     # we have experienced some large perf hits in this case, even in bandwidth bound regimes
     if (
         dtype is torch.bfloat16
-        and K > M
-        and K > N
+        and bool(sympy.And(sympy.Gt(K, M), sympy.Gt(K, N)))
         and (torch.xpu.is_available() or torch.cuda.get_device_capability() < (9, 0))
     ):  # doesn't repro on h100s:
         return True


### PR DESCRIPTION
In AOTI, we notice a guard being added in the `pad_mm` FX pass check, despite not even applying the `pad_mm` pass. This created a numerical issue due to backed symint specialization case.

The trail of events for my case:
- `K`:`128`
- `M`: `Dim(s0, min=3, max=128, hint=128)`
- `K > M` is `False`
- That implies `M >= K` is `True`
- Thus, `update_var_to_range s4 = VR[128, 128]`

So, the goal here is to avoid the guard on `M`/`s4`. Do this by wrapping in sympy operations (unless there's a more correct way).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171559



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo