### PR TITLE
[jit] Raise ValueError for invalid fusion strategy and add test

### DIFF
--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -259,6 +259,13 @@ class TestProfiler(JitTestCase):
         g = torch.jit.last_executed_optimized_graph()
         FileCheck().check_count(":TensorExprGroup", 2, exactly=True).run(g)
 
+    def test_invalid_fusion_strategy_raises_value_error(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"FusionBehavior.*(STATIC|DYNAMIC).*got:\s*COMPLEX",
+        ):
+            torch.jit.set_fusion_strategy([("STATIC", 2), ("COMPLEX", 3)])
+
     def test_iterative_fusion(self):
         @torch.jit.script
         def foo(a, b, c, d):

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -878,9 +878,8 @@ void initJITBindings(PyObject* module) {
               } else if (pair.first == "DYNAMIC") {
                 vec_conv.emplace_back(FusionBehavior::DYNAMIC, pair.second);
               } else {
-                TORCH_INTERNAL_ASSERT(
-                    false,
-                    "FusionBehavior only supported 'STATIC' or 'DYNAMIC', got: ",
+                throw py::value_error(
+                    "FusionBehavior only supported 'STATIC' or 'DYNAMIC', got: " +
                     pair.first);
               }
             }


### PR DESCRIPTION
Fixes #171494.

This is a user-facing API. Invalid input should raise a Python ValueError instead of triggering an internal assert.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel