### PR TITLE
Dumping input tensors for triton kernels generated with Inductor backend

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: inductor"]
 
 import functools
+import os
 import sys
+import tempfile
 import unittest
 from unittest import skipUnless
 from unittest.mock import MagicMock, patch
@@ -382,6 +384,116 @@ class TestArgumentCloneAndRestore(TestCase):
         self.assertTrue(arg.storage_offset() > 0)
 
         self._do_test(arg)
+
+
+class TestDumpLaunchTensors(TestCase):
+    """Test the _dump_launch_tensors functionality"""
+
+    def setUp(self):
+        super().setUp()
+        # Create a temporary directory for test dumps
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Clean up temporary directory
+        import shutil
+
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+        super().tearDown()
+
+    @skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_dump_launch_tensors(self):
+        """
+        Test that dump_launch_tensors functions correctly:
+        1. Creates the dump directory when torch.compile() runs
+        2. Saves tensor files that can be loaded
+        3. Loads tensors to match the original values
+        4. Properly rotates when max_kernel_dump_occurrences is reached
+        """
+        from torch._inductor.config import triton as inductor_triton_config
+        from torch._inductor.runtime.runtime_utils import cache_dir
+
+        # Clear any existing state
+        inductor_triton_config.debug_dump_kernel_inputs.clear()
+
+        # Define a simple function that will generate Triton kernels
+        def simple_model(x):
+            y = x * 2.0
+            z = y + 1.0
+            return z.sum()
+
+        old_dump_env = os.environ.get("TORCHINDUCTOR_DUMP_LAUNCH_TENSORS")
+        os.environ["TORCHINDUCTOR_DUMP_LAUNCH_TENSORS"] = "1"
+
+        try:
+            compiled_fn = torch.compile(simple_model)
+
+            # Run the compiled function multiple times to test rotation
+            max_runs = inductor_triton_config.max_kernel_dump_occurrences
+
+            for i in range(max_runs + 2):
+                test_input = torch.randn(100, 100, device=GPU_TYPE) * (i + 1)
+                _ = compiled_fn(test_input)
+
+            # After multiple runs, verify rotation and tensor correctness
+            kernel_bases = {}
+            verified_tensor_load = False
+
+            for root, dirs, files in os.walk(cache_dir()):
+                for d in dirs:
+                    if "_run_" in d:
+                        full_path = os.path.join(root, d)
+                        tensor_files = [
+                            f
+                            for f in os.listdir(full_path)
+                            if f.startswith("tensor_") and f.endswith(".pt")
+                        ]
+                        if not tensor_files:
+                            continue
+
+                        dir_name = os.path.basename(full_path)
+                        base_name = dir_name.rsplit("_run_", 1)[0]
+                        run_idx = int(dir_name.rsplit("_run_", 1)[1])
+
+                        # Track run indices per kernel
+                        if base_name not in kernel_bases:
+                            kernel_bases[base_name] = []
+                        kernel_bases[base_name].append(run_idx)
+
+                        # Verify we can successfully load at least one saved tensor
+                        if not verified_tensor_load:
+                            first_tensor_file = os.path.join(full_path, tensor_files[0])
+                            loaded_tensor = torch.load(first_tensor_file)
+
+                            # Verify it's a valid tensor with expected properties
+                            self.assertIsInstance(loaded_tensor, torch.Tensor)
+                            self.assertEqual(loaded_tensor.device.type, GPU_TYPE)
+                            verified_tensor_load = True
+
+            # Verify rotation constraints
+            if kernel_bases:
+                for base_name, indices in kernel_bases.items():
+                    self.assertLessEqual(
+                        len(indices),
+                        max_runs,
+                        f"Kernel {base_name} has more runs ({len(indices)}) than max ({max_runs})",
+                    )
+
+                    # Verify the indices are within [0, max_runs)
+                    for idx in indices:
+                        self.assertLess(
+                            idx,
+                            max_runs,
+                            f"Run index {idx} exceeds max_runs-1 ({max_runs - 1})",
+                        )
+
+        finally:
+            # Restore environment variable
+            if old_dump_env is None:
+                os.environ.pop("TORCHINDUCTOR_DUMP_LAUNCH_TENSORS", None)
+            else:
+                os.environ["TORCHINDUCTOR_DUMP_LAUNCH_TENSORS"] = old_dump_env
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1752,12 +1752,12 @@ class triton:
 
     # Map for storing the amount of kernel runs with dumped imput tensors
     # Based on hash of Triton source code to avoid bloating the folder
-    kernel_dump_occurency_map: dict[str, int] = {}
+    debug_dump_kernel_inputs: dict[str, int] = {}
 
     # Value for the maximum amount of runs with dumped kernel input tensors
     # When the maximum is reached the first values get overwritten
     # This ensures the last N runs are saved, where N is this value
-    max_kernel_dump_occurencies = 3
+    max_kernel_dump_occurrences = 3
 
 
 class aot_inductor:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1750,6 +1750,15 @@ class triton:
         os.environ.get("TORCHINDUCTOR_ENABLE_TLX_TEMPLATES", "0") == "1"
     )
 
+    # Map for storing the amount of kernel runs with dumped imput tensors
+    # Based on hash of Triton source code to avoid bloating the folder
+    kernel_dump_occurency_map: dict[str, int] = {}
+
+    # Value for the maximum amount of runs with dumped kernel input tensors
+    # When the maximum is reached the first values get overwritten
+    # This ensures the last N runs are saved, where N is this value
+    max_kernel_dump_occurencies = 3
+
 
 class aot_inductor:
     """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1750,7 +1750,7 @@ class triton:
         os.environ.get("TORCHINDUCTOR_ENABLE_TLX_TEMPLATES", "0") == "1"
     )
 
-    # Map for storing the amount of kernel runs with dumped imput tensors
+    # Map for storing the amount of kernel runs with dumped input tensors
     # Based on hash of Triton source code to avoid bloating the folder
     debug_dump_kernel_inputs: dict[str, int] = {}
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -227,13 +227,13 @@ def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
         kernel_hash = kernel_name
 
     # Saving only the last N runs of the kernels to avoid bloating the folder
-    if kernel_hash in inuctor_triton_config.kernel_dump_occurency_map:
-        run_index = inuctor_triton_config.kernel_dump_occurency_map[kernel_hash] + 1
+    if kernel_hash in inuctor_triton_config.debug_dump_kernel_inputs:
+        run_index = inuctor_triton_config.debug_dump_kernel_inputs[kernel_hash] + 1
 
-        if run_index >= inuctor_triton_config.max_kernel_dump_occurencies:
+        if run_index >= inuctor_triton_config.max_kernel_dump_occurrences:
             run_index = 0
 
-    inuctor_triton_config.kernel_dump_occurency_map[kernel_hash] = run_index
+    inuctor_triton_config.debug_dump_kernel_inputs[kernel_hash] = run_index
 
     # Default path for kernels with no hash
     if not kernel_path:
@@ -243,7 +243,6 @@ def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
     directory_path = f"{directory_path}/{kernel_name}_run_{run_index}"
     os.makedirs(directory_path, exist_ok=True)
 
-    # Log the saved tensor path for this kernel (once per kernel, not per input)
     log.info(
         "Dumping %d tensor(s) for kernel %s to %s",
         len(tensor_list),

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -26,6 +26,7 @@ from torch._inductor import metrics
 from torch._prims_common import compute_required_storage_length
 from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._ordered_set import OrderedSet
+from torch._inductor.config import triton as inuctor_triton_config
 
 from ..triton_bundler import TritonBundler
 from ..utils import (
@@ -214,6 +215,39 @@ def _dump_launch_params(args, kwargs, launcher, kernel_name, grid):
         f.write(f"{kernel_name} | {args_str} | {grid!r}\n")
 
 
+def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
+    tensor_list = [arg for arg in args if isinstance(arg, torch.Tensor)]
+
+    run_index = 0
+
+    # Some kernels don't have path and hash stored
+    # Using only the name to differentiate between those
+    if not kernel_path:
+        kernel_hash = kernel_name
+
+    # Saving only the last N runs of the kernels to avoid bloating the folder
+    if kernel_hash in inuctor_triton_config.kernel_dump_occurency_map:
+        run_index = inuctor_triton_config.kernel_dump_occurency_map[kernel_hash] + 1
+
+        if run_index >= inuctor_triton_config.max_kernel_dump_occurencies:
+            run_index = 0
+
+    inuctor_triton_config.kernel_dump_occurency_map[kernel_hash] = run_index
+
+    # Default path for kernels with no hash
+    if not kernel_path:
+        directory_path = "/tmp/torchinductor_root/unhashed_kernel_inputs"
+    else:
+        directory_path = os.path.dirname(kernel_path)
+    directory_path = f"{directory_path}/{kernel_name}_run_{run_index}"
+    os.makedirs(directory_path, exist_ok=True)
+
+    tensor_index = 0
+    for tensor in tensor_list:
+        torch.save(tensor, f"{directory_path}/tensor_{tensor_index}.pt")
+        tensor_index +=1
+
+
 def check_autotune_cache(
     configs: list[Config], filename: str | None, inductor_meta: dict[str, Any]
 ) -> tuple[list[Config], AutotuneCache | None, dict[str, Any]]:
@@ -368,6 +402,10 @@ class CachingAutotuner(KernelInterface):
         self.dump_launch_params = (
             os.environ.get("TORCHINDUCTOR_DUMP_LAUNCH_PARAMS", "0") == "1"
         )
+        self.dump_launch_tensors = (
+            os.environ.get("TORCHINDUCTOR_DUMP_LAUNCH_TENSORS", "0") == "1"
+        )
+        self.kernels_to_dump = os.environ.get("TORCHINDUCTOR_KERNELS_TO_DUMP", "").split(",")
 
         self.triton_interpret = os.environ.get("TRITON_INTERPRET", "0") == "1"
 
@@ -1420,6 +1458,11 @@ class CachingAutotuner(KernelInterface):
         if self.dump_launch_params:
             new_args, grid = self._interpret_args_grid(args, launcher.config)
             _dump_launch_params(new_args, kwargs, launcher, self.fn.__name__, grid)
+
+        if self.dump_launch_tensors:
+            # Check the kernel name if the list was provided
+            if not self.kernels_to_dump or any(kernel_name in self.fn.__name__ for kernel_name in self.kernels_to_dump):
+                _dump_launch_tensors(args, self.filename, self.kernel_hash, self.fn.__name__)
 
         # it is faster than entering and exiting a context manager, even if the context
         # manager is a nullcontext.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -50,6 +50,7 @@ from .hints import (
     TRITON_MAX_RSPLIT,
 )
 from .runtime_utils import (
+    cache_dir,
     ceildiv,
     conditional_product,
     create_bandwidth_info_str,
@@ -236,11 +237,19 @@ def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
 
     # Default path for kernels with no hash
     if not kernel_path:
-        directory_path = "/tmp/torchinductor_root/unhashed_kernel_inputs"
+        directory_path = os.path.join(cache_dir(), "unhashed_kernel_inputs")
     else:
         directory_path = os.path.dirname(kernel_path)
     directory_path = f"{directory_path}/{kernel_name}_run_{run_index}"
     os.makedirs(directory_path, exist_ok=True)
+
+    # Log the saved tensor path for this kernel (once per kernel, not per input)
+    log.info(
+        "Dumping %d tensor(s) for kernel %s to %s",
+        len(tensor_list),
+        kernel_name,
+        directory_path,
+    )
 
     for index, tensor in enumerate(tensor_list):
         torch.save(tensor, f"{directory_path}/tensor_{index}.pt")

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -23,10 +23,10 @@ from typing import Any, Generic, Literal, TYPE_CHECKING, TypeVar, Union
 import torch
 from torch._dynamo.utils import counters, set_feature_use
 from torch._inductor import metrics
+from torch._inductor.config import triton as inuctor_triton_config
 from torch._prims_common import compute_required_storage_length
 from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._ordered_set import OrderedSet
-from torch._inductor.config import triton as inuctor_triton_config
 
 from ..triton_bundler import TritonBundler
 from ..utils import (
@@ -242,10 +242,8 @@ def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
     directory_path = f"{directory_path}/{kernel_name}_run_{run_index}"
     os.makedirs(directory_path, exist_ok=True)
 
-    tensor_index = 0
-    for tensor in tensor_list:
-        torch.save(tensor, f"{directory_path}/tensor_{tensor_index}.pt")
-        tensor_index +=1
+    for index, tensor in enumerate(tensor_list):
+        torch.save(tensor, f"{directory_path}/tensor_{index}.pt")
 
 
 def check_autotune_cache(
@@ -405,7 +403,9 @@ class CachingAutotuner(KernelInterface):
         self.dump_launch_tensors = (
             os.environ.get("TORCHINDUCTOR_DUMP_LAUNCH_TENSORS", "0") == "1"
         )
-        self.kernels_to_dump = os.environ.get("TORCHINDUCTOR_KERNELS_TO_DUMP", "").split(",")
+        self.kernels_to_dump = os.environ.get(
+            "TORCHINDUCTOR_KERNELS_TO_DUMP", ""
+        ).split(",")
 
         self.triton_interpret = os.environ.get("TRITON_INTERPRET", "0") == "1"
 
@@ -1461,8 +1461,12 @@ class CachingAutotuner(KernelInterface):
 
         if self.dump_launch_tensors:
             # Check the kernel name if the list was provided
-            if not self.kernels_to_dump or any(kernel_name in self.fn.__name__ for kernel_name in self.kernels_to_dump):
-                _dump_launch_tensors(args, self.filename, self.kernel_hash, self.fn.__name__)
+            if not self.kernels_to_dump or any(
+                kernel_name in self.fn.__name__ for kernel_name in self.kernels_to_dump
+            ):
+                _dump_launch_tensors(
+                    args, self.filename, self.kernel_hash, self.fn.__name__
+                )
 
         # it is faster than entering and exiting a context manager, even if the context
         # manager is a nullcontext.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -23,7 +23,7 @@ from typing import Any, Generic, Literal, TYPE_CHECKING, TypeVar, Union
 import torch
 from torch._dynamo.utils import counters, set_feature_use
 from torch._inductor import metrics
-from torch._inductor.config import triton as inuctor_triton_config
+from torch._inductor.config import triton as inductor_triton_config
 from torch._prims_common import compute_required_storage_length
 from torch.utils._debug_mode import get_active_debug_mode
 from torch.utils._ordered_set import OrderedSet
@@ -227,13 +227,13 @@ def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
         kernel_hash = kernel_name
 
     # Saving only the last N runs of the kernels to avoid bloating the folder
-    if kernel_hash in inuctor_triton_config.debug_dump_kernel_inputs:
-        run_index = inuctor_triton_config.debug_dump_kernel_inputs[kernel_hash] + 1
+    if kernel_hash in inductor_triton_config.debug_dump_kernel_inputs:
+        run_index = inductor_triton_config.debug_dump_kernel_inputs[kernel_hash] + 1
 
-        if run_index >= inuctor_triton_config.max_kernel_dump_occurrences:
+        if run_index >= inductor_triton_config.max_kernel_dump_occurrences:
             run_index = 0
 
-    inuctor_triton_config.debug_dump_kernel_inputs[kernel_hash] = run_index
+    inductor_triton_config.debug_dump_kernel_inputs[kernel_hash] = run_index
 
     # Default path for kernels with no hash
     if not kernel_path:


### PR DESCRIPTION
Fixes #166949.

This is a remake of https://github.com/pytorch/pytorch/pull/166948 due to github PAT issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo