### PR TITLE
[DTensor] pr time benchmarks for collectives, from/to_local, backwards

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
@@ -3,7 +3,7 @@ import sys
 from benchmark_base import BenchmarkBase
 
 import torch
-from torch.distributed._tensor import DTensor, Replicate
+from torch.distributed._tensor import DTensor, Partial, Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
@@ -45,6 +45,60 @@ class BenchmarkDetach(BenchmarkDTensorDispatch):
         self.a.detach()
 
 
+class BenchmarkToFromLocal(BenchmarkDTensorDispatch):
+    def __init__(self, world_size) -> None:
+        super().__init__(operator="to_from_local", world_size=world_size)
+
+    def _work(self) -> None:
+        local = self.a.to_local()
+        DTensor.from_local(local, self.mesh, [Replicate()])
+
+
+class BenchmarkCollectives(BenchmarkDTensorDispatch):
+    def __init__(self, world_size) -> None:
+        super().__init__(operator="collectives", world_size=world_size)
+
+    def _prepare_once(self) -> None:
+        super()._prepare_once()
+        self.c = DTensor.from_local(
+            torch.ones(10, 10, device=self.device()), self.mesh, [Partial()]
+        )
+
+    def _work(self) -> None:
+        # shard
+        a = self.a.redistribute(placements=[Shard(0)])
+        # alltoall
+        a = a.redistribute(placements=[Shard(1)])
+        # allgather
+        a = a.redistribute(placements=[Replicate()])
+        # allreduce
+        self.c.redistribute(placements=[Replicate()])
+        # reducescatter
+        self.c.redistribute(placements=[Shard(0)])
+
+
+class BenchmarkAddBackward(BenchmarkDTensorDispatch):
+    def __init__(self, world_size) -> None:
+        super().__init__(operator="add_backward", world_size=world_size)
+
+    def _prepare_once(self) -> None:
+        super()._prepare_once()
+        self.a = DTensor.from_local(
+            torch.ones(2, 512, device=self.device(), requires_grad=True),
+            self.mesh,
+            [Shard(0)],
+        )
+        self.b = DTensor.from_local(
+            torch.ones(512, 2, device=self.device(), requires_grad=True),
+            self.mesh,
+            [Shard(1)],
+        )
+
+    def _work(self) -> None:
+        out = self.a + self.b
+        out.sum().backward()
+
+
 def main():
     world_size = 256
     fake_store = FakeStore()
@@ -55,6 +109,15 @@ def main():
     BenchmarkDetach(world_size).enable_instruction_count().collect_all().append_results(
         result_path
     )
+    BenchmarkToFromLocal(
+        world_size
+    ).enable_instruction_count().collect_all().append_results(result_path)
+    BenchmarkCollectives(
+        world_size
+    ).enable_instruction_count().collect_all().append_results(result_path)
+    BenchmarkAddBackward(
+        world_size
+    ).enable_instruction_count().collect_all().append_results(result_path)
     torch.distributed.destroy_process_group()
 
 


### PR DESCRIPTION
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo