### PR TITLE
flash attention exposing window_size_left and window_size_right

### DIFF
--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -83,7 +83,7 @@ class AttentionBlock(nn.Module):
         seq_lengths: torch.Tensor,
         is_causal: bool = False,
         scale: float | None = None,
-        window_size: tuple[int, int] = -1,
+        window_size: tuple[int, int] = (-1, -1),
     ):
         batch_size, seq_len, _ = x_padded.shape
 

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -71,7 +71,16 @@ class AttentionBlock(nn.Module):
         q, k, v = self.get_varlen_qkv(x_packed)
 
         attn_out = varlen_attn(
-            q, k, v, cu_seq, cu_seq, max_len, max_len, is_causal, scale=scale, window_size=window_size
+            q,
+            k,
+            v,
+            cu_seq,
+            cu_seq,
+            max_len,
+            max_len,
+            is_causal,
+            scale=scale,
+            window_size=window_size,
         )
         attn_out = attn_out.view(-1, self.embed_dim)
 
@@ -108,7 +117,9 @@ class AttentionBlock(nn.Module):
 
         # --- Window attention ---
         if window_size[0] >= 0 or window_size[1] >= 0:
-            window_mask = torch.zeros(seq_len, seq_len, dtype=torch.bool, device=x_padded.device)
+            window_mask = torch.zeros(
+                seq_len, seq_len, dtype=torch.bool, device=x_padded.device
+            )
             for i in range(seq_len):
                 start = i - window_size[0] if window_size[0] >= 0 else 0
                 end = i + window_size[1] + 1 if window_size[1] >= 0 else seq_len

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -66,11 +66,13 @@ class AttentionBlock(nn.Module):
         max_len: int,
         is_causal: bool = False,
         scale: float | None = None,
+        window_size_left: int = -1,
+        window_size_right: int = -1,
     ):
         q, k, v = self.get_varlen_qkv(x_packed)
 
         attn_out = varlen_attn(
-            q, k, v, cu_seq, cu_seq, max_len, max_len, is_causal, scale=scale
+            q, k, v, cu_seq, cu_seq, max_len, max_len, is_causal, scale=scale, window_size_left=window_size_left, window_size_right=window_size_right
         )
         attn_out = attn_out.view(-1, self.embed_dim)
 
@@ -82,6 +84,8 @@ class AttentionBlock(nn.Module):
         seq_lengths: torch.Tensor,
         is_causal: bool = False,
         scale: float | None = None,
+        window_size_left: int = -1,
+        window_size_right: int = -1,
     ):
         batch_size, seq_len, _ = x_padded.shape
 
@@ -103,6 +107,17 @@ class AttentionBlock(nn.Module):
             )
             # Combine: attention allowed where BOTH padding is valid AND causal constraint is met
             attn_mask = attn_mask & causal_mask[None, None, :, :]
+
+        # --- Window attention ---
+        if window_size_left >= 0 or window_size_right >= 0:
+            window_mask = torch.zeros(seq_len, seq_len, dtype=torch.bool, device=x_padded.device)
+            for i in range(seq_len):
+                start = i - window_size_left if window_size_left >= 0 else 0
+                end = i + window_size_right + 1 if window_size_right >= 0 else seq_len
+                start = max(start, 0)
+                end = min(end, seq_len)
+                window_mask[i, start:end] = True
+            attn_mask = attn_mask & window_mask[None, None, :, :]
 
         q = q.view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
         k = k.view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
@@ -332,7 +347,9 @@ class TestVarlenAttention(NNTestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     @parametrize("is_causal", [False, True])
     @parametrize("scale", [None, 0.1])
-    def test_varlen_vs_sdpa(self, device, dtype, is_causal, scale):
+    @parametrize("window_size_left", [-1, 4])
+    @parametrize("window_size_right", [-1, 4])
+    def test_varlen_vs_sdpa(self, device, dtype, is_causal, scale, window_size_left, window_size_right):
         torch.manual_seed(42)
 
         shape = VarlenShape(
@@ -358,12 +375,16 @@ class TestVarlenAttention(NNTestCase):
             variable_length_batch_data["max_len"],
             is_causal=is_causal,
             scale=scale,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
         sdpa_output = attention_block.forward_sdpa(
             variable_length_batch_data["x_padded"],
             variable_length_batch_data["seq_lengths"],
             is_causal=is_causal,
             scale=scale,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
 
         golden_sdpa_output = golden_attention_block.forward_sdpa(
@@ -371,6 +392,8 @@ class TestVarlenAttention(NNTestCase):
             golden_variable_length_batch_data["seq_lengths"],
             is_causal=is_causal,
             scale=scale,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
 
         start_idx = 0

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -151,8 +151,8 @@ def varlen_attn(
     is_causal: bool = False,
     return_aux: AuxRequest | None = None,
     scale: float | None = None,
-    window_size_left: int = -1,
-    window_size_right: int = -1,
+    window_size: tuple[int, int] = (-1, -1),
+    kwargs: Any = {},
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     Compute variable-length attention using Flash Attention.
@@ -170,6 +170,8 @@ def varlen_attn(
         is_causal (bool, optional): If set to True, applies causal masking (default: False).
         return_aux (Optional[AuxRequest]): If not None and ``return_aux.lse`` is True, also returns the logsumexp tensor.
         scale (float, optional): Scaling factor for attention scores
+        window_size (tuple[int, int], optional): Left and right window sizes for windowed attention.
+        kwargs: Additional keyword arguments for future extensions.
 
     Returns:
         output (Tensor): Output tensor from attention computation; shape :math:`(T_q, H, D)`.
@@ -218,7 +220,7 @@ def varlen_attn(
         ... )
     """
     out, lse, _ = torch.ops.torch_attn._varlen_attn(
-        query, key, value, cu_seq_q, cu_seq_k, max_q, max_k, is_causal, scale, window_size_left, window_size_right
+        query, key, value, cu_seq_q, cu_seq_k, max_q, max_k, is_causal, scale, window_size[0], window_size[1], **kwargs
     )
     if return_aux is not None and return_aux.lse:
         return out, lse

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -151,8 +151,7 @@ def varlen_attn(
     is_causal: bool = False,
     return_aux: AuxRequest | None = None,
     scale: float | None = None,
-    window_size: tuple[int, int] = (-1, -1),
-    kwargs: Any = {},
+    **kwargs,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     Compute variable-length attention using Flash Attention.
@@ -170,8 +169,8 @@ def varlen_attn(
         is_causal (bool, optional): If set to True, applies causal masking (default: False).
         return_aux (Optional[AuxRequest]): If not None and ``return_aux.lse`` is True, also returns the logsumexp tensor.
         scale (float, optional): Scaling factor for attention scores
-        window_size (tuple[int, int], optional): Left and right window sizes for windowed attention.
         kwargs: Additional keyword arguments for future extensions.
+            - window_size (tuple[int, int], optional): Left and right window sizes for windowed attention.
 
     Returns:
         output (Tensor): Output tensor from attention computation; shape :math:`(T_q, H, D)`.
@@ -219,6 +218,7 @@ def varlen_attn(
         ...     query, key, value, cu_seq, cu_seq, max_len, max_len, is_causal=False
         ... )
     """
+    window_size = kwargs.pop("window_size", (-1, -1))
     out, lse, _ = torch.ops.torch_attn._varlen_attn(
         query, key, value, cu_seq_q, cu_seq_k, max_q, max_k, is_causal, scale, window_size[0], window_size[1], **kwargs
     )


### PR DESCRIPTION

**Fixes** [#171577](https://github.com/pytorch/pytorch/issues/171577)

This PR extends the `varlen` function signature with:

```python
window_size_left: int = -1,
window_size_right: int = -1,
```

This makes it possible to easily use and implement sliding window attention.

---

I have updated `test/test_varlen_attention.py` so that the tests also run with `window_size_left` and `window_size_right` enabled.

---

**Note:**

Increasing the window size can cause test failures. These failures appear to be due to slightly larger numerical deviations than the current test tolerances allow. I suggest increasing the tolerance in these tests to account for this.
