### PR TITLE
[pallas backend] Fix scalar store shape mismatch

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_inplace_where_pointwise_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_inplace_where_pointwise_cpu
@@ -1,5 +1,0 @@
-ERROR
-  File "/home/oulgen/py312/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 1141, in op
-    return getattr(self.aval, f"_{name}")(self, *args)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ValueError: Invalid shape for `swap`. Ref shape: (1,). Expected shape: (1,). Value shape: (). Transforms: ().

--- a/test/inductor/pallas_expected_failures/CpuTests.test_resize_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_resize_cpu
@@ -1,5 +1,2 @@
-ERROR
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/oulgen/dev/pytorch/torch/_inductor/ops_handler.py", line 120, in masked
-    raise NotImplementedError
-torch._inductor.exc.InductorError: NotImplementedError:
+FAIL
+Accuracy failed: allclose not within tol

--- a/test/inductor/pallas_expected_failures/CpuTests.test_setitem_with_int_parameter_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_setitem_with_int_parameter_cpu
@@ -1,5 +1,0 @@
-ERROR
-  File "/home/oulgen/py312/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 1141, in op
-    return getattr(self.aval, f"_{name}")(self, *args)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ValueError: Invalid shape for `swap`. Ref shape: (7,). Expected shape: (7,). Value shape: (). Transforms: ().

--- a/test/inductor/pallas_expected_failures/CpuTests.test_slice_view_with_graph_break_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_slice_view_with_graph_break_cpu
@@ -1,5 +1,0 @@
-ERROR
-  File "/home/oulgen/py312/lib/python3.12/site-packages/jax/_src/numpy/array_methods.py", line 1141, in op
-    return getattr(self.aval, f"_{name}")(self, *args)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ValueError: Invalid shape for `swap`. Ref shape: (1,). Expected shape: (1,). Value shape: (). Transforms: ().

--- a/test/inductor/pallas_expected_failures/CpuTests.test_softmax_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_softmax_cpu
@@ -1,5 +1,3 @@
 FAIL
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/oulgen/dev/pytorch/torch/testing/_internal/common_utils.py", line 4280, in assertEqual
-    raise error_metas.pop()[0].to_error(  # type: ignore[index]
 AssertionError: Tensor-likes are not close!
+Numerical accuracy issue

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2335,8 +2335,12 @@ class PallasKernel(SIMDKernel):
         is_scalar = buf is not None and len(buf.get_size()) == 0
 
         if is_scalar:
-            # For scalar outputs, use [...] to assign the entire scalar
-            store_expr = f"{out}[...] = {value}"
+            # For scalar outputs, use jnp.full to handle shape mismatch
+            store_expr = (
+                f"{out}[...] = ("
+                f"jnp.full({out}.shape, {value}) if jnp.asarray({value}).ndim == 0 "
+                f"else jnp.asarray({value}).reshape({out}.shape))"
+            )
         else:
             # Check for scatter pattern (indirect indexing for stores)
             scatter_info = self._detect_scatter_pattern(index, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #171581
* #171579
* #171571

When storing a scalar value into a buffer, use jnp.full to handle shape differences.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo