### PR TITLE
[ROCm] Fix AMDSMI return types for memory_usage and utilization

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1344,12 +1344,12 @@ def _get_amdsmi_device_memory_used(device: Device = None) -> int:
 
 def _get_amdsmi_memory_usage(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_gpu_activity(handle)["umc_activity"]
+    return int(amdsmi.amdsmi_get_gpu_activity(handle)["umc_activity"])
 
 
 def _get_amdsmi_utilization(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_gpu_activity(handle)["gfx_activity"]
+    return int(amdsmi.amdsmi_get_gpu_activity(handle)["gfx_activity"])
 
 
 def _get_amdsmi_temperature(device: Device = None) -> int:


### PR DESCRIPTION
## Summary
Add explicit `int()` conversion for `_get_amdsmi_memory_usage()` and `_get_amdsmi_utilization()` to match their declared return type `-> int`.

## Details
The amdsmi library may return string values from `amdsmi_get_gpu_activity()`, which need conversion to match the function signature. This is consistent with the fix in #171555 for `_get_amdsmi_power_draw()` and `_get_amdsmi_clock_rate()`.

## Test plan
- [x] Code review confirms change is safe
- [ ] Hardware verification on ROCm (will post results)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)