### PR TITLE
[Build] Narrow broad exceptions in compiler detection functions

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -501,7 +501,7 @@ def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVer
             compiler_info = subprocess.check_output(compiler, stderr=subprocess.STDOUT)
         match = re.search(r'(\d+)\.(\d+)\.(\d+)', compiler_info.decode(*SUBPROCESS_DECODE_ARGS).strip())
         version = ['0', '0', '0'] if match is None else list(match.groups())
-    except (FileNotFoundError, subprocess.CalledProcessError, OSError) as error:
+    except (subprocess.CalledProcessError, OSError) as error:
         logger.warning('Error checking compiler version for %s: %s', compiler, error)
         return (False, TorchVersion('0.0.0'))
 
@@ -1829,10 +1829,10 @@ def check_compiler_is_gcc(compiler) -> bool:
     env['LC_ALL'] = 'C'  # Don't localize output
     try:
         version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
-    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+    except (subprocess.CalledProcessError, OSError):
         try:
             version_string = subprocess.check_output([compiler, '--version'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
-        except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        except (subprocess.CalledProcessError, OSError):
             return False
     # Check for GCC by verifying both COLLECT_GCC and gcc version string are present
     # This works for c++, g++, gcc, and versioned variants like g++-13

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -501,8 +501,8 @@ def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVer
             compiler_info = subprocess.check_output(compiler, stderr=subprocess.STDOUT)
         match = re.search(r'(\d+)\.(\d+)\.(\d+)', compiler_info.decode(*SUBPROCESS_DECODE_ARGS).strip())
         version = ['0', '0', '0'] if match is None else list(match.groups())
-    except (subprocess.CalledProcessError, OSError) as error:
-        logger.warning('Error checking compiler version for %s: %s', compiler, error)
+    except (subprocess.CalledProcessError, OSError):
+        logger.warning('Error checking compiler version for %s', compiler, exc_info=True)
         return (False, TorchVersion('0.0.0'))
 
     # convert alphanumeric string to numeric string

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -501,8 +501,7 @@ def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVer
             compiler_info = subprocess.check_output(compiler, stderr=subprocess.STDOUT)
         match = re.search(r'(\d+)\.(\d+)\.(\d+)', compiler_info.decode(*SUBPROCESS_DECODE_ARGS).strip())
         version = ['0', '0', '0'] if match is None else list(match.groups())
-    except Exception:
-        _, error, _ = sys.exc_info()
+    except (FileNotFoundError, subprocess.CalledProcessError, OSError) as error:
         logger.warning('Error checking compiler version for %s: %s', compiler, error)
         return (False, TorchVersion('0.0.0'))
 
@@ -1830,10 +1829,10 @@ def check_compiler_is_gcc(compiler) -> bool:
     env['LC_ALL'] = 'C'  # Don't localize output
     try:
         version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
-    except Exception:
+    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
         try:
             version_string = subprocess.check_output([compiler, '--version'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
-        except Exception:
+        except (FileNotFoundError, subprocess.CalledProcessError, OSError):
             return False
     # Check for GCC by verifying both COLLECT_GCC and gcc version string are present
     # This works for c++, g++, gcc, and versioned variants like g++-13


### PR DESCRIPTION
## Summary
Replace `except Exception:` with specific exceptions in compiler detection functions.

## Details
The current broad exception handlers can mask real errors during compiler detection, making debugging difficult especially for ROCm toolchain issues with amdclang++.

### Changes

**_get_compiler_version() - line 504**
```python
# Before:
except Exception:
    _, error, _ = sys.exc_info()

# After:
except (FileNotFoundError, subprocess.CalledProcessError, OSError) as error:
```

**check_compiler_is_gcc() - lines 1833, 1836**
```python
# Before:
except Exception:
    try:
        ...
    except Exception:
        return False

# After:
except (FileNotFoundError, subprocess.CalledProcessError, OSError):
    try:
        ...
    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
        return False
```

These are the standard exceptions raised by `subprocess.check_output()`.

## Test plan
- [x] Code review confirms change is safe
- [x] Local testing with various compilers

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)