### PR TITLE
[ROCm] Fix AMDSMI return types for remaining functions

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1354,11 +1354,13 @@ def _get_amdsmi_utilization(device: Device = None) -> int:
 
 def _get_amdsmi_temperature(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return int(amdsmi.amdsmi_get_temp_metric(
-        handle,
-        amdsmi.AmdSmiTemperatureType.JUNCTION,
-        amdsmi.AmdSmiTemperatureMetric.CURRENT,
-    ))
+    return int(
+        amdsmi.amdsmi_get_temp_metric(
+            handle,
+            amdsmi.AmdSmiTemperatureType.JUNCTION,
+            amdsmi.AmdSmiTemperatureMetric.CURRENT,
+        )
+    )
 
 
 def _get_amdsmi_power_draw(device: Device = None) -> int:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1337,7 +1337,7 @@ def _get_amdsmi_device_index(device: Device) -> int:
 def _get_amdsmi_device_memory_used(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
     # amdsmi_get_gpu_vram_usage returns mem usage in megabytes
-    mem_mega_bytes = amdsmi.amdsmi_get_gpu_vram_usage(handle)["vram_used"]
+    mem_mega_bytes = int(amdsmi.amdsmi_get_gpu_vram_usage(handle)["vram_used"])
     mem_bytes = mem_mega_bytes * 1024 * 1024
     return mem_bytes
 
@@ -1354,22 +1354,22 @@ def _get_amdsmi_utilization(device: Device = None) -> int:
 
 def _get_amdsmi_temperature(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_temp_metric(
+    return int(amdsmi.amdsmi_get_temp_metric(
         handle,
         amdsmi.AmdSmiTemperatureType.JUNCTION,
         amdsmi.AmdSmiTemperatureMetric.CURRENT,
-    )
+    ))
 
 
 def _get_amdsmi_power_draw(device: Device = None) -> int:
     handle = _get_amdsmi_handler(device)
     socket_power = amdsmi.amdsmi_get_power_info(handle)["average_socket_power"]
     if socket_power != "N/A":
-        return socket_power
+        return int(socket_power)
     else:
         socket_power = amdsmi.amdsmi_get_power_info(handle)["current_socket_power"]
         if socket_power != "N/A":
-            return socket_power
+            return int(socket_power)
         else:
             return 0
 
@@ -1382,7 +1382,7 @@ def _get_amdsmi_clock_rate(device: Device = None) -> int:
     else:
         clock_rate = clock_info["clk"]
     if clock_rate != "N/A":
-        return clock_rate
+        return int(clock_rate)
     else:
         return 0
 


### PR DESCRIPTION
## Summary
Add explicit `int()` conversion for remaining AMDSMI functions to match their declared return type `-> int`.

## Details
The amdsmi library may return string or float values that need explicit conversion to match the function signature. This is a follow-up to PR #171584 which fixed `_get_amdsmi_memory_usage` and `_get_amdsmi_utilization`.

### Functions fixed

| Function | Line | Change |
|----------|------|--------|
| `_get_amdsmi_device_memory_used` | 1340 | Added `int()` around `vram_used` before arithmetic |
| `_get_amdsmi_temperature` | 1357 | Added `int()` around `amdsmi_get_temp_metric()` return |
| `_get_amdsmi_power_draw` | 1368, 1372 | Added `int()` around `socket_power` returns |
| `_get_amdsmi_clock_rate` | 1385 | Added `int()` around `clock_rate` return |

## Test plan
- [x] Code review confirms change is safe
- [ ] Hardware verification on ROCm (will post results)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @malfet

🤖 Generated with [Claude Code](https://claude.com/claude-code)