### PR TITLE
Bump MKL version from 2024.2.0 to 2025.3.0

### DIFF
--- a/.ci/docker/common/install_mkl.sh
+++ b/.ci/docker/common/install_mkl.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # MKL
-MKL_VERSION=2024.2.0
+MKL_VERSION=2025.3.0
 
 MKLROOT=/opt/intel
 mkdir -p ${MKLROOT}


### PR DESCRIPTION
We've been building PyTorch wheels with MKL 2025.3.0 and we're seeing parity in the test results. Caveat: we're our own APK-packaged MKL, not the wheels.

