### PR TITLE
[ROCm][CI] Add existence check for /etc/rocm_env.sh

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -8,7 +8,9 @@ set -ex -o pipefail
 # for ROCm environment variables
 if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
   # shellcheck disable=SC1091
-  source /etc/rocm_env.sh
+  if [[ -f /etc/rocm_env.sh ]]; then
+    source /etc/rocm_env.sh
+  fi
 fi
 
 # Required environment variables:


### PR DESCRIPTION
## Summary

Adds an existence check before sourcing `/etc/rocm_env.sh` in the CI common script to prevent failures on standard ROCm installations.

## Problem

As reported in #170983, the `common.sh` script unconditionally sources `/etc/rocm_env.sh` for ROCm builds:

```bash
if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
  source /etc/rocm_env.sh
fi
```

This file doesn't exist in all ROCm environments (e.g., standard ROCm SDK installations), causing the script to fail with:
```
.ci/pytorch/common.sh: line 11: /etc/rocm_env.sh: No such file or directory
```

## Solution

Add a simple existence check before sourcing:

```bash
if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
  if [[ -f /etc/rocm_env.sh ]]; then
    source /etc/rocm_env.sh
  fi
fi
```

This maintains backward compatibility with environments that have the file while allowing the script to work in standard ROCm installations.

## Testing

- [x] Syntax check: `bash -n .ci/pytorch/common.sh` passes
- [x] Logic review: The nested conditional is standard bash pattern

Fixes #170983

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.com/claude-code)