### PR TITLE
[docs] Clarify torch.unique behavior with dim parameter

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -813,13 +813,18 @@ def _unique_impl(
         dim (int, optional): the dimension to operate upon. If ``None``, the
             unique of the flattened input is returned. Otherwise, each of the
             tensors indexed by the given dimension is treated as one of the
-            elements to apply the unique operation upon. See examples for more
-            details. Default: ``None``
+            elements to apply the unique operation upon. **Important:** when ``dim``
+            is specified, the operation finds unique sub-tensors (e.g., unique rows
+            or columns), not unique scalar values. This means individual values may
+            appear multiple times in the output if they exist in different sub-tensors.
+            See examples for more details. Default: ``None``
 
     Returns:
         (Tensor, Tensor (optional), Tensor (optional)): A tensor or a tuple of tensors containing
 
-            - **output** (*Tensor*): the output list of unique scalar elements.
+            - **output** (*Tensor*): the output list of unique scalar elements if :attr:`dim`
+              is ``None``; otherwise, the unique sub-tensors along the specified dimension.
+              Note that when :attr:`dim` is specified, scalar values may repeat in the output.
             - **inverse_indices** (*Tensor*): (optional) if
               :attr:`return_inverse` is True, there will be an additional
               returned tensor (same shape as input) representing the indices
@@ -851,6 +856,22 @@ def _unique_impl(
         >>> inverse_indices
         tensor([[0, 2],
                 [1, 2]])
+
+        >>> # When using dim, the operation finds unique sub-tensors, not unique values.
+        >>> # Notice how values can repeat in the output:
+        >>> x = torch.tensor([[1, 3, 2, 3], [1, 2, 1, 2]], dtype=torch.long)
+        >>> torch.unique(x, dim=0)  # unique rows
+        tensor([[1, 2, 1, 2],
+                [1, 3, 2, 3]])
+        >>> # Both rows are kept because they're different from each other,
+        >>> # even though values 1, 2, 3 appear multiple times in the output.
+        >>> torch.unique(x, dim=1)  # unique columns
+        tensor([[1, 2, 3],
+                [1, 1, 2]])
+        >>> # The value 1 appears twice because we're comparing columns, not values.
+        >>> # Compare with flattened (no dim):
+        >>> torch.unique(x)
+        tensor([1, 2, 3])
 
         >>> a = torch.tensor([
         ...     [


### PR DESCRIPTION
When dim is specified, torch.unique finds unique sub-tensors (rows/columns), not unique scalar values. This means individual values may appear multiple times in the output if they exist in different sub-tensors.

Added:
- Enhanced dim parameter description with important note
- Clarified return value documentation
- Added illustrative example showing value repetition with dim=0 and dim=1

Fixes #166143
