### PR TITLE
[c10d] Fix cross-thread work registry lookup in wait_tensor

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -647,6 +647,60 @@ class ProcessGroupDummy(dist.ProcessGroup):
         )
 
 
+class CrossThreadWaitTest(TestCase):
+    """
+    Test that wait_tensor can find work registered on a different thread.
+    This validates the cross-thread work registry lookup in wait_tensor
+    that handles the case where wait() is called from a different thread
+    than where the collective was initiated.
+    """
+
+    def test_wait_tensor_cross_thread(self) -> None:
+        """
+        Test that wait_tensor works when called from a different thread
+        than where the collective was registered.
+        """
+        wait_called = False
+        exception_in_thread: Optional[BaseException] = None
+
+        class MyWork(dist.Work):
+            def wait(self, _=None):
+                nonlocal wait_called
+                wait_called = True
+                return True
+
+        # Create tensor and register work in main thread
+        tensor = torch.rand(2, 2)
+        work = MyWork()
+        torch._C._distributed_c10d._register_work(tensor, work)
+
+        # Verify work is registered
+        self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 1)
+
+        # Wait for the tensor in a different thread
+        def wait_in_different_thread():
+            nonlocal exception_in_thread
+            try:
+                # This should find the work registered in the main thread
+                torch.ops._c10d_functional.wait_tensor(tensor)
+            except Exception as e:
+                exception_in_thread = e
+
+        thread = threading.Thread(target=wait_in_different_thread)
+        thread.start()
+        thread.join()
+
+        # Check no exception occurred
+        if exception_in_thread is not None:
+            raise exception_in_thread
+
+        # Verify wait was called
+        self.assertTrue(wait_called)
+
+        # Verify work was removed from registry
+        self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
+
+
 class PyWorkTest(TestCase):
     """
     Native functional collectives have some interesting interactions with

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -398,7 +398,27 @@ void register_work(
 }
 
 at::Tensor wait_tensor(const at::Tensor& tensor) {
+  // First try to find work in the current thread's registry (fast path)
   auto works = RankLocal<WorkRegistry>::get().pop_works(tensor);
+
+  // If no work found in current thread's registry, search all registries.
+  // This handles the case where wait() is called from a different thread
+  // than where the collective was initiated (e.g., user-created threads).
+  if (works.empty()) {
+    auto result = RankLocal<WorkRegistry>::find_across_all(
+        [&tensor](WorkRegistry& registry)
+            -> std::optional<std::vector<c10::intrusive_ptr<c10d::Work>>> {
+          auto w = registry.pop_works(tensor);
+          if (!w.empty()) {
+            return w;
+          }
+          return std::nullopt;
+        });
+    if (result.has_value()) {
+      works = std::move(result.value());
+    }
+  }
+
   for (const auto& work : works) {
     work->wait();
   }


### PR DESCRIPTION
I have mentioned the bug detail in https://github.com/pytorch/pytorch/issues/160833#issuecomment-3704759917.  AI generated the fix and draws out the issue as graph below:
```
Thread A (Main Thread)                    Thread B (Worker Thread)
========================                  ========================
                                          
1. all_reduce() called                    
   └─> Work registered in                 
       Thread A's WorkRegistry            
                                          
2. AsyncCollectiveTensor created          
   └─> self.elem = output tensor          
   └─> self.completed = False             
                                          
3. Pass tensor to Thread B ───────────────> 4. worker() receives tensor
                                          
                                          5. tensor.wait() called
                                             └─> wait_tensor(self.elem)
                                          
                                          6. In C++ wait_tensor():
                                             └─> RankLocal<WorkRegistry>::get()
                                                 └─> Returns Thread B's registry
                                                     (which is EMPTY!)
                                             └─> pop_works() returns {}
                                             └─> No work to wait on!
                                          
Thread A's registry still                 Thread B's registry is empty
has the unwaited work! ────────────────────> Work never found!
```
Fixes #160833