### PR TITLE
[FSDP] Preserve container object identity in _recursive_to function

### DIFF
--- a/test/distributed/fsdp/test_fsdp_input.py
+++ b/test/distributed/fsdp/test_fsdp_input.py
@@ -72,6 +72,47 @@ class TestInput(FSDPTestContinuous):
             optim.step()
             optim.zero_grad()
 
+    @skip_if_lt_x_gpu(1)
+    @parametrize("input_cls", [subtest(dict, name="dict"), subtest(list, name="list")])
+    def test_input_identity_preserved(self, device, input_cls):
+        """
+        Test that FSDP preserves object identity for container inputs.
+        """
+
+        class MutatingModel(Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = Linear(4, 4)
+
+            def forward(self, input):
+                if isinstance(input, list):
+                    input.append(torch.randn(4, 4, device=input[0].device))
+                    x = input[0]
+                else:
+                    assert isinstance(input, dict), input
+                    input["added"] = torch.randn(4, 4, device=input["in"].device)
+                    x = input["in"]
+                return self.layer(x)
+
+        fsdp_kwargs = {
+            "device_id": device,
+        }
+        model = FSDP(MutatingModel().to(device), **fsdp_kwargs)
+
+        in_data = torch.rand(64, 4, device=device)
+        if input_cls is list:
+            in_data = [in_data]
+            initial_len = len(in_data)
+            model(in_data)
+            # The list should have been mutated (appended to)
+            self.assertEqual(len(in_data), initial_len + 1)
+        else:
+            self.assertTrue(input_cls is dict)
+            in_data = {"in": in_data}
+            model(in_data)
+            # The dict should have been mutated (new key added)
+            self.assertIn("added", in_data)
+
 
 devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(TestInput, globals(), only_for=devices, allow_xpu=True)

--- a/test/distributed/fsdp/test_fsdp_input.py
+++ b/test/distributed/fsdp/test_fsdp_input.py
@@ -89,7 +89,7 @@ class TestInput(FSDPTestContinuous):
                     input.append(torch.randn(4, 4, device=input[0].device))
                     x = input[0]
                 else:
-                    assert isinstance(input, dict), input
+                    assert isinstance(input, dict), input  # noqa: S101
                     input["added"] = torch.randn(4, 4, device=input["in"].device)
                     x = input["in"]
                 return self.layer(x)

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -135,7 +135,7 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
 
         def _handle_container(obj, elements, make_container):
             """Handle container types with object identity preservation."""
-            # pyrefly: ignore [no-matching-overload]
+            # pyrefly: ignore [invalid-argument]
             mapped = list(map(to_map, elements))
             # Preserve object identity when all elements are unchanged (single-device case)
             if all(len(m) == 1 for m in mapped):

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -133,18 +133,31 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
 
         from torch.nn.parallel.scatter_gather import _is_namedtuple
 
+        def _handle_container(obj, elements, make_container):
+            """Handle container types with object identity preservation."""
+            # pyrefly: ignore [no-matching-overload]
+            mapped = list(map(to_map, elements))
+            # Preserve object identity when all elements are unchanged (single-device case)
+            if all(len(m) == 1 for m in mapped):
+                transformed = [m[0] for m in mapped]
+                if all(t is o for t, o in zip(transformed, elements)):
+                    return [obj]
+                # pyrefly: ignore [no-matching-overload]
+                return [make_container(transformed)]
+            # pyrefly: ignore [no-matching-overload]
+            return [make_container(args) for args in zip(*mapped)]
+
         if _is_namedtuple(obj):
-            # pyrefly: ignore [bad-argument-type, no-matching-overload]
-            return [type(obj)(*args) for args in zip(*map(to_map, obj))]
+            return _handle_container(obj, obj, lambda x: type(obj)(*x))
         if isinstance(obj, tuple) and len(obj) > 0:
-            # pyrefly: ignore [bad-argument-type, no-matching-overload]
-            return list(zip(*map(to_map, obj)))
+            return _handle_container(obj, obj, tuple)
         if isinstance(obj, list) and len(obj) > 0:
-            # pyrefly: ignore [bad-argument-type, no-matching-overload]
-            return [list(i) for i in zip(*map(to_map, obj))]
+            return _handle_container(obj, obj, list)
         if isinstance(obj, dict) and len(obj) > 0:
-            # pyrefly: ignore [bad-argument-type, no-matching-overload]
-            return [type(obj)(i) for i in zip(*map(to_map, obj.items()))]
+            keys = list(obj.keys())
+            return _handle_container(
+                obj, obj.values(), lambda v: type(obj)(zip(keys, v))
+            )
         return [obj]
 
     # Avoid reference cycle

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -135,7 +135,7 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
 
         def _handle_container(obj, elements, make_container):
             """Handle container types with object identity preservation."""
-            # pyrefly: ignore [invalid-argument]
+            # pyrefly: ignore [bad-argument-type]
             mapped = list(map(to_map, elements))
             # Preserve object identity when all elements are unchanged (single-device case)
             if all(len(m) == 1 for m in mapped):


### PR DESCRIPTION
Fix a bug where _recursive_to in torch/distributed/utils.py was creating new container objects (list, tuple, dict, namedtuple) even when all elements were unchanged. This broke code relying on object identity being preserved through FSDP-wrapped modules.

The fix adds identity checks for the single-device case, if all transformed elements are identical to the originals, return the original container instead of creating a new one.

Fixes #157832
