### PR TITLE
[CUDA][Inductor] Disable `pad_mm` fx pass in `test_int8_woq_mm_gpu` tests

### DIFF
--- a/test/inductor/test_gpu_select_algorithm.py
+++ b/test/inductor/test_gpu_select_algorithm.py
@@ -75,7 +75,12 @@ def patches(fn):
 class TestSelectAlgorithmGpu(BaseTestSelectAlgorithm):
     common = check_model
 
-    @inductor_config.patch({"freezing": True, "shape_padding": False,})
+    @inductor_config.patch(
+        {
+            "freezing": True,
+            "shape_padding": False,
+        }
+    )
     @patches
     @torch.no_grad
     @dtypes(torch.bfloat16)

--- a/test/inductor/test_gpu_select_algorithm.py
+++ b/test/inductor/test_gpu_select_algorithm.py
@@ -75,7 +75,7 @@ def patches(fn):
 class TestSelectAlgorithmGpu(BaseTestSelectAlgorithm):
     common = check_model
 
-    @inductor_config.patch({"freezing": True})
+    @inductor_config.patch({"freezing": True, "shape_padding": False,})
     @patches
     @torch.no_grad
     @dtypes(torch.bfloat16)


### PR DESCRIPTION
Otherwise some paddings seem to fail pattern-match

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo