### PR TITLE
Add validation for out_channels in quantized ConvTranspose modules

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -1592,6 +1592,16 @@ class TestDynamicQuantizedModule(QuantizationTestCase):
         for bias in [True, False]:
             self._test_qconv_impl(q_mod, dq_mod, dim, dtype, bias)
 
+    def test_convtranspose_invalid_out_channels(self):
+        """Test that ConvTranspose modules raise ValueError for out_channels <= 0"""
+        for module_class in [
+            torch.ao.nn.quantized.ConvTranspose1d,
+            torch.ao.nn.quantized.ConvTranspose2d,
+            torch.ao.nn.quantized.ConvTranspose3d,
+        ]:
+            with self.assertRaisesRegex(ValueError, "out_channels must be greater than 0"):
+                module_class(in_channels=3, out_channels=0, kernel_size=3)
+
     @given(
         batch_size=st.integers(1, 5),
         in_features=st.integers(16, 32),

--- a/torch/ao/nn/quantized/modules/conv.py
+++ b/torch/ao/nn/quantized/modules/conv.py
@@ -73,6 +73,8 @@ class _ConvNd(WeightedQuantizedModule):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
 
+        if out_channels <= 0:
+            raise ValueError(f"out_channels must be greater than 0, got {out_channels}")
         if in_channels % groups != 0:
             raise ValueError("in_channels must be divisible by groups")
         if out_channels % groups != 0:


### PR DESCRIPTION
Fixes #171591

Fixes crash when creating quantized ConvTranspose modules with out_channels <= 0.

Previously these modules would crash with FPE errors. Now they raise a clear ValueError at construction time