### PR TITLE
Cleanup unused ignores 2

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -133,7 +133,6 @@ if is_available():
     # Variables prefixed with underscore are not auto imported
     # See the comment in `distributed_c10d.py` above `_backend` on why we expose
     # this.
-
     from .distributed_c10d import *  # noqa: F403
     from .distributed_c10d import (
         _all_gather_base,

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -133,9 +133,9 @@ if is_available():
     # Variables prefixed with underscore are not auto imported
     # See the comment in `distributed_c10d.py` above `_backend` on why we expose
     # this.
-    # pyrefly: ignore [deprecated]
+
     from .distributed_c10d import *  # noqa: F403
-    from .distributed_c10d import (  # pyrefly: ignore  # deprecated; pyrefly: ignore [deprecated]
+    from .distributed_c10d import (
         _all_gather_base,
         _coalescing_manager,
         _CoalescingManager,

--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -234,7 +234,6 @@ def contract(
             # TODO: verify that installed distributed paradigms are compatible with
             # each other.
 
-
             return updated
 
         def get_state(module: nn.Module) -> _State:

--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -234,7 +234,7 @@ def contract(
             # TODO: verify that installed distributed paradigms are compatible with
             # each other.
 
-            # pyrefly: ignore [bad-return]
+
             return updated
 
         def get_state(module: nn.Module) -> _State:

--- a/torch/distributed/_composable_state.py
+++ b/torch/distributed/_composable_state.py
@@ -32,7 +32,6 @@ def _get_module_state(module: nn.Module) -> _State | None:
     """
     global _module_state_mapping
     if isinstance(module, _State):
-
         return cast(_State, module)
     else:
         # https://github.com/pytorch/pytorch/issues/107054

--- a/torch/distributed/_composable_state.py
+++ b/torch/distributed/_composable_state.py
@@ -32,7 +32,7 @@ def _get_module_state(module: nn.Module) -> _State | None:
     """
     global _module_state_mapping
     if isinstance(module, _State):
-        # pyrefly: ignore [redundant-cast]
+
         return cast(_State, module)
     else:
         # https://github.com/pytorch/pytorch/issues/107054

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1055,7 +1055,7 @@ class AsyncCollectiveTensor(torch.Tensor):
         if func is torch.ops.aten.view.default:
             # Fast handle aten.view as a lot of view related op goes to aten.view
             # eventually, this avoids pytree slowdown
-            # pyrefly: ignore [index-error]
+
             res = func(args[0].elem, args[1])
             wrapper_res = AsyncCollectiveTensor(res)
             return wrapper_res
@@ -1679,17 +1679,17 @@ def all_gather_inplace(
     for t in tensor_list:
         is_scalar = t.dim() == 0
         t_offset = 1 if is_scalar else t.size(0)
-        # pyrefly: ignore [unsupported-operation]
+
         out = output[offset] if is_scalar else output[offset : offset + t_offset]
         output_splits.append(out)
-        # pyrefly: ignore [unsupported-operation]
+
         offset += t_offset
     for dst, src in zip(tensor_list, output_splits):
         dst.copy_(src)
     return tensor_list
 
 
-from torch.distributed.distributed_c10d import (  # pyrefly: ignore  # deprecated; pyrefly: ignore [deprecated]
+from torch.distributed.distributed_c10d import (
     _all_gather_base as legacy_all_gather_base,
     _reduce_scatter_base as legacy_reduce_scatter_base,
     all_gather as legacy_all_gather,

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1919,7 +1919,7 @@ class _LocalPhiloxState:
 
         if len(set(offsets.values())) == 1:
             return next(iter(offsets.values()))
-        # pyrefly: ignore [bad-argument-type, bad-argument-count]
+
         return SymInt(LocalIntNode(offsets))
 
     @offset.setter

--- a/torch/distributed/_shard/sharded_tensor/utils.py
+++ b/torch/distributed/_shard/sharded_tensor/utils.py
@@ -79,7 +79,6 @@ def _flatten_tensor_size(size) -> torch.Size:
     Checks if tensor size is valid, then flatten/return a torch.Size object.
     """
     if len(size) == 1 and isinstance(size[0], collections.abc.Sequence):
-
         dims = list(*size)
     else:
         dims = list(size)

--- a/torch/distributed/_shard/sharded_tensor/utils.py
+++ b/torch/distributed/_shard/sharded_tensor/utils.py
@@ -79,7 +79,7 @@ def _flatten_tensor_size(size) -> torch.Size:
     Checks if tensor size is valid, then flatten/return a torch.Size object.
     """
     if len(size) == 1 and isinstance(size[0], collections.abc.Sequence):
-        # pyrefly: ignore [not-iterable]
+
         dims = list(*size)
     else:
         dims = list(size)

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
@@ -425,9 +425,7 @@ def _handle_row_wise_sharding(
         else:
             split_sizes = torch.cat(
                 (
-
                     offsets[1 : offsets.size(0)] - offsets[0:-1],
-
                     (input.size(0) - offsets[-1]).unsqueeze(0),
                 ),
                 dim=-1,

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
@@ -425,9 +425,9 @@ def _handle_row_wise_sharding(
         else:
             split_sizes = torch.cat(
                 (
-                    # pyrefly: ignore [unsupported-operation]
+
                     offsets[1 : offsets.size(0)] - offsets[0:-1],
-                    # pyrefly: ignore [unsupported-operation]
+
                     (input.size(0) - offsets[-1]).unsqueeze(0),
                 ),
                 dim=-1,

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -201,7 +201,6 @@ def _iterate_state_dict(
                             ret.local_shards()[idx].tensor, non_blocking=non_blocking
                         )
                 else:
-
                     companion_obj.copy_(ret, non_blocking=non_blocking)
                 ret = companion_obj
     else:

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -201,7 +201,7 @@ def _iterate_state_dict(
                             ret.local_shards()[idx].tensor, non_blocking=non_blocking
                         )
                 else:
-                    # pyrefly: ignore [missing-attribute]
+
                     companion_obj.copy_(ret, non_blocking=non_blocking)
                 ret = companion_obj
     else:

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -392,7 +392,6 @@ class FSDPMemTracker(MemTracker):
                 if fsdp_param_group := fsdp_state._fsdp_param_group:
                     self._instrument_fsdp_sharded_params_grads(fsdp_param_group)
                     fsdp_state._pre_forward_hook_handle = (
-
                         module.register_forward_pre_hook(
                             self._fsdp_state_pre_forward(
                                 module, fsdp_state._pre_forward
@@ -419,7 +418,6 @@ class FSDPMemTracker(MemTracker):
                             module, fsdp_param_group.post_backward
                         )
                     )
-
 
         for buffer in self._root_mod.buffers():
             self._update_and_maybe_create_winfos(

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -373,7 +373,7 @@ class FSDPMemTracker(MemTracker):
         # get the unique _MultiHandlers/RemoveHandlers and store in dictionary
         # the _MultiHandlers object will only need to be grabbed once.
         unique_handlers: dict[RemovableHandle, bool] = {}
-        # pyrefly: ignore  # missing-attribute
+
         for module in self._root_mod.modules():
             if isinstance(module, FSDPModule):
                 fsdp_state = module._get_fsdp_state()
@@ -385,14 +385,14 @@ class FSDPMemTracker(MemTracker):
         # call remove on the handles once
         for f_hook_handle in unique_handlers:
             f_hook_handle.remove()
-        # pyrefly: ignore  # missing-attribute
+
         for module in self._root_mod.modules():
             if isinstance(module, FSDPModule):
                 fsdp_state = module._get_fsdp_state()
                 if fsdp_param_group := fsdp_state._fsdp_param_group:
                     self._instrument_fsdp_sharded_params_grads(fsdp_param_group)
                     fsdp_state._pre_forward_hook_handle = (
-                        # pyrefly: ignore [missing-attribute]
+
                         module.register_forward_pre_hook(
                             self._fsdp_state_pre_forward(
                                 module, fsdp_state._pre_forward
@@ -401,7 +401,7 @@ class FSDPMemTracker(MemTracker):
                             with_kwargs=True,
                         )
                     )
-                    # pyrefly: ignore [missing-attribute]
+
                     fsdp_state._post_forward_hook_handle = module.register_forward_hook(
                         self._fsdp_state_post_forward(module, fsdp_state._post_forward),
                         prepend=False,
@@ -420,7 +420,7 @@ class FSDPMemTracker(MemTracker):
                         )
                     )
 
-        # pyrefly: ignore [missing-attribute]
+
         for buffer in self._root_mod.buffers():
             self._update_and_maybe_create_winfos(
                 buffer,

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -232,9 +232,9 @@ class MemoryTracker:
         def _pre_forward_hook(module: nn.Module, inputs: Any) -> None:
             self._cur_module_name = f"{name}.forward"
             if (
-                # pyrefly: ignore [invalid-argument]
+
                 hasattr(module, "_memory_tracker_is_root")
-                # pyrefly: ignore [not-callable]
+
                 and module._memory_tracker_is_root
             ):
                 self._add_marker("fw_start")
@@ -250,9 +250,9 @@ class MemoryTracker:
             outputs: Sequence[torch.Tensor],
         ) -> None:
             if (
-                # pyrefly: ignore [invalid-argument]
+
                 hasattr(module, "_memory_tracker_is_root")
-                # pyrefly: ignore [not-callable]
+
                 and module._memory_tracker_is_root
             ):
                 self._add_marker("fw_bw_boundary")

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -232,9 +232,7 @@ class MemoryTracker:
         def _pre_forward_hook(module: nn.Module, inputs: Any) -> None:
             self._cur_module_name = f"{name}.forward"
             if (
-
                 hasattr(module, "_memory_tracker_is_root")
-
                 and module._memory_tracker_is_root
             ):
                 self._add_marker("fw_start")
@@ -250,9 +248,7 @@ class MemoryTracker:
             outputs: Sequence[torch.Tensor],
         ) -> None:
             if (
-
                 hasattr(module, "_memory_tracker_is_root")
-
                 and module._memory_tracker_is_root
             ):
                 self._add_marker("fw_bw_boundary")

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -155,7 +155,6 @@ def get_element(
         elif not isinstance(cur_value, Mapping) or part not in cur_value:
             return default_value
 
-
         cur_value = cast(CONTAINER_TYPE, cur_value[part])
     return cast(T | None, cur_value)
 

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -155,7 +155,7 @@ def get_element(
         elif not isinstance(cur_value, Mapping) or part not in cur_value:
             return default_value
 
-        # pyrefly: ignore [index-error]
+
         cur_value = cast(CONTAINER_TYPE, cur_value[part])
     return cast(T | None, cur_value)
 

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -330,7 +330,6 @@ def async_save(
     upload_future: Future = upload_executor.execute_save(
         staging_future_or_state_dict,
         checkpoint_id=checkpoint_id,
-
         storage_writer=storage_writer,
         planner=planner,
         process_group=process_group,

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -330,7 +330,7 @@ def async_save(
     upload_future: Future = upload_executor.execute_save(
         staging_future_or_state_dict,
         checkpoint_id=checkpoint_id,
-        # pyrefly: ignore [bad-argument-type]
+
         storage_writer=storage_writer,
         planner=planner,
         process_group=process_group,

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -117,7 +117,7 @@ def broadcast(
             error_msg += f": stage {sync_obj.stage_name}"
         if sync_obj.exception is not None:
             error_msg += f": exception {sync_obj.exception}"
-        # pyrefly: ignore [invalid-inheritance]
+
         raise RuntimeError(error_msg) from sync_obj.exception
 
     return cast(T, sync_obj.payload)
@@ -195,7 +195,7 @@ def all_gather(
         if not sync_obj.success:
             raise RuntimeError(
                 f"all_gather failed with exception {sync_obj.exception}",
-                # pyrefly: ignore [invalid-inheritance]
+
             ) from sync_obj.exception
         return [sync_obj.payload]  # type: ignore[list-item]
 

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -195,7 +195,6 @@ def all_gather(
         if not sync_obj.success:
             raise RuntimeError(
                 f"all_gather failed with exception {sync_obj.exception}",
-
             ) from sync_obj.exception
         return [sync_obj.payload]  # type: ignore[list-item]
 

--- a/torch/distributed/debug/_frontend.py
+++ b/torch/distributed/debug/_frontend.py
@@ -461,7 +461,7 @@ class FrontendServer:
 
     def _render_fr_trace(self, addrs: list[str], resps: list[Response]) -> bytes:
         config = JobConfig()
-        # pyrefly: ignore [bad-assignment]
+
         args = config.parse_args(args=[])
         args.allow_incomplete_ranks = True
         args.verbose = True

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1879,7 +1879,6 @@ def _get_split_source(pg: ProcessGroup):
         split_from = pg._get_backend(pg.bound_device_id)
     elif pg is _world.default_pg:
         try:
-
             split_from = pg._get_backend(torch.device("cuda"))
         except RuntimeError:
             # no cuda device associated with this backend

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1197,7 +1197,7 @@ def _as_iterable(obj) -> collections.abc.Iterable:
 
 def _ensure_all_tensors_same_dtype(*tensors) -> None:
     last_dtype = None
-    # pyrefly: ignore [bad-assignment]
+
     for tensor in itertools.chain.from_iterable(map(_as_iterable, tensors)):
         tensor_dtype = tensor.dtype
         # Mixing complex and its element type is allowed
@@ -1879,7 +1879,7 @@ def _get_split_source(pg: ProcessGroup):
         split_from = pg._get_backend(pg.bound_device_id)
     elif pg is _world.default_pg:
         try:
-            # pyrefly: ignore [missing-attribute]
+
             split_from = pg._get_backend(torch.device("cuda"))
         except RuntimeError:
             # no cuda device associated with this backend

--- a/torch/distributed/elastic/utils/data/elastic_distributed_sampler.py
+++ b/torch/distributed/elastic/utils/data/elastic_distributed_sampler.py
@@ -53,7 +53,7 @@ class ElasticDistributedSampler(DistributedSampler[T]):
             raise TypeError("Dataset must be an instance of collections.abc.Sized")
 
         # Cast to Sized for mypy
-        # pyrefly: ignore [redundant-cast]
+
         sized_dataset = cast(Sized, dataset)
 
         if start_index >= len(sized_dataset):

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -2490,7 +2490,7 @@ class FlatParamHandle:
     ###########
     def flat_param_to(self, *args, **kwargs):
         """Wrap an in-place call to ``.to()`` for ``self.flat_param``."""
-        # pyrefly: ignore [not-iterable]
+
         self.flat_param.data = self.flat_param.to(*args, **kwargs)
         if self._use_orig_params:
             # Refresh the views because their storage may have changed

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -876,7 +876,7 @@ class FSDPParam:
                     f"instead of {self.sharded_param}"
                 )
             self.sharded_param = new_param
-        # pyrefly: ignore [missing-attribute]
+
         local_tensor = new_param._local_tensor
         if local_tensor.is_meta:
             return

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -930,7 +930,7 @@ def _rekey_sharded_optim_state_dict(
         flat_param_key = unflat_param_names_to_flat_param_key.get(
             key.unflat_param_names, key.unflat_param_names
         )
-        # pyrefly: ignore [unsupported-operation]
+
         rekeyed_osd_state[flat_param_key] = param_state
 
     # Only process param_groups if it exists in sharded_osd

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -111,7 +111,7 @@ def rendezvous(url: str, rank: int = -1, world_size: int = -1, **kwargs):
     if not isinstance(world_size, numbers.Integral):
         raise RuntimeError(f"`world_size` must be an integer. {world_size}")
 
-    # pyrefly: ignore [bad-argument-type]
+
     return _rendezvous_helper(url, rank, world_size, **kwargs)
 
 

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -111,7 +111,6 @@ def rendezvous(url: str, rank: int = -1, world_size: int = -1, **kwargs):
     if not isinstance(world_size, numbers.Integral):
         raise RuntimeError(f"`world_size` must be an integer. {world_size}")
 
-
     return _rendezvous_helper(url, rank, world_size, **kwargs)
 
 

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -95,7 +95,7 @@ def register_backend(
     BackendType.__repr__ = _backend_type_repr  # type: ignore[assignment]
     if BackendType.__doc__:
         BackendType.__doc__ = _backend_type_doc
-    # pyrefly: ignore [unsupported-operation]
+
     return BackendType[backend_name]
 
 

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -883,7 +883,7 @@ def config_from_args(args) -> tuple[LaunchConfig, Callable | str, list[str]]:
             ) from e
 
     logs_specs_cls: type[LogsSpecs] = _get_logs_specs_class(args.logs_specs)
-    # pyrefly: ignore [bad-instantiation]
+
     logs_specs = logs_specs_cls(
         log_dir=args.log_dir,
         redirects=Std.from_str(args.redirects),

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -568,7 +568,6 @@ class OpDispatcher:
                 kwargs_schema[k] = self._try_replicate_spec_for_scalar_tensor(
                     op_call,
                     v,
-
                     compute_mesh,
                 )
                 local_kwargs[k] = v
@@ -582,7 +581,6 @@ class OpDispatcher:
         )
         op_info = OpInfo(
             compute_mesh,
-
             OpSchema(
                 op_call,
                 (

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -568,7 +568,7 @@ class OpDispatcher:
                 kwargs_schema[k] = self._try_replicate_spec_for_scalar_tensor(
                     op_call,
                     v,
-                    # pyrefly: ignore [bad-argument-type]
+
                     compute_mesh,
                 )
                 local_kwargs[k] = v
@@ -582,7 +582,7 @@ class OpDispatcher:
         )
         op_info = OpInfo(
             compute_mesh,
-            # pyrefly: ignore [bad-argument-type]
+
             OpSchema(
                 op_call,
                 (

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -92,7 +92,7 @@ class DTensorSpec:
         if not isinstance(self.placements, tuple):
             self.placements = tuple(self.placements)
         if self.shard_order is None:
-            # pyrefly: ignore [bad-assignment]
+
 
             _, self.shard_order = self._normalize_placements_into_shard_order(
                 self.placements, self.mesh

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -92,8 +92,6 @@ class DTensorSpec:
         if not isinstance(self.placements, tuple):
             self.placements = tuple(self.placements)
         if self.shard_order is None:
-
-
             _, self.shard_order = self._normalize_placements_into_shard_order(
                 self.placements, self.mesh
             )

--- a/torch/distributed/tensor/_ops/_common_rules.py
+++ b/torch/distributed/tensor/_ops/_common_rules.py
@@ -174,7 +174,7 @@ def einop_rule(
                             skip_offset=True,
                         )
                         cost += prod(local_shape) * input_spec.mesh.size(mesh_dim)
-                # pyrefly: ignore [bad-argument-type]
+
                 costs.append(cost)
             d_to_keep_sharding = dims[costs.index(max(costs))]
             for d in dims:

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -141,7 +141,6 @@ class _NormPartial(Partial):
                     f"Expected int or float, got {type(self.norm_type)}"
                 )
             if self.norm_type != 0 and self.norm_type != 1:
-
                 return tensor**self.norm_type
         return tensor
 
@@ -152,7 +151,6 @@ class _NormPartial(Partial):
                     f"Expected int or float, got {type(self.norm_type)}"
                 )
             if self.norm_type != 0 and self.norm_type != 1:
-
                 return tensor ** (1.0 / self.norm_type)
         return tensor
 

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -141,7 +141,7 @@ class _NormPartial(Partial):
                     f"Expected int or float, got {type(self.norm_type)}"
                 )
             if self.norm_type != 0 and self.norm_type != 1:
-                # pyrefly: ignore [unsupported-operation]
+
                 return tensor**self.norm_type
         return tensor
 
@@ -152,7 +152,7 @@ class _NormPartial(Partial):
                     f"Expected int or float, got {type(self.norm_type)}"
                 )
             if self.norm_type != 0 and self.norm_type != 1:
-                # pyrefly: ignore [unsupported-operation]
+
                 return tensor ** (1.0 / self.norm_type)
         return tensor
 

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -200,7 +200,7 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
     else:
         cpp_module = torch._C.import_ir_module_from_buffer(
             cu,
-            # pyrefly: ignore [missing-attribute]
+
             f.read(),
             map_location,
             _extra_files,

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -200,7 +200,6 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
     else:
         cpp_module = torch._C.import_ir_module_from_buffer(
             cu,
-
             f.read(),
             map_location,
             _extra_files,

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -337,7 +337,7 @@ def _check_trace(
 
         if is_trace_module:
             copied_dict = {}
-            # pyrefly: ignore [missing-attribute]
+
             for name, data in inputs.items():
                 copied_dict[name] = _clone_inputs(data)
             check_mod = torch.jit.trace_module(

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -47,7 +47,7 @@ def _load_for_lite_interpreter(f, map_location=None):
         cpp_module = torch._C._load_for_lite_interpreter(os.fspath(f), map_location)
     else:
         cpp_module = torch._C._load_for_lite_interpreter_from_buffer(
-            # pyrefly: ignore [missing-attribute]
+
             f.read(),
             map_location,
         )
@@ -107,7 +107,7 @@ def _get_model_bytecode_version(f_input) -> int:
     if isinstance(f_input, (str, os.PathLike)):
         return torch._C._get_model_bytecode_version(os.fspath(f_input))
     else:
-        # pyrefly: ignore [missing-attribute]
+
         return torch._C._get_model_bytecode_version_from_buffer(f_input.read())
 
 
@@ -140,7 +140,7 @@ def _get_mobile_model_contained_types(f_input) -> int:
     if isinstance(f_input, (str, os.PathLike)):
         return torch._C._get_mobile_model_contained_types(os.fspath(f_input))
     else:
-        # pyrefly: ignore [missing-attribute]
+
         return torch._C._get_mobile_model_contained_types_from_buffer(f_input.read())
 
 
@@ -171,7 +171,7 @@ def _backport_for_mobile(f_input, f_output, to_version):
         )
     else:
         return torch._C._backport_for_mobile_from_buffer(
-            # pyrefly: ignore [missing-attribute]
+
             f_input.read(),
             str(f_output),
             to_version,
@@ -196,7 +196,7 @@ def _backport_for_mobile_to_buffer(f_input, to_version):
         return torch._C._backport_for_mobile_to_buffer(os.fspath(f_input), to_version)
     else:
         return torch._C._backport_for_mobile_from_buffer_to_buffer(
-            # pyrefly: ignore [missing-attribute]
+
             f_input.read(),
             to_version,
         )
@@ -240,5 +240,5 @@ def _get_model_ops_and_info(f_input):
     if isinstance(f_input, (str, os.PathLike)):
         return torch._C._get_model_ops_and_info(os.fspath(f_input))
     else:
-        # pyrefly: ignore [missing-attribute]
+
         return torch._C._get_model_ops_and_info(f_input.read())

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -47,7 +47,6 @@ def _load_for_lite_interpreter(f, map_location=None):
         cpp_module = torch._C._load_for_lite_interpreter(os.fspath(f), map_location)
     else:
         cpp_module = torch._C._load_for_lite_interpreter_from_buffer(
-
             f.read(),
             map_location,
         )
@@ -107,7 +106,6 @@ def _get_model_bytecode_version(f_input) -> int:
     if isinstance(f_input, (str, os.PathLike)):
         return torch._C._get_model_bytecode_version(os.fspath(f_input))
     else:
-
         return torch._C._get_model_bytecode_version_from_buffer(f_input.read())
 
 
@@ -140,7 +138,6 @@ def _get_mobile_model_contained_types(f_input) -> int:
     if isinstance(f_input, (str, os.PathLike)):
         return torch._C._get_mobile_model_contained_types(os.fspath(f_input))
     else:
-
         return torch._C._get_mobile_model_contained_types_from_buffer(f_input.read())
 
 
@@ -171,7 +168,6 @@ def _backport_for_mobile(f_input, f_output, to_version):
         )
     else:
         return torch._C._backport_for_mobile_from_buffer(
-
             f_input.read(),
             str(f_output),
             to_version,
@@ -196,7 +192,6 @@ def _backport_for_mobile_to_buffer(f_input, to_version):
         return torch._C._backport_for_mobile_to_buffer(os.fspath(f_input), to_version)
     else:
         return torch._C._backport_for_mobile_from_buffer_to_buffer(
-
             f_input.read(),
             to_version,
         )
@@ -240,5 +235,4 @@ def _get_model_ops_and_info(f_input):
     if isinstance(f_input, (str, os.PathLike)):
         return torch._C._get_model_ops_and_info(os.fspath(f_input))
     else:
-
         return torch._C._get_model_ops_and_info(f_input.read())


### PR DESCRIPTION
Removes unused pyrefly ignores to keep the codebase as clean as possible. 

Splitting this by directory to make it easier to land.

Test Plan:
```
pyrefly check --remove-unused-ignores
pyrefly check
lintrunner
```

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel