### PR TITLE
Fix: RelaxedOneHotCategorical.log_prob incorrect output shape

### DIFF
--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -103,6 +103,8 @@ class ExpRelaxedCategorical(Distribution):
         ).lgamma() - self.temperature.log().mul(-(K - 1))
         score = logits - value.mul(self.temperature)
         score = (score - score.logsumexp(dim=-1, keepdim=True)).sum(-1)
+        while log_scale.dim() > score.dim():
+            log_scale = log_scale.squeeze(-1)
         return score + log_scale
 
 


### PR DESCRIPTION
Fixes #37162

### Summary
Fix `ExpRelaxedCategorical.log_prob` to return correct output shape when temperature tensor has trailing singleton dimensions.

### Problem
When creating a batch of `RelaxedOneHotCategorical` distributions with temperature of shape `[n, 1]` and logits of shape `[n, k]`, calling `log_prob()` incorrectly returns shape `[n, n]` instead of `[n]`.

```
temperature = torch.rand(5, 1)
logits = torch.randn(5, 3)
dist = RelaxedOneHotCategorical(temperature=temperature, logits=logits)
sample = dist.rsample()
log_prob = dist.log_prob(sample)
print(log_prob.shape)  # Was [5, 5], now correctly [5]
```

### Root Cause
The `log_scale` variable inherits the shape of `self.temperature` (e.g., `[n, 1]`), while `score` has shape `[n]` after summing over the event dimension. Broadcasting `[n] + [n, 1]` produces `[n, n]`.

### Fix
Squeeze trailing singleton dimensions from `log_scale` until it matches `score`'s dimensionality.

cc @fritzo @neerajprad @alicanb @nikitaved