### PR TITLE
Typecheck test_device_bias_linter.py and gen_operators_yaml.py

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -23,11 +23,6 @@ project-includes = [
 project-excludes = [
   # ==== below will be enabled directory by directory ====
   # ==== to test Pyrefly on a specific directory, simply comment it out ====
-<<<<<<< HEAD
-=======
-  "torch/_inductor/codegen/triton.py",
->>>>>>> 9a836750dfe (Typecheck test_device_bias_linter.py)
-  "tools/code_analyzer/gen_operators_yaml.py",
   "torch/_inductor/runtime/triton_heuristics.py",
   "torch/_inductor/runtime/triton_helpers.py",
   "torch/_inductor/runtime/halide_helpers.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -23,6 +23,10 @@ project-includes = [
 project-excludes = [
   # ==== below will be enabled directory by directory ====
   # ==== to test Pyrefly on a specific directory, simply comment it out ====
+<<<<<<< HEAD
+=======
+  "torch/_inductor/codegen/triton.py",
+>>>>>>> 9a836750dfe (Typecheck test_device_bias_linter.py)
   "tools/code_analyzer/gen_operators_yaml.py",
   "torch/_inductor/runtime/triton_heuristics.py",
   "torch/_inductor/runtime/triton_helpers.py",

--- a/tools/code_analyzer/gen_operators_yaml.py
+++ b/tools/code_analyzer/gen_operators_yaml.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from argparse import Namespace
 from typing import Any
 
 import yaml
+
+# pyrefly: ignore [missing-import]
 from gen_op_registration_allowlist import (
     canonical_name,
     gen_transitive_closure,
@@ -197,6 +200,7 @@ def create_debug_info_from_selected_models(
         asset = model_info["asset"]
         hash = model_info["md5_hash"]
 
+        # pyrefly: ignore [missing-attribute]
         asset_info = model_dict["asset_info"].setdefault(asset, {})
 
         asset_info.setdefault("md5_hash", []).append(hash)
@@ -205,7 +209,7 @@ def create_debug_info_from_selected_models(
     output["debug_info"] = [json.dumps(model_dict)]
 
 
-def fill_output(output: dict[str, object], options: object) -> None:
+def fill_output(output: dict[str, object], options: Namespace) -> None:
     """Populate the output dict with the information required to serialize
     the YAML file used for selective build.
     """
@@ -310,6 +314,7 @@ def fill_output(output: dict[str, object], options: object) -> None:
             all_build_features = all_build_features | set(model_info["build_features"])
 
     # This following section on transitive closure is relevant to static build only
+    # pyrefly: ignore [bad-argument-type]
     canonical_root_ops = canonical_opnames(static_root_ops)
     # If no canonical_root_ops exist, don't compute the transitive closure
     # otherwise, we will include __BASE__ and __ROOT__ ops and mark them as required
@@ -319,6 +324,7 @@ def fill_output(output: dict[str, object], options: object) -> None:
     else:
         closure_op_list = set()
 
+    # pyrefly: ignore [bad-argument-type]
     canonical_training_root_ops = canonical_opnames(static_training_root_ops)
     # If no canonical_training_root_ops exist, don't compute the transitive closure
     # otherwise, we will include __BASE__ and __ROOT__ ops and mark them as required
@@ -609,7 +615,7 @@ def main(argv) -> None:
         "asset_info": {},
         "is_new_style_rule": False,
     }
-    output = {
+    output: dict[str, object] = {
         "debug_info": [json.dumps(model_dict)],
     }
 

--- a/tools/linter/adapters/test_device_bias_linter.py
+++ b/tools/linter/adapters/test_device_bias_linter.py
@@ -103,7 +103,8 @@ class DeviceBiasVisitor(ast.NodeVisitor):
         val = subnode.value
         if isinstance(val, ast.Constant) and any(
             # pyrefly: ignore [not-iterable, unsupported-operation]
-            bias in val.value for bias in DEVICE_BIAS
+            bias in val.value
+            for bias in DEVICE_BIAS
         ):
             self.record(
                 subnode,
@@ -138,7 +139,8 @@ class DeviceBiasVisitor(ast.NodeVisitor):
             arg = subnode.args[0]
             if isinstance(arg, ast.Constant) and any(
                 # pyrefly: ignore [not-iterable, unsupported-operation]
-                bias in arg.value for bias in DEVICE_BIAS
+                bias in arg.value
+                for bias in DEVICE_BIAS
             ):
                 self.record(
                     subnode,

--- a/tools/linter/adapters/test_device_bias_linter.py
+++ b/tools/linter/adapters/test_device_bias_linter.py
@@ -103,8 +103,7 @@ class DeviceBiasVisitor(ast.NodeVisitor):
         val = subnode.value
         if isinstance(val, ast.Constant) and any(
             # pyrefly: ignore [not-iterable, unsupported-operation]
-            bias in val.value
-            for bias in DEVICE_BIAS
+            bias in val.value for bias in DEVICE_BIAS
         ):
             self.record(
                 subnode,
@@ -139,8 +138,7 @@ class DeviceBiasVisitor(ast.NodeVisitor):
             arg = subnode.args[0]
             if isinstance(arg, ast.Constant) and any(
                 # pyrefly: ignore [not-iterable, unsupported-operation]
-                bias in arg.value
-                for bias in DEVICE_BIAS
+                bias in arg.value for bias in DEVICE_BIAS
             ):
                 self.record(
                     subnode,


### PR DESCRIPTION
removes these two files from the pyrefly excludes list. Adds additional type annotations where needed to reduce the amount of type errors reported in these files. 

Adds suppressions and cleans up lint where needed. 
