### PR TITLE
[pytorch] Fix IndexError in remote module instantiator

### DIFF
--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -51,18 +51,17 @@ def get_arg_return_types_from_interface(module_interface):
     return args_str, arg_types_str, return_type_str
 
 
-class _StringLoader(importlib.abc.SourceLoader):
+class _StringLoader(importlib.abc.Loader):
     def __init__(self, data):
         self.data = data
 
-    def get_source(self, fullname):
-        return self.data
+    def create_module(self, spec):
+        return None  # Use default module creation
 
-    def get_data(self, path):
-        return self.data.encode("utf-8")
-
-    def get_filename(self, fullname):
-        return fullname
+    def exec_module(self, module):
+        # Compile and execute the source code directly without caching
+        code = compile(self.data, module.__name__, "exec")
+        exec(code, module.__dict__)
 
 
 def _do_instantiate_remote_module_template(


### PR DESCRIPTION
Summary:
The `_StringLoader.get_filename()` method was returning just the module name without a `.py` extension, causing Python's `cache_from_source()` to fail with "IndexError: string index out of range" when trying to compute bytecode cache paths.

This bug affects MUTE and other systems using PyTorch 2.11.0a0+fb that import `torch.distributed` modules.

Test Plan:
Verified fix resolves the IndexError in MUTE jobs that were failing during torch.distributed.nn.api.remote_module imports.

./run-python.sh projects/wearables/llama4_eyaml/eval/launch_all_evals.py --text-eval-modes [wearables_tito_pod_full] --checkpoint-dirs [/mnt/manifold/wearable_ai_llm_voice/tree/common_checkpoints/wy4dpo_wearables_17b_yonder4_dpo-ll39gsg572plkc/checkpoints/checkpoint_0000100] --local-mute

https://www.internalfb.com/mlhub/pipelines/runs/mast/upfront-consolidate-wy4dpo_wearables_17b_yonder4_d-vfnzbcx5cb3gc

Differential Revision: D90050491




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel