### PR TITLE
Add configurable threshold to avoid power-of-two rounding for large pinned memory allocations

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -441,15 +441,7 @@ struct CachingHostAllocatorImpl {
       pool.free_list_[i].list_.clear();
 
       for (auto* block : blocks_to_remove) {
-        pool.blocks_.erase(block);
-        pool.ptr_to_block_.erase(block->ptr_);
-        auto index = size_index(block->size_);
-        free_block(block);
-        stats_.allocations.decrease(1);
-        stats_.allocated_bytes.decrease(block->size_);
-        stats_.allocation_bucket_stats[index].decrease(1);
-        stats_.allocated_bytes_bucket_stats[index].decrease(block->size_);
-        delete block;
+        destroy_block(block, pool, /*is_active=*/false);
       }
     }
   }
@@ -743,31 +735,39 @@ struct CachingHostAllocatorImpl {
     auto index = size_index(size);
 
     if (size > pinned_max_cached_size()) {
-      {
-        std::lock_guard<std::mutex> g(pool.blocks_mutex_);
-        pool.blocks_.erase(block);
-        pool.ptr_to_block_.erase(block->ptr_);
-      }
-      free_block(block);
-
-      {
-        std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
-        stats_.allocations.decrease(1);
-        stats_.allocated_bytes.decrease(size);
-        stats_.allocation_bucket_stats[index].decrease(1);
-        stats_.allocated_bytes_bucket_stats[index].decrease(size);
-        stats_.active_bucket_stats[index].decrease(1);
-        stats_.active_bytes_bucket_stats[index].decrease(size);
-      }
-      delete block;
+      std::lock(pool.free_list_[index].mutex_, pool.blocks_mutex_);
+      std::lock_guard<std::mutex> gf(pool.free_list_[index].mutex_, std::adopt_lock);
+      std::lock_guard<std::mutex> gb(pool.blocks_mutex_, std::adopt_lock);
+      destroy_block(block, pool, /*is_active=*/true);
     } else {
-      {
-        std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
-        pool.free_list_[index].list_.push_back(block);
-        stats_.active_bucket_stats[index].decrease(1);
-        stats_.active_bytes_bucket_stats[index].decrease(size);
-      }
+      std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
+      pool.free_list_[index].list_.push_back(block);
+      stats_.active_bucket_stats[index].decrease(1);
+      stats_.active_bytes_bucket_stats[index].decrease(size);
     }
+  }
+
+  // Remove a block from the pool, free its memory, update stats, and delete it.
+  // Caller must hold both pool.blocks_mutex_ and pool.free_list_[index].mutex_.
+  // When is_active is true, also decrements active stats (for blocks going
+  // directly from in-use to freed without being cached first).
+  void destroy_block(B* block, BlockPool& pool, bool is_active) {
+    auto size = block->size_;
+    auto index = size_index(size);
+
+    pool.blocks_.erase(block);
+    pool.ptr_to_block_.erase(block->ptr_);
+    free_block(block);
+
+    stats_.allocations.decrease(1);
+    stats_.allocated_bytes.decrease(size);
+    stats_.allocation_bucket_stats[index].decrease(1);
+    stats_.allocated_bytes_bucket_stats[index].decrease(size);
+    if (is_active) {
+      stats_.active_bucket_stats[index].decrease(1);
+      stats_.active_bytes_bucket_stats[index].decrease(size);
+    }
+    delete block;
   }
 
   virtual size_t pinned_max_round_threshold() const {

--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -299,7 +299,8 @@ struct CachingHostAllocatorImpl {
     // Round up the allocation to the nearest power of two to improve reuse.
     // These power of two sizes are also used to index into the free list.
     const auto roundSize = [&]() -> size_t {
-      if (size <= pinned_max_round_threshold()) {
+      if (size <= pinned_max_round_threshold() &&
+          size <= pinned_max_cached_size()) {
         return c10::llvm::PowerOf2Ceil(size);
       } else {
         return size;

--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -246,7 +246,9 @@ size_t AcceleratorAllocatorConfig::parsePinnedMaxRoundThreshold(
     const ConfigTokenizer& tokenizer,
     size_t i) {
   tokenizer.checkToken(++i, ":");
-  pinned_max_round_threshold_ = tokenizer.toSizeT(++i) * 1024 * 1024;
+  constexpr size_t max_allowed_mb = std::numeric_limits<size_t>::max() / kMB;
+  size_t val = std::min(tokenizer.toSizeT(++i), max_allowed_mb);
+  pinned_max_round_threshold_ = val * kMB;
   return i;
 }
 
@@ -254,7 +256,9 @@ size_t AcceleratorAllocatorConfig::parsePinnedMaxCachedSize(
     const ConfigTokenizer& tokenizer,
     size_t i) {
   tokenizer.checkToken(++i, ":");
-  pinned_max_cached_size_ = tokenizer.toSizeT(++i) * 1024 * 1024;
+  constexpr size_t max_allowed_mb = std::numeric_limits<size_t>::max() / kMB;
+  size_t val = std::min(tokenizer.toSizeT(++i), max_allowed_mb);
+  pinned_max_cached_size_ = val * kMB;
   return i;
 }
 
@@ -326,11 +330,11 @@ void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
   if (max_round_threshold_set && max_cached_size_set &&
       pinned_max_round_threshold_ > pinned_max_cached_size_) {
     TORCH_WARN_ONCE(
-        "max_round_threshold_mb (",
+        "pinned_max_round_threshold_mb (",
         pinned_max_round_threshold_ >> 20,
-        ") > max_cached_size_mb (",
+        ") > pinned_max_cached_size_mb (",
         pinned_max_cached_size_ >> 20,
-        "). Allocations between these thresholds will be rounded up but not cached, which may be unexpected.");
+        "). The cache size limit takes precedence: allocations above pinned_max_cached_size_mb are never rounded up.");
   }
 }
 

--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -1,6 +1,8 @@
 #include <c10/core/AllocatorConfig.h>
+#include <c10/util/Exception.h>
 #include <c10/util/env.h>
 #include <array>
+#include <limits>
 
 namespace c10::CachingAllocator {
 
@@ -19,7 +21,9 @@ std::unordered_set<std::string>& AcceleratorAllocatorConfig::getMutableKeys() {
       "garbage_collection_threshold",
       "roundup_power2_divisions",
       "expandable_segments",
-      "pinned_use_background_threads"};
+      "pinned_use_background_threads",
+      "pinned_max_round_threshold_mb",
+      "pinned_max_cached_size_mb"};
   return keys;
 }
 
@@ -238,6 +242,22 @@ size_t AcceleratorAllocatorConfig::parsePinnedUseBackgroundThreads(
   return i;
 }
 
+size_t AcceleratorAllocatorConfig::parsePinnedMaxRoundThreshold(
+    const ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  pinned_max_round_threshold_ = tokenizer.toSizeT(++i) * 1024 * 1024;
+  return i;
+}
+
+size_t AcceleratorAllocatorConfig::parsePinnedMaxCachedSize(
+    const ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  pinned_max_cached_size_ = tokenizer.toSizeT(++i) * 1024 * 1024;
+  return i;
+}
+
 void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
   // The following option will be reset to its default value if not explicitly
   // set each time.
@@ -262,6 +282,7 @@ void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
   }
   max_non_split_rounding_size_ = large_segment_size_.load();
 
+  bool max_round_threshold_set{false}, max_cached_size_set{false};
   for (size_t i = 0; i < tokenizer.size(); i++) {
     const auto& key = tokenizer[i];
     if (key == "large_segment_size_mb") {
@@ -278,6 +299,12 @@ void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
       i = parseExpandableSegments(tokenizer, i);
     } else if (key == "pinned_use_background_threads") {
       i = parsePinnedUseBackgroundThreads(tokenizer, i);
+    } else if (key == "pinned_max_round_threshold_mb") {
+      i = parsePinnedMaxRoundThreshold(tokenizer, i);
+      max_round_threshold_set = true;
+    } else if (key == "pinned_max_cached_size_mb") {
+      i = parsePinnedMaxCachedSize(tokenizer, i);
+      max_cached_size_set = true;
     } else {
       // If a device-specific configuration parser hook is registered, it will
       // check if the key is unrecognized.
@@ -294,6 +321,16 @@ void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
     if (i + 1 < tokenizer.size()) {
       tokenizer.checkToken(++i, ",");
     }
+  }
+
+  if (max_round_threshold_set && max_cached_size_set &&
+      pinned_max_round_threshold_ > pinned_max_cached_size_) {
+    TORCH_WARN_ONCE(
+        "max_round_threshold_mb (",
+        pinned_max_round_threshold_ >> 20,
+        ") > max_cached_size_mb (",
+        pinned_max_cached_size_ >> 20,
+        "). Allocations between these thresholds will be rounded up but not cached, which may be unexpected.");
   }
 }
 

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -223,6 +223,16 @@ class C10_API AcceleratorAllocatorConfig {
     return instance().pinned_use_background_threads_;
   }
 
+  // Returns the max size to allocate power-of-2.
+  static size_t pinned_max_round_threshold() {
+    return instance().pinned_max_round_threshold_;
+  }
+
+  // Returns the max size to cache blocks in the free list.
+  static size_t pinned_max_cached_size() {
+    return instance().pinned_max_cached_size_;
+  }
+
   /* Settings for both device and host allocator */
 
   // Returns the current allocator settings as a string. This string is useful
@@ -316,6 +326,13 @@ class C10_API AcceleratorAllocatorConfig {
       const ConfigTokenizer& tokenizer,
       size_t i);
 
+  // Parse `max_round_threshold` from environment variable.
+  size_t parsePinnedMaxRoundThreshold(
+      const ConfigTokenizer& tokenizer,
+      size_t i);
+  // Parse `max_cached_size` from environment variable.
+  size_t parsePinnedMaxCachedSize(const ConfigTokenizer& tokenizer, size_t i);
+
   /* The following members are specifically used for the device allocator. */
 
   // "large" allocations may be packed in blocks of this size
@@ -338,6 +355,13 @@ class C10_API AcceleratorAllocatorConfig {
 
   // A flag to enable background thread for processing events.
   std::atomic<bool> pinned_use_background_threads_{false};
+
+  // Above this threshold, don't round allocations to power-of-2.
+  std::atomic<size_t> pinned_max_round_threshold_{
+      std::numeric_limits<size_t>::max()};
+  // Above this threshold, don't cache blocks in the free list.
+  std::atomic<size_t> pinned_max_cached_size_{
+      std::numeric_limits<size_t>::max()};
 
   /* The following members are used for both device and host allocator. */
 

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -357,11 +357,9 @@ class C10_API AcceleratorAllocatorConfig {
   std::atomic<bool> pinned_use_background_threads_{false};
 
   // Above this threshold, don't round allocations to power-of-2.
-  std::atomic<size_t> pinned_max_round_threshold_{
-      std::numeric_limits<size_t>::max()};
+  size_t pinned_max_round_threshold_{std::numeric_limits<size_t>::max()};
   // Above this threshold, don't cache blocks in the free list.
-  std::atomic<size_t> pinned_max_cached_size_{
-      std::numeric_limits<size_t>::max()};
+  size_t pinned_max_cached_size_{std::numeric_limits<size_t>::max()};
 
   /* The following members are used for both device and host allocator. */
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -4518,6 +4518,9 @@ class NativeCachingAllocator : public CUDAAllocator {
         CUDAAllocatorConfig::graph_capture_record_stream_reuse();
     md.roundup_power2_divisions =
         AcceleratorAllocatorConfig::roundup_power2_divisions();
+    md.max_round_threshold =
+        AcceleratorAllocatorConfig::pinned_max_round_threshold();
+    md.max_cached_size = AcceleratorAllocatorConfig::pinned_max_cached_size();
 
     return result;
   }

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -72,6 +72,8 @@ struct AllocatorConfigInfo {
   bool graph_capture_record_stream_reuse;
   std::string last_allocator_settings;
   std::vector<size_t> roundup_power2_divisions;
+  size_t max_round_threshold;
+  size_t max_cached_size;
 };
 
 struct SnapshotInfo {

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -616,6 +616,24 @@ Available options:
   segment. This allocates a large segment of pinned memory upfront and then uses to allocate
   small size requests. This helps reduce the number of expensive device library calls.
 
+* `pinned_max_round_threshold_mb` option sets the maximum allocation size (in MB)
+  that will be rounded up to the nearest power-of-2. Allocations larger than this threshold
+  will use their exact requested size, which can reduce memory waste for large pinned memory
+  allocations. For example, with a threshold of 128 MB, a 129 MB allocation will use 129 MB
+  instead of being rounded to 256 MB. By default, this option is disabled.
+
+* `pinned_max_cached_size_mb` option sets the maximum block size (in MB) that will be cached
+  in the free list for reuse. Blocks larger than this threshold will be freed immediately
+  when no longer in use, rather than being cached. This can help reduce peak memory usage for
+  workloads with large pinned memory allocations that are used infrequently.
+  By default, this option is disabled (all blocks are cached).
+
+.. note::
+
+    If `pinned_max_round_threshold_mb` is greater than `pinned_max_cached_size_mb`,
+    allocations between these thresholds will be rounded up but not cached, which
+    may lead to unexpected behavior. A warning is emitted when this configuration is detected.
+
 * ``graph_capture_record_stream_reuse`` (experimental, default: `False`)
   If set to `True`, the CUDA caching allocator will attempt to reclaim device memory during
   CUDA Graph capture by using the graph topology (instead of CUDA events) to determine

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -621,18 +621,14 @@ Available options:
   will use their exact requested size, which can reduce memory waste for large pinned memory
   allocations. For example, with a threshold of 128 MB, a 129 MB allocation will use 129 MB
   instead of being rounded to 256 MB. By default, this option is disabled.
+  Allocations that exceed `pinned_max_cached_size_mb` are never rounded up, regardless
+  of this setting, since rounding is only useful for cached blocks.
 
 * `pinned_max_cached_size_mb` option sets the maximum block size (in MB) that will be cached
-  in the free list for reuse. Blocks larger than this threshold will be freed immediately
-  when no longer in use, rather than being cached. This can help reduce peak memory usage for
-  workloads with large pinned memory allocations that are used infrequently.
-  By default, this option is disabled (all blocks are cached).
-
-.. note::
-
-    If `pinned_max_round_threshold_mb` is greater than `pinned_max_cached_size_mb`,
-    allocations between these thresholds will be rounded up but not cached, which
-    may lead to unexpected behavior. A warning is emitted when this configuration is detected.
+  in the free list for reuse. Blocks larger than this threshold will not be rounded up to
+  power-of-2 and will be freed immediately when no longer in use, rather than being cached.
+  This can help reduce peak memory usage for workloads with large pinned memory allocations
+  that are used infrequently. By default, this option is disabled (all blocks are cached).
 
 * ``graph_capture_record_stream_reuse`` (experimental, default: `False`)
   If set to `True`, the CUDA caching allocator will attempt to reclaim device memory during

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6240,6 +6240,79 @@ def caching_host_allocator_use_background_threads(use_background_threads: bool):
             )
 
 
+@contextlib.contextmanager
+def caching_host_allocator_max_round_threshold_and_max_cached_size(
+    max_round_threshold_mb: int | None = None, max_cached_size_mb: int | None = None
+):
+    allocator_settings = torch._C._cuda_memorySnapshot(None)["allocator_settings"]
+    cur_max_round_threshold_mb = (
+        allocator_settings["max_round_threshold"] // 1024 // 1024
+    )
+    cur_max_cached_size_mb = allocator_settings["max_cached_size"] // 1024 // 1024
+
+    if max_round_threshold_mb is None:
+        max_round_threshold_mb = cur_max_round_threshold_mb
+    if max_cached_size_mb is None:
+        max_cached_size_mb = cur_max_cached_size_mb
+    torch._C._accelerator_setAllocatorSettings(
+        f"pinned_max_round_threshold_mb:{max_round_threshold_mb},pinned_max_cached_size_mb:{max_cached_size_mb}"
+    )
+    try:
+        yield
+    finally:
+        torch._C._accelerator_setAllocatorSettings(
+            f"pinned_max_round_threshold_mb:{cur_max_round_threshold_mb},pinned_max_cached_size_mb:{cur_max_cached_size_mb}"
+        )
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
+class TestCachingHostAllocatorConfig(TestCase):
+    def setUp(self):
+        super().setUp()
+        gc.collect()
+        torch._C._host_emptyCache()
+
+    def tearDown(self):
+        torch._C._host_emptyCache()
+        super().tearDown()
+
+    def test_max_round_threshold(self):
+        size_bytes = 129 * 1024 * 1024
+
+        with caching_host_allocator_max_round_threshold_and_max_cached_size(128, None):
+            t = torch.empty(size_bytes, dtype=torch.uint8, pin_memory=True)
+            stats = torch.cuda.host_memory_stats()
+
+            allocated = stats["allocated_bytes.current"]
+            self.assertLess(allocated, 256 * 1024 * 1024)
+            self.assertGreaterEqual(allocated, size_bytes)
+
+    def test_max_cached_size(self):
+        size_bytes = 64 * 1024 * 1024
+
+        with caching_host_allocator_max_round_threshold_and_max_cached_size(None, 32):
+            t = torch.empty(size_bytes, dtype=torch.uint8, pin_memory=True)
+            del t
+            gc.collect()
+
+            stats = torch.cuda.host_memory_stats()
+            self.assertEqual(stats["allocations.current"], 0)
+
+    def test_both_thresholds(self):
+        size_bytes = 150 * 1024 * 1024
+
+        with caching_host_allocator_max_round_threshold_and_max_cached_size(128, 256):
+            t = torch.empty(size_bytes, dtype=torch.uint8, pin_memory=True)
+            stats = torch.cuda.host_memory_stats()
+
+            self.assertLess(stats["allocated_bytes.current"], 256 * 1024 * 1024)
+            del t
+            gc.collect()
+
+            stats = torch.cuda.host_memory_stats()
+            self.assertEqual(stats["allocations.current"], 1)
+
+
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCachingHostAllocatorCudaGraph(TestCase):
     # As soon as pinned host memory allocated by a private pool is
@@ -9437,6 +9510,7 @@ instantiate_parametrized_tests(TestCuda)
 instantiate_parametrized_tests(TestCudaAllocator)
 instantiate_parametrized_tests(TestCompileKernel)
 instantiate_parametrized_tests(TestCachingHostAllocatorCudaGraph)
+instantiate_parametrized_tests(TestCachingHostAllocatorConfig)
 instantiate_device_type_tests(TestCudaOptims, globals())
 instantiate_device_type_tests(TestCudaDeviceParametrized, globals())
 instantiate_device_type_tests(TestCudaGreenContexts, globals(), except_for="cpu")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6250,13 +6250,12 @@ def caching_host_allocator_max_round_threshold_and_max_cached_size(
     )
     cur_max_cached_size_mb = allocator_settings["max_cached_size"] // 1024 // 1024
 
-    if max_round_threshold_mb is None:
-        max_round_threshold_mb = cur_max_round_threshold_mb
-    if max_cached_size_mb is None:
-        max_cached_size_mb = cur_max_cached_size_mb
-    torch._C._accelerator_setAllocatorSettings(
-        f"pinned_max_round_threshold_mb:{max_round_threshold_mb},pinned_max_cached_size_mb:{max_cached_size_mb}"
-    )
+    parts = []
+    if max_round_threshold_mb is not None:
+        parts.append(f"pinned_max_round_threshold_mb:{max_round_threshold_mb}")
+    if max_cached_size_mb is not None:
+        parts.append(f"pinned_max_cached_size_mb:{max_cached_size_mb}")
+    torch._C._accelerator_setAllocatorSettings(",".join(parts))
     try:
         yield
     finally:
@@ -6311,6 +6310,28 @@ class TestCachingHostAllocatorConfig(TestCase):
 
             stats = torch.cuda.host_memory_stats()
             self.assertEqual(stats["allocations.current"], 1)
+
+    def test_round_threshold_larger_than_cached_size(self):
+        # When round_threshold > cached_size, allocations above the cache
+        # limit should be neither rounded up nor cached.
+        size_bytes = 100 * 1024 * 1024
+
+        with caching_host_allocator_max_round_threshold_and_max_cached_size(256, 64):
+            t = torch.empty(size_bytes, dtype=torch.uint8, pin_memory=True)
+            stats = torch.cuda.host_memory_stats()
+
+            # 100 MB is within the 256 MB round threshold but above the
+            # 64 MB cache limit — should NOT be rounded to 128 MB.
+            allocated = stats["allocated_bytes.current"]
+            self.assertGreaterEqual(allocated, size_bytes)
+            self.assertLess(allocated, 128 * 1024 * 1024)
+
+            del t
+            gc.collect()
+
+            # Block should have been freed, not cached.
+            stats = torch.cuda.host_memory_stats()
+            self.assertEqual(stats["allocations.current"], 0)
 
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -947,9 +947,9 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   allocator_settings[graph_capture_record_stream_reuse_s] =
       snapshot.config_metadata.graph_capture_record_stream_reuse;
   allocator_settings[max_round_threshold_s] =
-      snapshot.config_metadata.max_round_threshold;
+      int64_t(snapshot.config_metadata.max_round_threshold);
   allocator_settings[max_cached_size_s] =
-      snapshot.config_metadata.max_cached_size;
+      int64_t(snapshot.config_metadata.max_cached_size);
   unsigned int roundup_key = 1;
   py::dict roundup_settings;
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -927,6 +927,8 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str roundup_power2_divisions_s = "roundup_power2_divisions";
   py::str graph_capture_record_stream_reuse_s =
       "graph_capture_record_stream_reuse";
+  py::str max_round_threshold_s = "max_round_threshold";
+  py::str max_cached_size_s = "max_cached_size";
 
   allocator_settings[last_allocator_settings_s] =
       snapshot.config_metadata.last_allocator_settings;
@@ -944,6 +946,10 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
       snapshot.config_metadata.pinned_use_host_register;
   allocator_settings[graph_capture_record_stream_reuse_s] =
       snapshot.config_metadata.graph_capture_record_stream_reuse;
+  allocator_settings[max_round_threshold_s] =
+      snapshot.config_metadata.max_round_threshold;
+  allocator_settings[max_cached_size_s] =
+      snapshot.config_metadata.max_cached_size;
   unsigned int roundup_key = 1;
   py::dict roundup_settings;
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -468,6 +468,8 @@ std::string _memory_snapshot_pickled() {
   IValue roundup_power2_divisions_s = "roundup_power2_divisions";
   IValue graph_capture_record_stream_reuse_s =
       "graph_capture_record_stream_reuse";
+  IValue max_round_threshold_s = "max_round_threshold";
+  IValue max_cached_size_s = "max_cached_size";
 
   allocator_settings.insert(
       last_allocator_settings_s,
@@ -491,6 +493,11 @@ std::string _memory_snapshot_pickled() {
   allocator_settings.insert(
       graph_capture_record_stream_reuse_s,
       snapshot.config_metadata.graph_capture_record_stream_reuse);
+  allocator_settings.insert(
+      max_round_threshold_s,
+      int64_t(snapshot.config_metadata.max_round_threshold));
+  allocator_settings.insert(
+      max_cached_size_s, int64_t(snapshot.config_metadata.max_cached_size));
   unsigned int roundup_key = 1;
   auto roundup_settings = new_dict();
   for (const auto& v : snapshot.config_metadata.roundup_power2_divisions) {


### PR DESCRIPTION
See under "correction" for up to date description
This pull request introduces a configurable threshold for the maximum allocation size that will be cached by the CUDA pinned memory (host) allocator. Allocations larger than this threshold will no longer be rounded up to the next power of two or cached, which helps avoid memory waste for large allocations that are just above a power-of-two boundary. The threshold is controlled via a new `pinned_max_cachesize_mb` option in `PYTORCH_CUDA_ALLOC_CONF`. The default behavior remains unchanged unless this option is set. Documentation and configuration parsing have been updated accordingly.

**Pinned memory allocator improvements:**

* Added logic in `CachingHostAllocatorImpl` and `CUDACachingHostAllocatorImpl` to skip power-of-two rounding and caching for allocations larger than a configurable threshold, freeing them immediately instead. The threshold is set by the new `pinned_max_cachesize_mb` option. [[1]](diffhunk://#diff-e5e0c1712b7fcf5df02f52b0c70ae85ac6adcc53b50166b79710bd878705274dL301-R309) [[2]](diffhunk://#diff-e5e0c1712b7fcf5df02f52b0c70ae85ac6adcc53b50166b79710bd878705274dR392-R420) [[3]](diffhunk://#diff-e5e0c1712b7fcf5df02f52b0c70ae85ac6adcc53b50166b79710bd878705274dR768-R794) [[4]](diffhunk://#diff-5d3beb56bf9b6f380f91d5f6f063480ce2e14ca15c415d59d153436018089223R306-R320)

**Configuration and API changes:**

* Introduced the `pinned_max_cachesize_mb` option to `CUDAAllocatorConfig`, including parsing, storage, and API for retrieving the value. This option is now recognized and handled in the allocator configuration. [[1]](diffhunk://#diff-76350449d9aa3583a0f77288be8a20e871a7ac685afc0f252ad1b7225ad26d3cR106-R108) [[2]](diffhunk://#diff-76350449d9aa3583a0f77288be8a20e871a7ac685afc0f252ad1b7225ad26d3cR198-R214) [[3]](diffhunk://#diff-c64a3aaa904f0a5f20c92f06d9a6a074d5edc8da0f5aaee6445a6a3d4236246fR88-R102) [[4]](diffhunk://#diff-c64a3aaa904f0a5f20c92f06d9a6a074d5edc8da0f5aaee6445a6a3d4236246fR175) [[5]](diffhunk://#diff-c64a3aaa904f0a5f20c92f06d9a6a074d5edc8da0f5aaee6445a6a3d4236246fR198-R200) [[6]](diffhunk://#diff-c64a3aaa904f0a5f20c92f06d9a6a074d5edc8da0f5aaee6445a6a3d4236246fR210-R213) [[7]](diffhunk://#diff-acc6337586bf9cdcf0a684380779300ec171897d05b8569bf439820dc8c93bd5R4179) [[8]](diffhunk://#diff-b9a0773c48ce53900355ab72505056fae68c7117993028c826c9cc1e3f3c502dR168)

**Documentation:**

* Updated the CUDA notes documentation to describe the new `pinned_max_cachesize_mb` option, its usage, and its default behavior.

**Miscellaneous:**

* Added missing includes for `<limits>` where needed to support the new logic. [[1]](diffhunk://#diff-e5e0c1712b7fcf5df02f52b0c70ae85ac6adcc53b50166b79710bd878705274dR10) [[2]](diffhunk://#diff-5d3beb56bf9b6f380f91d5f6f063480ce2e14ca15c415d59d153436018089223R9)

Rel: https://github.com/pytorch/pytorch/issues/150517

Used Claude Opus 4.5


**Correction**

  This PR adds two new PYTORCH_CUDA_ALLOC_CONF options for the pinned memory (host) caching allocator to address memory waste from power-of-2
   rounding and caching of large allocations:

  - pinned_max_round_threshold_mb: allocations above this threshold skip power-of-2 rounding.
  - pinned_max_cached_size_mb: allocations above this threshold are freed immediately instead of cached in the free list. Allocations that
  exceed this limit are also never rounded up, since rounding is only useful for cached blocks.

  Both options default to unlimited (disabled), preserving existing behavior. A warning is emitted if pinned_max_round_threshold_mb is
  explicitly set larger than pinned_max_cached_size_mb.

  The block caching/freeing logic is refactored into a shared maybe_cache_block method used by both the direct free path and the
  event-processing path. The new config values are also exposed in the memory snapshot allocator settings.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo