### PR TITLE
Add device, dtype opts to nn::Linear (#145337)

### DIFF
--- a/torch/csrc/api/include/torch/nn/options/linear.h
+++ b/torch/csrc/api/include/torch/nn/options/linear.h
@@ -11,6 +11,7 @@ namespace torch::nn {
 /// Example:
 /// ```
 /// Linear model(LinearOptions(5, 2).bias(false));
+/// Linear cuda_model(LinearOptions(5, 2).device(torch::kCUDA));
 /// ```
 struct TORCH_API LinearOptions {
   LinearOptions(int64_t in_features, int64_t out_features);
@@ -22,6 +23,12 @@ struct TORCH_API LinearOptions {
 
   /// If set to false, the layer will not learn an additive bias. Default: true
   TORCH_ARG(bool, bias) = true;
+
+  /// Device to create tensors on (optional, defaults to CPU)
+  TORCH_ARG(std::optional<torch::Device>, device) = std::nullopt;
+
+  /// Data type for the tensors (optional, defaults to float32)
+  TORCH_ARG(std::optional<torch::Dtype>, dtype) = std::nullopt;
 };
 
 // ============================================================================

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -29,10 +29,19 @@ LinearImpl::LinearImpl(const LinearOptions& options_) : options(options_) {
 }
 
 void LinearImpl::reset() {
+  // Build tensor options from device/dtype if specified
+  auto tensor_opts = torch::TensorOptions();
+  if (options.device().has_value()) {
+    tensor_opts = tensor_opts.device(options.device().value());
+  }
+  if (options.dtype().has_value()) {
+    tensor_opts = tensor_opts.dtype(options.dtype().value());
+  }
+
   weight = register_parameter(
-      "weight", torch::empty({options.out_features(), options.in_features()}));
+      "weight", torch::empty({options.out_features(), options.in_features()}, tensor_opts));
   if (options.bias()) {
-    bias = register_parameter("bias", torch::empty(options.out_features()));
+    bias = register_parameter("bias", torch::empty(options.out_features(), tensor_opts));
   } else {
     bias = register_parameter("bias", {}, /*requires_grad=*/false);
   }


### PR DESCRIPTION
Fixes #145337

Reduced model initialization time from 10 seconds to ~130 ms, based on benchmarks of the code below.

``` cpp
#include <torch/torch.h>
#include <iostream>
#include <thread>


using namespace torch;
namespace nn = torch::nn;

// Helper function to get the device - avoids global initialization order issues
torch::Device getDefaultDevice() {
    return torch::Device(torch::cuda::is_available() ? torch::kCUDA : torch::kCPU);
}

// a dummy model for demonstration - uses Linear with device option to create tensors directly on GPU
struct NetImpl : nn::Module {
    nn::Sequential layers;

    NetImpl(std::vector<int64_t> sizes, torch::Device device)
   : layers{ register_module("layers", torch::nn::Sequential()) } 
    {
        for (size_t i = 0; i < sizes.size() - 1; i++) {
            // Use Linear with .device() to create tensors directly on the target device
            layers->push_back(nn::Linear(nn::LinearOptions(sizes[i], sizes[i + 1]).device(device)));
            layers->push_back(nn::Functional(torch::relu));
        }
        // No need for this->to(device) since tensors are already on device
    }

    auto forward(Tensor x) -> Tensor {
        x = layers->forward(x);
        return x;
    }
};
TORCH_MODULE(Net);

struct Timer {

    std::string name;
    std::chrono::time_point<std::chrono::high_resolution_clock> start;

    Timer(std::string name="")
    : name {name}, start {std::chrono::high_resolution_clock::now()}
    {
        std::cerr << "Timer " << name << " started" << std::endl;
    }

    double elapsed() {
        auto now = std::chrono::high_resolution_clock::now();
        return std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
    }

    ~Timer() {
        std::cerr << "Timer " << name << " ended: " << elapsed() << "ms" << std::endl;
    }
};


int main() {
    std::cerr << "torch version " << TORCH_VERSION << std::endl;
    std::cerr << "CUDA available: " << (torch::cuda::is_available() ? "Yes" : "No") << std::endl;
    
    if (torch::cuda::is_available()) {
        std::cerr << "CUDA device count: " << torch::cuda::device_count() << std::endl;
    }
    
    // deep network; FFN with a lot of layers to make it deep
    std::vector<int64_t> dims = { 
        1024, 4096, 8192, 16384, 8192, 4096, 1024, 512, 256, 512,
        1024, 4096, 8192, 16384, 8192, 4096, 1024, 512, 256, 512,
        1024, 4096, 8192, 16384, 8192, 4096, 1024, 512, 256, 512,
        1024, 4096, 8192, 16384, 8192, 4096, 1024, 512, 256, 512,
        1024, 4096, 8192, 16384, 8192, 4096, 1024, 512, 256, 512,
        };

    if (!torch::cuda::is_available()) {
        std::cerr << "WARNING: CUDA is not available, falling back to CPU" << std::endl;
        return 0;
    }
    
    std::vector<torch::Device> devices;
    try {
        for (auto i = 0; i < torch::cuda::device_count(); i++) {
            devices.push_back(torch::Device(torch::kCUDA, i));
        }
    } catch (const std::exception& e) {
        std::cerr << "Error creating CUDA devices: " << e.what() << std::endl;
        return 1;
    }
    { // scope for timer 
        int n_threads = devices.size();
        Timer timer("[" + std::to_string(n_threads) + "-threaded initializer]");
        std::vector<std::thread> threads;
        for (int i = 0; i < n_threads; i++) {
            threads.emplace_back([i, &dims, &devices] {
                try {
                    auto device = devices[i];
                    std::cerr << "Thread " << i << " using device: " << device.str() << std::endl;
                    Timer timer(device.str());
                    auto model = Net(dims, device);
                    std::cerr << "Thread " << i << " completed successfully" << std::endl;
                } catch (const std::exception& e) {
                    std::cerr << "Thread " << i << " error: " << e.what() << std::endl;
                }
            });
        }
        for (auto& t : threads) {
            t.join();
        }
    }
    return 0;
}
```

