### PR TITLE
[inductor][caching] stricter typing for caching module

### DIFF
--- a/test/inductor/test_caching.py
+++ b/test/inductor/test_caching.py
@@ -1297,9 +1297,11 @@ class InterfacesTest(TestMixin, TestCase):
             test_filepath = tmp_file.name
             dump_data = {
                 "cache_size": 2,
-                "cache_entries": {
-                    "key1": {"params": {"x": 1}, "result": 10},
-                    "key2": {"params": {"x": 2}, "result": 20},
+                "collections": {
+                    "null": {
+                        "key1": {"params": {"x": 1}, "result": 10},
+                        "key2": {"params": {"x": 2}, "result": 20},
+                    },
                 },
             }
             json.dump(dump_data, tmp_file)
@@ -1401,7 +1403,7 @@ class InterfacesTest(TestMixin, TestCase):
         """Test that PersistentMemoizer loads cache from sub_dir nested structure.
 
         Verifies that when sub_dir is set, the PersistentMemoizer loads entries
-        from the nested cache_entries[sub_dir] structure.
+        from the nested collections[sub_dir] structure.
         """
         import json
         import os
@@ -1415,7 +1417,7 @@ class InterfacesTest(TestMixin, TestCase):
             test_filepath = tmp_file.name
             dump_data = {
                 "cache_size": 2,
-                "cache_entries": {
+                "collections": {
                     "test_subdir": {
                         "nested_key1": {"params": {"x": 1}, "result": 100},
                         "nested_key2": {"params": {"x": 2}, "result": 200},
@@ -1459,7 +1461,7 @@ class InterfacesTest(TestMixin, TestCase):
         """Test that PersistentMemoizer loads from root when sub_dir is empty.
 
         Verifies that when sub_dir is empty string, entries are loaded from
-        the root cache_entries level (not from any nested structure).
+        collections["null"] (the root collection).
         """
         import json
         import os
@@ -1470,11 +1472,15 @@ class InterfacesTest(TestMixin, TestCase):
             mode="w", suffix=".json", delete=False
         ) as tmp_file:
             test_filepath = tmp_file.name
+            # Note: "null" is the JSON representation of Python None
+            # When sub_dir is empty string (""), the Memoizer's sub_key is None
             dump_data = {
                 "cache_size": 3,
-                "cache_entries": {
-                    "root_key1": {"params": {"x": 1}, "result": 10},
-                    "root_key2": {"params": {"x": 2}, "result": 20},
+                "collections": {
+                    "null": {
+                        "root_key1": {"params": {"x": 1}, "result": 10},
+                        "root_key2": {"params": {"x": 2}, "result": 20},
+                    },
                     "some_subdir": {
                         "nested_key": {"params": {"x": 3}, "result": 30},
                     },
@@ -1527,10 +1533,16 @@ class InterfacesTest(TestMixin, TestCase):
             test_filepath = tmp_file.name
             # Simulate a cache entry for compute(5) -> 10
             cache_key = interfaces._BaseMemoizer._make_key(None, 5)
+            # Note: "null" is the JSON representation of Python None (no sub_key)
             dump_data = {
                 "cache_size": 1,
-                "cache_entries": {
-                    cache_key: {"params": {"args": (5,), "kwargs": {}}, "result": 10},
+                "collections": {
+                    "null": {
+                        cache_key: {
+                            "params": {"args": (5,), "kwargs": {}},
+                            "result": 10,
+                        },
+                    },
                 },
             }
             json.dump(dump_data, tmp_file)
@@ -1588,12 +1600,15 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("cache_entries", data)
+        self.assertIn("collections", data)
         self.assertIn("cache_size", data)
         self.assertEqual(data["cache_size"], 2)
 
+        # Note: "null" is the JSON representation of Python None (no sub_key)
+        self.assertIn("null", data["collections"])
+
         # Verify entries have correct format
-        for entry in data["cache_entries"].values():
+        for entry in data["collections"]["null"].values():
             self.assertIn("params", entry)
             self.assertIn("result", entry)
 
@@ -1603,7 +1618,7 @@ class InterfacesTest(TestMixin, TestCase):
         """Test that _dump_to_disk uses sub_key for nested structure.
 
         Verifies that when a Memoizer is initialized with a sub_key,
-        the cache entries are stored under cache_entries[sub_key].
+        the cache entries are stored under collections[sub_key].
         """
         # Setup: create a memoizer with sub_key and cache a value
         sub_key = "test_sub_key"
@@ -1622,11 +1637,11 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("cache_entries", data)
-        self.assertIn(sub_key, data["cache_entries"])
+        self.assertIn("collections", data)
+        self.assertIn(sub_key, data["collections"])
 
         # The sub_key should contain the cache entries
-        sub_entries = data["cache_entries"][sub_key]
+        sub_entries = data["collections"][sub_key]
         self.assertEqual(len(sub_entries), 1)
 
         # Verify entry format
@@ -1670,7 +1685,8 @@ class InterfacesTest(TestMixin, TestCase):
             data = json.load(f)
 
         self.assertEqual(data["cache_size"], 2)
-        self.assertEqual(len(data["cache_entries"]), 2)
+        # Note: "null" is the JSON representation of Python None (no sub_key)
+        self.assertEqual(len(data["collections"]["null"]), 2)
 
     @patch_on_disk_cache_base_dir
     @set_caching_module_enabled(True)
@@ -1722,7 +1738,7 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("cache_entries", data)
+        self.assertIn("collections", data)
         self.assertEqual(data["cache_size"], 1)
 
     @patch_on_disk_cache_base_dir
@@ -1749,8 +1765,8 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer._shared_cache_filepath) as f:
             data = json.load(f)
 
-        # Get the single entry
-        entries = data["cache_entries"]
+        # Get the single entry (under "null" since no sub_key was set)
+        entries = data["collections"]["null"]
         self.assertEqual(len(entries), 1)
 
         entry = next(iter(entries.values()))
@@ -1789,12 +1805,12 @@ class InterfacesTest(TestMixin, TestCase):
         with open(memoizer1._shared_cache_filepath) as f:
             data = json.load(f)
 
-        self.assertIn("feature_a", data["cache_entries"])
-        self.assertIn("feature_b", data["cache_entries"])
+        self.assertIn("feature_a", data["collections"])
+        self.assertIn("feature_b", data["collections"])
 
         # Verify each sub_key has one entry with correct result
-        feature_a_entries = data["cache_entries"]["feature_a"]
-        feature_b_entries = data["cache_entries"]["feature_b"]
+        feature_a_entries = data["collections"]["feature_a"]
+        feature_b_entries = data["collections"]["feature_b"]
 
         self.assertEqual(len(feature_a_entries), 1)
         self.assertEqual(len(feature_b_entries), 1)

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -1,13 +1,10 @@
-# pyre-strict
-
 """
-Custom encoder functions for use with PersistentMemoizer.
+Custom encoder functions
 
 This module provides reusable encoder functions that convert function parameters
 into JSON-serializable dictionaries for caching purposes.
 """
 
-from typing import cast
 from typing_extensions import TypedDict
 
 import torch
@@ -64,8 +61,7 @@ def should_pad_params_encoder(
         mat2_exclude_padding_time=should_exclude_padding_time(match, "mat2"),
         tf32=False
         if mat1.dtype != torch.float32
-        else cast(
-            bool,
-            torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32,
+        else bool(
+            torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32
         ),
     )

--- a/torch/_inductor/runtime/caching/exceptions.py
+++ b/torch/_inductor/runtime/caching/exceptions.py
@@ -1,5 +1,3 @@
-# pyre-strict
-
 """Exception classes for PyTorch Inductor runtime caching.
 
 This module defines a hierarchy of exceptions used throughout the caching system.

--- a/torch/_inductor/runtime/caching/locks.py
+++ b/torch/_inductor/runtime/caching/locks.py
@@ -1,4 +1,4 @@
-"""Lock acquisition utilities for caching system with timeout support.
+"""Lock acquisition utilities
 
 This module provides safe and unsafe lock acquisition functions for both threading.Lock
 and FileLock objects, with configurable timeout behaviors. It supports three timeout modes:

--- a/torch/_inductor/runtime/caching/utils.py
+++ b/torch/_inductor/runtime/caching/utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for caching operations in PyTorch Inductor runtime.
+"""Utility functions
 
 This module provides helper functions for LRU caching decorators used
 throughout the caching system.
@@ -33,9 +33,9 @@ def _lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
     cached_fn = lru_cache(maxsize=64, typed=True)(fn)
 
     @wraps(fn)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # type: ignore[type-var]
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
-            return cached_fn(*args, **kwargs)  # type: ignore[arg-type]
+            return cached_fn(*args, **kwargs)
         except TypeError:
             return fn(*args, **kwargs)
 


### PR DESCRIPTION
Summary:
## Summary

This diff improves type safety in the `torch/_inductor/runtime/caching` module by removing type ignores and casts, and restructuring `CacheDump` for cleaner typing.

## Changes

### CacheDump Structure Refactoring (`interfaces.py`)

Changed `CacheDump` TypedDict to use separate `singletons` and `collections` fields instead of a single `cache_entries` field:

```python
# Before
class CacheDump(TypedDict):
    cache_entries: dict[str, CacheDumpEntry | dict[str, CacheDumpEntry]]
    cache_size: int

# After
class CacheDump(TypedDict):
    singletons: dict[str, CacheDumpEntry]
    collections: dict[str, dict[str, CacheDumpEntry]]
    cache_size: int

Test Plan:
```
buck test fbcode//mode/opt caffe2/test/inductor:caching
```

Differential Revision: D90074228




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo