### PR TITLE
[Doc] Fix typos in flat_apply.py comments

### DIFF
--- a/torch/_higher_order_ops/flat_apply.py
+++ b/torch/_higher_order_ops/flat_apply.py
@@ -17,12 +17,12 @@ _Ts = TypeVarTuple("_Ts")
 
 
 def is_graphable(val: object) -> TypeIs[torch.fx.node.BaseArgumentTypes]:
-    """Definition: a graphable type is a type that that is an acceptable input/output type to a FX node."""
+    """Definition: a graphable type is a type that is an acceptable input/output type to a FX node."""
     return isinstance(val, torch.fx.node.base_types) or is_opaque_type(type(val))
 
 
 def is_graphable_type(typ: type[object]) -> bool:
-    """Return whether the given type is graphable"""
+    """Return whether the given type is graphable."""
     return issubclass(typ, torch.fx.node.base_types) or is_opaque_type(typ)
 
 


### PR DESCRIPTION
### Description
This PR fixes two minor typos in the code comments within `torch/_higher_order_ops/flat_apply.py`:

- **Redundancy Fix**: Removed a duplicated word "that" in the definition of a "graphable type" (Line 20).
- **Punctuation Fix**: Added a missing period at the end of the docstring for clarity (Line 25).

### Impact
- Documentation/Comments only. 
- No functional changes to the code.

### Test Plan
N/A (Documentation fix only)

cc @tugsbayasgalan @zou3519 @ydwu4 @chillee @kshitij12345
