### PR TITLE
Fixes Cannot access storage of TensorWrapper when using AsyncCollectiveTensor with torch.func.jvp

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -979,40 +979,6 @@ class TestAsyncCollectiveTensorWithFunctorch(TestCase):
         self.assertIsInstance(result, torch.Tensor)
         self.assertEqual(result, inp.sum())
 
-    def test_trigger_wait_with_multiple_levels(self):
-        class F(torch.autograd.Function):
-            @staticmethod
-            def forward(input):
-                return input
-
-            @staticmethod
-            def backward(ctx, grad_output):
-                return grad_output
-
-            @staticmethod
-            def setup_context(ctx, inputs, output):
-                pass
-
-            @staticmethod
-            def jvp(ctx, input_tangent):
-                wrapped = ft_c._maybe_wrap_tensor(input_tangent)
-                return wrapped.trigger_wait()
-
-        def nested_fn(x):
-            def inner(y):
-                return F.apply(y).sum()
-
-            _, jvp_out = torch.func.jvp(inner, (x,), (torch.ones_like(x),))
-            return jvp_out
-
-        inp = torch.randn(3)
-        tangent = torch.ones(3)
-
-        result, jvp_result = torch.func.jvp(nested_fn, (inp,), (tangent,))
-
-        self.assertIsInstance(result, torch.Tensor)
-        self.assertIsInstance(jvp_result, torch.Tensor)
-
 
 # Update the supported devices in DEVICE
 instantiate_device_type_tests(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1062,8 +1062,7 @@ class AsyncCollectiveTensor(torch.Tensor):
             # Fast handle aten.view as a lot of view related op goes to aten.view
             # eventually, this avoids pytree slowdown
 
-            elem = _recursive_unwrap_functorch(args[0].elem)
-            res = func(elem, args[1])
+            res = func(_recursive_unwrap_functorch(args[0].elem), args[1])
             wrapper_res = AsyncCollectiveTensor(res)
             return wrapper_res
 


### PR DESCRIPTION

Fixes #171604

This PR adds recursive unwrapping of TensorWrapper before accessing storage.

In `torch/csrc/distributed/c10d/ProcessGroup.cpp`, the tensor.storage() for work registry lookup was failing so I added `recursive_unwrap()` helper that uses `maybeGetTensorWrapper()` to unwrap `functorch` wrappers before accessing tensor storage in `register_work()` and `pop_works()`.

In `torch/distributed/_functional_collectives.py`, the ops receiving TensorWrapper I added `_recursive_unwrap_functorch()` helper and modified `AsyncCollectiveTensor.__torch_dispatch__` to unwrap functorch wrappers before passing tensors.

Added tests in `test/distributed/test_functional_api.py`
