### PR TITLE
docs: clarify torch._dynamo.mark_dynamic usage with torch.compile

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -6,25 +6,6 @@
 (torch.compiler_api)=
 # torch.compiler API reference
 
-> ⚠️ **Warning**
->
-> `torch._dynamo.mark_dynamic()` must **NOT** be called inside a model’s
-> `forward()` method when using `torch.compile()`.
->
-> This function is a *tracing-time API*. Calling it inside compiled
-> functions will raise an error such as:
->
-> ```
-> AssertionError: Attempt to trace forbidden callable
-> ```
->
-> **Correct usage** is to call `mark_dynamic` on input tensors
-> **outside** the compiled model, or to use:
->
-> ```python
-> torch.compile(model, dynamic=True)
-> ```
-
 For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 
 ```{eval-rst}

--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -6,6 +6,25 @@
 (torch.compiler_api)=
 # torch.compiler API reference
 
+> ⚠️ **Warning**
+>
+> `torch._dynamo.mark_dynamic()` must **NOT** be called inside a model’s
+> `forward()` method when using `torch.compile()`.
+>
+> This function is a *tracing-time API*. Calling it inside compiled
+> functions will raise an error such as:
+>
+> ```
+> AssertionError: Attempt to trace forbidden callable
+> ```
+>
+> **Correct usage** is to call `mark_dynamic` on input tensors
+> **outside** the compiled model, or to use:
+>
+> ```python
+> torch.compile(model, dynamic=True)
+> ```
+
 For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 
 ```{eval-rst}

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamic_shapes.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamic_shapes.md
@@ -170,6 +170,26 @@ dynamic shapes.
 
 #### `mark_dynamic(tensor, dim, min=min, max=max)`
 
+> ⚠️ **Warning**
+>
+> `torch._dynamo.mark_dynamic()` must not be called inside a model’s
+> `forward()` method when using `torch.compile()`.
+>
+> This function is a *tracing-time API*. Calling it inside compiled
+> function will raise an error such as:
+>
+> ```
+> AssertionError: Attempt to trace forbidden callable
+> ```
+>
+> **Correct usage** is to call `mark_dynamic` on input tensors
+> **outside** the compiled model, or to use:
+>
+> ```python
+> torch.compile(model, dynamic=True)
+> ```
+
+
 The {func}`torch._dynamo.mark_dynamic` function marks a tensor dimension as dynamic and will fail if it
 gets specialized. It does not work for integers. Use this function only if you know
 all graphs in the frame using this input converge to a single dynamic graph.

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamic_shapes.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamic_shapes.md
@@ -172,21 +172,23 @@ dynamic shapes.
 
 > ⚠️ **Warning**
 >
-> `torch._dynamo.mark_dynamic()` must not be called inside a model’s
-> `forward()` method when using `torch.compile()`.
+> `torch._dynamo.mark_dynamic()` must not be called inside any function
+> that is being compiled by `torch.compile()` (for example, a model’s
+> `forward()` method or any function it calls).
 >
-> This function is a *tracing-time API*. Calling it inside compiled
-> function will raise an error such as:
+> This function is a *tracing-time API*. If it is invoked from within
+> compiled code, Dynamo will raise an error such as:
 >
 > ```
 > AssertionError: Attempt to trace forbidden callable
 > ```
 >
-> **Correct usage** is to call `mark_dynamic` on input tensors
-> **outside** the compiled model, or to use:
+> **Correct usage** is to call `mark_dynamic` on input tensors *before*
+> invoking `torch.compile`, for example:
 >
 > ```python
-> torch.compile(model, dynamic=True)
+> torch._dynamo.mark_dynamic(x, 0)
+> compiled_model = torch.compile(model)
 > ```
 
 


### PR DESCRIPTION
Added a warning to the torch.compiler API docs clarifying that torch._dynamo.mark_dynamic() must not be called inside a model’s forward() method when using torch.compile().