### PR TITLE
[dynamo] Fix the bench profiler

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4170,14 +4170,19 @@ def run(runner, args, original_dir=None):
             write_outputs(output_filename, [], [args.only, batch_size])
         return
 
+    should_profile_details = args.profile_details
     args.profile_details = {}
     if args.export_profiler_trace:
-        if args.profile_details:
+        if should_profile_details:
             args.profile_details = {
                 "record_shapes": True,
                 "profile_memory": True,
                 "with_stack": True,
                 "with_modules": True,
+                "activities": [
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ],
             }
 
         if args.profiler_trace_name is None:


### PR DESCRIPTION
Summary:
--profile-details option added in D68134547 seems not working (not generating stacks). The reason for it is that just before reading, we set it to empty dictionary  args.profile_details = {}, hence checking it is always false. 

This diff fixes it. See test plan on when need to see it used.

Test Plan:
```
buck2 run mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.nvcc_arch=b200a \
  -c fbcode.platform010_cuda_version=12.8 \
  //pytorch/benchmark:pt2 -- \
  --only hf_GPT2 \
  --device=cuda \
  --backend=inductor \
  --performance \
  --training \
  --iterations 5 \
  --batch-size 2 \
  --export-profiler-trace \
  --profile-details \
  --profiler-trace-name /tmp/kineto_trace.json
```

This produces /tmp/kineto_trace.json_hf_GPT2_rank_0.json file, but it doesn't contain stacks when opening it. 

Before this change, run this command and it fails

```
  buck2 run mode/opt -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=b200a -c fbcode.platform010_cuda_version=12.8 durin/cli:durin -- analyze --run python_function --log-to-scuba --trace /tmp/kineto_trace.json_hf_GPT2_rank_0.json 
```

After this change, it runs successfully as in P2107487250

Differential Revision: D90092142




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo