### PR TITLE
[c10d] Fix USE_NCCL=0 build failure in nccl_dev_cap.hpp

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#if USE_NCCL
+
 #include <nccl.h>
 #include <torch/csrc/cuda/nccl.h>
 
@@ -11,3 +13,4 @@
 #define NCCL_HAS_SYMMEM_DEVICE_SUPPORT
 #include <nccl_device.h>
 #endif
+#endif // USE_NCCL


### PR DESCRIPTION
**Issue**: The header nccl_dev_cap.hpp was unconditionally including NCCL headers (<nccl.h>, <nccl_device.h>) without any preprocessor guards. This caused compilation to fail on systems where NCCL was disabled or not installed.

**Fix**: Added #if USE_NCCL guard to conditionally include NCCL-dependent code only when NCCL is enabled.
**Result**: Builds now succeed with USE_NCCL=0 on systems without NCCL headers.

Fixes #171692

cc: @mansiag05 @arkadip-maitra 