### PR TITLE
[Docs] Fix broken torch.compiler documentation URLs

### DIFF
--- a/docs/source/torch.compiler_troubleshooting_old.md
+++ b/docs/source/torch.compiler_troubleshooting_old.md
@@ -10,7 +10,7 @@ orphan: true
 
 :::{note}
 This document is outdated and is now mainly a primary resource on how to run the `torch.compile` minifier.
-Please see the [updated troubleshooting document](https://pytorch.org/docs/main/torch.compiler_troubleshooting.html).
+Please see the [updated troubleshooting document](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_troubleshooting.html).
 There is also a more [comprehensive manual for torch.compile](https://docs.google.com/document/d/1y5CRfMLdwEoF1nTk9q8qEu1mgMUuUtvhklPKJ2emLU8/edit#heading=h.ivdr7fmrbeab)
 available.
 :::

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -788,7 +788,7 @@ Optimizations
 
     compile
 
-`torch.compile documentation <https://pytorch.org/docs/main/torch.compiler.html>`__
+`torch.compile documentation <https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler.html>`__
 
 Operator Tags
 ------------------------------------

--- a/docs/source/user_guide/torch_compiler/export.md
+++ b/docs/source/user_guide/torch_compiler/export.md
@@ -528,7 +528,7 @@ As we can see, the previously in-place operator,
 ### Core ATen IR
 
 We can further lower the Inference IR to the
-`Core ATen Operator Set <https://pytorch.org/docs/main/torch.compiler_ir.html#core-aten-ir>`__,
+`Core ATen Operator Set <https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_ir.html#core-aten-ir>`__,
 which contains only ~180 operators. This is achieved by passing `decomp_table=None`
 (which uses the default decomposition table) to `run_decompositions()`. This IR
 is optimal for backends who want to minimize the number of operators they need

--- a/docs/source/user_guide/torch_compiler/export/programming_model.md
+++ b/docs/source/user_guide/torch_compiler/export/programming_model.md
@@ -26,11 +26,11 @@ covered in the {ref}`export IR spec <export.ir_spec>`.
 In *non-strict mode*, we trace through the program using the normal Python
 interpreter. Your code executes exactly as it would in eager mode; the only
 difference is that all Tensors are replaced by
-[fake Tensors](https://pytorch.org/docs/main/torch.compiler_fake_tensor.html),
+[fake Tensors](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_fake_tensor.html),
 **which have shapes and other forms of metadata but no data**, wrapped in
 [Proxy objects](https://pytorch.org/docs/main/fx.html) that record all
 operations on them into a graph. We also capture
-[conditions on Tensor shapes](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html#the-guard-model)
+[conditions on Tensor shapes](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_dynamic_shapes.html#the-guard-model)
 **that guard the correctness of the generated code**.
 
 In *strict mode*, we first trace through the program using
@@ -247,7 +247,7 @@ model are different in these cases.
 #### Dynamic Shape-Dependent Control Flow
 
 When the value involved in a control flow is a
-[dynamic shape](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html),
+[dynamic shape](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_dynamic_shapes.html),
 in most cases **we will also know the concrete value of the dynamic shape
 during tracing**: see the following section for more details on how the
 compiler tracks this information.
@@ -297,7 +297,7 @@ class M_new(torch.nn.Module):
 ```
 
 A special case of data-dependent control flow is where it involves a
-[data-dependent dynamic shape](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html#unbacked-symints):
+[data-dependent dynamic shape](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_dynamic_shapes.html#unbacked-symints):
 typically, the shape of some intermediate Tensor that depends on input data
 rather than on input shapes (thus not shape-dependent). Instead of using a
 control flow operator, in this case you can provide an assertion that decides
@@ -351,7 +351,7 @@ Moreover, as we encounter control flow in the program, we create boolean
 expressions, typically involving relational operators, describing conditions
 along the traced path. These **expressions are evaluated to decide which path
 to trace through the program**, and recorded in a
-[shape environment](https://pytorch.org/docs/main/torch.compiler_dynamic_shapes.html#overall-architecture)
+[shape environment](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_dynamic_shapes.html#overall-architecture)
 to guard the correctness of the traced path and to evaluate subsequently
 created expressions.
 
@@ -360,7 +360,7 @@ We briefly introduce these subsystems next.
 ### Fake Implementations of PyTorch Operators
 
 Recall that during tracing, we are executing the program with
-[fake Tensors](https://pytorch.org/docs/main/torch.compiler_fake_tensor.html),
+[fake Tensors](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_fake_tensor.html),
 which have no data. In general we cannot call the actual implementations of
 PyTorch operators with fake Tensors. Thus each operator needs to have an
 additional fake (a.k.a. "meta") implementation, which inputs and outputs fake

--- a/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
@@ -81,7 +81,7 @@ Registration serves two purposes:
 
 - You can pass a string containing your backend function's name to `torch.compile` instead of the function itself,
   for example, `torch.compile(model, backend="my_compiler")`.
-- It is required for use with the [minifier](https://pytorch.org/docs/main/torch.compiler_troubleshooting_old.html#minifier). Any generated
+- It is required for use with the [minifier](https://docs.pytorch.org/docs/main/torch.compiler_troubleshooting_old.html#minifier). Any generated
   code from the minifier must call your code that registers your backend function, typically through an `import` statement.
 
 ## Custom Backends after AOTAutograd
@@ -90,7 +90,7 @@ It is possible to define custom backends that are called by AOTAutograd rather t
 This is useful for 2 main reasons:
 
 - Users can define backends that support model training, as AOTAutograd can generate the backward graph for compilation.
-- AOTAutograd produces FX graphs consisting of [core Aten ops](https://pytorch.org/docs/main/torch.compiler_ir.html#core-aten-ir). As a result,
+- AOTAutograd produces FX graphs consisting of [core Aten ops](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_ir.html#core-aten-ir). As a result,
   custom backends only need to support the core Aten opset, which is a significantly smaller opset than the entire torch/Aten opset.
 
 Wrap your backend with

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
@@ -848,7 +848,7 @@ Below are additional details and references for concepts mentioned in this docum
 
 [^5]: Interestingly enough, it does understand NumPy code! Have a look at
     [this blogpost](https://pytorch.org/blog/compiling-numpy-code/)
-    and [the docs](https://pytorch.org/docs/main/torch.compiler_faq.html#does-numpy-work-with-torch-compile).
+    and [the docs](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_faq.html#does-numpy-work-with-torch-compile).
     Now, this is just possible because we reimplemented NumPy using
     PyTorch. Good luck implementing Django in PyTorch though…
 

--- a/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
@@ -566,7 +566,7 @@ with a {ref}`minimal reproducer <torch.compiler_troubleshooting>`.
 ### I `torch.compile` some NumPy code and I did not see any speed-up.
 
 The best place to start is the
-[tutorial with general advice for how to debug these sort of torch.compile issues](https://pytorch.org/docs/main/torch.compiler_faq.html#why-am-i-not-seeing-speedups).
+[tutorial with general advice for how to debug these sort of torch.compile issues](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_faq.html#why-am-i-not-seeing-speedups).
 
 Some graph breaks may happen because of the use of unsupported features. See
 {ref}`nonsupported-numpy-feats`. More generally, it is useful to keep in mind


### PR DESCRIPTION
Fix outdated documentation links in torch.compile docs.

While reading the torch.compile documentation, I noticed several links pointing to
deprecated pytorch.org URLs. This PR updates them to the correct pages under
docs.pytorch.org to avoid broken references.
