### PR TITLE
[CPU][Inductor] fuse "round" and "to" in quant

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -170,6 +170,53 @@ at::vec::Vectorized<uint8_t> inline convert_float_to_int8(
 }
 
 template <typename T>
+at::vec::Vectorized<T> inline round_convert_float_to_int8(
+    at::vec::Vectorized<float> src);
+
+template <>
+at::vec::Vectorized<int8_t> inline round_convert_float_to_int8(
+    at::vec::Vectorized<float> src) {
+  // Convert from float32 to int32 with truncation
+  __m256i x_values_int32 = _mm256_cvttps_epi32(src);
+
+  // Convert from int32 to int16 using signed saturation
+  __m256i xy_packed_v = _mm256_packs_epi32(x_values_int32, x_values_int32);
+
+  constexpr auto min_val = std::numeric_limits<int8_t>::min();
+  constexpr auto max_val = std::numeric_limits<int8_t>::max();
+
+  // Convert from int16 to int8 using unsigned saturation
+  __m256i xyzw_clamped_v = pack_saturate_and_clamp<int8_t>(
+      xy_packed_v, xy_packed_v, min_val, max_val);
+  __m256i permute_mask_v =
+      _mm256_set_epi32(0x07, 0x03, 0x06, 0x02, 0x05, 0x01, 0x04, 0x00);
+  return _mm256_permutevar8x32_epi32(xyzw_clamped_v, permute_mask_v);
+}
+
+template <>
+at::vec::Vectorized<uint8_t> inline round_convert_float_to_int8(
+    at::vec::Vectorized<float> src) {
+  // The type of *_val should be int32_t to ensure correct clamping behavior.
+  constexpr auto min_val = std::numeric_limits<int32_t>::min();
+  constexpr auto max_val = std::numeric_limits<int32_t>::max();
+  __m256 float32_min_val = _mm256_set1_ps(float(min_val));
+  __m256 float32_max_val = _mm256_set1_ps(float(max_val));
+  __m256 float32_src = _mm256_max_ps(src, float32_min_val);
+  float32_src = _mm256_min_ps(float32_src, float32_max_val);
+  __m256i truncated_src = _mm256_cvttps_epi32(float32_src);
+
+  __m128i r1 = _mm256_castsi256_si128(truncated_src);
+  __m128i mask = _mm_setr_epi8(
+      0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+  __m128i r1_shuffled = _mm_shuffle_epi8(r1, mask);
+  __m128i r2 = _mm256_extractf128_si256(truncated_src, 1);
+  __m128i r2_shuffled = _mm_shuffle_epi8(r2, mask);
+  __m128i result = _mm_unpacklo_epi32(r1_shuffled, r2_shuffled);
+
+  return _mm256_castsi128_si256(result);
+}
+
+template <typename T>
 __FORCE_INLINE void QuantizeAvx2(
     const float* src,
     T* dst,

--- a/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
@@ -222,8 +222,10 @@ struct VecRoundConvert<
     2,
     typename std::enable_if_t<is_8bit_integer_v<dst_t>, void>> {
   static inline VectorizedN<dst_t, 1> apply(const VectorizedN<float, 2>& src) {
-    at::vec::Vectorized<dst_t> vec1 = round_convert_float_to_int8<dst_t>(src[0]);
-    at::vec::Vectorized<dst_t> vec2 = round_convert_float_to_int8<dst_t>(src[1]);
+    at::vec::Vectorized<dst_t> vec1 =
+        round_convert_float_to_int8<dst_t>(src[0]);
+    at::vec::Vectorized<dst_t> vec2 =
+        round_convert_float_to_int8<dst_t>(src[1]);
     __m128 lane2 = _mm512_castps512_ps128(_mm512_castsi512_ps(vec2));
     __m512 result = _mm512_insertf32x4(
         _mm512_castsi512_ps(vec1),

--- a/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
@@ -226,12 +226,9 @@ struct VecRoundConvert<
         round_convert_float_to_int8<dst_t>(src[0]);
     at::vec::Vectorized<dst_t> vec2 =
         round_convert_float_to_int8<dst_t>(src[1]);
-    __m128 lane2 = _mm512_castps512_ps128(_mm512_castsi512_ps(vec2));
-    __m512 result = _mm512_insertf32x4(
-        _mm512_castsi512_ps(vec1),
-        lane2,
-        1); // Insert lane2 into the second 128-bit lane
-    return at::vec::Vectorized<dst_t>(_mm512_castps_si512(result));
+    __m128i vec2_lo = _mm512_castsi512_si128(vec2);
+    __m512i out = _mm512_inserti32x4(vec1, vec2_lo, 1);
+    return VectorizedN<dst_t, 1>(at::vec::Vectorized<dst_t>(out));
   }
 };
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -131,50 +131,26 @@ at::vec::Vectorized<T> inline convert_float_to_int8(
 template <>
 at::vec::Vectorized<int8_t> inline convert_float_to_int8(
     at::vec::Vectorized<float> src) {
-  // Convert from float32 to int32 with truncation
-  __m512i x_values_int32 = _mm512_cvttps_epi32(src);
-
-  // Convert from int32 to int16 using signed saturation
-  __m512i xy_packed_v = _mm512_packs_epi32(x_values_int32, x_values_int32);
-
-  constexpr auto min_val = std::numeric_limits<int8_t>::min();
-  constexpr auto max_val = std::numeric_limits<int8_t>::max();
-
-  // Convert from int16 to int8 using unsigned saturation
-  __m512i xyzw_clamped_v = pack_saturate_and_clamp<int8_t>(
-      xy_packed_v, xy_packed_v, min_val, max_val);
-  __m512i permute_mask_v = _mm512_set_epi32(
-      0x0f,
-      0x0b,
-      0x07,
-      0x03,
-      0x0e,
-      0x0a,
-      0x06,
-      0x02,
-      0x0d,
-      0x09,
-      0x05,
-      0x01,
-      0x0c,
-      0x08,
-      0x04,
-      0x00);
-  return _mm512_permutexvar_epi32(permute_mask_v, xyzw_clamped_v);
+  // Convert from float32 to int32 with round nearest
+  __m512i int32_src_clamped = _mm512_cvt_roundps_epi32(
+      src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+  // Convert from int32 to int8 with saturate
+  __m128i int8_src = _mm512_cvtsepi32_epi8(int32_src_clamped);
+  return _mm512_castsi128_si512(int8_src);
 }
 
 template <>
 at::vec::Vectorized<uint8_t> inline convert_float_to_int8(
     at::vec::Vectorized<float> src) {
-  // The type of *_val should be int32_t to ensure correct clamping behavior.
+  // Clamp float32 to unsigned int range
   constexpr auto min_val = std::numeric_limits<uint8_t>::min();
-  constexpr auto max_val = std::numeric_limits<uint8_t>::max();
   __m512 float32_min_val = _mm512_set1_ps(float(min_val));
-  __m512 float32_max_val = _mm512_set1_ps(float(max_val));
   __m512 float32_src = _mm512_max_ps(src, float32_min_val);
-  float32_src = _mm512_min_ps(float32_src, float32_max_val);
-  __m512i int32_src_clamped = _mm512_cvttps_epi32(float32_src);
-  __m128i int8_src = _mm512_cvtepi32_epi8(int32_src_clamped);
+  // Convert from float32 to int32 with round nearest
+  __m512i int32_src_clamped = _mm512_cvt_roundps_epi32(
+      float32_src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+  // Convert from int32 to int8 with saturate
+  __m128i int8_src = _mm512_cvtusepi32_epi8(int32_src_clamped);
   return _mm512_castsi128_si512(int8_src);
 }
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -131,26 +131,50 @@ at::vec::Vectorized<T> inline convert_float_to_int8(
 template <>
 at::vec::Vectorized<int8_t> inline convert_float_to_int8(
     at::vec::Vectorized<float> src) {
-  // Convert from float32 to int32 with round nearest
-  __m512i int32_src_clamped = _mm512_cvt_roundps_epi32(
-      src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
-  // Convert from int32 to int8 with saturate
-  __m128i int8_src = _mm512_cvtsepi32_epi8(int32_src_clamped);
-  return _mm512_castsi128_si512(int8_src);
+  // Convert from float32 to int32 with truncation
+  __m512i x_values_int32 = _mm512_cvttps_epi32(src);
+
+  // Convert from int32 to int16 using signed saturation
+  __m512i xy_packed_v = _mm512_packs_epi32(x_values_int32, x_values_int32);
+
+  constexpr auto min_val = std::numeric_limits<int8_t>::min();
+  constexpr auto max_val = std::numeric_limits<int8_t>::max();
+
+  // Convert from int16 to int8 using unsigned saturation
+  __m512i xyzw_clamped_v = pack_saturate_and_clamp<int8_t>(
+      xy_packed_v, xy_packed_v, min_val, max_val);
+  __m512i permute_mask_v = _mm512_set_epi32(
+      0x0f,
+      0x0b,
+      0x07,
+      0x03,
+      0x0e,
+      0x0a,
+      0x06,
+      0x02,
+      0x0d,
+      0x09,
+      0x05,
+      0x01,
+      0x0c,
+      0x08,
+      0x04,
+      0x00);
+  return _mm512_permutexvar_epi32(permute_mask_v, xyzw_clamped_v);
 }
 
 template <>
 at::vec::Vectorized<uint8_t> inline convert_float_to_int8(
     at::vec::Vectorized<float> src) {
-  // Clamp float32 to unsigned int range
+  // The type of *_val should be int32_t to ensure correct clamping behavior.
   constexpr auto min_val = std::numeric_limits<uint8_t>::min();
+  constexpr auto max_val = std::numeric_limits<uint8_t>::max();
   __m512 float32_min_val = _mm512_set1_ps(float(min_val));
+  __m512 float32_max_val = _mm512_set1_ps(float(max_val));
   __m512 float32_src = _mm512_max_ps(src, float32_min_val);
-  // Convert from float32 to int32 with round nearest
-  __m512i int32_src_clamped = _mm512_cvt_roundps_epi32(
-      float32_src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
-  // Convert from int32 to int8 with saturate
-  __m128i int8_src = _mm512_cvtusepi32_epi8(int32_src_clamped);
+  float32_src = _mm512_min_ps(float32_src, float32_max_val);
+  __m512i int32_src_clamped = _mm512_cvttps_epi32(float32_src);
+  __m128i int8_src = _mm512_cvtepi32_epi8(int32_src_clamped);
   return _mm512_castsi128_si512(int8_src);
 }
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -167,8 +167,8 @@ template <>
 at::vec::Vectorized<uint8_t> inline convert_float_to_int8(
     at::vec::Vectorized<float> src) {
   // The type of *_val should be int32_t to ensure correct clamping behavior.
-  constexpr auto min_val = std::numeric_limits<int32_t>::min();
-  constexpr auto max_val = std::numeric_limits<int32_t>::max();
+  constexpr auto min_val = std::numeric_limits<uint8_t>::min();
+  constexpr auto max_val = std::numeric_limits<uint8_t>::max();
   __m512 float32_min_val = _mm512_set1_ps(float(min_val));
   __m512 float32_max_val = _mm512_set1_ps(float(max_val));
   __m512 float32_src = _mm512_max_ps(src, float32_min_val);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -186,10 +186,10 @@ template <>
 at::vec::Vectorized<int8_t> inline round_convert_float_to_int8(
     at::vec::Vectorized<float> src) {
   // Convert from float32 to int32 with round nearest
-  __m512i int32_src_clamped = _mm512_cvt_roundps_epi32(
+  __m512i int32_src_round = _mm512_cvt_roundps_epi32(
       src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
   // Convert from int32 to int8 with saturate
-  __m128i int8_src = _mm512_cvtsepi32_epi8(int32_src_clamped);
+  __m128i int8_src = _mm512_cvtsepi32_epi8(int32_src_round);
   return _mm512_castsi128_si512(int8_src);
 }
 
@@ -201,10 +201,10 @@ at::vec::Vectorized<uint8_t> inline round_convert_float_to_int8(
   __m512 float32_min_val = _mm512_set1_ps(float(min_val));
   __m512 float32_src = _mm512_max_ps(src, float32_min_val);
   // Convert from float32 to int32 with round nearest
-  __m512i int32_src_clamped = _mm512_cvt_roundps_epi32(
+  __m512i int32_src_round = _mm512_cvt_roundps_epi32(
       float32_src, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
   // Convert from int32 to int8 with saturate
-  __m128i int8_src = _mm512_cvtusepi32_epi8(int32_src_clamped);
+  __m128i int8_src = _mm512_cvtusepi32_epi8(int32_src_round);
   return _mm512_castsi128_si512(int8_src);
 }
 

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -105,6 +105,12 @@ template <typename T>
 constexpr bool is_floating_point_v = is_floating_point<T>::value;
 
 template <typename T>
+struct is_integer : std::integral_constant<bool, std::is_integral_v<T>> {};
+
+template <typename T>
+constexpr bool is_integer_v = is_integer<T>::value;
+
+template <typename T>
 struct is_reduced_floating_point
     : std::integral_constant<
           bool,

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -105,10 +105,7 @@ template <typename T>
 constexpr bool is_floating_point_v = is_floating_point<T>::value;
 
 template <typename T>
-struct is_integer : std::integral_constant<bool, std::is_integral_v<T>> {};
-
-template <typename T>
-constexpr bool is_integer_v = is_integer<T>::value;
+constexpr bool is_integer_v = std::is_integral_v<T>;
 
 template <typename T>
 struct is_reduced_floating_point

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -47,7 +47,7 @@ struct VecRoundConvert {
         static_cast<src_t>(std::numeric_limits<dst_t>::max());
     for (int i = 0; i < count; i++) {
       dst_buf[i] = static_cast<dst_t>(
-        std::min(std::max(std::round(src_buf[i]), min_val), max_val));
+          std::min(std::max(std::round(src_buf[i]), min_val), max_val));
     }
     return VectorizedN<dst_t, dst_n>::loadu(dst_buf, count);
   }

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -76,7 +76,8 @@ template <
     typename src_t,
     int src_n,
     std::enable_if_t<dst_n != 1, int> = 0>
-inline VectorizedN<dst_t, dst_n> round_convert(const VectorizedN<src_t, src_n>& src) {
+inline VectorizedN<dst_t, dst_n> round_convert(
+    const VectorizedN<src_t, src_n>& src) {
   return VecRoundConvert<dst_t, dst_n, src_t, src_n>::apply(src);
 }
 

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -42,7 +42,7 @@ struct VecRoundConvert {
     src.store(src_buf);
     __at_align__ dst_t dst_buf[VectorizedN<dst_t, dst_n>::size()];
     for (int i = 0; i < count; i++) {
-      dst_buf[i] = static_cast<dst_t>(src_buf[i]);
+      dst_buf[i] = static_cast<dst_t>(std::round(src_buf[i]));
     }
     return VectorizedN<dst_t, dst_n>::loadu(dst_buf, count);
   }

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -41,8 +41,12 @@ struct VecRoundConvert {
     __at_align__ src_t src_buf[VectorizedN<src_t, src_n>::size()];
     src.store(src_buf);
     __at_align__ dst_t dst_buf[VectorizedN<dst_t, dst_n>::size()];
+    constexpr auto min_val =
+        static_cast<src_t>(std::numeric_limits<dst_t>::min());
+    constexpr auto max_val =
+        static_cast<src_t>(std::numeric_limits<dst_t>::max());
     for (int i = 0; i < count; i++) {
-      dst_buf[i] = static_cast<dst_t>(std::round(src_buf[i]));
+      dst_buf[i] = static_cast<dst_t>(std::min(std::max(std::round(src_buf[i]), min_val), max_val));
     }
     return VectorizedN<dst_t, dst_n>::loadu(dst_buf, count);
   }

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -46,7 +46,8 @@ struct VecRoundConvert {
     constexpr auto max_val =
         static_cast<src_t>(std::numeric_limits<dst_t>::max());
     for (int i = 0; i < count; i++) {
-      dst_buf[i] = static_cast<dst_t>(std::min(std::max(std::round(src_buf[i]), min_val), max_val));
+      dst_buf[i] = static_cast<dst_t>(
+        std::min(std::max(std::round(src_buf[i]), min_val), max_val));
     }
     return VectorizedN<dst_t, dst_n>::loadu(dst_buf, count);
   }

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -32,7 +32,8 @@ template <
     int dst_n,
     typename src_t,
     int src_n,
-    typename Enabled = void>
+    typename =
+        std::enable_if_t<is_integer_v<dst_t> && is_floating_point_v<src_t>>>
 struct VecRoundConvert {
   static inline VectorizedN<dst_t, dst_n> apply(
       const VectorizedN<src_t, src_n>& src) {

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -27,6 +27,9 @@ struct VecConvert {
   }
 };
 
+// Specialized for float-to-int vector conversion.
+// It ensures the result staying within the destination
+// type's limits without any undefined behavior.
 template <
     typename dst_t,
     int dst_n,

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -676,9 +676,9 @@ class RecordOptimizationContext:
 
 
 def decltype_promoted(*args):
-    assert not any(
-        isinstance(arg, CppCSEVariable) and arg.is_vec for arg in args
-    ), "Promotion of vector types is not supported"
+    assert not any(isinstance(arg, CppCSEVariable) and arg.is_vec for arg in args), (
+        "Promotion of vector types is not supported"
+    )
 
     if (dt := get_promote_dtype(args)) is not None:
         return DTYPE_TO_CPP[dt]
@@ -3543,8 +3543,8 @@ class CppVecKernel(CppKernel):
         elif src_dtype != dtype:
             expr = ""
             if (
-                rounding 
-                and src_dtype in [torch.float, torch.double] 
+                rounding
+                and src_dtype in [torch.float, torch.double]
                 and dtype in [torch.int8, torch.uint8]
             ):
                 expr = "at::vec::round_convert"
@@ -3554,7 +3554,7 @@ class CppVecKernel(CppKernel):
                 expr = expr + f"<{dst_cpp_type}>({src})"
             else:
                 expr = (
-                    expr 
+                    expr
                     + f"<{dst_cpp_type},{dst_num_vectors},{src_cpp_type},{src_num_vectors}>({src})")
         return expr
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3542,14 +3542,20 @@ class CppVecKernel(CppKernel):
             expr = f"{src}.to<{dst_cpp_type},{dst_num_vectors}>()"
         elif src_dtype != dtype:
             expr = ""
-            if rounding and src_dtype in [torch.float, torch.double] and dtype in [torch.int8,torch.uint8]:
+            if (
+                rounding 
+                and src_dtype in [torch.float, torch.double] 
+                and dtype in [torch.int8, torch.uint8]
+            ):
                 expr = "at::vec::round_convert"
             else:
                 expr = "at::vec::convert"
             if src_num_vectors == dst_num_vectors == 1:
                 expr = expr + f"<{dst_cpp_type}>({src})"
             else:
-                expr = expr + f"<{dst_cpp_type},{dst_num_vectors},{src_cpp_type},{src_num_vectors}>({src})"
+                expr = (
+                    expr 
+                    + f"<{dst_cpp_type},{dst_num_vectors},{src_cpp_type},{src_num_vectors}>({src})")
         return expr
 
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -743,7 +743,7 @@ class CppOverrides(OpOverrides):
             """
             V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
-    
+
     @staticmethod
     def round_to_int(x, dtype, src_dtype=None, use_compute_types=True):
         assert isinstance(x, CppCSEVariable)
@@ -1670,7 +1670,7 @@ class CppVecOverrides(CppOverrides):
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
             V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
-    
+
     @staticmethod
     def round_to_int(x, dtype, src_dtype=None, use_compute_types=True):
         assert dtype in [

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3555,7 +3555,8 @@ class CppVecKernel(CppKernel):
             else:
                 expr = (
                     expr
-                    + f"<{dst_cpp_type},{dst_num_vectors},{src_cpp_type},{src_num_vectors}>({src})")
+                    + f"<{dst_cpp_type},{dst_num_vectors},{src_cpp_type},{src_num_vectors}>({src})"
+                )
         return expr
 
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1672,7 +1672,7 @@ class CppVecOverrides(CppOverrides):
         return csevar
     
     @staticmethod
-    def round_to_int(x, dtype):
+    def round_to_int(x, dtype, src_dtype=None, use_compute_types=True):
         assert dtype in [
             torch.uint8,
             torch.int8,

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2621,9 +2621,6 @@ class CppKernel(Kernel):
             return f"c10::convert<{DTYPE_TO_CPP[dtype]}>(std::round({src}))"
         return f"c10::convert<{DTYPE_TO_CPP[dtype]}>({src})"
 
-    def get_round_int_expr(self, src, dtype, src_dtype):
-        return f"c10::convert<{DTYPE_TO_CPP[dtype]}>({src})"
-
     def cache_dtype_convert(self, dst, dst_dtype, src, src_dtype):
         expr = self.get_to_dtype_expr(src, dst_dtype, src_dtype)
         self.cse.put(expr, dst)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1762,9 +1762,7 @@ def quantized_decomposed_quantize_per_tensor_tensor(
         if zero_point.dtype != torch.float32:
             _zero_point = ops.to_dtype(_zero_point, torch.float32)
         val = ops.round(input * ops.reciprocal(_scale)) + _zero_point
-        qmin, qmax = _create_constants(quant_min, quant_max, dtype=torch.float32)
-        clamped = ops.minimum(ops.maximum(val, qmin), qmax)
-        return ops.to_dtype(clamped, dtype)
+        return ops.to_dtype(val, dtype)
 
     return Pointwise.create(
         device=input.get_device(),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1761,7 +1761,7 @@ def quantized_decomposed_quantize_per_tensor_tensor(
             _scale = ops.to_dtype(_scale, torch.float32)
         if zero_point.dtype != torch.float32:
             _zero_point = ops.to_dtype(_zero_point, torch.float32)
-        val = ops.round(input * ops.reciprocal(_scale)) + _zero_point
+        val = input * ops.reciprocal(_scale) + _zero_point
         return ops.to_dtype(val, dtype)
 
     return Pointwise.create(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1761,7 +1761,7 @@ def quantized_decomposed_quantize_per_tensor_tensor(
             _scale = ops.to_dtype(_scale, torch.float32)
         if zero_point.dtype != torch.float32:
             _zero_point = ops.to_dtype(_zero_point, torch.float32)
-        val = input * ops.reciprocal(_scale) + _zero_point
+        val = ops.round(input * ops.reciprocal(_scale)) + _zero_point
         return ops.to_dtype(val, dtype)
 
     return Pointwise.create(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1753,8 +1753,6 @@ def quantized_decomposed_quantize_per_tensor_tensor(
     scale_loader = scale.make_loader()
     zero_point_loader = zero_point.make_loader()
 
-    is_cpu_device = input.get_device().type == "cpu"
-
     def inner_fn(idx):
         input = input_loader(idx)
         _scale = scale_loader((0,) if len(scale.get_size()) == 1 else ())
@@ -1763,11 +1761,8 @@ def quantized_decomposed_quantize_per_tensor_tensor(
             _scale = ops.to_dtype(_scale, torch.float32)
         if zero_point.dtype != torch.float32:
             _zero_point = ops.to_dtype(_zero_point, torch.float32)
-        if is_cpu_device:
-            return ops.round_to_int(input * ops.reciprocal(_scale)+_zero_point,dtype)
-        else:
-            val = ops.round(input * ops.reciprocal(_scale)) + _zero_point
-            return ops.to_dtype(val, dtype)
+        val = ops.fma(input, ops.reciprocal(_scale), _zero_point)
+        return ops.round_to_int(val, dtype)
 
     return Pointwise.create(
         device=input.get_device(),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1753,6 +1753,8 @@ def quantized_decomposed_quantize_per_tensor_tensor(
     scale_loader = scale.make_loader()
     zero_point_loader = zero_point.make_loader()
 
+    device = input.get_device()
+
     def inner_fn(idx):
         input = input_loader(idx)
         _scale = scale_loader((0,) if len(scale.get_size()) == 1 else ())
@@ -1761,8 +1763,13 @@ def quantized_decomposed_quantize_per_tensor_tensor(
             _scale = ops.to_dtype(_scale, torch.float32)
         if zero_point.dtype != torch.float32:
             _zero_point = ops.to_dtype(_zero_point, torch.float32)
-        val = ops.fma(input, ops.reciprocal(_scale), _zero_point)
-        return ops.round_to_int(val, dtype)
+        if device and device.type == "cpu":
+            val = ops.fma(input, ops.reciprocal(_scale), _zero_point)
+            return ops.round_to_int(val, dtype)
+        val = ops.round(input * ops.reciprocal(_scale)) + _zero_point
+        qmin, qmax = _create_constants(quant_min, quant_max, dtype=torch.float32)
+        clamped = ops.minimum(ops.maximum(val, qmin), qmax)
+        return ops.to_dtype(clamped, dtype)
 
     return Pointwise.create(
         device=input.get_device(),


### PR DESCRIPTION
`quant` uses default rounding mode (round to nearest)  to convert fp32 to int8, while `to` use truncate. Current `quant` pass is `round->min/max->to(also have a min/max internal)`. 
There is duplicate min/max in this pass. And CPU support rounding convert.

This PR add a new pass `round_to_int` to avoid calling `to` in `quant` and remove the duplicate min/max. `round_to_int` will directly use rounding convert intrinsic on CPU and it will still decompose to `round+to` in other device. 
In addition, element `mul` and `add` can be fused to `fma` after remove round.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo