### PR TITLE
sdpa: Enforce requires_grad=False for attn_mask

### DIFF
--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -432,6 +432,9 @@ void cpu_flash_attention(
   const scalar_t* q_data = query.const_data_ptr<scalar_t>();
   const scalar_t* k_data = key.const_data_ptr<scalar_t>();
   const scalar_t* v_data = value.const_data_ptr<scalar_t>();
+  // NOTE: use of data_ptr over const_data_ptr here means that if the attn_mask is COW, it will be
+  // unnecessarily materialized (see also the allow_cow_input_materialize_forward kwarg to OpInfo
+  // for nn.functional.scaled_dot_product_attention in common_methods_invocations.py)
   mask_t* mask_data = has_attn_mask
       ? attn_mask.value().data_ptr<mask_t>()
       : nullptr;

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -530,8 +530,8 @@ inline void validate_sdpa_input(
       !query_.is_nested() && !key.is_nested(),
       "Scaled_dot_product_attention: Nested tensors for query / key are not supported "
       "when an explicit attn_mask is set");
+    TORCH_CHECK(!attn_mask_->requires_grad(), "attn_mask cannot require grad");
   }
-  return;
 }
 // This function is used to produce an attn_mask
 // in a standard format that can be consumed by both

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16660,6 +16660,9 @@ op_db: list[OpInfo] = [
         supports_forward_ad=False,
         supports_fwgrad_bwgrad=True,
         check_batched_forward_grad=False,
+        # NOTE: since changing the sample inputs to not apply requires_grad on attn_mask, on CPU,
+        # the flash attention kernel is now used which materializes the attn_mask if it is COW
+        allow_cow_input_materialize_forward=["attn_mask"],
         decorators=[DecorateInfo(toleranceOverride(
             {torch.float32: tol(atol=5e-05, rtol=5e-6)}), 'TestCommon',), ],
         skips=(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9019,6 +9019,7 @@ def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
 
 def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_grad, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    make_attn_mask = partial(make_tensor, device=device)
     batch, seq_q, seq_kv, num_heads, head_dim = 4, 3, 6, 4, 8
 
     dim_3_q_shape = (batch, seq_q, head_dim)
@@ -9053,13 +9054,24 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
         dropout_p=dropout_p
     )
 
-    # Add an attn_mask
+    # Add an attn_mask, with matching dtype
     samples.append(
         SampleInput(
             make((batch, num_heads, seq_q, head_dim)),
             make((batch, num_heads, seq_kv, head_dim)),
             make((batch, num_heads, seq_kv, head_dim)),
-            attn_mask=make((seq_q, seq_kv)),
+            attn_mask=make_attn_mask((seq_q, seq_kv), dtype=dtype),
+            is_causal=False,
+            dropout_p=0.0)
+    )
+
+    # Add a boolean attn_mask
+    samples.append(
+        SampleInput(
+            make((batch, num_heads, seq_q, head_dim)),
+            make((batch, num_heads, seq_kv, head_dim)),
+            make((batch, num_heads, seq_kv, head_dim)),
+            attn_mask=make_attn_mask((seq_q, seq_kv), dtype=torch.bool),
             is_causal=False,
             dropout_p=0.0)
     )


### PR DESCRIPTION
Requiring grad for the attention mask worked for the `MATH` backend because autograd was able to compute the grad naturally from the decomposition. However, this won't work for other SDPA backends, because there is no explicit grad output for the attention mask in their backward implementations.

Ensure the attention mask does not have `requires_grad=True` at the composite op level for all backends, update the sample inputs to not generate an attention mask requiring grad and add a sample input with a boolean `attn_mask` too.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01