### PR TITLE
[ROCm] Add gfx1150/gfx1151 (Strix Halo) architecture support

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -219,7 +219,7 @@ def is_tf32_supported() -> bool:
     r"""Return a bool indicating if the current CUDA/ROCm device supports dtype tf32."""
     if torch.version.hip:
         prop_name = torch.cuda.get_device_properties().gcnArchName
-        archs = ("gfx94", "gfx95")
+        archs = ("gfx94", "gfx95", "gfx115")
         for arch in archs:
             if arch in prop_name:
                 return True

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -104,8 +104,8 @@ SEED = 1234
 MI350_ARCH = ("gfx950",)
 MI300_ARCH = ("gfx942",)
 MI200_ARCH = ("gfx90a",)
-NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
-NAVI3_ARCH = ("gfx1100", "gfx1101")
+NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201")
+NAVI3_ARCH = ("gfx1100", "gfx1101", "gfx1150", "gfx1151")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
 
 class ProfilingMode(Enum):


### PR DESCRIPTION
## Summary

Add Strix Halo (gfx1150/gfx1151) RDNA3.5 architecture support to PyTorch:

1. **TF32 Support**: Add `gfx115` to the TF32-supported architectures in `torch/cuda/__init__.py`
2. **NAVI Architecture Lists**: Add `gfx1150`/`gfx1151` to `NAVI_ARCH` and `NAVI3_ARCH` in test utilities

## Background

Strix Halo (gfx1151) is AMD's RDNA3.5 APU with:
- Wave32 execution (like gfx1100/gfx1101)
- Up to 128GB unified memory
- TF32 support for AI workloads

This enables proper feature detection and test execution on Strix Halo hardware.

## Test Plan

- Verified architecture string matching follows existing NAVI3 patterns
- `is_tf32_supported()` will correctly return True for gfx1150/gfx1151
- `is_navi3_arch()` will correctly identify Strix Halo as NAVI3 family

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang