### PR TITLE
Fix integer overflow in avg_pool with large parameters

### DIFF
--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -29,7 +29,7 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
   const int64_t kW_val = kernel_size.size() == 1 ? kH_val : kernel_size[1];
   TORCH_CHECK(kH_val > 0 && kH_val <= std::numeric_limits<int>::max() &&
               kW_val > 0 && kW_val <= std::numeric_limits<int>::max(),
-    "avg_pool2d: kernel_size values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+    "integer out of range");
   const int kH = static_cast<int>(kH_val);
   const int kW = static_cast<int>(kW_val);
 
@@ -40,7 +40,7 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
   if (!stride.empty()) {
     TORCH_CHECK(dH_val > 0 && dH_val <= std::numeric_limits<int>::max() &&
                 dW_val > 0 && dW_val <= std::numeric_limits<int>::max(),
-      "avg_pool2d: stride values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+      "integer out of range");
   }
   const int dH = static_cast<int>(dH_val);
   const int dW = static_cast<int>(dW_val);
@@ -49,9 +49,10 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
     "avg_pool2d: padding must either be a single int, or a tuple of two ints");
   const int64_t padH_val = padding[0];
   const int64_t padW_val = padding.size() == 1 ? padH_val : padding[1];
-  TORCH_CHECK(padH_val >= 0 && padH_val <= std::numeric_limits<int>::max() &&
-              padW_val >= 0 && padW_val <= std::numeric_limits<int>::max(),
-    "avg_pool2d: padding values must be in range [0, ", std::numeric_limits<int>::max(), "]");
+  // note: negative padding is checked later in pool2d_shape_check with "pad must be non-negative" error
+  TORCH_CHECK(padH_val <= std::numeric_limits<int>::max() &&
+              padW_val <= std::numeric_limits<int>::max(),
+    "integer out of range");
   const int padH = static_cast<int>(padH_val);
   const int padW = static_cast<int>(padW_val);
 
@@ -127,7 +128,7 @@ TORCH_META_FUNC(avg_pool2d_backward) (
   const int64_t kW_val = kernel_size.size() == 1 ? kH_val : kernel_size[1];
   TORCH_CHECK(kH_val > 0 && kH_val <= std::numeric_limits<int>::max() &&
               kW_val > 0 && kW_val <= std::numeric_limits<int>::max(),
-    "avg_pool2d: kernel_size values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+    "integer out of range");
   const int kH = static_cast<int>(kH_val);
   const int kW = static_cast<int>(kW_val);
 
@@ -138,7 +139,7 @@ TORCH_META_FUNC(avg_pool2d_backward) (
   if (!stride.empty()) {
     TORCH_CHECK(dH_val > 0 && dH_val <= std::numeric_limits<int>::max() &&
                 dW_val > 0 && dW_val <= std::numeric_limits<int>::max(),
-      "avg_pool2d: stride values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+      "integer out of range");
   }
   const int dH = static_cast<int>(dH_val);
   const int dW = static_cast<int>(dW_val);
@@ -147,9 +148,10 @@ TORCH_META_FUNC(avg_pool2d_backward) (
     "avg_pool2d: padding must either be a single int, or a tuple of two ints");
   const int64_t padH_val = padding[0];
   const int64_t padW_val = padding.size() == 1 ? padH_val : padding[1];
-  TORCH_CHECK(padH_val >= 0 && padH_val <= std::numeric_limits<int>::max() &&
-              padW_val >= 0 && padW_val <= std::numeric_limits<int>::max(),
-    "avg_pool2d: padding values must be in range [0, ", std::numeric_limits<int>::max(), "]");
+  // note: negative padding is checked later in avg_pool2d_backward_shape_check with "pad must be non-negative" error
+  TORCH_CHECK(padH_val <= std::numeric_limits<int>::max() &&
+              padW_val <= std::numeric_limits<int>::max(),
+    "integer out of range");
   const int padH = static_cast<int>(padH_val);
   const int padW = static_cast<int>(padW_val);
 

--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -38,9 +38,12 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
   const int64_t dH_val = stride.empty() ? kH_val : stride[0];
   const int64_t dW_val = stride.empty() ? kW_val : (stride.size() == 1 ? dH_val : stride[1]);
   if (!stride.empty()) {
-    TORCH_CHECK(dH_val > 0 && dH_val <= std::numeric_limits<int>::max() &&
-                dW_val > 0 && dW_val <= std::numeric_limits<int>::max(),
-      "integer out of range");
+    // Check for negative values (invalid) and overflow (values > INT_MAX)
+    // Zero stride is validated later in pooling_output_shape with proper error message
+    if (dH_val < 0 || dH_val > std::numeric_limits<int>::max() ||
+        dW_val < 0 || dW_val > std::numeric_limits<int>::max()) {
+      TORCH_CHECK(false, "integer out of range");
+    }
   }
   const int dH = static_cast<int>(dH_val);
   const int dW = static_cast<int>(dW_val);
@@ -137,9 +140,12 @@ TORCH_META_FUNC(avg_pool2d_backward) (
   const int64_t dH_val = stride.empty() ? kH_val : stride[0];
   const int64_t dW_val = stride.empty() ? kW_val : (stride.size() == 1 ? dH_val : stride[1]);
   if (!stride.empty()) {
-    TORCH_CHECK(dH_val > 0 && dH_val <= std::numeric_limits<int>::max() &&
-                dW_val > 0 && dW_val <= std::numeric_limits<int>::max(),
-      "integer out of range");
+    // Check for negative values (invalid) and overflow (values > INT_MAX)
+    // Zero stride is validated later in pooling_output_shape with proper error message
+    if (dH_val < 0 || dH_val > std::numeric_limits<int>::max() ||
+        dW_val < 0 || dW_val > std::numeric_limits<int>::max()) {
+      TORCH_CHECK(false, "integer out of range");
+    }
   }
   const int dH = static_cast<int>(dH_val);
   const int dW = static_cast<int>(dW_val);

--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -25,19 +25,35 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
     "avg_pool2d: kernel_size must either be a single int, or a tuple of two ints");
-  const int kH = safe_downcast<int, int64_t>(kernel_size[0]);
-  const int kW = kernel_size.size() == 1 ? kH : safe_downcast<int, int64_t>(kernel_size[1]);
+  const int64_t kH_val = kernel_size[0];
+  const int64_t kW_val = kernel_size.size() == 1 ? kH_val : kernel_size[1];
+  TORCH_CHECK(kH_val > 0 && kH_val <= std::numeric_limits<int>::max() &&
+              kW_val > 0 && kW_val <= std::numeric_limits<int>::max(),
+    "avg_pool2d: kernel_size values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+  const int kH = static_cast<int>(kH_val);
+  const int kW = static_cast<int>(kW_val);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "avg_pool2d: stride must either be omitted, a single int, or a tuple of two ints");
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[0]);
-  const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : safe_downcast<int, int64_t>(stride[1]);
+  const int64_t dH_val = stride.empty() ? kH_val : stride[0];
+  const int64_t dW_val = stride.empty() ? kW_val : (stride.size() == 1 ? dH_val : stride[1]);
+  if (!stride.empty()) {
+    TORCH_CHECK(dH_val > 0 && dH_val <= std::numeric_limits<int>::max() &&
+                dW_val > 0 && dW_val <= std::numeric_limits<int>::max(),
+      "avg_pool2d: stride values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+  }
+  const int dH = static_cast<int>(dH_val);
+  const int dW = static_cast<int>(dW_val);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
     "avg_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = safe_downcast<int, int64_t>(padding[0]);
-  const int padW = padding.size() == 1 ? padH : safe_downcast<int, int64_t>(padding[1]);
+  const int64_t padH_val = padding[0];
+  const int64_t padW_val = padding.size() == 1 ? padH_val : padding[1];
+  TORCH_CHECK(padH_val >= 0 && padH_val <= std::numeric_limits<int>::max() &&
+              padW_val >= 0 && padW_val <= std::numeric_limits<int>::max(),
+    "avg_pool2d: padding values must be in range [0, ", std::numeric_limits<int>::max(), "]");
+  const int padH = static_cast<int>(padH_val);
+  const int padW = static_cast<int>(padW_val);
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0,
     "divisor must be not zero");
@@ -107,19 +123,35 @@ TORCH_META_FUNC(avg_pool2d_backward) (
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
     "avg_pool2d: kernel_size must either be a single int, or a tuple of two ints");
-  const int kH = safe_downcast<int, int64_t>(kernel_size[0]);
-  const int kW = kernel_size.size() == 1 ? kH : safe_downcast<int, int64_t>(kernel_size[1]);
+  const int64_t kH_val = kernel_size[0];
+  const int64_t kW_val = kernel_size.size() == 1 ? kH_val : kernel_size[1];
+  TORCH_CHECK(kH_val > 0 && kH_val <= std::numeric_limits<int>::max() &&
+              kW_val > 0 && kW_val <= std::numeric_limits<int>::max(),
+    "avg_pool2d: kernel_size values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+  const int kH = static_cast<int>(kH_val);
+  const int kW = static_cast<int>(kW_val);
 
   TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "avg_pool2d: stride must either be omitted, a single int, or a tuple of two ints");
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[0]);
-  const int dW = stride.empty() ? kW :
-                 stride.size() == 1 ? dH : safe_downcast<int, int64_t>(stride[1]);
+  const int64_t dH_val = stride.empty() ? kH_val : stride[0];
+  const int64_t dW_val = stride.empty() ? kW_val : (stride.size() == 1 ? dH_val : stride[1]);
+  if (!stride.empty()) {
+    TORCH_CHECK(dH_val > 0 && dH_val <= std::numeric_limits<int>::max() &&
+                dW_val > 0 && dW_val <= std::numeric_limits<int>::max(),
+      "avg_pool2d: stride values must be in range (0, ", std::numeric_limits<int>::max(), "]");
+  }
+  const int dH = static_cast<int>(dH_val);
+  const int dW = static_cast<int>(dW_val);
 
   TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
     "avg_pool2d: padding must either be a single int, or a tuple of two ints");
-  const int padH = safe_downcast<int, int64_t>(padding[0]);
-  const int padW = padding.size() == 1 ? padH : safe_downcast<int, int64_t>(padding[1]);
+  const int64_t padH_val = padding[0];
+  const int64_t padW_val = padding.size() == 1 ? padH_val : padding[1];
+  TORCH_CHECK(padH_val >= 0 && padH_val <= std::numeric_limits<int>::max() &&
+              padW_val >= 0 && padW_val <= std::numeric_limits<int>::max(),
+    "avg_pool2d: padding values must be in range [0, ", std::numeric_limits<int>::max(), "]");
+  const int padH = static_cast<int>(padH_val);
+  const int padW = static_cast<int>(padW_val);
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8789,6 +8789,15 @@ class TestNNDeviceType(NNTestCase):
                 padding=0
             )
 
+        # Zero stride (invalid)
+        with self.assertRaisesRegex(RuntimeError, r"stride should not be zero"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=2,
+                stride=0,  # Zero stride
+                padding=0
+            )
+
         # Extremely large stride (would overflow int)
         with self.assertRaisesRegex(RuntimeError, r"integer out of range"):
             torch.nn.functional.avg_pool2d(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8772,7 +8772,7 @@ class TestNNDeviceType(NNTestCase):
         x = torch.randn(1, 2, 4, 4, device=device, dtype=torch.float32)
 
         # Extremely large kernel_size (would overflow int)
-        with self.assertRaisesRegex(RuntimeError, r"kernel_size values must be in range"):
+        with self.assertRaisesRegex(RuntimeError, r"integer out of range"):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=(9223372036854775807, 100),  # INT64_MAX
@@ -8781,7 +8781,7 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Negative stride (invalid)
-        with self.assertRaisesRegex(RuntimeError, r"stride values must be in range"):
+        with self.assertRaisesRegex(RuntimeError, r"integer out of range"):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=2,
@@ -8790,7 +8790,7 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Extremely large stride (would overflow int)
-        with self.assertRaisesRegex(RuntimeError, r"stride values must be in range"):
+        with self.assertRaisesRegex(RuntimeError, r"integer out of range"):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=2,
@@ -8799,7 +8799,7 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Negative padding (invalid)
-        with self.assertRaisesRegex(RuntimeError, r"padding values must be in range"):
+        with self.assertRaisesRegex(RuntimeError, r"pad must be non-negative"):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=2,
@@ -8808,7 +8808,7 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Extremely large padding (would overflow int)
-        with self.assertRaisesRegex(RuntimeError, r"padding values must be in range"):
+        with self.assertRaisesRegex(RuntimeError, r"integer out of range"):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=2,
@@ -8817,7 +8817,7 @@ class TestNNDeviceType(NNTestCase):
             )
 
         # Combined invalid parameters
-        with self.assertRaisesRegex(RuntimeError, r"kernel_size values must be in range"):
+        with self.assertRaisesRegex(RuntimeError, r"integer out of range"):
             torch.nn.functional.avg_pool2d(
                 x,
                 kernel_size=(9223372036854775807, 5868783964474102731),
@@ -8835,6 +8835,7 @@ class TestNNDeviceType(NNTestCase):
             padding=0
         )
         self.assertEqual(result.shape, (1, 2, 3, 3))
+
 
     @onlyCUDA
     @largeTensorTest("24GB", "cpu")

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8763,6 +8763,79 @@ class TestNNDeviceType(NNTestCase):
         # reduce memory usage
         self.assertEqual(inp.grad.sum(), inp_cpu.grad.sum())
 
+    def test_avg_pool2d_invalid_parameters(self, device):
+        """Test that avg_pool2d properly validates parameters and prevents integer overflow.
+
+        This tests the fix for issue #145077 where extremely large or negative values
+        could cause crashes or undefined behavior.
+        """
+        x = torch.randn(1, 2, 4, 4, device=device, dtype=torch.float32)
+
+        # Extremely large kernel_size (would overflow int)
+        with self.assertRaisesRegex(RuntimeError, r"kernel_size values must be in range"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=(9223372036854775807, 100),  # INT64_MAX
+                stride=1,
+                padding=0
+            )
+
+        # Negative stride (invalid)
+        with self.assertRaisesRegex(RuntimeError, r"stride values must be in range"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=2,
+                stride=(-1, 2),  # Negative stride
+                padding=0
+            )
+
+        # Extremely large stride (would overflow int)
+        with self.assertRaisesRegex(RuntimeError, r"stride values must be in range"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=2,
+                stride=(1, 3010182406857593769),  # Extremely large
+                padding=0
+            )
+
+        # Negative padding (invalid)
+        with self.assertRaisesRegex(RuntimeError, r"padding values must be in range"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=2,
+                stride=1,
+                padding=(-1, 0)  # Negative padding
+            )
+
+        # Extremely large padding (would overflow int)
+        with self.assertRaisesRegex(RuntimeError, r"padding values must be in range"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=2,
+                stride=1,
+                padding=(9223372036854775807, 0)  # INT64_MAX
+            )
+
+        # Combined invalid parameters
+        with self.assertRaisesRegex(RuntimeError, r"kernel_size values must be in range"):
+            torch.nn.functional.avg_pool2d(
+                x,
+                kernel_size=(9223372036854775807, 5868783964474102731),
+                stride=(-1, 3010182406857593769),
+                padding=(0,),
+                ceil_mode=True,
+                count_include_pad=True
+            )
+
+        # Valid parameters should work fine
+        result = torch.nn.functional.avg_pool2d(
+            x,
+            kernel_size=2,
+            stride=1,
+            padding=0
+        )
+        self.assertEqual(result.shape, (1, 2, 3, 3))
+
     @onlyCUDA
     @largeTensorTest("24GB", "cpu")
     @largeTensorTest("24GB", "cuda")


### PR DESCRIPTION
Validate kernel_size, stride, and padding before casting to prevent crashes when values exceed INT32_MAX or are negative. Add validation in meta functions to protect all backends (CPU, CUDA, etc.).

Previously, safe_downcast would crash with values > 2147483647.

Fixes #145077