### PR TITLE
[folly][caffe2] Remove use of `folly:molly` target

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -1382,7 +1382,7 @@ def define_buck_targets(
             ":torch_mobile_deserialize",
             ":torch_mobile_headers",
             ":torch_mobile_observer",
-        ] + ([] if IS_OSS else ["//xplat/folly:molly"]),
+        ],
         exported_deps = [
             ":aten_cpu",
             ":torch_common",
@@ -1697,7 +1697,7 @@ def define_buck_targets(
             ":torch_mobile_headers",
             ":torch_mobile_observer",
             ":torch_mobile_core",
-        ] + ([] if IS_OSS else ["//xplat/folly:molly"]),
+        ],
         exported_deps = [
             ":aten_cpu",
             ":torch_common",


### PR DESCRIPTION
Summary: `folly:molly` is a re-exported target which brings in a bunch of dependencies. We should not need most if any of them.

Test Plan:
CI

```
$ buck build xplat/caffe2:torch_mobile_model_tracerAndroid[shared]
```

Reviewed By: rexzhang123

Differential Revision: D89693569


