### PR TITLE
Remove files from pyrefly excludes

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -23,14 +23,10 @@ project-includes = [
 project-excludes = [
   # ==== below will be enabled directory by directory ====
   # ==== to test Pyrefly on a specific directory, simply comment it out ====
-  "tools/linter/adapters/test_device_bias_linter.py",
   "tools/code_analyzer/gen_operators_yaml.py",
   "torch/_inductor/runtime/triton_heuristics.py",
   "torch/_inductor/runtime/triton_helpers.py",
   "torch/_inductor/runtime/halide_helpers.py",
-  "torch/utils/tensorboard/summary.py",
-  "torch/ao/quantization/pt2e/qat_utils.py",
-  "torch/_inductor/codegen/common.py",
   "torch/utils/data/typing.ipynb",
   "torch/utils/data/dataframes_pipes.ipynb",
   "torch/utils/data/standard_pipes.ipynb",

--- a/tools/linter/adapters/test_device_bias_linter.py
+++ b/tools/linter/adapters/test_device_bias_linter.py
@@ -102,7 +102,9 @@ class DeviceBiasVisitor(ast.NodeVisitor):
             return
         val = subnode.value
         if isinstance(val, ast.Constant) and any(
-            bias in val.value for bias in DEVICE_BIAS
+            # pyrefly: ignore [not-iterable, unsupported-operation]
+            bias in val.value
+            for bias in DEVICE_BIAS
         ):
             self.record(
                 subnode,
@@ -114,6 +116,7 @@ class DeviceBiasVisitor(ast.NodeVisitor):
                 and val.func.attr == "device"
                 and len(val.args) > 0
                 and isinstance(val.args[0], ast.Constant)
+                # pyrefly: ignore [not-iterable, unsupported-operation]
                 and any(bias in val.args[0].value for bias in DEVICE_BIAS)
             ):
                 self.record(
@@ -135,7 +138,9 @@ class DeviceBiasVisitor(ast.NodeVisitor):
         elif method_name == "to" and subnode.args:
             arg = subnode.args[0]
             if isinstance(arg, ast.Constant) and any(
-                bias in arg.value for bias in DEVICE_BIAS
+                # pyrefly: ignore [not-iterable, unsupported-operation]
+                bias in arg.value
+                for bias in DEVICE_BIAS
             ):
                 self.record(
                     subnode,
@@ -154,6 +159,7 @@ class DeviceBiasVisitor(ast.NodeVisitor):
                     and func.value.id == "torch"
                     and ctx_expr.args
                     and isinstance(ctx_expr.args[0], ast.Constant)
+                    # pyrefly: ignore [not-iterable, unsupported-operation]
                     and any(bias in ctx_expr.args[0].value for bias in DEVICE_BIAS)
                 ):
                     self.record(

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -960,6 +960,7 @@ def _all_in_parens(string: str) -> bool:
     return True
 
 
+# pyrefly: ignore [inconsistent-inheritance]
 class OpOverrides(BasicMathOpsMixin, OpDecompositions, OpsHandler[Any]):
     @staticmethod
     def paren(string: OpVarT) -> OpVarT:


### PR DESCRIPTION
Continuing work to expand the files that pyrefly type checks. 

Removed files from the excludes list, and silenced any errors that resulted. 


`pyrefly check --suppress-errors`
`lintrunner`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo