### PR TITLE
linalg: sort eigenvalues in eig/eigvals comparison tests

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2229,7 +2229,25 @@ class TestLinalg(TestCase):
 
             # compare eigenvalues with CPU
             expected = torch.linalg.eig(a.to(complementary_device))
-            self.assertEqual(expected[0], actual[0])
+
+            # sort eigenvalues because the order is not guaranteed
+            # move eigenvalues to CPU to ensure same sorting
+            actual_eigvals = actual[0].cpu()
+            expected_eigvals = expected[0].cpu()
+
+            idx = torch.argsort(actual_eigvals.imag, dim=-1)
+            actual_eigvals = torch.gather(actual_eigvals, -1, idx)
+
+            idx = torch.argsort(actual_eigvals.real, dim=-1)
+            actual_eigvals = torch.gather(actual_eigvals, -1, idx)
+
+            idx = torch.argsort(expected_eigvals.imag, dim=-1)
+            expected_eigvals = torch.gather(expected_eigvals, -1, idx)
+
+            idx = torch.argsort(expected_eigvals.real, dim=-1)
+            expected_eigvals = torch.gather(expected_eigvals, -1, idx)
+
+            self.assertEqual(expected_eigvals, actual_eigvals)
 
 
             # set tolerance for correctness check

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2255,6 +2255,10 @@ class TestLinalg(TestCase):
             w_only = torch.linalg.eigvals(a)
             self.assertEqual(w_only.shape, w.shape)
 
+            # move to CPU for better performance
+            w_only = w_only.cpu()
+            w = w.cpu()
+
             #check all eigenvalues found by eig are in eigvals output
             for batch_idx in itertools.product(*[range(s) for s in w.shape[:-1]]):
                 w_b = w[batch_idx]

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -111,22 +111,6 @@ def get_tunableop_untuned_filename():
     untuned_filename = f"{untuned_filename_base}{ordinal}.csv"
     return untuned_filename
 
-def _sort_complex_real_first(x):
-    """Sort complex values lexicographically by (real, imag) along the last dimension.
-    Intended for test comparisons only. Returns sorted x on CPU.
-    """
-
-    # move eigenvalues to CPU to ensure same sorting
-    x = x.cpu()
-
-    idx = torch.argsort(x.imag, dim=-1)
-    x = torch.gather(x, -1, idx)
-
-    idx = torch.argsort(x.real, dim=-1)
-    x = torch.gather(x, -1, idx)
-
-    return x
-
 
 class TestLinalg(TestCase):
     def setUp(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2511,7 +2511,25 @@ class TestLinalg(TestCase):
                 self.assertFalse(out.is_contiguous())
                 ans = torch.linalg.eigvals(a, out=out)
                 self.assertEqual(ans, out)
-                self.assertEqual(expected.to(complex_dtype), out)
+
+                # sort eigenvalues because the order is not guaranteed
+                # move eigenvalues to CPU to ensure same sorting
+                out = out.cpu()
+                expected = expected.cpu()
+
+                idx = torch.argsort(out.imag, dim=-1)
+                out = torch.gather(out, -1, idx)
+
+                idx = torch.argsort(out.real, dim=-1)
+                out = torch.gather(out, -1, idx)
+
+                idx = torch.argsort(expected.imag, dim=-1)
+                expected = torch.gather(expected, -1, idx)
+
+                idx = torch.argsort(expected.real, dim=-1)
+                expected = torch.gather(expected, -1, idx)
+
+                self.assertEqual(expected, out)
 
         shapes = [(0, 0),  # Empty matrix
                   (5, 5),  # Single matrix


### PR DESCRIPTION
Continuation of [#170430](https://github.com/pytorch/pytorch/pull/170430), now retargeted to `main`.

Thanks to @nikitaved and @lezcano for the feedback in the original PR.

**Motivation:**
Eigenvalues of a general matrix are only defined up to permutation, but the current test compares them elementwise. This can fail when different backends return the same spectrum in different orders.

**Solution:**
Since `eig` is already validated via the eigen-identity, this PR verifies `eigvals` by matching its eigenvalues to those returned by `eig` within tolerance (order-independent, one-to-one matching). This makes the backend comparison robust while still catching potential behavior changes when eigenvectors are not computed.

Thanks to @nikitaved for the distance-matrix formulation used for the matching.
