### PR TITLE
[ROCm][CI] Increase operator_microbenchmark.yml shards to avoid timeouts

### DIFF
--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -98,7 +98,9 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [
-          { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx942.1" },
+          { config: "operator_microbenchmark_test", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx942.1" },
+          { config: "operator_microbenchmark_test", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx942.1" },
+          { config: "operator_microbenchmark_test", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx942.1" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
There are currently timeouts with the operator_microbenchmarks: https://github.com/pytorch/pytorch/actions/runs/20688683143/workflow
This PR is meant to reduce those timeouts.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang