### PR TITLE
[Inductor] Add native ldexp lowering with libdevice/std::ldexp codegen

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -952,6 +952,10 @@ class CppOverrides(OpOverrides):
         return f"std::log2({x})"
 
     @staticmethod
+    def ldexp(x, n):
+        return f"std::ldexp({x}, {n})"
+
+    @staticmethod
     def nextafter(x, y):
         return f"std::nextafter({x}, {y})"
 

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -452,6 +452,10 @@ class HalideOverrides(OpOverrides):
         return f"hl.pow({a}, {b})"  # hl.fast_pow fails accuracy
 
     @staticmethod
+    def ldexp(x, n):
+        raise Unsupported("ldexp")
+
+    @staticmethod
     def log(x):
         return f"hl.log({x})"  # hl.fast_log fails accuracy
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1611,6 +1611,10 @@ class TritonOverrides(OpOverrides):
         return f"libdevice.log2({x})"
 
     @staticmethod
+    def ldexp(x, n):
+        return f"libdevice.ldexp({x}, {n}.to(tl.int32))"
+
+    @staticmethod
     @maybe_upcast_float32()
     def nextafter(x, y):
         return f"libdevice.nextafter({x}, {y})"

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -76,7 +76,6 @@ inductor_decompositions = get_decompositions(
         aten.gelu,
         aten.hardtanh,
         aten.lcm,
-        aten.ldexp,
         aten.leaky_relu,
         aten.linalg_vector_norm,
         aten._log_softmax,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -933,14 +933,15 @@ def register_pointwise(
     return fn
 
 
+register_op_dtype_propagation_rules(
+    "ldexp",
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    override_return_dtype=None,
+)
+
+
 @register_lowering(aten.ldexp, broadcast=True, type_promotion_kind=None)
 def ldexp_lowering(x: TensorBox, n: TensorBox):
-    register_op_dtype_propagation_rules(
-        "ldexp",
-        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-        override_return_dtype=None,
-    )
-
     ldexp_fn = ops_wrapper("ldexp")
 
     x_dtype = x.get_dtype()

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -398,6 +398,9 @@ class OpsHandler(Generic[T]):
     def log2(self, x0: T) -> T:
         raise NotImplementedError
 
+    def ldexp(self, x0: T, n: T) -> T:
+        raise NotImplementedError
+
     def nextafter(self, x0: T, x1: T) -> T:
         raise NotImplementedError
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14295,7 +14295,6 @@ op_db: list[OpInfo] = [
                         # automatic differentiation, but one of the arguments requires grad
                         # https://github.com/pytorch/pytorch/issues/68966
                         # Eager tests pass but there is an error in the inductor tests.
-                        DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_variant_consistency_eager'),
                         DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_conj_view'),
                         DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_neg_view'),
                         DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_neg_conj_view'),


### PR DESCRIPTION
Used a custom @register_lowering(aten.ldexp...) method in "torch/_inductor/lowering.py" that calls libdevice.ldexp or std::ldexp if the device is CUDA or CPU respectively and if the dtype of 'input' is a floating type and the dtype of 'other' is an integer type. Otherwise it falls back to a method that computes ldexp with the decomposition: input * pow(2, other) .   

Fixes #171624

cc
@ngimel 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos