### PR TITLE
[CUDA] Abate `thrust::distance` deprecation warnings

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/sparse/cuda/SoftMax.cu
@@ -316,7 +316,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
       [offsets_ptr] __device__(int64_t x, int64_t y) {
         return offsets_ptr[x] == offsets_ptr[y];
       });
-  auto new_sz = thrust::distance(
+  auto new_sz = ::cuda::std::distance(
       thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
   pool_sizes.resize_({new_sz});
 

--- a/aten/src/ATen/native/sparse/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/sparse/cuda/SoftMax.cu
@@ -316,8 +316,13 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
       [offsets_ptr] __device__(int64_t x, int64_t y) {
         return offsets_ptr[x] == offsets_ptr[y];
       });
+#if !defined(USE_ROCM)
   auto new_sz = ::cuda::std::distance(
       thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
+#else
+  auto new_sz = thrust::distance
+      thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
+#endif
   pool_sizes.resize_({new_sz});
 
   auto pool_offsets = pool_sizes.clone();

--- a/aten/src/ATen/native/sparse/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/sparse/cuda/SoftMax.cu
@@ -320,7 +320,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
   auto new_sz = ::cuda::std::distance(
       thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
 #else
-  auto new_sz = thrust::distance
+  auto new_sz = thrust::distance(
       thrust_ptr(pool_sizes.template data_ptr<int64_t>()), new_end.second);
 #endif
   pool_sizes.resize_({new_sz});


### PR DESCRIPTION
Fixes #ISSUE_NUMBER


cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia