### PR TITLE
Serialize from_node info in torch export serializer

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -2069,6 +2069,54 @@ class TestSaveLoad(TestCase):
         self.assertEqual(unf.int_buffer2.dtype, torch.uint8)
         self.assertEqual(unf.float_buffer.dtype, torch.float32)
 
+    def test_from_node_metadata_serialization(self):
+        """Test that from_node metadata is properly serialized and deserialized."""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv_layer = torch.nn.Conv2d(
+                    in_channels=1, out_channels=64, kernel_size=3, padding=1
+                )
+
+            def forward(self, x):
+                return self.conv_layer(x)
+
+        m = Model()
+        inputs = (torch.randn(1, 1, 32, 32),)
+
+        ep = export(m, inputs, strict=True)
+        reexported_ep = export(
+            ep.module(), inputs, strict=True
+        )  # for generating more complex from_node metadata
+        serialized = serialize(reexported_ep)
+        reexported_ep_loaded = deserialize(serialized)
+
+        # Verify that node names and from_node metadata are preserved after serialization/deserialization
+        self.assertEqual(
+            len(list(reexported_ep.graph_module.graph.nodes)),
+            len(list(reexported_ep_loaded.graph_module.graph.nodes)),
+        )
+        for node, node_loaded in zip(
+            reexported_ep.graph_module.graph.nodes,
+            reexported_ep_loaded.graph_module.graph.nodes,
+        ):
+            if node.op not in {"placeholder", "output"}:
+                from_node_orig = node.meta.get("from_node")
+                from_node_loaded = node_loaded.meta.get("from_node")
+
+                if from_node_orig is None:
+                    self.assertIsNone(from_node_loaded)
+                else:
+                    self.assertIsNotNone(from_node_loaded)
+                    self.assertEqual(len(from_node_orig), len(from_node_loaded))
+                    for node_source_orig, node_source_loaded in zip(
+                        from_node_orig, from_node_loaded
+                    ):
+                        self.assertEqual(
+                            node_source_orig.to_dict(), node_source_loaded.to_dict()
+                        )
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestSerializeCustomClass(TestCase):


### PR DESCRIPTION
Summary:
This change adds from_node metadata serialization support to the torch export serializer (torch.export.save) to unblock the pt2e compare_result API on reloaded model. Details can be found in https://fburl.com/workplace/jtrdc0f1.

The from_node information is needed in the deserialized exported graph for operator tracing and provenance tracking. This ensures that provenance information is preserved when models are saved and loaded using torch.export.save/load.

Test Plan: buck test fbcode//caffe2/test/export:test_serialize -- test_from_node_metadata_serialization

Differential Revision: D90127207


