### PR TITLE
Fix PixelUnshuffle stride overflow on CUDA with empty tensors

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -116,6 +116,10 @@ Tensor math_pixel_shuffle(const Tensor& self, int64_t upscale_factor) {
 Tensor math_pixel_unshuffle(const Tensor& self, int64_t downscale_factor) {
   check_pixel_unshuffle_shapes(self, downscale_factor);
 
+  if (self.numel() == 0) {
+    return self.clone();
+  }
+
   // Format: (B1, ..., Bn), C, H, W
   int64_t c = self.size(-3);
   int64_t h = self.size(-2);


### PR DESCRIPTION
Fixes #171536 

Fixes a CUDA-specific bug where torch.nn.PixelUnshuffle throws RuntimeError of Stride calculation overflowed when given empty input tensors with large downscale factors, while CPU handles it correctly.

I followed issue reporter's suggestion of  returning an empty tensor (consistent with CPU behavior).

Now both CPU and CUDA handle empty tensors consistently


cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia