### PR TITLE
[Inductor] [Blackwell] Create exhaustive configs for Blackwell template

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -3,6 +3,11 @@ import unittest
 
 import torch
 from torch._inductor import config
+from torch._inductor.template_heuristics.triton import (
+    BlackwellGPUGemmConfig,
+    CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
+    CUDABlackwellPersistentTMATemplateConfigHeuristic,
+)
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
@@ -302,6 +307,61 @@ class TestMaxAutotuneBlackwell(TestCase):
         ).check_count(write_api, write_count).run(code[0])
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
+
+
+@instantiate_parametrized_tests
+class TestBlackwellExhaustiveConfigs(TestCase):
+    """Tests for exhaustive config generation for Blackwell templates."""
+
+    # Expected valid values for each parameter based on _generate_exhaustive_configs
+    VALID_BLOCK_SIZES = {32, 64, 128, 256}
+    VALID_GROUP_M = {8}
+    VALID_NUM_STAGES = {2, 3, 4, 5, 6}
+    VALID_NUM_WARPS = {4, 8}
+    VALID_EPILOGUE_SUBTILE = {True, False}
+
+    @parametrize(
+        "heuristic_cls",
+        (
+            CUDABlackwellPersistentTMATemplateConfigHeuristic,
+            CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
+        ),
+    )
+    def test_exhaustive_configs_parameter_variety(self, heuristic_cls):
+        """Test that exhaustive configs have variety in all expected parameters."""
+        heuristic = heuristic_cls()
+        configs = heuristic.exhaustive_configs
+
+        # Ensure we have at least 128 configs
+        self.assertGreaterEqual(len(configs), 128)
+
+        # Collect all unique values for each parameter
+        block_m_values = set()
+        block_n_values = set()
+        block_k_values = set()
+        group_m_values = set()
+        num_stages_values = set()
+        num_warps_values = set()
+        epilogue_subtile_values = set()
+
+        for cfg in configs:
+            self.assertIsInstance(cfg, BlackwellGPUGemmConfig)
+            block_m_values.add(cfg.block_m)
+            block_n_values.add(cfg.block_n)
+            block_k_values.add(cfg.block_k)
+            group_m_values.add(cfg.group_m)
+            num_stages_values.add(cfg.num_stages)
+            num_warps_values.add(cfg.num_warps)
+            epilogue_subtile_values.add(cfg.epilogue_subtile)
+
+        # Verify multiple values exist for each parameter via set membership
+        self.assertEqual(block_m_values, self.VALID_BLOCK_SIZES)
+        self.assertEqual(block_n_values, self.VALID_BLOCK_SIZES)
+        self.assertEqual(block_k_values, self.VALID_BLOCK_SIZES)
+        self.assertEqual(group_m_values, self.VALID_GROUP_M)
+        self.assertEqual(num_stages_values, self.VALID_NUM_STAGES)
+        self.assertEqual(num_warps_values, self.VALID_NUM_WARPS)
+        self.assertEqual(epilogue_subtile_values, self.VALID_EPILOGUE_SUBTILE)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2067,6 +2067,32 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
                 "FLATTEN": flatten,
             }
 
+    @staticmethod
+    def _generate_exhaustive_configs() -> list[BaseConfig]:
+        configs: list[BaseConfig] = []
+        for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
+            [32, 64, 128, 256],
+            repeat=3,
+        ):
+            for num_stages in [2, 3, 4, 5, 6]:
+                # AutoWS doesn't work with num_warps < 4
+                for num_warps in [4, 8]:
+                    for EPILOGUE_SUBTILE in [True, False]:
+                        configs.append(
+                            BlackwellGPUGemmConfig(
+                                block_m=BLOCK_M,
+                                block_n=BLOCK_N,
+                                block_k=BLOCK_K,
+                                num_stages=num_stages,
+                                num_warps=num_warps,
+                                group_m=8,
+                                epilogue_subtile=EPILOGUE_SUBTILE,
+                                warp_specialize=True,
+                                flatten=True,
+                            )
+                        )
+        return configs
+
 
 # Scaled MM-specific mixin for scaled MM templates
 class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
@@ -2361,6 +2387,7 @@ class CUDABlackwellPersistentTMATemplateConfigHeuristic(
     def __init__(self) -> None:
         super().__init__()
         self.mm_configs = self.blackwell_persistent_mm_configs
+        self.exhaustive_configs = self._generate_exhaustive_configs()
 
 
 @register_template_heuristic(
@@ -2393,6 +2420,7 @@ class CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic(
             self.blackwell_persistent_mm_configs
             + self.blackwell_persistent_addmm_configs
         )
+        self.exhaustive_configs = self._generate_exhaustive_configs()
 
 
 @register_template_heuristic(


### PR DESCRIPTION
Summary: Adds the exhaustive template options for all of the Blackwell Triton configs.

Test Plan: Depends on CI.

Differential Revision: D89690936




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo