### PR TITLE
Suppress OpenMP pragma Werror when using re-cc

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -700,6 +700,8 @@ if(USE_FBGEMM)
     endif()
     target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
     target_compile_options_if_supported(asmjit -Wno-unused-variable)
+    # Suppress unknown-pragmas error when OpenMP is not available
+    target_compile_options_if_supported(fbgemm -Wno-error=unknown-pragmas)
   endif()
   if(USE_FBGEMM)
     list(APPEND Caffe2_DEPENDENCY_LIBS fbgemm)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169801
* #170258
* #170257
* __->__ #171739

Authored with claude code

Signed-off-by: Edward Z. Yang <ezyang@meta.com>