### PR TITLE
Fix some compiler warnings in pytorch

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -225,7 +225,7 @@ struct Vectorized {
     return vector;
   }
 // Workaround for https: //gcc.gnu.org/bugzilla/show_bug.cgi?id=117001
-#if __GNUC__ <= 12 && !defined(__clang__) && defined(__ARM_FEATURE_SVE)
+#if defined(__GNUC__) && __GNUC__ <= 12 && !defined(__clang__) && defined(__ARM_FEATURE_SVE)
   static Vectorized<T> __attribute__((optimize("-fno-tree-loop-vectorize")))
   blendv(
       const Vectorized<T>& a,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
@@ -283,6 +283,7 @@ def define_qnnpack(third_party, labels = []):
             "-O2",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
             "-fvisibility=default",
+            "-Wno-vla",
         ] + select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": [
@@ -388,6 +389,8 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-error=unused-variable",
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
+            "-Wno-empty-translation-unit",
+            "-Wno-gnu-pointer-arith",
         ] + select({
             "DEFAULT": [],
             "ovr_config//cpu:arm32": [

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/requantization/runtime-neon.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/requantization/runtime-neon.h
@@ -10,7 +10,7 @@
 
 #include <arm_neon.h>
 
-PYTORCH_QNNP_INLINE uint16x8_t
+static PYTORCH_QNNP_INLINE uint16x8_t
 sub_zero_point(const uint8x8_t va, const uint8x8_t vzp) {
 #if PYTORCH_QNNPACK_RUNTIME_QUANTIZATION
   // Run-time quantization

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/requantization/runtime-sse2.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/requantization/runtime-sse2.h
@@ -10,7 +10,7 @@
 
 #include <immintrin.h>
 
-PYTORCH_QNNP_INLINE __m128i
+static PYTORCH_QNNP_INLINE __m128i
 sub_zero_point(const __m128i va, const __m128i vzp) {
 #if PYTORCH_QNNPACK_RUNTIME_QUANTIZATION
   // Run-time quantization


### PR DESCRIPTION
Summary: The ARVR toolchains enable a lot more c++ warning and compliance flags.  Currently, things in xplat are opted out. Trying to fix any errors in xplat, to turn off this opt out.

Test Plan: CI

Differential Revision: D90033341




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01