### PR TITLE
[cuDNN][Convolution] Disable a cuDNN Convolution engine preemptively

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -410,18 +410,6 @@ struct ConvParams {
       return false;
     }
     static long cudnn_version = detail::getCUDAHooks().versionRuntimeCuDNN();
-    // broken on cuDNN 9.8 - 9.14
-    if (cudnn_version >= 90800 && cudnn_version < 91500) {
-      if (cudnn_conv_suggest_memory_format(input, weight) == at::MemoryFormat::Contiguous &&
-          (input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf) &&
-          weight.dim() == 5) {
-        for (int i = 2; i < weight.dim(); i++) {
-          if (weight.size(i) != 1) {
-            return false;
-          }
-        }
-      }
-    }
     if (needs_64bit_indexing_no_split(input, weight)) {
       if (!(cudnn_version >= 90300 && at::native::cudnnv8_enabled_check_debug())) {
         TORCH_WARN_ONCE("cuDNN cannot be used for large non-batch-splittable convolutions"

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -652,20 +652,20 @@ bool plan_errata_exception(
   // rule_id is an arbitrary string, here we use the issue number if there is
   // one
   static auto hardcoded_errata_json_handle = nlohmann::json::parse(R"(
-            { "version" : 1, 
-              "rules"   : 
-                [ 
-                    { "rule_id"             : "163539", 
+            { "version" : 1,
+              "rules"   :
+                [
+                    { "rule_id"             : "163539",
                       "operation"           : "ConvFwd",
-                      "engine"              : 23, 
-                      "cudnn_version_start" : 90800, 
-                      "cudnn_version_end"   : 91500 
+                      "engine"              : 23,
+                      "cudnn_version_start" : 90800,
+                      "cudnn_version_end"   : 91500
                     },
-                    { "rule_id"             : "ConvBwdData", 
+                    { "rule_id"             : "ConvBwdData",
                       "operation"           : "ConvBwdData",
-                      "engine"              : 23, 
-                      "cudnn_version_start" : 8000, 
-                      "cudnn_version_end"   : -1 
+                      "engine"              : 23,
+                      "cudnn_version_start" : 8000,
+                      "cudnn_version_end"   : -1
                     }
                 ]
             })");

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -649,6 +649,7 @@ bool plan_errata_exception(
     const std::string& executionPlanTag) {
   static bool has_json =
       cudnn_frontend::load_from_config(errata_json_handle, "");
+  // rule_id is an arbitrary string, here we use the issue number if there is one
   static auto hardcoded_errata_json_handle = nlohmann::json::parse(R"(
             { "version" : 1, 
               "rules"   : 
@@ -661,7 +662,7 @@ bool plan_errata_exception(
                     },
                     { "rule_id"             : "ConvBwdData", 
                       "operation"           : "ConvBwdData",
-                      "engine"              : 24, 
+                      "engine"              : 23, 
                       "cudnn_version_start" : 8000, 
                       "cudnn_version_end"   : -1 
                     }
@@ -677,11 +678,7 @@ bool plan_errata_exception(
                errata_json_handle,
                executionPlanTag,
                handle,
-               []() { return true; }) or
-        cudnn_frontend::check_errata(
-               hardcoded_errata_json_handle, executionPlanTag, handle, []() {
-                 return true;
-               });
+               []() { return true; });
   }
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -649,7 +649,8 @@ bool plan_errata_exception(
     const std::string& executionPlanTag) {
   static bool has_json =
       cudnn_frontend::load_from_config(errata_json_handle, "");
-  // rule_id is an arbitrary string, here we use the issue number if there is one
+  // rule_id is an arbitrary string, here we use the issue number if there is
+  // one
   static auto hardcoded_errata_json_handle = nlohmann::json::parse(R"(
             { "version" : 1, 
               "rules"   : 
@@ -675,10 +676,7 @@ bool plan_errata_exception(
         });
   } else {
     return cudnn_frontend::check_errata(
-               errata_json_handle,
-               executionPlanTag,
-               handle,
-               []() { return true; });
+        errata_json_handle, executionPlanTag, handle, []() { return true; });
   }
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -680,7 +680,7 @@ bool plan_errata_exception(
         errata_json_handle, executionPlanTag, handle, []() { return true; });
   } else {
     return false;
- }
+  }
 }
 
 void generate_and_filter_plans(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -653,12 +653,19 @@ bool plan_errata_exception(
             { "version" : 1, 
               "rules"   : 
                 [ 
+                    { "rule_id"             : "163539", 
+                      "operation"           : "ConvFwd",
+                      "engine"              : 23, 
+                      "cudnn_version_start" : 90800, 
+                      "cudnn_version_end"   : 91500 
+                    },
                     { "rule_id"             : "ConvBwdData", 
                       "operation"           : "ConvBwdData",
                       "engine"              : 24, 
                       "cudnn_version_start" : 8000, 
                       "cudnn_version_end"   : -1 
                     }
+                ]
             })");
   if (!has_json) {
     return cudnn_frontend::check_errata(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -662,12 +662,19 @@ bool plan_errata_exception(
             })");
   if (!has_json) {
     return cudnn_frontend::check_errata(
-        hardcoded_errata_json_handle, executionPlanTag, handle, []() { return true; });
+        hardcoded_errata_json_handle, executionPlanTag, handle, []() {
+          return true;
+        });
   } else {
     return cudnn_frontend::check_errata(
-        errata_json_handle, executionPlanTag, handle, []() { return true; })
-    or cudnn_frontend::check_errata(
-        hardcoded_errata_json_handle, executionPlanTag, handle, []() { return true; });
+               errata_json_handle,
+               executionPlanTag,
+               handle,
+               []() { return true; }) or
+        cudnn_frontend::check_errata(
+               hardcoded_errata_json_handle, executionPlanTag, handle, []() {
+                 return true;
+               });
   }
 }
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4226,7 +4226,9 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @serialTest()
     @dtypes(*(torch.half, torch.bfloat16))
     def test_conv3d_cudnn_backward_broken(self, device, dtype):
-        x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device, requires_grad=True)
+        x = torch.rand(
+            1, 16, 124, 1282, 722, dtype=dtype, device=device, requires_grad=True
+        )
         m = torch.nn.Conv3d(
             16,
             16,

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4202,23 +4202,52 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @onlyCUDA
     @largeTensorTest("48GB", "cuda")
     @serialTest()
+    @dtypes(*(torch.half, torch.bfloat16))
     def test_conv3d_cudnn_broken(self, device):
-        for dtype in (torch.half, torch.bfloat16):
-            x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device)
-            m = torch.nn.Conv3d(
-                16,
-                16,
-                kernel_size=(1, 3, 3),
-                padding=0,
-                stride=1,
-                bias=False,
-                dtype=dtype,
-                device=device,
-            )
-            with torch.backends.cudnn.flags(enabled=False):
-                yref = m(x)
-            y = m(x)
-            self.assertEqual(yref, y)
+        x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device)
+        m = torch.nn.Conv3d(
+            16,
+            16,
+            kernel_size=(1, 3, 3),
+            padding=0,
+            stride=1,
+            bias=False,
+            dtype=dtype,
+            device=device,
+        )
+        with torch.backends.cudnn.flags(enabled=False):
+            yref = m(x)
+        y = m(x)
+        self.assertEqual(yref, y)
+
+    @skipCUDAIfRocm
+    @onlyCUDA
+    @largeTensorTest("96GB", "cuda")
+    @serialTest()
+    @dtypes(*(torch.half, torch.bfloat16))
+    def test_conv3d_cudnn_backward_broken(self, device, dtype):
+        x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device, requires_grad=True)
+        m = torch.nn.Conv3d(
+            16,
+            16,
+            kernel_size=(1, 3, 3),
+            padding=0,
+            stride=1,
+            bias=False,
+            dtype=dtype,
+            device=device,
+        )
+        with torch.backends.cudnn.flags(enabled=False):
+            yref = m(x)
+            grad = torch.randn_like(yref)
+            yref.backward(grad)
+        gradref = x.grad
+        x.grad = None
+        y = m(x)
+        y.backward(grad)
+        self.assertEqual(yref, y)
+        atol = 5e-3 if dtype == torch.half else 5e-2
+        self.assertEqual(gradref, x.grad, atol=atol, rtol=1e-3)
 
     @onlyCUDA
     @largeTensorTest("20GB")

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4203,7 +4203,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @largeTensorTest("48GB", "cuda")
     @serialTest()
     @dtypes(*(torch.half, torch.bfloat16))
-    def test_conv3d_cudnn_broken(self, device):
+    def test_conv3d_cudnn_broken(self, device, dtype):
         x = torch.rand(1, 16, 124, 1282, 722, dtype=dtype, device=device)
         m = torch.nn.Conv3d(
             16,


### PR DESCRIPTION
Internal testing seems to show numerical issues even though heuristics is not selecting it for the affected use-case

Also introduces json-based errata filter for future reference.

cc @csarofeen @ptrblck @xwang233 @nWEIdia @msaroufim @jerryzh168 @tinglvv @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01