### PR TITLE
[kineto] Add custom config options to selectively disable MTIA profiler event types

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -281,7 +281,28 @@ void prepareTrace(
     k_activities.insert(kXpuTypes.begin(), kXpuTypes.end());
   }
   if (activities.count(torch::autograd::profiler::ActivityType::MTIA)) {
-    k_activities.insert(kMtiaTypes.begin(), kMtiaTypes.end());
+    if (config.custom_profiler_config.empty()) {
+      k_activities.insert(kMtiaTypes.begin(), kMtiaTypes.end());
+    } else {
+      if (config.custom_profiler_config.find("disable_runtime_events") ==
+          std::string::npos) {
+        k_activities.insert(libkineto::ActivityType::MTIA_RUNTIME);
+      } else {
+        LOG(INFO) << "Disabling MTIA runtime events";
+      }
+      if (config.custom_profiler_config.find("disable_ccp_events") ==
+          std::string::npos) {
+        k_activities.insert(libkineto::ActivityType::MTIA_CCP_EVENTS);
+      } else {
+        LOG(INFO) << "Disabling MTIA CCP events";
+      }
+      if (config.custom_profiler_config.find("disable_insight_events") ==
+          std::string::npos) {
+        k_activities.insert(libkineto::ActivityType::MTIA_INSIGHT);
+      } else {
+        LOG(INFO) << "Disabling MTIA insight events";
+      }
+    }
   }
   if (activities.count(torch::autograd::profiler::ActivityType::HPU)) {
     k_activities.insert(hpuTypes.begin(), hpuTypes.end());


### PR DESCRIPTION
Summary:
Add support for selectively disabling MTIA profiler event types (runtime, CCP, insight) via `custom_profiler_config` parameter of `experimental_config`. This enables overhead benchmarking for individual MTIA profiler components by allowing users to disable specific event types while keeping others enabled.

Previously, enabling ProfilerActivity.MTIA would turn on all MTIA profiler types (runtime, CCP, and insight events) together, making it impossible to isolate and measure the overhead of individual components.

The following config options are now supported:

`disable_runtime_events` - Disables MTIA runtime event collection
`disable_ccp_events` - Disables MTIA CCP event collection
`disable_insight_events` - Disables MTIA insight event collection

**Example usage**
```
# Dsiable MTIA runtime and insight profiler events and only collect CCP events
with profile(
        activities=[ProfilerActivity.MTIA, ProfilerActivity.CPU],
        with_stack=False,
        record_shapes=True,
        experimental_config=_ExperimentalConfig(
        custom_profiler_config="disable_runtime_events,disable_insight_events\n" # <- string containing disable options separated by commas and finished with a newline
    ),
) as prof:
    # code to profile
```

Test Plan:
- Modified `test_kernel.py` to use the new config options to disable different event types while profiling
- Verified that only CCP events are collected when using `custom_profiler_config="disable_runtime_events,disable_insight_events\n"`
https://fburl.com/rs35cuut
{F1984397794} 
- Verified that only runtime events are collected when using `custom_profiler_config="disable_ccp_events,disable_insight_events\n"`
https://fburl.com/c4inon0f
 {F1984397808}

Differential Revision: D89936607


