### PR TITLE
[dynamo] Disable gc after compile by default on free-threaded python

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -390,7 +390,7 @@ class TestDynamoTimed(TestCase):
             self.run_forward_backward()
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
 
-        def filter_expected(s):
+        def filter_expected(s: str) -> str:
             d = eval(s)
             if not dynamo_config.run_gc_after_compile:
                 d.pop("gc", None)

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -390,12 +390,20 @@ class TestDynamoTimed(TestCase):
             self.run_forward_backward()
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
 
+        def filter_expected(s):
+            d = eval(s)
+            if not dynamo_config.run_gc_after_compile:
+                d.pop("gc", None)
+                if "gc_time_us" in d:
+                    d["gc_time_us"] = None
+            return pprint.pformat(d)
+
         # Validate utils.compile_times(). Unfortunately, we can't test the output
         # reliably because it depends on whether 'tabulate' is installed. So we'll
         # directly inspect the dict it prints instead:
         self.assertExpectedInline(
             pprint.pformat(utils.compilation_time_metrics),
-            (
+            filter_expected(
                 """\
 {'GraphLowering.codegen': [0.0, 0.0],
  'GraphLowering.compile_to_fn': [0.0, 0.0],
@@ -466,7 +474,7 @@ class TestDynamoTimed(TestCase):
         time_spent = utils.calculate_time_spent()
         self.assertExpectedInline(
             pprint.pformat(time_spent),
-            (
+            filter_expected(
                 """\
 {'_recursive_joint_graph_passes': 0.0,
  '_recursive_post_grad_passes': 0.0,
@@ -529,7 +537,7 @@ class TestDynamoTimed(TestCase):
         del raw["guard_latency_us"]
         self.assertExpectedInline(
             pprint.pformat(raw),
-            (
+            filter_expected(
                 """\
 {'accumulated_cache_size': 0,
  'aot_autograd_cumulative_compile_time_us': 0,

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -13,6 +13,7 @@ behavior, including:
 import getpass
 import os
 import sys
+import sysconfig
 import tempfile
 from collections.abc import Callable
 from os.path import abspath, dirname
@@ -763,7 +764,8 @@ pt2_compile_id_prefix: Optional[str] = os.environ.get("PT2_COMPILE_ID_PREFIX", N
 
 # Run GC at the end of compilation
 run_gc_after_compile = Config(  # type: ignore[var-annotated]
-    default=True,
+    # Disable by default on free-threaded builds since they always do a full collection, which can be slow
+    default=sysconfig.get_config_var("Py_GIL_DISABLED") != 1,
     justknob="pytorch/compiler:enable_run_gc_after_compile",
     env_name_default="TORCH_DYNAMO_RUN_GC_AFTER_COMPILE",
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #167407
* #167577
* #167376
* __->__ #171749

Currently dynamo calls `gc.collect(1)` after each compilation attempt.  This does a partial collection in default python,
but a full collection in free-threaded python.  In local testing this is a difference of .015s vs .04s (default vs
free-threaded).  This doesn't matter much for simple compiled functions, but adds up for functions that require many
compilation attempts.  For example, compiling scipy.stats.kstest takes 10.6s with gc vs 5.8s without.

This seems to have been added primarily to address https://github.com/pytorch/pytorch/issues/139734 so will need to make
sure that test isn't affected

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo