### PR TITLE
[inductor] config for MixOrderRed numel threshold

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1746,6 +1746,11 @@ class triton:
         == "1"
     )
 
+    # the fused version may have worse perf than non-fused version for
+    # small workload. When a workload is small enough, data can be
+    # fully cached in GPU L2 cache.
+    mix_order_reduction_numel_threshold = 5 * 2**20
+
     enable_tlx_templates: bool = (
         os.environ.get("TORCHINDUCTOR_ENABLE_TLX_TEMPLATES", "0") == "1"
     )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1746,9 +1746,10 @@ class triton:
         == "1"
     )
 
-    # the fused version may have worse perf than non-fused version for
+    # The fused version may have worse perf than non-fused version for
     # small workload. When a workload is small enough, data can be
-    # fully cached in GPU L2 cache.
+    # fully cached in GPU L2 cache. We skip MixOrderReduction when
+    # `num_columns * num_rows` is smaller than this threshold.
     mix_order_reduction_numel_threshold = 5 * 2**20
 
     enable_tlx_templates: bool = (

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -271,15 +271,12 @@ class MixOrderReduction:
         nrow = sympy.Max(g1[0], g1[1])
         ncol = sympy.Min(g1[0], g1[1])
 
-        # the fused version has worse perf than non-fused version for
-        # small workload. When a workload is small enough, data can be
-        # fully cached by L2
-        size_thres = 5 * 2**20
-
         # Call evaluate_expr rather than statically_known_geq since nrow can
         # have dynamic shape in real models.
         # Don't use hint directly since hint can be non-representative.
-        if not V.graph.sizevars.evaluate_expr(sympy.Ge(nrow * ncol, size_thres)):
+        if not V.graph.sizevars.evaluate_expr(
+            sympy.Ge(nrow * ncol, config.triton.mix_order_reduction_numel_threshold)
+        ):
             return False
 
         # We require more more row than columns since


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171753

The default config causes recompilation for some internal use cases. E.g. for some input the numel check pass; while for others they don't.

Make the threshold a config to enable people to tune the config for their use cases.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo