### PR TITLE
[torchbench] Add cinder option

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4170,14 +4170,16 @@ def run(runner, args, original_dir=None):
             write_outputs(output_filename, [], [args.only, batch_size])
         return
 
+    should_profile_details = args.profile_details
     args.profile_details = {}
     if args.export_profiler_trace:
-        if args.profile_details:
+        if should_profile_details:
             args.profile_details = {
                 "record_shapes": True,
                 "profile_memory": True,
                 "with_stack": True,
                 "with_modules": True,
+                "activities": [torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
             }
 
         if args.profiler_trace_name is None:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3240,6 +3240,11 @@ def parse_args(args=None):
         help="Use same settings as --inductor for baseline comparisons",
     )
     parser.add_argument(
+        "--cinder-jit",
+        action="store_true",
+        help="Enable CinderX JIT via cinderx.jit.auto() before running benchmarks",
+    )
+    parser.add_argument(
         "--suppress-errors",
         action="store_true",
         help="Suppress errors instead of raising them",
@@ -3791,6 +3796,13 @@ def run(runner, args, original_dir=None):
     # Pass the parsed args object to benchmark runner object
     torch._dynamo.reset()
     runner.args = args
+
+    if args.cinder_jit:
+        import cinderx.jit
+
+        # cinderx.jit.auto()
+        cinderx.jit.compile_after_n_calls(10)
+        log.info("CinderX JIT enabled via cinderx.jit.auto()")
 
     args.filter = args.filter or [r"."]
     args.exclude = args.exclude or [r"^$"]


### PR DESCRIPTION
Summary:
Add an option to enable cinder jit for torchbench. We've tested both auto and compile after 10 invocations seems to be a good default to run the most.

This diff also adds small script to detect gpu and run proper bench.

Test Plan:
```
 ./scripts/sashko/cinder_torchbench.sh
```

Or directly run

```
buck2 run mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.nvcc_arch=b200a \
  -c fbcode.platform010_cuda_version=12.8 \
  //pytorch/benchmark:pt2 -- \
  --only hf_GPT2 \
  --device=cuda \
  --backend=inductor \
  --performance \
  --training \
  --iterations 3 \
  --batch-size 16 \
  --export-profiler-trace \
  --profile-details \
  --profiler-trace-name /tmp/jit_kineto_trace.json \
  --cinder-jit
```

See JIT enabled. Look in logs like 

```
============================================================
PYTHON OVERHEAD SUMMARY (exposed = time blocking GPU)
============================================================
  Total Python Duration:         13.48 ms
  Exposed Python Duration:        0.57 ms
  Overhead Percentage:             4.2 %
============================================================
```

Full results

```
| GPU   | JIT   | Total Python Duration (ms) | Exposed Python Duration (ms) | Overhead Percentage |
|-------|-------|---------------------------|------------------------------|---------------------|
| B200  | Yes   | 13.48                     | 0.57                         | 4.2%                |
| B200  | No    | 328.79                    | 192.18                       | 58.4%               |
| H100  | Yes   | 15.65                     | 0.04                         | 0.2%                |
| H100  | No    | 370.96                    | 107.54                       | 29.0%               |
| A100  | Yes   | 42.91                     | 8.20                         | 19.1%               |
| A100  | No    | 678.40                    | 169.93                       | 25.0%               |
```

Differential Revision: D90118048




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo