### PR TITLE
[POC] Recursive Dynamo compilation

### DIFF
--- a/spike.py
+++ b/spike.py
@@ -1,0 +1,201 @@
+"""
+Spike: Recursive Dynamo Tracing - Step 2
+
+Goal: Demonstrate that torch.compile can trace through a pre-existing torch.compile
+region and have the graph invocation appear as an invoke_subgraph HOP in the graph.
+
+With the modifications to PyTorch:
+1. When Dynamo encounters a function with a cached compilation, it uses invoke_subgraph
+   instead of inlining the function
+2. The cached GraphModule is installed in the outer graph's nn_modules
+3. No guard evaluation - we assume the first cache entry hits
+"""
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+
+def simple_fn(x, y):
+    """A simple function to compile."""
+    return x * 2 + y
+
+
+# Test inputs
+x = torch.randn(3, 3)
+y = torch.randn(3, 3)
+
+
+# =============================================================================
+# Test 1: make_fx tracing (previous test - should still work)
+# =============================================================================
+print("=" * 60)
+print("Test 1: make_fx tracing with invoke_subgraph")
+print("=" * 60)
+
+from torch.fx.experimental.proxy_tensor import make_fx
+
+# Step 1: Create a compiled function
+compiled_fn = torch.compile(simple_fn, backend="eager")
+
+# Step 2: Warm up with FakeTensor to match the tracing context
+print("Warming up compiled function with FakeTensor...")
+fake_mode = FakeTensorMode()
+with fake_mode:
+    fake_x = fake_mode.from_tensor(x)
+    fake_y = fake_mode.from_tensor(y)
+    warmup_result = compiled_fn(fake_x, fake_y)
+    print(f"Warmup result shape: {warmup_result.shape}")
+print()
+
+
+# Step 3: Define an outer function that calls the compiled function
+def outer_fn(x, y):
+    z = x + 1
+    result = compiled_fn(z, y)
+    return result * 2
+
+
+# Step 4: Trace the outer function with make_fx
+print("Tracing outer function with make_fx(tracing_mode='symbolic')...")
+try:
+    traced = make_fx(outer_fn, tracing_mode="symbolic")(x, y)
+    print("\n✓ SUCCESS! Traced graph:")
+    print(traced.code)
+
+    # Check for invoke_subgraph in the graph
+    print("\nAnalyzing graph nodes:")
+    found_invoke_subgraph = False
+    for node in traced.graph.nodes:
+        if node.op == "call_function":
+            if "invoke_subgraph" in str(node.target):
+                found_invoke_subgraph = True
+                print(f"  ✓ Found invoke_subgraph node: {node}")
+                print(f"    Target: {node.target}")
+                print(f"    Args: {node.args}")
+
+    if not found_invoke_subgraph:
+        print("  ✗ No invoke_subgraph node found")
+        print("\n  All call_function nodes:")
+        for node in traced.graph.nodes:
+            if node.op == "call_function":
+                print(f"    {node}: {node.target}")
+
+    # Verify execution still works
+    print("\nVerifying execution:")
+    expected = (x + 1) * 2 + y  # z = x + 1, then z * 2 + y
+    expected = expected * 2  # final * 2
+    actual = traced(x, y)
+    # Note: the graph might return a tuple - handle that
+    if isinstance(actual, tuple):
+        actual = actual[0]
+    print(f"  Expected shape: {expected.shape}")
+    print(f"  Actual shape: {actual.shape}")
+    print(f"  Values match: {torch.allclose(actual, expected)}")
+
+except Exception as e:
+    import traceback
+    print(f"\n✗ Error: {e}")
+    traceback.print_exc()
+
+print()
+
+# =============================================================================
+# Test 2: Recursive torch.compile - outer compile calls inner compile
+# =============================================================================
+print("=" * 60)
+print("Test 2: Recursive torch.compile with invoke_subgraph")
+print("=" * 60)
+
+# Reset the cache and create fresh functions
+torch._dynamo.reset()
+from torch._dynamo.output_graph import _invoke_subgraph_cache
+_invoke_subgraph_cache.clear()
+
+
+def inner_fn(x, y):
+    """The inner function that gets compiled first."""
+    return x * 2 + y
+
+
+# Step 1: Compile the inner function first
+inner_compiled = torch.compile(inner_fn, backend="eager")
+
+# Step 2: Warm up the inner compiled function
+print("Step 1: Warming up inner compiled function...")
+with FakeTensorMode() as fake_mode:
+    fake_x = fake_mode.from_tensor(x)
+    fake_y = fake_mode.from_tensor(y)
+    inner_warmup = inner_compiled(fake_x, fake_y)
+    print(f"  Inner warmup result shape: {inner_warmup.shape}")
+
+print(f"  Cache entries: {len(_invoke_subgraph_cache)}")
+print()
+
+
+# Step 3: Define an outer function that calls the inner compiled function
+def outer_fn_for_compile(x, y):
+    z = x + 1
+    result = inner_compiled(z, y)
+    return result * 2
+
+
+# Step 4: Compile the outer function - this should detect the inner compilation
+#         and use invoke_subgraph instead of re-inlining
+print("Step 2: Compiling outer function (should use invoke_subgraph for inner)...")
+
+# Use a custom backend to capture the graph
+captured_graphs = []
+
+def capture_backend(gm, example_inputs):
+    global captured_graphs
+    captured_graphs.append(gm)
+    print(f"\n  Captured graph #{len(captured_graphs)}:")
+    print(gm.code)
+    # Wrap with torch._dynamo.disable to prevent re-tracing during execution
+    return torch._dynamo.disable(gm.forward)
+
+outer_compiled = torch.compile(outer_fn_for_compile, backend=capture_backend, fullgraph=True)
+
+try:
+    # Run the outer compiled function - this triggers compilation
+    result = outer_compiled(x, y)
+
+    if captured_graphs:
+        print(f"\nAnalyzing captured graphs ({len(captured_graphs)} total):")
+        for i, graph in enumerate(captured_graphs):
+            print(f"\n  Graph #{i+1}:")
+            found_invoke_subgraph = False
+            for node in graph.graph.nodes:
+                if node.op == "call_function":
+                    if "invoke_subgraph" in str(node.target):
+                        found_invoke_subgraph = True
+                        print(f"    ✓ Found invoke_subgraph node: {node}")
+                        print(f"      Target: {node.target}")
+                        print(f"      Args: {node.args}")
+
+            if not found_invoke_subgraph:
+                print("    ✗ No invoke_subgraph node found")
+                print("    All call_function nodes:")
+                for node in graph.graph.nodes:
+                    if node.op == "call_function":
+                        print(f"      {node}: {node.target}")
+
+    # Verify correctness
+    print("\nVerifying execution:")
+    expected = (x + 1) * 2 + y  # z = x + 1, then z * 2 + y
+    expected = expected * 2  # final * 2
+    print(f"  Expected shape: {expected.shape}")
+    # Handle tuple result
+    actual = result[0] if isinstance(result, tuple) else result
+    print(f"  Actual shape: {actual.shape}")
+    print(f"  Values match: {torch.allclose(actual, expected)}")
+
+except Exception as e:
+    import traceback
+    print(f"\n✗ Error: {e}")
+    traceback.print_exc()
+
+print()
+print("=" * 60)
+print("Done")
+print("=" * 60)

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1294,6 +1294,11 @@ def is_from_skip_guard_source(source: Source) -> bool:
     if isinstance(source, SkipGuardSource):
         return True
 
+    # SPIKE: Skip guards from TorchFunctionModeStackSource to enable recursive tracing
+    # The torch_fn_counts dict changes during tracing, causing guard failures
+    if isinstance(source, TorchFunctionModeStackSource):
+        return True
+
     if isinstance(source, ChainedSource):
         return is_from_skip_guard_source(source.base)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #171766

Authored with claude code. Many spots are intentionally implemented incorrectly; the point here is to just show that it is possible.

PROMPT 1:

We're going to implement recursive Dynamo tracing. The idea is that we will be
able to trace through a pre-existing torch.compile region from an outer
torch.compile, and when we hit the Dynamo bytecode that calls into graph, we
then go ahead and inline that graph into our trace.  We will do this in steps.
First, we need to make sure we can identify the graph invocation inside of the
Dynamo residual bytecode and trace that as a HOP invoke_subgraph call. Let's
test this functionality by doing a make_fx on some code that calls a
torch.compile with backend="aot_eager". Furthermore, we need the AOTAutograd
produced wrapper code to be wrapped in an allow_in_graph style annotation that
will induce make_fx to directly put the call into the graph. Write a small
test script in spike.py which exhibits this, and stop to let me look at it.

PROMPT 2:

OK, let's start patching PyTorch. Modification: for the inner compile region,
we're not going to even run AOTAutograd. It will just be Dynamo eager
GraphModule. This way, we can feed it to invoke_subgraph directly. In Dynamo's
residual bytecode construction, we should (for now unconditionally) wrap the
call into the graph with the invoke_subgraph wrapper. Let's also disable
(unconditionally, for now) the logic which blocks going into torch.compile
while doing fx tracing; we only need to block *compilation* (we will assume
we've warmed up all of the compile blocks before we do our actual trace).
Here, the simpler spike should pass. You can delete the POC KEY TEST then.

To avoid the compile during tracing let us first warm up with fake tensors without tracing, and then run again with tracing. To do this we must ensure the guards don't invalidate our trace when we do proxy. The torch dispatch guards likely will. Let's comment those guards out too for the spike.

PROMPT 3:

OK, let's now make it work with a recursive torch.compile on the outside.
The main difference is that we need to simulate the eval frame handler that
the inner torch.compile sets. To do this, whenever we enter a code object,
we need to manually check if there is a Dynamo cache entry for it. There are
some APIs for doing this that are bound from C. We won't evaluate guards (as
many of them are in C++) and will simply assume that the first entry hits
(we will need to eventually fix this). Once we have the code object we can
continue Dynamo tracing in it. Dynamo shouldn't trace into compiled_fn. This function should be directly allow_in_graph'ed. You can apply that decorator to the function to force this.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo