### PR TITLE
[Windows] Improve robustness of cpp extension build root & tempdir cleanup

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -19,7 +19,7 @@ import torch.multiprocessing as mp
 import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
-from torch.testing._internal.common_utils import gradcheck, TEST_XPU
+from torch.testing._internal.common_utils import gradcheck, TEST_XPU, win_safe_rmtree
 from torch.utils.cpp_extension import (
     _get_cuda_arch_flags,
     _TORCH_PATH,
@@ -155,9 +155,7 @@ class TestCppExtensionJIT(common.TestCase):
             self.assertEqual(z, torch.ones_like(z))
         finally:
             if IS_WINDOWS:
-                # rmtree returns permission error: [WinError 5] Access is denied
-                # on Windows, this is a workaround
-                subprocess.run(["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE)
+                win_safe_rmtree(temp_dir)
             else:
                 shutil.rmtree(temp_dir)
 
@@ -303,9 +301,7 @@ class TestCppExtensionJIT(common.TestCase):
                 _check_cuobjdump_output(expected[1], is_ptx=True)
         finally:
             if IS_WINDOWS:
-                # rmtree returns permission error: [WinError 5] Access is denied
-                # on Windows, this is a word-around
-                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE)
+                win_safe_rmtree(temp_dir)
             else:
                 shutil.rmtree(temp_dir)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5814,7 +5814,7 @@ def win_safe_rmtree(path):
     try:
         shutil.rmtree(path, onerror=handle_error)
     except Exception:
-        log.exception("Fatal exception during directory traversal for %s", path)
+        log.exception("Fatal exception during directory removal for %s", path)
 
 def remove_cpp_extensions_build_root():
     """

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5778,7 +5778,7 @@ def win_safe_rmtree(path):
         """
         # exc_info is a tuple: (type, value, traceback)
         exc_type, exc_value, exc_traceback = exc_info
-        
+
         # 1. Attempt to fix permission issues (e.g., read-only files)
         try:
             # S_IWRITE ensures the file is writable, bypassing WinError 5 for attributes
@@ -5794,7 +5794,7 @@ def win_safe_rmtree(path):
         # WinError 32: The file is being used by another process (Sharing Violation)
         # WinError 5: Access is denied (Common when a DLL/.pyd is loaded in memory)
         winerror = getattr(exc_value, 'winerror', None)
-        
+
         if winerror in (5, 32):
             log.warning(
                 "Cleanup skipped: Build artifact is locked. "
@@ -5813,8 +5813,8 @@ def win_safe_rmtree(path):
     # Execute rmtree using the logic above
     try:
         shutil.rmtree(path, onerror=handle_error)
-    except Exception as e:
-        log.error("Fatal exception during directory traversal for %s: %s", path, e)
+    except Exception:
+        log.exception("Fatal exception during directory traversal for %s", path)
 
 def remove_cpp_extensions_build_root():
     """

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5789,7 +5789,7 @@ def win_safe_rmtree(path):
         except Exception:
             # If chmod doesn't solve it, move to lock detection
             pass
-            
+
         # 2. If it's a lock (5/32) or any other failure, raise it!
         # This is CRITICAL for the outer retry loop to catch it.
         raise exc_value

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5811,10 +5811,17 @@ def win_safe_rmtree(path):
             )
 
     # Execute rmtree using the logic above
-    try:
-        shutil.rmtree(path, onerror=handle_error)
-    except Exception:
-        log.exception("Fatal exception during directory removal for %s", path)
+    max_retries = 3
+    for i in range(max_retries):
+        try:
+            shutil.rmtree(path, onerror=handle_error)
+            break
+        except OSError:
+            if i < max_retries - 1:
+                time.sleep(0.1)  # Wait briefly for the system to release the file lock
+                continue
+            else:
+                raise  # If the last attempt fails, propagate the exception
 
 def remove_cpp_extensions_build_root():
     """

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5772,6 +5772,11 @@ def win_safe_rmtree(path):
     if not os.path.exists(path):
         return
 
+    # --- Long Path Fix ---
+    path = os.path.abspath(path)
+    if not path.startswith("\\\\?\\"):
+        path = "\\\\?\\" + path
+
     def handle_error(func, path, exc_info):
         """
         Custom error handler for shutil.rmtree to manage Windows-specific failures.


### PR DESCRIPTION
### **Summary**

This PR refactors the Cpp extension build root & tempdir cleanup logic on Windows to be **Python-native** and **robust**. It eliminates dependencies on external POSIX tools (`rm`) and shell built-ins (`rd`), while unifying the cleanup strategy across the global utility and XPU-specific unit tests.

### **The Problem**

The current implementation of `remove_cpp_extensions_build_root()` relies on an external `rm -rf` command via `subprocess`, which leads to several issues on Windows:

* **Environmental Dependency**: It assumes the presence of Git-POSIX tools (like `rm.exe`) in the system `PATH`. While this passes in CI environments where these tools are pre-installed, it frequently fails on local Windows setups with a `FileNotFoundError (WinError 2)`.
* **Cleanup Fragility**: Standard `shutil.rmtree` is often insufficient for Windows build environments because:
1. **Attribute Restrictions**: Compiler-generated artifacts (e.g., `.tlog` files) are often marked **read-only**, triggering `Access Denied (WinError 5)`.
2. **Process Locks**: JIT-compiled modules (`.pyd` DLLs) remain mapped in memory if loaded by the Python process, causing a `Sharing Violation (WinError 32)` that crashes the script.


#### **The Solution**

* **Remove Subprocess Calls**: Completely removed dependencies on external `rm` and `rd` commands in favor of a Python-native approach.
* **Implement `win_safe_rmtree` Helper**:
* **Auto-fix Permissions**: Automatically applies `os.chmod(stat.S_IWRITE)` to read-only files and retries deletion.
* **Graceful Lock Handling**: Detects process locks (WinError 32/5). Instead of crashing, it logs a `logging.warning`, allowing the test suite to proceed even if a specific DLL cannot be removed immediately.


* **Unify XPU Test Cleanup**: Updated the `finally` blocks in XPU unit tests to use the new robust cleanup logic, ensuring consistency across the codebase.

* **Platform Optimization**: Linux remains on the fast-path (`ignore_errors=True`), while Windows uses the new robust path.

#### **Benefits**

* **Zero External Dependency**: Works out-of-the-box on clean Windows installations without requiring POSIX-simulated environments.
* **Better Debuggability**: Clear logs notify developers when a cleanup is skipped due to process locks, preventing silent "stale code" issues.