### PR TITLE
[BE] Take reference after a null check in MPSStream::checkLastError

### DIFF
--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -280,10 +280,10 @@ id<MTLBuffer> MPSStream::getErrorBuffer() {
 
 void MPSStream::checkLastError() {
   auto msgs = reinterpret_cast<c10::metal::ErrorMessages*>([_errorBuffer contents]);
-  const auto& msg = msgs->msg[0];
   if (!msgs) {
     return;
   }
+  const auto& msg = msgs->msg[0];
   unsigned int count = 0;
   std::swap(count, msgs->count);
   if (!count) {


### PR DESCRIPTION
Fix potential null pointer dereference crash in checkLastError

why not `if(!msg)`,because the const & is not null

cc @malfet @cyyever 