### PR TITLE
[Profiler][Easy] Let `MemRecordsAcc.in_interval` to use nanoseconds directly

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -635,7 +635,7 @@ class profile:
             if kineto_event.device_type() == DeviceType.CPU:
                 # find the corresponding memory allocation events
                 for mem_record in mem_records_acc.in_interval(
-                    kineto_event.start_ns() / 1000, abs_end_ns / 1000
+                    kineto_event.start_ns(), abs_end_ns
                 ):
                     cpu_memory_usage += _cpu_memory_usage(mem_record[0])
                     device_memory_usage += _device_memory_usage(mem_record[0])

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -987,13 +987,12 @@ class MemRecordsAcc:
             tmp = sorted([(r[0].start_ns(), i) for i, r in enumerate(mem_records)])
             self._start_nses, self._indices = zip(*tmp)  # type: ignore[assignment]
 
-    def in_interval(self, start_us, end_us):
+    def in_interval(self, start_ns, end_ns):
         r"""
         Return all records in the given interval
-        To maintain backward compatibility, convert us to ns in function
         """
-        start_idx = bisect.bisect_left(self._start_nses, start_us * 1000)
-        end_idx = bisect.bisect_right(self._start_nses, end_us * 1000)
+        start_idx = bisect.bisect_left(self._start_nses, start_ns)
+        end_idx = bisect.bisect_right(self._start_nses, end_ns)
         for i in range(start_idx, end_idx):
             yield self._mem_records[self._indices[i]]
 


### PR DESCRIPTION
## Summary

Refactors `MemRecordsAcc.in_interval()` method to accept nanoseconds directly instead of microseconds, removing the internal conversion and improving API consistency.

## Details

Previously, the `in_interval()` method in `torch/autograd/profiler_util.py` accepted time parameters in microseconds and converted them to nanoseconds internally:
```python
def in_interval(self, start_us, end_us):
    start_idx = bisect.bisect_left(self._start_nses, start_us * 1000)
    end_idx = bisect.bisect_right(self._start_nses, end_us * 1000)
```

This was inconsistent with the fact that `MemRecordsAcc` stores timestamps in nanoseconds (`_start_nses`). 

**Changes:**
- Updated `in_interval()` signature to accept `start_ns` and `end_ns` parameters instead of `start_us` and `end_us`
- Removed the `* 1000` conversion inside the method
- Updated the call site in `torch/autograd/profiler.py` (the only place) to pass nanosecond values directly (removed `/ 1000` conversion)