### PR TITLE
Add meta-pytorch/MSLK as a submodule to migrate away from FBGEMM GenAI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -132,3 +132,6 @@
 [submodule "third_party/aiter"]
 	path = third_party/aiter
 	url = https://github.com/ROCm/aiter.git
+[submodule "third_party/mslk"]
+	path = third_party/mslk
+	url = https://github.com/meta-pytorch/MSLK.git


### PR DESCRIPTION
Summary: PyTorch uses FBGEMM GenAI for several GenAI kernels:
 - MI300X fp8 grouped gemm https://github.com/pytorch/pytorch/pull/159075
 - Blackwell mxfp8, nvfp4, mxfp4 grouped gemm https://github.com/pytorch/pytorch/pull/166530 https://github.com/pytorch/pytorch/pull/166308 https://github.com/pytorch/pytorch/pull/162209
 - Blackwell mxfp4 gemm gemm https://github.com/pytorch/pytorch/pull/166526
 
We are deprecating the [FBGEMM GenAI](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/experimental/gen_ai) project and moving to [meta-pytorch/MSLK](https://github.com/meta-pytorch/MSLK). Note this does not impact FBGEMM CPU. In this PR we add [meta-pytorch/MSLK](https://github.com/meta-pytorch/MSLK) as a new submodule as a pre-requisite. The reason we do this in a separate PR is we need to land https://github.com/pytorch/pytorch/pull/171712 from fbcode due to BUCK integration.
 
Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
