### PR TITLE
[Fix] Fix broken size mismatch check in __init__ (always False)

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -429,6 +429,13 @@ class TestTensorDataset(TestCase):
             self.assertEqual(t2[i], source[i][2])
             self.assertEqual(t3[i], source[i][3])
 
+    def test_size_mismatch(self):
+        tensor1 = torch.randn(10, 5)
+        tensor2 = torch.randn(10, 3)
+        tensor3 = torch.randn(20, 7)
+        with self.assertRaisesRegex(AssertionError, "Size mismatch between tensors"):
+            TensorDataset(tensor1, tensor2, tensor3)
+
 
 @unittest.skipIf(
     TEST_WITH_TSAN,

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -198,7 +198,7 @@ class TensorDataset(Dataset[tuple[Tensor, ...]]):
     tensors: tuple[Tensor, ...]
 
     def __init__(self, *tensors: Tensor) -> None:
-        if all(tensors[0].size(0) != tensor.size(0) for tensor in tensors):
+        if any(tensors[0].size(0) != tensor.size(0) for tensor in tensors):
             raise AssertionError("Size mismatch between tensors")
         self.tensors = tensors
 


### PR DESCRIPTION
```python
if all(tensors[0].size(0) != tensor.size(0) for tensor in tensors):
```
always `false`

`tensors[0].size(0) == tensor.size(0)  when tensor == tensors[0]`

cc @divyanshk @ramanishsingh @aelavender