### PR TITLE
[canary] tracing contexts

### DIFF
--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -63,13 +63,12 @@ def process_inputs(
                 return x
             if is_traceable_wrapper_subclass(x):
                 attrs, _ = x.__tensor_flatten__()
-                if any(isinstance(getattr(x, attr), FakeTensor) for attr in attrs):
-                    for attr in attrs:
-                        attr_val = getattr(x, attr)
-                        if attr_val.fake_mode is not fake_mode:
-                            setattr(x, attr, fake_mode.from_tensor(attr_val))
+                if all(isinstance(getattr(x, attr), FakeTensor) for attr in attrs):
+                    if all(getattr(x, attr).fake_mode is fake_mode for attr in attrs):
+                        return x
+                    # FakeTensor subclass from a different mode.
+                    # Fall through to refakify.
 
-                    return x
 
             # see note [Tensor Fakification and Symbol Caching]
             symbolic_context = None

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1281,16 +1281,15 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
         get_plain_tensors,
     )
 
-    fake_modes = []
-
+    # If TracingContext has a fake_mode, use it authoritatively.
+    # This is the case when Dynamo is driving compilation - any fake tensors
+    # from other modes in the inputs will be refakified by the caller.
     if context := TracingContext.try_get():
         fake_mode = context.fake_mode
         if fake_mode is not None:
-            # When doing cross precompilation we expect to have some input tensors
-            # with a different fake mode than the one we use when compiling. Instead of
-            # aggregating the fake_modes like in normal torch.compile and verifying they
-            # are all the same fake mode, we instead use the first one we find.
             return fake_mode
+
+    fake_modes = []
 
     from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #171799
* #171886
* #171829
* #171831
* #171830
* #171803
* __->__ #171798
* #171752
* #171600
* #171599

