### PR TITLE
[IG CTR] Fix constexpr Compilation Error in ttir

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2665,12 +2665,15 @@ def forward(self, arg0_1, arg1_1):
             dst_ptr,
             n_elements,
             stride,
+            clip_limit,
             BLOCK_SIZE: tl.constexpr,
         ):
             pid = tl.program_id(0)
             offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
             mask = offs < n_elements
             x = tl.load(src_ptr + offs * stride, mask=mask)
+            if clip_limit is not None:
+                x = tl.clamp(x, min=-1000.1, max=1000.1)
             tl.store(dst_ptr + offs * stride, x, mask=mask)
 
         t = torch.randn(1024, device=GPU_TYPE)
@@ -2681,6 +2684,7 @@ def forward(self, arg0_1, arg1_1):
             "dst_ptr": out,
             "n_elements": 1024,
             "stride": 1,
+            "clip_limit": None,
             "BLOCK_SIZE": 256,
         }
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -441,11 +441,11 @@ def generate_ttir(
 
     # Triton explicitly interprets ASTSource.constants entries as constexpr
     # (triton-lang/triton#8248). Thus, only arguments marked `is_constexpr`
-    # should be treated as such, not just non-tensor-like arguments.
+    # or None values should be treated as such, not just non-tensor-like arguments.
     constants = {
-        (i,): arg
-        for i, ((_, arg), param) in enumerate(zip(ordered_args.items(), kernel.params))
-        if param.is_constexpr
+        name: arg
+        for ((name, arg), param) in zip(ordered_args.items(), kernel.params)
+        if param.is_constexpr or arg is None
     }
 
     if (mangle_type := getattr(triton.runtime.jit, "mangle_type", None)) is not None:


### PR DESCRIPTION
Summary: Some constexpr seems to have no `_flatten_ir_types` attribute, which causes identifying mutated tensors to fail during ttir generation, and as a result all inputs are considered to be mutated. Note that the breaking change was introduced in D89669796, and this is a partial revert of the diff.

Test Plan: buck run fbcode//mode/opt-amd-gpu -c 'fbcode.enable_gpu_sections=true' -c 'fbcode.split-dwarf=true' -c 'fbcode.use_link_groups=true' -c fbcode.rocm_arch=mi300  fbcode//inference_enablement/model_processing/infra/components/lowering/client/re/test/ae:test_local_lowering_replay_v0 -- -r test_aot_inductor_ig_ctr_v0

Differential Revision: D90155022




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo