### PR TITLE
Add is_infra_mode() to TorchFunctionMode for filtering infrastructure modes

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -834,11 +834,11 @@ class InfraModeCompileTests(torch._dynamo.test_case.TestCase):
 
         mode = MutableInfraMode()
         with mode:
-            result1 = compiled_fn(x)
+            compiled_fn(x)
             # NB: not 200, which would happen if the infra mode was on inside
             # during compilation!
             self.assertEqual(mode.mul_count, 100)
-            result2 = compiled_fn(x)
+            compiled_fn(x)
             self.assertEqual(mode.mul_count, 200)
 
 

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -799,6 +799,49 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
                     )
 
 
+class InfraModeCompileTests(torch._dynamo.test_case.TestCase):
+    def test_infra_mode_with_mutable_state_succeeds(self):
+        """Test that infra modes with mutable state don't cause recompilation.
+
+        A mode marked as is_infra_mode=True is filtered from guard creation,
+        so even if its state mutates during compilation, it won't cause
+        guard failures or recompilation. If we call a function with 100 muls
+        twice, we should see exactly 200 muls total (no recompilation).
+        """
+        torch._dynamo.reset()
+
+        class MutableInfraMode(TorchFunctionMode):
+            def __init__(self):
+                self.mul_count = 0
+
+            @classmethod
+            def is_infra_mode(cls) -> bool:
+                return True
+
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                if getattr(func, "__name__", None) == "mul":
+                    self.mul_count += 1
+                return func(*args, **(kwargs or {}))
+
+        def many_ops_fn(x):
+            for _ in range(100):
+                x = x * 1.0
+            return x
+
+        compiled_fn = torch.compile(many_ops_fn, backend="eager")
+
+        x = torch.randn(3, 3)
+
+        mode = MutableInfraMode()
+        with mode:
+            result1 = compiled_fn(x)
+            # NB: not 200, which would happen if the infra mode was on inside
+            # during compilation!
+            self.assertEqual(mode.mul_count, 100)
+            result2 = compiled_fn(x)
+            self.assertEqual(mode.mul_count, 200)
+
+
 class TorchFunctionModeLifecycleTests(torch._dynamo.test_case.TestCase):
     def test_default_device_restored_after_mode_tests(self):
         case = TorchFunctionModeTests("test_stack_state_mutation_default_device")

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -305,9 +305,9 @@ class SymbolicTorchFunctionState:
             # creating guards on their internal state during FX tracing
             if not type(val).is_infra_mode():
                 self.mode_stack.append(
-                    LazyVariableTracker.create(
+                    LazyVariableTracker.create(  # type: ignore[arg-type]
                         val, source=TorchFunctionModeStackSource(i)
-                    )  # type: ignore[arg-type]
+                    )
                 )
 
     def in_torch_function_mode(self) -> bool:

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -255,7 +255,9 @@ class TorchFunctionModeStackStateManager:
     @contextlib.contextmanager
     def temp_restore_stack(self) -> Generator[None, None, None]:
         prev = torch.overrides._get_current_function_mode_stack()
-        set_torch_function_mode_stack(self.stack)
+        # Filter out infra modes when restoring - they shouldn't be active during Dynamo tracing
+        non_infra_stack = [m for m in self.stack if not type(m).is_infra_mode()]
+        set_torch_function_mode_stack(non_infra_stack)
         try:
             yield
         finally:
@@ -299,9 +301,14 @@ class SymbolicTorchFunctionState:
         )
 
         for i, val in enumerate(py_stack):
-            self.mode_stack.append(
-                LazyVariableTracker.create(val, source=TorchFunctionModeStackSource(i))  # type: ignore[arg-type]
-            )
+            # Skip infra modes (like TorchFunctionMetadataMode) to avoid
+            # creating guards on their internal state during FX tracing
+            if not type(val).is_infra_mode():
+                self.mode_stack.append(
+                    LazyVariableTracker.create(
+                        val, source=TorchFunctionModeStackSource(i)
+                    )  # type: ignore[arg-type]
+                )
 
     def in_torch_function_mode(self) -> bool:
         return len(self.mode_stack) > 0

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1564,6 +1564,10 @@ class TorchFunctionMetadataMode(TorchFunctionMode):
     def __init__(self, tracer: _ProxyTracer) -> None:
         self.tracer = tracer
 
+    @classmethod
+    def is_infra_mode(cls) -> bool:
+        return True
+
     def __torch_function__(
         self,
         func: OpOverload,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -2064,6 +2064,15 @@ class TorchFunctionMode:
         _pop_mode()
 
     @classmethod
+    def is_infra_mode(cls) -> bool:
+        """
+        Returns True if this mode is an infrastructure mode that should not
+        be tracked by Dynamo. Infrastructure modes are internal implementation
+        details (e.g., for tracing) that shouldn't have guards created on them.
+        """
+        return False
+
+    @classmethod
     def push(cls, *args, **kwargs):
         warnings.warn(
             "`Mode.push()` is no longer necessary and can be replaced with just `with Mode()`",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #171819
* __->__ #171817

This adds a mechanism to mark TorchFunctionMode subclasses as "infrastructure"
modes that should not be tracked by Dynamo during tracing. Infrastructure modes
are internal implementation details (like make_fx's TorchFunctionMetadataMode)
that shouldn't have guards created on them and shouldn't be on when we
trace the compiled code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo