### PR TITLE
torch.distrubuted: lazy import pdb only when user calls breakpoint()

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -79,8 +79,8 @@ if is_available():
             def interaction(self, *args, **kwargs):
                 _stdin = sys.stdin
                 try:
-                    sys.stdin = open("/dev/stdin")
-                    pdb.Pdb.interaction(self, *args, **kwargs)
+                    with open("/dev/stdin") as sys.stdin:
+                        pdb.Pdb.interaction(self, *args, **kwargs)
                 finally:
                     sys.stdin = _stdin
 

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 import logging
-import pdb
 import sys
 import traceback
 import typing
@@ -65,21 +64,27 @@ if is_available():
         Work as _Work,
     )
 
-    class _DistributedPdb(pdb.Pdb):
+    def _make_distributed_pdb():
         """
         Supports using PDB from inside a multiprocessing child process.
 
         Usage:
-        _DistributedPdb().set_trace()
+        _make_distributed_pdb().set_trace()
         """
 
-        def interaction(self, *args, **kwargs):
-            _stdin = sys.stdin
-            try:
-                with open("/dev/stdin") as sys.stdin:
+        # Lazy import pdb only if we set breakpoints.
+        import pdb
+
+        class _DistributedPdb(pdb.Pdb):
+            def interaction(self, *args, **kwargs):
+                _stdin = sys.stdin
+                try:
+                    sys.stdin = open("/dev/stdin")
                     pdb.Pdb.interaction(self, *args, **kwargs)
-            finally:
-                sys.stdin = _stdin
+                finally:
+                    sys.stdin = _stdin
+
+        return _DistributedPdb()
 
     _breakpoint_cache: dict[int, typing.Any] = {}
 
@@ -108,7 +113,7 @@ if is_available():
                 )
 
         if get_rank() == rank:
-            pdb = _DistributedPdb()
+            pdb = _make_distributed_pdb()
             pdb.message(
                 "\n!!! ATTENTION !!!\n\n"
                 f"Type 'up' to get to the frame that called dist.breakpoint(rank={rank})\n"


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/159645

Makes `torch/distributed/__init__.py` only import `pdb` when needed, because we should avoid debugging-specific dependencies in production code.

In Python 3.13.1 through 3.13.7, this also avoids the following chain of imports from :
`torch` -> `torch.distributed` -> `pdb` -> `rlcompleter` -> `readline`

Importing `readline`, in turn, attempts to access stdin, which deadlocks if run from a subprocess launched with `process_group=0` or `preexec_fn=setpgrp` because it doesn't have access to stdin.

Python 3.13.8 [fixed the `pdb` -> `rlcompleter` -> `readline` dependency](https://github.com/python/cpython/pull/139280), but it's still good to import `pdb` only when necessary.

## Testing

(All tests below on Mac.)

### Test script: 

`deadline_minimal.py`:

```
import sys
import subprocess

if __name__ == "__main__":
    code = """
print('importing torch...')
import sys
import torch
print('imported torch.')
if "pdb" in sys.modules:
    print("ERROR: pdb imported")
    exit(1)
"""

    kwargs = dict(process_group=0)
    proc = subprocess.Popen([sys.executable, "-c", code], **kwargs)
    try:
        proc.communicate(timeout=20)
        if proc.returncode == 0:
            print("PASS")
        else:
            print("FAIL")
    except subprocess.TimeoutExpired:
        print("FAIL: Process deadlocked after 20 seconds")
        proc.kill()
```

### Failure repro: python 3.13.7, old pytorch

Deadlocks:

```
% conda create -n "pytorch-pdb-3.13.7" python=3.13.7 numpy pytorch -c conda-forge -y
% conda activate pytorch-pdb-3.13.7
% python deadlock_minimal.py
importing torch...
FAIL: Process deadlocked after 10 seconds
```

### Failure repro: python 3.13.8, new pytorch

Does not deadlock due to underlying python fix, but still imports pdb:

```
% conda create -n "pytorch-pdb-3.13.8" python=3.13.8 numpy pytorch -c conda-forge -y
% conda activate pytorch-pdb-3.13.8
% python deadlock_minimal.py
imported torch.
ERROR: pdb imported
FAIL
```

### Fix confirmation: python 3.13.7, new pytorch

No longer deadlocks, does not import pdb.

```
% conda create -n "pytorch-3.13.7" python=3.13.7
% conda activate pytorch-3.13.7
% pip install --group dev
% conda install pkg-config libuv
% USE_DISTRIBUTED=1 python -m pip install --no-build-isolation -v -e .
% python deadlock_minimal.py
importing torch...
imported torch.
PASS
```


```
% conda create -n "pytorch-3.13.11" python=3.13.11
% conda activate pytorch-3.13.11
% pip install --group dev
% conda install pkg-config libuv
% USE_DISTRIBUTED=1 python -m pip install --no-build-isolation -v -e .
% python deadlock_minimal.py
importing torch...
imported torch.
PASS
```

### Test that `torch.distributed.breakpoint()` still works:

`torch_breakpoint.py`:
```
import sys
import torch.distributed as dist
print(f"is available: {dist.is_available()}")
dist.init_process_group()
dist.breakpoint(rank = 0)
print(f"pdb imported after breakpoint: {"pdb" in sys.modules}")
```

Then built with distributed on Mac and did a basic test:

```
% USE_DISTRIBUTED=1 python setup.py build --cmake
% RANK=0 WORLD_SIZE=1 MASTER_ADDR=127.0.0.1 MASTER_PORT=49999 python torch_breakpoint.py
is available: True
# snipped some errors due to not actually setting up a full scenario
> /Users/kelu/kelu-wandb/pytorch/torch/distributed/__init__.py(121)breakpoint()
-> pdb.set_trace()
(Pdb)
```

