### PR TITLE
Update Rough 2026-2027 Release dates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,11 +97,12 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.8 | Jun 2025 | Jul 2025 | (Aug 2025) | (Sep 2025) |
 | 2.9 | Sept 2025 | Oct 2025 | (Nov 2025) | (Dec 2025) |
 | 2.10 | Dec 2025 | Jan 2026 | (Feb 2026) | (Mar 2026) |
-| 2.11 | Mar 2026 | Apr 2026 | (May 2026) | (Jun 2026) |
-| 2.12 | May 2026 | Jun 2026 | (Jul 2026) | (Aug 2026) |
-| 2.13 | Jul 2026 | Aug 2026 | (Sept 2026) | (Oct 2026) |
-| 2.14 | Oct 2026 | Nov 2026 | (Dec 2026) | (Jan 2027) |
-| 2.15 | Dec 2026 | Jan 2027 | (Feb 2027) | (Mar 2027) |
+| 2.11 | Feb 2026 | Mar 2026 | (Apr 2026) | (May 2026) |
+| 2.12 | Apr 2026 | May 2026 | (Jun 2026) | (Jul 2026) |
+| 2.13 | Jun 2026 | Jul 2026 | (Aug 2026) | (Sept 2026) |
+| 2.14 | Aug 2026 | Sept 2026 | (Oct 2026) | (Nov 2026) |
+| 2.15 | Sept 2026 | Oct 2027 | (Nov 2026) | (Dec 2026) |
+| 2.16 | Nov 2026 | Dec 2027 | (Jan 2027) | (Feb 2027) |
 
 ## General Overview
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,7 +97,7 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.8 | Jun 2025 | Jul 2025 | (Aug 2025) | (Sep 2025) |
 | 2.9 | Sept 2025 | Oct 2025 | (Nov 2025) | (Dec 2025) |
 | 2.10 | Dec 2025 | Jan 2026 | (Feb 2026) | (Mar 2026) |
-| 2.11 | 17 Feb 2026 | 18 Mar 2026 | (Apr 2026) | (May 2026) |
+| 2.11 | 16 Feb 2026 | 18 Mar 2026 | (Apr 2026) | (May 2026) |
 | 2.12 | 13 Apr 2026 | 13 May 2026 | (Jun 2026) | (Jul 2026) |
 | 2.13 | 8 Jun 2026 | 8 Jul 2026 | (Aug 2026) | (Sept 2026) |
 | 2.14 | 3 Aug 2026 | 2 Sept 2026 | (Oct 2026) | (Nov 2026) |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -101,8 +101,8 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.12 | Apr 2026 | May 2026 | (Jun 2026) | (Jul 2026) |
 | 2.13 | Jun 2026 | Jul 2026 | (Aug 2026) | (Sept 2026) |
 | 2.14 | Aug 2026 | Sept 2026 | (Oct 2026) | (Nov 2026) |
-| 2.15 | Sept 2026 | Oct 2027 | (Nov 2026) | (Dec 2026) |
-| 2.16 | Nov 2026 | Dec 2027 | (Jan 2027) | (Feb 2027) |
+| 2.15 | Sept 2026 | Oct 2026 | (Nov 2026) | (Dec 2026) |
+| 2.16 | Nov 2026 | Dec 2026 | (Jan 2027) | (Feb 2027) |
 
 ## General Overview
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -100,7 +100,7 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.11 | Feb 2026 | Apr 2026 | (May 2026) | (Jun 2026) |
 | 2.12 | May 2026 | Jun 2026 | (Jul 2026) | (Aug 2026) |
 | 2.13 | Jul 2026 | Aug 2026 | (Sept 2026) | (Oct 2026) |
-| 2.14 | Oct 2026 | Nov 2026 | (Dec 2026) | (Jan 2027) |
+| 2.14 | Sept 2026 | Nov 2026 | (Dec 2026) | (Jan 2027) |
 | 2.15 | Dec 2026 | Jan 2027 | (Feb 2027) | (Mar 2027) |
 
 ## General Overview

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,10 +97,10 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.8 | Jun 2025 | Jul 2025 | (Aug 2025) | (Sep 2025) |
 | 2.9 | Sept 2025 | Oct 2025 | (Nov 2025) | (Dec 2025) |
 | 2.10 | Dec 2025 | Jan 2026 | (Feb 2026) | (Mar 2026) |
-| 2.11 | Feb 2026 | Apr 2026 | (May 2026) | (Jun 2026) |
+| 2.11 | Mar 2026 | Apr 2026 | (May 2026) | (Jun 2026) |
 | 2.12 | May 2026 | Jun 2026 | (Jul 2026) | (Aug 2026) |
 | 2.13 | Jul 2026 | Aug 2026 | (Sept 2026) | (Oct 2026) |
-| 2.14 | Sept 2026 | Nov 2026 | (Dec 2026) | (Jan 2027) |
+| 2.14 | Oct 2026 | Nov 2026 | (Dec 2026) | (Jan 2027) |
 | 2.15 | Dec 2026 | Jan 2027 | (Feb 2027) | (Mar 2027) |
 
 ## General Overview

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,12 +97,12 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.8 | Jun 2025 | Jul 2025 | (Aug 2025) | (Sep 2025) |
 | 2.9 | Sept 2025 | Oct 2025 | (Nov 2025) | (Dec 2025) |
 | 2.10 | Dec 2025 | Jan 2026 | (Feb 2026) | (Mar 2026) |
-| 2.11 | Feb 2026 | Mar 2026 | (Apr 2026) | (May 2026) |
-| 2.12 | Apr 2026 | May 2026 | (Jun 2026) | (Jul 2026) |
-| 2.13 | Jun 2026 | Jul 2026 | (Aug 2026) | (Sept 2026) |
-| 2.14 | Aug 2026 | Sept 2026 | (Oct 2026) | (Nov 2026) |
-| 2.15 | Sept 2026 | Oct 2026 | (Nov 2026) | (Dec 2026) |
-| 2.16 | Nov 2026 | Dec 2026 | (Jan 2027) | (Feb 2027) |
+| 2.11 | 17 Feb 2026 | 18 Mar 2026 | (Apr 2026) | (May 2026) |
+| 2.12 | 13 Apr 2026 | 13 May 2026 | (Jun 2026) | (Jul 2026) |
+| 2.13 | 8 Jun 2026 | 8 Jul 2026 | (Aug 2026) | (Sept 2026) |
+| 2.14 | 3 Aug 2026 | 2 Sept 2026 | (Oct 2026) | (Nov 2026) |
+| 2.15 | 28 Sept 2026 | 28 Oct 2026 | (Nov 2026) | (Dec 2026) |
+| 2.16 | 2 Nov 2026 | 22 Dec 2026 | (Jan 2027) | (Feb 2027) |
 
 ## General Overview
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,7 +97,11 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.8 | Jun 2025 | Jul 2025 | (Aug 2025) | (Sep 2025) |
 | 2.9 | Sept 2025 | Oct 2025 | (Nov 2025) | (Dec 2025) |
 | 2.10 | Dec 2025 | Jan 2026 | (Feb 2026) | (Mar 2026) |
-| 2.11 | Mar 2026 | Apr 2026 | (Jun 2026) | (Jul 2026) |
+| 2.11 | Feb 2026 | Apr 2026 | (May 2026) | (Jun 2026) |
+| 2.12 | May 2026 | Jun 2026 | (Jul 2026) | (Aug 2026) |
+| 2.13 | Jul 2026 | Aug 2026 | (Sept 2026) | (Oct 2026) |
+| 2.14 | Oct 2026 | Nov 2026 | (Dec 2026) | (Jan 2027) |
+| 2.15 | Dec 2026 | Jan 2027 | (Feb 2027) | (Mar 2027) |
 
 ## General Overview
 


### PR DESCRIPTION
Update Future Release cadence. Please notes all dates here are tentative and can be changed:

2.11
Release Milestones | Schedule | Date
-- | -- | --
M1: Release Announcement - Start | Week 1 (Monday) | January 26, 2026
M2: Land Target PRs in PyTorch repo | Week 3 (Friday) | Feb 13, 2026
M3.1: Release branch cut | Week 4 (Mon, Tue & Wed) | Feb 16-19, 2026
M4: Release branch finalized. Final RC produced. | Week 6 (Monday) | March 9, 2026
M4.1: Tutorial drafts & external content deadlines | Week 7 (Wed, Fri) | March 11 &1 3, 2026
M6: Release Day | Week 8 (Wednesday) | March 18, 2026

2.12
Release Milestones | Schedule | Date
-- | -- | --
M1: Release Announcement - Start | Week 1 (Monday) | March 23, 2026
M2: Land Target PRs in PyTorch repo | Week 3 (Friday) | April 10, 2026
M3.1: Release branch cut | Week 4 (Mon, Tue & Wed) | April 13 - 15, 2026
M4: Release branch finalized. Final RC produced. | Week 6 (Monday) | April 27, 2026
M4.1: Tutorial drafts & external content deadlines | Week 7 (Wed, Fri) | May 6 & 8, 2026
M6: Release Day | Week 8 (Wednesday) | May 13, 2026

2.13
Release Milestones | Schedule | Date
-- | -- | --
M1: Release Announcement - Start | Week 1 (Monday) | May 18, 2026
M2: Land Target PRs in PyTorch repo | Week 3 (Friday) | June 5, 2026
M3.1: Release branch cut | Week 4 (Mon, Tue & Wed) | June 8 - 10, 2026
M4: Release branch finalized. Final RC produced. | Week 6 (Monday) | June 22, 2026
M4.1: Tutorial drafts & external content deadlines | Week 7 (Wed, Fri) | June 30 & July 1, 2026
M6: Release Day | Week 8 (Wednesday) | July 8, 2026

2.14
Release Milestones | Schedule | Date
-- | -- | --
M1: Release Announcement - Start | Week 1 (Monday) | July 13, 2026
M2: Land Target PRs in PyTorch repo | Week 3 (Friday) | July 31, 2026
M3.1: Release branch cut | Week 4 (Mon, Tue & Wed) | Aug 3 - 5, 2026
M4: Release branch finalized. Final RC produced. | Week 6 (Monday) | Aug 17, 2026
M4.1: Tutorial drafts & external content deadlines | Week 7 (Wed, Fri) | Aug 26 & 28, 2026
M6: Release Day | Week 8 (Wednesday) | Sept 2, 2026

2.15
Release Milestones | Schedule | Date
-- | -- | --
M1: Release Announcement - Start | Week 1 (Monday) | Sept 8, 2026
M2: Land Target PRs in PyTorch repo | Week 3 (Friday) | Sept 25, 2026
M3.1: Release branch cut | Week 4 (Mon, Tue & Wed) | Sept 28 - 30, 2026
M4: Release branch finalized. Final RC produced. | Week 6 (Monday) | Oct 12, 2026
M4.1: Tutorial drafts & external content deadlines | Week 7 (Wed, Fri) | Oct 21 & 23, 2026
M6: Release Day | Week 8 (Wednesday) | Oct 28, 2027

2.16
Release Milestones | Schedule | Date
-- | -- | --
M1: Release Announcement - Start | Week 1 (Monday) | Nov 2, 2026
M2: Land Target PRs in PyTorch repo | Week 3 (Friday) | Nov 20, 2026
M3.1: Release branch cut | Week 4 (Mon, Tue & Wed) | Nov 23 - 25, 2026
M4: Release branch finalized. Final RC produced. | Week 6 (Monday) | Dec 7, 2026
M4.1: Tutorial drafts & external content deadlines | Week 7 (Wed, Fri) | Dec 15 & 17, 2026
M6: Release Day | Week 8 (Wednesday) | Dec 22  13, 2026

