### PR TITLE
Opt in more test files to Pyrefly type checking

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -10,7 +10,7 @@ project-includes = [
     "test/test_bundled_inputs.py",
     "test/test_complex.py",
     "test/test_datapipe.py",
-    # "test/test_futures.py", # uncomment when enabling pyrefly
+    "test/test_futures.py",
     "test/test_numpy_interop.py",
     # We exclude test_torch.py because it is full of errors, but most functions lack type signatures,
     # and mypy.ini specifies `check_untyped_defs = False` for this file.
@@ -18,7 +18,7 @@ project-includes = [
     # "test/test_torch.py",
     "test/test_type_hints.py",
     "test/test_type_info.py",
-    # "test/test_utils.py", # uncomment when enabling pyrefly
+    "test/test_utils.py",
 ]
 project-excludes = [
   # ==== below will be enabled directory by directory ====

--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -24,6 +24,7 @@ class TestFuture(TestCase):
 
         f = Future[T]()  # type: ignore[valid-type]
         # Set exception
+        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         # Exception should throw on wait
         with self.assertRaisesRegex(ValueError, "Intentional"):
@@ -31,6 +32,7 @@ class TestFuture(TestCase):
 
         # Exception should also throw on value
         f = Future[T]()  # type: ignore[valid-type]
+        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         with self.assertRaisesRegex(ValueError, "Intentional"):
             f.value()
@@ -39,6 +41,7 @@ class TestFuture(TestCase):
             fut.value()
 
         f = Future[T]()  # type: ignore[valid-type]
+        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
 
         with self.assertRaisesRegex(RuntimeError, "Got the following error"):
@@ -58,6 +61,7 @@ class TestFuture(TestCase):
         f = Future[T]()  # type: ignore[valid-type]
         t = threading.Thread(target=wait_future, args=(f, ))
         t.start()
+        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         t.join()
 
@@ -72,6 +76,7 @@ class TestFuture(TestCase):
         f = Future[T]()  # type: ignore[valid-type]
         t = threading.Thread(target=then_future, args=(f, ))
         t.start()
+        # pyrefly: ignore [bad-argument-type]
         f.set_exception(value_error)
         t.join()
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1014,8 +1014,10 @@ def _deprecated_api(x, y=15):
 class TestDeprecate(TestCase):
     def test_deprecated(self):
         with self.assertWarnsRegex(Warning, "is DEPRECATED"):
+            # pyrefly: ignore [unknown-name]
             deprecated_api(1, 2)  # noqa: F821
         with self.assertWarnsRegex(Warning, "is DEPRECATED"):
+            # pyrefly: ignore [unknown-name]
             deprecated_api(1, y=2)  # noqa: F821
         _deprecated_api(1, 2)
         _deprecated_api(1, y=2)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2295,6 +2295,7 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
         if self.fn in (
             dist.all_reduce,
             dist.reduce_scatter_tensor,
+            # pyrefly: ignore [deprecated]
             dist._reduce_scatter_base,
         ):
             reduce_op_var = kwargs.get("op")

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -210,7 +210,9 @@ def tracing_state_functions() -> dict[Callable[[], Any], Optional[bool]]:
         torch.fx._symbolic_trace.is_fx_tracing: False,
         torch.fx._symbolic_trace.is_fx_symbolic_tracing: False,
         torch.onnx.is_in_onnx_export: False,
+        # pyrefly: ignore [deprecated]
         torch._dynamo.external_utils.is_compiling: True,
+        # pyrefly: ignore [deprecated]
         torch._utils.is_compiling: True,
         torch.compiler.is_compiling: True,
         torch.compiler.is_dynamo_compiling: True,
@@ -564,7 +566,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             assert not args and not kwargs
             # See: https://github.com/pytorch/pytorch/issues/110765
             if self.value in (
+                # pyrefly: ignore [deprecated]
                 torch._utils.is_compiling,
+                # pyrefly: ignore [deprecated]
                 torch._dynamo.external_utils.is_compiling,
                 torch.compiler.is_compiling,
                 torch.compiler.is_dynamo_compiling,


### PR DESCRIPTION
Opts in files that were omitted in the early rollout 

`pyrefly check`
`lintrunner -a`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo