### PR TITLE
Support installing Python bindings in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1385,6 +1385,13 @@ if(BUILD_SHARED_LIBS)
       FILE Caffe2Targets.cmake
       COMPONENT dev)
   endif()
+  if(BUILD_PYTHON)
+    install(
+      EXPORT TorchPythonTargets
+      DESTINATION share/cmake/Torch
+      FILE TorchPythonTargets.cmake
+      COMPONENT python)
+  endif()
 else()
   message(WARNING "Generated cmake files are only available when building "
                   "shared libs.")

--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -12,7 +12,17 @@
 #
 # and the following imported targets:
 #
-#   torch
+#   torch              -- The main PyTorch library
+#   torch_python       -- Python bindings (requires Python component)
+#
+# Components:
+#
+#   Python             -- Python bindings (torch_python, shm targets)
+#
+# Example usage:
+#
+#   find_package(Torch REQUIRED)                     # libtorch only
+#   find_package(Torch REQUIRED COMPONENTS Python)   # with Python bindings
 macro(append_torchlib_if_found)
   foreach (_arg ${ARGN})
     find_library(${_arg}_LIBRARY ${_arg} PATHS "${TORCH_INSTALL_PREFIX}/lib")
@@ -165,6 +175,21 @@ set_target_properties(torch PROPERTIES
 )
 if(TORCH_CXX_FLAGS)
   set_property(TARGET torch PROPERTY INTERFACE_COMPILE_OPTIONS "${TORCH_CXX_FLAGS}")
+endif()
+
+# Handle Python component for torch_python target
+if("Python" IN_LIST Torch_FIND_COMPONENTS)
+  set(_torch_python_targets_file "${CMAKE_CURRENT_LIST_DIR}/TorchPythonTargets.cmake")
+  if(EXISTS "${_torch_python_targets_file}")
+    include("${_torch_python_targets_file}")
+    set(Torch_Python_FOUND TRUE)
+  else()
+    set(Torch_Python_FOUND FALSE)
+    if(Torch_FIND_REQUIRED_Python)
+      message(FATAL_ERROR "Torch Python component requested but TorchPythonTargets.cmake not found. "
+                          "Was PyTorch built with BUILD_PYTHON=ON?")
+    endif()
+  endif()
 endif()
 
 find_package_handle_standard_args(Torch DEFAULT_MSG TORCH_LIBRARY TORCH_INCLUDE_DIRS)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -469,7 +469,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
     set_target_properties(torch_python PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
 endif()
 
-install(TARGETS torch_python EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+install(TARGETS torch_python EXPORT TorchPythonTargets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
 
 # Generate torch/version.py from the appropriate CMake cache variables.
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -51,32 +51,35 @@ endif()
 set(TORCH_PYTHON_INCLUDE_DIRECTORIES
     ${PYTHON_INCLUDE_DIR}
 
-    ${TORCH_ROOT}
-    ${TORCH_ROOT}/aten/src
-    ${TORCH_ROOT}/aten/src/TH
+    $<BUILD_INTERFACE:${TORCH_ROOT}>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/aten/src>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/aten/src/TH>
 
-    ${CMAKE_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/aten/src
-    ${CMAKE_BINARY_DIR}/caffe2/aten/src
-    ${CMAKE_BINARY_DIR}/third_party
-    ${CMAKE_BINARY_DIR}/third_party/onnx
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/aten/src>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/caffe2/aten/src>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/third_party>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/third_party/onnx>
 
-    ${TORCH_ROOT}/third_party/valgrind-headers
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/valgrind-headers>
 
-    ${TORCH_ROOT}/third_party/gloo
-    ${TORCH_ROOT}/third_party/onnx
-    ${TORCH_ROOT}/third_party/flatbuffers/include
-    ${TORCH_ROOT}/third_party/kineto/libkineto/include
-    ${TORCH_ROOT}/third_party/cpp-httplib
-    ${TORCH_ROOT}/third_party/nlohmann/include
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/gloo>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/onnx>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/flatbuffers/include>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/kineto/libkineto/include>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/cpp-httplib>
+    $<BUILD_INTERFACE:${TORCH_ROOT}/third_party/nlohmann/include>
 
-    ${TORCH_SRC_DIR}/csrc
-    ${TORCH_SRC_DIR}/csrc/api/include
-    ${TORCH_SRC_DIR}/lib
-    ${TORCH_SRC_DIR}/standalone
+    $<BUILD_INTERFACE:${TORCH_SRC_DIR}/csrc>
+    $<BUILD_INTERFACE:${TORCH_SRC_DIR}/csrc/api/include>
+    $<BUILD_INTERFACE:${TORCH_SRC_DIR}/lib>
+    $<BUILD_INTERFACE:${TORCH_SRC_DIR}/standalone>
+
+    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/torch/csrc/api/include>
     )
 
-list(APPEND TORCH_PYTHON_INCLUDE_DIRECTORIES ${LIBSHM_SRCDIR})
+list(APPEND TORCH_PYTHON_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${LIBSHM_SRCDIR}>)
 
 set(TORCH_PYTHON_LINK_LIBRARIES
     Python::Module
@@ -466,7 +469,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
     set_target_properties(torch_python PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
 endif()
 
-install(TARGETS torch_python DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+install(TARGETS torch_python EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
 
 # Generate torch/version.py from the appropriate CMake cache variables.
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")

--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -70,6 +70,6 @@ endif()
 set_target_properties(torch_shm_manager PROPERTIES
   INSTALL_RPATH "${_rpath_portable_origin}/../lib")
 
-install(TARGETS shm EXPORT Caffe2Targets LIBRARY DESTINATION ${LIBSHM_INSTALL_LIB_SUBDIR})
+install(TARGETS shm EXPORT TorchPythonTargets LIBRARY DESTINATION ${LIBSHM_INSTALL_LIB_SUBDIR})
 install(FILES libshm.h DESTINATION "include")
 install(TARGETS torch_shm_manager DESTINATION "bin")

--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -14,7 +14,8 @@ if(HAVE_SOVERSION)
 endif()
 
 target_include_directories(shm PUBLIC
-  ${TORCH_ROOT}/torch/lib # provides "libshm/libshm.h"
+  $<BUILD_INTERFACE:${TORCH_ROOT}/torch/lib> # provides "libshm/libshm.h"
+  $<INSTALL_INTERFACE:include>
 )
 
 ### Torch packages supposes libraries prefix is "lib"
@@ -69,6 +70,6 @@ endif()
 set_target_properties(torch_shm_manager PROPERTIES
   INSTALL_RPATH "${_rpath_portable_origin}/../lib")
 
-install(TARGETS shm LIBRARY DESTINATION ${LIBSHM_INSTALL_LIB_SUBDIR})
+install(TARGETS shm EXPORT Caffe2Targets LIBRARY DESTINATION ${LIBSHM_INSTALL_LIB_SUBDIR})
 install(FILES libshm.h DESTINATION "include")
 install(TARGETS torch_shm_manager DESTINATION "bin")


### PR DESCRIPTION
Fixes #159232
and follows up on #159441
 
it would be nice for out-of-tree backends to not have to work around torch_python not being exported, but installed.

A consuming project's cmake would therefore only have to do something like (assuming `Torch_ROOT` is set to the output of `import torch; print(torch.utils.cmake_prefix_path`):
```cmake
find_package(Torch REQUIRED COMPONENTS Python) 
```
and the `torch_python` target should be available.