### PR TITLE
Test that FSDP2 works with cuda graphs.

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -1674,7 +1674,9 @@ class TestFullyShardCudaGraph(FSDPTest):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_two_layer_fully_shard_cudagraph(self):
         if device_type.type == "cuda":
             torch.cuda.set_device(self.rank)

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -52,6 +52,7 @@ from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     MI200_ARCH,
     run_tests,
+    TEST_CUDA_GRAPH,
     TEST_HPU,
     TEST_XPU,
     wrapSwapTensorsTest,
@@ -1665,6 +1666,66 @@ class TestFullyShardWorldSize1(FSDPTest):
             optim.step()
 
             self.assertEqual(losses[0], losses[1])
+
+
+class TestFullyShardCudaGraph(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
+    def test_two_layer_fully_shard_cudagraph(self):
+        if device_type.type == "cuda":
+            torch.cuda.set_device(self.rank)
+        device = torch.device(device_type.type, self.rank)
+        torch.manual_seed(42)
+        model = nn.Sequential(
+            nn.Linear(8, 8, bias=False),
+            nn.Linear(8, 8, bias=False),
+        ).to(device)
+        for param in model.parameters():
+            dist.broadcast(param, src=0)
+        fully_shard(model[0])
+        fully_shard(model[1])
+        fully_shard(model)
+
+        stream = torch.cuda.Stream()
+
+        # warmup
+        with torch.cuda.stream(stream):
+            input_tensor = torch.randn(4, 8, device=device)
+            output = model(input_tensor)
+            output.sum().backward()
+            model.zero_grad(set_to_none=True)
+            del output
+
+        # stream capture to graph
+        static_input = input_tensor.clone()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            static_output = model(static_input)
+            static_output.sum().backward()
+            static_output_grads = [
+                param.grad.detach().clone() for param in model.parameters()
+            ]
+
+        # equivalence check
+        with torch.cuda.stream(stream):
+            for _ in range(2):
+                replay_input = torch.randn(4, 8, device=device)
+                ref_output = model(replay_input)
+                ref_output.sum().backward()
+                ref_grads = [
+                    param.grad.detach().clone() for param in model.parameters()
+                ]
+
+                static_input.copy_(replay_input)
+                graph.replay()
+                self.assertTrue(torch.equal(static_output, ref_output))
+                for graph_grad, ref_grad in zip(static_output_grads, ref_grads):
+                    self.assertTrue(torch.equal(graph_grad, ref_grad))
+                model.zero_grad(set_to_none=True)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -1674,7 +1674,7 @@ class TestFullyShardCudaGraph(FSDPTest):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
+    @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
     def test_two_layer_fully_shard_cudagraph(self):
         if device_type.type == "cuda":
             torch.cuda.set_device(self.rank)


### PR DESCRIPTION
I initially wrote in #164264 that there was a missing wait_stream() call to put a stream into stream capture mode, but surprisingly since I made that issue the problem has been fixed. I was not able to locate the exact commit that coincidentally made that fix after a brief search. Since CachingHostAllocator supports memory allocation during stream capture since #167507, the purpose of this PR is simply to make sure that the support does not regress.

An important detail is that we need to make sure that cuda graph still overlaps the all-gather and reduce-scatter streams with computation streams. To check for that, I applied this patch:

```
diff --git a/test/distributed/_composable/fsdp/test_fully_shard_training.py b/test/distributed/_composable/fsdp/test_fully_shard_training.py
index c0831d87d7c..c0fecdf787d 100644
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -1681,8 +1681,8 @@ class TestFullyShardCudaGraph(FSDPTest):
         device = torch.device(device_type.type, self.rank)
         torch.manual_seed(42)
         model = nn.Sequential(
-            nn.Linear(8, 8, bias=False),
-            nn.Linear(8, 8, bias=False),
+            nn.Linear(4096, 4096, bias=False),
+            nn.Linear(4096, 4096, bias=False),
         ).to(device)
         for param in model.parameters():
             dist.broadcast(param, src=0)
@@ -1694,7 +1694,7 @@ class TestFullyShardCudaGraph(FSDPTest):

         # warmup
         with torch.cuda.stream(stream):
-            input_tensor = torch.randn(4, 8, device=device)
+            input_tensor = torch.randn(4, 4096, device=device)
             output = model(input_tensor)
             output.sum().backward()
             model.zero_grad(set_to_none=True)
@@ -1711,7 +1711,7 @@ class TestFullyShardCudaGraph(FSDPTest):
             ]

         # equivalence check
-        with torch.cuda.stream(stream):
+        with torch.cuda.stream(stream), torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA], record_shapes=True, profile_memory=True) as prof:
             for _ in range(2):
                 replay_input = torch.randn(4, 8, device=device)
                 ref_output = model(replay_input)
@@ -1726,6 +1726,8 @@ class TestFullyShardCudaGraph(FSDPTest):
                 for graph_grad, ref_grad in zip(static_output_grads, ref_grads):
                     self.assertTrue(torch.equal(graph_grad, ref_grad))
                 model.zero_grad(set_to_none=True)
+                prof.step()
+        prof.export_chrome_trace(f"two_layer_fully_shard_cudagraph_{self.rank}.json")

 if __name__ == "__main__":
```

I then inspection the json file manually to check for overlap.

Closes issue #164264

Fixes #164264


cc @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng