### PR TITLE
Remove unused ignores of pyrefly

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -394,7 +394,7 @@ def to_real_dtype(dtype: torch.dtype):
 def mse_loss(
     self: Tensor, target: Tensor, reduction: int = Reduction.MEAN.value
 ) -> Tensor:
-    # pyrefly: ignore [unsupported-operation]
+
     loss = (self - target) ** 2
     return apply_loss_reduction(loss, reduction)
 
@@ -428,7 +428,7 @@ def smooth_l1_loss(
     beta: float = 1.0,
 ):
     loss = (self - target).abs()
-    # pyrefly: ignore [unsupported-operation]
+
     loss = torch.where(loss < beta, 0.5 * loss**2 / beta, loss - 0.5 * beta)
     return apply_loss_reduction(loss, reduction)
 
@@ -5302,7 +5302,7 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
         alpha = int(alpha)
     result = torch.bmm(batch1, batch2)
     if not isinstance(alpha, numbers.Number) or alpha != 1:
-        # pyrefly: ignore [unsupported-operation]
+
         result = result * alpha
     if beta == 0:
         return result

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -394,7 +394,6 @@ def to_real_dtype(dtype: torch.dtype):
 def mse_loss(
     self: Tensor, target: Tensor, reduction: int = Reduction.MEAN.value
 ) -> Tensor:
-
     loss = (self - target) ** 2
     return apply_loss_reduction(loss, reduction)
 
@@ -5302,7 +5301,6 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
         alpha = int(alpha)
     result = torch.bmm(batch1, batch2)
     if not isinstance(alpha, numbers.Number) or alpha != 1:
-
         result = result * alpha
     if beta == 0:
         return result

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -77,7 +77,7 @@ class Instruction:
     offset: Optional[int] = None
     starts_line: Optional[int] = None
     is_jump_target: bool = False
-    # pyrefly: ignore[missing-attribute]
+
     positions: Optional["dis.Positions"] = None
     # extra fields to make modification easier:
     target: Optional["Instruction"] = None

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2594,7 +2594,6 @@ class GuardBuilder(GuardBuilderBase):
         self.check_fn_manager.global_state = global_state
 
         code = [
-
             f"___check_global_state() against {self.check_fn_manager.global_state.__getstate__()}"
         ]
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2594,7 +2594,7 @@ class GuardBuilder(GuardBuilderBase):
         self.check_fn_manager.global_state = global_state
 
         code = [
-            # pyrefly: ignore[missing-attribute]
+
             f"___check_global_state() against {self.check_fn_manager.global_state.__getstate__()}"
         ]
 

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -419,7 +419,7 @@ if "__compile_source__" in globals():
                 # pyrefly: ignore [missing-attribute]
                 kernel._fn_name
                 if isinstance(kernel, JITFunction)
-                # pyrefly: ignore [missing-attribute]
+
                 else kernel.fn._fn_name
             )
             fn_name = fn_name.split(".")[-1]

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -419,7 +419,6 @@ if "__compile_source__" in globals():
                 # pyrefly: ignore [missing-attribute]
                 kernel._fn_name
                 if isinstance(kernel, JITFunction)
-
                 else kernel.fn._fn_name
             )
             fn_name = fn_name.split(".")[-1]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2277,7 +2277,7 @@ class InstructionTranslatorBase(
             val = self.stack[-2]
             assert self._isinstance_exception(val)
             typ = BuiltinVariable(val.exc_type)  # type: ignore[attr-defined]
-            # pyrefly: ignore[bad-argument-type]
+
             tb = val.var_getattr(self, "__traceback__")
 
         args += [typ, val, tb]
@@ -2389,7 +2389,7 @@ class InstructionTranslatorBase(
                     # Traceback is currently mapped to UnknownVariable
                     self.push(variables.UnknownVariable())
                     self.push(old_exception)
-                    # pyrefly: ignore[missing-attribute]
+
                     self.push(variables.BuiltinVariable(old_exception.exc_type))
                 else:
                     # Push empty exception tb, value, type
@@ -2401,7 +2401,7 @@ class InstructionTranslatorBase(
                 # Traceback is currently mapped to UnknownVariable
                 self.push(variables.UnknownVariable())
                 self.push(exception_var)
-                # pyrefly: ignore[missing-attribute]
+
                 self.push(variables.BuiltinVariable(exception_var.exc_type))
 
                 # Jump to target

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -189,11 +189,11 @@ class CPythonTestCase(TestCase):
     ) -> Callable[..., Any]:
         # We want to compile only the test function, excluding any setup code
         # from unittest
-        # pyrefly: ignore[missing-attribute]
+
         method = getattr(self, self._testMethodName)
         method = torch._dynamo.optimize(backend, error_on_graph_break=nopython)(method)
 
-        # pyrefly: ignore[missing-attribute]
+
         setattr(self, self._testMethodName, method)
         return fn
 

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -193,7 +193,6 @@ class CPythonTestCase(TestCase):
         method = getattr(self, self._testMethodName)
         method = torch._dynamo.optimize(backend, error_on_graph_break=nopython)(method)
 
-
         setattr(self, self._testMethodName, method)
         return fn
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1348,7 +1348,6 @@ class VariableBuilder:
             self.install_guards(GuardBuilder.TYPE_MATCH)
             return WrapperUserFunctionVariable(value, "__wrapped__", source=self.source)
         elif value is sys.exc_info or (
-
             sys.version_info >= (3, 11) and value is sys.exception
         ):
             return SysFunctionVariable(value, source=self.source)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1348,7 +1348,7 @@ class VariableBuilder:
             self.install_guards(GuardBuilder.TYPE_MATCH)
             return WrapperUserFunctionVariable(value, "__wrapped__", source=self.source)
         elif value is sys.exc_info or (
-            # pyrefly: ignore[missing-attribute]
+
             sys.version_info >= (3, 11) and value is sys.exception
         ):
             return SysFunctionVariable(value, source=self.source)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2668,7 +2668,7 @@ class SysFunctionVariable(VariableTracker):
     ) -> VariableTracker:
         if self.value is sys.exc_info:
             return self.exc_info(tx)
-        # pyrefly: ignore[missing-attribute]
+
         assert self.value is sys.exception
         return self.exception(tx)
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2318,7 +2318,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # this results in cleaner graphs, but only works for inputs
         # pyrefly: ignore [missing-attribute]
         if data.source:
-            # pyrefly: ignore[bad-argument-type]
+
             return cls._nn_param_via_prefix_insert(tx, data, requires_grad)
 
         if config.graph_break_on_nn_param_ctor:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2318,7 +2318,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         # this results in cleaner graphs, but only works for inputs
         # pyrefly: ignore [missing-attribute]
         if data.source:
-
             return cls._nn_param_via_prefix_insert(tx, data, requires_grad)
 
         if config.graph_break_on_nn_param_ctor:

--- a/torch/_export/passes/_node_metadata_hook.py
+++ b/torch/_export/passes/_node_metadata_hook.py
@@ -84,7 +84,6 @@ def _node_metadata_hook(
         "torch_fn",
         (
             f"{node.target.__name__}_0",
-
             f"{node.target.__class__.__name__}.{node.target.__name__}",
         ),
     )

--- a/torch/_export/passes/_node_metadata_hook.py
+++ b/torch/_export/passes/_node_metadata_hook.py
@@ -84,7 +84,7 @@ def _node_metadata_hook(
         "torch_fn",
         (
             f"{node.target.__name__}_0",
-            # pyrefly: ignore [missing-attribute]
+
             f"{node.target.__class__.__name__}.{node.target.__name__}",
         ),
     )

--- a/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
+++ b/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
@@ -638,7 +638,6 @@ def replace_quantized_ops_with_standard_ops(gm: torch.fx.GraphModule):
                         ]:
                             buffer_name_to_clean.add(b_name)
                     for b_name in buffer_name_to_clean:
-
                         v.pop(b_name, None)
             for attr_name in attr_names_to_clean:
                 delattr(submod, attr_name)

--- a/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
+++ b/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
@@ -630,7 +630,7 @@ def replace_quantized_ops_with_standard_ops(gm: torch.fx.GraphModule):
                     attr_names_to_clean.add(k)
                 if k == "_buffers":
                     buffer_name_to_clean = set()
-                    # pyrefly: ignore [missing-attribute]
+
                     for b_name, b_value in v.items():
                         if isinstance(b_value, torch.Tensor) and b_value.dtype in [
                             torch.qint8,
@@ -638,7 +638,7 @@ def replace_quantized_ops_with_standard_ops(gm: torch.fx.GraphModule):
                         ]:
                             buffer_name_to_clean.add(b_name)
                     for b_name in buffer_name_to_clean:
-                        # pyrefly: ignore [missing-attribute]
+
                         v.pop(b_name, None)
             for attr_name in attr_names_to_clean:
                 delattr(submod, attr_name)

--- a/torch/_functorch/_aot_autograd/fx_utils.py
+++ b/torch/_functorch/_aot_autograd/fx_utils.py
@@ -78,7 +78,7 @@ def get_all_input_and_grad_nodes(
                 continue
             if isinstance(desc, SubclassGetAttrAOTInput):
                 _raise_autograd_subclass_not_implemented(n, desc)
-            # pyrefly: ignore [unsupported-operation]
+
             input_index[desc] = (n, None)
         elif n.op == "output":
             assert "desc" in n.meta, (n, n.meta)
@@ -130,7 +130,7 @@ def get_all_output_and_tangent_nodes(
                     continue
                 if isinstance(sub_d, SubclassGetAttrAOTOutput):
                     _raise_autograd_subclass_not_implemented(sub_n, sub_d)
-                # pyrefly: ignore [unsupported-operation]
+
                 output_index[sub_d] = (sub_n, None)
     for n in g.nodes:
         if n.op == "placeholder":

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -616,7 +616,7 @@ def collect_bw_donated_buffer_idxs(
         fw_ins,
         user_fw_outs,
         bw_outs,
-        # pyrefly: ignore [bad-argument-type]
+
         saved_tensors,
     )
 
@@ -1929,7 +1929,7 @@ def _aot_stage2b_bw_compile(
                 with suppress_ctx:
                     for k in range(len(ph_arg.stride())):
                         # real_stride can't be symbolic.
-                        # pyrefly: ignore [index-error]
+
                         if guard_or_true(ph_arg.stride()[k] != int(real_stride[k])):
                             stride_different = True
                             break
@@ -1953,7 +1953,7 @@ def _aot_stage2b_bw_compile(
 
                     ph_size = ph_arg.size()
 
-                    # pyrefly: ignore [bad-argument-type]
+
                     placeholder_list[i] = ph_arg.as_strided(ph_size, real_stride)
             compiled_bw_func = None
             if (

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -616,7 +616,6 @@ def collect_bw_donated_buffer_idxs(
         fw_ins,
         user_fw_outs,
         bw_outs,
-
         saved_tensors,
     )
 
@@ -1952,7 +1951,6 @@ def _aot_stage2b_bw_compile(
                     # tensor which is wrong.
 
                     ph_size = ph_arg.size()
-
 
                     placeholder_list[i] = ph_arg.as_strided(ph_size, real_stride)
             compiled_bw_func = None

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1301,13 +1301,13 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
 
     for i, m in enumerate(reversed(_get_current_dispatch_mode_stack())):
         if isinstance(m, FakeTensorMode):
-            # pyrefly: ignore [bad-argument-type]
+
             fake_modes.append((m, "active fake mode", i))
 
     flat_inputs = pytree.tree_leaves(inputs)
     for i, flat_input in enumerate(flat_inputs):
         if isinstance(flat_input, FakeTensor):
-            # pyrefly: ignore [bad-argument-type]
+
             fake_modes.append((flat_input.fake_mode, "fake tensor input", i))
         if is_traceable_wrapper_subclass(flat_input):
             out: list[torch.Tensor | int | torch.SymInt] = []
@@ -1316,7 +1316,7 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
                 x for x in out if isinstance(x, FakeTensor)
             ]
             fake_modes.extend(
-                # pyrefly: ignore [bad-argument-type]
+
                 [
                     (tensor.fake_mode, f"subclass input {i}", ix)
                     for ix, tensor in enumerate(fake_tensors)
@@ -1329,12 +1329,12 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
             if fake_mode is not m:
                 raise AssertionError(
                     f"fake mode ({fake_mode}) from {desc1} {i1} doesn't match mode ({m}) from {desc2} {i2}\n\n"
-                    # pyrefly: ignore [missing-attribute]
+
                     f"fake mode from {desc1} {i1} allocated at:\n{fake_mode.stack}\n"
-                    # pyrefly: ignore [missing-attribute]
+
                     f"fake mode from {desc2} {i2} allocated at:\n{m.stack}"
                 )
-        # pyrefly: ignore [bad-return]
+
         return fake_mode
     else:
         return None

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1301,13 +1301,11 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
 
     for i, m in enumerate(reversed(_get_current_dispatch_mode_stack())):
         if isinstance(m, FakeTensorMode):
-
             fake_modes.append((m, "active fake mode", i))
 
     flat_inputs = pytree.tree_leaves(inputs)
     for i, flat_input in enumerate(flat_inputs):
         if isinstance(flat_input, FakeTensor):
-
             fake_modes.append((flat_input.fake_mode, "fake tensor input", i))
         if is_traceable_wrapper_subclass(flat_input):
             out: list[torch.Tensor | int | torch.SymInt] = []
@@ -1316,7 +1314,6 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
                 x for x in out if isinstance(x, FakeTensor)
             ]
             fake_modes.extend(
-
                 [
                     (tensor.fake_mode, f"subclass input {i}", ix)
                     for ix, tensor in enumerate(fake_tensors)
@@ -1329,9 +1326,7 @@ def detect_fake_mode(inputs: Any = None) -> FakeTensorMode | None:
             if fake_mode is not m:
                 raise AssertionError(
                     f"fake mode ({fake_mode}) from {desc1} {i1} doesn't match mode ({m}) from {desc2} {i2}\n\n"
-
                     f"fake mode from {desc1} {i1} allocated at:\n{fake_mode.stack}\n"
-
                     f"fake mode from {desc2} {i2} allocated at:\n{m.stack}"
                 )
 

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -460,7 +460,7 @@ def trace_flex_attention(
         example_out,
         out_proxy,
         constant=None,
-        # pyrefly: ignore [bad-argument-type]
+
         tracer=proxy_mode.tracer,
     )
 
@@ -1192,7 +1192,7 @@ def trace_flex_attention_backward(
         example_out,
         out_proxy,
         constant=None,
-        # pyrefly: ignore [bad-argument-type]
+
         tracer=proxy_mode.tracer,
     )
 

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -460,7 +460,6 @@ def trace_flex_attention(
         example_out,
         out_proxy,
         constant=None,
-
         tracer=proxy_mode.tracer,
     )
 
@@ -1192,7 +1191,6 @@ def trace_flex_attention_backward(
         example_out,
         out_proxy,
         constant=None,
-
         tracer=proxy_mode.tracer,
     )
 

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -448,7 +448,6 @@ class LocalMapAutogradOp(torch.autograd.Function):
             )
 
             for i, meta in ctx.expected_tangent_metadata.items():
-
                 grads[i] = coerce_to_expected_memory_format(grads[i], meta)
 
             grad_ins = local_map_hop(ctx.bw_gm, *saved_activations, *grads)

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -448,7 +448,7 @@ class LocalMapAutogradOp(torch.autograd.Function):
             )
 
             for i, meta in ctx.expected_tangent_metadata.items():
-                # pyrefly: ignore [bad-argument-type]
+
                 grads[i] = coerce_to_expected_memory_format(grads[i], meta)
 
             grad_ins = local_map_hop(ctx.bw_gm, *saved_activations, *grads)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -264,7 +264,6 @@ def generate_ttir(
 
     assert isinstance(kernel, JITFunction)
 
-
     context = triton._C.libtriton.ir.context()
     target = triton.runtime.driver.active.get_current_target()
     backend = triton.compiler.compiler.make_backend(target)
@@ -387,7 +386,6 @@ def generate_ttir(
                 except TypeError:  # Unknown arg `specialize_extra`
                     # Older versions of Triton take specialize_extra as an arg to specialize_impl
                     specialize_impl = functools.partial(
-
                         triton.runtime.jit.create_specialize_impl(),
                         specialize_extra=backend.get_arg_specialization,
                     )
@@ -478,7 +476,6 @@ def generate_ttir(
             if i not in constexprs
         }
 
-
     triton._C.libtriton.ir.load_dialects(context)
     backend.load_dialects(context)
 
@@ -488,14 +485,11 @@ def generate_ttir(
     # backward compatibility here.
     make_ir_sig_params = len(inspect.signature(src.make_ir).parameters)
     get_codegen_implementation_sig_params = len(
-
         inspect.signature(backend.get_codegen_implementation).parameters
     )
     if make_ir_sig_params == 2:
-
         ttir_module = src.make_ir(options, context)
     elif make_ir_sig_params == 3:
-
         codegen_fns = backend.get_codegen_implementation()
 
         ttir_module = src.make_ir(options, codegen_fns, context)
@@ -2098,7 +2092,6 @@ class TraceableTritonKernelWrapper:
         kernel_idx: Optional[int],
         grid: Optional["TritonGridType"],
     ) -> None:
-
         self.kernel = None
         self.grid = None
         tracing_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -264,7 +264,7 @@ def generate_ttir(
 
     assert isinstance(kernel, JITFunction)
 
-    # pyrefly: ignore [missing-attribute]
+
     context = triton._C.libtriton.ir.context()
     target = triton.runtime.driver.active.get_current_target()
     backend = triton.compiler.compiler.make_backend(target)
@@ -306,7 +306,7 @@ def generate_ttir(
                 base_tensor = torch.empty(
                     [elements_per_dim] * len(block_shape), dtype=a.dtype
                 )
-            # pyrefly: ignore [bad-argument-type]
+
             ordered_args[name] = TensorDescriptor.from_tensor(base_tensor, block_shape)
         elif isinstance(a, (FakeTensor, torch._inductor.ir.TensorBox)):
             with torch._C._DisableTorchDispatch():
@@ -370,7 +370,7 @@ def generate_ttir(
 
             target = triton.runtime.driver.active.get_current_target()
             backend_ = triton.compiler.compiler.make_backend(target)
-            # pyrefly: ignore [missing-attribute]
+
             return backend_.get_attrs_descriptor(args, kernel.params)
         else:
             assert (
@@ -382,14 +382,14 @@ def generate_ttir(
                 try:
                     # Latest versions of Triton take specialize_extra as an arg to create_specialize_impl
                     specialize_impl = triton.runtime.jit.create_specialize_impl(
-                        specialize_extra=backend.get_arg_specialization  # pyrefly: ignore [missing-attribute]
+                        specialize_extra=backend.get_arg_specialization
                     )
                 except TypeError:  # Unknown arg `specialize_extra`
                     # Older versions of Triton take specialize_extra as an arg to specialize_impl
                     specialize_impl = functools.partial(
-                        # pyrefly: ignore [missing-argument, bad-argument-type]
+
                         triton.runtime.jit.create_specialize_impl(),
-                        specialize_extra=backend.get_arg_specialization,  # pyrefly: ignore [missing-attribute]
+                        specialize_extra=backend.get_arg_specialization,
                     )
             # create_specialize_impl is removed in https://github.com/triton-lang/triton/pull/7771
             # switch to native_specialize_impl instead
@@ -413,7 +413,7 @@ def generate_ttir(
 
                 specialize_impl = functools.partial(
                     specialize_impl_orig,
-                    specialize_extra=backend.get_arg_specialization,  # pyrefly: ignore [missing-attribute]
+                    specialize_extra=backend.get_arg_specialization,
                 )
 
             from triton._utils import find_paths_if, get_iterable_path
@@ -478,7 +478,7 @@ def generate_ttir(
             if i not in constexprs
         }
 
-    # pyrefly: ignore [missing-attribute]
+
     triton._C.libtriton.ir.load_dialects(context)
     backend.load_dialects(context)
 
@@ -488,30 +488,30 @@ def generate_ttir(
     # backward compatibility here.
     make_ir_sig_params = len(inspect.signature(src.make_ir).parameters)
     get_codegen_implementation_sig_params = len(
-        # pyrefly: ignore [missing-attribute]
+
         inspect.signature(backend.get_codegen_implementation).parameters
     )
     if make_ir_sig_params == 2:
-        # pyrefly: ignore [missing-argument, bad-argument-type]
+
         ttir_module = src.make_ir(options, context)
     elif make_ir_sig_params == 3:
-        # pyrefly: ignore [missing-attribute]
+
         codegen_fns = backend.get_codegen_implementation()
-        # pyrefly: ignore [missing-argument, bad-argument-type]
+
         ttir_module = src.make_ir(options, codegen_fns, context)
     elif make_ir_sig_params == 4:
         codegen_args = [options] if get_codegen_implementation_sig_params == 1 else []
-        # pyrefly: ignore [missing-attribute]
+
         codegen_fns = backend.get_codegen_implementation(*codegen_args)
         module_map = backend.get_module_map()
-        # pyrefly: ignore[missing-argument,bad-argument-type]
+
         ttir_module = src.make_ir(options, codegen_fns, module_map, context)
     else:
         codegen_args = [options] if get_codegen_implementation_sig_params == 1 else []
-        # pyrefly: ignore [missing-attribute]
+
         codegen_fns = backend.get_codegen_implementation(*codegen_args)
         module_map = backend.get_module_map()
-        # pyrefly: ignore [bad-argument-count]
+
         ttir_module = src.make_ir(target, options, codegen_fns, module_map, context)
     if not ttir_module.verify():
         raise RuntimeError("Verification for TTIR module has failed")
@@ -1136,7 +1136,7 @@ def triton_kernel_wrapper_mutation_dense(
                 from triton.tools.tensor_descriptor import TensorDescriptor
 
                 block_shape = stable_meta[0]
-                # pyrefly: ignore [bad-argument-type]
+
                 kwargs[k] = TensorDescriptor.from_tensor(tensor, block_shape)
 
     # move as many positional arguments from dicts to args as we
@@ -1693,7 +1693,7 @@ class TritonHOPifier:
                     "Passing multiple @triton.autotune decorators is not supported. "
                     "Please use a single @triton.autotune decorator instead."
                 )
-            # pyrefly: ignore [missing-attribute]
+
             iter_kernel = iter_kernel.fn
 
         # Process the @triton.heuristics decorator:
@@ -1904,7 +1904,7 @@ class TritonHOPifier:
 
         # Both for grid's meta as well as for the kernel, we need combined
         # args and kwargs combined and normalized
-        # pyrefly: ignore [missing-attribute]
+
         combined_args_raw = {**dict(zip(variable.kernel.arg_names, args)), **kwargs}
 
         # precompute the grid for the kernel
@@ -2098,7 +2098,7 @@ class TraceableTritonKernelWrapper:
         kernel_idx: Optional[int],
         grid: Optional["TritonGridType"],
     ) -> None:
-        # pyrefly: ignore [bad-assignment]
+
         self.kernel = None
         self.grid = None
         tracing_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -151,7 +151,7 @@ def aoti_compile_and_package(
     return aot_inductor_minifier_wrapper(
         _aoti_compile_and_package_inner,
         exported_program,
-        # pyrefly: ignore [bad-argument-type]
+
         package_path=package_path,
         inductor_configs=inductor_configs,
     )

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -151,7 +151,6 @@ def aoti_compile_and_package(
     return aot_inductor_minifier_wrapper(
         _aoti_compile_and_package_inner,
         exported_program,
-
         package_path=package_path,
         inductor_configs=inductor_configs,
     )

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -643,7 +643,6 @@ class InductorChoices:
 
         type_score = node1.is_reduction() == node2.is_reduction() and memory_score > 0
 
-
         return FusionScore(
             template_score,
             type_score,

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -643,7 +643,7 @@ class InductorChoices:
 
         type_score = node1.is_reduction() == node2.is_reduction() and memory_score > 0
 
-        # pyrefly: ignore [bad-return]
+
         return FusionScore(
             template_score,
             type_score,

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2432,7 +2432,6 @@ class KernelTemplate:
             class DetailedTemplateSyntaxError(TemplateSyntaxError):
                 def __init__(self, original_error: TemplateSyntaxError) -> None:
                     super().__init__(
-
                         original_error.message,
                         original_error.lineno,
                         original_error.name,
@@ -2444,7 +2443,6 @@ class KernelTemplate:
                     error_info = f"Error in template at line {self.lineno}\n"
                     error_info += f"Error message: {self.message}\n"
                     if hasattr(self.original_error, "source"):
-
                         lines = self.original_error.source.split("\n")
                         error_info += "Context:\n"
                         start = max(0, self.lineno - 2)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -970,7 +970,7 @@ class OpOverrides(BasicMathOpsMixin, OpDecompositions, OpsHandler[Any]):
             or _all_in_parens(string)
         ):
             # don't put extra parens for strings that are already wrapped in parens
-            # pyrefly: ignore [bad-return]
+
             return string
         return f"({string})"
 
@@ -2432,7 +2432,7 @@ class KernelTemplate:
             class DetailedTemplateSyntaxError(TemplateSyntaxError):
                 def __init__(self, original_error: TemplateSyntaxError) -> None:
                     super().__init__(
-                        # pyrefly: ignore [bad-argument-type]
+
                         original_error.message,
                         original_error.lineno,
                         original_error.name,
@@ -2444,7 +2444,7 @@ class KernelTemplate:
                     error_info = f"Error in template at line {self.lineno}\n"
                     error_info += f"Error message: {self.message}\n"
                     if hasattr(self.original_error, "source"):
-                        # pyrefly: ignore [missing-attribute]
+
                         lines = self.original_error.source.split("\n")
                         error_info += "Context:\n"
                         start = max(0, self.lineno - 2)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2041,7 +2041,7 @@ class CppKernel(Kernel):
                 # mask's dtype should be bool
                 mask.dtype = torch.bool
 
-        # pyrefly: ignore [bad-assignment]
+
         self._load_mask = mask
         try:
             yield mask
@@ -5220,7 +5220,7 @@ class CppScheduling(BaseScheduling):
                             )
                             local_buffers.append(local_buffer_used)
                             local_to_global_buffers[local_buffer_used.name] = []  # type: ignore[index]
-                        # pyrefly: ignore [index-error]
+
                         local_to_global_buffers[local_buffer_used.name].append(
                             global_buffer,
                         )

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2041,7 +2041,6 @@ class CppKernel(Kernel):
                 # mask's dtype should be bool
                 mask.dtype = torch.bool
 
-
         self._load_mask = mask
         try:
             yield mask

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1541,7 +1541,6 @@ class CppGemmTemplate(CppTemplate):
             self.n,
             self.k,
             input_dtype=X.get_dtype(),
-
             input2_dtype=W.get_dtype(),
             output_dtype=output_dtype,
             compute_dtype=compute_dtype,

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -1541,7 +1541,7 @@ class CppGemmTemplate(CppTemplate):
             self.n,
             self.k,
             input_dtype=X.get_dtype(),
-            # pyrefly: ignore [missing-attribute]
+
             input2_dtype=W.get_dtype(),
             output_dtype=output_dtype,
             compute_dtype=compute_dtype,

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -399,7 +399,6 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
             self.n,
             self.k,
             input_dtype=X_list[0].get_dtype(),
-
             input2_dtype=W_list[0].get_dtype(),
             output_dtype=output_dtype,
             compute_dtype=compute_dtype,
@@ -437,7 +436,6 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
         for x_idx in range(wgt_start_idx):
             kernel_args["X" + str(x_idx)] = act_deduplicated[x_idx]
         for w_idx in range(self.gemm_grouped_num):
-
             kernel_args["W" + str(w_idx)] = W_list[w_idx]
         for inp_idx in range(self.gemm_grouped_num):
             kernel_args["inp" + str(inp_idx)] = inp_list[inp_idx]

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -331,7 +331,7 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
                     template_buffer.inputs[idx] = (
                         ir.InputsKernel.unwrap_storage_for_input(W_packed_constant)
                     )
-            # pyrefly: ignore [bad-return]
+
             return output
 
         template = DataProcessorTemplateWrapper(
@@ -399,7 +399,7 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
             self.n,
             self.k,
             input_dtype=X_list[0].get_dtype(),
-            # pyrefly: ignore [missing-attribute]
+
             input2_dtype=W_list[0].get_dtype(),
             output_dtype=output_dtype,
             compute_dtype=compute_dtype,
@@ -437,7 +437,7 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
         for x_idx in range(wgt_start_idx):
             kernel_args["X" + str(x_idx)] = act_deduplicated[x_idx]
         for w_idx in range(self.gemm_grouped_num):
-            # pyrefly: ignore [unsupported-operation]
+
             kernel_args["W" + str(w_idx)] = W_list[w_idx]
         for inp_idx in range(self.gemm_grouped_num):
             kernel_args["inp" + str(inp_idx)] = inp_list[inp_idx]

--- a/torch/_inductor/codegen/cpp_template.py
+++ b/torch/_inductor/codegen/cpp_template.py
@@ -85,7 +85,6 @@ class CppTemplate(KernelTemplate):
         bmreq = CppBenchmarkRequest(
             kernel_name=kernel_name,
             input_tensor_meta=TensorMeta.from_irnodes(self.input_nodes),
-
             output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
             extra_args=extra_args,
             source_code=code,

--- a/torch/_inductor/codegen/cpp_template.py
+++ b/torch/_inductor/codegen/cpp_template.py
@@ -85,7 +85,7 @@ class CppTemplate(KernelTemplate):
         bmreq = CppBenchmarkRequest(
             kernel_name=kernel_name,
             input_tensor_meta=TensorMeta.from_irnodes(self.input_nodes),
-            # pyrefly: ignore [bad-argument-type]
+
             output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
             extra_args=extra_args,
             source_code=code,

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -411,7 +411,6 @@ class CppTemplateKernel(CppKernel):
                     )
                     epilogue_nodes = scope.localize_nodes(epilogue_nodes)
                 return self.store_pointwise_nodes(
-
                     dst,
                     epilogue_nodes,  # type: ignore[arg-type]
                     offsets,

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -411,7 +411,7 @@ class CppTemplateKernel(CppKernel):
                     )
                     epilogue_nodes = scope.localize_nodes(epilogue_nodes)
                 return self.store_pointwise_nodes(
-                    # pyrefly: ignore [bad-argument-type]
+
                     dst,
                     epilogue_nodes,  # type: ignore[arg-type]
                     offsets,
@@ -423,7 +423,7 @@ class CppTemplateKernel(CppKernel):
                 copy = L.copy(dst, src).data.data
                 with LocalBufferContext(self.args) as scope:
                     scope.add_local_buffer(src)
-                    # pyrefly: ignore [bad-argument-type]
+
                     return self.store_pointwise_nodes(dst, [copy])
             else:
                 assert dst.layout == src.layout, f"{dst=}, {src=}"

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -281,7 +281,7 @@ class CuteDSLOpOverrides(OpOverrides):
             else "mlir_math.absi"
         )
         return CuteDSLOpOverrides._apply_unary_op(
-            # pyrefly: ignore [bad-argument-type]
+
             x,
             f"cute.TensorSSA({abs_op}({{x}}), {{x}}.shape, {{x}}.dtype)",
         )

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -281,7 +281,6 @@ class CuteDSLOpOverrides(OpOverrides):
             else "mlir_math.absi"
         )
         return CuteDSLOpOverrides._apply_unary_op(
-
             x,
             f"cute.TensorSSA({abs_op}({{x}}), {{x}}.shape, {{x}}.dtype)",
         )

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -598,7 +598,6 @@ class MetalKernel(SIMDKernel):
         reduction_idx = ""
         acc_buf_size = 1
         for rd in self.range_trees:
-
             if not rd.is_reduction:
                 continue
             if reduction_idx:
@@ -695,10 +694,7 @@ class MetalKernel(SIMDKernel):
                 )
                 idx_val = self._new_idxvar(dtype, default_value=0, is_threadgroup=False)  # type: ignore[assignment]
                 idx_var = next(
-                    t
-                    for t in self.range_tree_nodes.values()
-
-                    if t.is_reduction
+                    t for t in self.range_tree_nodes.values() if t.is_reduction
                 )
                 cmp_op = ">" if reduction_type == "argmax" else "<"
                 nan_suffix = (
@@ -764,7 +760,6 @@ class MetalKernel(SIMDKernel):
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry) -> None:
         index_expr = self.rename_indexing(entry.expr)
         index_str = self.sexpr(index_expr)  # type: ignore[misc]
-
 
         if not entry.is_reduction or (
             isinstance(entry.root.numel, sympy.Integer)
@@ -877,10 +872,7 @@ class MetalKernel(SIMDKernel):
 
             if self.inside_reduction:
                 total_reduction_size = math.prod(
-                    t.numel
-                    for t in self.range_trees
-
-                    if t.is_reduction
+                    t.numel for t in self.range_trees if t.is_reduction
                 )
                 # If using dynamic shapes, set the threadgroup size to be the
                 # max possible size
@@ -984,7 +976,6 @@ class MetalKernel(SIMDKernel):
             else:
                 expr = V.graph.wrapper_code.generate_numel_expr(name, tree).inner
 
-
             if not tree.is_reduction or self.inside_reduction:
                 args.append(str(expr))
                 arg_types.append(int)
@@ -1004,7 +995,6 @@ class MetalKernel(SIMDKernel):
             threads = [
                 expr_printer(
                     sympy.Min(v.numel, self.max_threadgroup_size)  # type: ignore[misc]
-
                     if v.is_reduction
                     else v.numel
                 )
@@ -1020,7 +1010,6 @@ class MetalKernel(SIMDKernel):
         if self.inside_reduction:
             threads = [
                 expr_printer(sympy.Min(v.numel, self.max_threadgroup_size))  # type: ignore[misc]
-
                 if v.is_reduction
                 else "1"
                 for v in self.active_range_trees()

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -531,7 +531,7 @@ class MetalKernel(SIMDKernel):
         var = self.args.output(name)
         index = self.prepare_indexing(index)
         dtype_str = self.dtype_to_str(V.graph.get_dtype(name))
-        # pyrefly: ignore [missing-argument]
+
         reduction_dim = next(t for t in self.range_trees if t.is_reduction)
         # Only one thread in the reduction group needs to store the results
         line = f"{var}[{self.index_to_str(index)}] = static_cast<{dtype_str}>({value});"
@@ -598,7 +598,7 @@ class MetalKernel(SIMDKernel):
         reduction_idx = ""
         acc_buf_size = 1
         for rd in self.range_trees:
-            # pyrefly: ignore [missing-argument]
+
             if not rd.is_reduction:
                 continue
             if reduction_idx:
@@ -697,7 +697,7 @@ class MetalKernel(SIMDKernel):
                 idx_var = next(
                     t
                     for t in self.range_tree_nodes.values()
-                    # pyrefly: ignore [missing-argument]
+
                     if t.is_reduction
                 )
                 cmp_op = ">" if reduction_type == "argmax" else "<"
@@ -765,7 +765,7 @@ class MetalKernel(SIMDKernel):
         index_expr = self.rename_indexing(entry.expr)
         index_str = self.sexpr(index_expr)  # type: ignore[misc]
 
-        # pyrefly: ignore [missing-argument]
+
         if not entry.is_reduction or (
             isinstance(entry.root.numel, sympy.Integer)
             and entry.root.numel <= self.max_threadgroup_size
@@ -879,7 +879,7 @@ class MetalKernel(SIMDKernel):
                 total_reduction_size = math.prod(
                     t.numel
                     for t in self.range_trees
-                    # pyrefly: ignore [missing-argument]
+
                     if t.is_reduction
                 )
                 # If using dynamic shapes, set the threadgroup size to be the
@@ -984,7 +984,7 @@ class MetalKernel(SIMDKernel):
             else:
                 expr = V.graph.wrapper_code.generate_numel_expr(name, tree).inner
 
-            # pyrefly: ignore [missing-argument]
+
             if not tree.is_reduction or self.inside_reduction:
                 args.append(str(expr))
                 arg_types.append(int)
@@ -1004,7 +1004,7 @@ class MetalKernel(SIMDKernel):
             threads = [
                 expr_printer(
                     sympy.Min(v.numel, self.max_threadgroup_size)  # type: ignore[misc]
-                    # pyrefly: ignore [missing-argument]
+
                     if v.is_reduction
                     else v.numel
                 )
@@ -1020,7 +1020,7 @@ class MetalKernel(SIMDKernel):
         if self.inside_reduction:
             threads = [
                 expr_printer(sympy.Min(v.numel, self.max_threadgroup_size))  # type: ignore[misc]
-                # pyrefly: ignore [missing-argument]
+
                 if v.is_reduction
                 else "1"
                 for v in self.active_range_trees()

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -1388,7 +1388,6 @@ class PallasKernel(SIMDKernel):
         """Compute total reduction numel."""
         result = 1
         for tree in self.range_trees:
-
             if tree.is_reduction:
                 numel = self._safe_int(tree.numel)
                 if numel is None:
@@ -1721,7 +1720,6 @@ class PallasKernel(SIMDKernel):
         matching_vars = [
             v
             for v, e in self.range_tree_nodes.items()
-
             if self._safe_int(e.length) == buf_length and not e.is_reduction
         ]
         if len(matching_vars) != 1:
@@ -2178,7 +2176,6 @@ class PallasKernel(SIMDKernel):
             var = used_iter_vars[0]
             var_name = str(var)
             is_reduction_var = (
-
                 var in self.range_tree_nodes and self.range_tree_nodes[var].is_reduction
             )
 
@@ -2541,9 +2538,7 @@ class PallasKernel(SIMDKernel):
 
         # Count the number of pointwise and reduction dimensions
         n_reduction_dims = sum(
-            1
-            for var, entry in self.range_tree_nodes.items()
-            if entry.is_reduction
+            1 for var, entry in self.range_tree_nodes.items() if entry.is_reduction
         )
 
         if reduction_type == "xor_sum":

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -1162,7 +1162,7 @@ class PallasKernel(SIMDKernel):
             return False
 
         # Skip for reduction variables
-        # pyrefly: ignore [missing-argument]
+
         if any(entry.is_reduction for _, entry in var_items):
             return False
 
@@ -1388,7 +1388,7 @@ class PallasKernel(SIMDKernel):
         """Compute total reduction numel."""
         result = 1
         for tree in self.range_trees:
-            # pyrefly: ignore [missing-argument]
+
             if tree.is_reduction:
                 numel = self._safe_int(tree.numel)
                 if numel is None:
@@ -1721,7 +1721,7 @@ class PallasKernel(SIMDKernel):
         matching_vars = [
             v
             for v, e in self.range_tree_nodes.items()
-            # pyrefly: ignore [missing-argument]
+
             if self._safe_int(e.length) == buf_length and not e.is_reduction
         ]
         if len(matching_vars) != 1:
@@ -2178,7 +2178,7 @@ class PallasKernel(SIMDKernel):
             var = used_iter_vars[0]
             var_name = str(var)
             is_reduction_var = (
-                # pyrefly: ignore [missing-argument]
+
                 var in self.range_tree_nodes and self.range_tree_nodes[var].is_reduction
             )
 
@@ -2543,7 +2543,7 @@ class PallasKernel(SIMDKernel):
         n_reduction_dims = sum(
             1
             for var, entry in self.range_tree_nodes.items()
-            if entry.is_reduction  # pyrefly: ignore [missing-argument]
+            if entry.is_reduction
         )
 
         if reduction_type == "xor_sum":
@@ -2576,7 +2576,7 @@ class PallasKernel(SIMDKernel):
                     reduction_vars = [
                         var
                         for var, entry in self.range_tree_nodes.items()
-                        if entry.is_reduction  # pyrefly: ignore [missing-argument]
+                        if entry.is_reduction
                     ]
                     if reduction_vars:
                         r_var = reduction_vars[0]
@@ -2589,7 +2589,7 @@ class PallasKernel(SIMDKernel):
                         pw_vars = [
                             var
                             for var, entry in self.range_tree_nodes.items()
-                            if not entry.is_reduction  # pyrefly: ignore [missing-argument]
+                            if not entry.is_reduction
                         ]
                         if pw_vars:
                             pw_var = pw_vars[0]

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -192,7 +192,7 @@ class IterationRangesRoot(IterationRanges):
 
         # True if the dimension is implemented as a single program looping over
         # the full dimension (currently only used for non-persistent reduction)
-        # pyrefly: ignore [missing-argument]
+
         assert not is_loop or (self.is_reduction and grid_dim is None)
         self.is_loop = is_loop
         # Index of corresponding dimension on triton tensors
@@ -589,7 +589,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             if tree.tensor_dim is None:
                 continue
 
-            # pyrefly: ignore [missing-argument]
+
             if not tree.is_reduction or self.inside_reduction:
                 sizes[tree.tensor_dim] = f"{tree.prefix.upper()}BLOCK"
         return sizes
@@ -1009,7 +1009,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         return [
             t
             for t in self.range_trees
-            # pyrefly: ignore [missing-argument]
+
             if not t.is_reduction or self.inside_reduction
         ]
 
@@ -2086,13 +2086,13 @@ class SIMDScheduling(BaseScheduling):
 
             for input_name in kernel.named_input_nodes:
                 subgraph_name = f"<LOAD_INPUT_{input_name}>"
-                # pyrefly: ignore [missing-attribute]
+
                 partial_code.finalize_hook(subgraph_name, strict=False)
 
             num_store_subgraphs = kernel.get_store_output_count()
             for i in range(num_store_subgraphs):
                 subgraph_name = kernel._get_store_output_subgraph_name(i)
-                # pyrefly: ignore [missing-attribute]
+
                 partial_code.finalize_hook(subgraph_name)
 
             if isinstance(partial_code, str):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -589,7 +589,6 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             if tree.tensor_dim is None:
                 continue
 
-
             if not tree.is_reduction or self.inside_reduction:
                 sizes[tree.tensor_dim] = f"{tree.prefix.upper()}BLOCK"
         return sizes
@@ -1007,10 +1006,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
 
     def active_range_trees(self) -> list[IterationRangesRoot]:
         return [
-            t
-            for t in self.range_trees
-
-            if not t.is_reduction or self.inside_reduction
+            t for t in self.range_trees if not t.is_reduction or self.inside_reduction
         ]
 
     def codegen_indexing(self, expr: sympy.Expr) -> sympy.Expr:

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -435,7 +435,6 @@ class ComboKernel(Kernel):
                 assert f"{tree.prefix}numel_{num}" in self.dynamic_shape_args
                 uniquify_block_sizes.append(f"{tree.prefix}numel")
 
-
             if not tree.is_reduction:
                 if isinstance(simplified_tree_numel, (Integer, int)):
                     grid.append(int(simplified_tree_numel))
@@ -702,7 +701,6 @@ class ComboKernel(Kernel):
         for sub_kernel in self.sub_kernels:
             # TODO: we assume all sub_kernels have the same block size
             for tree in sub_kernel.range_trees:
-
                 if tree.is_reduction and (
                     not sub_kernel.inside_reduction or sub_kernel.persistent_reduction
                 ):
@@ -1034,7 +1032,6 @@ class ComboKernel(Kernel):
         for num, sub_kernel in enumerate(self.sub_kernels):
             meta[f"no_x_dim_{num}"] = sub_kernel.no_x_dim
             for tree in sub_kernel.range_trees:
-
                 if not tree.is_reduction:
                     numel_name = f"{tree.prefix}numel_{num}"
                     if numel_name in self.dynamic_shape_args:

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -435,7 +435,7 @@ class ComboKernel(Kernel):
                 assert f"{tree.prefix}numel_{num}" in self.dynamic_shape_args
                 uniquify_block_sizes.append(f"{tree.prefix}numel")
 
-            # pyrefly: ignore [missing-argument]
+
             if not tree.is_reduction:
                 if isinstance(simplified_tree_numel, (Integer, int)):
                     grid.append(int(simplified_tree_numel))
@@ -702,7 +702,7 @@ class ComboKernel(Kernel):
         for sub_kernel in self.sub_kernels:
             # TODO: we assume all sub_kernels have the same block size
             for tree in sub_kernel.range_trees:
-                # pyrefly: ignore [missing-argument]
+
                 if tree.is_reduction and (
                     not sub_kernel.inside_reduction or sub_kernel.persistent_reduction
                 ):
@@ -741,7 +741,7 @@ class ComboKernel(Kernel):
                     expr = V.graph.wrapper_code.generate_numel_expr(
                         name, tree, suffix=str(num)
                     )
-                # pyrefly: ignore [missing-argument]
+
                 if not tree.is_reduction or sub_kernel.inside_reduction:
                     call_args.append(expr)
                     arg_types.append(type(expr))
@@ -753,7 +753,7 @@ class ComboKernel(Kernel):
                 numel_name = f"{tree.prefix}numel_{num}"
                 if numel_name not in self.dynamic_shape_args:
                     continue
-                # pyrefly: ignore [missing-argument]
+
                 if not tree.is_reduction or sub_kernel.inside_reduction:
                     extra_args.append(
                         str(
@@ -1034,7 +1034,7 @@ class ComboKernel(Kernel):
         for num, sub_kernel in enumerate(self.sub_kernels):
             meta[f"no_x_dim_{num}"] = sub_kernel.no_x_dim
             for tree in sub_kernel.range_trees:
-                # pyrefly: ignore [missing-argument]
+
                 if not tree.is_reduction:
                     numel_name = f"{tree.prefix}numel_{num}"
                     if numel_name in self.dynamic_shape_args:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -326,14 +326,14 @@ def user_defined_triton_kernel_transitive_closure_source_code(kernel) -> str:
                 if isinstance(symbol, JITFunction):
                     compile_wrapper.newline()
                     compile_wrapper.writeline("@triton.jit")
-                    # pyrefly: ignore [missing-attribute]
+
                     compile_wrapper.splice(symbol.src, strip=True)
                     symbols_included.add(symbol_name)
                     traverse(symbol)
                 elif hasattr(triton, "constexpr_function") and isinstance(
-                    # pyrefly: ignore [missing-attribute]
+
                     symbol,
-                    # pyrefly: ignore [missing-attribute]
+
                     triton.runtime.jit.ConstexprFunction,
                 ):
                     compile_wrapper.newline()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -331,9 +331,7 @@ def user_defined_triton_kernel_transitive_closure_source_code(kernel) -> str:
                     symbols_included.add(symbol_name)
                     traverse(symbol)
                 elif hasattr(triton, "constexpr_function") and isinstance(
-
                     symbol,
-
                     triton.runtime.jit.ConstexprFunction,
                 ):
                     compile_wrapper.newline()

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -187,7 +187,7 @@ class WrapperFxCodegen(PythonWrapperCodegen):
         """
         Get the input nodes corresponding to FX graph placeholders.
         """
-        # pyrefly: ignore [missing-argument]
+
         if V.aot_compilation and not self.is_subgraph:
             # AOT graphs must match the signature of the input module.
             return {
@@ -212,7 +212,7 @@ class WrapperFxCodegen(PythonWrapperCodegen):
             graph_inputs=self.get_fx_graph_inputs(),
             graph_outputs=self.get_graph_outputs(),
             subgms=self.subgms,
-            # pyrefly: ignore [missing-argument]
+
             is_subgraph=self.is_subgraph,
         ).generate()
 
@@ -950,9 +950,9 @@ class FxConverter:
             from triton.runtime import driver
 
             log.info("Autotuning Triton kernel %s at compile time.", kernel_name)
-            # pyrefly: ignore [missing-attribute]
+
             device = driver.active.get_current_device()
-            # pyrefly: ignore [missing-attribute]
+
             stream = driver.active.get_current_stream(device)
 
             def node_to_tuning_arg(arg: Any) -> Any:

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -212,7 +212,6 @@ class WrapperFxCodegen(PythonWrapperCodegen):
             graph_inputs=self.get_fx_graph_inputs(),
             graph_outputs=self.get_graph_outputs(),
             subgms=self.subgms,
-
             is_subgraph=self.is_subgraph,
         ).generate()
 

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -820,7 +820,7 @@ def _format_and_log_reordering_stats(
         for snode, node_info in node_stats.items()
     ]
     if importlib.util.find_spec("tabulate"):
-        # pyrefly: ignore[import-error]
+
         from tabulate import tabulate
 
         reorder_log_str += tabulate(
@@ -923,7 +923,7 @@ def _reorder_communication_preserving_peak_memory_internal(
         _next_curr = _next[curr]
         if iterative_recompute_error:
             break
-        # pyrefly: ignore [bad-argument-type]
+
         if not contains_async_collective(curr):
             curr = _next_curr
             continue
@@ -991,7 +991,7 @@ def _reorder_communication_preserving_peak_memory_internal(
                     group_unmet_deps_names.update(node_dep_sets[candidate])
                     group_output_names.update(node_output_sets[candidate])
 
-                    # pyrefly: ignore[unbound-name]
+
                     if config_comms.reorder_iterative_use_runtime_estimations:
                         if contains_wait(candidate):
                             comm_time, comp_time, _ = wait_exposed_communication_time(
@@ -1017,7 +1017,7 @@ def _reorder_communication_preserving_peak_memory_internal(
                     info.limiting_factor = msg
                     break
 
-            # pyrefly: ignore[unbound-name]
+
             if config_comms.reorder_iterative_use_runtime_estimations:
                 # Check if candidate has sync runtime
                 if not contains_async_collective(candidate):
@@ -1121,7 +1121,7 @@ def _reorder_communication_preserving_peak_memory_internal(
 
             if (
                 potential_peak - peak_memory
-                # pyrefly: ignore[unbound-name]
+
                 > peak_memory * config_comms.reorder_iterative_peak_memory_budget
             ):
                 info.limiting_factor = (
@@ -1420,7 +1420,7 @@ def _is_node_groupable_for_sink_waits(
             f"candidate contains_async_collective {candidate.get_name()}",
         )
 
-    # pyrefly: ignore[unbound-name]
+
     if not config_comms.sink_iterative_use_runtime_estimations:
         # Heuristics pre-use_runtime_estimations:
         # TODO(ivankobzarev): Remove them after confirming,
@@ -1672,7 +1672,7 @@ def _format_and_log_sink_waits_stats(
     ]
     log_str = ""
     if importlib.util.find_spec("tabulate"):
-        # pyrefly: ignore[import-error]
+
         from tabulate import tabulate
 
         log_str += tabulate(
@@ -1815,7 +1815,7 @@ def _sink_waits_iterative_internal(
         ):
             break
 
-        # pyrefly: ignore [bad-argument-type]
+
         if not (contains_wait(curr) and curr not in processed_waits):
             curr = _prev_curr
             continue
@@ -1860,7 +1860,7 @@ def _sink_waits_iterative_internal(
             # Conservative sink wait, limiting by space before next collective.
             # The global strategy is that bucketing should create space.
             # For 2D we can experiment with allowing to sink Wait beyond non current group collective.
-            # pyrefly: ignore[unbound-name]
+
             if not config_comms.sink_waits_iterative_swap_with_collectives:
                 if contains_async_collective(candidate):
                     info.limiting_factor = (
@@ -1887,7 +1887,7 @@ def _sink_waits_iterative_internal(
                     )
 
                     if (
-                        # pyrefly: ignore[unbound-name]
+
                         config_comms.sink_iterative_use_runtime_estimations
                         and contains_collective(candidate)
                     ):
@@ -1907,7 +1907,7 @@ def _sink_waits_iterative_internal(
                     continue
                 elif not data_dep:
                     if (
-                        # pyrefly: ignore[unbound-name]
+
                         not config_comms.sink_waits_iterative_unsafe_collectives_reorder
                         and both_contain_comms
                     ):
@@ -1924,7 +1924,7 @@ def _sink_waits_iterative_internal(
                     )
                     break
 
-            # pyrefly: ignore[unbound-name]
+
             if config_comms.sink_iterative_use_runtime_estimations:
                 if is_wait(candidate.node):
                     # Corresponding collective is before the group,
@@ -2018,7 +2018,7 @@ def _sink_waits_iterative_internal(
             )
             if (
                 potential_peak - peak_memory
-                # pyrefly: ignore[unbound-name]
+
                 > peak_memory * config_comms.sink_iterative_peak_memory_budget
             ):
                 info.limiting_factor = (

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -820,7 +820,6 @@ def _format_and_log_reordering_stats(
         for snode, node_info in node_stats.items()
     ]
     if importlib.util.find_spec("tabulate"):
-
         from tabulate import tabulate
 
         reorder_log_str += tabulate(
@@ -991,7 +990,6 @@ def _reorder_communication_preserving_peak_memory_internal(
                     group_unmet_deps_names.update(node_dep_sets[candidate])
                     group_output_names.update(node_output_sets[candidate])
 
-
                     if config_comms.reorder_iterative_use_runtime_estimations:
                         if contains_wait(candidate):
                             comm_time, comp_time, _ = wait_exposed_communication_time(
@@ -1016,7 +1014,6 @@ def _reorder_communication_preserving_peak_memory_internal(
                     )
                     info.limiting_factor = msg
                     break
-
 
             if config_comms.reorder_iterative_use_runtime_estimations:
                 # Check if candidate has sync runtime
@@ -1121,7 +1118,6 @@ def _reorder_communication_preserving_peak_memory_internal(
 
             if (
                 potential_peak - peak_memory
-
                 > peak_memory * config_comms.reorder_iterative_peak_memory_budget
             ):
                 info.limiting_factor = (
@@ -1420,7 +1416,6 @@ def _is_node_groupable_for_sink_waits(
             f"candidate contains_async_collective {candidate.get_name()}",
         )
 
-
     if not config_comms.sink_iterative_use_runtime_estimations:
         # Heuristics pre-use_runtime_estimations:
         # TODO(ivankobzarev): Remove them after confirming,
@@ -1672,7 +1667,6 @@ def _format_and_log_sink_waits_stats(
     ]
     log_str = ""
     if importlib.util.find_spec("tabulate"):
-
         from tabulate import tabulate
 
         log_str += tabulate(
@@ -1815,7 +1809,6 @@ def _sink_waits_iterative_internal(
         ):
             break
 
-
         if not (contains_wait(curr) and curr not in processed_waits):
             curr = _prev_curr
             continue
@@ -1887,7 +1880,6 @@ def _sink_waits_iterative_internal(
                     )
 
                     if (
-
                         config_comms.sink_iterative_use_runtime_estimations
                         and contains_collective(candidate)
                     ):
@@ -1907,7 +1899,6 @@ def _sink_waits_iterative_internal(
                     continue
                 elif not data_dep:
                     if (
-
                         not config_comms.sink_waits_iterative_unsafe_collectives_reorder
                         and both_contain_comms
                     ):
@@ -1923,7 +1914,6 @@ def _sink_waits_iterative_internal(
                         f"\n non_group_reason:{groupable_reason}"
                     )
                     break
-
 
             if config_comms.sink_iterative_use_runtime_estimations:
                 if is_wait(candidate.node):
@@ -2018,7 +2008,6 @@ def _sink_waits_iterative_internal(
             )
             if (
                 potential_peak - peak_memory
-
                 > peak_memory * config_comms.sink_iterative_peak_memory_budget
             ):
                 info.limiting_factor = (

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1150,7 +1150,7 @@ def _compile_fx_inner(
         )
         log.info("-" * 130)
         for row in mm_table_data:
-            # pyrefly: ignore [not-iterable]
+
             log.info("{:<30} | {:<20} | {:<20} | {:<20} | {:<20} | {:<20}".format(*row))  # noqa: G001
             log.info("-" * 130)
 
@@ -1713,7 +1713,7 @@ class _InProcessFxCompile(FxCompile):
                             )
 
                     return CompiledFxGraph(
-                        # pyrefly: ignore [bad-argument-type]
+
                         compiled_fn,
                         graph,
                         gm,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1150,7 +1150,6 @@ def _compile_fx_inner(
         )
         log.info("-" * 130)
         for row in mm_table_data:
-
             log.info("{:<30} | {:<20} | {:<20} | {:<20} | {:<20} | {:<20}".format(*row))  # noqa: G001
             log.info("-" * 130)
 
@@ -1713,7 +1712,6 @@ class _InProcessFxCompile(FxCompile):
                             )
 
                     return CompiledFxGraph(
-
                         compiled_fn,
                         graph,
                         gm,

--- a/torch/_inductor/config_comms.py
+++ b/torch/_inductor/config_comms.py
@@ -16,7 +16,6 @@ runtime_estimations_align_across_all_distributed_ranks: bool = False
 reorder_iterative_debug_memory_recompute: bool = False
 reorder_iterative_debug_limit_to_reorder: Optional[int] = (
     None
-
     if (env_str := os.getenv("PYTORCH_REORDER_COLLECTIVES_LIMIT")) is None
     else int(env_str)
 )

--- a/torch/_inductor/config_comms.py
+++ b/torch/_inductor/config_comms.py
@@ -16,7 +16,7 @@ runtime_estimations_align_across_all_distributed_ranks: bool = False
 reorder_iterative_debug_memory_recompute: bool = False
 reorder_iterative_debug_limit_to_reorder: Optional[int] = (
     None
-    # pyrefly: ignore[unbound-name]
+
     if (env_str := os.getenv("PYTORCH_REORDER_COLLECTIVES_LIMIT")) is None
     else int(env_str)
 )

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -279,7 +279,6 @@ extern "C" __m512i __avx512_vnni_chk_kernel_2(__m512i src, __m512i a, __m512i b)
 """
 
     @functools.cache  # noqa: B019
-
     def __bool__(self) -> bool:
         if super().__bool__():
             if config.is_fbcode():

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -279,7 +279,7 @@ extern "C" __m512i __avx512_vnni_chk_kernel_2(__m512i src, __m512i a, __m512i b)
 """
 
     @functools.cache  # noqa: B019
-    # pyrefly: ignore [bad-override]
+
     def __bool__(self) -> bool:
         if super().__bool__():
             if config.is_fbcode():

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -930,7 +930,6 @@ class CUDAGraphNode:
             return None
 
         self.static_input_data_ptrs: InputList[Optional[int]] = [
-
             maybe_get_static_data_ptr(i, inputs, self.static_input_idxs)
             for i in range(len(inputs))
         ]

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -409,7 +409,7 @@ def cudagraphify_impl(
         fn = align_inputs_from_check_idxs(
             fn, inputs_to_check=check_input_idxs, mutated_input_idxs=mutated_input_idxs
         )
-        # pyrefly: ignore [unsupported-operation]
+
         fn_cache[int_key] = fn
 
         return out
@@ -930,7 +930,7 @@ class CUDAGraphNode:
             return None
 
         self.static_input_data_ptrs: InputList[Optional[int]] = [
-            # pyrefly: ignore [bad-argument-type]
+
             maybe_get_static_data_ptr(i, inputs, self.static_input_idxs)
             for i in range(len(inputs))
         ]
@@ -977,10 +977,10 @@ class CUDAGraphNode:
             self.expected_dead_indices_before_graph = different_indices
 
         rng_states = [inp for inp in inputs if isinstance(inp, torch.Generator)]
-        # pyrefly: ignore [bad-argument-type]
+
         recording_inputs = self._allocate_and_copy_recording_inputs(inputs)
         # recording inputs will copy over memory, so we can free non recording inputs
-        # pyrefly: ignore [missing-attribute]
+
         inputs.clear()
         del inputs
 
@@ -1698,7 +1698,7 @@ class CUDAGraphNode:
             for i, inp in enumerate(inputs):
                 if not isinstance(inp, torch.Tensor):
                     assert isinstance(inp, (int, torch.Generator))
-                    # pyrefly: ignore [bad-argument-type]
+
                     recording_inputs.append(inp)
                 elif i not in self.static_input_idxs:
                     # static_input does an allocation!

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -98,7 +98,7 @@ def draw_buffers(
             dtype = node.data.dtype
 
         metadata = TensorMetadata(group, dtype, None, None, None, None, None)  # type: ignore[arg-type]
-        # pyrefly: ignore [missing-attribute]
+
         node.meta["tensor_meta"] = metadata
 
     if print_graph:

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -58,7 +58,6 @@ def promote_types(
 ):
     dtype_prop_candidates = []
 
-
     for arg in args:
         assert not isinstance(arg, str)
         if isinstance(arg, OpsValue):

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -58,7 +58,7 @@ def promote_types(
 ):
     dtype_prop_candidates = []
 
-    # pyrefly: ignore [bad-assignment]
+
     for arg in args:
         assert not isinstance(arg, str)
         if isinstance(arg, OpsValue):

--- a/torch/_inductor/fuzzer.py
+++ b/torch/_inductor/fuzzer.py
@@ -100,12 +100,12 @@ class TypeExemplars:
         """
         Return an example of a class.
         """
-        # pyrefly: ignore [bad-argument-type, bad-argument-count]
+
         return TypeExemplars.TYPE_EXEMPLARS.get(t.__name__, None)
 
     @staticmethod
     def contains(t: type[T]) -> bool:
-        # pyrefly: ignore [bad-argument-type, bad-argument-count]
+
         return t.__name__ in TypeExemplars.TYPE_EXEMPLARS
 
 

--- a/torch/_inductor/fuzzer.py
+++ b/torch/_inductor/fuzzer.py
@@ -105,7 +105,6 @@ class TypeExemplars:
 
     @staticmethod
     def contains(t: type[T]) -> bool:
-
         return t.__name__ in TypeExemplars.TYPE_EXEMPLARS
 
 

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -613,9 +613,7 @@ def propagate_permute(permute_node: Node) -> _HandlerRetType:
         if input_meta is not None:
             assert input_meta.chunk_dim == new_chunk_dim
         return _bool_to_status(
-            set_chunking_meta(
-                input_node, meta=output_meta, chunk_dim=new_chunk_dim
-            )
+            set_chunking_meta(input_node, meta=output_meta, chunk_dim=new_chunk_dim)
         )
 
     return propagate_fwd(), propagate_bwd()

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -606,7 +606,7 @@ def propagate_permute(permute_node: Node) -> _HandlerRetType:
             return PropagateStatus.FAIL
 
         orig_chunk_dim = output_meta.chunk_dim
-        # pyrefly: ignore[bad-index, unsupported-operation]
+
         new_chunk_dim = order[orig_chunk_dim]
 
         # sanity check
@@ -615,7 +615,7 @@ def propagate_permute(permute_node: Node) -> _HandlerRetType:
         return _bool_to_status(
             set_chunking_meta(
                 input_node, meta=output_meta, chunk_dim=new_chunk_dim
-            )  # pyrefly: ignore[bad-argument-type]
+            )
         )
 
     return propagate_fwd(), propagate_bwd()

--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -308,7 +308,7 @@ def _scatter_fused_allreduce_waits(
     # in orig_comm_blocks. This index will be later used to determine what users
     # nodes need to be move to maintain a correct topological sort order.
     last_wait_node_idx = 0
-    # pyrefly: ignore [bad-assignment]
+
     for node in graph.nodes:
         last_wait_node_idx = max(
             node_indices.get(node, last_wait_node_idx), last_wait_node_idx
@@ -358,7 +358,7 @@ def _scatter_fused_allreduce_waits(
             user_node = nodes.popleft()
             if not isinstance(user_node, fx.Node):
                 continue
-            # pyrefly: ignore [unsupported-operation]
+
             if node_indices[user_node] < last_wait_node_idx:
                 incorrect_order_nodes.append(user_node)
                 nodes.extend(list(user_node.users))

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -931,7 +931,7 @@ def mul_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
 
         inp = inp * sign
         max_ = torch.amax(inp, dim=dim, keepdim=keepdim)
-        # pyrefly: ignore [unsupported-operation]
+
         return (inp - max_) * (sign * other)
 
     # pyrefly: ignore [bad-argument-type]
@@ -961,7 +961,7 @@ def div_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
 
         inp = inp * sign
         max_ = torch.amax(inp, dim=dim, keepdim=keepdim)
-        # pyrefly: ignore [unsupported-operation]
+
         return (inp - max_) / (sign * other)
 
     # pyrefly: ignore [bad-argument-type]

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -716,7 +716,7 @@ if torch._C._has_mkldnn:
             if any(_other_input_not_inplaceable(n, other_index) for n in binary_nodes):
                 return False
             if any(
-                # pyrefly: ignore [missing-attribute]
+
                 n.args[other_index].op in ["placeholder", "output"]
                 for n in binary_nodes
             ):

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -716,7 +716,6 @@ if torch._C._has_mkldnn:
             if any(_other_input_not_inplaceable(n, other_index) for n in binary_nodes):
                 return False
             if any(
-
                 n.args[other_index].op in ["placeholder", "output"]
                 for n in binary_nodes
             ):

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -290,7 +290,7 @@ def normalize_unbind_default(match: Match, *args, **kwargs):
         log.debug("example value absent for node: %s", input)
         return
     ndim = input.meta["example_value"].ndim
-    # pyrefly: ignore [unsupported-operation]
+
     if dim < 0:  # Normalize unbind dim
         dim += ndim
     with graph.inserting_after(node):
@@ -340,7 +340,7 @@ def normalize_cat_default(match: Match, *args, **kwargs):
         ndim == x.meta["example_value"].dim() or is_empty_tensor(x) for x in tensors
     )
 
-    # pyrefly: ignore [unsupported-operation]
+
     if cat_dim < 0:  # Normalize cat dim
         cat_dim += ndim
 
@@ -1427,7 +1427,7 @@ def simplify_split_cat(match: Match, split_sections: list[int], dim: int):
     if not isinstance(split_sections, (list, tuple)):  # Unnormalized split
         return
     split_node = next(node for node in match.nodes if node.target is torch.split)
-    # pyrefly: ignore [bad-argument-type]
+
     SplitCatSimplifier().simplify(match.graph, split_node, split_sections)
 
 
@@ -1973,7 +1973,7 @@ def normalize_cat_default_aten(match: Match, *args, **kwargs):
 
     assert all(ndim == x.meta["val"].dim() or is_empty_tensor(x) for x in tensors)
 
-    # pyrefly: ignore [unsupported-operation]
+
     if cat_dim < 0:  # Normalize cat dim
         cat_dim += ndim
 

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -340,7 +340,6 @@ def normalize_cat_default(match: Match, *args, **kwargs):
         ndim == x.meta["example_value"].dim() or is_empty_tensor(x) for x in tensors
     )
 
-
     if cat_dim < 0:  # Normalize cat dim
         cat_dim += ndim
 
@@ -1972,7 +1971,6 @@ def normalize_cat_default_aten(match: Match, *args, **kwargs):
         return len(x_shape) == 1 and x_shape[0] == 0
 
     assert all(ndim == x.meta["val"].dim() or is_empty_tensor(x) for x in tensors)
-
 
     if cat_dim < 0:  # Normalize cat dim
         cat_dim += ndim

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1802,7 +1802,7 @@ class GraphLowering(torch.fx.Interpreter):
                         # require_exact_strides to handle views. But ultimately it's better to require
                         # the right strides at the tensor definition.
                         if n.meta["val"]._is_view() or isinstance(
-                            # pyrefly: ignore [missing-attribute]
+
                             result.data,
                             ir.BaseView,
                         ):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1802,7 +1802,6 @@ class GraphLowering(torch.fx.Interpreter):
                         # require_exact_strides to handle views. But ultimately it's better to require
                         # the right strides at the tensor definition.
                         if n.meta["val"]._is_view() or isinstance(
-
                             result.data,
                             ir.BaseView,
                         ):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5391,7 +5391,7 @@ class CppTemplateBuffer(TemplateBuffer):
     def get_layout(self) -> Layout:
         if isinstance(self.layout, MultiOutputLayout):
             assert isinstance(self.outputs, Iterable), type(self.outputs)
-            # pyrefly: ignore [index-error]
+
             first_output = self.outputs[0]
             assert isinstance(first_output, Buffer), type(first_output)
             layout = first_output.layout
@@ -7052,7 +7052,7 @@ class UserDefinedTritonKernel(ExternKernel):
 
             configs = kernel.configs
             kernel = kernel.fn
-        # pyrefly: ignore [bad-return]
+
         return kernel, configs, restore_value_args, reset_to_zero_args
 
     @override
@@ -7208,7 +7208,7 @@ class UserDefinedTritonKernel(ExternKernel):
         self.mutable_args = [
             kernel_args[key]
             for key in identify_mutated_tensors(
-                # pyrefly: ignore [bad-argument-type]
+
                 kernel,
                 {**kernel_args, **autotuned_kwargs},
                 tma_descriptor_metadata,
@@ -7860,7 +7860,7 @@ class FallbackKernel(ExternKernelAlloc):
                         add_alias(optional_tensor_arg)
             else:
                 assert library_utils.is_tensor_like_type(info.type)
-                # pyrefly: ignore [bad-argument-type]
+
                 add_alias(arg)
 
         for info, arg in torch._library.utils.zip_schema(schema, args, kwargs):
@@ -8299,7 +8299,7 @@ class FallbackKernel(ExternKernelAlloc):
             packed.outputs = tuple(outputs)
         else:
             packed.outputs = [outputs]
-        # pyrefly: ignore [bad-return]
+
         return outputs
 
 
@@ -9729,7 +9729,7 @@ class _WaitKernel(_CollectiveKernel):
             # Case 1
             if isinstance(coll, _CollectiveKernel):
                 _, idx = inp.indices[0]
-                # pyrefly: ignore [bad-return]
+
                 return [coll.inputs[idx]]
             # Case 2
             return []

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7208,7 +7208,6 @@ class UserDefinedTritonKernel(ExternKernel):
         self.mutable_args = [
             kernel_args[key]
             for key in identify_mutated_tensors(
-
                 kernel,
                 {**kernel_args, **autotuned_kwargs},
                 tma_descriptor_metadata,

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -480,7 +480,6 @@ def autotune_custom_op(
     template = SubgraphTemplate(name=name)
     choices = template.generate_custom_op_choices(
         name=name,
-
         decompositions=decompositions,
         # pyrefly: ignore [no-matching-overload]
         input_nodes=list(inputs),

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -480,7 +480,7 @@ def autotune_custom_op(
     template = SubgraphTemplate(name=name)
     choices = template.generate_custom_op_choices(
         name=name,
-        # pyrefly: ignore [bad-argument-type]
+
         decompositions=decompositions,
         # pyrefly: ignore [no-matching-overload]
         input_nodes=list(inputs),

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -98,16 +98,16 @@ def get_fwd_subgraph_outputs(
     subgraph_buffer: SubgraphResults, mask_graph_buffer: SubgraphResults
 ) -> list[Optional[ComputedBuffer]]:
     subgraph_buffer = (
-        # pyrefly: ignore [bad-assignment]
+
         subgraph_buffer if isinstance(subgraph_buffer, Sequence) else [subgraph_buffer]
     )
     mask_graph_buffer = (
-        # pyrefly: ignore [bad-assignment]
+
         mask_graph_buffer
         if isinstance(mask_graph_buffer, Sequence)
         else [mask_graph_buffer]
     )
-    # pyrefly: ignore [not-iterable]
+
     return [*subgraph_buffer, *mask_graph_buffer]
 
 

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -98,11 +98,9 @@ def get_fwd_subgraph_outputs(
     subgraph_buffer: SubgraphResults, mask_graph_buffer: SubgraphResults
 ) -> list[Optional[ComputedBuffer]]:
     subgraph_buffer = (
-
         subgraph_buffer if isinstance(subgraph_buffer, Sequence) else [subgraph_buffer]
     )
     mask_graph_buffer = (
-
         mask_graph_buffer
         if isinstance(mask_graph_buffer, Sequence)
         else [mask_graph_buffer]

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -930,7 +930,6 @@ def flex_attention_backward(*args, **kwargs):
             **cur_kernel_options,
         )
     inputs_for_autotuning = (
-
         [
             query,
             key,
@@ -1001,11 +1000,9 @@ def get_bwd_subgraph_outputs(
     joint_outputs: JointOutputResult,
 ) -> list[Optional[Union[ComputedBuffer, TensorBox]]]:
     subgraph_buffer = (
-
         subgraph_buffer if isinstance(subgraph_buffer, Sequence) else [subgraph_buffer]
     )
     mask_graph_buffer = (
-
         mask_graph_buffer
         if isinstance(mask_graph_buffer, Sequence)
         else [mask_graph_buffer]
@@ -1016,6 +1013,5 @@ def get_bwd_subgraph_outputs(
         *joint_outputs.captured_grads,
         *joint_outputs.mutated_grads,
     ]
-
 
     return [*subgraph_buffer, *mask_graph_buffer, *joint_output_buffers]

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -930,7 +930,7 @@ def flex_attention_backward(*args, **kwargs):
             **cur_kernel_options,
         )
     inputs_for_autotuning = (
-        # pyrefly: ignore [unsupported-operation]
+
         [
             query,
             key,
@@ -1001,11 +1001,11 @@ def get_bwd_subgraph_outputs(
     joint_outputs: JointOutputResult,
 ) -> list[Optional[Union[ComputedBuffer, TensorBox]]]:
     subgraph_buffer = (
-        # pyrefly: ignore [bad-assignment]
+
         subgraph_buffer if isinstance(subgraph_buffer, Sequence) else [subgraph_buffer]
     )
     mask_graph_buffer = (
-        # pyrefly: ignore [bad-assignment]
+
         mask_graph_buffer
         if isinstance(mask_graph_buffer, Sequence)
         else [mask_graph_buffer]
@@ -1017,5 +1017,5 @@ def get_bwd_subgraph_outputs(
         *joint_outputs.mutated_grads,
     ]
 
-    # pyrefly: ignore [not-iterable]
+
     return [*subgraph_buffer, *mask_graph_buffer, *joint_output_buffers]

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -392,7 +392,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
     ]
 
     inputs_for_flex_decoding = (
-        # pyrefly: ignore [unsupported-operation]
+
         [
             query,
             key,

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -392,7 +392,6 @@ def create_flex_decoding_kernel(*args, **kwargs):
     ]
 
     inputs_for_flex_decoding = (
-
         [
             query,
             key,

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -337,12 +337,12 @@ def _tuned_grouped_mm_common(
         if len(m2_size) == 2:
             m, k1 = m1_size
             k2, n = m2_size
-            # pyrefly: ignore [missing-attribute]
+
             g = offs.get_size()[0]
             k = V.graph.sizevars.check_equals(k1, k2)
             a_is_2d, b_is_2d = True, True
         else:
-            # pyrefly: ignore [missing-attribute]
+
             g1 = offs.layout.size[0]
             m, k1 = m1_size
             g2, k2, n = m2_size
@@ -351,7 +351,7 @@ def _tuned_grouped_mm_common(
             a_is_2d, b_is_2d = True, False
     else:
         if len(m2_size) == 2:
-            # pyrefly: ignore [missing-attribute]
+
             g1 = offs.layout.size[0]
             g2, m, k1 = m1_size
             k2, n = m2_size

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -342,7 +342,6 @@ def _tuned_grouped_mm_common(
             k = V.graph.sizevars.check_equals(k1, k2)
             a_is_2d, b_is_2d = True, True
         else:
-
             g1 = offs.layout.size[0]
             m, k1 = m1_size
             g2, k2, n = m2_size
@@ -351,7 +350,6 @@ def _tuned_grouped_mm_common(
             a_is_2d, b_is_2d = True, False
     else:
         if len(m2_size) == 2:
-
             g1 = offs.layout.size[0]
             g2, m, k1 = m1_size
             k2, n = m2_size

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -28,7 +28,7 @@ from torch._higher_order_ops.associative_scan import associative_scan_op
 from torch._higher_order_ops.triton_kernel_wrap import triton_kernel_wrapper_mutation
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.utils import get_layout_constraint_tag
-from torch._prims_common import (  # pyrefly: ignore  # deprecated; pyrefly: ignore [deprecated]
+from torch._prims_common import (
     canonicalize_dim,
     canonicalize_dims,
     check,
@@ -162,7 +162,7 @@ def group_foreach_args(
                 break
         assert device is not None, "foreach op should have at least one tensor arg"
         if unpack_args:
-            # pyrefly: ignore [bad-unpacking]
+
             (args,) = args
         out[(device, use_foreach)].append((i, args))
     return out
@@ -279,7 +279,7 @@ def decode_dtype(dtype: Union[int, torch.dtype]) -> torch.dtype:
     if not isinstance(dtype, int):
         return dtype
     assert dtype in DTYPE_ID_LOOKUP, f"id {dtype} missing from DTYPE_ID_LOOKUP"
-    # pyrefly: ignore [bad-assignment]
+
     dtype = DTYPE_ID_LOOKUP[dtype]
     return dtype
 
@@ -695,7 +695,7 @@ def make_pointwise(
         if not override_device:
             device = None
             for i in inputs:
-                # pyrefly: ignore [missing-attribute]
+
                 if is_gpu(i.get_device().type):
                     device = i.get_device()
                     break
@@ -3140,10 +3140,10 @@ def copy(self, src, non_blocking=False):
         src = tensor(src, dtype=self.get_dtype(), device=self.get_device())
     x = src
     if self.get_device() != src.get_device():
-        # pyrefly: ignore [bad-argument-type]
+
         x = to_device(x, self.get_device())
     if self.get_dtype() != src.get_dtype():
-        # pyrefly: ignore [bad-argument-type]
+
         x = to_dtype(x, self.get_dtype())
 
     if self.get_size() != src.get_size():
@@ -6444,7 +6444,7 @@ def pow(a, b):
     if isinstance(a, Number):
         if a == 1:
             return full_like(b, 1)
-        # pyrefly: ignore [missing-attribute]
+
         if a == 2 and is_float_dtype(b.get_dtype()):
             return exp2(b)
 
@@ -7571,7 +7571,7 @@ def with_effects(token, op, *args, **kwargs):
                 op_name = new_op.get_name()  # pyrefly: ignore[missing-attribute]
                 V.graph.additional_star_deps[op_name].add(prev_effect_buffer.get_name())
         # Update the effectful ops chain to point to the latest operation
-        V.graph.effectful_ops[effect_type] = (  # pyrefly: ignore[missing-attribute]
+        V.graph.effectful_ops[effect_type] = (
             new_op  # pyrefly: ignore[unsupported-operation]
         )
 
@@ -7590,7 +7590,7 @@ def with_effects(token, op, *args, **kwargs):
                     ):
                         return (
                             storage.data.get_example()
-                        )  # pyrefly: ignore[missing-attribute]
+                        )
                 except (AttributeError, NotImplementedError):
                     pass
                 # Fall back to returning the TensorBox itself if get_example fails

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -162,7 +162,6 @@ def group_foreach_args(
                 break
         assert device is not None, "foreach op should have at least one tensor arg"
         if unpack_args:
-
             (args,) = args
         out[(device, use_foreach)].append((i, args))
     return out
@@ -695,7 +694,6 @@ def make_pointwise(
         if not override_device:
             device = None
             for i in inputs:
-
                 if is_gpu(i.get_device().type):
                     device = i.get_device()
                     break
@@ -3140,10 +3138,8 @@ def copy(self, src, non_blocking=False):
         src = tensor(src, dtype=self.get_dtype(), device=self.get_device())
     x = src
     if self.get_device() != src.get_device():
-
         x = to_device(x, self.get_device())
     if self.get_dtype() != src.get_dtype():
-
         x = to_dtype(x, self.get_dtype())
 
     if self.get_size() != src.get_size():
@@ -7588,9 +7584,7 @@ def with_effects(token, op, *args, **kwargs):
                     if hasattr(storage, "data") and hasattr(
                         storage.data, "get_example"
                     ):
-                        return (
-                            storage.data.get_example()
-                        )
+                        return storage.data.get_example()
                 except (AttributeError, NotImplementedError):
                     pass
                 # Fall back to returning the TensorBox itself if get_example fails

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -792,9 +792,7 @@ def register_onednn_fusion_ops():
                     ) = create_int8_compensation(
                         W_tensor,
                         packed_weight,
-
                         x_scale,
-
                         x_zp,
                         w_scale,
                     )
@@ -1044,7 +1042,6 @@ def register_onednn_fusion_ops():
                 )
 
             if w_zp is None:
-
                 w_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="w_zp"
                 )
@@ -1120,9 +1117,7 @@ def register_onednn_fusion_ops():
                     ) = create_int8_compensation(
                         W_tensor,
                         packed_weight,
-
                         x_scale,
-
                         x_zp,
                         w_scale,
                     )

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -748,7 +748,7 @@ def register_onednn_fusion_ops():
                 # If w_zp is None, then it's a dummy tensor created to denote the
                 # absence of a zero point, and thus w is int8 symmetrically quantized.
                 # Moreover, oneDNN qlinear API doesn't accept None value for zp
-                # pyrefly: ignore [bad-assignment]
+
                 w_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="w_zp"
                 )
@@ -792,9 +792,9 @@ def register_onednn_fusion_ops():
                     ) = create_int8_compensation(
                         W_tensor,
                         packed_weight,
-                        # pyrefly: ignore [bad-argument-type]
+
                         x_scale,
-                        # pyrefly: ignore [bad-argument-type]
+
                         x_zp,
                         w_scale,
                     )
@@ -1044,7 +1044,7 @@ def register_onednn_fusion_ops():
                 )
 
             if w_zp is None:
-                # pyrefly: ignore [bad-assignment]
+
                 w_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="w_zp"
                 )
@@ -1120,9 +1120,9 @@ def register_onednn_fusion_ops():
                     ) = create_int8_compensation(
                         W_tensor,
                         packed_weight,
-                        # pyrefly: ignore [bad-argument-type]
+
                         x_scale,
-                        # pyrefly: ignore [bad-argument-type]
+
                         x_zp,
                         w_scale,
                     )

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2328,7 +2328,7 @@ def clone_graph(input_graph: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_node.node.name = self.new_graph._graph_namespace.create_name(
                     old_node.name, None
                 )
-            # pyrefly: ignore [bad-return]
+
             return new_node
 
     return CopyGraph(input_graph).transform()

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -112,7 +112,7 @@ def get_max_y_grid() -> int:
 
 
 try:
-    # pyrefly: ignore [import-error]
+
     import colorama
 
     HAS_COLORAMA = True

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -112,7 +112,6 @@ def get_max_y_grid() -> int:
 
 
 try:
-
     import colorama
 
     HAS_COLORAMA = True

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -264,7 +264,6 @@ class StaticallyLaunchedCudaKernel:
             self.num_warps,
             self.shared,
             arg_tys,
-
             args,
             stream,
         )

--- a/torch/_inductor/runtime/static_cuda_launcher.py
+++ b/torch/_inductor/runtime/static_cuda_launcher.py
@@ -251,7 +251,7 @@ class StaticallyLaunchedCudaKernel:
             if has_scratch:
                 arg_tys = arg_tys + "O"
                 args = (*args, None)
-        # pyrefly: ignore [bad-argument-type]
+
         assert len(args) == len(arg_tys)
 
         # TODO: can handle grid functions here or in C++, so
@@ -264,7 +264,7 @@ class StaticallyLaunchedCudaKernel:
             self.num_warps,
             self.shared,
             arg_tys,
-            # pyrefly: ignore [bad-argument-type]
+
             args,
             stream,
         )

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1303,7 +1303,7 @@ def maybe_estimate_runtime_benchmark(snode: BaseSchedulerNode) -> Optional[float
         if mm_fn is None:
             return None
         bench_fn = mm_fn
-        # pyrefly: ignore [unbound-name]
+
         args_kwargs_fn = lambda: snode_args_kwargs(snode)  # noqa: E731
     else:
         return None
@@ -5891,7 +5891,7 @@ class Scheduler:
             signatures.append(partition_signature)
 
             unmet_output_names = partition_input_names.union(
-                # pyrefly: ignore [unsupported-operation]
+
                 unmet_output_names - returned_output_names
             )
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5891,7 +5891,6 @@ class Scheduler:
             signatures.append(partition_signature)
 
             unmet_output_names = partition_input_names.union(
-
                 unmet_output_names - returned_output_names
             )
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1233,7 +1233,6 @@ class TritonTemplateKernel(TritonKernel):
                                 val_shape[i],
                                 i,
                                 len(val_shape),
-
                                 block_name=range_tree.symt.name,
                             )
                         )
@@ -1321,7 +1320,6 @@ class TritonTemplateKernel(TritonKernel):
                 output_index = self.rename_indexing(output_index)
                 if output_index == contiguous_index:
                     output_index = sympy.Symbol("xindex", integer=True)
-
 
             self.template_out_shape = val_shape if val_shape else val
             acc_dtype = (
@@ -2780,7 +2778,6 @@ class AlgorithmSelectorCache(PersistentCache):
             choice for choice in choices if isinstance(choice, ExternKernelChoice)
         ]
         if len(externs) > 0:
-
             return externs[0]
         else:
             return choices[0]
@@ -4312,7 +4309,6 @@ class AlgorithmSelectorCache(PersistentCache):
             node.get_device(),
             node.get_dtype(),
             V.graph.sizevars.atomically_apply_size_hint(
-
                 node.layout.offset,
                 fallback=config.unbacked_symint_fallback,
                 hint_override=hint_override,
@@ -4323,7 +4319,6 @@ class AlgorithmSelectorCache(PersistentCache):
                     fallback=config.unbacked_symint_fallback,
                     hint_override=hint_override,
                 )
-
                 for size in V.graph.get_allocation_size(node)
             ),
         )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -437,7 +437,7 @@ class TritonTemplateKernel(TritonKernel):
             reduction_idx = None
             for i, prefix in enumerate(tiling):
                 rt = prefix_to_range_tree[prefix]
-                # pyrefly: ignore  # missing-argument
+
                 if rt.is_reduction:
                     reduction_idx = i
                     break
@@ -1233,7 +1233,7 @@ class TritonTemplateKernel(TritonKernel):
                                 val_shape[i],
                                 i,
                                 len(val_shape),
-                                # pyrefly: ignore [missing-argument]
+
                                 block_name=range_tree.symt.name,
                             )
                         )
@@ -1247,7 +1247,7 @@ class TritonTemplateKernel(TritonKernel):
                         )
                         # Update the val_shape information to use consistent naming
                         # after the remapping.
-                        # pyrefly: ignore [missing-argument]
+
                         val_shape_copy[i] = range_tree.symt.name
                     # pyrefly: ignore [bad-assignment]
                     val_shape = tuple(val_shape_copy)
@@ -1322,7 +1322,7 @@ class TritonTemplateKernel(TritonKernel):
                 if output_index == contiguous_index:
                     output_index = sympy.Symbol("xindex", integer=True)
 
-            # pyrefly: ignore [bad-assignment]
+
             self.template_out_shape = val_shape if val_shape else val
             acc_dtype = (
                 triton_type_to_torch(self.meta["ACC_TYPE"])
@@ -2589,7 +2589,7 @@ class DataProcessorTemplateWrapper:
             self._postprocessor = lambda x: x
         assert "input_nodes" in kwargs
         assert "layout" in kwargs
-        # pyrefly: ignore [not-callable]
+
         kwargs["input_nodes"], kwargs["layout"] = preprocessor(
             kwargs["input_nodes"], kwargs["layout"]
         )
@@ -2780,7 +2780,7 @@ class AlgorithmSelectorCache(PersistentCache):
             choice for choice in choices if isinstance(choice, ExternKernelChoice)
         ]
         if len(externs) > 0:
-            # pyrefly: ignore [bad-return]
+
             return externs[0]
         else:
             return choices[0]
@@ -4312,7 +4312,7 @@ class AlgorithmSelectorCache(PersistentCache):
             node.get_device(),
             node.get_dtype(),
             V.graph.sizevars.atomically_apply_size_hint(
-                # pyrefly: ignore [missing-attribute]
+
                 node.layout.offset,
                 fallback=config.unbacked_symint_fallback,
                 hint_override=hint_override,
@@ -4323,7 +4323,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     fallback=config.unbacked_symint_fallback,
                     hint_override=hint_override,
                 )
-                # pyrefly: ignore [bad-argument-type]
+
                 for size in V.graph.get_allocation_size(node)
             ),
         )

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2194,7 +2194,6 @@ class ScaledBlackwellTMAConfigMixin(
     This inherits from ScaledMMConfigMixin, which inherits the scale_mm_epilogue, and adds TMA-specific options.
     """
 
-
     def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
         """
         Warp specialization-specific filtering (BlackwellTMATemplateConfigMixin)
@@ -2326,7 +2325,6 @@ class CUDAScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, CUDAConfigHeurist
         super().__init__()
         # Override mm_configs to use scaled_mm_configs
         self.mm_configs = self.scaled_mm_configs
-
 
     def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
         configs = [c for c in configs if c.block_k >= 32]

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2194,7 +2194,7 @@ class ScaledBlackwellTMAConfigMixin(
     This inherits from ScaledMMConfigMixin, which inherits the scale_mm_epilogue, and adds TMA-specific options.
     """
 
-    # pyrefly: ignore [bad-override]
+
     def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
         """
         Warp specialization-specific filtering (BlackwellTMATemplateConfigMixin)
@@ -2327,7 +2327,7 @@ class CUDAScaledMMTemplateConfigHeuristic(ScaledMMConfigMixin, CUDAConfigHeurist
         # Override mm_configs to use scaled_mm_configs
         self.mm_configs = self.scaled_mm_configs
 
-    # pyrefly: ignore [bad-override]
+
     def _filter_configs(self, configs: list[BaseConfig]) -> list[BaseConfig]:
         configs = [c for c in configs if c.block_k >= 32]
         return super()._filter_configs(configs)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2772,14 +2772,11 @@ def get_device_tflops(dtype: torch.dtype) -> float:
             return get_max_simd_tflops(torch.float32, sm_clock)
     else:
         if dtype in (torch.float16, torch.bfloat16) and SM80OrLater:
-
             return get_max_tensorcore_tflops(dtype)
 
         if torch.backends.cuda.matmul.allow_tf32:
-
             return get_max_tensorcore_tflops(torch.float32)
         else:
-
             return get_max_simd_tflops(torch.float32)
 
 
@@ -2792,7 +2789,6 @@ def get_gpu_dram_gbps() -> int:
 
 def get_gpu_shared_memory() -> int:
     from triton.runtime import driver
-
 
     return driver.active.utils.get_device_properties(0).get("max_shared_mem", 0)
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -723,7 +723,7 @@ def cache_property_on_self(
     """
     Variant of cache_on_self for properties. The only difference is the type signature.
     """
-    # pyrefly: ignore [bad-argument-type]
+
     return cache_on_self(fn)
 
 
@@ -1549,7 +1549,7 @@ class IndentedBuffer:
     ) -> None:
         if isinstance(other_code, IndentedBuffer):
             dedent = float("inf")
-            # pyrefly: ignore [bad-assignment]
+
             for line in other_code._lines:
                 if not isinstance(line, LineContext) and line:
                     dedent = min(dedent, len(line) - len(line.lstrip()))
@@ -2772,14 +2772,14 @@ def get_device_tflops(dtype: torch.dtype) -> float:
             return get_max_simd_tflops(torch.float32, sm_clock)
     else:
         if dtype in (torch.float16, torch.bfloat16) and SM80OrLater:
-            # pyrefly: ignore [missing-argument]
+
             return get_max_tensorcore_tflops(dtype)
 
         if torch.backends.cuda.matmul.allow_tf32:
-            # pyrefly: ignore [missing-argument]
+
             return get_max_tensorcore_tflops(torch.float32)
         else:
-            # pyrefly: ignore [missing-argument]
+
             return get_max_simd_tflops(torch.float32)
 
 
@@ -2793,7 +2793,7 @@ def get_gpu_dram_gbps() -> int:
 def get_gpu_shared_memory() -> int:
     from triton.runtime import driver
 
-    # pyrefly: ignore [missing-attribute]
+
     return driver.active.utils.get_device_properties(0).get("max_shared_mem", 0)
 
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1460,7 +1460,6 @@ def container_checker(obj, target_type) -> bool:
                 return False
         return True
     elif origin_type is Union or issubclass(
-
         origin_type,
         BuiltinUnionType,
     ):  # also handles Optional

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -152,7 +152,7 @@ def _qualified_name(obj, mangle_name=True) -> str:
 
     # If the module is actually a torchbind module, then we should short circuit
     if module_name == "torch._classes":
-        return obj.qualified_name  # pyrefly: ignore [missing-attribute]
+        return obj.qualified_name
 
     # The Python docs are very clear that `__module__` can be None, but I can't
     # figure out when it actually would be.
@@ -769,7 +769,7 @@ def unused(fn: Callable[_P, _R]) -> Callable[_P, _R]:
                 prop.fset, "_torchscript_modifier", FunctionModifiers.UNUSED
             )
 
-        return prop  # pyrefly: ignore [bad-return]
+        return prop
 
     fn._torchscript_modifier = FunctionModifiers.UNUSED  # type: ignore[attr-defined]
     return fn
@@ -1460,7 +1460,7 @@ def container_checker(obj, target_type) -> bool:
                 return False
         return True
     elif origin_type is Union or issubclass(
-        # pyrefly: ignore [bad-argument-type]
+
         origin_type,
         BuiltinUnionType,
     ):  # also handles Optional

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -252,7 +252,7 @@ def derived_types(
 
 
 def get_supported_param_types():
-    # pyrefly: ignore [bad-assignment]
+
     data: list[tuple[Union[type, typing._SpecialForm], str, bool, bool, bool]] = [
         # (python type, schema type, type[] variant, type?[] variant, type[]? variant
         (Tensor, "Tensor", True, True, False),
@@ -301,7 +301,7 @@ def parse_return(annotation, error_fn):
                 f"Return has unsupported type {annotation}. "
                 f"The valid types are: {SUPPORTED_RETURN_TYPES}."
             )
-        # pyrefly: ignore [index-error]
+
         return SUPPORTED_RETURN_TYPES[annotation]
 
     args = typing.get_args(annotation)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -252,7 +252,6 @@ def derived_types(
 
 
 def get_supported_param_types():
-
     data: list[tuple[Union[type, typing._SpecialForm], str, bool, bool, bool]] = [
         # (python type, schema type, type[] variant, type?[] variant, type[]? variant
         (Tensor, "Tensor", True, True, False),

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -1062,7 +1062,7 @@ class LOBPCG:
 
         return torch.matmul(
             U * d_col.mT,
-            # pyrefly: ignore [unsupported-operation]
+
             Z * E**-0.5,
         )
 

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -1062,7 +1062,6 @@ class LOBPCG:
 
         return torch.matmul(
             U * d_col.mT,
-
             Z * E**-0.5,
         )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7205,7 +7205,6 @@ def rnn_cell_checkSizes(
     )
     torch._check(
         all(
-
             x.device == input_gates.device
             for x in [hidden_gates, input_bias, hidden_bias, prev_hidden]
         ),

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5436,7 +5436,7 @@ def full(size, fill_value, *args, **kwargs):
     if not dtype:
         dtype = utils.get_dtype(fill_value)
     kwargs["dtype"] = dtype
-    # pyrefly: ignore [not-iterable]
+
     return torch.empty(size, *args, **kwargs)
 
 
@@ -7205,7 +7205,7 @@ def rnn_cell_checkSizes(
     )
     torch._check(
         all(
-            # pyrefly: ignore [missing-attribute]
+
             x.device == input_gates.device
             for x in [hidden_gates, input_bias, hidden_bias, prev_hidden]
         ),

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -1001,9 +1001,9 @@ class OpOverload(OperatorBase, Generic[_P, _T]):
 
         r = self.py_kernels.get(final_key, final_key)
         if cache_result:
-            self._dispatch_cache[key] = r  # pyrefly: ignore [unsupported-operation]
+            self._dispatch_cache[key] = r
             add_cached_op(self)
-        return r  # pyrefly: ignore [bad-return]
+        return r
 
     def name(self):
         return self._name
@@ -1109,7 +1109,7 @@ class TorchBindOpOverload(OpOverload[_P, _T]):
 
         if not isinstance(handler, Callable):  # type: ignore[arg-type]
             raise AssertionError(f"handler must be callable, got {type(handler)}")
-        return handler(*args, **kwargs)  # pyrefly: ignore [bad-return]
+        return handler(*args, **kwargs)
 
 
 def _must_dispatch_in_python(args, kwargs):

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1341,7 +1341,7 @@ def get_higher_dtype(
 
         raise RuntimeError("Unexpected type given to _extract_dtype!")
 
-    # pyrefly: ignore [bad-argument-type]
+
     a, b = _extract_dtype(a), _extract_dtype(b)
 
     if a is b:
@@ -1708,10 +1708,10 @@ def elementwise_dtypes(
 
         # Prefers dtype of tensors with one or more dimensions
         if one_plus_dim_tensor_dtype is not None:
-            # pyrefly: ignore [bad-return]
+
             return one_plus_dim_tensor_dtype
 
-        # pyrefly: ignore [bad-return]
+
         return zero_dim_tensor_dtype
 
     if highest_type is float:

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1341,7 +1341,6 @@ def get_higher_dtype(
 
         raise RuntimeError("Unexpected type given to _extract_dtype!")
 
-
     a, b = _extract_dtype(a), _extract_dtype(b)
 
     if a is b:
@@ -1708,9 +1707,7 @@ def elementwise_dtypes(
 
         # Prefers dtype of tensors with one or more dimensions
         if one_plus_dim_tensor_dtype is not None:
-
             return one_plus_dim_tensor_dtype
-
 
         return zero_dim_tensor_dtype
 

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -299,7 +299,6 @@ def out_wrapper(
                         kwargs[k] = out_attr
 
             def maybe_check_copy_devices(out):
-
                 if isinstance(out, TensorLike) and isinstance(args[0], TensorLike):
                     check_copy_devices(copy_from=args[0], copy_to=out)
 

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -299,7 +299,7 @@ def out_wrapper(
                         kwargs[k] = out_attr
 
             def maybe_check_copy_devices(out):
-                # pyrefly: ignore [unsupported-operation]
+
                 if isinstance(out, TensorLike) and isinstance(args[0], TensorLike):
                     check_copy_devices(copy_from=args[0], copy_to=out)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -905,7 +905,6 @@ def logsumexp(
     if not isinstance(dim, Iterable):
         dim = (dim,)
     if self.numel() == 0:
-
         return torch.sum(torch.exp(self), dim, keepdim).log()
 
     maxes = torch.amax(torch.real(self), dim, keepdim=True)
@@ -3445,7 +3444,6 @@ def native_layer_norm(
         input.ndim >= normalized_ndim
         and sym_eq(
             input.shape[(input.ndim - normalized_ndim) :],
-
             tuple(normalized_shape),
         ),
         lambda: "Given normalized_shape="
@@ -4089,7 +4087,6 @@ def roll(a: TensorLikeType, shifts: DimsType, dims: DimsType = ()) -> TensorLike
         # Takes care of the case when dims is not specified (default)
         # By default, the tensor is flattened before shifting, after which the original shape is restored
         if len_dims == 0 and len_shifts == 1:
-
             return torch.roll(torch.flatten(a), shifts, 0).view(a.shape)
         if len_shifts != len_dims:
             raise RuntimeError(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -905,14 +905,14 @@ def logsumexp(
     if not isinstance(dim, Iterable):
         dim = (dim,)
     if self.numel() == 0:
-        # pyrefly: ignore [no-matching-overload]
+
         return torch.sum(torch.exp(self), dim, keepdim).log()
-    # pyrefly: ignore [bad-argument-type]
+
     maxes = torch.amax(torch.real(self), dim, keepdim=True)
     maxes = torch.masked_fill(maxes, maxes.abs() == float("inf"), 0)
-    # pyrefly: ignore [no-matching-overload]
+
     maxes_squeezed = maxes if keepdim else torch.squeeze(maxes, dim)
-    # pyrefly: ignore [no-matching-overload]
+
     result = torch.sum(torch.exp(self - maxes), dim, keepdim)
     return result.log().add(maxes_squeezed)
 
@@ -1372,7 +1372,7 @@ def float_power(
     b = _maybe_convert_to_dtype(b, dtype)
 
     a, b = _maybe_broadcast(a, b)
-    # pyrefly: ignore [bad-return]
+
     return pow(a, b)
 
 
@@ -3445,7 +3445,7 @@ def native_layer_norm(
         input.ndim >= normalized_ndim
         and sym_eq(
             input.shape[(input.ndim - normalized_ndim) :],
-            # pyrefly: ignore [bad-argument-type]
+
             tuple(normalized_shape),
         ),
         lambda: "Given normalized_shape="
@@ -4089,7 +4089,7 @@ def roll(a: TensorLikeType, shifts: DimsType, dims: DimsType = ()) -> TensorLike
         # Takes care of the case when dims is not specified (default)
         # By default, the tensor is flattened before shifting, after which the original shape is restored
         if len_dims == 0 and len_shifts == 1:
-            # pyrefly: ignore [bad-argument-type]
+
             return torch.roll(torch.flatten(a), shifts, 0).view(a.shape)
         if len_shifts != len_dims:
             raise RuntimeError(
@@ -4529,7 +4529,7 @@ def hsplit(
                 + "!"
             ),
         )
-        # pyrefly: ignore [bad-argument-type]
+
         return tensor_split(a, split_size, dim)
 
     torch._check_type(
@@ -4571,7 +4571,7 @@ def vsplit(
                 f"!"
             ),
         )
-        # pyrefly: ignore [bad-argument-type]
+
         return tensor_split(a, split_size, 0)
 
     torch._check_type(
@@ -5997,7 +5997,7 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
 
     # Since `where` allows type-promotion,
     # cast value to correct type before passing to `where`
-    # pyrefly: ignore [no-matching-overload]
+
     value = _maybe_convert_to_dtype(value, a.dtype)
     r = torch.where(mask, value, a)  # type: ignore[arg-type]
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -142,11 +142,11 @@ def _inplace_wrapper(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     # nb. We use the name of the first argument used in the unary references
     @wraps(fn)
     def _fn(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        # pyrefly: ignore [unsupported-operation]
+
         a = args[0]
         if "inplace" not in kwargs:
             kwargs["inplace"] = False
-        # pyrefly: ignore [unsupported-operation]
+
         if kwargs["inplace"]:
             torch._check(
                 "out" not in kwargs,
@@ -627,7 +627,7 @@ def smooth_l1_loss(
         )
     else:
         loss = torch.abs(input - target)
-        # pyrefly: ignore [unsupported-operation]
+
         loss = torch.where(loss < beta, 0.5 * loss**2 / beta, loss - 0.5 * beta)
         return _apply_loss_reduction(loss, reduction)
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -142,7 +142,6 @@ def _inplace_wrapper(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     # nb. We use the name of the first argument used in the unary references
     @wraps(fn)
     def _fn(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-
         a = args[0]
         if "inplace" not in kwargs:
             kwargs["inplace"] = False

--- a/torch/_strobelight/compile_time_profiler.py
+++ b/torch/_strobelight/compile_time_profiler.py
@@ -145,7 +145,7 @@ class StrobelightCompileTimeProfiler:
             async_stack_max_len=cls.max_stack_length,
             run_user_name="pt2-profiler/"
             + os.environ.get("USER", os.environ.get("USERNAME", "")),
-            sample_tags={cls.identifier},  # pyrefly: ignore  # bad-argument-type
+            sample_tags={cls.identifier},
         )
 
     @classmethod

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1506,7 +1506,7 @@ class FakeTensorMode(TorchDispatchMode):
             # Do this dispatch outside the above except handler so if it
             # generates its own exception there won't be a __context__ caused by
             # the caching mechanism.
-            # pyrefly: ignore [bad-argument-type]
+
             return self._dispatch_impl(func, types, args, kwargs)
 
         assert state is not None
@@ -1524,27 +1524,27 @@ class FakeTensorMode(TorchDispatchMode):
                 # This represents a negative cache entry - we already saw that the
                 # output is uncachable. Compute it from first principals.
                 FakeTensorMode.cache_bypasses[entry.reason] += 1
-                # pyrefly: ignore [bad-argument-type]
+
                 return self._dispatch_impl(func, types, args, kwargs)
 
             # We have a cache entry.
-            # pyrefly: ignore [bad-argument-type]
+
             output = self._output_from_cache_entry(state, entry, key, func, args)
             FakeTensorMode.cache_hits += 1
             if self.cache_crosscheck_enabled:
                 # For debugging / testing: Validate that the output synthesized
                 # from the cache matches the output created by normal dispatch.
                 with disable_fake_tensor_cache(self):
-                    # pyrefly: ignore [bad-argument-type]
+
                     self._crosscheck_cache_output(output, func, types, args, kwargs)
             return output
 
         # We don't have a cache entry.
-        # pyrefly: ignore [bad-argument-type]
+
         output = self._dispatch_impl(func, types, args, kwargs)
 
         try:
-            # pyrefly: ignore [bad-argument-type]
+
             entry = self._make_cache_entry(state, key, func, args, kwargs, output)
         except _BypassDispatchCache as e:
             # We ran "extra" checks on the cache key and determined that it's no
@@ -1929,7 +1929,7 @@ class FakeTensorMode(TorchDispatchMode):
                 self._validate_output_for_cache_entry(
                     state,
                     key,
-                    # pyrefly: ignore [bad-argument-type]
+
                     func,
                     args,
                     kwargs,
@@ -1939,7 +1939,7 @@ class FakeTensorMode(TorchDispatchMode):
             self._validate_output_for_cache_entry(
                 state,
                 key,
-                # pyrefly: ignore [bad-argument-type]
+
                 func,
                 args,
                 kwargs,
@@ -1951,7 +1951,7 @@ class FakeTensorMode(TorchDispatchMode):
                 self._get_output_info_for_cache_entry(
                     state,
                     key,
-                    # pyrefly: ignore [bad-argument-type]
+
                     func,
                     args,
                     kwargs,
@@ -1969,7 +1969,7 @@ class FakeTensorMode(TorchDispatchMode):
             output_info = self._get_output_info_for_cache_entry(
                 state,
                 key,
-                # pyrefly: ignore [bad-argument-type]
+
                 func,
                 args,
                 kwargs,
@@ -2516,7 +2516,7 @@ class FakeTensorMode(TorchDispatchMode):
             )
 
             with self, maybe_ignore_fresh_unbacked_symbols():
-                # pyrefly: ignore [index-error]
+
                 return registered_hop_fake_fns[func](*args, **kwargs)
 
         self.invalidate_written_to_constants(func, flat_arg_fake_tensors, args, kwargs)
@@ -2671,7 +2671,7 @@ class FakeTensorMode(TorchDispatchMode):
                 # TODO: Is this really needed?
                 compute_unbacked_bindings(self.shape_env, fake_out, peek=True)
 
-            # pyrefly: ignore [bad-return]
+
             return fake_out
 
         # Try for fastpath

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1535,7 +1535,6 @@ class FakeTensorMode(TorchDispatchMode):
                 # For debugging / testing: Validate that the output synthesized
                 # from the cache matches the output created by normal dispatch.
                 with disable_fake_tensor_cache(self):
-
                     self._crosscheck_cache_output(output, func, types, args, kwargs)
             return output
 
@@ -1544,7 +1543,6 @@ class FakeTensorMode(TorchDispatchMode):
         output = self._dispatch_impl(func, types, args, kwargs)
 
         try:
-
             entry = self._make_cache_entry(state, key, func, args, kwargs, output)
         except _BypassDispatchCache as e:
             # We ran "extra" checks on the cache key and determined that it's no
@@ -1929,7 +1927,6 @@ class FakeTensorMode(TorchDispatchMode):
                 self._validate_output_for_cache_entry(
                     state,
                     key,
-
                     func,
                     args,
                     kwargs,
@@ -1939,7 +1936,6 @@ class FakeTensorMode(TorchDispatchMode):
             self._validate_output_for_cache_entry(
                 state,
                 key,
-
                 func,
                 args,
                 kwargs,
@@ -1951,7 +1947,6 @@ class FakeTensorMode(TorchDispatchMode):
                 self._get_output_info_for_cache_entry(
                     state,
                     key,
-
                     func,
                     args,
                     kwargs,
@@ -1969,7 +1964,6 @@ class FakeTensorMode(TorchDispatchMode):
             output_info = self._get_output_info_for_cache_entry(
                 state,
                 key,
-
                 func,
                 args,
                 kwargs,
@@ -2516,7 +2510,6 @@ class FakeTensorMode(TorchDispatchMode):
             )
 
             with self, maybe_ignore_fresh_unbacked_symbols():
-
                 return registered_hop_fake_fns[func](*args, **kwargs)
 
         self.invalidate_written_to_constants(func, flat_arg_fake_tensors, args, kwargs)
@@ -2670,7 +2663,6 @@ class FakeTensorMode(TorchDispatchMode):
                 # may need to get the unbacked settings "early"
                 # TODO: Is this really needed?
                 compute_unbacked_bindings(self.shape_env, fake_out, peek=True)
-
 
             return fake_out
 

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -269,7 +269,7 @@ class FunctionalTensor(torch.Tensor):
                 device=self.device,
                 layout=self.layout,
             )
-        # pyrefly: ignore [not-iterable]
+
         return super().to(*args, **kwargs)
 
     def cuda(self, device=None, *args, **kwargs):

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -1408,7 +1408,7 @@ class MetaConverter(Generic[_TensorT]):
                     if t.requires_grad:
                         r.requires_grad = True
                     if t.requires_grad and not is_leaf:
-                        # pyrefly: ignore [bad-argument-type]
+
                         r = self._backward_error(r)
                 elif t.is_nested and not t.is_traceable_wrapper_subclass:
                     # TODO: Handle this better in Dynamo?
@@ -1451,7 +1451,7 @@ class MetaConverter(Generic[_TensorT]):
                     if t.requires_grad:
                         r.requires_grad = True
                     if t.requires_grad and not is_leaf:
-                        # pyrefly: ignore [bad-argument-type]
+
                         r = self._backward_error(r)
                 elif t.is_functorch_wrapped:
                     if t.is_view:

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -1408,7 +1408,6 @@ class MetaConverter(Generic[_TensorT]):
                     if t.requires_grad:
                         r.requires_grad = True
                     if t.requires_grad and not is_leaf:
-
                         r = self._backward_error(r)
                 elif t.is_nested and not t.is_traceable_wrapper_subclass:
                     # TODO: Handle this better in Dynamo?
@@ -1451,7 +1450,6 @@ class MetaConverter(Generic[_TensorT]):
                     if t.requires_grad:
                         r.requires_grad = True
                     if t.requires_grad and not is_leaf:
-
                         r = self._backward_error(r)
                 elif t.is_functorch_wrapped:
                     if t.is_view:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -554,7 +554,7 @@ class Tensor(torch._C.TensorBase):
             raise RuntimeError("__setstate__ can be only called on leaf Tensors")
         if len(state) == 4:
             # legacy serialization of Tensor
-            # pyrefly: ignore [not-iterable]
+
             self.set_(*state)
             return
         elif len(state) == 5:
@@ -1066,7 +1066,7 @@ class Tensor(torch._C.TensorBase):
         else:
             return torch._VF.split_with_sizes(
                 self,
-                # pyrefly: ignore [bad-argument-type]
+
                 split_size,
                 dim,
             )

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1066,7 +1066,6 @@ class Tensor(torch._C.TensorBase):
         else:
             return torch._VF.split_with_sizes(
                 self,
-
                 split_size,
                 dim,
             )

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -751,7 +751,7 @@ class ExceptionWrapper:
         if exc_info is None:
             exc_info = sys.exc_info()
         self.exc_type = exc_info[0]
-        # pyrefly: ignore [not-iterable]
+
         self.exc_msg = "".join(traceback.format_exception(*exc_info))
         self.where = where
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -85,7 +85,7 @@ def compile_time_strobelight_meta(
         @functools.wraps(function)
         def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             if "skip" in kwargs and isinstance(
-                # pyrefly: ignore [unsupported-operation]
+
                 skip := kwargs["skip"],
                 int,
             ):

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -85,7 +85,6 @@ def compile_time_strobelight_meta(
         @functools.wraps(function)
         def wrapper_function(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             if "skip" in kwargs and isinstance(
-
                 skip := kwargs["skip"],
                 int,
             ):

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -421,7 +421,7 @@ class Unpickler:
                 inst = self.stack[-1]
                 if type(inst) is torch.Tensor:
                     # Legacy unpickling
-                    # pyrefly: ignore [not-iterable]
+
                     inst.set_(*state)
                 elif type(inst) is torch.nn.Parameter:
                     inst.__setstate__(state)


### PR DESCRIPTION
Removes unused ignores to keep the code base as clean as possible. 

`pyrefly check`
`lintrunner -a`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela