### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,8 +244,8 @@ docs/source/scripts/lr_scheduler_images/
 
 # build, distribute, and bins (+ python proto bindings)
 build/
-# Allow tools/build/ for build support.
-!tools/build/
+# Allow tools/build/bazel for build support.
+!tools/build/bazel
 build_host_protoc
 build_android
 build_ios


### PR DESCRIPTION
When use pytorch/tools like `build_libtorch.py`, many sub-dirs will be generated in the `tools/build`, ignore them for better development experience.
