### PR TITLE
torch.nn.functional.pixel_shuffle throws SIGFPE (Floating Point Exception) with large upscale_factor #171838

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -11,7 +11,10 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
               "pixel_shuffle expects a positive upscale_factor, but got ",
               upscale_factor);
   int64_t c = self.size(-3);
-  TORCH_CHECK_VALUE(upscale_factor <= std::numeric_limits<decltype(upscale_factor)>::max() / upscale_factor,
+  // Check for overflow before computing upscale_factor^2
+  // sqrt(2^63 - 1) ≈ 3037000499, so if upscale_factor > 3037000499, then upscale_factor^2 will overflow
+  constexpr int64_t max_sqrt = 3037000499; // floor(sqrt(2^63 - 1))
+  TORCH_CHECK_VALUE(upscale_factor <= max_sqrt,
         "upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=", upscale_factor);
   int64_t upscale_factor_squared = upscale_factor * upscale_factor;
   TORCH_CHECK(c % upscale_factor_squared == 0,

--- a/aten/src/ATen/native/PixelShuffle.h
+++ b/aten/src/ATen/native/PixelShuffle.h
@@ -11,10 +11,7 @@ inline void check_pixel_shuffle_shapes(const Tensor& self, int64_t upscale_facto
               "pixel_shuffle expects a positive upscale_factor, but got ",
               upscale_factor);
   int64_t c = self.size(-3);
-  // Check for overflow before computing upscale_factor^2
-  // sqrt(2^63 - 1) ≈ 3037000499, so if upscale_factor > 3037000499, then upscale_factor^2 will overflow
-  constexpr int64_t max_sqrt = 3037000499; // floor(sqrt(2^63 - 1))
-  TORCH_CHECK_VALUE(upscale_factor <= max_sqrt,
+  TORCH_CHECK_VALUE(upscale_factor <= std::numeric_limits<decltype(upscale_factor)>::max() / upscale_factor,
         "upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=", upscale_factor);
   int64_t upscale_factor_squared = upscale_factor * upscale_factor;
   TORCH_CHECK(c % upscale_factor_squared == 0,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4627,9 +4627,32 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             _test_pixel_unshuffle_error_case_helper(num_input_dims=num_input_dims, downscale_factor=-2)
 
         def test_pixel_shuffle_large_upscale_factor():
-            with self.assertRaises(ValueError):
+            # RuntimeError from Python layer (torch._check) or ValueError from C++ layer
+            with self.assertRaises((RuntimeError, ValueError)):
                 ps = nn.PixelShuffle(545460846592)
                 ps(torch.randn(2, 16, 9, 3))
+
+        def test_pixel_shuffle_overflow_upscale_factor():
+            # Regression test for https://github.com/pytorch/pytorch/issues/171838
+            # Large upscale_factor that causes integer overflow when squared
+            # should raise an error instead of SIGFPE crash
+            # RuntimeError from Python layer (torch._check) or ValueError from C++ layer
+            with self.assertRaises((RuntimeError, ValueError)):
+                input_tensor = torch.zeros([0, 0, 0], dtype=torch.float32)
+                F.pixel_shuffle(input_tensor, 4323455642275676160)
+
+            # Test with non-empty tensor as well
+            with self.assertRaises((RuntimeError, ValueError)):
+                F.pixel_shuffle(torch.randn(1, 4, 2, 2), 4323455642275676160)
+
+        def test_pixel_shuffle_negative_upscale_factor():
+            # Negative upscale_factor should raise an error
+            # RuntimeError from Python layer (torch._check) or ValueError from C++ layer
+            with self.assertRaises((RuntimeError, ValueError)):
+                F.pixel_shuffle(torch.randn(1, 4, 2, 2), -1)
+
+            with self.assertRaises((RuntimeError, ValueError)):
+                F.pixel_shuffle(torch.randn(1, 4, 2, 2), 0)
 
         def test_pixel_shuffle_unshuffle_1D():
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=1)
@@ -4647,6 +4670,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=5)
 
         test_pixel_shuffle_large_upscale_factor()
+        test_pixel_shuffle_overflow_upscale_factor()
+        test_pixel_shuffle_negative_upscale_factor()
         test_pixel_shuffle_unshuffle_1D()
         test_pixel_shuffle_unshuffle_2D()
         test_pixel_shuffle_unshuffle_3D()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4654,6 +4654,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaises((RuntimeError, ValueError)):
                 F.pixel_shuffle(torch.randn(1, 4, 2, 2), 0)
 
+        def test_pixel_shuffle_overflow_boundary():
+            # Test boundary value for overflow check (max_sqrt = 3037000499)
+            # Values <= 3037000499 should work (if channel dim is divisible)
+            # Values > 3037000499 should raise ValueError from C++ layer
+            max_sqrt = 3037000499
+            
+            # Test boundary value - should work if valid input
+            # Using a value that would work if not for overflow check
+            with self.assertRaises((RuntimeError, ValueError)):
+                # This should fail due to overflow check, not channel divisibility
+                F.pixel_shuffle(torch.randn(1, 4, 2, 2), max_sqrt + 1)
+            
+            # Test direct aten.ops call to ensure C++ checks work
+            # This bypasses Python layer, so should use C++ checks directly
+            with self.assertRaises(ValueError):
+                torch.ops.aten.pixel_shuffle.default(torch.randn(1, 4, 2, 2), max_sqrt + 1)
+
         def test_pixel_shuffle_unshuffle_1D():
             _test_pixel_shuffle_unshuffle_for_input_dims(num_input_dims=1)
 
@@ -4672,6 +4689,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         test_pixel_shuffle_large_upscale_factor()
         test_pixel_shuffle_overflow_upscale_factor()
         test_pixel_shuffle_negative_upscale_factor()
+        test_pixel_shuffle_overflow_boundary()
         test_pixel_shuffle_unshuffle_1D()
         test_pixel_shuffle_unshuffle_2D()
         test_pixel_shuffle_unshuffle_3D()

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7741,6 +7741,12 @@ def meta_pixel_shuffle(self, upscale_factor):
         upscale_factor > 0,
         lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
     )
+    # Check for overflow when squaring upscale_factor
+    INT64_MAX = torch.iinfo(torch.int64).max
+    torch._check(
+        upscale_factor <= INT64_MAX // upscale_factor,
+        lambda: f"pixel_shuffle upscale_factor is too large, (upscale_factor)^2 would overflow: upscale_factor={upscale_factor}",
+    )
     if not (
         len(self.shape) > 2 and self.shape[-3] % (upscale_factor * upscale_factor) == 0
     ):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7737,17 +7737,9 @@ def linear_backward(input_, grad_output_, weight_, output_mask):
 
 @register_meta(aten.pixel_shuffle.default)
 def meta_pixel_shuffle(self, upscale_factor):
-    # Check for overflow when squaring upscale_factor
-    # INT64_MAX = 2^63 - 1 = 9223372036854775807
-    # sqrt(INT64_MAX) ≈ 3037000499
-    INT64_MAX = 9223372036854775807
     torch._check(
         upscale_factor > 0,
         lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
-    )
-    torch._check(
-        upscale_factor <= INT64_MAX // upscale_factor,
-        lambda: f"pixel_shuffle upscale_factor is too large, (upscale_factor)^2 would overflow: upscale_factor={upscale_factor}",
     )
     if not (
         len(self.shape) > 2 and self.shape[-3] % (upscale_factor * upscale_factor) == 0

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7737,6 +7737,18 @@ def linear_backward(input_, grad_output_, weight_, output_mask):
 
 @register_meta(aten.pixel_shuffle.default)
 def meta_pixel_shuffle(self, upscale_factor):
+    # Check for overflow when squaring upscale_factor
+    # INT64_MAX = 2^63 - 1 = 9223372036854775807
+    # sqrt(INT64_MAX) ≈ 3037000499
+    INT64_MAX = 9223372036854775807
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
+    torch._check(
+        upscale_factor <= INT64_MAX // upscale_factor,
+        lambda: f"pixel_shuffle upscale_factor is too large, (upscale_factor)^2 would overflow: upscale_factor={upscale_factor}",
+    )
     if not (
         len(self.shape) > 2 and self.shape[-3] % (upscale_factor * upscale_factor) == 0
     ):

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1233,20 +1233,6 @@ def pdist(a: TensorLikeType, p: float = 2) -> TensorLikeType:
 @register_decomposition(aten.pixel_shuffle)
 @out_wrapper()
 def pixel_shuffle(self: Tensor, upscale_factor: int):
-    torch._check(
-        self.dim() >= 3,
-        lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
-    )
-    torch._check(
-        upscale_factor > 0,
-        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
-    )
-    # Check for overflow when squaring upscale_factor (INT64_MAX ≈ 9.2e18, sqrt ≈ 3.0e9)
-    INT64_MAX = 9223372036854775807
-    torch._check(
-        upscale_factor <= INT64_MAX // upscale_factor,
-        lambda: f"pixel_shuffle upscale_factor is too large, (upscale_factor)^2 would overflow: upscale_factor={upscale_factor}",
-    )
     batch = self.shape[:-3]
     C_out = self.shape[-3] // upscale_factor**2
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1237,6 +1237,16 @@ def pixel_shuffle(self: Tensor, upscale_factor: int):
         self.dim() >= 3,
         lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
     )
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
+    # Check for overflow when squaring upscale_factor (INT64_MAX ≈ 9.2e18, sqrt ≈ 3.0e9)
+    INT64_MAX = 9223372036854775807
+    torch._check(
+        upscale_factor <= INT64_MAX // upscale_factor,
+        lambda: f"pixel_shuffle upscale_factor is too large, (upscale_factor)^2 would overflow: upscale_factor={upscale_factor}",
+    )
     batch = self.shape[:-3]
     C_out = self.shape[-3] // upscale_factor**2
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1233,6 +1233,20 @@ def pdist(a: TensorLikeType, p: float = 2) -> TensorLikeType:
 @register_decomposition(aten.pixel_shuffle)
 @out_wrapper()
 def pixel_shuffle(self: Tensor, upscale_factor: int):
+    torch._check(
+        self.dim() >= 3,
+        lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
+    )
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
+    # Check for overflow when squaring upscale_factor
+    INT64_MAX = torch.iinfo(torch.int64).max
+    torch._check(
+        upscale_factor <= INT64_MAX // upscale_factor,
+        lambda: f"pixel_shuffle upscale_factor is too large, (upscale_factor)^2 would overflow: upscale_factor={upscale_factor}",
+    )
     batch = self.shape[:-3]
     C_out = self.shape[-3] // upscale_factor**2
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)


### PR DESCRIPTION
## Fix pixel_shuffle SIGFPE crash with large upscale_factor

Fixes https://github.com/pytorch/pytorch/issues/171838

**Bug:** `F.pixel_shuffle` crashes with SIGFPE when given extremely large `upscale_factor` (e.g., `4323455642275676160`) due to integer overflow when squaring.

**Fix:** Added validation checks before computation:
- `upscale_factor > 0`
- `upscale_factor² ≤ INT64_MAX`

**Tests:** Added regression tests reproducing the exact crash + edge cases.