### PR TITLE
[inductor] fix: aten.lift internal assert failure with FunctionalTensor input

### DIFF
--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -202,7 +202,9 @@ static const at::Tensor & resize__functionalization(c10::DispatchKeySet dispatch
 
 
 static at::Tensor lift_functionalize(const at::Tensor & self) {
-  TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(self));
+  if (at::functionalization::impl::isFunctionalTensor(self)) {
+    return self;
+  }
   at::AutoDispatchSkipFunctionalize guard;
   auto out = at::lift(self);
   return at::functionalization::impl::to_functional_tensor(out);


### PR DESCRIPTION
Fixes #171375

When using `torch.compile(backend="inductor")` with `torch.ops.aten.lift`, it crashes with an internal assert failure because `lift_functionalize` doesn't handle already-wrapped FunctionalTensor inputs.

The fix checks if the input is already a FunctionalTensor and returns it as-is, consistent with lift's no-op semantics and matching the existing behavior in `lift_fresh_functionalize`.

cc @bdhirsh @ezyang