### PR TITLE
[optim] fix: MultiStepLR.load_state_dict to handle string milestone keys

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2106,6 +2106,14 @@ class TestLRScheduler(TestCase):
             lambda: MultiStepLR(self.opt, gamma=0.01, milestones=[1, 4, 6]),
         )
 
+    def test_multi_step_lr_state_dict_with_string_keys(self):
+        scheduler = MultiStepLR(self.opt, gamma=0.1, milestones=[3, 6, 9])
+        state_dict = scheduler.state_dict()
+        state_dict["milestones"] = {"3": 1, "6": 1, "9": 1}
+        scheduler.load_state_dict(state_dict)
+        self.assertEqual(dict(scheduler.milestones), {3: 1, 6: 1, 9: 1})
+        self.assertTrue(all(isinstance(k, int) for k in scheduler.milestones))
+
     def test_exp_step_lr_state_dict(self):
         self._check_scheduler_state_dict(
             lambda: ExponentialLR(self.opt, gamma=0.1),

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -771,6 +771,25 @@ class MultiStepLR(LRScheduler):
             for base_lr in self.base_lrs
         ]
 
+    @override
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Load the scheduler's state.
+
+        Args:
+            state_dict (dict): scheduler state. Should be an object returned
+                from a call to :meth:`state_dict`.
+
+        Note:
+            This method converts the milestone keys to integers to handle
+            checkpoints where the keys were serialized as strings.
+        """
+        if "milestones" in state_dict:
+            state_dict = state_dict.copy()
+            state_dict["milestones"] = Counter(
+                {int(k): v for k, v in state_dict["milestones"].items()}
+            )
+        super().load_state_dict(state_dict)
+
 
 class ConstantLR(LRScheduler):
     """Multiply the learning rate of each parameter group by a small constant factor.


### PR DESCRIPTION
Fixes #153842

When checkpoints are saved by DCP (Distributed CheckPoint Saver), all `state_dict` keys are converted to strings. 

When loading a checkpoint, the milestone keys in MultiStepLR don't get converted back to integers, resulting in duplicate keys and lookup failures.

This fix overrides `load_state_dict` in MultiStepLR to convert milestone keys from strings to integers when loading state.

cc @janeyx99 @albanD