### PR TITLE
Skip cudagraphs for certain models in performance benchmarks

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3899,6 +3899,16 @@ def run(runner, args, original_dir=None):
     elif args.performance:
         # Ensure that we test on real scenarios
         args.use_eval_mode = False
+        # same cudagraph disable for performance as for accuracy tests (see above):
+        if not args.disable_cudagraphs:
+            runner.skip_models.update(
+                {
+                    # xfail: https://github.com/pytorch/pytorch/issues/145773
+                    "convit_base",
+                    "llama",
+                    "cm3leon_generate",
+                }
+            )
 
     if args.partition_id > args.total_partitions or args.partition_id < 0:
         print("Invalid partition id")


### PR DESCRIPTION
In dynamo bechmarks, some explicit cudagraph skips are added for 
```
"convit_base",
"llama",
"cm3leon_generate",
```
but only for accuracy tests.  The same skips should be added for performance tests as well (and to all test to that matter..).

For `convit_base` in particular, this seems to be the line that breaks cudagraph playback: https://github.com/huggingface/pytorch-image-models/blob/d4ab5165b4e97a28047bdaca52123d4fb74bab00/timm/models/convit.py#L73
(adding a simple `.clone()` into that would actually solve the issue).

Sorry to add such a dirty patch - but it follows the same (dirty) pattern of sprinkling these model skips all over `common.py` and `timm_models.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo