### PR TITLE
[BugFix] Fix calculation and initialization bugs in AvgPool3d backward (Channels Last)

### DIFF
--- a/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
@@ -1012,7 +1012,7 @@ void cpu_avg_pool3d_backward_channels_last(
   at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
     for (const auto n : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + n * input_depth * input_height * input_width * channels;
-      scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
+      scalar_t* grad_output_ptr = grad_output_data + n * output_depth * output_height * output_width * channels;
 
       for (const auto od : c10::irange(output_depth)) {
         for (const auto oh : c10::irange(output_height)) {

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1114,6 +1114,78 @@ torch.cuda.synchronize()
         helper(10, 512, 31, 31, 3, stride=2)
         helper(1, 129, 8, 8, 3, stride=2)
 
+    @expectedFailureMPS  # TODO: fixme
+    @onlyNativeDeviceTypes
+    @gcIfJetson
+    @dtypes(torch.float, torch.double)
+    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    def test_avg_pool3d_nhwc(self, device, dtype):
+        def helper(
+            n,
+            c,
+            d,
+            h,
+            w,
+            kernel_size,
+            stride=None,
+            count_include_pad=True,
+            divisor_override=None,
+            padding=0,
+        ):
+            if stride is None:
+                stride = kernel_size
+            input = torch.randn(n, c, d, h, w, dtype=dtype, device=device)
+            input = input.contiguous(memory_format=torch.channels_last_3d).requires_grad_()
+            # Calculate output size considering padding
+            out_d = (d + 2 * padding - kernel_size) // stride + 1
+            out_h = (h + 2 * padding - kernel_size) // stride + 1
+            out_w = (w + 2 * padding - kernel_size) // stride + 1
+            grad = torch.randn(
+                n,
+                c,
+                out_d,
+                out_h,
+                out_w,
+                dtype=dtype,
+                device=device,
+            )
+            pool = torch.nn.AvgPool3d(
+                kernel_size,
+                stride=stride,
+                padding=padding,
+                count_include_pad=count_include_pad,
+                divisor_override=divisor_override,
+            ).to(device)
+
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_pool = torch.nn.AvgPool3d(
+                kernel_size,
+                stride=stride,
+                padding=padding,
+                count_include_pad=count_include_pad,
+                divisor_override=divisor_override,
+            ).to(device)
+
+            out = pool(input)
+            out.backward(grad)
+            ref_out = ref_pool(ref_input)
+            ref_out.backward(ref_grad)
+
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last_3d))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(input.grad, ref_input.grad)
+
+        helper(4, 8, 8, 8, 8, 3)
+        helper(4, 8, 8, 8, 8, 3, count_include_pad=False, padding=1)
+        helper(4, 8, 8, 8, 8, 3, count_include_pad=False, padding=2, stride=2)
+        helper(4, 8, 8, 8, 8, 3, divisor_override=42)
+        helper(4, 8, 8, 8, 8, 7)
+        helper(4, 8, 7, 7, 7, 3, stride=1)
+        helper(4, 8, 7, 7, 7, 3, padding=2, stride=1)
+        helper(2, 16, 10, 10, 10, 3, stride=2)
+
     @onlyCPU
     @dtypes(torch.float, torch.double)
     def test_max_pool1d_corner_cases(self, device, dtype):

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1114,11 +1114,11 @@ torch.cuda.synchronize()
         helper(10, 512, 31, 31, 3, stride=2)
         helper(1, 129, 8, 8, 3, stride=2)
 
-    @expectedFailureMPS  # TODO: fixme
     @onlyNativeDeviceTypes
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfMPS(torch.float)
     def test_avg_pool3d_nhwc(self, device, dtype):
         def helper(
             n,

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1174,18 +1174,16 @@ torch.cuda.synchronize()
             ref_out = ref_pool(ref_input)
             ref_out.backward(ref_grad)
 
-            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last_3d))
-            self.assertTrue(ref_out.is_contiguous())
             self.assertEqual(out, ref_out)
             self.assertEqual(input.grad, ref_input.grad)
 
         helper(4, 8, 8, 8, 8, 3)
         helper(4, 8, 8, 8, 8, 3, count_include_pad=False, padding=1)
-        helper(4, 8, 8, 8, 8, 3, count_include_pad=False, padding=2, stride=2)
+        helper(4, 8, 8, 8, 8, 3, count_include_pad=False, padding=1, stride=2)
         helper(4, 8, 8, 8, 8, 3, divisor_override=42)
         helper(4, 8, 8, 8, 8, 7)
         helper(4, 8, 7, 7, 7, 3, stride=1)
-        helper(4, 8, 7, 7, 7, 3, padding=2, stride=1)
+        helper(4, 8, 7, 7, 7, 3, padding=1, stride=1)
         helper(2, 16, 10, 10, 10, 3, stride=2)
 
     @onlyCPU

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1175,7 +1175,10 @@ torch.cuda.synchronize()
             ref_out.backward(ref_grad)
 
             self.assertEqual(out, ref_out)
-            self.assertEqual(input.grad, ref_input.grad)
+            if dtype == torch.half:
+                self.assertEqual(input.grad, ref_input.grad, atol=2e-4, rtol=1e-2)
+            else:
+                self.assertEqual(input.grad, ref_input.grad)
 
         helper(4, 8, 8, 8, 8, 3)
         helper(4, 8, 8, 8, 8, 3, count_include_pad=False, padding=1)

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1176,7 +1176,7 @@ torch.cuda.synchronize()
 
             self.assertEqual(out, ref_out)
             if dtype == torch.half:
-                self.assertEqual(input.grad, ref_input.grad, atol=2e-4, rtol=1e-2)
+                self.assertEqual(input.grad, ref_input.grad, atol=5e-4, rtol=1e-1)
             else:
                 self.assertEqual(input.grad, ref_input.grad)
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1135,7 +1135,9 @@ torch.cuda.synchronize()
             if stride is None:
                 stride = kernel_size
             input = torch.randn(n, c, d, h, w, dtype=dtype, device=device)
-            input = input.contiguous(memory_format=torch.channels_last_3d).requires_grad_()
+            input = input.contiguous(
+                memory_format=torch.channels_last_3d
+            ).requires_grad_()
             # Calculate output size considering padding
             out_d = (d + 2 * padding - kernel_size) // stride + 1
             out_h = (h + 2 * padding - kernel_size) // stride + 1


### PR DESCRIPTION
Fix incorrect batch stride in AvgPool3d backward (Channels Last)

Just according to context

#### Context 0

https://github.com/pytorch/pytorch/blob/98dbbd562c8e2535df6477231c183295eb550368/aten/src/ATen/native/cpu/AvgPoolKernel.cpp#L936-L937

#### Context 1

https://github.com/pytorch/pytorch/blob/98dbbd562c8e2535df6477231c183295eb550368/aten/src/ATen/native/cpu/AvgPoolKernel.cpp#L1045

I think it's a serious bug —— Silent Failure

It computes the batch stride using only height * width * channels, completely missing the depth dimension. In the Channels Last 3D memory layout `(N, D, H, W, C)`, the correct stride to access the $n$-th sample must be $D \times H \times W \times C$.

Need review and test.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @malfet @cyyever @Skylion007 