### PR TITLE
[HIM][enable][14/n] Fix IMA in TMA mm kernel

### DIFF
--- a/torch/_inductor/kernel/templates/triton_persistent_tma_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_persistent_tma_mm.py.jinja
@@ -2,25 +2,16 @@
     M = {{size("A", 0)}}
     N = {{size("B", 1)}}
     K = {{size("A", 1)}}
-    if M * N == 0:
+
+    if (M == 0) or (N == 0):
         # early exit due to zero-size input(s)
         return
 
     start_pid = tl.program_id(0).to(INDEX_DTYPE)
     grid_m = tl.cdiv(M, BLOCK_M)
     grid_n = tl.cdiv(N, BLOCK_N)
-    k_tiles = tl.cdiv(K, BLOCK_K)
     num_tiles = grid_m * grid_n
-    tiles_per_SM = num_tiles // NUM_SMS
-    if start_pid < num_tiles % NUM_SMS:
-        tiles_per_SM += 1
-
-    tile_id = start_pid - NUM_SMS
-    ki = -1
-
     width = GROUP_M * grid_n
-    rk_for_mask = tl.arange(0, BLOCK_K)
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 
     {%- if TMA_EXPERIMENTAL_API %}
     workspace_base = ws_ptr + start_pid * 2 * TMA_SIZE
@@ -50,6 +41,7 @@
     stride_ak = {{stride("A", 1)}}
     stride_bk = {{stride("B", 0)}}
     stride_bn = {{stride("B", 1)}}
+
     a_desc = triton.language.make_tensor_descriptor(
         base=A,
         shape=[M, K] if A_ROW_MAJOR else [K, M],
@@ -64,66 +56,69 @@
     )
     {%- endif %}
 
-    pid_m = 0
-    pid_n = 0
-    rm = 0
-    rn = 0
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS):
 
-    for _ in range(0, k_tiles * tiles_per_SM):
-        ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
-        if ki == 0:
-            tile_id += NUM_SMS
-            # re-order program ID for better L2 performance
-            group_id = tile_id // width
-            group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-            pid_m = group_id * GROUP_M + (tile_id % group_size)
-            pid_n = (tile_id % width) // (group_size)
+        # re-order program ID for better L2 performance
+        group_id = tile_id // width
+        group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+        pid_m = group_id * GROUP_M + (tile_id % group_size)
+        pid_n = (tile_id % width) // (group_size)
 
-            rm = pid_m * BLOCK_M
-            rn = pid_n * BLOCK_N
+        rm = pid_m * BLOCK_M
+        rn = pid_n * BLOCK_N
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 
-        rk = ki * BLOCK_K
+        for rk in tl.range(0, K, BLOCK_K):
 
-        {%- if TMA_EXPERIMENTAL_API %}
-        a = tl._experimental_descriptor_load(
-            a_desc_ptr,
-            [rm, rk] if A_ROW_MAJOR else [rk, rm],
-            [BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
-            A.dtype.element_ty,
-        )
-        b = tl._experimental_descriptor_load(
-            b_desc_ptr,
-            [rk, rn] if B_ROW_MAJOR else [rn, rk],
-            [BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
-            B.dtype.element_ty,
-        )
-        {%- else %}
-        a = tl.load_tensor_descriptor(
-            a_desc,
-            [rm, rk] if A_ROW_MAJOR else [rk, rm],
-        )
-        b = tl.load_tensor_descriptor(
-            b_desc,
-            [rk, rn] if B_ROW_MAJOR else [rn, rk],
-        )
-        {%- endif %}
-        acc += tl.dot(
-            a if A_ROW_MAJOR else a.T,
-            b if B_ROW_MAJOR else b.T,
-            allow_tf32=ALLOW_TF32,
-        )
-
-        if ki == k_tiles - 1:
-            # inductor generates a suffix
             {%- if TMA_EXPERIMENTAL_API %}
-            # rematerialize rm and rn to save registers
-            rcm = rm + tl.arange(0, BLOCK_M)
-            rcn = rn + tl.arange(0, BLOCK_N)
-            idx_m = rcm[:, None]
-            idx_n = rcn[None, :]
-            mask = (idx_m < M) & (idx_n < N)
-            {{store_output(("idx_m", "idx_n"), "acc", "mask", indent_width=12, val_shape=("BLOCK_M", "BLOCK_N"))}}
+            a = tl._experimental_descriptor_load(
+                a_desc_ptr,
+                [rm, rk] if A_ROW_MAJOR else [rk, rm],
+                [BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
+                A.dtype.element_ty,
+            )
+            b = tl._experimental_descriptor_load(
+                b_desc_ptr,
+                [rk, rn] if B_ROW_MAJOR else [rn, rk],
+                [BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
+                B.dtype.element_ty,
+            )
             {%- else %}
-            {{store_output(("rm", "rn"), "acc", indent_width=12, val_shape=("BLOCK_M", "BLOCK_N"), block_indexing=True)}}
+            a = tl.load_tensor_descriptor(
+                a_desc,
+                [rm, rk] if A_ROW_MAJOR else [rk, rm],
+            )
+            b = tl.load_tensor_descriptor(
+                b_desc,
+                [rk, rn] if B_ROW_MAJOR else [rn, rk],
+            )
             {%- endif %}
-            acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+            if USE_FAST_ACCUM:
+                acc = tl.dot(
+                    a if A_ROW_MAJOR else a.T,
+                    b if B_ROW_MAJOR else b.T,
+                    acc,
+                    allow_tf32=ALLOW_TF32,
+                    )
+            else:
+                acc += tl.dot(
+                    a if A_ROW_MAJOR else a.T,
+                    b if B_ROW_MAJOR else b.T,
+                    allow_tf32=ALLOW_TF32,
+                )
+
+        # rematerialize rm and rn to save registers
+        rm = pid_m * BLOCK_M
+        rn = pid_n * BLOCK_N
+
+        # inductor generates a suffix
+        {%- if TMA_EXPERIMENTAL_API %}
+        rcm = rm + tl.arange(0, BLOCK_M)
+        rcn = rn + tl.arange(0, BLOCK_N)
+        idx_m = rcm[:, None]
+        idx_n = rcn[None, :]
+        mask = (idx_m < M) & (idx_n < N)
+        {{store_output(("idx_m", "idx_n"), "acc", "mask", indent_width=8, val_shape=("BLOCK_M", "BLOCK_N"))}}
+        {%- else %}
+        {{store_output(("rm", "rn"), "acc", indent_width=8, val_shape=("BLOCK_M", "BLOCK_N"), block_indexing=True)}}
+        {%- endif %}


### PR DESCRIPTION
Summary: As titled, fix IMA issue by limiting GEMM on only valid MNK ~

Test Plan:
Acquired IMA [log](https://www.internalfb.com/intern/paste/P2110451795/) by following cmd:
```
/usr/local/cuda/bin/compute-sanitizer --tool memcheck bash ~/scripts/run_814976029.sh
```

With this fix, [run_814976029.sh](https://www.internalfb.com/intern/paste/P2110453717/) could run [E2E](https://www.internalfb.com/intern/paste/P2110470170/). Also, performed unit test:
```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:max_autotune -c fbcode.nvcc_arch=h100a -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 -c fbcode.re_gpu_tests=False -- test_max_autotune_regular_mm_persistent_tma
```

Differential Revision: D90086674




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo