### PR TITLE
Fix typos in comments and variable names

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/BinaryOps.cpp
@@ -461,7 +461,7 @@ Tensor qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
 #endif // USE_XNNPACK
 
 #ifdef USE_PYTORCH_QNNPACK
-    if(qa.sizes() == qb.sizes() && /* qnnpack does not support boardcasting */
+    if(qa.sizes() == qb.sizes() && /* qnnpack does not support broadcasting */
       qa.scalar_type() == kQUInt8) {
     return qnnpack_add<ReLUFused>(qa, qb, scale, zero_point);
     }

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -489,7 +489,7 @@ class DDPOptimizer:
         """
         Implements graph splitting, first determining a set of of buckets by counting
         parameter sizes in reverse graph order, then invoking the user/backend compiler
-        to compile each subgraph. Finally, stiches compiled graphs into one graphmodule
+        to compile each subgraph. Finally, stitches compiled graphs into one graphmodule
         and returns its callable.
         """
         # 1: compute the partition map according to DDP bucket logic

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1947,9 +1947,7 @@ class VariableBuilder:
         # As long as this runs before AOT this is sound
         if value in self.tx.output.side_effects:
             var = self.tx.output.side_effects[value]
-            # type: ignore[attr-defiend]
             var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
-                # type: ignore[attr-defiend]
                 value._dynamo_static_input_type
             )
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1947,7 +1947,9 @@ class VariableBuilder:
         # As long as this runs before AOT this is sound
         if value in self.tx.output.side_effects:
             var = self.tx.output.side_effects[value]
+            # type: ignore[attr-defined]
             var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
+                # type: ignore[attr-defined]
                 value._dynamo_static_input_type
             )
 

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -689,7 +689,7 @@ inline void {{kernel_name}}_transpose_b_kernel(
     //   which introduces an additional transpose overhead of [K, N] compared to the non-transpose version.
     // Second implementation:
     //   Directly perform inner product calculation in sub-blocks,
-    //   which introduces an additional vector reduction of [M, N] compared to the non-tranpose version.
+    //   which introduces an additional vector reduction of [M, N] compared to the non-transpose version.
     // Therefore, when M * N / (K * N) is large, the first implementation has better performance.
     {%- if tail_n %}
     if (K % Vectorized::size() == 0 && N % Vectorized::size() == 0 && 24 * BLOCK_M > K) {

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -210,12 +210,12 @@ class DeferredTritonCallWrapper:
             self.arg_types,
             params["def_args"],
         )
-        arg_type_loookup = dict(zip(params["def_args"], self.arg_types))
+        arg_type_lookup = dict(zip(params["def_args"], self.arg_types))
         # difference between Python and C++ wrapper: C++ wrapper strips out equal_to_1 constants
         call_args = [
             name for name in params["call_args"] if name not in triton_meta["constants"]
         ]
-        arg_types = [arg_type_loookup[name] for name in call_args]
+        arg_types = [arg_type_lookup[name] for name in call_args]
         arg_signatures = [triton_meta["signature"][name] for name in call_args]
         scratch_spaces = {
             name: params[name]

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -474,7 +474,7 @@ def propagate_general_copy_metadata(
         ):
             return PropagateStatus.FAIL
 
-        # apply any to a list to avoid short-curcuit
+        # apply any to a list to avoid short-circuit
         changed = any(  # noqa: C419
             [  # noqa: C419
                 copy_chunking_meta(node, meta)

--- a/torch/_inductor/fx_passes/efficient_conv_bn_eval.py
+++ b/torch/_inductor/fx_passes/efficient_conv_bn_eval.py
@@ -85,7 +85,7 @@ def efficient_conv_bn_eval_decomposed(
     conv_weight,
     conv_bias,
     x,
-    conv_remainging_args,
+    conv_remaining_args,
 ):
     """
     Implementation based on https://arxiv.org/abs/2305.11624
@@ -131,7 +131,7 @@ def efficient_conv_bn_eval_decomposed(
     )
 
     input = x
-    return conv(*((input, weight_on_the_fly, bias_on_the_fly) + conv_remainging_args))
+    return conv(*((input, weight_on_the_fly, bias_on_the_fly) + conv_remaining_args))
 
 
 @register_graph_pattern(
@@ -193,7 +193,7 @@ def efficient_conv_bn_eval_graph_transform_inlined(match: Match, *args, **kwargs
         conv_input = conv_node.args[0]  # type: ignore[union-attr]
         conv_weight = conv_node.args[1]  # type: ignore[union-attr]
         conv_bias = conv_node.args[2] if len(conv_node.args) >= 3 else None  # type: ignore[union-attr]
-        conv_remainging_args = conv_node.args[3:]  # type: ignore[union-attr]
+        conv_remaining_args = conv_node.args[3:]  # type: ignore[union-attr]
         args = (
             bn_weight,
             bn_bias,
@@ -204,7 +204,7 @@ def efficient_conv_bn_eval_graph_transform_inlined(match: Match, *args, **kwargs
             conv_weight,
             conv_bias,
             conv_input,
-            conv_remainging_args,
+            conv_remaining_args,
         )
 
         # create a new node
@@ -285,7 +285,7 @@ def efficient_conv_bn_eval_graph_transform_decomposed(match: Match, *args, **kwa
         conv_input = conv_node.args[0]  # type: ignore[union-attr]
         conv_weight = conv_node.args[1]  # type: ignore[union-attr]
         conv_bias = conv_node.args[2] if len(conv_node.args) >= 3 else None  # type: ignore[union-attr]
-        conv_remainging_args = conv_node.args[3:]  # type: ignore[union-attr]
+        conv_remaining_args = conv_node.args[3:]  # type: ignore[union-attr]
         args = (
             bn_weight,
             bn_bias,
@@ -296,7 +296,7 @@ def efficient_conv_bn_eval_graph_transform_decomposed(match: Match, *args, **kwa
             conv_weight,
             conv_bias,
             conv_input,
-            conv_remainging_args,
+            conv_remaining_args,
         )
 
         # create a new node

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -624,7 +624,7 @@ def register_onednn_fusion_ops():
             alpha,
             unary_attr,
             unary_scalars,
-            unary_algorithmm,
+            unary_algorithm,
         ):
             if not isinstance(x_scale, ir.TensorBox):
                 assert type(x_scale) is float
@@ -681,7 +681,7 @@ def register_onednn_fusion_ops():
                     alpha,
                     unary_attr,
                     unary_scalars,
-                    unary_algorithmm,
+                    unary_algorithm,
                 )
             )
 
@@ -1012,7 +1012,7 @@ def register_onednn_fusion_ops():
             alpha,
             unary_attr,
             unary_scalars,
-            unary_algorithmm,
+            unary_algorithm,
             layout=None,
         ):
             x_size = x.get_size()
@@ -1207,7 +1207,7 @@ def register_onednn_fusion_ops():
                                 output_buf,
                                 unary_attr,
                                 scalars=unary_scalars,
-                                algorithm=unary_algorithmm,
+                                algorithm=unary_algorithm,
                             )
 
                         # Step 5: Cast output to Target Dtype
@@ -1284,7 +1284,7 @@ def register_onednn_fusion_ops():
                     binary_alpha=alpha,
                     unary_post_op=unary_attr,
                     unary_post_op_args=unary_scalars,
-                    unary_post_op_algorithm=unary_algorithmm,
+                    unary_post_op_algorithm=unary_algorithm,
                 )
                 if bias is None:
                     kwargs["bias"] = None

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4547,7 +4547,7 @@ class Scheduler:
         The current attempt is a quick, possibly hacky, heuristic to prevent the
         fusion of nodes that are far away in the original order.
 
-        A better but difficult to implement heurisitic would be to use live
+        A better but difficult to implement heuristic would be to use live
         intervals of the buffers, find region of peak pressure in the original
         program and prevent fusion that crosses that peak region. We might need
         special care or good approximation in this implementation, as fusion of

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -701,7 +701,7 @@ def nested_compile_region(
 
         if not dynamo_config.enable_invoke_subgraph_regional_compile:
             raise RuntimeError(
-                "nested_compile_region config is an experiemntal feature for testing only."
+                "nested_compile_region config is an experimental feature for testing only."
             )
 
     from torch._higher_order_ops.invoke_subgraph import (

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -403,7 +403,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
     // TODO: change the `ptr` below to `tensor.data_ptr()` when adding support
     // for user slice/view operations. For MemPool support,
-    // `tensor.storate().data_ptr()` is fine (today's `ptr`).
+    // `tensor.storage().data_ptr()` is fine (today's `ptr`).
 
     // If the tensor's ptr happen to be the same as allocation ptr
     if (ptr == allocation->ptr) {

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -378,7 +378,7 @@ void all_to_all_vdev(
 // offsets between peers.
 
 /* Arguments:
- * `in_splits_offsets`: input splits and offsets (optinoal), of size (2, nsplits), or (1, nsplits) if no offsets are provided.
+ * `in_splits_offsets`: input splits and offsets (optional), of size (2, nsplits), or (1, nsplits) if no offsets are provided.
  * `out_splits_offsets`: output splits and offsets, of size (2, nsplits).
  * `mype`: the rank of the current PE.
  * `npes`: the number of PEs.

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
@@ -10,7 +10,7 @@
 namespace torch::inductor {
 
 // Regarding a aten operation implemented by AOTI, the metadata of the input
-// tensors will be cached on the disk to accelerate next run. TensorMetada
+// tensors will be cached on the disk to accelerate next run. TensorMetadata
 // structure is to represent the metadata of each input tensor. It includes
 // whether the tensor is symbolic, the dtype, the device, the sizes and the
 // strides of the tensor. When the metadata of the input tensors is the same as
@@ -19,7 +19,7 @@ namespace torch::inductor {
 // library.
 // Beyond the TensorMetadata, we build guard/TensorCheck for each input tensor
 // as well to support symbolic shape. We intend to utilize TensorCheck to find
-// out the proper kernel rather than TensorMetada comparison. Suppose an
+// out the proper kernel rather than TensorMetadata comparison. Suppose an
 // operation with a single input tensor and two kernels:
 //   kernel1: TensorMetadata(is_symbolic=false, dtype=Float, device=CPU,
 //   sizes=[s0, s1, s2], strides=[s1 * s2, s2, 1]) kernel2:
@@ -27,7 +27,7 @@ namespace torch::inductor {
 //   s2], strides=[s1 * s2, s2, 1])
 // If a tensor with sizes=[3, 4, 5] is passed to the operation, both kernel1 and
 // kernel2 support the tensor shape. In this case, we need to use TensorCheck
-// plus some heruistic rules to find out the proper kernel.
+// plus some heuristic rules to find out the proper kernel.
 struct TensorMetadata {
   // Indicate whether the tensor is symbolic and it may be concluded by sizes_
   // and strides_ in the future.

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -270,7 +270,7 @@ static void writeJsonNode(
     const std::string& kernelBackend = "",
     const std::string& kernelFile = "",
     const std::string& tensor_range = "",
-    const std::string& additiona_attrs = "") {
+    const std::string& additional_attrs = "") {
   if (!out.is_open() || out.fail() || out.bad()) {
     return;
   }
@@ -305,7 +305,7 @@ static void writeJsonNode(
         kernelBackend,
         kernelFile,
         tensor_range,
-        additiona_attrs);
+        additional_attrs);
   } catch (const std::exception& e) {
     LOG(ERROR) << "Failed to write json node to execution trace: " << e.what();
   }
@@ -842,7 +842,7 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
         op_schema_str = json_str_escape(c10::toString(op_schema.value()));
       }
 
-      const std::string additiona_attrs =
+      const std::string additional_attrs =
           fn.isNcclMeta() ? getCommsNodeAttrs(fn) : "";
       {
         const std::lock_guard<std::recursive_mutex> lock(ob->gMutex);
@@ -873,7 +873,7 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
             fc.kernelBackend,
             fc.kernelFile,
             fc.get_string_for_tensor_range(),
-            additiona_attrs);
+            additional_attrs);
         ob->out << ',';
       }
     } catch (const std::exception& e) {

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -372,24 +372,24 @@ std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
 // -- NCCL Metadata -----------------------------------------------------------
 // ----------------------------------------------------------------------------
 
-static constexpr int32_t kTruncatLength = 30;
+static constexpr int32_t kTruncateLength = 30;
 
 template <typename ListLikeType>
 static inline std::string format_list(
     ListLikeType list,
     bool truncate,
     bool with_escaped_quotes = true) {
-  if (truncate && list.size() > kTruncatLength) {
+  if (truncate && list.size() > kTruncateLength) {
     if (with_escaped_quotes == true) {
       auto x = fmt::format(
           "\"[{}, ..., {}]\"",
-          fmt::join(list.begin(), list.begin() + kTruncatLength - 1, ", "),
+          fmt::join(list.begin(), list.begin() + kTruncateLength - 1, ", "),
           *std::prev(list.end()));
       return x;
     } else {
       auto x = fmt::format(
           "[{}, ..., {}]",
-          fmt::join(list.begin(), list.begin() + kTruncatLength - 1, ", "),
+          fmt::join(list.begin(), list.begin() + kTruncateLength - 1, ", "),
           *std::prev(list.end()));
       return x;
     }

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -849,7 +849,7 @@ def _get_object_coll_device(group: ProcessGroup | None = None) -> str:
 def _get_pg_default_device(group: ProcessGroup | None = None) -> torch.device:
     """
     .. note:: This method will be deprecated, it only stays for
-        backward-compatiblity reason. Alternatives:
+        backward-compatibility reason. Alternatives:
 
         - If you need to find a device for object collectives, please use
         `_get_object_coll_device(group)`.
@@ -874,7 +874,7 @@ def _get_pg_default_device(group: ProcessGroup | None = None) -> torch.device:
 
     warnings.warn(
         "`_get_pg_default_device` will be deprecated, it only stays for "
-        "backward-compatiblity reason. If you need to find a device for object "
+        "backward-compatibility reason. If you need to find a device for object "
         "collectives, please use `_get_object_coll_device`. If you need to query "
         "the device types supported by group, please use "
         "`_device_capability(group)`. ",

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -179,7 +179,7 @@ def _alloc_storage(tensor: torch.Tensor, size: torch.Size) -> None:
                 tensor_storage_size = tensor._typed_storage()._size()
                 _p_assert(
                     tensor_storage_size == 0,
-                    "Tensor storage should have been resized to be 0 but got PLACEHOLDEr",
+                    "Tensor storage should have been resized to be 0 but got PLACEHOLDER",
                 )
                 tensor._typed_storage()._resize_(size.numel())
 

--- a/torch/fx/experimental/accelerator_partitioner.py
+++ b/torch/fx/experimental/accelerator_partitioner.py
@@ -835,10 +835,10 @@ class Partitioner:
                     return float("inf")
                 # Check if the modified partition list can be mapped to devices after combination
                 reset_partition_device(partitions)
-                found_deivce = get_device_to_partitions_mapping(
+                found_device = get_device_to_partitions_mapping(
                     partitions, self.devices
                 )
-                if not found_deivce:
+                if not found_device:
                     return float("inf")
                 # Calculate the new cost
                 partition_to_latency_mapping = get_partition_to_latency_mapping(

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -230,7 +230,7 @@ def get_attr_inference_rule(n: Node, traced):
     """
     The current getattr rule only handles the shape attribute
     Can be extended to other attributes
-    The most representitive type we have is "Dyn" but the system
+    The most representative type we have is "Dyn" but the system
     can be extended with more types, such as a type to represent shapes
     """
     attr_name = n.args[1]

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -535,7 +535,7 @@ def resolve_unbacked_bindings(
     with these new symints. To ensure consistency we use PropagateUnbackedSymInts
     to rename unbacked bindings to their old ones. But all of the node metas are
     still using the old bindings from before the renaming. This function helps to
-    post facto apply any renamings discovered in the PropogateUnbackedSymInts pass.
+    post facto apply any renamings discovered in the PropagateUnbackedSymInts pass.
     """
     if bindings is None:
         return None
@@ -2495,7 +2495,7 @@ def _maybe_evaluate_static_worker(
         return None
 
     # We need to canonicalize, as after expand we may have something like `a + b = a` and
-    # sympy will not simplify the a. The two appeareances of the a will then make value ranges
+    # sympy will not simplify the a. The two appearances of the a will then make value ranges
     # analysis give lose bounds
     new_expr = canonicalize_bool_expr(safe_expand(new_expr))
     if new_expr.is_number:

--- a/torch/fx/experimental/unify_refinements.py
+++ b/torch/fx/experimental/unify_refinements.py
@@ -19,7 +19,7 @@ def infer_symbolic_types(traced):
     Calls our symbolic inferencer twice.
     This is useful when one pass is not enough
     to infer all the information such as the case
-    for braodcasting.
+    for broadcasting.
     """
     r = Refine(traced)
     r.refine()

--- a/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
@@ -25,7 +25,7 @@ def standard_kwargs(kwarg_names, expanded_args):
     r"""Separate args and kwargs from `__torch_function__`s that standardize kwargs.
 
     Most `__torch_function__`s standardize the kwargs that they give, so this will separate
-    the args and kwargs they pass. Functions that don't are linear and convND.
+    the args and kwargs they pass. Functions that don't are linear and convAND.
     """
     kwarg_values = expanded_args[len(expanded_args) - len(kwarg_names) :]
     expanded_args_without_kwargs = expanded_args[

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -75,10 +75,10 @@ class BasePruningMethod(ABC):
 
     @classmethod
     def apply(cls, module, name, *args, importance_scores=None, **kwargs):
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -427,10 +427,10 @@ class Identity(BasePruningMethod):
 
     @classmethod
     def apply(cls, module, name):  # type: ignore[override]
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -482,10 +482,10 @@ class RandomUnstructured(BasePruningMethod):
 
     @classmethod
     def apply(cls, module, name, amount):  # type: ignore[override]
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -541,10 +541,10 @@ class L1Unstructured(BasePruningMethod):
 
     @classmethod
     def apply(cls, module, name, amount, importance_scores=None):  # type: ignore[override]
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -652,10 +652,10 @@ class RandomStructured(BasePruningMethod):
 
     @classmethod
     def apply(cls, module, name, amount, dim=-1):  # type: ignore[override]
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -768,10 +768,10 @@ class LnStructured(BasePruningMethod):
 
     @classmethod
     def apply(cls, module, name, amount, n, dim, importance_scores=None):  # type: ignore[override]
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -819,10 +819,10 @@ class CustomFromMask(BasePruningMethod):
 
     @classmethod
     def apply(cls, module, name, mask):  # type: ignore[override]
-        r"""Add pruning on the fly and reparametrization of a tensor.
+        r"""Add pruning on the fly and reparameterization of a tensor.
 
         Adds the forward pre-hook that enables pruning on the fly and
-        the reparametrization of a tensor in terms of the original tensor
+        the reparameterization of a tensor in terms of the original tensor
         and the pruning mask.
 
         Args:
@@ -834,9 +834,9 @@ class CustomFromMask(BasePruningMethod):
 
 
 def identity(module, name):
-    r"""Apply pruning reparametrization without pruning any units.
+    r"""Apply pruning reparameterization without pruning any units.
 
-    Applies pruning reparametrization to the tensor corresponding to the
+    Applies pruning reparameterization to the tensor corresponding to the
     parameter called ``name`` in ``module`` without actually pruning any
     units. Modifies module in place (and also return the modified module)
     by:

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -114,7 +114,7 @@ def weight_norm(module: T_module, name: str = "weight", dim: int = 0) -> T_modul
           respectively.  If this is bothering you, please comment on
           https://github.com/pytorch/pytorch/issues/102999
 
-        * To remove the weight normalization reparametrization, use
+        * To remove the weight normalization reparameterization, use
           :func:`torch.nn.utils.parametrize.remove_parametrizations`.
 
         * The weight is no longer recomputed once at module forward; instead, it will

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -629,7 +629,7 @@ class Optimizer:
                 pre-hooks. (default: False)
 
         Returns:
-            :class:`torch.utils.hooks.RemoveableHandle`:
+            :class:`torch.utils.hooks.RemovableHandle`:
                 a handle that can be used to remove the added hook by calling
                 ``handle.remove()``
         """
@@ -663,7 +663,7 @@ class Optimizer:
                 post-hooks. (default: False)
 
         Returns:
-            :class:`torch.utils.hooks.RemoveableHandle`:
+            :class:`torch.utils.hooks.RemovableHandle`:
                 a handle that can be used to remove the added hook by calling
                 ``handle.remove()``
         """
@@ -827,7 +827,7 @@ class Optimizer:
                 pre-hooks. (default: False)
 
         Returns:
-            :class:`torch.utils.hooks.RemoveableHandle`:
+            :class:`torch.utils.hooks.RemovableHandle`:
                 a handle that can be used to remove the added hook by calling
                 ``handle.remove()``
         """
@@ -861,7 +861,7 @@ class Optimizer:
                 post-hooks. (default: False)
 
         Returns:
-            :class:`torch.utils.hooks.RemoveableHandle`:
+            :class:`torch.utils.hooks.RemovableHandle`:
                 a handle that can be used to remove the added hook by calling
                 ``handle.remove()``
         """

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -70,7 +70,7 @@ def any_torch_dispatch_mode_on_stack() -> bool:
 class TorchDispatchMode:
     """
     A ``TorchDispatchMode`` allows you to override the meaning of all
-    ``__torch_dispatch__`` overrideable functions within a dynamic scope,
+    ``__torch_dispatch__`` overridable functions within a dynamic scope,
     without having to actually create a tensor subclass or manually
     monkey-patch functions in the PyTorch API.  Some common situations
     where you should use a mode:

--- a/torch/utils/bundled_inputs.py
+++ b/torch/utils/bundled_inputs.py
@@ -19,13 +19,13 @@ class InflatableArg(NamedTuple):
     must be of the same type as the argument to the function that it is a deflated
     input for.
 
-    'fmt' is a formatable code string that is executed to inflate the compressed data into
+    'fmt' is a formattable code string that is executed to inflate the compressed data into
     the appropriate input. It can use 'value' as an input to the format str. It must result
     in a value of the same type as 'value'.
 
-    'fmt_fn' is a formatable function code string that is executed to inflate the compressed
+    'fmt_fn' is a formattable function code string that is executed to inflate the compressed
     data into the appropriate input. It must result in a value of the same type as 'value'.
-    The function name should be the formatable part of the string.
+    The function name should be the formattable part of the string.
 
     Note: Only top level InflatableArgs can be inflated. i.e. you cannot place
     an inflatable arg inside of some other structure. You should instead create


### PR DESCRIPTION
This PR fixes typos. Note that public API is not touched.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @ezyang @EikanWang @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela