### PR TITLE
[dcp][hf] Write metadata file for Consolidate hf safetensors file on every rank method

### DIFF
--- a/test/distributed/checkpoint/test_consolidate_hf_safetensors.py
+++ b/test/distributed/checkpoint/test_consolidate_hf_safetensors.py
@@ -263,6 +263,19 @@ class TestConsolidateHFSafeTensors(DTensorTestBase):
         self.assertEqual(loaded_dict_col.keys(), {"dtensor_col"})
         self.assertTrue(torch.equal(loaded_dict_col["dtensor_col"], global_tensor))
 
+        metadata_path = os.path.join(output_dir, _metadata_fn)
+        self.assertTrue(os.path.exists(metadata_path))
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+            self.assertEqual(metadata["metadata"]["total_size"], 16 * 4 * 2)
+            self.assertEqual(
+                metadata["weight_map"],
+                {
+                    "dtensor": "model-00001-of-00002.safetensors",
+                    "dtensor_col": "model-00002-of-00002.safetensors",
+                },
+            )
+
         dist.barrier()
 
     @with_comms


### PR DESCRIPTION
Summary: Titan uses the consolidate_safetensors_file_on_every_rank method and it was reported by a user there that this flow doesn't write the model.safetensors.index.json metadata file with the checkpoint. This updates the method to write this metadata file https://github.com/pytorch/torchtitan/issues/2137.

Test Plan: Unit test

Differential Revision: D90259417


