### PR TITLE
Use std:: random distributions wherever possible

### DIFF
--- a/aten/src/ATen/CPUGeneratorImpl.cpp
+++ b/aten/src/ATen/CPUGeneratorImpl.cpp
@@ -273,7 +273,7 @@ void CPUGeneratorImpl::set_next_double_normal_sample(std::optional<double> randn
 /**
  * Get the engine of the CPUGeneratorImpl
  */
-at::mt19937 CPUGeneratorImpl::engine() {
+at::mt19937& CPUGeneratorImpl::engine() {
   return engine_;
 }
 

--- a/aten/src/ATen/CPUGeneratorImpl.h
+++ b/aten/src/ATen/CPUGeneratorImpl.h
@@ -28,7 +28,7 @@ struct TORCH_API CPUGeneratorImpl : public c10::GeneratorImpl {
   std::optional<double> next_double_normal_sample();
   void set_next_float_normal_sample(std::optional<float> randn);
   void set_next_double_normal_sample(std::optional<double> randn);
-  at::mt19937 engine();
+  at::mt19937& engine();
   void set_engine(at::mt19937 engine);
 
  private:

--- a/aten/src/ATen/core/MT19937RNGEngine.h
+++ b/aten/src/ATen/core/MT19937RNGEngine.h
@@ -110,6 +110,16 @@ struct mt19937_data_pod {
 class mt19937_engine {
 public:
 
+  using result_type = uint32_t;
+
+  static constexpr result_type min() {
+    return 0;
+  }
+
+  static constexpr result_type max() {
+    return 0xffffffff;
+  }
+
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   inline explicit mt19937_engine(uint64_t seed = 5489) {
     init_with_uint32(seed);
@@ -127,7 +137,7 @@ public:
     return data_.seed_;
   }
 
-  inline bool is_valid() {
+  inline bool is_valid() const {
     if ((data_.seeded_ == true)
       && (data_.left_ > 0 && data_.left_ <= MERSENNE_STATE_N)
       && (data_.next_ <= MERSENNE_STATE_N)) {
@@ -136,7 +146,7 @@ public:
     return false;
   }
 
-  inline uint32_t operator()() {
+  inline result_type operator()() {
     if (--(data_.left_) == 0) {
         next_state();
     }
@@ -163,11 +173,11 @@ private:
     data_.next_ = 0;
   }
 
-  inline uint32_t mix_bits(uint32_t u, uint32_t v) {
+  inline uint32_t mix_bits(uint32_t u, uint32_t v) const {
     return (u & UMASK) | (v & LMASK);
   }
 
-  inline uint32_t twist(uint32_t u, uint32_t v) {
+  inline uint32_t twist(uint32_t u, uint32_t v) const {
     return (mix_bits(u,v) >> 1) ^ (v & 1 ? MATRIX_A : 0);
   }
 

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -361,10 +361,9 @@ Tensor _s_binomial_cpu(const Tensor& count, const Tensor& prob, std::optional<Ge
     CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(generator->mutex_);
-    std::mt19937 stdgenerator(generator->random());
-    cpu_serial_kernel(iter, [&stdgenerator](scalar_t count_val, scalar_t prob_val) -> scalar_t{
+    cpu_serial_kernel(iter, [generator](scalar_t count_val, scalar_t prob_val) -> scalar_t{
       std::binomial_distribution<int64_t> dist(count_val, static_cast<double>(prob_val));
-      return dist(stdgenerator);
+      return dist(generator->engine());
     });
   });
   return ret;
@@ -380,10 +379,9 @@ Tensor _s_poisson_cpu(const Tensor& lambda, std::optional<Generator> gen) {
     CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(generator->mutex_);
-    std::mt19937 stdgenerator(generator->random());
-    cpu_serial_kernel(iter, [&stdgenerator](scalar_t lambda_val) -> scalar_t{
+    cpu_serial_kernel(iter, [generator](scalar_t lambda_val) -> scalar_t{
       std::poisson_distribution<int64_t> dist(static_cast<double>(lambda_val));
-      return dist(stdgenerator);
+      return dist(generator->engine());
     });
   });
   return ret;
@@ -399,10 +397,9 @@ Tensor _s_gamma_cpu(const Tensor& alpha, std::optional<Generator> gen) {
     CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(generator->mutex_);
-    std::mt19937 stdgenerator(generator->random());
-    cpu_serial_kernel(iter, [&stdgenerator](scalar_t alpha_val) -> scalar_t{
+    cpu_serial_kernel(iter, [generator](scalar_t alpha_val) -> scalar_t{
       std::gamma_distribution<double> dist(alpha_val);
-      return std::max<scalar_t>(std::numeric_limits<scalar_t>::min(), dist(stdgenerator));
+      return std::max<scalar_t>(std::numeric_limits<scalar_t>::min(), dist(generator->engine()));
     });
   });
 


### PR DESCRIPTION
Replaces custom implementations of binomial, poisson and gamma distributions with the standard library