### PR TITLE
[cherry-pick][cuDNN][SDPA] cuDNN SDPA off-by-default for cuDNN versions < 12.9 (#171627)

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -80,12 +80,16 @@ bool check_prefer_cudnn_attention() {
   if (!prefer_cudnn) {
     return false;
   }
-#if (defined(CUDNN_VERSION) && (CUDNN_VERSION >= 90900))
+// cuDNN 9.15.1 required for seq_len not divisible by 128 fix, CUDA <= 12.9 wheels
+// ship with older cuDNN see #169849
+#if defined(CUDNN_VERSION)
+  static long cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
   try {
     auto dprops = at::cuda::getCurrentDeviceProperties();
     auto major = dprops->major;
-    return (major == 9 || major == 10) && !dprops->minor;
-  } catch (c10::Error const& e) {
+    auto minor = dprops->minor;
+    return cudnn_version > 91500 && (major == 9 || major == 10) && (!minor || minor == 3);
+  } catch ([[maybe_unused]] c10::Error const& e) {
 #ifdef DEBUG
     TORCH_WARN("check_prefer_cudnn_attention() caught exception ", e.what());
 #endif


### PR DESCRIPTION
Cherry-Pick Of:
Simpler fix for https://github.com/pytorch/pytorch/issues/169849 , supersedes https://github.com/pytorch/pytorch/pull/167101

Test Plan: https://github.com/pytorch/pytorch/issues/169849#issuecomment-3712300335

``
compute-sanitizer --tool=memcheck python test.py
``

<details>

```
import torch

torch.__version__

buf117 = torch.empty_strided((1, 24, 261, 64), (400896, 64, 1536, 1), device='cuda:0', dtype=torch.bfloat16)
cat_459 = torch.empty_strided((1, 24, 261, 64), (400896, 16704, 64, 1), device='cuda:0', dtype=torch.bfloat16, requires_grad=True)
cat_461 = torch.empty_strided((1, 24, 261, 64), (400896, 16704, 64, 1), device='cuda:0', dtype=torch.bfloat16, requires_grad=True)
permute_1393 = torch.empty_strided((1, 24, 261, 64), (1202688, 64, 4608, 1), device='cuda:0', dtype=torch.bfloat16, requires_grad=True)
getitem_2659 = torch.empty_strided((1, 24, 261, 64), (400896, 16704, 64, 1), device='cuda:0', dtype=torch.bfloat16)
getitem_2660 = torch.empty_strided((1, 24, 261, 1), (6264, 261, 1, 1), device='cuda:0', dtype=torch.float32)
getitem_2665 = torch.empty_strided((), (), device='cuda:0', dtype=torch.int64)
getitem_2666 = torch.empty_strided((), (), device='cuda:0', dtype=torch.int64)

with torch.cuda.stream(torch.cuda.Stream()):
        for _ in range(10):
                getitem_2659 = torch.nn.functional.scaled_dot_product_attention(cat_459, cat_461, permute_1393)
                getitem_2659.backward(buf117)
torch.cuda.synchronize()
g = torch.cuda.CUDAGraph()
with torch.cuda.graph(g):
    getitem_2659 = torch.nn.functional.scaled_dot_product_attention(cat_459, cat_461, permute_1393)
    getitem_2659.backward(buf117)

g.replay()
g.replay()

```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/171627