### PR TITLE
[BE][Ez]: Fix dataclass_transform shim

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -6,7 +6,6 @@ import enum
 import functools
 import logging
 import re
-import sys
 import threading
 import traceback
 import unittest.mock
@@ -16,18 +15,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Generic, NamedTuple, Optional, overload, TYPE_CHECKING, TypeVar
-
-
-if sys.version_info >= (3, 11):
-    from typing import dataclass_transform
-else:
-
-    def dataclass_transform():
-        def decorator(fn):
-            return fn
-
-        return decorator
-
+from typing_extensions import dataclass_transform
 
 import torch
 from torch.utils import _pytree as pytree


### PR DESCRIPTION
typing_extensions already has this shim, we should just use that. Ruff will clean it up when we upgrade.

Test Plan is the pyyrefly and pytest unit tests. Pyrefly will complain statically know with the newer settings, and also the import will fail on the 3.10 runner otherwise. This was added in 4.1.0 in https://typing-extensions.readthedocs.io/en/latest/#decorators and we require a much newer typing_extensions as a requirement for other features like TypeIs