### PR TITLE
[CUDA][cuBLAS][TEST] use `assertLess` in cuBLAS explicit workspace allocation test 

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -712,7 +712,7 @@ print(t.is_pinned())
 
         # check valid config
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":128:8:64:16:32:32"
-        self.assertLess(check_workspace_size(a) - (3072 * 1024)), 524288)
+        self.assertLess(check_workspace_size(a) - (3072 * 1024), 524288)
         self.assertLess(abs(check_workspace_size(a) - (3072 * 1024)), 524288)
 
         torch._C._cuda_clearCublasWorkspaces()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -702,15 +702,18 @@ print(t.is_pinned())
 
         # check default
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ""
-        self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)
+        self.assertLess(check_workspace_size(a) - default_workspace_size, 524288)
+        self.assertLess(abs(check_workspace_size(a) - default_workspace_size), 524288)
 
         # check default with bad user config
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = "-1"
-        self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)
+        self.assertLess(check_workspace_size(a) - default_workspace_size, 524288)
+        self.assertLess(abs(check_workspace_size(a) - default_workspace_size), 524288)
 
         # check valid config
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":128:8:64:16:32:32"
-        self.assertTrue(abs(check_workspace_size(a) - (3072 * 1024)) < 524288)
+        self.assertLess(check_workspace_size(a) - (3072 * 1024)), 524288)
+        self.assertLess(abs(check_workspace_size(a) - (3072 * 1024)), 524288)
 
         torch._C._cuda_clearCublasWorkspaces()
 


### PR DESCRIPTION
For easier debugging of CI failures, e.g., for https://github.com/pytorch/pytorch/pull/163955/files

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mruberry @csarofeen @xwang233