### PR TITLE
[BE][Ez]: Fix TypeAliasType backports with typing_extensions

### DIFF
--- a/torch/_numpy/_normalizations.py
+++ b/torch/_numpy/_normalizations.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import functools
 import inspect
 import operator
+import types
 import typing
 
 import torch
@@ -37,10 +38,9 @@ KeepDims = typing.TypeVar("KeepDims")
 #
 OutArray = typing.TypeVar("OutArray")
 
-try:
-    from typing import NotImplementedType
-except ImportError:
-    NotImplementedType = typing.TypeVar("NotImplementedType")
+NotImplementedType = typing.TypeVar(
+    "NotImplementedType", bound=types.NotImplementedType
+)
 
 
 def normalize_array_like(x, parm=None):  # codespell:ignore

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -3,6 +3,7 @@
 import sys
 from collections.abc import Callable
 from typing import Optional, Union
+from typing_extensions import TypeAliasType
 
 import torch
 from torch import Tensor
@@ -21,15 +22,9 @@ from .stubs import *  # noqa: F403
 
 
 # ensure __module__ is set correctly for public APIs
-if sys.version_info < (3, 12):
-    ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
-    ObserverOrFakeQuantize.__module__ = "torch.ao.quantization"
-else:
-    from typing import TypeAliasType
-
-    ObserverOrFakeQuantize = TypeAliasType(
-        "ObserverOrFakeQuantize", ObserverBase | FakeQuantizeBase
-    )
+ObserverOrFakeQuantize = TypeAliasType(
+    "ObserverOrFakeQuantize", ObserverBase | FakeQuantizeBase
+)
 
 
 __all__ = [

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -1,10 +1,9 @@
 # mypy: allow-untyped-defs
 import copy
-import sys
 import warnings
 from collections import namedtuple
-from typing import Any, Optional, Union
-from typing_extensions import deprecated
+from typing import Any, Union
+from typing_extensions import deprecated, TypeAliasType
 
 import torch
 import torch.nn as nn
@@ -572,13 +571,7 @@ def _assert_valid_qconfig(qconfig: QConfig | None, mod: torch.nn.Module) -> None
             )
 
 
-if sys.version_info < (3, 12):
-    QConfigAny = Optional[QConfig]
-    QConfigAny.__module__ = "torch.ao.quantization.qconfig"
-else:
-    from typing import TypeAliasType
-
-    QConfigAny = TypeAliasType("QConfigAny", QConfig | None)
+QConfigAny = TypeAliasType("QConfigAny", QConfig | None)
 
 
 def _add_module_to_qconfig_obs_ctr(

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -4,12 +4,12 @@ Utils shared by different modes of quantization (eager/graph)
 """
 
 import functools
-import sys
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable
 from inspect import getfullargspec, signature
-from typing import Any, Union
+from typing import Any
+from typing_extensions import TypeAliasType
 
 import torch
 from torch.ao.quantization.quant_type import QuantType
@@ -17,15 +17,9 @@ from torch.fx import Node
 from torch.nn.utils.parametrize import is_parametrized
 
 
-if sys.version_info < (3, 12):
-    NodePattern = Union[tuple[Node, Node], tuple[Node, tuple[Node, Node]], Any]
-    NodePattern.__module__ = "torch.ao.quantization.utils"
-else:
-    from typing import TypeAliasType
-
-    NodePattern = TypeAliasType(
-        "NodePattern", tuple[Node, Node] | tuple[Node, tuple[Node, Node]] | Any
-    )
+NodePattern = TypeAliasType(
+    "NodePattern", tuple[Node, Node] | tuple[Node, tuple[Node, Node]] | Any
+)
 
 
 # This is the Quantizer class instance from torch/quantization/fx/quantize.py.
@@ -39,24 +33,14 @@ QuantizerCls = Any
 # see pattern.md for docs
 # TODO: not sure if typing supports recursive data types
 
-if sys.version_info < (3, 12):
-    Pattern = Union[
-        Callable,
-        tuple[Callable, Callable],
-        tuple[Callable, tuple[Callable, Callable]],
-        Any,
-    ]
-    Pattern.__module__ = "torch.ao.quantization.utils"
-else:
-    from typing import TypeAliasType
 
-    Pattern = TypeAliasType(
-        "Pattern",
-        Callable
-        | tuple[Callable, Callable]
-        | tuple[Callable, tuple[Callable, Callable]]
-        | Any,
-    )
+Pattern = TypeAliasType(
+    "Pattern",
+    Callable
+    | tuple[Callable, Callable]
+    | tuple[Callable, tuple[Callable, Callable]]
+    | Any,
+)
 
 
 # TODO: maybe rename this to MatchInputNode


### PR DESCRIPTION
We already have typing_extensions for backports, might as well use it. Also, it caught a broken import 
