### PR TITLE
[CI] Mark sam model as flaky in inductor accuracy checks

### DIFF
--- a/benchmarks/dynamo/check_accuracy.py
+++ b/benchmarks/dynamo/check_accuracy.py
@@ -17,6 +17,8 @@ flaky_models = {
     "mobilenetv3_large_100",
     # https://github.com/pytorch/pytorch/issues/163670
     "vision_maskrcnn",
+    # boolean mask outputs are non-deterministic due to thresholding
+    "sam",
 }
 
 


### PR DESCRIPTION
# Summary

Adds sam to the flaky_models set in benchmarks/dynamo/check_accuracy.py to prevent intermittent CI failures in inductor-test / test (inductor_torchbench, *, *, linux.g5.4xlarge.nvidia.gpu).

# Problem
The sam (Segment Anything Model) accuracy check is flaky, failing with:

```
sam                                 FAIL:     accuracy=fail_accuracy, expected=pass
```

The error logs show:

```
Accuracy failed: uint8 tensor did not matchAccuracy failed for key name masks
```

this is evident on signal `inductor-test / test (inductor_torchbench, 2, 2, linux.g5.4xlarge.nvidia.gpu)` cases where it is [passing](https://github.com/pytorch/pytorch/actions/runs/20777618364/job/59674519469#step:27:2106) and [failing](https://github.com/pytorch/pytorch/actions/runs/20777296251/job/59673824541#step:27:2102)

# Root Cause
The SAM model outputs boolean segmentation masks. Small floating-point differences during inference get thresholded into boolean values - a pixel value of 0.4999 vs 0.5001 becomes False vs True. This is expected numerical behavior for segmentation models, not a correctness bug.

Boolean tensor comparisons are exact (no tolerance), so tuning floating-point tolerance settings won't help.

# Solution

Add sam to flaky_models, similar to how `vision_maskrcnn` (another segmentation model with mask outputs) is already handled.

# Test Plan

CI will now report FAIL_BUT_FLAKY instead of FAIL when sam accuracy is non-deterministic, preventing spurious CI blocks.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo