### PR TITLE
Remove stale @skipIfTorchDynamo for closed issue #115653

### DIFF
--- a/test/distributed/_tools/test_fake_collectives.py
+++ b/test/distributed/_tools/test_fake_collectives.py
@@ -25,7 +25,7 @@ from torch.distributed._tools.fake_collectives import (
     non_functional_collectives,
 )
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.utils._python_dispatch import TorchDispatchMode
 
@@ -43,7 +43,6 @@ class TestFakeCollectives(TestCase):
         dist.init_process_group("fake", rank=0, world_size=world_size, store=store)
         torch.cuda.set_device(torch.cuda.current_device())
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_collectives(self):
         try:

--- a/test/distributed/_tools/test_mem_tracker.py
+++ b/test/distributed/_tools/test_mem_tracker.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 from torch.distributed._tools.mem_tracker import MemTracker
 from torch.testing._internal.common_utils import (
     run_tests,
-    skipIfTorchDynamo,
     TEST_CUDA,
     TEST_XPU,
     TestCase,
@@ -29,7 +28,6 @@ class TestMemTracker(TestCase):
         mod.reset_accumulated_memory_stats(dev)
         mod.reset_peak_memory_stats(dev)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(
         not TEST_CUDA and not TEST_XPU, "Neither CUDA or XPU is not available"
     )
@@ -82,7 +80,6 @@ class TestMemTracker(TestCase):
         accuracy = tracker_max / acc_max
         self.assertAlmostEqual(accuracy, 1.0, delta=0.1)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(
         not TEST_CUDA and not TEST_XPU, "Neither CUDA or XPU is not available"
     )
@@ -155,7 +152,6 @@ class TestMemTracker(TestCase):
         accuracy = tracker_max / acc_max
         self.assertAlmostEqual(accuracy, 1.0, delta=0.1)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     def test_tracker_attribution(self):
         """
         Tests that the tracker correctly categorizes params, gradients, and optimizer states.

--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -9,7 +9,7 @@ from torch import nn, optim
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tools.runtime_estimator import RuntimeEstimator
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -129,7 +129,6 @@ class TestRuntimeEstimator(TestCase):
             raise NotImplementedError("Only Transformer and CNN is supported")
         return (model, optimizer, inp)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_transformer_runtime(
         self,
@@ -166,7 +165,6 @@ class TestRuntimeEstimator(TestCase):
         # self.assertAlmostEqual(benchmark_accuracy, 1.0, delta=0.2)
         # self.assertAlmostEqual(roofline_accuracy, 1.0, delta=0.3)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_conv_model_runtime(
         self,

--- a/test/distributed/_tools/test_sac_estimator.py
+++ b/test/distributed/_tools/test_sac_estimator.py
@@ -5,7 +5,7 @@ import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tools.sac_estimator import SACEstimator
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -25,7 +25,6 @@ class TestSACEstimator(TestCase):
         loss.backward()
         sace.pwlf_sac_tradeoff_curve(n_segments=2, save_tradeoff_graphs=False)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_transformer_sac_estimation(self):
         """Runs a basic GPT-2 model"""
@@ -50,7 +49,6 @@ class TestSACEstimator(TestCase):
             self._sac_estimation("operator-level-benchmark", model, inp)
             self._sac_estimation("operator-level-cost-model", model, inp)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_simple_model_sac_estimation(self):
         """This test checks the correctness of view_ops, random_ops and inplace_ops"""

--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_utils import (
     MI300_ARCH,
     run_tests,
     skipIfRocmArch,
-    skipIfTorchDynamo,
     TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -134,7 +133,6 @@ class TestSACILP(TestCase):
             )
         return mod_info
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     @skipIfRocmArch(MI300_ARCH)
     def test_sac_ilp_case1(self):
@@ -177,7 +175,6 @@ class TestSACILP(TestCase):
             (recomputation_time / compute_time) / (6.97 / 97.97), 1, delta=0.25
         )
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_sac_ilp_case2(self):
         """
@@ -193,7 +190,6 @@ class TestSACILP(TestCase):
         self.assertEqual(recomputation_time, 0)
         self.assertGreater(peak_mem, 1)
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_sac_ilp_case3(self):
         """
@@ -236,7 +232,6 @@ class TestOptimalCheckpointingPolicy(TestCase):
             force_store_random=False,
         )
 
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_get_optimial_checkpointing_policy_per_module(self):
         for memory_budget, optimal_soln in [


### PR DESCRIPTION
Removes `@skipIfTorchDynamo` decorators from distributed tools tests that referenced issue #115653 (torch_dispatch mode silent incorrectness with torch.compile). 

The issue was closed in June 2024 but the skips remained. These tests now run correctly under TorchDynamo.

**Tests enabled (12 total across 5 files):**
- `test_fake_collectives.py`: test_collectives
- `test_mem_tracker.py`: test_accelerator_tracker_equivalence, test_tracker_with_activation_checkpointing, test_tracker_attribution  
- `test_runtime_estimator.py`: test_transformer_runtime, test_conv_model_runtime
- `test_sac_estimator.py`: test_transformer_sac_estimation, test_simple_model_sac_estimation
- `test_sac_ilp.py`: test_sac_ilp_case1, test_sac_ilp_case2, test_sac_ilp_case3, test_get_optimial_checkpointing_policy_per_module

Also removes unused `skipIfTorchDynamo` imports from each file.