### PR TITLE
[inductor][caching] add memoizers and encoders for all tuned kernels

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -6,6 +6,7 @@ import torch
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from torch._inductor.kernel.mm_common import load_kernel_template
+from torch._inductor.runtime.caching import decoders, encoders, memoizers
 
 from .. import config as inductor_config, ir, lowering as L
 from ..kernel_inputs import MMKernelInputs
@@ -69,11 +70,16 @@ aten_baddbmm = ExternKernelChoice(
 
 
 @L.register_lowering(aten.bmm)
+@memoizers.tuned_bmm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_bmm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_bmm_result_decoder,
+)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.bmm with different backends (Aten, Triton, CUTLASS, etc.)
     """
-    if all(x.get_device().type == "cpu" for x in [mat1, mat2]):
+    if all((device := x.get_device()) and device.type == "cpu" for x in [mat1, mat2]):
         # decompose to small ops when memory bound
         if mat1.get_size()[1] == 1 or mat2.get_size()[2] == 1:
             mat1 = L.unsqueeze(mat1, -1)
@@ -223,6 +229,11 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
 
 
 @L.register_lowering(aten.baddbmm)
+@memoizers.tuned_baddbmm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_baddbmm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_baddbmm_result_decoder,
+)
 def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     """
     Lowering for autotuning aten.mm with different backends (Aten, Triton, CUTLASS, etc.)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -14,6 +14,7 @@ from torch._inductor.autoheuristic.autoheuristic_utils import (
 )
 from torch._inductor.codegen.cpp_gemm_template import CppGemmTemplate
 from torch._inductor.remote_gemm_autotune_cache import gen_best_config
+from torch._inductor.runtime.caching import decoders, encoders, memoizers
 from torch._inductor.virtualized import ops, V
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.functional import ScalingType  # type: ignore[attr-defined]
@@ -68,6 +69,7 @@ from .mm_common import (
 try:
     import triton
 
+    # pyre-ignore[16]: triton module may not have __version__ attribute
     triton_version = TorchVersion(triton.__version__)
     has_triton = True
 except ImportError:
@@ -302,6 +304,11 @@ addmm_contiguous_subgraph_template = ContiguousTemplate(
 
 
 @register_lowering(aten.mm, type_promotion_kind=None)
+@memoizers.tuned_mm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_mm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_mm_result_decoder,
+)
 def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
     """
     Lowering for autotuning aten.mm with different backends (Aten, Triton, CUTLASS, etc.)
@@ -313,7 +320,7 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
             lambda: "input dtypes must be the same",
         )
         torch._check(
-            mat1.get_device().type in ("cuda", "xpu"),
+            (device := mat1.get_device()) and device.type in ("cuda", "xpu"),
             lambda: "out_dtype is only supported for CUDA or XPU",
         )
         torch._check(
@@ -551,6 +558,11 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
 
 
 @register_lowering(aten._int_mm, type_promotion_kind=None)
+@memoizers.tuned_int_mm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_int_mm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_int_mm_result_decoder,
+)
 def tuned_int_mm(mat1, mat2, *, layout=None):
     # TODO(coconutruben): integrate into MMKernelInputs when all callsites use that
     m, n, k, layout, mat1, mat2 = mm_args(
@@ -600,6 +612,11 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
 
 
 @register_lowering(aten.addmm, type_promotion_kind=None)
+@memoizers.tuned_addmm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_addmm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_addmm_result_decoder,
+)
 def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     """
     Lowering for autotuning aten.addmm with different backends (Aten, Triton, CUTLASS, etc.)
@@ -860,6 +877,11 @@ def get_scaling_options(
 
 
 @register_lowering(aten._scaled_mm.default, type_promotion_kind=None)  # type: ignore[misc]
+@memoizers.tuned_scaled_mm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_scaled_mm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_scaled_mm_result_decoder,
+)
 def tuned_scaled_mm(
     mat_a,
     mat_b,
@@ -950,7 +972,9 @@ def tuned_scaled_mm(
         # TODO (paulzhan): There is no template that exists for bias and TMA
         # Don't run tma template currently if bias exist
         if use_triton_tma_template(mat_a, mat_b, output_layout=layout) and not bias:
+            # pyre-ignore[6]: scale option values are ints, not bools
             overriders["SCALE_RECIPE_A"] = scale_option_a.value
+            # pyre-ignore[6]: scale option values are ints, not bools
             overriders["SCALE_RECIPE_B"] = scale_option_b.value
 
             if use_triton_scaling_template(
@@ -958,17 +982,19 @@ def tuned_scaled_mm(
             ):
                 templates_to_use.append(scaled_mm_device_tma_epilogue_scaling_template)
                 kwarg_overrides[scaled_mm_device_tma_epilogue_scaling_template.uid] = (
-                    overriders
+                    overriders  # pyre-ignore[6]
                 )
             elif use_triton_scaling_template(
                 scale_option_a, scale_option_b, main_loop_scaling_types
             ):
+                # pyre-ignore[6]: tile size values are ints, not bools
                 overriders["TILE_SIZE_A"] = get_tile_size(scale_option_a)
+                # pyre-ignore[6]: tile size values are ints, not bools
                 overriders["TILE_SIZE_B"] = get_tile_size(scale_option_b)
 
                 templates_to_use.append(scaled_mm_device_tma_main_loop_scaling_template)
                 kwarg_overrides[scaled_mm_device_tma_main_loop_scaling_template.uid] = (
-                    overriders
+                    overriders  # pyre-ignore[6]
                 )
             else:
                 raise AssertionError(
@@ -982,13 +1008,14 @@ def tuned_scaled_mm(
         ):
             templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
             kwarg_overrides[blackwell_ws_persistent_device_tma_mm_template.uid] = (
-                overriders
+                overriders  # pyre-ignore[6]
             )
 
         if use_triton_scaling_template(
             scale_option_a, scale_option_b, epilogue_scaling_types
         ):
             templates_to_use.append(mm_template)
+            # pyre-ignore[6]: overriders type is compatible at runtime
             kwarg_overrides[mm_template.uid] = overriders
 
     # Single unified call for all templates

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -8,6 +8,7 @@ import torch
 from .. import config as inductor_config
 from ..kernel_inputs import MMKernelInputs
 from ..lowering import lowerings
+from ..runtime.caching import decoders, encoders, memoizers
 from ..select_algorithm import (
     autotune_select_algorithm,
     ExternKernelChoice,
@@ -125,6 +126,11 @@ mm_plus_mm_template = TritonTemplate(
 )
 
 
+@memoizers.tuned_mm_plus_mm_memoizer.memoize(
+    custom_params_encoder=encoders.tuned_mm_plus_mm_params_encoder,
+    custom_result_encoder=encoders.tuned_kernel_result_encoder,
+    custom_result_decoder=decoders.tuned_mm_plus_mm_result_decoder,
+)
 def tuned_mm_plus_mm(mat1, mat2, mat3, mat4, *, layout=None):
     """
     Computes mm(mat1, mat2) + mm(mat3, mat4)

--- a/torch/_inductor/runtime/caching/__init__.py
+++ b/torch/_inductor/runtime/caching/__init__.py
@@ -1,4 +1,4 @@
-from . import config, encoders, memoizers
+from . import config, decoders, encoders, memoizers
 from .context import IsolationSchema, SelectedCompileContext, SelectedRuntimeContext
 from .exceptions import (
     CacheError,
@@ -27,6 +27,7 @@ __all__ = [
     "UserError",
     "ValueDecodingError",
     "ValueEncodingError",
+    "decoders",
     "encoders",
     "memoizers",
 ]

--- a/torch/_inductor/runtime/caching/decoders.py
+++ b/torch/_inductor/runtime/caching/decoders.py
@@ -1,0 +1,65 @@
+# pyre-strict
+
+"""
+Custom decoder functions for use with PersistentMemoizer.
+
+This module provides reusable decoder functions that reconstruct function results
+from cached data for deterministic cache replay.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import ParamSpec, TypeVar
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# Type alias for the encoded result
+TunedKernelEncodedResultDict = dict[str, object]
+
+# Type variable for function parameters
+_P = ParamSpec("_P")
+# Type variable for return type
+_R = TypeVar("_R")
+
+
+def tuned_kernel_result_decoder(
+    fn: Callable[_P, _R],
+) -> Callable[_P, Callable[[TunedKernelEncodedResultDict], _R]]:
+    """Factory factory that returns a params-to-decoder factory for tuned kernel results.
+
+    This is a placeholder implementation that doesn't actually decode cached results.
+    It just re-executes the underlying function.
+
+    Args:
+        fn: The underlying unwrapped function (passed by the memoizer)
+
+    Returns:
+        A factory that takes (*args, **kwargs) and returns a decoder function
+    """
+
+    def params_to_decoder(
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Callable[[TunedKernelEncodedResultDict], _R]:
+        """Factory that returns a decoder function for the given params."""
+
+        def decode_result(encoded: TunedKernelEncodedResultDict) -> _R:
+            return fn(*args, **kwargs)
+
+        return decode_result
+
+    return params_to_decoder
+
+
+# Operation-specific decoders (all use placeholder for now)
+tuned_mm_result_decoder = tuned_kernel_result_decoder
+tuned_addmm_result_decoder = tuned_kernel_result_decoder
+tuned_bmm_result_decoder = tuned_kernel_result_decoder
+tuned_baddbmm_result_decoder = tuned_kernel_result_decoder
+tuned_mm_plus_mm_result_decoder = tuned_kernel_result_decoder
+tuned_int_mm_result_decoder = tuned_kernel_result_decoder
+tuned_scaled_mm_result_decoder = tuned_kernel_result_decoder

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -5,12 +5,98 @@ This module provides reusable encoder functions that convert function parameters
 into JSON-serializable dictionaries for caching purposes.
 """
 
-from typing_extensions import TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import ParamSpec, TypedDict
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import torch
 from torch import Tensor
-from torch._inductor.pattern_matcher import Match
-from torch._inductor.runtime.caching.utils import _encode_tensor, EncodedTensor
+from torch._inductor.runtime.caching.interfaces import DeferredRecording
+
+
+if TYPE_CHECKING:
+    from torch._inductor.ir import (
+        Buffer,
+        IRNode,
+        Layout,
+        MultiTemplateBuffer,
+        TemplateBuffer,
+        TensorBox,
+    )
+    from torch._inductor.kernel_inputs import MMKernelInputs
+    from torch._inductor.kernel_template_choice import KernelTemplateChoice
+    from torch._inductor.pattern_matcher import Match
+    from torch._inductor.select_algorithm import ChoiceCaller
+
+
+# Type variable for function parameters
+_P = ParamSpec("_P")
+
+
+# =============================================================================
+# Encoded Types
+# =============================================================================
+
+
+class EncodedTensor(TypedDict):
+    """TypedDict for encoded tensor metadata."""
+
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: str
+
+
+class EncodedNode(TypedDict):
+    """TypedDict for encoded input node information (dtype, shape, stride)."""
+
+    dtype: str
+    shape: list[int]
+    stride: list[int]
+
+
+class EncodedChoice(TypedDict, total=False):
+    """TypedDict for an encoded choice from a KernelTemplateChoice.
+
+    Fields:
+        template_id: identifies which template (e.g., "aten::mm", "mm")
+        params: serialized params from ktc.params.to_serializeable_dict()
+        rank: optional rank for multi-choice encoding (lower is better)
+    """
+
+    template_id: str
+    params: dict[str, str]
+    rank: int
+
+
+class TunedKernelEncodedParams(TypedDict, total=False):
+    """TypedDict for encoded tuned kernel parameters (mm, addmm, etc.).
+
+    This structure mirrors the key format from LookupTableChoices._generate_kernel_inputs_key:
+    - nodes: list of (dtype, shape, stride) for each input node
+    - scalars: optional dict of scalar key=value pairs (e.g., alpha, beta for addmm)
+    """
+
+    nodes: list[EncodedNode]
+    scalars: dict[str, float | int]
+
+
+class TunedKernelEncodedResult(TypedDict, total=False):
+    """TypedDict for encoded tuned kernel result (mm, addmm, etc.).
+
+    The `_type` field determines which other fields are present:
+    - "single_choice": `choice` is present
+    - "multi_template_buffer": `choices` is present
+    - "unknown": encoding failed, decoder should recompute
+    """
+
+    _type: str
+    choice: EncodedChoice
+    choices: list[EncodedChoice]
 
 
 class ShouldPadEncodedParams(TypedDict):
@@ -23,6 +109,237 @@ class ShouldPadEncodedParams(TypedDict):
     mat1_exclude_padding_time: bool
     mat2_exclude_padding_time: bool
     tf32: bool
+
+
+# =============================================================================
+# Encoder Helper Functions
+# =============================================================================
+
+
+def _encode_tensor(t: Tensor) -> EncodedTensor:
+    """Encode a tensor's metadata into a JSON-serializable dict."""
+    return EncodedTensor(
+        shape=tuple(t.shape),
+        stride=tuple(t.stride()),
+        dtype=str(t.dtype),
+    )
+
+
+def _encode_kernel_inputs(kernel_inputs: MMKernelInputs) -> TunedKernelEncodedParams:
+    """Encode MMKernelInputs into a human-readable dict."""
+    dtypes = kernel_inputs.dtypes()
+    shapes = kernel_inputs.shapes_hinted()
+    strides = kernel_inputs.strides_hinted()
+
+    nodes: list[EncodedNode] = [
+        EncodedNode(
+            dtype=str(dtype),
+            shape=list(shape),
+            stride=list(stride),
+        )
+        for dtype, shape, stride in zip(dtypes, shapes, strides)
+    ]
+
+    result = TunedKernelEncodedParams(nodes=nodes)
+
+    if kernel_inputs._scalars:
+        result["scalars"] = dict(kernel_inputs._scalars)
+
+    return result
+
+
+def _encode_choice_from_ktc(
+    ktc: KernelTemplateChoice,
+    rank: int | None = None,
+) -> EncodedChoice | None:
+    """Encode a choice from a KernelTemplateChoice."""
+    if not hasattr(ktc, "template") or ktc.template is None:
+        return None
+    if not hasattr(ktc, "params") or ktc.params is None:
+        return None
+
+    # Convert params values to strings to ensure JSON serializability
+    # (e.g., torch.dtype objects are not JSON serializable)
+    raw_params = ktc.params.to_serializeable_dict()
+    serializable_params = {k: str(v) for k, v in raw_params.items()}
+
+    result = EncodedChoice(
+        template_id=ktc.template.uid,
+        params=serializable_params,
+    )
+
+    if rank is not None:
+        result["rank"] = rank
+
+    return result
+
+
+def _encode_choice_from_caller_or_node(
+    obj: ChoiceCaller | TemplateBuffer | IRNode,
+    rank: int | None = None,
+) -> EncodedChoice | None:
+    """Encode a choice from a ChoiceCaller or buffer node by extracting its KTC annotation.
+
+    This function is general and works with any object that has an annotations dict
+    containing a "ktc" key. This includes:
+    - ChoiceCaller instances (from autotune_select_algorithm)
+    - TemplateBuffer nodes (from output_node())
+    - Other IRNode types with annotations
+
+    Args:
+        obj: A ChoiceCaller, TemplateBuffer, IRNode, or any object with annotations["ktc"]
+        rank: Optional rank for multi-choice encoding (lower is better)
+
+    Returns:
+        EncodedChoice if encoding succeeded, None otherwise
+    """
+    annotations = getattr(obj, "annotations", None)
+    if not annotations or "ktc" not in annotations:
+        return None
+
+    ktc = annotations["ktc"]
+    return _encode_choice_from_ktc(ktc, rank=rank)
+
+
+def _encode_multi_template_buffer(
+    buffer: MultiTemplateBuffer,
+    fn: Callable[..., TensorBox],
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> DeferredRecording[TensorBox, TunedKernelEncodedResult]:
+    """Encode a MultiTemplateBuffer using deferred recording.
+
+    This function wraps the buffer's choice_timings method to capture timing
+    results and encode them when the timings are computed.
+
+    Memory management:
+    To avoid a reference cycle that would keep the DeferredRecording alive
+    as long as the buffer exists, we use a mutable holder for the deferred
+    reference and clear it after finalization.
+
+    Interim result handling:
+    When make_interim_result creates a new buffer, we need to map the cached
+    timings to the new buffer's ChoiceCaller objects. Since each call to the
+    underlying function produces different ChoiceCaller objects, we use their
+    hash to match corresponding choices between the original and new buffers.
+    """
+    from torch._inductor.ir import MultiTemplateBuffer, StorageBox, TensorBox
+
+    deferred: DeferredRecording[TensorBox, TunedKernelEncodedResult] = (
+        DeferredRecording()
+    )
+
+    original_choice_timings = buffer.choice_timings  # type: ignore[union-attr]
+    finalized = False
+
+    # Store deferred in a mutable holder so we can clear it after finalization.
+    deferred_holder: list[
+        DeferredRecording[TensorBox, TunedKernelEncodedResult] | None
+    ] = [deferred]
+
+    # Cache timing results by ChoiceCaller hash_key for mapping to new buffers in interim results.
+    # When make_interim_result creates a new buffer, its ChoiceCallers are different objects
+    # but have the same hash_key as the corresponding original ChoiceCallers.
+    cached_timings_by_hash: dict[str, float] | None = None
+
+    def wrapped_choice_timings(
+        hint_override: int | None = None,
+    ) -> dict[ChoiceCaller, float]:
+        nonlocal finalized, cached_timings_by_hash
+        timings_result = original_choice_timings(hint_override)
+
+        if hint_override is None and not finalized:
+            finalized = True
+
+            # Cache timings by hash_key for use by interim results
+            cached_timings_by_hash = {
+                caller.hash_key(): timing for caller, timing in timings_result.items()
+            }
+
+            # Get deferred from holder and clear it to break the reference cycle.
+            deferred_obj = deferred_holder[0]
+            deferred_holder[0] = None
+            assert deferred_obj is not None
+
+            sorted_choices = sorted(timings_result.items(), key=lambda x: x[1])
+            encoded_choices: list[EncodedChoice] = []
+            encoding_failed = False
+
+            for rank, (choice_caller, _timing) in enumerate(sorted_choices):
+                encoded = _encode_choice_from_caller_or_node(choice_caller, rank=rank)
+                if encoded is None:
+                    encoding_failed = True
+                    break
+                encoded_choices.append(encoded)
+
+            if encoding_failed or not encoded_choices:
+                encoded_result = TunedKernelEncodedResult(_type="unknown")
+            else:
+                encoded_result = TunedKernelEncodedResult(
+                    _type="multi_template_buffer",
+                    choices=encoded_choices,
+                )
+
+            deferred_obj.finalize(encoded_result)
+
+        return timings_result
+
+    buffer.choice_timings = wrapped_choice_timings  # type: ignore[union-attr]
+
+    def make_interim_result() -> TensorBox:
+        new_result = fn(*args, **kwargs)
+
+        if isinstance(new_result, TensorBox) and isinstance(
+            new_result.data, StorageBox
+        ):
+            new_buffer = new_result.data.data
+            if isinstance(new_buffer, MultiTemplateBuffer):
+                # Save the new buffer's original choice_timings for fallback
+                new_choice_timings = new_buffer.choice_timings  # type: ignore[union-attr]
+
+                def mapped_choice_timings(
+                    hint_override: int | None = None,
+                ) -> dict[ChoiceCaller, float]:
+                    # Check if cached timings are available (set when original choice_timings completes)
+                    if cached_timings_by_hash is not None:
+                        # Get the new buffer's choices by calling its original choice_timings.
+                        # This returns dict[ChoiceCaller, float] - we need the keys.
+                        new_timings = new_choice_timings(hint_override)
+
+                        # Safety check: verify all choices have cached timings.
+                        # If any choice's hash_key is missing, fall back to actual timings.
+                        all_choices_cached = all(
+                            choice.hash_key() in cached_timings_by_hash
+                            for choice in new_timings
+                        )
+
+                        if all_choices_cached:
+                            # Map cached timings to new buffer's choices by hash_key.
+                            # Each ChoiceCaller has a hash_key that identifies the choice,
+                            # so we can match new ChoiceCallers to their cached timings.
+                            return {
+                                choice: cached_timings_by_hash[choice.hash_key()]
+                                for choice in new_timings
+                            }
+                        else:
+                            # Some choices weren't cached - use the actual timings we just computed
+                            return new_timings
+                    else:
+                        # Cached timings not ready yet, fall back to actual timing computation
+                        return new_choice_timings(hint_override)
+
+                new_buffer.choice_timings = mapped_choice_timings  # type: ignore[union-attr]
+
+        return new_result
+
+    deferred.make_interim_result = make_interim_result
+
+    return deferred
+
+
+# =============================================================================
+# Encoders
+# =============================================================================
 
 
 def should_pad_params_encoder(
@@ -65,3 +382,416 @@ def should_pad_params_encoder(
             torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32
         ),
     )
+
+
+def tuned_mm_params_encoder(
+    mat1: Buffer,
+    mat2: Buffer,
+    out_dtype: torch.dtype | None = None,
+    *,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_mm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_mm:
+    1. First calls mm_args to realize the matrices (just like tuned_mm does)
+    2. Creates MMKernelInputs with the realized matrices
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each input node
+    - scalars: any scalar values (not used in basic mm, but used in addmm)
+
+    Args:
+        mat1: First matrix buffer
+        mat2: Second matrix buffer
+        out_dtype: Optional output dtype
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_mm
+    _m, _n, _k, _layout, mat1_realized, mat2_realized = mm_args(
+        mat1, mat2, layout=layout, out_dtype=out_dtype
+    )
+
+    # Create MMKernelInputs with the realized matrices
+    kernel_inputs = MMKernelInputs([mat1_realized, mat2_realized], out_dtype=out_dtype)
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_addmm_params_encoder(
+    inp: Buffer,
+    mat1: Buffer,
+    mat2: Buffer,
+    *,
+    alpha: float | int = 1,
+    beta: float | int = 1,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_addmm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_addmm:
+    1. First calls mm_args to realize the matrices (just like tuned_addmm does)
+    2. Creates MMKernelInputs with the realized matrices and scalars
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each input node
+    - scalars: alpha and beta values
+
+    Args:
+        inp: Input bias buffer
+        mat1: First matrix buffer
+        mat2: Second matrix buffer
+        alpha: Scalar multiplier for mat1 @ mat2
+        beta: Scalar multiplier for inp
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_addmm
+    _m, _n, _k, _layout, mat1_realized, mat2_realized, inp_expanded = mm_args(
+        mat1, mat2, inp, layout=layout
+    )
+
+    # Create MMKernelInputs with the realized matrices
+    kernel_inputs = MMKernelInputs(
+        [inp_expanded, mat1_realized, mat2_realized],
+        scalars=dict(alpha=alpha, beta=beta),
+    )
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_bmm_params_encoder(
+    mat1: Buffer,
+    mat2: Buffer,
+    out_dtype: torch.dtype | None = None,
+    *,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_bmm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_bmm:
+    1. First calls mm_args to realize the matrices (just like tuned_bmm does)
+    2. Creates MMKernelInputs with the realized matrices
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each input node
+    - scalars: any scalar values (not used in basic bmm)
+
+    Args:
+        mat1: First matrix buffer (batched)
+        mat2: Second matrix buffer (batched)
+        out_dtype: Optional output dtype
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_bmm
+    _m, _n, _k, _layout, mat1_realized, mat2_realized = mm_args(
+        mat1, mat2, layout=layout, out_dtype=out_dtype
+    )
+
+    # Create MMKernelInputs with the realized matrices
+    kernel_inputs = MMKernelInputs([mat1_realized, mat2_realized], out_dtype=out_dtype)
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_baddbmm_params_encoder(
+    inp: Buffer,
+    mat1: Buffer,
+    mat2: Buffer,
+    *,
+    alpha: float | int = 1,
+    beta: float | int = 1,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_baddbmm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_baddbmm:
+    1. First calls mm_args to realize the matrices (just like tuned_baddbmm does)
+    2. Creates MMKernelInputs with the realized matrices and scalars
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each input node
+    - scalars: alpha and beta values
+
+    Args:
+        inp: Input bias buffer (batched)
+        mat1: First matrix buffer (batched)
+        mat2: Second matrix buffer (batched)
+        alpha: Scalar multiplier for mat1 @ mat2
+        beta: Scalar multiplier for inp
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_baddbmm
+    _m, _n, _k, _layout, mat1_realized, mat2_realized, inp_expanded = mm_args(
+        mat1, mat2, inp, layout=layout
+    )
+
+    # Create MMKernelInputs with the realized matrices
+    kernel_inputs = MMKernelInputs(
+        [inp_expanded, mat1_realized, mat2_realized],
+        scalars=dict(alpha=alpha, beta=beta),
+    )
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_mm_plus_mm_params_encoder(
+    mat1: Buffer,
+    mat2: Buffer,
+    mat3: Buffer,
+    mat4: Buffer,
+    *,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_mm_plus_mm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_mm_plus_mm:
+    1. First calls mm_args to realize all four matrices
+    2. Creates MMKernelInputs with all four realized matrices
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each of the 4 input nodes
+
+    Args:
+        mat1: First matrix buffer (for first mm)
+        mat2: Second matrix buffer (for first mm)
+        mat3: Third matrix buffer (for second mm)
+        mat4: Fourth matrix buffer (for second mm)
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_mm_plus_mm
+    _m1, _n1, _k1, _layout1, mat1_realized, mat2_realized = mm_args(
+        mat1, mat2, layout=layout
+    )
+    _m2, _n2, _k2, _layout2, mat3_realized, mat4_realized = mm_args(
+        mat3, mat4, layout=layout
+    )
+
+    # Create MMKernelInputs with all 4 realized matrices
+    kernel_inputs = MMKernelInputs(
+        [mat1_realized, mat2_realized, mat3_realized, mat4_realized],
+        mat1_idx=0,
+        mat2_idx=1,
+    )
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_int_mm_params_encoder(
+    mat1: Buffer,
+    mat2: Buffer,
+    *,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_int_mm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_int_mm:
+    1. First calls mm_args to realize the matrices (with out_dtype=torch.int32)
+    2. Creates MMKernelInputs with the realized matrices
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for each input node
+
+    Args:
+        mat1: First matrix buffer (int8)
+        mat2: Second matrix buffer (int8)
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+
+    # First call mm_args to realize the matrices, exactly as done in tuned_int_mm
+    _m, _n, _k, _layout, mat1_realized, mat2_realized = mm_args(
+        mat1, mat2, layout=layout, out_dtype=torch.int32
+    )
+
+    # Create MMKernelInputs with the realized matrices
+    kernel_inputs = MMKernelInputs(
+        [mat1_realized, mat2_realized], out_dtype=torch.int32
+    )
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_scaled_mm_params_encoder(
+    mat_a: Buffer,
+    mat_b: Buffer,
+    scale_a: Buffer,
+    scale_b: Buffer,
+    bias: Buffer | None = None,
+    scale_result: Buffer | None = None,
+    out_dtype: torch.dtype | None = None,
+    use_fast_accum: bool = False,
+    layout: Layout | None = None,
+) -> TunedKernelEncodedParams:
+    """Encode parameters for tuned_scaled_mm into a human-readable dict.
+
+    This encoder mirrors the behavior of tuned_scaled_mm:
+    1. First calls mm_args to realize the matrices
+    2. Creates MMKernelInputs with all input nodes
+    3. Extracts the same information used by _generate_kernel_inputs_key
+
+    The encoding includes:
+    - nodes: dtype, shape (hinted), and stride (hinted) for mat_a, mat_b, scale_a, scale_b, and optional bias
+
+    Args:
+        mat_a: First matrix buffer (float8)
+        mat_b: Second matrix buffer (float8)
+        scale_a: Scale factor for mat_a
+        scale_b: Scale factor for mat_b
+        bias: Optional bias buffer
+        scale_result: Optional scale for result (unused in encoding)
+        out_dtype: Optional output dtype
+        use_fast_accum: Whether to use fast accumulation
+        layout: Optional layout
+
+    Returns:
+        A dict containing the encoded parameters in human-readable form
+    """
+    from torch._inductor.kernel.mm_common import mm_args
+    from torch._inductor.kernel_inputs import MMKernelInputs
+    from torch._inductor.select_algorithm import realize_inputs
+
+    # First call mm_args to realize the matrices
+    _m, _n, _k, _layout, mat_a_realized, mat_b_realized = mm_args(
+        mat_a, mat_b, layout=layout, out_dtype=out_dtype
+    )
+
+    scale_a_real, scale_b_real = realize_inputs(scale_a, scale_b)
+
+    input_nodes: list[Buffer]
+    if not bias:
+        input_nodes = [mat_a_realized, mat_b_realized, scale_a_real, scale_b_real]
+    else:
+        bias_real = realize_inputs(bias)
+        input_nodes = [
+            mat_a_realized,
+            mat_b_realized,
+            scale_a_real,
+            scale_b_real,
+            bias_real,
+        ]
+
+    # Create MMKernelInputs
+    kernel_inputs = MMKernelInputs(
+        input_nodes, mat1_idx=0, mat2_idx=1, out_dtype=out_dtype
+    )
+
+    return _encode_kernel_inputs(kernel_inputs)
+
+
+def tuned_kernel_result_encoder(
+    fn: Callable[_P, TensorBox],
+) -> Callable[
+    _P,
+    Callable[
+        [TensorBox],
+        TunedKernelEncodedResult
+        | DeferredRecording[TensorBox, TunedKernelEncodedResult],
+    ],
+]:
+    """Factory factory that returns a params-to-encoder factory for tuned kernel results.
+
+    This is a generic result encoder that works with any tuned kernel function
+    (tuned_mm, tuned_addmm, etc.). It encodes choices using the KernelTemplateChoice
+    (KTC) annotations on ChoiceCallers and/or the buffer's annotations dict.
+
+    Encoding strategy:
+    1. MultiTemplateBuffer → deferred recording (choice_timings is expensive)
+       - When choice_timings completes, encode each ChoiceCaller via its KTC annotation
+    2. Single output node (TemplateBuffer or ExternKernelOut) → extract KTC from
+       buffer.annotations["ktc"]
+    3. Unknown types → return "unknown" for recomputation on decode
+
+    Args:
+        fn: The underlying unwrapped function (passed by the memoizer)
+
+    Returns:
+        A factory that takes (*args, **kwargs) and returns an encoder function
+    """
+
+    def params_to_encoder(
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Callable[
+        [TensorBox],
+        TunedKernelEncodedResult
+        | DeferredRecording[TensorBox, TunedKernelEncodedResult],
+    ]:
+        """Factory that returns an encoder function for the given params."""
+
+        def encode_result(
+            result: TensorBox,
+        ) -> (
+            TunedKernelEncodedResult
+            | DeferredRecording[TensorBox, TunedKernelEncodedResult]
+        ):
+            # Import at runtime to avoid circular imports
+            from torch._inductor.ir import (
+                MultiTemplateBuffer,
+                StorageBox,
+                TensorBox as TensorBoxType,
+            )
+
+            # Cases 1-2: TensorBox containing a StorageBox
+            if isinstance(result, TensorBoxType) and isinstance(
+                result.data, StorageBox
+            ):
+                buffer = result.data.data
+
+                # Case 1: MultiTemplateBuffer - use deferred recording
+                if isinstance(buffer, MultiTemplateBuffer):
+                    return _encode_multi_template_buffer(buffer, fn, args, kwargs)
+
+                # Case 2: Single output node - encode via annotations["ktc"] if available
+                encoded = _encode_choice_from_caller_or_node(buffer)
+                if encoded is not None:
+                    return TunedKernelEncodedResult(
+                        _type="single_choice",
+                        choice=encoded,
+                    )
+
+            # Fallback for unknown types - mark as unknown
+            return TunedKernelEncodedResult(_type="unknown")
+
+        return encode_result
+
+    return params_to_encoder

--- a/torch/_inductor/runtime/caching/memoizers.py
+++ b/torch/_inductor/runtime/caching/memoizers.py
@@ -5,3 +5,24 @@ from .interfaces import PersistentMemoizer
 
 # Memoizer for _should_pad in pad_mm
 should_pad_memoizer = PersistentMemoizer(sub_dir=Path("should_pad"))
+
+# Memoizer for tuned_mm in kernel/mm
+tuned_mm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_mm"))
+
+# Memoizer for tuned_addmm in kernel/mm
+tuned_addmm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_addmm"))
+
+# Memoizer for tuned_bmm in kernel/bmm
+tuned_bmm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_bmm"))
+
+# Memoizer for tuned_baddbmm in kernel/bmm
+tuned_baddbmm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_baddbmm"))
+
+# Memoizer for tuned_mm_plus_mm in kernel/mm_plus_mm
+tuned_mm_plus_mm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_mm_plus_mm"))
+
+# Memoizer for tuned_int_mm in kernel/mm
+tuned_int_mm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_int_mm"))
+
+# Memoizer for tuned_scaled_mm in kernel/mm
+tuned_scaled_mm_memoizer = PersistentMemoizer(sub_dir=Path("tuned_scaled_mm"))

--- a/torch/_inductor/runtime/caching/utils.py
+++ b/torch/_inductor/runtime/caching/utils.py
@@ -6,9 +6,7 @@ throughout the caching system.
 
 from collections.abc import Callable
 from functools import lru_cache, wraps
-from typing_extensions import ParamSpec, TypedDict, TypeVar
-
-from torch import Tensor
+from typing_extensions import ParamSpec, TypeVar
 
 
 # Type specification for function parameters
@@ -40,27 +38,3 @@ def _lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
             return fn(*args, **kwargs)
 
     return wrapper
-
-
-class EncodedTensor(TypedDict):
-    """TypedDict for encoded tensor metadata."""
-
-    shape: tuple[int, ...]
-    stride: tuple[int, ...]
-    dtype: str
-
-
-def _encode_tensor(t: Tensor) -> EncodedTensor:
-    """Encode a tensor's metadata into a JSON-serializable dict.
-
-    Args:
-        t: PyTorch tensor to encode
-
-    Returns:
-        Dict containing shape, stride, and dtype information
-    """
-    return EncodedTensor(
-        shape=tuple(t.shape),
-        stride=tuple(t.stride()),
-        dtype=str(t.dtype),
-    )


### PR DESCRIPTION
Summary:
Extends the caching infrastructure to support memoization for all tuned matrix multiplication kernels. This enables caching of algorithm selection results to avoid redundant autotuning.

## Changes

### New Memoizers (`memoizers.py`)
Adds `PersistentMemoizer` instances for each tuned kernel operation:
- `tuned_mm_memoizer` - basic matrix multiplication
- `tuned_addmm_memoizer` - matrix multiplication with bias addition
- `tuned_bmm_memoizer` - batched matrix multiplication
- `tuned_baddbmm_memoizer` - batched matrix multiplication with bias
- `tuned_mm_plus_mm_memoizer` - fused double matrix multiplication
- `tuned_int_mm_memoizer` - int8 matrix multiplication
- `tuned_scaled_mm_memoizer` - float8 scaled matrix multiplication

### New Encoders (`encoders.py`)
Adds parameter encoders that mirror each kernel's behavior by calling `mm_args` to realize matrices and creating `MMKernelInputs`:
- `tuned_mm_params_encoder`
- `tuned_addmm_params_encoder` (includes alpha/beta scalars)
- `tuned_bmm_params_encoder`
- `tuned_baddbmm_params_encoder` (includes alpha/beta scalars)
- `tuned_mm_plus_mm_params_encoder` (handles 4 input matrices)
- `tuned_int_mm_params_encoder` (uses int32 output dtype)
- `tuned_scaled_mm_params_encoder` (handles scales and optional bias)

Adds a generic `tuned_kernel_result_encoder` that handles:
- `MultiTemplateBuffer` results via deferred recording (waits for `choice_timings`)
- Single output nodes by extracting KTC annotations
- Unknown types with fallback for recomputation

### New Decoders (`decoders.py`)
Adds placeholder decoders that re-execute the underlying function on cache miss. These will be enhanced later to actually decode cached results.

### TypedDicts for Encoding
Moves and extends type definitions:
- `EncodedTensor`, `EncodedNode`, `EncodedChoice`
- `TunedKernelEncodedParams`, `TunedKernelEncodedResult`
- `ShouldPadEncodedParams`

### Integration
Updates kernel files (`mm.py`, `bmm.py`, `mm_plus_mm.py`) to import the new caching components.

Test Plan: buck test fbcode//mode/opt caffe2/test/inductor:caching

Differential Revision: D90284855




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo