### PR TITLE
[ROCm] Optimize single-block TopK with warp-level compaction

### DIFF
--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -405,7 +405,7 @@ void launch(
       TORCH_INTERNAL_ASSERT(false, "Unsupported warp size: ", warp_size);
     }
 #endif
-C10_CUDA_KERNEL_LAUNCH_CHECK();
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 } // namespace sbtopk
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -135,9 +135,9 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
     uint64_t ballot = WARP_BALLOT(hasTopK); // a bitmask of threads that have hasTopK == true within the warp.
     int warp_count = __popcll(ballot); // count the number of threads that have hasTopK == true within the warp.
 
-    // if > 0 threads have hasTopK == true within the warp, 
+    // if > 0 threads have hasTopK == true within the warp,
     // reserve space for them by incrementing writeIndexStart atomically + saving the old value in warp_bases.
-    if (lane_id == 0 && warp_count > 0) { 
+    if (lane_id == 0 && warp_count > 0) {
       warp_bases[warp_id] = atomicAdd(&writeIndexStart, warp_count);
     }
     __syncwarp();
@@ -206,7 +206,7 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
       }
       __syncwarp();
       // now warp has reserved space for itself.
-    
+
       // if warp_bases[warp_id] overshoots outputSliceSize, there is no space to add topk values. Break out of the loop.
       if (outputSliceSize <= warp_bases[warp_id]){
         break;

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -261,7 +261,7 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 
   IndexType WARP_BITS = __builtin_ctz(warpSize);
   int warp_id = threadIdx.x >> WARP_BITS; // = threadIdx.x / warpSize
-  int lane_id = threadIdx.x & (warpSize - 1); // = threadIdx.x % warpSize
+  int lane_id = at::cuda::getLaneId(); // = threadIdx.x % warpSize
   // Initialize writeIndexStart to 0 by the first thread in the block.
   if (threadIdx.x == 0) {
     writeIndexStart = 0;

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -242,7 +242,7 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
   // each warp counts its own number of hasTopk threads and
   // reserves space for them by incrementing writeIndexStart atomically + saving the old value in warp_bases.
 
-  CountType WARP_BITS = __builtin_ctz(warpSize);
+  IndexType WARP_BITS = __builtin_ctz(warpSize);
   int warp_id = threadIdx.x >> WARP_BITS; // = threadIdx.x / warpSize
   int lane_id = threadIdx.x & (warpSize - 1); // = threadIdx.x % warpSize
   // Initialize writeIndexStart to 0 by the first thread in the block.
@@ -272,8 +272,8 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 
     // now warp has reserved space for itself. If hasTopK == true, we need to find the index to write the result to.
     if (hasTopK) {
-      uint64_t warp_offset = (1ULL << lane_id) - 1; // a bitmask: [0, 0, 0, ..., 0, 1, 1, 1, ..., 1] with (64-lane_id) 0s and lane_id 1s.
-      int my_offset = __popcll(ballot & warp_offset); // count the number of threads that have hasTopK == true to the right of the current thread in bitmask.
+      uint64_t warp_mask = (1ULL << lane_id) - 1; // a bitmask: [0, 0, 0, ..., 0, 1, 1, 1, ..., 1] with (64-lane_id) 0s and lane_id 1s.
+      int my_offset = __popcll(ballot & warp_mask); // count the number of threads that have hasTopK == true to the right of the current thread in bitmask.
       int writeIndex = warp_bases[warp_id] + my_offset; // the index to write the result to.
       CUDA_KERNEL_ASSERT(writeIndex < outputSliceSize);
       IndexType topKOffset = writeIndex * topKWithinSliceStride;

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -326,13 +326,13 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
   T v = (threadIdx.x < inputSliceSize) ? doLdg(&inputSliceStart[threadIdx.x * inputWithinSliceStride]) : static_cast<T>(0);
   for (IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
     T v_next = (i + blockDim.x < inputSliceSize) ? doLdg(&inputSliceStart[(i + blockDim.x) * inputWithinSliceStride]) : static_cast<T>(0);
-    
+
     bool hasTopK = false;
     if (i < inputSliceSize) {
       const auto convertedV = at::native::TopKTypeConfig<T>::convert(v);
       hasTopK = (largest) ? (convertedV > topKConverted) : (convertedV < topKConverted);
     }
-    
+
     int start_index, my_offset, warp_count;
     reserveWarpSpace(hasTopK, writeIndexStart, start_index, my_offset, warp_count);
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -178,21 +178,20 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 #else
 
 /*
-This implementation of gatherTopK is a modified version of the original gatherTopK kernel.
-This kernel is called after we have found the k-th highest element in our input.
-It gathers values that are greater (or less than, depending on the sort direction) than the k-th highest element (phase 1)
-and then adds the values that are equal to the k-th highest element as long as there is space available (phase 2).
-In the original implementation, we call exclusiveBinaryPrefixScan to calculate the index to write the result to.
-However, exclusiveBinaryPrefixScan has two block level synchronization points, which is not efficient, specially
-considering that exclusiveBinaryPrefixScan is called in a loop.
-In this implementation, we use warp level compaction to calculate the index to write the result to.
-In both phases, each warp first counts the number of values it intends to add to the result.
-Then through an atomic add, the warp reserves space for itself (atomically increases the write index variable)
-and then writes the result to the corresponding indices. This requires no block level synchronization.
-It should be noted that we have added a block level synchronization point after phase 1 to make sure all threads have completed phase 1.
-This synchronization is cheaper than the ones in exclusiveBinaryPrefixScan because it is called only once.
-This synchronization is necessary because phase1 assumes it always has space to write all the values that are larger (or smaller) 
-than the k-th highest (or lowest) element but phase 2 tops off the output as long as there is space available.
+This implementation of gatherTopK is a modified version of the original gatherTopK kernel. This kernel is called
+after we have found the k-th highest (or lowest, depending on the sort direction) element in our input. It gathers
+values that are greater (or less than) than the k-th element (phase 1) and then adds the values that are equal to
+the k-th element as long as there is space available (phase 2). In the original implementation, we call
+exclusiveBinaryPrefixScan to calculate the index to write the result to. However, exclusiveBinaryPrefixScan has two
+block level synchronization points, which is not efficient, specially considering that exclusiveBinaryPrefixScan is
+called in a loop. In this implementation, we use warp level compaction to calculate the index to write the result
+to. In both phases, each warp first counts the number of values it intends to add to the result. Then through an
+atomic add, the warp reserves space for itself (atomically increases the write index variable) and then writes the
+result to the corresponding indices. This requires no block level synchronization. It should be noted that we have
+added a block level synchronization point after phase 1 to make sure all threads have completed phase 1. This
+synchronization is cheaper than the ones in exclusiveBinaryPrefixScan because it is called only once. This
+synchronization is necessary because phase 1 assumes it always has space to write all the values that are larger (or
+smaller) than the k-th element but phase 2 tops off the output as long as there is space available.
 */
 
 template <typename T, typename IndexType, int Dim, bool WithKthValues>

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -319,8 +319,8 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
       // if hasTopK == true, we need to find the index to write the result to.
       if (hasTopK){
         int slots_available = outputSliceSize - warp_bases[warp_id]; // the number of slots available to write the result to.
-        uint64_t warp_offset = (1ULL << lane_id) - 1; // a bitmask: [0, 0, 0, ..., 0, 1, 1, 1, ..., 1] with (64-lane_id) 0s and lane_id 1s.
-        int my_offset = __popcll(ballot & warp_offset); // count the number of threads that have hasTopK == true to the right of the current thread in bitmask.
+        uint64_t warp_mask = (1ULL << lane_id) - 1; // a bitmask: [0, 0, 0, ..., 0, 1, 1, 1, ..., 1] with (64-lane_id) 0s and lane_id 1s.
+        int my_offset = __popcll(ballot & warp_mask); // count the number of threads that have hasTopK == true to the right of the current thread in bitmask.
         if (my_offset < slots_available){
           IndexType writeIndex = warp_bases[warp_id] + my_offset; // the index to write the result to.
           IndexType topKOffset = writeIndex * topKWithinSliceStride;


### PR DESCRIPTION
Summary:
This PR optimizes the gatherTopK kernel used in the single-block TopK algorithm for ROCm/AMD GPUs by replacing synchronization-heavy prefix scans with efficient warp-level operations.

Changes:
* Replaced exclusiveBinaryPrefixScan with warp-level compaction:
  - Uses WARP_BALLOT + __popcll intrinsics for per-warp counting
  - Each warp reserves write space via a single atomicAdd, then threads compute local offsets using bit manipulation
  - Eliminates 3 __syncthreads() calls per iteration
 * Added critical synchronization barrier:
   - Explicit __syncthreads() between Phase 1 (collect values > topK) and Phase 2 (collect values == topK)
   - Prevents race conditions where Phase 2 could start while Phase 1 atomics are in flight
 * Optimized inter-warp coordination:
   - Uses __shfl_sync() for broadcasting warp results
   - Avoids additional shared memory overhead
* Performance:
  - Achieves 10% average latency improvement on AMD MI350 (gfx950) for the single-block TopK path.
* Testing:
  - Verified correctness across multiple data types (float32, float16, bfloat16) and input shapes.
<img width="2311" height="1537" alt="topk_latency_comparison" src="https://github.com/user-attachments/assets/8cbf8980-397c-458a-bfa5-7f94b13f0b55" />
  
* benchmark config: correctness check + 100 warmup + running for 100 iterations over which average is taken
  benchmark code: [code](https://github.com/user-attachments/files/24484540/benchmark.py)


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang