### PR TITLE
[DTensor] fix _StridedShard(sf=) bug in single dim strategy

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -531,8 +531,8 @@ class TestExpandPlaceholder(TestCase):
 
         self.assertEqual(expanded_replicate, expected_replicate)
 
-        # Test Case 2: Shard-only inputs - only Shard expansion
-        # Expected: 3 strategies with placeholders filled using Shard + implicit replicate
+        # Test Case 2: (_Strided)Shard-only inputs - only (_Strided)Shard expansion
+        # Expected: 3 strategies with placeholders filled using (_Strided)Shard + implicit replicate
         expected_shard = [
             [Partial(), Shard(1), Shard(0)],
             [Shard(0), Shard(0), Replicate()],
@@ -543,6 +543,48 @@ class TestExpandPlaceholder(TestCase):
         expanded_shard = _fill_single_dim_strategy_placeholders(
             {Replicate(), Shard(0), Shard(1)}, single_dim_strategies
         )
+
+        expected_strided_shard = [
+            [
+                Partial(),
+                _StridedShard(1, split_factor=2),
+                _StridedShard(0, split_factor=2),
+            ],
+            [
+                Partial(),
+                _StridedShard(1, split_factor=4),
+                _StridedShard(0, split_factor=4),
+            ],
+            [
+                _StridedShard(dim=0, split_factor=2),
+                _StridedShard(dim=0, split_factor=2),
+                Replicate(),
+            ],
+            [
+                _StridedShard(dim=0, split_factor=4),
+                _StridedShard(dim=0, split_factor=4),
+                Replicate(),
+            ],
+            [
+                _StridedShard(dim=1, split_factor=2),
+                Replicate(),
+                _StridedShard(dim=1, split_factor=2),
+            ],
+            [
+                _StridedShard(dim=1, split_factor=4),
+                Replicate(),
+                _StridedShard(dim=1, split_factor=4),
+            ],
+            [Replicate(), Replicate(), Replicate()],
+        ]
+        expanded_strided_shard = _fill_single_dim_strategy_placeholders(
+            {
+                _StridedShard(0, split_factor=2),
+                _StridedShard(0, split_factor=4),
+            },
+            single_dim_strategies,
+        )
+        self.assertEqual(expanded_strided_shard, expected_strided_shard)
 
         self.assertEqual(expanded_shard, expected_shard)
 

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -1,7 +1,7 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates
+import functools
 import logging
 from collections.abc import Callable, Sequence
-from functools import lru_cache
 from typing import Any, cast, Optional, TypeAlias, TypeVar, Union
 
 import torch
@@ -98,9 +98,8 @@ def _fill_single_dim_strategy_placeholders(
         if isinstance(placement, _StridedShard):
             key = f"StridedShard(sf={placement.split_factor})"
             if key not in shard_builders:
-                sf = placement.split_factor
-                shard_builders[key] = lambda tensor_dim: _StridedShard(
-                    tensor_dim, split_factor=sf
+                shard_builders[key] = functools.partial(
+                    _StridedShard, split_factor=placement.split_factor
                 )
         elif isinstance(placement, Shard):
             key = "Shard()"
@@ -181,7 +180,7 @@ def _expand_single_dim_strategy_to_mesh(
     # Note: circular import, failed to untangle with #168221, reverted
     from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
 
-    @lru_cache
+    @functools.lru_cache
     def _create_expanded_strategy(
         op_schema: OpSchema,
         output_tensor_meta: TensorMeta | Sequence[TensorMeta | None],


### PR DESCRIPTION
follow up on previous discussion https://github.com/pytorch/pytorch/pull/167677/files#r2621338335

this PR makes sure  'sf' is evaluated when defining `_StridedShard(split_factor=sf)`

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171942

