### PR TITLE
[DTensor] Correct tensor_meta in _dtensor_init_helper

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -857,13 +857,6 @@ class DistTensorRandomOpsTest3D(DTensorTestBase):
         compute_rankwise_if_local_tensor(weight_local, self.rank)
 
 
-class DTensorRandomOpsSeedConsistencyTest(DTensorTestBase):
-    @property
-    def world_size(self):
-        return 8
-
-
-
 DistTensorRandomInitTestWithLocalTensor = create_local_tensor_test_class(
     DistTensorRandomInitTest,
 )

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -321,7 +321,6 @@ class DistTensorRandomInitTest(DTensorTestBase):
         # Wrap tracker to capture specs
         random_module._rng_tracker = SpecCapturingTracker(random_module._rng_tracker)
 
-        torch.manual_seed(42)
         torch.distributed.tensor.randn(
             (8, 8), device_mesh=device_mesh, placements=[Shard(0)]
         )

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -308,9 +308,6 @@ class DistTensorRandomInitTest(DTensorTestBase):
             def __init__(self, tracker):
                 self._tracker = tracker
 
-            def __getattr__(self, name):
-                return getattr(self._tracker, name)
-
             def _distribute_region(self, spec):
                 captured_specs.append(spec.tensor_meta)
                 return self._tracker._distribute_region(spec)

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -293,6 +293,129 @@ class DistTensorRandomInitTest(DTensorTestBase):
 
         compute_rankwise_if_local_tensor(weight_local, weight_gather.wait(), self.rank)
 
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_dtensor_init_helper_tensor_meta_strides(self):
+        """
+        Test that DTensorSpec.tensor_meta has correct strides in _dtensor_init_helper.
+
+        Background:
+        ===========
+        In _dtensor_init_helper (torch/distributed/tensor/_api.py), when creating
+        DTensor via random factory functions (randn, rand), a DTensorSpec is created
+        with tensor_meta that includes shape, strides, and dtype.
+
+        The strides in tensor_meta should match the expected contiguous strides for
+        the tensor shape. For example, a tensor of shape (8, 8) should have strides
+        (8, 1) for row-major contiguous layout.
+
+        What This Test Verifies:
+        ========================
+        1. Creates a SpecCapturingTracker wrapper that intercepts calls to
+           _distribute_region and captures the DTensorSpec passed to it.
+
+        2. Calls torch.distributed.tensor.randn() to trigger _dtensor_init_helper.
+
+        3. Inspects the captured spec to verify:
+           - Shape is correct: torch.Size([8, 8])
+           - Strides are correct: (8, 1) for contiguous 8x8 tensor
+
+        Test Strategy:
+        ==============
+        - Use a wrapper class (SpecCapturingTracker) to intercept _distribute_region
+        - Capture the spec argument for inspection
+        - Assert that tensor_meta.stride matches expected contiguous strides
+        """
+        mesh = torch.arange(self.world_size)
+        device_mesh = DeviceMesh(self.device_type, mesh)
+        captured_specs = []
+
+        class SpecCapturingTracker:
+            """
+            Wrapper class to intercept and capture DTensorSpec passed to _distribute_region.
+
+            This wrapper delegates all attribute access to the underlying tracker,
+            except for _distribute_region which it intercepts to capture the spec.
+            """
+
+            def __init__(self, tracker):
+                self._tracker = tracker
+
+            def __getattr__(self, name):
+                # Delegate all attribute access to the wrapped tracker
+                return getattr(self._tracker, name)
+
+            def _distribute_region(self, spec):
+                """
+                Intercept _distribute_region to capture the spec for inspection.
+
+                Args:
+                    spec: DTensorSpec containing tensor_meta with shape, strides, dtype
+                """
+                captured_specs.append(
+                    {
+                        "shape": spec.tensor_meta.shape,
+                        "strides": spec.tensor_meta.stride,
+                        "dtype": spec.tensor_meta.dtype,
+                    }
+                )
+                return self._tracker._distribute_region(spec)
+
+        import torch.distributed.tensor._random as random_module
+
+        original_tracker = random_module._rng_tracker
+
+        torch.manual_seed(42)
+        torch.distributed.tensor.randn(
+            (8, 8),
+            device_mesh=device_mesh,
+            placements=[Shard(0)],
+        )
+
+        random_module._rng_tracker = SpecCapturingTracker(random_module._rng_tracker)
+
+        try:
+            # Call randn again - this time we capture the spec
+            torch.manual_seed(42)
+            torch.distributed.tensor.randn(
+                (8, 8),
+                device_mesh=device_mesh,
+                placements=[Shard(0)],
+            )
+
+            # Verify we captured exactly one spec
+            self.assertEqual(
+                len(captured_specs),
+                1,
+                f"Expected to capture 1 spec, but captured {len(captured_specs)}",
+            )
+            captured_spec = captured_specs[0]
+
+            expected_shape = torch.Size([8, 8])
+            self.assertEqual(
+                captured_spec["shape"],
+                expected_shape,
+                f"Shape mismatch: expected {expected_shape}, got {captured_spec['shape']}",
+            )
+
+            # Verify the strides are correct for contiguous layout
+            # For a (8, 8) tensor with row-major contiguous layout:
+            # - stride[0] = 8 (stepping one row = 2 elements)
+            # - stride[1] = 1 (stepping one column = 1 element)
+            expected_strides = (8, 1)
+            actual_strides = captured_spec["strides"]
+
+            self.assertEqual(
+                actual_strides,
+                expected_strides,
+                f"Strides mismatch in tensor_meta passed to _distribute_region: "
+                f"expected {expected_strides} for contiguous (8, 8) tensor, "
+                f"got {actual_strides}",
+            )
+
+        finally:
+            random_module._rng_tracker = original_tracker
+
 
 class DistTensorRandomOpTest(DTensorTestBase):
     @with_comms
@@ -732,6 +855,13 @@ class DistTensorRandomOpsTest3D(DTensorTestBase):
                     )
 
         compute_rankwise_if_local_tensor(weight_local, self.rank)
+
+
+class DTensorRandomOpsSeedConsistencyTest(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
 
 
 DistTensorRandomInitTestWithLocalTensor = create_local_tensor_test_class(

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -1109,7 +1109,11 @@ def _dtensor_init_helper(  # type: ignore[no-untyped-def]
         # this tensor meta is not used except `shape`
         dtype = kwargs.get("dtype", torch.get_default_dtype())
 
-        tensor_meta = TensorMeta(size, (0,), dtype)
+        strides: tuple[int, ...] = (1,)
+        for dim in reversed(size[1:]):
+            strides = (strides[0] * dim,) + strides
+
+        tensor_meta = TensorMeta(size, strides, dtype)
         spec = DTensorSpec(device_mesh, tuple(placements), tensor_meta=tensor_meta)
 
         if random.is_rng_supported_mesh(device_mesh) and not random._rng_tracker:

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -1109,11 +1109,7 @@ def _dtensor_init_helper(  # type: ignore[no-untyped-def]
         # this tensor meta is not used except `shape`
         dtype = kwargs.get("dtype", torch.get_default_dtype())
 
-        strides: tuple[int, ...] = (1,)
-        for dim in reversed(size[1:]):
-            strides = (strides[0] * dim,) + strides
-
-        tensor_meta = TensorMeta(size, strides, dtype)
+        tensor_meta = TensorMeta(size, torch_stride, dtype)
         spec = DTensorSpec(device_mesh, tuple(placements), tensor_meta=tensor_meta)
 
         if random.is_rng_supported_mesh(device_mesh) and not random._rng_tracker:


### PR DESCRIPTION
Before this PR, in `_dtensor_init_helper`, tensor_meta = TensorMeta(size, (0,), dtype), where strides which is (0,) here is incorrect.
The wrong spec with tensor_meta would affect local_tensor

This PR fix strides here with the correct valuds, and add unit test `test_dtensor_init_helper_tensor_meta_strides` to ensure tensor_meta values are correct.