### PR TITLE
Add run_tests() to elastic rendezvous test files

### DIFF
--- a/test/distributed/elastic/rendezvous/api_test.py
+++ b/test/distributed/elastic/rendezvous/api_test.py
@@ -15,6 +15,7 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousInfo,
     RendezvousParameters,
 )
+from torch.testing._internal.common_utils import run_tests
 
 
 class RendezvousParametersTest(TestCase):
@@ -287,3 +288,7 @@ class RendezvousHandlerRegistryTest(TestCase):
             self._params.backend = "dummy_backend_2"
 
             self._registry.create_handler(self._params)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -27,6 +27,7 @@ from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import (
     create_backend,
 )
 from torch.distributed.elastic.utils.distributed import get_free_port
+from torch.testing._internal.common_utils import run_tests
 
 
 class TCPStoreBackendTest(TestCase, RendezvousBackendTestMixin):
@@ -285,3 +286,7 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -51,6 +51,7 @@ from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
     RendezvousTimeout,
     Token,
 )
+from torch.testing._internal.common_utils import run_tests
 
 
 TEST_PORT = 54321
@@ -1926,3 +1927,7 @@ class _InMemoryRendezvousBackend(RendezvousBackend):
 
             self._state = state
             self._token = self._token + 1 if self._token is not None else 0
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/etcd_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_rendezvous_backend_test.py
@@ -27,6 +27,7 @@ from torch.distributed.elastic.rendezvous.etcd_rendezvous_backend import (
 )
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 from torch.distributed.elastic.rendezvous.etcd_store import EtcdStore
+from torch.testing._internal.common_utils import run_tests
 
 
 class EtcdRendezvousBackendTest(TestCase, RendezvousBackendTestMixin):
@@ -182,3 +183,7 @@ class CreateBackendTest(TestCase):
             )
         if not (result_dict["time"] >= 2):
             raise AssertionError(f"Expected time >= 2, got {result_dict['time']}")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/etcd_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_rendezvous_test.py
@@ -13,6 +13,7 @@ import uuid
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.testing._internal.common_utils import run_tests
 
 
 if os.getenv("CIRCLECI"):
@@ -81,3 +82,7 @@ class EtcdRendezvousTest(unittest.TestCase):
         etcd_rdzv = create_rdzv_handler(rdzv_params)
 
         self.assertEqual("etcd", etcd_rdzv.get_backend())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -12,6 +12,7 @@ import unittest
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.testing._internal.common_utils import run_tests
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +59,7 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/out_of_tree_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/out_of_tree_rendezvous_test.py
@@ -10,6 +10,7 @@ import sys
 import unittest
 
 import torch.distributed.elastic.rendezvous as rdvz
+from torch.testing._internal.common_utils import run_tests
 
 
 BACKEND_NAME = "testbackend"
@@ -36,3 +37,7 @@ class OutOfTreeRendezvousTest(unittest.TestCase):
 
         # Removing testbackend from python path
         sys.path.remove(current_path + TEST_PACKAGE_PATH)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/rendezvous_backend_test.py
@@ -15,6 +15,7 @@ from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
     RendezvousBackend,
     Token,
 )
+from torch.testing._internal.common_utils import run_tests
 
 
 class RendezvousBackendTestMixin(ABC):
@@ -108,3 +109,7 @@ class RendezvousBackendTestMixin(ABC):
         self.assertEqual(state1, state2)
         self.assertEqual(token1, token2)
         self.assertFalse(has_set)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/static_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/static_rendezvous_test.py
@@ -13,6 +13,7 @@ from torch.distributed.elastic.rendezvous.static_tcp_rendezvous import (
     create_rdzv_handler,
 )
 from torch.distributed.elastic.utils import get_socket_with_port
+from torch.testing._internal.common_utils import run_tests
 
 
 class StaticTCPRendezvousTest(unittest.TestCase):
@@ -100,3 +101,7 @@ class StaticTCPRendezvousTest(unittest.TestCase):
         self.assertIsNotNone(rdzv_info.store)
         self.assertEqual(0, rdzv_info.rank)
         self.assertEqual(1, rdzv_info.world_size)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/rendezvous/utils_test.py
+++ b/test/distributed/elastic/rendezvous/utils_test.py
@@ -21,6 +21,7 @@ from torch.distributed.elastic.rendezvous.utils import (
     _try_parse_port,
     parse_rendezvous_endpoint,
 )
+from torch.testing._internal.common_utils import run_tests
 
 
 class UtilsTest(TestCase):
@@ -401,3 +402,7 @@ class PeriodicTimerTest(TestCase):
                 f"The interval between two function calls was {actual_call_interval} second(s) but "
                 f"expected to be at least {call_interval} second(s).",
             )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary
This PR adds the standard PyTorch test runner pattern to all test files under `test/distributed/elastic/rendezvous/`.

## Problem
The test files in the elastic rendezvous directory were missing the standard `run_tests()` pattern:
```python
from torch.testing._internal.common_utils import run_tests

# ... test classes ...

if __name__ == "__main__":
    run_tests()
```

This meant these tests could not be executed directly as standalone scripts and may not have been properly discovered by the PyTorch test infrastructure.

## Version Verification

Confirmed the issue exists in all versions mentioned in #169752:

| Version | `run_tests()` in test files |
|---------|----------------------------|
| **v2.7.1** | ❌ MISSING in all 10 files |
| **v2.9.0** | ❌ MISSING in all 10 files |
| **main branch** | ❌ MISSING in all 10 files |

Verification method:
```bash
# Example check for v2.7.1
curl -s "https://raw.githubusercontent.com/pytorch/pytorch/v2.7.1/test/distributed/elastic/rendezvous/api_test.py" | grep "run_tests()"
# Returns empty - no run_tests() found
```

## Changes
Added the `run_tests()` import and `if __name__ == "__main__": run_tests()` block to:

| File | Description |
|------|-------------|
| `api_test.py` | RendezvousParameters and RendezvousHandlerRegistry tests |
| `c10d_rendezvous_backend_test.py` | C10d rendezvous backend tests |
| `dynamic_rendezvous_test.py` | Dynamic rendezvous tests |
| `etcd_rendezvous_backend_test.py` | Etcd rendezvous backend tests |
| `etcd_rendezvous_test.py` | Etcd rendezvous handler tests |
| `etcd_server_test.py` | Etcd server tests |
| `out_of_tree_rendezvous_test.py` | Out-of-tree handler loading tests |
| `rendezvous_backend_test.py` | Rendezvous backend test mixin |
| `static_rendezvous_test.py` | Static TCP rendezvous tests |
| `utils_test.py` | Rendezvous utility function tests |

## Testing

### Environment
- **OS**: RHEL 9.6
- **PyTorch**: 2.11.0a0+git6d1f6cd (main branch)

### Test Results
```
=== utils_test.py ===
Ran 26 tests in 1.310s - OK

=== api_test.py ===
Ran 22 tests in 0.002s - OK

=== static_rendezvous_test.py ===
Ran 6 tests in 0.003s - OK
```

All tests pass successfully with the added `run_tests()` pattern.

## Related Issues
Fixes #169752

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @mruberry