### PR TITLE
Fix mark_dynamic hint_override should update stride hint.

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4685,6 +4685,25 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         res2 = fn(torch.ones((12,)))
         self.assertEqual(res1, res2)
 
+    def test_hint_override_consistent_stride(self):
+        @torch.compile(fullgraph=True)
+        def func(x):
+            # a = torch.fx.experimental.symbolic_shapes.size_hint(x.size()[0])
+            # b =  torch.fx.experimental.symbolic_shapes.size_hint(x.stride()[1])
+
+            # torch._check(a==b, lambda:f"{a}, {b} are not the same")
+            # a = torch.fx.experimental.symbolic_shapes.size_hint(x.size()[0]*x.size()[1])
+            # b =  torch.fx.experimental.symbolic_shapes.size_hint(x.stride()[2])
+            # torch._check(a==b, lambda:f"{a}, {b} are not the same")
+
+            return x*a
+
+        x = torch.rand(10, 20, 30)
+        # torch._dynamo.mark_dynamic(x, 0, hint_override=2)
+        # torch._dynamo.mark_dynamic(x, 1, hint_override=2)
+        # torch._dynamo.mark_dynamic(x, 2, hint_override=2)
+        func(x)
+
     def test_size_hint(self):
         @torch.compile(fullgraph=True)
         def func(x):

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -216,7 +216,7 @@ class SymNode:
                     else self.shape_env.var_to_val[s]
                     for s in self.expr.free_symbols
                 }
-                return self.expr.xreplace(replacements)
+                return int(self.expr.xreplace(replacements))
             # NB: we expect this to raise
             return self.shape_env.size_hint(self.expr)
         return self._hint

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3806,6 +3806,9 @@ class ShapeEnv:
         self.unique_ids: set[int] = set()
         # Maps symbolic ints to their original concrete values
         # Currently populated from tensors
+        # when hint is overriden in mark_dynamic, the value stored in
+        # self.var_to_val is the overriden hint.
+        # only used for backed dynamic shapes symbols.
         self.var_to_val: dict[sympy.Symbol, sympy.Integer] = {}
         # Like var_to_val, but only set when propagate_real_tensors is on.
         # Used as last resort to avoid GuardOnDataDependent error
@@ -4682,6 +4685,11 @@ class ShapeEnv:
             )
             for i, (sym, hint) in enumerate(zip(size, ex_size))
         ]
+        symbol_to_override_hint = {}
+
+        for i, s in enumerate(size):
+            if i in hint_overrides:
+                symbol_to_override_hint[s] = hint_overrides[i]
 
         for i, sym in enumerate(sym_sizes):
             if isinstance(sym, torch.SymInt) and i in hint_overrides:
@@ -4692,10 +4700,16 @@ class ShapeEnv:
             # NB: Don't duck size the stride; instead use the expression
             # we computed
             assert stride_expr is not None
+            hint_stride = stride_expr.xreplace(self.var_to_hint_override)
+            if isinstance(hint_stride, (int, sympy.core.numbers.Integer)):
+                hint_stride = int(hint_stride)
+            else:
+                hint_stride = ex_stride[i]
+            # The remaining
             sym_stride.append(
                 self.create_symintnode(
                     stride_expr,
-                    hint=ex_stride[i],
+                    hint=hint_stride,
                     source=TensorPropertySource(source, TensorProperty.STRIDE, i),
                 )
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171961
* #171944
* #171843


When we override hint with mark_dynamic, strides that uses sym size that have hints overridden should also 
have their hint overridden.
for example for
        mul: "f32[s77, s27, s53][s27*s53, s53, 1]cpu" = l_x_ * 100;  l_x_ = None
hint (stride[0]) must be == hint(size[1]*size[2])

check the added a unit test for more details. 

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv