### PR TITLE
[CUDA] Prevent custom allocator from dying until all allocated blocks die.

### DIFF
--- a/aten/src/ATen/cuda/MemPool.h
+++ b/aten/src/ATen/cuda/MemPool.h
@@ -3,6 +3,8 @@
 #include <c10/core/Allocator.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 
+#include <memory>
+
 namespace at::cuda {
 
 // Keep BC only
@@ -17,7 +19,8 @@ using c10::MempoolId_t;
 // system allocator such as ncclMemAlloc.
 struct TORCH_CUDA_CPP_API MemPool {
   MemPool(
-      c10::cuda::CUDACachingAllocator::CUDAAllocator* allocator = nullptr,
+      std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> allocator =
+          nullptr,
       bool is_user_created = true,
       bool use_on_oom = false,
       bool no_split = false);

--- a/aten/src/ATen/hip/impl/HIPAllocatorMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPAllocatorMasqueradingAsCUDA.h
@@ -142,8 +142,8 @@ public:
   void createOrIncrefPool(
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
-      HIPAllocator* allocator = nullptr) override {
-    allocator_->createOrIncrefPool(device, mempool_id, allocator);
+      std::shared_ptr<HIPAllocator> allocator = nullptr) override {
+    allocator_->createOrIncrefPool(device, mempool_id, std::move(allocator));
   }
 
   void setUseOnOOM(c10::DeviceIndex device, MempoolId_t mempool_id, bool use_on_oom) override {

--- a/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h
@@ -148,8 +148,8 @@ inline void releasePool(c10::DeviceIndex device, MempoolId_t mempool_id) {
 inline void createOrIncrefPool(
     c10::DeviceIndex device,
     MempoolId_t mempool_id,
-    HIPCachingAllocator::HIPAllocator* allocator_ptr = nullptr) {
-  get()->createOrIncrefPool(device, mempool_id, allocator_ptr);
+    std::shared_ptr<HIPCachingAllocator::HIPAllocator> allocator_ptr = nullptr) {
+  get()->createOrIncrefPool(device, mempool_id, std::move(allocator_ptr));
 }
 
 inline void setUseOnOOM(c10::DeviceIndex device, MempoolId_t mempool_id, bool use_on_oom) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -968,9 +968,11 @@ class EventPool {
 
 // CUDA graphs helper
 struct PrivatePool {
-  explicit PrivatePool(MempoolId_t id, CUDAAllocator* allocator = nullptr)
+  explicit PrivatePool(
+      MempoolId_t id,
+      std::shared_ptr<CUDAAllocator> allocator = nullptr)
       : id(std::move(id)),
-        allocator_(allocator),
+        allocator_(std::move(allocator)),
         large_blocks(/*small=*/false, this),
         small_blocks(/*small=*/true, this) {}
   PrivatePool(const PrivatePool&) = delete;
@@ -991,13 +993,13 @@ struct PrivatePool {
   // distinguish private blocks by adding a "pool id" check above the stream
   // check in BlockComparator. BlockComparator is performance- critical though,
   // I'd rather not add more logic to it.
-  CUDAAllocator* allocator_;
+  std::shared_ptr<CUDAAllocator> allocator_;
   BlockPool large_blocks;
   BlockPool small_blocks;
 
  public:
   CUDAAllocator* allocator() {
-    return allocator_;
+    return allocator_.get();
   }
 };
 
@@ -2594,11 +2596,13 @@ class DeviceCachingAllocator {
     }
   }
 
-  void createOrIncrefPool(MempoolId_t mempool_id, CUDAAllocator* allocator) {
+  void createOrIncrefPool(
+      MempoolId_t mempool_id,
+      std::shared_ptr<CUDAAllocator> allocator) {
     // Create a PrivatePool object if it does not exist yet
     // and increment its use_count
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    create_or_incref_pool(mempool_id, allocator);
+    create_or_incref_pool(mempool_id, std::move(allocator));
   }
 
   void setUseOnOOM(MempoolId_t mempool_id, bool use_on_oom) {
@@ -2762,7 +2766,7 @@ class DeviceCachingAllocator {
 
   void create_or_incref_pool(
       MempoolId_t mempool_id,
-      CUDAAllocator* allocator = nullptr) {
+      std::shared_ptr<CUDAAllocator> allocator = nullptr) {
     auto it = graph_pools.find(mempool_id);
     if (it == graph_pools.end()) {
       // mempool_id does not reference an existing pool.
@@ -2770,14 +2774,15 @@ class DeviceCachingAllocator {
       // usage. use_count is initially 1, which means the pool is
       // being used since somebody called createOrIncrefPool.
       graph_pools.emplace(
-          mempool_id, std::make_unique<PrivatePool>(mempool_id, allocator));
+          mempool_id,
+          std::make_unique<PrivatePool>(mempool_id, std::move(allocator)));
     } else {
       // mempool_id references an existing pool, which the current CUDAGraph
       // capture or torch.cuda.use_mem_pool will
       // share. Check this pool is live (at least one other capture already
       // references it). Increment it to establish the usage.
       TORCH_INTERNAL_ASSERT(it->second->use_count > 0);
-      TORCH_INTERNAL_ASSERT(allocator == nullptr);
+      TORCH_INTERNAL_ASSERT(!allocator);
       it->second->use_count++;
     }
   }
@@ -4295,10 +4300,10 @@ class NativeCachingAllocator : public CUDAAllocator {
   void createOrIncrefPool(
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
-      CUDAAllocator* allocator) override {
+      std::shared_ptr<CUDAAllocator> allocator) override {
     assertValidDevice(device);
     device_allocator[device]->createOrIncrefPool(
-        std::move(mempool_id), allocator);
+        std::move(mempool_id), std::move(allocator));
   }
 
   void setUseOnOOM(

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -257,7 +257,7 @@ class CUDAAllocator : public DeviceAllocator {
   virtual void createOrIncrefPool(
       c10::DeviceIndex /*device*/,
       MempoolId_t /*mempool_id*/,
-      CUDAAllocator* allocator = nullptr) {
+      std::shared_ptr<CUDAAllocator> allocator = nullptr) {
     TORCH_CHECK(
         false,
         name(),
@@ -527,8 +527,8 @@ inline void releasePool(c10::DeviceIndex device, MempoolId_t mempool_id) {
 inline void createOrIncrefPool(
     c10::DeviceIndex device,
     MempoolId_t mempool_id,
-    CUDAAllocator* allocator_ptr = nullptr) {
-  get()->createOrIncrefPool(device, mempool_id, allocator_ptr);
+    std::shared_ptr<CUDAAllocator> allocator_ptr = nullptr) {
+  get()->createOrIncrefPool(device, mempool_id, std::move(allocator_ptr));
 }
 inline void setUseOnOOM(
     c10::DeviceIndex device,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5799,6 +5799,37 @@ class TestMemPool(TestCase):
         # out tensor
         self.assertEqual(called_dummy_free.value, 321)
 
+    def test_tensor_delete_after_allocator_delete(self):
+        allocator, dummy_allocator = self.get_dummy_allocator(check_vars=True)
+        pool = torch.cuda.MemPool(allocator.allocator())
+
+        with torch.cuda.use_mem_pool(pool):
+            data = torch.empty(4, device="cuda")
+
+        alloc_lib = ctypes.CDLL(dummy_allocator)
+        called_dummy_alloc = ctypes.c_int.in_dll(alloc_lib, "called_dummy_alloc")
+        called_dummy_free = ctypes.c_int.in_dll(alloc_lib, "called_dummy_free")
+
+        self.assertEqual(called_dummy_alloc.value, 123)
+        self.assertEqual(called_dummy_free.value, 0)
+
+        # Explicitly drop the allocator before releasing the
+        # tensor. CUDACachingAllocator's PrivatePool instance should
+        # keep the allocator live until all tensors die.
+
+        # N.B.: Deleting the pool doesn't actually do anything, since
+        # it doesn't own the allocator object. But we do it anyway
+        # because it is the situation that users are likely to face.
+        del pool
+        del allocator
+
+        self.assertEqual(called_dummy_free.value, 0)
+
+        del data
+        torch.cuda.empty_cache()
+
+        self.assertEqual(called_dummy_free.value, 321)
+
     @serialTest()
     def test_mempool_limited_memory_with_allocator(self):
         allocator, _ = self.get_dummy_allocator(check_vars=False)

--- a/torch/csrc/cuda/MemPool.cpp
+++ b/torch/csrc/cuda/MemPool.cpp
@@ -14,14 +14,15 @@ using shared_ptr_class_ = py::class_<T, std::shared_ptr<T>>;
 void THCPMemPool_init(PyObject* module) {
   auto torch_C_m = py::handle(module).cast<py::module>();
   shared_ptr_class_<::at::cuda::MemPool>(torch_C_m, "_MemPool")
-      .def(
-          py::init([](c10::cuda::CUDACachingAllocator::CUDAAllocator* allocator,
-                      bool is_user_created,
-                      bool use_on_oom,
-                      bool no_split) {
+      .def(py::init(
+          [](std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
+                 allocator,
+             bool is_user_created,
+             bool use_on_oom,
+             bool no_split) {
             torch::utils::device_lazy_init(at::kCUDA);
             return std::make_shared<::at::cuda::MemPool>(
-                allocator, is_user_created, use_on_oom, no_split);
+                std::move(allocator), is_user_created, use_on_oom, no_split);
           }))
       .def_property_readonly("id", &::at::cuda::MemPool::id)
       .def_property_readonly("allocator", &::at::cuda::MemPool::allocator)

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <exception>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
@@ -5861,11 +5862,10 @@ at::Tensor ProcessGroupNCCL::allocateTensor(
   // Create memory pool
   if (!memPool_) {
     // Needs a CUDAAllocator
-    auto allocator =
-        reinterpret_cast<c10::cuda::CUDACachingAllocator::CUDAAllocator*>(
-            getMemAllocator().get());
+    auto allocator = std::static_pointer_cast<
+        c10::cuda::CUDACachingAllocator::CUDAAllocator>(getMemAllocator());
     // Pool is created
-    memPool_ = std::make_unique<at::cuda::MemPool>(allocator);
+    memPool_ = std::make_unique<at::cuda::MemPool>(std::move(allocator));
     // Register so that we call ncclCommRegister on all new allocations
     registerMemPool(memPool_.get(), /*symmetric*/ false);
     LOG(INFO) << logPrefix() << "Created memory pool";


### PR DESCRIPTION
I make sure that the PrivatePool associated with a pool id created by torch.cuda.MemPool owns a shared_ptr to the custom allocator, not a raw pointer.

Before this change, when using torch.cuda.MemPool, if your custom allocator dies before all segments (or, from the user's perspective, tensors) die, then when those segments are freed, you will get a segfault or UB when calling the custom allocator's raw_delete() function on those blocks here: https://github.com/pytorch/pytorch/blob/a588def33fbacbe917c304da0403b90eae17e110/c10/cuda/CUDACachingAllocator.cpp#L3500C32-L3500C55

I encountered this issue while working on https://github.com/pytorch/pytorch/pull/160351. There, I would create a custom allocator owned by a cuda graph instance. However, there is no way to ensure that tensors created at stream capture time are all dead by the time that the cuda graph dies. This is a general problem; it's very normal for a tensor to outlive the context in which it was created, so right now users are burdened with keeping their custom allocator alive manually as long as any tensors allocated with it are stilll live.

This problem was never encountered before because it just so happened that the main custom allocator in use, the nccl one, uses a `static shared_ptr` to hold it globally: https://github.com/pytorch/pytorch/blob/a588def33fbacbe917c304da0403b90eae17e110/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L5826-L5829

This means that the NCCL custom allocator will never die until the process itself dies, which is safely after all tensors will have been cleaned up already.

The infrastructure to make sure that the python bindings use std::share_ptr Holders for CUDAPluggableAllocator and CUDAAllocator has been around for a [while](https://github.com/pytorch/pytorch/blob/a588def33fbacbe917c304da0403b90eae17e110/torch/csrc/cuda/Module.cpp#L1207-L1225), so this change fortunately does not break any existing users.

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia