### PR TITLE
Fix pytest collection when --runslow option is not registered

### DIFF
--- a/test/torch_np/conftest.py
+++ b/test/torch_np/conftest.py
@@ -22,7 +22,9 @@ class Inaccessible:
 
 
 def pytest_sessionstart(session):
-    if session.config.getoption("--nonp"):
+    # Use default=False to handle case when option isn't registered
+    # (e.g., when pytest is run from the root directory)
+    if session.config.getoption("--nonp", default=False):
         sys.modules["numpy"] = Inaccessible()
 
 
@@ -72,7 +74,10 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_collection_modifyitems(config, items):
-    if not config.getoption("--runslow"):
+    # Use default=False to handle case when option isn't registered
+    # (e.g., when pytest is run from the root directory)
+    # See: https://github.com/pytorch/pytorch/issues/171563
+    if not config.getoption("--runslow", default=False):
         skip_slow = pytest.mark.skip(reason="slow test, use --runslow to run")
         for item in items:
             if "slow" in item.keywords:


### PR DESCRIPTION
## Summary
This PR fixes a pytest collection error that can occur when running `pytest --collect-only -q` from the PyTorch root directory.

## Problem
When pytest loads the `test/torch_np/conftest.py` file, it may fail with:
```
INTERNALERROR>   File "/home/xxxx/pytorch/test/torch_np/conftest.py", line 75, in pytest_collection_modifyitems
INTERNALERROR>     if not config.getoption("--runslow"):
INTERNALERROR>   File "..._pytest/config/__init__.py", line 1571, in getoption
INTERNALERROR>     raise ValueError(f"no option named {name!r}") from e
INTERNALERROR> ValueError: no option named 'runslow'
```

This happens because the `--runslow` option may not be registered when pytest loads conftest files in a different order or in certain environment configurations.

## Solution
Use `config.getoption('--runslow', default=False)` to provide a safe default value when the option isn't registered. This matches the expected behavior (slow tests are skipped by default).

The same fix is applied to the `--nonp` option for consistency.

## Changes
```diff
- if session.config.getoption("--nonp"):
+ if session.config.getoption("--nonp", default=False):

- if not config.getoption("--runslow"):
+ if not config.getoption("--runslow", default=False):
```

## Testing

### Simulated Error Condition (Proves Fix Works)
```
ERROR without default: no option named '--runslow'   ← Original code fails
Option value (with default): False                   ← Fixed code works!
1 test collected in 0.40s                           ← Test succeeds
```

### PyTorch 2.11.0a0 (Latest Main)
| Test | Result |
|------|--------|
| torch_np collection | 6744 tests collected ✅ |
| torch_np/test_basic.py | 451 passed ✅ |
| `--runslow` option | Works correctly ✅ |
| `--nonp` option | Works correctly ✅ |

### PyTorch 2.7.1 (Version from Issue)
| Test | Result |
|------|--------|
| Collection from ROOT | 3407 tests collected ✅ |
| torch_np/test_basic.py | 451 passed ✅ |
| No regressions | Same results before/after ✅ |

### Test Environment
- RHEL 9.6
- Python 3.11/3.12
- pytest 9.0.2

## Related Issues
Fixes #171563

cc @mruberry @ZainRizvi @huydhn @clee2000