### PR TITLE
[Bugfix] Partitioner doesn't recompute `aten.full` if it is followed by in-place mutations

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -443,8 +443,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
     @parametrize(
         "factory_op",
         [
-            # Skipping because of https://github.com/pytorch/pytorch/issues/170160
-            # subtest(torch.ones_like, name="ones_like"),
+            subtest(torch.ones_like, name="ones_like"),
+            subtest(torch.zeros_like, name="zeros_like"),
             subtest(torch.empty_like, name="empty_like"),
         ],
     )

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2324,6 +2324,7 @@ def get_default_op_list() -> OpTypes:
 
     default_recomputable_ops += [
         aten.zeros_like,
+        aten.ones_like,
     ]
 
     default_recomputable_ops += [method_to_operator(m) for m in magic_methods]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -130,6 +130,8 @@ decomps_to_exclude: list[Union[torch._ops.OpOverload, torch._ops.OpOverloadPacke
     aten.sum,  # inductor lowers this directly
     aten.unbind,  # inductor lowers this directly
     aten.baddbmm,  # upcasts to fp32, perf issue
+    aten.ones_like,  # need to be in the ATen graph for partitioner to recognize as recomputable factory op
+    aten.zeros_like,  # need to be in the ATen graph for partitioner to recognize as recomputable factory op
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3564,8 +3564,8 @@ def constant_like(fill_value):
 
 
 empty_like = register_lowering(aten.empty_like)(create_tensor_like(empty))
-ones_like = create_tensor_like(tensor_constructor(1))
-zeros_like = create_tensor_like(tensor_constructor(0))
+ones_like = register_lowering(aten.ones_like)(create_tensor_like(tensor_constructor(1)))
+zeros_like = register_lowering(aten.zeros_like)(create_tensor_like(tensor_constructor(0)))
 
 
 def new_constant(fill_value):


### PR DESCRIPTION
Fixes #170160

## Problem
`ones_like` followed by in-place mutations were failing to trigger recomputation in the backward graph.

The partitioner was opting to save (materialize) instead of recomputing them.

## Root Cause
1. **AOT Autograd (Graph Construction):**
   - `ones_like` decomposes into `aten.full`.
   - The subsequent in-place op (`sin_`) is captured as `auto_functionalized_v2` (a Higher-Order Op).

2. **Partitioner (`min_cut_rematerialization_partition`):**
   - The algorithm iterates nodes to determine recomputability.
   - It hits `aten.full` and calls `is_materialized_backwards(node)`.

3. **Heuristic Failure (`is_materialized_backwards`):**
   - It checks `is_fusible(full, auto_functionalized_v2_user)`.
   - Inside `is_fusible`, the check `can_fuse_into_auto_functionalized(a, b)` returns **False**.
   - **Reason:** The current implementation only checks `target == auto_functionalized` (v1) and fails on `v2`. ⚠️
   - Since `fusible` is `False`, `is_materialized_backwards` returns `True`.

4. **Result:**
   - The cost model forces `aten.full` to be saved (materialized) in the forward graph instead of being recomputed in the backward graph.

## Solution

Still under the discussion with the team, please refer the disucussion in comments

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo