### PR TITLE
[CI] Run unit tests for XPU without timeout

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -178,6 +178,8 @@ elif [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="xpu"
   # setting PYTHON_TEST_EXTRA_OPTION
   export PYTHON_TEST_EXTRA_OPTION="--xpu"
+  # disable timeout due to shard not balance for xpu
+  export NO_TEST_TIMEOUT=True
 fi
 
 if [[ "$TEST_CONFIG" == *crossref* ]]; then


### PR DESCRIPTION
Currently, the unit test will be interrupt when the cmd timeout (default 30mins), and the test result won't write into xml report. 
Partially workaround for #167746
