### PR TITLE
[Autograd] Allow propagation of fw_metadata to partition function

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -10,6 +10,7 @@ An aot_dispatch_* function:
 """
 
 import copy
+import inspect
 import dataclasses
 import itertools
 import logging
@@ -1664,13 +1665,26 @@ def _aot_stage2a_partition(
                 # pyrefly: ignore [bad-assignment]
                 fx_g = torch._functorch.config.joint_custom_pass(fx_g, joint_inputs)
 
+            # Check if partition_fn accepts fw_metadata
+            partition_fn_sig = inspect.signature(aot_config.partition_fn)
+            partition_fn_params = partition_fn_sig.parameters
             static_lifetime_input_indices = fw_metadata.static_input_indices
-            fw_module, bw_module = aot_config.partition_fn(
-                fx_g,
-                joint_inputs,
-                num_fwd_outputs=num_inner_fwd_outputs,
-                static_lifetime_input_indices=static_lifetime_input_indices,
-            )
+            if 'fw_metadata' in partition_fn_params:
+                fw_module, bw_module = aot_config.partition_fn(
+                    fx_g,
+                    joint_inputs,
+                    num_fwd_outputs=num_inner_fwd_outputs,
+                    static_lifetime_input_indices=static_lifetime_input_indices,
+                    fw_metadata=fw_metadata,
+                )
+            else:
+                # Backward compatible - don't pass if not expected
+                fw_module, bw_module = aot_config.partition_fn(
+                    fx_g,
+                    joint_inputs,
+                    num_fwd_outputs=num_inner_fwd_outputs,
+                    static_lifetime_input_indices=static_lifetime_input_indices,
+                )
             rng_states = [
                 n
                 for n in fw_module.graph.find_nodes(op="placeholder")


### PR DESCRIPTION
We allow the forwarding fw_metadata to user-defined partition_fn if it is specified in AOTConfig. This allows us access to ViewAndMutationMeta in the custom partition_fn allowing for aliasing-analysis for buffer-reuse.

Fixes #169870
