### PR TITLE
Avoid multiprocess tests hanging forever.

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2052,7 +2052,9 @@ class MultiProcContinuousTest(TestCase):
                 for i, (p, completion_queue) in enumerate(
                     zip(self.processes, self.completion_queues)
                 ):
-                    rv = retrieve_result_from_process_queue(p, completion_queue)
+                    rv = retrieve_result_from_process_queue(
+                        p, completion_queue, timeout=get_timeout(self.id())
+                    )
                     if deferred_exception is not None:
                         # Already captured an exception; just drain
                         continue

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2027,6 +2027,7 @@ class MultiProcContinuousTest(TestCase):
                     while True:
                         try:
                             rv = completion_queue.get(timeout=120)
+                            break
                         except queue.Empty:
                             # If not alive do a last check because the timeout might have happened just before completion
                             if not p.is_alive() and completion_queue.empty():

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2019,8 +2019,19 @@ class MultiProcContinuousTest(TestCase):
                 # Drain all completion queues before raising any exception,
                 # so stale results don't desync subsequent tests.
                 deferred_exception = None
-                for i, completion_queue in enumerate(self.completion_queues):
-                    rv = completion_queue.get()
+                for i, (p, completion_queue) in enumerate(
+                    zip(self.processes, self.completion_queues)
+                ):
+                    # When the process died before filling the completion queue `get` will never return.
+                    # Hence periodically check the process for liveness
+                    while True:
+                        try:
+                            rv = completion_queue.get(timeout=120)
+                        except queue.Empty:
+                            # If not alive do a last check because the timeout might have happened just before completion
+                            if not p.is_alive() and completion_queue.empty():
+                                rv = RuntimeError(f"Exited with {p.exitcode}")
+                                break
                     if deferred_exception is not None:
                         # Already captured an exception; just drain
                         continue

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -609,7 +609,10 @@ if TEST_WITH_TSAN:
     TIMEOUT_DEFAULT = 500
 else:
     TIMEOUT_DEFAULT = int(os.getenv("DISTRIBUTED_TESTS_DEFAULT_TIMEOUT", "300"))
-TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
+TIMEOUT_OVERRIDE = {
+    "test_ddp_uneven_inputs": 400,
+    "test_DistributedDataParallel": 500,
+}
 
 
 # https://github.com/pytorch/pytorch/issues/75665

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -737,6 +737,33 @@ def cleanup_temp_dir() -> None:
         tmp_dir.cleanup()
 
 
+def retrieve_result_from_process_queue(
+    process: torch.multiprocessing.Process,
+    queue: torch.multiprocessing.Queue,
+    timeout: int | None = None,
+) -> Any:
+    """Get result from queue associated with process.
+
+    When the process finished without putting a result or the timeout expired an exception instance will be returned"""
+    queue_timeout = 120 if timeout is None else max(10, min(120, timeout // 4))
+    start_time = time.time()
+    # Periodically check the process for liveness
+    while True:
+        try:
+            return queue.get(timeout=queue_timeout)
+        except queue.Empty:
+            # If not alive do a last check because the timeout might have happened just before completion
+            if not process.is_alive() and queue.empty():
+                # Clean up process to avoid keeping a zombie process
+                process.terminate()  # Just to be sure
+                process.join(600)  # Usually completes immediately
+                return RuntimeError(f"Exited with {process.exitcode}")
+        if timeout is not None:
+            elapsed = time.time() - start_time
+            if elapsed > timeout:
+                return RuntimeError(f"Process timeout out after {elapsed}s")
+
+
 # Most tests operate with this worldsize
 if TEST_WITH_ROCM:
     DEFAULT_WORLD_SIZE = min(4, max(2, torch.cuda.device_count()))
@@ -2022,20 +2049,7 @@ class MultiProcContinuousTest(TestCase):
                 for i, (p, completion_queue) in enumerate(
                     zip(self.processes, self.completion_queues)
                 ):
-                    # When the process died before filling the completion queue `get` will never return.
-                    # Hence periodically check the process for liveness
-                    while True:
-                        try:
-                            rv = completion_queue.get(timeout=120)
-                            break
-                        except queue.Empty:
-                            # If not alive do a last check because the timeout might have happened just before completion
-                            if not p.is_alive() and completion_queue.empty():
-                                # Clean up process to avoid keeping a zombie process
-                                p.terminate()  # Just to be sure
-                                p.join(600)  # Usually completes immediately
-                                rv = RuntimeError(f"Exited with {p.exitcode}")
-                                break
+                    rv = retrieve_result_from_process_queue(p, completion_queue)
                     if deferred_exception is not None:
                         # Already captured an exception; just drain
                         continue

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2030,6 +2030,9 @@ class MultiProcContinuousTest(TestCase):
                         except queue.Empty:
                             # If not alive do a last check because the timeout might have happened just before completion
                             if not p.is_alive() and completion_queue.empty():
+                                # Clean up process to avoid keeping a zombie process
+                                p.terminate()  # Just to be sure
+                                p.join(600)  # Usually completes immediately
                                 rv = RuntimeError(f"Exited with {p.exitcode}")
                                 break
                     if deferred_exception is not None:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -757,9 +757,6 @@ def retrieve_result_from_process_queue(
         except queue.Empty:
             # If not alive do a last check because the timeout might have happened just before completion
             if not process.is_alive() and queue.empty():
-                # Clean up process to avoid keeping a zombie process
-                process.terminate()  # Just to be sure
-                process.join(600)  # Usually completes immediately
                 return RuntimeError(f"Exited with {process.exitcode}")
         if timeout is not None:
             elapsed = time.time() - start_time

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -740,12 +740,12 @@ def cleanup_temp_dir() -> None:
         tmp_dir.cleanup()
 
 
-def retrieve_result_from_process_queue(
+def retrieve_result_from_completion_queue(
     process: torch.multiprocessing.Process,
-    queue: torch.multiprocessing.Queue,
+    completion_queue: torch.multiprocessing.Queue,
     timeout: int | None = None,
 ) -> Any:
-    """Get result from queue associated with process.
+    """Get result from the completion_queue associated with process.
 
     When the process finished without putting a result or the timeout expired an exception instance will be returned"""
     queue_timeout = 120 if timeout is None else max(10, min(120, timeout // 4))
@@ -753,15 +753,17 @@ def retrieve_result_from_process_queue(
     # Periodically check the process for liveness
     while True:
         try:
-            return queue.get(timeout=queue_timeout)
+            return completion_queue.get(timeout=queue_timeout)
         except queue.Empty:
-            # If not alive do a last check because the timeout might have happened just before completion
-            if not process.is_alive() and queue.empty():
+            # If the process is no longer alive we cannot get a result from the queue unless it is there right now.
+            # This can happen if the timeout occurred just before the process put its result and terminated.
+            # So do a last check for emptiness before considering it as a failure.
+            if not process.is_alive() and completion_queue.empty():
                 return RuntimeError(f"Exited with {process.exitcode}")
         if timeout is not None:
             elapsed = time.time() - start_time
             if elapsed > timeout:
-                return RuntimeError(f"Process timeout out after {elapsed}s")
+                return RuntimeError(f"Process timed out out after {elapsed}s")
 
 
 # Most tests operate with this worldsize
@@ -2049,7 +2051,7 @@ class MultiProcContinuousTest(TestCase):
                 for i, (p, completion_queue) in enumerate(
                     zip(self.processes, self.completion_queues)
                 ):
-                    rv = retrieve_result_from_process_queue(
+                    rv = retrieve_result_from_completion_queue(
                         p, completion_queue, timeout=get_timeout(self.id())
                     )
                     if deferred_exception is not None:

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -198,9 +198,6 @@ skipIfNoTorchVision = skip_but_pass_in_sandcastle_if(
 BACKEND = os.environ["BACKEND"]
 INIT_METHOD = os.getenv("INIT_METHOD", "env://")
 
-DEFAULT_TIMEOUT = 300
-CUSTOMIZED_TIMEOUT = {"test_DistributedDataParallel": 500}
-
 
 def get_profiling_event(event_name, profiler, dedup_gpu_user_annotation=False):
     event_list = (
@@ -400,14 +397,6 @@ class ControlFlowToyModel(nn.Module):
             return self.lin2(F.relu(self.lin1(x)))
         else:
             return F.relu(self.lin1(x))
-
-
-def get_timeout(test_id):
-    test_name = test_id.split(".")[-1]
-    if test_name in CUSTOMIZED_TIMEOUT:
-        return CUSTOMIZED_TIMEOUT[test_name]
-    else:
-        return DEFAULT_TIMEOUT
 
 
 default_pg_timeout = 60


### PR DESCRIPTION
When a child process exits before filling the completion queue the parent process will wait forever for it to be filled. As the reason for the termination can be anything check if the process is still alive after a given timeout.

If it is not alive and the queue is still empty this indicates such a situation and we handle it like an exception returned by the subprocess.

See #171796
