### PR TITLE
Skip SAC ILP tests when pulp package is not installed

### DIFF
--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -26,6 +26,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     Transformer,
 )
 
+
 # sac_ilp depends on the pulp package which may not be installed
 # See: https://github.com/pytorch/pytorch/issues/162453
 HAS_PULP = True

--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -13,10 +13,6 @@ from torch.distributed._tools.ilp_utils import (
 from torch.distributed._tools.mem_tracker import _ModState, MemTracker
 from torch.distributed._tools.runtime_estimator import RuntimeEstimator
 from torch.distributed._tools.sac_estimator import SACEstimator, SACStats
-from torch.distributed._tools.sac_ilp import (
-    get_optimal_checkpointing_policy_per_module,
-    sac_milp,
-)
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     MI300_ARCH,
@@ -29,6 +25,19 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
 )
+
+# sac_ilp depends on the pulp package which may not be installed
+# See: https://github.com/pytorch/pytorch/issues/162453
+HAS_PULP = True
+try:
+    from torch.distributed._tools.sac_ilp import (
+        get_optimal_checkpointing_policy_per_module,
+        sac_milp,
+    )
+except ImportError:
+    HAS_PULP = False
+    get_optimal_checkpointing_policy_per_module = None  # type: ignore[assignment, misc]
+    sac_milp = None  # type: ignore[assignment]
 
 
 class TestSACILP(TestCase):
@@ -136,6 +145,7 @@ class TestSACILP(TestCase):
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(not HAS_PULP, "pulp package not installed")
     @skipIfRocmArch(MI300_ARCH)
     def test_sac_ilp_case1(self):
         """
@@ -179,6 +189,7 @@ class TestSACILP(TestCase):
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(not HAS_PULP, "pulp package not installed")
     def test_sac_ilp_case2(self):
         """
         This is a case where the memory budget is not binding, meaning that no
@@ -195,6 +206,7 @@ class TestSACILP(TestCase):
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(not HAS_PULP, "pulp package not installed")
     def test_sac_ilp_case3(self):
         """
         This is a case where the memory budget is too tight, meaning that even with
@@ -238,6 +250,7 @@ class TestOptimalCheckpointingPolicy(TestCase):
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(not HAS_PULP, "pulp package not installed")
     def test_get_optimial_checkpointing_policy_per_module(self):
         for memory_budget, optimal_soln in [
             (0, [1, 0, 0, 0, 1, 0, 0, 0]),


### PR DESCRIPTION
## Summary
This PR fixes the test file `test/distributed/_tools/test_sac_ilp.py` which fails to load when the `pulp` package is not installed.

## Problem
The test file imports from `torch.distributed._tools.sac_ilp` at module level, but `sac_ilp.py` requires the `pulp` package. When `pulp` is not installed, this causes:

```
ImportError: Please install pulp package. See: https://github.com/coin-or/pulp.
```

This prevents the test module from loading at all, causing CI failures on environments where `pulp` is not installed.

## Solution
1. Wrap the `sac_ilp` import in a try/except block
2. Set `HAS_PULP` flag based on import success
3. Add `@unittest.skipIf(not HAS_PULP, "pulp package not installed")` to all tests

This follows the standard PyTorch pattern for handling optional dependencies (similar to how `torchdistx` is handled in `test_fsdp_meta.py`).

## Testing

Tested on Ubuntu 22.04 (Jammy) with PyTorch 2.7.1:

### Without pulp installed:
```
$ python test_sac_ilp.py -v
test_get_optimial_checkpointing_policy_per_module ... skipped
test_sac_ilp_case1 ... skipped
test_sac_ilp_case2 ... skipped
test_sac_ilp_case3 ... skipped

----------------------------------------------------------------------
Ran 4 tests in 0.001s

OK (skipped=4)
```
File loads successfully, tests skipped gracefully

### With pulp installed:
```python
>>> from torch.distributed._tools.sac_ilp import sac_milp
>>> sac_milp
<function sac_milp at 0x...>
```
Import works, tests would run normally

### Original behavior (without fix):
```
ImportError: Please install pulp package. See: https://github.com/coin-or/pulp.
```
Test module fails to load

## Related Issues
Fixes #162453

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @ezyang