### PR TITLE
docs: add docstring for torch.autograd.graph.Node.next_functions

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -70,6 +70,36 @@ class Node(abc.ABC):
     @property
     @abc.abstractmethod
     def next_functions(self) -> tuple[tuple[Optional["Node"], int], ...]:
+        r"""Return the next functions in the autograd graph.
+
+        This property provides access to the edges connecting this node to its
+        input nodes in the autograd computation graph. Each edge represents a
+        gradient flow path during backpropagation.
+
+        Returns:
+            A tuple of ``(Node, int)`` pairs. Each pair contains:
+                - ``Node``: The next function (gradient function) in the backward
+                  graph, or ``None`` if there is no connected node (e.g., for
+                  leaf tensors).
+                - ``int``: The output index of the corresponding node, indicating
+                  which output of the next function this edge connects to.
+
+        Example::
+
+            >>> import torch
+            >>> a = torch.tensor([1., 2., 3.], requires_grad=True)
+            >>> b = torch.tensor([4., 5., 6.], requires_grad=True)
+            >>> c = a * b
+            >>> # c.grad_fn is MulBackward0, which has two inputs (a and b)
+            >>> print(c.grad_fn.name())
+            MulBackward0
+            >>> # next_functions shows the gradient functions for a and b
+            >>> for next_fn, idx in c.grad_fn.next_functions:
+            ...     if next_fn is not None:
+            ...         print(f"Node: {next_fn.name()}, output index: {idx}")
+            Node: AccumulateGrad, output index: 0
+            Node: AccumulateGrad, output index: 0
+        """
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -87,6 +87,7 @@ class Node(abc.ABC):
 
         Example::
 
+            >>> # xdoctest: +SKIP
             >>> import torch
             >>> a = torch.tensor([1., 2., 3.], requires_grad=True)
             >>> b = torch.tensor([4., 5., 6.], requires_grad=True)


### PR DESCRIPTION
## Summary

  Add comprehensive documentation for the `next_functions` property in `torch.autograd.graph.Node`, addressing issue #171620.

  The current documentation page only describes the structure of the object but not what it does. This PR adds a complete docstring explaining:

  - **Purpose**: Access edges connecting this node to input nodes in the autograd graph
  - **Return value**: Tuple of (Node, int) pairs representing gradient flow paths
  - **Working example**: Demonstrates how to traverse the graph using next_functions

  ## Changes
  - `torch/autograd/graph.py`: Added docstring to `Node.next_functions` property

  Fixes #171620

  cc @soulitzer