### PR TITLE
[Dynamo] Clearer compile error messages for sparse tensors

### DIFF
--- a/torch/_dynamo/graph_break_hints.py
+++ b/torch/_dynamo/graph_break_hints.py
@@ -24,3 +24,8 @@ INFERENCE_MODE = [
     "This is primarily used in conjunction with `torch.inference_mode`. Consider using `torch.no_grad` instead "
     "because `torch.no_grad` leads to same improvements as `inference_mode` when `torch.compile` is used.",
 ]
+SPARSE_TENSOR = [
+    "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. "
+    "Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation "
+    "outside the compiled region.",
+]

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -179,6 +179,14 @@
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
+    },
+    {
+      "Gb_type": "Attempted getattr on sparse Tensor",
+      "Context": "",
+      "Explanation": "torch.compile does not support sparse Tensors",
+      "Hints": [
+        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
+      ]
     }
   ],
   "GB0016": [
@@ -700,16 +708,6 @@
       "Explanation": "{seq} cannot be unpacked into a list for the BUILD_LIST_UNPACK bytecode (`[*x, *y, ...]`).",
       "Hints": [
         "Dynamo has detected that tracing the code will result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled."
-      ]
-    }
-  ],
-  "GB4790": [
-    {
-      "Gb_type": "Attempted getattr on sparse Tensor",
-      "Context": "",
-      "Explanation": "torch.compile does not support sparse Tensors",
-      "Hints": [
-        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
       ]
     }
   ],

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -157,6 +157,14 @@
   ],
   "GB0015": [
     {
+      "Gb_type": "Sparse tensor creation not supported",
+      "Context": "function: {fn_name}",
+      "Explanation": "torch.compile does not support sparse tensor creation functions like {fn_name}. Sparse tensors require specialized handling that is not yet implemented in the compiler.",
+      "Hints": [
+        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
+      ]
+    },
+    {
       "Gb_type": "Attempted to wrap sparse Tensor",
       "Context": "",
       "Explanation": "torch.compile does not support sparse Tensors",
@@ -692,16 +700,6 @@
       "Explanation": "{seq} cannot be unpacked into a list for the BUILD_LIST_UNPACK bytecode (`[*x, *y, ...]`).",
       "Hints": [
         "Dynamo has detected that tracing the code will result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled."
-      ]
-    }
-  ],
-  "GB2023": [
-    {
-      "Gb_type": "Sparse tensor creation not supported",
-      "Context": "function: {fn_name}",
-      "Explanation": "torch.compile does not support sparse tensor creation functions like {fn_name}. Sparse tensors require specialized handling that is not yet implemented in the compiler.",
-      "Hints": [
-        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
       ]
     }
   ],

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -161,6 +161,14 @@
       "Context": "",
       "Explanation": "torch.compile does not support sparse Tensors",
       "Hints": [
+        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
+      ]
+    },
+    {
+      "Gb_type": "Attempted to wrap sparse Tensor",
+      "Context": "",
+      "Explanation": "torch.compile does not support sparse Tensors",
+      "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
     }
@@ -684,6 +692,26 @@
       "Explanation": "{seq} cannot be unpacked into a list for the BUILD_LIST_UNPACK bytecode (`[*x, *y, ...]`).",
       "Hints": [
         "Dynamo has detected that tracing the code will result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled."
+      ]
+    }
+  ],
+  "GB2023": [
+    {
+      "Gb_type": "Sparse tensor creation not supported",
+      "Context": "function: {fn_name}",
+      "Explanation": "torch.compile does not support sparse tensor creation functions like {fn_name}. Sparse tensors require specialized handling that is not yet implemented in the compiler.",
+      "Hints": [
+        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
+      ]
+    }
+  ],
+  "GB4790": [
+    {
+      "Gb_type": "Attempted getattr on sparse Tensor",
+      "Context": "",
+      "Explanation": "torch.compile does not support sparse Tensors",
+      "Hints": [
+        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
       ]
     }
   ],
@@ -3074,6 +3102,14 @@
     }
   ],
   "GB0277": [
+    {
+      "Gb_type": "Attempted to wrap sparse Tensor with VariableTracker",
+      "Context": "str(example_value)",
+      "Explanation": "torch.compile does not support sparse Tensors with VariableTracker",
+      "Hints": [
+        "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
+      ]
+    },
     {
       "Gb_type": "Attempted to wrap sparse Tensor with VariableTracker",
       "Context": "str(example_value)",

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -67,10 +67,10 @@ from .variables import (
     PyTreeTreeIsLeafFunctionVariable,
     ReparametrizeModuleCallVariable,
     SkipFunctionVariable,
+    SparseTensorCreationSkipVariable,
     TorchInGraphFunctionVariable,
     UserFunctionVariable,
     UserMethodVariable,
-    SparseTensorCreationSkipVariable
 )
 from .variables.base import VariableTracker
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -70,6 +70,7 @@ from .variables import (
     TorchInGraphFunctionVariable,
     UserFunctionVariable,
     UserMethodVariable,
+    SparseTensorCreationSkipVariable
 )
 from .variables.base import VariableTracker
 
@@ -366,11 +367,11 @@ manual_torch_name_rule_map: dict[
     "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
     "torch.utils.hooks.BackwardHook": TorchInGraphFunctionVariable,
     "torch.set_default_device": UserFunctionVariable,
-    "torch.sparse_bsc_tensor": SkipFunctionVariable,
-    "torch.sparse_bsr_tensor": SkipFunctionVariable,
-    "torch.sparse_csc_tensor": SkipFunctionVariable,
-    "torch.sparse_csr_tensor": SkipFunctionVariable,
-    "torch.sparse_compressed_tensor": SkipFunctionVariable,
+    "torch.sparse_bsc_tensor": SparseTensorCreationSkipVariable,
+    "torch.sparse_bsr_tensor": SparseTensorCreationSkipVariable,
+    "torch.sparse_csc_tensor": SparseTensorCreationSkipVariable,
+    "torch.sparse_csr_tensor": SparseTensorCreationSkipVariable,
+    "torch.sparse_compressed_tensor": SparseTensorCreationSkipVariable,
     "torch._C._autograd._unsafe_set_version_counter": TorchInGraphFunctionVariable,
     "torch.xpu.get_rng_state": SkipFunctionVariable,
     "torch.xpu.set_rng_state": SkipFunctionVariable,

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -75,6 +75,7 @@ from .functions import (
     UserMethodVariable,
     WrapperUserFunctionVariable,
     WrapperUserMethodVariable,
+    SparseTensorCreationSkipVariable
 )
 from .higher_order_ops import (
     FunctionalCallVariable,

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -69,13 +69,13 @@ from .functions import (
     PyTreeGetNodeTypeFunctionVariable,
     PyTreeTreeIsLeafFunctionVariable,
     SkipFunctionVariable,
+    SparseTensorCreationSkipVariable,
     TMADescriptorExperimentalVariable,
     TMADescriptorStableVariable,
     UserFunctionVariable,
     UserMethodVariable,
     WrapperUserFunctionVariable,
     WrapperUserMethodVariable,
-    SparseTensorCreationSkipVariable
 )
 from .higher_order_ops import (
     FunctionalCallVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2297,7 +2297,7 @@ class VariableBuilder:
                 gb_type="Attempted to wrap sparse Tensor",
                 context="",
                 explanation="torch.compile does not support sparse Tensors",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[*graph_break_hints.SPARSE_TENSOR],
             )
 
         if (
@@ -3158,7 +3158,7 @@ def handle_traced_output(
                 gb_type="Attempted to wrap sparse Tensor with VariableTracker",
                 context=str(example_value),
                 explanation="torch.compile does not support sparse Tensors with VariableTracker",
-                hints=[*graph_break_hints.SUPPORTABLE],
+                hints=[*graph_break_hints.SPARSE_TENSOR],
             )
         var = construct_tensor_variable(
             target_cls, tx, proxy, example_value, subclass_type, options

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2671,10 +2671,10 @@ class BuiltinVariable(VariableTracker):
                     and (not tx.export or not config.capture_sparse_compute)
                 ):
                     unimplemented(
-                        gb_type="Attempted to wrap sparse Tensor",
+                        gb_type="Attempted getattr on sparse Tensor",
                         context="",
                         explanation="torch.compile does not support sparse Tensors",
-                        hints=[*graph_break_hints.SUPPORTABLE],
+                        hints=[*graph_break_hints.SPARSE_TENSOR],
                     )
 
             try:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3164,14 +3164,15 @@ class PyTreeTreeIsLeafFunctionVariable(UserFunctionVariable):
         out = supported_nodes_var.call_method(tx, "__contains__", [node_type_var], {})
         return ConstantVariable.create(not out.value)
 
+
 class SparseTensorCreationSkipVariable(SkipFunctionVariable):
     """
     Skip variable for sparse tensor factory functions with clear messaging regarding lack of support.
     """
 
     def __init__(self, value: Any, **kwargs: Any) -> None:
-          reason = "sparse tensor creation is not supported in torch.compile"
-          super().__init__(value, reason=reason, **kwargs)
+        reason = "sparse tensor creation is not supported in torch.compile"
+        super().__init__(value, reason=reason, **kwargs)
 
     def call_function(
         self,
@@ -3191,4 +3192,3 @@ class SparseTensorCreationSkipVariable(SkipFunctionVariable):
             ),
             hints=[*graph_break_hints.SPARSE_TENSOR],
         )
-

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3163,3 +3163,32 @@ class PyTreeTreeIsLeafFunctionVariable(UserFunctionVariable):
         )
         out = supported_nodes_var.call_method(tx, "__contains__", [node_type_var], {})
         return ConstantVariable.create(not out.value)
+
+class SparseTensorCreationSkipVariable(SkipFunctionVariable):
+    """
+    Skip variable for sparse tensor factory functions with clear messaging regarding lack of support.
+    """
+
+    def __init__(self, value: Any, **kwargs: Any) -> None:
+          reason = "sparse tensor creation is not supported in torch.compile"
+          super().__init__(value, reason=reason, **kwargs)
+
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .. import graph_break_hints
+
+        fn_name = getattr(self.value, "__name__", str(self.value))
+        unimplemented(
+            gb_type="Sparse tensor creation not supported",
+            context=f"function: {fn_name}",
+            explanation=(
+                f"torch.compile does not support sparse tensor creation functions like {fn_name}. "
+                "Sparse tensors require specialized handling that is not yet implemented in the compiler."
+            ),
+            hints=[*graph_break_hints.SPARSE_TENSOR],
+        )
+


### PR DESCRIPTION
Addresses [#171865](https://github.com/pytorch/pytorch/issues/171865)

## Motivation

To the best of my understanding, sparse tensors are currently not supported in `compile`. If this missing functionality is expected to remain for a while, it might make sense to clearly communicate that to users in the meantime. 

## Summary

Improves the error message when `torch.compile(fullgraph=True)` encounters sparse tensor creation functions like `torch.sparse_csr_tensor()`.

**Before:**
```
  torch._dynamo.exc.Unsupported: Attempted to call function marked as skipped
    Explanation: Dynamo does not know how to trace the builtin
    torch._VariableFunctionsClass.sparse_csr_tensor. This function is either
    a Python builtin (e.g. _warnings.warn) or a third-party C/C++ Python extension.
```
**After:**
```
  torch._dynamo.exc.Unsupported: Sparse tensor creation not supported
    Explanation: torch.compile does not support sparse tensor creation functions
    like sparse_csr_tensor. Sparse tensors require specialized handling that is
    not yet implemented in the compiler.
    Hint: Sparse tensor support is in beta and not yet fully supported in
    torch.compile with fullgraph=True. Consider using fullgraph=False to allow
    graph breaks, or move sparse tensor creation outside the compiled region.
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @mlazos