### PR TITLE
Prepare CUDA inputs only on CUDA device

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8955,107 +8955,108 @@ def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
     mat1 = make_mat_e4m3((M, K))
     mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
 
-    dmajor, dminor = torch.cuda.get_device_capability()
+    if torch.device(device).type == "cuda":
+        dmajor, dminor = torch.cuda.get_device_capability()
 
-    # Blockwise scaling requires cublasLt >= 12.9 (CUDA 12.9+)
-    # See: https://github.com/pytorch/pytorch/issues/172227
-    cuda_version = _get_torch_cuda_version()
-    if dmajor == 9 and not torch.version.hip and cuda_version >= (12, 9):
-        # 1x128 x 1x128
-        scale1 = make_scale((K // 128, M)).t()
-        scale2 = make_scale((K // 128, N)).t()
-        samples.append(
-            SampleInput(
-                mat1,
-                mat2,
-                [scale1, ],
-                [ScalingType.BlockWise1x128, ],
-                [SwizzleType.NO_SWIZZLE, ],
-                [scale2, ],
-                [ScalingType.BlockWise1x128, ],
-                [SwizzleType.NO_SWIZZLE, ],
-                None,  # bias
-                torch.bfloat16,  # out_dtype
+        # Blockwise scaling requires cublasLt >= 12.9 (CUDA 12.9+)
+        # See: https://github.com/pytorch/pytorch/issues/172227
+        cuda_version = _get_torch_cuda_version()
+        if dmajor == 9 and not torch.version.hip and cuda_version >= (12, 9):
+            # 1x128 x 1x128
+            scale1 = make_scale((K // 128, M)).t()
+            scale2 = make_scale((K // 128, N)).t()
+            samples.append(
+                SampleInput(
+                    mat1,
+                    mat2,
+                    [scale1, ],
+                    [ScalingType.BlockWise1x128, ],
+                    [SwizzleType.NO_SWIZZLE, ],
+                    [scale2, ],
+                    [ScalingType.BlockWise1x128, ],
+                    [SwizzleType.NO_SWIZZLE, ],
+                    None,  # bias
+                    torch.bfloat16,  # out_dtype
+                )
             )
-        )
-        # 128x128 x 1x128
-        L4 = round_up(K // 128, 4)
-        scale1 = make_scale((M // 128, L4)).t()
-        scale2 = make_scale((K // 128, N)).t()
-        samples.append(
-            SampleInput(
-                mat1,
-                mat2,
-                [scale1, ],
-                [ScalingType.BlockWise128x128, ],
-                [SwizzleType.NO_SWIZZLE, ],
-                [scale2, ],
-                [ScalingType.BlockWise1x128, ],
-                [SwizzleType.NO_SWIZZLE, ],
-                None,  # bias
-                torch.bfloat16,  # out_dtype
+            # 128x128 x 1x128
+            L4 = round_up(K // 128, 4)
+            scale1 = make_scale((M // 128, L4)).t()
+            scale2 = make_scale((K // 128, N)).t()
+            samples.append(
+                SampleInput(
+                    mat1,
+                    mat2,
+                    [scale1, ],
+                    [ScalingType.BlockWise128x128, ],
+                    [SwizzleType.NO_SWIZZLE, ],
+                    [scale2, ],
+                    [ScalingType.BlockWise1x128, ],
+                    [SwizzleType.NO_SWIZZLE, ],
+                    None,  # bias
+                    torch.bfloat16,  # out_dtype
+                )
             )
-        )
-        # 1x128 x 128x128
-        L4 = round_up(K // 128, 4)
-        scale1 = make_scale((K // 128, M)).t()
-        scale2 = make_scale((N // 128, L4)).t()
-        samples.append(
-            SampleInput(
-                mat1,
-                mat2,
-                [scale1, ],
-                [ScalingType.BlockWise1x128, ],
-                [SwizzleType.NO_SWIZZLE, ],
-                [scale2, ],
-                [ScalingType.BlockWise128x128, ],
-                [SwizzleType.NO_SWIZZLE, ],
-                None,  # bias
-                torch.bfloat16,  # out_dtype
+            # 1x128 x 128x128
+            L4 = round_up(K // 128, 4)
+            scale1 = make_scale((K // 128, M)).t()
+            scale2 = make_scale((N // 128, L4)).t()
+            samples.append(
+                SampleInput(
+                    mat1,
+                    mat2,
+                    [scale1, ],
+                    [ScalingType.BlockWise1x128, ],
+                    [SwizzleType.NO_SWIZZLE, ],
+                    [scale2, ],
+                    [ScalingType.BlockWise128x128, ],
+                    [SwizzleType.NO_SWIZZLE, ],
+                    None,  # bias
+                    torch.bfloat16,  # out_dtype
+                )
             )
-        )
 
-    if dmajor >= 10:
-        # MXFP8
-        scale1 = make_scale((M, K // 32)).to(torch.float8_e8m0fnu)
-        scale2 = make_scale((K // 32, N)).to(torch.float8_e8m0fnu)
-        samples.append(
-            SampleInput(
-                mat1,
-                mat2,
-                [scale1, ],
-                [ScalingType.BlockWise1x32, ],
-                [SwizzleType.SWIZZLE_32_4_4, ],
-                [scale2, ],
-                [ScalingType.BlockWise1x32, ],
-                [SwizzleType.SWIZZLE_32_4_4, ],
-                None,  # bias
-                torch.bfloat16,  # out_dtype
+        if dmajor >= 10:
+            # MXFP8
+            scale1 = make_scale((M, K // 32)).to(torch.float8_e8m0fnu)
+            scale2 = make_scale((K // 32, N)).to(torch.float8_e8m0fnu)
+            samples.append(
+                SampleInput(
+                    mat1,
+                    mat2,
+                    [scale1, ],
+                    [ScalingType.BlockWise1x32, ],
+                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    [scale2, ],
+                    [ScalingType.BlockWise1x32, ],
+                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    None,  # bias
+                    torch.bfloat16,  # out_dtype
+                )
             )
-        )
-        # NVFP4
-        # [M, K] -> [M, K // 2]
-        # [K, N] -> [K // 2, N]
-        mat1_fp4 = _bfloat16_to_float4_e2m1fn_x2(mat1.to(torch.bfloat16))
-        mat2_fp4 = _bfloat16_to_float4_e2m1fn_x2(mat2.to(torch.bfloat16).t()).t()
-        scale1 = make_scale((M, K // 16)).to(torch.float8_e4m3fn)
-        global_scale1 = make_scale((1, ))
-        scale2 = make_scale((K // 16, N)).to(torch.float8_e4m3fn)
-        global_scale2 = make_scale((1, ))
-        samples.append(
-            SampleInput(
-                mat1_fp4,
-                mat2_fp4,
-                [scale1, global_scale1],
-                [ScalingType.BlockWise1x16, ScalingType.TensorWise],
-                [SwizzleType.SWIZZLE_32_4_4, ],
-                [scale2, global_scale2],
-                [ScalingType.BlockWise1x16, ScalingType.TensorWise],
-                [SwizzleType.SWIZZLE_32_4_4, ],
-                None,  # bias
-                torch.bfloat16,  # out_dtype
+            # NVFP4
+            # [M, K] -> [M, K // 2]
+            # [K, N] -> [K // 2, N]
+            mat1_fp4 = _bfloat16_to_float4_e2m1fn_x2(mat1.to(torch.bfloat16))
+            mat2_fp4 = _bfloat16_to_float4_e2m1fn_x2(mat2.to(torch.bfloat16).t()).t()
+            scale1 = make_scale((M, K // 16)).to(torch.float8_e4m3fn)
+            global_scale1 = make_scale((1, ))
+            scale2 = make_scale((K // 16, N)).to(torch.float8_e4m3fn)
+            global_scale2 = make_scale((1, ))
+            samples.append(
+                SampleInput(
+                    mat1_fp4,
+                    mat2_fp4,
+                    [scale1, global_scale1],
+                    [ScalingType.BlockWise1x16, ScalingType.TensorWise],
+                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    [scale2, global_scale2],
+                    [ScalingType.BlockWise1x16, ScalingType.TensorWise],
+                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    None,  # bias
+                    torch.bfloat16,  # out_dtype
+                )
             )
-        )
 
 
     yield from samples


### PR DESCRIPTION
In the `sample_input_scaled_mm_v2` function, some samples are generated only if specific CUDA device capabilites are met. However, to check these capabilites the following function is used: `torch.cuda.get_device_capability()`. For non-CUDA based PyTorch builds, such as XPU, this will trigger the following error: `AssertionError: Torch not compiled with CUDA enabled`.

This commit wraps the code for generating the capability-based input samples into an if statement, which checks if the current device type is CUDA.
