### PR TITLE
[xpu][fix] Skip some UTs in test_export.py for XPU

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -8127,6 +8127,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
 
     @requires_gpu
     @skipIfRocm
+    @skipIfXpu
     @testing.expectedFailureSerDer
     @testing.expectedFailureSerDerNonStrict
     def test_export_lstm_gpu(self):
@@ -8153,6 +8154,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
 
     @requires_gpu
     @skipIfRocm
+    @skipIfXpu
     @testing.expectedFailureSerDer
     @testing.expectedFailureSerDerNonStrict
     def test_export_gru_gpu(self):
@@ -8179,6 +8181,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
 
     @requires_gpu
     @skipIfRocm
+    @skipIfXpu
     @testing.expectedFailureSerDer
     @testing.expectedFailureSerDerNonStrict
     def test_export_rnn_flatten_parameters_gpu(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #171997
* __->__ #171995

# Motivation
https://github.com/pytorch/pytorch/issues/169710 introduces these UTs that could pass on XPU, so I skip them in this PR to avoid `unexpected successes` failures.

# Additional Context
Fix https://github.com/pytorch/pytorch/issues/171984