### PR TITLE
[xpu][fix] Fix test_max_pool2d_with_indices_backward UT to avoid expected failure on XPU

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9967,11 +9967,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
-        # Note: Kernel count varies by backend (CUDA ~3, ROCm ~2) due to fusion.
+        # Note: Kernel count varies by backend (CUDA/XPU ~3, ROCm ~2) due to fusion.
         # Correctness is validated by self.common() above.
         self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
-    @expectedFailureXPU
     def test_max_pool2d_with_indices_backward5(self):
         # Large window size - decomposition handles via scatter_add
         def fn(a, b, c):
@@ -9997,7 +9996,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
-        # Note: Kernel count varies by backend (CUDA ~3, ROCm ~2) due to fusion.
+        # Note: Kernel count varies by backend (CUDA/XPU ~3, ROCm ~2) due to fusion.
         # Correctness is validated by self.common() above.
         # MPS: decomposition falls back to native kernel, so no inductor kernels generated
         if self.device != "mps":
@@ -10029,7 +10028,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
-        # Note: Kernel count varies by backend (CUDA ~3, ROCm ~2) due to fusion.
+        # Note: Kernel count varies by backend (CUDA/XPU ~3, ROCm ~2) due to fusion.
         # Correctness is validated by self.common() above.
         # MPS: decomposition falls back to native kernel, so no inductor kernels generated
         if self.device != "mps":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #171997
* #171995

# Motivation
https://github.com/pytorch/pytorch/pull/167318 fixes expected failure UTs about `test_max_pool2d_with_indices_backward`. So this PR removes the expected failure decorator for XPU.

# Additional Context
Fix https://github.com/pytorch/pytorch/issues/171987
Fix https://github.com/pytorch/pytorch/issues/171985


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo