### PR TITLE
add Inductor support for axis keyword argument when using torch.cat 

### DIFF
--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -61,12 +61,15 @@ class TestFxFusion(TestCase):
         def test_kwarg3(x, y):
             return torch.cat(tensors=[x, y], dim=0).view(128).tanh()
 
+        def test_axis(x, y):
+            return torch.cat([x, y], axis=-1).tanh()
+
         trace_func = chain_passes(torch.fx.symbolic_trace, sink_cat_after_pointwise)
         inputs = [
             torch.randn(8, 8),
             torch.randn(8, 8),
         ]
-        for f in [test_kwarg, test_arg, test_arg2, test_kwarg2, test_kwarg3]:
+        for f in [test_kwarg, test_arg, test_arg2, test_kwarg2, test_kwarg3, test_axis]:
             traced = trace_func(f, inputs)
             torch.testing.assert_close(f(*inputs), traced(*inputs))
             self.assertEqual(count_call_method(traced, "tanh"), 2)

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -716,7 +716,9 @@ def sink_cat_after_pointwise(module: torch.fx.GraphModule) -> torch.fx.GraphModu
         if user and is_pointwise_unary(user):
             with g.inserting_before(node):
 
-                def cat_args(tensors, dim=0):
+                def cat_args(tensors, dim=0, axis=None):
+                    if axis is not None:
+                        dim = axis
                     return tensors, dim
 
                 tensors, dim = cat_args(*node.args, **node.kwargs)


### PR DESCRIPTION
Fixes #171979

## Description
Fixes a TypeError when using `torch.cat` with the NumPy-style `axis` keyword argument instead of `dim` when compiling with the inductor backend.

## Before
`torch.compile(model, backend="inductor")` fails with:
```
TypeError: sink_cat_after_pointwise.<locals>.cat_args() got an unexpected keyword argument 'axis'
```

## After

Both dim and axis kwargs work correctly.

## Test
Added test_axis case to test_sink_cat_after_pointwise.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos