### PR TITLE
[dynamo] Fix property setter on nested MutableMapping objects

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1542,6 +1542,83 @@ class FunctionTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    def test_mutable_mapping_property_setter_nested(self):
+        """Test that property setters work correctly on nested MutableMapping objects.
+
+        This tests the fix for a bug where property setters on newly created
+        MutableMapping objects would fail when accessing nested objects.
+        The issue was that property.__set__ is a slot wrapper (not a Python function),
+        so Dynamo wasn't tracing the property setter (fset), causing the setter code
+        to run on uninitialized example objects.
+
+        See: https://github.com/pytorch/pytorch/issues/XXXXX
+        """
+        from collections.abc import MutableMapping
+
+        class Container(MutableMapping):
+            def __init__(self, data=None, batch_size=None):
+                self._data = data if data is not None else {}
+                self._batch_size = batch_size if batch_size is not None else ()
+                self._names = None
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __setitem__(self, key, value):
+                self._data[key] = value
+
+            def __delitem__(self, key):
+                del self._data[key]
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def __len__(self):
+                return len(self._data)
+
+            @property
+            def batch_size(self):
+                return self._batch_size
+
+            @property
+            def names(self):
+                return self._names
+
+            @names.setter
+            def names(self, value):
+                self._set_names(value)
+
+            def _set_names(self, value):
+                self._names = value
+                for item in self._data.values():
+                    if isinstance(item, Container):
+                        child_size = len(item.batch_size)
+                        item._names = list(value) + [None] * (child_size - len(value))
+
+        # Test that both direct method call and property setter work identically
+        @torch.compile(backend="eager", fullgraph=True)
+        def using_method():
+            nested = Container({"b": torch.tensor(2.0)}, (3,))
+            root = Container({"nested": nested}, (3,))
+            root._set_names(["time"])
+            return root
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def using_property_setter():
+            nested = Container({"b": torch.tensor(2.0)}, (3,))
+            root = Container({"nested": nested}, (3,))
+            root.names = ["time"]
+            return root
+
+        # Both should work without error
+        result_method = using_method()
+        self.assertEqual(result_method._names, ["time"])
+        self.assertEqual(result_method["nested"]._names, ["time"])
+
+        result_property = using_property_setter()
+        self.assertEqual(result_property._names, ["time"])
+        self.assertEqual(result_property["nested"]._names, ["time"])
+
     def _test_default_dict_helper(self, factory):
         dd = collections.defaultdict(factory)
         param = torch.nn.Parameter(torch.ones([2, 2]))

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1551,7 +1551,7 @@ class FunctionTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         so Dynamo wasn't tracing the property setter (fset), causing the setter code
         to run on uninitialized example objects.
 
-        See: https://github.com/pytorch/pytorch/issues/XXXXX
+        See: https://github.com/pytorch/pytorch/issues/172000
         """
         from collections.abc import MutableMapping
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1266,6 +1266,20 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 func_var = VariableTracker.build(tx, setter, func_source)
                 args = [desc_var, self, value]
                 return func_var.call_function(tx, args, {})
+
+            # Check for property descriptors with fset.
+            # property.__set__ is a slot wrapper (not a Python function), so
+            # try_get_descritor_and_setter_py_func returns None.
+            # We need to handle properties specially by calling their fset.
+            property_fset = self.try_get_property_fset(name_str)
+            if property_fset is not None:
+                fset_source = None
+                if self.cls_source:
+                    desc_source = self.get_source_by_walking_mro(name_str)
+                    fset_source = AttrSource(desc_source, "fset")
+                fset_vt = VariableTracker.build(tx, property_fset, fset_source)
+                return fset_vt.call_function(tx, [self, value], {})
+
             # NOTE: else we assume the descriptor (if any) has a
             # side-effect-free `__set__` as far as Dynamo tracing is concerned.
 
@@ -1441,6 +1455,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             # Skip if `__set__` was traceable (no need to redo the side effect).
             if inspect.isfunction(setter):
                 return True
+            # Skip for property descriptors with fset - we trace fset directly.
+            if isinstance(descriptor, property) and descriptor.fset is not None:
+                return True
             # For untraceable `__set__` we should still skip if the attribute
             # was mutated via instance `__dict__`.
             elif attr_name in self.attrs_directly_modifed_on_dict:
@@ -1454,6 +1471,20 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         setter = inspect.getattr_static(type(descriptor), "__set__", None)
         if inspect.isfunction(setter):
             return (descriptor, setter)
+        return None
+
+    def try_get_property_fset(self, attr_name: str) -> types.FunctionType | None:
+        """
+        Check if attr_name corresponds to a property descriptor with an fset.
+        Returns the fset function if found, None otherwise.
+
+        This is needed because property.__set__ is a slot wrapper (C function),
+        not a Python function, so try_get_descritor_and_setter_py_func returns None
+        for properties. But property.fset IS a Python function that we can trace.
+        """
+        descriptor = inspect.getattr_static(type(self.value), attr_name, None)
+        if isinstance(descriptor, property) and descriptor.fset is not None:
+            return descriptor.fset
         return None
 
     def has_key_in_generic_dict(self, tx: "InstructionTranslator", key: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes #172000

When a compiled function creates nested `MutableMapping` instances and uses a **property setter** that accesses nested objects, Dynamo fails with `AttributeError`. This PR fixes the issue by properly tracing property setter functions.

## Problem

Property setters were not being traced correctly because `property.__set__` is a slot wrapper (C function), not a Python function. When Dynamo encountered a property setter like `obj.names = value`, it would:

1. Not trace the property's `fset` function
2. Run the setter code on uninitialized example objects
3. Fail when the setter accessed nested objects that were missing attributes

This caused the asymmetry where `obj._set_names(value)` worked but `obj.names = value` failed, even though they execute identical code.

## Solution

Added special handling for property descriptors in `UserDefinedObjectVariable.method_setattr_standard`:

1. **New method `try_get_property_fset`**: Detects if an attribute is a property with an `fset` function
2. **Trace `fset` directly**: When a property setter is detected, we now build a `VariableTracker` for `fset` and call it, just like we do for regular method calls
3. **Skip reconstruction for properties**: Updated `should_reconstruct_setattr` to skip properties with `fset` since we trace them directly

## Test

Added `test_mutable_mapping_property_setter_nested` that verifies both direct method calls and property setters work identically on nested `MutableMapping` objects.

## Workaround (for users on older PyTorch versions)

Call methods directly instead of using property setters:
```python
# Instead of:
obj.names = ["time"]

# Use:
obj._set_names(["time"])
```

This workaround was applied in TensorDict: https://github.com/pytorch/tensordict/pull/1521



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo