### PR TITLE
Add __getitems__ to TensorDataset for faster DataLoader iteration

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -436,6 +436,90 @@ class TestTensorDataset(TestCase):
         with self.assertRaisesRegex(AssertionError, "Size mismatch between tensors"):
             TensorDataset(tensor1, tensor2, tensor3)
 
+    def test_getitems(self):
+        """Test batch fetching with __getitems__ for improved DataLoader performance."""
+        t = torch.randn(15, 10, 2, 3)
+        labels = torch.randn(15, 5)
+        source = TensorDataset(t, labels)
+
+        # Test that __getitems__ exists
+        self.assertTrue(hasattr(source, "__getitems__"))
+
+        # Test fetching multiple indices at once
+        indices = [0, 5, 10, 14]
+        batch = source.__getitems__(indices)
+
+        # Should return a list of samples
+        self.assertIsInstance(batch, list)
+        self.assertEqual(len(batch), len(indices))
+
+        # Each sample should be a tuple matching __getitem__ output
+        for i, idx in enumerate(indices):
+            self.assertIsInstance(batch[i], tuple)
+            self.assertEqual(len(batch[i]), 2)
+            # Verify data matches what __getitem__ would return
+            expected = source[idx]
+            self.assertEqual(batch[i][0], expected[0])
+            self.assertEqual(batch[i][1], expected[1])
+
+    def test_getitems_single_tensor(self):
+        """Test __getitems__ with a single tensor dataset."""
+        t = torch.randn(10, 5)
+        source = TensorDataset(t)
+
+        indices = [1, 3, 7]
+        batch = source.__getitems__(indices)
+
+        self.assertEqual(len(batch), 3)
+        for i, idx in enumerate(indices):
+            self.assertEqual(batch[i][0], t[idx])
+
+    def test_getitems_empty_indices(self):
+        """Test __getitems__ with empty indices list."""
+        t = torch.randn(10, 5)
+        source = TensorDataset(t)
+
+        batch = source.__getitems__([])
+        self.assertEqual(len(batch), 0)
+
+    def test_getitems_1d_tensor(self):
+        """Test __getitems__ with list indices including a 1D tensor."""
+        # batch_sampler yields lists, not tuples. This test ensures
+        # __getitems__ handles indices correctly, including for 1D tensors.
+        t = torch.randn(100, 2, 3, 5)
+        labels = torch.randperm(50).repeat(2)  # 1D tensor
+        source = TensorDataset(t, labels)
+
+        indices = [0, 5, 10]
+        batch = source.__getitems__(indices)
+
+        self.assertEqual(len(batch), 3)
+        for i, idx in enumerate(indices):
+            expected = source[idx]
+            self.assertEqual(batch[i][0], expected[0])
+            self.assertEqual(batch[i][1], expected[1])
+
+    def test_getitems_with_dataloader(self):
+        """Test that __getitems__ integrates correctly with DataLoader."""
+        t = torch.randn(100, 10)
+        labels = torch.randint(0, 10, (100,))
+        source = TensorDataset(t, labels)
+
+        loader = DataLoader(source, batch_size=16, shuffle=False)
+
+        # Verify DataLoader produces correct batches
+        batch_count = 0
+        for batch_t, batch_labels in loader:
+            start_idx = batch_count * 16
+            end_idx = min(start_idx + 16, 100)
+            expected_t = t[start_idx:end_idx]
+            expected_labels = labels[start_idx:end_idx]
+            self.assertEqual(batch_t, expected_t)
+            self.assertEqual(batch_labels, expected_labels)
+            batch_count += 1
+
+        self.assertEqual(batch_count, 7)  # ceil(100/16) = 7 batches
+
 
 @unittest.skipIf(
     TEST_WITH_TSAN,

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -202,8 +202,29 @@ class TensorDataset(Dataset[tuple[Tensor, ...]]):
             raise AssertionError("Size mismatch between tensors")
         self.tensors = tensors
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> tuple[Tensor, ...]:
         return tuple(tensor[index] for tensor in self.tensors)
+
+    def __getitems__(self, indices: list) -> list[tuple[Tensor, ...]]:
+        r"""Fetch multiple samples by indices in a single operation.
+
+        This method enables efficient batch fetching for DataLoader by using
+        advanced tensor indexing instead of individual __getitem__ calls.
+
+        Args:
+            indices: List of indices to fetch.
+
+        Returns:
+            List of tuples, where each tuple contains the tensors for one sample.
+
+        Example:
+            >>> t1 = torch.tensor([[1, 2], [3, 4], [5, 6]])
+            >>> t2 = torch.tensor([7, 8, 9])
+            >>> ds = TensorDataset(t1, t2)
+            >>> ds.__getitems__([0, 2])
+            [(tensor([1, 2]), tensor(7)), (tensor([5, 6]), tensor(9))]
+        """
+        return list(zip(*(tensor[indices] for tensor in self.tensors)))
 
     def __len__(self) -> int:
         return self.tensors[0].size(0)


### PR DESCRIPTION
Fixes #106704

## Summary

Implements the `__getitems__` protocol for `TensorDataset`, enabling batch fetching of samples instead of individual `__getitem__` calls.

### Root Cause

`TensorDataset` was the only standard dataset missing `__getitems__` — both `StackDataset` and `Subset` already implement it. Without it, `_MapDatasetFetcher` falls back to per-sample `__getitem__` calls in a Python loop, missing the opportunity for batched tensor indexing.

### Implementation

Uses `tensor[indices]` (advanced indexing) to gather all requested rows from each tensor in a single operation, then zips the results into per-sample tuples. This matches the pattern used by `Subset.__getitems__`.

### Testing Performed

- `test_getitems`: basic multi-tensor batch fetching, verifies consistency with `__getitem__`
- `test_getitems_single_tensor`: single-tensor edge case
- `test_getitems_empty_indices`: empty indices edge case
- `test_getitems_1d_tensor`: 1D tensor indexing (BatchSampler yields lists)
- `test_getitems_with_dataloader`: full DataLoader integration test

cc @VitalyFedyunin @ejguan