### PR TITLE
[Inductor] Add TlxGemmConfig for TLX template autotuning support

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2417,8 +2417,15 @@ class test_configs:
 
     # regex to control the set of considered autotuning
     # choices (aka configs) by name and / or description
-    autotune_choice_name_regex: Optional[str] = None
-    autotune_choice_desc_regex: Optional[str] = None
+    # Can be set via TORCHINDUCTOR_AUTOTUNE_CHOICE_NAME_REGEX and
+    # TORCHINDUCTOR_AUTOTUNE_CHOICE_DESC_REGEX environment variables
+
+    autotune_choice_name_regex: Optional[str] = os.environ.get(
+        "TORCHINDUCTOR_AUTOTUNE_CHOICE_NAME_REGEX"
+    )
+    autotune_choice_desc_regex: Optional[str] = os.environ.get(
+        "TORCHINDUCTOR_AUTOTUNE_CHOICE_DESC_REGEX"
+    )
 
     graphsafe_rng_func_ignores_fallback_random = False
 


### PR DESCRIPTION
Summary:
D89186750 introduced BlackwellGPUGemmConfig which changed how config-specific fields are handled in the autotuning deduplication logic. TLX templates were broken because their configs with different epilogue_subtile values were incorrectly deduplicated.

This adds TlxGemmConfig dataclass with TLX-specific fields (group_size_m, smem_num, tmem_num, epilogue_subtile) and integrates it with the template heuristics system via get_tlx_config_key_and_kwargs(), following the encapsulation pattern used by append_tlx().

Test Plan:
`buck run fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:tlx_templates -- -r test_tlx_mm`

All 8 TLX template tests pass (blackwell_gemm_clc and blackwell_gemm_2cta with dynamic=True/False and epilogue_subtile=True/False).

Differential Revision: D90337115




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo