### PR TITLE
Add weight dtype validation to CUDA nll_loss

### DIFF
--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -287,6 +287,15 @@ void nll_loss_forward_out_cuda_template(
 
   auto weight_ = weight.defined() ? weight.contiguous() : weight;
 
+  if (weight_.defined()) {
+  TORCH_CHECK(
+      input.scalar_type() == weight_.scalar_type(),
+      "expected weight tensor dtype to be ",
+      input.scalar_type(),
+      " but found ",
+      weight_.scalar_type());
+  }
+
   if (reduction == Reduction::None && n_dims == 2) {
     at::native::resize_output(output, {batch_size});
     total_weight.zero_();

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -290,7 +290,7 @@ void nll_loss_forward_out_cuda_template(
   if (weight_.defined()) {
   TORCH_CHECK(
       input.scalar_type() == weight_.scalar_type(),
-      "expected weight tensor dtype to be ",
+      "expected scalar type ",
       input.scalar_type(),
       " but found ",
       weight_.scalar_type());

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -418,6 +418,14 @@ static void nllnd_loss_forward_impl(Tensor& output,
                                     bool is2D) {
   TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(output.scalar_type()),
                               "nlld_loss for complex is not supported for MPS");
+  if (weight.defined()) {
+    TORCH_CHECK(
+        input_arg.scalar_type() == weight.scalar_type(),
+        "expected scalar type ",
+        input_arg.scalar_type(),
+        " but found ",
+        weight.scalar_type());
+  }
   std::vector<long long> reshapedTarget(target_arg.sizes().begin(), target_arg.sizes().end());
   reshapedTarget.push_back(1);
 

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -419,12 +419,11 @@ static void nllnd_loss_forward_impl(Tensor& output,
   TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(output.scalar_type()),
                               "nlld_loss for complex is not supported for MPS");
   if (weight.defined()) {
-    TORCH_CHECK(
-        input_arg.scalar_type() == weight.scalar_type(),
-        "expected scalar type ",
-        input_arg.scalar_type(),
-        " but found ",
-        weight.scalar_type());
+    TORCH_CHECK(input_arg.scalar_type() == weight.scalar_type(),
+                "expected scalar type ",
+                input_arg.scalar_type(),
+                " but found ",
+                weight.scalar_type());
   }
   std::vector<long long> reshapedTarget(target_arg.sizes().begin(), target_arg.sizes().end());
   reshapedTarget.push_back(1);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12324,15 +12324,6 @@ class TestNNDeviceType(NNTestCase):
             out_cpu.backward()
             with torch.no_grad():
                 self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol))
-    
-    @onlyCUDA
-    def test_nll_loss_empty_tensor_weight_dtype_mismatch(self, device):
-        input_t = torch.tensor([], dtype=torch.float32, device=device).reshape(0, 0)
-        weight_t = torch.tensor([], dtype=torch.float16, device=device)
-        target_t = torch.tensor([], dtype=torch.long, device=device)
-
-        with self.assertRaisesRegex(RuntimeError, "expected weight tensor dtype to be Float but found Half"):
-            F.nll_loss(input_t, target_t, weight=weight_t)
 
     # Ref: https://github.com/pytorch/pytorch/issues/108345
     @onlyCUDA

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12324,6 +12324,15 @@ class TestNNDeviceType(NNTestCase):
             out_cpu.backward()
             with torch.no_grad():
                 self.assertTrue(torch.allclose(input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol))
+    
+    @onlyCUDA
+    def test_nll_loss_empty_tensor_weight_dtype_mismatch(self, device):
+        input_t = torch.tensor([], dtype=torch.float32, device=device).reshape(0, 0)
+        weight_t = torch.tensor([], dtype=torch.float16, device=device)
+        target_t = torch.tensor([], dtype=torch.long, device=device)
+
+        with self.assertRaisesRegex(RuntimeError, "expected weight tensor dtype to be Float but found Half"):
+            F.nll_loss(input_t, target_t, weight=weight_t)
 
     # Ref: https://github.com/pytorch/pytorch/issues/108345
     @onlyCUDA

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3243,7 +3243,8 @@ def module_error_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_gr
     Regression test for device parity between CPU and CUDA with empty tensors.
     """
     input_t = torch.tensor([], device=device, dtype=dtype).reshape((0, 0))
-    weight_t = torch.tensor([], device=device, dtype=torch.float16)
+    weight_dtype = torch.float32 if dtype == torch.float16 else torch.float16
+    weight_t = torch.tensor([], device=device, dtype=weight_dtype)
     target_t = torch.tensor([], device=device, dtype=torch.long)
 
     return [
@@ -3254,7 +3255,7 @@ def module_error_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_gr
             ),
             error_on=ModuleErrorEnum.FORWARD_ERROR,
             error_type=RuntimeError,
-            error_regex=r"expected scalar type \w+ but found Half"
+            error_regex=r"expected scalar type \w+ but found \w+"
         ),
     ]
 

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3242,7 +3242,7 @@ def module_error_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_gr
     Error inputs for NLLLoss that test weight dtype must match input dtype.
     Regression test for device parity between CPU and CUDA with empty tensors.
     """
-    input_t = torch.tensor([], device=device, dtype=torch.float32).reshape((0, 0))
+    input_t = torch.tensor([], device=device, dtype=dtype).reshape((0, 0))
     weight_t = torch.tensor([], device=device, dtype=torch.float16)
     target_t = torch.tensor([], device=device, dtype=torch.long)
 
@@ -3254,7 +3254,7 @@ def module_error_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_gr
             ),
             error_on=ModuleErrorEnum.FORWARD_ERROR,
             error_type=RuntimeError,
-            error_regex="expected weight tensor dtype to be Float but found Half"
+            error_regex=r"expected scalar type \w+ but found Half"
         ),
     ]
 

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3237,6 +3237,27 @@ rnn_gru_lstm_module_info_decorators = (
 
 # Start of module error inputs functions.
 
+def module_error_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_grad, training, **kwargs):
+    """
+    Error inputs for NLLLoss that test weight dtype must match input dtype.
+    Regression test for device parity between CPU and CUDA with empty tensors.
+    """
+    input_t = torch.tensor([], device=device, dtype=torch.float32).reshape((0, 0))
+    weight_t = torch.tensor([], device=device, dtype=torch.float16)
+    target_t = torch.tensor([], device=device, dtype=torch.long)
+
+    return [
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(weight=weight_t),
+                forward_input=FunctionInput(input_t, target_t),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex="expected weight tensor dtype to be Float but found Half"
+        ),
+    ]
+
 def module_error_inputs_torch_nn_RNN_GRU_Cell(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
     samples = [
@@ -3994,6 +4015,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.NLLLoss,
                module_inputs_func=module_inputs_torch_nn_NLLLoss,
+               module_error_inputs_func=module_error_inputs_torch_nn_NLLLoss,
                skips=(
                    # No channels_last support for loss functions.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),


### PR DESCRIPTION
Fixes #171931 

The CUDA implementation of ```nll_loss_forward``` was missing a dtype validation check for the weight tensor when the input is empty. This caused it to silently return ```NaN``` instead of raising an error like the CPU implementation does.

Added a ```TORCH_CHECK``` to validate that the weight tensor dtype matches the input dtype before the early return for empty tensors, ensuring device parity between CPU and CUDA.
