### PR TITLE
Skip test_lobpcg when running with slow gradcheck

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -76,6 +76,7 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfMPS,
     skipIfNoLapack,
+    skipIfSlowGradcheckEnv,
     skipIfTorchDynamo,
     skipIfWindows,
     skipIfXpu,
@@ -4563,6 +4564,7 @@ class TestAutograd(TestCase):
         torch.autograd.backward(r2, grad)
         self.assertEqual(input1.grad, input2.grad, rtol=0.01, atol=0.0)
 
+    @skipIfSlowGradcheckEnv
     @skipIfNoLapack
     def test_lobpcg(self):
         def func(k, A, largest=True, B=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172021

This test is causing
```
PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 PYTORCH_TEST_WITH_SLOW_GRADCHECK=1 python test/test_autograd.py TestAutograd.test_lobpcg
```
to fail periodically.

Claude was able to come up with a "fix" but it was bigger impact than I was willing to try to understand:

Investigation attempted several fixes:
1. Fixed non-deterministic RNG in _symeig_backward_partial_eigenspace by
   adding manual_seed(0) to the torch.Generator
2. Fixed incorrect use of loop variable 'k' instead of D.size(-1) for
   num_eigenvalues in the backward computation
3. Added symmetrization of input matrix in the non-grad code path

However, these fixes were insufficient. The slow gradcheck computes the
full Jacobian matrix, which exposes inherent numerical precision issues
in the lobpcg backward pass that the fast gradcheck (using random
projections) does not catch. Relaxing tolerances required atol=1e-1 for
gradcheck and atol=5 for gradgradcheck, which are unacceptably high.

Since the test passes with fast gradcheck and the underlying precision
issues are fundamental to the algorithm, the pragmatic solution is to
skip the test during slow gradcheck runs.