### PR TITLE
Fix FA3 wheel stats and tests

### DIFF
--- a/.ci/pytorch/test_fa3_abi_stable.sh
+++ b/.ci/pytorch/test_fa3_abi_stable.sh
@@ -16,11 +16,12 @@ env
 echo "Testing FA3 stable wheel still works with currently built torch"
 
 echo "Installing ABI Stable FA3 wheel"
-# The wheel was built on https://github.com/Dao-AILab/flash-attention/commit/b3846b059bf6b143d1cd56879933be30a9f78c81
-# on torch nightly torch==2.9.0.dev20250830+cu129
+# The wheel was built on https://github.com/Dao-AILab/flash-attention/commit/3e87e421f898c6919fa417d00e5afcec5909debe
+# on torch 2.10rc for CUDA 12.8
 $MAYBE_SUDO pip -q install https://s3.amazonaws.com/ossci-linux/wheels/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl
 
 pushd flash-attention/hopper
+export FLASH_ATTENTION_ENABLE_OPCHECK=TRUE  # Enable testing for compile on the smoke tests
 export PYTHONPATH=$PWD
 pytest -v -s \
   "test_flash_attn.py::test_flash_attn_output[1-1-192-False-False-False-0.0-False-False-mha-dtype0]" \

--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -24,7 +24,7 @@ on:
       timeout-minutes:
         required: false
         type: number
-        default: 30
+        default: 60
         description: |
           Set the maximum (in minutes) how long the workflow should take to finish
       s3-bucket:


### PR DESCRIPTION
- increase the timeout cuz it takes super long just to pull a docker container
- I uploaded a new wheel so am also updating the description
- I added the env var so we also test compile on the smoke tests

Note, the bc test will still break cuz it's broken on main for FA3 right now, but that should get rectified in the coming days.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #172030

