### PR TITLE
[ONNX] Expose ONNXProgram.rename_axes for renaming dims

### DIFF
--- a/test/onnx/exporter/test_onnx_program.py
+++ b/test/onnx/exporter/test_onnx_program.py
@@ -1,0 +1,191 @@
+# Owner(s): ["module: onnx"]
+"""Unit tests for the ONNXProgram class."""
+
+from __future__ import annotations
+
+import torch
+from torch.onnx._internal._lazy_import import onnx_ir as ir
+from torch.testing._internal import common_utils
+
+
+class ONNXProgramRenameAxesTest(common_utils.TestCase):
+    """Tests for ONNXProgram.rename_axes method."""
+
+    def _create_onnx_program_with_dynamic_shapes(
+        self, input_shapes: list[list[str | int]]
+    ) -> torch.onnx.ONNXProgram:
+        """Helper to create an ONNXProgram with specified dynamic shapes."""
+        from torch.onnx._internal.exporter._onnx_program import ONNXProgram
+
+        inputs = []
+        for i, shape in enumerate(input_shapes):
+            inputs.append(
+                ir.Value(
+                    name=f"input_{i}",
+                    type=ir.DataType.FLOAT,
+                    shape=ir.Shape(shape),
+                )
+            )
+
+        model = ir.Model(
+            ir.Graph(
+                inputs=inputs,
+                outputs=[
+                    ir.Value(
+                        name="output",
+                        type=ir.DataType.FLOAT,
+                        shape=ir.Shape(["s0", "s1"]),
+                    )
+                ],
+                nodes=[],
+            ),
+            ir_version=9,
+            producer_name="pytorch",
+            producer_version=torch.__version__,
+        )
+        return ONNXProgram(model, exported_program=None)
+
+    def test_rename_axes_with_string_keys(self):
+        """Test renaming axes using string keys."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes(
+            [["s0", "s1"], ["s0", "s2"]]
+        )
+
+        onnx_program.rename_axes(
+            {
+                "s0": "batch_size",
+                "s1": "sequence_length",
+                "s2": "hidden_size",
+            }
+        )
+
+        self.assertEqual(
+            onnx_program.model.graph.inputs[0].shape,
+            ir.Shape(["batch_size", "sequence_length"]),
+        )
+        self.assertEqual(
+            onnx_program.model.graph.inputs[1].shape,
+            ir.Shape(["batch_size", "hidden_size"]),
+        )
+        # Outputs should also be renamed
+        self.assertEqual(
+            onnx_program.model.graph.outputs[0].shape,
+            ir.Shape(["batch_size", "sequence_length"]),
+        )
+
+    def test_rename_axes_with_symbolic_dim_keys(self):
+        """Test renaming axes using SymbolicDim objects as keys."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes(
+            [["s0", "s1"], ["s0", "s2"]]
+        )
+
+        # Get SymbolicDim objects from the model
+        batch_dim = onnx_program.model.graph.inputs[0].shape[0]
+        seq_dim = onnx_program.model.graph.inputs[0].shape[1]
+
+        onnx_program.rename_axes(
+            {
+                batch_dim: "batch_size",
+                seq_dim: "sequence_length",
+            }
+        )
+
+        self.assertEqual(
+            onnx_program.model.graph.inputs[0].shape,
+            ir.Shape(["batch_size", "sequence_length"]),
+        )
+        # s0 should be renamed in both inputs
+        self.assertEqual(
+            onnx_program.model.graph.inputs[1].shape[0],
+            ir.SymbolicDim("batch_size"),
+        )
+
+    def test_rename_axes_with_mixed_string_and_symbolic_dim_keys(self):
+        """Test renaming axes using a mix of string and SymbolicDim keys."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes(
+            [["s0", "s1", "s2"]]
+        )
+
+        # Get SymbolicDim object from the model
+        batch_dim = onnx_program.model.graph.inputs[0].shape[0]
+
+        onnx_program.rename_axes(
+            {
+                batch_dim: "batch_size",
+                "s1": "sequence_length",
+                "s2": "hidden_size",
+            }
+        )
+
+        self.assertEqual(
+            onnx_program.model.graph.inputs[0].shape,
+            ir.Shape(["batch_size", "sequence_length", "hidden_size"]),
+        )
+
+    def test_rename_axes_with_complex_shape_expressions(self):
+        """Test renaming axes in complex shape expressions like 's1 + s2'."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes(
+            [["s0", "s1 + s2", "s1*2"]]
+        )
+
+        onnx_program.rename_axes(
+            {
+                "s0": "batch_size",
+                "s1": "seq_len",
+                "s2": "past_seq_len",
+                "s1 + s2": "total_seq_len",
+            }
+        )
+
+        self.assertEqual(
+            onnx_program.model.graph.inputs[0].shape,
+            ir.Shape(["batch_size", "total_seq_len", "seq_len*2"]),
+        )
+
+    def test_rename_axes_with_nonexistent_axis_is_ignored(self):
+        """Test that renaming a non-existent axis is silently ignored."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes([["s0", "s1"]])
+
+        # Include a mapping for a non-existent axis
+        onnx_program.rename_axes(
+            {
+                "s0": "batch_size",
+                "nonexistent": "should_be_ignored",
+            }
+        )
+
+        # Only s0 should be renamed
+        self.assertEqual(
+            onnx_program.model.graph.inputs[0].shape,
+            ir.Shape(["batch_size", "s1"]),
+        )
+
+    def test_rename_axes_with_empty_mapping(self):
+        """Test renaming with an empty mapping does nothing."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes([["s0", "s1"]])
+
+        original_shape = onnx_program.model.graph.inputs[0].shape
+
+        onnx_program.rename_axes({})
+
+        self.assertEqual(onnx_program.model.graph.inputs[0].shape, original_shape)
+
+    def test_rename_axes_with_static_dimensions_unchanged(self):
+        """Test that static (integer) dimensions are not affected by renaming."""
+        onnx_program = self._create_onnx_program_with_dynamic_shapes([["s0", 10, "s1"]])
+
+        onnx_program.rename_axes(
+            {
+                "s0": "batch_size",
+                "s1": "hidden_size",
+            }
+        )
+
+        self.assertEqual(
+            onnx_program.model.graph.inputs[0].shape,
+            ir.Shape(["batch_size", 10, "hidden_size"]),
+        )
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/onnx/exporter/test_onnx_program.py
+++ b/test/onnx/exporter/test_onnx_program.py
@@ -30,13 +30,7 @@ class ONNXProgramRenameAxesTest(common_utils.TestCase):
         model = ir.Model(
             ir.Graph(
                 inputs=inputs,
-                outputs=[
-                    ir.Value(
-                        name="output",
-                        type=ir.DataType.FLOAT,
-                        shape=ir.Shape(["s0", "s1"]),
-                    )
-                ],
+                outputs=[inputs[0]],
                 nodes=[],
             ),
             ir_version=9,

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -74,15 +74,27 @@ def _replace_names(shape_expr: str, rename_mapping: dict[str, str]) -> str:
     return shape_expr
 
 
-def rename_axis(model: ir.Model, rename_mapping: dict[str, str]) -> None:
+def rename_axis(
+    model: ir.Model, rename_mapping: dict[str | ir.SymbolicDim, str]
+) -> None:
     """Rename dynamic axes in a model according to the specified dynamic_axes names."""
+
+    # Create a mapping from string to string for easier replacement
+    string_mapping: dict[str, str] = {}
+    for key, value in tuple(rename_mapping.items()):
+        if isinstance(key, ir.SymbolicDim):
+            if isinstance(key.value, str):
+                string_mapping[key.value] = value
+            # Skip non-string keys (None)
+        else:
+            string_mapping[key] = value
 
     # NOTE: Mapping needs to be srted by length because the shape expression
     # could have multiple ways to be expressed, for example,
     # {"s1": sequence_length, "s11": "past_sequence_length", "s1 + s11": "masked_sequence_length"}
     # We prefer the replacement starts from the longest match.
     sorted_rename_mapping = dict(
-        sorted(rename_mapping.items(), key=lambda item: len(item[0]), reverse=True)
+        sorted(string_mapping.items(), key=lambda item: len(item[0]), reverse=True)
     )
     for value in _all_values(model):
         if value.shape is None:

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -89,7 +89,7 @@ def rename_axis(
         else:
             string_mapping[key] = value
 
-    # NOTE: Mapping needs to be srted by length because the shape expression
+    # NOTE: Mapping needs to be sorted by length because the shape expression
     # could have multiple ways to be expressed, for example,
     # {"s1": sequence_length, "s11": "past_sequence_length", "s1 + s11": "masked_sequence_length"}
     # We prefer the replacement starts from the longest match.

--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -85,9 +85,18 @@ def rename_axis(
         if isinstance(key, ir.SymbolicDim):
             if isinstance(key.value, str):
                 string_mapping[key.value] = value
-            # Skip non-string keys (None)
-        else:
+            else:
+                raise ValueError(
+                    f"Invalid SymbolicDim value in rename_mapping: {key.value!r}. "
+                    "Expected str."
+                )
+        elif isinstance(key, str):
             string_mapping[key] = value
+        else:
+            raise ValueError(
+                f"Invalid key type in rename_mapping: {type(key)}({key!r}). Expected "
+                "str or ir.SymbolicDim."
+            )
 
     # NOTE: Mapping needs to be sorted by length because the shape expression
     # could have multiple ways to be expressed, for example,

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -470,8 +470,8 @@ ONNXProgram(
         Args:
             rename_mapping: A dictionary mapping old axes to new axis names.
                 Keys can be either:
-                - String axis names (e.g., "s1", "s2")
-                - SymbolicDim objects obtained from the model
+                * String axis names (e.g., "s1", "s2")
+                * SymbolicDim objects obtained from the model
                   (e.g., onnx_program.model.graph.inputs[0].shape[0])
                 Values must be strings representing the new axis names.
         """

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -458,6 +458,7 @@ ONNXProgram(
         """Rename axes in a model according to the specified rename mapping.
 
         Example::
+
             batch = onnx_program.model.graph.inputs[0].shape[0]
             seq_len = onnx_program.model.graph.inputs[0].shape[2]
             rename_mapping = {

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -470,9 +470,11 @@ ONNXProgram(
         Args:
             rename_mapping: A dictionary mapping old axes to new axis names.
                 Keys can be either:
+
                 * String axis names (e.g., "s1", "s2")
                 * SymbolicDim objects obtained from the model
                   (e.g., onnx_program.model.graph.inputs[0].shape[0])
+
                 Values must be strings representing the new axis names.
         """
         _ir_passes.rename_axis(self.model, rename_mapping)

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -454,6 +454,23 @@ ONNXProgram(
             self._tempdir.cleanup()
             self._tempdir = None
 
+    def rename_axes(self, rename_mapping: dict[str | ir.SymbolicDim, str]) -> None:
+        """Rename axes in a model according to the specified rename mapping.
+
+        Example::
+            batch = onnx_program.model.graph.inputs[0].shape[0]
+            seq_len = onnx_program.model.graph.inputs[0].shape[2]
+            rename_mapping = {
+                batch: "batch",
+                seq_len: "seq_len",
+            }
+            onnx_program.rename_axes(rename_mapping)
+
+        Args:
+            rename_mapping: A dictionary mapping old axis names to new axis names.
+        """
+        _ir_passes.rename_axis(self.model, rename_mapping)
+
     def _rename_dynamic_axes(
         self,
         dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any],

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -468,7 +468,12 @@ ONNXProgram(
             onnx_program.rename_axes(rename_mapping)
 
         Args:
-            rename_mapping: A dictionary mapping old axis names to new axis names.
+            rename_mapping: A dictionary mapping old axes to new axis names.
+                Keys can be either:
+                - String axis names (e.g., "s1", "s2")
+                - SymbolicDim objects obtained from the model
+                  (e.g., onnx_program.model.graph.inputs[0].shape[0])
+                Values must be strings representing the new axis names.
         """
         _ir_passes.rename_axis(self.model, rename_mapping)
 


### PR DESCRIPTION
Users can now do this to rename dynamic shapes. Note that the current api does not allow users to change a static shape into a dynamic shape, or vice versa. Only renaming is allowed. Not sure if that's sufficient?

```py
batch = onnx_program.model.graph.inputs[0].shape[0]
seq_len = onnx_program.model.graph.inputs[0].shape[2]
rename_mapping = {
    batch: "batch",
    seq_len: "seq_len",
}
onnx_program.rename_axes(rename_mapping)
```

Fixes https://github.com/pytorch/pytorch/issues/171755

@titaiwangms @xadupre @gramalingam I find the way to access original dims a bit cumbersome (`onnx_program.model.graph.inputs[0].shape[0]`). Do you have a better idea?


cc @titaiwangms