### PR TITLE
[PT2 Compile] Manually Set Variable Memory Budget At Model Definition

### DIFF
--- a/torch/_functorch/_activation_checkpointing/memory_budget.py
+++ b/torch/_functorch/_activation_checkpointing/memory_budget.py
@@ -1,0 +1,189 @@
+# mypy: allow-untyped-defs
+
+from typing import Literal, Optional
+
+import torch
+import torch.fx.traceback as fx_traceback
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+__all__ = ["MemoryBudgetMode", "set_memory_budget"]
+
+
+def _ensure_memory_budget_in_copy_meta_fields() -> None:
+    """
+    Ensure 'memory_budget' is in _COPY_META_FIELDS for FX metadata propagation.
+
+    This is a defensive fallback - if proxy.py already contains 'memory_budget',
+    this is a no-op. Otherwise, it registers the field at runtime.
+    """
+    import torch.fx.proxy as fx_proxy
+
+    if "memory_budget" not in fx_proxy._COPY_META_FIELDS:
+        fx_proxy._COPY_META_FIELDS.append("memory_budget")
+
+
+# Ensure memory_budget is registered for FX metadata propagation
+_ensure_memory_budget_in_copy_meta_fields()
+
+
+def set_memory_budget(budget: float) -> None:
+    """
+    Set the memory budget for activation checkpointing on subsequent FX nodes.
+
+    This function directly sets the memory_budget metadata that the activation
+    checkpointing partitioner uses to decide what to save vs recompute.
+
+    The memory budget controls the trade-off between memory usage and
+    recomputation during the backward pass:
+    - budget=0.0: Aggressive recomputation, minimal memory (save almost nothing)
+    - budget=1.0: No recomputation, maximum memory (save everything)
+    - budget=0.5: Balanced approach
+
+    Args:
+        budget: Float between 0 and 1 controlling memory/recompute trade-off.
+
+    Example:
+        >>> # In a model's forward method:
+        >>> set_memory_budget(0.1)  # Aggressive recomputation for expensive encoder
+        >>> x = self.encoder(x)
+        >>> set_memory_budget(0.8)  # Save most activations for cheap head
+        >>> x = self.head(x)
+
+    Note:
+        This function only has an effect during torch.compile tracing.
+        In eager mode, it is a no-op.
+    """
+    if not isinstance(budget, (int, float)):
+        raise TypeError(f"budget must be a float, got {type(budget)}")
+    if not (0.0 <= budget <= 1.0):
+        raise ValueError(f"budget must be between 0 and 1, got {budget}")
+
+    # Check if we're being traced by PT2
+    # ProxyTorchDispatchMode is active during AOTAutograd's FX tracing
+    is_fx_tracing = (
+        torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.PROXY) is not None
+    )
+
+    # Also check if Dynamo is currently tracing
+    # This catches the case where we're in the Dynamo graph capture phase
+    is_dynamo_tracing = torch._dynamo.is_compiling()
+
+    if is_fx_tracing or is_dynamo_tracing:
+        fx_traceback.current_meta["memory_budget"] = float(budget)
+
+
+class MemoryBudgetMode(TorchDispatchMode):
+    """
+    A TorchDispatchMode that sets memory_budget metadata on FX nodes during
+    PT2 compilation for activation checkpointing control.
+
+    The memory budget controls the trade-off between memory usage and
+    recomputation during the backward pass:
+    - budget=0.0: Aggressive recomputation, minimal memory (save almost nothing)
+    - budget=1.0: No recomputation, maximum memory (save everything)
+    - budget=0.5: Balanced approach
+
+    Args:
+        budget: Float between 0 and 1 controlling memory/recompute trade-off.
+        strategy: How to handle nested MemoryBudgetMode contexts.
+            - "override": Inner budget replaces outer (default)
+            - "min": Use minimum budget (most aggressive recomputation wins)
+            - "max": Use maximum budget (most memory-saving wins)
+
+    Example:
+        >>> # Basic usage
+        >>> with MemoryBudgetMode(0.3):
+        ...     output = model(input)
+
+        >>> # Nested with min strategy
+        >>> with MemoryBudgetMode(0.5):
+        ...     x = layer1(x)  # budget=0.5
+        ...     with MemoryBudgetMode(0.2, strategy="min"):
+        ...         x = layer2(x)  # budget=min(0.5, 0.2)=0.2
+
+    Note:
+        This mode only has an effect during torch.compile tracing.
+        In eager mode, it passes through operations unchanged.
+    """
+
+    def __init__(
+        self,
+        budget: float,
+        strategy: Literal["override", "min", "max"] = "override",
+    ):
+        super().__init__()
+        if not isinstance(budget, (int, float)):
+            raise TypeError(f"budget must be a float, got {type(budget)}")
+        if not (0.0 <= budget <= 1.0):
+            raise ValueError(f"budget must be between 0 and 1, got {budget}")
+        if strategy not in ("override", "min", "max"):
+            raise ValueError(
+                f"strategy must be 'override', 'min', or 'max', got {strategy}"
+            )
+
+        self.budget = float(budget)
+        self.strategy = strategy
+        self._prev_budget: Optional[float] = None
+
+    def __enter__(self):
+        # Save any existing budget from outer context
+        self._prev_budget = fx_traceback.current_meta.get("memory_budget", None)
+        # Set our effective budget so nested contexts can see it
+        fx_traceback.current_meta["memory_budget"] = self._get_effective_budget()
+        return super().__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Restore previous budget when exiting
+        if self._prev_budget is not None:
+            fx_traceback.current_meta["memory_budget"] = self._prev_budget
+        else:
+            fx_traceback.current_meta.pop("memory_budget", None)
+        return super().__exit__(exc_type, exc_val, exc_tb)
+
+    def _get_effective_budget(self) -> float:
+        """
+        Compute effective budget based on nesting strategy.
+        """
+        if self._prev_budget is None or self.strategy == "override":
+            return self.budget
+        elif self.strategy == "min":
+            return min(self.budget, self._prev_budget)
+        elif self.strategy == "max":
+            return max(self.budget, self._prev_budget)
+        else:
+            # Should never reach here due to __init__ validation
+            raise ValueError(f"Unknown strategy: {self.strategy}")
+
+    def __torch_dispatch__(self, func, _types, args=(), kwargs=None):
+        kwargs = kwargs if kwargs is not None else {}
+
+        # Check if we're being traced by PT2
+        # ProxyTorchDispatchMode is active during AOTAutograd's FX tracing
+        is_fx_tracing = (
+            torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.PROXY)
+            is not None
+        )
+
+        # Also check if Dynamo is currently tracing
+        is_dynamo_tracing = torch._dynamo.is_compiling()
+
+        if is_fx_tracing or is_dynamo_tracing:
+            fx_traceback.current_meta["memory_budget"] = self._get_effective_budget()
+
+        # Pass through to next mode/kernel unchanged
+        return func(*args, **kwargs)
+
+    def __repr__(self):
+        return f"MemoryBudgetMode(budget={self.budget}, strategy='{self.strategy}')"
+
+    @classmethod
+    def ignore_compile_internals(cls) -> bool:
+        """Allow torch.compile to trace through this mode without graph breaks.
+
+        Returns True so that this TorchDispatchMode does not cause graph breaks
+        when used inside a compiled function. The mode's effect (setting
+        memory_budget metadata on FX nodes) happens during tracing via
+        __torch_dispatch__, so we don't need Dynamo to special-case this mode.
+        """
+        return True


### PR DESCRIPTION
Summary:
This diff introduces a new feature that allows for manually setting a variable memory budget at model definition, enhancing the PT2 compile functionality. The change is implemented across two files: `fbcode/caffe2/torch/_functorch/_activation_checkpointing/memory_budget.py` and `xplat/caffe2/torch/_functorch/_activation_checkpointing/memory_budget.py`.

**Key Changes**

*   A new file `memory_budget.py`. This file contains the implementation of the `MemoryBudgetMode` and `set_memory_budget` function.
*   `MemoryBudgetMode` allows for setting memory budget metadata(picked up by partitioners.py) for specific parts of the model. 
*   The `set_memory_budget` function is used to set the memory budget for the model.


This change provides more control over memory usage in PT2 compilation, allowing developers to optimize memory allocation for their models manually. By setting a variable memory budget, developers can ensure that their models are trained and deployed efficiently, optimizing performance and reducing memory-related issues.

Test Plan:
### E2E Testing

I added print statements and kicked off a local run. At the partitioner level was able to observe that memory budget was varied:

https://www.internalfb.com/mlhub/pipeline/1575840746888976?tab=EXECUTION_DETAILS

```
[DEBUG PRINT Partitioner] Found memory_budget=0.3 on node cat
DEBUG PRINT memory budget 0.3
[DEBUG PRINT Partitioner] Found memory_budget=0.3 on node cat
DEBUG PRINT memory budget 0.3
[DEBUG PRINT Partitioner] Found memory_budget=0.2 on node mul_858
DEBUG PRINT memory budget 0.2
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node full_default
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node expand
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node add_71
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node expand
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node expand
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node expand
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node expand
DEBUG PRINT memory budget 0.8
[DEBUG PRINT Partitioner] Found memory_budget=0.8 on node expand
DEBUG PRINT memory budget 0.8
```

* Link to logs: https://fburl.com/logarithm/878p2jg5

---

Was able to get this by adding the following changes to the model definition:

```
class PMRankingOCGPUModelTrain(
    AdsTrainModel[
        PMRankingOCGPUModelConfig,
        EmbeddingBagCollectionsSparseArch,
        GroupBasedSplitEmbeddingBagCollectionSparseArchNonKJT,
    ]
):
    def __init__(
        self,
        model_config: PMRankingOCGPUModelConfig,
        sparse_arch: EmbeddingBagCollectionsSparseArch,
        device: Optional[torch.device] = None,
    ) -> None:
        super().__init__(
            model_config=model_config, sparse_arch=sparse_arch, device=device
        )

        sparse_arch_dim = self.sparse_arch.dim_by_embedding_group()

        self.model_config: PMRankingOCGPUModelConfig = aps_none_throws(model_config)

        user_arch_config: DSNNEntityArchConfig = aps_none_throws(
            self.model_config.entity_configs[USER_FEATURE_GROUP].arch
        )

        ## replace uhm_config with uhm_config from model_config

        uhm_config = self.model_config.entity_configs[USER_FEATURE_GROUP].uhm_config
        if uhm_config:
            user_arch_config.entity_module.user_embedding_arch.uhm_config = uhm_config

        object_arch_config: DSNNEntityArchConfig = aps_none_throws(
            self.model_config.entity_configs[OBJECT_FEATURE_GROUP].arch
        )

        mix_arch_config: MixArchConfig = aps_none_throws(
            self.model_config.entity_configs[MIX_FEATURE_GROUP].mix_arch
        )

        dsnn_config = DSNNConfig(
            user_arch=user_arch_config,
            object_arch=object_arch_config,
            mixed_arch=mix_arch_config,
        )

        self.user_dsi_embedding_dim: int = self._get_dsi_embedding_dim(
            USER_FEATURE_GROUP
        )
        self.object_dsi_embedding_dim: int = self._get_dsi_embedding_dim(
            OBJECT_FEATURE_GROUP
        )

        user_sparse_arch_dim = sparse_arch_dim["user:sparse_arch"]
        user_inputs = model_config.entity_configs[USER_FEATURE_GROUP].inputs

        object_sparse_arch_dim = sparse_arch_dim["object:sparse_arch"]
        object_inputs = model_config.entity_configs[OBJECT_FEATURE_GROUP].inputs

        # update the user entity input dim
        aps_none_throws(dsnn_config.user_arch).update_entity_input_dim(
            sparse_arch_dim=user_sparse_arch_dim,
            model_inputs_config=aps_none_throws(user_inputs),
            embedding_dim=self.user_dsi_embedding_dim,
        )

        # update the object entity input dim
        aps_none_throws(dsnn_config.object_arch).update_entity_input_dim(
            sparse_arch_dim=object_sparse_arch_dim,
            model_inputs_config=aps_none_throws(object_inputs),
            embedding_dim=self.object_dsi_embedding_dim,
        )

        self.dsnn = DSNN(dsnn_config)

        self.task_archs = TaskArchs(config=model_config.task_archs)

        self.kt_regroup: KTRegroupAsDict = adjust_kt_regroup(
            sparse_arch=self.sparse_arch,
            enable_bf16_train=self.model_config.enable_bf16_train or False,
        )
        self.concat_kjt_id_list_features = ConcatenateKJTs()
        self.concat_kjt_id_score_list_features = ConcatenateKJTs()

    def _get_dsi_embedding_dim(self, entity: str) -> int:
        return self.model_config.entity_configs[entity].dense_embedding_dim

    def _get_sparse_arch_dict(self, input: ModelInput) -> Dict[str, torch.Tensor]:
        id_list_features = self.concat_kjt_id_list_features(
            user_features=input.id_list_features.get(USER_FEATURE_GROUP, None),
            mix_features=input.id_list_features.get(MIX_FEATURE_GROUP, None),
            object_features=input.id_list_features.get(OBJECT_FEATURE_GROUP, None),
        )
        id_score_list_features = self.concat_kjt_id_score_list_features(
            user_features=input.id_score_list_features.get(USER_FEATURE_GROUP, None),
            mix_features=input.id_score_list_features.get(MIX_FEATURE_GROUP, None),
            object_features=input.id_score_list_features.get(
                OBJECT_FEATURE_GROUP, None
            ),
        )

        with record_function("## forward:sparse_arch ##"):
            embs_kt_list = self.sparse_arch(
                id_list_features=id_list_features,
                id_score_list_features=id_score_list_features,
            )

        # NOTE: Regroup as dict is intentionally put after the dense arch to overlap
        #       the dense compute with sparse embedding all to alls. Placing this
        #       before the dense embeddings has non-trivial performance degradations.
        with record_function("## forward:kt regroup as dict ##"):
            pooled_embs = self.kt_regroup(keyed_tensors=embs_kt_list)

            # delete embs_kt_list after it's regrouped to save peak memory
            del embs_kt_list

        return pooled_embs

    def forward(
        self, train_input: TrainModelInput
    ) -> Tuple[torch.Tensor, AdsTrainOutput]:
        # Set medium memory budget (0.3) for sparse arch / embedding operations
        # These are moderately expensive and benefit from some recomputation
        **with MemoryBudgetMode(0.3):**
            pooled_embs = self._get_sparse_arch_dict(input=train_input.model_input)

            user_float_features = train_input.model_input.float_features[
                USER_FEATURE_GROUP
            ]
            object_float_features = train_input.model_input.float_features[
                OBJECT_FEATURE_GROUP
            ]

            user_arch_config: DSNNEntityArchConfig = aps_none_throws(
                self.model_config.entity_configs[USER_FEATURE_GROUP].arch
            )
            user_entity_module = aps_none_throws(user_arch_config.entity_module)
            uhm_config = (
                user_entity_module.event_submodels_dict
                or user_entity_module.user_embedding_arch
            )
            if uhm_config:
                event_inputs = train_input.model_input.event_based_features[
                    USER_FEATURE_GROUP
                ]
                sid = train_input.supervision_input.separable_id
                current_timestamps = (
                    event_inputs.current_timestamps
                    if user_entity_module.event_submodels_dict
                    else train_input.supervision_input.timestamp
                )
                user_history_lengths = event_inputs.num_objects_seqs
                user_history_timestamp = event_inputs.uhm_history_timestamps
                event_timestamps = event_inputs.event_timestamps_dict
                user_history_id_list_features = event_inputs.event_id_list_features_seqs
                user_event_id_list_inverted_indexes = (
                    event_inputs.event_id_list_feature_invert_indexes
                )
            else:
                current_timestamps = None
                user_history_lengths = None
                user_history_timestamp = None
                user_history_id_list_features = None
                sid = None
                event_timestamps = None
                user_event_id_list_inverted_indexes = None

            user_embedding_features = train_input.model_input.embedding_features[
                USER_FEATURE_GROUP
            ]
            object_embedding_features = train_input.model_input.embedding_features[
                OBJECT_FEATURE_GROUP
            ]

            user_pooled_embs = torch_split_fx_wrap(
                pooled_embs["user:sparse_arch"],
                self.user_dsi_embedding_dim,
                1,
            )
            object_pooled_embs = torch_split_fx_wrap(
                pooled_embs["object:sparse_arch"],
                self.object_dsi_embedding_dim,
                1,
            )

            dsnn_input = DSNNInput(
                user_float_features=user_float_features,
                user_embedding_features=user_embedding_features,
                user_sparse_feature_embeddings=user_pooled_embs,
                user_specialized_embeddings=[
                    pooled_embs["user:specialized_embedding_arch_0"]
                ],
                object_float_features=object_float_features,
                object_embedding_features=object_embedding_features,
                object_sparse_feature_embeddings=object_pooled_embs,
                object_specialized_embeddings=[
                    pooled_embs["object:specialized_embedding_arch_0"],
                    pooled_embs["object:specialized_embedding_arch_1"],
                    pooled_embs["object:specialized_embedding_arch_2"],
                ],
                current_timestamps=current_timestamps,
                user_history_lengths=user_history_lengths,
                user_history_timestamp=user_history_timestamp,
                user_history_id_list_features=user_history_id_list_features,
                sid=sid,
                event_timestamps=event_timestamps,
                user_event_id_list_inverted_indexes=user_event_id_list_inverted_indexes,
            )

        # Set low memory budget (0.2) for DSNN forward pass
        # DSNN is the expensive encoder - aggressive recomputation saves memory
        **with MemoryBudgetMode(0.2):**
            dsnn_output = self.dsnn(inputs=dsnn_input)

        train_only_raw_float_features: Dict[str, torch.Tensor] = (
            train_input.supervision_input.raw_features.float_features
        )

        teacher_label = train_only_raw_float_features["teacher_label"]

        # Set high memory budget (0.8) for task archs
        # Task archs are cheap heads - save most activations to avoid recomputation
        **with MemoryBudgetMode(0.8):**
            task_archs_output = self.task_archs(
                label=train_input.supervision_input.multi_labels,
                weight=train_input.supervision_input.weight,
                teacher_label=teacher_label,
                dsnn_output=dsnn_output,
                train_only_raw_float_features=train_only_raw_float_features,
            )

        named_tensors = {}
        for i, name in enumerate(
            aps_none_throws(
                self.model_config.task_archs.independent_task_archs.keys()
            )  # with no dependent task arch only, to make it easier for removing some tasks in the task arch
        ):
            named_tensors[f"{name}:loss"] = task_archs_output.losses[i]
            named_tensors[f"{name}:label"] = task_archs_output.labels[i]
            named_tensors[f"{name}:weight"] = task_archs_output.weights[i]
            named_tensors[f"{name}:prediction"] = task_archs_output.predictions[i]
        named_tensors["object_embeddings"] = dsnn_output.object_embeddings
        named_tensors["user_embeddings"] = dsnn_output.user_embeddings

        return task_archs_output.losses, AdsTrainOutput(
            losses=task_archs_output.losses,
            predictions=task_archs_output.predictions.detach(),
            labels=task_archs_output.labels.detach(),
            weights=task_archs_output.weights.detach(),
            named_tensors=named_tensors,
        )
```

or

```
class PMRankingOCGPUModelTrain(
    AdsTrainModel[
        PMRankingOCGPUModelConfig,
        EmbeddingBagCollectionsSparseArch,
        GroupBasedSplitEmbeddingBagCollectionSparseArchNonKJT,
    ]
):
    def __init__(
        self,
        model_config: PMRankingOCGPUModelConfig,
        sparse_arch: EmbeddingBagCollectionsSparseArch,
        device: Optional[torch.device] = None,
    ) -> None:
        super().__init__(
            model_config=model_config, sparse_arch=sparse_arch, device=device
        )

        sparse_arch_dim = self.sparse_arch.dim_by_embedding_group()

        self.model_config: PMRankingOCGPUModelConfig = aps_none_throws(model_config)

        user_arch_config: DSNNEntityArchConfig = aps_none_throws(
            self.model_config.entity_configs[USER_FEATURE_GROUP].arch
        )

        ## replace uhm_config with uhm_config from model_config

        uhm_config = self.model_config.entity_configs[USER_FEATURE_GROUP].uhm_config
        if uhm_config:
            user_arch_config.entity_module.user_embedding_arch.uhm_config = uhm_config

        object_arch_config: DSNNEntityArchConfig = aps_none_throws(
            self.model_config.entity_configs[OBJECT_FEATURE_GROUP].arch
        )

        mix_arch_config: MixArchConfig = aps_none_throws(
            self.model_config.entity_configs[MIX_FEATURE_GROUP].mix_arch
        )

        dsnn_config = DSNNConfig(
            user_arch=user_arch_config,
            object_arch=object_arch_config,
            mixed_arch=mix_arch_config,
        )

        self.user_dsi_embedding_dim: int = self._get_dsi_embedding_dim(
            USER_FEATURE_GROUP
        )
        self.object_dsi_embedding_dim: int = self._get_dsi_embedding_dim(
            OBJECT_FEATURE_GROUP
        )

        user_sparse_arch_dim = sparse_arch_dim["user:sparse_arch"]
        user_inputs = model_config.entity_configs[USER_FEATURE_GROUP].inputs

        object_sparse_arch_dim = sparse_arch_dim["object:sparse_arch"]
        object_inputs = model_config.entity_configs[OBJECT_FEATURE_GROUP].inputs

        # update the user entity input dim
        aps_none_throws(dsnn_config.user_arch).update_entity_input_dim(
            sparse_arch_dim=user_sparse_arch_dim,
            model_inputs_config=aps_none_throws(user_inputs),
            embedding_dim=self.user_dsi_embedding_dim,
        )

        # update the object entity input dim
        aps_none_throws(dsnn_config.object_arch).update_entity_input_dim(
            sparse_arch_dim=object_sparse_arch_dim,
            model_inputs_config=aps_none_throws(object_inputs),
            embedding_dim=self.object_dsi_embedding_dim,
        )

        self.dsnn = DSNN(dsnn_config)

        self.task_archs = TaskArchs(config=model_config.task_archs)

        self.kt_regroup: KTRegroupAsDict = adjust_kt_regroup(
            sparse_arch=self.sparse_arch,
            enable_bf16_train=self.model_config.enable_bf16_train or False,
        )
        self.concat_kjt_id_list_features = ConcatenateKJTs()
        self.concat_kjt_id_score_list_features = ConcatenateKJTs()

    def _get_dsi_embedding_dim(self, entity: str) -> int:
        return self.model_config.entity_configs[entity].dense_embedding_dim

    def _get_sparse_arch_dict(self, input: ModelInput) -> Dict[str, torch.Tensor]:
        id_list_features = self.concat_kjt_id_list_features(
            user_features=input.id_list_features.get(USER_FEATURE_GROUP, None),
            mix_features=input.id_list_features.get(MIX_FEATURE_GROUP, None),
            object_features=input.id_list_features.get(OBJECT_FEATURE_GROUP, None),
        )
        id_score_list_features = self.concat_kjt_id_score_list_features(
            user_features=input.id_score_list_features.get(USER_FEATURE_GROUP, None),
            mix_features=input.id_score_list_features.get(MIX_FEATURE_GROUP, None),
            object_features=input.id_score_list_features.get(
                OBJECT_FEATURE_GROUP, None
            ),
        )

        with record_function("## forward:sparse_arch ##"):
            embs_kt_list = self.sparse_arch(
                id_list_features=id_list_features,
                id_score_list_features=id_score_list_features,
            )

        # NOTE: Regroup as dict is intentionally put after the dense arch to overlap
        #       the dense compute with sparse embedding all to alls. Placing this
        #       before the dense embeddings has non-trivial performance degradations.
        with record_function("## forward:kt regroup as dict ##"):
            pooled_embs = self.kt_regroup(keyed_tensors=embs_kt_list)

            # delete embs_kt_list after it's regrouped to save peak memory
            del embs_kt_list

        return pooled_embs

    def forward(
        self, train_input: TrainModelInput
    ) -> Tuple[torch.Tensor, AdsTrainOutput]:
        # Set medium memory budget (0.3) for sparse arch / embedding operations
        # These are moderately expensive and benefit from some recomputation
        **set_memory_budget(0.3):**
            pooled_embs = self._get_sparse_arch_dict(input=train_input.model_input)

            user_float_features = train_input.model_input.float_features[
                USER_FEATURE_GROUP
            ]
            object_float_features = train_input.model_input.float_features[
                OBJECT_FEATURE_GROUP
            ]

            user_arch_config: DSNNEntityArchConfig = aps_none_throws(
                self.model_config.entity_configs[USER_FEATURE_GROUP].arch
            )
            user_entity_module = aps_none_throws(user_arch_config.entity_module)
            uhm_config = (
                user_entity_module.event_submodels_dict
                or user_entity_module.user_embedding_arch
            )
            if uhm_config:
                event_inputs = train_input.model_input.event_based_features[
                    USER_FEATURE_GROUP
                ]
                sid = train_input.supervision_input.separable_id
                current_timestamps = (
                    event_inputs.current_timestamps
                    if user_entity_module.event_submodels_dict
                    else train_input.supervision_input.timestamp
                )
                user_history_lengths = event_inputs.num_objects_seqs
                user_history_timestamp = event_inputs.uhm_history_timestamps
                event_timestamps = event_inputs.event_timestamps_dict
                user_history_id_list_features = event_inputs.event_id_list_features_seqs
                user_event_id_list_inverted_indexes = (
                    event_inputs.event_id_list_feature_invert_indexes
                )
            else:
                current_timestamps = None
                user_history_lengths = None
                user_history_timestamp = None
                user_history_id_list_features = None
                sid = None
                event_timestamps = None
                user_event_id_list_inverted_indexes = None

            user_embedding_features = train_input.model_input.embedding_features[
                USER_FEATURE_GROUP
            ]
            object_embedding_features = train_input.model_input.embedding_features[
                OBJECT_FEATURE_GROUP
            ]

            user_pooled_embs = torch_split_fx_wrap(
                pooled_embs["user:sparse_arch"],
                self.user_dsi_embedding_dim,
                1,
            )
            object_pooled_embs = torch_split_fx_wrap(
                pooled_embs["object:sparse_arch"],
                self.object_dsi_embedding_dim,
                1,
            )

            dsnn_input = DSNNInput(
                user_float_features=user_float_features,
                user_embedding_features=user_embedding_features,
                user_sparse_feature_embeddings=user_pooled_embs,
                user_specialized_embeddings=[
                    pooled_embs["user:specialized_embedding_arch_0"]
                ],
                object_float_features=object_float_features,
                object_embedding_features=object_embedding_features,
                object_sparse_feature_embeddings=object_pooled_embs,
                object_specialized_embeddings=[
                    pooled_embs["object:specialized_embedding_arch_0"],
                    pooled_embs["object:specialized_embedding_arch_1"],
                    pooled_embs["object:specialized_embedding_arch_2"],
                ],
                current_timestamps=current_timestamps,
                user_history_lengths=user_history_lengths,
                user_history_timestamp=user_history_timestamp,
                user_history_id_list_features=user_history_id_list_features,
                sid=sid,
                event_timestamps=event_timestamps,
                user_event_id_list_inverted_indexes=user_event_id_list_inverted_indexes,
            )

        # Set low memory budget (0.2) for DSNN forward pass
        # DSNN is the expensive encoder - aggressive recomputation saves memory
        **set_memory_budget(0.2):**
        dsnn_output = self.dsnn(inputs=dsnn_input)

        train_only_raw_float_features: Dict[str, torch.Tensor] = (
            train_input.supervision_input.raw_features.float_features
        )

        teacher_label = train_only_raw_float_features["teacher_label"]

        # Set high memory budget (0.8) for task archs
        # Task archs are cheap heads - save most activations to avoid recomputation
        **set_memory_budget(0.8)**
        task_archs_output = self.task_archs(
            label=train_input.supervision_input.multi_labels,
            weight=train_input.supervision_input.weight,
            teacher_label=teacher_label,
            dsnn_output=dsnn_output,
            train_only_raw_float_features=train_only_raw_float_features,
        )

        named_tensors = {}
        for i, name in enumerate(
            aps_none_throws(
                self.model_config.task_archs.independent_task_archs.keys()
            )  # with no dependent task arch only, to make it easier for removing some tasks in the task arch
        ):
            named_tensors[f"{name}:loss"] = task_archs_output.losses[i]
            named_tensors[f"{name}:label"] = task_archs_output.labels[i]
            named_tensors[f"{name}:weight"] = task_archs_output.weights[i]
            named_tensors[f"{name}:prediction"] = task_archs_output.predictions[i]
        named_tensors["object_embeddings"] = dsnn_output.object_embeddings
        named_tensors["user_embeddings"] = dsnn_output.user_embeddings

        return task_archs_output.losses, AdsTrainOutput(
            losses=task_archs_output.losses,
            predictions=task_archs_output.predictions.detach(),
            labels=task_archs_output.labels.detach(),
            weights=task_archs_output.weights.detach(),
            named_tensors=named_tensors,
        )
```

Differential Revision: D89701539


