### PR TITLE
Fix unexpected failure in test_prepare_softmax_nrow_2048_dim_0 when SM/CU count is <= 32

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -7,6 +7,7 @@ import torch
 import torch._inductor.config as inductor_config
 import torch.nn.functional as F
 from torch._dynamo.utils import rmse, same
+from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import (
@@ -139,12 +140,17 @@ class TestOnlineSoftmax(TestCase):
 
         if nrow == 2048 and dim == 0:
             num_kernels = 2
-            # Note: split reduction is not triggered for this shape on some xpu devices.
-            #       check "num_splits" for more details
-            if GPU_TYPE == "xpu":
+            # split reduction may be triggered depending on the device's SM/CU count.
+            # The heuristic in num_splits() in ir.py returns split=1 (no split) when:
+            #   numel_hint >= num_sm * 2 * 32
+            # When dim=0, numel_hint (output size) = ncol (2048)
+            # split is expected only when num_sm > 32
+            props = DeviceProperties.create(torch.device(GPU_TYPE))
+            num_sm = props.multi_processor_count
+            split_not_expected = 2048 >= num_sm * 2 * 32
+            if split_not_expected:
                 num_kernels = 1
 
-            # split reduction is triggered. We have multiple kernels
             self.assertTrue(code.count("def triton") >= num_kernels)
         else:
             if nrow == 2 and dim == 0:


### PR DESCRIPTION
### Description
The test `test_prepare_softmax_nrow_2048_dim_0` was failing on GPUs with lower SM/CU counts like AMD Radeon AI PRO R9700 (32CUs). The test assumed that split reduction would always be triggered for a (2048, 2048) tensor reduced along dim=0, expecting at least 2 triton kernels to be generated.
However, the split reduction heuristic `num_splits()` in `ir.py` returns split=1 (no split) when:
`numel_hint >= num_sm * 2 * 32`
For GPUs with num_sm <= 32 (like AMD Radeon R9700 with 32 CUs), this evaluates to 2048 >= 2048, which prevents split reduction from being triggered.
Something similar was worked on for XPUs in #163251, this is a more general solution for any GPU with num_sm <= 32
### Fix:
Made the test device-aware by checking the GPU's SM count at runtime and only asserting split reduction when it's actually expected based on the heuristics:
```
props = DeviceProperties.create(torch.device(GPU_TYPE))
num_sm = props.multi_processor_count
split_not_expected = 2048 >= num_sm * 2 * 32
```

This ensures the test passes on all GPU configurations while still validating split reduction behavior on hardware where it's expected to occur.
### Test Plan:
Verified all `test_prepare_softmax*` tests pass on AMD Radeon AI PRO R9700 (32CUs). ~Didn't verify on an XPU but I assume this approach would work from the conversation in #163251~

Edit: [weishi-deng](https://github.com/weishi-deng) - the person who worked on the original #163251 XPU fix - confirmed that this change does indeed work on XPUs with both with more and less than 32 CUs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo