### PR TITLE
Prepare PT2 inductor perf number 2.10 (v2)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -888,6 +888,19 @@ test_dynamo_benchmark() {
   local shard_id="$1"
   shift
 
+  ### Perf benchmark 2.10, need to reinstall detectron2 to avoid crashing when importing it
+  pip_uninstall torch torchvision torchaudio torchrec fbgemm-gpu triton pytorch-triton detectron2
+  pip_install torch==2.10.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
+  # Rebuild torchrec and fbgemm_gpu because they don't have RC for 2.10 yet
+  if [[ "${TEST_CONFIG}" == *torchbench* ]] && [[ "${TEST_CONFIG}" != *cpu* ]]; then
+    rm -rf dist/torchrec
+    rm -rf dist/fbgemm_gpu
+    install_torchrec_and_fbgemm
+  fi
+  # Same pinned commit as used in TorchBench (no ci)
+  pip_install git+https://github.com/facebookresearch/detectron2.git@0df2d73d0013db7de629602c23cc120219b4f2b8 --no-build-isolation
+  pip freeze
+
   # Exclude torchrec_dlrm for CUDA 13 as FBGEMM is not compatible
   local extra_args=()
   if [[ "$BUILD_ENVIRONMENT" == *cuda13* ]]; then


### PR DESCRIPTION
Same as https://github.com/pytorch/pytorch/pull/171857, but base on `release/2.10` branch

No need to review

Runs:
* RC4 https://github.com/pytorch/pytorch/actions/runs/20837908962
