### PR TITLE
[precompile] Only wrap RegionalOutputCode under config.

### DIFF
--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -232,11 +232,14 @@ def regional_inductor(gm, *example_args):
         }
     }):
     """
-    from torch._inductor.output_code import RegionalOutputCode
 
     # fuser utils create new nodes using create_proxy which retains the seq_nr
     # metadata and cause issues
     with torch.fx.traceback.preserve_node_meta(enable=False):
         gm = _create_inductor_marked_regions(gm)
         gm = _compile_inductor_marked_regions(gm)
-        return RegionalOutputCode(gm)
+        if torch._functorch.config.force_autograd_cache:
+            from torch._inductor.output_code import RegionalOutputCode
+
+            gm = RegionalOutputCode(gm)
+        return gm


### PR DESCRIPTION
Summary:

Fixing forward errors like missing attributes from regional inductor backend.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo