### PR TITLE
[Allocator] Make large segment size configurable

### DIFF
--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -12,12 +12,6 @@ constexpr size_t kRoundUpPowerOfTwoEnd = 64 * 1024ul * kMB; // 64GB
 
 AcceleratorAllocatorConfig& AcceleratorAllocatorConfig::instance() {
   static AcceleratorAllocatorConfig instance;
-#define C10_ALLOCATOR_CONFIG_PARSE_ENV(env)    \
-  auto env##_name = c10::utils::get_env(#env); \
-  if (env##_name.has_value()) {                \
-    instance.parseArgs(env##_name.value());    \
-    return true;                               \
-  }
   static bool env_flag [[maybe_unused]] = []() {
     // Parse allocator configuration from environment variables.
     // The first two entries are kept for backward compatibility with legacy
@@ -25,12 +19,18 @@ AcceleratorAllocatorConfig& AcceleratorAllocatorConfig::instance() {
     // (PYTORCH_ALLOC_CONF) should be used going forward.
     // Note: keep the parsing order and logic stable to avoid potential
     // performance regressions in internal tests.
-    C10_ALLOCATOR_CONFIG_PARSE_ENV(PYTORCH_CUDA_ALLOC_CONF)
-    C10_ALLOCATOR_CONFIG_PARSE_ENV(PYTORCH_HIP_ALLOC_CONF)
-    C10_ALLOCATOR_CONFIG_PARSE_ENV(PYTORCH_ALLOC_CONF)
+    constexpr std::array<const char*, 3> vars{
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "PYTORCH_HIP_ALLOC_CONF",
+        "PYTORCH_ALLOC_CONF"};
+    for (const char* var : vars) {
+      if (std::optional<std::string> name = c10::utils::get_env(var)) {
+        instance.parseArgs(*name);
+        return true;
+      }
+    }
     return false;
   }();
-#undef C10_ALLOCATOR_CONFIG_PARSE_ENV
   return instance;
 }
 
@@ -56,11 +56,32 @@ size_t AcceleratorAllocatorConfig::roundup_power2_divisions(size_t size) {
   return instance().roundup_power2_divisions_[index];
 }
 
+size_t AcceleratorAllocatorConfig::parseLargeSegmentSize(
+    const ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+
+  constexpr size_t min_allowed_segment_size_mb = kMinLargeAlloc / kMB;
+  constexpr size_t max_allowed_segment_size_mb =
+      std::numeric_limits<size_t>::max() / kMB;
+
+  size_t val_env = tokenizer.toSizeT(++i);
+  TORCH_CHECK_VALUE(
+      val_env > min_allowed_segment_size_mb,
+      "CachingAllocator option large_segment_size_mb must be > ",
+      min_allowed_segment_size_mb,
+      " MB");
+  val_env = std::min(val_env, max_allowed_segment_size_mb);
+  large_segment_size_ = val_env * kMB;
+
+  return i;
+}
+
 size_t AcceleratorAllocatorConfig::parseMaxSplitSize(
     const ConfigTokenizer& tokenizer,
     size_t i) {
   tokenizer.checkToken(++i, ":");
-  constexpr size_t min_allowed_split_size_mb = kLargeBuffer / kMB;
+  size_t min_allowed_split_size_mb = large_segment_size_ / kMB;
   constexpr size_t max_allowed_split_size_mb =
       std::numeric_limits<size_t>::max() / kMB;
 
@@ -79,7 +100,7 @@ size_t AcceleratorAllocatorConfig::parseMaxNonSplitRoundingSize(
     const ConfigTokenizer& tokenizer,
     size_t i) {
   tokenizer.checkToken(++i, ":");
-  constexpr size_t min_allowed_split_size_mb = kLargeBuffer / kMB;
+  size_t min_allowed_split_size_mb = large_segment_size_ / kMB;
   constexpr size_t max_allowed_split_size_mb =
       std::numeric_limits<size_t>::max() / kMB;
 
@@ -194,21 +215,36 @@ size_t AcceleratorAllocatorConfig::parsePinnedUseBackgroundThreads(
 }
 
 void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
-  // The following option will be reset to its default value if not explicitly
-  // set each time.
-  max_split_size_ = std::numeric_limits<size_t>::max();
-  roundup_power2_divisions_.assign(kRoundUpPowerOfTwoIntervals, 0);
-  garbage_collection_threshold_ = 0;
-
   {
     std::lock_guard<std::mutex> lock(last_allocator_settings_mutex_);
     last_allocator_settings_ = env;
   }
 
   ConfigTokenizer tokenizer(env);
+
+  // The following option will be reset to its default value
+  // if not explicitly set each time.
+  {
+    max_split_size_ = std::numeric_limits<size_t>::max();
+    roundup_power2_divisions_.assign(kRoundUpPowerOfTwoIntervals, 0);
+    garbage_collection_threshold_ = 0;
+
+    large_segment_size_ = 20971520; // 20 MB by default
+    for (size_t i = 0; i < tokenizer.size(); ++i) {
+      const auto& key = tokenizer[i];
+      if (key == "large_segment_size_mb") {
+        i = parseLargeSegmentSize(tokenizer, i);
+      }
+    }
+
+    max_non_split_rounding_size_ = large_segment_size_.load();
+  }
+
   for (size_t i = 0; i < tokenizer.size(); i++) {
     const auto& key = tokenizer[i];
-    if (key == "max_split_size_mb") {
+    if (key == "large_segment_size_mb") {
+      i = tokenizer.skipKey(i); // handled previously
+    } else if (key == "max_split_size_mb") {
       i = parseMaxSplitSize(tokenizer, i);
     } else if (key == "max_non_split_rounding_mb") {
       i = parseMaxNonSplitRoundingSize(tokenizer, i);

--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/AllocatorConfig.h>
 #include <c10/util/env.h>
+#include <array>
 
 namespace c10::CachingAllocator {
 

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -12,8 +12,6 @@
 
 namespace c10::CachingAllocator {
 
-// "large" allocations may be packed in 20 MiB blocks
-constexpr size_t kLargeBuffer = 20971520;
 // "small" allocations are packed in 2 MiB blocks
 constexpr size_t kSmallBuffer = 2097152;
 // all sizes are rounded to at least 512 bytes
@@ -172,6 +170,10 @@ class C10_API AcceleratorAllocatorConfig {
 
   /* Device allocator settings */
 
+  static size_t large_segment_size() {
+    return instance().large_segment_size_;
+  }
+
   // Returns the maximum block size (in MB) that is allowed to be split. The
   // default is unlimited (all blocks can be split).
   static size_t max_split_size() {
@@ -234,6 +236,7 @@ class C10_API AcceleratorAllocatorConfig {
   // issue.
   static std::unordered_set<std::string>& getMutableKeys() {
     static std::unordered_set<std::string> keys{
+        "large_segment_size_mb",
         "max_split_size_mb",
         "max_non_split_rounding_mb",
         "garbage_collection_threshold",
@@ -294,6 +297,8 @@ class C10_API AcceleratorAllocatorConfig {
 
   /* Internal functions for device allocator */
 
+  // Parse `large_segment_size_mb` from environment variable.
+  size_t parseLargeSegmentSize(const ConfigTokenizer& tokenizer, size_t i);
   // Parse `max_split_size_mb` from environment variable.
   size_t parseMaxSplitSize(const ConfigTokenizer& tokenizer, size_t i);
   // Parse `max_non_split_rounding_mb` from environment variable.
@@ -320,11 +325,13 @@ class C10_API AcceleratorAllocatorConfig {
 
   /* The following members are specifically used for the device allocator. */
 
+  // "large" allocations may be packed in blocks of this size
+  std::atomic<size_t> large_segment_size_;
   // The maximum block size that is allowed to be split.
   std::atomic<size_t> max_split_size_{std::numeric_limits<size_t>::max()};
   // The maximum allowable extra size of a memory block without requiring
   // splitting when searching for a free block.
-  std::atomic<size_t> max_non_split_rounding_size_{kLargeBuffer};
+  std::atomic<size_t> max_non_split_rounding_size_;
   // Used to store how memory allocations of different sizes should be rounded
   // up to the nearest power of 2 divisions.
   std::vector<size_t> roundup_power2_divisions_;

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -326,7 +326,7 @@ class C10_API AcceleratorAllocatorConfig {
   /* The following members are specifically used for the device allocator. */
 
   // "large" allocations may be packed in blocks of this size
-  std::atomic<size_t> large_segment_size_;
+  std::atomic<size_t> large_segment_size_{20971520}; // 20 MB by default
   // The maximum block size that is allowed to be split.
   std::atomic<size_t> max_split_size_{std::numeric_limits<size_t>::max()};
   // The maximum allowable extra size of a memory block without requiring

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2824,7 +2824,9 @@ class DeviceCachingAllocator {
         return c;
       }
     }
-    auto segment_size = pool->is_small ? kSmallBuffer : kLargeBuffer;
+    auto segment_size = pool->is_small
+        ? kSmallBuffer
+        : AcceleratorAllocatorConfig::large_segment_size();
     expandable_segments_.emplace_back(new ExpandableSegment(
         device, stream, segment_size, devices_with_peer_access_));
 
@@ -3109,7 +3111,7 @@ class DeviceCachingAllocator {
     if (size <= kSmallSize) {
       return kSmallBuffer;
     } else if (size < kMinLargeAlloc) {
-      return kLargeBuffer;
+      return AcceleratorAllocatorConfig::large_segment_size();
     } else {
       return kRoundLarge * ((size + kRoundLarge - 1) / kRoundLarge);
     }

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -51,7 +51,6 @@ namespace c10::cuda::CUDACachingAllocator {
 
 // Preserved only for BC reasons
 // NOLINTNEXTLINE(misc-unused-using-decls)
-using c10::CachingAllocator::kLargeBuffer;
 using c10::CachingDeviceAllocator::DeviceStats;
 
 typedef std::shared_ptr<GatheredContext> (*CreateContextFn)();

--- a/c10/test/core/AllocatorConfig_test.cpp
+++ b/c10/test/core/AllocatorConfig_test.cpp
@@ -58,6 +58,7 @@ TEST(AllocatorConfigTest, allocator_config_test) {
       "device_specific_option_mb:64";
   c10::CachingAllocator::setAllocatorSettings(env);
   EXPECT_EQ(c10::CachingAllocator::getAllocatorSettings(), env);
+  EXPECT_EQ(AcceleratorAllocatorConfig::large_segment_size(), 20 * kMB);
   EXPECT_EQ(AcceleratorAllocatorConfig::max_split_size(), 40 * kMB);
   EXPECT_EQ(
       AcceleratorAllocatorConfig::max_non_split_rounding_size(), 30 * kMB);
@@ -80,11 +81,13 @@ TEST(AllocatorConfigTest, allocator_config_test) {
   EXPECT_EQ(ExtendedAllocatorConfig::device_specific_option(), 64 * kMB);
 
   env =
+      "large_segment_size_mb:15,"
       "max_split_size_mb:20,"
       "max_non_split_rounding_mb:40,"
       "garbage_collection_threshold:0.8";
   c10::CachingAllocator::setAllocatorSettings(env);
   EXPECT_EQ(c10::CachingAllocator::getAllocatorSettings(), env);
+  EXPECT_EQ(AcceleratorAllocatorConfig::large_segment_size(), 15 * kMB);
   EXPECT_EQ(AcceleratorAllocatorConfig::max_split_size(), 20 * kMB);
   EXPECT_EQ(
       AcceleratorAllocatorConfig::max_non_split_rounding_size(), 40 * kMB);
@@ -124,6 +127,10 @@ TEST(AllocatorConfigTest, allocator_config_test) {
   c10::CachingAllocator::setAllocatorSettings(env);
   EXPECT_EQ(c10::CachingAllocator::getAllocatorSettings(), env);
   EXPECT_EQ(AcceleratorAllocatorConfig::pinned_use_background_threads(), false);
+
+  // max_split_size_mb must be >= large_segment_size_mb
+  env = "max_split_size_mb:20,large_segment_size_mb:25";
+  ASSERT_THROW(c10::CachingAllocator::setAllocatorSettings(env), c10::Error);
 
   env = "foo:123,bar:456";
   ASSERT_THROW(c10::CachingAllocator::setAllocatorSettings(env), c10::Error);

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -661,7 +661,7 @@ class DeviceCachingAllocator {
     if (size <= kSmallSize) {
       return kSmallBuffer;
     } else if (size < kMinLargeAlloc) {
-      return kLargeBuffer;
+      return AcceleratorAllocatorConfig::large_segment_size();
     } else {
       return kRoundLarge * ((size + kRoundLarge - 1) / kRoundLarge);
     }
@@ -727,7 +727,9 @@ class DeviceCachingAllocator {
         return c;
       }
     }
-    auto segment_size = pool->is_small ? kSmallBuffer : kLargeBuffer;
+    auto segment_size = pool->is_small
+        ? kSmallBuffer
+        : AcceleratorAllocatorConfig::large_segment_size();
     expandable_segments.emplace_back(new ExpandableSegment(
         device, queue, segment_size, devices_with_peer_access));
 

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -508,6 +508,9 @@ Available options:
   ``cudaMallocAsync`` requires CUDA 11.4 or newer. The default is ``native``.
   ``backend`` applies to all devices used by the process, and can't be
   specified on a per-device basis.
+* ``large_segment_size_mb`` the native allocator uses small and large blocks
+  to manage allocated memory. This setting is used to configure the size of
+  the large block. The default value is 20 MB.
 * ``max_split_size_mb`` prevents the native allocator
   from splitting blocks larger than this size (in MB). This can reduce
   fragmentation and may allow some borderline workloads to complete without


### PR DESCRIPTION
The ability to configure segment sizes can be a useful performance tuning knob when large allocations are common.