### PR TITLE
Allow opaque types to be registered multiple times

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -990,6 +990,28 @@ def forward(self, arg0_1):
         x = torch.randn(3, 3)
         self.assertEqual(opt_f(x), foo(x))
 
+    def test_register_opaque_type_multiple_times(self):
+        # Test that registering the same opaque type multiple times works.
+        # This is useful when multiple libraries or modules independently
+        # try to register the same type.
+        class MultiRegisterClass:
+            def __init__(self, value):
+                self.value = value
+
+        # First registration should succeed
+        register_opaque_type(MultiRegisterClass, typ="reference")
+        self.assertTrue(is_opaque_type(MultiRegisterClass))
+
+        # Second registration with the same type should also succeed
+        register_opaque_type(MultiRegisterClass, typ="reference")
+        self.assertTrue(is_opaque_type(MultiRegisterClass))
+
+        # Verify the type name is still correct
+        expected_name = (
+            f"{MultiRegisterClass.__module__}.{MultiRegisterClass.__qualname__}"
+        )
+        self.assertEqual(get_opaque_type_name(MultiRegisterClass), expected_name)
+
 
 instantiate_parametrized_tests(TestOpaqueObject)
 

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -50,11 +50,9 @@ static std::unordered_set<std::string>& getOpaqueTypes() {
 
 void registerOpaqueType(const std::string& type_name) {
   auto& global_opaque_types = getOpaqueTypes();
-  auto [_, inserted] = global_opaque_types.insert(type_name);
-  if (!inserted) {
-    throw std::runtime_error(
-        "Type '" + type_name + "' is already registered as an opaque type");
-  }
+  // Allow opaque types to be registered multiple times. Why not? It's just a
+  // string name.
+  global_opaque_types.insert(type_name);
 }
 
 bool isRegisteredOpaqueType(const std::string& type_name) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172057

Remove the error thrown when registering an opaque type that is already
registered. This fixes flaky test failures that depend on test order -
if one test registers a type and another test tries to register the same
type, the second registration would fail.

Since opaque type registration is just tracking a string name, there's
no reason to disallow duplicate registrations.

Added test_register_opaque_type_multiple_times to verify this works.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel