### PR TITLE
[BE][CI] Remove `CONDA_RUN`/`print_cmake_info`

### DIFF
--- a/.ci/pytorch/macos-build.sh
+++ b/.ci/pytorch/macos-build.sh
@@ -33,7 +33,6 @@ if which sccache > /dev/null; then
   export PATH="${tmp_dir}:$PATH"
 fi
 
-print_cmake_info
 if [[ ${BUILD_ENVIRONMENT} == *"distributed"* ]]; then
   # Needed for inductor benchmarks, as lots of HF networks make `torch.distribtued` calls
   USE_DISTRIBUTED=1 USE_OPENMP=1 WERROR=1 python -m build --wheel --no-isolation

--- a/.ci/pytorch/macos-common.sh
+++ b/.ci/pytorch/macos-common.sh
@@ -12,12 +12,3 @@ sysctl -a | grep machdep.cpu
 export MACOSX_DEPLOYMENT_TARGET=11.1
 export CXX=clang++
 export CC=clang
-
-print_cmake_info() {
-  CMAKE_EXEC=$(which cmake)
-  echo "$CMAKE_EXEC"
-
-  CONDA_INSTALLATION_DIR=$(dirname "$CMAKE_EXEC")
-  # Print all libraries under cmake rpath for debugging
-  ls -la "$CONDA_INSTALLATION_DIR/../lib"
-}

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -41,7 +41,7 @@ test_python_mps() {
   setup_test_python
 
   time python test/run_test.py --verbose --mps
-  MTL_CAPTURE_ENABLED=1 ${CONDA_RUN} python3 test/test_mps.py --verbose -k test_metal_capture
+  MTL_CAPTURE_ENABLED=1 python3 test/test_mps.py --verbose -k test_metal_capture
 
   assert_git_not_dirty
 }
@@ -101,8 +101,6 @@ test_libtorch() {
 }
 
 test_custom_backend() {
-  print_cmake_info
-
   echo "Testing custom backends"
   pushd test/custom_backend
   rm -rf build && mkdir build
@@ -123,8 +121,6 @@ test_custom_backend() {
 }
 
 test_custom_script_ops() {
-  print_cmake_info
-
   echo "Testing custom script operators"
   pushd test/custom_operator
   # Build the custom operator library.
@@ -145,8 +141,6 @@ test_custom_script_ops() {
 }
 
 test_jit_hooks() {
-  print_cmake_info
-
   echo "Testing jit hooks in cpp"
   pushd test/jit_hooks
   # Build the custom operator library.
@@ -224,8 +218,6 @@ pip_benchmark_deps() {
 
 
 test_torchbench_perf() {
-  print_cmake_info
-
   echo "Launching torchbench setup"
   pip_benchmark_deps
   torchbench_setup_macos
@@ -251,8 +243,6 @@ test_torchbench_perf() {
 }
 
 test_torchbench_smoketest() {
-  print_cmake_info
-
   echo "Launching torchbench setup"
   pip_benchmark_deps
   # shellcheck disable=SC2119,SC2120
@@ -314,8 +304,6 @@ test_torchbench_smoketest() {
 }
 
 test_aoti_torchbench_smoketest() {
-  print_cmake_info
-
   echo "Launching AOTInductor torchbench setup"
   pip_benchmark_deps
   # shellcheck disable=SC2119,SC2120
@@ -356,7 +344,6 @@ test_aoti_torchbench_smoketest() {
 }
 
 test_hf_perf() {
-  print_cmake_info
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
   pip_benchmark_deps
@@ -372,7 +359,6 @@ test_hf_perf() {
 }
 
 test_timm_perf() {
-  print_cmake_info
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
   pip_benchmark_deps


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172077
* #172076
* __->__ #172075

MacOS test has been conda free for quite some time, and those functions does not make much sense anymore

For example, `print_cmake_info` simply prints contens of venv lib dir, which has nothing but python fodler, see below
```
+ print_cmake_info
++ which cmake
+ CMAKE_EXEC=/Users/ec2-user/runner/_work/_temp/venv-3.12-1767919468/bin/cmake
+ echo /Users/ec2-user/runner/_work/_temp/venv-3.12-1767919468/bin/cmake
/Users/ec2-user/runner/_work/_temp/venv-3.12-1767919468/bin/cmake
++ dirname /Users/ec2-user/runner/_work/_temp/venv-3.12-1767919468/bin/cmake
+ CONDA_INSTALLATION_DIR=/Users/ec2-user/runner/_work/_temp/venv-3.12-1767919468/bin
+ ls -la /Users/ec2-user/runner/_work/_temp/venv-3.12-1767919468/bin/../lib
total 0
drwxr-xr-x  3 ec2-user  staff   96 Jan  9 00:44 .
drwxr-xr-x  8 ec2-user  staff  256 Jan  9 00:44 ..
drwxr-xr-x  3 ec2-user  staff   96 Jan  9 00:44 python3.12
```


Pull-Request: https://github.com/pytorch/pytorch/pull/172051