### PR TITLE
[CI] Run slow tests during MPS shard run

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -40,7 +40,7 @@ test_python_all() {
 test_python_mps() {
   setup_test_python
 
-  time python test/run_test.py --verbose --mps
+  time PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --verbose --mps
   MTL_CAPTURE_ENABLED=1 python3 test/test_mps.py --verbose -k test_metal_capture
 
   assert_git_not_dirty

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -699,6 +699,7 @@ if torch.backends.mps.is_available():
             "index_fill": [torch.float16, torch.float32],  # missing `aten::_unique`.
             "igamma": None,  # currently not supported for any device
             "igammac": None,  # currently not supported for any device
+            "linalg.pinvsingular": None,  # Missing `aten::linalg_qr.out`.
             "linalg.solve": [torch.float16, torch.float32],  # missing `aten::lu_solve`.
             "linalg.solve_ex": [
                 torch.float16,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172077
* __->__ #172076
* #172075

As MPS does not have a separate slow shard, run slow test during MPS run

Pull-Request: https://github.com/pytorch/pytorch/pull/172052