### PR TITLE
[AMD] Bump magma library revision for fix cholesky API, part 1

### DIFF
--- a/.ci/docker/common/install_rocm_magma.sh
+++ b/.ci/docker/common/install_rocm_magma.sh
@@ -12,8 +12,8 @@ function do_install() {
 
     rocm_version_nodot=${rocm_version//./}
 
-    # https://github.com/icl-utk-edu/magma/pull/65
-    MAGMA_VERSION=d6e4117bc88e73f06d26c6c2e14f064e8fc3d1ec
+    # https://github.com/icl-utk-edu/magma/pull/77
+    MAGMA_VERSION=a68b9257ac435afa1ebdfb8f50d67668950aef61
     magma_archive="magma-rocm${rocm_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"
 
     rocm_dir="/opt/rocm"

--- a/.ci/docker/common/install_rocm_magma.sh
+++ b/.ci/docker/common/install_rocm_magma.sh
@@ -12,8 +12,8 @@ function do_install() {
 
     rocm_version_nodot=${rocm_version//./}
 
-    # https://github.com/icl-utk-edu/magma/pull/77
-    MAGMA_VERSION=a68b9257ac435afa1ebdfb8f50d67668950aef61
+    # https://github.com/icl-utk-edu/magma/pull/65
+    MAGMA_VERSION=d6e4117bc88e73f06d26c6c2e14f064e8fc3d1ec
     magma_archive="magma-rocm${rocm_version_nodot}-${MAGMA_VERSION}-1.tar.bz2"
 
     rocm_dir="/opt/rocm"

--- a/.ci/magma-rocm/build_magma.sh
+++ b/.ci/magma-rocm/build_magma.sh
@@ -6,8 +6,8 @@ set -eou pipefail
 # The script expects DESIRED_CUDA and PACKAGE_NAME to be set
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# https://github.com/icl-utk-edu/magma/pull/65
-MAGMA_VERSION=d6e4117bc88e73f06d26c6c2e14f064e8fc3d1ec
+# https://github.com/icl-utk-edu/magma/pull/77
+MAGMA_VERSION=a68b9257ac435afa1ebdfb8f50d67668950aef61
 
 # Folders for the build
 PACKAGE_FILES=${ROOT_DIR}/magma-rocm/package_files # metadata
@@ -20,7 +20,7 @@ mkdir -p ${PACKAGE_DIR} ${PACKAGE_OUTPUT}/linux-64 ${PACKAGE_BUILD} ${PACKAGE_RE
 
 # Fetch magma sources and verify checksum
 pushd ${PACKAGE_DIR}
-git clone https://github.com/jeffdaily/magma
+git clone https://github.com/k-artem/magma.git
 pushd magma
 git checkout ${MAGMA_VERSION}
 popd


### PR DESCRIPTION
This is a 2-part PR.  magma packages must be built as part of a first PR after it merges upstream, then a second PR will update Dockerfiles to install the new packages.

Fix for next pytorch UT testcases:
- TestCommonCUDA.test_out_cholesky_solve_cuda_float32
- TestMathBitsCUDA.test_conj_view_cholesky_solve_cuda_complex64
- TestCommonCUDA.test_noncontiguous_samples_cholesky_solve_cuda_float32
- TestCommonCUDA.test_noncontiguous_samples_cholesky_inverse_cuda_float32
- TestCommonCUDA.test_noncontiguous_samples_cholesky_inverse_cuda_complex64
- TestMathBitsCUDA.test_neg_view_cholesky_inverse_cuda_float64

Script with one of pytorch UT testcases for verification:
```
#!/bin/bash

export PYTORCH_TEST_WITH_ROCM=1
COMMAND="python test/test_ops.py -v TestCommonCUDA.test_out_cholesky_solve_cuda_float32"
RUN_COUNT=0

while true; do
    RUN_COUNT=$((RUN_COUNT + 1))

    echo "Run #$RUN_COUNT: Running command: $COMMAND"
    $COMMAND
    EXIT_CODE=$?

    if [ $EXIT_CODE -ne 0 ]; then
        echo "Command failed on run #$RUN_COUNT with exit code $EXIT_CODE. Exiting loop."
        break
    fi
done
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang