### PR TITLE
[nativert] Refactor LaunchParams to use target-specific subclasses

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -641,6 +641,7 @@ libtorch_nativert_sources = [
     "torch/nativert/graph/passes/pass_manager/PassManager.cpp",
     "torch/nativert/kernels/KernelHandlerRegistry.cpp",
     "torch/nativert/kernels/TritonKernel.cpp",
+    "torch/nativert/executor/triton/TritonKernelManager.cpp",
     "torch/nativert/executor/triton/CpuTritonKernelManager.cpp",
     "torch/nativert/executor/AOTInductorDelegateExecutor.cpp",
     "torch/nativert/kernels/ETCallDelegateKernel.cpp",

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -58,7 +58,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TemporaryFileName,
-    TEST_WITH_ROCM,
     TestCase,
 )
 from torch.testing._internal.torchbind_impls import init_torchbind_implementations
@@ -722,8 +721,7 @@ def forward(self, x):
                 )
 
     @unittest.skipIf(
-        not torch.cuda.is_available() or not has_triton() or TEST_WITH_ROCM,
-        "requires cuda and triton, ROCm doesn't support bool tl.cosntexpr.",
+        not torch.cuda.is_available() or not has_triton(), "requires cuda and triton"
     )
     def test_triton_constexpr_matching(self) -> None:
         """Test that constexpr values are properly matched during serialization.

--- a/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CpuTritonKernelManager.cpp
@@ -8,6 +8,22 @@
 
 namespace torch::nativert {
 
+// CPU-specific launch parameters
+class CpuLaunchParams : public LaunchParams {
+ public:
+  int num_cpu_threads = 0; // 0 means use all available threads
+
+  void parseAttributes(const Node* node) {
+    parseCommonAttributes(node);
+    for (const auto& attr : node->attributes()) {
+      set_from_variant<int64_t>(
+          num_cpu_threads, "num_cpu_threads", attr, [](auto v) {
+            return v >= 0;
+          });
+    }
+  }
+};
+
 namespace {
 void* _dlopen(const char* filename) {
 #if defined(_WIN32)
@@ -58,6 +74,14 @@ class CpuTritonKernelManager final : public TritonKernelManager {
       std::string kernel_bin_path,
       std::string kernel_launcher_bin_path);
   ~CpuTritonKernelManager() final = default;
+
+  std::unique_ptr<LaunchParams> createLaunchParams(
+      const Node* node) const override {
+    auto params = std::make_unique<CpuLaunchParams>();
+    params->parseAttributes(node);
+    return params;
+  }
+
   void launch(const LaunchParams& launch_params, void** args) final;
 
  private:
@@ -116,12 +140,13 @@ void CpuTritonKernelManager::load() {
 void CpuTritonKernelManager::launch(
     const LaunchParams& launch_params,
     void** args /* { ...inputs, output }*/) {
+  const auto& cpu_params = static_cast<const CpuLaunchParams&>(launch_params);
   load();
   launcher_fn_(
-      launch_params.grid_dims.x,
-      launch_params.grid_dims.y,
-      launch_params.grid_dims.z,
-      launch_params.num_cpu_threads,
+      cpu_params.grid_dims.x,
+      cpu_params.grid_dims.y,
+      cpu_params.grid_dims.z,
+      cpu_params.num_cpu_threads,
       args,
       kernel_fn_);
 }

--- a/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
@@ -24,6 +24,25 @@ const at::cuda::NVRTC& get_nvrtc() {
 
 namespace torch::nativert {
 
+// CUDA/HIP-specific launch parameters
+class CudaLaunchParams : public LaunchParams {
+ public:
+  int num_warps = 4;
+  int shared_memory_bytes = 0;
+
+  void parseAttributes(const Node* node) {
+    parseCommonAttributes(node);
+    for (const auto& attr : node->attributes()) {
+      set_from_variant<int64_t>(
+          num_warps, "num_warps", attr, [](auto v) { return v > 0; });
+      set_from_variant<int64_t>(
+          shared_memory_bytes, "shared_memory_bytes", attr, [](auto v) {
+            return v > 0;
+          });
+    }
+  }
+};
+
 // cuda kernels require an extra level of indirection
 // for who knows what reason.
 class CudaKernelInputs final : public KernelInputs {
@@ -57,6 +76,13 @@ class CudaTritonKernelManager final : public TritonKernelManager {
   CudaTritonKernelManager& operator=(const CudaTritonKernelManager& other);
   CudaTritonKernelManager(CudaTritonKernelManager&& other) noexcept;
   CudaTritonKernelManager& operator=(CudaTritonKernelManager&& other) noexcept;
+
+  std::unique_ptr<LaunchParams> createLaunchParams(
+      const Node* node) const override {
+    auto params = std::make_unique<CudaLaunchParams>();
+    params->parseAttributes(node);
+    return params;
+  }
 
   void launch(const LaunchParams& launch_params, void** args) final;
   std::unique_ptr<KernelInputs> create_inputs(
@@ -123,6 +149,7 @@ CUfunction CudaTritonKernelManager::load() {
 void CudaTritonKernelManager::launch(
     const LaunchParams& launch_params,
     void** args /* { ...inputs, output }*/) {
+  const auto& cuda_params = static_cast<const CudaLaunchParams&>(launch_params);
   const constexpr int kThreadsPerWarp = 2 << 4;
 
   auto kernel_fn = load();
@@ -132,13 +159,13 @@ void CudaTritonKernelManager::launch(
 
   AT_CUDA_DRIVER_CHECK(get_nvrtc().cuLaunchKernel(
       kernel_fn,
-      launch_params.grid_dims.x,
-      launch_params.grid_dims.y,
-      launch_params.grid_dims.z,
-      /* blockDimX = */ kThreadsPerWarp * launch_params.num_warps,
+      cuda_params.grid_dims.x,
+      cuda_params.grid_dims.y,
+      cuda_params.grid_dims.z,
+      /* blockDimX = */ kThreadsPerWarp * cuda_params.num_warps,
       /* blockDimY = */ 1,
       /* blockDimZ = */ 1,
-      /* sharedMemBytes = */ launch_params.shared_memory_bytes,
+      /* sharedMemBytes = */ cuda_params.shared_memory_bytes,
       stream,
       args,
       nullptr));

--- a/torch/nativert/executor/triton/TritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/TritonKernelManager.cpp
@@ -1,0 +1,27 @@
+#include <torch/nativert/executor/triton/TritonKernelManager.h>
+
+#include <c10/util/Exception.h>
+
+namespace torch::nativert {
+
+void LaunchParams::parseCommonAttributes(const Node* node) {
+  for (const auto& attr : node->attributes()) {
+    std::vector<int64_t> grid;
+    if (set_from_variant<std::vector<int64_t>>(grid, "grid", attr)) {
+      TORCH_CHECK(grid.size() == 3, "grid must be a 3D vector");
+      grid_dims = GridDims(
+          static_cast<int>(grid[0]),
+          static_cast<int>(grid[1]),
+          static_cast<int>(grid[2]));
+    }
+  }
+}
+
+std::unique_ptr<LaunchParams> TritonKernelManager::createLaunchParams(
+    const Node* node) const {
+  auto params = std::make_unique<LaunchParams>();
+  params->parseCommonAttributes(node);
+  return params;
+}
+
+} // namespace torch::nativert

--- a/torch/nativert/kernels/TritonKernel.h
+++ b/torch/nativert/kernels/TritonKernel.h
@@ -27,7 +27,7 @@ class TritonKernel : public OpKernel {
   // Storage for float attributes that were serialized as doubles
   std::vector<float> float_attrs_;
   std::vector<int64_t> output_indices_;
-  LaunchParams launch_params_;
+  std::unique_ptr<LaunchParams> launch_params_;
   KernelInputParams kernel_input_params_;
 };
 


### PR DESCRIPTION
Summary:
Refactor the Triton kernel launch parameter handling to use polymorphism instead of a monolithic struct containing all target parameters.

Previously, `LaunchParams` was a flat struct containing parameters for all targets (CPU, CUDA, MTIA), and `TritonKernel.cpp` parsed all of them regardless of which target was being used.

This change converts `LaunchParams` to a virtual base class with only common parameters (grid_dims), and introduces target-specific subclasses: `CpuLaunchParams` (num_cpu_threads), `CudaLaunchParams` (num_warps, shared_memory_bytes), and `MtiaLaunchParams` (tile_width, tile_height, base_pe). Each target manager now creates and parses its own launch parameters via an overridden `createLaunchParams()` method.

This improves separation of concerns - each target owns its launch parameter definitions and parsing, making it easier to add new targets or modify existing ones without touching shared code.

Test Plan: Unit tests

Differential Revision: D90334661
