### PR TITLE
[opaque obj] Minor refactor for method support on value-types

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -131,6 +131,9 @@ class ValueConfig:
     def __fx_repr__(self):
         return f"ValueConfig(mode={self.mode!r})", {"ValueConfig": ValueConfig}
 
+    def print_mode(self):
+        print(self.mode)
+
 
 class SizeStore:
     def __init__(self, size: int):
@@ -884,6 +887,24 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             "Opaque object member with method-type USE_REAL returned a reference-type opaque objects.",
         ):
             torch.compile(foo)(NestedCounters(Counter(1, 5)), torch.ones(2, 3))
+
+        config = ValueConfig("double")
+
+        def foo(mode, x):
+            return config.mode
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Attempted to access unregistered member on an OpaqueObject"
+        ):
+            torch.compile(foo)(config, torch.ones(2, 3))
+
+        def bar(mode, x):
+            config.print_mode()
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Attempted to access unregistered member on an OpaqueObject"
+        ):
+            torch.compile(bar)(config, torch.ones(2, 3))
 
     def test_export_joint(self):
         torch.library.define(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -56,7 +56,11 @@ from torch._dynamo.utils import (
 from torch._guards import TracingContext
 from torch._higher_order_ops.flat_apply import flat_apply
 from torch._higher_order_ops.torchbind import call_torchbind
-from torch._library.opaque_object import is_opaque_type, is_opaque_value_type
+from torch._library.opaque_object import (
+    is_opaque_reference_type,
+    is_opaque_type,
+    is_opaque_value_type,
+)
 from torch._ops import HigherOrderOperator, OpOverload, OpOverloadPacket
 from torch._subclasses.fake_tensor import (
     FakeTensor,
@@ -1532,23 +1536,13 @@ class VariableBuilder:
                     source=self.source,
                 )
 
-            if is_opaque_type(type(value)):
-                # Check if this is a value-type opaque object (registered as both opaque type and constant)
-                if is_opaque_value_type(type(value)):
-                    # Value-type: guard on equality (will use __eq__)
-                    self.install_guards(GuardBuilder.CONSTANT_MATCH)
-                    return TorchScriptObjectVariable.create(
-                        value,  # type: ignore[arg-type]
-                        value,
-                        source=self.source,
-                    )
-                else:
-                    # Reference-type: guard only on type/identity
-                    self.install_guards(GuardBuilder.TYPE_MATCH)
-
-                    # Install guards on GUARDED members
-                    self.install_guards(GuardBuilder.OPAQUE_OBJ_GUARD_FN_MATCH)
-
+            if is_opaque_value_type(type(value)):
+                # Value-type: guard on equality (will use __eq__)
+                self.install_guards(GuardBuilder.CONSTANT_MATCH)
+            elif is_opaque_reference_type(type(value)):
+                # Reference-type: guard only on type/identity
+                self.install_guards(GuardBuilder.TYPE_MATCH)
+                self.install_guards(GuardBuilder.OPAQUE_OBJ_GUARD_FN_MATCH)
             elif not hasattr(value, "__obj_flatten__"):
                 # This exists to allow a smoother transition.
                 # The implications are:
@@ -1576,25 +1570,27 @@ class VariableBuilder:
             fake_script_obj = torch._library.fake_class_registry.maybe_to_fake_obj(
                 self.tx.output.fake_mode, value
             )
+            if is_opaque_value_type(type(value)):
+                proxy = value
+            else:
+                proxy = self.tx.output.root_tracer.create_graph_input(
+                    re.sub(r"[^a-zA-Z0-9]+", "_", self.name),
+                    type(value),
+                    fake_script_obj,
+                    source=self.source,
+                )
+                # setting is_unspecialized=False to not insert a as_tensor call in reconstruct by default
+                # setting example to be real value because these example values will be used
+                # as example_inputs for user compiler.
+                proxy.node.meta["grapharg"] = GraphArg(
+                    self.source,
+                    value,  # type: ignore[arg-type]
+                    False,
+                    None,
+                    False,
+                    fake_script_obj,  # type: ignore[arg-type]
+                )
 
-            proxy = self.tx.output.root_tracer.create_graph_input(
-                re.sub(r"[^a-zA-Z0-9]+", "_", self.name),
-                type(value),
-                fake_script_obj,
-                source=self.source,
-            )
-
-            # setting is_unspecialized=False to not insert a as_tensor call in reconstruct by default
-            # setting example to be real value because these example values will be used
-            # as example_inputs for user compiler.
-            proxy.node.meta["grapharg"] = GraphArg(
-                self.source,
-                value,  # type: ignore[arg-type]
-                False,
-                None,
-                False,
-                fake_script_obj,  # type: ignore[arg-type]
-            )
             return TorchScriptObjectVariable.create(
                 proxy,
                 fake_script_obj,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1522,10 +1522,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             getattribute_fn = inspect.getattr_static(
                 type(self.value), "__getattribute__"
             )
-            if self.source:
-                new_source: AttrSource | None = AttrSource(
-                    self.source, "__getattribute__"
-                )
+            new_source: AttrSource | None = (
+                AttrSource(self.source, "__getattribute__") if self.source else None
+            )
 
             try:
                 return variables.UserMethodVariable(


### PR DESCRIPTION
Refactored some of the dynamo opaque object code -- previously if we had a value-type we would set `TorchScriptObjectVariable.value` to be the opaque obj itself, but I refactored so that we also create a FakeScriptObject. This simplifies the logic so that `TorchScriptObjectVariable.value` is always a FakeScriptObject, and we can always access the real obj by looking at `TorchScriptObjectVariable.value.real_obj`. By creating a FakeScriptObject, we can also error if a method that is not specified as a member is being accessed.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172099
* __->__ #172092
* #171484
* #171483



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo