### PR TITLE
[device mesh] Change isinstance checks on DeviceMesh

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1146,20 +1146,20 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> tuple[str, list[int], int
         rankset = dist.get_process_group_ranks(group)
         group_size = len(rankset)
         tag = tag or c10d._get_group_tag(group)
-    elif isinstance(group, DeviceMesh):
-        if group.ndim != 1:
+    elif DeviceMesh._isinstance(group):
+        if group.ndim != 1:  # pyrefly: ignore[missing-attribute]
             raise AssertionError(
                 "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
             )
         # TODO: it should run collective in the whole mesh instead of dim 0
-        pg = group.get_group()
+        pg = group.get_group()  # pyrefly: ignore[missing-attribute]
         rankset = dist.get_process_group_ranks(pg)
         group_size = len(rankset)
         tag = tag or c10d._get_group_tag(pg)
     elif isinstance(group, tuple):
         if (
             len(group) == 2
-            and isinstance(group[0], DeviceMesh)
+            and DeviceMesh._isinstance(group[0])
             and isinstance(group[1], int)
         ):
             dmesh = group[0]
@@ -1192,16 +1192,16 @@ def _resolve_group_name(group: RANK_TYPES, tag: str = "") -> c10d.GroupName:
         # literally the underlying type so this is fine). I haven't been able to
         # reproduce it in isolation (see T247631668).
         return cast(c10d.GroupName, group)  # c10d.GroupName(group)
-    elif isinstance(group, DeviceMesh):
-        if group.ndim != 1:
+    elif DeviceMesh._isinstance(group):
+        if group.ndim != 1:  # pyrefly: ignore[missing-attribute]
             raise AssertionError(
                 "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
             )
-        return group._dim_group_names[0]
+        return group._dim_group_names[0]  # pyrefly: ignore[missing-attribute]
     elif isinstance(group, tuple):
         if (
             len(group) == 2
-            and isinstance(group[0], DeviceMesh)
+            and DeviceMesh._isinstance(group[0])
             and isinstance(group[1], int)
         ):
             dmesh = group[0]

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -193,7 +193,7 @@ def _is_valid_hybrid_shard_pg_type(process_group: Any) -> bool:
 
 @no_type_check
 def _is_valid_hybrid_shard_device_mesh(device_mesh: DeviceMesh) -> bool:
-    return isinstance(device_mesh, DeviceMesh) and device_mesh.ndim == 2
+    return DeviceMesh._isinstance(device_mesh) and device_mesh.ndim == 2
 
 
 @no_type_check

--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -485,7 +485,7 @@ class ShardingPropagator:
 
             if single_dim_strategy is not None:
                 mesh = try_find_mesh_from_args(op_schema.op, op_schema.args_schema)
-                assert isinstance(mesh, DeviceMesh), "Expected to find a valid mesh"
+                assert DeviceMesh._isinstance(mesh), "Expected to find a valid mesh"
                 # if we run into a case where we register a single-dim rule for an op that can't propagate tensor meta,
                 # we could loosen this assert, but it's better to fix gaps in tensor meta prop. We want to end up
                 # with the invariant that all DTensorSpec have a valid tensormeta, but many existing sharding rules


### PR DESCRIPTION
When tracing with DeviceMesh, we represent it as a FakeScriptObject. However this causes all `isinstance(x, DeviceMesh)` checks to return False. I tried a couple of solutions before settling on this one:

1. Instead of creating a FakeScriptObject, we create a new class that subclasses both FakeScriptObject and the original Opaque type. This was attempted in https://github.com/pytorch/pytorch/pull/171738/ and generally worked, but ran into issues when trying to make ProcessGroup a reference type. Since ProcessGroup is a pybind/implemented in cpp, it requires you to call ProcessGroup's `__init__` function when double subclassing, which is not possible to do generically.

2. Override `__class__` to be the Opaque type. This results in all `isinstance(x, FakeScriptObject)` checks in the codebase to fail, causing a bunch of other errors.

3. Make all reference-types classes override `__instancecheck__` to accept FakeScriptObjects. It seems like to do this, the custom classes themselves need to set their metaclass with the overrided `__instancecheck__`, which is not very monkeypatchable.

4. [this solution] Change `isinstance(x, DeviceMesh)` checks. Since there doesn't seem to be a lot of `isinstance(x, DeviceMesh)` calls, we will try changing those calls to check for if a DeviceMesh-specific attribute exists on the FakeScriptObject.


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172093
* #171482
* #172099
* #172092
* #171484
* #171483

