### PR TITLE
Optimise Pickler::pushGlobal

### DIFF
--- a/c10/util/FbcodeMaps.h
+++ b/c10/util/FbcodeMaps.h
@@ -18,11 +18,15 @@ template <typename Key, typename Value>
 using FastMap = folly::F14FastMap<Key, Value>;
 template <typename Key>
 using FastSet = folly::F14FastSet<Key>;
+template <typename Key>
+using HashedKey = folly::F14HashedKey<Key>;
 #else
 template <typename Key, typename Value>
 using FastMap = std::unordered_map<Key, Value>;
 template <typename Key>
 using FastSet = std::unordered_set<Key>;
+template <typename Key>
+using HashedKey = Key;
 #endif
 } // namespace c10
 

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -91,6 +91,7 @@ class TORCH_API Pickler {
       const IValue& ivalue,
       const char* list_name,
       const std::function<void(const IValue&)>& item_pusher);
+  void pushGlobal(const c10::HashedKey<std::string>& module_and_class_name);
   void pushGlobal(std::string_view module_name, std::string_view class_name);
   // raw string data is appended directly to the byte stream
   void pushBytes(const std::string& string);


### PR DESCRIPTION
Summary:
As per title, optimising `Pickler::pushGlobal`.

Currently, `pushGlobal` takes two 'parts' to a key. It must perform string operations and (implicitly) F14 hash calculation on these parts. However, many uses of `pushGlobal` use hard-coded parts to this key; in these cases all of this work is duplicated on each call to `pushGlobal`.

To resolve this, we create a new interface for `pushGlobal` that takes a standalone pre-hashed string, allowing this work to be skipped.

Admittedly, the bulk of this saving relies on having the folly dependency (as the standard library otherwise used for containers does not support pre-hashing) but there will still be some small improvement from avoiding redundant string operations.

Test Plan: CI

Differential Revision: D90383652




cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel