### PR TITLE
Explicitly cast unused value to void

### DIFF
--- a/c10/test/util/optional_test.cpp
+++ b/c10/test/util/optional_test.cpp
@@ -67,7 +67,7 @@ TYPED_TEST(OptionalTest, Empty) {
   EXPECT_FALSE(empty.has_value());
 
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access,hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(empty.value(), std::bad_optional_access);
+  EXPECT_THROW((void)empty.value(), std::bad_optional_access);
 }
 
 TYPED_TEST(OptionalTest, Initialized) {


### PR DESCRIPTION
Some newer toolchains do not accept unused return values unless you cast them to void. Casting them to void more clearly communicates the intent that the function is not supposed to return any kind of value that is used.