### PR TITLE
[DTensor] Automatically set release_notes label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -124,6 +124,10 @@
 - torchgen/aoti/**
 - torchgen/gen_aoti_c_shim.py
 
+"release notes: distributed (dtensor)":
+- torch/distributed/_tensor/**
+- torch/distributed/tensor/**
+
 "ciflow/vllm":
 - .github/ci_commit_pins/vllm.txt
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172121

Up for discussion whether folks prefer to automatically set
release_notes: distributed (dtensor) label for any edits to dtensor core
files.  There could be false positives this way but it saves an annoying
step of manually labeling every PR.