### PR TITLE
Skip modded_nanogpt model in TorchInductor benchmark

### DIFF
--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -205,6 +205,9 @@ skip:
     - stable_diffusion
     - stable_diffusion_text_encoder
     - stable_diffusion_unet
+    # Has never been working correctly
+    # https://github.com/pytorch/pytorch/issues/172015#issuecomment-3730509098
+    - modded_nanogpt
 
   device:
     cpu:


### PR DESCRIPTION
This has never been working correctly https://github.com/pytorch/pytorch/issues/172015#issuecomment-3730509098, so let's skip it completely. For more context, this model switches from [eager_fail_to_run to fail_accuracy](https://hud.pytorch.org/benchmark/v3/dashboard/compiler_inductor?renderGroupId=main&time.start=2026-01-02T00%3A00%3A00.000Z&time.end=2026-01-09T23%3A59%3A59.999Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.backend=&filters.mode=training&filters.dtype=amp&filters.deviceName=cuda+%28h100%29&filters.device=cuda&filters.arch=h100&filters.model=modded_nanogpt&lbranch=prepare-perf-number-2.9.1&rbranch=prepare-perf-number-2.10-v2&rcommit.commit=48ac90a47e9eb80c30282ae991f2bb3399427919&rcommit.workflow_id=20837908962&rcommit.date=2026-01-09T04%3A00%3A00Z&rcommit.branch=prepare-perf-number-2.10-v2&lcommit.commit=be32f077fb50b49ad856e957a6860d37565583db&lcommit.workflow_id=20799100249&lcommit.date=2026-01-08T02%3A00%3A00Z&lcommit.branch=prepare-perf-number-2.9.1&maxSampling=110) status recently, root cause is not clear, but it's not related to 2.10 RC 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo