### PR TITLE
Skip shared memory pruning test on devices without shared memory query support

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2588,6 +2588,8 @@ class TestTemplateConfigPruning(TestCase):
         exceeds_checker = heuristic._get_exceeding_shared_memory_checker(
             **shared_memory_checker_opts
         )
+        if exceeds_checker is None:
+            self.skipTest("Device does not support shared memory size query")
         for c in self.gemm_configs:
             smem_estimation = heuristic.get_shared_memory_estimation(
                 c, dtype_size, **shared_memory_checker_opts


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172128

Fix TypeError on XPU devices where _get_exceeding_shared_memory_checker
returns None because XPU lacks shared_memory_per_block_optin (NVIDIA) and
shared_memory_per_block (ROCm) properties.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo