### PR TITLE
[Inductor] Allow disabling aten convolution

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -150,6 +150,9 @@ class TuningProcess:
             "TORCHINDUCTOR_PROFILE_WITH_DO_BENCH_USING_PROFILING": "1"
             if config.profile_bandwidth_with_do_bench_using_profiling
             else "0",
+            # Disable aten conv in subprocesses when config.disable_aten_conv is True.
+            # This ensures benchmarking doesn't use aten conv when it's disabled.
+            "TORCHINDUCTOR_DISABLE_ATEN_CONV": "1" if config.disable_aten_conv else "0",
         }
         if self.device is not None:
             env[CUDA_VISIBLE_DEVICES] = str(self.device)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1223,6 +1223,8 @@ profile_bandwidth_with_do_bench_using_profiling = (
     os.environ.get("TORCHINDUCTOR_PROFILE_WITH_DO_BENCH_USING_PROFILING") == "1"
 )
 
+# Disable aten conv (uses cudnn for nvda and miopen for amd)
+disable_aten_conv = os.environ.get("TORCHINDUCTOR_DISABLE_ATEN_CONV") == "1"
 
 # TODO: remove later
 # incompatible with cpp_wrapper

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1758,7 +1758,13 @@ def _use_autotune_backend(backend: str) -> bool:
 
 
 def _use_conv_autotune_backend(backend: str) -> bool:
-    return backend.upper() in [
+    backend_upper = backend.upper()
+    # When aten conv is disabled (via config.disable_aten_conv), skip ATEN backend
+    # since it relies on cudnn/miopen for GPU convolutions
+    if backend_upper == "ATEN" and config.disable_aten_conv:
+        log.info("Skipping ATEN convolution backend because config.disable_aten_conv=True")
+        return False
+    return backend_upper in [
         x.strip() for x in config.max_autotune_conv_backends.upper().split(",")
     ]
 


### PR DESCRIPTION
Summary: Aten conv requires cudnn / miopen to work at runtime. However, at the moment miopen cannot be used on AMD machines. Therefore, adding an option to skip aten convolution in inductor so it's forced to use triton.

Test Plan:
Build a custom lowering package ien.lower.mi300x.

Original model: f1017999376. Fails in ICE https://fburl.com/unidash/2y7nblud

Test model: f1018205956

Differential Revision: D90282647




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo