### PR TITLE
[Reland][inductor] Remove implicit float64 upcast in triton

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2030,7 +2030,7 @@ class TestStandaloneCompile(TestCase):
                             file_contents = f.read()
                         if device == GPU_TYPE:
                             file_contents = file_contents.replace(
-                                "tmp1 = 2.0", "tmp1 = 8.0"
+                                "2.0, tl.float32", "8.0, tl.float32"
                             )
                         else:
                             assert device == "cpu"

--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -1160,6 +1160,87 @@ class ForeachTests(TestCase):
             self.assertEqual(a, b, atol=0, rtol=0)
 
     @requires_gpu
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
+    @parametrize(
+        "op",
+        [
+            torch._foreach_add,
+            torch._foreach_mul,
+            torch._foreach_sub,
+            # Note: _foreach_div excluded due to pre-existing eager precision
+            # mismatch between python scalar and tensor scalar arguments
+        ],
+        name_fn=lambda op: op.__name__,
+    )
+    @parametrize(
+        "value",
+        [
+            0.123456789,
+            -1.987654321,
+            1e-8,
+            1e8,
+            3.141592653589793,  # pi - more precision than fp32
+            -2.718281828459045,  # -e - more precision than fp32
+            0.000000001234567890123456,
+            # Values that expose fp32/fp64 casting issues:
+            1.0000001192092896,  # 1 + 2^-23 (smallest diff from 1.0 in fp32)
+            1.00000001,  # Between fp32 representable values
+            1e-38,  # Very small but not subnormal
+            1.1754944e-38,  # Near fp32 min normal
+            0.333333333333333333,  # 1/3 with full fp64 precision
+            0.1,  # Cannot be exactly represented in binary
+            1.0000000000000002,  # 1 + eps in fp64, rounds to 1.0 in fp32
+            0.30000000000000004,  # 0.1 + 0.2 in fp64 (famous precision issue)
+        ],
+    )
+    def test_foreach_scalar_vs_scalar_tensor(self, op, value):
+        """Test that foreach binary ops with python scalar second argument
+        match tensor scalar second argument in both eager and compiled modes."""
+
+        def fn_python_scalar(a0, a1):
+            return op([a0, a1], value)
+
+        def fn_tensor_scalar(a0, a1, val):
+            return op([a0, a1], val)
+
+        # Use specific values that are sensitive to fp32/fp64 precision differences
+        inputs = (
+            torch.tensor(
+                [[1.0000001192092896, 0.333333333333333333], [1e-7, 3.4028235e30]],
+                device=GPU_TYPE,
+                dtype=torch.float32,
+            ),
+            torch.tensor(
+                [[1.0000000000000002, 0.1], [1e-38, 2.718281828459045]],
+                device=GPU_TYPE,
+                dtype=torch.float32,
+            ),
+        )
+        scalar_tensor = torch.tensor(value, device=GPU_TYPE, dtype=torch.float64)
+
+        # Eager mode comparison - assert bitwise equality
+        eager_python_scalar = fn_python_scalar(*inputs)
+        eager_tensor_scalar = fn_tensor_scalar(*inputs, scalar_tensor)
+        for a, b in zip(eager_python_scalar, eager_tensor_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+
+        # Compiled mode comparison - assert bitwise equality
+        compiled_python_scalar = torch.compile(fn_python_scalar, fullgraph=True)(
+            *inputs
+        )
+        compiled_tensor_scalar = torch.compile(fn_tensor_scalar, fullgraph=True)(
+            *inputs, scalar_tensor
+        )
+        for a, b in zip(compiled_python_scalar, compiled_tensor_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+
+        # Cross comparison: eager vs compiled - assert bitwise equality
+        for a, b in zip(eager_python_scalar, compiled_python_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+        for a, b in zip(eager_tensor_scalar, compiled_tensor_scalar):
+            self.assertEqual(a, b, atol=0, rtol=0)
+
+    @requires_gpu
     @foreach_map_un_ops
     def test_foreach_map_backward_unary(self, op):
         from torch._dynamo.polyfills import foreach_map_fn

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3442,9 +3442,9 @@ class TestPrologueFusion(TestCase):
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
         # check that we do not CSE any variables between prologues, epilogues
-        FileCheck().check("def triton").check_count("= 1.1", 3, exactly=True).check(
-            "tl.store"
-        ).run(code[0])
+        FileCheck().check("def triton").check_count(
+            "tl.full([1], 1.1, tl.float32)", 3, exactly=True
+        ).check("tl.store").run(code[0])
 
     @config.patch(
         {

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3656,6 +3656,8 @@ class CommonTemplate:
         cf(x, 1e-5)
         cf(x, 1e-6)
 
+    # I think Triton CPU doesn't preserve -0.0 sign in tl.full
+    @xfail_if_triton_cpu
     def test_div_by_zero(self):
         def fn(x, runtime_zero, runtime_neg_zero):
             zero = torch.zeros_like(x)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1183,12 +1183,9 @@ class TritonOverrides(OpOverrides):
         triton_val = constant_repr(type_(value))
         triton_type = triton_compute_type(dtype)
 
-        if triton_type == "tl.float32":
-            # Float constants are always f32 in triton
-            return triton_val
-
-        # NOTE: We use a tensor here in order to get the expected type.
-        # Otherwise, e.g. float64 constants would be truncated to float32.
+        # NOTE: We use tl.full here to get the expected type.
+        # Otherwise, subnormal float32 values are treated as fp64
+        # causing fp32 * fp64 promotion and different numerical results.
         if value < 0 and not dtype.is_signed:
             triton_signed_type = f"tl.{triton_type[4:]}"
             return f"tl.full({shape}, {triton_val}, {triton_signed_type}).to({triton_type})"

--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -82,12 +82,10 @@ class ShapePropagationOpsHandler:
 
     @staticmethod
     def constant(value: torch.types.Number, dtype: torch.dtype) -> BlockShapeType:
-        # See implementation of constant for triton for the reason
-        from torch._inductor.codegen.triton import triton_compute_type, TritonKernel
+        # TritonKernelOverrides.constant uses tl.full with shape=[1]*ndim for all types
+        from torch._inductor.codegen.triton import TritonKernel
 
-        triton_type = triton_compute_type(dtype)
-
-        if isinstance(V.kernel, TritonKernel) and triton_type != "tl.float32":
+        if isinstance(V.kernel, TritonKernel):
             ndim = V.kernel.triton_tensor_ndim()
             return tuple([1] * ndim)
         else:


### PR DESCRIPTION
Reland of https://github.com/pytorch/pytorch/pull/170393

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #170532
* #170531
* __->__ #172143



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo