### PR TITLE
[inductor] Fix race condition in FxGraphCache when reading temp files

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1044,6 +1044,8 @@ class GuardedCache(Generic[T]):
             subdir = cls._get_tmp_dir_for_key(key)
             if os.path.exists(subdir):
                 for path in sorted(os.listdir(subdir)):
+                    if path.startswith("."):
+                        continue  # Skip temp files from concurrent write_atomic() calls
                     try:
                         with open(os.path.join(subdir, path), "rb") as f:
                             content = f.read()


### PR DESCRIPTION
## Summary

Fixes a race condition in `iterate_over_candidates()` that can cause `pickle.loads()` to fail with truncated data errors during concurrent `torch.compile()` usage.

### Problem

When multiple processes use `torch.compile()` concurrently (e.g., distributed training with multiple ranks), `write_atomic()` creates temporary files with a `.` prefix (e.g., `.12345.140123456789.tmp`) before atomically renaming them to the final path.

However, `iterate_over_candidates()` iterates over **all** files in the cache directory via `os.listdir()`, including these incomplete temp files. If a process scans the cache while another is writing, it may read a partially-written temp file, causing:

```
_pickle.UnpicklingError: pickle data was truncated
```

### Solution

Skip files starting with `.` in `iterate_over_candidates()`. This is safe because:
- Valid cache entries are named by `sha256_hash()` which returns base32-encoded strings (characters `a-z`, `2-7`)
- Base32 encoding can never produce a string starting with `.`
- The `.` prefix is the established convention for temp files in `write_atomic()`

### Test Plan

This fix was developed to address errors observed in large-scale distributed training (512 GPUs). The error manifests stochastically when multiple ranks compile the same model concurrently:

```
[rank7]:W1212 13:17:44.569000 torch/_inductor/codecache.py:974] fx graph cache unable to load compiled graph
[rank7]:W1212 13:17:44.569000 torch/_inductor/codecache.py:974] _pickle.UnpicklingError: pickle data was truncated
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel @eellison

🤖 Generated with [Claude Code](https://claude.ai/code)