### PR TITLE
[ROCm] Increase the timeout value for ops microbenchmark

### DIFF
--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -107,7 +107,8 @@ jobs:
     uses: ./.github/workflows/_rocm-test.yml
     needs: opmicrobenchmark-build-rocm
     with:
-      timeout-minutes: 500
+      # TODO (huydo): Need to implement sharding for ops micro benchmark
+      timeout-minutes: 720
       build-environment: ${{ needs.opmicrobenchmark-build-rocm.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-rocm.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-rocm.outputs.test-matrix }}


### PR DESCRIPTION
We need sharding for this job, but this is a quick mitigation for https://github.com/pytorch/pytorch/actions/runs/20633756042/job/59256709062.  Let's see if 12 hours is enough to finish the job.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang