### PR TITLE
[SymmMem] Deprecate enable_symm_mem_for_group

### DIFF
--- a/benchmarks/distributed/bench_nvshmem_tile_reduce.py
+++ b/benchmarks/distributed/bench_nvshmem_tile_reduce.py
@@ -68,7 +68,6 @@ class NVSHMEMTileReduceBenchmark(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
 

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -190,7 +190,6 @@ dist.init_process_group(backend="nccl", pg_options=opts, device_id=device)
 # Set up symmetric memory with NCCL backend
 symm_mem.set_backend("NCCL")
 group_name = dist.group.WORLD.group_name
-symm_mem.enable_symm_mem_for_group(group_name)
 
 # Allocate tensors using symmetric memory
 numel = 1024 * 1024

--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -47,7 +47,6 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         # initialize NCCL communicator.
         dist.all_reduce(torch.ones(1, device=self.device))
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         # Prepare a profiler
         prof = torch.profiler.profile(

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -238,7 +238,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # initialize NCCL communicator.
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -266,7 +265,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # initialize NCCL communicator.
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -298,7 +296,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # initialize NCCL communicator.
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -339,7 +336,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # initialize NCCL communicator.
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -371,7 +367,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # initialize NCCL communicator.
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -400,7 +395,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         # initialize NCCL communicator.
         c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         dim = 1024

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -63,7 +63,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -82,7 +81,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         # Set NVSHMEM as SymmMem backend
         symm_mem.set_backend("NVSHMEM")
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -97,7 +95,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -123,7 +120,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -147,7 +143,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         dim = 1024
@@ -173,7 +168,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -195,7 +189,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -224,7 +217,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         """
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         my_tensor = symm_mem.empty(1, device=self.device).fill_(self.rank)
         remote_tensors = torch.ops.symm_mem.get_remote_tensors(my_tensor, group_name)
@@ -237,7 +229,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nvshmem_put(self) -> None:
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -260,7 +251,6 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
     def test_nvshmem_get(self) -> None:
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -299,7 +289,6 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel_per_peer = 10
@@ -324,7 +313,6 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         # Number of elements for a peer is random between [0, k)
@@ -388,7 +376,6 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         # Number of experts per rank
@@ -497,7 +484,6 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         # Number of experts per rank
@@ -614,7 +600,6 @@ def dispatch_then_combine(device, align: int, group) -> None:
     exactly the same as the original input data
     """
     group_name = group.group_name
-    symm_mem.enable_symm_mem_for_group(group_name)
 
     dtype = torch.float
     # Number of experts per rank
@@ -739,7 +724,6 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
         """
         torch.manual_seed(42 + self.rank)
         self._init_device()
-        symm_mem.enable_symm_mem_for_group(dist.group.WORLD.group_name)
         # Test on two concurrent subgroups
         ngroups = 2
         subgroup_size = self.world_size // ngroups
@@ -774,7 +758,6 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
 
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         full_inp = symm_mem.empty(
             full_size, full_size, dtype=dtype, device=self.device
@@ -819,7 +802,6 @@ class NVSHMEMTileCommTest(MultiProcContinuousTest):
 
         self._init_device()
         group_name = dist.group.WORLD.group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         full_inp = symm_mem.empty(
             full_size, full_size, dtype=dtype, device=self.device

--- a/test/distributed/test_nvshmem_triton.py
+++ b/test/distributed/test_nvshmem_triton.py
@@ -294,7 +294,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
 
         # Configuration
@@ -348,7 +347,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
 
         # Configuration
@@ -388,7 +386,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
         world_size = dist.get_world_size()
 
@@ -430,7 +427,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
 
         msg_size_bytes = 8
@@ -488,7 +484,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
 
         msg_size_bytes = 8
@@ -544,7 +539,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         rank = self.rank
         peer = 1 - rank
@@ -591,7 +585,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
     def test_triton_signal_wait_until(self) -> None:
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
         peer = 1 - rank
 
@@ -661,7 +654,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
         peer = 1 - rank
         # Message configuration
@@ -726,7 +718,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
         peer = 1 - rank
 
@@ -776,7 +767,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
         numel = 1
         dtype = torch.int32
@@ -812,7 +802,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         self._init_device()
 
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
         numel = 1
         dtype = torch.int32
@@ -855,7 +844,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
         rank = self.rank
         # Each PE will send 2 int64 elements to every other PE
@@ -902,7 +890,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         rank = self.rank
 
         # Configuration
@@ -970,7 +957,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
         rank = self.rank
         # Configuration
@@ -1032,7 +1018,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
         rank = self.rank
         # Configuration
@@ -1118,7 +1103,6 @@ class NVSHMEMTritonTest(MultiProcContinuousTest):
         torch.manual_seed(42 + self.rank)
         self._init_device()
         group_name = dist.distributed_c10d._get_default_group().group_name
-        symm_mem.enable_symm_mem_for_group(group_name)
         world_size = dist.get_world_size()
         rank = self.rank
         # Configuration

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -18,7 +18,6 @@ from torch.distributed._symmetric_memory import (
     _fused_all_gather_scaled_matmul_fallback,
     _fused_matmul_reduce_scatter_fallback,
     _test_mode,
-    enable_symm_mem_for_group,
     restride_A_for_fused_matmul_reduce_scatter,
     restride_A_shard_for_fused_all_gather_matmul,
 )
@@ -764,7 +763,6 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
     def test_empty_strided_p2p(self, set_device: bool) -> None:
         self._init_process(set_device)
         group_name = dist.group.WORLD.group_name
-        enable_symm_mem_for_group(group_name)
 
         alloc_args = self._get_test_alloc_args()
 
@@ -786,7 +784,6 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
     def test_empty_strided_p2p_persistent(self, set_device: bool) -> None:
         self._init_process(set_device)
         group_name = dist.group.WORLD.group_name
-        enable_symm_mem_for_group(group_name)
 
         alloc_args = self._get_test_alloc_args()
 
@@ -1219,7 +1216,6 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
 class LoweringTest(MultiProcContinuousTest):
     def _init_process(self) -> None:
         torch.cuda.set_device(self.device)
-        enable_symm_mem_for_group(dist.group.WORLD.group_name)
         torch.manual_seed(42 + self.rank)
         torch._inductor.config._collective.auto_select = True
 
@@ -1377,7 +1373,6 @@ class SymmMemPoolTest(MultiProcContinuousTest):
     def test_mempool_tensor_factory(self):
         self._init_process()
         group_name = dist.group.WORLD.group_name
-        enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         numel = 1024
@@ -1402,7 +1397,6 @@ class SymmMemPoolTest(MultiProcContinuousTest):
     def test_mempool_compute_ops(self):
         self._init_process()
         group_name = dist.group.WORLD.group_name
-        enable_symm_mem_for_group(group_name)
 
         dtype = torch.float
         dim = 1024

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -1,3 +1,4 @@
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp>
@@ -619,7 +620,7 @@ template <bool use_fabric_handle>
 c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     void* ptr,
     c10::intrusive_ptr<Block> block,
-    const GroupInfo& group_info) {
+    const std::string& group_name) {
 #if defined(USE_ROCM)
   using BlockHandleType = int;
 #else
@@ -634,9 +635,10 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     LOG(INFO) << "using fabric handle to import symmetric memory handles.";
   }
 
-  auto store = group_info.store;
-  int rank = group_info.rank;
-  int world_size = group_info.world_size;
+  auto group = resolve_process_group(group_name);
+  auto rank = group->getRank();
+  auto world_size = group->getSize();
+  auto store = group->getStore();
 
   // Currently, IpcChannel is using a file based socket for inter-process
   // communication
@@ -779,8 +781,8 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       mc_addr,
       block->buffer_size,
       block->device_idx,
-      group_info.rank,
-      group_info.world_size);
+      rank,
+      world_size);
 
   return pai;
 }
@@ -822,14 +824,13 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
   auto it = block->symm_mems.find(group_name_);
   if (it == block->symm_mems.end()) {
     // Create PeerAllocInfo for this block (this is the costly part)
-    auto group_info = get_group_info(group_name_);
     TORCH_INTERNAL_ASSERT(
         handle_type_ != Expandable_Segments_Handle_Type::UNSPECIFIED)
     bool use_fabric =
         handle_type_ == Expandable_Segments_Handle_Type::FABRIC_HANDLE;
     // PeerAllocInfo captures this block's rendezvous info
-    auto pai = use_fabric ? make_peer_alloc_info<true>(ptr, block, group_info)
-                          : make_peer_alloc_info<false>(ptr, block, group_info);
+    auto pai = use_fabric ? make_peer_alloc_info<true>(ptr, block, group_name_)
+                          : make_peer_alloc_info<false>(ptr, block, group_name_);
     // Cache it with the group name
     it = block->symm_mems.emplace(group_name_, pai).first;
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
@@ -41,10 +41,6 @@ class NCCLSymmetricMemory : public SymmetricMemory {
 
   c10::Device get_device() override;
 
-  const std::vector<int>& get_rank_to_global_rank() override;
-
-  int* get_rank_to_global_rank_dev() override;
-
   ncclWindow_t get_window();
 
   ncclWindow_t get_signal_pad_handle();

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cu
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.h>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
@@ -49,6 +50,11 @@ struct NVSHMEMAllocation {
   }
 };
 
+// A map from group name to rank-to-global rank mapping
+static std::unordered_map<std::string, std::vector<int>> rank_to_global_rank_map{};
+// A map from group name to rank-to-global rank device array
+static std::unordered_map<std::string, int*> rank_to_global_rank_dev_map{};
+
 // A class to hold the base pointers and signal pad pointers for a group of
 // peers. One `NVSHMEMPeerAllocInfo` object can be shared by multiple
 // `NVSHMEMSymmetricMemory` objects when latter reside on the same allocation
@@ -64,30 +70,43 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
     static int exchanged_n_times = 0;
     c10::cuda::CUDAGuard guard(allocation->device_idx);
 
-    auto global_rank = get_group_info("0").rank;
-    GroupInfo& group_info = get_group_info(group_name);
-    auto store = group_info.store;
-    rank_ = group_info.rank;
-    world_size_ = group_info.world_size;
+    auto group = resolve_process_group(group_name);
+    rank_ = group->getRank();
+    world_size_ = group->getSize();
+    auto store = group->getStore();
+
     // Exchange rank to global rank mapping for this group.
     // If it is already available, skip the exchange.
-    if (group_info.rank_to_global_rank.empty()) {
-      group_info.rank_to_global_rank =
+    auto it = rank_to_global_rank_map.find(group_name);
+    if (it == rank_to_global_rank_map.end()) {
+      auto global_group = resolve_process_group("0");
+      auto global_rank = global_group->getRank();
+      auto rank_to_global_rank =
           storeExchange.all_gather(store, rank_, world_size_, global_rank);
       exchanged_n_times++;
       if (rank_ == 0) {
         LOG(INFO) << "[rank " << rank_ << ']'
-                  << " rank_to_global_rank: " << group_info.rank_to_global_rank
+                  << " rank_to_global_rank: " << rank_to_global_rank
                   << ", group_name: " << group_name
                   << ", exchanged_n_times: " << exchanged_n_times;
       }
+      it = rank_to_global_rank_map.emplace_hint(it, group_name, rank_to_global_rank);
+
+      // Emplace a device array of rank to global rank mapping
+      auto rank_to_global_rank_dev = reinterpret_cast<int*>(
+          c10::cuda::CUDACachingAllocator::raw_alloc(sizeof(int) * world_size_));
+      AT_CUDA_CHECK(cudaMemcpy(
+          rank_to_global_rank_dev,
+          rank_to_global_rank.data(),
+          sizeof(int) * world_size_,
+          cudaMemcpyHostToDevice));
+      rank_to_global_rank_dev_map[group_name] = rank_to_global_rank_dev;
     }
-    TORCH_INTERNAL_ASSERT(!group_info.rank_to_global_rank.empty());
-    rank_to_global_rank_ = group_info.rank_to_global_rank;
+    auto& rank_to_global_rank = it->second;
 
     world_within_cuda_p2p_ = true;
     for (int r = 0; r < world_size_; ++r) {
-      auto peer_ptr = nvshmem_ptr(base_ptr_, rank_to_global_rank_[r]);
+      auto peer_ptr = nvshmem_ptr(base_ptr_, rank_to_global_rank[r]);
       buffers_.push_back(peer_ptr);
       // If a peer is over network, `nvshmem_ptr` returns null
       if (peer_ptr == nullptr) {
@@ -103,7 +122,7 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
 
     for (int r = 0; r < world_size_; ++r) {
       signal_pads_.push_back(
-          nvshmem_ptr(signal_pad_ptr, rank_to_global_rank_[r]));
+          nvshmem_ptr(signal_pad_ptr, rank_to_global_rank[r]));
     }
 
     const size_t arr_size = sizeof(void*) * world_size_;
@@ -119,14 +138,6 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
         signal_pads_.data(),
         arr_size,
         cudaMemcpyHostToDevice));
-
-    rank_to_global_rank_dev_ = reinterpret_cast<int*>(
-        c10::cuda::CUDACachingAllocator::raw_alloc(sizeof(int) * world_size_));
-    AT_CUDA_CHECK(cudaMemcpy(
-        rank_to_global_rank_dev_,
-        rank_to_global_rank_.data(),
-        sizeof(int) * world_size_,
-        cudaMemcpyHostToDevice));
   }
 
  private:
@@ -138,8 +149,6 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
   std::vector<void*> signal_pads_;
   void** buffers_dev_;
   void** signal_pads_dev_;
-  std::vector<int> rank_to_global_rank_;
-  int* rank_to_global_rank_dev_;
   // Whether the world is within CUDA P2P only, not network
   bool world_within_cuda_p2p_;
 
@@ -235,11 +244,19 @@ class NVSHMEMSymmetricMemory : public SymmetricMemory {
   }
 
   const std::vector<int>& get_rank_to_global_rank() override {
-    return pai_->rank_to_global_rank_;
+    auto it = rank_to_global_rank_map.find(group_name_);
+    if (it == rank_to_global_rank_map.end()) {
+      TORCH_CHECK(false, "Group name not found in rank_to_global_rank_map");
+    }
+    return it->second;
   };
 
   int* get_rank_to_global_rank_dev() override {
-    return pai_->rank_to_global_rank_dev_;
+    auto it = rank_to_global_rank_dev_map.find(group_name_);
+    if (it == rank_to_global_rank_dev_map.end()) {
+      TORCH_CHECK(false, "Group name not found in rank_to_global_rank_dev_map");
+    }
+    return it->second;
   };
 
   bool world_within_direct_access() override {
@@ -328,12 +345,10 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         "must not be called with a group_name");
     c10::cuda::CUDAGuard guard(device_idx);
 
-    auto group_info = get_group_info("0");
-    auto store = group_info.store;
-    int rank = group_info.rank;
-    int world_size = group_info.world_size;
+    // NVSHMEM needs to be initialized with the global group
+    auto group = resolve_process_group("0");
+    initialize_nvshmem_with_store(group->getStore(), group->getRank(), group->getSize(), device_idx);
 
-    initialize_nvshmem_with_store(store, rank, world_size, device_idx);
     auto ptr = nvshmem_malloc(size);
     // If size is 0 (which is legal allocation request) we shouldn't error out
     TORCH_CHECK(ptr != nullptr || size == 0, "nvshmem_malloc failed");

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -145,10 +145,6 @@ struct GroupInfo {
   int rank;
   int world_size;
   c10::intrusive_ptr<c10d::Store> store;
-  // Note this field is not automatically populated by set_group_info().  If a
-  // SymmetricMemory implementation needs to use it, it must be populated by a
-  // call to exchange_global_ranks() first.
-  std::vector<int> rank_to_global_rank;
 };
 
 C10_EXPORT GroupInfo& get_group_info(const std::string& group_name);

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from enum import Enum
 from functools import partial
 from typing import Any, Literal
+from typing_extensions import deprecated
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -21,6 +22,9 @@ from torch._C._distributed_c10d import _SymmetricMemory, Work as _Work
 _group_name_to_store: dict[str, c10d.Store] = {}
 
 
+@deprecated(
+    "`enable_symm_mem_for_group` is deprecated. There is no need to call this function anymore."
+)
 def enable_symm_mem_for_group(group_name: c10d.GroupName) -> None:
     """
     Enables symmetric memory for a process group.
@@ -104,8 +108,6 @@ def get_symm_mem_workspace(
         _SymmetricMemory: the symmetric memory workspace associated with the
         group.
     """
-    enable_symm_mem_for_group(group_name)
-
     tensor = _group_name_to_workspace_tensor.get(group_name)
     size = tensor.numel() * tensor.element_size() if tensor is not None else 0
     if tensor is None or size < min_size:
@@ -1958,7 +1960,6 @@ def rendezvous(
     else:
         raise TypeError(f"rendezvous: unsupported group type: {type(group)}")
 
-    enable_symm_mem_for_group(group_name)
     return _SymmetricMemory.rendezvous(tensor, group_name)
 
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -23,7 +23,8 @@ _group_name_to_store: dict[str, c10d.Store] = {}
 
 
 @deprecated(
-    "`enable_symm_mem_for_group` is deprecated. There is no need to call this function anymore."
+    "`enable_symm_mem_for_group` is deprecated. There is no need to call this function anymore.",
+    category=FutureWarning,
 )
 def enable_symm_mem_for_group(group_name: c10d.GroupName) -> None:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #172163

Resolves #171827

`enable_symm_mem_for_group` is for getting access to the store of a group. 
But the store can be also retrieved by `ProcessGroup.getStore()` in C++. 
Thus makes little sense to require users to call `enable_symm_mem_for_group`.

cc @Skylion007 . Thanks for pointing out the inconvenience. 