### PR TITLE
[3/3][Code Clean] Refactor assertions in `torch/testing/_internal` to raise AssertionError with descriptive messages

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -57,7 +57,10 @@ class SpectralFuncPythonRefInfo(SpectralFuncInfo):
         self.torch_opinfo = _find_referenced_opinfo(
             torch_opinfo_name, torch_opinfo_variant, op_db=op_db
         )
-        assert isinstance(self.torch_opinfo, SpectralFuncInfo)
+        if not isinstance(self.torch_opinfo, SpectralFuncInfo):
+            raise TypeError(
+                f"torch_opinfo must be a SpectralFuncInfo instance, got {type(self.torch_opinfo)}"
+            )
 
         inherited = self.torch_opinfo._original_spectral_func_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -476,7 +476,8 @@ def sample_inputs_matrix_rank(op_info, device, dtype, requires_grad=False, **kwa
             return None
         if kwarg_type == "float":
             return 1.0
-        assert kwarg_type == "tensor"
+        if kwarg_type != "tensor":
+            raise AssertionError(f"kwarg_type must be 'tensor', got {kwarg_type}")
         return torch.ones(inp.shape[:-2], device=device)
 
     for tol_type in ["float", "tensor"]:
@@ -488,7 +489,10 @@ def sample_inputs_matrix_rank(op_info, device, dtype, requires_grad=False, **kwa
             for sample in sample_inputs_linalg_invertible(
                 op_info, device, dtype, requires_grad
             ):
-                assert sample.kwargs == {}
+                if sample.kwargs != {}:
+                    raise AssertionError(
+                        f"sample.kwargs must be empty, got {sample.kwargs}"
+                    )
                 sample.kwargs = {
                     "atol": make_tol_arg(atol_type, sample.input),
                     "rtol": make_tol_arg(rtol_type, sample.input),

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -411,7 +411,10 @@ def unbind_reference(op, sample, wrap_output_as_njt=True):
         ):
             num_returns = len(out_ref_components[0])
             # ensure we get the same number of returns for each invocation
-            assert all(len(o) == num_returns for o in out_ref_components)
+            if any(len(o) != num_returns for o in out_ref_components):
+                raise AssertionError(
+                    f"All output components must have {num_returns} returns"
+                )
             # construct NJTs from same index returns from each invocation
             njt_returns = [
                 torch.nested.as_nested_tensor(
@@ -428,32 +431,40 @@ def unbind_reference(op, sample, wrap_output_as_njt=True):
 # Computes the reference value for a non-reduction unary op with dim-wise application.
 def unary_dimwise_reference(op, sample, batchwise_reference=None):
     # extract info about the dim args this op supports
-    assert op._extra_op_data.dim_args is not None
+    if op._extra_op_data.dim_args is None:
+        raise AssertionError(f"op {op.name} must have _extra_op_data.dim_args defined")
     single_dim_argname, dimlist_argname = op._extra_op_data.get_dim_argnames()
     # only support a single non-list dim arg for now
-    assert dimlist_argname is None
-    assert single_dim_argname is not None
+    if dimlist_argname is not None:
+        raise AssertionError(f"dimlist_argname must be None, got {dimlist_argname}")
+    if single_dim_argname is None:
+        raise AssertionError(f"single_dim_argname must be defined for op {op.name}")
     if sample.kwargs[single_dim_argname] == 0:
         # unbind reference won't work for batch-wise operation; handle this case here
-        assert batchwise_reference is not None
+        if batchwise_reference is None:
+            raise AssertionError("batchwise_reference must be provided when dim=0")
         return batchwise_reference(op, sample)
     return unbind_reference(op, sample)
 
 
 # Computes the reference value for a reduction op.
 def reduction_reference(op, sample):
-    assert sample.input.is_nested
+    if not sample.input.is_nested:
+        raise AssertionError("sample.input must be a nested tensor")
 
     # extract info about the dim args this op supports
-    assert op._extra_op_data.dim_args is not None
+    if op._extra_op_data.dim_args is None:
+        raise AssertionError(f"op {op.name} must have _extra_op_data.dim_args defined")
     single_dim_argname, dimlist_argname = op._extra_op_data.get_dim_argnames()
-    assert single_dim_argname is not None
+    if single_dim_argname is None:
+        raise AssertionError(f"single_dim_argname must be defined for op {op.name}")
 
     dim = sample.kwargs.get(
         dimlist_argname, sample.kwargs.get(single_dim_argname, None)
     )
     keepdim = sample.kwargs.get("keepdim", False)
-    assert dim != 0, "reductions over just the batch dim are not supported"
+    if dim == 0:
+        raise AssertionError("reductions over just the batch dim are not supported")
     if isinstance(dim, (tuple, list)):
         reduce_on_ragged = sample.input._ragged_idx in dim
         reduce_on_batch = 0 in dim
@@ -470,7 +481,8 @@ def reduction_reference(op, sample):
         from torch.nested._internal.ops import _outer_to_inner_dim
 
         ref_kwargs = dict(sample.kwargs)
-        assert dimlist_argname is not None
+        if dimlist_argname is None:
+            raise AssertionError(f"dimlist_argname must be defined for op {op.name}")
         ref_kwargs[dimlist_argname] = _outer_to_inner_dim(
             sample.input.dim(), dim, sample.input._ragged_idx, canonicalize=True
         )
@@ -492,7 +504,10 @@ def reduction_reference(op, sample):
             # some ops return multiple things; stack all of them
             num_returns = len(out_ref_components[0])
             # ensure we get the same number of returns for each invocation
-            assert all(len(o) == num_returns for o in out_ref_components)
+            if any(len(o) != num_returns for o in out_ref_components):
+                raise AssertionError(
+                    f"All output components must have {num_returns} returns"
+                )
             # stack same index returns from each invocation
             stacked_returns = [
                 torch.stack([o[r] for o in out_ref_components], dim=0)
@@ -675,12 +690,18 @@ def sample_inputs_njt_reduction(
         op_kwargs = {}
 
     # extract info about the dim args this op supports
-    assert op_info._extra_op_data.dim_args is not None
+    if op_info._extra_op_data.dim_args is None:
+        raise AssertionError(
+            f"op_info {op_info.name} must have _extra_op_data.dim_args defined"
+        )
     (
         single_dim_argname,
         dimlist_argname,
     ) = op_info._extra_op_data.get_dim_argnames()
-    assert single_dim_argname is not None
+    if single_dim_argname is None:
+        raise AssertionError(
+            f"single_dim_argname must be defined for op {op_info.name}"
+        )
     supports_dimlist = dimlist_argname is not None
 
     for njt in _sample_njts(
@@ -794,10 +815,15 @@ def sample_inputs_unary_dimwise(
         op_kwargs = {}
 
     # only support a single non-list dim arg for now
-    assert op_info._extra_op_data is not None
+    if op_info._extra_op_data is None:
+        raise AssertionError(f"op_info {op_info.name} must have _extra_op_data defined")
     single_dim_argname, dimlist_argname = op_info._extra_op_data.get_dim_argnames()
-    assert single_dim_argname is not None
-    assert dimlist_argname is None
+    if single_dim_argname is None:
+        raise AssertionError(
+            f"single_dim_argname must be defined for op {op_info.name}"
+        )
+    if dimlist_argname is not None:
+        raise AssertionError(f"dimlist_argname must be None, got {dimlist_argname}")
 
     for njt in _sample_njts(
         device=device, dtype=dtype, requires_grad=requires_grad, dims=[2, 3, 4]

--- a/torch/testing/_internal/opinfo/definitions/sparse.py
+++ b/torch/testing/_internal/opinfo/definitions/sparse.py
@@ -171,7 +171,10 @@ def sample_inputs_sparse_reduction(
                 dtype=inp.dtype,
                 device=inp.device,
             )
-            assert not inp.is_coalesced()
+            if inp.is_coalesced():
+                raise AssertionError(
+                    "Input sparse tensor must be uncoalesced for this sample"
+                )
             yield SampleInput(
                 inp.requires_grad_(requires_grad),
                 args=sample_input.args,

--- a/torch/testing/_internal/opinfo/refs.py
+++ b/torch/testing/_internal/opinfo/refs.py
@@ -111,7 +111,10 @@ class PythonRefInfo(OpInfo):
             torch_opinfo_name, torch_opinfo_variant_name, op_db=op_db
         )
         self.validate_view_consistency = validate_view_consistency
-        assert isinstance(self.torch_opinfo, OpInfo)
+        if not (isinstance(self.torch_opinfo, OpInfo)):
+            raise TypeError(
+                f"torch_opinfo must be an OpInfo instance, got {type(self.torch_opinfo)}"
+            )
 
         inherited = self.torch_opinfo._original_opinfo_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)
@@ -138,7 +141,10 @@ class ReductionPythonRefInfo(ReductionOpInfo):
         self.torch_opinfo = _find_referenced_opinfo(
             torch_opinfo_name, torch_opinfo_variant_name, op_db=op_db
         )
-        assert isinstance(self.torch_opinfo, ReductionOpInfo)
+        if not (isinstance(self.torch_opinfo, ReductionOpInfo)):
+            raise TypeError(
+                f"torch_opinfo must be a ReductionOpInfo instance, got {type(self.torch_opinfo)}"
+            )
 
         inherited = self.torch_opinfo._original_reduction_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)
@@ -171,7 +177,10 @@ class ElementwiseUnaryPythonRefInfo(UnaryUfuncInfo):
             torch_opinfo_name, torch_opinfo_variant_name, op_db=op_db
         )
         self.validate_view_consistency = validate_view_consistency
-        assert isinstance(self.torch_opinfo, UnaryUfuncInfo)
+        if not (isinstance(self.torch_opinfo, UnaryUfuncInfo)):
+            raise TypeError(
+                f"torch_opinfo must be a UnaryUfuncInfo instance, got {type(self.torch_opinfo)}"
+            )
 
         inherited = self.torch_opinfo._original_unary_ufunc_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)
@@ -199,7 +208,10 @@ class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
         self.torch_opinfo = _find_referenced_opinfo(
             torch_opinfo_name, torch_opinfo_variant_name, op_db=op_db
         )
-        assert isinstance(self.torch_opinfo, BinaryUfuncInfo)
+        if not (isinstance(self.torch_opinfo, BinaryUfuncInfo)):
+            raise TypeError(
+                f"torch_opinfo must be a BinaryUfuncInfo instance, got {type(self.torch_opinfo)}"
+            )
 
         inherited = self.torch_opinfo._original_binary_ufunc_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -59,7 +59,8 @@ class _dynamic_dispatch_dtypes(_dispatch_dtypes):
 
 def get_supported_dtypes(op, sample_inputs_fn, device_type):
     # Returns the supported dtypes for the given operator and device_type pair.
-    assert device_type in ["cpu", "cuda"]
+    if device_type not in ("cpu", "cuda"):
+        raise ValueError(f"device_type must be 'cpu' or 'cuda', got {device_type!r}")
     if not TEST_CUDA and device_type == "cuda":
         warnings.warn(
             "WARNING: CUDA is not available, empty_dtypes dispatch will be returned!",
@@ -232,7 +233,10 @@ def reference_reduction_numpy(f, supports_keepdims=True):
         if "mask" in keys:
             mask = kwargs.pop("mask")
             if mask is not None:
-                assert mask.layout == torch.strided
+                if mask.layout != torch.strided:
+                    raise ValueError(
+                        f"mask must have strided layout, got {mask.layout}"
+                    )
                 kwargs["where"] = mask.cpu().numpy()
 
         if "identity" in keys:

--- a/torch/testing/_internal/optests/aot_autograd.py
+++ b/torch/testing/_internal/optests/aot_autograd.py
@@ -127,7 +127,8 @@ def _test_aot_autograd_forwards_backwards_helper(
                 # operator is a complex Tensor and autograd will yell at autograd.grad
                 # on a complex Tensor unless we manually provide the grad_output flag.
                 sm += i.sum().abs()
-        assert isinstance(sm, torch.Tensor)
+        if not isinstance(sm, torch.Tensor):
+            raise TypeError(f"Expected torch.Tensor, got {type(sm).__name__}")
         return out, torch.autograd.grad(sm, diff_args, allow_unused=True)
 
     def check(args, ignore_failure=False):

--- a/torch/testing/_internal/optests/autograd_registration.py
+++ b/torch/testing/_internal/optests/autograd_registration.py
@@ -45,7 +45,8 @@ def autograd_registration_check(op, args, kwargs):
       AutoDispatchBelowAutograd and re-invokes the operator.
 
     """
-    assert isinstance(op, torch._ops.OpOverload)
+    if not isinstance(op, torch._ops.OpOverload):
+        raise TypeError(f"Expected torch._ops.OpOverload, got {type(op).__name__}")
     # Implementation details
     # -----------------------------------------------
     # If an operator doesn't have an autograd kernel at an autograd key,

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -269,7 +269,8 @@ def generate_opcheck_tests(
                 for mark in pytestmark:
                     if isinstance(mark, pytest.Mark) and mark.name == "parametrize":
                         argnames, argvalues = mark.args
-                        assert not mark.kwargs, "NYI"
+                        if mark.kwargs:
+                            raise AssertionError("NYI")
                         # Special case for device, we want to run on all
                         # devices
                         if argnames != "device":
@@ -808,8 +809,12 @@ class FailuresDict:
                 }
             else:
                 dct = json.loads(contents)
-                assert "data" in dct
-                assert "_version" in dct and dct["_version"] == VERSION
+                if "data" not in dct:
+                    raise AssertionError("'data' field must be present in JSON")
+                if "_version" not in dct or dct["_version"] != VERSION:
+                    raise AssertionError(
+                        f"'_version' must be {VERSION}, got {dct.get('_version', 'missing')}"
+                    )
         return FailuresDict(path, dct["data"])
 
     def _save(self, to_str=False) -> Optional[str]:


### PR DESCRIPTION
## Summary
This is the last PR in a series of three that refactors assertion statements in `torch/testing/_internal` to raise error with descriptive messages instead of using bare `assert` statements.

## Changes
- Refactored assertions in 116 files to use explicit `raise AssertionError()` or other proper errors with descriptive error messages
- Improves error handling and debugging by providing clear error messages
- Maintains the same semantic behavior while making error messages more informative

## Other PRs
For easy review, I split the changes into 3 PRs.
- https://github.com/pytorch/pytorch/pull/172165
- https://github.com/pytorch/pytorch/pull/172166

## Additional Context
Fixes parts of #164878

cc @malfet @albanD