### PR TITLE
[1/3][Code Clean] Refactor assertions in `torch/testing/_internal` to raise AssertionError with descriptive messages

### DIFF
--- a/torch/testing/_internal/autograd_function_db.py
+++ b/torch/testing/_internal/autograd_function_db.py
@@ -331,8 +331,10 @@ class NumpyTake(torch.autograd.Function):
 
     @staticmethod
     def jvp(ctx, x_tangent, ind_tangent, ind_inv_tangent, _):
-        assert ind_tangent is None
-        assert ind_inv_tangent is None
+        if ind_tangent is not None:
+            raise ValueError("ind_tangent must be None")
+        if ind_inv_tangent is not None:
+            raise ValueError("ind_inv_tangent must be None")
         ind, ind_inv = ctx.saved_tensors
         return NumpyTake.apply(x_tangent, ind, ind_inv, ctx.dim)
 

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -180,7 +180,8 @@ __cuda_ctx_rng_initialized = False
 # after this call, CUDA context and RNG must have been initialized on each GPU
 def initialize_cuda_context_rng():
     global __cuda_ctx_rng_initialized
-    assert TEST_CUDA, 'CUDA must be available when calling initialize_cuda_context_rng'
+    if not TEST_CUDA:
+        raise RuntimeError('CUDA must be available when calling initialize_cuda_context_rng')
     if not __cuda_ctx_rng_initialized:
         # initialize cuda context and rng for memory tests
         for i in range(torch.cuda.device_count()):
@@ -417,4 +418,5 @@ requires_triton_ptxas_compat = unittest.skipIf(torch.version.hip is None and _ge
 
 # Importing this module should NOT eagerly initialize CUDA
 if not CUDA_ALREADY_INITIALIZED_ON_IMPORT:
-    assert not torch.cuda.is_initialized()
+    if torch.cuda.is_initialized():
+        raise RuntimeError("CUDA was initialized during import of common_cuda.py")

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -11,7 +11,8 @@ import torch
 # Verifies each given dtype is a torch.dtype
 def _validate_dtypes(*dtypes):
     for dtype in dtypes:
-        assert isinstance(dtype, torch.dtype)
+        if not isinstance(dtype, torch.dtype):
+            raise TypeError(f"Expected torch.dtype, got {type(dtype).__name__}")
     return dtypes
 
 
@@ -20,7 +21,8 @@ class _dispatch_dtypes(tuple):
     __slots__ = ()
 
     def __add__(self, other):
-        assert isinstance(other, tuple)
+        if not isinstance(other, tuple):
+            raise TypeError(f"Expected tuple, got {type(other).__name__}")
         return _dispatch_dtypes(tuple.__add__(self, other))
 
 

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -567,7 +567,8 @@ def no_batch_dim_reference_fn(m, p, *args, **kwargs):
     is_criterion = get_and_pop('is_criterion', False)
 
     if kwargs_to_batchify is not None:
-        assert isinstance(kwargs_to_batchify, dict)
+        if not isinstance(kwargs_to_batchify, dict):
+            raise TypeError(f"kwargs_to_batchify must be a dict, got {type(kwargs_to_batchify).__name__}")
         for k, v in kwargs.items():
             if k in kwargs_to_batchify and v is not None:
                 bdim = kwargs_to_batchify[k]
@@ -2536,7 +2537,8 @@ def module_inputs_torch_nn_TransformerEncoderLayer(module_info, device, dtype, r
     # since the fast path requires no_grad mode, we run the fast path in .eval()
     # and no_grad() in the reference_fn and verify that against the results in train mode.
     def fast_path_reference_fn(module, parameters, *args, **kwargs):
-        assert module.training
+        if not module.training:
+            raise AssertionError("module must be in training mode")
         module.train(False)
         with torch.no_grad():
             output = module(*args, **kwargs)

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1333,7 +1333,8 @@ def _get_device_type(device: Union[str, torch.device]) -> str:
     # Returns the device type as a string, e.g., "cpu" or "cuda"
     if isinstance(device, torch.device):
         device = str(device.type)
-    assert isinstance(device, str)
+    if not isinstance(device, str):
+        raise TypeError(f"device must be a string or torch.device, got {type(device)}")
     return device.split(":")[0]
 
 
@@ -1351,9 +1352,10 @@ def _get_optim_inputs_including_global_cliquey_kwargs(
     trivial. That said, we sometimes want to test for all possible configs on an
     optimizer including all supported flags, so this helper returns all optim inputs.
     """
-    assert all(x in ["foreach", "fused", "differentiable"] for x in skip), (
-        "skip must be a subset of ['foreach', 'fused', 'differentiable']"
-    )
+    if any(x not in ["foreach", "fused", "differentiable"] for x in skip):
+        raise AssertionError(
+            "skip must be a subset of ['foreach', 'fused', 'differentiable']"
+        )
 
     optim_inputs = optim_info.optim_inputs_func(device)
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -576,9 +576,14 @@ def _group_quantize_tensor_symmetric(w, n_bit=4, groupsize=32):
     # W is of shape [K x N]
     # We transpose W as Quantization is applied on [N x K]
     w = w.transpose(0, 1).contiguous()
-    assert w.dim() == 2
-    assert groupsize > 1
-    assert w.shape[-1] % groupsize == 0
+    if w.dim() != 2:
+        raise AssertionError(f"w must be 2-dimensional, got {w.dim()} dimensions")
+    if groupsize <= 1:
+        raise AssertionError(f"groupsize must be > 1, got {groupsize}")
+    if w.shape[-1] % groupsize:
+        raise AssertionError(
+            f"w.shape[-1] ({w.shape[-1]}) must be divisible by groupsize ({groupsize})"
+        )
     # Calculate scale and zeros
     to_quant = w.reshape(-1, groupsize)
     max_val = to_quant.abs().amax(dim=1, keepdim=True)
@@ -1069,7 +1074,10 @@ class QuantizationTestCase(TestCase):
                     mod = getattr(gm, node.target)
                     return type(mod)
                 else:
-                    assert node.op in ("call_function", "call_method")
+                    if node.op not in ("call_function", "call_method"):
+                        raise AssertionError(
+                            f"node.op must be 'call_function' or 'call_method', got '{node.op}'"
+                        )
                     return node.target
 
             self.assertTrue(
@@ -1156,14 +1164,33 @@ class QuantizationTestCase(TestCase):
                                         + f"have a shape mismatch at idx {idx}.",
                                     )
                                 else:
-                                    assert isinstance(
-                                        values_0, tuple
-                                    ), f"unhandled type {type(values_0)}"
-                                    assert len(values_0) == 2
-                                    assert len(values_0[1]) == 2
-                                    assert values_0[0].shape == values_1[0].shape
-                                    assert values_0[1][0].shape == values_1[1][0].shape
-                                    assert values_0[1][1].shape == values_1[1][1].shape
+                                    if not isinstance(values_0, tuple):
+                                        raise TypeError(
+                                            f"unhandled type {type(values_0)}"
+                                        )
+                                    if len(values_0) != 2:
+                                        raise AssertionError(
+                                            f"values_0 must have length 2, got {len(values_0)}"
+                                        )
+                                    if len(values_0[1]) != 2:
+                                        raise AssertionError(
+                                            f"values_0[1] must have length 2, got {len(values_0[1])}"
+                                        )
+                                    if values_0[0].shape != values_1[0].shape:
+                                        raise AssertionError(
+                                            f"Shape mismatch: values_0[0].shape={values_0[0].shape}, "
+                                            f"values_1[0].shape={values_1[0].shape}"
+                                        )
+                                    if values_0[1][0].shape != values_1[1][0].shape:
+                                        raise AssertionError(
+                                            f"Shape mismatch: values_0[1][0].shape={values_0[1][0].shape}, "
+                                            f"values_1[1][0].shape={values_1[1][0].shape}"
+                                        )
+                                    if values_0[1][1].shape != values_1[1][1].shape:
+                                        raise AssertionError(
+                                            f"Shape mismatch: values_0[1][1].shape={values_0[1][1].shape}, "
+                                            f"values_1[1][1].shape={values_1[1][1].shape}"
+                                        )
 
                         # verify that ref_node_name is valid
                         ref_node_name_0 = layer_data_0["ref_node_name"]
@@ -1264,10 +1291,10 @@ class QuantizationTestCase(TestCase):
 
             # overwrite qconfig_dict with custom_qconfig_dict
             if custom_qconfig_dict is not None:
-                assert type(custom_qconfig_dict) in (
-                    QConfigMapping,
-                    dict,
-                ), "custom_qconfig_dict should be a QConfigMapping or a dict"
+                if not isinstance(custom_qconfig_dict, (QConfigMapping, dict)):
+                    raise TypeError(
+                        "custom_qconfig_dict should be a QConfigMapping or a dict"
+                    )
                 if isinstance(custom_qconfig_dict, QConfigMapping):
                     qconfig_mapping = custom_qconfig_dict
                 else:
@@ -1349,7 +1376,10 @@ class QuantizationTestCase(TestCase):
         # Check unpacked weight values explicitly
         for key in emb_dict:
             if isinstance(emb_dict[key], torch._C.ScriptObject):
-                assert isinstance(loaded_dict[key], torch._C.ScriptObject)
+                if not isinstance(loaded_dict[key], torch._C.ScriptObject):
+                    raise TypeError(
+                        f"loaded_dict[{key}] must be a ScriptObject, got {type(loaded_dict[key]).__name__}"
+                    )
                 emb_weight = embedding_unpack(emb_dict[key])
                 loaded_weight = embedding_unpack(loaded_dict[key])
                 self.assertEqual(emb_weight, loaded_weight)


### PR DESCRIPTION
## Summary
This is the first PR in a series of three that refactors assertion statements in `torch/testing/_internal` to raise error with descriptive messages instead of using bare `assert` statements.

## Changes
- Refactored assertions in 116 files to use explicit `raise AssertionError()` or other proper errors with descriptive error messages
- Improves error handling and debugging by providing clear error messages
- Maintains the same semantic behavior while making error messages more informative

## Other PRs
For easy review, I split the changes into 3 PRs.
- https://github.com/pytorch/pytorch/pull/172166
- https://github.com/pytorch/pytorch/pull/172164

## Additional Context
Fixes parts of #164878

cc @malfet @albanD