### PR TITLE
[2/3][Code Clean] Refactor assertions in `torch/testing/_internal` to raise AssertionError with descriptive messages

### DIFF
--- a/torch/testing/_internal/common_subclass.py
+++ b/torch/testing/_internal/common_subclass.py
@@ -116,7 +116,8 @@ class WrapperTensorWithCustomStrides(WrapperTensor):
 class DiagTensorBelow(WrapperTensor):
     @classmethod
     def get_wrapper_properties(cls, diag, requires_grad=False):
-        assert diag.ndim == 1
+        if diag.ndim != 1:
+            raise ValueError(f"diag must be 1-dimensional, got {diag.ndim} dimensions")
         return diag, {"size": diag.size() + diag.size(), "requires_grad": requires_grad}
 
     def __init__(self, diag, requires_grad=False):
@@ -126,7 +127,7 @@ class DiagTensorBelow(WrapperTensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-        if not all(issubclass(cls, t) for t in types):
+        if any(not issubclass(cls, t) for t in types):
             return NotImplemented
 
         # For everything else, call the handler:
@@ -158,7 +159,8 @@ class DiagTensorBelow(WrapperTensor):
 class SparseTensor(WrapperTensor):
     @classmethod
     def get_wrapper_properties(cls, size, values, indices, requires_grad=False):
-        assert values.device == indices.device
+        if values.device != indices.device:
+            raise ValueError(f"Device mismatch: values on {values.device}, indices on {indices.device}")
         return values, {"size": size, "requires_grad": requires_grad}
 
     def __init__(self, size, values, indices, requires_grad=False):

--- a/torch/testing/_internal/composite_compliance.py
+++ b/torch/testing/_internal/composite_compliance.py
@@ -120,8 +120,9 @@ def generate_cct_and_mode(autograd_view_consistency=True):
 
         @staticmethod
         def __new__(cls, elem, mode, *args, **kwargs):
-            assert type(elem) is not cls, \
-                "Wrapping a CompositeCompliantTensor in a CompositeCompliantTensor is not supported"
+            if type(elem) is cls:
+                raise AssertionError(
+                    "Wrapping a CompositeCompliantTensor in a CompositeCompliantTensor is not supported")
 
             # The storage of CompositeCompliantTensor should never be used directly
             # by a Composite operation; if the Composite
@@ -155,7 +156,8 @@ def generate_cct_and_mode(autograd_view_consistency=True):
             else:
                 r.elem = elem
 
-            assert r.stride() == r.elem.stride()
+            if r.stride() != r.elem.stride():
+                raise AssertionError(f"stride mismatch: tensor stride {r.stride()} != elem stride {r.elem.stride()}")
 
             # Propagate conjugate bits to the wrapper tensor
             # Ref: https://github.com/albanD/subclass_zoo/issues/24
@@ -436,11 +438,13 @@ def compute_expected_grads(op, args, kwargs, output_process_fn_grad=None, gradch
     flat_results = pytree.tree_leaves(results)
     flat_results = [r for r in flat_results if isinstance(r, torch.Tensor)]
     flat_diff_results = [r for r in flat_results if r.requires_grad]
-    assert len(flat_diff_results) > 0
+    if len(flat_diff_results) == 0:
+        raise AssertionError("At least one result must require gradients")
 
     grads = [torch.ones(r.shape, device=r.device, dtype=r.dtype) for r in flat_diff_results]
     leaf_tensors = gather_leaf_tensors(args, kwargs)
-    assert len(leaf_tensors) > 0
+    if len(leaf_tensors) == 0:
+        raise AssertionError("At least one leaf tensor required for gradient computation")
     return torch.autograd.grad(flat_diff_results, leaf_tensors,
                                grads, allow_unused=True, retain_graph=True)
 
@@ -462,7 +466,8 @@ def check_backward_formula(op: Callable, args, kwargs,
     for choice in generate_subclass_choices_args_kwargs(args, kwargs, CCT, cct_mode):
         new_args, new_kwargs, which_args_are_wrapped, which_kwargs_are_wrapped = choice
         leaf_tensors = gather_leaf_tensors(new_args, new_kwargs)
-        assert len(leaf_tensors) > 0
+        if len(leaf_tensors) == 0:
+            raise AssertionError("At least one leaf tensor required for gradient computation")
 
         try:
             if gradcheck_wrapper is None:
@@ -482,7 +487,8 @@ def check_backward_formula(op: Callable, args, kwargs,
         flat_results = pytree.tree_leaves(results)
         flat_results = [r for r in flat_results if isinstance(r, torch.Tensor)]
         flat_diff_results = [r for r in flat_results if r.requires_grad]
-        assert len(flat_diff_results) > 0
+        if len(flat_diff_results) == 0:
+            raise AssertionError("At least one result must require gradients for backward check")
 
         # NB: ones, not ones_like, so we get a regular Tensor here
         grads = [torch.ones(r.shape, device=r.device, dtype=r.dtype)
@@ -516,7 +522,8 @@ def check_forward_ad_formula(op: Callable, args, kwargs, gradcheck_wrapper=None,
     CCT, cct_mode = generate_cct_and_mode(autograd_view_consistency=False)
 
     def maybe_tangent(t):
-        assert type(t) is not CCT
+        if type(t) is CCT:
+            raise AssertionError(f"Input should not be a CompositeCompliantTensor, got {type(t).__name__}")
         # Generate `tangent` tensor
         # if given object is a Tensor and requires grad is set.
         if isinstance(t, torch.Tensor) and t.requires_grad:

--- a/torch/testing/_internal/custom_op_db.py
+++ b/torch/testing/_internal/custom_op_db.py
@@ -62,7 +62,8 @@ def numpy_mul(x: Tensor, y: Tensor) -> Tensor:
 
 @numpy_mul.register_fake
 def _(x, y):
-    assert x.device == y.device
+    if x.device != y.device:
+        raise ValueError(f"Device mismatch: x is on {x.device}, y is on {y.device}")
     return (x * y).contiguous()
 
 def numpy_mul_setup_context(ctx, inputs, output):
@@ -159,10 +160,14 @@ def numpy_take(x: Tensor, ind: Tensor, ind_inv: Tensor, dim: int) -> Tensor:
 
 @numpy_take.register_fake
 def _(x, ind, ind_inv, dim):
-    assert x.device == ind.device
-    assert x.device == ind_inv.device
-    assert ind.dtype == torch.long
-    assert ind_inv.dtype == torch.long
+    if x.device != ind.device:
+        raise ValueError(f"Device mismatch: x is on {x.device}, ind is on {ind.device}")
+    if x.device != ind_inv.device:
+        raise ValueError(f"Device mismatch: x is on {x.device}, ind_inv is on {ind_inv.device}")
+    if ind.dtype != torch.long:
+        raise ValueError(f"ind.dtype must be torch.long, got {ind.dtype}")
+    if ind_inv.dtype != torch.long:
+        raise ValueError(f"ind_inv.dtype must be torch.long, got {ind_inv.dtype}")
     return torch.empty_like(x)
 
 def numpy_take_setup_context(ctx, inputs, output):
@@ -261,18 +266,24 @@ def sample_inputs_numpy_view_copy(opinfo, device, dtype, requires_grad, **kwargs
 
 @torch.library.custom_op('_torch_testing::numpy_cat', mutates_args=())
 def numpy_cat(xs: Sequence[Tensor], dim: int) -> Tensor:
-    assert len(xs) > 0
-    assert all(x.device == xs[0].device for x in xs)
-    assert all(x.dtype == xs[0].dtype for x in xs)
+    if len(xs) == 0:
+        raise ValueError("xs must be non-empty")
+    if any(x.device != xs[0].device for x in xs):
+        raise ValueError("All tensors must be on the same device")
+    if any(x.dtype != xs[0].dtype for x in xs):
+        raise ValueError("All tensors must have the same dtype")
     np_xs = [to_numpy(x) for x in xs]
     np_out = np.concatenate(np_xs, axis=dim)
     return torch.tensor(np_out, device=xs[0].device)
 
 @numpy_cat.register_fake
 def _(xs, dim):
-    assert len(xs) > 0
-    assert all(x.device == xs[0].device for x in xs)
-    assert all(x.dtype == xs[0].dtype for x in xs)
+    if len(xs) == 0:
+        raise ValueError("xs must be non-empty")
+    if any(x.device != xs[0].device for x in xs):
+        raise ValueError("All tensors must be on the same device")
+    if any(x.dtype != xs[0].dtype for x in xs):
+        raise ValueError("All tensors must have the same dtype")
     return torch.cat(xs, dim=dim)
 
 def numpy_cat_setup_context(ctx, inputs, output):
@@ -370,15 +381,18 @@ numpy_split_copy_with_int.register_vmap(numpy_split_copy_with_int_vmap)
 def numpy_nms(boxes: Tensor, scores: Tensor, iou_threshold: Number) -> Tensor:
     # Adapted from Ross Girshick's fast-rcnn implementation at
     # https://github.com/rbgirshick/fast-rcnn/blob/master/lib/utils/nms.py
-    assert boxes.device == scores.device
+    if boxes.device != scores.device:
+        raise ValueError(f"Device mismatch: boxes is on {boxes.device}, scores is on {scores.device}")
     device = boxes.device
 
     boxes = to_numpy(boxes)
     scores = to_numpy(scores)
 
     N = boxes.shape[0]
-    assert boxes.shape == (N, 4)
-    assert scores.shape == (N,)
+    if boxes.shape != (N, 4):
+        raise ValueError(f"boxes must have shape (N, 4), got {boxes.shape}")
+    if scores.shape != (N,):
+        raise ValueError(f"scores must have shape (N,), got {scores.shape}")
 
     x1 = boxes[:, 0]
     y1 = boxes[:, 1]
@@ -407,15 +421,19 @@ def numpy_nms(boxes: Tensor, scores: Tensor, iou_threshold: Number) -> Tensor:
 
     result = torch.tensor(np.stack(keep), device=device)
     # Needed for data-dependent condition :(
-    assert result.size(0) >= 2
+    if result.size(0) < 2:
+        raise ValueError(f"Result must have at least 2 elements, got {result.size(0)}")
     return result
 
 @numpy_nms.register_fake
 def _(boxes, scores, iou_threshold):
-    assert boxes.device == scores.device
+    if boxes.device != scores.device:
+        raise ValueError(f"Device mismatch: boxes is on {boxes.device}, scores is on {scores.device}")
     N = boxes.shape[0]
-    assert boxes.shape == (N, 4)
-    assert scores.shape == (N,)
+    if boxes.shape != (N, 4):
+        raise ValueError(f"boxes must have shape (N, 4), got {boxes.shape}")
+    if scores.shape != (N,):
+        raise ValueError(f"scores must have shape (N,), got {scores.shape}")
 
     ctx = torch._custom_op.impl.get_ctx()
     i0 = ctx.create_unbacked_symint()

--- a/torch/testing/_internal/custom_tensor.py
+++ b/torch/testing/_internal/custom_tensor.py
@@ -44,7 +44,8 @@ class ConstantExtraMetadataTensor(torch.Tensor):
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
-        assert meta is not None
+        if meta is None:
+            raise AssertionError("meta must not be None")
         elem = inner_tensors["elem"]
         out = ConstantExtraMetadataTensor(elem)
         out.constant_attribute = meta

--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -127,7 +127,8 @@ def with_temp_dir(
     """
     Wrapper to initialize temp directory for distributed checkpoint.
     """
-    assert func is not None
+    if func is None:
+        raise TypeError("func must not be None")
 
     @wraps(func)
     def wrapper(self, *args: tuple[object], **kwargs: dict[str, Any]) -> None:
@@ -174,7 +175,8 @@ def with_checkpoint_logging(
         logger_name: Name of the logger to configure (default: 'torch.distributed.checkpoint')
         level: Logging level to set (default: logging.INFO)
     """
-    assert func is not None
+    if func is None:
+        raise TypeError("func must not be None")
 
     @wraps(func)
     def wrapper(self, *args: tuple[object], **kwargs: dict[str, Any]) -> None:

--- a/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
@@ -165,7 +165,11 @@ class HybridModel(nn.Module):
             RemoteEM.forward, self.remote_em_rref, input.sparse_features
         )
         # The same size of mini batch.
-        assert sparse.shape[0] == input.dense_features.shape[0]
+        if sparse.shape[0] != input.dense_features.shape[0]:
+            raise AssertionError(
+                f"Shape mismatch: sparse.shape[0]={sparse.shape[0]}, "
+                f"dense_features.shape[0]={input.dense_features.shape[0]}"
+            )
         dense = self.fc1(input.dense_features)
         x = torch.cat((dense, sparse), 1)
         gLogger.debug("Concatenated feature: %s", x)
@@ -299,7 +303,10 @@ def get_training_examples():
                     idx += 1
 
     # Split the examples among NUM_TRAINERS trainers
-    assert 0 == (n % NUM_TRAINERS)
+    if n % NUM_TRAINERS:
+        raise AssertionError(
+            f"n ({n}) must be divisible by NUM_TRAINERS ({NUM_TRAINERS})"
+        )
     examples_per_trainer = int(n / NUM_TRAINERS)
     return [
         FeatureSet(

--- a/torch/testing/_internal/distributed/distributed_utils.py
+++ b/torch/testing/_internal/distributed/distributed_utils.py
@@ -24,7 +24,8 @@ def mock_init_dist(rank, world_size):
     # !!! WARNING !!!
     # Kids don't try this at home, this is a cute pile of hacks that
     # depends on a small mountain of c10d internals
-    assert not dist.is_initialized()
+    if dist.is_initialized():
+        raise AssertionError("torch.distributed is already initialized")
     store = dist.HashStore()
     # Trick _store_based_barrier into believing everyone else already checked-in
     # Zero is the group index

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -242,7 +242,8 @@ def simple_local_map_hop(inp1, inp2):
 
     gm = torch.fx.symbolic_trace(body_gm)
 
-    assert torch.distributed.is_available()
+    if not torch.distributed.is_available():
+        raise RuntimeError("torch.distributed must be available")
     from torch.distributed.tensor.placement_types import Replicate
 
     gm.meta["local_map_kwargs"] = {

--- a/torch/testing/_internal/hypothesis_utils.py
+++ b/torch/testing/_internal/hypothesis_utils.py
@@ -162,10 +162,12 @@ Example:
 @st.composite
 def array_shapes(draw, min_dims=1, max_dims=None, min_side=1, max_side=None, max_numel=None):
     """Return a strategy for array shapes (tuples of int >= 1)."""
-    assert min_dims < 32
+    if min_dims >= 32:
+        raise ValueError(f"min_dims must be < 32, got {min_dims}")
     if max_dims is None:
         max_dims = min(min_dims + 2, 32)
-    assert max_dims < 32
+    if max_dims >= 32:
+        raise ValueError(f"max_dims must be < 32, got {max_dims}")
     if max_side is None:
         max_side = min_side + 5
     candidate = st.lists(st.integers(min_side, max_side), min_size=min_dims, max_size=max_dims)
@@ -333,7 +335,8 @@ def tensor_conv(
     # Resolve the tensors
     if qparams is not None:
         if isinstance(qparams, (list, tuple)):
-            assert len(qparams) == 3, "Need 3 qparams for X, w, b"
+            if len(qparams) != 3:
+                raise AssertionError("Need 3 qparams for X, w, b")
         else:
             qparams = [qparams] * 3
 
@@ -376,4 +379,5 @@ def assert_deadline_disabled():
         )
         warnings.warn(warning_message, stacklevel=2)
     else:
-        assert settings().deadline is None
+        if settings().deadline is not None:
+            raise AssertionError("settings().deadline must be None for GPU tests")

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -19,7 +19,8 @@ import math  # noqa: F401
 # Testing utils
 from torch import inf
 
-assert torch.get_default_dtype() == torch.float32
+if torch.get_default_dtype() != torch.float32:
+    raise RuntimeError(f"Default dtype must be torch.float32, got {torch.get_default_dtype()}")
 
 L = 20
 M = 10

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -767,7 +767,9 @@ def _get_py3_code(code, fn_name):
         spec = importlib.util.spec_from_file_location(fn_name, script_path)
         module = importlib.util.module_from_spec(spec)
         loader = spec.loader
-        assert isinstance(loader, Loader)  # Assert type to meet MyPy requirement
+        # Assert type to meet MyPy requirement
+        if not isinstance(loader, Loader):
+            raise TypeError(f"Expected Loader, got {type(loader).__name__}")
         loader.exec_module(module)
         fn = getattr(module, fn_name)
         return fn

--- a/torch/testing/_internal/subclasses.py
+++ b/torch/testing/_internal/subclasses.py
@@ -38,11 +38,14 @@ class WrapperSubclass(torch.Tensor):
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
-        assert meta is None
+        if meta is not None:
+            raise AssertionError("meta must be None for WrapperSubclass")
         a = inner_tensors["a"]
         if is_fake(a):
-            assert outer_size is not None
-            assert outer_stride is not None
+            if outer_size is None:
+                raise AssertionError("outer_size must not be None when a is fake")
+            if outer_stride is None:
+                raise AssertionError("outer_stride must not be None when a is fake")
         return WrapperSubclass(a, outer_size, outer_stride)
 
     @classmethod

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -1072,7 +1072,10 @@ if has_triton():
                     tensor.element_size(),
                 )
             else:
-                assert len(block_sizes) == 2
+                if len(block_sizes) != 2:
+                    raise AssertionError(
+                        f"block_sizes must have length 2, got {len(block_sizes)}"
+                    )
                 return triton.tools.experimental_descriptor.create_2d_tma_descriptor(
                     tensor.data_ptr(),
                     tensor.size(0),


### PR DESCRIPTION
## Summary
This is the second PR in a series of three that refactors assertion statements in `torch/testing/_internal` to raise error with descriptive messages instead of using bare `assert` statements.

## Changes
- Refactored assertions in 116 files to use explicit `raise AssertionError()` or other proper errors with descriptive error messages
- Improves error handling and debugging by providing clear error messages
- Maintains the same semantic behavior while making error messages more informative

## Other PRs
For easy review, I split the changes into 3 PRs.
- https://github.com/pytorch/pytorch/pull/172165
- https://github.com/pytorch/pytorch/pull/172164

## Additional Context
Fixes parts of #164878

cc @malfet @albanD