### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,8 +245,8 @@ docs/source/scripts/lr_scheduler_images/
 
 # build, distribute, and bins (+ python proto bindings)
 build/
-# Allow tools/build/ for build support.
-!tools/build/
+# Allow tools/build/bazel for build support.
+!tools/build/bazel
 build_host_protoc
 build_android
 build_ios


### PR DESCRIPTION
Expilicitly tracking `tools/build/bazel` dir rather than `tools/build`. 

When building tools (e.g. python build_libtorch.py), it will generate many sub-dirs in `tools/build`. Currently these sud-dirs will be recognized as untracked files which is inappropriate.
