### PR TITLE
Inductor: make sympy_subs robust to non-comparable Min/Max args

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from sympy import Symbol, sympify
+from sympy import I, Max, Min, Symbol, sympify
 
 import torch
 from torch._inductor.fx_utils import count_flops_fx, countable_fx
@@ -79,6 +79,18 @@ class TestUtils(TestCase):
         self.assertEqual(result.name, "y")
         self.assertEqual(result.is_integer, None)
         self.assertEqual(result.is_nonnegative, None)
+
+    def testSympySubsNonComparableMinMax(self):
+        q0 = Symbol("q0")
+        q1 = Symbol("q1")
+        q2 = Symbol("q2")
+        expr = (
+            2073600 * Min(2, Max(0, q0))
+            + 1920 * Min(1079, Max(0, q1 - 4))
+            + Min(1919, q2)
+        )
+        result = sympy_subs(expr, {q0: I, q1: 0, q2: 0})
+        self.assertTrue(result.has(I))
 
     def test_sympy_str(self):
         self.assertEqual(sympy_str(sympify("a+b+c")), "a + b + c")


### PR DESCRIPTION
## Summary
- Prevent SymPy substitution crashes in Inductor when `Min/Max` encounter non-comparable arguments.
- Preserve symbolic terms (e.g., `I`) by safely rebuilding the expression.

## Motivation
AOTI export hit `ValueError: The argument 'I' is not comparable` inside `torch._inductor.utils.sympy_subs`.
This is a general SymPy substitution pitfall and is not specific to any external model.

## Repro
New unit test `testSympySubsNonComparableMinMax` in `test/inductor/test_utils.py`:
- `sympy_subs(Min(2, Max(0, q0)), {q0: I})`
- Ensures it doesn’t crash and keeps `I` in the result.

## Implementation
- Keep the fast-path `xreplace`.
- On `ValueError` for comparability, rebuild the expression safely.
- Use `evaluate=False` for `Min/Max` to avoid SymPy comparability errors while preserving structure.

## Testing
- `python -m pytest test/inductor/test_utils.py -k SympySubsNonComparableMinMax`
- `lintrunner --skip PYREFLY torch/_inductor/utils.py test/inductor/test_utils.py`

## Reference
- Observed during AOTI export of a MEMFOF optical‑flow model.
https://github.com/msu-video-group/memfof


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo