### PR TITLE
[ROCm] Enable hipBLASLt on gfx1103

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -473,7 +473,7 @@ at::BlasBackend Context::blasPreferredBackend() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
-          "gfx1100", "gfx1101", "gfx1200", "gfx1201", "gfx908",
+          "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
 #endif
 #if ROCM_VERSION >= 70000
           "gfx950", "gfx1150", "gfx1151"

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -123,7 +123,7 @@ static bool isGloballyDisabledAddmmCudaLt(const at::Device& device) {
   static const std::vector<std::string> archs = {
         "gfx90a", "gfx942",
     #if ROCM_VERSION >= 60300
-        "gfx1100", "gfx1101", "gfx1200", "gfx1201", "gfx908",
+        "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
     #endif
     #if ROCM_VERSION >= 70000
         "gfx950", "gfx1150", "gfx1151"


### PR DESCRIPTION
During testing https://github.com/ROCm/TheRock/issues/2591, I found hipBLASLt was not enabled on gfx1103, and this may cause performance drop when using spda in comfyui.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang