### PR TITLE
Speed up GB_REGISTRY linter by caching ast._splitlines_no_ff

### DIFF
--- a/tools/linter/adapters/gb_registry_linter.py
+++ b/tools/linter/adapters/gb_registry_linter.py
@@ -3,12 +3,27 @@
 from __future__ import annotations
 
 import argparse
+import ast
+import functools
 import json
 import random
 import sys
 from enum import Enum
 from pathlib import Path
 from typing import Any, NamedTuple
+
+
+# Patch ast._splitlines_no_ff with caching to avoid O(n²) re-splitting.
+# get_source_segment() calls _splitlines_no_ff() for every keyword argument,
+# but the same source string is passed repeatedly for the same file.
+if hasattr(ast, "_splitlines_no_ff"):
+    _original_splitlines_no_ff = ast._splitlines_no_ff
+
+    @functools.lru_cache(maxsize=128)
+    def _cached_splitlines_no_ff(*args: Any) -> Any:
+        return _original_splitlines_no_ff(*args)
+
+    ast._splitlines_no_ff = _cached_splitlines_no_ff
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tools/linter/adapters/gb_registry_linter.py
+++ b/tools/linter/adapters/gb_registry_linter.py
@@ -17,13 +17,7 @@ from typing import Any, NamedTuple
 # get_source_segment() calls _splitlines_no_ff() for every keyword argument,
 # but the same source string is passed repeatedly for the same file.
 if hasattr(ast, "_splitlines_no_ff"):
-    _original_splitlines_no_ff = ast._splitlines_no_ff
-
-    @functools.lru_cache(maxsize=128)
-    def _cached_splitlines_no_ff(*args: Any) -> Any:
-        return _original_splitlines_no_ff(*args)
-
-    ast._splitlines_no_ff = _cached_splitlines_no_ff
+    ast._splitlines_no_ff = functools.lru_cache(maxsize=128)(ast._splitlines_no_ff)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172188

The linter was taking ~48s because ast.get_source_segment() calls
_splitlines_no_ff() for every keyword argument, re-splitting the same
source file repeatedly. This adds a simple LRU cache wrapper that
reduces runtime to ~2.3s (20x speedup).

Authored with Claude.