### PR TITLE
Fix clamp(None, nan) to propagate scalar NaNs

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
 #include <ATen/NamedTensorUtils.h>
@@ -826,21 +827,26 @@ TORCH_IMPL_FUNC(clamp_out)
  const OptionalScalarRef max,
  const Tensor& result) {
   using at::native::detail::ClampLimits;
-  if (min && max) {
-    if (min.get().toDouble() != min.get().toDouble() ||
-        max.get().toDouble() != max.get().toDouble()) {
-      at::fill_(
-          const_cast<Tensor&>(result),
-          std::numeric_limits<double>::quiet_NaN());
-    } else {
-      clamp_scalar_stub(device_type(), *this, min.get(), max.get());
-    }
+
+  // If either scalar bound is NaN, the result should be all NaNs
+  const bool min_is_nan =
+      min.has_value() && (min.get().toDouble() != min.get().toDouble());
+  const bool max_is_nan =
+      max.has_value() && (max.get().toDouble() != max.get().toDouble());
+
+  if (min_is_nan || max_is_nan) {
+    at::fill_(
+        const_cast<Tensor&>(result),
+        std::numeric_limits<double>::quiet_NaN());
+  } else if (min && max) {
+    clamp_scalar_stub(device_type(), *this, min.get(), max.get());
   } else if (max) {
     clamp_max_scalar_stub(device_type(), *this, max.get());
   } else if (min) {
     clamp_min_scalar_stub(device_type(), *this, min.get());
   }
 }
+
 
 TORCH_IMPL_FUNC(clamp_Tensor_out)
 (const Tensor& self,

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -836,8 +836,7 @@ TORCH_IMPL_FUNC(clamp_out)
 
   if (min_is_nan || max_is_nan) {
     at::fill_(
-        const_cast<Tensor&>(result),
-        std::numeric_limits<double>::quiet_NaN());
+        const_cast<Tensor&>(result), std::numeric_limits<double>::quiet_NaN());
   } else if (min && max) {
     clamp_scalar_stub(device_type(), *this, min.get(), max.get());
   } else if (max) {
@@ -846,7 +845,6 @@ TORCH_IMPL_FUNC(clamp_out)
     clamp_min_scalar_stub(device_type(), *this, min.get());
   }
 }
-
 
 TORCH_IMPL_FUNC(clamp_Tensor_out)
 (const Tensor& self,

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -7,7 +7,6 @@ from functools import partial
 from itertools import chain, combinations, permutations, product
 
 import numpy as np
-
 import torch
 from torch import nan
 from torch.testing import make_tensor
@@ -28,10 +27,10 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_utils import (
     IS_JETSON,
-    run_tests,
-    skipIfTorchDynamo,
     TEST_PRIVATEUSE1_DEVICE_TYPE,
     TestCase,
+    run_tests,
+    skipIfTorchDynamo,
     torch_to_numpy_dtype_dict,
 )
 
@@ -389,6 +388,13 @@ class TestShapeOps(TestCase):
                     Y_out = torch.empty_like(X)
                     op(X, min_val, max_val, out=Y_out)
                     self.assertEqual(Y_expected, torch.isnan(Y_out))
+
+    def test_clamp_scalar_nan_bounds(self, device):
+        x = torch.ones(3, device=device)
+        y = torch.clamp(x, None, float("nan"))
+        self.assertTrue(torch.isnan(y).all())
+        y = torch.clamp(x, float("nan"), None)
+        self.assertTrue(torch.isnan(y).all())
 
     def test_clamp_raises_arg_errors(self, device):
         X = torch.randn(100, dtype=torch.float, device=device)

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -7,6 +7,7 @@ from functools import partial
 from itertools import chain, combinations, permutations, product
 
 import numpy as np
+
 import torch
 from torch import nan
 from torch.testing import make_tensor
@@ -27,10 +28,10 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_utils import (
     IS_JETSON,
-    TEST_PRIVATEUSE1_DEVICE_TYPE,
-    TestCase,
     run_tests,
     skipIfTorchDynamo,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
+    TestCase,
     torch_to_numpy_dtype_dict,
 )
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Callable, Iterable, Sequence
 from enum import Enum
 from functools import partial, reduce, singledispatch, wraps
-from typing import Any, Optional, Union, cast, overload
+from typing import Any, cast, Optional, overload, Union
 
 import torch
 import torch._prims as prims
@@ -18,29 +18,29 @@ import torch._prims_common as utils
 import torch.utils._pytree as pytree
 from torch import sym_float, sym_int, sym_max, sym_min
 from torch._prims_common import (
-    ELEMENTWISE_TYPE_PROMOTION_KIND,
-    REDUCTION_OUTPUT_TYPE_KIND,
     BoolLike,
     DeviceLikeType,
     Dim,
     DimsSequenceType,
     DimsType,
+    dtype_to_type,
+    ELEMENTWISE_TYPE_PROMOTION_KIND,
     FloatLike,
     FloatWithoutSymFloat,
     IntLike,
+    is_contiguous_for_memory_format_or_false,
+    is_contiguous_or_false,
+    is_weakly_lesser_type,
     Number,
     NumberType,
     RealNumberType,
+    REDUCTION_OUTPUT_TYPE_KIND,
     ShapeType,
     StrideType,
     TensorLike,
     TensorLikeType,
     TensorOrNumberLikeType,
     TensorSequenceType,
-    dtype_to_type,
-    is_contiguous_for_memory_format_or_false,
-    is_contiguous_or_false,
-    is_weakly_lesser_type,
 )
 from torch._prims_common.wrappers import (
     _maybe_convert_to_dtype,
@@ -50,6 +50,7 @@ from torch._prims_common.wrappers import (
     elementwise_unary_scalar_wrapper,
     out_wrapper,
 )
+
 
 # Experimental module containing prototype Python references for existing
 #   PyTorch operations.
@@ -526,6 +527,7 @@ def _maybe_broadcast(*args, preserve_cpu_scalar_tensors=True):
 
 # Utilities should come BEFORE this import
 from torch._decomp import register_decomposition
+
 
 #
 # Elementwise unary references

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Callable, Iterable, Sequence
 from enum import Enum
 from functools import partial, reduce, singledispatch, wraps
-from typing import Any, cast, Optional, overload, Union
+from typing import Any, Optional, Union, cast, overload
 
 import torch
 import torch._prims as prims
@@ -18,29 +18,29 @@ import torch._prims_common as utils
 import torch.utils._pytree as pytree
 from torch import sym_float, sym_int, sym_max, sym_min
 from torch._prims_common import (
+    ELEMENTWISE_TYPE_PROMOTION_KIND,
+    REDUCTION_OUTPUT_TYPE_KIND,
     BoolLike,
     DeviceLikeType,
     Dim,
     DimsSequenceType,
     DimsType,
-    dtype_to_type,
-    ELEMENTWISE_TYPE_PROMOTION_KIND,
     FloatLike,
     FloatWithoutSymFloat,
     IntLike,
-    is_contiguous_for_memory_format_or_false,
-    is_contiguous_or_false,
-    is_weakly_lesser_type,
     Number,
     NumberType,
     RealNumberType,
-    REDUCTION_OUTPUT_TYPE_KIND,
     ShapeType,
     StrideType,
     TensorLike,
     TensorLikeType,
     TensorOrNumberLikeType,
     TensorSequenceType,
+    dtype_to_type,
+    is_contiguous_for_memory_format_or_false,
+    is_contiguous_or_false,
+    is_weakly_lesser_type,
 )
 from torch._prims_common.wrappers import (
     _maybe_convert_to_dtype,
@@ -50,7 +50,6 @@ from torch._prims_common.wrappers import (
     elementwise_unary_scalar_wrapper,
     out_wrapper,
 )
-
 
 # Experimental module containing prototype Python references for existing
 #   PyTorch operations.
@@ -527,7 +526,6 @@ def _maybe_broadcast(*args, preserve_cpu_scalar_tensors=True):
 
 # Utilities should come BEFORE this import
 from torch._decomp import register_decomposition
-
 
 #
 # Elementwise unary references
@@ -2004,6 +2002,7 @@ def clamp(
     if min is None and max is None:
         msg = "clamp called but both min and max are none!"
         raise ValueError(msg)
+
     if min is not None:
         a_isnan = torch.isnan(a)
         condition = torch.bitwise_or(torch.ge(a, min), a_isnan)  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #172067
Summary

This PR fixes eager torch.clamp behavior when a scalar NaN is provided as the sole bound (e.g. torch.clamp(x, None, nan)), which previously returned the input unchanged.

Details

Aligned ATen eager semantics with _refs and existing clamp_min / clamp_max scalar-NaN handling.

Added a regression test covering scalar NaN bounds to prevent future regressions.