### PR TITLE
Fix test_partial_flat_weights flakiness with relaxed tolerances

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4343,7 +4343,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         inp = inp.cuda()
         # otherwise, subsequent warnings will be hidden, and further tests rely on them
         warnings.simplefilter("always")
-        self.assertEqual(m(inp)[0].cpu(), out_expected[0])
+        # Relax tolerances: non-contiguous weights cause cuDNN to use different
+        # algorithms, leading to small numerical differences vs CPU computation.
+        # Observed max: atol ~6.4e-5, rtol ~3.1e-3. Using 1.5x margin.
+        # See https://github.com/pytorch/pytorch/issues/163072
+        self.assertEqual(m(inp)[0].cpu(), out_expected[0], atol=1e-4, rtol=5e-3)
 
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     @set_default_dtype(torch.double)


### PR DESCRIPTION
The test was failing frequently because of numerical differences.

Observed differences across 50 runs on H200:
- Max absolute difference: ~6.4e-05
- Max relative difference: ~3.1e-03

Added explicit tolerances (atol=1e-4, rtol=5e-3) with ~1.5x margin to prevent flakiness while still catching real bugs.

Fixes https://github.com/pytorch/pytorch/issues/163072
