### PR TITLE
Fix libuv build error in windows-arm64-build-test.

### DIFF
--- a/.ci/pytorch/windows/arm64/bootstrap_libuv.bat
+++ b/.ci/pytorch/windows/arm64/bootstrap_libuv.bat
@@ -11,7 +11,7 @@ call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Buil
 where cl.exe
 
 cd %DEPENDENCIES_DIR%
-git clone https://github.com/libuv/libuv.git -b v1.39.0
+git clone https://github.com/libuv/libuv.git -b v1.47.0
 
 echo Configuring libuv...
 mkdir libuv\build


### PR DESCRIPTION
Fix windows-arm64-build-test build error.
https://github.com/pytorch/pytorch/actions/workflows/win-arm64-build-test.yml
https://github.com/pytorch/pytorch/actions/runs/20908075245/job/60065482014
```
Configuring libuv...
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
-- Building for: Visual Studio 17 2022
  Compatibility with CMake < 3.5 has been removed from CMake.
```

Cmake 4.0 doesn't support older version than 3.5.
`Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed.`
https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

libuv 1.39 use cmake 3.4 which is not supported by cmake 4.x.
`cmake_minimum_required(VERSION 3.4)`

Update libuv version to use newer cmake.
https://github.com/libuv/libuv/blob/v1.47.0/CMakeLists.txt
`cmake_minimum_required(VERSION 3.9)`

cc @malfet @seemethere