### PR TITLE
Use TORCH_XPU_OPS_DIR when possible

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1191,7 +1191,7 @@ if(USE_XPU)
   list(APPEND ${Caffe2_XPU_INCLUDE} ${TORCH_XPU_OPS_DIR}/src/ATen/)
   set(TORCH_XPU_OPS_PYTORCH_DEPS ATEN_CPU_FILES_GEN_TARGET)
 
-  add_subdirectory(${TORCH_ROOT}/third_party/torch-xpu-ops
+  add_subdirectory(${TORCH_XPU_OPS_DIR}
       ${CMAKE_BINARY_DIR}/caffe2/aten_xpu)
   if(NOT TARGET torch_xpu_ops)
     message(WARNING "Failed to include ATen XPU implementation target")


### PR DESCRIPTION
Avoid using `${TORCH_ROOT}/third_party/torch-xpu-ops` in two places, instead use `TORCH_XPU_OPS_DIR` where possible
