### PR TITLE
Add CUDA version check for blockwise scaling in sample_inputs_scaled_mm_v2

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     SM53OrLater, SM80OrLater, SM89OrLater, with_tf32_off, TEST_CUDNN,
+    _get_torch_cuda_version,
 )
 from torch.testing._internal.common_quantized import (
     _bfloat16_to_float4_e2m1fn_x2,
@@ -8956,7 +8957,10 @@ def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
 
     dmajor, dminor = torch.cuda.get_device_capability()
 
-    if dmajor == 9 and not torch.version.hip:
+    # Blockwise scaling requires cublasLt >= 12.9 (CUDA 12.9+)
+    # See: https://github.com/pytorch/pytorch/issues/172227
+    cuda_version = _get_torch_cuda_version()
+    if dmajor == 9 and not torch.version.hip and cuda_version >= (12, 9):
         # 1x128 x 1x128
         scale1 = make_scale((K // 128, M)).t()
         scale2 = make_scale((K // 128, N)).t()


### PR DESCRIPTION
## Summary
This PR adds a CUDA version check to `sample_inputs_scaled_mm_v2` to prevent test failures on SM90 hardware with CUDA < 12.9.

## Problem
The test `test_out_warning_torch__scaled_mm_v2_cuda` fails on systems with SM90 (Hopper) GPUs running CUDA < 12.9 because blockwise scaling requires cublasLt >= 12.9.

**Error:**
```
NotImplementedError: DeepSeek style (1x128, 128x128) scaling requires cublasLt >= 12.9
```

## Root Cause
In `torch/testing/_internal/common_methods_invocations.py`, the `sample_inputs_scaled_mm_v2` function checks for SM90 hardware but does not check the CUDA version before generating blockwise scaling samples (`BlockWise1x128`, `BlockWise128x128`).

## Solution
Add a CUDA version check to skip generating blockwise scaling samples when CUDA < 12.9:

```python
cuda_version = _get_torch_cuda_version() if torch.cuda.is_available() else (0, 0)
if dmajor == 9 and not torch.version.hip and cuda_version >= (12, 9):
    # Generate blockwise samples
```

## Testing
Verified on:
- **CUDA 12.8 + SM90 (H200):** Blockwise scaling fails → fix skips these samples ✅
- **TensorWise scaling:** Works correctly on CUDA 12.8 (not affected) ✅

## Environment
- PyTorch: 2.11.0a0+git6d1f6cd (main branch)
- CUDA: 12.8
- GPU: NVIDIA H200 (SM90)
- OS: RHEL 9.6

Fixes #172227

cc @eqy @drisspg