### PR TITLE
[MPS] Compile shaders using latest OS capabilities

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
@@ -38,8 +38,9 @@ typedef NS_ENUM(NSInteger, MTLMathFloatingPointFunctions) {
 @property(readwrite, nonatomic) MTLMathFloatingPointFunctions mathFloatingPointFunctions;
 @end
 
-#endif // MacOS-15 is not defined
+#define MTLLanguageVersion3_2 ((MTLLanguageVersion)((3 << 16) + 2))
+#endif // Building for target older than MacOS-15
 
 #if !defined(__MAC_26_0) && (!defined(MAC_OS_X_VERSION_26_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_26_0))
 #define MTLLanguageVersion4_0 ((MTLLanguageVersion)((4 << 16) + 0))
-#endif // MacOS-26 not defined
+#endif // Building for target older than MacOS-26

--- a/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
@@ -38,4 +38,8 @@ typedef NS_ENUM(NSInteger, MTLMathFloatingPointFunctions) {
 @property(readwrite, nonatomic) MTLMathFloatingPointFunctions mathFloatingPointFunctions;
 @end
 
-#endif
+#endif // MacOS-15 is not defined
+
+#if !defined(__MAC_26_0) && (!defined(MAC_OS_X_VERSION_26_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_26_0))
+#define MTLLanguageVersion4_0 ((MTLLanguageVersion)((4 << 16) + 0))
+#endif // MacOS-26 not defined

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -860,7 +860,15 @@ id<MTLLibrary> MetalShaderLibrary::compileLibrary(const std::string& src) {
   MTLCompileOptions* options = compile_options;
   if (!options) {
     options = [[MTLCompileOptions new] autorelease];
-    [options setLanguageVersion:MTLLanguageVersion3_1];
+    if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_0_PLUS)) {
+      // Metal-4.0 allows tensor template arguments
+      [options setLanguageVersion:MTLLanguageVersion4_0];
+    } else if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS)) {
+      // Metal-3.2 allows lambdas in shader code
+      [options setLanguageVersion:MTLLanguageVersion3_2];
+    } else {
+      [options setLanguageVersion:MTLLanguageVersion3_1];
+    }
     if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS)) {
       options.mathMode = fast_math ? MTLMathModeFast : MTLMathModeSafe;
       options.mathFloatingPointFunctions =

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: mps"]
 # ruff: noqa: F841
+import contextlib
 import io
 import sys
 import math
@@ -13204,6 +13205,28 @@ class TestMetalLibrary(TestCaseMPS):
         shutil.rmtree(capture_dirname)
         self.assertGreater(len(capture_listdir), 3,
                            f"Capture file {capture_dirname} contains only metadata, i.e. {capture_listdir}")
+
+    def test_metal_lambda_expressions(self):
+        # Lambda expressions require Metal 3.2 (macOS 15+)
+        # Test that shaders with lambda expressions compile on macOS 15+ but fail on macOS 14
+        shader_with_lambda = """
+            kernel void lambda_test(device float* x, uint idx [[thread_position_in_grid]]) {
+                auto f = [](float val) { return val * 2.0; };
+                x[idx] = f(x[idx]);
+            }
+        """
+
+        # Expect compilation error on MacOS 14 / Sonoma
+        ctx = contextlib.nullcontext() if MACOS_VERSION >= 15.0 else self.assertRaises(SyntaxError)
+        with ctx:
+            lib = torch.mps.compile_shader(shader_with_lambda)
+
+        # Run shader on MacOS 15 and above
+        if MACOS_VERSION >= 15.0:
+            x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
+            lib.lambda_test(x)
+            expected = torch.tensor([2.0, 4.0, 6.0, 8.0], device="mps")
+            self.assertEqual(x, expected)
 
     def test_metal_error_buffer(self):
         # Test that error_buf_idx parameter works correctly


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #172230

Use Metal-3.2 on MacOS-15 (supports lambdas)
Use Metal-4.0 on MacOS-26 (supports lambdas, more C++17 features and tensor arguments)
 
Add regression test that validates lambda support on MacOS-15+