### PR TITLE
Add Backend.FAKE

### DIFF
--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -453,10 +453,11 @@ def estimate_nccl_collective_runtime_from_fx_node(
         from torch.distributed.distributed_c10d import (
             _get_pg_default_device,
             _resolve_process_group,
+            Backend,
         )
 
         pg = _resolve_process_group(group_name)
-        if torch.distributed.distributed_c10d.get_backend(pg) == "fake":
+        if torch.distributed.distributed_c10d.get_backend(pg) == Backend.FAKE:
             # nccl estimator requires real process group
             return None
 

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -57,7 +57,10 @@ def can_benchmark_collective() -> bool:
         return False
 
     pg = c10d.distributed_c10d._get_default_group()
-    if torch.distributed.distributed_c10d.get_backend(pg) == "fake":
+    if (
+        torch.distributed.distributed_c10d.get_backend(pg)
+        == torch.distributed.distributed_c10d.Backend.FAKE
+    ):
         return False
 
     return True

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -243,7 +243,7 @@ class Backend(str):  # noqa: SLOT000
     """
     An enum-like class for backends.
 
-    Available backends: GLOO, NCCL, UCC, MPI, XCCL, and other registered backends.
+    Available backends: GLOO, NCCL, UCC, MPI, XCCL, FAKE, and other registered backends.
 
     The values of this class are lowercase strings, e.g., ``"gloo"``. They can
     be accessed as attributes, e.g., ``Backend.NCCL``.
@@ -264,12 +264,13 @@ class Backend(str):  # noqa: SLOT000
     UCC = "ucc"
     MPI = "mpi"
     XCCL = "xccl"
+    FAKE = "fake"
 
     _BackendPlugin = namedtuple("_BackendPlugin", ["creator_fn", "extended_api"])
 
     _plugins: dict[str, _BackendPlugin] = {}
 
-    backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI]
+    backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI, FAKE]
 
     # 3rd-party devices can register the default backend support here
     default_device_backend_map: dict[str, str] = {
@@ -285,6 +286,7 @@ class Backend(str):  # noqa: SLOT000
         XCCL: ["xpu"],
         UCC: ["cpu", "cuda"],
         MPI: ["cpu", "cuda"],
+        FAKE: ["cpu", "cuda", "hpu", "xpu"],
     }
 
     backend_type_map: dict[str, ProcessGroup.BackendType] = {
@@ -294,6 +296,7 @@ class Backend(str):  # noqa: SLOT000
         XCCL: ProcessGroup.BackendType.XCCL,
         UCC: ProcessGroup.BackendType.UCC,
         MPI: ProcessGroup.BackendType.MPI,
+        FAKE: ProcessGroup.BackendType.CUSTOM,
     }
 
     def __new__(cls, name: str):
@@ -1795,7 +1798,7 @@ def init_process_group(
     else:
         # backward compatible API
         if store is None:
-            if backend == "fake":
+            if backend == Backend.FAKE:
                 from torch.testing._internal.distributed.fake_pg import FakeStore
 
                 store = FakeStore()

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -28,5 +28,8 @@ def _create_fake_pg(common_opts, backend_opts):
 
 
 dist.Backend.register_backend(
-    "fake", _create_fake_pg, extended_api=True, devices=["cpu", "cuda", "hpu", "xpu"]
+    dist.Backend.FAKE,
+    _create_fake_pg,
+    extended_api=True,
+    devices=["cpu", "cuda", "hpu", "xpu"],
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172241

1. torch/distributed/distributed_c10d.py
  - Added FAKE = "fake" constant to the Backend class
  - Added FAKE to backend_list
  - Added FAKE to backend_capability with devices ["cpu", "cuda", "hpu", "xpu"]
  - Added FAKE to backend_type_map mapping to ProcessGroup.BackendType.CUSTOM
  - Updated docstring to mention FAKE
  - Changed backend == "fake" to backend == Backend.FAKE

  2. torch/_inductor/fx_passes/node_runtime_estimation.py
  - Changed get_backend(pg) == "fake" to get_backend(pg) == torch.distributed.distributed_c10d.Backend.FAKE

  3. torch/_inductor/comm_analysis.py
  - Added Backend to the import statement
  - Changed get_backend(pg) == "fake" to get_backend(pg) == Backend.FAKE

  4. torch/testing/_internal/distributed/fake_pg.py
  - Changed "fake" to dist.Backend.FAKE in the register_backend call

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo