### PR TITLE
ci: Use buildx directly

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -390,7 +390,7 @@ if [[ -n "${CI:-}" ]]; then
 fi
 
 # Build image
-docker build \
+docker buildx build \
        ${no_cache_flag} \
        ${progress_flag} \
        --build-arg "BUILD_ENVIRONMENT=${image}" \
@@ -428,6 +428,7 @@ docker build \
        --build-arg "SKIP_LLVM_SRC_BUILD_INSTALL=${SKIP_LLVM_SRC_BUILD_INSTALL:-}" \
        --build-arg "INSTALL_MINGW=${INSTALL_MINGW:-}" \
        -f $(dirname ${DOCKERFILE})/Dockerfile \
+       --load \
        -t "$tmp_tag" \
        "$@" \
        .


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #172244
* __->__ #172243

We should just use buildx directly since it comes with a lot more
features than base docker build that we might want to take advantage
while making improvements.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>