### PR TITLE
ci: Give root the ability to run apt

### DIFF
--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -8,6 +8,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG CLANG_VERSION
 
+# Important Line: Allow APT to run as root
+RUN echo 'APT::Sandbox::User "root";' | tee -a /etc/apt/apt.conf.d/10sandbox
+
 # Install common dependencies (so that this step can be cached separately)
 COPY ./common/install_base.sh install_base.sh
 RUN bash ./install_base.sh && rm install_base.sh

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG CLANG_VERSION
 
-# Important Line: Allow APT to run as root
+# Allow APT to run as root
 RUN echo 'APT::Sandbox::User "root";' | tee -a /etc/apt/apt.conf.d/10sandbox
 
 # Install common dependencies (so that this step can be cached separately)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #172244
* #172243

This was failing in specific rootless scenarios, not really affecting CI
but affected local development on machines that I had access to.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>