### PR TITLE
[ROCm][CK] Enable variable-length attention support for CK SDPA backend

### DIFF
--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -711,6 +711,10 @@ class TestVarlenAttention(NNTestCase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
+    @parametrize(
+        "sdpa_backend",
+        ["aotriton", "ck"] if PLATFORM_SUPPORTS_CK_SDPA else ["aotriton"],
+    )
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     @parametrize("num_splits", [1, None])
     @parametrize(

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -297,10 +297,6 @@ class TestVarlenAttention(NNTestCase):
     @setSdpaBackendsToDefaultFinally
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     @parametrize(
-        "sdpa_backend",
-        ["aotriton", "ck"] if PLATFORM_SUPPORTS_CK_SDPA else ["aotriton"],
-    )
-    @parametrize(
         "backend",
         _varlen_backends(include_fa4_paged_kv=False),
     )


### PR DESCRIPTION
## Summary

Enables variable-length (varlen) attention support for the Composable Kernel (CK) SDPA backend on ROCm.

## Changes

### Forward pass (`mha_varlen_fwd_ck.hip`)

- Fixed LSE tensor allocation: changed from 3D `{batch_size, num_heads, max_seqlen_q}` to 2D `{num_heads, total_q}` to match CK group mode expectation
- Fixed `nhead_stride_lse`: use `stride(0)` instead of `stride(1)` for 2D layout
- Fixed `batch_stride_lse`: set to `0` (no batch dimension in group mode LSE)
- Fixed `min_seqlen_q`: changed from `-1` to `1` (valid minimum for kernel dispatch)

### Backward pass (`mha_varlen_bwd_ck.hip`)

- Fixed philox seed/offset access: guarded with `if (is_dropout)` to avoid dtype mismatch when dropout is disabled

### Test infrastructure (`test/test_varlen_attention.py`)

- Added `sdpa_backend` parametrization to test both `aotriton` and `ck` backends on ROCm
- Backend selection: `["aotriton", "ck"]` when CK is available, `["aotriton"]` otherwise
- Uses `preferred_rocm_fa_library()` to switch backends per test

### Platform detection

- Added `PLATFORM_SUPPORTS_CK_SDPA` in `torch/testing/_internal/common_cuda.py`
- Added `_is_ck_sdpa_available()` in `torch/csrc/Module.cpp` for runtime CK availability check

### Fake tensor implementation (`torch/nn/attention/varlen.py`)

- Updated `_varlen_attn_fake` to use standard `[num_heads, total_q]` logsumexp format (matches aotriton/CUDA)

## Dependencies: CK submodule bump

- **CK PR**: (https://github.com/ROCm/rocm-libraries/pull/4292)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang 