### PR TITLE
use _has_symbolic_sizes_strides more pervasively for perf

### DIFF
--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import collections
 import functools
-import itertools
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, NewType, Optional, Protocol, TYPE_CHECKING, TypeVar, Union
@@ -186,13 +185,7 @@ class MemoryFormatMeta:
             or is_traceable_wrapper_subclass(t)
         )
         if not use_memory_format:
-            is_static_shape = True
-            for s in itertools.chain(t.shape, t.stride()):
-                if not isinstance(s, int):
-                    is_static_shape = False
-                    break
-
-            use_memory_format = not is_static_shape
+            use_memory_format = t._has_symbolic_sizes_strides
 
         if use_memory_format:
             return MemoryFormatMeta(

--- a/torch/_inductor/fx_passes/auto_chunker/__init__.py
+++ b/torch/_inductor/fx_passes/auto_chunker/__init__.py
@@ -63,7 +63,7 @@ def chunk(gm: GraphModule) -> GraphModule:
     if amplifier_node is None:
         raise CantChunk("Skip chunking due to no amplifier node found")
 
-    if not all(isinstance(s, int) for s in amplifier_node.meta["val"].shape):
+    if amplifier_node.meta["val"]._has_symbolic_sizes_strides:
         raise CantChunk("Can't chunk due to dynamic shape")
 
     propagate(amplifier_node)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1176,8 +1176,7 @@ def sympy_subs(expr: sympy.Expr, replacements: dict[sympy.Expr, Any]) -> sympy.E
 
 def is_symbolic(a: Any) -> TypeGuard[Union[torch.SymInt, torch.Tensor]]:
     return isinstance(a, torch.SymInt) or (
-        isinstance(a, torch.Tensor)
-        and any(is_symbolic(x) for x in itertools.chain(a.size(), a.stride()))
+        isinstance(a, torch.Tensor) and a._has_symbolic_sizes_strides
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172249



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo