### PR TITLE
[DTensor] reduce test size due to timeout

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -1142,10 +1142,8 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
                 # even sharding
                 (16, 8),
                 (8, 16, 32),
-                (8, 32, 16, 16),
                 # uneven sharding with padding
                 (17, 5),
-                (13, 2, 13),
                 (33, 16, 8, 1),
             ]
 


### PR DESCRIPTION
Summary:
After using the real communication cost, DTensor redistribute test takes longer and sometimes exceed the 300s limit. This PR reduces the test size.

Fixes T251123717.

Test Plan: N/A

Differential Revision: D90517903


