### PR TITLE
Reformat files before usort upgrade

### DIFF
--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 
 import torch
 from torch.autograd.profiler import record_function
-
 from .fuser import set_fuser
 from .runner import get_nn_runners
 

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 
 import torch
 from torch import Tensor
-
 from .cells import flat_lstm_cell, lstm_cell, premul_lstm_cell, premul_lstm_cell_no_bias
 
 

--- a/benchmarks/fastrnns/profile.py
+++ b/benchmarks/fastrnns/profile.py
@@ -5,7 +5,6 @@ import sys
 import time
 
 import torch
-
 from .runner import get_nn_runners
 
 

--- a/benchmarks/fastrnns/runner.py
+++ b/benchmarks/fastrnns/runner.py
@@ -4,7 +4,6 @@ from functools import partial
 import torchvision.models as cnn
 
 import torch
-
 from .factory import (
     dropoutlstm_creator,
     imagenet_cnn_creator,

--- a/benchmarks/fastrnns/test.py
+++ b/benchmarks/fastrnns/test.py
@@ -2,7 +2,6 @@ import argparse
 
 import torch
 import torch.nn as nn
-
 from .factory import pytorch_lstm_creator, varlen_pytorch_lstm_creator
 from .runner import get_nn_runners
 

--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -1,7 +1,6 @@
 import pytest
 
 import torch
-
 from .fuser import set_fuser
 from .runner import get_nn_runners
 

--- a/benchmarks/framework_overhead_benchmark/framework_overhead_benchmark.py
+++ b/benchmarks/framework_overhead_benchmark/framework_overhead_benchmark.py
@@ -2,7 +2,6 @@ import argparse
 
 from pt_wrapper_module import WrapperModule
 from SimpleAddModule import add_tensors_loop, SimpleAddModule
-
 from utils import benchmark_module, BenchmarkConfig, ModuleConfig, ms_to_us
 
 

--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -19,7 +19,6 @@ except ImportError:
 import audio_text_models
 import ppl_models
 import vision_models
-
 from utils import GetterType, InputsType, TimingResultType, to_markdown_table, VType
 
 

--- a/benchmarks/instruction_counts/core/utils.py
+++ b/benchmarks/instruction_counts/core/utils.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 from core.api import GroupedBenchmark, TimerArgs
 from core.types import Definition, FlatIntermediateDefinition, Label
-
 from torch.utils.benchmark.utils.common import _make_temp_dir
 
 

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -11,7 +11,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
 import benchmark_utils
-
 import numpy as np
 
 import torch

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -1,7 +1,6 @@
 import argparse
 
 import benchmark_core
-
 import benchmark_utils
 
 import torch

--- a/benchmarks/operator_benchmark/pt/activation_test.py
+++ b/benchmarks/operator_benchmark/pt/activation_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/addmm_test.py
+++ b/benchmarks/operator_benchmark/pt/addmm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/ao_sparsifier_test.py
+++ b/benchmarks/operator_benchmark/pt/ao_sparsifier_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 from torch import nn
 from torch.ao import pruning

--- a/benchmarks/operator_benchmark/pt/arange_test.py
+++ b/benchmarks/operator_benchmark/pt/arange_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn.functional as F
 

--- a/benchmarks/operator_benchmark/pt/binary_inplace_test.py
+++ b/benchmarks/operator_benchmark/pt/binary_inplace_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/binary_test.py
+++ b/benchmarks/operator_benchmark/pt/binary_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/bmm_test.py
+++ b/benchmarks/operator_benchmark/pt/bmm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/boolean_test.py
+++ b/benchmarks/operator_benchmark/pt/boolean_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -1,7 +1,6 @@
 import random
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/channel_shuffle_test.py
+++ b/benchmarks/operator_benchmark/pt/channel_shuffle_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/chunk_test.py
+++ b/benchmarks/operator_benchmark/pt/chunk_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/clip_ranges_test.py
+++ b/benchmarks/operator_benchmark/pt/clip_ranges_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -1,7 +1,6 @@
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/diag_test.py
+++ b/benchmarks/operator_benchmark/pt/diag_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -2,7 +2,6 @@ import numpy
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 from torch.testing._internal.common_device_type import get_all_device_types
 

--- a/benchmarks/operator_benchmark/pt/gather_test.py
+++ b/benchmarks/operator_benchmark/pt/gather_test.py
@@ -1,7 +1,6 @@
 import numpy
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/gelu_test.py
+++ b/benchmarks/operator_benchmark/pt/gelu_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/groupnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/groupnorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn.functional as F
 

--- a/benchmarks/operator_benchmark/pt/hardsigmoid_test.py
+++ b/benchmarks/operator_benchmark/pt/hardsigmoid_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/hardswish_test.py
+++ b/benchmarks/operator_benchmark/pt/hardswish_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/index_add__test.py
+++ b/benchmarks/operator_benchmark/pt/index_add__test.py
@@ -1,7 +1,6 @@
 import numpy
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/index_select_test.py
+++ b/benchmarks/operator_benchmark/pt/index_select_test.py
@@ -1,7 +1,6 @@
 import numpy
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/instancenorm_test.py
+++ b/benchmarks/operator_benchmark/pt/instancenorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn.functional as F
 

--- a/benchmarks/operator_benchmark/pt/interpolate_test.py
+++ b/benchmarks/operator_benchmark/pt/interpolate_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/layernorm_test.py
+++ b/benchmarks/operator_benchmark/pt/layernorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn.functional as F
 

--- a/benchmarks/operator_benchmark/pt/linear_prepack_fp16_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_prepack_fp16_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -1,7 +1,6 @@
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/linear_unpack_fp16_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_unpack_fp16_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/matrix_mult_test.py
+++ b/benchmarks/operator_benchmark/pt/matrix_mult_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/mm_test.py
+++ b/benchmarks/operator_benchmark/pt/mm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/nan_to_num_test.py
+++ b/benchmarks/operator_benchmark/pt/nan_to_num_test.py
@@ -1,7 +1,6 @@
 import math
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/norm_test.py
+++ b/benchmarks/operator_benchmark/pt/norm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/optimizer_test.py
+++ b/benchmarks/operator_benchmark/pt/optimizer_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.optim as optim
 

--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.quantized.functional as qF
 

--- a/benchmarks/operator_benchmark/pt/qarithmetic_test.py
+++ b/benchmarks/operator_benchmark/pt/qarithmetic_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 from torch._ops import ops
 

--- a/benchmarks/operator_benchmark/pt/qatembedding_ops_test.py
+++ b/benchmarks/operator_benchmark/pt/qatembedding_ops_test.py
@@ -2,7 +2,6 @@ import numpy
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.qat as nnqat
 from torch.ao.quantization import default_embedding_qat_qconfig

--- a/benchmarks/operator_benchmark/pt/qbatchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qbatchnorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qcat_test.py
+++ b/benchmarks/operator_benchmark/pt/qcat_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.quantized as nnq
 

--- a/benchmarks/operator_benchmark/pt/qcomparators_test.py
+++ b/benchmarks/operator_benchmark/pt/qcomparators_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -1,7 +1,6 @@
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.quantized as nnq
 

--- a/benchmarks/operator_benchmark/pt/qembedding_bag_lookups_test.py
+++ b/benchmarks/operator_benchmark/pt/qembedding_bag_lookups_test.py
@@ -3,7 +3,6 @@ from typing import Optional
 import numpy as np
 
 import operator_benchmark as op_bench
-
 import torch
 from torch.testing._internal.common_quantization import lengths_to_offsets
 

--- a/benchmarks/operator_benchmark/pt/qembedding_pack_test.py
+++ b/benchmarks/operator_benchmark/pt/qembedding_pack_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
@@ -2,7 +2,6 @@ import numpy
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.quantized as nnq
 

--- a/benchmarks/operator_benchmark/pt/qgroupnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qgroupnorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qinstancenorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qinstancenorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qinterpolate_test.py
+++ b/benchmarks/operator_benchmark/pt/qinterpolate_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qlayernorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qlayernorm_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qlinear_test.py
+++ b/benchmarks/operator_benchmark/pt/qlinear_test.py
@@ -1,7 +1,6 @@
 from pt import configs
 
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.quantized as nnq
 import torch.ao.nn.quantized.dynamic as nnqd

--- a/benchmarks/operator_benchmark/pt/qobserver_test.py
+++ b/benchmarks/operator_benchmark/pt/qobserver_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.quantization.observer as obs
 

--- a/benchmarks/operator_benchmark/pt/qpool_test.py
+++ b/benchmarks/operator_benchmark/pt/qpool_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/qrnn_test.py
+++ b/benchmarks/operator_benchmark/pt/qrnn_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 from torch import nn
 

--- a/benchmarks/operator_benchmark/pt/qtensor_method_test.py
+++ b/benchmarks/operator_benchmark/pt/qtensor_method_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/quantization_test.py
+++ b/benchmarks/operator_benchmark/pt/quantization_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.ao.nn.quantized as nnq
 import torch.ao.quantization as tq

--- a/benchmarks/operator_benchmark/pt/qunary_test.py
+++ b/benchmarks/operator_benchmark/pt/qunary_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/remainder_test.py
+++ b/benchmarks/operator_benchmark/pt/remainder_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/scaled_grouped_mm_test.py
+++ b/benchmarks/operator_benchmark/pt/scaled_grouped_mm_test.py
@@ -7,7 +7,6 @@ from pt.scaled_mm_common import (
 )
 
 import operator_benchmark as op_bench
-
 import torch
 from torch.nn.functional import ScalingType
 from torch.testing._internal.common_cuda import (

--- a/benchmarks/operator_benchmark/pt/scaled_mm_test.py
+++ b/benchmarks/operator_benchmark/pt/scaled_mm_test.py
@@ -8,7 +8,6 @@ from pt.scaled_mm_common import (
 )
 
 import operator_benchmark as op_bench
-
 import torch
 from torch.nn.functional import ScalingType, SwizzleType
 from torch.testing._internal.common_cuda import (

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 import torch.nn as nn
 

--- a/benchmarks/operator_benchmark/pt/split_test.py
+++ b/benchmarks/operator_benchmark/pt/split_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/stack_test.py
+++ b/benchmarks/operator_benchmark/pt/stack_test.py
@@ -1,7 +1,6 @@
 import random
 
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/sum_test.py
+++ b/benchmarks/operator_benchmark/pt/sum_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/tensor_to_test.py
+++ b/benchmarks/operator_benchmark/pt/tensor_to_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/ternary_test.py
+++ b/benchmarks/operator_benchmark/pt/ternary_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/topk_test.py
+++ b/benchmarks/operator_benchmark/pt/topk_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/where_test.py
+++ b/benchmarks/operator_benchmark/pt/where_test.py
@@ -1,5 +1,4 @@
 import operator_benchmark as op_bench
-
 import torch
 
 

--- a/benchmarks/record_function_benchmark/record_function_bench.py
+++ b/benchmarks/record_function_benchmark/record_function_bench.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from benchmarks.fastrnns.factory import lstm_creator
-
 from torchvision.models import resnet50
 
 import torch

--- a/benchmarks/sparse/dlmc/matmul_bench.py
+++ b/benchmarks/sparse/dlmc/matmul_bench.py
@@ -13,7 +13,6 @@ from scipy.sparse import isspmatrix
 
 import torch
 import torch.utils.benchmark as benchmark_utils
-
 from .utils import load_dlmc_dataset
 
 

--- a/benchmarks/sparse/spmv.py
+++ b/benchmarks/sparse/spmv.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 import torch
-
 from .utils import Event, gen_sparse_coo, gen_sparse_coo_and_csr, gen_sparse_csr
 
 

--- a/benchmarks/tensorexpr/attention.py
+++ b/benchmarks/tensorexpr/attention.py
@@ -3,7 +3,6 @@
 # https://github.com/mlcommons/training/blob/master/retired_benchmarks/gnmt/pytorch/seq2seq/models/attention.py
 
 import torch
-
 from . import benchmark
 
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -6,7 +6,6 @@ import time
 import numpy as np
 
 import torch
-
 from . import tensor_engine
 
 

--- a/benchmarks/tensorexpr/broadcast.py
+++ b/benchmarks/tensorexpr/broadcast.py
@@ -4,7 +4,6 @@ import operator
 import numpy as np
 
 import torch
-
 from . import benchmark
 
 

--- a/benchmarks/tensorexpr/concat.py
+++ b/benchmarks/tensorexpr/concat.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import torch
-
 from . import benchmark
 
 

--- a/benchmarks/tensorexpr/elementwise.py
+++ b/benchmarks/tensorexpr/elementwise.py
@@ -5,7 +5,6 @@ import numpy as np
 import scipy.special
 
 import torch
-
 from . import benchmark
 
 

--- a/benchmarks/tensorexpr/rnn_eltwise.py
+++ b/benchmarks/tensorexpr/rnn_eltwise.py
@@ -1,5 +1,4 @@
 import torch
-
 from . import benchmark
 
 

--- a/benchmarks/tensorexpr/swish.py
+++ b/benchmarks/tensorexpr/swish.py
@@ -1,5 +1,4 @@
 import torch
-
 from . import benchmark
 
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1383,6 +1383,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             else:
                 return None
 
+        # pyrefly: ignore [deprecated]
         @register(torch.fx.experimental.symbolic_shapes.guard_size_oblivious)
         def handle_guard_size_oblivious(
             self, tx: "InstructionTranslator", expr: VariableTracker
@@ -1391,6 +1392,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
                 # TODO: some of the other symbolic_shapes special tools can also get this treatment too
                 return variables.ConstantVariable.create(
+                    # pyrefly: ignore [deprecated]
                     torch.fx.experimental.symbolic_shapes.guard_size_oblivious(
                         expr.sym_num
                     )

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -296,6 +296,7 @@ class StaticallyLaunchedCudaKernel(StaticallyLaunchedTritonKernel):
 class StaticallyLaunchedXpuKernel(StaticallyLaunchedTritonKernel):
     @cached_property
     def C_impl(self):
+        # pyrefly: ignore [missing-module-attribute]
         from torch._C import _StaticXpuLauncher
 
         return _StaticXpuLauncher

--- a/torch/_subclasses/schema_check_mode.py
+++ b/torch/_subclasses/schema_check_mode.py
@@ -29,7 +29,9 @@ class Aliasing(NamedTuple):
 
 
 # Simplified naming for C++ classes
+# pyrefly: ignore [missing-attribute]
 SchemaArgument = torch._C._SchemaArgument
+# pyrefly: ignore [missing-attribute]
 SchemaArgType = torch._C._SchemaArgType
 SchemaInfo = torch._C._SchemaInfo
 
@@ -124,6 +126,7 @@ class SchemaCheckMode(TorchDispatchMode):
 
         def has_aliased(lhs: Any, rhs: Any) -> bool:
             try:
+                # pyrefly: ignore [missing-attribute]
                 return torch._C._overlaps(lhs, rhs)
             except Exception as exception:
                 if str(exception).startswith("Cannot inspect value of type "):
@@ -186,6 +189,7 @@ class SchemaCheckMode(TorchDispatchMode):
         tuple_out = tree_map(unwrap, tuple_out)
 
         schema_info = SchemaInfo(func._schema)
+        # pyrefly: ignore [missing-attribute]
         schema_info.add_argument_values(pre_arguments)
 
         # Process arguments with outputs
@@ -203,6 +207,7 @@ class SchemaCheckMode(TorchDispatchMode):
                         has_aliased(tuple_out[j], after)
                         and func._schema.name not in unsafe_ops
                     ):
+                        # pyrefly: ignore [missing-attribute]
                         if not schema_info.may_contain_alias(
                             SchemaArgument(SchemaArgType.output, j),
                             SchemaArgument(SchemaArgType.input, i),
@@ -245,6 +250,7 @@ However, we found that `outputs[{str(j)}] is {name}"""
         # Aliasing between outputs
         for i, j in combinations(range(len(func._schema.returns)), 2):
             if has_aliased(tuple_out[i], tuple_out[j]):
+                # pyrefly: ignore [missing-attribute]
                 if not schema_info.may_contain_alias(
                     SchemaArgument(SchemaArgType.output, i),
                     SchemaArgument(SchemaArgType.output, j),

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -393,6 +393,7 @@ def is_ck_sdpa_available() -> bool:
     Returns whether composable_kernel may be used as the backend for
     scaled-dot-product-attention.
     """
+    # pyrefly: ignore [missing-attribute]
     return torch._C._is_ck_sdpa_available()
 
 

--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -262,6 +262,7 @@ def memory_snapshot(
     """
     if not is_initialized():
         return []
+    # pyrefly: ignore [missing-attribute]
     return torch._C._xpu_memorySnapshot(mempool_id)["segments"]
 
 
@@ -343,6 +344,7 @@ def _record_memory_history(
 
             Defaults to ``None`` (record all actions).
     """
+    # pyrefly: ignore [missing-attribute]
     torch._C._xpu_recordMemoryHistory(
         enabled,
         context,


### PR DESCRIPTION
I am working on upgrading usort to unblock type checking additional files with pyrefly. 

Initial PR was too large to land easily, so breaking it into smaller PRs to hopefully land with out disruptions / spurious errors. 

Original PR: https://github.com/pytorch/pytorch/pull/171758




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela