### PR TITLE
Remove libstdcxx conda-forge hack when building Docker images

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -56,11 +56,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
              ${SYSROOT_DEP} \
              "icu<78"
 
-
-  # libstdcxx from conda default channels are too old, we need GLIBCXX_3.4.30
-  # which is provided in libstdcxx 12 and up.
-  conda_install libstdcxx-ng=12.3.0 --update-deps -c conda-forge
-
   # Miniforge installer doesn't install sqlite by default
   if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     conda_install sqlite


### PR DESCRIPTION
This is causing `aarch64` CI to fail with `ImportError: /opt/conda/envs/py_3.10/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/lib/libtorch_python.so)`. We don't need this anymore on both x86 and aarch64

### Testing
* Ops benchmark on aarch64 https://github.com/pytorch/pytorch/actions/runs/20892131668/job/60026086535?pr=172159
* TODO