### PR TITLE
Upgrade usort

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1451,7 +1451,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'usort==1.0.8.post1',
+    'usort==1.1.3',
     'isort==6.0.1',
     'ruff==0.14.4',  # sync with RUFF
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,10 @@ multi_line_output = 3
 include_trailing_comma = true
 combine_as_imports = true
 
+[tool.usort]
+preserve_inline_comments = true
+collapse_blank_lines_in_category = false
+
 [tool.usort.known]
 first_party = ["caffe2", "torch", "torchgen", "functorch", "test"]
 standard_library = ["typing_extensions"]

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autograd.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autograd.py
@@ -3,7 +3,6 @@
 import os
 
 import psutil
-
 import torch
 from torch.testing._internal.common_utils import (
     run_tests,

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
@@ -4,7 +4,6 @@ import gc
 import time
 
 import torch
-
 import torch_openreg  # noqa: F401
 from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -7,7 +7,6 @@ import tempfile
 import unittest
 
 import numpy
-
 import torch
 from torch.serialization import safe_globals
 from torch.testing._internal.common_utils import (

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/__init__.py
@@ -1,7 +1,6 @@
 import torch
 
 import torch_openreg._C  # type: ignore[misc]
-
 from . import meta  # noqa: F401
 from .amp import get_amp_supported_dtype  # noqa: F401
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/random.py
@@ -1,7 +1,6 @@
 import torch
 
 import torch_openreg._C  # type: ignore[misc]
-
 from . import _lazy_init, current_device, device_count
 
 


### PR DESCRIPTION
Previously isort / usort would take code that looked like this:

        # After (preserve_inline_comments = true)
        from torch._C import (
            _add_docstr,
            _linalg,  # pyrefly: ignore
            _LinAlgError as LinAlgError,  # pyrefly: ignore
        )
and reformat it to look like this:

        # After (preserve_inline_comments = true)
        from torch._C import ( # pyrefly: ignore
            _add_docstr,
            _linalg, 
            _LinAlgError as LinAlgError,  # pyrefly: ignore
        )
which would cause type suppressions to be moved away. This change allows us to preserve error suppression comments while still being able to run lintrunner and avoid adding extra comments to skip isort / usort.

```
lintrunner --take PYFMT -a --all-files
pyrefly check 
```

Usort had changed how they handle grouping imports together, and ugprading it means changing white space between import statements in many files.

This change makes type checking easier and unblocks us from opting in additional python files to type checking



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @ezyang @EikanWang @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @Lucaskabela