### PR TITLE
Rewrap KeyError into RuntimeError for better Dynamo handling

### DIFF
--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -592,9 +592,14 @@ class FunctionalTensorMode(TorchDispatchMode):
                             for a in pytree.tree_leaves([args, kwargs]):
                                 if not isinstance(a, FunctionalTensor):
                                     continue
-                                curr_node = m.tracer.tensor_tracker[
-                                    torch._from_functional_tensor(a.elem)
-                                ].proxy.node
+                                unwrapped = torch._from_functional_tensor(a.elem)
+                                try:
+                                    tracker_entry = m.tracer.tensor_tracker[unwrapped]
+                                except KeyError:
+                                    raise RuntimeError(
+                                        f"cannot find {unwrapped} in tensor_tracker"
+                                    ) from None
+                                curr_node = tracker_entry.proxy.node
                                 with fx_traceback.set_current_replay_node(curr_node):
                                     torch._sync(a)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #172644
* __->__ #172271

KeyError overrides msg to be the key that missed, which looks ugly when we add
extra traceback info to it, so not having a KeyError here makes downstream
error message look nicer.

Signed-off-by: Edward Yang <ezyang@meta.com>