### PR TITLE
[POC] Add FakeTensor, ProxyTensor and serialization support to inductor_compiled_code HOP

### DIFF
--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -1064,20 +1064,75 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
 
-    def test_fake_tensor_mode_raises_error(self):
-        """Test that running compiled code inside FakeTensorMode raises a clear error"""
+    def test_fake_tensor_mode_works(self):
+        """Test that running compiled code inside FakeTensorMode works with FX graph fallback"""
         from torch._subclasses.fake_tensor import FakeTensorMode
 
         with FakeTensorMode():
             model = torch.nn.Linear(4, 4)
             inp = torch.rand(4, 4)
 
+            # The FX graph is now serialized using SerializedGraphModule, so it
+            # survives cache serialization/deserialization and works with caching
             with inductor_config.patch({"wrap_inductor_compiled_regions": True}):
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "Inductor compiled code cannot be run with FakeTensor inputs",
-                ):
-                    torch.compile(model)(inp)
+                # This should now work - the inductor_compiled_code HOP will
+                # use the stored FX graph to propagate fake tensors
+                result = torch.compile(model)(inp)
+                # Verify the result has the expected shape
+                self.assertEqual(result.shape, (4, 4))
+
+    def test_proxy_tensor_mode_works(self):
+        """Test that running compiled code inside ProxyTensorMode works with FX graph fallback"""
+        from torch._higher_order_ops.wrap import (
+            InductorCompiledCallable,
+            inductor_code_side_table,
+            inductor_compiled_code,
+        )
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        # Reset the side table for a clean test
+        inductor_code_side_table.reset_table()
+
+        # Create a simple FX graph
+        class SimpleModel(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        model = SimpleModel()
+        gm = torch.fx.symbolic_trace(model)
+
+        # Create an InductorCompiledCallable
+        # The compiled callable should match FX graph's output convention
+        def simple_compiled(inputs):
+            return inputs[0] + 1
+
+        callable_obj = InductorCompiledCallable(simple_compiled, gm)
+
+        # Wrapper that uses the HOP
+        def wrapper(x):
+            return inductor_compiled_code(callable_obj, [x])
+
+        inp = torch.randn(4, 4)
+        traced = make_fx(wrapper)(inp)
+
+        # Verify the traced graph contains the inductor_compiled_code HOP
+        hop_found = False
+        for node in traced.graph.nodes:
+            if node.op == "call_function" and "inductor_compiled_code" in str(
+                node.target
+            ):
+                hop_found = True
+                # Verify the callable index is an int
+                self.assertIsInstance(node.args[0], int)
+                break
+        self.assertTrue(
+            hop_found, "inductor_compiled_code HOP not found in traced graph"
+        )
+
+        # Verify the traced graph can be executed and produces correct results
+        result = traced(inp)
+        expected = inp + 1
+        torch.testing.assert_close(result, expected)
 
 
 if __name__ == "__main__":

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -68,9 +68,87 @@ inductor_compiled_code.fallthrough(DispatchKey.AutogradCPU)
 inductor_compiled_code.fallthrough(DispatchKey.AutogradCUDA)
 
 
+class InductorCompiledCallable:
+    """
+    A wrapper class that holds both the Inductor-compiled callable and
+    the pre-compilation FX graph. This allows the inductor_compiled_code
+    HOP to properly handle FakeTensor and FunctionalTensor inputs by
+    running the FX graph instead of the compiled callable.
+    """
+
+    def __init__(self, compiled_callable, fx_graph):
+        self.compiled_callable = compiled_callable
+        self.fx_graph = fx_graph
+        # AOT autograd needs this to know inputs are passed as a list
+        self._boxed_call = True
+
+    def __call__(self, inputs):
+        return self.compiled_callable(inputs)
+
+
+class InductorCodeSideTable:
+    """
+    Side table for storing InductorCompiledCallable objects.
+
+    Similar to KernelSideTable for Triton kernels, we cannot put
+    InductorCompiledCallable objects directly into the FX graph as the
+    graph nodes do not support arbitrary objects. We use a side table
+    and pass an index instead.
+
+    We use two dicts so that fetching both the callable and id are O(1).
+    """
+
+    def __init__(self):
+        self.id_to_callable: dict[int, InductorCompiledCallable] = {}
+        self.callable_to_id: dict[int, int] = {}  # id(callable) -> idx
+
+    def add_callable(self, callable_obj: InductorCompiledCallable) -> int:
+        """Add a callable to the table and return its index."""
+        obj_id = id(callable_obj)
+        if obj_id in self.callable_to_id:
+            return self.callable_to_id[obj_id]
+
+        idx = len(self.id_to_callable)
+        self.id_to_callable[idx] = callable_obj
+        self.callable_to_id[obj_id] = idx
+        return idx
+
+    def get_callable(self, idx: int) -> InductorCompiledCallable:
+        """Get the callable at the given index."""
+        assert idx in self.id_to_callable, f"Invalid inductor code index: {idx}"
+        return self.id_to_callable[idx]
+
+    def reset_table(self) -> None:
+        """Reset the table (only meant to be used in unit tests)."""
+        self.id_to_callable = {}
+        self.callable_to_id = {}
+
+
+inductor_code_side_table = InductorCodeSideTable()
+
+
+def _resolve_inductor_callable(func):
+    """
+    Resolve func to an InductorCompiledCallable.
+
+    func can be:
+    - An int index into the side table
+    - An InductorCompiledCallable directly
+    - A raw callable (legacy case)
+    """
+    if isinstance(func, int):
+        return inductor_code_side_table.get_callable(func)
+    return func
+
+
 @inductor_compiled_code.py_impl(DispatchKey.CompositeExplicitAutograd)
 def inductor_compiled_code_impl(func, inputs):
-    return func(inputs)
+    # Resolve func from side table if it's an index
+    resolved = _resolve_inductor_callable(func)
+    # resolved can be either a raw callable or an InductorCompiledCallable
+    if isinstance(resolved, InductorCompiledCallable):
+        return resolved.compiled_callable(inputs)
+    return resolved(inputs)
 
 
 redirect_to_mode(inductor_compiled_code, DebugMode)
@@ -80,10 +158,71 @@ redirect_to_mode(inductor_compiled_code, _CachedTorchDispatchMode)
 
 @register_fake(inductor_compiled_code)
 def inductor_compiled_code_fake(func, inputs):
+    # Resolve func from side table if it's an index
+    resolved = _resolve_inductor_callable(func)
+
+    # If resolved is an InductorCompiledCallable with an FX graph, run the graph
+    if isinstance(resolved, InductorCompiledCallable) and resolved.fx_graph is not None:
+        from torch.fx import Interpreter
+
+        # The FX graph expects boxed inputs (as a list)
+        return Interpreter(resolved.fx_graph).boxed_run(inputs)
+
     raise RuntimeError(
         "Inductor compiled code cannot be run with FakeTensor inputs. "
         "This can happen when torch.compile is called inside a FakeTensorMode. "
         "Consider using backend='eager' or backend='aot_eager' instead."
+    )
+
+
+@inductor_compiled_code.py_functionalize_impl
+def inductor_compiled_code_functionalize(ctx, func, inputs):
+    # Unwrap the functional tensors to get the underlying tensors
+    unwrapped_inputs = ctx.unwrap_tensors(inputs)
+
+    # Redispatch to the next handler in the dispatch chain
+    with ctx.redispatch_to_next():
+        result = inductor_compiled_code(func, unwrapped_inputs)
+        return ctx.wrap_tensors(result)
+
+
+@inductor_compiled_code.py_impl(ProxyTorchDispatchMode)
+def inductor_compiled_code_proxy(mode, func, inputs):
+    # Resolve func from side table if it's an index
+    resolved = _resolve_inductor_callable(func)
+
+    # If resolved is an InductorCompiledCallable with an FX graph, run the graph
+    # to get example outputs for tracing
+    if isinstance(resolved, InductorCompiledCallable) and resolved.fx_graph is not None:
+        from torch.fx import Interpreter
+
+        # Run the FX graph to get example outputs
+        # Note: boxed_run clears the input list, so we pass a copy
+        example_out = Interpreter(resolved.fx_graph).boxed_run(list(inputs))
+
+        # Add the callable to the side table and get its index
+        # This ensures the same callable gets the same index
+        callable_idx = inductor_code_side_table.add_callable(resolved)
+
+        # Unwrap proxies from inputs
+        proxy_inputs = pytree.tree_map(mode.tracer.unwrap_proxy, inputs)
+
+        # Create a proxy for the HOP call with the index (an int, which is serializable)
+        out_proxy = mode.tracer.create_proxy(
+            "call_function",
+            inductor_compiled_code,
+            (callable_idx, proxy_inputs),
+            {},
+        )
+
+        return track_tensor_tree(
+            example_out, out_proxy, constant=None, tracer=mode.tracer
+        )
+
+    raise RuntimeError(
+        "Inductor compiled code cannot be traced with ProxyTorchDispatchMode. "
+        "This can happen when make_fx is called on code with inductor_compiled_code HOPs. "
+        "Ensure that InductorCompiledCallable has an fx_graph attached."
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #172274
* #171819

Use a side table (InductorCodeSideTable) to store InductorCompiledCallable
objects, similar to how Triton kernels use KernelSideTable. This allows
passing an integer index in the FX graph instead of the unserializable
callable object.

For FakeTensor support, we store the original FX graph prior to Inductor
compilation and do fake prop through it (this can be up for discussion).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela