### PR TITLE
docker build disable ucc cpp warning

### DIFF
--- a/.ci/docker/common/install_ucc.sh
+++ b/.ci/docker/common/install_ucc.sh
@@ -80,7 +80,10 @@ function install_ucc() {
     --with-nvcc-gencode="${NVCC_GENCODE}" \
     --with-rocm=$with_rocm                \
     --with-rocm-arch="${HIP_OFFLOAD}"
-  time make -j
+  # First observed by ROCm nightly builds, ucc rccl sources fail compile with
+  # error: #warning "NCCL C++ API is disabled because C compiler is being used. [-Werror=cpp]
+  # Work-around by adding make CFLAGS=-Wno-error=cpp
+  time make -j CFLAGS=-Wno-error=cpp
   sudo make install
 
   popd


### PR DESCRIPTION
Works around build errors in ROCm nightly images where ucc's rccl sources are C files but RCCL header warns against this.