### PR TITLE
[dtensor][partial] fixing torch.sum(NormPartial) correctness

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -18,6 +18,7 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
+from torch.distributed.tensor._ops._math_ops import _NormPartial
 from torch.distributed.tensor._ops.utils import is_tensor_partial, normalize_dim
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.parallel import (
@@ -688,6 +689,45 @@ class DistMathOpsTest(DTensorTestBase):
         # partial result
         partial_out = torch.ops.aten.linalg_vector_norm(partial_grad, 2)
         self.assertEqual(partial_out.full_tensor(), out)
+
+    @with_comms
+    def test_vector_norm_sharded_reduction(self):
+        """
+        Test vector norm when reducing along a sharded dimension.
+
+        This tests the _NormPartial reduction path where:
+        - Tensor is sharded along dim=1
+        - Norm is computed along dim=1 (the sharded dim)
+        - Each rank has partial norm contributions
+        - _NormPartial reduction combines them correctly
+
+        Example with 2 ranks:
+            Full tensor: [[3, 4], [5, 12]]
+            Sharded on dim=1:
+                rank 0: [[3], [5]]
+                rank 1: [[4], [12]]
+            After local partial computation:
+                rank 0: [3, 5]
+                rank 1: [4, 12]
+            After _NormPartial(2) reduction:
+                [sqrt(3²+4²), sqrt(5²+12²)] = [5, 13]
+        """
+        device_mesh = self.build_device_mesh()
+
+        # Use Pythagorean triples for easy verification:
+        # [3, 4] -> norm = 5, [5, 12] -> norm = 13
+        tensor = torch.tensor([[3.0, 4.0], [5.0, 12.0]], device=self.device_type)
+
+        # Shard along dim=1
+        sharded_tensor = distribute_tensor(tensor, device_mesh, [Shard(1)])
+
+        # Compute norm along sharded dimension - uses _NormPartial internally
+        norm_partial = torch.linalg.vector_norm(sharded_tensor, ord=2, dim=1)
+
+        self.assertTrue(isinstance(norm_partial.placements[0], _NormPartial))
+        res = torch.sum(norm_partial)
+
+        self.assertEqual(res, 18)
 
     @with_comms
     def test_foreach_norm(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -691,7 +691,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(partial_out.full_tensor(), out)
 
     @with_comms
-    def test_vector_norm_sharded_reduction(self):
+    def test_vector_norm_sum(self):
         """
         Test vector norm when reducing along a sharded dimension.
 

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -314,9 +314,13 @@ def common_reduction_strategy(
         for p in op_spec.output_spec.placements:
             # when the partial reduction op matches the global reduction op,
             # we can delay redistribution (i.e max, max)
-            if isinstance(p, Partial) and p.reduce_op != reduction_op:
-                reduction_linear = False
-                break
+
+            if isinstance(p, Partial):
+                op_mismatch = p.reduce_op != reduction_op
+                is_norm_sum = isinstance(p, _NormPartial) and p.reduce_op == "sum"
+                if op_mismatch or is_norm_sum:
+                    reduction_linear = False
+                    break
 
         if not reduction_linear:
             # input placements for this strategy should clear out pending sum and sharding


### PR DESCRIPTION
**Summary:** torch.sum(NormPartial) incorrectly propagates the NormPartial leading to correctness issues. An example of this is:

normpartial
Rank 0: [3, 5]
Rank 1: [4, 12]
___________________________________________________
torch.sum(normpartial): propagate partial
Rank 0: 8
Rank 1: 16

sum: sqrt(8^2 + 16^2) = **17.88**
___________________________________________________
torch.sum(normpartial): force redistribute partial
sum: sqrt(3^2 + 4^2) + sqrt(5^2 + 12^2) = 5 + 13 = **18**
___________________________________________________

We change math_ops so that when a partial is detected, we if that partial is NormPartial(sum). This change doesn't need to apply to NormPartials other reduce ops of max and min since NormPartial(max, min) is just checking the max and min of the absolute values of the vector. This is in line with what we do with torch.max(p(max)) and torch.min(p(min)).

**Test Cases**
1. pytest test/distributed/tensor/test_math_ops.py -k test_vector_norm_sum

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172288

