### PR TITLE
[SymmMem] Back symm_mem.emtpy() with implicit pool

### DIFF
--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1950,25 +1950,17 @@ def empty(  # type: ignore[misc]
     else:
         device = torch.device(device)
 
+    stride = torch._prims_common.make_contiguous_strides_for(size)
+
     if _should_use_implicit_mempool() and device.type == "cuda":
         # Allocate tensor from an implicit memory pool
         mempool = get_mem_pool(device)
         # TODO: this path can be made device-agnostic if `use_mem_pool` is
         # elevated from torch.cuda to torch accelerator.
         with torch.cuda.use_mem_pool(mempool):
-            return _SymmetricMemory.empty_strided_p2p(
-                size=size,
-                stride=torch._prims_common.make_contiguous_strides_for(size),
-                dtype=dtype,
-                device=device,
-            )
+            return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
     else:
-        return _SymmetricMemory.empty_strided_p2p(
-            size=size,
-            stride=torch._prims_common.make_contiguous_strides_for(size),
-            dtype=dtype,
-            device=device,
-        )
+        return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
 
 
 def rendezvous(

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1879,6 +1879,26 @@ if TYPE_CHECKING:
     from torch.types import _device, _dtype, _int
 
 
+_use_implicit_mempool: bool | None = None  # type: ignore[assignment]
+
+
+def _should_use_implicit_mempool() -> bool:
+    r"""
+    Check if the implicit memory pool should be used for symmetric memory allocations.
+
+    Returns:
+        bool: True if the implicit memory pool should be used, False otherwise.
+
+    By default, use implicit memory pool for `symm_mem.empty`.  Users can
+    disable this by setting the environment variable `TORCH_SYMMMEM_IMPLICIT_POOL` to `0`.
+    """
+    global _use_implicit_mempool
+    if _use_implicit_mempool is None:
+        _use_implicit_mempool = os.getenv("TORCH_SYMMMEM_IMPLICIT_POOL", "1") == "1"
+
+    return _use_implicit_mempool
+
+
 @overload
 def empty(
     *size: _int, dtype: _dtype | None = None, device: _device | None = None
@@ -1927,13 +1947,28 @@ def empty(  # type: ignore[misc]
 
     if device is None:
         device = torch.get_default_device()
+    else:
+        device = torch.device(device)
 
-    return _SymmetricMemory.empty_strided_p2p(
-        size=size,
-        stride=torch._prims_common.make_contiguous_strides_for(size),
-        dtype=dtype,
-        device=torch.device(device),
-    )
+    if _should_use_implicit_mempool() and device.type == "cuda":
+        # Allocate tensor from an implicit memory pool
+        mempool = get_mem_pool(device)
+        # TODO: this path can be made device-agnostic if `use_mem_pool` is
+        # elevated from torch.cuda to torch accelerator.
+        with torch.cuda.use_mem_pool(mempool):
+            return _SymmetricMemory.empty_strided_p2p(
+                size=size,
+                stride=torch._prims_common.make_contiguous_strides_for(size),
+                dtype=dtype,
+                device=device,
+            )
+    else:
+        return _SymmetricMemory.empty_strided_p2p(
+            size=size,
+            stride=torch._prims_common.make_contiguous_strides_for(size),
+            dtype=dtype,
+            device=device,
+        )
 
 
 def rendezvous(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #172292

Resolves https://github.com/pytorch/pytorch/issues/172050

Two motivations:
- Give better UX and perf to users who explicitly use `symm_mem.empty()`.
- Simplify the code generated by Inductor, i.e. `symm_mem.empty()` would automatically reuse memory, rather than requiring Inductor to bookkeep it. 

The MemPool infra for all CUDA backends (`CUDA`, `NVSHMEM`, `NCCL`) has been built previously. 