### PR TITLE
[ROCm] Skip test_mixed_mm - pattern not properly supported on ROCm

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -35,7 +35,7 @@ from torch._inductor.virtualized import V
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater, xfailIfSM89
-from torch.testing._internal.common_device_type import skipCUDAIf
+from torch.testing._internal.common_device_type import skipCUDAIf, skipCUDAIfRocm
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
@@ -341,6 +341,7 @@ class TestPatternMatcher(TestCase):
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
+    @skipCUDAIfRocm(msg="mixed_mm pattern matcher not supported on ROCm")
     def test_mixed_mm(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))


### PR DESCRIPTION
## Summary
Skip test_mixed_mm on ROCm as the mixed_mm pattern matcher is not properly supported.

Fixes #145192

## Problem
The test_mixed_mm test is flaky on ROCm CI, passing ~90% of the time but occasionally failing with FileCheck assertion errors when the `.to()` call isn't present in generated code.

## Root Cause
The mixed_mm pattern matcher optimization lacks ROCm-specific infrastructure:
- No `ROCmMixedMMTemplateConfigHeuristic` exists (unlike `ROCmInt8MMTemplateConfigHeuristic`, `ROCmScaledMMTemplateConfigHeuristic`, etc.)
- Autoheuristic only has NVIDIA artifacts (`_MixedMMH100.py`, `_MixedMMA100.py`)
- `mixed_mm_configs` only defined with NVIDIA-style `GemmConfig`, not `ROCmGemmConfig`

The test passes intermittently because the pattern sometimes matches by chance, but it's not a properly tuned codepath for ROCm.

## Fix
Add `@skipCUDAIfRocm` decorator since mixed_mm is not a supported ROCm optimization.

## Hardware Verification
- **GPU:** AMD Instinct MI300X (gfx942)
- **ROCm:** 7.0.51831-a3e329ad8
- **PyTorch:** 2.9.0.dev20250821+rocm7.0.0

**Before (flaky):** 9/10 pass, 1/10 fail with `RuntimeError: Expected to find ".to(" but did not find it`
**After:** Test consistently skipped on ROCm (5/5 verified)

## Test Plan
- [x] Verified test skipped on ROCm
- [x] Verified similar precedent exists (e.g., #164163, #171147)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben