### PR TITLE
[dynamo] disable dynamo recursively on compiled code if fullgraph=True

### DIFF
--- a/test/dynamo/test_frame_init.py
+++ b/test/dynamo/test_frame_init.py
@@ -100,7 +100,8 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
                         CompileId(
                             frame_id=None, frame_compile_id=0, compiled_autograd_id=0
                         ),
-                    )
+                    ),
+                    False,
                 )
             return ConvertFrameReturn()
 
@@ -114,7 +115,8 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
                         CompileId(
                             frame_id=None, frame_compile_id=0, compiled_autograd_id=0
                         ),
-                    )
+                    ),
+                    False,
                 )
             return ConvertFrameReturn()
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1606,7 +1606,7 @@ def _compile(
             # they are benign and do not generate any new graphs.
             hooks.guard_export_fn(output.guards)
 
-        return wrap_guarded_code(guarded_code), tracer_output
+        return wrap_guarded_code(guarded_code, one_graph), tracer_output
 
     metrics_context = get_metrics_context()
     code_context = (

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -227,6 +227,7 @@ class Tracker:
 input_codes = Tracker()
 output_codes = Tracker()
 
+
 initial_global_state: Optional[GlobalStateGuard] = None
 
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -227,7 +227,8 @@ def debug_insert_nops(
                 code,
                 CheckFunctionManager(frame.f_code, graph).guard_manager,  # type: ignore[arg-type]
                 CompileId(frame_id=0, frame_compile_id=0),
-            )
+            ),
+            False,
         )
 
 

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -85,9 +85,16 @@ class ConvertFrameReturn:
     guarded_code: Optional[GuardedCode] = None
 
 
-def wrap_guarded_code(guarded_code: GuardedCode) -> ConvertFrameReturn:
+def wrap_guarded_code(guarded_code: GuardedCode, fullgraph: bool) -> ConvertFrameReturn:
+    """
+    Wraps GuardedCode for output from convert_frame.py.
+
+    NOTE: if fullgraph is True, then the recursive action is to SKIP to prevent unintended
+    additional Dynamo invocations. Otherwise, the recursive action is DEFAULT.
+    """
+    recursive_action = FrameAction.SKIP if fullgraph else FrameAction.DEFAULT
     return ConvertFrameReturn(
-        frame_exec_strategy=FrameExecStrategy(FrameAction.DEFAULT, FrameAction.DEFAULT),
+        frame_exec_strategy=FrameExecStrategy(FrameAction.DEFAULT, recursive_action),
         guarded_code=guarded_code,
     )
 

--- a/torch/csrc/dynamo/cache_entry.cpp
+++ b/torch/csrc/dynamo/cache_entry.cpp
@@ -4,8 +4,12 @@
 #include <torch/csrc/dynamo/debug_macros.h>
 #include <torch/csrc/dynamo/extra_state.h>
 
-CacheEntry::CacheEntry(const py::handle& guarded_code, PyObject* backend)
-    : backend{py::cast<py::object>(get_backend(backend))} {
+CacheEntry::CacheEntry(
+    const py::handle& guarded_code,
+    PyObject* backend,
+    std::optional<FrameAction> recursive_action)
+    : backend{py::cast<py::object>(get_backend(backend))},
+      recursive_action{recursive_action} {
   this->guard_manager = guarded_code.attr("guard_manager");
   this->code = guarded_code.attr("code");
   this->compile_id = guarded_code.attr("compile_id");

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -218,6 +218,7 @@ void initDynamoBindings(PyObject* torch) {
       .def_readonly("compile_id", &CacheEntry::compile_id)
       .def_readonly("trace_annotation", &CacheEntry::trace_annotation)
       .def_readonly("backend", &CacheEntry::backend)
+      .def_readonly("recursive_action", &CacheEntry::recursive_action)
       .def_property_readonly("next", &CacheEntry::next)
       .def(
           "update_diff_guard_root_manager",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172694
* __->__ #172295

I tried a few 1-line changes but none were sufficient to get the behavior we wanted. The issue is that we want to control the recursive eval_frame behavior depending on current top-level compilation call (i.e. we need different recursive_action for each CacheEntry). This was not supported, so we implement per-CacheEntry recursive_action here.

There are some rules we introduced for dealing with ExtraState (code-level) vs. CacheEntry (frame-level) recursive_action:
1. If the current (NOT recursive) action for the code object (i.e. ExtraState) is SKIP, then use ExtraState's recursive_action. This is because we don't even perform a cache lookup, so there is no CacheEntry recursive_action to use.
2. Otherwise, we will get a CacheEntry. If it has a recursive_action, use that.
3. Otherwise, default to the ExtraState's recursive_action.

This is potentially BC-breaking since `torch.compile` will not be invoked again on code compiled with `fullgraph=True`, but it is unlikely for anyone to really be depending on this behavior (see the added test, which does some really weird behavior in order to invoke a nested `torch.compile` when `fullgraph=True`).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos