### PR TITLE
Support boxed GraphModule in flex attention math

### DIFF
--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -111,6 +111,25 @@ def make_boxed_func(f):
     return g
 
 
+def make_unboxed_func(f):
+    """
+    If f uses boxed calling convention, wrap it to accept unpacked arguments.
+
+    Boxed callables expect a single list argument: f([arg1, arg2, ...])
+    This wrapper allows calling them with unpacked args: wrapper(arg1, arg2, ...)
+
+    This is the inverse of make_boxed_func.
+    """
+    if getattr(f, "_boxed_call", False):
+
+        @simple_wraps(f)
+        def g(*args):
+            return f(list(args))
+
+        return g
+    return f
+
+
 def make_boxed_compiler(compiler):
     @wraps(compiler)
     def f(fx_g, inps):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #172296

I think it doesn't matter to actually do the boxed convention for real
since all the inputs will stay live across the function, and Claude
wasn't able to one shot that version of the code.

Authored with Claude.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @drisspg @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv