### PR TITLE
[DTensor] Fix for incorrect Tensor Meta Population in `expand_to_full_mesh_op_strategy`

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -865,5 +865,219 @@ class TestOpSchemaMetaProperties(TestCase):
         self.assertEqual(kwargs_meta["alpha"], 1.0)
 
 
+class TestExpandToFullMeshOpStrategy(TestCase):
+    """Tests for expand_to_full_mesh_op_strategy function.
+
+    These tests verify that tensor_meta is correctly assigned to input/output specs,
+    especially when the placement list contains None entries (e.g., optional outputs
+    like grad_bias in SDPA backward when attn_bias is not used).
+    """
+
+    def setUp(self):
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        super().setUp()
+        self.world_size = 4
+        self.fake_store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=self.world_size, store=self.fake_store
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
+
+    def _create_op_strategy_with_tensor_meta(
+        self, mesh: DeviceMesh, shape: tuple, dtype: torch.dtype
+    ) -> OpStrategy:
+        """Create an OpStrategy with tensor_meta for testing."""
+        placements = tuple(Replicate() for _ in range(mesh.ndim))
+        strides = []
+        stride = 1
+        for s in reversed(shape):
+            strides.append(stride)
+            stride *= s
+        strides = tuple(reversed(strides))
+
+        tensor_meta = TensorMeta(shape=torch.Size(shape), stride=strides, dtype=dtype)
+        spec = DTensorSpec(mesh=mesh, placements=placements, tensor_meta=tensor_meta)
+        op_spec = OpSpec(
+            output_specs=spec, input_specs=(spec,), redistribute_cost=[[0.0]]
+        )
+        return OpStrategy([op_spec])
+
+    def test_expand_strategy_with_none_in_outputs(self):
+        """Test that None entries in outputs don't shift input tensor_meta assignment.
+
+        This test simulates SDPA backward where grad_bias output is None when
+        attn_bias is not used. The bug was that the None entry caused subsequent
+        input specs to get wrong tensor_meta (shifted by one position).
+        """
+        from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
+
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+
+        # Simulate MLA-style attention with different dimensions for q/k vs v
+        batch, heads, seq_len = 2, 8, 64
+        d_qk = 192  # query/key head dimension
+        d_v = 128  # value head dimension (different!)
+
+        # Create input OpStrategy objects with distinct shapes
+        grad_out_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (batch, heads, seq_len, d_v), torch.float32
+        )
+        query_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (batch, heads, seq_len, d_qk), torch.float32
+        )
+        key_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (batch, heads, seq_len, d_qk), torch.float32
+        )
+        value_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (batch, heads, seq_len, d_v), torch.float32
+        )
+
+        # Build OpSchema (attn_bias is None at position 4)
+        args_schema = (
+            grad_out_strategy,
+            query_strategy,
+            key_strategy,
+            value_strategy,
+        )
+        op_schema = OpSchema(
+            torch.ops.aten.add.Tensor,  # dummy op for testing
+            args_schema,
+            {},
+            RuntimeSchemaInfo(needs_pytree=False),
+        )
+
+        # Placement list with None at position 3 (simulating grad_bias = None)
+        # Structure: [out0, out1, out2, None, in0, in1, in2, in3]
+        single_mesh_dim_strategies = [
+            [
+                Replicate(),  # output 0
+                Replicate(),  # output 1
+                Replicate(),  # output 2
+                None,  # output 3 (None, like grad_bias when attn_bias is None)
+                Replicate(),  # input 0: grad_out
+                Replicate(),  # input 1: query
+                Replicate(),  # input 2: key
+                Replicate(),  # input 3: value
+            ]
+        ]
+
+        result = expand_to_full_mesh_op_strategy(
+            mesh,
+            op_schema,
+            single_mesh_dim_strategies,
+            input_index=4,  # 4 outputs (including the None)
+        )
+
+        # Verify the input specs have correct tensor_meta
+        strategy = result.strategies[0]
+        input_specs = strategy.input_specs
+
+        self.assertEqual(len(input_specs), 4)
+
+        # Check that each input got the correct tensor_meta shape
+        # Before the fix, these would be shifted by one position
+        self.assertEqual(input_specs[0].tensor_meta.shape[-1], d_v)  # grad_out
+        self.assertEqual(input_specs[1].tensor_meta.shape[-1], d_qk)  # query
+        self.assertEqual(input_specs[2].tensor_meta.shape[-1], d_qk)  # key
+        self.assertEqual(input_specs[3].tensor_meta.shape[-1], d_v)  # value
+
+    def test_expand_strategy_without_none_in_outputs(self):
+        """Test that expand_to_full_mesh_op_strategy works correctly without None entries."""
+        from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
+
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+
+        # Create input OpStrategy objects
+        input1_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (10, 20), torch.float32
+        )
+        input2_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (10, 30), torch.float32
+        )
+
+        args_schema = (input1_strategy, input2_strategy)
+        op_schema = OpSchema(
+            torch.ops.aten.add.Tensor,
+            args_schema,
+            {},
+            RuntimeSchemaInfo(needs_pytree=False),
+        )
+
+        # Placement list without any None entries
+        single_mesh_dim_strategies = [
+            [
+                Replicate(),  # output
+                Replicate(),  # input 0
+                Replicate(),  # input 1
+            ]
+        ]
+
+        result = expand_to_full_mesh_op_strategy(
+            mesh,
+            op_schema,
+            single_mesh_dim_strategies,
+            input_index=1,
+        )
+
+        strategy = result.strategies[0]
+        input_specs = strategy.input_specs
+
+        self.assertEqual(len(input_specs), 2)
+        self.assertEqual(input_specs[0].tensor_meta.shape, torch.Size([10, 20]))
+        self.assertEqual(input_specs[1].tensor_meta.shape, torch.Size([10, 30]))
+
+    def test_expand_strategy_with_multiple_nones_in_outputs(self):
+        """Test handling of multiple None entries in outputs."""
+        from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
+
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+
+        input1_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (5, 10), torch.float32
+        )
+        input2_strategy = self._create_op_strategy_with_tensor_meta(
+            mesh, (5, 20), torch.float32
+        )
+
+        args_schema = (input1_strategy, input2_strategy)
+        op_schema = OpSchema(
+            torch.ops.aten.add.Tensor,
+            args_schema,
+            {},
+            RuntimeSchemaInfo(needs_pytree=False),
+        )
+
+        # Placement list with multiple None entries in outputs
+        single_mesh_dim_strategies = [
+            [
+                Replicate(),  # output 0 (non-None)
+                None,  # output 1 (None)
+                Replicate(),  # output 2 (non-None)
+                None,  # output 3 (None)
+                Replicate(),  # input 0
+                Replicate(),  # input 1
+            ]
+        ]
+
+        result = expand_to_full_mesh_op_strategy(
+            mesh,
+            op_schema,
+            single_mesh_dim_strategies,
+            input_index=4,  # 4 outputs (2 None, 2 non-None)
+        )
+
+        strategy = result.strategies[0]
+        input_specs = strategy.input_specs
+
+        self.assertEqual(len(input_specs), 2)
+        # Verify correct tensor_meta assignment despite multiple Nones
+        self.assertEqual(input_specs[0].tensor_meta.shape, torch.Size([5, 10]))
+        self.assertEqual(input_specs[1].tensor_meta.shape, torch.Size([5, 20]))
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -400,29 +400,38 @@ def expand_to_full_mesh_op_strategy(
     all_strategies = []
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
-        spec_index = 0
-        for specs in zip(*strategy_comb):
+        # Track how many non-None output specs we've seen (for output_tensor_meta indexing)
+        output_spec_count = 0
+        # Track input args separately since not all tensor inputs have OpStrategy
+        # (e.g., philox_seed/offset in SDPA are scalar tensors without OpStrategy)
+        input_strategy_counter = 0
+        for position, specs in enumerate(zip(*strategy_comb)):
             if specs[0] is not None:
                 # Populate tensor_meta field for both output and input specs,
                 # including for tuple output cases
                 tensor_meta = None
-                if spec_index < input_index:
+                # Use position to determine output vs input territory
+                # (position includes None entries, unlike the old spec_index)
+                if position < input_index:
+                    # This is an output position
                     if output_tensor_meta is not None:
                         if isinstance(output_tensor_meta, TensorMeta):
                             tensor_meta = output_tensor_meta
                         elif isinstance(output_tensor_meta, (tuple, list)):
-                            if spec_index < len(output_tensor_meta):
-                                tensor_meta = output_tensor_meta[spec_index]
+                            if output_spec_count < len(output_tensor_meta):
+                                tensor_meta = output_tensor_meta[output_spec_count]
+                    output_spec_count += 1
                 else:
-                    input_strategy_index = spec_index - input_index
-                    if input_strategy_index < len(input_args_strategy):
+                    # This is an input position
+                    # Only get tensor_meta if we have a corresponding input_args_strategy entry
+                    if input_strategy_counter < len(input_args_strategy):
                         tensor_meta = input_args_strategy[
-                            input_strategy_index
+                            input_strategy_counter
                         ].tensor_meta
+                        input_strategy_counter += 1
 
                 # pyrefly: ignore [bad-argument-type]
                 spec_list.append(DTensorSpec(mesh, specs, tensor_meta=tensor_meta))
-                spec_index += 1
             else:
                 spec_list.append(None)
 

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -400,12 +400,14 @@ def expand_to_full_mesh_op_strategy(
     all_strategies = []
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
-        # Track how many non-None output specs we've seen (for output_tensor_meta indexing)
+        # Track how many non-None output specs we've seen (for output_tensor_meta indexing).
+        # This is needed because output_tensor_meta may contain only non-None entries,
+        # so we can't use position directly when there are None entries in the output.
         output_spec_count = 0
         # Track input args separately since not all tensor inputs have OpStrategy
         # (e.g., philox_seed/offset in SDPA are scalar tensors without OpStrategy)
         input_strategy_counter = 0
-        for position, specs in enumerate(zip(*strategy_comb)):
+        for position, specs in enumerate(zip(*strategy_comb, strict=True)):
             if specs[0] is not None:
                 # Populate tensor_meta field for both output and input specs,
                 # including for tuple output cases


### PR DESCRIPTION
Fixes #172303 

Output of Repro in #172303 after the fix:

```
=== Checking tensor_meta assignment ===
grad_out input_spec shape: torch.Size([2, 8, 64, 128])
query input_spec shape: torch.Size([2, 8, 64, 192])
key input_spec shape: torch.Size([2, 8, 64, 192])
value input_spec shape: torch.Size([2, 8, 64, 128])

Expected query d (last dim): 192
Expected value d (last dim): 128

Actual query input_spec d: 192
Actual value input_spec d: 128

✓ All tensor_meta assignments are correct!
```

## Summary of the Bug Fix

### The Problem

In `expand_to_full_mesh_op_strategy` (in `torch/distributed/tensor/_ops/utils.py`), the code used a single `spec_index` counter to:

1. Determine if a position was an output or input (`spec_index < input_index`)
2. Index into `output_tensor_meta` for outputs
3. Index into `input_args_strategy` for inputs

However, `spec_index` only incremented for **non-None** entries in the placement list, while `input_index` counts the **total** number of outputs (including None entries).

For SDPA backward without `attn_bias`, the placement list looks like:

```
[grad_q, grad_k, grad_v, None(grad_bias), grad_out, query, key, value, ...]
                         ^-- position 3 is None
```

When `grad_bias` is None at position 3:

- `spec_index` stayed at 3 (not incremented for None)
- Position 4 (`grad_out`) checked `spec_index=3 < input_index=4` → **incorrectly treated as output**
- This shifted all subsequent `tensor_meta` assignments by one position

**The result:** `query` received `grad_out`'s `tensor_meta`, `key` received `query`'s `tensor_meta`, `value` received `key`'s `tensor_meta`, etc. This caused shape mismatches in the flop counter for MLA attention where query/key have `d=192` but value has `d=128`.

### The Fix

Introduced three separate counters:

| Counter | Purpose |
|---------|---------|
| `position` | Tracks actual position in placement list (always incremented, even for None) |
| `output_spec_count` | Tracks non-None output specs (for `output_tensor_meta` indexing) |
| `input_strategy_counter` | Tracks input specs (for `input_args_strategy` indexing) |

This ensures correct output vs input classification and proper `tensor_meta` assignment.

cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @tianyu-l @XilunWu @SherlockNoMad @ppwwyyxx @EikanWang @jgong5 @wenzhe-nrv @sanchitintel