### PR TITLE
Remove misleading TODO in _expand_group for DeviceMesh

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1151,7 +1151,6 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> tuple[str, list[int], int
             raise AssertionError(
                 "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
             )
-        # TODO: it should run collective in the whole mesh instead of dim 0
         pg = group.get_group()
         rankset = dist.get_process_group_ranks(pg)
         group_size = len(rankset)


### PR DESCRIPTION
The TODO suggested changing from `get_group()` to `mesh.flatten()` for getting ranks. However, after discussion with @fegin and @wconstab:

Functional collectives are a manual API, so being explicit about which process group to use is the right approach. The existing `ndim != 1` check already explicitly rejects n-dim meshes before reaching `get_group()`. For 1D meshes, both approaches return the same ranks and auto-flattening belongs at the DTensor layer, not the funcol layer

The TODO was misleading, so this PR simply removes it while keeping the original explicit implementation.