### PR TITLE
[dynamo] Refactor cycle detection to iterative DFS with visited tracking

### DIFF
--- a/test/dynamo/test_graph_deduplication.py
+++ b/test/dynamo/test_graph_deduplication.py
@@ -620,7 +620,7 @@ class <lambda>(torch.nn.Module):
         add_node.args = (args[0], add_2)
         self.assertExpectedInline(
             _detect_cycles(mod.graph, {add_2: OrderedSet([add_2])}),
-            """cycle detected in path: deque([output, add_2, add_2])""",
+            """cycle detected in path: [output, add_2, sum_1, add, add_2]""",
         )
 
     def test_cycle_detection_two_node(self):
@@ -644,7 +644,7 @@ class <lambda>(torch.nn.Module):
                 mod.graph,
                 {add_2: OrderedSet([add_node]), add_node: OrderedSet([add_2])},
             ),
-            """cycle detected in path: deque([output, add_2, add, add_2])""",
+            """cycle detected in path: [output, add_2, sum_1, add, add_2]""",
         )
 
     def test_cycle_detection_arg_and_additional_deps(self):
@@ -665,7 +665,7 @@ class <lambda>(torch.nn.Module):
         add_node.args = (args[0], add_2)
         self.assertExpectedInline(
             _detect_cycles(mod.graph, {add_2: OrderedSet([add_node])}),
-            """cycle detected in path: deque([output, add_2, add, add_2])""",
+            """cycle detected in path: [output, add_2, sum_1, add, add_2]""",
         )
 
     def test_cycle_detection_simple(self):
@@ -676,7 +676,7 @@ class <lambda>(torch.nn.Module):
         add_node.args = (args[0], add_2)
         self.assertExpectedInline(
             _detect_cycles(mod.graph, {}),
-            """cycle detected in path: deque([output, add_2, sum_1, add, add_2])""",
+            """cycle detected in path: [output, add_2, sum_1, add, add_2]""",
         )
 
     def test_cycle_detection_complex(self):
@@ -711,7 +711,7 @@ class <lambda>(torch.nn.Module):
         invoke_subgraph_node.args = (add_2, args[1])
         self.assertExpectedInline(
             _detect_cycles(mod.graph, {}),
-            """cycle detected in path: deque([output, add_2, add_1, sum_1, getitem, invoke_subgraph, add_2])""",
+            """cycle detected in path: [output, add_2, add_1, sum_1, getitem, invoke_subgraph, add_2]""",
         )
 
     def test_autocast_ordering(self):

--- a/torch/_dynamo/graph_utils.py
+++ b/torch/_dynamo/graph_utils.py
@@ -64,7 +64,12 @@ def _detect_cycles(
 
                 if child_state == 0:
                     state[child] = 1
-                    stack.append((child, iter(_get_flat_args_unique(child, node_to_additional_deps))))
+                    stack.append(
+                        (
+                            child,
+                            iter(_get_flat_args_unique(child, node_to_additional_deps)),
+                        )
+                    )
                 # child_state == 2 means already verified safe; skip.
 
             except StopIteration:

--- a/torch/_dynamo/graph_utils.py
+++ b/torch/_dynamo/graph_utils.py
@@ -1,4 +1,3 @@
-from collections import deque
 from typing import Any
 
 import torch
@@ -35,46 +34,54 @@ def _get_flat_args_unique(
 def _detect_cycles(
     graph: Graph, node_to_additional_deps: dict[Node, OrderedSet[Node]]
 ) -> str:
-    current_path: deque[Node] = deque()
-    current_path_set: set[Node] = set()
-    pending: deque[tuple[Node, Node]] = deque()
+    # States: 0=Unvisited, 1=Visiting, 2=Visited(Safe)
+    state: dict[Node, int] = {}
 
-    def add_to_current_path(node: Node) -> None:
-        current_path.append(node)
-        current_path_set.add(node)
+    for root in reversed(graph.nodes):
+        if root in state:
+            continue
 
-    def pop_current_path() -> None:
-        node = current_path.pop()
-        current_path_set.remove(node)
+        # Stack holds (current_node, children_iterator).
+        # Using an iterator allows us to pause and resume processing a node's children.
+        stack = [
+            (root, iter(_get_flat_args_unique(root, node_to_additional_deps)))
+        ]
+        state[root] = 1  # Visiting
 
-    def current_path_head() -> Node:
-        return current_path[-1]
+        while stack:
+            parent, children = stack[-1]
 
-    for origin in graph.find_nodes(op="output"):
-        current_path.clear()
-        current_path_set.clear()
-        add_to_current_path(origin)
-        for child in _get_flat_args_unique(origin, node_to_additional_deps):
-            pending.append((child, origin))
+            try:
+                child = next(children)
 
-        while pending:
-            cur_node, parent = pending.pop()
+                if not isinstance(child, Node):
+                    continue
 
-            # handle backtracking
-            while current_path and current_path_head() != parent:
-                pop_current_path()
+                child_state = state.get(child, 0)
 
-            if not isinstance(cur_node, Node):
-                continue
+                if child_state == 1:
+                    # Back-edge: child is on the current DFS path -> cycle
+                    cycle_path = [node for node, _ in stack] + [child]
+                    return f"cycle detected in path: {cycle_path}"
 
-            if cur_node in current_path_set:
-                current_path.append(cur_node)
-                return f"cycle detected in path: {current_path}"
+                if child_state == 0:
+                    state[child] = 1
+                    stack.append(
+                        (
+                            child,
+                            iter(
+                                _get_flat_args_unique(
+                                    child, node_to_additional_deps
+                                )
+                            ),
+                        )
+                    )
+                # child_state == 2 means already verified safe; skip.
 
-            add_to_current_path(cur_node)
-
-            for child in _get_flat_args_unique(cur_node, node_to_additional_deps):
-                pending.append((child, cur_node))
+            except StopIteration:
+                # All children processed — mark safe and pop.
+                stack.pop()
+                state[parent] = 2
 
     return "no cycle detected"
 

--- a/torch/_dynamo/graph_utils.py
+++ b/torch/_dynamo/graph_utils.py
@@ -43,9 +43,7 @@ def _detect_cycles(
 
         # Stack holds (current_node, children_iterator).
         # Using an iterator allows us to pause and resume processing a node's children.
-        stack = [
-            (root, iter(_get_flat_args_unique(root, node_to_additional_deps)))
-        ]
+        stack = [(root, iter(_get_flat_args_unique(root, node_to_additional_deps)))]
         state[root] = 1  # Visiting
 
         while stack:
@@ -66,16 +64,7 @@ def _detect_cycles(
 
                 if child_state == 0:
                     state[child] = 1
-                    stack.append(
-                        (
-                            child,
-                            iter(
-                                _get_flat_args_unique(
-                                    child, node_to_additional_deps
-                                )
-                            ),
-                        )
-                    )
+                    stack.append((child, iter(_get_flat_args_unique(child, node_to_additional_deps))))
                 # child_state == 2 means already verified safe; skip.
 
             except StopIteration:


### PR DESCRIPTION
## Summary

  Refactor `_detect_cycles()` in `graph_utils.py` from a queue-based traversal with manual backtracking to a clean iterative DFS using three-state coloring (Unvisited/Visiting/Visited).

  ## Motivation

The old implementation used `deque`-based path tracking with explicit backtracking logic (`while current_path_head() != parent`). The new implementation uses a standard DFS pattern with an explicit stack and child iterators, which is more efficient: skips already-verified safe subgraphs (state=2), avoids redundant backtracking.

  ## Algorithm

  ```python
  # For each unvisited node, run iterative DFS:
  #   State 0 (Unvisited) → push to stack, mark as Visiting (1)
  #   State 1 (Visiting)  → back-edge detected → cycle!
  #   State 2 (Visited)   → already verified safe, skip
```

  ## Unit Test

 Updated all 5 cycle detection tests in test_graph_deduplication.py. The new DFS visits children in forward iteration order (first child first) instead of the old LIFO order (last child first), so reported cycle paths may differ but are equally valid.


## Benchmark: Old vs New cycle detection

  <details>
  <summary>bench_cycle_detection.py (click to expand)</summary>

  ```python
  """
  Benchmark: old vs new cycle detection algorithm for FX graphs.

  Run: python3 bench_cycle_detection.py
  """

  import time
  from collections import OrderedDict, deque


  class Node:
      def __init__(self, name, op="call_function"):
          self.name = name
          self.op = op
          self.args = ()
          self.kwargs = {}

      def __repr__(self):
          return self.name


  class Graph:
      def __init__(self):
          self.nodes = []

      def add_node(self, name, op="call_function"):
          n = Node(name, op)
          self.nodes.append(n)
          return n

      def find_nodes(self, *, op):
          return [n for n in self.nodes if n.op == op]


  class OrderedSet:
      def __init__(self, items=None):
          self._d = OrderedDict()
          if items:
              for i in items:
                  self.add(i)

      def add(self, item):
          self._d[item] = None

      def update(self, items):
          for i in items:
              self.add(i)

      def __iter__(self):
          return iter(self._d)

      def __contains__(self, item):
          return item in self._d


  def _get_flat_args_unique(node, node_to_additional_deps):
      args = OrderedSet()
      for a in node.args:
          if isinstance(a, Node):
              args.add(a)
      if node in node_to_additional_deps:
          args.update(node_to_additional_deps[node])
      return args


  def detect_cycles_old(graph, node_to_additional_deps):
      """Old: deque + manual backtracking."""
      current_path = deque()
      current_path_set = set()
      pending = deque()

      def add_to_current_path(node):
          current_path.append(node)
          current_path_set.add(node)

      def pop_current_path():
          node = current_path.pop()
          current_path_set.remove(node)

      def current_path_head():
          return current_path[-1]

      for origin in graph.find_nodes(op="output"):
          current_path.clear()
          current_path_set.clear()
          add_to_current_path(origin)
          for child in _get_flat_args_unique(origin, node_to_additional_deps):
              pending.append((child, origin))
          while pending:
              cur_node, parent = pending.pop()
              while current_path and current_path_head() != parent:
                  pop_current_path()
              if not isinstance(cur_node, Node):
                  continue
              if cur_node in current_path_set:
                  current_path.append(cur_node)
                  return f"cycle detected in path: {current_path}"
              add_to_current_path(cur_node)
              for child in _get_flat_args_unique(cur_node, node_to_additional_deps):
                  pending.append((child, cur_node))
      return "no cycle detected"


  def detect_cycles_new(graph, node_to_additional_deps):
      """New: iterative DFS + 3-state coloring."""
      state = {}
      for root in reversed(graph.nodes):
          if root in state:
              continue
          stack = [(root, iter(_get_flat_args_unique(root, node_to_additional_deps)))]
          state[root] = 1
          while stack:
              parent, children = stack[-1]
              try:
                  child = next(children)
                  if not isinstance(child, Node):
                      continue
                  child_state = state.get(child, 0)
                  if child_state == 1:
                      cycle_path = [node for node, _ in stack] + [child]
                      return f"cycle detected in path: {cycle_path}"
                  if child_state == 0:
                      state[child] = 1
                      stack.append((child, iter(_get_flat_args_unique(child, node_to_additional_deps))))
              except StopIteration:
                  stack.pop()
                  state[parent] = 2
      return "no cycle detected"


  def build_diamond_graph(depth):
      """Diamond DAG: shared subgraphs at each level. Exponential for old algo."""
      g = Graph()
      prev_layer = [g.add_node("leaf")]
      for d in range(depth):
          left = g.add_node(f"L{d}_left")
          right = g.add_node(f"L{d}_right")
          for n in [left, right]:
              n.args = tuple(prev_layer)
          merge = g.add_node(f"L{d}_merge")
          merge.args = (left, right)
          prev_layer = [merge]
      out = g.add_node("output", op="output")
      out.args = tuple(prev_layer)
      return g


  def build_chain_graph(n, has_cycle=False):
      g = Graph()
      nodes = [g.add_node(f"n_{i}") for i in range(n)]
      for i in range(1, n):
          nodes[i].args = (nodes[i - 1],)
      out = g.add_node("output", op="output")
      out.args = (nodes[-1],)
      if has_cycle:
          nodes[0].args = (nodes[-1],)
      return g


  def build_binary_tree_graph(depth):
      g = Graph()
      counter = [0]
      def make_tree(d):
          n = g.add_node(f"t_{counter[0]}")
          counter[0] += 1
          if d > 0:
              n.args = (make_tree(d - 1), make_tree(d - 1))
          return n
      root = make_tree(depth)
      out = g.add_node("output", op="output")
      out.args = (root,)
      return g


  def bench(fn, graph, deps, warmup=3, repeats=50):
      for _ in range(warmup):
          fn(graph, deps)
      times = []
      for _ in range(repeats):
          t0 = time.perf_counter()
          result = fn(graph, deps)
          t1 = time.perf_counter()
          times.append(t1 - t0)
      return sorted(times)[len(times) // 2], result


  def run_benchmark(name, graph, deps, repeats=50):
      t_old, r_old = bench(detect_cycles_old, graph, deps, repeats=repeats)
      t_new, r_new = bench(detect_cycles_new, graph, deps, repeats=repeats)
      has_cycle_old = r_old.startswith("cycle detected")
      has_cycle_new = r_new.startswith("cycle detected")
      speedup = t_old / t_new if t_new > 0 else float("inf")
      print(f"\n{'=' * 60}")
      print(f"  {name}  ({len(graph.nodes)} nodes)")
      print(f"{'=' * 60}")
      print(f"  Old algorithm:  {t_old*1e6:10.1f} us  (cycle={has_cycle_old})")
      print(f"  New algorithm:  {t_new*1e6:10.1f} us  (cycle={has_cycle_new})")
      print(f"  Speedup:        {speedup:10.2f}x")
      assert has_cycle_old == has_cycle_new, f"MISMATCH: old={r_old}, new={r_new}"


  def main():
      print("Cycle Detection Benchmark")
      print("Old = deque + backtracking | New = iterative DFS + 3-state coloring")

      run_benchmark("Chain (no cycle, 1000 nodes)", build_chain_graph(1000), {})
      run_benchmark("Chain (with cycle, 1000 nodes)", build_chain_graph(1000, True), {})

      for depth in [10, 15, 20]:
          run_benchmark(f"Diamond DAG (depth={depth})", build_diamond_graph(depth), {})

      for depth in [10, 13, 15]:
          run_benchmark(f"Binary tree (depth={depth})", build_binary_tree_graph(depth), {})

      print(f"\n{'=' * 60}\n  Done.\n{'=' * 60}")


  if __name__ == "__main__":
      main()
  ```

  ```
  Chain (no cycle, 1000 nodes)   Old:    553 us | New:    638 us | 0.87x
  Chain (with cycle, 1000 nodes) Old:    557 us | New:    512 us | 1.09x
  Diamond DAG (depth=10)         Old:  2,565 us | New:     22 us | 118x
  Diamond DAG (depth=15)         Old: 83,618 us | New:     37 us | 2,263x
  Diamond DAG (depth=20)         Old:  2.63s    | New:     41 us | 64,046x
  Binary tree (depth=10)         Old:  1,310 us | New:  1,273 us | 1.03x
  Binary tree (depth=13)         Old: 10,711 us | New: 10,209 us | 1.05x
  Binary tree (depth=15)         Old: 42,140 us | New: 42,641 us | 1.00x
  ```

  </details>

  ### Results

  | Nodes | Old | New | Speedup |
  |---|---|---|---|
  | 32 | 2.6ms | 22us | **118x** |
  | 47 | 84ms | 37us | **2,263x** |
  | 62 | 2.6s | 41us | **64,046x** |

  The old algorithm re-explores shared subgraphs exponentially (no visited tracking). The new algorithm's `state=2` skip makes it linear — **118x–64,046x faster on diamond DAGs**, which are common in deduplicated FX graphs. On non-shared patterns (chains, trees), both perform equivalently.

  cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @yanboliang 