### PR TITLE
Increase NCCL default timeout to 120 minutes

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -153,7 +153,7 @@ constexpr const char* kStoreErrorSignalKey = "remote_error";
 constexpr const int kWorkStatusUpdatePeriodMs = 30 * 1000; // 30 seconds
 
 constexpr auto kProcessGroupNCCLDefaultTimeout =
-    std::chrono::milliseconds(10 * 60 * 1000);
+    std::chrono::milliseconds(120 * 60 * 1000);
 
 // NoHandling: do not handle asynchronous NCCL errors
 // TearDown: tear down process upon error, see `WorkNCCL::handleException`


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

The default NCCL timeout in PyTorch is set to 10 minutes, which is often too short for large-scale training workloads. Operations such as data loading, checkpoint I/O, and other system-level activities can easily take longer than this, especially in distributed environments with high I/O contention or network variability.

While the timeout can be customized via the timeout parameter in torch.distributed.init_process_group, the majority of users rely on the default value — leaving them vulnerable to unexpected hangs or false-positive failures during long-running operations.

Based on our extensive production training experience, we have found that a significantly longer timeout — ranging from 30 minutes to even 2 hours — greatly improves training stability and resilience. Such a change helps avoid unnecessary job interruptions caused by transient delays that are normal under real-world conditions.

We recommend either increasing the default timeout or strongly emphasizing in best-practice guidelines that users should explicitly set it according to their infrastructure characteristics.