### PR TITLE
[fx] Don't delete keys from previous metadata

### DIFF
--- a/test/fx/test_fx_traceback.py
+++ b/test/fx/test_fx_traceback.py
@@ -1,10 +1,11 @@
 # Owner(s): ["module: fx"]
+import unittest
 
 import torch
 from torch._inductor.compile_fx import aot_export_module
 from torch.export import default_decompositions
 from torch.fx.traceback import get_graph_provenance_json, NodeSource, NodeSourceAction
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import TEST_WITH_CROSSREF, TestCase
 
 
 CREATE_STR = NodeSourceAction.CREATE.name.lower()
@@ -123,6 +124,9 @@ class TestFXNodeSource(TestCase):
         self.assertNotEqual(node_source_replace, node_source_create)
         self.assertNotEqual(hash(node_source_replace), hash(node_source_create))
 
+    @unittest.skipIf(
+        TEST_WITH_CROSSREF, "generator unsupported triggers assertion error"
+    )
     def test_graph_provenance(self):
         def check_node_source(node_source_dict, name, pass_name, action):
             self.assertEqual(node_source_dict["name"], name)
@@ -277,6 +281,35 @@ class TestFXNodeSource(TestCase):
                 "Interpreter_DynamoGraphTransformer",
                 CREATE_STR,
             )
+
+    def test_override_metadata(self):
+        def simple_fn(x):
+            return x + 1
+
+        gm = torch.fx.symbolic_trace(simple_fn)
+
+        with torch.fx.traceback.preserve_node_meta():
+            torch.fx.traceback.current_meta["custom"] = "1"
+            gm = torch.fx.Transformer(gm).transform()
+            del torch.fx.traceback.current_meta["custom"]
+
+        # There should be no metadata on the call function nodes previously, so
+        # we should be able to set the node.meta["custom"] = "1"
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                self.assertEqual(node.meta["custom"], "1")
+
+        with torch.fx.traceback.preserve_node_meta():
+            torch.fx.traceback.current_meta["custom"] = "2"
+            gm = torch.fx.Transformer(gm).transform()
+            del torch.fx.traceback.current_meta["custom"]
+
+        # Due to the set_node_metadata call in fx.Interpreter/Transformer, the
+        # existing value on node.meta["custom"] should take precedence, and
+        # should not change
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                self.assertEqual(node.meta["custom"], "1")
 
 
 if __name__ == "__main__":

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -46,6 +46,7 @@ from functorch.experimental import control_flow
 
 from fx.named_tup import MyNamedTup
 from fx.test_common_passes import TestCommonPass  # noqa: F401
+from fx.test_fx_traceback import TestFXNodeSource  # noqa: F401
 from fx.test_cse_pass import TestCSEPass  # noqa: F401
 from fx.test_dce_pass import TestDCE  # noqa: F401
 from fx.test_fx_const_fold import TestConstFold  # noqa: F401


### PR DESCRIPTION
When compiling the backwards, we use [`set_partitioner_is_backward`](https://www.internalfb.com/code/fbsource/[99561d1bc40efda1d6633a727cf2e1c9f21c429e]/fbcode/caffe2/torch/_functorch/_aot_autograd/graph_capture_wrappers.py?lines=376-380) which sets the metadata for nodes created during AOTAutograd tracing as `meta["partitioner_tag"] = "is_backward"`. This metadata isn't important for non-effectful nodes, as the partitioning information can be determined by their node arguments. But for side-effectful operators who might not have arguments from backwards, we need to record if this op was in the backwards through `set_partitioner_is_backward` which sets the node's `partitioner_tag` metadata as being `is_backward`, and then later we use this metadata to process if the node belongs in the backwards graph.

However, when running the AutogradFunctionApply higher order operator, it uses [fx.Interpreter](https://www.internalfb.com/code/fbsource/[99561d1bc40efda1d6633a727cf2e1c9f21c429e]/fbcode/caffe2/torch/_functorch/autograd_function.py?lines=789) to run the backward graph, which calls set_node_meta, which then resets fx_traceback's metadata to be the bwd graph node's metadata. This causes the `set_partitioner_is_backward` metadata to not be added. 

This PR updates the behavior of set_node_metadata, where if there are nested usages of set_current_meta, then we will merge the keys (with the most recent set_current_meta taking precedence) instead of completely overwriting them. 

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv