### PR TITLE
[vLLM] Retry vLLM tests with a delay

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/vllm/lib.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/lib.py
@@ -12,6 +12,10 @@ from cli.lib.common.utils import run_command, temp_environ, working_directory
 from jinja2 import Template
 
 
+VLLM_DEFAULT_RERUN_FAILURES_COUNT = 2
+VLLM_DEFAULT_RERUN_FAILURES_DELAY = 10
+
+
 logger = logging.getLogger(__name__)
 
 _VLLM_TEST_LIBRARY_PATH = Path(__file__).parent / "vllm_test_library.yaml"
@@ -127,13 +131,25 @@ def run_test_plan(
             if step.startswith("pytest"):
                 # Use a low retry count and a high delay value to lower the risk of
                 # having a retry storm and make thing worse
-                rerun_count = os.getenv("VLLM_RERUN_FAILURES_COUNT", 2)
-                rerun_delay = os.getenv("VLLM_RERUN_FAILURES_DELAY", 10)
-                step = step.replace(
-                    "pytest",
-                    f"pytest --reruns {rerun_count} --reruns-delay {rerun_delay}",
-                    1,
+                rerun_count = os.getenv(
+                    "VLLM_RERUN_FAILURES_COUNT", VLLM_DEFAULT_RERUN_FAILURES_COUNT
                 )
+                rerun_delay = os.getenv(
+                    "VLLM_RERUN_FAILURES_DELAY", VLLM_DEFAULT_RERUN_FAILURES_DELAY
+                )
+                if rerun_delay:
+                    step = step.replace(
+                        "pytest",
+                        f"pytest --reruns {rerun_count} --reruns-delay {rerun_delay}",
+                        1,
+                    )
+                else:
+                    step = step.replace(
+                        "pytest",
+                        f"pytest --reruns {rerun_count}",
+                        1,
+                    )
+
             code = run_command(cmd=step, check=False, use_shell=True)
             if code != 0:
                 failures.append(step)

--- a/.ci/lumen_cli/cli/lib/core/vllm/lib.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/lib.py
@@ -125,8 +125,10 @@ def run_test_plan(
             # the number of requests to HF until #172300 can be landed to enable
             # HF offline mode
             if step.startswith("pytest"):
-                rerun_count = os.getenv("VLLM_RERUN_FAILURES_COUNT", 3)
-                rerun_delay = os.getenv("VLLM_RERUN_FAILURES_DELAY", 2)
+                # Use a low retry count and a high delay value to lower the risk of
+                # having a retry storm and make thing worse
+                rerun_count = os.getenv("VLLM_RERUN_FAILURES_COUNT", 2)
+                rerun_delay = os.getenv("VLLM_RERUN_FAILURES_DELAY", 10)
                 step = step.replace(
                     "pytest",
                     f"pytest --reruns {rerun_count} --reruns-delay {rerun_delay}",

--- a/.ci/lumen_cli/cli/lib/core/vllm/vllm_test.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/vllm_test.py
@@ -213,6 +213,12 @@ class VllmTestRunner(BaseRunner):
             raise ValueError(
                 "missing required TORCH_CUDA_ARCH_LIST, please set TORCH_CUDA_ARCH_LIST env var"
             )
+        # HF_HOME is absolutely needed on CI to avoid rate limit to HF, so explicitly fail
+        # vLLM jobs when it's not set so that we know when it's missing
+        if get_env("CI") and not get_env("HF_HOME"):
+            raise ValueError(
+                "missing required HF_HOME when running on CI, please set HF_HOME env var"
+            )
 
 
 def preprocess_test_in(


### PR DESCRIPTION
I'm blocked from landing https://github.com/pytorch/pytorch/pull/172300 because of an issue with the current latest transformers 4.57.3 https://github.com/huggingface/transformers/issues/42886. Until the issue is resolved, I think we can try rerun vLLM tests with a delay value.

1. vLLM already includes https://github.com/pytest-dev/pytest-rerunfailures as its test dependency
2. When the test fails, only retry it one more time, with a delay value of 10 second (I guess long enough to slow down the request rate, which is reset every 5 minutes)
3. The `pytest-rerunfailures` plugin only supports fixed delay

### Testing

CI, the pytest commands looks like this https://github.com/pytorch/pytorch/actions/runs/20953304910/job/60216783755#step:27:3981