### PR TITLE
Update memory error message documentation link and variable name for PYTORCH_CUDA_ALLOC_CONF

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1607,7 +1607,7 @@ class DeviceCachingAllocator {
               reserved_bytes - allocated_bytes - allocated_in_private_pools),
           " is reserved by PyTorch but unallocated.",
           " If reserved but unallocated memory is large try setting",
-          " PYTORCH_ALLOC_CONF=expandable_segments:True to avoid"
+          " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
           " fragmentation.  See documentation for Memory Management "
           " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)");
     }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1609,7 +1609,7 @@ class DeviceCachingAllocator {
           " If reserved but unallocated memory is large try setting",
           " PYTORCH_ALLOC_CONF=expandable_segments:True to avoid"
           " fragmentation.  See documentation for Memory Management "
-          " (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)");
+          " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)");
     }
 
     bool split_remainder = should_split(


### PR DESCRIPTION
This pull request updates an environment variable name and documentation link in the CUDA memory management warning message to improve clarity and accuracy for users.

When I ran into OOM error, the link to documentation points to the right webpage but unvalid permalink. The error message also mentions an env variable that does not match the ones in the corresponding link.

Improvements to environment variable usage and documentation:

* Updated the environment variable in the warning message from `PYTORCH_ALLOC_CONF` to the correct `PYTORCH_CUDA_ALLOC_CONF` to avoid user confusion.
* Changed the documentation link to point to the more relevant section on optimizing memory usage with `PYTORCH_CUDA_ALLOC_CONF`.