### PR TITLE
env variable for disabling dynamic shapes

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -123,9 +123,9 @@ assume_static_by_default = True
 # with assume_static_by_default=True.
 # With this flag enabled, we always compile a frame as fully static for the first time, and, if we fail
 # any guards due to wobbles in shape, we recompile with *all* the wobbled shapes as being marked dynamic.
-automatic_dynamic_shapes = True
-if os.environ.get("TORCH_DYNAMO_DISABLE_AUTOMATIC_DYNAMIC_SHAPES") == "1":
-    automatic_dynamic_shapes = False
+automatic_dynamic_shapes = (
+    os.environ.get("TORCH_DYNAMO_AUTOMATIC_DYNAMIC_SHAPES", "1") == "1"
+)
 
 # Valid options: "dynamic", "unbacked"
 automatic_dynamic_shapes_mark_as: Literal["dynamic", "unbacked"] = "dynamic"

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -124,6 +124,8 @@ assume_static_by_default = True
 # With this flag enabled, we always compile a frame as fully static for the first time, and, if we fail
 # any guards due to wobbles in shape, we recompile with *all* the wobbled shapes as being marked dynamic.
 automatic_dynamic_shapes = True
+if os.environ.get("TORCH_DYNAMO_DISABLE_AUTOMATIC_DYNAMIC_SHAPES") == "1":
+    automatic_dynamic_shapes = False
 
 # Valid options: "dynamic", "unbacked"
 automatic_dynamic_shapes_mark_as: Literal["dynamic", "unbacked"] = "dynamic"


### PR DESCRIPTION
Added a new env variable to disable dynamic shapes globally:

`TORCH_DYNAMO_AUTOMATIC_DYNAMIC_SHAPES=0`

There are many use-cases where this comes handy.

In our particular case, we are running various e2e stock workloads (setting dynamic=false everywhere or modifying the python code itself is a no-go) and want to capture all gemm tuning results.
With dynamic shapes and when doing matmul with dimension M,K,N, the K dimension is only tuned once, but
we want to tune it always.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos