### PR TITLE
[ROCm] Skip test_progressive - optimization not tuned for ROCm

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -18,7 +18,7 @@ import torch.library
 from torch._inductor.compile_fx import _InProcessFxCompile, FxCompile, FxCompileMode
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS, TEST_WITH_ASAN
+from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS, skipIfRocm, TEST_WITH_ASAN
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     IS_BIG_GPU,
@@ -99,6 +99,7 @@ class TestSubprocess(TestCase):
     @unittest.skipIf(
         not IS_BIG_GPU, "Skipping triton backend only since not big GPU (not enough SM)"
     )
+    @skipIfRocm(msg="progressive compile optimization not tuned for ROCm")
     def test_progressive(self):
         from triton.testing import do_bench
 


### PR DESCRIPTION
## Summary
Skip test_progressive on ROCm as the progressive compile optimization is not tuned for ROCm.

Fixes #157724

## Problem
The test_progressive test is flaky on ROCm CI, failing ~73% of the time with assertion errors when comparing baseline vs optimized compilation times.

## Root Cause
The progressive compile optimization (`fx_compile_progressive`) relies on autotuning infrastructure that hasn't been tuned for ROCm:
- The test asserts `baseline_time > optimized_time` (progressive should be faster)
- On ROCm, the progressively optimized code isn't consistently faster than baseline
- Error: `AssertionError: 0.04482530935471503 not greater than 0.04578580703772162`

## Fix
Add `@skipIfRocm` decorator since progressive compile optimization hasn't been tuned for ROCm hardware.

## Test Plan
- [x] Verified similar precedent exists (e.g., #172294 for test_mixed_mm)
- [x] Issue documents 14 failures / 5 successes (~73% failure rate) in CI

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben