### PR TITLE
[ROCm] Skip test_repeat_graph_capture_cublas_workspace_memory - cuBLAS not available

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2407,6 +2407,7 @@ exit(2)
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    @skipIfRocm(msg="cuBLAS is not available on ROCm")
     @serialTest()
     @setBlasBackendsToDefaultFinally
     def test_repeat_graph_capture_cublas_workspace_memory(self):


### PR DESCRIPTION
## Summary
Skip test_repeat_graph_capture_cublas_workspace_memory on ROCm as cuBLAS is not available.

Fixes #144922

## Problem
The test explicitly uses `torch.backends.cuda.preferred_blas_library("cublas")` which is NVIDIA-specific. ROCm uses hipBLAS/rocBLAS instead.

## Fix
Add `@skipIfRocm` decorator since cuBLAS is an NVIDIA-only library.

## Test Plan
- [x] Verified fix follows established pattern
- [x] Similar precedent exists (e.g., #172294, #172336, #172337, #172339)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang