### PR TITLE
[ROCm] Skip test_profiler_cuda_sync_events - cuda_sync events not supported on ROCm

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1483,6 +1483,7 @@ class TestProfiler(TestCase):
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    @unittest.skipIf(TEST_WITH_ROCM, "cuda_sync profiler events not supported on ROCm")
     def test_profiler_cuda_sync_events(self):
         device = torch.device("cuda:0")
         t1, t2 = torch.ones(1, device=device), torch.ones(1, device=device)


### PR DESCRIPTION
## Summary
Skip test_profiler_cuda_sync_events on ROCm as cuda_sync profiler events are not supported.

Fixes #106027

## Problem
The test uses `enable_cuda_sync_events=True` profiler functionality which is CUDA-specific and not supported on ROCm.

## Fix
Add `@unittest.skipIf(TEST_WITH_ROCM, ...)` decorator since cuda_sync profiler events are not available on ROCm.

## Test Plan
- [x] Verified fix follows established pattern
- [x] Similar precedent exists (e.g., #172294, #172336, #172337, #172339)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang