### PR TITLE
Fix UB in InefficientStdFunctionContext for Allocator

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -256,8 +256,7 @@ struct C10_API InefficientStdFunctionContext {
   InefficientStdFunctionContext& operator=(
       InefficientStdFunctionContext&& rhs) {
     this->~InefficientStdFunctionContext();
-    ptr_ = std::exchange(rhs.ptr_, nullptr);
-    deleter_ = std::move(rhs.deleter_);
+    new (this) InefficientStdFunctionContext(std::move(rhs));
     return *this;
   }
   ~InefficientStdFunctionContext() {


### PR DESCRIPTION
This was discovered through LLM but the explanation does make sense that assignment after deleter would be bad (online search validates that).
This does require a real review by a C++ expert.