### PR TITLE
[Inductor][NVGEMM] Cache GemmArguments to save creation time

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
+from torch._dynamo.utils import counters
 from torch._inductor import config
 from torch._inductor.codegen.cuda.cuda_env import is_datacenter_blackwell_arch
 from torch._inductor.template_heuristics.nv_universal_gemm import (
@@ -68,8 +69,6 @@ class TestNVUniversalGemm(TestCase):
 
         expected = matmul(a, b)
 
-        torch._dynamo.reset()
-
         with config.patch(
             {
                 "max_autotune": True,
@@ -124,8 +123,6 @@ class TestNVUniversalGemm(TestCase):
         a = create_tensor_with_layout(layout_a, m, k)
         b = create_tensor_with_layout(layout_b, k, n)
 
-        torch._dynamo.reset()
-
         with config.patch(
             {
                 "max_autotune": True,
@@ -155,8 +152,6 @@ class TestNVUniversalGemm(TestCase):
 
         a = torch.randn(m, k, device=device, dtype=dtype)
         b = torch.randn(k, n, device=device, dtype=dtype)
-
-        torch._dynamo.reset()
 
         with config.patch(
             {
@@ -195,8 +190,6 @@ class TestNVUniversalGemm(TestCase):
 
         expected = fn(x, weight)
 
-        torch._dynamo.reset()
-
         with config.patch(
             {
                 "max_autotune": True,
@@ -227,8 +220,6 @@ class TestNVUniversalGemm(TestCase):
         b = torch.randn(k, n, device=device, dtype=dtype)
 
         expected = matmul(a, b)
-
-        torch._dynamo.reset()
 
         # Patch cutlass_api.Kernel.get_workspace_size to return non-zero
         import cutlass_api
@@ -274,8 +265,6 @@ class TestNVUniversalGemm(TestCase):
 
         expected = bmm(a, b)
 
-        torch._dynamo.reset()
-
         with config.patch(
             {
                 "max_autotune": True,
@@ -289,12 +278,13 @@ class TestNVUniversalGemm(TestCase):
         torch.testing.assert_close(result, expected)
 
     def test_gemm_args_caching(self):
-        """Test that GemmArguments caching works correctly with multiple calls.
+        """Test that GemmArguments caching works correctly with cudagraphs.
 
         The NVGEMM kernel caches GemmArguments per (shape, dtype) and updates tensor
         references on subsequent calls. This test verifies that:
         1. Multiple calls with different tensors of the same shape produce correct results
         2. The caching mechanism correctly updates tensor references (results differ)
+        3. Cudagraphs are enabled and not skipped
         """
         m, n, k = 512, 512, 512
         dtype = torch.bfloat16
@@ -311,24 +301,26 @@ class TestNVUniversalGemm(TestCase):
         expected1 = matmul(a1, b1)
         expected2 = matmul(a2, b2)
 
-        torch._dynamo.reset()
+        counters.clear()
 
         with config.patch(
             {
-                "max_autotune": True,
                 "max_autotune_gemm_backends": "NVGEMM",
                 "cuda.nvgemm_max_profiling_configs": 3,
             }
         ):
-            compiled_fn = torch.compile(matmul)
+            compiled_fn = torch.compile(matmul, mode="max-autotune")
 
-            result1 = compiled_fn(a1, b1)
+            result1 = compiled_fn(a1, b1).clone()
             torch.testing.assert_close(result1, expected1)
 
-            result2 = compiled_fn(a2, b2)
+            result2 = compiled_fn(a2, b2).clone()
             torch.testing.assert_close(result2, expected2)
 
             self.assertFalse(torch.allclose(result1, result2))
+
+        # Verify cudagraphs were used (not skipped)
+        self.assertEqual(counters["inductor"]["cudagraph_skips"], 0)
 
 
 class TestNVUniversalGemmHeuristics(TestCase):

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -157,9 +157,9 @@ class NVUniversalGemmKernel(Kernel):
                     _nv_universal_gemm_compiled_cache[cache_key] = (args, artifact)
                 else:
                     args, artifact = _nv_universal_gemm_compiled_cache[cache_key]
-                    args.A = in_ptr0
-                    args.B = in_ptr1
-                    args.out = out_ptr0
+                    args.A.tensor.runtime_tensor = in_ptr0
+                    args.B.tensor.runtime_tensor = in_ptr1
+                    args.out.tensor.runtime_tensor = out_ptr0
 
                 kernel.run(args, artifact, stream=stream, workspace={workspace_arg}, assume_supported_args=True)
             """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172582
* #172525
* #172524
* #172417
* #172402
* #172391
* #172388
* #172378
* __->__ #172366
* #172283
* #172280

Creating GemmArguments takes around ~0.06ms which is non-negligible for small Gemms, thus caching their creation an updating the pointers is necessary.

`python test/inductor/test_nv_universal_gemm.py -k test_gemm_args_caching`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo