### PR TITLE
[ROCm] Skip test_conv3d_64bit_indexing_cuda - large tensor conv3d not supported

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4187,6 +4187,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(grad_weight.shape, weight.shape)
 
     @skipCUDAIfRocmHipBlasltVersionLessThan((1, 2, 0))
+    @skipCUDAIfRocm
     @onlyCUDA
     @largeTensorTest("40GB")
     @largeTensorTest("24GB", "cpu")


### PR DESCRIPTION
## Summary
Skip test_conv3d_64bit_indexing_cuda on ROCm as large tensor 3D convolution is not supported.

Fixes #104366

## Problem
Large tensor 3D convolution test (40GB) fails on ROCm since ROCm 5.5. This is a known limitation with 64-bit indexing in MIOpen.

## Fix
Add `@skipCUDAIfRocm` decorator since this is a known MIOpen limitation.

## Test Plan
- [x] Verified fix follows established pattern
- [x] Similar precedent exists (e.g., #172294, #172336, #172337)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang