### PR TITLE
[ROCm] Skip test_decompose_k_custom_op_autotune - autotune not tuned for ROCm

### DIFF
--- a/test/inductor/test_custom_op_autotune.py
+++ b/test/inductor/test_custom_op_autotune.py
@@ -14,7 +14,7 @@ from torch._inductor.kernel.custom_op import (
     register_custom_op_autotuning,
 )
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import skipIfXpu
+from torch.testing._internal.common_utils import skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import HAS_GPU
 
 
@@ -232,6 +232,7 @@ class TestCustomOpAutoTune(TestCase):
         )
         return a, b, bias
 
+    @skipIfRocm
     @skipIfXpu
     def test_decompose_k_custom_op_autotune_dynamic_config_for_input_shape(self):
         """Test decompose_k autotuning with with epilogue fusion(matmul+bias+relu+scale) and


### PR DESCRIPTION
## Summary
Skip test_decompose_k_custom_op_autotune_dynamic_config_for_input_shape on ROCm as custom op autotune is not tuned for ROCm.

Fixes #171519

## Problem
The test is flaky on ROCm CI. The custom op autotune infrastructure hasn't been tuned for ROCm hardware.

## Fix
Add `@skipIfRocm` decorator since autotune configs are NVIDIA-specific.

## Test Plan
- [x] Verified fix follows established pattern
- [x] Similar precedent exists (e.g., #172294, #172336)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben