### PR TITLE
[ROCm] remove gfx940 gfx941

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -517,7 +517,7 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t* self_data_start, int64_t index, int64_t numel, const scalar_t * src_data) const {
-#if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+#if (defined(__gfx942__) || defined(__gfx950__))
     opportunistic_fastAtomicAdd(self_data_start, index, numel, *src_data);
 #else
     fastAtomicAdd(self_data_start, index, numel, *src_data, true);

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -258,7 +258,7 @@ __device__ inline void cmtdStore(void* address, T value) {
 }
 #endif
 
-#if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+#if (defined(__gfx942__) || defined(__gfx950__))
 // This function implements warp-level opportunistic fastatomics
 // To reduce contention on an atomicAdd, this replaces per-thread atomicAdd with a per-warp atomicAdd.
 // We identify all the threads within a warp that will perform an atomicAdd on the same destination

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -32,7 +32,7 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t* self_data_start, int64_t index, int64_t numel, const scalar_t * src_data) const {
-#if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+#if (defined(__gfx942__) || defined(__gfx950__))
     opportunistic_fastAtomicAdd(self_data_start, index, numel, *src_data);
 #else
     fastAtomicAdd(self_data_start, index, numel, *src_data, true);

--- a/aten/src/ATen/native/hip/ck_types.h
+++ b/aten/src/ATen/native/hip/ck_types.h
@@ -7,7 +7,7 @@
  */
 
 // work around CK assuming only a single FP8 interpretation at a time
-#if(defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)) && __HIP_DEVICE_COMPILE__
+#if defined(__gfx942__) && __HIP_DEVICE_COMPILE__
 #define CK_USE_FNUZ_FP8 1
 #undef CK_USE_OCP_FP8
 #elif __HIP_DEVICE_COMPILE__

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -54,7 +54,7 @@ def evaluate_gfx_arch_within(arch_list):
     return any(arch in effective_arch for arch in arch_list)
 
 def CDNA3OrLater():
-    return evaluate_gfx_arch_within(["gfx940", "gfx941", "gfx942", "gfx950"])
+    return evaluate_gfx_arch_within(["gfx942", "gfx950"])
 
 def CDNA2OrLater():
     return evaluate_gfx_arch_within(["gfx90a", "gfx942"])


### PR DESCRIPTION
These were early gfx targets for MI300 that are no longer valid.  gfx942 is the correct target for all MI300 systems.

Fixes #172275.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang