### PR TITLE
[ROCm] Skip test_sparse_add on ROCm

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2274,6 +2274,7 @@ class TestSparseCSR(TestCase):
                         self.assertEqual(res_out, res_in)
 
     @skipCPUIfNoMklSparse
+    @skipCUDAIfRocm(msg="hipSPARSE sparse_add is flaky on ROCm")
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
     def test_sparse_add(self, device, dtype):
         def run_test(m, n, index_dtype):


### PR DESCRIPTION
## Summary
Skip `test_sparse_add` on ROCm as hipSPARSE sparse_add is flaky.

## Problem
The test `test_sparse_add_cuda_float32` is disabled on ROCm due to flaky behavior with hipSPARSE.

## Root Cause
hipSPARSE sparse_add operation is not reliable on ROCm, causing intermittent test failures.

## Fix
Add `@skipCUDAIfRocm` decorator to skip the test on ROCm platforms.

Fixes #167783

## Test Plan
- Test is properly skipped on ROCm CI
- Test continues to run on CUDA platforms

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang