### PR TITLE
[ROCm] Skip test_triu_tril_large_matrix_64bit on ROCm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10095,6 +10095,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(C, B.sum().expand(B.shape))
 
     @onlyCUDA
+    @skipCUDAIfRocm(msg="ROCm triu/tril has issues with 64-bit indexing for large matrices")
     @largeTensorTest("40GB")
     def test_triu_tril_large_matrix_64bit(self, device):
         """


### PR DESCRIPTION
## Summary
Skip `test_triu_tril_large_matrix_64bit` on ROCm due to 64-bit indexing issues with large matrices.

## Problem
The test `test_triu_tril_large_matrix_64bit_cuda` is disabled on ROCm because ROCm triu/tril operations have issues with 64-bit indexing for very large matrices (100k x 100k, requiring 40GB GPU memory).

## Root Cause
ROCm's implementation of triu/tril has issues handling matrices that require 64-bit indexing (>2B elements).

## Fix
Add `@skipCUDAIfRocm` decorator to skip the test on ROCm platforms.

Fixes #165966

## Test Plan
- Test is properly skipped on ROCm CI
- Test continues to run on CUDA platforms with sufficient memory (40GB)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang