### PR TITLE
Fix tracing of .grad on nn.Parameter created in forward

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -443,6 +443,20 @@ class TensorVariable(VariableTracker):
             torch._C._autograd._get_data_attr  # type: ignore[attr-defined]
         ).call_function(tx, [self], {})
 
+    def method_attr_grad(
+        self, tx: "InstructionTranslator"
+    ) -> VariableTracker | None:
+        from .builder import wrap_fx_proxy
+        from .misc import GetAttrVariable
+
+        grad_value = self.proxy.node.meta["example_value"].grad
+        if grad_value is None:
+            return variables.ConstantVariable(None)
+
+        grad_proxy = GetAttrVariable.create_getattr_proxy(self.as_proxy(), "grad")
+        source = AttrSource(self.source, "grad") if self.source else None
+        return wrap_fx_proxy(tx=tx, proxy=grad_proxy, example_value=grad_value, source=source)
+
     def method_attr_grad_fn(
         self, tx: "InstructionTranslator"
     ) -> ConstantVariable | None:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -443,9 +443,7 @@ class TensorVariable(VariableTracker):
             torch._C._autograd._get_data_attr  # type: ignore[attr-defined]
         ).call_function(tx, [self], {})
 
-    def method_attr_grad(
-        self, tx: "InstructionTranslator"
-    ) -> VariableTracker | None:
+    def method_attr_grad(self, tx: "InstructionTranslator") -> VariableTracker | None:
         from .builder import wrap_fx_proxy
         from .misc import GetAttrVariable
 
@@ -455,7 +453,9 @@ class TensorVariable(VariableTracker):
 
         grad_proxy = GetAttrVariable.create_getattr_proxy(self.as_proxy(), "grad")
         source = AttrSource(self.source, "grad") if self.source else None
-        return wrap_fx_proxy(tx=tx, proxy=grad_proxy, example_value=grad_value, source=source)
+        return wrap_fx_proxy(
+            tx=tx, proxy=grad_proxy, example_value=grad_value, source=source
+        )
 
     def method_attr_grad_fn(
         self, tx: "InstructionTranslator"


### PR DESCRIPTION
Fixes #171204 

Fixes issue where accessing .grad on an nn.Parameter created inside a traced function would fail with unknown type error. Added method_attr_grad handle that checks the fake tensor's .grad value and returns ConstantVariable(None) or TensorVariable instead of falling back to GetAttrVaraible. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo