### PR TITLE
Remove inaccurate summary from L1Loss docs.

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -82,8 +82,6 @@ class L1Loss(_Loss):
     :math:`x` and :math:`y` are tensors of arbitrary shapes with a total
     of :math:`N` elements each.
 
-    The sum operation still operates over all the elements, and divides by :math:`N`.
-
     The division by :math:`N` can be avoided if one sets ``reduction = 'sum'``.
 
     Supports real-valued and complex-valued inputs.


### PR DESCRIPTION
The description of the reduction was incorrect and confusing.

The docs already exist in the `reduce` docs.