### PR TITLE
[Inductor][NVGEMM] Remove guards now handled by new cutlass api version

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -36,12 +36,15 @@ class TestNVUniversalGemm(TestCase):
             ("aligned_offset", "contiguous"),
             ("contiguous", "view"),
             ("aligned_offset", "view"),
+            ("padded", "contiguous"),
         ),
     )
     def test_matmul(self, dtype, layout_a, layout_b):
         """Test matmul with various dtypes and tensor layouts.
 
-        These layouts all have 16-byte aligned strides and should work with NVIDIA Universal GEMM.
+        These layouts test various alignment scenarios:
+        - contiguous/view/aligned_offset: Standard aligned layouts
+        - padded: Non-16-byte-aligned stride, Inductor pads to aligned size
         M=513 tests that non-divisible M dimension works (only N and K must be divisible by 16).
         """
         m, n, k = 513, 512, 512
@@ -55,13 +58,20 @@ class TestNVUniversalGemm(TestCase):
             if layout == "contiguous":
                 return torch.randn(rows, cols, device=device, dtype=dtype)
             elif layout == "aligned_offset":
-                # Allocate bigger buffer than needed, use nonzero storage offset
+                # Allocate bigger buffer than needed, use 16-byte aligned offset
+                # offset=128 elements * 2 bytes = 256 bytes (16-byte aligned)
                 storage = torch.randn(rows * cols + 512, device=device, dtype=dtype)
                 offset = 128
                 return torch.as_strided(storage[offset:], (rows, cols), (cols, 1))
             elif layout == "view":
                 storage = torch.randn(rows * cols, device=device, dtype=dtype)
                 return storage.view(rows, cols)
+            elif layout == "padded":
+                # Simulate row pitch > cols with non-16-byte-aligned stride
+                # row_stride = cols + 8 = 520, 520 * 2 bytes = 1040 bytes (not 16-byte aligned)
+                row_pitch = cols + 8
+                storage = torch.randn(rows * row_pitch, device=device, dtype=dtype)
+                return torch.as_strided(storage, (rows, cols), (row_pitch, 1))
 
         a = create_tensor_with_layout(layout_a, m, k)
         b = create_tensor_with_layout(layout_b, k, n)
@@ -82,21 +92,12 @@ class TestNVUniversalGemm(TestCase):
 
         torch.testing.assert_close(result, expected)
 
-    @parametrize(
-        "layout_a,layout_b",
-        (
-            ("padded", "contiguous"),
-            ("contiguous", "padded"),
-            ("offset", "contiguous"),
-            ("contiguous", "offset"),
-        ),
-    )
-    def test_unaligned_layouts_rejected(self, layout_a, layout_b):
-        """Test that matmul with unaligned layouts is rejected by NVIDIA Universal GEMM.
+    def test_unaligned_base_pointer_rejected(self):
+        """Test that matmul with unaligned base pointer is rejected.
 
-        Padded layouts have strides that aren't 16-byte aligned,
-        the guard function should reject NVIDIA Universal GEMM and we should get no choices
-        when NVGEMM is the only backend.
+        cutlass_api requires 16-byte aligned base pointers. Since alignment
+        can't be checked at compile time (FakeTensors don't have real pointers),
+        Inductor must guard against unaligned buffers.
         """
         m, n, k = 512, 512, 512
         dtype = torch.bfloat16
@@ -105,55 +106,10 @@ class TestNVUniversalGemm(TestCase):
         def matmul(a, b):
             return a @ b
 
-        def create_tensor_with_layout(layout, rows, cols):
-            """Create a tensor with the specified layout."""
-            if layout == "contiguous":
-                return torch.randn(rows, cols, device=device, dtype=dtype)
-            elif layout == "offset":
-                # Allocate bigger buffer than needed, use nonzero storage offset
-                storage = torch.randn(rows * cols + 512, device=device, dtype=dtype)
-                offset = 117
-                return torch.as_strided(storage[offset:], (rows, cols), (cols, 1))
-            elif layout == "padded":
-                # Simulate row pitch > cols with non-16-byte-aligned stride
-                # row_stride = cols + 8 = 520, 520 * 2 bytes = 1040 bytes (not 16-byte aligned)
-                row_pitch = cols + 8
-                storage = torch.randn(rows * row_pitch, device=device, dtype=dtype)
-                return torch.as_strided(storage, (rows, cols), (row_pitch, 1))
-
-        a = create_tensor_with_layout(layout_a, m, k)
-        b = create_tensor_with_layout(layout_b, k, n)
-
-        torch._dynamo.reset()
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "NVGEMM",
-                "cuda.nvgemm_max_profiling_configs": 3,
-            }
-        ):
-            compiled_fn = torch.compile(matmul)
-            with self.assertRaisesRegex(
-                Exception, "NoValidChoicesError|no valid choice"
-            ):
-                compiled_fn(a, b)
-
-    @parametrize("m,n,k", ((512, 513, 512), (512, 512, 513)))
-    def test_non_divisible_n_or_k_rejected(self, m, n, k):
-        """Test that matmul with n or k not divisible by 16 is rejected.
-
-        NVIDIA Universal GEMM requires n and k to be divisible by 16. When they're not,
-        the guard function should reject it and we should get no choices
-        when NVGEMM is the only backend.
-        """
-        dtype = torch.bfloat16
-        device = "cuda"
-
-        def matmul(a, b):
-            return a @ b
-
-        a = torch.randn(m, k, device=device, dtype=dtype)
+        # Create tensor with unaligned base pointer
+        # offset=117 elements * 2 bytes = 234 bytes (NOT 16-byte aligned)
+        storage = torch.randn(m * k + 512, device=device, dtype=dtype)
+        a = torch.as_strided(storage[117:], (m, k), (k, 1))
         b = torch.randn(k, n, device=device, dtype=dtype)
 
         torch._dynamo.reset()
@@ -259,18 +215,31 @@ class TestNVUniversalGemm(TestCase):
         torch.testing.assert_close(result, expected)
 
     @parametrize("dtype", (torch.float16, torch.bfloat16))
-    def test_bmm_sliced(self, dtype):
-        """Test BMM path with sliced tensors"""
+    def test_bmm_non_standard_batch_stride(self, dtype):
+        """Test BMM path with non-standard batch strides."""
         batch, m, n, k = 8, 64, 256, 128
         device = "cuda"
 
         def bmm(a, b):
             return torch.bmm(a, b)
 
-        a_full = torch.randn(batch * 2, m, k, device=device, dtype=dtype)
-        b_full = torch.randn(batch * 2, k, n, device=device, dtype=dtype)
-        a = a_full[:batch]
-        b = b_full[batch:]
+        # Create tensors with non-largest batch stride by transposing
+        # a_base shape: (m, batch, k), stride: (batch*k, k, 1)
+        # After transpose: shape (batch, m, k), stride: (k, batch*k, 1)
+        # batch_stride = k = 128, but m*k = 64*128 = 8192, so batch_stride < m*k
+        a_base = torch.randn(m, batch, k, device=device, dtype=dtype)
+        a = a_base.transpose(0, 1)  # (batch, m, k) with stride (k, batch*k, 1)
+
+        b_base = torch.randn(k, batch, n, device=device, dtype=dtype)
+        b = b_base.transpose(0, 1)  # (batch, k, n) with stride (n, batch*n, 1)
+
+        # Verify batch stride is not largest (i.e., batch_stride_largest_or_zero would be False)
+        assert a.stride()[0] != a.shape[1] * a.shape[2], (
+            "Test setup error: a should have non-standard batch stride"
+        )
+        assert b.stride()[0] != b.shape[1] * b.shape[2], (
+            "Test setup error: b should have non-standard batch stride"
+        )
 
         expected = bmm(a, b)
 

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -220,12 +220,7 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     if use_ck_gemm_template(layout, m, n, k):
         CKGemmTemplate.add_ck_gemm_choices(choices, layout, kernel_inputs.nodes())
 
-    if (
-        # TODO(nikhilap) There is a bug in cutlass_api, their compatibility check does not catch this failure cases
-        batch_stride_largest_or_zero
-        and is_nonzero
-        and use_nv_universal_gemm_template(layout, m, n, k, mat1, mat2)
-    ):
+    if is_nonzero and use_nv_universal_gemm_template(layout, m, n, k, mat1, mat2):
         from ..codegen.nv_universal_gemm import add_nv_universal_gemm_choices
 
         add_nv_universal_gemm_choices(choices, layout, kernel_inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172607
* #172582
* #172525
* #172524
* #172417
* #172402
* #172391
* __->__ #172388
* #172378
* #172283
* #172280

In previous versions of the Cutlass API, we needed certain guards checking input shapes and strides since the Cutlass API's `get_kernels()` returned erroneous results. This has now been fixed so the guards can be removed.

`python /home/nikhilap/pytorch/test/inductor/test_nv_universal_gemm.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo