### PR TITLE
[Inductor][NVGEMM] Enable dynamic shape support

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -397,15 +397,8 @@ class TestNVUniversalGemmHeuristics(TestCase):
 class TestNVUniversalGemmDynamicShapes(TestCase):
     """Test cases for NVIDIA Universal GEMM with dynamic shapes."""
 
-    def test_dynamic_shapes_extreme(self):
-        """Stress test dynamic shapes with extreme variations.
-
-        Tests that a single compiled graph handles:
-        - Large to small transitions (2048 -> 16)
-        - Non-square matrices with varying aspect ratios
-        - Rapid alternation between different shapes
-        - Return to previously seen shapes (cache hits)
-        """
+    def test_dynamic_shapes(self):
+        """Stress test dynamic shapes with extreme variations."""
 
         def matmul(a, b):
             return a @ b

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -397,6 +397,34 @@ class TestNVUniversalGemmHeuristics(TestCase):
 class TestNVUniversalGemmDynamicShapes(TestCase):
     """Test cases for NVIDIA Universal GEMM with dynamic shapes."""
 
+    @torch._dynamo.config.patch({"capture_dynamic_output_shape_ops": True})
+    def test_unbacked_symint_rejected(self):
+        """Test that NVGEMM rejects unbacked symbolic integers."""
+
+        def fn(x, w):
+            nz = torch.nonzero(x)  # Creates unbacked symint for nz.size(0)
+            # Use unbacked symint as M dimension in matmul
+            a = torch.ones(nz.size(0), w.size(0), dtype=w.dtype, device=w.device)
+            return a @ w
+
+        x = torch.tensor([1.0, 0.0, 1.0, 0.0, 1.0], device="cuda")
+        w = torch.randn(64, 64, dtype=torch.bfloat16, device="cuda")
+
+        torch._dynamo.reset()
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "NVGEMM",
+                "cuda.nvgemm_max_profiling_configs": 2,
+            }
+        ):
+            compiled_fn = torch.compile(fn, dynamic=True)
+            with self.assertRaisesRegex(
+                Exception, "NoValidChoicesError|no valid choice"
+            ):
+                compiled_fn(x, w)
+
     def test_dynamic_shapes(self):
         """Stress test dynamic shapes with extreme variations."""
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172607
* #172582
* #172525
* #172524
* #172417
* #172402
* __->__ #172391
* #172388
* #172378
* #172283
* #172280

After some empirical testing, the cutlass API + Inductor/Dynamo's existing guard structure are sufficient to ensure that dynamic shapes mostly work. We just have to ensure we aren't using unbacked symints.

`python /home/nikhilap/pytorch/test/inductor/test_nv_universal_gemm.py -k test_dynamic_shapes`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo