### PR TITLE
Fix nvcc path finding when only CUDA_HOME is set

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3810,8 +3810,10 @@ def _cuda_compiler() -> str | None:
         return os.path.join(build_paths.sdk_home, "bin", "nvcc")
     if cuda_env.nvcc_exist(os.getenv("CUDACXX")):
         return os.getenv("CUDACXX", "")
-    if cuda_env.nvcc_exist(os.getenv("CUDA_HOME")):
-        return os.path.realpath(os.path.join(os.getenv("CUDA_HOME", ""), "bin/nvcc"))
+    if os.getenv("CUDA_HOME") is not None:
+        path = os.path.realpath(os.path.join(os.getenv("CUDA_HOME", ""), "bin/nvcc"))
+        if cuda_env.nvcc_exist(path):
+            return path
     return "nvcc"
 
 

--- a/torch/_inductor/codegen/cuda/cuda_env.py
+++ b/torch/_inductor/codegen/cuda/cuda_env.py
@@ -50,6 +50,7 @@ def get_cuda_version() -> Optional[str]:
         return None
 
 
+@clear_on_fresh_cache
 @functools.cache
 def nvcc_exist(nvcc_path: Optional[str] = "nvcc") -> bool:
     return nvcc_path is not None and shutil.which(nvcc_path) is not None


### PR DESCRIPTION
Currently `cuda_env.nvcc_exist(os.getenv("CUDA_HOME"))` is called which returns False since `shutil.which(os.getenv("CUDA_HOME"))` is False because CUDA_HOME is a directory.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo