### PR TITLE
[SymmMem] Use initializer for devComm requirement

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
@@ -63,10 +63,16 @@ class NCCLDevCommManager {
     }
     c10::cuda::CUDAGuard guard(device_);
     ncclDevComm devComm;
+
+    // Initializer available from NCCL 2.29
+#ifdef NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER
+    ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+#else
+    // In 2.28, we can set it to zero
     ncclDevCommRequirements reqs;
-    // See example in
-    // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/deviceapi.html#simple-lsa-kernel
     memset(&reqs, 0, sizeof(ncclDevCommRequirements));
+#endif
+
     // Specifies the number of memory barriers to allocate.
     reqs.lsaBarrierCount = NCCL_LSA_BARRIER_COUNT;
     // TODO (kwen2501): Add network barrier count.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #172400

Fixes https://github.com/pytorch/pytorch/issues/172398

`NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER` available in NCCL 2.29.