### PR TITLE
[dynamo] use closure cell name in recompilation reasons

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -256,7 +256,7 @@ class LoggingTests(LoggingTestCase):
         record_str = "\n".join(r.getMessage() for r in records)
         # The recompilation log should include a hint explaining which closure variable
         # the cell_contents refers to
-        self.assertIn('[HINT: guard on "n2"]', record_str)
+        self.assertIn('(HINT: guard on "n2")', record_str)
 
     @make_logging_test(recompiles=True)
     def test_recompiles_nested_closure_variable_hint(self, records):
@@ -291,7 +291,7 @@ class LoggingTests(LoggingTestCase):
 
         record_str = "\n".join(r.getMessage() for r in records)
         # The recompilation log should show the hint for the first closure variable
-        self.assertIn('[HINT: guard on "inner_val"]', record_str)
+        self.assertIn('(HINT: guard on "inner_val")', record_str)
         # Verify it shows the full nested path
         self.assertIn("cell_contents.__closure__", record_str)
 
@@ -322,7 +322,7 @@ class LoggingTests(LoggingTestCase):
 
         record_str = "\n".join(r.getMessage() for r in records)
         # The hint should show the full path from closure var: "transform".scale
-        self.assertIn('[HINT: guard on "transform".scale]', record_str)
+        self.assertIn('(HINT: guard on "transform".scale)', record_str)
 
     test_dynamo_debug = within_range_record_test(30, 90, dynamo=logging.DEBUG)
     test_dynamo_info = within_range_record_test(2, 10, dynamo=logging.INFO)

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -254,8 +254,9 @@ class LoggingTests(LoggingTestCase):
         fn(make_cl(0, 2), torch.ones(3))
 
         record_str = "\n".join(r.getMessage() for r in records)
-        # The recompilation log should include a HINT with "n2"
-        self.assertIn("(HINT: n2)", record_str)
+        # The recompilation log should include a hint explaining which closure variable
+        # the cell_contents refers to
+        self.assertIn('refers to "n2" in user code', record_str)
 
     test_dynamo_debug = within_range_record_test(30, 90, dynamo=logging.DEBUG)
     test_dynamo_info = within_range_record_test(2, 10, dynamo=logging.INFO)

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -256,7 +256,73 @@ class LoggingTests(LoggingTestCase):
         record_str = "\n".join(r.getMessage() for r in records)
         # The recompilation log should include a hint explaining which closure variable
         # the cell_contents refers to
-        self.assertIn('refers to "n2" in user code', record_str)
+        self.assertIn('[HINT: guard on "n2"]', record_str)
+
+    @make_logging_test(recompiles=True)
+    def test_recompiles_nested_closure_variable_hint(self, records):
+        # block_mask.mask_mod.__closure__[0].cell_contents.__closure__[0].cell_contents
+        def make_inner_fn(inner_val):
+            def inner(x):
+                return x + inner_val
+
+            return inner
+
+        def make_outer_fn(outer_val, inner_fn):
+            def outer(x):
+                return inner_fn(x) * outer_val
+
+            return outer
+
+        class BlockMask:
+            def __init__(self, mask_mod):
+                self.mask_mod = mask_mod
+
+        @torch.compile(backend="eager")
+        def fn(block_mask, x):
+            return block_mask.mask_mod(x)
+
+        # inner_fn captures inner_val, outer captures (outer_val, inner_fn)
+        # This creates: block_mask.mask_mod.__closure__[0].cell_contents.__closure__[0].cell_contents
+        bm1 = BlockMask(make_outer_fn(2, make_inner_fn(10)))
+        bm2 = BlockMask(make_outer_fn(2, make_inner_fn(20)))
+
+        fn(bm1, torch.ones(3))
+        fn(bm2, torch.ones(3))
+
+        record_str = "\n".join(r.getMessage() for r in records)
+        # The recompilation log should show the hint for the first closure variable
+        self.assertIn('[HINT: guard on "inner_val"]', record_str)
+        # Verify it shows the full nested path
+        self.assertIn("cell_contents.__closure__", record_str)
+
+    @make_logging_test(recompiles=True)
+    def test_recompiles_closure_variable_attribute_hint(self, records):
+        # Test when guard is on an attribute of the closure cell contents
+        # e.g., block_mask.mask_mod.__closure__[0].cell_contents.__code__
+        # The hint should still show which closure variable is involved
+        class Transform:
+            def __init__(self, scale):
+                self.scale = scale
+
+            def __call__(self, x):
+                return x * self.scale
+
+        def make_fn(transform):
+            def fn(x):
+                return transform(x)
+
+            return fn
+
+        @torch.compile(backend="eager")
+        def outer(inner_fn, x):
+            return inner_fn(x)
+
+        outer(make_fn(Transform(2)), torch.ones(3))
+        outer(make_fn(Transform(3)), torch.ones(3))  # transform.scale changes
+
+        record_str = "\n".join(r.getMessage() for r in records)
+        # The hint should show the full path from closure var: "transform".scale
+        self.assertIn('[HINT: guard on "transform".scale]', record_str)
 
     test_dynamo_debug = within_range_record_test(30, 90, dynamo=logging.DEBUG)
     test_dynamo_info = within_range_record_test(2, 10, dynamo=logging.INFO)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -121,6 +121,7 @@ from .source import (
     AttrSource,
     CallFunctionNoArgsSource,
     CallMethodItemSource,
+    CellContentsSource,
     ChainedSource,
     ClosureSource,
     CodeSource,
@@ -813,6 +814,7 @@ def get_verbose_code_parts(
     verbose_code_parts = [
         get_verbose_code_part(code_part, guard) for code_part in code_parts
     ]
+
     if recompile_hint:
         verbose_code_parts = [
             f"{part} (HINT: {recompile_hint})" for part in verbose_code_parts
@@ -1480,7 +1482,9 @@ class GuardBuilder(GuardBuilderBase):
                 example_value=example_value,
                 guard_manager_enum=guard_manager_enum,
             )
-        elif istype(source, (AttrSource, UnspecializedParamBufferSource)):
+        elif istype(
+            source, (AttrSource, CellContentsSource, UnspecializedParamBufferSource)
+        ):
             assert base_guard_manager  # to make mypy happy
             assert isinstance(source, AttrSource)
             if should_optimize_getattr_on_nn_module(base_example_value):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -828,7 +828,7 @@ def get_verbose_code_parts(
 
     if recompile_hint:
         verbose_code_parts = [
-            f"{part} [HINT: {recompile_hint}]" for part in verbose_code_parts
+            f"{part} (HINT: {recompile_hint})" for part in verbose_code_parts
         ]
 
     return verbose_code_parts
@@ -852,7 +852,6 @@ def _get_closure_var_hint(source: Optional[Source]) -> Optional[str]:
             #       suffix=".scale"
             path_suffix = full_name[len(current.name) :]
             return f'guard on "{current.freevar_name}"{path_suffix}'
-        # Walk up the chain following the standard pattern
         current = current.base if isinstance(current, ChainedSource) else None
     return None
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -88,6 +88,7 @@ from torch._dynamo.source import (
 )
 from torch._dynamo.utils import CompileEventLogger, get_metrics_context
 from torch._guards import (
+    ChainedSource,
     CompileContext,
     CompileId,
     DuplicateInputs,
@@ -815,17 +816,15 @@ def get_verbose_code_parts(
         get_verbose_code_part(code_part, guard) for code_part in code_parts
     ]
 
-    # For CellContentsSource, add a hint explaining which closure variable is being checked
-    # This helps users understand which closure variable caused the guard failure
-    if (
-        guard is not None
-        and isinstance(source := guard.originating_source, CellContentsSource)
-        and source.freevar_name
-    ):
-        closure_hint = f'{source.name} refers to "{source.freevar_name}" in user code'
-        recompile_hint = (
-            f"{closure_hint}, {recompile_hint}" if recompile_hint else closure_hint
-        )
+    # For CellContentsSource (or any source with a CellContentsSource ancestor),
+    # add a hint explaining which closure variable is being checked.
+    # This helps users understand which closure variable caused the guard failure.
+    if guard is not None:
+        closure_hint = _get_closure_var_hint(guard.originating_source)
+        if closure_hint:
+            recompile_hint = (
+                f"{closure_hint}, {recompile_hint}" if recompile_hint else closure_hint
+            )
 
     if recompile_hint:
         verbose_code_parts = [
@@ -833,6 +832,29 @@ def get_verbose_code_parts(
         ]
 
     return verbose_code_parts
+
+
+def _get_closure_var_hint(source: Optional[Source]) -> Optional[str]:
+    """
+    Walk up the source chain to find a CellContentsSource ancestor.
+    Returns a hint like 'guard on "varname".attr' or None if not found.
+    """
+    if source is None:
+        return None
+
+    full_name = source.name
+    current: Optional[Source] = source
+    while current is not None:
+        if isinstance(current, CellContentsSource) and current.freevar_name:
+            # Compute the path suffix by comparing names
+            # e.g., full_name="x.__closure__[0].cell_contents.scale"
+            #       current.name="x.__closure__[0].cell_contents"
+            #       suffix=".scale"
+            path_suffix = full_name[len(current.name) :]
+            return f'guard on "{current.freevar_name}"{path_suffix}'
+        # Walk up the chain following the standard pattern
+        current = current.base if isinstance(current, ChainedSource) else None
+    return None
 
 
 def convert_int_to_concrete_values(dim: Any) -> Optional[int]:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -815,22 +815,21 @@ def get_verbose_code_parts(
         get_verbose_code_part(code_part, guard) for code_part in code_parts
     ]
 
-    # For CellContentsSource, include the freevar_name in the hint
+    # For CellContentsSource, add a hint explaining which closure variable is being checked
     # This helps users understand which closure variable caused the guard failure
     if (
         guard is not None
         and isinstance(source := guard.originating_source, CellContentsSource)
         and source.freevar_name
     ):
+        closure_hint = f'{source.name} refers to "{source.freevar_name}" in user code'
         recompile_hint = (
-            f"{source.freevar_name}, {recompile_hint}"
-            if recompile_hint
-            else source.freevar_name
+            f"{closure_hint}, {recompile_hint}" if recompile_hint else closure_hint
         )
 
     if recompile_hint:
         verbose_code_parts = [
-            f"{part} (HINT: {recompile_hint})" for part in verbose_code_parts
+            f"{part} [HINT: {recompile_hint}]" for part in verbose_code_parts
         ]
 
     return verbose_code_parts

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -88,7 +88,6 @@ from torch._dynamo.source import (
 )
 from torch._dynamo.utils import CompileEventLogger, get_metrics_context
 from torch._guards import (
-    ChainedSource,
     CompileContext,
     CompileId,
     DuplicateInputs,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -815,6 +815,19 @@ def get_verbose_code_parts(
         get_verbose_code_part(code_part, guard) for code_part in code_parts
     ]
 
+    # For CellContentsSource, include the freevar_name in the hint
+    # This helps users understand which closure variable caused the guard failure
+    if (
+        guard is not None
+        and isinstance(source := guard.originating_source, CellContentsSource)
+        and source.freevar_name
+    ):
+        recompile_hint = (
+            f"{source.freevar_name}, {recompile_hint}"
+            if recompile_hint
+            else source.freevar_name
+        )
+
     if recompile_hint:
         verbose_code_parts = [
             f"{part} (HINT: {recompile_hint})" for part in verbose_code_parts

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -305,6 +305,32 @@ class AttrSource(ChainedSource):
 
 
 @dataclass_with_cached_hash(frozen=True)
+class CellContentsSource(AttrSource):
+    """
+    Source for closure cell contents that also stores the freevar name.
+    This allows guard failure messages to show which variable the closure cell refers to.
+    """
+
+    freevar_name: str = ""
+
+    def __post_init__(self) -> None:
+        # Don't call super().__post_init__() to avoid the member splitting logic
+        assert self.base, (
+            "Can't construct a CellContentsSource without a valid base source"
+        )
+        assert self.member == "cell_contents", (
+            "CellContentsSource should only be used for cell_contents"
+        )
+
+    @functools.cached_property
+    def name(self) -> str:
+        # Use the freevar name directly if available, for clearer guard messages
+        if self.freevar_name:
+            return self.freevar_name
+        return self._name_template.format(self.base.name)
+
+
+@dataclass_with_cached_hash(frozen=True)
 class GenericAttrSource(ChainedSource):
     member: str
 

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -311,23 +311,16 @@ class CellContentsSource(AttrSource):
     This allows guard failure messages to show which variable the closure cell refers to.
     """
 
-    freevar_name: str = ""
+    # freevar_name is only for display purposes and should not affect hash/equality
+    freevar_name: str = dataclasses.field(default="")
 
     def __post_init__(self) -> None:
-        # Don't call super().__post_init__() to avoid the member splitting logic
         assert self.base, (
             "Can't construct a CellContentsSource without a valid base source"
         )
         assert self.member == "cell_contents", (
             "CellContentsSource should only be used for cell_contents"
         )
-
-    @functools.cached_property
-    def name(self) -> str:
-        # Use the freevar name directly if available, for clearer guard messages
-        if self.freevar_name:
-            return self.freevar_name
-        return self._name_template.format(self.base.name)
 
 
 @dataclass_with_cached_hash(frozen=True)

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -311,7 +311,6 @@ class CellContentsSource(AttrSource):
     This allows guard failure messages to show which variable the closure cell refers to.
     """
 
-    # freevar_name is only for display purposes and should not affect hash/equality
     freevar_name: str = dataclasses.field(default="")
 
     def __post_init__(self) -> None:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -60,6 +60,7 @@ from ..exc import (
 from ..guards import GuardBuilder, install_guard
 from ..source import (
     AttrSource,
+    CellContentsSource,
     ClosureSource,
     CollectionsSource,
     ConstantSource,
@@ -547,7 +548,9 @@ class UserFunctionVariable(BaseUserFunctionVariable):
 
             elif source:
                 closure_cell = GetItemSource(ClosureSource(source), idx)
-                closure_cell_contents = AttrSource(closure_cell, "cell_contents")
+                closure_cell_contents = CellContentsSource(
+                    closure_cell, "cell_contents", freevar_name=name
+                )
                 try:
                     contents_var = VariableTracker.build(
                         parent, cell.cell_contents, closure_cell_contents


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172403


Fix https://github.com/pytorch/pytorch/issues/172382

  Before:
```python
Recompiling function fn in <string>:10
  triggered by the following guard failure(s):
  - 0/0: cl.__closure__[1].cell_contents == 1   # return x + n1 + n2  # <string>:6 in inner
```
  After:
```python
  Recompiling function fn in <string>:10
      triggered by the following guard failure(s):
      - 0/0: cl.__closure__[1].cell_contents == 1  # return x + n1 + n2  # <string>:6 in inner [HINT: guard on "n2"]

```
The key difference is the "(HINT: guard on "n2"])" at the end.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos