### PR TITLE
explicit dynamic shapes maps naming

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11761,7 +11761,7 @@ ShapeEnv not equal: field values don't match:
 ==> var_to_sources: values don't match.
   >  Left: {s44: [TensorPropertySource(base=ConstantSource(source_name='x'), prop=<TensorProperty.SIZE: 0>, idx=1)], s93: [TensorPropertySource(base=ConstantSource(source_name='x'), prop=<TensorProperty.SIZE: 0>, idx=0)]}
   > Right: {}
-==> var_to_val: values don't match.
+==> backed_var_to_val: values don't match.
   >  Left: {s44: 2, s93: 3}
   > Right: {}
 """,

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11740,6 +11740,9 @@ ShapeEnv not equal: field values don't match:
             """\
 ShapeEnv not equal: field values don't match:
 
+==> backed_var_to_val: values don't match.
+  >  Left: {s44: 2, s93: 3}
+  > Right: {}
 ==> name_to_node: values don't match.
   >  Left: {x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
   > Right: {}
@@ -11760,9 +11763,6 @@ ShapeEnv not equal: field values don't match:
   > Right: {}
 ==> var_to_sources: values don't match.
   >  Left: {s44: [TensorPropertySource(base=ConstantSource(source_name='x'), prop=<TensorProperty.SIZE: 0>, idx=1)], s93: [TensorPropertySource(base=ConstantSource(source_name='x'), prop=<TensorProperty.SIZE: 0>, idx=0)]}
-  > Right: {}
-==> backed_var_to_val: values don't match.
-  >  Left: {s44: 2, s93: 3}
   > Right: {}
 """,
         )

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1644,7 +1644,7 @@ class GraphModule(torch.nn.Module):
 
                 return DoubleSizeMaybeAddGeThreeTensor(out_inner)
 
-        curr_backed_var_to_val = None
+        curr_var_to_val = None
         curr_var_to_sources = None
         guards = None
 
@@ -1652,12 +1652,12 @@ class GraphModule(torch.nn.Module):
             context = torch._guards.TracingContext.get()
 
             # Grab info on sources and guards from the shapeenv
-            nonlocal curr_backed_var_to_val
+            nonlocal curr_var_to_val
             nonlocal curr_var_to_sources
             nonlocal guards
 
             guards = [str(g.expr) for g in context.fake_mode.shape_env.guards]
-            curr_backed_var_to_val = {
+            curr_var_to_val = {
                 str(k): v
                 for k, v in context.fake_mode.shape_env.backed_var_to_val.items()
             }
@@ -1681,7 +1681,7 @@ class GraphModule(torch.nn.Module):
         res = fn(x)  # noqa: F841
         # During fakeifying, we end up allocating a separate symint
         # for the outer and inner tensor (in this test, s0 is unused).
-        expected_backed_var_to_val = {
+        expected_var_to_val = {
             "s50": 4,
             "s77": 8,
         }
@@ -1689,7 +1689,7 @@ class GraphModule(torch.nn.Module):
             "s50": "L['x'].inner_elem.size()[0]",
             "s77": "L['x'].size()[0]",
         }
-        self.assertEqual(curr_backed_var_to_val, expected_backed_var_to_val)
+        self.assertEqual(curr_var_to_val, expected_var_to_val)
         self.assertEqual(curr_var_to_sources, expected_var_to_sources)
         self.assertExpectedInline(
             "\n".join(guards),

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1644,7 +1644,7 @@ class GraphModule(torch.nn.Module):
 
                 return DoubleSizeMaybeAddGeThreeTensor(out_inner)
 
-        curr_var_to_val = None
+        curr_backed_var_to_val = None
         curr_var_to_sources = None
         guards = None
 
@@ -1652,13 +1652,14 @@ class GraphModule(torch.nn.Module):
             context = torch._guards.TracingContext.get()
 
             # Grab info on sources and guards from the shapeenv
-            nonlocal curr_var_to_val
+            nonlocal curr_backed_var_to_val
             nonlocal curr_var_to_sources
             nonlocal guards
 
             guards = [str(g.expr) for g in context.fake_mode.shape_env.guards]
-            curr_var_to_val = {
-                str(k): v for k, v in context.fake_mode.shape_env.var_to_val.items()
+            curr_backed_var_to_val = {
+                str(k): v
+                for k, v in context.fake_mode.shape_env.backed_var_to_val.items()
             }
             curr_var_to_sources = {
                 str(k): v[0].name
@@ -1680,7 +1681,7 @@ class GraphModule(torch.nn.Module):
         res = fn(x)  # noqa: F841
         # During fakeifying, we end up allocating a separate symint
         # for the outer and inner tensor (in this test, s0 is unused).
-        expected_var_to_val = {
+        expected_backed_var_to_val = {
             "s50": 4,
             "s77": 8,
         }
@@ -1688,7 +1689,7 @@ class GraphModule(torch.nn.Module):
             "s50": "L['x'].inner_elem.size()[0]",
             "s77": "L['x'].size()[0]",
         }
-        self.assertEqual(curr_var_to_val, expected_var_to_val)
+        self.assertEqual(curr_backed_var_to_val, expected_backed_var_to_val)
         self.assertEqual(curr_var_to_sources, expected_var_to_sources)
         self.assertExpectedInline(
             "\n".join(guards),

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -9387,7 +9387,7 @@ class TestHopSchema(TestCase):
             symbol = shape_env.create_symbol(
                 val,
                 source=ConstantSource(
-                    f"__testing_hop_schema{len(shape_env.var_to_val)}"
+                    f"__testing_hop_schema{len(shape_env.backed_var_to_val)}"
                 ),
             )
             return cls(SymNode(symbol, shape_env, pytype, hint=val))

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -218,7 +218,7 @@ def create_symtype(cls, pytype, shape_env, val, duck=True, **kwargs):
 
     symbol = shape_env.create_symbol(
         val,
-        source=ConstantSource(f"__testing_only{len(shape_env.var_to_val)}"),
+        source=ConstantSource(f"__testing_only{len(shape_env.backed_var_to_val)}"),
         dynamic_dim=DimDynamic.DUCK if duck else DimDynamic.DYNAMIC,
         constraint_dim=None,
         **kwargs,
@@ -714,7 +714,7 @@ def forward(self, x_1):
     def test_data_dependent_guard_propagate_real_tensors(self):
         shape_env = ShapeEnv()
         s0 = shape_env.create_unbacked_symint()
-        shape_env.set_unbacked_var_to_val(s0.node.expr, 0)
+        shape_env.set_real_tensor_prop_unbacked_vals(s0.node.expr, 0)
         self.assertEqual(bool(s0 == 0), True)
 
     def test_expect_true_basic(self):
@@ -2202,10 +2202,10 @@ class TestDimConstraints(TestCase):
             s5: [src5, src8],
             s6: [src6, src9, src10],
         }
-        var_to_val = {s0: 8, s1: 96, s5: 22, s6: 21}
+        backed_var_to_val = {s0: 8, s1: 96, s5: 22, s6: 21}
         marked_dynamic = {s0, s1, s5, s6}
         dim_constraints = DimConstraints(
-            symbol_to_source, var_to_val, marked_dynamic, {}
+            symbol_to_source, backed_var_to_val, marked_dynamic, {}
         )
         dim_constraints.add_equality(src2, s0)
         dim_constraints.add_equality(src3, s0)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -2202,10 +2202,10 @@ class TestDimConstraints(TestCase):
             s5: [src5, src8],
             s6: [src6, src9, src10],
         }
-        backed_var_to_val = {s0: 8, s1: 96, s5: 22, s6: 21}
+        var_to_val = {s0: 8, s1: 96, s5: 22, s6: 21}
         marked_dynamic = {s0, s1, s5, s6}
         dim_constraints = DimConstraints(
-            symbol_to_source, backed_var_to_val, marked_dynamic, {}
+            symbol_to_source, var_to_val, marked_dynamic, {}
         )
         dim_constraints.add_equality(src2, s0)
         dim_constraints.add_equality(src3, s0)

--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -366,7 +366,7 @@ def forward(self):
         index = 2
         shape_env = ShapeEnv()
         symbol = shape_env.create_symbol(index, source=ConstantSource(
-            f"__testing_only{len(shape_env.var_to_val)}"))
+            f"__testing_only{len(shape_env.backed_var_to_val)}"))
         sym_index = torch.SymInt(SymNode(symbol, shape_env, int, hint=index))
 
         inpt = [x, sym_index]

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -990,7 +990,7 @@ def _get_node(fx_g, cond):
     raise AssertionError
 
 def _get_free_symbols(shape_env):
-    vars = tuple(shape_env.var_to_val.keys())
+    vars = tuple(shape_env.backed_var_to_val.keys())
     return len([var for var in vars if var not in shape_env.replacements])
 
 def _trace(f, *args):
@@ -1916,7 +1916,7 @@ L['a'].size()[1] <= 18""")
         self.assertEqual(fx_g(*inp), f(*inp))
 
     def _assert_no_guards(self, fx_g, free_symbols):
-        assert _get_free_symbols(fx_g.shape_env) == free_symbols, fx_g.shape_env.var_to_val
+        assert _get_free_symbols(fx_g.shape_env) == free_symbols, fx_g.shape_env.backed_var_to_val
         assert len(fx_g.shape_env.get_nontrivial_guards()) == 0, fx_g.shape_env.format_guards()
 
     def test_guards_equal(self):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3462,12 +3462,12 @@ def get_concrete_sizes_from_symints(
     pattern = r"\(s(\d+)\)"
     assert fake_mode.shape_env is not None
     shape_env = fake_mode.shape_env
-    var_to_val = shape_env.var_to_val
+    backed_var_to_val = shape_env.backed_var_to_val
 
     def replace_sym(match: Any) -> str:
         sym_name = f"s{match.group(1)}"
         val = next(
-            (v for k, v in var_to_val.items() if k.name == sym_name),
+            (v for k, v in backed_var_to_val.items() if k.name == sym_name),
             None,
         )
         if isinstance(val, (int, Integer)):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2147,8 +2147,8 @@ class GraphModuleDeserializer(metaclass=Final):
                     ):
                         self.unbacked_symbols.add(sym)
                 # hints
-                if hint is not None and sym not in self.shape_env.var_to_val:
-                    self.shape_env.add_var_to_val(sym, hint)  # type: ignore[arg-type]
+                if hint is not None and sym not in self.shape_env.backed_var_to_val:
+                    self.shape_env.add_backed_var_to_val(sym, hint)  # type: ignore[arg-type]
                 # ValueRanges
                 if vr := self.symbol_name_to_range.get(expr_str):
                     self.shape_env.constrain_symbol_range(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2290,7 +2290,7 @@ class PythonWrapperCodegen(CodeGen):
 
             for name, value in V.graph.graph_inputs.items():
                 if isinstance(value, sympy.Symbol) and isinstance(
-                    V.graph.sizevars.var_to_val.get(value, None), SingletonInt
+                    V.graph.sizevars.backed_var_to_val.get(value, None), SingletonInt
                 ):
                     # Inductor should only work with dense -> dense graph, and
                     # SingletonInts belong to metadata that should only live on

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -554,7 +554,7 @@ class GraphLowering(torch.fx.Interpreter):
             # create_symbolic_sizes_strides_storage_offset but we hope we can
             # just delete this entirely
             source = ConstantSource(
-                f"__inductor_unknown_tensor_{len(self._shape_env.var_to_val)}"
+                f"__inductor_unknown_tensor_{len(self._shape_env.backed_var_to_val)}"
             )
             (
                 size,

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -77,7 +77,7 @@ class SizeVarAllocator:
         if shape_env is None:
             shape_env = ShapeEnv()
         self.shape_env = shape_env
-        self.var_to_val = self.shape_env.var_to_val
+        self.backed_var_to_val = self.shape_env.backed_var_to_val
         self.var_to_hint_override = self.shape_env.var_to_hint_override
         self.replacements: dict[sympy.Symbol, Expr] = self.shape_env.replacements
         self.unbacked_replacements: Optional[dict[Expr, Expr]] = None
@@ -590,7 +590,7 @@ class SizeVarAllocator:
         if use_user_provided_hint_override:
             expr = sympy_subs(expr, self.var_to_hint_override)
 
-        return sympy_subs(expr, self.var_to_val)
+        return sympy_subs(expr, self.backed_var_to_val)
 
     def size_hint(
         self,
@@ -983,7 +983,9 @@ class SizeVarAllocator:
         return self.precomputed_replacements[expr]
 
     def free_symbols(self) -> OrderedSet[sympy.Symbol]:
-        return OrderedSet(self.var_to_val.keys()) - OrderedSet(self.replacements.keys())
+        return OrderedSet(self.backed_var_to_val.keys()) - OrderedSet(
+            self.replacements.keys()
+        )
 
     def combine_modular_indexing_pairs(self, index: sympy.Expr) -> sympy.Expr:
         """

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2228,8 +2228,8 @@ class FakeTensorMode(TorchDispatchMode):
                     )
                 if (
                     not fake.node.expr.free_symbols
-                    - self.shape_env.var_to_val.keys()
-                    - self.shape_env.unbacked_var_to_val.keys()
+                    - self.shape_env.backed_var_to_val.keys()
+                    - self.shape_env.real_tensor_prop_unbacked_vals.keys()
                 ):
                     if (
                         self.shape_env._maybe_evaluate_static(
@@ -2588,8 +2588,8 @@ class FakeTensorMode(TorchDispatchMode):
                         "self.shape_env must not be None for symbolic types"
                     )
                 return t.node.pytype(
-                    t.node.expr.xreplace(self.shape_env.var_to_val).xreplace(
-                        self.shape_env.unbacked_var_to_val
+                    t.node.expr.xreplace(self.shape_env.backed_var_to_val).xreplace(
+                        self.shape_env.real_tensor_prop_unbacked_vals
                     )
                 )
             elif isinstance(t, FakeScriptObject):
@@ -2613,7 +2613,10 @@ class FakeTensorMode(TorchDispatchMode):
                     isinstance(a, py_sym_types)
                     and (syms := free_unbacked_symbols(a))
                     and self.shape_env is not None
-                    and any(s not in self.shape_env.unbacked_var_to_val for s in syms)
+                    and any(
+                        s not in self.shape_env.real_tensor_prop_unbacked_vals
+                        for s in syms
+                    )
                 )
                 for a in flat_args
             )
@@ -2656,7 +2659,9 @@ class FakeTensorMode(TorchDispatchMode):
                 func,
                 flat_arg_fake_tensors,
                 flat_args,
-                self.shape_env.unbacked_var_to_val if self.shape_env else None,
+                self.shape_env.real_tensor_prop_unbacked_vals
+                if self.shape_env
+                else None,
             )
 
         def maybe_propagate_real_tensors(fake_out: T) -> T:
@@ -2682,7 +2687,9 @@ class FakeTensorMode(TorchDispatchMode):
                             raise AssertionError(
                                 "self.shape_env must not be None for symbolic Symbol"
                             )
-                        self.shape_env.set_unbacked_var_to_val(t.node.expr, real_t)
+                        self.shape_env.set_real_tensor_prop_unbacked_vals(
+                            t.node.expr, real_t
+                        )
                     elif (
                         isinstance(s := t.node.expr, sympy.Eq)
                         and isinstance(s.lhs, sympy.Symbol)
@@ -2693,7 +2700,9 @@ class FakeTensorMode(TorchDispatchMode):
                                 "self.shape_env must not be None for symbolic Eq"
                             )
 
-                        self.shape_env.set_unbacked_var_to_val(s, int(real_t))
+                        self.shape_env.set_real_tensor_prop_unbacked_vals(
+                            s, int(real_t)
+                        )
 
             if real_out is not nil:
                 # cross check fake/real outputs, and optionally override fake kernel mismatches
@@ -2715,7 +2724,7 @@ class FakeTensorMode(TorchDispatchMode):
                         real_out,
                     )
 
-                # populate unbacked_var_to_val
+                # populate real_tensor_prop_unbacked_vals
                 if (
                     not isinstance(fake_out, Tensor)
                     and not isinstance(real_out, Tensor)

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -213,7 +213,7 @@ class SymNode:
                 replacements = {
                     s: fallback
                     if s in unbacked_symbols
-                    else self.shape_env.var_to_val[s]
+                    else self.shape_env.backed_var_to_val[s]
                     for s in self.expr.free_symbols
                 }
                 return int(self.expr.xreplace(replacements))

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -374,7 +374,7 @@ def tensorify_python_scalars(
     # symfloat and thus we need to deduce specializations have happened
     # via shape_env.replacements. NB: there's an important invariant here
     # that symfloats keep consistent names across restarts.
-    for k, v in shape_env.var_to_val.items():
+    for k, v in shape_env.backed_var_to_val.items():
         if symbol_is_type(k, SymT.FLOAT) and isinstance(v, sympy.core.numbers.Float):
             name = str(k)
             if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172533
* #172490
* #172429
* __->__ #172405

- this map only used for backed. 
var_to_val -> backed_var_to_val

-  this map only used for real tensor prop
unbacked_var_to_val -> real_tensor_prop_unbacked_vals

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela