### PR TITLE
Fix MPS Inductor for tanh implementation

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -62,6 +62,28 @@ class MPSBasicTests(TestCase):
     def test_atanh(self):
         self.common(lambda x: x.atanh(), (torch.rand(1024),))
 
+    def test_tanh(self):
+        self.common(lambda x: x.tanh(), (torch.rand(1024),))
+
+    def test_tanh_large_values(self):
+        # Test that tanh handles large values correctly (should saturate to ±1)
+        x = torch.tensor([-100.0, -50.0, -15.0, 0.0, 15.0, 50.0, 100.0], device="mps")
+
+        @torch.compile
+        def fn(x):
+            return x.tanh()
+
+        result = fn(x)
+        assert torch.allclose(result[0], torch.tensor(-1.0, device="mps")), (
+            "tanh(-100) should be -1"
+        )
+        assert torch.allclose(result[-1], torch.tensor(1.0, device="mps")), (
+            "tanh(100) should be +1"
+        )
+        assert not torch.isnan(result).any(), (
+            "tanh should not produce NaN for large values"
+        )
+
     def test_floor(self):
         self.common(lambda x: x.floor(), (torch.rand(1024),))
 
@@ -187,6 +209,23 @@ class MPSBasicTestsAOTI(TestCase):
         inp = (torch.ones(3, 3, device="mps"), torch.ones(3, 3, device="mps"))
         m = M().to("mps")
         self.check_model(m, inp)
+
+    def test_tanh_codegen(self):
+        # Verify that tanh uses metal::precise::tanh in generated Metal shader
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.tanh()
+
+        example_inputs = (torch.randn(1024, device="mps"),)
+        model = Model()
+
+        ep = torch.export.export(model, example_inputs)
+        package_path = torch._export.aot_compile(ep.module(), example_inputs)
+
+        with open(os.path.splitext(package_path)[0] + ".cpp") as cpp:
+            src_code = cpp.read()
+            # Verify metal::precise::tanh is used (not clamped version)
+            FileCheck().check("metal::precise::tanh").run(src_code)
 
     def test_fallback_mps(self):
         class M(torch.nn.Module):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -320,7 +320,7 @@ class MetalOverrides(OpOverrides):
 
     @staticmethod
     def tanh(x: CSEVariable) -> str:
-        return f"metal::tanh({x})"
+        return f"metal::precise::tanh({x})"
 
     @staticmethod
     def atanh(x: CSEVariable) -> str:


### PR DESCRIPTION
When running the Parakeet TDT (speech recognition) model with the Metal/MPS backend via TorchInductor AOTI, the model produces NaN values deterministically after exactly 101 LSTM iterations.

Root Cause: 

Metal's tanh() implementation doesn't handle large values well. For large inputs (|x| > ~44), exp(x) overflows, causing the division to produce a quiet NaN (0x7fc00000). 

In the Parakeet model's decoder LSTM, the cell state at one position grows linearly (~1.0 per iteration) due to the learned weights (forget gate ≈ 0.9999). After ~100 iterations, the cell state reaches ~44, and tanh(c_new) in the LSTM's h = o * tanh(c) computation returns NaN.

Fix: 

Use metal::precise::tanh() which provides a more numerically stable implementation. This is similar to MLX implementation in https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/unary_ops.h#L413


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo