### PR TITLE
[ROCm] Re-enable test_cdist_large on MI300X

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -35,9 +35,9 @@ from torch.testing._internal.common_optimizers import (
     optim_db, optims, _get_optim_inputs_including_global_cliquey_kwargs)
 
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
-    MI300_ARCH, TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, run_tests, IS_JETSON,
+    TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, run_tests, IS_JETSON,
     IS_FILESYSTEM_UTF8_ENCODING,
-    IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
+    IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
     skipIfCrossRef, TEST_WITH_CROSSREF, skipIfTorchDynamo, skipRocmIfTorchInductor, set_default_dtype,
     skipCUDAMemoryLeakCheckIf, BytesIOContext,
     skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
@@ -2488,7 +2488,6 @@ class TestTorchDeviceType(TestCase):
                         self.assertEqual(x1.grad, x2.grad, rtol=0, atol=0.001)
                         self.assertEqual(y1.grad, y2.grad, rtol=0, atol=0.001)
 
-    @skipIfRocmArch(MI300_ARCH)
     @tf32_on_and_off(0.005)
     @reduced_f32_on_and_off(0.08)
     def test_cdist_large(self, device):


### PR DESCRIPTION
## Summary
Re-enable test_cdist_large on MI300X by removing stale skip decorator.

Fixes #168867

## Problem
Test was skipped on MI300X with `@skipIfRocmArch(MI300_ARCH)`, but it now passes.

## Fix
Remove the `@skipIfRocmArch(MI300_ARCH)` decorator.

## Hardware Verification
- **GPU:** AMD Instinct MI300X (gfx942)
- **ROCm:** 7.0
- **Stability:** 3/3 runs passed

```
test_cdist_large_cuda ... ok
Ran 4 tests in 7.260s
OK (skipped=2)
```

## Test Plan
- [x] Verified test passes on MI300X (3 runs)
- [x] No flakiness observed

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang