### PR TITLE
[ROCm] Re-enable test_rnn_fused on MI300X

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9578,7 +9578,6 @@ class TestNNDeviceType(NNTestCase):
             unfold(inp)
 
     @onlyCUDA
-    @skipIfRocmArch(MI300_ARCH)
     @dtypes(torch.float, torch.double)
     @tf32_on_and_off(0.005)
     def test_rnn_fused(self, device, dtype):


### PR DESCRIPTION
## Summary
Remove stale `@skipIfRocmArch(MI300_ARCH)` decorator from `test_rnn_fused` as this test now passes on MI300X.

Fixes #168805

## Problem
`test_rnn_fused` was disabled on MI300X (gfx942) architecture but now passes consistently.

## Hardware Verification
- **GPU:** AMD Instinct MI300X (gfx942)
- **ROCm:** 6.3
- **PyTorch:** 2.9.0.dev (release/2.9 branch)

**Test Results (3 runs, all pass):**
```
Run 1: PASSED (0.61s)
Run 2: PASSED (0.55s)  
Run 3: PASSED (0.55s)
```

## Test Plan
- [x] Verified test passes on MI300X (3/3 runs)
- [x] No flakiness observed
- [ ] CI passing

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @pytorch/pytorch-rocm