### PR TITLE
[ROCm] Re-enable test_variable_sequence on MI300X

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12062,7 +12062,6 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "log_probs tensor must not be empty"):
             F.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
 
-    @skipIfRocmArch(MI300_ARCH)
     @expectedFailureMPS  # RuntimeError: LSTM with projections is not currently supported with MPS.
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)


### PR DESCRIPTION
## Summary
Remove stale `@skipIfRocmArch(MI300_ARCH)` decorator from `test_variable_sequence` as this test now passes on MI300X.

Fixes #168811

## Problem
`test_variable_sequence` was disabled on MI300X (gfx942) architecture but now passes consistently.

## Hardware Verification
- **GPU:** AMD Instinct MI300X (gfx942)
- **ROCm:** 6.3
- **PyTorch:** 2.9.0.dev (release/2.9 branch)

**Test Results (3 runs, all pass):**
```
Run 1: PASSED (3.55s)
Run 2: PASSED (3.35s)
Run 3: PASSED (3.35s)
```

## Test Plan
- [x] Verified test passes on MI300X (3/3 runs)
- [x] No flakiness observed
- [ ] CI passing

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @pytorch/pytorch-rocm