### PR TITLE
[vLLM] Install deep_gemm

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -102,6 +102,7 @@ jobs:
             dist/vision/torchvision-*.whl \
             dist/audio/torchaudio-*.whl \
             dist/vllm/vllm-*.whl \
+            dist/deepgemm/deep_gemm-*.whl \
             --extra-index-url https://download.pytorch.org/whl/cu129 \
             --index-strategy unsafe-best-match
 

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -99,6 +99,13 @@ jobs:
           mkdir -p dist/vllm
           mv vllm-project/vllm/dist/*.whl dist/vllm
 
+      - name: Build DeepGEMM
+        working-directory: vllm-project/vllm
+        shell: bash
+        run: |
+          set -eux
+          bash tools/install_deepgemm.sh --wheel-dir ../dist/deepgemm
+
       - name: Archive artifacts into zip
         run: |
           zip -1 -r artifacts.zip dist/

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         run: |
           set -eux
-          bash tools/install_deepgemm.sh --wheel-dir ../dist/deepgemm
+          bash tools/install_deepgemm.sh --wheel-dir ../../dist/deepgemm
 
       - name: Archive artifacts into zip
         run: |

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -104,7 +104,12 @@ jobs:
         shell: bash
         run: |
           set -eux
-          bash tools/install_deepgemm.sh --wheel-dir ../../dist/deepgemm
+
+          # The install_deepgemm script from vLLM only works with abs path
+          DEEPGEMM_WHEEL_DIR=$(realpath ../../dist/deepgemm)
+          mkdir -p "${DEEPGEMM_WHEEL_DIR}"
+
+          bash tools/install_deepgemm.sh --wheel-dir "${DEEPGEMM_WHEEL_DIR}"
 
       - name: Archive artifacts into zip
         run: |


### PR DESCRIPTION
vLLM benchmark of DeepSeek v3.2 model is failing because PyTorch CI doesn't have its DeepGEMM dependency, e.g. https://github.com/pytorch/pytorch/actions/runs/20958567907/job/60237488203#step:15:24311. This is only an optional dependency of vLLM, so we need to be built and installed ourselves.  I use the same `tools/install_deepgemm.sh` script from vLLM, so no code duplication here.

### Testing

https://github.com/pytorch/pytorch/actions/runs/21276268156