### PR TITLE
[xpu][fix] Skip test_fx_memory_profiler_augmentation when using expandable segments

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -924,6 +924,10 @@ if __name__ == "__main__":
                 f = self.net2(e)
                 return f
 
+        if self.expandable_segments:
+            self.skipTest(
+                "Requires driver update to fix oneDNN primitive operations when using expandable segments."
+            )
         mod = MLPModule()
         gc.collect()
         torch.xpu.memory.empty_cache()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172418

# Motivation
The root cause is that current driver would cause oneDNN primitive operations failed when using expandable segments. It would be fix in the next driver release.

# Additional Context

Fix https://github.com/pytorch/pytorch/issues/172202

