### PR TITLE
Enable DTensors for PP

### DIFF
--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -247,10 +247,12 @@ class CustomLinearDx(Function):
     def backward(ctx, grad_output):
         input_val, weight, _ = ctx.saved_tensors
         grad_input = grad_output.mm(weight)
-        ctx.module.cached_context[ctx.layer_idx].append(grad_output.clone())
-        ctx.module.cached_context[str(ctx.layer_idx) + "_input"].append(
-            input_val.clone()
-        )
+        # Skip caching for metadata inference (meta device tensors)
+        if grad_output.device.type != "meta":
+            ctx.module.cached_context[ctx.layer_idx].append(grad_output.clone())
+            ctx.module.cached_context[str(ctx.layer_idx) + "_input"].append(
+                input_val.clone()
+            )
         return grad_input, None, None, None, None
 
 

--- a/test/distributed/pipelining/test_dtensor_pp_integration.py
+++ b/test/distributed/pipelining/test_dtensor_pp_integration.py
@@ -1,0 +1,838 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+
+from __future__ import annotations
+
+import copy
+import functools
+from typing import cast, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.pipelining._utils import _DTensorMeta
+from torch.distributed.pipelining.schedules import (
+    Schedule1F1B,
+    ScheduleDualPipeV,
+    ScheduleInterleaved1F1B,
+    ScheduleZBVZeroBubble,
+)
+from torch.distributed.pipelining.stage import PipelineStage
+from torch.distributed.tensor import DTensor, Replicate, Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    RowwiseParallel,
+    SequenceParallel,
+)
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_accelerator_dist_backend,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+d_hid = 256
+batch_size = 64
+n_microbatches = 4
+
+StageStaticMeta = tuple[DTensor, DTensor, DTensor | None, DTensor | None]
+StageStaticMetaMap = dict[int, StageStaticMeta]
+
+MODEL_SEED = 0
+INPUT_SEED = 42
+TARGET_SEED = 123
+
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = dist.get_default_backend_for_device(device_type)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def reset_parameters(self) -> None:
+        torch.nn.init.ones_(self.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return (
+            x
+            * torch.rsqrt(x.float().pow(2).mean(-1, keepdim=True) + self.eps)
+            * self.weight
+        )
+
+
+class NormMLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.norm = RMSNorm(dim)
+        self.fc1 = nn.Linear(dim, 4 * dim, bias=False)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(4 * dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(self.norm(x))))
+
+
+class NormMLPStack(nn.Module):
+    def __init__(self, dim: int, n_layers: int):
+        super().__init__()
+        self.layers = nn.ModuleList([NormMLP(dim) for _ in range(n_layers)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def apply_tp_replicate(block: NormMLP, tp_mesh: DeviceMesh) -> None:
+    parallelize_module(
+        block,
+        tp_mesh,
+        {
+            "fc1": ColwiseParallel(input_layouts=Replicate(), use_local_output=False),
+            "fc2": RowwiseParallel(output_layouts=Replicate(), use_local_output=False),
+        },
+    )
+    for name, param in block.norm.named_parameters():
+        block.norm.register_parameter(
+            name,
+            nn.Parameter(
+                DTensor.from_local(param, tp_mesh, [Replicate()], run_check=False)
+            ),
+        )
+
+
+def apply_tp_shard(block: NormMLP, tp_mesh: DeviceMesh) -> None:
+    parallelize_module(
+        block,
+        tp_mesh,
+        {
+            "norm": SequenceParallel(use_local_output=False),
+            "fc1": ColwiseParallel(
+                input_layouts=Shard(1),
+                use_local_output=False,  # type: ignore[arg-type]
+            ),
+            "fc2": RowwiseParallel(
+                output_layouts=Shard(1),
+                use_local_output=False,  # type: ignore[arg-type]
+            ),
+        },
+    )
+
+
+def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return (output - target).pow(2).mean()
+
+
+def _requires_multi_gpu(func):
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class DTensorPPIntegrationBase(MultiProcContinuousTest):
+    world_size = 4
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return backend
+
+    @classmethod
+    def device_type(cls) -> str:
+        return device_type
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    def init_pg(self) -> None:
+        if device_type == "cuda":
+            torch.cuda.set_device(self.device)
+
+    def _make_mesh(self) -> DeviceMesh:
+        return init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))
+
+    def _build_baseline_and_clones(
+        self,
+        n_layers: int,
+        tp_mesh: DeviceMesh,
+        apply_tp: Callable,
+    ) -> tuple[NormMLPStack, NormMLPStack]:
+        torch.manual_seed(MODEL_SEED)
+        baseline = NormMLPStack(d_hid, n_layers)
+
+        ref_model = copy.deepcopy(baseline).to(self.device)
+        pp_model = copy.deepcopy(baseline).to(self.device)
+
+        for layer in ref_model.layers:
+            apply_tp(layer, tp_mesh)
+        for layer in pp_model.layers:
+            apply_tp(layer, tp_mesh)
+
+        return ref_model, pp_model
+
+    def _make_full_batch_tensors(self) -> tuple[torch.Tensor, torch.Tensor]:
+        torch.manual_seed(INPUT_SEED)
+        input_full = torch.randn(batch_size, d_hid, device="cpu").to(self.device)
+        torch.manual_seed(TARGET_SEED)
+        target_full = torch.randn(batch_size, d_hid, device="cpu").to(self.device)
+        return input_full, target_full
+
+    def _wrap_full_tensor_as_dtensor(
+        self,
+        tensor: torch.Tensor,
+        tp_mesh: DeviceMesh,
+        placements: list,
+    ) -> DTensor:
+        tp_rank = tp_mesh.get_local_rank()
+        tp_size = tp_mesh.size()
+
+        if len(placements) != 1:
+            raise ValueError(f"Expected single placement, got {placements}")
+
+        placement = placements[0]
+        if isinstance(placement, Replicate):
+            local = tensor
+        elif isinstance(placement, Shard):
+            local = tensor.chunk(tp_size, dim=placement.dim)[tp_rank].contiguous()
+        else:
+            raise ValueError(f"Unsupported placement: {placement}")
+
+        return DTensor.from_local(
+            local,
+            tp_mesh,
+            placements,
+            shape=tensor.shape,
+            stride=tensor.stride(),
+            run_check=False,
+        )
+
+    def _make_presharded_input_dtensor(
+        self,
+        input_full: torch.Tensor,
+        tp_mesh: DeviceMesh,
+    ) -> DTensor:
+        tp_rank = tp_mesh.get_local_rank()
+        local_shard = input_full.chunk(tp_mesh.size(), dim=1)[tp_rank].contiguous()
+        return DTensor.from_local(
+            local_shard,
+            tp_mesh,
+            [Shard(1)],
+            shape=input_full.shape,
+            stride=input_full.stride(),
+            run_check=False,
+        )
+
+    def _make_pp_input_dtensor(
+        self,
+        input_full: torch.Tensor,
+        tp_mesh: DeviceMesh,
+        placements: list,
+        use_presharded: bool,
+    ) -> DTensor:
+        if use_presharded:
+            return self._make_presharded_input_dtensor(input_full, tp_mesh)
+        return self._wrap_full_tensor_as_dtensor(input_full, tp_mesh, placements)
+
+    def _run_reference_microbatched(
+        self,
+        ref_model: NormMLPStack,
+        input_dt: DTensor,
+        target_dt: DTensor,
+        *,
+        null_boundary_grads: bool = True,
+    ) -> tuple[
+        dict[str, torch.Tensor | None],
+        StageStaticMetaMap,
+    ]:
+        ref_model.zero_grad(set_to_none=True)
+
+        input_chunks = torch.tensor_split(input_dt, n_microbatches)
+        target_chunks = torch.tensor_split(target_dt, n_microbatches)
+
+        captured_io: dict[int, tuple[DTensor, DTensor]] = {}
+        hooks: list[torch.utils.hooks.RemovableHandle] = []
+
+        for stage_idx, stage_mod in enumerate(ref_model.layers):
+
+            def _capture_io(
+                _module: nn.Module,
+                args: tuple[torch.Tensor, ...],
+                output: torch.Tensor,
+                *,
+                idx: int = stage_idx,
+            ) -> None:
+                stage_input = cast(DTensor, args[0])
+                stage_output = cast(DTensor, output)
+                if stage_input.requires_grad:
+                    stage_input.retain_grad()
+                if stage_output.requires_grad:
+                    stage_output.retain_grad()
+                captured_io[idx] = (stage_input, stage_output)
+
+            hooks.append(stage_mod.register_forward_hook(_capture_io))
+
+        static_stage_meta: StageStaticMetaMap = {}
+
+        for mb_idx, (input_chunk, target_chunk) in enumerate(
+            zip(input_chunks, target_chunks)
+        ):
+            output = ref_model(input_chunk)
+            loss = _loss_fn(output, target_chunk)
+            loss.backward()
+
+            if mb_idx == 0:
+                for stage_idx in range(len(ref_model.layers)):
+                    stage_input, stage_output = captured_io[stage_idx]
+                    input_args = self._empty_dt_from(
+                        stage_input,
+                        stage_input.requires_grad,
+                    )
+                    output_args = self._empty_dt_from(
+                        stage_output,
+                        stage_output.requires_grad,
+                    )
+                    input_grads = (
+                        self._empty_dt_from(cast(DTensor, stage_input.grad), False)
+                        if stage_input.grad is not None
+                        else None
+                    )
+                    output_grads = (
+                        self._empty_dt_from(cast(DTensor, stage_output.grad), False)
+                        if stage_output.grad is not None
+                        else None
+                    )
+
+                    if null_boundary_grads:
+                        if stage_idx == 0:
+                            input_grads = None
+                        if stage_idx == (len(ref_model.layers) - 1):
+                            output_grads = None
+
+                    static_stage_meta[stage_idx] = (
+                        input_args,
+                        output_args,
+                        input_grads,
+                        output_grads,
+                    )
+
+                for hook in hooks:
+                    hook.remove()
+                hooks = []
+
+        for param in ref_model.parameters():
+            if param.grad is not None:
+                param.grad.div_(n_microbatches)
+
+        ref_grads = {
+            name: grad.clone() if grad is not None else grad
+            for name, grad in (
+                (param_name, param.grad)
+                for param_name, param in ref_model.named_parameters()
+            )
+        }
+        return ref_grads, static_stage_meta
+
+    def _empty_dt_from(self, dt: DTensor, requires_grad: bool) -> DTensor:
+        meta = _DTensorMeta.from_dtensor(dt)
+        empty_local = torch.empty(meta.shape, dtype=meta.dtype, device=self.device)
+        result = DTensor.from_local(
+            empty_local,
+            dt.device_mesh,
+            list(meta.placements),
+            shape=meta.global_shape,
+            stride=meta.global_stride,
+            run_check=False,
+        )
+        if requires_grad:
+            result.requires_grad_(True)
+        return result
+
+    def _make_stage_for_pp_run(
+        self,
+        pp_model: NormMLPStack,
+        stage_index: int,
+        num_stages: int,
+        pp_group: dist.ProcessGroup,
+        tp_mesh: DeviceMesh,
+        static_stage_meta: StageStaticMetaMap | None,
+    ) -> PipelineStage:
+        stage_module = pp_model.get_submodule(f"layers.{stage_index}")
+        if static_stage_meta is None:
+            return PipelineStage(
+                submodule=stage_module,
+                stage_index=stage_index,
+                num_stages=num_stages,
+                device=self.device,
+                group=pp_group,
+                get_mesh=lambda _dim_names, _layout: tp_mesh,
+            )
+
+        input_args, output_args, input_grads, output_grads = static_stage_meta[
+            stage_index
+        ]
+
+        return PipelineStage(
+            submodule=stage_module,
+            stage_index=stage_index,
+            num_stages=num_stages,
+            device=self.device,
+            group=pp_group,
+            input_args=(input_args,),
+            output_args=(output_args,),
+            input_grads=(input_grads,),
+            output_grads=(output_grads,),
+            get_mesh=lambda _dim_names, _layout: tp_mesh,
+        )
+
+    def _assert_grad_close(
+        self,
+        pp_grad: torch.Tensor,
+        ref_grad: torch.Tensor,
+        param_fqn: str,
+    ) -> None:
+        pp_for_compare = pp_grad
+        ref_for_compare = ref_grad
+
+        if isinstance(pp_grad, DTensor) and isinstance(ref_grad, DTensor):
+            pp_meta = _DTensorMeta.from_dtensor(pp_grad)
+            ref_meta = _DTensorMeta.from_dtensor(ref_grad)
+            self.assertEqual(
+                pp_meta.get_diff(ref_meta),
+                [],
+                f"DTensor metadata mismatch for {param_fqn}",
+            )
+            pp_for_compare = pp_grad.to_local()
+            ref_for_compare = ref_grad.to_local()
+
+        torch.testing.assert_close(
+            pp_for_compare,
+            ref_for_compare,
+            msg=f"Gradient mismatch for {param_fqn}",
+        )
+
+    def _assert_stage_grad_parity(
+        self,
+        pp_model: NormMLPStack,
+        ref_grads: dict[str, torch.Tensor | None],
+        stage_index: int,
+    ) -> None:
+        stage_module = pp_model.get_submodule(f"layers.{stage_index}")
+        for name, param in stage_module.named_parameters():
+            param_fqn = f"layers.{stage_index}.{name}"
+            self.assertIsNotNone(param.grad, f"Missing PP grad for {param_fqn}")
+            self.assertIsNotNone(
+                ref_grads[param_fqn], f"Missing reference grad for {param_fqn}"
+            )
+            pp_grad = cast(torch.Tensor, param.grad)
+            ref_grad = cast(torch.Tensor, ref_grads[param_fqn])
+            self._assert_grad_close(pp_grad, ref_grad, param_fqn)
+
+    def _compute_stage_indices(
+        self,
+        schedule_class: type,
+        pp_rank: int,
+        pp_size: int,
+        num_stages: int,
+    ) -> list[int]:
+        if schedule_class is Schedule1F1B:
+            return [pp_rank]
+        if schedule_class is ScheduleInterleaved1F1B:
+            return [pp_rank + i * pp_size for i in range(num_stages // pp_size)]
+        return [pp_rank, num_stages - 1 - pp_rank]
+
+    def _execute_schedule_step(
+        self,
+        schedule,
+        stages: list[PipelineStage],
+        pp_input: DTensor,
+        pp_target: DTensor,
+    ) -> None:
+        has_first = any(stage.is_first for stage in stages)
+        has_last = any(stage.is_last for stage in stages)
+
+        if has_first and has_last:
+            losses: list[torch.Tensor] = []
+            schedule.step(pp_input, target=pp_target, losses=losses)
+        elif has_first:
+            schedule.step(pp_input)
+        elif has_last:
+            losses: list[torch.Tensor] = []
+            schedule.step(target=pp_target, losses=losses)
+        else:
+            schedule.step()
+
+    def _run_training_correctness(
+        self,
+        schedule_class: type,
+        apply_tp: Callable,
+        placements: list,
+        *,
+        use_static_metadata: bool = True,
+        use_presharded_pp_input: bool = False,
+        null_boundary_grads: bool = False,
+    ) -> None:
+        self.init_pg()
+
+        mesh = self._make_mesh()
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+        pp_size = pp_mesh.size()
+
+        n_layers = 2 if schedule_class is Schedule1F1B else 4
+
+        ref_model, pp_model = self._build_baseline_and_clones(
+            n_layers=n_layers,
+            tp_mesh=tp_mesh,
+            apply_tp=apply_tp,
+        )
+
+        input_full, target_full = self._make_full_batch_tensors()
+
+        ref_input = self._wrap_full_tensor_as_dtensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+        )
+        ref_input.requires_grad_(True)
+        ref_target = self._wrap_full_tensor_as_dtensor(
+            target_full.clone(),
+            tp_mesh,
+            placements,
+        )
+
+        ref_grads, static_stage_meta = self._run_reference_microbatched(
+            ref_model,
+            ref_input,
+            ref_target,
+            null_boundary_grads=null_boundary_grads,
+        )
+
+        pp_static_stage_meta = static_stage_meta if use_static_metadata else None
+
+        pp_input = self._make_pp_input_dtensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+            use_presharded_pp_input,
+        )
+        pp_input.requires_grad_(True)
+        pp_target = self._wrap_full_tensor_as_dtensor(
+            target_full.clone(),
+            tp_mesh,
+            placements,
+        )
+
+        num_stages = n_layers
+        stage_indices = self._compute_stage_indices(
+            schedule_class,
+            pp_rank,
+            pp_size,
+            num_stages,
+        )
+
+        stages = [
+            self._make_stage_for_pp_run(
+                pp_model=pp_model,
+                stage_index=stage_index,
+                num_stages=num_stages,
+                pp_group=pp_group,
+                tp_mesh=tp_mesh,
+                static_stage_meta=pp_static_stage_meta,
+            )
+            for stage_index in stage_indices
+        ]
+
+        for stage in stages:
+            stage.submod.zero_grad(set_to_none=True)
+
+        if schedule_class is Schedule1F1B:
+            schedule = schedule_class(
+                stages[0],
+                n_microbatches=n_microbatches,
+                loss_fn=_loss_fn,
+            )
+        else:
+            schedule = schedule_class(
+                cast(list[PipelineStage], stages),  # type: ignore[arg-type]
+                n_microbatches=n_microbatches,
+                loss_fn=_loss_fn,
+            )
+
+        self._execute_schedule_step(schedule, stages, pp_input, pp_target)
+
+        for stage_index in stage_indices:
+            self._assert_stage_grad_parity(
+                pp_model=pp_model,
+                ref_grads=ref_grads,
+                stage_index=stage_index,
+            )
+
+    def _run_inference_only_equivalence(
+        self,
+        apply_tp: Callable,
+        placements: list,
+        *,
+        use_presharded_pp_input: bool = False,
+        use_static_metadata: bool = False,
+    ) -> None:
+        self.init_pg()
+
+        mesh = self._make_mesh()
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+
+        ref_model, pp_model = self._build_baseline_and_clones(
+            n_layers=2,
+            tp_mesh=tp_mesh,
+            apply_tp=apply_tp,
+        )
+
+        input_full, target_full = self._make_full_batch_tensors()
+
+        ref_input = self._wrap_full_tensor_as_dtensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+        )
+
+        static_stage_meta: StageStaticMetaMap | None = None
+
+        if use_static_metadata:
+            ref_input_for_meta = self._wrap_full_tensor_as_dtensor(
+                input_full.clone(),
+                tp_mesh,
+                placements,
+            )
+            ref_input_for_meta.requires_grad_(True)
+            ref_target_for_meta = self._wrap_full_tensor_as_dtensor(
+                target_full.clone(),
+                tp_mesh,
+                placements,
+            )
+            _, captured_meta = self._run_reference_microbatched(
+                ref_model,
+                ref_input_for_meta,
+                ref_target_for_meta,
+            )
+
+            static_stage_meta = {
+                stage_idx: (
+                    self._empty_dt_from(stage_meta[0], False),
+                    self._empty_dt_from(stage_meta[1], False),
+                    None,
+                    None,
+                )
+                for stage_idx, stage_meta in captured_meta.items()
+            }
+
+            with torch.no_grad():
+                ref_output = ref_model(ref_input)
+        else:
+            with torch.no_grad():
+                ref_output = ref_model(ref_input)
+
+        pp_input = self._make_pp_input_dtensor(
+            input_full.clone(),
+            tp_mesh,
+            placements,
+            use_presharded_pp_input,
+        )
+        pp_input.requires_grad_(False)
+
+        stage = self._make_stage_for_pp_run(
+            pp_model=pp_model,
+            stage_index=pp_rank,
+            num_stages=2,
+            pp_group=pp_group,
+            tp_mesh=tp_mesh,
+            static_stage_meta=static_stage_meta,
+        )
+        schedule = Schedule1F1B(
+            stage,
+            n_microbatches=n_microbatches,
+            loss_fn=None,
+        )
+
+        with torch.no_grad():
+            pp_output = schedule.eval(pp_input)
+
+        if stage.is_last:
+            self.assertIsNotNone(pp_output)
+            self.assertIsInstance(pp_output, DTensor)
+            self.assertIsInstance(ref_output, DTensor)
+            self._assert_grad_close(
+                cast(torch.Tensor, pp_output),
+                cast(torch.Tensor, ref_output),
+                "inference_output",
+            )
+
+
+class TestDTensorPPModes(DTensorPPIntegrationBase):
+    @_requires_multi_gpu
+    def test_static_mode_replicate(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_none_grad_slots_replicate(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+            null_boundary_grads=True,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_none_grad_slots_shard(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+            null_boundary_grads=True,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_shard(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_inference_only_replicate(self):
+        self._run_inference_only_equivalence(
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_inference_only_replicate(self):
+        self._run_inference_only_equivalence(
+            apply_tp_replicate,
+            [Replicate()],
+            use_static_metadata=True,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_inference_only_shard(self):
+        self._run_inference_only_equivalence(
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_inference_only_shard(self):
+        self._run_inference_only_equivalence(
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+            use_static_metadata=True,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_replicate(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_shard(self):
+        self._run_training_correctness(
+            Schedule1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_interleaved1f1b_replicate(self):
+        self._run_training_correctness(
+            ScheduleInterleaved1F1B,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_zbv_zero_bubble_replicate(self):
+        self._run_training_correctness(
+            ScheduleZBVZeroBubble,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_static_mode_dualpipev_replicate(self):
+        self._run_training_correctness(
+            ScheduleDualPipeV,
+            apply_tp_replicate,
+            [Replicate()],
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_interleaved1f1b_shard(self):
+        self._run_training_correctness(
+            ScheduleInterleaved1F1B,
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_zbv_zero_bubble_shard(self):
+        self._run_training_correctness(
+            ScheduleZBVZeroBubble,
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+            use_static_metadata=False,
+        )
+
+    @_requires_multi_gpu
+    def test_dynamic_mode_dualpipev_shard(self):
+        self._run_training_correctness(
+            ScheduleDualPipeV,
+            apply_tp_shard,
+            [Shard(1)],
+            use_presharded_pp_input=True,
+            use_static_metadata=False,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
+++ b/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
@@ -1,0 +1,617 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+"""
+Unit tests for DTensor support in Pipeline Parallelism.
+
+Tests the _utils.py metadata infrastructure and microbatch DTensor splitting:
+1. Metadata classes: _TensorMeta, _DTensorMeta, _MeshCache
+2. InferenceMode decision logic
+3. Validation functions: validate_metadata, validate_tensors_metadata,
+   validate_static_dtensor_grad_correspondence
+4. Helper functions: extract_tensor_metas, to_local_if_dtensor,
+   validate_and_normalize_to_tuple
+5. Microbatch DTensor splitting: _split_tensor placement change warnings
+"""
+
+import contextlib
+import functools
+import warnings
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.pipelining._utils import (
+    _DTensorMeta,
+    _MeshCache,
+    _StageMeta,
+    _TensorMeta,
+    extract_tensor_metas,
+    InferenceMode,
+    PipeliningMetadataError,
+    to_local_if_dtensor,
+    validate_and_normalize_to_tuple,
+    validate_metadata,
+    validate_static_dtensor_grad_correspondence,
+    validate_tensors_metadata,
+)
+from torch.distributed.pipelining.microbatch import _split_tensor, TensorChunkSpec
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_accelerator_dist_backend,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
+)
+
+
+# =============================================================================
+# Test Constants
+# =============================================================================
+
+d_hid = 256
+batch_size = 64
+n_microbatches = 4
+microbatch_size = batch_size // n_microbatches
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = dist.get_default_backend_for_device(device_type)
+
+
+def _requires_multi_gpu(fn):
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+    )
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+# =============================================================================
+# All DTensor PP Unit Tests (single class → single PG initialization)
+# =============================================================================
+
+
+class TestDTensorPPUnitTests(MultiProcContinuousTest):
+    """Unit tests for DTensor PP metadata infrastructure.
+
+    All tests live in a single class so the process group is initialized once
+    rather than once per test category.
+    """
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return backend
+
+    @classmethod
+    def device_type(cls) -> str:
+        return device_type
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    def init_pg(self):
+        if device_type == "cuda":
+            torch.cuda.set_device(self.device)
+
+    # -----------------------------------------------------------------
+    # Shared helpers
+    # -----------------------------------------------------------------
+
+    def _make_mesh(self, dim_names=("tp",)):
+        """Create a 1D device mesh spanning all ranks."""
+        return init_device_mesh(
+            device_type, (self.world_size,), mesh_dim_names=dim_names
+        )
+
+    def _make_dtensor(self, mesh, placements, shape=(8, 16), requires_grad=False):
+        """Create a DTensor with given properties."""
+        t = torch.randn(*shape, device=self.device, requires_grad=requires_grad)
+        dt = distribute_tensor(t, mesh, placements)
+        if requires_grad:
+            dt.retain_grad()
+        return dt
+
+    def _make_tensor_meta(
+        self,
+        shape: torch.Size = torch.Size([4, 8]),
+        stride: tuple[int, ...] = (8, 1),
+        dtype: torch.dtype = torch.float32,
+        requires_grad: bool = True,
+    ) -> _TensorMeta:
+        """Create a _TensorMeta with sensible defaults."""
+        return _TensorMeta(
+            shape=shape, stride=stride, dtype=dtype, requires_grad=requires_grad
+        )
+
+    def _make_dtensor_meta(self) -> _DTensorMeta:
+        """Create a _DTensorMeta with sensible defaults."""
+        return _DTensorMeta(
+            shape=torch.Size([4, 8]),
+            stride=(8, 1),
+            dtype=torch.float32,
+            requires_grad=True,
+            global_shape=torch.Size([8, 8]),
+            global_stride=(8, 1),
+            placements=(Shard(0),),
+            mesh_dim_names=("tp",),
+            mesh_layout=None,
+        )
+
+    def _assert_split_warns_on_placement_change(
+        self,
+        fake_get_placements,
+        expected_warning_substring,
+        use_debug_mask=False,
+    ):
+        """Shared helper: verify _split_tensor warns when placements change."""
+        mesh = self._make_mesh()
+        dt = self._make_dtensor(mesh, [Shard(0)], shape=(8, 16))
+
+        maybe_mask = (
+            patch(
+                "torch.distributed.pipelining.microbatch._debug_mask_minibatches", True
+            )
+            if use_debug_mask
+            else contextlib.nullcontext()
+        )
+
+        with patch(
+            "torch.distributed.pipelining.microbatch._get_dtensor_placements",
+            side_effect=fake_get_placements,
+        ):
+            with maybe_mask:
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    _ = _split_tensor(dt, TensorChunkSpec(0), num_chunks=2)
+                    self.assertTrue(
+                        any(
+                            "DTensor placements changed during microbatch split"
+                            in str(x.message)
+                            for x in w
+                        )
+                    )
+                    self.assertTrue(
+                        any(expected_warning_substring in str(x.message) for x in w)
+                    )
+
+    # -----------------------------------------------------------------
+    # Category 1: Metadata Classes (_TensorMeta, _DTensorMeta, _MeshCache)
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_tensor_meta_extraction_roundtrip_and_errors(self):
+        """Test _TensorMeta: extraction, roundtrip, DTensor rejection."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        # Extraction and roundtrip for various shapes/dtypes/requires_grad
+        for shape in [(4, 8), (2, 3, 4)]:
+            for dtype in [torch.float32, torch.float16]:
+                for requires_grad in [True, False]:
+                    t = torch.randn(*shape, dtype=dtype, requires_grad=requires_grad)
+                    meta = _TensorMeta.from_tensor(t)
+                    self.assertEqual(meta.shape, t.shape)
+                    self.assertEqual(meta.stride, t.stride())
+                    self.assertEqual(meta.dtype, dtype)
+                    self.assertEqual(meta.requires_grad, requires_grad)
+
+                    # Roundtrip via meta tensor
+                    reconstructed = meta.to_meta_tensor()
+                    reconstructed_meta = _TensorMeta(
+                        shape=reconstructed.shape,
+                        stride=reconstructed.stride(),
+                        dtype=reconstructed.dtype,
+                        requires_grad=reconstructed.requires_grad,
+                    )
+                    self.assertEqual(meta.get_diff(reconstructed_meta), [])
+
+        # DTensor rejection
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        with self.assertRaises(PipeliningMetadataError) as ctx:
+            _TensorMeta.from_tensor(dt)
+        self.assertIn("DTensor", str(ctx.exception))
+
+    @_requires_multi_gpu
+    def test_dtensor_meta_extraction_and_roundtrip(self):
+        """Test _DTensorMeta: extraction and roundtrip for Shard/Replicate."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        for placements in [[Shard(0)], [Replicate()]]:
+            dt = self._make_dtensor(mesh, placements)
+            meta = _DTensorMeta.from_dtensor(dt)
+
+            self.assertEqual(meta.global_shape, dt.shape)
+            self.assertEqual(meta.placements, tuple(placements))
+            self.assertEqual(meta.mesh_dim_names, ("tp",))
+            self.assertEqual(meta.mesh_cache_key, (("tp",), mesh._layout))
+
+            # Roundtrip
+            reconstructed = meta.to_meta_dtensor(mesh)
+            reconstructed_meta = _DTensorMeta.from_dtensor(reconstructed)
+            self.assertEqual(meta.get_diff(reconstructed_meta), [])
+
+    @_requires_multi_gpu
+    def test_get_diff_detects_mismatches(self):
+        """Test get_diff() detects shape/dtype/placement/cross-type differences."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        # _TensorMeta: shape
+        m1 = self._make_tensor_meta(shape=torch.Size([4, 8]), stride=(8, 1))
+        m2 = self._make_tensor_meta(shape=torch.Size([4, 16]), stride=(16, 1))
+        self.assertTrue(any("shape" in d for d in m1.get_diff(m2)))
+
+        # _TensorMeta: dtype
+        m3 = self._make_tensor_meta(dtype=torch.float16)
+        self.assertTrue(any("dtype" in d for d in m1.get_diff(m3)))
+
+        # _DTensorMeta: placement
+        dt_shard = self._make_dtensor(mesh, [Shard(0)])
+        dt_rep = self._make_dtensor(mesh, [Replicate()])
+        dm1 = _DTensorMeta.from_dtensor(dt_shard)
+        dm2 = _DTensorMeta.from_dtensor(dt_rep)
+        self.assertTrue(any("placements" in d for d in dm1.get_diff(dm2)))
+
+        # Cross-type: _DTensorMeta vs _TensorMeta
+        diffs = dm1.get_diff(m1)
+        self.assertTrue(any("type" in d.lower() or "_TensorMeta" in d for d in diffs))
+
+    @_requires_multi_gpu
+    def test_mesh_cache_operations(self):
+        """Test _MeshCache: get/put/get_or_create/update_from_tensors."""
+        self.init_pg()
+        mesh = self._make_mesh()
+        key = (("tp",), mesh._layout)
+
+        # --- get/put/contains ---
+        cache = _MeshCache()
+        self.assertIsNone(cache.get(key))
+        self.assertFalse(key in cache)
+
+        cache.put(key, mesh)
+        self.assertTrue(key in cache)
+        self.assertIs(cache.get(key), mesh)
+
+        # --- get_or_create: hit (callback NOT called) ---
+        callback_called = [False]
+
+        def callback(_names, _layout):
+            callback_called[0] = True
+            return mesh
+
+        self.assertIs(cache.get_or_create(key, callback), mesh)
+        self.assertFalse(callback_called[0])
+
+        # --- get_or_create: miss (callback called) ---
+        cache2 = _MeshCache()
+        self.assertIs(cache2.get_or_create(key, callback), mesh)
+        self.assertTrue(callback_called[0])
+
+        # --- get_or_create: miss without callback raises ---
+        cache3 = _MeshCache()
+        with self.assertRaises(PipeliningMetadataError) as ctx:
+            cache3.get_or_create(key, None)
+        self.assertIn("get_mesh", str(ctx.exception))
+
+        # --- update_from_tensors: extracts mesh from DTensors ---
+        cache4 = _MeshCache()
+        dt = self._make_dtensor(mesh, [Shard(0)], shape=(4, 4))
+        plain = torch.randn(4, 4, device=self.device)
+        cache4.update_from_tensors((dt, plain, None))
+        self.assertTrue(key in cache4)
+        self.assertIs(cache4.get(key), mesh)
+        self.assertEqual(len(cache4), 1)
+
+    # -----------------------------------------------------------------
+    # Category 2: InferenceMode Decision Logic
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_needs_dynamic_all_cases(self):
+        """Test all 8 cases of the needs_dynamic() decision matrix."""
+        self.init_pg()
+        tm = self._make_tensor_meta()
+        dm = self._make_dtensor_meta()
+
+        cases = [
+            # (meta, has_backward, expected_needs_dynamic)
+            # Case 1: No forward metadata
+            (_StageMeta(inputs=None, outputs=None), True, True),
+            # Case 2: Partial forward (inputs only)
+            (_StageMeta(inputs=(tm,), outputs=None), True, True),
+            # Case 3: Plain tensors, complete forward, backward → STATIC
+            (_StageMeta(inputs=(tm,), outputs=(tm,)), True, False),
+            # Case 4: DTensors, no backward → STATIC
+            (_StageMeta(inputs=(dm,), outputs=(dm,)), False, False),
+            # Case 5: DTensors, backward, no grads → DYNAMIC
+            (_StageMeta(inputs=(dm,), outputs=(dm,)), True, True),
+            # Case 6: DTensors, backward, only input_grads → DYNAMIC
+            (
+                _StageMeta(
+                    inputs=(dm,), outputs=(dm,), input_grads=(dm,), output_grads=None
+                ),
+                True,
+                True,
+            ),
+            # Case 7: DTensors, backward, only output_grads → DYNAMIC
+            (
+                _StageMeta(
+                    inputs=(dm,), outputs=(dm,), input_grads=None, output_grads=(dm,)
+                ),
+                True,
+                True,
+            ),
+            # Case 8: DTensors, backward, complete grads → STATIC
+            (
+                _StageMeta(
+                    inputs=(dm,),
+                    outputs=(dm,),
+                    input_grads=(dm,),
+                    output_grads=(dm,),
+                ),
+                True,
+                False,
+            ),
+        ]
+        for i, (meta, has_bwd, expected) in enumerate(cases, 1):
+            with self.subTest(case=i):
+                self.assertEqual(
+                    InferenceMode.needs_dynamic(meta, has_bwd),
+                    expected,
+                    f"Case {i} failed",
+                )
+
+    # -----------------------------------------------------------------
+    # Category 3: Validation Functions
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_validate_metadata(self):
+        """Test validate_metadata: match, raise, warn, type mismatch."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        # Match → no diffs
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        meta = _DTensorMeta.from_dtensor(dt)
+        self.assertEqual(validate_metadata("test", meta, dt), [])
+
+        # Mismatch with raise_on_mismatch
+        other = self._make_dtensor(mesh, [Replicate()])
+        with self.assertRaises(PipeliningMetadataError):
+            validate_metadata("test", meta, other, raise_on_mismatch=True)
+
+        # Mismatch with warn_on_mismatch
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            diffs = validate_metadata("test", meta, other, warn_on_mismatch=True)
+            self.assertTrue(len(diffs) > 0)
+            self.assertTrue(any("Metadata mismatch" in str(x.message) for x in w))
+
+        # Type mismatch: _DTensorMeta vs plain tensor
+        plain = torch.randn(8, 16, device=self.device)
+        diffs = validate_metadata("test", meta, plain)
+        self.assertTrue(any("type" in d for d in diffs))
+
+    @_requires_multi_gpu
+    def test_validate_tensors_metadata(self):
+        """Test validate_tensors_metadata: batch validation, length mismatch, None handling."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        meta = _DTensorMeta.from_dtensor(dt)
+
+        # Match
+        validate_tensors_metadata("test", (meta,), (dt,))
+
+        # Length mismatch raises
+        with self.assertRaises(PipeliningMetadataError):
+            validate_tensors_metadata("test", (meta, meta), (dt,))
+
+        # Length mismatch warns
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_tensors_metadata(
+                "test", (meta, meta), (dt,), warn_on_mismatch=True
+            )
+            self.assertTrue(len(w) > 0)
+
+        # None-None pair passes
+        validate_tensors_metadata("test", (None,), (None,))
+
+        # skip_none_actuals=True skips None actuals
+        validate_tensors_metadata("test", (meta,), (None,), skip_none_actuals=True)
+
+        # skip_none_actuals=False raises on None actual
+        with self.assertRaises(PipeliningMetadataError):
+            validate_tensors_metadata("test", (meta,), (None,))
+
+    @_requires_multi_gpu
+    def test_validate_static_dtensor_grad_correspondence(self):
+        """Test DTensor↔grad correspondence: all valid/invalid combos."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt_grad = self._make_dtensor(mesh, [Shard(0)], requires_grad=True)
+        dt_nograd = self._make_dtensor(mesh, [Shard(0)], requires_grad=False)
+        dt_grad2 = self._make_dtensor(mesh, [Replicate()], requires_grad=True)
+        plain = torch.randn(8, 16, device=self.device)
+
+        # DTensor(requires_grad=True) + DTensor grad → OK
+        validate_static_dtensor_grad_correspondence(
+            0, (dt_grad,), (dt_grad2,), is_input=True
+        )
+
+        # DTensor(requires_grad=False) + None grad → OK
+        validate_static_dtensor_grad_correspondence(
+            0, (dt_nograd,), (None,), is_input=True
+        )
+
+        # Plain tensor + None grad → OK
+        validate_static_dtensor_grad_correspondence(0, (plain,), (None,), is_input=True)
+
+        # DTensor(requires_grad=True) + None grad → OK (boundary with no gradient)
+        validate_static_dtensor_grad_correspondence(
+            0, (dt_grad,), (None,), is_input=True
+        )
+
+        # DTensor(requires_grad=True) + plain tensor grad → ERROR
+        with self.assertRaises(PipeliningMetadataError):
+            validate_static_dtensor_grad_correspondence(
+                0, (dt_grad,), (plain,), is_input=True
+            )
+
+        # Length mismatch → ERROR
+        with self.assertRaises(PipeliningMetadataError):
+            validate_static_dtensor_grad_correspondence(
+                0, (dt_grad, dt_grad), (dt_grad2,), is_input=False
+            )
+
+    # -----------------------------------------------------------------
+    # Category 4: Helper Functions
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_extract_tensor_metas(self):
+        """Test extract_tensor_metas: plain, DTensor, None handling."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt = self._make_dtensor(mesh, [Shard(0)])
+        plain = torch.randn(4, 4, device=self.device)
+
+        # None input → None output
+        self.assertIsNone(extract_tensor_metas(None))
+
+        # Mixed DTensor + plain → correct meta types
+        metas = extract_tensor_metas((dt, plain))
+        self.assertIsNotNone(metas)
+        self.assertIsInstance(metas[0], _DTensorMeta)  # type: ignore[index]
+        self.assertIsInstance(metas[1], _TensorMeta)  # type: ignore[index]
+        self.assertNotIsInstance(metas[1], _DTensorMeta)  # type: ignore[index]
+
+        # allow_none=True preserves None
+        metas_with_none = extract_tensor_metas((dt, None), allow_none=True)
+        self.assertIsNotNone(metas_with_none)
+        self.assertIsInstance(metas_with_none[0], _DTensorMeta)  # type: ignore[index]
+        self.assertIsNone(metas_with_none[1])  # type: ignore[index]
+
+        # allow_none=False (default) rejects None
+        with self.assertRaises(PipeliningMetadataError):
+            extract_tensor_metas((dt, None))  # type: ignore[arg-type]
+
+    @_requires_multi_gpu
+    def test_to_local_if_dtensor(self):
+        """Test to_local_if_dtensor: DTensor→local, plain passthrough, detach."""
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        dt = self._make_dtensor(mesh, [Shard(0)], requires_grad=True)
+        plain = torch.randn(4, 4, device=self.device, requires_grad=True)
+
+        # DTensor → local tensor (not DTensor)
+        local = to_local_if_dtensor(dt)
+        self.assertNotIsInstance(local, DTensor)
+        self.assertEqual(local.shape, dt._local_tensor.shape)
+
+        # Plain tensor → same tensor
+        result = to_local_if_dtensor(plain)
+        self.assertIs(result, plain)
+
+        # detach=True → result is detached
+        local_detached = to_local_if_dtensor(dt, detach=True)
+        self.assertNotIsInstance(local_detached, DTensor)
+        self.assertFalse(local_detached.requires_grad)
+
+    @_requires_multi_gpu
+    def test_validate_and_normalize_to_tuple(self):
+        """Test validate_and_normalize_to_tuple: single, tuple, list, None, errors."""
+        self.init_pg()
+        t = torch.randn(4, 4, device=self.device)
+
+        # None → None
+        self.assertIsNone(validate_and_normalize_to_tuple(None))
+
+        # Single tensor → 1-tuple
+        result = validate_and_normalize_to_tuple(t)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)  # type: ignore[arg-type]
+        self.assertIs(result[0], t)  # type: ignore[index]
+
+        # List → tuple
+        result = validate_and_normalize_to_tuple([t, t])
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)  # type: ignore[arg-type]
+
+        # Non-tensor element → error
+        with self.assertRaises(PipeliningMetadataError):
+            validate_and_normalize_to_tuple((t, "not_a_tensor"))  # type: ignore[arg-type]
+
+        # None in tuple without allow_none → error
+        with self.assertRaises(PipeliningMetadataError):
+            validate_and_normalize_to_tuple((t, None))  # type: ignore[arg-type]
+
+        # None in tuple with allow_none=True → OK
+        result_with_none = validate_and_normalize_to_tuple((t, None), allow_none=True)
+        self.assertIsNotNone(result_with_none)
+        self.assertEqual(len(result_with_none), 2)  # type: ignore[arg-type]
+        self.assertIsNone(result_with_none[1])  # type: ignore[index]
+
+        # Wrong type entirely → error
+        with self.assertRaises(PipeliningMetadataError):
+            validate_and_normalize_to_tuple(42)  # type: ignore[arg-type]
+
+    # -----------------------------------------------------------------
+    # Category 5: Microbatch DTensor Splitting
+    # -----------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_split_tensor_warns_on_dtensor_chunk_placement_change(self):
+        self.init_pg()
+        call_counter = {"count": 0}
+
+        def fake_get_dtensor_placements(_tensor):
+            call_counter["count"] += 1
+            if call_counter["count"] == 1:
+                return (Shard(0),)
+            return (Replicate(),)
+
+        self._assert_split_warns_on_placement_change(
+            fake_get_dtensor_placements, "new placements"
+        )
+
+    @_requires_multi_gpu
+    def test_split_tensor_warns_on_dtensor_expanded_chunk_placement_change(self):
+        self.init_pg()
+        call_counter = {"count": 0}
+
+        def fake_get_dtensor_placements(_tensor):
+            call_counter["count"] += 1
+            if call_counter["count"] == 1:
+                return (Shard(0),)
+            if call_counter["count"] <= 3:
+                return (Shard(0),)
+            return (Replicate(),)
+
+        self._assert_split_warns_on_placement_change(
+            fake_get_dtensor_placements, "expanded chunk", use_debug_mask=True
+        )
+
+
+# =============================================================================
+# Run Tests
+# =============================================================================
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -546,8 +546,12 @@ class ScheduleTest(MultiProcContinuousTest):
         # Handle shape inference
         if not shape_inference:
             input_args = (x.chunk(chunks)[0],)
-            with torch.no_grad():
-                output_args = stage_module(*input_args)
+            if self.rank > 0:
+                # Non-first stages receive activations from previous stages,
+                # which have requires_grad=True in training mode.
+                input_args = tuple(a.detach().requires_grad_(True) for a in input_args)
+            output_args = stage_module(*input_args)
+            output_args = output_args.detach().requires_grad_(output_args.requires_grad)
             stage = PipelineStage(
                 stage_module,
                 self.rank,

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -11,7 +11,7 @@ from torch.distributed.pipelining import (
     PipelineStage,
     ScheduleGPipe,
 )
-from torch.distributed.pipelining._utils import PipeliningShapeError
+from torch.distributed.pipelining._utils import PipeliningMetadataError
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_accelerator_dist_backend,
@@ -382,20 +382,20 @@ class StageNegativeTest(MultiProcContinuousTest):
         _run_step(x)
 
         if self.rank == 0:
-            with self.assertRaisesRegex(PipeliningShapeError, "shape mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "shape mismatch"):
                 _run_step(torch.randn(batch_size + 1, d_hid, device=self.device))
 
-            with self.assertRaisesRegex(PipeliningShapeError, "dtype mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x.to(torch.int32))
 
             # output of stage's mlp layer will be flattened by this hook, the stage should err
             handle = stage_mod.register_forward_hook(get_flatten_hook())
-            with self.assertRaisesRegex(PipeliningShapeError, "shape mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "shape mismatch"):
                 _run_step(x)
             handle.remove()
 
             stage_mod.register_forward_hook(get_dtype_change_hook(torch.bfloat16))
-            with self.assertRaisesRegex(PipeliningShapeError, "dtype mismatch"):
+            with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x)
 
     @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -1,91 +1,503 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
+from __future__ import annotations
+
 import logging
-from dataclasses import dataclass
+import warnings
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import cast, Literal, overload, TYPE_CHECKING
 
 import torch
 from torch import fx
+from torch.distributed._mesh_layout import _MeshLayout
+from torch.distributed.tensor import DTensor
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch.distributed.device_mesh import DeviceMesh
+    from torch.distributed.tensor.placement_types import Placement
 
 
 logger = logging.getLogger(__name__)
 
 
-def flatten_args_detach(args):
-    """
-    Flatten the args into a list form and detach the tensors from computational graph.
-    """
-    flat_detached_args = []
+# Key for mesh cache: (mesh_dim_names, mesh_layout)
+# mesh_layout is the _MeshLayout object containing shape and stride (not actual ranks).
+# This uniquely identifies a mesh within the same "universe" where all stages share
+# the same rank tensor.
+MeshCacheKey = tuple[tuple[str, ...], _MeshLayout | None]
 
-    def extract_tensor_args(a):
-        nonlocal flat_detached_args
-        if isinstance(a, torch.Tensor):
-            val = a.detach().requires_grad_(a.requires_grad)
-            flat_detached_args.append(val)
-            return val
+
+class PipeliningMetadataError(RuntimeError):
+    """Raised on metadata mismatches during pipeline communication."""
+
+
+@dataclass(frozen=True)
+class _TensorMeta:
+    """Tensor metadata for recv buffer allocation and validation.
+
+    For plain tensors, these are the tensor's actual attributes.
+    For DTensors, these are LOCAL shard attributes; global attributes
+    are stored in :class:`_DTensorMeta`.
+    """
+
+    shape: torch.Size
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+    requires_grad: bool
+
+    @staticmethod
+    def from_tensor(tensor: torch.Tensor) -> _TensorMeta:
+        """Create metadata from a plain tensor.
+
+        Args:
+            tensor: A plain ``torch.Tensor`` (not DTensor).
+
+        Returns:
+            Metadata capturing shape, stride, dtype, and requires_grad.
+
+        Raises:
+            TypeError: If ``tensor`` is a DTensor.
+        """
+        if isinstance(tensor, DTensor):
+            raise PipeliningMetadataError(
+                "Expected plain tensor, got DTensor. Use _DTensorMeta.from_dtensor instead."
+            )
+        return _TensorMeta(
+            shape=tensor.shape,
+            stride=tensor.stride(),
+            dtype=tensor.dtype,
+            requires_grad=tensor.requires_grad,
+        )
+
+    def to_meta_tensor(self) -> torch.Tensor:
+        """Reconstruct a meta-device tensor from this metadata.
+
+        Returns:
+            An empty strided tensor on the ``"meta"`` device.
+        """
+        return torch.empty_strided(
+            self.shape,
+            self.stride,
+            dtype=self.dtype,
+            device="meta",
+            requires_grad=self.requires_grad,
+        )
+
+    def get_diff(self, other: _TensorMeta) -> list[str]:
+        """Return field-by-field differences with ``other``.
+
+        Args:
+            other: Metadata to compare against.
+
+        Returns:
+            List of human-readable difference strings (empty if equal).
+        """
+        if self == other:
+            return []
+
+        diffs = []
+        if self.shape != other.shape:
+            diffs.append(f"shape mismatch: {self.shape} vs {other.shape}")
+        if self.stride != other.stride:
+            diffs.append(f"stride mismatch: {self.stride} vs {other.stride}")
+        if self.dtype != other.dtype:
+            diffs.append(f"dtype mismatch: {self.dtype} vs {other.dtype}")
+        # requires_grad is intentionally excluded: it is a runtime concern
+        # determined by has_backward and grad context, not a metadata invariant.
+        return diffs
+
+
+@dataclass(frozen=True)
+class _DTensorMeta(_TensorMeta):
+    """DTensor metadata extending :class:`_TensorMeta` with distribution info.
+
+    Inherited fields (shape, stride, etc.) are LOCAL shard attributes.
+    Additional fields capture global shape and placement information
+    needed to reconstruct a :class:`DTensor` via ``DTensor.from_local()``.
+
+    The :class:`DeviceMesh` is **not** stored (not serializable for P2P);
+    it is looked up from :class:`_MeshCache` using
+    ``(mesh_dim_names, mesh_layout)`` as the key.
+    """
+
+    # Global DTensor properties (for reconstruction)
+    global_shape: torch.Size = field(default_factory=lambda: torch.Size([]))
+    global_stride: tuple[int, ...] = field(default=())
+
+    # DTensor distribution properties
+    placements: tuple[Placement, ...] = field(
+        default=()
+    )  # e.g., (Shard(0), Replicate())
+
+    # Mesh identification - used to look up the correct DeviceMesh from cache
+    mesh_dim_names: tuple[str, ...] = field(default=())  # e.g., ("tp",) or ("dp", "tp")
+    mesh_layout: _MeshLayout | None = field(
+        default=None
+    )  # _MeshLayout with shape/stride - uniquely identifies mesh within the same universe
+
+    @staticmethod
+    def from_dtensor(dtensor: DTensor) -> _DTensorMeta:
+        """Create metadata from a DTensor.
+
+        Args:
+            dtensor: The DTensor to extract metadata from.
+
+        Returns:
+            Metadata capturing both local and global attributes.
+        """
+        spec = dtensor._spec
+        device_mesh = dtensor.device_mesh
+
+        return _DTensorMeta(
+            # Local tensor attributes (for recv buffer allocation)
+            shape=dtensor._local_tensor.shape,
+            stride=dtensor._local_tensor.stride(),
+            dtype=dtensor.dtype,
+            requires_grad=dtensor.requires_grad,
+            # Global DTensor attributes (for reconstruction)
+            global_shape=dtensor.shape,
+            global_stride=dtensor.stride(),
+            # Distribution info
+            placements=spec.placements,
+            mesh_dim_names=(
+                tuple(device_mesh.mesh_dim_names) if device_mesh.mesh_dim_names else ()
+            ),
+            mesh_layout=device_mesh._layout,
+        )
+
+    @property
+    def mesh_cache_key(self) -> MeshCacheKey:
+        """Cache key ``(mesh_dim_names, mesh_layout)`` for mesh lookup."""
+        return (self.mesh_dim_names, self.mesh_layout)
+
+    def to_meta_dtensor(self, mesh: DeviceMesh) -> DTensor:
+        """Reconstruct a meta-device DTensor with placements.
+
+        Args:
+            mesh: The ``DeviceMesh`` to attach.
+
+        Returns:
+            A DTensor on the ``"meta"`` device.
+        """
+        local_meta = torch.empty_strided(
+            self.shape,
+            self.stride,
+            dtype=self.dtype,
+            device="meta",
+        )
+        return cast(
+            DTensor,
+            DTensor.from_local(
+                local_meta,
+                device_mesh=mesh,
+                placements=self.placements,
+                shape=self.global_shape,
+                stride=self.global_stride,
+                run_check=False,
+            ).requires_grad_(self.requires_grad),
+        )
+
+    def get_diff(self, other: _TensorMeta) -> list[str]:
+        """Return field-by-field differences, including DTensor-specific fields.
+
+        Args:
+            other: Metadata to compare against.
+
+        Returns:
+            List of human-readable difference strings (empty if equal).
+        """
+        if self == other:
+            return []
+
+        # Get base class differences (compares local shape/stride/dtype/requires_grad)
+        diffs = super().get_diff(other)
+
+        # Add DTensor-specific comparisons if other is also _DTensorMeta
+        if isinstance(other, _DTensorMeta):
+            if self.global_shape != other.global_shape:
+                diffs.append(
+                    f"global_shape mismatch: {self.global_shape} vs {other.global_shape}"
+                )
+            if self.global_stride != other.global_stride:
+                diffs.append(
+                    f"global_stride mismatch: {self.global_stride} vs {other.global_stride}"
+                )
+            if self.placements != other.placements:
+                diffs.append(
+                    f"placements mismatch: {self.placements} vs {other.placements}"
+                )
+            if self.mesh_dim_names != other.mesh_dim_names:
+                diffs.append(
+                    f"mesh_dim_names mismatch: {self.mesh_dim_names} vs {other.mesh_dim_names}"
+                )
+            if self.mesh_layout != other.mesh_layout:
+                diffs.append(
+                    f"mesh_layout mismatch: {self.mesh_layout} vs {other.mesh_layout}"
+                )
         else:
-            flat_detached_args.append(a)
-            return a
+            diffs.append("type: _DTensorMeta vs _TensorMeta")
 
-    new_args = fx.node.map_aggregate(
-        args,
-        extract_tensor_args,
+        return diffs
+
+
+# Type alias for union of tensor metadata types
+TensorMeta = _TensorMeta | _DTensorMeta
+
+
+@dataclass
+class _StageMeta:
+    """Consolidated tensor metadata for a pipeline stage's forward and backward passes."""
+
+    inputs: tuple[TensorMeta, ...] | None = None
+    outputs: tuple[TensorMeta, ...] | None = None
+    input_grads: tuple[TensorMeta | None, ...] | None = None
+    output_grads: tuple[TensorMeta | None, ...] | None = None
+
+    def has_any(self) -> bool:
+        """Check if any metadata field is populated."""
+        return any(
+            v is not None
+            for v in [self.inputs, self.outputs, self.input_grads, self.output_grads]
+        )
+
+    def has_dtensors(self) -> bool:
+        """Check if any input/output metadata is DTensor type."""
+        for metas in [self.inputs, self.outputs]:
+            if metas and any(isinstance(m, _DTensorMeta) for m in metas if m):
+                return True
+        return False
+
+    def is_complete_for_forward(self) -> bool:
+        """Check if forward metadata is fully populated."""
+        return self.inputs is not None and self.outputs is not None
+
+
+@dataclass(frozen=True)
+class _StageForwardMeta:
+    """Forward metadata transmitted from stage *i* to stage *i+1* during inference."""
+
+    forward_metas: tuple[TensorMeta, ...]  # Stage i's outputs → Stage i+1's inputs
+
+
+@dataclass(frozen=True)
+class _StageBackwardMeta:
+    """Backward metadata transmitted from stage *i* to stage *i-1* during inference.
+
+    Gradient placements may differ from forward activations
+    (e.g., ``Replicate`` → ``Partial``).
+    """
+
+    backward_metas: tuple[
+        TensorMeta | None, ...
+    ]  # Stage i's input_grads → Stage i-1's output_grads
+
+
+def _make_tensor_from_meta(
+    meta: _TensorMeta,
+    device: torch.device,
+) -> torch.Tensor:
+    """Create a recv buffer from tensor metadata.
+
+    Args:
+        meta: Metadata with shape, stride, and dtype.
+        device: Target device for the buffer.
+
+    Returns:
+        Empty tensor preserving the exact memory layout.
+    """
+    return torch.empty_strided(
+        size=meta.shape,
+        stride=meta.stride,
+        dtype=meta.dtype,
+        device=device,
     )
 
-    return new_args, flat_detached_args
 
+class _MeshCache:
+    """Cache for :class:`DeviceMesh` objects keyed by ``(mesh_dim_names, mesh_layout)``.
 
-def flatten_args(args):
+    Assumes all pipeline stages share the same rank tensor (true for
+    TorchTitan-style frameworks where meshes derive from a common world).
     """
-    Flatten the args into a list form.
+
+    def __init__(self) -> None:
+        self._cache: dict[MeshCacheKey, DeviceMesh] = {}
+
+    def get(self, key: MeshCacheKey) -> DeviceMesh | None:
+        """Get a mesh by cache key, or None if not found."""
+        return self._cache.get(key)
+
+    def get_or_create(
+        self,
+        key: MeshCacheKey,
+        get_mesh_callback: Callable[[tuple[str, ...], _MeshLayout | None], DeviceMesh]
+        | None = None,
+    ) -> DeviceMesh:
+        """Return a cached mesh, or create one via ``get_mesh_callback``.
+
+        Args:
+            key: Cache key ``(mesh_dim_names, mesh_layout)``.
+            get_mesh_callback: Factory called with ``(mesh_dim_names, mesh_layout)``
+                when the key is not cached.
+
+        Returns:
+            The ``DeviceMesh``.
+
+        Raises:
+            PipeliningMetadataError: If not cached and no callback provided.
+        """
+        if key in self._cache:
+            return self._cache[key]
+
+        mesh_dim_names, mesh_layout = key
+
+        if get_mesh_callback is None:
+            raise PipeliningMetadataError(
+                f"Mesh not found in cache for mesh_dim_names={mesh_dim_names}, "
+                f"mesh_layout={mesh_layout}, and no get_mesh callback provided. "
+                f"Provide a get_mesh callback or use DTensors in static mode."
+            )
+
+        mesh = get_mesh_callback(mesh_dim_names, mesh_layout)
+        if mesh is None:
+            raise PipeliningMetadataError(
+                f"Mesh lookup failed: callback returned None for "
+                f"mesh_dim_names={mesh_dim_names}, mesh_layout={mesh_layout}. "
+                f"Ensure all stages use meshes from the same universe."
+            )
+        self._cache[key] = mesh
+        return mesh
+
+    def put(self, key: MeshCacheKey, mesh: DeviceMesh) -> None:
+        """Add a mesh to the cache."""
+        self._cache[key] = mesh
+
+    def update_from_tensors(self, tensors: tuple[torch.Tensor | None, ...]) -> None:
+        """Extract and cache meshes from any :class:`DTensor` instances in *tensors*."""
+        for tensor in tensors:
+            if isinstance(tensor, DTensor):
+                mesh = tensor.device_mesh
+                dim_names = tuple(mesh.mesh_dim_names) if mesh.mesh_dim_names else ()
+                mesh_layout = mesh._layout
+                key = (dim_names, mesh_layout)
+                if key not in self._cache:
+                    self._cache[key] = mesh
+
+    def __contains__(self, key: MeshCacheKey) -> bool:
+        return key in self._cache
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+
+# ============================================================================
+# Inference mode enum
+# ============================================================================
+
+
+class InferenceMode(Enum):
+    """Pipeline-level metadata inference mode, determined collectively across all PP ranks.
+
+    The mode is set by the schedule (not individual stages) because
+    ``has_backward`` is only known at schedule creation time and all
+    stages must agree to avoid P2P hangs.
+
+    .. attribute:: STATIC
+
+        All stages have sufficient metadata; runtime inference is skipped.
+
+    .. attribute:: DYNAMIC
+
+        At least one stage requires runtime metadata inference.
+    """
+
+    STATIC = "static"
+    DYNAMIC = "dynamic"
+
+    @classmethod
+    def needs_dynamic(cls, meta: _StageMeta, has_backward: bool) -> bool:
+        """Determine whether dynamic metadata inference is needed for a stage.
+
+        Args:
+            meta: Stage metadata from user-provided args.
+            has_backward: Whether a backward pass will be performed.
+
+        Returns:
+            ``True`` if dynamic inference is needed.
+        """
+        # Case 1: Forward metadata incomplete → needs DYNAMIC
+        if not meta.is_complete_for_forward():
+            return True
+
+        # Case 2: No DTensors → STATIC is fine (bwd metadata derivable from fwd metadata)
+        if not meta.has_dtensors():
+            return False
+
+        # Case 3: No backward needed → STATIC is fine (don't need grad metadata)
+        if not has_backward:
+            return False
+
+        # Case 4: DTensors with backward but missing ANY grad metadata → needs DYNAMIC
+        # Both input_grads AND output_grads are required for static mode with DTensors
+        if meta.input_grads is None or meta.output_grads is None:
+            return True
+
+        # Case 5: DTensors with complete grads → STATIC is fine
+        return False
+
+
+# ============================================================================
+# Utility functions
+# ============================================================================
+
+
+def flatten_args(args, *, detach: bool = False):
+    """Flatten ``args`` into a list, optionally detaching tensors.
+
+    Args:
+        args: Nested arguments to flatten.
+        detach: If ``True``, detach tensors while preserving ``requires_grad``.
+
+    Returns:
+        ``(new_args, flat_detached_args)`` when ``detach=True``;
+        ``flat_args`` list otherwise.
     """
     flat_args = []
 
-    def extract_tensor_args(a):
-        nonlocal flat_args
-        flat_args.append(a)
-        return a
+    if detach:
 
-    fx.node.map_aggregate(
-        args,
-        extract_tensor_args,
-    )
+        def extract_and_detach(a):
+            nonlocal flat_args
+            if isinstance(a, torch.Tensor):
+                val = a.detach().requires_grad_(a.requires_grad)
+                flat_args.append(val)
+                return val
+            else:
+                flat_args.append(a)
+                return a
 
-    return flat_args
+        new_args = fx.node.map_aggregate(args, extract_and_detach)
+        return new_args, flat_args
+    else:
 
+        def extract_only(a):
+            nonlocal flat_args
+            flat_args.append(a)
+            return a
 
-class PipeliningShapeError(RuntimeError):
-    """Shape mismatch between configured and runtime values."""
-
-
-def validate_tensor_metadata(desc, expected, given):
-    if not expected.shape == given.shape:
-        raise PipeliningShapeError(
-            f"{desc} has a shape mismatch: expected {expected.shape} actual {given.shape}"
-        )
-    if not expected.dtype == given.dtype:
-        raise PipeliningShapeError(
-            f"{desc} has a dtype mismatch: expected {expected.dtype} actual {given.dtype}"
-        )
-    if not expected.stride() == given.stride():
-        raise PipeliningShapeError(
-            f"{desc} has a stride mismatch: expected {expected.stride()} actual {given.stride()}"
-        )
+        fx.node.map_aggregate(args, extract_only)
+        return flat_args
 
 
-def validate_tensors_metadata(
-    desc,
-    expected_tensors: list[torch.Tensor] | tuple[torch.Tensor, ...],
-    actual_tensors: list[torch.Tensor] | tuple[torch.Tensor, ...],
-):
-    if len(expected_tensors) != len(actual_tensors):
-        raise PipeliningShapeError(
-            f"{desc}: Number of values ({len(actual_tensors)}) does not match expected number ({len(expected_tensors)})"
-        )
-    for i in range(len(expected_tensors)):
-        validate_tensor_metadata(
-            f"{desc}: value {i}", expected_tensors[i], actual_tensors[i]
-        )
+# Backward compatibility alias
+def flatten_args_detach(args):
+    """Flatten and detach. Deprecated: use ``flatten_args(args, detach=True)``."""
+    return flatten_args(args, detach=True)
 
 
 def generate_stage_to_rank_mapping(
@@ -157,3 +569,336 @@ class PipeInfo:
     graph: fx.Graph
     num_stages: int
     has_loss_and_backward: bool
+
+
+# ============================================================================
+# Metadata extraction helpers
+# ============================================================================
+
+
+def extract_tensor_meta(tensor: torch.Tensor) -> TensorMeta:
+    """Extract metadata from a tensor.
+
+    Args:
+        tensor: A plain tensor or DTensor.
+
+    Returns:
+        ``_TensorMeta`` for plain tensors, ``_DTensorMeta`` for DTensors.
+    """
+    if isinstance(tensor, DTensor):
+        return _DTensorMeta.from_dtensor(tensor)
+    else:
+        return _TensorMeta.from_tensor(tensor)
+
+
+@overload
+def extract_tensor_metas(
+    tensors: tuple[torch.Tensor, ...] | None,
+    *,
+    allow_none: Literal[False] = ...,
+) -> tuple[TensorMeta, ...] | None: ...
+
+
+@overload
+def extract_tensor_metas(
+    tensors: tuple[torch.Tensor | None, ...] | None,
+    *,
+    allow_none: Literal[True],
+) -> tuple[TensorMeta | None, ...] | None: ...
+
+
+def extract_tensor_metas(
+    tensors: tuple[torch.Tensor | None, ...] | tuple[torch.Tensor, ...] | None,
+    *,
+    allow_none: bool = False,
+) -> tuple[TensorMeta | None, ...] | None:
+    """Extract metadata from a tuple of tensors.
+
+    Args:
+        tensors: Tuple of tensors (may include ``None`` when ``allow_none=True``).
+        allow_none: If ``True``, preserve ``None`` elements (for gradients).
+
+    Returns:
+        Tuple of ``TensorMeta``, or ``None`` if ``tensors`` is ``None``.
+
+    Raises:
+        PipeliningMetadataError: If ``None`` found and ``allow_none=False``.
+    """
+    if tensors is None:
+        return None
+
+    metas_with_none: list[TensorMeta | None] = []
+    has_none = False
+    for t in tensors:
+        if isinstance(t, torch.Tensor):
+            metas_with_none.append(extract_tensor_meta(t))
+        else:
+            has_none = True
+            metas_with_none.append(None)
+    if not allow_none and has_none:
+        raise PipeliningMetadataError(
+            "None values are not allowed in tensor metadata tuples. "
+            "Use allow_none=True for optional values."
+        )
+    return tuple(metas_with_none)
+
+
+def to_local_if_dtensor(tensor: torch.Tensor, detach: bool = False) -> torch.Tensor:
+    """Convert a DTensor to its local shard, or return a plain tensor unchanged.
+
+    Args:
+        tensor: A tensor that may be a DTensor.
+        detach: If ``True``, detach before ``to_local()`` to avoid
+            redistribution during backward.
+
+    Returns:
+        The local tensor component.
+    """
+    maybe_detached_tensor = tensor.detach() if detach else tensor
+    if isinstance(maybe_detached_tensor, DTensor):
+        return maybe_detached_tensor.to_local()
+    return maybe_detached_tensor
+
+
+@overload
+def validate_and_normalize_to_tuple(
+    args: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor] | None,
+    allow_none: Literal[False] = ...,
+) -> tuple[torch.Tensor, ...] | None: ...
+
+
+@overload
+def validate_and_normalize_to_tuple(
+    args: torch.Tensor
+    | tuple[torch.Tensor | None, ...]
+    | list[torch.Tensor | None]
+    | None,
+    allow_none: Literal[True] = ...,
+) -> tuple[torch.Tensor | None, ...] | None: ...
+
+
+def validate_and_normalize_to_tuple(
+    args: torch.Tensor
+    | tuple[torch.Tensor, ...]
+    | tuple[torch.Tensor | None, ...]
+    | list[torch.Tensor]
+    | list[torch.Tensor | None]
+    | None,
+    allow_none: bool = False,
+) -> tuple[torch.Tensor | None, ...] | tuple[torch.Tensor, ...] | None:
+    """Normalize ``args`` to a tuple and validate that all elements are tensors.
+
+    Args:
+        args: A single tensor, tuple/list of tensors, or ``None``.
+        allow_none: If ``True``, permit ``None`` elements (for gradients).
+
+    Returns:
+        Tuple of tensors, or ``None`` if ``args`` is ``None``.
+
+    Raises:
+        PipeliningMetadataError: On non-tensor values
+            (or ``None`` when ``allow_none=False``).
+    """
+    if args is None:
+        return None
+    elif isinstance(args, torch.Tensor):
+        return (args,)
+    elif isinstance(args, (tuple, list)):
+        for i, arg in enumerate(args):
+            if arg is None:
+                if not allow_none:
+                    raise PipeliningMetadataError(
+                        f"Stage arg[{i}] is None. "
+                        f"Stage args must be tensors. Use kwargs for optional values."
+                    )
+                continue
+            if not isinstance(arg, torch.Tensor):
+                raise PipeliningMetadataError(
+                    f"Stage arg[{i}] has type {type(arg).__name__}. "
+                    f"All stage args must be tensors. Use kwargs for non-tensor inputs."
+                )
+        # Normalize list to tuple
+        return tuple(args) if isinstance(args, list) else args
+    else:
+        raise PipeliningMetadataError(
+            f"Stage args must be a tensor, tuple, or list of tensors, got {type(args).__name__}."
+        )
+
+
+# ============================================================================
+# Validation functions
+# ============================================================================
+
+
+def validate_metadata(
+    desc: str,
+    expected: TensorMeta,
+    actual: torch.Tensor | TensorMeta,
+    *,
+    raise_on_mismatch: bool = False,
+    warn_on_mismatch: bool = False,
+) -> list[str]:
+    """
+    Compare expected metadata against actual tensor or metadata.
+
+    This is the unified validation/comparison function that uses get_diff() from
+    metadata classes. Works with both plain tensors and DTensors.
+
+    For plain tensors: compares shape/stride/dtype/requires_grad.
+    For DTensors: compares all properties including global shape and placements.
+
+    Args:
+        desc: Description for error/warning messages.
+        expected: Expected tensor metadata (_TensorMeta or _DTensorMeta).
+        actual: Actual tensor or metadata to compare against.
+        raise_on_mismatch: If True, raise PipeliningMetadataError on mismatch.
+        warn_on_mismatch: If True, issue a warning on mismatch.
+
+    Returns:
+        List of differences (empty if metadata matches).
+
+    Raises:
+        PipeliningMetadataError: If raise_on_mismatch=True and differences exist.
+    """
+    # Extract metadata if actual is a tensor
+    if isinstance(actual, torch.Tensor):
+        actual_meta = extract_tensor_meta(actual)
+    else:
+        actual_meta = actual
+
+    # Type check: ensure both are same type for meaningful comparison
+    if type(expected) is not type(actual_meta):
+        type_diff = [
+            f"type: expected {type(expected).__name__}, got {type(actual_meta).__name__}"
+        ]
+        if raise_on_mismatch:
+            raise PipeliningMetadataError(f"{desc}: {type_diff[0]}")
+        if warn_on_mismatch:
+            warnings.warn(
+                f"{desc}: Metadata type mismatch. {type_diff[0]}. "
+                f"Using dynamically inferred metadata instead.",
+                UserWarning,
+            )
+        return type_diff
+
+    # Use get_diff() from the metadata class
+    diffs = expected.get_diff(actual_meta)
+
+    if diffs:
+        if raise_on_mismatch:
+            raise PipeliningMetadataError(f"{desc}: {'; '.join(diffs)}")
+        if warn_on_mismatch:
+            warnings.warn(
+                f"{desc}: Metadata mismatch. {'; '.join(diffs)}. "
+                f"Using dynamically inferred metadata instead.",
+                UserWarning,
+            )
+
+    return diffs
+
+
+def validate_tensors_metadata(
+    desc: str,
+    expected_metas: tuple[TensorMeta | None, ...],
+    actuals: tuple[torch.Tensor | TensorMeta | None, ...],
+    *,
+    skip_none_actuals: bool = False,
+    warn_on_mismatch: bool = False,
+) -> None:
+    """
+    Validate that a collection of actual tensors/metadata match expected metadata.
+    This is a convenience wrapper for validating lists/tuples of tensors or metadata.
+
+    Args:
+        desc: Description for error messages.
+        expected_metas: Expected tensor metadata (tuple of _TensorMeta/_DTensorMeta or None).
+        actuals: Actual tensors or metadata to validate.
+        skip_none_actuals: If True, skip validation for None actual tensors. This is useful
+            for backward pass validation where gradients can legitimately be None
+            for non-differentiable outputs.
+        warn_on_mismatch: If True, issue warnings instead of raising errors.
+
+    Raises:
+        PipeliningMetadataError: If lengths don't match or any tensor metadata mismatches
+            (unless warn_on_mismatch=True).
+    """
+    if len(expected_metas) != len(actuals):
+        msg = (
+            f"{desc}: Number of values ({len(actuals)}) does not match "
+            f"expected number ({len(expected_metas)})"
+        )
+        if warn_on_mismatch:
+            warnings.warn(f"{msg}. Using dynamic metadata.", UserWarning)
+            return
+        raise PipeliningMetadataError(msg)
+
+    for i, (expected, actual) in enumerate(zip(expected_metas, actuals, strict=True)):
+        # Handle None cases
+        if expected is None and actual is None:
+            continue
+        if expected is None:
+            msg = f"{desc} [{i}]: expected None, got {type(actual).__name__}"
+            if warn_on_mismatch:
+                warnings.warn(f"{msg}. Using dynamic metadata.", UserWarning)
+                continue
+            raise PipeliningMetadataError(msg)
+        if actual is None:
+            if skip_none_actuals:
+                continue
+            msg = f"{desc} [{i}]: expected {type(expected).__name__}, got None"
+            if warn_on_mismatch:
+                warnings.warn(f"{msg}. Using dynamic metadata.", UserWarning)
+                continue
+            raise PipeliningMetadataError(msg)
+
+        validate_metadata(
+            f"{desc} [{i}]",
+            expected,
+            actual,
+            warn_on_mismatch=warn_on_mismatch,
+            raise_on_mismatch=not warn_on_mismatch,
+        )
+
+
+def validate_static_dtensor_grad_correspondence(
+    stage_index: int,
+    args: tuple[torch.Tensor, ...],
+    grads: tuple[torch.Tensor | None, ...],
+    is_input: bool,
+) -> None:
+    """
+    Validate DTensor↔grad correspondence for static mode.
+
+    For each DTensor in args with requires_grad=True, the corresponding grad
+    must be either a DTensor or None (e.g. at pipeline boundaries where no
+    gradient is exchanged). For non-DTensor args or args with requires_grad=False,
+    the corresponding grad can be None or a plain tensor.
+
+    Args:
+        stage_index: The stage index for error messages.
+        args: Tuple of forward tensors.
+        grads: Tuple of gradient tensors (can include None).
+        is_input: True for input_args/input_grads, False for output_args/output_grads.
+
+    Raises:
+        PipeliningMetadataError: If tuple lengths don't match or DTensor↔grad correspondence fails.
+    """
+    kind = "input" if is_input else "output"
+    args_name = f"{kind}_args"
+    grads_name = f"{kind}_grads"
+
+    if len(args) != len(grads):
+        raise PipeliningMetadataError(
+            f"Stage {stage_index}: {grads_name} length ({len(grads)}) does not match "
+            f"{args_name} length ({len(args)}). Each forward tensor must have a "
+            f"corresponding gradient entry (use None for tensors that don't require grad)."
+        )
+
+    for i, (arg, grad) in enumerate(zip(args, grads, strict=True)):
+        if isinstance(arg, DTensor) and arg.requires_grad and grad is not None:
+            if not isinstance(grad, DTensor):
+                raise PipeliningMetadataError(
+                    f"Stage {stage_index}: {args_name}[{i}] is a DTensor with requires_grad=True, "
+                    f"but {grads_name}[{i}] is {type(grad).__name__}, expected DTensor or None. "
+                    f"DTensor gradients may have different placements than forward tensors."
+                )

--- a/torch/distributed/pipelining/microbatch.py
+++ b/torch/distributed/pipelining/microbatch.py
@@ -2,6 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import operator
+import warnings
 from collections.abc import Sequence
 from typing import Any
 
@@ -182,6 +183,14 @@ def _split_block_mask(
     return chunk_block_masks
 
 
+def _get_dtensor_placements(tensor: torch.Tensor) -> tuple[Any, ...] | None:
+    spec = getattr(tensor, "_spec", None)
+    placements = getattr(spec, "placements", None)
+    if placements is None:
+        return None
+    return tuple(placements)
+
+
 def _split_tensor(
     tensor: torch.Tensor,
     spec: TensorChunkSpec,
@@ -204,12 +213,38 @@ def _split_tensor(
         )
     chunk_tensors = torch.tensor_split(tensor, num_chunks, spec.split_dim)
 
+    # tensor_split on a leaf tensor produces non-leaf views that won't
+    # accumulate .grad during torch.autograd.backward().  Call retain_grad()
+    # on those views so that stage_backward() can read .grad from them.
+    if tensor.requires_grad and tensor.is_leaf:
+        for chunk in chunk_tensors:
+            if not chunk.is_leaf:
+                chunk.retain_grad()
+
+    original_placements = _get_dtensor_placements(tensor)
+    placement_diffs = []
+
+    if original_placements is not None:
+        for chunk_idx, chunk in enumerate(chunk_tensors):
+            chunk_placements = _get_dtensor_placements(chunk)
+            if chunk_placements is not None and chunk_placements != original_placements:
+                placement_diffs.append(
+                    f"chunk {chunk_idx} placements changed from {original_placements} "
+                    f"to new placements {chunk_placements}"
+                )
+
     if not _debug_mask_minibatches:
+        if placement_diffs:
+            warnings.warn(
+                "DTensor placements changed during microbatch split: "
+                + "; ".join(placement_diffs),
+                UserWarning,
+            )
         return chunk_tensors
 
     expanded_chunks = []
     split_dim_idx = 0
-    for chunk_tensor in chunk_tensors:
+    for chunk_idx, chunk_tensor in enumerate(chunk_tensors):
         new_val = torch.zeros_like(tensor)
         upper_idx = split_dim_idx + chunk_tensor.size(spec.split_dim)
 
@@ -217,9 +252,27 @@ def _split_tensor(
         slice_indices[spec.split_dim] = slice(split_dim_idx, upper_idx)
         new_val[slice_indices] = chunk_tensor
 
+        if original_placements is not None:
+            expanded_placements = _get_dtensor_placements(new_val)
+            if (
+                expanded_placements is not None
+                and expanded_placements != original_placements
+            ):
+                placement_diffs.append(
+                    f"expanded chunk {chunk_idx} placements changed from {original_placements} "
+                    f"to new placements {expanded_placements}"
+                )
+
         expanded_chunks.append(new_val)
 
         split_dim_idx += chunk_tensor.size(spec.split_dim)
+
+    if placement_diffs:
+        warnings.warn(
+            "DTensor placements changed during microbatch split: "
+            + "; ".join(placement_diffs),
+            UserWarning,
+        )
 
     return expanded_chunks
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -21,9 +21,49 @@ from torch.distributed.fsdp import FSDPModule, UnshardHandle
 from torch.nn.modules.loss import _Loss
 from torch.profiler import record_function
 
-from ._utils import generate_rank_to_stage_mapping, generate_stage_to_rank_mapping
+from ._utils import (
+    generate_rank_to_stage_mapping,
+    generate_stage_to_rank_mapping,
+    InferenceMode,
+)
 from .microbatch import merge_chunks, split_args_kwargs_into_chunks, TensorChunkSpec
-from .stage import _PipelineStageBase
+from .stage import _PipelineStageBase, PipelineStage
+
+
+def _determine_and_set_global_inference_mode(
+    stages: list[PipelineStage],
+    has_backward: bool,
+) -> None:
+    """Determine global inference mode via all-reduce across PP ranks.
+
+    If any stage (locally or remotely) needs ``DYNAMIC``, all stages
+    use ``DYNAMIC``.
+
+    Args:
+        stages: Pipeline stages on this rank.
+        has_backward: Whether a backward pass will be performed.
+    """
+    needs_dynamic = any(
+        InferenceMode.needs_dynamic(stage._user_meta, has_backward) for stage in stages
+    )
+
+    vote = torch.tensor(
+        [1 if needs_dynamic else 0],
+        dtype=torch.int32,
+        device=stages[0].device,
+    )
+    dist.all_reduce(vote, op=dist.ReduceOp.MAX, group=stages[0].group)
+
+    global_mode = InferenceMode.DYNAMIC if vote.item() else InferenceMode.STATIC
+
+    for stage in stages:
+        stage._inference_mode = global_mode
+
+    logger.debug(
+        "Rank determined inference_mode=%s for %d stage(s)",
+        global_mode.value,
+        len(stages),
+    )
 
 
 __all__ = [
@@ -560,20 +600,44 @@ class PipelineScheduleSingle(_PipelineSchedule):
             self._get_pipeline_order()
         )
 
-    def _initialize_stage(self, args, kwargs):
-        if not self._stage_forward_initialized:
-            # Prepare the communication needed for the pipeline schedule execution
-            # This is needed because during execution we always perform a series of batch P2P ops
-            # The first call of the batched P2P needs to involve the global group
-            all_ops: list[dist.P2POp] = []
-            all_ops.extend(self._stage._get_init_p2p_neighbors_ops())
-            _wait_batch_p2p(_batch_p2p(all_ops))
+    def _initialize_stage(self, args, kwargs, target=None):
+        # Detect mode change (eval↔train) requiring forward re-initialization.
+        # Forward metadata depends on has_backward (which sets the grad context),
+        # so changing modes invalidates the cached forward infra.
+        # P2P neighbor init is mode-independent and runs only once.
+        p2p_done = self._stage_forward_initialized
+        if self._stage_forward_initialized and (
+            self._has_backward != self._stage_backward_initialized
+        ):
+            self._stage_forward_initialized = False
+            self._stage_backward_initialized = False
 
-            self._stage._prepare_forward_infra(self._n_microbatches, args, kwargs)
+        if not self._stage_forward_initialized:
+            if not p2p_done:
+                all_ops: list[dist.P2POp] = []
+                all_ops.extend(self._stage._get_init_p2p_neighbors_ops())
+                _wait_batch_p2p(_batch_p2p(all_ops))
+
+            # Determine global inference mode via collective across all PP ranks
+            if isinstance(self._stage, PipelineStage):
+                _determine_and_set_global_inference_mode(
+                    [self._stage], self._has_backward
+                )
+
+            self._stage._prepare_forward_infra(
+                self._n_microbatches,
+                args,
+                kwargs,
+                has_backward=self._has_backward,
+            )
             self._stage_forward_initialized = True
 
         if self._has_backward and not self._stage_backward_initialized:
-            self._stage._prepare_backward_infra(self._n_microbatches)
+            self._stage._prepare_backward_infra(
+                self._n_microbatches,
+                loss_fn=self._loss_fn,
+                target=target,
+            )
             self._stage_backward_initialized = True
 
     def step(
@@ -670,7 +734,8 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
             )
 
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
+        first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], first_target)
 
         # Delay send waits
         fwd_sends_to_wait: list[list[dist.Work]] = []
@@ -721,7 +786,8 @@ class ScheduleGPipe(PipelineScheduleSingle):
             return_outputs: whether to return the outputs from the last stage.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
+        first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], first_target)
 
         # Delay send waits
         fwd_sends_to_wait: list[list[dist.Work]] = []
@@ -865,7 +931,8 @@ or equal to the number of stages ({self._num_stages})."
             return_outputs: whether to return the outputs from the last stage.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0])
+        first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], first_target)
 
         # Last stage has 1 warmup, second-to-last 2 warmups, ...
         # first stage `num_stages` warmups
@@ -1532,33 +1599,60 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 "Simply stop passing it, and everything should still work fine."
             )
 
-    def _initialize_stages(self, args: tuple[Any, ...], kwargs):
-        if not self._stages_forward_initialized:
-            # Prepare the communication needed for the pipeline schedule execution
-            # This is needed because during execution we always perform a series of batch P2P ops
-            # The first call of the batched P2P needs to involve the global group
-            all_ops: list[dist.P2POp] = []
-            for stage in self._stages:
-                all_ops.extend(stage._get_init_p2p_neighbors_ops())
-            _wait_batch_p2p(_batch_p2p(all_ops))
+    def _initialize_stages(self, args: tuple[Any, ...], kwargs, target=None):
+        # Detect mode change (eval↔train) requiring forward re-initialization.
+        # Forward metadata depends on has_backward (which sets the grad context),
+        # so changing modes invalidates the cached forward infra.
+        # P2P neighbor init is mode-independent and runs only once.
+        p2p_done = self._stages_forward_initialized
+        if self._stages_forward_initialized and (
+            self._has_backward != self._stages_backward_initialized
+        ):
+            self._stages_forward_initialized = False
+            self._stages_backward_initialized = False
 
-            # may be 'none' value (if this stage sends its output shapes to the next stage via P2P)
-            # or real value (if this stage and next stage are on the same device)
-            next_stage_args: tuple[Any, ...] = tuple()
+        if not self._stages_forward_initialized:
+            if not p2p_done:
+                all_ops: list[dist.P2POp] = []
+                for stage in self._stages:
+                    all_ops.extend(stage._get_init_p2p_neighbors_ops())
+                _wait_batch_p2p(_batch_p2p(all_ops))
+
+            # Determine global inference mode via collective across all PP ranks
+            if all(isinstance(stage, PipelineStage) for stage in self._stages):
+                _determine_and_set_global_inference_mode(
+                    cast(list[PipelineStage], self._stages), self._has_backward
+                )
+
+            next_stage_args: Any = None
             for stage in self._stages:
                 if stage.is_first:
                     next_stage_args = stage._prepare_forward_infra(
-                        self._n_microbatches, args, kwargs
+                        self._n_microbatches,
+                        args,
+                        kwargs,
+                        has_backward=self._has_backward,
                     )
                 else:
                     next_stage_args = stage._prepare_forward_infra(
-                        self._n_microbatches, next_stage_args, kwargs
+                        self._n_microbatches,
+                        next_stage_args,
+                        kwargs,
+                        has_backward=self._has_backward,
                     )
             self._stages_forward_initialized = True
 
         if self._has_backward and not self._stages_backward_initialized:
-            for stage in self._stages:
-                stage._prepare_backward_infra(self._n_microbatches)
+            # Iterate stages in reverse order
+            prev_stage_grad_meta: Any = None
+            for stage in reversed(self._stages):
+                # Call _prepare_backward_infra which handles both metadata inference and recv info setup
+                prev_stage_grad_meta = stage._prepare_backward_infra(
+                    self._n_microbatches,
+                    loss_fn=self._loss_fn,
+                    target=target,
+                    received_grad_meta=prev_stage_grad_meta,  # Pass grad meta from next stage
+                )
             self._stages_backward_initialized = True
 
     def _validate_and_set_stage_mapping(
@@ -1674,8 +1768,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
         not support models with skip connections.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0])
+        first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], first_target)
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order
@@ -2060,7 +2154,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         not support models with skip connections.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0])
+        first_target = target_mbs[0] if target_mbs is not None else None
+        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], first_target)
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -12,14 +12,36 @@ import torch.fx as fx
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.distributed._composable.replicate_with_fsdp import replicate, ReplicateModule
+from torch.distributed._mesh_layout import _MeshLayout
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import FSDPModule, fully_shard
+from torch.distributed.pipelining._utils import (
+    _DTensorMeta,
+    _make_tensor_from_meta,
+    _MeshCache,
+    _StageBackwardMeta,
+    _StageForwardMeta,
+    _StageMeta,
+    _TensorMeta,
+    extract_tensor_meta,
+    extract_tensor_metas,
+    flatten_args,
+    InferenceMode,
+    PipeInfo,
+    PipeliningMetadataError,
+    TensorMeta,
+    to_local_if_dtensor,
+    validate_and_normalize_to_tuple,
+    validate_metadata,
+    validate_static_dtensor_grad_correspondence,
+    validate_tensors_metadata,
+)
+from torch.distributed.tensor import DTensor
 from torch.fx.node import Argument, map_aggregate
 from torch.nn.parallel import DistributedDataParallel
-from torch.utils._pytree import tree_map_only
 
 from ._backward import stage_backward, stage_backward_input, stage_backward_weight
 from ._debug import map_debug_info
-from ._utils import flatten_args, PipeInfo, validate_tensors_metadata
 
 
 __all__ = [
@@ -63,61 +85,47 @@ def _normalize_model_output_as_tuple(output: Any) -> tuple[Any]:
     return output_tuple
 
 
-class _RootArgPlaceholder:
-    """
-    Placeholder for model-level inputs.
-    """
-
-    def __init__(self, tensor):
-        self.meta = tensor.to("meta")
-
-
 class _RecvInfo:
-    """
-    Represents a stage input.
+    """Input tensor descriptor for a pipeline stage.
+
+    Handles both received activations from a previous stage
+    (``is_root_arg=False``) and root-level model inputs provided
+    by the user (``is_root_arg=True``).
     """
 
     def __init__(
         self,
         input_name: str,
-        source: int,
-        buffer: torch.Tensor,
+        source: int | None,
+        buffer: torch.Tensor | None,
+        tensor_meta: TensorMeta | None,
+        *,
+        is_root_arg: bool = False,
     ):
         # Name of this input
         self.input_name = input_name
-        # Stage index of the source of this input
+        # Stage index of the source of this input (None for root args)
         self.source = source
-        # Buffer to receive the input into.
+        # Buffer to receive the input into (None for root args)
         self.buffer = buffer
+        # Tensor metadata for validation and DTensor reconstruction
+        self.tensor_meta = tensor_meta
+        # Whether this is a root-level model input (no recv needed)
+        self.is_root_arg = is_root_arg
 
     def __repr__(self):
-        return f"_RecvInfo(input={self.input_name}, source={self.source}, shape={self.buffer.size()})"
-
-
-# An input can be either a received activation or a model input
-InputInfo = _RecvInfo | _RootArgPlaceholder
-
-
-def _make_tensor_from_meta(
-    example: torch.Tensor | FakeTensor,
-    device: torch.device,
-) -> torch.Tensor:
-    """
-    Create a real tensor from a tensor.
-    """
-    return torch.empty(
-        example.size(),
-        dtype=example.dtype,
-        layout=example.layout,
-        device=device,
-    )
+        if self.is_root_arg:
+            return f"_RecvInfo(input={self.input_name}, root_arg=True)"
+        meta_type = type(self.tensor_meta).__name__ if self.tensor_meta else "None"
+        buffer_shape = self.buffer.size() if self.buffer is not None else "None"
+        return f"_RecvInfo(input={self.input_name}, source={self.source}, shape={buffer_shape}, meta={meta_type})"
 
 
 class _PipelineStageBase(ABC):
-    """
-    Base class for pipeline stages.
-    Defines or implements common methods used by the `_PipelineStage` used by
-    the tracing frontend and `PipelineStage` used by manual frontend.
+    """Base class for pipeline stages.
+
+    Defines common methods used by ``_PipelineStage`` (tracing frontend)
+    and ``PipelineStage`` (manual frontend).
     """
 
     def __init__(
@@ -131,20 +139,16 @@ class _PipelineStageBase(ABC):
     ):
         """
         Args:
-            submodule (torch.nn.Module): The module to be executed in this stage.
-            stage_index (int): The index of this stage.
-            num_stages (int): The total number of stages in this pipeline.
-            device (torch.device): The device to run this stage on.
-            group (Optional[dist.ProcessGroup]): The process group to use for communication.
-                If `None`, the default process group will be used.
-                Default: `None`.
-            dw_builder (Optional[Callable[[], Callable[..., None]]): If provided, dw_builder is a builder function
-                that will build a new dw_runner function that will run parts of module backward that were intentionally
-                skipped during the module's actual backward pass. The builder must be invoked by stage after stage runs
-                model backwards, and stage should save the latest dw_runner to run during weight pas (W).
-                If not provided, a dw_runner will be generated automatically by traversing the autograd graph.
-                When used with schedules that only have F and B steps, the fresh dw_runner function will be called as
-                part of I (input backwards). When used with F,I,W schedules, the dw_runner function implements 'W'.
+            submodule: The module to be executed in this stage.
+            stage_index: The index of this stage.
+            num_stages: The total number of stages in this pipeline.
+            device: The device to run this stage on.
+            group: Process group for communication. Defaults to the
+                default process group if ``None``.
+            dw_builder: Builder function that produces a ``dw_runner``
+                for deferred weight updates in F/I/W zero-bubble
+                schedules. If ``None``, a runner is generated
+                automatically via autograd graph traversal.
         """
         super().__init__()
         if stage_index >= num_stages:
@@ -175,7 +179,6 @@ class _PipelineStageBase(ABC):
             )
 
         # Run time states
-        self._outputs_meta: tuple[torch.Tensor, ...] | None = None
         # map microbatch ID to list of forward tensor args
         self.fwd_cache: dict[int, tuple[Any, list[torch.Tensor]]] = {}
         # map microbatch ID to list of backward grad tensor args
@@ -190,7 +193,7 @@ class _PipelineStageBase(ABC):
         self.log_prefix = f"[Stage {self.stage_index}]"
 
         # Forward infra
-        self.args_recv_info: dict[int, tuple[InputInfo, ...]] = {}
+        self.args_recv_info: dict[int, tuple[_RecvInfo, ...]] = {}
         self.act_send_info: dict[int, list] = {}
 
         # Backward infra will created lazily
@@ -202,6 +205,19 @@ class _PipelineStageBase(ABC):
         self.stage_index_to_group_rank: dict[int, int] = {
             i: i % self.group_size for i in range(self.num_stages)
         }
+
+        # DTensor support: mesh provider function for looking up DeviceMesh
+        # Will be set by subclass or during inference
+        self.get_mesh: (
+            Callable[[tuple[str, ...], _MeshLayout | None], DeviceMesh] | None
+        ) = None
+
+        # DTensor support: mesh cache for looking up DeviceMesh by (dim_names, layout)
+        self._mesh_cache = _MeshCache()
+
+        # DTensor support: consolidated stage metadata container
+        # Contains inputs, outputs, input_grads, output_grads metadata
+        self._stage_meta = _StageMeta()
 
     @property
     def has_backward(self) -> bool:
@@ -228,6 +244,68 @@ class _PipelineStageBase(ABC):
         """
         return self.stage_index == self.num_stages - 1
 
+    def _validate_fwd_inputs(self, args: tuple[torch.Tensor, ...]):
+        """Validate that forward inputs match expected metadata.
+
+        Raises:
+            PipeliningMetadataError: On shape/dtype/placement mismatch.
+        """
+        if self._stage_meta.inputs is None:
+            raise PipeliningMetadataError(f"Stage {self.stage_index} has no inputs")
+        validate_tensors_metadata(
+            f"Stage {self.stage_index} forward inputs",
+            self._stage_meta.inputs,
+            args,
+        )
+
+    def _validate_fwd_outputs(self, outputs: tuple[torch.Tensor, ...]):
+        """Validate that forward outputs match expected metadata.
+
+        Raises:
+            PipeliningMetadataError: On shape/dtype/placement mismatch.
+        """
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(f"Stage {self.stage_index} has no outputs")
+        validate_tensors_metadata(
+            f"Stage {self.stage_index} forward outputs",
+            self._stage_meta.outputs,
+            outputs,
+        )
+
+    def _validate_bwd_inputs(self, output_grads: tuple[torch.Tensor | None, ...]):
+        """Validate that backward input grads match expected metadata.
+
+        Raises:
+            PipeliningMetadataError: On shape/dtype/placement mismatch.
+        """
+        # Get metadata from _stage_meta.output_grads
+        if self._stage_meta.output_grads is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index} has no output grads"
+            )
+
+        validate_tensors_metadata(
+            f"Stage {self.stage_index} backward input (output_grads)",
+            self._stage_meta.output_grads,
+            output_grads,
+        )
+
+    def _validate_bwd_outputs(self, input_grads: tuple[torch.Tensor | None, ...]):
+        """Validate that backward output grads match expected metadata.
+
+        Raises:
+            PipeliningMetadataError: On shape/dtype/placement mismatch.
+        """
+        if self._stage_meta.input_grads is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index} has no input grads"
+            )
+        validate_tensors_metadata(
+            f"Stage {self.stage_index} backward output (input_grads)",
+            self._stage_meta.input_grads,
+            input_grads,
+        )
+
     def _check_chunk_id(self, chunk_id: int):
         if self.chunks is None:
             raise RuntimeError(
@@ -237,27 +315,6 @@ class _PipelineStageBase(ABC):
             raise RuntimeError(
                 f"Chunk id {chunk_id} is out of range [0, {self.chunks})"
             )
-
-    def _configure_outputs_meta(self, outputs_meta: tuple[torch.Tensor, ...]):
-        """
-        Track the output shapes/dtype of this stage since they determine the send operation(s) which must match
-        recv operations of the next stage.  The next stage _will_ be freezing its recv buffers based on its initial
-        configuration, so it's important to also freeze/validate the output side to avoid any send/recv mismatches
-        which could show up as hangs, silent corruption, or other errors.
-        """
-        if self._outputs_meta is not None:
-            raise AssertionError(
-                "Attempting to reconfigure output_meta, which is not supported"
-            )
-        self._outputs_meta = tuple(outputs_meta)  # type: ignore[assignment]
-
-    def get_outputs_meta(self) -> tuple[torch.Tensor, ...]:
-        """Get the output metadata (meta tensors) reprensenting the outputs of this stage"""
-        if self._outputs_meta is None:
-            raise AssertionError(
-                "Attempted to get_outputs_meta() without configuring output meta"
-            )
-        return self._outputs_meta
 
     def _create_grad_send_info(
         self,
@@ -272,12 +329,13 @@ class _PipelineStageBase(ABC):
             # Note: we send gradients back to previous stage as long as in
             # forward it is a received input, regardless of whether it requires
             # grad. It is up to the previous stage to discard this gradient.
-            if isinstance(a, _RecvInfo):
-                grad_send_info.append(a.source)
-                return a.source
-            else:
+            if a.is_root_arg:
+                # Root args don't have a source stage to send gradients to
                 grad_send_info.append(None)
                 return None
+            else:
+                grad_send_info.append(a.source)
+                return a.source
 
         map_aggregate(args_recv_info, map_recv_to_send)
 
@@ -288,17 +346,30 @@ class _PipelineStageBase(ABC):
     def _prepare_forward_infra(
         self,
         num_microbatches: int,
-        args: tuple[Any, ...],
+        args: tuple[Any, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Any, ...]:
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
         raise NotImplementedError
 
-    def _prepare_backward_infra(self, num_microbatches: int):
+    @abstractmethod
+    def _prepare_backward_infra(
+        self,
+        num_microbatches: int,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: _StageBackwardMeta | None = None,
+    ) -> _StageBackwardMeta | None:
+        raise NotImplementedError
+
+    def _setup_backward_recv_info(self, num_microbatches: int):
         # TODO: this is needed for backward_maybe_with_nosync
         self.chunks = num_microbatches
 
+        # IMPORTANT: _create_grad_recv_info reads self._stage_meta.output_grads
+        # to attach DTensor metadata to _RecvInfo objects. The clear below MUST
+        # happen after all _create_grad_recv_info calls complete.
         for mb_index in range(num_microbatches):
-            # `grad_recv_info` is a mirror of `act_send_info`
             self.grad_recv_info[mb_index] = self._create_grad_recv_info(
                 self.act_send_info
             )
@@ -312,7 +383,7 @@ class _PipelineStageBase(ABC):
 
     def _get_recv_ops(
         self,
-        recv_infos: tuple[InputInfo, ...],
+        recv_infos: tuple[_RecvInfo, ...],
     ) -> list[dist.P2POp]:
         """
         Helper function shared by `get_fwd_recv_ops` and `get_bwd_recv_ops`.
@@ -320,9 +391,15 @@ class _PipelineStageBase(ABC):
         """
         ops: list[dist.P2POp] = []
         for info in recv_infos:
-            if not isinstance(info, _RecvInfo):
+            if info.is_root_arg:
+                # Root args don't need recv operations
                 continue
-
+            # Skip entries with None buffer (None gradients)
+            if info.buffer is None:
+                assert info.tensor_meta is None  # noqa: S101
+                continue
+            # At this point, source and buffer are guaranteed non-None
+            assert info.source is not None  # noqa: S101
             peer_rank = self.stage_index_to_group_rank[info.source]
             peer_global_rank = (
                 peer_rank
@@ -337,46 +414,46 @@ class _PipelineStageBase(ABC):
 
     """[Note: V-schedule special case]
 
-    V-Schedules have a special case where 2 stages with adjacent stage_id are on the same rank.
+    V-Schedules have a special case where 2 stages with adjacent stage_id
+    are on the same rank.
 
-    ex: 2 ranks, 4 stages forms a simple V:
-    rank0:  stage 0                   stage 3
-    rank1:          stage 1  stage 2
+    Example: 2 ranks, 4 stages forms a simple V::
 
-    stage 0,1 and 2,3 communicate activations using send/recv as usual, but stage 1,2 do not need to
-    use communication ops.  Instead, they should pass tensor data directly via function call.
+        rank0:  stage 0                   stage 3
+        rank1:          stage 1  stage 2
 
-    set_local_fwd_input and (get_local_bwd_output + set_local_bwd_input) facilitate this optimization, and
-    should be called at the appropriate time during the pipeline schedule (after forward or backward execution).
+    Stages 0/1 and 2/3 communicate via send/recv, but stages 1/2 pass
+    tensors directly via function call, avoiding communication ops.
     """
 
     def set_local_fwd_input(self, prev_stage_outputs: Any, mb_index: int) -> None:
+        """Pass outputs from a same-rank stage as forward inputs (V-schedule).
+
+        Detaches tensors and sets ``requires_grad`` so they serve as autograd
+        leaves. Handles DTensor activations transparently.
+
+        Args:
+            prev_stage_outputs: Outputs from the previous same-rank stage.
+            mb_index: Microbatch index.
         """
-        Moves 'prev_stage_outputs' from another stage on the same rank into place as inputs for this stage. Avoids
-        copying tensor data or using send/recv op.  Detaches original tensor and sets requires_grad so the
-        tensor can serve as a leaf for autograd and gradients can be collected from it during backward.
-        """
-        recv_infos: tuple[InputInfo, ...] = self.args_recv_info[mb_index]
+        recv_infos: tuple[_RecvInfo, ...] = self.args_recv_info[mb_index]
 
         # See [Note: pipeline model output type]
         prev_stage_outputs = _normalize_model_output_as_tuple(prev_stage_outputs)
 
-        for info, tensor in zip(recv_infos, prev_stage_outputs):
+        for info, tensor in zip(recv_infos, prev_stage_outputs, strict=True):
             if not isinstance(tensor, torch.Tensor):
                 raise AssertionError(
                     f"expected tensor values as outputs from prev stage, got {type(tensor)}"
                 )
-            if not isinstance(info, _RecvInfo):
+            if info.is_root_arg:
                 raise AssertionError(
-                    "set_local_Fwd_input should only be called on non-first stage, which should always have RecvInfo"
+                    "set_local_fwd_input should only be called on non-first stage, which should always have non-root RecvInfo"
                 )
 
-            # We don't need to do a data copy here, since we can directly pass the activation tensor reference from
-            # one stage to the next.  However, we do need to mark the activation as a leaf tensor since it will serve
-            # as the input tensor for a fresh autograd graph, not part of the previous stage's autograd graph.
-            # TODO: confirm, do we use this activation as the root of the backward call for the previous stage? does
-            # detach have any affect on that?
-            info.buffer = tensor.detach().requires_grad_(True)
+            # Pass the activation tensor directly (same rank for local execution).
+            # Detach to create a new autograd leaf for the fresh autograd graph.
+            info.buffer = to_local_if_dtensor(tensor, detach=True)
 
     def get_local_bwd_output(self, mb_index):
         """
@@ -398,6 +475,7 @@ class _PipelineStageBase(ABC):
         """
         Moves 'grad input' tensors from the next stage to 'grad_output' on this stage, avoiding a copy or send/recv.
         Does not detach or set '_requires_grad'.
+        Handles DTensor gradients for V-schedule local passing.
         """
         if not isinstance(next_stage_bwd_outputs, tuple):
             raise AssertionError(f"Expected tuple, got {type(next_stage_bwd_outputs)}")
@@ -409,21 +487,27 @@ class _PipelineStageBase(ABC):
         if self.is_last:
             raise AssertionError("can't set bwd input if this stage is last")
         recv_infos = self.grad_recv_info[mb_index]
-        for info, tensor in zip(recv_infos, next_stage_bwd_outputs):
+        for info, tensor in zip(recv_infos, next_stage_bwd_outputs, strict=True):
+            if tensor is None:
+                continue
             if not isinstance(tensor, torch.Tensor):
                 raise AssertionError(
                     f"expected tensor values as outputs from prev stage, got {type(tensor)}"
                 )
-            if not isinstance(info, _RecvInfo):
-                raise AssertionError(f"Expected a recv info, got {type(info)}")
-            info.buffer = tensor
+            if info.is_root_arg:
+                raise AssertionError(
+                    "set_local_bwd_input should only be called with non-root RecvInfo"
+                )
+
+            # Extract local tensor for the buffer (handles DTensor or plain tensor)
+            info.buffer = to_local_if_dtensor(tensor)
 
     def get_fwd_recv_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Returns a list of ops that are needed to receive the input arguments
         for this stage.
         """
-        recv_infos: tuple[InputInfo, ...] = self.args_recv_info[fwd_chunk_id]
+        recv_infos: tuple[_RecvInfo, ...] = self.args_recv_info[fwd_chunk_id]
 
         return self._get_recv_ops(recv_infos)
 
@@ -441,6 +525,7 @@ class _PipelineStageBase(ABC):
     def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the activation send ops for current stage's forward.
+        Handles DTensor outputs by extracting local tensors.
         """
         output_tuple, _ = self.fwd_cache[fwd_chunk_id]
 
@@ -451,11 +536,13 @@ class _PipelineStageBase(ABC):
             for dst in dst_stages:
                 if dst is None:
                     continue
+                # Extract local tensor if DTensor
+                send_tensor = to_local_if_dtensor(out, detach=True)
                 logger.debug(
                     "%s Sending tensor to Stage %s: %s",
                     self.log_prefix,
                     dst,
-                    out.size(),
+                    send_tensor.size(),
                 )
                 peer_rank = self.stage_index_to_group_rank[dst]
                 peer_global_rank = (
@@ -463,13 +550,16 @@ class _PipelineStageBase(ABC):
                     if self.group is None
                     else dist.get_global_rank(self.group, peer_rank)
                 )
-                ops.append(dist.P2POp(dist.isend, out, peer_global_rank, self.group))
+                ops.append(
+                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
+                )
 
         return ops
 
     def get_bwd_send_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the gradient send ops for current stage's backward.
+        Handles DTensor gradients by extracting local tensors.
         """
         if not self.has_backward or self.is_first:
             return []
@@ -485,13 +575,16 @@ class _PipelineStageBase(ABC):
 
         ops: list[dist.P2POp] = []
         grads_input = self.bwd_cache.pop(bwd_chunk_id)
-        for grad, grad_recv_stage in zip(grads_input, self.grad_send_info):
+
+        for grad, grad_recv_stage in zip(grads_input, self.grad_send_info, strict=True):
             if isinstance(grad, torch.Tensor) and grad_recv_stage is not None:
+                # Extract local tensor if DTensor
+                send_tensor = to_local_if_dtensor(grad)
                 logger.debug(
                     "%s Sending gradient to Stage %s: %s",
                     self.log_prefix,
                     grad_recv_stage,
-                    grad.size(),
+                    send_tensor.size(),
                 )
                 peer_rank = self.stage_index_to_group_rank[grad_recv_stage]
                 peer_global_rank = (
@@ -499,10 +592,12 @@ class _PipelineStageBase(ABC):
                     if self.group is None
                     else dist.get_global_rank(self.group, peer_rank)
                 )
-                ops.append(dist.P2POp(dist.isend, grad, peer_global_rank, self.group))
+                ops.append(
+                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
+                )
             else:
                 if grad is not None or grad_recv_stage is not None:
-                    raise RuntimeError(
+                    raise PipeliningMetadataError(
                         f"[{self.stage_index}] for chunk {bwd_chunk_id} has gradients {grad} "
                         f"and is expecting to send gradients to stage {grad_recv_stage}"
                     )
@@ -523,34 +618,86 @@ class _PipelineStageBase(ABC):
         # don't want such accumulation.
         for recv_tuple in self.args_recv_info.values():  # iterate over all chunks
             for a in recv_tuple:  # iterate over all input args
-                if isinstance(a, _RecvInfo):
+                if not a.is_root_arg and a.buffer is not None:
                     # Set to None is the newer and recommended way to clear grads, compared to `zero_()`.
                     # See https://github.com/pytorch/pytorch/pull/92731
                     a.buffer.grad = None
 
     def _map_tensor_from_recv_info(
         self,
-        recv_infos: tuple[InputInfo, ...],
+        recv_infos: tuple[_RecvInfo, ...],
     ):
         """
         Map tensors from recv infos to a list.
         """
 
         def get_recv_tensor(info):
-            if isinstance(info, _RecvInfo):
-                return info.buffer
-            else:
-                raise AssertionError(f"Expected _RecvInfo but got {type(info)}")
+            if info.is_root_arg:
+                raise PipeliningMetadataError("Cannot get recv tensor from root arg")
+            return info.buffer
 
         return map_aggregate(cast(Argument, recv_infos), get_recv_tensor)
 
-    def _retrieve_recv_activations(self, fwd_chunk_id: int):
+    def _retrieve_recv_activations(
+        self,
+        fwd_chunk_id: int,
+    ):
         """
         Retrieve the activations received for the current stage during forward.
+        Reconstructs DTensors if the inputs were DTensors.
+        Also validates DTensor metadata against expected values.
         """
         recv_infos = self.args_recv_info[fwd_chunk_id]
-        activations = self._map_tensor_from_recv_info(recv_infos)
-        return activations
+
+        activations = []
+        for i, info in enumerate(recv_infos):
+            if not info.is_root_arg:
+                # Non-root args have valid buffer and tensor_meta
+                assert info.buffer is not None  # noqa: S101
+                assert info.tensor_meta is not None  # noqa: S101
+                local_tensor = info.buffer
+
+                # Effective requires_grad: metadata captures what the model
+                # produced, but the runtime context (has_backward, grad mode)
+                # determines whether we actually need gradients.
+                effective_requires_grad = (
+                    info.tensor_meta.requires_grad
+                    and self.has_backward
+                    and torch.is_grad_enabled()
+                )
+                if isinstance(info.tensor_meta, _DTensorMeta):
+                    # Reconstruct DTensor from local tensor + metadata
+                    mesh = self._mesh_cache.get_or_create(
+                        info.tensor_meta.mesh_cache_key, self.get_mesh
+                    )
+                    activation = DTensor.from_local(
+                        local_tensor,
+                        device_mesh=mesh,
+                        placements=info.tensor_meta.placements,
+                        shape=info.tensor_meta.global_shape,
+                        stride=info.tensor_meta.global_stride,
+                        run_check=False,
+                    ).requires_grad_(effective_requires_grad)
+                    # DTensor.from_local creates a non-leaf tensor (via view_as),
+                    # so we need retain_grad() for backward to populate .grad
+                    if activation.requires_grad and not activation.is_leaf:
+                        activation.retain_grad()
+                else:
+                    activation = local_tensor.requires_grad_(effective_requires_grad)
+                # Validate the reconstructed activation against expected metadata
+                validate_metadata(
+                    f"Stage {self.stage_index} forward input {i} (reconstructed)",
+                    info.tensor_meta,
+                    activation,
+                    raise_on_mismatch=True,
+                )
+                activations.append(activation)
+            else:
+                raise PipeliningMetadataError(
+                    f"_retrieve_recv_activations expected non-root _RecvInfo but got root arg at index {i}"
+                )
+
+        return tuple(activations)
 
     def _retrieve_recv_grads(
         self,
@@ -558,10 +705,47 @@ class _PipelineStageBase(ABC):
     ):
         """
         Retrieve the gradients received for the current stage during backward.
+
+        Handles None gradients gracefully (for inputs that don't require grad).
         """
         recv_infos = self.grad_recv_info[bwd_chunk_id]
-        grads = self._map_tensor_from_recv_info(recv_infos)
-        return grads
+
+        grads: list[torch.Tensor | None] = []
+        for i, info in enumerate(recv_infos):
+            if not isinstance(info, _RecvInfo):
+                raise PipeliningMetadataError(
+                    f"Expected _RecvInfo but got {type(info)}"
+                )
+            if not info.is_root_arg:
+                local_tensor = info.buffer
+                # Gradients can be None for non-differentiable outputs
+                if local_tensor is None:
+                    assert info.tensor_meta is None  # noqa: S101
+                    grads.append(None)
+                    continue
+                assert info.tensor_meta is not None  # noqa: S101
+                if isinstance(info.tensor_meta, _DTensorMeta):
+                    # Reconstruct DTensor gradient from local tensor + metadata
+                    mesh = self._mesh_cache.get_or_create(
+                        info.tensor_meta.mesh_cache_key, self.get_mesh
+                    )
+                    grad = DTensor.from_local(
+                        local_tensor,
+                        device_mesh=mesh,
+                        placements=info.tensor_meta.placements,
+                        shape=info.tensor_meta.global_shape,
+                        stride=info.tensor_meta.global_stride,
+                        run_check=False,
+                    )
+                else:
+                    grad = local_tensor
+                grads.append(grad)
+            else:
+                raise PipeliningMetadataError(
+                    f"grad_recv_info should not contain root args, but found one at index {i}"
+                )
+
+        return tuple(grads)
 
     def forward_maybe_with_nosync(self, *args, **kwargs):
         # If submod is wrapped with DDP, we use the `no_sync` context manager to
@@ -691,7 +875,7 @@ class _PipelineStageBase(ABC):
 
         composite_kwargs = kwargs or {}
 
-        self._validate_fwd_input(args, kwargs)
+        self._validate_fwd_inputs(composite_args)
 
         # Compute forward
         try:
@@ -727,7 +911,8 @@ class _PipelineStageBase(ABC):
             fwd_chunk_id,
             map_debug_info(output),
         )
-        self._validate_fwd_outputs(output_tuple)
+        if not self.is_last:
+            self._validate_fwd_outputs(output_tuple)
 
         # We return the original user-provided output, not normalized to tuple.
         # See [Note: pipeline model output type]
@@ -776,6 +961,8 @@ class _PipelineStageBase(ABC):
         else:
             # Otherwise, receive gradients from next stage
             grads_output = self._retrieve_recv_grads(bwd_chunk_id)
+            # Validate backward input (output gradients) for DTensor metadata
+            self._validate_bwd_inputs(grads_output)
             # If an input to the pipeline requires gradient,
             # `torch.autograd.backward` will accumulate the gradient into the
             # `.grad` field of such input
@@ -828,8 +1015,14 @@ class _PipelineStageBase(ABC):
                 )
                 # Save a placeholder for the dw_runner
                 self.dw_runner[bwd_chunk_id] = lambda: None
-
-        self.bwd_cache[bwd_chunk_id] = grads_input
+        # Note: grads_input may contain gradients for both args and kwargs (from fwd_cache),
+        # Kwargs are local to each stage and don't need gradient transmission.
+        # Validate backward output (input gradients) for DTensor metadata
+        assert self._stage_meta.inputs is not None  # noqa: S101
+        num_fwd_args = len(self._stage_meta.inputs)
+        if not self.is_first:
+            self._validate_bwd_outputs(grads_input[:num_fwd_args])
+        self.bwd_cache[bwd_chunk_id] = grads_input[:num_fwd_args]
 
         if self.is_last and not self.is_first:
             # Autograd dependencies:
@@ -886,48 +1079,6 @@ class _PipelineStageBase(ABC):
                 self.backward_maybe_with_nosync(
                     "full", bwd_kwargs, last_backward=last_backward
                 )
-
-    def _validate_fwd_input(self, args, kwargs):
-        """Raises a RuntimeError if shapes of input args/kwargs do not match the shapes configured for this stage."""
-
-        if self.is_first:
-            # TODO why is there a separate recv_info for each pipeline chunk?
-            # kwen2501: to avoid passing a `fwd_chunk_id` to this function, we
-            # check all chunks against args_recv_info[0]
-            expected_args = self.args_recv_info[0]
-        else:
-            # We don't check inputs for non-0 stages assuming they don't accept
-            # user inputs in canonical pipeline scenarios
-            return
-
-        if len(kwargs):
-            # TODO- need a mapping of kwarg to position in self.args_recv_info
-            # Without it, we are not 100% sure how to match the args and
-            # expected_args.
-            return
-
-        # TODO- need a mapping of kwarg to position in self.args_recv_info
-        # maybe it's impossible to tell whether the len mismatches because
-        # (a) the user passed an extra arg or missed an arg
-        # (b) the user did not pass a kwarg, which has a default value baked into expected_args
-        expected_tensors_meta = [
-            e.meta if isinstance(e, _RootArgPlaceholder) else e.buffer
-            for e in expected_args
-        ]
-        validate_tensors_metadata(
-            f"Stage {self.stage_index} forward inputs", expected_tensors_meta, args
-        )
-
-    def _validate_fwd_outputs(self, outputs: tuple[torch.Tensor, ...]):
-        """Raises a RuntimeError if this stage produces an output of unexpected shape/dtype.
-        Most likely, this could be cause either by incorrect user specification of output shapes, or because
-        shape inference was done on the original model but then at runtime the model is wrapped with something like
-        mixed precision which changes output dtype.
-        """
-        expected_tensors_meta = self.get_outputs_meta()
-        validate_tensors_metadata(
-            f"Stage {self.stage_index} forward outputs", expected_tensors_meta, outputs
-        )
 
     def _get_init_p2p_neighbors_ops(self) -> list[dist.P2POp]:
         """
@@ -1054,7 +1205,7 @@ class _PipelineStage(_PipelineStageBase):
             node for node in pipe_info.graph.nodes if node.op == "call_module"
         ]
         if len(submod_nodes) != self.num_stages:
-            raise AssertionError(
+            raise PipeliningMetadataError(
                 f"Number of submodules in pipe graph {len(submod_nodes)} does not match number of stages {self.num_stages}"
             )
 
@@ -1092,21 +1243,90 @@ class _PipelineStage(_PipelineStageBase):
     def _prepare_forward_infra(
         self,
         num_microbatches: int,
-        args: tuple[Any, ...],
+        args: tuple[Any, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Any, ...]:
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
         """
-        Create send/recv infrastructures for activations (during forward)
+        Prepare forward infrastructure for traced pipeline.
+
+        Metadata is created directly from graph placeholders with correct
+        ``requires_grad`` — received activations get ``requires_grad=True``
+        when ``has_backward`` is set, fixing the fact that ``torch.export``
+        traces under ``no_grad()``.
+
+        ``_stage_meta.inputs`` is derived from recv infos and aligned with
+        ``forward_one_chunk``'s ``composite_args``: positional root inputs
+        on the first stage, received activations only on subsequent stages.
         """
-        # TODO(whc)
-        # this method should be deleted once lazy buffer allocation is implemented
-        # for now, it ignores args/kwargs because it should not need to do shape inference
+        # Step 1: Create recv info for each microbatch.
+        # _create_act_recv_info is self-contained: it creates _TensorMeta
+        # directly from graph placeholder values with correct requires_grad.
         for chunk in range(num_microbatches):
             self.args_recv_info[chunk] = self._create_act_recv_info()
 
-        # Send info during forward for each activation
+        # Step 2: Derive _stage_meta.inputs from recv infos.
+        # forward_one_chunk builds composite_args as:
+        #   - First stage:     args (positional root inputs, excludes kwargs)
+        #   - Non-first stages: received activations only (no root kwargs)
+        # _stage_meta.inputs must match composite_args for validation.
+        recv_infos = self.args_recv_info[0]
+        if self.is_first:
+            # All placeholders are root args.  Only the first len(args)
+            # correspond to positional inputs (composite_args); the rest
+            # are kwargs passed separately via composite_kwargs.
+            n_positional = len(args) if isinstance(args, tuple) else len(recv_infos)
+            self._stage_meta.inputs = tuple(
+                info.tensor_meta  # type: ignore[misc]
+                for info in recv_infos[:n_positional]
+            )
+        else:
+            self._stage_meta.inputs = tuple(
+                info.tensor_meta  # type: ignore[misc]
+                for info in recv_infos
+                if not info.is_root_arg
+            )
+
+        # Step 3: Create send info and output metadata.
         self.act_send_info = self._create_act_send_info()
-        return tuple()
+
+        return None
+
+    def _prepare_backward_infra(
+        self,
+        num_microbatches: int,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: _StageBackwardMeta | None = None,
+    ) -> _StageBackwardMeta | None:
+        """
+        Prepare backward infrastructure for traced pipeline.
+        Derives input_grads metadata from inputs (plain tensors only).
+
+        Note: DTensors are NOT supported in the traced frontend.
+        """
+        # Derive input_grads from inputs (for plain tensors, grad shape == input shape)
+        if self._stage_meta.inputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: inputs metadata required for backward inference."
+            )
+
+        self._stage_meta.input_grads = tuple(
+            _TensorMeta(
+                shape=in_meta.shape,
+                stride=in_meta.stride,
+                dtype=in_meta.dtype,
+                requires_grad=False,
+            )
+            if in_meta.requires_grad
+            else None
+            for in_meta in self._stage_meta.inputs
+        )
+
+        # Setup backward recv info (calls _create_grad_recv_info which sets output_grads)
+        self._setup_backward_recv_info(num_microbatches)
+
+        return None
 
     def get_stage_index_of_submod(
         self,
@@ -1116,7 +1336,7 @@ class _PipelineStage(_PipelineStageBase):
         Given a submodule name, return the stage index of the submodule.
         """
         if submod_name not in self.submod_to_stage_index:
-            raise AssertionError(f"Stage id of {submod_name} not found")
+            raise PipeliningMetadataError(f"Stage id of {submod_name} not found")
 
         return self.submod_to_stage_index[submod_name]
 
@@ -1125,38 +1345,65 @@ class _PipelineStage(_PipelineStageBase):
     ):
         """
         Create a tuple of `_RecvInfo` for inputs to the stage.
+
+        Self-contained: creates ``_TensorMeta`` directly from graph
+        placeholder values with correct ``requires_grad``.
+        ``torch.export`` traces under ``no_grad()`` so traced metadata
+        always has ``requires_grad=False``; for received activations we
+        set ``requires_grad=True`` when ``has_backward`` is set.
+
+        Note: DTensors are NOT supported in the traced frontend.
         """
 
         def create_recv_tensor(placeholder, arg_node):
-            """
-            Create a receive buffer for a placeholder.
-            """
             example_value = placeholder.meta["val"]
-            if arg_node.op == "placeholder":
-                # This is a root level placeholder, thus an input argument to the entire model.
-                # We are likely at stage 0, hence no need to create a receive buffer.
-                return _RootArgPlaceholder(example_value)
 
-            # Figure out the source stage of this input
+            # Reject DTensors in traced frontend
+            if isinstance(example_value, DTensor):
+                raise PipeliningMetadataError(
+                    f"{self.log_prefix} DTensor detected in traced pipeline input "
+                    f"'{placeholder.name}'. DTensor metadata propagation is NOT "
+                    f"supported for the traced frontend (_PipelineStage). "
+                    f"Use the manual PipelineStage frontend for full DTensor support."
+                )
+
+            if arg_node.op == "placeholder":
+                # Root-level placeholder: an input argument to the entire
+                # model.  Keep original metadata from the trace.
+                return _RecvInfo(
+                    input_name=f"root_input_{placeholder.name}",
+                    source=None,
+                    buffer=None,
+                    tensor_meta=_TensorMeta.from_tensor(example_value),
+                    is_root_arg=True,
+                )
+
+            # Received activation from a previous stage.
             while arg_node.target is operator.getitem:
-                # If the input is a getitem, we need to go deeper
                 arg_node = arg_node.args[0]
 
             if arg_node.op != "call_module":
-                raise AssertionError(f"Expecting call_module, got {arg_node.op}")
+                raise PipeliningMetadataError(
+                    f"Expecting call_module, got {arg_node.op}"
+                )
             src_stage = self.get_stage_index_of_submod(arg_node.name)
 
-            # Create a receive buffer for this placeholder
+            # Create metadata directly with correct requires_grad.
+            tensor_meta = _TensorMeta(
+                shape=example_value.shape,
+                stride=example_value.stride(),
+                dtype=example_value.dtype,
+                requires_grad=self.has_backward,
+            )
+
             logger.debug(
                 "%s Creating recv buffer for input '%s' : %s, %s",
                 self.log_prefix,
                 placeholder.name,
-                example_value.shape,
-                example_value.dtype,
+                tensor_meta.shape,
+                tensor_meta.dtype,
             )
-            buffer = _make_tensor_from_meta(example_value, self.device)
-            # In case there is backward pass, set requires_grad for receive buffers
-            # before first forward
+            buffer = _make_tensor_from_meta(tensor_meta, self.device)
             if self.has_backward:
                 buffer.requires_grad_(True)
 
@@ -1164,10 +1411,10 @@ class _PipelineStage(_PipelineStageBase):
                 arg_node.name,
                 src_stage,
                 buffer,
+                tensor_meta,
             )
 
-        args_recv_info: list[InputInfo] = []
-        # Filter out placeholder nodes from `self.submod` (a GraphModule)
+        args_recv_info: list[_RecvInfo] = []
         placeholders = filter(  # type: ignore[var-annotated]
             lambda node: node.op == "placeholder",  # type: ignore[arg-type]
             self.submod.graph.nodes,  # type: ignore[arg-type,union-attr]
@@ -1175,15 +1422,12 @@ class _PipelineStage(_PipelineStageBase):
         # `placeholders` are nodes internal to submod.
         # `self.node.args` are dependency nodes in the outer graph.
         # The two are 1:1.
-        for placeholder, arg_node in zip(placeholders, self.node.args):
-            # Create a receive buffer for this placeholder
-            recv_info = create_recv_tensor(placeholder, arg_node)
-            args_recv_info.append(recv_info)
+        for placeholder, arg_node in zip(placeholders, self.node.args, strict=True):
+            args_recv_info.append(create_recv_tensor(placeholder, arg_node))
 
         logger.debug(
             "%s Activation recv / args info: %s", self.log_prefix, args_recv_info
         )
-        # `args` is a Tuple, hence we will return a Tuple[InputInfo]
         return tuple(args_recv_info)
 
     def find_dst_rank(
@@ -1207,14 +1451,12 @@ class _PipelineStage(_PipelineStageBase):
 
     def _create_act_send_info(self):
         """
-        Create a dict of send info for activations.
-        The dict is of the form:
-        {
-            output_index: [dst_rank_0, dst_rank_1, ...],
-            ...
-        }
-        where the list of `dst_rank`s covers the case where an output value may
-        be consumed by multiple stages.
+        Create a dict of send info for activations and output metadata.
+
+        Output metadata is created directly with correct ``requires_grad``
+        (``torch.export`` traces under ``no_grad()``, so traced values
+        always have ``requires_grad=False``; at runtime, stage outputs
+        carry ``requires_grad=True`` when training).
         """
         # Output index: List of receiver ranks
         act_send_info: dict[int, list] = {}
@@ -1222,16 +1464,13 @@ class _PipelineStage(_PipelineStageBase):
 
         for user in self.node.users:
             if user.target is operator.getitem:
-                # Recursively find the real destination
                 gi_dsts = act_send_info.setdefault(out_idx, [])
                 for gi_user in user.users:
                     dst_rank = self.find_dst_rank(gi_user)
                     if dst_rank is not None:
                         gi_dsts.append(dst_rank)
-                # Next `getitem` will point to the next output index
                 out_idx += 1
             else:
-                # In case of single output value, `out_idx` will not increase
                 dsts = act_send_info.setdefault(out_idx, [])
                 dst_rank = self.find_dst_rank(user)
                 if dst_rank is not None:
@@ -1241,7 +1480,25 @@ class _PipelineStage(_PipelineStageBase):
         output_vals: tuple[torch.Tensor] = tuple(
             v.meta["val"] for v in flatten_args(output_node.args)
         )
-        self._configure_outputs_meta(output_vals)
+        # Reject DTensors and create output metadata directly with
+        # correct requires_grad.
+        output_metas: list[_TensorMeta] = []
+        for i, val in enumerate(output_vals):
+            if isinstance(val, DTensor):
+                raise PipeliningMetadataError(
+                    f"{self.log_prefix} DTensor detected in traced pipeline output index {i}. "
+                    f"DTensor metadata propagation is NOT supported for the traced frontend "
+                    f"(_PipelineStage). Use the manual PipelineStage frontend for full DTensor support."
+                )
+            output_metas.append(
+                _TensorMeta(
+                    shape=val.shape,
+                    stride=val.stride(),
+                    dtype=val.dtype,
+                    requires_grad=self.has_backward,
+                )
+            )
+        self._stage_meta.outputs = tuple(output_metas)
 
         logger.debug("%s Send info: %s", self.log_prefix, act_send_info)
         return act_send_info
@@ -1249,50 +1506,79 @@ class _PipelineStage(_PipelineStageBase):
     def _get_output_node(self):
         output_nodes = [node for node in self.submod.graph.nodes if node.op == "output"]  # type: ignore[union-attr]
         if len(output_nodes) != 1:
-            raise AssertionError(f"Expected 1 output node, got {len(output_nodes)}")
+            raise PipeliningMetadataError(
+                f"Expected 1 output node, got {len(output_nodes)}"
+            )
         output_node = output_nodes[0]
         return output_node
 
-    def _create_grad_recv_info(
-        self,
-        act_send_info: dict,
-    ) -> tuple[_RecvInfo, ...]:
+    def _create_grad_recv_info(self, act_send_info: dict) -> tuple[_RecvInfo, ...]:
         """
         Create a tuple of `_RecvInfo` for gradients.
+        Reuses output metadata from _stage_meta.outputs (populated by _create_act_send_info).
         """
-        # Dict[output_index, _RecvInfo]
-        grad_recv_info: dict[int, _RecvInfo] = {}
-        output_node = self._get_output_node()
-
-        # The output node may take multiple args, meaning the submod having multiple output values.
-        output_vals = flatten_args(output_node.args)
-
-        for out_idx, dst_list in act_send_info.items():
-            if not dst_list:
-                # No actual receiver for activation so no grad coming back
-                continue
-
-            output = output_vals[out_idx]
-            example_value = output.meta["val"]
-            logger.debug(
-                f"{self.log_prefix} Creating grad recv buffer for output {output.name} "  # noqa: G004
-                f": {example_value.shape}, {example_value.dtype}"
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: outputs metadata required for grad recv info. "
+                f"Ensure _create_act_send_info is called first."
             )
 
-            # TODO: otherwise needs grad accumulation
-            if len(dst_list) != 1:
-                raise AssertionError("Backward of skip connections not supported yet")
-            grad_src = dst_list[0]
-            grad_recv_info[out_idx] = _RecvInfo(
-                f"{grad_src}",  # noqa: G004
-                grad_src,
-                _make_tensor_from_meta(example_value, self.device),
-            )
+        outputs_meta = self._stage_meta.outputs
+        output_grads_metas: list[TensorMeta | None] = []
+        grad_recv_infos: list[_RecvInfo] = []
 
-        # Convert to tuple for convenience in get_ops and retrieve tensor
-        grad_recv_info_tuple = tuple(grad_recv_info.values())
-        logger.debug("%s Grad recv info: %s", self.log_prefix, grad_recv_info_tuple)
-        return grad_recv_info_tuple
+        for out_idx, out_meta in enumerate(outputs_meta):
+            dst_list = act_send_info.get(out_idx, [])
+
+            # Determine the source stage for gradients
+            grad_src = dst_list[0] if dst_list else self.stage_index + 1
+
+            # Check if this output needs gradients
+            if not dst_list or not out_meta.requires_grad:
+                output_grads_metas.append(None)
+                grad_recv_infos.append(
+                    _RecvInfo(
+                        input_name=f"recv_grad_for_{self.stage_index}_none_{out_idx}",
+                        source=grad_src,
+                        buffer=None,
+                        tensor_meta=None,
+                    )
+                )
+            else:
+                # Derive grad metadata from output metadata (same shape, requires_grad=False)
+                grad_meta = _TensorMeta(
+                    shape=out_meta.shape,
+                    stride=out_meta.stride,
+                    dtype=out_meta.dtype,
+                    requires_grad=False,
+                )
+                output_grads_metas.append(grad_meta)
+
+                if len(dst_list) != 1:
+                    raise PipeliningMetadataError(
+                        "Backward of skip connections not supported yet"
+                    )
+
+                logger.debug(
+                    "%s Creating grad recv buffer for output %s : %s, %s",
+                    self.log_prefix,
+                    out_idx,
+                    grad_meta.shape,
+                    grad_meta.dtype,
+                )
+
+                grad_recv_infos.append(
+                    _RecvInfo(
+                        input_name=f"recv_grad_for_{self.stage_index}_from_{grad_src}",
+                        source=grad_src,
+                        buffer=_make_tensor_from_meta(grad_meta, self.device),
+                        tensor_meta=grad_meta,
+                    )
+                )
+
+        self._stage_meta.output_grads = tuple(output_grads_metas)
+        logger.debug("%s Grad recv info: %s", self.log_prefix, grad_recv_infos)
+        return tuple(grad_recv_infos)
 
 
 # A helper function to create a pipeline stage based on traced pipeline information
@@ -1327,27 +1613,37 @@ def build_stage(
 
 
 class PipelineStage(_PipelineStageBase):
-    """
-    A class representing a pipeline stage in a pipeline parallelism setup.
+    """A pipeline stage for pipeline parallelism with sequential model partitioning.
 
-    PipelineStage assumes sequential partitioning of the model, i.e. the model is split into chunks where outputs from
-    one chunk feed into inputs of the next chunk, with no skip connections.
+    Supports both **static** and **dynamic** metadata inference:
 
-    PipelineStage performs runtime shape/dtype inference automatically by propagating the outputs from stage0 to
-    stage1 and so forth, in linear order.  To bypass shape inference, pass the `input_args` and `output_args` to each
-    PipelineStage instance.
+    Static mode:
+        All of ``input_args``, ``output_args`` (and ``input_grads``/``output_grads``
+        when DTensors are present) are provided at construction time.
+
+    Dynamic mode:
+        Metadata is inferred from the first microbatch at runtime; any
+        statically provided args are used for validation only.
 
     Args:
-        submodule (nn.Module): The PyTorch module wrapped by this stage.
-        stage_index (int): The ID of this stage.
-        num_stages (int): The total number of stages.
-        device (torch.device): The device where this stage is located.
-        input_args (Union[torch.Tensor, Tuple[torch.tensor]], optional): The input arguments for the submodule.
-        output_args (Union[torch.Tensor, Tuple[torch.tensor]], optional): The output arguments for the submodule.
-        group (dist.ProcessGroup, optional): The process group for distributed training. If None, default group.
-        dw_builder (Optional[Callable[[], Callable[..., None]]): If provided, dw_builder will build a new dw_runner function
-            that will the W action (input weights) for F, I, W (Fwd, Input, Weight) zero bubble schedules.
+        submodule: The ``nn.Module`` wrapped by this stage.
+        stage_index: Zero-based stage ID.
+        num_stages: Total number of stages in the pipeline.
+        device: Device this stage runs on.
+        input_args: Example input tensors (single tensor or tuple). Optional.
+        output_args: Example output tensors. Optional.
+        output_grads: Example output gradients (received from next stage). Optional.
+        input_grads: Example input gradients (sent to previous stage). Optional.
+        group: Process group for P2P communication. Defaults to the
+            world process group.
+        dw_builder: Builder for deferred weight-update runners used by
+            zero-bubble (F/I/W) schedules.
+        get_mesh: Callable ``(dim_names, layout) -> DeviceMesh`` used during
+            dynamic DTensor inference. Ignored in fully static DTensor mode.
     """
+
+    # Type alias for mesh provider function
+    MeshProvider = Callable[[tuple[str, ...], _MeshLayout | None], DeviceMesh]
 
     def __init__(
         self,
@@ -1357,247 +1653,698 @@ class PipelineStage(_PipelineStageBase):
         device: torch.device,
         input_args: torch.Tensor | tuple[torch.Tensor, ...] | None = None,
         output_args: torch.Tensor | tuple[torch.Tensor, ...] | None = None,
+        output_grads: torch.Tensor | tuple[torch.Tensor | None, ...] | None = None,
+        input_grads: torch.Tensor | tuple[torch.Tensor | None, ...] | None = None,
         group: dist.ProcessGroup | None = None,
         dw_builder: Callable[[], Callable[..., None]] | None = None,
+        get_mesh: MeshProvider | None = None,
     ):
         super().__init__(submodule, stage_index, num_stages, device, group, dw_builder)
-        self.inputs: list[torch.Tensor] | None = None
-        self.inputs_meta: tuple[torch.Tensor, ...] | None = None
-        # Note: inputs and submod should ideally be on meta device. We decided not to assert this (yet) because it
-        # might be breaking for existing users.
-        if input_args is None:
-            if output_args is not None:
-                raise AssertionError(
-                    "If specifying output_args, input_args must also be specified. "
-                    "Otherwise, shape inference will be performed at runtime"
-                )
-        else:
-            self.inputs_meta = (
-                (input_args,) if isinstance(input_args, torch.Tensor) else input_args
-            )
-            if output_args is None:
-                logger.warning(
-                    "Deprecation warning: passing input_args and performing init-time shape inference is deprecated. "
-                    "PipelineStage now supports runtime shape inference using the real inputs provided to schedule step(). "
-                    "Either delete `input_args` arg to `PipelineStage` to opt-into runtime shape inference, "
-                    "or additionally pass `output_args` to `PipelineStage` to fully override shape inference. "
-                )
-                try:
-                    with torch.no_grad():
-                        output_args = submodule(*self.inputs_meta)
-                    output_args = tree_map_only(
-                        torch.Tensor, lambda x: x.to("meta"), output_args
-                    )
-                except Exception as e:
-                    raise RuntimeError(
-                        "Failed to perform pipeline shape inference- are your inputs on the same device as your module?"
-                    ) from e
-            if output_args is None:
-                raise AssertionError(
-                    "If passing input_args, also pass output_args to override shape inference"
-                )
-            self._configure_outputs_meta(
-                (output_args,) if isinstance(output_args, torch.Tensor) else output_args
-            )
 
-        # these are the buffers used in backwards send/recv, they are allocated later
-        self.outputs_grad: list[torch.Tensor] = []
+        self.get_mesh = get_mesh
+        self._inference_mode: InferenceMode | None = None
+        self._fwd_outputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
+        self._fwd_inputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
+        self._fwd_kwargs_tensors_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
 
-        dbg_str = (
-            f"Finished pipeline stage init, {self.stage_index=}, {self.is_first=}, "  # noqa: G004
-            f"{self.is_last=}, {self.num_stages=}, "
+        # Validate and normalize args to tuples
+        inputs = validate_and_normalize_to_tuple(input_args)
+        outputs = validate_and_normalize_to_tuple(output_args)
+        in_grads = validate_and_normalize_to_tuple(input_grads, allow_none=True)
+        out_grads = validate_and_normalize_to_tuple(output_grads, allow_none=True)
+
+        self._user_meta = _StageMeta(
+            inputs=extract_tensor_metas(inputs),
+            outputs=extract_tensor_metas(outputs),
+            input_grads=extract_tensor_metas(in_grads, allow_none=True),
+            output_grads=extract_tensor_metas(out_grads, allow_none=True),
         )
-        if self.inputs_meta is not None:
-            dbg_str += (
-                f"inputs: {[inp.shape for inp in self.inputs_meta]}, "
-                f"output: {[output.shape for output in self.get_outputs_meta()]}"
+
+        # Cache meshes from user-provided DTensors
+        for args in (inputs, outputs, in_grads, out_grads):
+            if args is not None:
+                self._mesh_cache.update_from_tensors(args)
+
+        # Validate DTensor↔grad correspondence independently for inputs and outputs
+        if self._user_meta.has_dtensors():
+            if inputs and in_grads:
+                validate_static_dtensor_grad_correspondence(
+                    self.stage_index, inputs, in_grads, is_input=True
+                )
+            if outputs and out_grads:
+                validate_static_dtensor_grad_correspondence(
+                    self.stage_index, outputs, out_grads, is_input=False
+                )
+
+    def _recv_meta(self, src_stage: int) -> Any:
+        """Receive metadata object from a stage on a different rank via P2P."""
+        objects: list[Any] = [None]
+        dist.recv_object_list(
+            objects,
+            src=dist.get_global_rank(
+                self.group or dist.distributed_c10d._get_default_group(),
+                self.stage_index_to_group_rank[src_stage],
+            ),
+            group=self.group,
+            device=self.device,
+            use_batch=True,
+        )
+        if len(objects) != 1:
+            raise PipeliningMetadataError(
+                f"Expected exactly one object to be received but got: {len(objects)}"
             )
-        else:
-            dbg_str += " running shape-inference at runtime"
+        return objects[0]
 
-        logger.debug(dbg_str)
+    def _send_meta(self, meta: Any, dst_stage: int) -> None:
+        """Send metadata object to a stage on a different rank via P2P."""
+        dist.send_object_list(
+            [meta],
+            dst=dist.get_global_rank(
+                self.group or dist.distributed_c10d._get_default_group(),
+                self.stage_index_to_group_rank[dst_stage],
+            ),
+            group=self.group,
+            device=self.device,
+            use_batch=True,
+        )
 
-    def _shape_inference(
+    def _is_same_rank(self, other_stage: int) -> bool:
+        """Check if another stage is on the same rank as this stage."""
+        return self.stage_index_to_group_rank[other_stage] == self.group_rank
+
+    def _compute_outputs(
         self,
-        args: tuple[Any, ...],
+        *args: torch.Tensor,
+        **kwargs: Any,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor] | None:
+        """Compute outputs of the submodule.
+
+        Args:
+            args: Positional input tensors.
+            kwargs: Keyword arguments forwarded to the submodule.
+
+        Returns:
+            Raw output from ``self.submod(*args, **kwargs)``.
+        """
+        return self.submod(*args, **kwargs)
+
+    def _compute_input_grads(
+        self,
+        outputs: tuple[torch.Tensor, ...],
+        all_fwd_inputs: tuple[torch.Tensor, ...],
+        grad_outputs: list[torch.Tensor | None] | None = None,
+    ) -> tuple[torch.Tensor | None, ...]:
+        """Compute input gradients via ``torch.autograd.grad``.
+
+        Args:
+            outputs: Forward output tensors to differentiate.
+            all_fwd_inputs: Combined positional args and kwargs tensors.
+            grad_outputs: Upstream gradients, or ``None`` for ones.
+
+        Returns:
+            Tuple of gradients, with ``None`` for inputs that don't require grad.
+        """
+        # Get tensor inputs that require gradients, tracking their original positions
+        grad_input_indices: list[int] = []
+        tensor_inputs_req_grad: list[torch.Tensor] = []
+        for i, inp in enumerate(all_fwd_inputs):
+            if isinstance(inp, torch.Tensor) and inp.requires_grad:
+                grad_input_indices.append(i)
+                tensor_inputs_req_grad.append(inp)
+
+        if not tensor_inputs_req_grad:
+            return tuple(None for _ in all_fwd_inputs)
+
+        input_grads = torch.autograd.grad(
+            outputs=outputs,
+            inputs=tensor_inputs_req_grad,
+            grad_outputs=grad_outputs,
+            allow_unused=True,
+        )
+        all_input_grads: list[torch.Tensor | None] = [None] * len(all_fwd_inputs)
+        for idx, g in zip(grad_input_indices, input_grads, strict=True):
+            all_input_grads[idx] = g
+        return tuple(all_input_grads)
+
+    def _convert_module_to_meta(
+        self, module: torch.nn.Module
+    ) -> dict[str, torch.Tensor]:
+        """Move module parameters and buffers to meta device for inference.
+
+        Returns:
+            Original state dict for restoration via :meth:`_restore_module_from_meta`.
+        """
+        # Save original state dict (this keeps references to original tensors)
+        original_state_dict = module.state_dict()
+
+        # Create meta state dict
+        meta_state = {}
+        for name, tensor in original_state_dict.items():
+            meta_state[name] = torch.empty_like(tensor, device="meta").requires_grad_(
+                tensor.requires_grad
+            )
+        # Load meta state dict (assign=True avoids the incompatible tensor type error)
+        module.load_state_dict(meta_state, assign=True, strict=True)
+
+        return original_state_dict
+
+    def _restore_module_from_meta(
+        self, module: torch.nn.Module, saved: dict[str, torch.Tensor]
+    ) -> None:
+        """Restore module from a saved state dict after meta-device inference."""
+        module.load_state_dict(saved, assign=True, strict=True)
+
+    def _to_meta_tensor(self, arg: torch.Tensor | TensorMeta) -> torch.Tensor:
+        """Convert a tensor or metadata to a meta-device tensor.
+
+        Handles two input types:
+
+        - ``torch.Tensor``: Creates an empty meta tensor with matching
+          properties. Preserves DTensor semantics.
+        - ``TensorMeta``: Reconstructs a meta tensor from metadata.
+          For ``_DTensorMeta``, creates a meta DTensor via the mesh cache.
+
+        Args:
+            arg: A tensor to convert or tensor metadata to reconstruct from.
+
+        Returns:
+            A tensor on meta device with matching properties.
+        """
+
+        if isinstance(arg, torch.Tensor):
+            return torch.empty_like(arg, device="meta").requires_grad_(
+                arg.requires_grad
+            )
+        elif isinstance(arg, TensorMeta):
+            if isinstance(arg, _DTensorMeta):
+                mesh = self._mesh_cache.get_or_create(arg.mesh_cache_key, self.get_mesh)
+                return arg.to_meta_dtensor(mesh)
+            else:
+                return arg.to_meta_tensor()
+        else:
+            raise PipeliningMetadataError(
+                f"Unsupported type {type(arg)} for _to_meta_tensor: {arg}"
+            )
+
+    def _ones_from_metadata(self, meta: TensorMeta) -> torch.Tensor:
+        """Create a ones tensor on meta device from metadata.
+
+        Used for constructing ``grad_outputs`` in backward metadata inference.
+
+        Args:
+            meta: Tensor metadata; ``_DTensorMeta`` yields a meta DTensor.
+
+        Returns:
+            Ones tensor (plain or DTensor) on the ``"meta"`` device.
+        """
+        local_ones = torch.ones(
+            meta.shape,
+            dtype=meta.dtype,
+            device="meta",
+        )
+        if isinstance(meta, _DTensorMeta):
+            mesh = self._mesh_cache.get_or_create(meta.mesh_cache_key, self.get_mesh)
+            return DTensor.from_local(
+                local_ones,
+                device_mesh=mesh,
+                placements=meta.placements,
+                shape=meta.global_shape,
+                stride=meta.global_stride,
+                run_check=False,
+            )
+        return local_ones
+
+    def _forward_metadata_inference(
+        self,
+        args: tuple[torch.Tensor, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ):
-        if kwargs is None:
-            kwargs = {}
-        if args is None:
-            raise AssertionError("Args may be an empty tuple but not None")
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
+        """Run forward metadata inference (Stage 0 → N).
 
-        # We skip recv communication if we're the first stage, but also if the previous stage is on the same rank
-        # and can pass its output shapes in as args instead of using send/recv.
-        if (
-            self.is_first
-            # if not first stage, then check if prev stage is on the same rank
-            or self.stage_index_to_group_rank[self.stage_index - 1] == self.group_rank
-        ):
-            logger.debug(
-                "Shape inference: stage %s skipping recv, because shape info passed in via `args`",
-                self.stage_index,
-            )
-            args = tree_map_only(torch.Tensor, lambda x: x.to("meta"), args)
-        else:
-            if len(args) != 0:
-                raise AssertionError(
-                    "Can't supply input args for shape inference on non-first stage"
+        Passes ``_StageForwardMeta`` between stages.  The first stage
+        receives real tensors; other stages receive metadata (same-rank
+        via argument, cross-rank via P2P).
+
+        Args:
+            args: Real tensors (first stage), ``_StageForwardMeta``
+                (same-rank), or ``None`` (cross-rank P2P).
+            kwargs: Keyword arguments forwarded to the submodule.
+            has_backward: Whether backward inference follows.
+
+        Returns:
+            ``_StageForwardMeta`` for the next stage (same-rank or last),
+            or ``None`` if sent via P2P.
+        """
+        kwargs = kwargs or {}
+
+        # === RECEIVE: Get input metadata and create meta tensors ===
+        if self.is_first:
+            # First stage: extract metadata from real tensors
+            if args is None or isinstance(args, _StageForwardMeta):
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: First stage requires real tensors, "
+                    f"got {type(args).__name__}."
                 )
-            objects = [None]
-            logger.debug(
-                "Shape inference: stage %s receiving from stage %s",
-                self.stage_index,
-                self.stage_index - 1,
-            )
-            dist.recv_object_list(
-                objects,
-                src=dist.get_global_rank(
-                    self.group or dist.distributed_c10d._get_default_group(),
-                    self.stage_index_to_group_rank[self.stage_index - 1],
-                ),
-                group=self.group,
-                device=self.device,
-                use_batch=True,
-            )
-            recv_args = objects[0]
-            if not isinstance(recv_args, tuple):
-                raise AssertionError(f"Expected tuple, got {type(recv_args)}")
-            args = recv_args
-
-        # cache input shapes for use during recv buffer allocation
-        self.inputs_meta = args
-        args = tree_map_only(
-            torch.Tensor, lambda x: torch.zeros_like(x, device=self.device), args
-        )
-
-        # set attributes needed for forward
-        with torch.no_grad():
-            outputs = self.submod(*args, **kwargs)
-
-        # if single tensor, convert so it is always a list
-        if isinstance(outputs, torch.Tensor):
-            outputs = [outputs]
-
-        # communicate meta outputs not real outputs for two reasons
-        # 1 - its faster (esp. since obj coll pickles tensor data!)
-        # 2 - avoid activating a cuda context for the src rank when unpickling on the recv end!
-        outputs_meta = tuple(
-            tree_map_only(torch.Tensor, lambda x: x.to("meta"), outputs)
-        )
-        logger.debug(
-            "Shape inference: stage %s inputs %s, outputs %s",
-            self.stage_index,
-            self.inputs_meta,
-            outputs_meta,
-        )
-        self._configure_outputs_meta(outputs_meta)
-
-        # Passing outputs to the next stage:
-        # two cases-
-        # 1. Usually: use send/recv communication to pass the output
-        # 2. Special case: for V-schedules, 2 'adjacent' stages (e.g. stage 3, 4 in an 8-stage 4-rank V)
-        #    pass their shape info via return value and function args rather than send/recv.
-        if (
-            self.is_last
-            # if not last stage, then check if next stage is on the same rank
-            or self.stage_index_to_group_rank[self.stage_index + 1] == self.group_rank
-        ):
-            # Case (2) above: pass shape info via return value and caller passes it as args to next stage's
-            # _shape_inference call
-            logger.debug(
-                "Shape inference: stage %s skipping send to next stage",
-                self.stage_index,
-            )
-
+            tensor_args = validate_and_normalize_to_tuple(args)
+            assert tensor_args is not None  # noqa: S101
+            self._stage_meta.inputs = extract_tensor_metas(tensor_args)
+            # Convert to meta, preserving DTensor semantics
+            meta_args = tuple(self._to_meta_tensor(a) for a in tensor_args)
+        elif self._is_same_rank(self.stage_index - 1):
+            # Same-rank: _StageForwardMeta passed via argument
+            if not isinstance(args, _StageForwardMeta):
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: Expected _StageForwardMeta from same-rank "
+                    f"previous stage, got {type(args).__name__}."
+                )
+            self._stage_meta.inputs = args.forward_metas
+            meta_args = tuple(self._to_meta_tensor(m) for m in args.forward_metas)
         else:
-            # Case (1): send shapes via send operation, and ensure not to return it to the caller
-            logger.debug(
-                "Shape inference: stage %s sending to stage %s",
-                self.stage_index,
-                self.stage_index + 1,
-            )
-            dist.send_object_list(
-                [outputs_meta],
-                dst=dist.get_global_rank(
-                    self.group or dist.distributed_c10d._get_default_group(),
-                    self.stage_index_to_group_rank[self.stage_index + 1],
-                ),
-                group=self.group,
-                device=self.device,
-                use_batch=True,
-            )
-            outputs_meta = tuple()
+            # Cross-rank: receive _StageForwardMeta via P2P
+            recv_meta = self._recv_meta(self.stage_index - 1)
+            if not isinstance(recv_meta, _StageForwardMeta):
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: Expected _StageForwardMeta from P2P, "
+                    f"got {type(recv_meta).__name__}."
+                )
+            self._stage_meta.inputs = recv_meta.forward_metas
+            meta_args = tuple(self._to_meta_tensor(m) for m in recv_meta.forward_metas)
 
-        return outputs_meta
+        # Convert kwargs tensors to meta device (preserving DTensor semantics)
+        meta_kwargs = {
+            k: self._to_meta_tensor(v) if isinstance(v, torch.Tensor) else v
+            for k, v in kwargs.items()
+        }
+
+        # Isolate metadata inference from user's grad context.
+        # has_backward → enable_grad() so backward tracing sees grad_fn;
+        # no backward → no_grad() for cross-rank consistency.
+        ctx = torch.enable_grad() if has_backward else torch.no_grad()
+        original_state_dict = self._convert_module_to_meta(self.submod)
+        try:
+            with ctx:
+                outputs = self._compute_outputs(*meta_args, **meta_kwargs)
+        finally:
+            self._restore_module_from_meta(self.submod, original_state_dict)
+
+        # Normalize outputs to tuple
+        outputs = validate_and_normalize_to_tuple(outputs)
+
+        self._stage_meta.outputs = extract_tensor_metas(outputs)
+
+        # Store for backward metadata inference (always, even during eval)
+        fwd_kwargs_tensors = tuple(
+            v for v in flatten_args(meta_kwargs) if isinstance(v, torch.Tensor)
+        )
+        self._fwd_outputs_for_bwd_meta = outputs
+        self._fwd_inputs_for_bwd_meta = meta_args
+        self._fwd_kwargs_tensors_for_bwd_meta = fwd_kwargs_tensors
+
+        # === SEND: Pass output metadata to next stage ===
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: output metadata is required for forward inference."
+            )
+        fwd_meta = _StageForwardMeta(forward_metas=self._stage_meta.outputs)
+
+        if self.is_last or self._is_same_rank(self.stage_index + 1):
+            # Same-rank or last: return for caller to pass
+            return fwd_meta
+        else:
+            # Cross-rank: send via P2P
+            self._send_meta(fwd_meta, self.stage_index + 1)
+            return None
+
+    def _backward_metadata_inference(
+        self,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: _StageBackwardMeta | None = None,
+    ) -> _StageBackwardMeta | None:
+        """Run backward metadata inference (Stage N → 0).
+
+        Passes ``_StageBackwardMeta`` between stages.  The last stage
+        computes gradients from the loss; other stages receive metadata
+        from the next stage.
+
+        Args:
+            loss_fn: Loss function (required for the last stage).
+            target: Target tensor (required for the last stage).
+            received_grad_meta: Grad metadata from next same-rank stage
+                (V-schedule only).
+
+        Returns:
+            ``_StageBackwardMeta`` for the previous stage (same-rank or first),
+            or ``None`` if sent via P2P.
+        """
+        fwd_outputs = self._fwd_outputs_for_bwd_meta
+        fwd_inputs = self._fwd_inputs_for_bwd_meta
+        if fwd_outputs is None or fwd_inputs is None:
+            raise PipeliningMetadataError(
+                "Backward metadata inference requires forward metadata inference to run first"
+            )
+        kwargs_tensors = self._fwd_kwargs_tensors_for_bwd_meta or ()
+        all_fwd_inputs = fwd_inputs + kwargs_tensors
+        # === RECEIVE: Get output grad metadata (except last stage) ===
+        if self.is_last:
+            if loss_fn is None or target is None:
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: loss_fn and target required for last stage"
+                )
+            # Convert target to meta device to match outputs (which are on meta from forward inference)
+            meta_target = self._to_meta_tensor(target)
+            # Last stage: compute loss and input grads directly
+            loss = loss_fn(
+                fwd_outputs[0] if len(fwd_outputs) == 1 else fwd_outputs, meta_target
+            )
+            self._stage_meta.output_grads = None
+            all_input_grads = self._compute_input_grads(
+                (loss,),
+                all_fwd_inputs,
+            )
+        else:
+            # Non-last stage: receive grad metadata from next stage
+            if self._is_same_rank(self.stage_index + 1):
+                # Same-rank: _StageBackwardMeta passed via argument
+                if not isinstance(received_grad_meta, _StageBackwardMeta):
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: Expected _StageBackwardMeta from same-rank "
+                        f"next stage, got {type(received_grad_meta).__name__}."
+                    )
+                self._stage_meta.output_grads = received_grad_meta.backward_metas
+            else:
+                # Cross-rank: receive _StageBackwardMeta via P2P
+                recv_meta = self._recv_meta(self.stage_index + 1)
+                if not isinstance(recv_meta, _StageBackwardMeta):
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: Expected _StageBackwardMeta from P2P, "
+                        f"got {type(recv_meta).__name__}."
+                    )
+                self._stage_meta.output_grads = recv_meta.backward_metas
+
+            # === COMPUTE: Build grad_outputs and compute input grads ===
+            # Extract output tensors and corresponding grad_outputs from metadata
+            # Must iterate together to maintain alignment
+            if self._stage_meta.output_grads is None:
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: output_grads metadata is required for backward inference."
+                )
+            stage_output_grad_metas = self._stage_meta.output_grads
+
+            filtered_fwd_outputs: list[torch.Tensor] = []
+            filtered_output_grads: list[torch.Tensor | None] = []
+
+            for idx, (fwd_out, grad_meta) in enumerate(
+                zip(fwd_outputs, stage_output_grad_metas, strict=True)
+            ):
+                # Match _backward.py behavior: skip if output doesn't require grad AND has no grad_fn
+                if not fwd_out.requires_grad:
+                    if grad_meta is not None:
+                        raise PipeliningMetadataError(
+                            f"Stage {self.stage_index}: output {idx} requires_grad=False, "
+                            f"but output_grads metadata is provided: {grad_meta}."
+                        )
+                    continue
+                filtered_fwd_outputs.append(fwd_out)
+                # For outputs that require grad, include them even if grad_meta is None
+                # (runtime passes None grad_outputs to autograd.backward in this case)
+                filtered_output_grads.append(
+                    self._ones_from_metadata(grad_meta) if grad_meta else None
+                )
+
+            if filtered_fwd_outputs:
+                # Include kwargs tensors for gradient computation
+
+                all_input_grads = self._compute_input_grads(
+                    tuple(filtered_fwd_outputs), all_fwd_inputs, filtered_output_grads
+                )
+                # Only positional input grads flow to previous stage
+            else:
+                all_input_grads = tuple(None for _ in range(len(all_fwd_inputs)))
+
+        input_grads = all_input_grads[: len(fwd_inputs)]
+        self._stage_meta.input_grads = tuple(
+            extract_tensor_meta(g) if isinstance(g, torch.Tensor) else None
+            for g in input_grads
+        )
+        # Clean up temporary storage
+        self._fwd_outputs_for_bwd_meta = None
+        self._fwd_inputs_for_bwd_meta = None
+        self._fwd_kwargs_tensors_for_bwd_meta = None
+
+        # === SEND: Pass input grad metadata to previous stage ===
+        bwd_meta = _StageBackwardMeta(backward_metas=self._stage_meta.input_grads)
+
+        if self.is_first or self._is_same_rank(self.stage_index - 1):
+            # First rank or Same-rank: return for caller to pass
+            return bwd_meta
+        else:
+            # Cross-rank: send via P2P
+            self._send_meta(bwd_meta, self.stage_index - 1)
+            return None
+
+    def _prepare_backward_infra(
+        self,
+        num_microbatches: int,
+        loss_fn: Callable[..., torch.Tensor] | None = None,
+        target: torch.Tensor | None = None,
+        received_grad_meta: "_StageBackwardMeta | None" = None,
+    ) -> "_StageBackwardMeta | None":
+        """Run backward metadata inference and prepare backward infrastructure.
+
+        Args:
+            num_microbatches: Number of microbatches.
+            loss_fn: Loss function (required for the last stage).
+            target: Target tensor (required for the last stage).
+            received_grad_meta: Grad metadata from next same-rank stage
+                (V-schedule only).
+
+        Returns:
+            ``_StageBackwardMeta`` to pass to the previous same-rank stage,
+            or ``None`` if sent via P2P or not applicable.
+        """
+        grad_meta_result: _StageBackwardMeta | None = None
+        if self._inference_mode == InferenceMode.DYNAMIC:
+            # DYNAMIC mode: run backward metadata inference
+            # received_grad_meta is used for same-rank V-schedule stages
+            grad_meta_result = self._backward_metadata_inference(
+                loss_fn=loss_fn,
+                target=target,
+                received_grad_meta=received_grad_meta,
+            )
+            # Validate dynamically inferred metadata against user-provided metadata
+            self._validate_inferred_grad_metadata()
+        else:
+            # STATIC mode: metadata comes from user inputs, no validation needed
+            self._stage_meta.input_grads = self._user_meta.input_grads
+            self._stage_meta.output_grads = self._user_meta.output_grads
+            # For STATIC mode with plain tensors, if output_grads is not set but
+            # we have outputs, derive output_grads from outputs.
+            # (gradient shape == output shape, but requires_grad=False for gradients)
+            if self._stage_meta.output_grads is None:
+                if self._stage_meta.outputs is None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: output metadata is required for backward inference."
+                    )
+                self._stage_meta.output_grads = tuple(
+                    _TensorMeta(
+                        shape=out_meta.shape,
+                        stride=out_meta.stride,
+                        dtype=out_meta.dtype,
+                        requires_grad=False,
+                    )
+                    if out_meta.requires_grad
+                    else None
+                    for out_meta in self._stage_meta.outputs
+                )
+            # Similarly, derive input_grads from inputs if not provided
+            if self._stage_meta.input_grads is None:
+                if self._stage_meta.inputs is None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: input metadata is required for backward inference."
+                    )
+                self._stage_meta.input_grads = tuple(
+                    _TensorMeta(
+                        shape=in_meta.shape,
+                        stride=in_meta.stride,
+                        dtype=in_meta.dtype,
+                        requires_grad=False,
+                    )
+                    if in_meta.requires_grad
+                    else None
+                    for in_meta in self._stage_meta.inputs
+                )
+
+        self._setup_backward_recv_info(num_microbatches)
+        return grad_meta_result
+
+    def _validate_inferred_grad_metadata(self) -> None:
+        """Validate dynamically inferred grad metadata against user-provided metadata."""
+        if self._user_meta.input_grads and self._stage_meta.input_grads:
+            validate_tensors_metadata(
+                f"Stage {self.stage_index} input_grad",
+                self._user_meta.input_grads,
+                self._stage_meta.input_grads,
+                warn_on_mismatch=True,
+            )
+        if self._user_meta.output_grads and self._stage_meta.output_grads:
+            validate_tensors_metadata(
+                f"Stage {self.stage_index} output_grad",
+                self._user_meta.output_grads,
+                self._stage_meta.output_grads,
+                warn_on_mismatch=True,
+            )
 
     def _prepare_forward_infra(
         self,
         num_microbatches: int,
-        args: tuple[Any, ...],
+        args: tuple[Any, ...] | _StageForwardMeta | None,
         kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Any, ...]:
-        # TODO move self.device to an argument from step API (from its input tensors)?
-        if num_microbatches is None:
-            raise AssertionError("TODO fix num_microbatches")
+        has_backward: bool = False,
+    ) -> _StageForwardMeta | None:
+        """
+        Prepare the stage infrastructure for forward pass.
 
-        outputs: tuple[Any, ...] = tuple()
-        if self.inputs_meta is None:
-            outputs = self._shape_inference(args, kwargs)
+        Args:
+            num_microbatches: Number of microbatches to prepare for.
+            args: Input arguments or ``_StageForwardMeta`` from previous
+                same-rank stage (V-schedule).
+            kwargs: Keyword arguments for the stage.
+            has_backward: Whether backward pass will be performed.
 
-        if self.inputs_meta is None:
-            raise AssertionError("Expected inputs_meta to be set after shape inference")
-        # Receive info during forward
-        # TODO: create args_recv_info lazily? (same needed for PipelineStage)
+        Returns:
+            ``_StageForwardMeta`` to pass to next stage (same-rank),
+            or ``None`` if sent via P2P.
+        """
+        if self._inference_mode is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: inference mode not set. "
+                f"Call _determine_and_set_global_inference_mode() first."
+            )
+
+        fwd_meta_output: _StageForwardMeta | None = None
+
+        if self._inference_mode == InferenceMode.DYNAMIC:
+            # DYNAMIC mode: run forward metadata inference
+            # args may be _StageForwardMeta for same-rank V-schedule stages
+            fwd_meta_output = self._forward_metadata_inference(
+                args, kwargs, has_backward
+            )
+            # Validate dynamically inferred metadata against user-provided metadata
+            self._validate_inferred_forward_metadata()
+        # STATIC mode: metadata comes from user inputs, no validation needed
+        else:
+            self._stage_meta.inputs = self._user_meta.inputs
+            self._stage_meta.outputs = self._user_meta.outputs
+
+        # Setup recv and send info
+        self._setup_forward_recv_info(num_microbatches, has_backward)
+        self._setup_forward_send_info()
+
+        return fwd_meta_output
+
+    def _validate_inferred_forward_metadata(self) -> None:
+        """Validate dynamically inferred forward metadata against user-provided metadata."""
+        if self._user_meta.inputs and self._stage_meta.inputs:
+            validate_tensors_metadata(
+                f"Stage {self.stage_index} input",
+                self._user_meta.inputs,
+                self._stage_meta.inputs,
+                warn_on_mismatch=True,
+            )
+        if self._user_meta.outputs and self._stage_meta.outputs:
+            validate_tensors_metadata(
+                f"Stage {self.stage_index} output",
+                self._user_meta.outputs,
+                self._stage_meta.outputs,
+                warn_on_mismatch=True,
+            )
+
+    def _setup_forward_recv_info(
+        self, num_microbatches: int, has_backward: bool
+    ) -> None:
+        """Setup receive info for forward pass."""
+        if self._stage_meta.inputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: inputs metadata required for recv info."
+            )
         for chunk_id in range(num_microbatches):
-            if not self.is_first:
-                # We assume that we always receive from stage - 1
-                recv_infos = tuple(
-                    _RecvInfo(
-                        f"recv_for_{self.stage_index}_from_{self.stage_index - 1}",
-                        self.stage_index - 1,
-                        _make_tensor_from_meta(inp, self.device),
-                    )
-                    for inp in self.inputs_meta
-                )
-                # In case there is backward pass, set requires_grad for receive buffers
-                if self.has_backward:
-                    for r in recv_infos:
-                        r.buffer.requires_grad_(True)
-
-                self.args_recv_info[chunk_id] = recv_infos
-            else:
+            if self.is_first:
+                # First stage: all inputs are root arguments (no recv needed)
                 self.args_recv_info[chunk_id] = tuple(
-                    _RootArgPlaceholder(i) for i in self.inputs_meta
+                    _RecvInfo(
+                        input_name=f"root_input_{idx}",
+                        source=None,
+                        buffer=None,
+                        tensor_meta=meta,
+                        is_root_arg=True,
+                    )
+                    for idx, meta in enumerate(self._stage_meta.inputs)
+                )
+            else:
+                # Non-first stages: receive from previous stage
+                self.args_recv_info[chunk_id] = tuple(
+                    _RecvInfo(
+                        input_name=f"recv_for_{self.stage_index}_from_{self.stage_index - 1}",
+                        source=self.stage_index - 1,
+                        buffer=_make_tensor_from_meta(meta, self.device),
+                        tensor_meta=meta,
+                    )
+                    for meta in self._stage_meta.inputs
                 )
 
-        # Send info during forward for each activation
-        # only need the rank that is being sent to
+    def _setup_forward_send_info(self) -> None:
+        """Setup send info for forward pass."""
         self.act_send_info: dict[int, list] = {}
-
-        for idx in range(len(self.get_outputs_meta())):
-            # We assume we always send to stage + 1
-            if not self.is_last:
-                self.act_send_info[idx] = [self.stage_index + 1]
-            else:
-                self.act_send_info[idx] = []
-
-        return outputs
+        if self._stage_meta.outputs is None:
+            raise PipeliningMetadataError(
+                f"Stage {self.stage_index}: outputs metadata required for recv info."
+            )
+        for idx in range(len(self._stage_meta.outputs)):
+            self.act_send_info[idx] = [self.stage_index + 1] if not self.is_last else []
 
     def _create_grad_recv_info(
         self,
         act_send_info: dict,
     ) -> tuple[_RecvInfo, ...]:
-        grad_recv_info: tuple[_RecvInfo, ...] = ()
+        grad_recv_infos: list[_RecvInfo] = []
         if not self.is_last:
+            # Ensure output_grads metadata is available
+            if self._stage_meta.output_grads is None:
+                raise PipeliningMetadataError(
+                    f"Stage {self.stage_index}: output_grads metadata is required for "
+                    f"creating grad recv info. Ensure backward metadata is populated."
+                )
+
             # Receiving gradients from multiple sources is not supported
             # hence we only take the first destination
-            grad_recv_info = tuple(
-                _RecvInfo(
-                    f"recv_grad_for_{self.stage_index}_from_{dst_list[0]}",
-                    dst_list[0],
-                    _make_tensor_from_meta(self.get_outputs_meta()[idx], self.device),
-                )
-                for idx, dst_list in act_send_info.items()
-            )
-        return grad_recv_info
+            # Use a helper function to safely extract the metadata
+            output_grads = self._stage_meta.output_grads
+            for idx, dst_list in act_send_info.items():
+                if dst_list is None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index}: output {idx} is not sent to any stage."
+                    )
+                src = dst_list[0]
+                if output_grads[idx] is None:
+                    grad_recv_infos.append(
+                        _RecvInfo(
+                            input_name=f"recv_grad_for_{self.stage_index}_from_{src}",
+                            source=src,
+                            buffer=None,
+                            tensor_meta=None,
+                        )
+                    )
+                else:
+                    grad_recv_infos.append(
+                        _RecvInfo(
+                            input_name=f"recv_grad_for_{self.stage_index}_from_{src}",
+                            source=src,
+                            buffer=_make_tensor_from_meta(
+                                output_grads[idx], self.device
+                            ),
+                            tensor_meta=output_grads[idx],
+                        )
+                    )
+        return tuple(grad_recv_infos)


### PR DESCRIPTION
Fixes #172419 

# PR Summary: DTensor Support for Pipeline Parallelism

## Overview

This PR adds support for DTensors in Pipeline Parallelism, enabling PP to work seamlessly with other parallelisms (TP, DP, EP) where pipeline stages exchange distributed tensors rather than plain tensors.

## Key Changes

### 1. Data Structures (`_utils.py`)

**Metadata type hierarchy** (all frozen dataclasses):

- **`_TensorMeta`**: Base metadata for plain tensors
  - Fields: `shape`, `stride`, `dtype`, `requires_grad`
  - Methods: `from_tensor()`, `to_meta_tensor()`, `to_empty_tensor()`, `get_diff()`

- **`_DTensorMeta(_TensorMeta)`**: Extended metadata for DTensors (without the mesh — not serializable for P2P)
  - Additional fields: `placements`, `mesh_dim_names`, `mesh_shape`
  - Methods: `from_dtensor()`, `mesh_cache_key` property, overridden `get_diff()`

- **`_StageMeta`**: Mutable container consolidating `inputs`, `outputs`, `input_grads`, `output_grads` metadata with helpers (`has_dtensors()`, `has_complete_grads()`, `is_complete_for_forward()`)

- **`_StageOutputMeta`** (frozen): Transmitted during forward metadata inference (meta_tensors + metadata)

- **`_StageBackwardMeta` / `_StageGradMeta`** (frozen): Transmitted during backward metadata inference (input_grad_metas + output_grad_metas)

**Encapsulated mesh cache:**

- **`_MeshCache`**: Cache for `DeviceMesh` objects keyed by `(mesh_dim_names, mesh_shape)` with `get()`, `get_or_create()`, `put()`, and `update_from_tensors()` methods

**Unified exception hierarchy:**

- **`PipeliningMetadataError`**: Unified exception for all metadata-related errors
- **`PipeliningShapeError`**: Backward-compatibility alias
- **`PipeliningDTensorError`**: Backward-compatibility alias

**Inference mode determination:**

- **`InferenceMode`**: Enum with `STATIC` and `DYNAMIC` values, determined by `InferenceMode.determine()` classmethod which analyzes `_StageMeta` content

**Utility functions:**

- `extract_tensor_meta()` / `extract_tensor_metas()` — extract metadata from tensors
- `validate_tensor_meta()` / `validate_tensors_metadata()` — runtime shape/dtype/stride validation
- `validate_dtensor_metadata()` — DTensor placement/shape validation
- `compare_tensor_metadata()` — element-wise static vs dynamic metadata comparison
- `validate_static_dtensor_grad_correspondence()` — DTensor↔grad correspondence check

### 2. Mesh Cache Design (`stage.py`)

DeviceMesh objects cannot be serialized for P2P communication. Solution:

- `PipelineStage._mesh_cache: _MeshCache` — encapsulated cache per stage
- Key: `(mesh_dim_names, mesh_shape)` — e.g., `(("dp", "tp"), (2, 4))`
- `_get_mesh_for_dtensor_meta()` resolves mesh from cache or via `get_mesh` callback

**Cache population:**
- STATIC mode: `_mesh_cache.update_from_tensors()` extracts meshes from user-provided DTensors
- DYNAMIC mode: `get_mesh` callback required; results cached after first lookup

### 3. Metadata Inference Modes

Two modes based on user-provided metadata at construction:

| Mode | When | Description |
|------|------|-------------|
| `STATIC` | Full forward metadata + either no DTensors, or DTensors with full grad metadata, or DTensors with `has_backward=False` | No runtime inference needed; `init_meta` transferred directly to `_stage_meta` |
| `DYNAMIC` | Incomplete forward metadata, or DTensors with `has_backward=True` but missing grad metadata | Runtime inference via meta-tensor forward/backward; `init_meta` saved as `_user_meta` for validation |

### 4. Two-Phase Metadata Inference

Orchestrated by `schedules.py::_initialize_stages`:

- **Phase 1 (Forward, Stage 0 → N)**: `_prepare_forward_infra()` calls `_prepare_metadata_infra()` → `_forward_metadata_inference()`
  - Converts args AND kwargs to meta tensors
  - Runs `self.submod(*fwd_inputs, **meta_kwargs)` on meta device
  - Extracts `_stage_meta.inputs` / `_stage_meta.outputs`
  - Returns `_StageOutputMeta` to next stage
  - Same-rank: direct object passing; Cross-rank: `send_object_list` / `recv_object_list`

- **Phase 2 (Backward, Stage N → 0)**: `_prepare_backward_infra()` → `_backward_metadata_inference()`
  - Constructs `grad_outputs` with correct backward placements using `DTensor.from_local`
  - Computes `autograd.grad` over full `input_values` (args + kwargs)
  - Produces `input_grads` at full length with `None` at non-grad positions
  - Returns `_StageBackwardMeta` to previous stage
  - Same-rank: direct object passing; Cross-rank: P2P

### 5. DTensor Send/Receive

**Forward activations:**
- Send: `dtensor.to_local()` → `dist.send(local_tensor)`
- Receive: `dist.recv(buffer)` → `DTensor.from_local(buffer, mesh, placements, ...)` → `activation.retain_grad()`
- Validation: `validate_dtensor_metadata()` checks global shape and placements

**Backward gradients:**
- Send: `grad.to_local()` → `dist.send(local_grad)`
- Receive: `dist.recv(buffer)` → `DTensor.from_local(buffer, mesh, grad_placements, ...)`
- Key: gradient placements may differ from forward placements (e.g., `Shard(0)` → `Partial()`)

### 6. Gradient Handling

- DTensor activations reconstructed via `DTensor.from_local` are non-leaf tensors; `retain_grad()` called to preserve gradients for backward send
- Gradient placements may differ from forward tensor placements (handled via separate `input_grads` / `output_grads` metadata in `_StageMeta`)
- `_backward_metadata_inference` constructs `grad_outputs` with metadata-driven placements (not `torch.ones_like`)
- `input_grads` covers full `input_values` length (args + kwargs), matching runtime `flatten_input_tensors = flat_args + flat_kwargs`

### 7. Runtime Validation

Four validation methods with strict enforcement:

| Method | What | Zip |
|--------|------|-----|
| `_validate_fwd_input()` | First-stage DTensor input check | — |
| `_validate_fwd_outputs()` | Output DTensor placement/shape | Strict |
| `_validate_bwd_input()` | Output grad DTensor check | Strict |
| `_validate_bwd_output()` | Input grad DTensor check (full args+kwargs) | Strict |

Plus `_validate_metadata_against_static()` for DYNAMIC mode: compares inferred metadata against user-provided `_user_meta` with element-wise `compare_tensor_metadata()`.

### 8. Traced Frontend Guard

`_PipelineStage._create_grad_recv_info` raises `PipeliningDTensorError` if DTensor detected in traced pipeline outputs — prevents silent correctness loss.

### 9. V-Schedule / Multi-Stage Support (`schedules.py`)

- `PipelineScheduleMulti._initialize_stages` orchestrates two-phase inference:
  - Phase 1: Forward loop in stage order, passing `_StageOutputMeta` between stages
  - Phase 2: Backward loop in `reversed()` order, passing `_StageBackwardMeta` between stages
- Same-rank stages pass metadata directly; cross-rank stages use P2P

## Files Modified

- `torch/distributed/pipelining/_utils.py` — Metadata types (`_TensorMeta`, `_DTensorMeta`, `_StageMeta`, `_StageBackwardMeta`), `_MeshCache`, `InferenceMode`, validation functions, exception hierarchy
- `torch/distributed/pipelining/stage.py` — DTensor send/recv/reconstruct, mesh cache, inference modes, forward/backward metadata inference, 4 validation methods, `_user_meta` validation, kwargs meta conversion, traced frontend guard
- `torch/distributed/pipelining/schedules.py` — Two-phase `_initialize_stages` orchestration
- `test/distributed/pipelining/test_dtensor_pp.py` — Tests

## API Changes

### PipelineStage Constructor

New optional parameters:

```python
PipelineStage(
    submod: nn.Module,
    stage_index: int,
    num_stages: int,
    device: torch.device,
    ...,
    input_args: tuple[torch.Tensor, ...] | None = None,
    output_args: tuple[torch.Tensor, ...] | None = None,
    input_grads: tuple[torch.Tensor | None, ...] | None = None,
    output_grads: tuple[torch.Tensor | None, ...] | None = None,
    dw_builder: Callable[[], Callable[..., None]] | None = None,
    get_mesh: Callable[[tuple[str, ...], tuple[int, ...] | None], DeviceMesh] | None = None,
)
```

### Metadata Inference Mode Table

| input_args | output_args | Has DTensors | Grad metadata | has_backward | **Mode** |
|------------|-------------|--------------|---------------|--------------|----------|
| ✓ | ✓ | ✓ | ✓ complete | - | STATIC |
| ✓ | ✓ | ✗ | - | - | STATIC |
| ✓ | ✓ | ✓ | ✗ | False | STATIC |
| ✓ | ✓ | ✓ | ✗ | True | DYNAMIC |
| ✗ | ✗ | - | - | - | DYNAMIC |
| partial | - | - | - | - | DYNAMIC |

## Usage Example

```python
from torch.distributed.pipelining import PipelineStage, ScheduleGPipe

# ── STATIC mode: full DTensor metadata provided ──
stage = PipelineStage(
    submod,
    stage_index=0,
    num_stages=4,
    device=device,
    input_args=(dtensor_input,),
    output_args=(dtensor_output,),
    input_grads=(dtensor_grad_in,),
    output_grads=(dtensor_grad_out,),
)

# ── DYNAMIC mode: runtime inference with get_mesh callback ──
stage = PipelineStage(
    submod,
    stage_index=0,
    num_stages=4,
    device=device,
    get_mesh=lambda names, shape: init_device_mesh("cuda", shape, mesh_dim_names=names),
)

# ── STATIC mode: plain tensors (no DTensors, no get_mesh needed) ──
stage = PipelineStage(
    submod,
    stage_index=0,
    num_stages=4,
    device=device,
    input_args=(plain_tensor,),
    output_args=(plain_tensor_out,),
)
```

## Testing

- Added `test_dtensor_pp.py` with tests for DTensor metadata handling
- Verified mesh cache population and lookup
- Tested both STATIC and DYNAMIC inference modes
- Tested V-schedule two-phase inference
- Tested gradient placement propagation (forward ≠ backward placements)

