### PR TITLE
docs: improve EMA equation docs (reviving #164960)

### DIFF
--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -547,10 +547,14 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
 {func}`torch.optim.swa_utils.get_ema_multi_avg_fn` returns a function that applies the following EMA equation to the weights:
 
 ```{math}
-W^\textrm{EMA}_{t+1} = \alpha W^\textrm{EMA}_{t} + (1 - \alpha) W^\textrm{model}_t
-```
+    W_0^{\text{EMA}} = W_0^{\text{model}}
+    ```
 
-where alpha is the EMA decay.
+    ```{math}
+    W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
+    ```
+
+    where $W_t^{\text{EMA}}$ is the EMA parameter at step $t$, $W_t^{\text{model}}$ is the model parameter at step $t$, and decay is the EMA decay rate (default: 0.999).
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -553,7 +553,7 @@ W_0^{\text{EMA}} = W_0^{\text{model}}
 ```{math}
 W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
 ```
- where :math:`W_t^{\text{EMA}}` is the EMA parameter at step `t`, :math:`W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
+ where $W_t^{\text{EMA}}$ is the EMA parameter at step `t`, $W_t^{\text{model}}$ is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -554,7 +554,7 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
     W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
     ```
 
-    where $W_t^{\text{EMA}}$ is the EMA parameter at step $t$, $W_t^{\text{model}}$ is the model parameter at step $t$, and decay is the EMA decay rate (default: 0.999).
+    where `W_t^{\text{EMA}}` is the EMA parameter at step `t`, `W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -553,7 +553,7 @@ W_0^{\text{EMA}} = W_0^{\text{model}}
 ```{math}
 W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
 ```
- where $W_t^{\text{EMA}}$ is the EMA parameter at step `t`, $W_t^{\text{model}}$ is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
+ where `W_t^{\text{EMA}}` is the EMA parameter at step `t`, `W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -546,10 +546,9 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
 
 {func}`torch.optim.swa_utils.get_ema_multi_avg_fn` returns a function that applies the following EMA equation to the weights:
 
-```{math}
-    W_0^{\text{EMA}} = W_0^{\text{model}}
-    ```
 
+    ```{math}
+    W_0^{\text{EMA}} = W_0^{\text{model}}
 
     ```{math}
     W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -546,15 +546,12 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
 
 {func}`torch.optim.swa_utils.get_ema_multi_avg_fn` returns a function that applies the following EMA equation to the weights:
 
+```{math}
+W_0^{\text{EMA}} = W_0^{\text{model}}
+```
 
-    ```{math}
-    W_0^{\text{EMA}} = W_0^{\text{model}}
-
-    ```{math}
-    W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
-    ```
-
-    where `W_t^{\text{EMA}}` is the EMA parameter at step `t`, `W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
+```{math}
+W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -552,6 +552,8 @@ W_0^{\text{EMA}} = W_0^{\text{model}}
 
 ```{math}
 W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
+```
+ where `W_t^{\text{EMA}}` is the EMA parameter at step `t`, `W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -553,7 +553,7 @@ W_0^{\text{EMA}} = W_0^{\text{model}}
 ```{math}
 W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
 ```
- where `W_t^{\text{EMA}}` is the EMA parameter at step `t`, `W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
+ where :math:`W_t^{\text{EMA}}` is the EMA parameter at step `t`, :math:`W_t^{\text{model}}` is the model parameter at step `t`, and decay is the EMA decay rate (default: 0.999).
 
 Here the model `model` can be an arbitrary {class}`torch.nn.Module` object. `averaged_model`
 will keep track of the running averages of the parameters of the `model`. To update these

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -550,6 +550,7 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
     W_0^{\text{EMA}} = W_0^{\text{model}}
     ```
 
+
     ```{math}
     W_{t+1}^{\text{EMA}} = \text{decay} \times W_t^{\text{EMA}} + (1 - \text{decay}) \times W_{t+1}^{\text{model}}
     ```

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -35,7 +35,26 @@ PARAM_LIST = Union[tuple[Tensor, ...], list[Tensor]]
 
 
 def get_ema_multi_avg_fn(decay=0.999):
-    """Get the function applying exponential moving average (EMA) across multiple params."""
+    """Get the function applying exponential moving average (EMA) across multiple params.
+
+    The EMA is computed as:
+
+    .. math::
+        W_0^{\\text{EMA}} = W_0^{\\text{model}}
+
+    .. math::
+        W_{t+1}^{\\text{EMA}} = \\text{decay} \\times W_t^{\\text{EMA}} + (1 - \\text{decay}) \\times W_{t+1}^{\\text{model}}
+
+    where :math:`W_t^{\\text{EMA}}` is the EMA parameter at step :math:`t`,
+    :math:`W_t^{\\text{model}}` is the model parameter at step :math:`t`,
+    and :math:`\\text{decay}` is the decay rate (default: 0.999).
+
+    Args:
+        decay (float): Decay rate for EMA. Must be in the range [0, 1]. Default: 0.999
+
+    Returns:
+        Callable: A function that updates EMA parameters given current model parameters
+    """
 
     if decay < 0.0 or decay > 1.0:
         raise ValueError(
@@ -93,7 +112,26 @@ def get_swa_multi_avg_fn():
 
 
 def get_ema_avg_fn(decay=0.999):
-    """Get the function applying exponential moving average (EMA) across a single param."""
+    """Get the function applying exponential moving average (EMA) across multiple params.
+
+    The EMA is computed as:
+
+    .. math::
+        W_0^{\\text{EMA}} = W_0^{\\text{model}}
+
+    .. math::
+        W_{t+1}^{\\text{EMA}} = \\text{decay} \\times W_t^{\\text{EMA}} + (1 - \\text{decay}) \\times W_{t+1}^{\\text{model}}
+
+    where :math:`W_t^{\\text{EMA}}` is the EMA parameter at step :math:`t`,
+    :math:`W_t^{\\text{model}}` is the model parameter at step :math:`t`,
+    and :math:`\\text{decay}` is the decay rate (default: 0.999).
+
+    Args:
+        decay (float): Decay rate for EMA. Must be in the range [0, 1]. Default: 0.999
+
+    Returns:
+        Callable: A function that updates EMA parameters given current model parameters
+    """
 
     if decay < 0.0 or decay > 1.0:
         raise ValueError(


### PR DESCRIPTION
Fixes #155551

## Summary
This PR improves the documentation for `get_ema_multi_avg_fn()` and `get_ema_avg_fn()` by adding detailed mathematical equations and parameter descriptions.

## Changes
- Updated `torch/optim/swa_utils.py`: Added LaTeX equations for EMA initialization and update rules.
- Updated `docs/source/optim.md`: Aligned the documentation with the Python docstrings as requested by @janeyx99.
- Clarified variable names (using `decay` instead of generic alpha).

## Context
This revives the work from PR #164960 by @Aerovity, which was approved but closed due to inactivity. I am bringing it to completion