### PR TITLE
Fixes UT, test_3layer_split_reduction by replacing hardcoded configs with device properties.

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -182,7 +182,7 @@ class MixOrderReductionTest(TestBase):
         def f(x):
             return x.sum(dim=-1), x.sum(dim=0)
 
-        x = torch.randn(32768 * 256, 2, dtype=torch.float, device=GPU_TYPE)
+        x = torch.randn(32768 * 1024, 2, dtype=torch.float, device=GPU_TYPE)
         self.check_numeric(f, (x,))
         # We don't do mix order reduction for split redutions
         # with more than 2 layers

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -428,13 +428,13 @@ class InductorChoices:
         so we will do the reduction in two phases."""
         props = DeviceProperties.create(device)
         num_sm = props.multi_processor_count
-        min_elements_per_thread = 32
+        min_elements_per_thread = props.warp_size
         max_elements_per_thread = 512
-        threads_per_sm = 2048
+        threads_per_sm = props.max_threads_per_multi_processor
         min_elements_per_device = min_elements_per_thread * num_sm * threads_per_sm
         max_elements_per_device = max_elements_per_thread * num_sm * threads_per_sm
         num_warps = 8
-        num_threads = 32 * num_warps
+        num_threads = props.warp_size * num_warps
 
         if inner_reduction:
             # do heuristics that's close to eager mode for split inner reduction

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -428,13 +428,19 @@ class InductorChoices:
         so we will do the reduction in two phases."""
         props = DeviceProperties.create(device)
         num_sm = props.multi_processor_count
-        min_elements_per_thread = props.warp_size
+        warp_size = props.warp_size if props.warp_size is not None else 32
+        max_threads_per_sm = (
+            props.max_threads_per_multi_processor
+            if props.max_threads_per_multi_processor is not None
+            else 2048
+        )
+        min_elements_per_thread = warp_size
         max_elements_per_thread = 512
-        threads_per_sm = props.max_threads_per_multi_processor
+        threads_per_sm = max_threads_per_sm
         min_elements_per_device = min_elements_per_thread * num_sm * threads_per_sm
         max_elements_per_device = max_elements_per_thread * num_sm * threads_per_sm
         num_warps = 8
-        num_threads = props.warp_size * num_warps
+        num_threads = warp_size * num_warps
 
         if inner_reduction:
             # do heuristics that's close to eager mode for split inner reduction


### PR DESCRIPTION
Fixes #166836 
Replace hardcoded configs in unit test, test_3layer_split_reduction with device properties.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo