### PR TITLE
[AOTI] Enable shared model loading from directory to avoid redundant unzipping

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import copy
 import functools
+import gc
 import io
 import os
 import shutil
@@ -253,6 +254,93 @@ class TestAOTInductorPackage(TestCase):
                 actual = loaded(*example_inputs)
 
             self.assertEqual(actual, expected)
+
+    def test_load_package_from_directory(self):
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x, y):
+                return x + self.linear(y)
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        model = Model()
+        with torch.no_grad():
+            model = model.to(self.device)
+            ref_model = copy.deepcopy(model)
+            ref_inputs = copy.deepcopy(example_inputs)
+            expected = ref_model(*ref_inputs)
+
+            with WritableTempFile(suffix=".pt2") as f:
+                ep = torch.export.export(model, example_inputs, strict=True)
+                package_path = torch._inductor.aoti_compile_and_package(
+                    ep,
+                    package_path=f.name,
+                    inductor_configs={
+                        "aot_inductor.package_cpp_only": self.package_cpp_only,
+                    },
+                )
+
+                # Unzip to a temporary directory
+                temp_dir = tempfile.mkdtemp()
+                try:
+                    with zipfile.ZipFile(package_path, "r") as zip_ref:
+                        zip_ref.extractall(temp_dir)
+
+                    # Identify prefix if any (ZipFile.extractall extracts as is)
+                    # The loader should be able to load from temp_dir which contains 'data/...'
+                    # or 'some_prefix/data/...'
+
+                    loaded = torch._inductor.aoti_load_package(temp_dir)
+                    actual = loaded(*example_inputs)
+                    self.assertEqual(actual, expected)
+
+                    collision_dir = tempfile.mkdtemp()
+                    try:
+                        with zipfile.ZipFile(package_path, "r") as zip_ref:
+                            zip_ref.extractall(collision_dir)
+
+                        model_dirs = [
+                            path
+                            for path in Path(collision_dir).rglob("model")
+                            if path.is_dir() and path.parent.name == "aotinductor"
+                        ]
+                        self.assertEqual(len(model_dirs), 1)
+                        model_dirs[0].rename(model_dirs[0].with_name("model2"))
+                        with self.assertRaises(RuntimeError):
+                            load_package(collision_dir, model_name="model")
+                    finally:
+                        shutil.rmtree(collision_dir)
+
+                    # Verify robustness: move data deeper
+                    nested_dir = os.path.join(temp_dir, "nested_dir")
+                    os.makedirs(nested_dir)
+                    # Move all contents to nested_dir
+                    for item in os.listdir(temp_dir):
+                        if item != "nested_dir":
+                            shutil.move(os.path.join(temp_dir, item), nested_dir)
+
+                    # Load from root temp_dir again, it should find it in nested_dir
+                    loaded_nested = torch._inductor.aoti_load_package(temp_dir)
+                    actual_nested = loaded_nested(*example_inputs)
+                    self.assertEqual(actual_nested, expected)
+
+                    # Determine if destructor deletes the files
+                    del loaded
+                    del loaded_nested
+                    gc.collect()
+
+                    # In shared mode, the directory should NOT be deleted
+                    # We check if we can still find some files.
+                    self.assertTrue(os.path.exists(nested_dir))
+                    self.assertTrue(len(os.listdir(nested_dir)) > 0)
+
+                finally:
+                    shutil.rmtree(temp_dir)
 
     def test_linear(self):
         class Model(torch.nn.Module):
@@ -588,6 +676,32 @@ class TestAOTInductorPackage(TestCase):
                     )
                 )
                 self.assertEqual(loaded_metadata.get("dummy"), "moo")
+
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    with zipfile.ZipFile(package_path, "r") as zip_ref:
+                        zip_ref.extractall(temp_dir)
+
+                    loaded_metadata_from_directory = (
+                        torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(
+                            temp_dir, "model"
+                        )
+                    )
+                    self.assertEqual(loaded_metadata_from_directory, loaded_metadata)
+
+                    nested_dir = os.path.join(temp_dir, "nested_dir")
+                    os.makedirs(nested_dir)
+                    for item in os.listdir(temp_dir):
+                        if item != "nested_dir":
+                            shutil.move(os.path.join(temp_dir, item), nested_dir)
+
+                    loaded_metadata_from_nested_directory = (
+                        torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(
+                            temp_dir, "model"
+                        )
+                    )
+                    self.assertEqual(
+                        loaded_metadata_from_nested_directory, loaded_metadata
+                    )
 
                 device = loaded_metadata["AOTI_DEVICE_KEY"]
                 current_device_info = torch._inductor.codecache.get_device_information(

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -681,10 +681,8 @@ class TestAOTInductorPackage(TestCase):
                     with zipfile.ZipFile(package_path, "r") as zip_ref:
                         zip_ref.extractall(temp_dir)
 
-                    loaded_metadata_from_directory = (
-                        torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(
-                            temp_dir, "model"
-                        )
+                    loaded_metadata_from_directory = torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(
+                        temp_dir, "model"
                     )
                     self.assertEqual(loaded_metadata_from_directory, loaded_metadata)
 
@@ -694,10 +692,8 @@ class TestAOTInductorPackage(TestCase):
                         if item != "nested_dir":
                             shutil.move(os.path.join(temp_dir, item), nested_dir)
 
-                    loaded_metadata_from_nested_directory = (
-                        torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(
-                            temp_dir, "model"
-                        )
+                    loaded_metadata_from_nested_directory = torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(
+                        temp_dir, "model"
                     )
                     self.assertEqual(
                         loaded_metadata_from_nested_directory, loaded_metadata

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -101,10 +101,6 @@ bool path_starts_with_directory(
       c10::starts_with(normalized_path, normalized_directory_with_sep);
 }
 
-bool is_zip_file(const std::string& path) {
-  return c10::ends_with(path, ".pt2") || c10::ends_with(path, ".zip");
-}
-
 void list_files_recursive(
     const std::string& root,
     std::vector<std::string>& out) {
@@ -120,7 +116,7 @@ std::string create_temp_dir() {
   // Transfer ownership of the temp directory path to the caller explicitly.
   // TempDir's destructor calls rmdir()/RemoveDirectory(); clearing the name
   // disables that RAII cleanup and lets callers manage lifecycle via
-  // recursive_rmdir().
+  // fs::remove_all().
   std::string path = temp_dir.name;
   temp_dir.name.clear();
   return path;
@@ -377,18 +373,6 @@ std::tuple<std::string, std::string> get_cpp_compile_command(
   return std::make_tuple(cmd, target_file);
 }
 
-bool recursive_mkdir(const std::string& dir) {
-  std::error_code ec;
-  fs::create_directories(dir, ec);
-  return !ec;
-}
-
-bool recursive_rmdir(const std::string& path) {
-  std::error_code ec;
-  fs::remove_all(path, ec);
-  return !ec;
-}
-
 std::string compile_so(
     const std::string& cpp_filename,
     std::vector<std::string>& obj_filenames) {
@@ -573,8 +557,7 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
         const std::string& model_package_path,
         const std::string& model_name) {
   const std::string metadata_suffix = "wrapper_metadata.json";
-  const bool is_directory_mode =
-      fs::is_directory(model_package_path) && !is_zip_file(model_package_path);
+  const bool is_directory_mode = fs::is_directory(model_package_path);
 
   std::vector<std::string> found_filenames;
   std::string metadata_path;
@@ -651,11 +634,13 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
           parent_path_idx != std::string::npos,
           "Failed to find parent path in " + output_path_str);
       std::string parent_path = output_path_str.substr(0, parent_path_idx);
+      std::error_code mkdir_ec;
       TORCH_CHECK(
-          recursive_mkdir(parent_path),
-          "Failed to create directory " + parent_path,
+          fs::create_directories(parent_path, mkdir_ec) || !mkdir_ec,
+          "Failed to create directory ",
+          parent_path,
           ": ",
-          c10::utils::str_error(errno));
+          mkdir_ec.message());
 
       LOG(INFO) << "Extract file: " << metadata_filename << " to "
                 << output_path_str;
@@ -668,7 +653,12 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
       for (auto& item : metadata_json_obj.items()) {
         metadata[item.key()] = item.value().get<std::string>();
       }
-      recursive_rmdir(temp_dir);
+      std::error_code remove_ec;
+      fs::remove_all(temp_dir, remove_ec);
+      if (remove_ec) {
+        LOG(WARNING) << "Failed to remove temporary directory " << temp_dir
+                     << ": " << remove_ec.message();
+      }
       return metadata;
     }
   }
@@ -733,9 +723,8 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
   std::vector<std::string> found_filenames;
   std::string model_directory;
 
-  if (fs::is_directory(model_package_path) &&
-      !is_zip_file(model_package_path)) {
-    shared_mode_ = true;
+  if (fs::is_directory(model_package_path)) {
+    is_directory_ = true;
     temp_dir_ =
         strip_trailing_separator(normalize_path_separator(model_package_path));
 
@@ -793,7 +782,7 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
 
   } else {
     // Extract all files within the zipfile to a temporary directory
-    shared_mode_ = false;
+    is_directory_ = false;
     RAIIMinizArchive zip_archive{model_package_path};
     auto zip_filenames = zip_archive.get_filenames();
     TORCH_CHECK(!zip_filenames.empty(), "No files found in zip archive.");
@@ -855,11 +844,13 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
             "Failed to find parent path in " + output_file_path);
 
         std::string parent_path = output_file_path.substr(0, parent_path_idx);
+        std::error_code mkdir_ec;
         TORCH_CHECK(
-            recursive_mkdir(parent_path),
-            "Failed to create directory " + parent_path,
+            fs::create_directories(parent_path, mkdir_ec) || !mkdir_ec,
+            "Failed to create directory ",
+            parent_path,
             ": ",
-            c10::utils::str_error(errno));
+            mkdir_ec.message());
 
         // Extracts file to the temp directory
         zip_archive.extract_file(zip_filename_str, output_path_str);
@@ -892,7 +883,7 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
         "Failed to find a generated cpp file or so file for model '",
         model_name,
         "' in the ",
-        (shared_mode_ ? "directory" : "zip archive"),
+        (is_directory_ ? "directory" : "zip archive"),
         ".\n\nAvailable models:\n",
         model_names_str,
         "\n\nTo load a specific model, please provide its name using the `model_name` parameter when calling AOTIModelPackageLoader() or torch._inductor.package.load_package.\n\n",
@@ -934,8 +925,13 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
 
 AOTIModelPackageLoader::~AOTIModelPackageLoader() {
   // Clean up the temporary directory
-  if (!temp_dir_.empty() && !shared_mode_) {
-    recursive_rmdir(temp_dir_);
+  if (!temp_dir_.empty() && !is_directory_) {
+    std::error_code remove_ec;
+    fs::remove_all(temp_dir_, remove_ec);
+    if (remove_ec) {
+      LOG(WARNING) << "Failed to remove temporary directory " << temp_dir_
+                   << ": " << remove_ec.message();
+    }
   }
 }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -1,42 +1,52 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
 
+#include <c10/util/FileSystem.h>
 #include <c10/util/error.h>
 #include <c10/util/string_view.h>
+#include <c10/util/tempfile.h>
 #include <torch/csrc/inductor/aoti_package/model_package_loader.h>
 #include <torch/csrc/inductor/aoti_runner/model_container_runner.h>
 
 #include <fmt/format.h>
 #include <miniz.h>
 #include <nlohmann/json.hpp>
+#include <cctype>
 #include <fstream>
 #include <iostream>
 #include <regex>
 
-#ifndef _WIN32
-#include <dirent.h>
-#include <sys/stat.h>
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-
-// TODO: C++17 has the filesystem header, which may replace these
 #ifdef _WIN32
 #include <Windows.h>
-// On Windows, the POSIX implementations are considered deprecated. We simply
-// map to the newer variant.
-#include <direct.h>
-#include <io.h>
-#include <process.h>
-#define access _access
-#define F_OK 0
-#else
-#include <unistd.h>
 #endif
+
+namespace fs = c10::filesystem;
 
 namespace {
 
 const std::string k_separator = "/";
+
+bool is_windows_drive_root(const std::string& path) {
+  return path.size() == 3 &&
+      std::isalpha(static_cast<unsigned char>(path[0])) && path[1] == ':' &&
+      path[2] == '/';
+}
+
+std::string strip_trailing_separator(const std::string& path) {
+  std::string stripped_path = path;
+  while (stripped_path.size() > 1 &&
+         c10::ends_with(stripped_path, k_separator) &&
+         !is_windows_drive_root(stripped_path)) {
+    stripped_path.pop_back();
+  }
+  return stripped_path;
+}
+
+std::string append_separator_if_needed(const std::string& path) {
+  if (path.empty() || c10::ends_with(path, k_separator)) {
+    return path;
+  }
+  return path + k_separator;
+}
 
 std::string remove_duplicate_separator_of_path(const std::string& path) {
   /*
@@ -76,34 +86,62 @@ std::string normalize_path_separator(const std::string& orig_path) {
   return normalized_path;
 }
 
-bool file_exists(const std::string& path) {
-#ifdef _WIN32
-  return fs::exists(path);
-#else
-  struct stat rc{};
-  return lstat(path.c_str(), &rc) == 0;
-#endif
+bool path_starts_with_directory(
+    const std::string& path,
+    const std::string& directory) {
+  const std::string normalized_path = normalize_path_separator(path);
+  const std::string normalized_directory =
+      strip_trailing_separator(normalize_path_separator(directory));
+  if (normalized_directory.empty()) {
+    return false;
+  }
+  const std::string normalized_directory_with_sep =
+      append_separator_if_needed(normalized_directory);
+  return normalized_path == normalized_directory ||
+      c10::starts_with(normalized_path, normalized_directory_with_sep);
+}
+
+bool is_zip_file(const std::string& path) {
+  return c10::ends_with(path, ".pt2") || c10::ends_with(path, ".zip");
+}
+
+void list_files_recursive(
+    const std::string& root,
+    std::vector<std::string>& out) {
+  for (auto const& e : fs::recursive_directory_iterator(root)) {
+    if (!fs::is_directory(e)) {
+      out.push_back(normalize_path_separator(e.path().string()));
+    }
+  }
 }
 
 std::string create_temp_dir() {
-#ifdef _WIN32
-  try {
-    fs::path temp_dir = fs::temp_directory_path();
-    return temp_dir.string();
-  } catch (const fs::filesystem_error& e) {
-    TORCH_CHECK(false, "Failed to get temporary directory: ", e.what());
-  } catch (...) {
-    TORCH_CHECK(
-        false, "Unknown error occurred while getting temporary directory");
+  c10::TempDir temp_dir = c10::make_tempdir("aotinductor_");
+  // Transfer ownership of the temp directory path to the caller explicitly.
+  // TempDir's destructor calls rmdir()/RemoveDirectory(); clearing the name
+  // disables that RAII cleanup and lets callers manage lifecycle via
+  // recursive_rmdir().
+  std::string path = temp_dir.name;
+  temp_dir.name.clear();
+  return path;
+}
+
+std::string detect_file_prefix(
+    const std::vector<std::string>& found_filenames) {
+  if (found_filenames.size() < 2) {
+    return "";
   }
-#else
-  std::string temp_dir = "/tmp/XXXXXX";
-  TORCH_CHECK(
-      mkdtemp(temp_dir.data()) != nullptr,
-      "Failed to create temporary directory: ",
-      c10::utils::str_error(errno));
-  return temp_dir;
-#endif
+
+  size_t pos = found_filenames[0].find('/');
+  std::string prefix0 = found_filenames[0].substr(0, pos);
+  pos = found_filenames[1].find('/');
+  std::string prefix1 = found_filenames[1].substr(0, pos);
+
+  if (!prefix0.empty() && !prefix1.empty() && prefix0 == prefix1) {
+    return prefix0 + "/";
+  }
+
+  return "";
 }
 
 const char* object_file_ext() {
@@ -123,11 +161,54 @@ const char* extension_file_ext() {
 }
 
 bool is_wrapper_library(const std::string& path) {
-#ifdef _WIN32
-  return c10::ends_with(path, ".wrapper.pyd");
-#else
-  return c10::ends_with(path, ".wrapper.so");
-#endif
+  return c10::ends_with(path, std::string(".wrapper") + extension_file_ext());
+}
+
+void categorize_model_file(
+    const std::string& filename,
+    const std::string& model_name,
+    std::string& cpp_filename,
+    std::vector<std::string>& obj_filenames,
+    std::string& so_filename,
+    std::string& weight_blob_filename) {
+  size_t extension_idx = filename.find_last_of('.');
+  if (extension_idx == std::string::npos) {
+    return;
+  }
+
+  std::string extension = filename.substr(extension_idx);
+  if (extension == ".cpp") {
+    cpp_filename = filename;
+  } else if (extension == object_file_ext()) {
+    obj_filenames.push_back(filename);
+  } else if (extension == extension_file_ext()) {
+    // Triton CPU AOTI has multiple .so files: kernel.so + launcher.so
+    // alongside wrapper.so. So, prefer *.wrapper.so, and fall back to
+    // first .so for non-CPU mode.
+    if (is_wrapper_library(filename)) {
+      if (!so_filename.empty() && is_wrapper_library(so_filename)) {
+        // Multiple wrapper libraries found - this is a packaging error.
+        TORCH_CHECK(
+            false,
+            "Multiple wrapper shared libraries found in AOTI package for model '",
+            model_name,
+            "': '",
+            so_filename,
+            "' and '",
+            filename,
+            "'. Each model should have exactly one wrapper library.");
+      }
+      so_filename = filename;
+    } else if (so_filename.empty()) {
+      // Get the first .so for non Triton CPU mode, where expecting a
+      // single .so.
+      so_filename = filename;
+    }
+    // else: auxiliary .so file (kernel.so, launcher.so for Triton CPU),
+    // ignore for wrapper selection but still extract or keep the file.
+  } else if (extension == ".blob") {
+    weight_blob_filename = filename;
+  }
 }
 
 const char* get_output_flags(bool compile_only) {
@@ -159,7 +240,7 @@ namespace torch::inductor {
 
 namespace {
 const nlohmann::json& load_json_file(const std::string& json_path) {
-  TORCH_CHECK(file_exists(json_path), "File not found: ", json_path);
+  TORCH_CHECK(fs::exists(json_path), "File not found: ", json_path);
 
   std::ifstream json_file(json_path);
   TORCH_CHECK(json_file.is_open());
@@ -297,99 +378,15 @@ std::tuple<std::string, std::string> get_cpp_compile_command(
 }
 
 bool recursive_mkdir(const std::string& dir) {
-  // Creates directories recursively, copied from jit_utils.cpp
-  // Check if current dir exists
-  const char* p_dir = dir.c_str();
-  const bool dir_exists = (access(p_dir, F_OK) == 0);
-  if (dir_exists) {
-    return true;
-  }
-
-  // Try to create current directory
-#ifdef _WIN32
-  int ret = _mkdir(dir.c_str());
-#else
-  int ret = mkdir(dir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
-#endif
-  // Success
-  if (ret == 0) {
-    return true;
-  }
-
-  // Find folder separator and check if we are at the top
-  auto pos = dir.find_last_of(k_separator);
-  if (pos == std::string::npos) {
-    return false;
-  }
-
-  // Try to create parent directory
-  if (!(recursive_mkdir(dir.substr(0, pos)))) {
-    return false;
-  }
-
-  // Try to create complete path again
-#ifdef _WIN32
-  ret = _mkdir(dir.c_str());
-#else
-  ret = mkdir(dir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
-#endif
-  return ret == 0;
+  std::error_code ec;
+  fs::create_directories(dir, ec);
+  return !ec;
 }
 
 bool recursive_rmdir(const std::string& path) {
-#ifdef _WIN32
   std::error_code ec;
-  return fs::remove_all(path, ec) != static_cast<std::uintmax_t>(-1);
-#else
-  DIR* dir = opendir(path.c_str());
-  if (!dir) {
-    return false;
-  }
-
-  struct dirent* entry = nullptr;
-  struct stat statbuf{};
-  bool success = true;
-
-  // Iterate through directory entries
-  while ((entry = readdir(dir)) != nullptr) {
-    std::string name = entry->d_name;
-
-    // Skip "." and ".."
-    if (name == "." || name == "..") {
-      continue;
-    }
-
-    std::string full_path = path;
-    full_path.append("/").append(name);
-
-    // Get file status
-    if (stat(full_path.c_str(), &statbuf) != 0) {
-      success = false;
-      continue;
-    }
-
-    if (S_ISDIR(statbuf.st_mode)) {
-      // Recursively delete subdirectory
-      if (!recursive_rmdir(full_path)) {
-        success = false;
-      }
-    } else {
-      // Delete file
-      if (unlink(full_path.c_str()) != 0) {
-        success = false;
-      }
-    }
-  }
-
-  closedir(dir);
-
-  // Remove the directory itself
-  if (rmdir(path.c_str()) != 0) {
-    success = false;
-  }
-
-  return success;
-#endif
+  fs::remove_all(path, ec);
+  return !ec;
 }
 
 std::string compile_so(
@@ -421,7 +418,7 @@ std::string compile_so(
 
   // Move the mmapped weights onto the .so
   std::string serialized_weights_path = filename + "_serialized_weights.bin";
-  if (file_exists(serialized_weights_path)) {
+  if (fs::exists(serialized_weights_path)) {
     std::ifstream serialized_weights_file(
         serialized_weights_path, std::ios::binary);
     TORCH_CHECK(
@@ -575,43 +572,108 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
     load_metadata_from_package(
         const std::string& model_package_path,
         const std::string& model_name) {
-  // Open the zip archive
-  RAIIMinizArchive zip_archive{model_package_path};
-  auto found_filenames{zip_archive.get_filenames()};
-  TORCH_CHECK(!found_filenames.empty(), "No files found in zip archive.");
+  const std::string metadata_suffix = "wrapper_metadata.json";
+  const bool is_directory_mode =
+      fs::is_directory(model_package_path) && !is_zip_file(model_package_path);
 
-  // Find the file prefix (similar to constructor logic)
-  std::string file_prefix;
-  if (found_filenames.size() >= 2) {
-    size_t pos = found_filenames[0].find('/');
-    std::string prefix0 = found_filenames[0].substr(0, pos);
-    pos = found_filenames[1].find('/');
-    std::string prefix1 = found_filenames[1].substr(0, pos);
+  std::vector<std::string> found_filenames;
+  std::string metadata_path;
+  std::string model_directory;
 
-    if (!prefix0.empty() && !prefix1.empty() && prefix0 == prefix1) {
-      file_prefix = prefix0 + "/";
+  if (is_directory_mode) {
+    std::string root_dir =
+        strip_trailing_separator(normalize_path_separator(model_package_path));
+    list_files_recursive(root_dir, found_filenames);
+    TORCH_CHECK(
+        !found_filenames.empty(),
+        "Shared model directory is empty: ",
+        root_dir);
+
+    std::string file_prefix;
+    std::string rel_model_path_suffix = std::string("data") + k_separator +
+        "aotinductor" + k_separator + model_name + k_separator;
+    std::string root_with_sep = append_separator_if_needed(root_dir);
+    for (const auto& path : found_filenames) {
+      size_t pos = path.find(rel_model_path_suffix);
+      if (pos != std::string::npos && c10::starts_with(path, root_with_sep) &&
+          pos >= root_with_sep.length()) {
+        if (pos > root_with_sep.length()) {
+          file_prefix =
+              path.substr(root_with_sep.length(), pos - root_with_sep.length());
+        }
+        break;
+      }
+    }
+
+    model_directory = normalize_path_separator(
+        file_prefix + "data" + k_separator + "aotinductor" + k_separator +
+        model_name);
+    std::string search_model_dir =
+        normalize_path_separator(root_dir + k_separator + model_directory);
+
+    for (const auto& cur_filename : found_filenames) {
+      if (path_starts_with_directory(cur_filename, search_model_dir) &&
+          c10::ends_with(cur_filename, metadata_suffix)) {
+        metadata_path = cur_filename;
+        break;
+      }
+    }
+  } else {
+    // Open the zip archive.
+    RAIIMinizArchive zip_archive{model_package_path};
+    found_filenames = zip_archive.get_filenames();
+    TORCH_CHECK(!found_filenames.empty(), "No files found in zip archive.");
+
+    std::string file_prefix = detect_file_prefix(found_filenames);
+    model_directory = normalize_path_separator(
+        file_prefix + "data" + k_separator + "aotinductor" + k_separator +
+        model_name);
+
+    std::string metadata_filename;
+    for (auto const& zip_filename_str : found_filenames) {
+      auto cur_filename = normalize_path_separator(zip_filename_str);
+      if (path_starts_with_directory(cur_filename, model_directory) &&
+          c10::ends_with(cur_filename, metadata_suffix)) {
+        metadata_filename = zip_filename_str;
+        break;
+      }
+    }
+
+    if (!metadata_filename.empty()) {
+      // Create temporary directory for extraction
+      std::string temp_dir = normalize_path_separator(create_temp_dir());
+      std::string output_path_str =
+          normalize_path_separator(temp_dir + k_separator + metadata_filename);
+
+      // Create the parent directory if it doesn't exist
+      size_t parent_path_idx = output_path_str.find_last_of(k_separator);
+      TORCH_CHECK(
+          parent_path_idx != std::string::npos,
+          "Failed to find parent path in " + output_path_str);
+      std::string parent_path = output_path_str.substr(0, parent_path_idx);
+      TORCH_CHECK(
+          recursive_mkdir(parent_path),
+          "Failed to create directory " + parent_path,
+          ": ",
+          c10::utils::str_error(errno));
+
+      LOG(INFO) << "Extract file: " << metadata_filename << " to "
+                << output_path_str;
+      zip_archive.extract_file(metadata_filename, output_path_str);
+      metadata_path = output_path_str;
+
+      // Clean up temporary directory after metadata is parsed.
+      const nlohmann::json metadata_json_obj = load_json_file(metadata_path);
+      std::unordered_map<std::string, std::string> metadata;
+      for (auto& item : metadata_json_obj.items()) {
+        metadata[item.key()] = item.value().get<std::string>();
+      }
+      recursive_rmdir(temp_dir);
+      return metadata;
     }
   }
 
-  // Construct the expected metadata file path within the zip
-  std::string model_directory = normalize_path_separator(
-      file_prefix + "data" + k_separator + "aotinductor" + k_separator +
-      model_name);
-  std::string metadata_suffix = "wrapper_metadata.json";
-
-  std::string metadata_filename;
-
-  for (auto const& zip_filename_str : found_filenames) {
-    auto cur_filename = normalize_path_separator(zip_filename_str);
-
-    if (c10::starts_with(cur_filename, model_directory) &&
-        c10::ends_with(cur_filename, metadata_suffix)) {
-      metadata_filename = cur_filename;
-      break;
-    }
-  }
-
-  if (metadata_filename.empty()) {
+  if (metadata_path.empty()) {
     std::string found_filenames_str;
     for (const std::string& filename : found_filenames) {
       found_filenames_str += filename + "\n";
@@ -624,45 +686,24 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
 
     TORCH_CHECK(
         false,
-        "Failed to find a generated cpp file or so file for model '",
+        "Failed to find wrapper metadata for model '",
         model_name,
-        "' in the zip archive.\n\nAvailable models in the archive:\n",
+        "' in the ",
+        (is_directory_mode ? "directory" : "zip archive"),
+        ".\n\nAvailable models:\n",
         model_names_str,
         "\n\nTo load a specific model, please provide its name using the `model_name` parameter when calling AOTIModelPackageLoader() or torch._inductor.package.load_package.\n\n",
-        "The following files were loaded from the archive:\n",
+        "The following files were found:\n",
         found_filenames_str);
   }
 
-  // Create temporary directory for extraction
-  std::string temp_dir = normalize_path_separator(create_temp_dir());
-  std::string output_path_str =
-      normalize_path_separator(temp_dir + k_separator + metadata_filename);
-
-  // Create the parent directory if it doesn't exist
-  size_t parent_path_idx = output_path_str.find_last_of(k_separator);
-  TORCH_CHECK(
-      parent_path_idx != std::string::npos,
-      "Failed to find parent path in " + output_path_str);
-  std::string parent_path = output_path_str.substr(0, parent_path_idx);
-  TORCH_CHECK(
-      recursive_mkdir(parent_path),
-      "Failed to create directory " + parent_path,
-      ": ",
-      c10::utils::str_error(errno));
-
-  LOG(INFO) << "Extract file: " << metadata_filename << " to "
-            << output_path_str;
-  zip_archive.extract_file(metadata_filename, output_path_str);
-
   // Parse the metadata json file
-  const nlohmann::json metadata_json_obj = load_json_file(output_path_str);
+  const nlohmann::json metadata_json_obj = load_json_file(metadata_path);
 
   std::unordered_map<std::string, std::string> metadata;
   for (auto& item : metadata_json_obj.items()) {
     metadata[item.key()] = item.value().get<std::string>();
   }
-  // Clean up temporary directory
-  recursive_rmdir(temp_dir);
 
   return metadata;
 }
@@ -683,110 +724,154 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
         "num_runners must be >=1 when run_single_threaded is false");
   }
 
-  // Extract all files within the zipfile to a temporary directory
-  RAIIMinizArchive zip_archive{model_package_path};
-  auto found_filenames{zip_archive.get_filenames()};
-  TORCH_CHECK(!found_filenames.empty(), "No files found in zip archive.");
-
-  // All the paths are prepended with a tmp/ directory. We need to find the
-  // prefix.
-  std::string file_prefix;
-  size_t pos = found_filenames[0].find('/');
-  std::string prefix0 = found_filenames[0].substr(0, pos);
-  pos = found_filenames[1].find('/');
-  std::string prefix1 = found_filenames[1].substr(0, pos);
-
-  if (!prefix0.empty() && !prefix1.empty() && prefix0 == prefix1) {
-    file_prefix = prefix0 + "/";
-  } else {
-    LOG(WARNING)
-        << "You are using an outdated version of the pt2 archive which do not have a prefix in front of each filename. Example: \n"
-        << found_filenames[0] << '\n'
-        << found_filenames[1];
-  }
-
-  temp_dir_ = normalize_path_separator(create_temp_dir());
-
   std::string so_filename;
   std::string cpp_filename;
   std::string weight_blob_filename;
   std::vector<std::string> obj_filenames;
-  std::string model_directory = normalize_path_separator(
-      file_prefix + "data" + k_separator + "aotinductor" + k_separator +
-      model_name);
-  std::string const_directory = normalize_path_separator(
-      file_prefix + "data" + k_separator + "constants");
+  std::string file_prefix; // zip prefix (can be empty in shared directory mode)
 
-  // zip_filename_str can't be normalize_path_separator, because it should be
-  // as index for mz_zip_reader_extract_file_to_file.
-  for (auto const& zip_filename_str : found_filenames) {
-    auto cur_filename = normalize_path_separator(zip_filename_str);
-    // Only compile files in the specified model directory
-    if (c10::starts_with(cur_filename, model_directory) ||
-        c10::starts_with(cur_filename, const_directory)) {
-      std::string output_path_str = temp_dir_;
+  std::vector<std::string> found_filenames;
+  std::string model_directory;
 
-      if (c10::starts_with(cur_filename, model_directory)) {
-        output_path_str += k_separator;
-        output_path_str += cur_filename;
-      } else { // startsWith(zip_filename_str, const_directory)
-        // Extract constants to the same directory as the rest of the files
-        // to be consistent with internal implementation
-        size_t lastSlash = cur_filename.find_last_of(k_separator);
-        std::string filename = cur_filename;
-        if (lastSlash != std::string::npos) {
-          filename = cur_filename.substr(lastSlash + 1);
+  if (fs::is_directory(model_package_path) &&
+      !is_zip_file(model_package_path)) {
+    shared_mode_ = true;
+    temp_dir_ =
+        strip_trailing_separator(normalize_path_separator(model_package_path));
+
+    list_files_recursive(temp_dir_, found_filenames);
+    TORCH_CHECK(
+        !found_filenames.empty(),
+        "Shared model directory is empty: ",
+        temp_dir_);
+
+    // model_directory should be relative to temp_dir_ to be consistent with zip
+    // mode and correct calculation of cubin_dir later.
+
+    // Attempt to detect prefix (e.g. if the directory contains a subdirectory
+    // structure).
+    // We look for "data/aotinductor/<model_name>/" in the found files.
+    std::string rel_model_path_suffix = std::string("data") + k_separator +
+        "aotinductor" + k_separator + model_name + k_separator;
+    std::string temp_dir_with_sep = append_separator_if_needed(temp_dir_);
+    for (const auto& path : found_filenames) {
+      size_t pos = path.find(rel_model_path_suffix);
+      if (pos != std::string::npos &&
+          c10::starts_with(path, temp_dir_with_sep) &&
+          pos >= temp_dir_with_sep.length()) {
+        if (pos > temp_dir_with_sep.length()) {
+          file_prefix = path.substr(
+              temp_dir_with_sep.length(), pos - temp_dir_with_sep.length());
         }
-        output_path_str.append(k_separator)
-            .append(model_directory)
-            .append(k_separator)
-            .append(filename);
+        break;
       }
+    }
 
-      std::string output_file_path = normalize_path_separator(output_path_str);
-      LOG(INFO) << "Extract file: " << zip_filename_str << " to "
-                << output_file_path;
+    model_directory = normalize_path_separator(
+        file_prefix + "data" + k_separator + "aotinductor" + k_separator +
+        model_name);
 
-      // Create the parent directory if it doesn't exist
-      size_t parent_path_idx = output_file_path.find_last_of(k_separator);
-      TORCH_CHECK(
-          parent_path_idx != std::string::npos,
-          "Failed to find parent path in " + output_file_path);
+    // Use absolute paths for matching
+    std::string search_model_dir =
+        normalize_path_separator(temp_dir_ + k_separator + model_directory);
+    std::string search_const_dir = normalize_path_separator(
+        temp_dir_ + k_separator + file_prefix + "data" + k_separator +
+        "constants");
 
-      std::string parent_path = output_file_path.substr(0, parent_path_idx);
-      TORCH_CHECK(
-          recursive_mkdir(parent_path),
-          "Failed to create directory " + parent_path,
-          ": ",
-          c10::utils::str_error(errno));
+    for (auto const& cur_filename : found_filenames) {
+      if (path_starts_with_directory(cur_filename, search_model_dir) ||
+          path_starts_with_directory(cur_filename, search_const_dir)) {
+        categorize_model_file(
+            cur_filename,
+            model_name,
+            cpp_filename,
+            obj_filenames,
+            so_filename,
+            weight_blob_filename);
+      }
+    }
 
-      // Extracts file to the temp directory
-      zip_archive.extract_file(zip_filename_str, output_path_str);
+  } else {
+    // Extract all files within the zipfile to a temporary directory
+    shared_mode_ = false;
+    RAIIMinizArchive zip_archive{model_package_path};
+    auto zip_filenames = zip_archive.get_filenames();
+    TORCH_CHECK(!zip_filenames.empty(), "No files found in zip archive.");
+    found_filenames = zip_filenames;
 
-      // Save the file for bookkeeping
-      size_t extension_idx = output_file_path.find_last_of('.');
-      if (extension_idx != std::string::npos) {
-        std::string filename_extension = output_file_path.substr(extension_idx);
-        if (filename_extension == ".cpp") {
-          cpp_filename = output_file_path;
-        } else if (filename_extension == object_file_ext()) {
-          obj_filenames.push_back(output_file_path);
-        } else if (is_wrapper_library(output_file_path)) {
-          // Triton CPU emits kernel.so + launcher.so alongside the
-          // wrapper; ignore the auxiliaries here (already extracted above).
-          TORCH_CHECK(
-              so_filename.empty(),
-              "Multiple wrapper libraries found for model '",
-              model_name,
-              "': '",
-              so_filename,
-              "' and '",
-              output_file_path,
-              "'");
-          so_filename = output_file_path;
-        } else if (filename_extension == ".blob") {
-          weight_blob_filename = output_file_path;
+    // All the paths are prepended with a tmp/ directory. We need to find the
+    // prefix.
+    file_prefix = detect_file_prefix(found_filenames);
+    if (file_prefix.empty()) {
+      LOG(WARNING)
+          << "You are using an outdated version of the pt2 archive which do not have a prefix in front of each filename. Example: \n"
+          << found_filenames[0]
+          << (found_filenames.size() >= 2 ? "\n" + found_filenames[1] : "");
+    }
+
+    temp_dir_ = normalize_path_separator(create_temp_dir());
+
+    model_directory = normalize_path_separator(
+        file_prefix + "data" + k_separator + "aotinductor" + k_separator +
+        model_name);
+    std::string const_directory = normalize_path_separator(
+        file_prefix + "data" + k_separator + "constants");
+
+    // zip_filename_str can't be normalize_path_separator, because it should be
+    // as index for mz_zip_reader_extract_file_to_file.
+    for (auto const& zip_filename_str : found_filenames) {
+      auto cur_filename = normalize_path_separator(zip_filename_str);
+      // Only compile files in the specified model directory
+      if (path_starts_with_directory(cur_filename, model_directory) ||
+          path_starts_with_directory(cur_filename, const_directory)) {
+        std::string output_path_str = temp_dir_;
+
+        if (path_starts_with_directory(cur_filename, model_directory)) {
+          output_path_str += k_separator;
+          output_path_str += cur_filename;
+        } else { // startsWith(zip_filename_str, const_directory)
+          // Extract constants to the same directory as the rest of the files
+          // to be consistent with internal implementation
+          size_t lastSlash = cur_filename.find_last_of(k_separator);
+          std::string filename = cur_filename;
+          if (lastSlash != std::string::npos) {
+            filename = cur_filename.substr(lastSlash + 1);
+          }
+          output_path_str.append(k_separator)
+              .append(model_directory)
+              .append(k_separator)
+              .append(filename);
         }
+
+        std::string output_file_path =
+            normalize_path_separator(output_path_str);
+        LOG(INFO) << "Extract file: " << zip_filename_str << " to "
+                  << output_file_path;
+
+        // Create the parent directory if it doesn't exist
+        size_t parent_path_idx = output_file_path.find_last_of(k_separator);
+        TORCH_CHECK(
+            parent_path_idx != std::string::npos,
+            "Failed to find parent path in " + output_file_path);
+
+        std::string parent_path = output_file_path.substr(0, parent_path_idx);
+        TORCH_CHECK(
+            recursive_mkdir(parent_path),
+            "Failed to create directory " + parent_path,
+            ": ",
+            c10::utils::str_error(errno));
+
+        // Extracts file to the temp directory
+        zip_archive.extract_file(zip_filename_str, output_path_str);
+
+        // Save the file for bookkeeping
+        categorize_model_file(
+            output_file_path,
+            model_name,
+            cpp_filename,
+            obj_filenames,
+            so_filename,
+            weight_blob_filename);
       }
     }
   }
@@ -806,10 +891,12 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
         false,
         "Failed to find a generated cpp file or so file for model '",
         model_name,
-        "' in the zip archive.\n\nAvailable models in the archive:\n",
+        "' in the ",
+        (shared_mode_ ? "directory" : "zip archive"),
+        ".\n\nAvailable models:\n",
         model_names_str,
         "\n\nTo load a specific model, please provide its name using the `model_name` parameter when calling AOTIModelPackageLoader() or torch._inductor.package.load_package.\n\n",
-        "The following files were loaded from the archive:\n",
+        "The following files were found:\n",
         found_filenames_str);
   }
 
@@ -819,7 +906,7 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
       : compile_so(cpp_filename, obj_filenames);
 
   // Load metadata which can be queried by user
-  load_metadata(cpp_filename);
+  load_metadata(!cpp_filename.empty() ? cpp_filename : so_path);
 
   // Construct the runner depending on the device information
   std::string device_key = metadata_["AOTI_DEVICE_KEY"];
@@ -847,7 +934,7 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
 
 AOTIModelPackageLoader::~AOTIModelPackageLoader() {
   // Clean up the temporary directory
-  if (!temp_dir_.empty()) {
+  if (!temp_dir_.empty() && !shared_mode_) {
     recursive_rmdir(temp_dir_);
   }
 }

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -65,7 +65,10 @@ class TORCH_API AOTIModelPackageLoader {
   std::string temp_dir_;
   std::unique_ptr<AOTIModelContainerRunner> runner_;
   std::unordered_map<std::string, std::string> metadata_;
-  bool shared_mode_ = false;
+  // True when loading from a user-provided unpacked package directory. In this
+  // mode temp_dir_ points to that directory and must not be removed by the
+  // loader. False when temp_dir_ is an owned extraction directory.
+  bool is_directory_ = false;
 
   void load_metadata(const std::string& cpp_filename);
 };

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -65,6 +65,7 @@ class TORCH_API AOTIModelPackageLoader {
   std::string temp_dir_;
   std::unique_ptr<AOTIModelContainerRunner> runner_;
   std::unordered_map<std::string, std::string> metadata_;
+  bool shared_mode_ = false;
 
   void load_metadata(const std::string& cpp_filename);
 };


### PR DESCRIPTION
Implement #169154.
Co-authored-by: Gemini

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo