### PR TITLE
[ROCm] fix test_preferred_blas_library_settings for RDNA4

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -625,7 +625,7 @@ print(t.is_pinned())
                 gcn_arch = str(
                     torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
                 )
-                if gcn_arch in ["gfx90a", "gfx942", "gfx950"]:
+                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1200", "gfx1201"]:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)


### PR DESCRIPTION
Starting from https://github.com/pytorch/pytorch/pull/153610 hipBLASLt is preferred BLAS backend for RDNA4

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang