### PR TITLE
Build docker images for s390x on fly

### DIFF
--- a/.ci/docker/common/install_cpython.sh
+++ b/.ci/docker/common/install_cpython.sh
@@ -6,7 +6,7 @@ PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 # Python versions to be installed in /opt/$VERSION_NO
-CPYTHON_VERSIONS=${CPYTHON_VERSIONS:-"3.9.0 3.10.1 3.11.0 3.12.0 3.13.0 3.13.0t 3.14.0 3.14.0t"}
+CPYTHON_VERSIONS=${CPYTHON_VERSIONS:-"3.9.0 3.10.1 3.11.14 3.12.0 3.13.0 3.13.0t 3.14.0 3.14.0t"}
 
 # Function to retry functions that sometimes timeout or have flaky failures
 retry () {

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -37,6 +37,7 @@ RUN yum install -y \
   gcc-toolset-${DEVTOOLSET_VERSION}-gcc \
   gcc-toolset-${DEVTOOLSET_VERSION}-gcc-c++ \
   gcc-toolset-${DEVTOOLSET_VERSION}-binutils \
+  gcc-toolset-${DEVTOOLSET_VERSION}-binutils-gold \
   gcc-toolset-${DEVTOOLSET_VERSION}-gcc-gfortran \
   cmake \
   rust \

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -119,27 +119,5 @@ RUN python3 -mpip install cmake==3.28.0
 ADD ./common/patch_libstdc.sh patch_libstdc.sh
 RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
 
-# build onnxruntime 1.21.0 from sources.
-# it is not possible to build it from sources using pip,
-# so just build it from upstream repository.
-# h5py is dependency of onnxruntime_training.
-# h5py==3.11.0 builds with hdf5-devel 1.10.5 from repository.
-# h5py 3.11.0 doesn't build with numpy >= 2.3.0.
-# install newest flatbuffers version first:
-# for some reason old version is getting pulled in otherwise.
-# packaging package is required for onnxruntime wheel build.
-RUN pip3 install flatbuffers && \
-  pip3 install cython 'pkgconfig>=1.5.5' 'setuptools>=77' 'numpy<2.3.0' && \
-  pip3 install --no-build-isolation h5py==3.11.0 && \
-  pip3 install packaging && \
-  git clone https://github.com/microsoft/onnxruntime && \
-  cd onnxruntime && git checkout v1.21.0 && \
-  git submodule update --init --recursive && \
-  wget https://github.com/microsoft/onnxruntime/commit/f57db79743c4d1a3553aa05cf95bcd10966030e6.patch && \
-  patch -p1 < f57db79743c4d1a3553aa05cf95bcd10966030e6.patch && \
-  ./build.sh --config Release --parallel 0 --enable_pybind \
-  --build_wheel --enable_training --enable_training_apis \
-  --enable_training_ops --skip_tests --allow_running_as_root \
-  --compile_no_warning_as_error && \
-  pip3 install ./build/Linux/Release/dist/onnxruntime_training-*.whl && \
-  cd .. && /bin/rm -rf ./onnxruntime
+COPY manywheel/build_scripts/dependencies_s390x.sh dependencies_s390x.sh
+RUN bash ./dependencies_s390x.sh && rm dependencies_s390x.sh

--- a/.ci/docker/manywheel/build_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/build_scripts/dependencies_s390x.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Helper dependencies build script for s390x
+# Script used only in CD pipeline
+
+# Stop at any error, show all commands
+set -ex
+
+# Function to retry functions that sometimes timeout or have flaky failures
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+
+
+# build onnxruntime 1.21.0 from sources.
+# it is not possible to build it from sources using pip,
+# so just build it from upstream repository.
+# h5py is dependency of onnxruntime_training.
+# h5py==3.11.0 builds with hdf5-devel 1.10.5 from repository.
+# h5py 3.11.0 doesn't build with numpy >= 2.3.0.
+# install newest flatbuffers version first:
+# for some reason old version is getting pulled in otherwise.
+# packaging package is required for onnxruntime wheel build.
+retry pip3 install flatbuffers
+retry pip3 install cython 'pkgconfig>=1.5.5' 'setuptools>=77' 'numpy<2.3.0'
+retry pip3 install --no-build-isolation h5py==3.11.0
+retry pip3 install packaging
+retry git clone https://github.com/microsoft/onnxruntime
+
+cd onnxruntime
+git checkout v1.21.0
+retry git submodule update --init --recursive
+retry wget https://github.com/microsoft/onnxruntime/commit/f57db79743c4d1a3553aa05cf95bcd10966030e6.patch
+patch -p1 < f57db79743c4d1a3553aa05cf95bcd10966030e6.patch
+retry ./build.sh --config Release --parallel 0 --enable_pybind \
+  --build_wheel --enable_training --enable_training_apis \
+  --enable_training_ops --skip_tests --allow_running_as_root \
+  --compile_no_warning_as_error
+
+pip3 install ./build/Linux/Release/dist/onnxruntime_training-*.whl
+cd ..
+/bin/rm -rf ./onnxruntime

--- a/.ci/docker/manywheel/build_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/build_scripts/dependencies_s390x.sh
@@ -10,6 +10,16 @@ retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
 }
 
+# protobuf with fix from https://github.com/protocolbuffers/protobuf/pull/25363
+retry wget https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz
+tar xzvf protobuf-6.33.5.tar.gz
+cd protobuf-6.33.5
+retry wget https://github.com/protocolbuffers/protobuf/pull/25363.patch
+patch -p1 < 25363.patch
+python3 setup.py bdist_wheel
+pip3 install dist/protobuf-*.whl
+cd ..
+/bin/rm -rf ./protobuf-6.33.5 ./protobuf-6.33.5.tar.gz
 
 # build onnxruntime 1.21.0 from sources.
 # it is not possible to build it from sources using pip,

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -265,7 +265,7 @@ WHEEL_CONTAINER_IMAGES = {
     "xpu": "manylinux2_28-builder:xpu",
     "cpu": "manylinux2_28-builder:cpu",
     "cpu-aarch64": "manylinux2_28_aarch64-builder:cpu-aarch64",
-    "cpu-s390x": "pytorch/manylinuxs390x-builder:cpu-s390x",
+    "cpu-s390x": "manylinuxs390x-builder:cpu-s390x",
 }
 
 RELEASE = "release"

--- a/.github/scripts/s390x-ci/README.md
+++ b/.github/scripts/s390x-ci/README.md
@@ -27,20 +27,7 @@ $ sudo systemctl enable --now qemu-user-static
 
 ## Rebuild the image
 
-First build s390x builder image `docker.io/pytorch/manylinuxs390x-builder`,
-using following commands:
-
-```
-$ cd ~
-$ git clone https://github.com/pytorch/pytorch
-$ cd pytorch
-$ git submodule update --init --recursive
-$ GPU_ARCH_TYPE=cpu-s390x "$(pwd)/.ci/docker/manywheel/build.sh" manylinuxs390x-builder
-$ docker image tag localhost/pytorch/manylinuxs390x-builder docker.io/pytorch/manylinuxs390x-builder:cpu-s390x
-$ docker image save -o ~/manywheel-s390x.tar docker.io/pytorch/manylinuxs390x-builder:cpu-s390x
-```
-
-Next step is to build `actions-runner` image using:
+Build `actions-runner` image using:
 
 ```
 $ cd self-hosted-builder

--- a/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile
+++ b/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile
@@ -105,15 +105,7 @@ WORKDIR /home/actions-runner
 # and it doesn't work for non-root user
 RUN virtualenv --system-site-packages venv
 
-# copy prebuilt manywheel docker image for builds and tests
-# build command is:
-# GPU_ARCH_TYPE=cpu-s390x "$(pwd)/manywheel/build_docker.sh"
-# and save command is:
-# docker image save -o manywheel-s390x.tar pytorch/manylinuxs390x-builder:cpu-s390x
-#
-COPY --chown=actions-runner:actions-runner manywheel-s390x.tar /home/actions-runner/manywheel-s390x.tar
-
-RUN curl -L https://github.com/actions/runner/releases/download/v2.322.0/actions-runner-linux-x64-2.322.0.tar.gz | tar -xz
+RUN curl -L https://github.com/actions/runner/releases/download/v2.331.0/actions-runner-linux-x64-2.331.0.tar.gz | tar -xz
 
 ENTRYPOINT ["/usr/bin/entrypoint"]
 CMD ["/usr/bin/actions-runner"]

--- a/.github/scripts/s390x-ci/self-hosted-builder/actions-runner@.service
+++ b/.github/scripts/s390x-ci/self-hosted-builder/actions-runner@.service
@@ -7,6 +7,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 Restart=always
+RuntimeMaxSec=14d
 ExecStartPre=-/usr/bin/docker rm --force actions-runner.%i
 ExecStartPre=/usr/local/bin/gh_token_generator.sh /etc/actions-runner/%i/appid.env /etc/actions-runner/%i/installid.env /etc/actions-runner/%i/key_private.pem /etc/actions-runner/%i/ghtoken.env
 ExecStartPre=/usr/local/bin/gh_cat_token.sh /etc/actions-runner/%i/ghtoken.env /etc/actions-runner/%i/ghtoken.socket

--- a/.github/scripts/s390x-ci/self-hosted-builder/fs/usr/bin/actions-runner
+++ b/.github/scripts/s390x-ci/self-hosted-builder/fs/usr/bin/actions-runner
@@ -2,13 +2,6 @@
 
 set -e -u
 
-# first import docker image
-if [ -f ./manywheel-s390x.tar ] ; then
-        docker image load --input manywheel-s390x.tar
-        docker image tag docker.io/pytorch/manylinuxs390x-builder:cpu-s390x docker.io/pytorch/manylinuxs390x-builder:cpu-s390x-main
-        rm -f manywheel-s390x.tar
-fi
-
 token_file=registration-token.json
 
 ACCESS_TOKEN="$(cat /run/runner_secret)"

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -76,7 +76,7 @@ jobs:
       {%- elif "s390x" in build_environment %}
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       {%- elif config["gpu_arch_type"] == "rocm" %}
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       timeout-minutes: 300
@@ -114,6 +114,7 @@ jobs:
       {%- elif "s390x" in build_environment %}
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
       {%- elif config["gpu_arch_type"] == "rocm" %}
       runs_on: linux.rocm.gpu
       {%- elif config["gpu_arch_type"] == "cuda" %}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -311,6 +311,15 @@ jobs:
         shell: bash
         run: |
           # on s390x stop the container for clean worker stop
-          # ignore expansion of "docker ps -q" since it could be empty
-          # shellcheck disable=SC2046
-          docker stop $(docker ps -q) || true
+          docker stop -a || true
+          docker kill -a || true
+
+          # If podman build command is interrupted,
+          # it can leave a couple of processes still running.
+          # Order them to stop for clean shutdown.
+          # It looks like sometimes some processes remain
+          # after first cleanup.
+          # Wait a bit and do cleanup again. It looks like it helps.
+          docker system prune --build -f || true
+          sleep 60
+          docker system prune --build -f || true

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -232,6 +232,23 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
+      - name: Build Docker Image
+        if: inputs.build_environment == 'linux-s390x-binary-manywheel'
+        env:
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
+        shell: bash
+        run: |
+          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
+
+          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
+          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
+          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
+
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
+
       - name: Build PyTorch binary
         if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
         env:

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -213,9 +213,10 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' && inputs.build_environment != 'linux-s390x-binary-manywheel' }}
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
+        uses: AlekseiNikiforovIBM/pytorch-test-infra/.github/actions/calculate-docker-image@s390x-calculate-docker-image
         with:
+          docker-build-script: ${{ inputs.build_environment != 'linux-s390x-binary-manywheel' && './build.sh' || './manywheel/build.sh' }}
           # If doing this in main or release branch, use docker.io. Otherwise
           # use ECR
           docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
@@ -224,6 +225,7 @@ jobs:
           # The build.sh script in this folder is not actually the correct one,
           # this is just needed for sha calculation
           docker-build-dir: .ci/docker
+          use-aws: ${{ inputs.build_environment != 'linux-s390x-binary-manywheel' }}
           working-directory: pytorch
 
       - name: Pull Docker image
@@ -232,27 +234,10 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
-      - name: Build Docker Image
-        if: inputs.build_environment == 'linux-s390x-binary-manywheel'
-        env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
-        shell: bash
-        run: |
-          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
-
-          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
-          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
-          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
-
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
-
       - name: Build PyTorch binary
         if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
         env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         run: |
           set -x
           mkdir -p artifacts/

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -246,3 +246,21 @@ jobs:
         uses: ./pytorch/.github/actions/chown-workspace
         with:
           ALPINE_IMAGE: ${{ inputs.ALPINE_IMAGE }}
+
+      - name: Cleanup docker
+        if: always() && inputs.build_environment == 'linux-s390x-binary-manywheel'
+        shell: bash
+        run: |
+          # on s390x stop the container for clean worker stop
+          docker stop -a || true
+          docker kill -a || true
+
+          # If podman build command is interrupted,
+          # it can leave a couple of processes still running.
+          # Order them to stop for clean shutdown.
+          # It looks like sometimes some processes remain
+          # after first cleanup.
+          # Wait a bit and do cleanup again. It looks like it helps.
+          docker system prune --build -f || true
+          sleep 60
+          docker system prune --build -f || true

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -214,6 +214,23 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
+      - name: Build Docker Image
+        if: inputs.build_environment == 'linux-s390x-binary-manywheel'
+        env:
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
+        shell: bash
+        run: |
+          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
+
+          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
+          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
+          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
+
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
+
       - name: Test Pytorch binary
         if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
         uses: ./pytorch/.github/actions/test-pytorch-binary

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -64,6 +64,11 @@ on:
         required: true
         type: string
         description: Hardware to run this job on. Valid values are linux.4xlarge, linux.g4dn.4xlarge.nvidia.gpu, linux.arm64.2xlarge, and linux.rocm.gpu
+      timeout-minutes:
+        required: false
+        default: 240
+        type: number
+        description: timeout for the job
     secrets:
       github-token:
         required: true
@@ -75,7 +80,7 @@ permissions:
 jobs:
   test:
     runs-on: ${{ inputs.runner_prefix}}${{ inputs.runs_on }}
-    timeout-minutes: 240
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       PYTORCH_ROOT: ${{ inputs.PYTORCH_ROOT }}
       PACKAGE_TYPE: ${{ inputs.PACKAGE_TYPE }}

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -204,13 +204,15 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' && inputs.build_environment != 'linux-s390x-binary-manywheel' }}
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
+        uses: AlekseiNikiforovIBM/pytorch-test-infra/.github/actions/calculate-docker-image@s390x-calculate-docker-image
         with:
+          docker-build-script: ${{ inputs.build_environment != 'linux-s390x-binary-manywheel' && './build.sh' || './manywheel/build.sh' }}
           docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
           docker-image-name: ${{ inputs.DOCKER_IMAGE }}
           custom-tag-prefix: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
           docker-build-dir: .ci/docker
+          use-aws: ${{ inputs.build_environment != 'linux-s390x-binary-manywheel' }}
           working-directory: pytorch
 
       - name: Pull Docker image
@@ -219,28 +221,11 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
-      - name: Build Docker Image
-        if: inputs.build_environment == 'linux-s390x-binary-manywheel'
-        env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
-        shell: bash
-        run: |
-          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
-
-          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
-          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
-          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
-
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
-
       - name: Test Pytorch binary
         if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
         uses: ./pytorch/.github/actions/test-pytorch-binary
         env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
       - name: Teardown Linux
         if: always() && inputs.build_environment != 'linux-s390x-binary-manywheel'

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -47,6 +47,11 @@ on:
           An option JSON description of what test configs to run later on. This
           is moved here from the Linux test workflow so that we can apply filter
           logic using test-config labels earlier and skip unnecessary builds
+      timeout-minutes:
+        required: false
+        default: 480
+        type: number
+        description: timeout for the job
       selected-test-configs:
         description: |
           A comma-separated list of test configurations from the test matrix to keep,
@@ -131,7 +136,7 @@ jobs:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
     runs-on: ${{ inputs.runner_prefix}}${{ inputs.runner }}
-    timeout-minutes: 480
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
       test-matrix: ${{ steps.filter.outputs.test-matrix }}

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -282,8 +282,7 @@ jobs:
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-          DOCKER_IMAGE_S390X: ${{ inputs.docker-image-name }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || inputs.docker-image-name }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
@@ -294,7 +293,6 @@ jobs:
           START_TIME=$(date +%s)
           if [[ ${BUILD_ENVIRONMENT} == *"s390x"* ]]; then
             JENKINS_USER=
-            USED_IMAGE="${DOCKER_IMAGE_S390X}"
             # ensure that docker container cleanly exits in 12 hours
             # if for some reason cleanup action doesn't stop container
             # when job is cancelled
@@ -305,7 +303,6 @@ jobs:
             env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
           else
             JENKINS_USER="--user jenkins"
-            USED_IMAGE="${DOCKER_IMAGE}"
             DOCKER_SHELL_CMD=
           fi
 
@@ -372,7 +369,7 @@ jobs:
             ${JENKINS_USER} \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
-            "${USED_IMAGE}" \
+            "${DOCKER_IMAGE}" \
             ${DOCKER_SHELL_CMD}
           )
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -207,6 +207,23 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
+      - name: Build Docker Image
+        if: inputs.build-environment == 'linux-s390x-binary-manywheel'
+        env:
+          DOCKER_IMAGE: ${{ inputs.docker-image-name }}
+        shell: bash
+        run: |
+          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
+
+          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
+          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
+          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
+
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
+
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -489,3 +489,13 @@ jobs:
           # on s390x stop the container for clean worker stop
           docker stop -a || true
           docker kill -a || true
+
+          # If podman build command is interrupted,
+          # it can leave a couple of processes still running.
+          # Order them to stop for clean shutdown.
+          # It looks like sometimes some processes remain
+          # after first cleanup.
+          # Wait a bit and do cleanup again. It looks like it helps.
+          docker system prune --build -f || true
+          sleep 60
+          docker system prune --build -f || true

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -191,10 +191,11 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        uses: AlekseiNikiforovIBM/pytorch-test-infra/.github/actions/calculate-docker-image@s390x-calculate-docker-image
         with:
+          docker-build-script: ${{ inputs.build-environment != 'linux-s390x-binary-manywheel' && './build.sh' || './manywheel/build.sh' }}
           docker-image-name: ${{ inputs.docker-image-name }}
+          use-aws: ${{ inputs.build-environment != 'linux-s390x-binary-manywheel' }}
 
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
@@ -211,23 +212,6 @@ jobs:
         if: inputs.build-environment != 'linux-s390x-binary-manywheel' && steps.use-old-whl.outputs.reuse != 'true'
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-
-      - name: Build Docker Image
-        if: inputs.build-environment == 'linux-s390x-binary-manywheel'
-        env:
-          DOCKER_IMAGE: ${{ inputs.docker-image-name }}
-        shell: bash
-        run: |
-          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
-
-          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
-          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
-          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
-
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
 
       - name: Parse ref
         id: parse-ref
@@ -287,7 +271,7 @@ jobs:
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || inputs.docker-image-name }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -355,8 +355,7 @@ jobs:
           SCCACHE_BUCKET: ${{ !contains(matrix.runner, 'b200') && 'ossci-compiler-cache-circleci-v2' || '' }}
           SCCACHE_REGION: ${{ !contains(matrix.runner, 'b200') && 'us-east-1' || '' }}
           SHM_SIZE: ${{ steps.install-nvidia-driver.outputs.has-nvidia == 'true' && '2g' || '1g' }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-          DOCKER_IMAGE_S390X: ${{ inputs.docker-image }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || inputs.docker-image }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
@@ -400,12 +399,10 @@ jobs:
             # if for some reason cleanup action doesn't stop container
             # when job is cancelled
             DOCKER_SHELL_CMD="sleep 12h"
-            USED_IMAGE="${DOCKER_IMAGE_S390X}"
           else
             SHM_OPTS="--shm-size=${SHM_SIZE}"
             JENKINS_USER="--user jenkins"
             DOCKER_SHELL_CMD=
-            USED_IMAGE="${DOCKER_IMAGE}"
           fi
 
           # Just create an empty HF_CACHE dir if it doesn't exist. This dir is not
@@ -491,7 +488,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -v "${HF_CACHE}:${HF_CACHE}" \
             -w /var/lib/jenkins/workspace \
-            "${USED_IMAGE}" \
+            "${DOCKER_IMAGE}" \
             ${DOCKER_SHELL_CMD}
           )
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -169,6 +169,23 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
+      - name: Build Docker Image
+        if: inputs.build-environment == 'linux-s390x-binary-manywheel'
+        env:
+          DOCKER_IMAGE: ${{ inputs.docker-image }}
+        shell: bash
+        run: |
+          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
+
+          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
+          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
+          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
+
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
+          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
+
       - name: Check if in a container runner
         shell: bash
         id: check_container_runner

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -593,3 +593,13 @@ jobs:
           # on s390x stop the container for clean worker stop
           docker stop -a || true
           docker kill -a || true
+
+          # If podman build command is interrupted,
+          # it can leave a couple of processes still running.
+          # Order them to stop for clean shutdown.
+          # It looks like sometimes some processes remain
+          # after first cleanup.
+          # Wait a bit and do cleanup again. It looks like it helps.
+          docker system prune --build -f || true
+          sleep 60
+          docker system prune --build -f || true

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Check if in a container runner
         shell: bash
         id: check_container_runner
+        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
         run: echo "IN_CONTAINER_RUNNER=$(if [ -f /.inarc ] || [ -f /.incontainer ]; then echo true ; else echo false; fi)" >> "$GITHUB_OUTPUT"
 
       - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
@@ -180,7 +181,7 @@ jobs:
         uses: pytorch/test-infra/.github/actions/setup-nvidia@main
         with:
           driver-version: '580.82.07'
-        if: ${{ !contains(matrix.runner, 'b200') }}
+        if: ${{ !contains(matrix.runner, 'b200') && inputs.build-environment != 'linux-s390x-binary-manywheel' }}
 
       - name: Setup GPU_FLAG for docker run
         id: setup-gpu-flag
@@ -568,7 +569,7 @@ jobs:
 
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false'
+        if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && inputs.build-environment != 'linux-s390x-binary-manywheel'
 
       - name: Cleanup docker
         if: always() && inputs.build-environment == 'linux-s390x-binary-manywheel'

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -148,10 +148,11 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        if: inputs.build-environment != 'linux-s390x-binary-manywheel'
+        uses: AlekseiNikiforovIBM/pytorch-test-infra/.github/actions/calculate-docker-image@s390x-calculate-docker-image
         with:
+          docker-build-script: ${{ inputs.build-environment != 'linux-s390x-binary-manywheel' && './build.sh' || './manywheel/build.sh' }}
           docker-image-name: ${{ inputs.docker-image }}
+          use-aws: ${{ inputs.build-environment != 'linux-s390x-binary-manywheel' }}
 
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
@@ -168,23 +169,6 @@ jobs:
         if: inputs.build-environment != 'linux-s390x-binary-manywheel'
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-
-      - name: Build Docker Image
-        if: inputs.build-environment == 'linux-s390x-binary-manywheel'
-        env:
-          DOCKER_IMAGE: ${{ inputs.docker-image }}
-        shell: bash
-        run: |
-          .ci/docker/manywheel/build.sh "${DOCKER_IMAGE}" -t "${DOCKER_IMAGE}"
-
-          GITHUB_REF="${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}"
-          GIT_BRANCH_NAME="${GITHUB_REF##*/}"
-          GIT_COMMIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-          CI_FOLDER_SHA="$(git rev-parse HEAD:.ci/docker)"
-
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_BRANCH_NAME}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${GIT_COMMIT_SHA}"
-          docker tag "${DOCKER_IMAGE}" "${DOCKER_IMAGE}-${CI_FOLDER_SHA}"
 
       - name: Check if in a container runner
         shell: bash
@@ -355,7 +339,7 @@ jobs:
           SCCACHE_BUCKET: ${{ !contains(matrix.runner, 'b200') && 'ossci-compiler-cache-circleci-v2' || '' }}
           SCCACHE_REGION: ${{ !contains(matrix.runner, 'b200') && 'us-east-1' || '' }}
           SHM_SIZE: ${{ steps.install-nvidia-driver.outputs.has-nvidia == 'true' && '2g' || '1g' }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || inputs.docker-image }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -64,7 +64,7 @@ jobs:
       DESIRED_PYTHON: "3.10"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_10-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -90,6 +90,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_10-cpu-s390x-upload:  # Uploading
@@ -132,7 +133,7 @@ jobs:
       DESIRED_PYTHON: "3.11"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_11-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -158,6 +159,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-cpu-s390x-upload:  # Uploading
@@ -200,7 +202,7 @@ jobs:
       DESIRED_PYTHON: "3.12"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_12-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -226,6 +228,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-cpu-s390x-upload:  # Uploading
@@ -268,7 +271,7 @@ jobs:
       DESIRED_PYTHON: "3.13"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_13-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -294,6 +297,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-cpu-s390x-upload:  # Uploading
@@ -336,7 +340,7 @@ jobs:
       DESIRED_PYTHON: "3.13t"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_13t-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -362,6 +366,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-cpu-s390x-upload:  # Uploading
@@ -404,7 +409,7 @@ jobs:
       DESIRED_PYTHON: "3.14"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_14-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -430,6 +435,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14-cpu-s390x-upload:  # Uploading
@@ -472,7 +478,7 @@ jobs:
       DESIRED_PYTHON: "3.14t"
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
-      timeout-minutes: 420
+      timeout-minutes: 600
       build_name: manywheel-py3_14t-cpu-s390x
       build_environment: linux-s390x-binary-manywheel
     secrets:
@@ -498,6 +504,7 @@ jobs:
       build_environment: linux-s390x-binary-manywheel
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
+      timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_14t-cpu-s390x-upload:  # Uploading

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -59,7 +59,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.10"
       runs_on: linux.s390x
@@ -83,7 +83,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-s390x
@@ -105,7 +105,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-s390x
@@ -127,7 +127,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.11"
       runs_on: linux.s390x
@@ -151,7 +151,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-s390x
@@ -173,7 +173,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-s390x
@@ -195,7 +195,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.12"
       runs_on: linux.s390x
@@ -219,7 +219,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.12"
       build_name: manywheel-py3_12-cpu-s390x
@@ -241,7 +241,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.12"
       build_name: manywheel-py3_12-cpu-s390x
@@ -263,7 +263,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.13"
       runs_on: linux.s390x
@@ -287,7 +287,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.13"
       build_name: manywheel-py3_13-cpu-s390x
@@ -309,7 +309,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.13"
       build_name: manywheel-py3_13-cpu-s390x
@@ -331,7 +331,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.13t"
       runs_on: linux.s390x
@@ -355,7 +355,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.13t"
       build_name: manywheel-py3_13t-cpu-s390x
@@ -377,7 +377,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.13t"
       build_name: manywheel-py3_13t-cpu-s390x
@@ -399,7 +399,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.14"
       runs_on: linux.s390x
@@ -423,7 +423,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.14"
       build_name: manywheel-py3_14-cpu-s390x
@@ -445,7 +445,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.14"
       build_name: manywheel-py3_14-cpu-s390x
@@ -467,7 +467,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.14t"
       runs_on: linux.s390x
@@ -491,7 +491,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.14t"
       build_name: manywheel-py3_14t-cpu-s390x
@@ -513,7 +513,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-s390x
-      DOCKER_IMAGE: pytorch/manylinuxs390x-builder
+      DOCKER_IMAGE: manylinuxs390x-builder
       DOCKER_IMAGE_TAG_PREFIX: cpu-s390x
       DESIRED_PYTHON: "3.14t"
       build_name: manywheel-py3_14t-cpu-s390x

--- a/.github/workflows/s390.yml
+++ b/.github/workflows/s390.yml
@@ -19,6 +19,6 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-s390x-binary-manywheel
-      docker-image-name: pytorch/manylinuxs390x-builder:cpu-s390x
+      docker-image-name: manylinuxs390x-builder:cpu-s390x
       runner: linux.s390x
     secrets: inherit

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -44,6 +44,7 @@ jobs:
       build-environment: linux-s390x-binary-manywheel
       docker-image-name: manylinuxs390x-builder:cpu-s390x
       runner: linux.s390x
+      timeout-minutes: 660
       test-matrix: |
         { include: [
           { config: "default", shard: 1,  num_shards: 10, runner: "linux.s390x" },

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-s390x-binary-manywheel
-      docker-image-name: pytorch/manylinuxs390x-builder:cpu-s390x
+      docker-image-name: manylinuxs390x-builder:cpu-s390x
       runner: linux.s390x
       test-matrix: |
         { include: [
@@ -70,7 +70,7 @@ jobs:
       - target-determination
     with:
       build-environment: ${{ needs.linux-manylinux-2_28-py3-cpu-s390x-build.outputs.build-environment }}
-      docker-image: pytorch/manylinuxs390x-builder:cpu-s390x
+      docker-image: manylinuxs390x-builder:cpu-s390x
       test-matrix: ${{ needs.linux-manylinux-2_28-py3-cpu-s390x-build.outputs.test-matrix }}
       timeout-minutes: 600
       use-gha: "yes"

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -72,6 +72,6 @@ jobs:
       build-environment: ${{ needs.linux-manylinux-2_28-py3-cpu-s390x-build.outputs.build-environment }}
       docker-image: manylinuxs390x-builder:cpu-s390x
       test-matrix: ${{ needs.linux-manylinux-2_28-py3-cpu-s390x-build.outputs.test-matrix }}
-      timeout-minutes: 600
+      timeout-minutes: 780
       use-gha: "yes"
     secrets: inherit

--- a/aten/src/ATen/test/memory_overlapping_test.cpp
+++ b/aten/src/ATen/test/memory_overlapping_test.cpp
@@ -69,7 +69,10 @@ TEST(MemoryOverlapTest, ContiguousExpandedTensor) {
   for (auto size : sizes) {
     Tensor t = at::rand(size);
     for (auto size_to_add : {1, 2, 3, 4}) {
+// there's some bug in current s390x compiler, gcc-14
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wrestrict")
       std::vector<int64_t> expanded_size(size);
+C10_DIAGNOSTIC_POP()
       expanded_size.insert(expanded_size.begin(), size_to_add);
       auto expanded = t.expand(expanded_size);
       EXPECT_TRUE(t.is_contiguous());

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -256,11 +256,19 @@ const WorkerInfo& RpcAgent::getWorkerInfo() const {
 std::shared_ptr<RpcAgent> RpcAgent::currentRpcAgent_ = nullptr;
 
 bool RpcAgent::isCurrentRpcAgentSet() {
+  // newer compilers say std::atomic<std::shared_ptr<T>> has to be used,
+  // but older clang versions fail to compile it
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
   return std::atomic_load(&currentRpcAgent_) != nullptr;
+  C10_DIAGNOSTIC_POP()
 }
 
 std::shared_ptr<RpcAgent> RpcAgent::getCurrentRpcAgent() {
+  // newer compilers say std::atomic<std::shared_ptr<T>> has to be used,
+  // but older clang versions fail to compile it
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
   std::shared_ptr<RpcAgent> agent = std::atomic_load(&currentRpcAgent_);
+  C10_DIAGNOSTIC_POP()
   TORCH_CHECK(
       agent,
       "Current RPC agent is not set! Did you initialize the RPC "
@@ -271,19 +279,27 @@ std::shared_ptr<RpcAgent> RpcAgent::getCurrentRpcAgent() {
 void RpcAgent::setCurrentRpcAgent(std::shared_ptr<RpcAgent> rpcAgent) {
   if (rpcAgent) {
     std::shared_ptr<RpcAgent> previousAgent;
+    // newer compilers say std::atomic<std::shared_ptr<T>> has to be used,
+    // but older clang versions fail to compile it
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
     // Use compare_exchange so that we don't actually perform the exchange if
     // that would trigger the assert just below. See:
     // https://en.cppreference.com/w/cpp/atomic/atomic_compare_exchange
     std::atomic_compare_exchange_strong(
         &currentRpcAgent_, &previousAgent, std::move(rpcAgent));
+    C10_DIAGNOSTIC_POP()
     TORCH_INTERNAL_ASSERT(
         previousAgent == nullptr, "Current RPC agent is set!");
   } else {
+    // newer compilers say std::atomic<std::shared_ptr<T>> has to be used,
+    // but older clang versions fail to compile it
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
     // We can't use compare_exchange (we don't know what value to expect) but we
     // don't need to, as the only case that would trigger the assert is if we
     // replaced nullptr with nullptr, which we can just do as it has no effect.
     std::shared_ptr<RpcAgent> previousAgent =
         std::atomic_exchange(&currentRpcAgent_, std::move(rpcAgent));
+    C10_DIAGNOSTIC_POP()
     TORCH_INTERNAL_ASSERT(
         previousAgent != nullptr, "Current RPC agent is not set!");
   }


### PR DESCRIPTION
This would allow propagating updates to s390x images immediately.
Downside is a bit longer build time due to rebuilding
docker images for each job that needs them.

Simplify code for choosing docker image name for s390x

Switch to python 3.11.14 from 3.11.0 for builds

It looks like there's some issue with regex implementation in python 3.11.0 on s390x
which may lead to errors during build of numpy, and those issues are fixed
in later releases of python 3.11.

Update s390x CI setup scripts

Regenerate workflows