### PR TITLE
Fix JIT class annotation lookup on Python 3.14

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -187,6 +187,20 @@ class TestClassType(JitTestCase):
 
             fn(2)
 
+    def test_script_module_without_class_annotations(self):
+        class NoClassAnnotations(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(2, 2)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        module = NoClassAnnotations()
+        scripted = torch.jit.script(module)
+        x = torch.randn(1, 2)
+        self.assertEqual(scripted(x), module(x))
+
     def test_conditional_set_attr(self):
         with self.assertRaisesRegexWithHighlight(
             RuntimeError, "assignment cannot be in a control-flow block", ""

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -187,20 +187,6 @@ class TestClassType(JitTestCase):
 
             fn(2)
 
-    def test_script_module_without_class_annotations(self):
-        class NoClassAnnotations(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear = nn.Linear(2, 2)
-
-            def forward(self, x):
-                return self.linear(x)
-
-        module = NoClassAnnotations()
-        scripted = torch.jit.script(module)
-        x = torch.randn(1, 2)
-        self.assertEqual(scripted(x), module(x))
-
     def test_conditional_set_attr(self):
         with self.assertRaisesRegexWithHighlight(
             RuntimeError, "assignment cannot be in a control-flow block", ""

--- a/torch/jit/_check.py
+++ b/torch/jit/_check.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import ast
 import inspect
-import sys
 import textwrap
 import warnings
 
@@ -74,17 +73,10 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
         # This AST only contains the `__init__` method of the nn.Module
         init_ast = ast.parse(textwrap.dedent(source_lines))
 
-        # Get items annotated in the class body
-        if sys.version_info >= (3, 14):
-            import annotationlib
-
-            self.class_level_annotations = list(
-                annotationlib.get_annotations(
-                    nn_module, format=annotationlib.Format.FORWARDREF
-                ).keys()
-            )
-        else:
-            self.class_level_annotations = list(nn_module.__annotations__.keys())
+        # Get items annotated in the class body.
+        self.class_level_annotations = list(
+            inspect.get_annotations(nn_module.__class__).keys()
+        )
 
         # Flag for later
         self.visiting_class_level_ann = False


### PR DESCRIPTION
Issue link:
  - https://github.com/pytorch/pytorch/issues/172254

Summary:
  - Use inspect.get_annotations on the module class to collect class-level annotations, avoiding instance-level annotation access.

Motivation:
  - Python 3.14 raises AttributeError when probing nn.Module instances for annotations, breaking torch.jit.script on models like MobileNetV2.

Validation:
  - Not run (local source build skipped).
  - Reproduced failure on Python 3.14 + torch 2.9.1+cpu; monkeypatching the new lookup unblocked scripting.
  - JIT tests are currently skipped on Python 3.14 (test/test_jit.py), so there is no 3.14 test coverage yet.
