### PR TITLE
Improve error message for missing CH_KEY_ID

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/update_expected.py
+++ b/benchmarks/dynamo/ci_expected_accuracy/update_expected.py
@@ -82,8 +82,15 @@ def query_job_sha(repo, sha):
     }
     # If you are a Meta employee, go to P1679979893 to get the id and secret.
     # Otherwise, ask a Meta employee give you the id and secret.
-    KEY_ID = os.environ["CH_KEY_ID"]
-    KEY_SECRET = os.environ["CH_KEY_SECRET"]
+    try:
+        KEY_ID = os.environ["CH_KEY_ID"]
+        KEY_SECRET = os.environ["CH_KEY_SECRET"]
+    except KeyError as e:
+        raise RuntimeError(
+            "CH_KEY_ID and CH_KEY_SECRET environment variables must be set. "
+            "If you are a Meta employee, go to P1679979893 to get the id and secret. "
+            "Otherwise, ask a Meta employee to give you the id and secret."
+        ) from e
 
     r = requests.post(
         url=ARTIFACTS_QUERY_URL,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #172451
* #172450
* __->__ #172449

Signed-off-by: Edward Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo