### PR TITLE
Simplify skip logic in test_gpu_cpp_wrapper.py

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -286,13 +286,12 @@ if RUN_GPU:
             )
         ],
         BaseTest("test_dtypeview_fusion"),
-        # skip if not enough SMs
+        # skip the next two tests if not enough SMs, logic for this is handled by TestSelectAlgorithm.setUp()
         BaseTest(
             "test_addmm",
             device=None,
             tests=test_select_algorithm.TestSelectAlgorithm(),
         ),
-        # skip if not enough SMs
         BaseTest(
             "test_linear_relu",
             device=None,
@@ -302,19 +301,6 @@ if RUN_GPU:
         if item.device == "xpu" and item.name in XPU_BASE_TEST_SKIP:
             continue
         make_test_case(item.name, item.device, item.tests, check_code=item.check_code)
-
-    from torch._inductor.utils import is_big_gpu
-
-    if GPU_TYPE in ("cuda", "xpu") and is_big_gpu():
-        skip_list = ["test_addmm", "test_linear_relu"]
-        # need to skip instead of omit, otherwise fbcode ci can be flaky
-        for test_name in skip_list:
-            test_failures_gpu_wrapper[f"{test_name}_{device_type}"] = (
-                test_torchinductor.TestFailure(("gpu_wrapper",), is_skip=True)
-            )
-            test_failures_gpu_wrapper[f"{test_name}_gpu_dynamic_shapes"] = (
-                test_torchinductor.TestFailure(("gpu_wrapper",), is_skip=True)
-            )
 
     test_torchinductor.copy_tests(
         GpuWrapperTemplate, TestGpuWrapper, "gpu_wrapper", test_failures_gpu_wrapper


### PR DESCRIPTION
This PR removes a block of test code that wasn't actually doing anything, and updates comments to explain how/why tests are being skipped on small GPUs.

Fixes #172139 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo