### PR TITLE
[pytorch][PR] reland D89141291 add fused compute_grad_weight kernel when segments are few but large

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/cub.cuh>
 #include <ATen/AccumulateType.h>
+#include <ATen/OpMathType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/native/cuda/SortingCommon.cuh>
@@ -33,6 +34,10 @@ namespace {
   make the size of the thread blocks in the final sum in step 2) too small.
 */
 constexpr int NROWS_PER_THREAD = 10;
+
+// If the number of blocks processed by each SM is larger than this value,
+// we will use the two-step sum and scatter approach.
+constexpr int32_t MAX_ATOMIC_ACCUM_BLOCKS_PER_SM = 4;
 
 // Fast ceil division (no overflow checking)
 __host__ __device__ __forceinline__
@@ -151,6 +156,82 @@ __global__ void compute_grad_weight(
     weight += gradOutput[target_row * stride + startFeature] * scale;
   }
   grad_weight_per_segment[id * stride + startFeature] = weight;
+}
+
+// Fused kernel that combines compute_grad_weight and sum_and_scatter using atomic adds.
+// This eliminates the serialization bottleneck when num_of_segments is small.
+// Each partial segment atomically adds its contribution directly to grad_weight.
+// Template parameters:
+//   scalar_t: input gradient type
+//   output_t: output gradient weight type (float for half/bf16 atomic accumulation)
+template <typename scalar_t, typename output_t, typename index_t>
+__global__ void compute_grad_weight_atomic_accumulate(
+    const index_t *orig_indices,
+    const scalar_t *gradOutput,
+    const index_t *count,
+    ptrdiff_t numel,
+    int64_t stride,
+    const index_t *partial_segment_offsets,
+    const int64_t *num_of_partial_segments_ptr,
+    const index_t *sorted_indices,
+    const index_t *partial_to_segment_idx,
+    const index_t *segment_offsets,
+    output_t *grad_weight,
+    const int64_t padding_idx,
+    const int64_t stride_warped) {
+
+  int64_t num_of_partial_segments = *num_of_partial_segments_ptr;
+  using accscalar_t = acc_type<scalar_t, true>;
+  const int32_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int32_t partial_id = gid / stride_warped;
+  const int32_t startFeature = gid % stride_warped;
+
+  if (startFeature >= stride) {
+    return;
+  }
+  if (partial_id >= num_of_partial_segments) {
+    return;
+  }
+
+  const index_t idx_begin = partial_segment_offsets[partial_id];
+  const index_t idx_end = (partial_id == num_of_partial_segments - 1)
+      ? numel
+      : partial_segment_offsets[partial_id + 1];
+
+  accscalar_t weight = 0;
+  for (index_t idx = idx_begin; idx < idx_end; ++idx) {
+    const index_t target_row = orig_indices[idx];
+    const accscalar_t scale = count ? (accscalar_t)1.0 / count[idx] : 1.0;
+    weight += gradOutput[target_row * stride + startFeature] * scale;
+  }
+
+  // Get the target row for this partial segment from the segment info
+  const index_t segment_id = partial_to_segment_idx[partial_id];
+  const index_t target_row = sorted_indices[segment_offsets[segment_id]];
+
+  if (target_row != padding_idx) {
+    gpuAtomicAddNoReturn(
+        &grad_weight[target_row * stride + startFeature],
+        static_cast<output_t>(weight));
+  }
+}
+
+// Kernel to build mapping from partial segment ID to segment ID
+template <typename index_t>
+__global__ void krn_partial_to_segment_idx(
+    index_t *partial_to_segment_idx,
+    const index_t *partials_per_segment,
+    const index_t *partials_per_segment_offset,
+    const int64_t *num_of_segments_ptr) {
+  int64_t num_of_segments = *num_of_segments_ptr;
+  const int32_t id = blockIdx.x * blockDim.x + threadIdx.x;
+  if (id < num_of_segments) {
+    index_t idx = partials_per_segment_offset[id];
+    const index_t num_partials = partials_per_segment[id];
+    for (index_t i = 0; i < num_partials; ++i) {
+      partial_to_segment_idx[idx++] = id;
+    }
+  }
 }
 
 // This kernel assumes that all input tensors are contiguous.
@@ -285,59 +366,129 @@ Tensor embedding_backward_cuda_kernel(
     const int block = std::min(stride_warped, MAX_BLOCK_SIZE);
     const int grid = ceil_div(max_partial_segment*stride_warped, block);
 
+    // Heuristic: Use fused kernel when sum_and_scatter would have poor parallelism
+    // This happens when max_segments * stride_warped is small relative to GPU capacity
+    // The fused kernel uses atomic adds but has grid size proportional to max_partial_segment
+    // instead of max_segments, giving much better parallelism when segments are few but large
+    // Note: Fused kernel uses atomics which are non-deterministic, so we skip it
+    // when deterministic algorithms are requested
+    const int32_t sum_scatter_grid = ceil_div(max_segments * stride_warped, block);
+    const int32_t num_sms = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+    const int32_t min_blocks_for_good_occupancy = num_sms * MAX_ATOMIC_ACCUM_BLOCKS_PER_SM;
+    const bool use_fused_kernel = !offset2bag.defined() &&
+        sum_scatter_grid < min_blocks_for_good_occupancy &&
+        max_partial_segment > sum_scatter_grid * 4 &&
+        !at::globalContext().deterministicAlgorithms();
+
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
       grad.scalar_type(), "embedding_bag_backward_cuda_compute_grad_weight", [&] {
         // For numerical stability, the dtype of `grad_weight_per_segment`
         // should match `acc_type`
         using partial_weight_t = acc_type<scalar_t, true>;
-        TensorOptions op;
-        if(grad.dtype() == at::kHalf || grad.dtype() == at::kBFloat16) {
-            op = grad.options().dtype(at::kFloat);
-        } else {
-            op = grad.options();
-        }
-        auto grad_weight_per_segment = at::empty({max_partial_segment, stride}, op);
-        // Compute the sum of each partial-segment and handle bags
-        if (offset2bag.defined()) {
-              compute_grad_weight_bags<scalar_t><<<grid, block, 0, stream>>>(
-                orig_indices.const_data_ptr<index_t>(),
-                grad.const_data_ptr<scalar_t>(),
-                offset2bag.const_data_ptr<index_t>(),
-                count.defined() ? count.const_data_ptr<index_t>() : nullptr, numel, stride,
-                mode_mean, bag_size.const_data_ptr<index_t>(),
-                per_sample_weights.defined() ? per_sample_weights.const_data_ptr<scalar_t>() : NULL,
-                per_sample_weights.defined() ? per_sample_weights.stride(0) : 0,
-                partial_segment_offset.const_data_ptr<index_t>(),
-                num_of_partial_segments_ptr, grad_weight_per_segment.mutable_data_ptr<partial_weight_t>(),
-                stride_warped);
-              C10_CUDA_KERNEL_LAUNCH_CHECK();
-        } else {
-              compute_grad_weight<scalar_t><<<grid, block, 0, stream>>>(
+
+        if (use_fused_kernel) {
+          // This eliminates the serialization bottleneck in sum_and_scatter
+          // by directly accumulating into grad_weight from all partial segments
+
+          // Build mapping from partial segment ID to segment ID
+          auto partial_to_segment_idx = at::empty({max_partial_segment}, orig_indices.options());
+          {
+            krn_partial_to_segment_idx<<<ceil_div(max_segments, 32), 32, 0, stream>>>(
+                partial_to_segment_idx.mutable_data_ptr<index_t>(),
+                partials_per_segment.const_data_ptr<index_t>(),
+                partials_per_segment_offset.const_data_ptr<index_t>(),
+                num_of_segments_ptr);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+
+          // For half/bfloat16 types, use opmath_type (float) intermediate buffer for atomic adds
+          // (float atomics are faster and more precise than half/bf16 atomics)
+          // For float/double, accumulate directly into grad_weight
+          if constexpr (!std::is_same_v<scalar_t, opmath_type<scalar_t>>) {
+            auto grad_weight_acc = at::zeros(
+                {num_weights, stride},
+                grad.options().dtype(toOpMathType(grad.scalar_type())));
+            compute_grad_weight_atomic_accumulate<scalar_t, partial_weight_t><<<grid, block, 0, stream>>>(
                 orig_indices.const_data_ptr<index_t>(),
                 grad.const_data_ptr<scalar_t>(),
                 count.defined() ? count.const_data_ptr<index_t>() : nullptr,
                 numel, stride,
                 partial_segment_offset.const_data_ptr<index_t>(),
                 num_of_partial_segments_ptr,
-                grad_weight_per_segment.mutable_data_ptr<partial_weight_t>(),
+                sorted_indices.const_data_ptr<index_t>(),
+                partial_to_segment_idx.const_data_ptr<index_t>(),
+                segment_offsets.const_data_ptr<index_t>(),
+                grad_weight_acc.mutable_data_ptr<partial_weight_t>(),
+                padding_idx,
+                stride_warped);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            // Convert back to original dtype
+            grad_weight.copy_(grad_weight_acc);
+          } else {
+            // For float/double, accumulate directly into grad_weight
+            compute_grad_weight_atomic_accumulate<scalar_t, scalar_t><<<grid, block, 0, stream>>>(
+                orig_indices.const_data_ptr<index_t>(),
+                grad.const_data_ptr<scalar_t>(),
+                count.defined() ? count.const_data_ptr<index_t>() : nullptr,
+                numel, stride,
+                partial_segment_offset.const_data_ptr<index_t>(),
+                num_of_partial_segments_ptr,
+                sorted_indices.const_data_ptr<index_t>(),
+                partial_to_segment_idx.const_data_ptr<index_t>(),
+                segment_offsets.const_data_ptr<index_t>(),
+                grad_weight.mutable_data_ptr<scalar_t>(),
+                padding_idx,
+                stride_warped);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        } else {
+
+          // Two-pass path: compute_grad_weight + sum_and_scatter
+          auto grad_weight_per_segment = at::empty(
+              {max_partial_segment, stride},
+              grad.options().dtype(toOpMathType(grad.scalar_type())));
+          // Compute the sum of each partial-segment and handle bags
+          if (offset2bag.defined()) {
+                compute_grad_weight_bags<scalar_t><<<grid, block, 0, stream>>>(
+                  orig_indices.const_data_ptr<index_t>(),
+                  grad.const_data_ptr<scalar_t>(),
+                  offset2bag.const_data_ptr<index_t>(),
+                  count.defined() ? count.const_data_ptr<index_t>() : nullptr, numel, stride,
+                  mode_mean, bag_size.const_data_ptr<index_t>(),
+                  per_sample_weights.defined() ? per_sample_weights.const_data_ptr<scalar_t>() : NULL,
+                  per_sample_weights.defined() ? per_sample_weights.stride(0) : 0,
+                  partial_segment_offset.const_data_ptr<index_t>(),
+                  num_of_partial_segments_ptr, grad_weight_per_segment.mutable_data_ptr<partial_weight_t>(),
+                  stride_warped);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+                compute_grad_weight<scalar_t><<<grid, block, 0, stream>>>(
+                  orig_indices.const_data_ptr<index_t>(),
+                  grad.const_data_ptr<scalar_t>(),
+                  count.defined() ? count.const_data_ptr<index_t>() : nullptr,
+                  numel, stride,
+                  partial_segment_offset.const_data_ptr<index_t>(),
+                  num_of_partial_segments_ptr,
+                  grad_weight_per_segment.mutable_data_ptr<partial_weight_t>(),
+                  stride_warped);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+
+          // Finally, we sum all the partial-sums and scatter them
+          // into `grad_weight`.
+          const int grid2 = ceil_div(max_segments*stride_warped, block);
+              sum_and_scatter<scalar_t><<<grid2, block, 0, stream>>>(
+                sorted_indices.const_data_ptr<index_t>(),
+                grad_weight.mutable_data_ptr<scalar_t>(),
+                stride,
+                segment_offsets.const_data_ptr<index_t>(),
+                num_of_segments_ptr, grad_weight_per_segment.const_data_ptr<partial_weight_t>(),
+                partials_per_segment_offset.const_data_ptr<index_t>(),
+                num_of_partial_segments_ptr,
+                padding_idx,
                 stride_warped);
               C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
-
-        // Finally, we sum all the partial-sums and scatter them
-        // into `grad_weight`.
-        const int grid2 = ceil_div(max_segments*stride_warped, block);
-            sum_and_scatter<scalar_t><<<grid2, block, 0, stream>>>(
-              sorted_indices.const_data_ptr<index_t>(),
-              grad_weight.mutable_data_ptr<scalar_t>(),
-              stride,
-              segment_offsets.const_data_ptr<index_t>(),
-              num_of_segments_ptr, grad_weight_per_segment.const_data_ptr<partial_weight_t>(),
-              partials_per_segment_offset.const_data_ptr<index_t>(),
-              num_of_partial_segments_ptr,
-              padding_idx,
-              stride_warped);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
     });
   });
   return grad_weight;

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4210,6 +4210,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.Embedding,
                module_inputs_func=module_inputs_torch_nn_Embedding,
+               gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
                decorators=[
                    DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-4, rtol=1e-4)}),
                                 'TestModule', 'test_non_contiguous_tensors',


### PR DESCRIPTION
Summary:
Current 2-step sum and scatter approach is not efficient when the number of segments is small but each segment is large. For example, we observed in our prod job that there is a sum_and_scatter kernel taking 40ms, but the launch grid size is 100 on Blackwell GPU (148 SMs). 1/3 of the SMs are idle why the other SMs are overloaded. And the kernel is bottlenecked by the largest segment in our case.
To improve the efficiency in this case, we add a fused atomic add kernel with grid size proportional to max_partial_segment instead of max_segments, giving much better parallelism when segments are few but large

Test Plan:
Test
Added unit test to cover the atomic accumulate kernel path. The large atol and rtol thresholds in the tests are needed for both original path and new atomic accmulate path.
- AMD MI300: https://www.internalfb.com/intern/testinfra/testrun/12666374093382243

- Verified numerical parity and perf improvement with e2e workflow.

Baseline: fire-renqincai-20251210-2133-a14d8be3, sum_and_scatter kernel takes about 40ms per iteration.
After optimization: fire-yjyao-20251214-1731-faeab2e0, reduced to about 6ms.
4% qps gain, NE on par

Differential Revision: D90689388


