### PR TITLE
[cherry pick] revert #155412 (#156757)

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -16,6 +16,7 @@ on:
       - rocm-mi300
       - inductor-micro-benchmark
       - inductor-micro-benchmark-x86
+      - inductor-cu124
       - inductor-rocm
       - inductor-rocm-mi300
       - mac-mps


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* (to be filled)

Revert "Remove remaining CUDA 12.4 CI code (#155412)"

This reverts commit 9fed2addedb42da86b657165fe14eadc911232cf.