### PR TITLE
[HIM][sparsity][51/n] Implement clone operator for semi sparse tensor

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1285,6 +1285,13 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         # PyTorch CUDA 12.4+ using cuSPARSELt v0.6.2+
         assert torch.backends.cusparselt.version() >= 602
 
+    @inference_dtypes
+    def test_cslt_sparse_tensor_clone(self, device, dtype):
+        A = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
+        A_clone = A.clone()
+        B = torch.ones((128, 256), device=device).to(dtype)
+        torch.testing.assert_equal(torch.mm(A, B), torch.mm(A_clone, B))
+
 if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) > 0:
     instantiate_device_type_tests(TestSparseSemiStructured, globals(), only_for="cuda")
 if "cutlass" in SEMI_STRUCTURED_SUPPORTED_BACKENDS:

--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -15,6 +15,7 @@ __all__ = [
     "semi_sparse_addmm",
     "semi_sparse_linear",
     "semi_sparse_scaled_mm",
+    "semi_sparse_clone",
 ]
 
 
@@ -234,3 +235,11 @@ def semi_sparse_scaled_mm(func, types, args=(), kwargs=None) -> torch.Tensor:
         out_dtype=out_dtype,
     )
     return sparse_result
+
+
+def semi_sparse_clone(func, types, args=(), kwargs=None) -> torch.Tensor:
+    if len(args) != 1:
+        raise AssertionError(f"expected 1 arg, got {len(args)}")
+    self = args[0]
+    assert isinstance(self, torch.sparse.SparseSemiStructuredTensor)
+    return self.__class__.from_dense(self.to_dense())

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -12,6 +12,7 @@ from torch.sparse._semi_structured_conversions import (
 from torch.sparse._semi_structured_ops import (
     fallback_dispatcher,
     semi_sparse_addmm,
+    semi_sparse_clone,
     semi_sparse_detach,
     semi_sparse_indices,
     semi_sparse_linear,
@@ -232,6 +233,7 @@ class SparseSemiStructuredTensor(torch.Tensor):
                 torch.ops.aten.linear: semi_sparse_linear,
                 torch.ops.aten._to_copy: fallback_dispatcher,
                 torch.ops.aten._scaled_mm: semi_sparse_scaled_mm,
+                torch.ops.aten.clone: semi_sparse_clone,
             }
             if custom_dispatch_table is not None:
                 cls.SPARSE_DISPATCH.update(custom_dispatch_table)


### PR DESCRIPTION
Summary: As titled ~ this is to enable "SemiSparseWeightConfig" for 2:4 sparsity, prototyped in D90085137

Test Plan:
```
python test/test_sparse_semi_structured.py 
```

Differential Revision: D90696911


