### PR TITLE
[NATIVE] [CUDA] Potential optimization of GammaBetaBackwardSimpleCUDAKernel

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -608,34 +608,56 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
     const T_ACC* rstd,
     T* dg,
     T* db) {
-  const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
-  if (j < N) {
-    T_ACC sum1 = 0;
-    T_ACC sum2 = 0;
-    for (int64_t i = 0; i < M; ++i) {
-      const int64_t index = i * N + j;
-      if constexpr (!rms_norm){
-        sum1 += dg == nullptr ? T_ACC(0)
-                              : static_cast<T_ACC>(dY[index]) *
-                (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) *
-                static_cast<T_ACC>(rstd[i]);
-        sum2 += db == nullptr ? T_ACC(0) : static_cast<T_ACC>(dY[index]);
-      } else {
-        sum1 += dg == nullptr ? T_ACC(0)
-                              : static_cast<T_ACC>(dY[index]) *
-                (static_cast<T_ACC>(X[index])) * static_cast<T_ACC>(rstd[i]);
-      }
+    const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
+    if (j < N) {
+        const bool need_dg = (dg != nullptr);
+        const bool need_db = (!rms_norm && db != nullptr);
+
+        if (!need_dg && !need_db) return;
+
+        T_ACC sum1 = 0;
+        T_ACC sum2 = 0;
+
+        if (need_db) {
+            if (need_dg) {
+                for (int64_t i = 0; i < M; ++i) {
+                    const int64_t index = i * N + j;
+                    const T_ACC dY_val = static_cast<T_ACC>(dY[index]);
+                    sum1 += dY_val *
+                            (static_cast<T_ACC>(X[index]) -
+                             static_cast<T_ACC>(mean[i])) *
+                            static_cast<T_ACC>(rstd[i]);
+                    sum2 += dY_val;
+                }
+                dg[j] = static_cast<T>(sum1);
+                db[j] = static_cast<T>(sum2);
+            } else {
+                for (int64_t i = 0; i < M; ++i) {
+                    sum2 += static_cast<T_ACC>(dY[i * N + j]);
+                }
+                db[j] = static_cast<T>(sum2);
+            }
+        } else if (rms_norm) {
+            for (int64_t i = 0; i < M; ++i) {
+                const int64_t index = i * N + j;
+                sum1 += static_cast<T_ACC>(dY[index]) *
+                        static_cast<T_ACC>(X[index]) *
+                        static_cast<T_ACC>(rstd[i]);
+            }
+            dg[j] = static_cast<T>(sum1);
+        } else {
+            for (int64_t i = 0; i < M; ++i) {
+                const int64_t index = i * N + j;
+                sum1 += static_cast<T_ACC>(dY[index]) *
+                        (static_cast<T_ACC>(X[index]) -
+                         static_cast<T_ACC>(mean[i])) *
+                        static_cast<T_ACC>(rstd[i]);
+            }
+            dg[j] = static_cast<T>(sum1);
+        }
     }
-    if (dg != nullptr) {
-      dg[j] = sum1;
-    }
-    if (db != nullptr) {
-      if constexpr (!rms_norm){
-        db[j] = sum2;
-      }
-    }
-  }
 }
+
 
 template <typename T, typename T_ACC,
 unsigned int block_dim_x,

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -619,7 +619,7 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
             const int64_t index = i * N + j;
             sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
             sum2 += static_cast<T_ACC>(dY[index]);
-            }
+          }
           dg[j] = sum1;
           db[j] = sum2;
         } else {

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -637,7 +637,7 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
                 }
                 db[j] = static_cast<T>(sum2);
             }
-        } else if (rms_norm) {
+        } else if constexpr (rms_norm) {
             for (int64_t i = 0; i < M; ++i) {
                 const int64_t index = i * N + j;
                 sum1 += static_cast<T_ACC>(dY[index]) *

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -610,52 +610,42 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
     T* db) {
     const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
     if (j < N) {
-        const bool need_dg = (dg != nullptr);
-        const bool need_db = (!rms_norm && db != nullptr);
-
-        if (!need_dg && !need_db) return;
-
-        T_ACC sum1 = 0;
-        T_ACC sum2 = 0;
-
-        if (need_db) {
-            if (need_dg) {
-                for (int64_t i = 0; i < M; ++i) {
-                    const int64_t index = i * N + j;
-                    const T_ACC dY_val = static_cast<T_ACC>(dY[index]);
-                    sum1 += dY_val *
-                            (static_cast<T_ACC>(X[index]) -
-                             static_cast<T_ACC>(mean[i])) *
-                            static_cast<T_ACC>(rstd[i]);
-                    sum2 += dY_val;
-                }
-                dg[j] = static_cast<T>(sum1);
-                db[j] = static_cast<T>(sum2);
-            } else {
-                for (int64_t i = 0; i < M; ++i) {
-                    sum2 += static_cast<T_ACC>(dY[i * N + j]);
-                }
-                db[j] = static_cast<T>(sum2);
-            }
-        } else if constexpr (rms_norm) {
-            for (int64_t i = 0; i < M; ++i) {
-                const int64_t index = i * N + j;
-                sum1 += static_cast<T_ACC>(dY[index]) *
-                        static_cast<T_ACC>(X[index]) *
-                        static_cast<T_ACC>(rstd[i]);
-            }
-            dg[j] = static_cast<T>(sum1);
-        } else {
-            for (int64_t i = 0; i < M; ++i) {
-                const int64_t index = i * N + j;
-                sum1 += static_cast<T_ACC>(dY[index]) *
-                        (static_cast<T_ACC>(X[index]) -
-                         static_cast<T_ACC>(mean[i])) *
-                        static_cast<T_ACC>(rstd[i]);
-            }
-            dg[j] = static_cast<T>(sum1);
-        }
-    }
+		if constexpr (!rms_norm) {
+			if (dg != nullptr) {
+				if (db != nullptr) {
+					T_ACC sum1 = 0;
+					T_ACC sum2 = 0;
+					for (int64_t i = 0; i < M; ++i) {
+						const int64_t index = i * N + j;
+						sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
+						sum2 += static_cast<T_ACC>(dY[index]);
+					}
+					dg[j] = sum1;
+					db[j] = sum2;
+				} else {
+					T_ACC sum1 = 0;
+					for (int64_t i = 0; i < M; ++i) {
+						const int64_t index = i * N + j;
+						sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
+					}
+					dg[j] = sum1;
+				}
+			} else if (db != nullptr) {
+				T_ACC sum2 = 0;
+				for (int64_t i = 0; i < M; ++i) {
+					sum2 += static_cast<T_ACC>(dY[i * N + j]);
+				}
+				db[j] = sum2;
+			}
+		} else if (dg != nullptr) {
+			T_ACC sum1 = 0;
+			for (int64_t i = 0; i < M; ++i) {
+				const int64_t index = i * N + j;		
+				sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index])) * static_cast<T_ACC>(rstd[i]);
+			}
+			dg[j] = sum1;
+		}
+	}
 }
 
 

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -608,8 +608,8 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
     const T_ACC* rstd,
     T* dg,
     T* db) {
-    const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
-    if (j < N) {
+  const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
+  if (j < N) {
 		if constexpr (!rms_norm) {
 			if (dg != nullptr) {
 				if (db != nullptr) {

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -610,42 +610,42 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
     T* db) {
   const int64_t j = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
   if (j < N) {
-		if constexpr (!rms_norm) {
-			if (dg != nullptr) {
-				if (db != nullptr) {
-					T_ACC sum1 = 0;
-					T_ACC sum2 = 0;
-					for (int64_t i = 0; i < M; ++i) {
-						const int64_t index = i * N + j;
-						sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
-						sum2 += static_cast<T_ACC>(dY[index]);
-					}
-					dg[j] = sum1;
-					db[j] = sum2;
-				} else {
-					T_ACC sum1 = 0;
-					for (int64_t i = 0; i < M; ++i) {
-						const int64_t index = i * N + j;
-						sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
-					}
-					dg[j] = sum1;
-				}
-			} else if (db != nullptr) {
-				T_ACC sum2 = 0;
-				for (int64_t i = 0; i < M; ++i) {
-					sum2 += static_cast<T_ACC>(dY[i * N + j]);
-				}
-				db[j] = sum2;
-			}
-		} else if (dg != nullptr) {
-			T_ACC sum1 = 0;
-			for (int64_t i = 0; i < M; ++i) {
-				const int64_t index = i * N + j;		
-				sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index])) * static_cast<T_ACC>(rstd[i]);
-			}
-			dg[j] = sum1;
-		}
-	}
+    if constexpr (!rms_norm) {
+      if (dg != nullptr) {
+        if (db != nullptr) {
+          T_ACC sum1 = 0;
+          T_ACC sum2 = 0;
+          for (int64_t i = 0; i < M; ++i) {
+            const int64_t index = i * N + j;
+            sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
+            sum2 += static_cast<T_ACC>(dY[index]);
+            }
+          dg[j] = sum1;
+          db[j] = sum2;
+        } else {
+          T_ACC sum1 = 0;
+          for (int64_t i = 0; i < M; ++i) {
+            const int64_t index = i * N + j;
+            sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index]) - static_cast<T_ACC>(mean[i])) * static_cast<T_ACC>(rstd[i]);
+          }
+          dg[j] = sum1;
+        }
+      } else if (db != nullptr) {
+        T_ACC sum2 = 0;
+        for (int64_t i = 0; i < M; ++i) {
+          sum2 += static_cast<T_ACC>(dY[i * N + j]);
+        }
+        db[j] = sum2;
+      }
+    } else if (dg != nullptr) {
+      T_ACC sum1 = 0;
+      for (int64_t i = 0; i < M; ++i) {
+        const int64_t index = i * N + j;
+        sum1 += static_cast<T_ACC>(dY[index]) * (static_cast<T_ACC>(X[index])) * static_cast<T_ACC>(rstd[i]);
+      }
+      dg[j] = sum1;
+    }
+  }
 }
 
 


### PR DESCRIPTION
This PR refactors GammaBetaBackwardSimpleCUDAKernel and aims to reduce unnecessary work and (hopefully (unfortunately, I couldn’t test it)) and increase performance.

Important note: There was a huge mistake in my PR description because unfortunately I wasn’t able to test the actual speed percentage changes and this PR could even lead to worse performance... I’m really sorry about that mistake because I just wrote the PR description by AI (not the code itself but the description) and it didn’t add the fact that these numbers are just expected (and unfortunately seem to be wrong and maybe this PR even makes performance worse…) I’m really sorry about that! So before merging again (after fixing at first these bugs in the inductor test) it is very important to measure the real impacts because it could be that this whole PR just makes everything even worse which I am really sorry about. So as long as nobody measured this in real scenarios, please don’t merge again, especially because I did some research (maybe not that comparable, but at least it exists) in Java and found out that the changes were (in contrast to the original expectation) even negative in performance (at least in some
cases and it could be that the whole PR is Even negative in performance)… I am really sorry about these mistakes!