### PR TITLE
[ROCm] Re-enable test_old_cholesky on MI300X

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -760,7 +760,6 @@ class TestLinalg(TestCase):
             cholesky_test_helper(3, batchsize, upper)
 
     @precisionOverride({torch.float32: 1e-4, torch.complex64: 1e-4})
-    @skipIfRocmArch(MI300_ARCH)
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())


### PR DESCRIPTION
## Summary
Remove @skipIfRocmArch(MI300_ARCH) decorator from test_old_cholesky.

Fixes #168757

## Dependency
This PR depends on #172465 (tf32 tolerance fix) being merged first.

## Hardware Verification
- **GPU:** AMD Instinct MI300X (gfx942)
- **Test:** Verified passing with tf32 tolerance fix

Signed-off-by: c0de128 <kevin.mckay@outlook.com>

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang