### PR TITLE
[ROCm] Re-enable test_addmm_sizes on MI300X

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7611,7 +7611,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     def test_addmm_gelu(self, device, dtype):
         self._test_addmm_impl(torch._addmm_activation, "gelu", device, dtype)
 
-    @skipIfRocmArch(MI300_ARCH)
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(*floating_and_complex_types())
     @tf32_on_and_off(0.005)


### PR DESCRIPTION
Fixes #168763
Depends on: #172465 (tf32 tolerance fix)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang