### PR TITLE
[ROCm] Re-enable test_broadcast_batched_matmul on MI300X

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9516,7 +9516,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             r1 = fntorch(t0_full, t1, t2)
             self.assertEqual(r0, r1)
 
-    @skipIfRocmArch(MI300_ARCH)
     @tf32_on_and_off(0.001)
     @reduced_f32_on_and_off(0.001)
     def test_broadcast_batched_matmul(self, device):


### PR DESCRIPTION
Fixes #168769
Depends on: #172465 (tf32 tolerance fix)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang