### PR TITLE
[ROCm] Re-enable test_affine_2d_rotate90 on MI300X

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8471,7 +8471,6 @@ class TestNNDeviceType(NNTestCase):
 
     @unittest.skipIf((not TEST_NUMPY) or (not TEST_SCIPY) or (scipy.__version__ < '1.0.0'),
                      "Scipy v1.0 and/or numpy not found")
-    @skipIfRocmArch(MI300_ARCH)
     @expectedFailureMPS  # Unsupported Border padding mode https://github.com/pytorch/pytorch/issues/125098
     @tf32_on_and_off(0.001)
     @reduced_f32_on_and_off(0.001)


### PR DESCRIPTION
Fixes #168802
Depends on: #172465 (tf32 tolerance fix)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang