### PR TITLE
[ROCm] Re-enable test_transformerencoder_fastpath on MI300X

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -428,7 +428,6 @@ class TestTransformers(NNTestCase):
         # remove hook
         handle.remove()
 
-    @skipIfRocmArch(MI300_ARCH)
     @tf32_on_and_off(0.001)
     @parametrize("use_torchscript", [False])
     @parametrize("enable_nested_tensor", [True, False])


### PR DESCRIPTION
Fixes #168870
Depends on: #172465 (tf32 tolerance fix)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang