### PR TITLE
[Graph Partition] Improve support for mutation ops

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6023,9 +6023,10 @@ class Scheduler:
                 return False
 
             if isinstance(buf.node.layout, NoneLayout):
-                if isinstance(buf.node, ir.MutationOutput) and (
-                    real_name := self.mutation_real_name.get(buf_name, None)
-                ):
+                # If there's a mutation real name, check the underlying buffer
+                # This handles both MutationOutput and other mutation ops like
+                # IndexPutFallback that have NoneLayout but mutate real buffers
+                if real_name := self.mutation_real_name.get(buf_name, None):
                     return is_none_layout(real_name)
 
                 return True

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6012,10 +6012,11 @@ class Scheduler:
         unmet_output_names = OrderedSet(V.graph.get_output_names())
         name_to_node = self.get_name_to_nodes()
 
-        def is_none_layout(buf_name: str) -> bool:
+        def is_unallocated_buffer(buf_name: str) -> bool:
             """
-            Checks if buf_name is NoneLayout. Buffers with NoneLayout is not allocated
-            so graph partition should not take it as inputs or outputs.
+            Checks if buf_name resolves to a NoneLayout buffer (following mutation_real_name).
+            Buffers with NoneLayout are not allocated so graph partition should not
+            take them as inputs or outputs.
             """
             buf = self.name_to_buf.get(buf_name, None)
 
@@ -6027,7 +6028,7 @@ class Scheduler:
                 # This handles both MutationOutput and other mutation ops like
                 # IndexPutFallback that have NoneLayout but mutate real buffers
                 if real_name := self.mutation_real_name.get(buf_name, None):
-                    return is_none_layout(real_name)
+                    return is_unallocated_buffer(real_name)
 
                 return True
 
@@ -6056,7 +6057,7 @@ class Scheduler:
                     [
                         x.name
                         for x in read_writes.reads | read_writes.writes
-                        if not is_none_layout(x.name)
+                        if not isinstance(x, WeakDep)
                     ]
                 )
                 - output_names
@@ -6112,7 +6113,7 @@ class Scheduler:
             output_nodes = [
                 name_to_node[name]
                 for name in returned_output_names
-                if not is_none_layout(name)
+                if not is_unallocated_buffer(name)
             ]
 
             constant_names = [


### PR DESCRIPTION
When collecting inputs/outputs of a graph partition, we skip NoneLayout buffers since they are not allocated. One special case is mutation ops (e.g., `buf1 = mutation(buf0)`), whose output `buf1` has NoneLayout and we will access `buf0` in the future. In this case, we should still include `buf0` as an input of the graph partition. So we have this check:
https://github.com/pytorch/pytorch/blob/9bbc5b2905c260adf41bc866a732f9c121a2828a/torch/_inductor/scheduler.py#L6025-L6031

It turns out there are other IR nodes that also have mutation output with NoneLayout. One example is IndexPutFallback, leading to #172442. So we should check for all ir nodes instead of just the ir nodes with `ir.MutationOutput`.

Close: #172442 
Close: #163129

cc @mcarilli @ezyang @eellison @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @zou3519 @ProExpertProg since we have seen similar issue for MOE custom op mutation in vllm.

cc @mcarilli @ezyang @eellison @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo