### PR TITLE
[DTensor] reduce test size due to timeout 

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -1268,7 +1268,7 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
                 (8, 16, 32),
                 # uneven sharding with padding
                 (17, 5),
-                (33, 16, 8, 1),
+                (13, 2, 13),
             ]
             placement_choice = [
                 Shard(0),

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -1268,7 +1268,6 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
                 (8, 16, 32),
                 # uneven sharding with padding
                 (17, 5),
-                (13, 2, 13),
                 (33, 16, 8, 1),
             ]
             placement_choice = [


### PR DESCRIPTION
test_ordered_redistribute_with_partial takes more than 10 mins causing timeout, reduce test size, cost 5 mins now.