### PR TITLE
[Inductor] Add cvt_e8m0_rceil prim with PTX lowering for SM100+

### DIFF
--- a/test/inductor/test_cvt_e8m0_rceil.py
+++ b/test/inductor/test_cvt_e8m0_rceil.py
@@ -1,0 +1,112 @@
+# Owner(s): ["module: inductor"]
+"""Tests for cvt_e8m0_rceil inductor prim with PTX lowering."""
+
+from unittest import skipIf
+
+import torch
+from torch._inductor import inductor_prims
+from torch._inductor.fx_passes.misc_patterns import _misc_patterns_init
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_cuda import SM100OrLater
+from torch.testing._internal.common_utils import run_tests, skipIfRocm, skipIfXpu
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
+
+
+class TestCvtE8M0Rceil(InductorTestCase):
+    """Tests for cvt_e8m0_rceil prim and pattern matching."""
+
+    @requires_gpu()
+    @skipIfRocm
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
+    @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
+    def test_correctness(self):
+        """Test correctness for powers of 2 and ceiling rounding cases."""
+
+        def fn(inp):
+            return inductor_prims.cvt_e8m0_rceil(inp)
+
+        # Powers of 2: biased exponent = log2(value) + 127
+        # Non-powers of 2: ceiling rounding (e.g., 1.5 -> exp 1 -> biased 128)
+        inp = torch.tensor(
+            [1.0, 2.0, 4.0, 0.5, 0.25, 1.5, 3.0, 5.0],
+            device=GPU_TYPE,
+            dtype=torch.float32,
+        )
+
+        eager_result = fn(inp)
+        compiled_result = torch.compile(fn)(inp)
+        self.assertEqual(compiled_result, eager_result)
+
+        expected = torch.tensor(
+            [127, 128, 129, 126, 125, 128, 129, 130],
+            device=GPU_TYPE,
+            dtype=torch.uint8,
+        )
+        self.assertEqual(eager_result, expected)
+
+    @requires_gpu()
+    @skipIfRocm
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
+    @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
+    def test_random_values(self):
+        """Test with random values and various dtypes."""
+
+        def fn(inp):
+            return inductor_prims.cvt_e8m0_rceil(inp)
+
+        for dtype in [torch.float32, torch.bfloat16, torch.float16]:
+            inp = torch.rand(1024, device=GPU_TYPE, dtype=dtype) * 100 + 0.01
+            eager_result = fn(inp)
+            compiled_result = torch.compile(fn)(inp)
+            self.assertEqual(compiled_result, eager_result)
+
+    @requires_gpu()
+    @skipIfRocm
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
+    @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
+    @skipIf(not SM100OrLater, "Pattern matching only enabled on SM100+")
+    def test_pattern_match(self):
+        """Test that patterns get matched and replaced."""
+        _misc_patterns_init()
+
+        # Test log2+ceil pattern (used by torchao)
+        E8M0_BIAS = 127
+
+        def fn_with_log2_pattern(inp):
+            log2_val = torch.log2(inp)
+            ceil_val = torch.ceil(log2_val)
+            clamped = torch.clamp(ceil_val, min=-E8M0_BIAS, max=E8M0_BIAS)
+            biased = clamped + E8M0_BIAS
+            return biased.to(torch.uint8)
+
+        inp = torch.tensor(
+            [1.0, 2.0, 4.0, 3.0, 1.5], device=GPU_TYPE, dtype=torch.float32
+        )
+
+        eager_result = fn_with_log2_pattern(inp)
+        compiled_result = torch.compile(fn_with_log2_pattern)(inp)
+        self.assertEqual(compiled_result, eager_result)
+
+    @requires_gpu()
+    @skipIfRocm
+    @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
+    @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
+    @skipIf(not SM100OrLater, "PTX instruction requires SM100+")
+    def test_ptx_code_generation(self):
+        """Test that PTX instruction appears in generated code on SM100+."""
+
+        def fn(inp):
+            return inductor_prims.cvt_e8m0_rceil(inp)
+
+        inp = torch.rand(32, device=GPU_TYPE, dtype=torch.float32)
+        compiled_fn = torch.compile(fn)
+        _, code = run_and_get_code(compiled_fn, inp)
+
+        code_str = "\n".join(code)
+        self.assertIn("cvt.rp.satfinite.ue8m0x2.f32", code_str)
+
+
+if __name__ == "__main__":
+    if HAS_GPU:
+        run_tests()

--- a/torch/_inductor/fx_passes/misc_patterns.py
+++ b/torch/_inductor/fx_passes/misc_patterns.py
@@ -76,6 +76,73 @@ def _misc_patterns_init():
         scalar_workaround={"slice_shape": 42},
     )
 
+    # Pattern: e8m0 extraction with ceiling rounding (for MX format scaling)
+    # Only register on SM100+ where the PTX instruction is available
+    if device == "cuda" and torch.cuda.get_device_capability() >= (10, 0):
+        from .. import inductor_prims
+
+        # Pattern 1: Bit manipulation approach
+        def e8m0_rceil_pattern(inp):
+            inp_bits = inp.view(torch.int32)
+            biased_exp = (inp_bits >> 23) & 0xFF
+            mantissa = inp_bits & 0x7FFFFF
+            needs_round_up = mantissa != 0
+            e8m0_biased = biased_exp + needs_round_up.to(torch.int32)
+            e8m0_biased = torch.clamp(e8m0_biased, 0, 255)
+            return e8m0_biased.to(torch.uint8)
+
+        def e8m0_rceil_replacement(inp):
+            return inductor_prims.cvt_e8m0_rceil(inp)
+
+        def e8m0_extra_check(match):
+            inp = match.kwargs.get("inp")
+            if inp is None:
+                return False
+            inp_val = inp.meta.get("val")
+            return (
+                inp_val is not None
+                and inp_val.device.type == "cuda"
+                and inp_val.dtype == torch.float32
+            )
+
+        register_replacement(
+            e8m0_rceil_pattern,
+            e8m0_rceil_replacement,
+            [torch.randn(32, device="cuda", dtype=torch.float32)],
+            fwd_only,
+            [post_grad_patterns],
+            extra_check=e8m0_extra_check,
+        )
+
+        # Pattern 2: log2 + ceil approach (used by torchao MX formats)
+        # Matches: (clamp(ceil(log2(x)), -127, 127) + 127).to(uint8)
+        E8M0_BIAS = 127
+
+        def e8m0_rceil_log2_pattern(inp):
+            log2_val = torch.log2(inp)
+            ceil_val = torch.ceil(log2_val)
+            clamped = torch.clamp(ceil_val, min=-E8M0_BIAS, max=E8M0_BIAS)
+            biased = clamped + E8M0_BIAS
+            return biased.to(torch.uint8)
+
+        def e8m0_rceil_log2_replacement(inp):
+            # The PTX instruction expects the raw float value, not log2
+            # So we need to convert: if inp is log2(x), then 2^inp is x
+            # But actually our pattern matches on the value before log2
+            return inductor_prims.cvt_e8m0_rceil(inp)
+
+        register_replacement(
+            e8m0_rceil_log2_pattern,
+            e8m0_rceil_log2_replacement,
+            [torch.randn(32, device="cuda", dtype=torch.float32).abs() + 1e-10],
+            fwd_only,
+            [post_grad_patterns],
+            extra_check=e8m0_extra_check,
+        )
+
+    # TODO: Add pattern for cvt.rn.bf16x2.ue8m0x2 (e8m0 -> bf16 conversion)
+    # This is the inverse operation for MX format dequantization
+
 
 class NumpyCompatNormalization:
     numpy_compat: dict[str, tuple[str, ...]] = {

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -224,3 +224,38 @@ _low_memory_max_pool_offsets_to_indices = make_prim(
     _low_memory_max_pool_offsets_to_indices_aten,
     doc="Convert small int offsets to regular indices.",
 )
+
+
+_CVT_E8M0_ALLOWED_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+def _cvt_e8m0_rceil_aten(inp: Tensor) -> Tensor:
+    """
+    Convert float to e8m0 format with ceiling rounding and satfinite semantics.
+
+    e8m0 format: 8-bit biased exponent (bias=127), no mantissa.
+    For MX format scaling, this extracts the exponent with ceiling rounding.
+    Uses satfinite semantics: inf is saturated to 254 (max finite e8m0).
+    Accepts float32, float16, or bfloat16 (upcasted to float32 internally).
+    """
+    if inp.dtype not in _CVT_E8M0_ALLOWED_DTYPES:
+        raise ValueError(
+            f"cvt_e8m0_rceil requires float32, float16, or bfloat16 input, got {inp.dtype}"
+        )
+    if inp.dtype != torch.float32:
+        inp = inp.to(torch.float32)
+    inp_bits = inp.view(torch.int32)
+    biased_exp = (inp_bits >> 23) & 0xFF
+    mantissa = inp_bits & 0x7FFFFF
+    needs_round_up = mantissa != 0
+    e8m0_biased = biased_exp + needs_round_up.to(torch.int32)
+    # satfinite: clamp to max finite e8m0 value (254), not 255 (inf/nan)
+    e8m0_biased = torch.clamp(e8m0_biased, 0, 254)
+    return e8m0_biased.to(torch.uint8)
+
+
+cvt_e8m0_rceil = make_prim(
+    "inductor_cvt_e8m0_rceil(Tensor input) -> Tensor",
+    _cvt_e8m0_rceil_aten,
+    doc="Convert float to e8m0 with ceiling rounding. Uses PTX cvt.rp.satfinite.ue8m0x2.f32 on SM100+.",
+)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172494

Add an inductor prim for converting float to e8m0 format with ceiling
rounding, used in MX (Microscaling) format scaling. The lowering uses
the PTX instruction `cvt.rp.satfinite.ue8m0x2.f32` on Blackwell (SM100+).

Components:
- inductor_prims.cvt_e8m0_rceil: Prim with eager fallback implementation
- Lowering using inline PTX assembly for SM100+ GPUs
- Pattern matcher to replace bit manipulation code with the optimized prim
- Tests for direct prim call, pattern matching, and PTX code generation

The PTX instruction outputs 2 e8m0 values packed in uint16. Currently
we pass 0.0 as the second input and use only the low byte result.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo