### PR TITLE
ROCm: Fixing test_truediv_base_not_bitwise_equivalent.

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -45,12 +45,10 @@ from torch.testing._internal.common_utils import (
     skipIfRocmArch,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    xfailIfROCm,
 )
 from torch.testing._internal.inductor_utils import IS_BIG_GPU
 
-from torch.testing._internal.common_utils import (
-    xfailIfROCm,
-)
 
 if TEST_WITH_ROCM:
     config.force_layout_optimization = 1

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -48,6 +48,9 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import IS_BIG_GPU
 
+from torch.testing._internal.common_utils import (
+    xfailIfROCm,
+)
 
 if TEST_WITH_ROCM:
     config.force_layout_optimization = 1
@@ -2653,6 +2656,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
                 self.assertEqual(eager_div, compiled_div)
 
     @config.patch({"emulate_divison_rounding": False})
+    @xfailIfROCm
     def test_truediv_base_not_bitwise_equivalent(self):
         from decimal import Decimal
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1729,6 +1729,10 @@ def xfailIfWindows(func):
     return unittest.expectedFailure(func) if IS_WINDOWS else func
 
 
+def xfailIfROCm(func):
+    return unittest.expectedFailure(func) if torch.version.hip is not None else func
+
+
 def skipIfTorchDynamo(msg="test doesn't currently work with dynamo"):
     """
     Usage:


### PR DESCRIPTION
Fixes #165671.

PR #170194 addressed this and was approved already. ROCm infra issues prevented pytorchbot merge there.

Marking the test, test_cuda_repro.py::CudaReproTests::test_truediv_base_not_bitwise_equivalent as xfail on ROCm.

This ROCm behavior produces bitwise equivalent results.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben