### PR TITLE
[ROCm] Fixes test_3layer_split_reduction by replacing hardcoded configs with device properties

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -60,7 +60,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
         super().setUp()
 
         self.model = Foo().to(GPU_TYPE)
-        self.inputs = torch.ones((2048, 1), device=GPU_TYPE)
+        self.inputs = torch.ones((4096, 1), device=GPU_TYPE)
         self.orig_reorder_method = memory.reorder_for_peak_memory
 
     @mock.patch.object(config, "reorder_for_peak_memory", True)

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -60,7 +60,8 @@ class TestOperatorReorderForPeakMemory(TestCase):
         super().setUp()
 
         self.model = Foo().to(GPU_TYPE)
-        self.inputs = torch.ones((4096, 1), device=GPU_TYPE)
+        M = 4096 if torch.version.hip is not None else 2048
+        self.inputs = torch.ones((M, 1), device=GPU_TYPE)
         self.orig_reorder_method = memory.reorder_for_peak_memory
 
     @mock.patch.object(config, "reorder_for_peak_memory", True)

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -186,7 +186,7 @@ class MixOrderReductionTest(TestBase):
         def f(x):
             return x.sum(dim=-1), x.sum(dim=0)
 
-        x = torch.randn(32768 * 256, 2, dtype=torch.float, device=GPU_TYPE)
+        x = torch.randn(32768 * 1024, 2, dtype=torch.float, device=GPU_TYPE)
         self.check_numeric(f, (x,))
         # We don't do mix order reduction for split redutions
         # with more than 2 layers

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -186,7 +186,8 @@ class MixOrderReductionTest(TestBase):
         def f(x):
             return x.sum(dim=-1), x.sum(dim=0)
 
-        x = torch.randn(32768 * 1024, 2, dtype=torch.float, device=GPU_TYPE)
+        M = 32768 * 1024 if torch.version.hip is not None else 32768 * 256
+        x = torch.randn(M, 2, dtype=torch.float, device=GPU_TYPE)
         self.check_numeric(f, (x,))
         # We don't do mix order reduction for split redutions
         # with more than 2 layers

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16609,7 +16609,7 @@ if RUN_GPU:
         def test_donated_buffer_inplace(self):
             batch_size = 32
             seq_length = 50
-            hidden_size = 512
+            hidden_size = 512 if torch.version.hip is not None else 256
 
             inp = torch.randn(
                 batch_size,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16609,7 +16609,7 @@ if RUN_GPU:
         def test_donated_buffer_inplace(self):
             batch_size = 32
             seq_length = 50
-            hidden_size = 256
+            hidden_size = 512
 
             inp = torch.randn(
                 batch_size,

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -514,7 +514,7 @@ class CommonTemplate:
                 2,
                 2,
             ),  # Multiple of max block. Uses loops.
-            ((256, 256), 3, 2),  # Test a large size, with loops.
+            ((128, 128), 3, 2),  # Test a large size, with loops.
         ],
     )
     def test_reduction(
@@ -529,6 +529,9 @@ class CommonTemplate:
         """
         if view_size ==(2, 3 * max_block) and torch.version.hip is not None:
             view_size = (4, 6 * max_block)
+
+        if view_size == (128, 128) and torch.version.hip is not None:
+            view_size = (256, 256)
         if self.device == "cpu" and all(
             # Multiple of max block. Uses loops.
             [

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -527,7 +527,7 @@ class CommonTemplate:
         """
         Tests a reduction kernel.
         """
-        if view_size ==(2, 3 * max_block) and torch.version.hip is not None:
+        if view_size == (2, 3 * max_block) and torch.version.hip is not None:
             view_size = (4, 6 * max_block)
 
         if view_size == (128, 128) and torch.version.hip is not None:
@@ -850,7 +850,7 @@ class CommonTemplate:
         the block pointer analysis, those cases would fall back to 1D.
         """
         if torch.version.hip is not None and expected_num_triton_kernels == 2:
-            size = (256, 256) 
+            size = (256, 256)
         view = self._discontiguous_tensor(size, self.device)
 
         # We expect many block pointers for this one.

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -510,7 +510,7 @@ class CommonTemplate:
                 ],
             ),
             (
-                (2, 3 * max_block),
+                (4, 6 * max_block),
                 2,
                 2,
             ),  # Multiple of max block. Uses loops.
@@ -527,6 +527,8 @@ class CommonTemplate:
         """
         Tests a reduction kernel.
         """
+        if view_size ==(2, 3 * max_block) and torch.version.hip is not None:
+            view_size = (4, 6 * max_block)
         if self.device == "cpu" and all(
             # Multiple of max block. Uses loops.
             [
@@ -803,6 +805,8 @@ class CommonTemplate:
         Tests 2D reduction kernels. These arise from "odd" shapes which are not
         expressible with a 1D block pointer.
         """
+        if reduction_op == torch.sum and torch.version.hip is not None:
+            view_size = (513, 513) if view_size == (129, 129) else view_size
         view = self._discontiguous_tensor(view_size, self.device)
 
         # Expect at least 1 block pointer for the input.
@@ -842,6 +846,8 @@ class CommonTemplate:
         doesn't generate a block pointer. Since tiling welford reductions depends on
         the block pointer analysis, those cases would fall back to 1D.
         """
+        if torch.version.hip is not None and expected_num_triton_kernels == 2:
+            size = (256, 256) 
         view = self._discontiguous_tensor(size, self.device)
 
         # We expect many block pointers for this one.

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -514,7 +514,7 @@ class CommonTemplate:
                 2,
                 2,
             ),  # Multiple of max block. Uses loops.
-            ((128, 128), 3, 2),  # Test a large size, with loops.
+            ((256, 256), 3, 2),  # Test a large size, with loops.
         ],
     )
     def test_reduction(

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -510,7 +510,7 @@ class CommonTemplate:
                 ],
             ),
             (
-                (4, 6 * max_block),
+                (2, 3 * max_block),
                 2,
                 2,
             ),  # Multiple of max block. Uses loops.
@@ -532,6 +532,7 @@ class CommonTemplate:
 
         if view_size == (128, 128) and torch.version.hip is not None:
             view_size = (256, 256)
+        
         if self.device == "cpu" and all(
             # Multiple of max block. Uses loops.
             [

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -532,7 +532,7 @@ class CommonTemplate:
 
         if view_size == (128, 128) and torch.version.hip is not None:
             view_size = (256, 256)
-        
+
         if self.device == "cpu" and all(
             # Multiple of max block. Uses loops.
             [

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -428,13 +428,13 @@ class InductorChoices:
         so we will do the reduction in two phases."""
         props = DeviceProperties.create(device)
         num_sm = props.multi_processor_count
-        min_elements_per_thread = 32
+        min_elements_per_thread = props.warp_size
         max_elements_per_thread = 512
-        threads_per_sm = 2048
+        threads_per_sm = props.max_threads_per_multi_processor
         min_elements_per_device = min_elements_per_thread * num_sm * threads_per_sm
         max_elements_per_device = max_elements_per_thread * num_sm * threads_per_sm
         num_warps = 8
-        num_threads = 32 * num_warps
+        num_threads = props.warp_size * num_warps
 
         if inner_reduction:
             # do heuristics that's close to eager mode for split inner reduction

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -428,13 +428,19 @@ class InductorChoices:
         so we will do the reduction in two phases."""
         props = DeviceProperties.create(device)
         num_sm = props.multi_processor_count
-        min_elements_per_thread = props.warp_size
+        warp_size = props.warp_size if props.warp_size is not None else 32
+        max_threads_per_sm = (
+            props.max_threads_per_multi_processor
+            if props.max_threads_per_multi_processor is not None
+            else 2048
+        )
+        min_elements_per_thread = warp_size
         max_elements_per_thread = 512
-        threads_per_sm = props.max_threads_per_multi_processor
+        threads_per_sm = max_threads_per_sm
         min_elements_per_device = min_elements_per_thread * num_sm * threads_per_sm
         max_elements_per_device = max_elements_per_thread * num_sm * threads_per_sm
         num_warps = 8
-        num_threads = props.warp_size * num_warps
+        num_threads = warp_size * num_warps
 
         if inner_reduction:
             # do heuristics that's close to eager mode for split inner reduction


### PR DESCRIPTION
Fixes #166836.

PR #172431 already addressed it and was approved for merge. ROCm infra issues prevented pytorchbot merge there.

Replace hardcoded configs in unit test, test_3layer_split_reduction with device properties.
This PR also fixes tests which were dependent on split_size in choices.py which was based on hardcoded values for Nvidia devices. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben