### PR TITLE
[inductor] nccl estimator support unbacked symints in all_to_all

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -2601,12 +2601,10 @@ class TestSyncDecisionCrossRanks(MultiProcessTestCase):
                     n, use_nccl_estimator=False
                 )
                 assert est_ms > 0
-                # TODO(ruisizhang123): Currently, NCCL estimation API does not support kwargs input
-                # (input_split_sizes & output_split_sizes in all-to-all) with dynamic shapes.
-                # est_ms_nccl = estimate_nccl_collective_runtime_from_fx_node(
-                #     n, use_nccl_estimator=True
-                # )
-                # assert est_ms_nccl > 0
+                est_ms_nccl = estimate_nccl_collective_runtime_from_fx_node(
+                    n, use_nccl_estimator=True
+                )
+                assert est_ms_nccl > 0
 
         # test for backed dynamic shape input estimation
         inp = torch.ones(4, 4, device=self.device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172502
* __->__ #172501

Before:
all_to_all input_splits, output_splits args (List[int]) were fed unchanged into nccl_estimator.
If they contain unbacked symints - it hard fails.

After:
Fallback for now on static fallback hint and do uniform splits for nccl estimator.

This is needed for DeepSeek EP.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo