### PR TITLE
Use opmath_t and not double compute in fused SGD and Adam

### DIFF
--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -165,9 +165,8 @@ void _fused_sgd_with_momentum_kernel_cuda_(
     const std::optional<at::Tensor>& grad_scale,
     const std::optional<at::Tensor>& found_inf) {
   TORCH_CHECK_GT(momentum, 0);
-  TORCH_CHECK(
-      at::native::check_fast_path_restrictions(
-          {params, grads, momentum_buffer_list}));
+  TORCH_CHECK(at::native::check_fast_path_restrictions(
+      {params, grads, momentum_buffer_list}));
   float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
   float* found_inf_ptr =
@@ -228,9 +227,8 @@ void _fused_sgd_with_momentum_kernel_cuda_(
     return;
   }
   TORCH_CHECK_GT(momentum, 0);
-  TORCH_CHECK(
-      at::native::check_fast_path_restrictions(
-          {params, grads, momentum_buffer_list}));
+  TORCH_CHECK(at::native::check_fast_path_restrictions(
+      {params, grads, momentum_buffer_list}));
   if (grad_scale.has_value()) {
     TORCH_CHECK(
         grad_scale->device() == params[0].device(),

--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -10,27 +10,29 @@ namespace at::native {
 
 namespace {
 
-template <typename scalar_t, int depth>
+constexpr uint8_t kParamIdx = 0;
+constexpr uint8_t kGradIdx = 1;
+constexpr uint8_t kMomentumBufferIdx = 2;
+
+template <typename scalar_t, typename opmath_t, int depth>
 C10_DEVICE __forceinline__ void sgd_math(
     scalar_t r_args[depth][kILP],
-    const double weight_decay,
-    const double momentum,
-    const float* lr_ptr,
-    const double lr,
-    const double dampening,
+    const opmath_t weight_decay,
+    const opmath_t momentum,
+    const opmath_t lr,
+    const opmath_t dampening,
     const bool nesterov,
     const bool maximize,
     const bool is_first_step,
     const float* grad_scale_ptr) {
-  using opmath_t = at::opmath_type<scalar_t>;
-  const double double_lr = lr_ptr != nullptr ? *lr_ptr : lr;
 #pragma unroll
   for (int ii = 0; ii < kILP; ii++) {
-    auto p = static_cast<opmath_t>(r_args[0][ii]);
-    auto g = static_cast<opmath_t>(r_args[1][ii]);
+    opmath_t p = static_cast<opmath_t>(r_args[kParamIdx][ii]);
+    opmath_t g = static_cast<opmath_t>(r_args[kGradIdx][ii]);
+
     if (grad_scale_ptr) {
-      g /= static_cast<double>(*grad_scale_ptr);
-      r_args[1][ii] = g;
+      g /= static_cast<opmath_t>(*grad_scale_ptr);
+      r_args[kGradIdx][ii] = g;
     }
     if (maximize) {
       g *= -1.0;
@@ -38,12 +40,12 @@ C10_DEVICE __forceinline__ void sgd_math(
     if (weight_decay != 0) {
       g += weight_decay * p;
     }
-    if (depth > 2) {
+    if constexpr (depth > 2) {
       const auto momentum_buffer = is_first_step
           ? g
-          : (momentum * static_cast<opmath_t>(r_args[2][ii]) +
+          : (momentum * static_cast<opmath_t>(r_args[kMomentumBufferIdx][ii]) +
              (1 - dampening) * g);
-      r_args[2][ii] = momentum_buffer;
+      r_args[kMomentumBufferIdx][ii] = momentum_buffer;
 
       if (nesterov) {
         g = g + momentum * momentum_buffer;
@@ -51,8 +53,8 @@ C10_DEVICE __forceinline__ void sgd_math(
         g = momentum_buffer;
       }
     }
-    p -= double_lr * g;
-    r_args[0][ii] = p;
+    p -= lr * g;
+    r_args[kParamIdx][ii] = p;
   }
 }
 
@@ -61,6 +63,8 @@ struct FusedSgdMathFunctor {
   static_assert(
       depth == 2 || depth == 3,
       "depth of 2 for SGD w/ momentum == 0, 3 for SGD w/ momentum != 0");
+  using opmath_t = at::opmath_type<scalar_t>;
+
   C10_DEVICE __forceinline__ void operator()(
       const int64_t chunk_size,
       TensorListMetadata<depth>& tl,
@@ -79,12 +83,15 @@ struct FusedSgdMathFunctor {
     }
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    const opmath_t lr_opmath =
+        lr_ptr ? static_cast<opmath_t>(*lr_ptr) : static_cast<opmath_t>(lr);
 
     scalar_t* args[depth];
     scalar_t r_args[depth][kILP];
+    const auto n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
+
     const auto all_aligned{
         init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc)};
-    const auto n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
 
     const auto use_faster_load_store =
         (n % kILP == 0) && (chunk_size % kILP == 0) && all_aligned;
@@ -96,13 +103,12 @@ struct FusedSgdMathFunctor {
         for (auto i = 0; i < depth; i++) {
           load_store(r_args[i], args[i], 0, i_start);
         }
-        sgd_math<scalar_t, depth>(
+        sgd_math<scalar_t, opmath_t, depth>(
             r_args,
-            weight_decay,
-            momentum,
-            lr_ptr,
-            lr,
-            dampening,
+            static_cast<opmath_t>(weight_decay),
+            static_cast<opmath_t>(momentum),
+            lr_opmath,
+            static_cast<opmath_t>(dampening),
             nesterov,
             maximize,
             is_first_step,
@@ -119,13 +125,12 @@ struct FusedSgdMathFunctor {
       for (auto i_start = 0; i_start < n && i_start < chunk_size;
            i_start += blockDim.x * kILP) {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
-        sgd_math<scalar_t, depth>(
+        sgd_math<scalar_t, opmath_t, depth>(
             r_args,
-            weight_decay,
-            momentum,
-            lr_ptr,
-            lr,
-            dampening,
+            static_cast<opmath_t>(weight_decay),
+            static_cast<opmath_t>(momentum),
+            lr_opmath,
+            static_cast<opmath_t>(dampening),
             nesterov,
             maximize,
             is_first_step,

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -127,8 +127,13 @@ struct FusedAdamMathFunctor {
       const float* found_inf_ptr) {
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+
     const opmath_t lr_opmath =
         lr_ptr ? static_cast<opmath_t>(*lr_ptr) : static_cast<opmath_t>(lr);
+    const opmath_t beta1_opmath = static_cast<opmath_t>(beta1);
+    const opmath_t beta2_opmath = static_cast<opmath_t>(beta2);
+    const opmath_t weight_decay_opmath = static_cast<opmath_t>(weight_decay);
+    const opmath_t eps_opmath = static_cast<opmath_t>(eps);
 
     if (found_inf_ptr && *found_inf_ptr == 1) {
       return;
@@ -140,10 +145,10 @@ struct FusedAdamMathFunctor {
               tl.state_steps_addresses[tensor_loc]));
 
       const opmath_t bias_correction1 =
-          1 - at::native::pow_(static_cast<opmath_t>(beta1), step_count);
+          1 - at::native::pow_(beta1_opmath, step_count);
 
       const opmath_t bias_correction2 =
-          1 - at::native::pow_(static_cast<opmath_t>(beta2), step_count);
+          1 - at::native::pow_(beta2_opmath, step_count);
       const opmath_t bias_correction2_sqrt = std::sqrt(bias_correction2);
 
       return {bias_correction1, bias_correction2_sqrt};
@@ -167,10 +172,10 @@ struct FusedAdamMathFunctor {
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
             lr_opmath,
-            static_cast<opmath_t>(beta1),
-            static_cast<opmath_t>(beta2),
-            static_cast<opmath_t>(weight_decay),
-            static_cast<opmath_t>(eps),
+            beta1_opmath,
+            beta2_opmath,
+            weight_decay_opmath,
+            eps_opmath,
             maximize,
             grad_scale_ptr,
             found_inf_ptr,
@@ -190,10 +195,10 @@ struct FusedAdamMathFunctor {
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
             lr_opmath,
-            beta1,
-            beta2,
-            weight_decay,
-            eps,
+            beta1_opmath,
+            beta2_opmath,
+            weight_decay_opmath,
+            eps_opmath,
             maximize,
             grad_scale_ptr,
             found_inf_ptr,

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -25,11 +25,11 @@ template <
     bool amsgrad>
 C10_DEVICE inline void adam_math(
     scalar_type r_args[depth][kILP],
-    const double& lr,
-    const double& beta1,
-    const double& beta2,
-    const double& weight_decay,
-    const double& eps,
+    const opmath_t& lr,
+    const opmath_t& beta1,
+    const opmath_t& beta2,
+    const opmath_t& weight_decay,
+    const opmath_t& eps,
     const bool& maximize,
     const float* grad_scale_ptr,
     const float* found_inf_ptr,
@@ -41,19 +41,23 @@ C10_DEVICE inline void adam_math(
     // Load values.
     opmath_t param = static_cast<opmath_t>(r_args[kParamIdx][ii]);
     opmath_t grad = static_cast<opmath_t>(r_args[kGradIdx][ii]);
-    if (grad_scale_ptr) {
-      grad /= (static_cast<double>(*grad_scale_ptr));
-    }
-    const opmath_t grad_to_store = grad;
-    if (maximize) {
-      grad = -grad;
-    }
     opmath_t exp_avg = static_cast<opmath_t>(r_args[kExpAvgIdx][ii]);
     opmath_t exp_avg_sq = static_cast<opmath_t>(r_args[kExpAvgSqIdx][ii]);
     opmath_t max_exp_avg_sq;
-    if (amsgrad) {
+    if constexpr (amsgrad) {
       max_exp_avg_sq = static_cast<opmath_t>(r_args[kMaxExpAvgSqIdx][ii]);
     }
+
+    // Scale gradient for AMP.
+    if (grad_scale_ptr) {
+      grad /= (static_cast<opmath_t>(*grad_scale_ptr));
+    }
+    const opmath_t grad_to_store = grad;
+
+    if (maximize) {
+      grad = -grad;
+    }
+
     // Update param, grad, 1st and 2nd order momentum.
     if (weight_decay != 0) {
       if constexpr (adam_mode == ADAM_MODE::ORIGINAL) {
@@ -66,9 +70,10 @@ C10_DEVICE inline void adam_math(
     // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
     exp_avg = beta1 * exp_avg + (1 - beta1) * grad;
     exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad * grad;
+
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
-    if (amsgrad) {
+    if constexpr (amsgrad) {
       max_exp_avg_sq = std::max(max_exp_avg_sq, exp_avg_sq);
       denom = (std::sqrt(max_exp_avg_sq) / bias_correction2_sqrt) + eps;
     } else {
@@ -83,7 +88,7 @@ C10_DEVICE inline void adam_math(
     }
     r_args[kExpAvgIdx][ii] = exp_avg;
     r_args[kExpAvgSqIdx][ii] = exp_avg_sq;
-    if (amsgrad) {
+    if constexpr (amsgrad) {
       r_args[kMaxExpAvgSqIdx][ii] = max_exp_avg_sq;
     }
   }
@@ -107,6 +112,7 @@ struct FusedAdamMathFunctor {
       depth == 4 || depth == 5,
       "depth of 4 for Adam, depth of 5 for Adam with AMSGrad.");
   using opmath_t = at::opmath_type<scalar_type>;
+
   C10_DEVICE __forceinline__ void operator()(
       int64_t chunk_size,
       FusedOptimizerTensorListMetadata<depth>& tl,
@@ -121,18 +127,25 @@ struct FusedAdamMathFunctor {
       const float* found_inf_ptr) {
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-    const double lr_double = lr_ptr ? *lr_ptr : lr;
+    const opmath_t lr_opmath =
+        lr_ptr ? static_cast<opmath_t>(*lr_ptr) : static_cast<opmath_t>(lr);
 
     if (found_inf_ptr && *found_inf_ptr == 1) {
       return;
     }
     const auto [bias_correction1, bias_correction2_sqrt] =
-        [&]() -> std::pair<double, double> {
-      auto* step_count =
-          reinterpret_cast<const float*>(tl.state_steps_addresses[tensor_loc]);
-      const auto bias_correction1 = 1 - at::native::pow_(beta1, *step_count);
-      const auto bias_correction2 = 1 - at::native::pow_(beta2, *step_count);
-      const auto bias_correction2_sqrt = std::sqrt(bias_correction2);
+        [&]() -> std::pair<opmath_t, opmath_t> {
+      opmath_t step_count =
+          static_cast<opmath_t>(*reinterpret_cast<const float*>(
+              tl.state_steps_addresses[tensor_loc]));
+
+      const opmath_t bias_correction1 =
+          1 - at::native::pow_(static_cast<opmath_t>(beta1), step_count);
+
+      const opmath_t bias_correction2 =
+          1 - at::native::pow_(static_cast<opmath_t>(beta2), step_count);
+      const opmath_t bias_correction2_sqrt = std::sqrt(bias_correction2);
+
       return {bias_correction1, bias_correction2_sqrt};
     }();
 
@@ -142,6 +155,7 @@ struct FusedAdamMathFunctor {
 
     const bool all_aligned{
         init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc)};
+
     if ((n % kILP == 0) && (chunk_size % kILP == 0) && all_aligned) {
       for (int64_t i_start = threadIdx.x;
            i_start * kILP < n && i_start * kILP < chunk_size;
@@ -152,11 +166,11 @@ struct FusedAdamMathFunctor {
         }
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
-            lr_double,
-            beta1,
-            beta2,
-            weight_decay,
-            eps,
+            lr_opmath,
+            static_cast<opmath_t>(beta1),
+            static_cast<opmath_t>(beta2),
+            static_cast<opmath_t>(weight_decay),
+            static_cast<opmath_t>(eps),
             maximize,
             grad_scale_ptr,
             found_inf_ptr,
@@ -175,7 +189,7 @@ struct FusedAdamMathFunctor {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
-            lr_double,
+            lr_opmath,
             beta1,
             beta2,
             weight_decay,

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -2284,7 +2284,7 @@ class TensorTracker:
         self.tensors.append(tensor.detach().clone())
 
     # pops from beginning, like a queue and not a stack!
-    def pop_check_set(self, tensor_to_set, testcase):
+    def pop_check_set(self, tensor_to_set, testcase, override_assert_eq_kwargs=None):
         """
         Pop the first element in the tensor tracker, assert equality between the popped tensor and
         the input tensor, and then set the input tensor to have the same values as the popped tensor
@@ -2294,7 +2294,8 @@ class TensorTracker:
         ref = self.tensors.pop(0)
 
         testcase.assertTrue(isinstance(ref, Tensor), f"{type(ref)=}")
-        testcase.assertEqual(tensor_to_set, ref, **self.assert_eq_kwargs)
+        assert_eq_kwargs = override_assert_eq_kwargs if override_assert_eq_kwargs is not None else self.assert_eq_kwargs
+        testcase.assertEqual(tensor_to_set, ref, **assert_eq_kwargs)
 
         with torch.no_grad():
             tensor_to_set.copy_(ref)


### PR DESCRIPTION
This brings over the finish line @MeetThePatel's work https://github.com/pytorch/pytorch/pull/154069 that got stuck due to CI.

The solution was to increase the tolerances for when comparing variance between the fused and forloop computation for when you use Adam and gradscaler together.