### PR TITLE
[invoke_subgraph] Fix dce_hop_extra_outputs to collect all callers first before pruning

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -14,6 +14,7 @@ import torch._inductor
 import torch._inductor.decomposition
 import torch.utils._pytree as pytree
 from functorch.compile import aot_function, nop
+from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 from torch._dynamo.testing import (
     AotEagerAndRecordGraphs,
     EagerAndRecordGraphs,
@@ -2999,6 +3000,107 @@ class GraphModule(torch.nn.Module):
             return (add,)
 """,
         )
+
+    def test_do_not_remove_used_output(self):
+        # Test that the ggn's outputs are not pruned.
+
+        @nested_compile_region
+        def ggn(x):
+            return torch.max(x, 0)
+
+        @nested_compile_region
+        def gn(x):
+            a, b = ggn(x)
+            return a, b
+
+        def fn(x):
+            _, b = ggn(x)
+            c, d = gn(x)
+            return b, c, d
+
+        x = torch.randn(64, 1)
+
+        ref = fn(x)
+        gm = dynamo_graph_capture_for_export(fn)(x)
+
+        res = gm(x)
+        self.assertEqual(ref, res)
+
+    def test_remove_unused_output(self):
+        # Test that the ggn's graph's output is pruned.
+
+        @nested_compile_region
+        def ggn(x):
+            return torch.max(x, 0)
+
+        @nested_compile_region
+        def gn(x):
+            a, b = ggn(x)
+            return a, b
+
+        def fn(x):
+            _, b = ggn(x)
+            _, d = gn(x)
+            return b, d
+
+        x = torch.randn(64, 1)
+
+        ref = fn(x)
+        gm = dynamo_graph_capture_for_export(fn)(x)
+
+        res = gm(x)
+        self.assertEqual(ref, res)
+
+        if not TEST_WITH_CROSSREF:
+            self.assertExpectedInline(
+                normalize_gm(gm.print_readable(print_output=False)),
+                """\
+class GraphModule(torch.nn.Module):
+    def forward(self, x):
+        _tree_leaf_0, = pytree.tree_leaves((x,))
+        L_x_, = self._in_shuffle_graph(_tree_leaf_0)
+        l_x_ = L_x_
+
+        subgraph_0 = self.subgraph_0
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_);  subgraph_0 = None
+        b: "i64[1]" = invoke_subgraph[1];  invoke_subgraph = None
+
+        subgraph_1 = self.subgraph_1
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(subgraph_1, 'subgraph_1', l_x_);  subgraph_1 = l_x_ = None
+        getitem_4: "i64[1]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, b, getitem_4), self._out_spec)
+
+    class subgraph_0(torch.nn.Module):
+        def forward(self, l_x_: "f32[64, 1]"):
+            max_1 = torch.max(l_x_, 0);  l_x_ = None
+            getitem: "f32[1]" = max_1[0]
+            getitem_1: "i64[1]" = max_1[1];  max_1 = None
+            return (getitem, getitem_1)
+
+    class subgraph_1(torch.nn.Module):
+        def forward(self, l_x_: "f32[64, 1]"):
+            subgraph_0 = self.subgraph_0
+            invoke_subgraph = torch.ops.higher_order.invoke_subgraph(subgraph_0, 'subgraph_0', l_x_);  subgraph_0 = l_x_ = None
+            a: "f32[1]" = invoke_subgraph[0];  a = None
+            b: "i64[1]" = invoke_subgraph[1];  invoke_subgraph = None
+            return (b,)
+
+        class subgraph_0(torch.nn.Module):
+            def forward(self, l_x_: "f32[64, 1]"):
+                max_1 = torch.max(l_x_, 0);  l_x_ = None
+                getitem: "f32[1]" = max_1[0]
+                getitem_1: "i64[1]" = max_1[1];  max_1 = None
+                return (getitem, getitem_1)
+
+    class _in_shuffle_graph(torch.nn.Module):
+        def forward(self, arg0_1: "f32[s75, 1]"):
+            return (arg0_1,)
+
+    class _out_shuffle_graph(torch.nn.Module):
+        def forward(self, arg0_1: "f32[64, 1]", arg1_1: "i64[1]", arg2_1: "i64[1]"):
+            return [arg1_1, arg2_1]
+""",
+            )
 
 
 @skipIfTorchDynamo("Not a torch._dynamo test")

--- a/torch/_dynamo/dce_extra_outputs.py
+++ b/torch/_dynamo/dce_extra_outputs.py
@@ -1,21 +1,17 @@
 """
 DCE pass for unused extra outputs in HOP subgraphs.
 
-When enable_side_effects_with_extra_outputs is True, HOPs like invoke_subgraph,
-checkpoint (tag_activation_checkpoint), and autograd.Function (autograd_function_apply)
+When enable_side_effects_with_extra_outputs is True, HOPs like invoke_subgraph and
+checkpoint (tag_activation_checkpoint)
 return all intermediate tensors/symints as extra outputs to support side effects.
 However, many of these extra outputs may not actually be used in the parent graph.
 
-Special handling for autograd_function_apply:
-- The forward subgraph MUST return (output, saved_values, ...) where indices 0 and 1
-  are always required by the runtime
-- Only indices 2+ (extra intermediates) can be removed by DCE
-
 This pass removes unused extra outputs by:
-1. Identifying which outputs of HOP calls are actually used
-2. Removing unused outputs from the subgraph's output node
-3. Updating the HOP call to reflect the new output arity
-4. Updating getitem indices to account for removed outputs
+1. Collecting all callers for each subgraph
+2. Checking if each output is used by all callers
+3. Removing unused outputs from the subgraph's output node
+4. Updating the HOP call and getitem indices in all call sites
+
 """
 
 import collections
@@ -34,12 +30,12 @@ _HOPS_WITH_EXTRA_OUTPUTS = {
 
 def dce_hop_extra_outputs(gm: torch.fx.GraphModule) -> bool:
     """
-    Remove unused extra outputs from HOP calls recursively.
+    Remove unused extra outputs from HOP calls in all submodules.
 
-    Processes graphs top-down: first DCE the current graph's HOP outputs,
-    then recursively process nested subgraphs. This ensures that when we
-    process a nested subgraph, the parent has already removed unused getitems,
-    so the nested subgraph sees the correct usage information.
+    For each subgraph output, check if any caller has a getitem for that index
+    with users. If no caller uses it, remove the output.
+    If the user in caller is an output node, to simply the algorithm, we do not recursively check
+    if the caller's output is used further up in the call chain.
 
     Args:
         gm: The GraphModule to optimize
@@ -47,13 +43,52 @@ def dce_hop_extra_outputs(gm: torch.fx.GraphModule) -> bool:
     Returns:
         True if any modifications were made, False otherwise
     """
+    # Collect all subgraph usages: subgraph_id -> list of (parent_gm, subgraph_name, hop_node)
+    subgraph_id_to_callers: dict[
+        int, list[tuple[torch.fx.GraphModule, str, torch.fx.Node]]
+    ] = collections.defaultdict(list)
+    _collect_all_subgraph_usages(gm, subgraph_id_to_callers)
+
+    if not subgraph_id_to_callers:
+        return False
+
     modified = False
 
-    # Group HOP nodes by subgraph name
-    # Multiple invocations may share the same subgraph, so we need to check
-    # which indices are used across ALL invocations before removing any
-    subgraph_to_nodes: dict[str, list[torch.fx.Node]] = collections.defaultdict(list)
+    for callers in subgraph_id_to_callers.values():
+        parent_gm, subgraph_name, _ = callers[0]
+        subgraph = getattr(parent_gm, subgraph_name)
 
+        if not isinstance(subgraph, torch.fx.GraphModule):
+            continue
+
+        output_node = next(n for n in subgraph.graph.nodes if n.op == "output")
+        output_args = output_node.args[0]
+        if not isinstance(output_args, (tuple, list)):
+            continue
+
+        num_outputs = len(output_args)
+        used_indices: set[int] = set()
+
+        # Check which outputs are used by any caller
+        for idx in range(num_outputs):
+            if _is_output_used(idx, callers):
+                used_indices.add(idx)
+
+        # DCE if some outputs are unused
+        if 0 < len(used_indices) < num_outputs:
+            if _dce_subgraph(subgraph, callers, used_indices):
+                modified = True
+
+    return modified
+
+
+def _collect_all_subgraph_usages(
+    gm: torch.fx.GraphModule,
+    subgraph_id_to_callers: dict[
+        int, list[tuple[torch.fx.GraphModule, str, torch.fx.Node]]
+    ],
+) -> None:
+    """Recursively collect all HOP usages across the graph tree."""
     for node in gm.graph.nodes:
         if node.op == "call_function" and node.target in _HOPS_WITH_EXTRA_OUTPUTS:
             subgraph_attr = node.args[0]
@@ -63,42 +98,41 @@ def dce_hop_extra_outputs(gm: torch.fx.GraphModule) -> bool:
             ):
                 subgraph_name = subgraph_attr.target
                 assert isinstance(subgraph_name, str)
-                subgraph_to_nodes[subgraph_name].append(node)
+                subgraph = getattr(gm, subgraph_name, None)
+                if isinstance(subgraph, torch.fx.GraphModule):
+                    subgraph_id = id(subgraph)
+                    subgraph_id_to_callers[subgraph_id].append(
+                        (gm, subgraph_name, node)
+                    )
+                    _collect_all_subgraph_usages(subgraph, subgraph_id_to_callers)
 
-    # STEP 1: DCE this graph's HOP outputs first (top-down)
-    for subgraph_name, hop_nodes in subgraph_to_nodes.items():
-        if _dce_subgraph(gm, subgraph_name, hop_nodes):
-            modified = True
 
-    if modified:
-        gm.graph.lint()
-        gm.recompile()
-
-    # STEP 2: Recursively process nested subgraphs
-    # After we've removed unused getitems from this graph, nested subgraphs
-    # will see the correct usage information
-    for subgraph_name in subgraph_to_nodes:
-        subgraph = getattr(gm, subgraph_name)
-        if isinstance(subgraph, torch.fx.GraphModule):
-            if dce_hop_extra_outputs(subgraph):
-                modified = True
-
-    return modified
+def _is_output_used(
+    output_idx: int,
+    callers: list[tuple[torch.fx.GraphModule, str, torch.fx.Node]],
+) -> bool:
+    """Check if output_idx is used by ANY caller (has a getitem with users)."""
+    for _parent_gm, _subgraph_name, hop_node in callers:
+        for user in hop_node.users:
+            if user.op == "call_function" and user.target == operator.getitem:
+                if user.args[1] == output_idx and len(user.users) > 0:
+                    return True
+    return False
 
 
 def _dce_subgraph(
-    gm: torch.fx.GraphModule, subgraph_name: str, hop_nodes: list[torch.fx.Node]
+    subgraph: torch.fx.GraphModule,
+    callers: list[tuple[torch.fx.GraphModule, str, torch.fx.Node]],
+    used_indices: set[int],
 ) -> bool:
     """
-    DCE a single subgraph by removing unused output indices.
+    DCE a subgraph by removing unused output indices.
+
+    Updates the subgraph's output node, all getitem nodes in callers,
+    and example_value metadata on HOP nodes.
     """
-    subgraph = getattr(gm, subgraph_name)
-
-    if not isinstance(subgraph, torch.fx.GraphModule):
-        return False
-
-    # Collect used indices for THIS subgraph
-    used_indices: set[int] = set()
+    output_node = next(n for n in subgraph.graph.nodes if n.op == "output")
+    old_outputs = list(output_node.args[0])
 
     # Check if this is the forward subgraph of autograd_function_apply
     # For autograd_function_apply, the fwd subgraph must return (output, saved_values, ...)
@@ -108,17 +142,6 @@ def _dce_subgraph(
     #     for node in hop_nodes
     # )
     is_autograd_fwd = False
-
-    for hop_node in hop_nodes:
-        for user in list(hop_node.users):
-            if user.op == "call_function" and user.target == operator.getitem:
-                if len(list(user.users)) > 0:
-                    idx = user.args[1]
-                    assert isinstance(idx, int)
-                    used_indices.add(idx)
-
-    output_node = next(n for n in subgraph.graph.nodes if n.op == "output")
-    old_outputs = list(output_node.args[0])
 
     # For autograd_function_apply forward subgraph, indices 0 (output) and 1 (saved_values)
     # are ALWAYS used by the runtime, even if not explicitly accessed via getitem
@@ -148,27 +171,28 @@ def _dce_subgraph(
     output_node.replace_all_uses_with(new_output_node)
     subgraph.graph.erase_node(output_node)
 
-    for hop_node in hop_nodes:
+    for parent_gm, _, hop_node in callers:
         # Update getitem nodes to use new indices
         for user in list(hop_node.users):
             if user.op == "call_function" and user.target == operator.getitem:
                 old_idx = user.args[1]
                 assert isinstance(old_idx, int)
+
                 if old_idx not in old_to_new:
                     assert len(list(user.users)) == 0
-                    gm.graph.erase_node(user)
+                    parent_gm.graph.erase_node(user)
                     continue
 
                 new_idx = old_to_new[old_idx]
                 # Create a new getitem node with the new index
-                with gm.graph.inserting_before(user):
-                    new_getitem = gm.graph.call_function(
+                with parent_gm.graph.inserting_before(user):
+                    new_getitem = parent_gm.graph.call_function(
                         operator.getitem, args=(user.args[0], new_idx)
                     )
                     # Copy metadata from old node
                     new_getitem.meta = user.meta.copy()
                 user.replace_all_uses_with(new_getitem)
-                gm.graph.erase_node(user)
+                parent_gm.graph.erase_node(user)
 
         # Update example_value metadata on hop_node
         if "example_value" in hop_node.meta:
@@ -181,7 +205,12 @@ def _dce_subgraph(
             )
             hop_node.meta["example_value"] = new_example
 
+    # Recompile subgraph and all modified parent graphs
     subgraph.graph.lint()
     subgraph.recompile()
+
+    for parent_gm in {caller[0] for caller in callers}:
+        parent_gm.graph.lint()
+        parent_gm.recompile()
 
     return True


### PR DESCRIPTION
Fixes #172462


```
python test/higher_order_ops/test_invoke_subgraph.py -k test_do_not_remove -k test_remove_unused_output -k test_dce_recursive
```

A subgraph may have multiple callers. We should consider the usage of outputs in all callers before pruning.
We cannot do this top-down, because of the following situation: 
- outer graph doesn't use all outputs, so we pruned some outputs
- However, inner graph does use all outputs. 

So, we need to first do a pass to collect all the call sites, and then prune.

Example:

```
        @nested_compile_region
        def ggn(x):
            return torch.max(x, 0)

        @nested_compile_region
        def gn(x):
            a, b = ggn(x)
            return a, b

        def fn(x):
            _, b = ggn(x)
            c, d = gn(x)
            return b, c, d
```

This issue is also observed when applying invoke_subgraph to flex_attention in torchtitan's llama3 run.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos