### PR TITLE
[inductor] Log NCCL estimations to tlparse in CSV format

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1706,6 +1706,34 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
                 )
 
 
+class TestNodeRuntimeEstimationFormat(torch._dynamo.test_case.TestCase):
+    """Test the CSV format for node runtime estimation logging."""
+
+    def test_format_csv_parseable(self):
+        """Verify _format_csv produces parseable CSV output."""
+        import csv
+        import io
+
+        from torch._inductor.fx_passes.node_runtime_estimation import _format_csv
+
+        headers = ["Collective Key", "NCCL Est(ms)", "Inductor Est(ms)"]
+        rows = [
+            ["all_reduce group_size:2 input_bytes:256", "0.1234", "0.1456"],
+            ["all_gather group_size:2 input_bytes:512", "0.2345", "0.2567"],
+        ]
+
+        result = _format_csv(headers, rows)
+
+        # Verify it's parseable with csv module
+        reader = csv.reader(io.StringIO(result))
+        parsed_rows = list(reader)
+
+        self.assertEqual(len(parsed_rows), 3)  # header + 2 data rows
+        self.assertEqual(parsed_rows[0], headers)
+        self.assertEqual(parsed_rows[1], rows[0])
+        self.assertEqual(parsed_rows[2], rows[1])
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1706,34 +1706,6 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
                 )
 
 
-class TestNodeRuntimeEstimationFormat(torch._dynamo.test_case.TestCase):
-    """Test the CSV format for node runtime estimation logging."""
-
-    def test_format_csv_parseable(self):
-        """Verify _format_csv produces parseable CSV output."""
-        import csv
-        import io
-
-        from torch._inductor.fx_passes.node_runtime_estimation import _format_csv
-
-        headers = ["Collective Key", "NCCL Est(ms)", "Inductor Est(ms)"]
-        rows = [
-            ["all_reduce group_size:2 input_bytes:256", "0.1234", "0.1456"],
-            ["all_gather group_size:2 input_bytes:512", "0.2345", "0.2567"],
-        ]
-
-        result = _format_csv(headers, rows)
-
-        # Verify it's parseable with csv module
-        reader = csv.reader(io.StringIO(result))
-        parsed_rows = list(reader)
-
-        self.assertEqual(len(parsed_rows), 3)  # header + 2 data rows
-        self.assertEqual(parsed_rows[0], headers)
-        self.assertEqual(parsed_rows[1], rows[0])
-        self.assertEqual(parsed_rows[2], rows[1])
-
-
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -389,7 +389,9 @@ def _log_collective_benchmarks(
         if has_benchmarks:
             benchmarked_ms = benchmarked_medians[i]
             nccl_diff_pct = (nccl_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
-            inductor_diff_pct = (inductor_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
+            inductor_diff_pct = (
+                (inductor_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
+            )
             rows.append(
                 [
                     key,

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -386,7 +386,7 @@ def _log_collective_benchmarks(
         key = collective_keys[i] if collective_keys else _get_collective_key(coll_node)
         nccl_ms, inductor_ms = _get_collective_estimations(coll_node)
 
-        if has_benchmarks:
+        if benchmarked_medians is not None:
             benchmarked_ms = benchmarked_medians[i]
             nccl_diff_pct = (nccl_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
             inductor_diff_pct = (

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -13,9 +13,70 @@ from typing import Any, Optional
 import torch
 import torch.fx as fx
 from torch._inductor.fx_passes.bucketing import _schedulable_wait_node
-from torch._inductor.utils import clear_on_fresh_cache, tabulate_2d
+from torch._inductor.utils import clear_on_fresh_cache
 from torch._logging import getArtifactLogger, trace_structured
 from torch.fx.operator_schemas import normalize_function
+
+
+def _format_csv(headers: list[str], rows: list[list[str]]) -> str:
+    """Format data as CSV. Human-readable and easily parseable."""
+    lines = [",".join(headers)]
+    for row in rows:
+        lines.append(",".join(str(v) for v in row))
+    return "\n".join(lines)
+
+
+def _get_collective_key(coll_node: fx.Node) -> str:
+    """Extract a unique key for a collective node including group info and tensor size."""
+    from torch._inductor import fx_utils
+
+    opt_args_kwargs = normalize_function(
+        coll_node.target,  # type: ignore[arg-type]
+        args=coll_node.args,
+        kwargs=coll_node.kwargs,
+        normalize_to_only_use_kwargs=True,
+    )
+    assert opt_args_kwargs is not None
+    _, kwargs = opt_args_kwargs
+    group_name = kwargs.get("group_name", None)
+    group_size = kwargs.get("group_size", None)
+
+    tensor_bytes: Optional[int] = None
+    success, args, kw = fx_utils.get_fake_args_kwargs(coll_node)
+    if success:
+
+        def extract_first_tensor_bytes(t: torch.Tensor) -> torch.Tensor:
+            nonlocal tensor_bytes
+            if tensor_bytes is None:
+                shape = [get_hint(dim) for dim in t.shape]
+                if all(s is not None for s in shape):
+                    numel = functools.reduce(operator.mul, shape, 1)
+                    tensor_bytes = numel * t.dtype.itemsize
+            return t
+
+        torch.utils._pytree.tree_map_only(
+            torch.Tensor, extract_first_tensor_bytes, (args, kw)
+        )
+
+    return f"{coll_node.target} group_size:{group_size} group_name:{group_name} input_bytes:{tensor_bytes}"
+
+
+def _get_collective_estimations(coll_node: fx.Node) -> tuple[float, float]:
+    """Get NCCL and Inductor analytical estimations for a collective node.
+
+    Returns: (nccl_ms, inductor_ms)
+    """
+    nccl_ms = (
+        torch._inductor.comm_analysis.estimate_nccl_collective_runtime_from_fx_node(
+            coll_node, None, use_nccl_estimator=True
+        )
+    )
+    inductor_ms = (
+        torch._inductor.comm_analysis.estimate_nccl_collective_runtime_from_fx_node(
+            coll_node, None, use_nccl_estimator=False
+        )
+    )
+    return nccl_ms, inductor_ms
 
 
 # Setup logger for artifact logging
@@ -236,18 +297,18 @@ def _log_compute_estimations(
     rows = [
         [
             _node_summary(node),
-            est_b * 1e3,
-            est_a * 1e3,
-            (est_a / est_b) if est_b > 0 else 0,
-            (est_a - est_b) * 1e3,
-            count_flops_fx(node),
+            f"{est_b * 1e3:.4f}",
+            f"{est_a * 1e3:.4f}",
+            f"{(est_a / est_b) if est_b > 0 else 0:.4f}",
+            f"{(est_a - est_b) * 1e3:.4f}",
+            str(count_flops_fx(node)),
         ]
         for node, est_b, est_a in zip(
             compute_nodes, benchmarked_estimations, analytical_estimations
         )
     ]
 
-    log_str = tabulate_2d(rows, headers)
+    log_str = _format_csv(headers, rows)
 
     trace_structured(
         "artifact",
@@ -260,8 +321,6 @@ def _log_compute_estimations(
 
 
 def _log_graph_collective_benchmarks(gm: fx.GraphModule, artifact_name: str) -> None:
-    from torch._inductor import fx_utils
-
     collective_nodes = []
     collective_keys = []
     benchmarked = []
@@ -270,38 +329,7 @@ def _log_graph_collective_benchmarks(gm: fx.GraphModule, artifact_name: str) -> 
         if _schedulable_wait_node(node):
             start = node.args[0]
             collective_nodes.append(start)
-            opt_args_kwargs = normalize_function(
-                start.target,  # type: ignore[arg-type]
-                args=start.args,
-                kwargs=start.kwargs,
-                normalize_to_only_use_kwargs=True,
-            )
-            assert opt_args_kwargs is not None
-            _, kwargs = opt_args_kwargs
-            group_name = kwargs.get("group_name", None)
-            group_size = kwargs.get("group_size", None)
-
-            # Extract first tensor input size in bytes
-            tensor_bytes: Optional[int] = None
-            success, args, kw = fx_utils.get_fake_args_kwargs(start)
-            if success:
-
-                def extract_first_tensor_bytes(t: torch.Tensor) -> torch.Tensor:
-                    nonlocal tensor_bytes
-                    if tensor_bytes is None:
-                        shape = [get_hint(dim) for dim in t.shape]
-                        if all(s is not None for s in shape):
-                            numel = functools.reduce(operator.mul, shape, 1)
-                            tensor_bytes = numel * t.dtype.itemsize
-                    return t
-
-                torch.utils._pytree.tree_map_only(
-                    torch.Tensor, extract_first_tensor_bytes, (args, kw)
-                )
-
-            collective_keys.append(
-                f"{start.target} group_size:{group_size} group_name:{group_name} input_bytes:{tensor_bytes}"
-            )
+            collective_keys.append(_get_collective_key(start))
             benchmarked_ms, _ = benchmark_collective_with_cuda_events(start, nruns=5)
             benchmarked.append(benchmarked_ms if benchmarked_ms else 0.0)
 
@@ -322,63 +350,67 @@ def _log_graph_collective_benchmarks(gm: fx.GraphModule, artifact_name: str) -> 
 
 def _log_collective_benchmarks(
     collective_nodes: list[fx.Node],
-    collective_keys: list[str],
-    benchmarked_medians: list[float],
-    world_size: int,
-    artifact_name: str,
+    collective_keys: Optional[list[str]] = None,
+    benchmarked_medians: Optional[list[float]] = None,
+    world_size: Optional[int] = None,
+    artifact_name: str = "fx_collectives_analytical_estimation",
 ) -> None:
-    """Log collective benchmarks with analytical comparisons for tlparse."""
-    headers = [
-        "Collective Key",
-        "Benchmarked(ms)",
-        "NCCL Est(ms)",
-        "Inductor Est(ms)",
-        "NCCL Diff(ratio)",
-        "Inductor Diff(ratio)",
-    ]
+    """Log collective estimations for tlparse. Includes benchmarks if provided."""
+    if world_size is None:
+        world_size = (
+            torch.distributed.get_world_size()
+            if torch.distributed.is_initialized()
+            else 1
+        )
+
+    has_benchmarks = benchmarked_medians is not None
+
+    if has_benchmarks:
+        headers = [
+            "Collective Key",
+            "Benchmarked(ms)",
+            "NCCL Est(ms)",
+            "Inductor Est(ms)",
+            "NCCL Diff(ratio)",
+            "Inductor Diff(ratio)",
+        ]
+    else:
+        headers = [
+            "Collective Key",
+            "NCCL Est(ms)",
+            "Inductor Est(ms)",
+        ]
 
     rows = []
-    collective_benchmarks = {}
-    for key, benchmarked_ms, coll_node in zip(
-        collective_keys, benchmarked_medians, collective_nodes
-    ):
-        # NCCL estimator (deterministic, no need to align)
-        nccl_ms = (
-            torch._inductor.comm_analysis.estimate_nccl_collective_runtime_from_fx_node(
-                coll_node, None, use_nccl_estimator=True
+    for i, coll_node in enumerate(collective_nodes):
+        key = collective_keys[i] if collective_keys else _get_collective_key(coll_node)
+        nccl_ms, inductor_ms = _get_collective_estimations(coll_node)
+
+        if has_benchmarks:
+            benchmarked_ms = benchmarked_medians[i]
+            nccl_diff_pct = (nccl_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
+            inductor_diff_pct = (inductor_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
+            rows.append(
+                [
+                    key,
+                    f"{benchmarked_ms:.4f}",
+                    f"{nccl_ms:.4f}",
+                    f"{inductor_ms:.4f}",
+                    f"{nccl_diff_pct:.2f}",
+                    f"{inductor_diff_pct:.2f}",
+                ]
             )
-        )
-
-        # Inductor analytical (deterministic, no need to align)
-        inductor_ms = (
-            torch._inductor.comm_analysis.estimate_nccl_collective_runtime_from_fx_node(
-                coll_node, None, use_nccl_estimator=False
+        else:
+            rows.append(
+                [
+                    key,
+                    f"{nccl_ms:.4f}",
+                    f"{inductor_ms:.4f}",
+                ]
             )
-        )
 
-        collective_benchmarks[key] = {
-            "benchmarked_ms": benchmarked_ms,
-            "analytical_nccl_ms": nccl_ms,
-            "analytical_inductor_ms": inductor_ms,
-        }
-
-        # Compute percentage differences
-        nccl_diff_pct = (nccl_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
-        inductor_diff_pct = (inductor_ms / benchmarked_ms) if benchmarked_ms > 0 else 0
-
-        rows.append(
-            [
-                key,
-                f"{benchmarked_ms:.4f}",
-                f"{nccl_ms:.4f}",
-                f"{inductor_ms:.4f}",
-                f"{nccl_diff_pct:.2f}",
-                f"{inductor_diff_pct:.2f}",
-            ]
-        )
-
-    log_str = f"World size: {world_size}\n"
-    log_str += tabulate_2d(rows, headers)
+    log_str = f"# World size: {world_size}\n"
+    log_str += _format_csv(headers, rows)
 
     trace_structured(
         "artifact",

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -710,6 +710,20 @@ class OverlapScheduler:
                 world_size,
                 "fx_collectives_node_runtime_estimation",
             )
+        else:
+            # No benchmarking - log analytical estimations for all collectives
+            from torch._inductor.fx_passes.node_runtime_estimation import (
+                _log_collective_benchmarks,
+            )
+
+            all_collective_nodes = [
+                info.start_node for info in self.collective_info.values()
+            ]
+            if all_collective_nodes:
+                _log_collective_benchmarks(
+                    all_collective_nodes,
+                    artifact_name="fx_collectives_analytical_estimation",
+                )
 
         log.info("Overlap scheduling: Runtime estimations aligned")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172510
* #172488

Always log analytical NCCL/Inductor collective estimations to tlparse,
even when compile-time benchmarking is disabled. Switch from tabulate
format to CSV for easier parsing.

Changes:
- Add _format_csv() for parseable output format
- Add _get_collective_key() and _get_collective_estimations() shared helpers
- Extend _log_collective_benchmarks() to handle optional benchmarked data
- Log fx_collectives_analytical_estimation when benchmarking disabled
- Add test for CSV format parseability

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo