### PR TITLE
Fixing the attention mask in test, test_qwen2_7b_sdpa_input_alignment

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2607,7 +2607,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             torch.randn(
                 (B * S, Hkv * D), dtype=torch.bfloat16, device=device
             ),  # k_proj
-            torch.zeros((B, 1, S, S), dtype=torch.bool, device=device),  # attn_mask
+            torch.ones((B, 1, S, S), dtype=torch.bool, device=device),  # attn_mask
         )
         correct = forward(*example_inputs)
         compiled = torch.compile(forward, dynamic=True)
@@ -2621,7 +2621,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             torch.randn(
                 (S * B, Hkv * D), dtype=torch.bfloat16, device=device
             ),  # k_proj
-            torch.zeros((B, 1, S, S), dtype=torch.bool, device=device),  # attn_mask
+            torch.ones((B, 1, S, S), dtype=torch.bool, device=device),  # attn_mask
         )
         correct = forward(*example_inputs)
         actual = compiled(*example_inputs)


### PR DESCRIPTION
Fixes #163689.

Replaces #170857.

This is a PR to fix the test, test_qwen2_7b_sdpa_input_alignment_requires_recompile>
All the values in the mask tensor were False which led to the bias being -inf which led to NaNs in the final output.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo