### PR TITLE
[Dynamo] Update nn module hook handling to work with kwargs=True

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3509,6 +3509,106 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         assert not hasattr(compiled_model.linear, "_tmp_weight")
         torch.testing.assert_close(eager_output, compiled_output)
 
+    def test_submodule_forward_hooks_with_kwargs(self):
+        # Repro from https://github.com/pytorch/pytorch/issues/170110
+        # Tests the forward_hooks_with_kwargs does not result in error
+        # or large number of recompiles by default
+        class SimpleLinear(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class NLayerModel(torch.nn.Module):
+            def __init__(self, num_layers, dim):
+                super().__init__()
+                self.layers = torch.nn.ModuleDict(
+                    {str(i): SimpleLinear(dim) for i in range(num_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        def noop_hook(module, args, kwargs, output):
+            pass
+
+        inp = torch.randn(4, 4)
+        model = NLayerModel(num_layers=20, dim=4)
+        output_eager = model(inp)
+
+        # Set hooks for compiled layers
+        for _, layer in model.layers.named_children():
+            layer.linear.register_forward_hook(noop_hook, with_kwargs=True)
+
+        for i, layer in model.layers.named_children():
+            model.layers.register_module(i, torch.compile(layer, fullgraph=True))
+
+        output = model(inp)
+        self.assertEqual(output_eager, output)
+
+    # We cannot skip hook_guards here for correctness - otherwise, we will not
+    # treat the compiled subgraphs correctly (i.e, setting to True results in
+    # incorrect number of compiled hooks called)
+    @patch.object(torch._dynamo.config, "skip_nnmodule_hook_guards", False)
+    def test_submodule_forward_hooks_with_kwargs_complex(self):
+        class SimpleLinear(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class NLayerModel(torch.nn.Module):
+            def __init__(self, num_layers, dim):
+                super().__init__()
+                self.layers = torch.nn.ModuleDict(
+                    {str(i): SimpleLinear(dim) for i in range(num_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        def noop_hook(module, args, kwargs, output):
+            pass
+
+        # Tensor avoids recompiles - check that this is called
+        # the same # of times.  NOTE: when skip_nnmodule_hook_guards
+        # is false, these values don't match as we explicitly don't guard
+        call_count = torch.zeros(1)
+
+        def scale_output(module, args, kwargs, output):
+            call_count[0] += 1
+            return output * 0.5
+
+        inp = torch.randn(4, 4)
+        model = NLayerModel(num_layers=20, dim=4)
+        for idx, (_, layer) in enumerate(model.layers.named_children()):
+            if idx % 3 == 0:
+                layer.linear.register_forward_hook(noop_hook, with_kwargs=True)
+            elif idx % 3 == 1:
+                layer.linear.register_forward_hook(scale_output, with_kwargs=True)
+
+        output_eager = model(inp)
+        eager_call_count = call_count[0]
+        self.assertEqual(eager_call_count, 7)
+
+        for i, layer in model.layers.named_children():
+            model.layers.register_module(i, torch.compile(layer, fullgraph=True))
+
+        call_count[0] = 0
+        output = model(inp)
+        compiled_call_count = call_count[0]
+
+        self.assertEqual(compiled_call_count, eager_call_count)
+        self.assertTrue(torch.allclose(output_eager, output))
+
 
 devices = ["cuda", "hpu", "xpu"]
 instantiate_device_type_tests(

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3596,7 +3596,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
                 layer.linear.register_forward_hook(scale_output, with_kwargs=True)
 
         output_eager = model(inp)
-        eager_call_count = call_count[0]
+        eager_call_count = call_count.item()
         self.assertEqual(eager_call_count, 7)
 
         for i, layer in model.layers.named_children():
@@ -3604,7 +3604,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
 
         call_count[0] = 0
         output = model(inp)
-        compiled_call_count = call_count[0]
+        compiled_call_count = call_count.item()
 
         self.assertEqual(compiled_call_count, eager_call_count)
         self.assertTrue(torch.allclose(output_eager, output))

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2593,6 +2593,47 @@ class GuardBuilder(GuardBuilderBase):
             return
         self.SEQUENCE_LENGTH(guard)
 
+    def NN_MODULE_HOOKS_IDENTITY(self, guard: Guard) -> None:
+        """
+        Guard on nn module hooks by checking the identity of hook functions.
+
+        This guard checks:
+        1. The length of the hooks dict
+        2. The identity (id) of each hook function in order
+
+        This allows reduces recompilations from O(num_modules) to O(num_unique_hook_patterns).
+        """
+        if config.skip_nnmodule_hook_guards:
+            return
+
+        ref = self.arg_ref(guard)
+        hooks_dict = self.get(guard)
+        self.SEQUENCE_LENGTH(guard)
+
+        # Set for export
+        hook_ids = tuple(id(hook) for hook in hooks_dict.values())
+        code = [f"tuple(id(v) for v in {ref}.values()) == {hook_ids!r}"]
+        self._set_guard_export_info(guard, code)
+
+        # Add guards for each function
+        guard_manager = self.get_guard_manager(guard)
+        assert isinstance(guard_manager, DictGuardManager), (
+            "Module hooks should be in dict guard manager"
+        )
+        for i, (hook, expected_id) in enumerate(zip(hooks_dict.values(), hook_ids)):
+            value_code = [f"id(list({ref}.values())[{i}]) == {expected_id}"]
+            value_manager = guard_manager.get_value_manager(
+                index=i,
+                source=f"{guard.name}[{i}]",
+                example_value=hook,
+                guard_manager_enum=GuardManagerType.GUARD_MANAGER,
+            )
+            value_manager.add_id_match_guard(
+                expected_id,
+                get_verbose_code_parts(value_code, guard),
+                guard.user_stack,
+            )
+
     def GRAD_MODE(self, guard: Guard) -> None:
         pass  # we always guard on this via GlobalStateGuard()
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3973,7 +3973,12 @@ def format_bytecode(
     return f"{prefix} {name} {filename} line {line_no} \n{dis.Bytecode(code).dis()}\n"
 
 
-forward_hook_names = ["_forward_pre_hooks", "_forward_hooks"]
+forward_hook_names = [
+    "_forward_pre_hooks",
+    "_forward_pre_hooks_with_kwargs",
+    "_forward_hooks_with_kwargs",
+    "_forward_hooks",
+]
 backward_hook_names = ["_backward_pre_hooks", "_backward_hooks"]
 state_dict_hook_names = [
     "_state_dict_pre_hooks",

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -1287,11 +1287,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
         ):
             hooks_dict = getattr(self.value, name)
             hooks_dict_source = AttrSource(self.source, name)
-            # Guard on hook function id's so that duplicate layers w/ identical hooks
-            # don't cause recompiles
-            install_guard(
-                hooks_dict_source.make_guard(GuardBuilder.NN_MODULE_HOOKS_IDENTITY)
-            )
+            install_guard(hooks_dict_source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
             tx.output.guard_on_key_order.add(hooks_dict_source)
 
             def build_key_value(

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -1098,7 +1098,13 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                     self.var_getattr(tx, "_backward_hooks").realize().len()  # type: ignore[attr-defined]
                     or self.var_getattr(tx, "_backward_pre_hooks").realize().len()  # type: ignore[attr-defined]
                     or self.var_getattr(tx, "_forward_hooks").realize().len()  # type: ignore[attr-defined]
+                    or self.var_getattr(tx, "_forward_hooks_with_kwargs")  # type: ignore[attr-defined]
+                    .realize()
+                    .len()
                     or self.var_getattr(tx, "_forward_pre_hooks").realize().len()  # type: ignore[attr-defined]
+                    or self.var_getattr(tx, "_forward_pre_hooks_with_kwargs")  # type: ignore[attr-defined]
+                    .realize()
+                    .len()
                     or globals_vt.var_getattr(tx, "_global_backward_pre_hooks").len()  # type: ignore[attr-defined]
                     or globals_vt.var_getattr(tx, "_global_backward_hooks").len()  # type: ignore[attr-defined]
                     or globals_vt.var_getattr(tx, "_global_forward_hooks").len()  # type: ignore[attr-defined]
@@ -1244,7 +1250,9 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
         if name in (
             "_backward_hooks",
             "_backward_pre_hooks",
+            "_forward_hooks_with_kwargs",
             "_forward_hooks",
+            "_forward_pre_hooks_with_kwargs",
             "_forward_pre_hooks",
         ):
             # For empty hooks, make an EMPTY_NN_MODULE_HOOKS_DICT. This allows us to control the installation of empty
@@ -1270,14 +1278,20 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
             self.source
             and name
             in (
+                "_forward_pre_hooks_with_kwargs",
                 "_forward_pre_hooks",
+                "_forward_hooks_with_kwargs",
                 "_forward_hooks",
             )
             and not tx.output.side_effects.has_pending_mutation_of_attr(self, name)
         ):
             hooks_dict = getattr(self.value, name)
             hooks_dict_source = AttrSource(self.source, name)
-            install_guard(hooks_dict_source.make_guard(GuardBuilder.SEQUENCE_LENGTH))
+            # Guard on hook function id's so that duplicate layers w/ identical hooks
+            # don't cause recompiles
+            install_guard(
+                hooks_dict_source.make_guard(GuardBuilder.NN_MODULE_HOOKS_IDENTITY)
+            )
             tx.output.guard_on_key_order.add(hooks_dict_source)
 
             def build_key_value(


### PR DESCRIPTION
Fixes #170110 by:

### Summary

Adding `forward_hooks_with_kwargs` and its "pre" equivalent into the existing hook checks.  This solves excessive recompiles in the simple, no-op case (see new test case, `test_submodule_forward_hooks_with_kwargs`), but requires "skip_nn_module_hooks" to be turned off for more complex test cases (see new test case`test_submodule_forward_hooks_with_kwargs_complex`)

### Unit Test

```
pytest test/dynamo/test_modules.py::OptimizedModuleTest::test_submodule_forward_hooks_with_kwargs_complex
```
and
```
pytest test/dynamo/test_modules.py::OptimizedModuleTest::test_submodule_forward_hooks_with_kwargs_complex
```

#### output
```
1 passed in 8.29s 
```
and
```
1 passed in 9.01s 
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @mlazos