### PR TITLE
[xpu][feature] Enable XPU_MKLDNN as shared library type

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1672,6 +1672,16 @@ endif()
 
 # ---[ XPU library.
 if(USE_XPU)
+  if(XPU_MKLDNN_SHARED_LIBRARY)
+    set_target_properties(torch_xpu PROPERTIES
+      INSTALL_RPATH "$ORIGIN" )
+    target_link_options(torch_xpu PRIVATE
+      "-Wl,--disable-new-dtags"
+    )
+    install(FILES ${XPU_MKLDNN_INSTALLED_FILES}
+      DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+  endif()
+
   target_link_libraries(torch_xpu INTERFACE torch::xpurt)
 
   target_link_libraries(torch_xpu PUBLIC c10_xpu)
@@ -1680,8 +1690,14 @@ if(USE_XPU)
       torch_xpu INTERFACE $<INSTALL_INTERFACE:include>)
   target_include_directories(
       torch_xpu PRIVATE ${Caffe2_XPU_INCLUDE})
-  target_link_libraries(
+  
+  if(XPU_MKLDNN_SHARED_LIBRARY)
+    target_link_libraries(
+      torch_xpu PUBLIC ${Caffe2_XPU_DEPENDENCY_LIBS})
+  else()
+    target_link_libraries(
       torch_xpu PRIVATE ${Caffe2_XPU_DEPENDENCY_LIBS})
+  endif()
 
   # Ensure that torch_cpu is ready before being linked by torch_xpu.
   add_dependencies(torch_xpu torch_cpu)


### PR DESCRIPTION
Currently, libtorch_xpu.so links a static libdnnl.a which prevents quickly debug via switching onednn library versions. 

This PR enable a build/link path that build xpu onednn libaray as shared library and link it dynamicly so that user could debug onednn issue via replace libdnnl.so.

I add a ENV var `XPU_MKLDNN_LIBRARY_TYPE` = `STATIC`(default) or `SHARED` to switch library type.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal