### PR TITLE
Fix torch.isin compile shape for scalar test_elements

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -13687,6 +13687,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             elements = torch.tensor([1, 2, 3, 4])
             test_elements = 1
             self.common(torch.isin, (elements, test_elements), {"invert": invert})
+            torch._dynamo.reset()
+            elements = torch.tensor([1, 2, 3, 4], device=self.device)
+            test_elements = torch.tensor(2, device=self.device)
+            self.common(torch.isin, (elements, test_elements), {"invert": invert})
 
         elements = torch.tensor(3.0)
         test_elements = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5400,6 +5400,9 @@ def bernoulli(
 def isin_default(elements, test_elements, *, invert=False):
     if elements.numel() == 0:
         return torch.empty_like(elements, dtype=torch.bool)
+    if test_elements.ndim == 0:
+        res = elements == test_elements
+        return ~res if invert else res
     expanded_elem_shape = elements.shape + (1,) * test_elements.ndim
     x = elements.view(expanded_elem_shape)
     dim = tuple(range(-1, -test_elements.ndim - 1, -1))


### PR DESCRIPTION
## Issue
- https://github.com/pytorch/pytorch/issues/172529

## Summary
- Handle 0-d `test_elements` in the `torch.isin` decomposition without reducing to a scalar in compiled mode.
- Add a regression test for tensor elements with 0-d tensor `test_elements` under `torch.compile`.

## Motivation
- `torch.compile` returned a scalar output when `test_elements` was a 0-d tensor, while eager returned a tensor matching `elements.shape`.

## Validation
- Local repro with nightly CPU wheel `2.11.0.dev20260114+cpu` on Python 3.13 (Windows).
- Verified eager vs `torch.compile` (Inductor) shape parity for `test_elements=[2]` and `test_elements=scalar`.
- No full test suite run.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos