### PR TITLE
Fix the expected number of imports in `test_cutedsl_template.py`

### DIFF
--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -87,7 +87,7 @@ class TestCuteDSLTemplate(TestCase):
         self.assertIsInstance(imports, str)
 
         lines = imports.strip().split("\n")
-        self.assertEqual(len(lines), 7)
+        self.assertEqual(len(lines), 8)
 
     def test_render_includes_imports(self):
         template_source = """@cute.kernel


### PR DESCRIPTION
As per title, because it seems that `CuteDSLTemplateKernel.gen_imports` has 8 imports:

https://github.com/pytorch/pytorch/blob/e040897dcb90a8e4c7b19e0b89eaf8eb69cffe7e/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py#L136-L151


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo