### PR TITLE
[inductor] Document `CUTEDSL` and `NVGEMM` in `max_autotune_gemm_backends` config

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -552,10 +552,12 @@ force_same_precision: bool = Config(
 multi_kernel_hints: list[int] = []
 
 # Specify candidate backends for gemm autotune.
-# Possible choices are combinations of: ATen, Triton, CUTLASS, CK, CKTILE, CPP.
+# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, NVGEMM, CK, CKTILE, CPP.
 # ATen: default Pytorch ATen kernels.
 # Triton: Triton templates defined in torch inductor (AMD and NVidia GPUs).
 # CUTLASS: Cutlass templates and kernels (NVidia GPUs only).
+# CUTEDSL: CuteDSL templates for Blackwell GPUs (NVidia SM100-SM109 only).
+# NVGEMM: NVIDIA Universal GEMM via cutlass_api (NVidia GPUs only).
 # CK: Composable Kernel templates and kernels (AMD Instinct GPUs only).
 # CKTILE: Composable Kernel templates and kernels, new API (AMD Instinct GPUs only).
 # CPP: CPP templates and kernels for CPU.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -551,6 +551,7 @@ force_same_precision: bool = Config(
 # as expected before turning it on for everyone.
 multi_kernel_hints: list[int] = []
 
+
 # Specify candidate backends for gemm autotune.
 # Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, NVGEMM, CK, CKTILE, CPP.
 # ATen: default Pytorch ATen kernels.


### PR DESCRIPTION
## Summary
Updates the documentation comment for `max_autotune_gemm_backends` config to include two missing backend options: `CUTEDSL` and `NVGEMM`.

## Details
The config comment listed only 6 backends (ATEN, Triton, CUTLASS, CK, CKTILE, CPP), but the codebase actually supports 8 backends. This PR adds documentation for:

- **CUTEDSL**: CuteDSL templates for Blackwell GPUs (SM100+), used for grouped GEMM operations
- **NVGEMM**: NVIDIA Universal GEMM via `cutlass_api` library

These backends are checked via `_use_autotune_backend()` in `torch/_inductor/utils.py` but were missing from the config documentation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo