### PR TITLE
[Quant][X86] Use onednn primitive for fp8 qconv

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -463,6 +463,9 @@ at::Tensor _qconv_prepack_onednn(
 #define FP8E4M3_MAX 448.0
 
 #define CACHE_ONEDNN_CONTEXT_FLAG "ONEDNN_CACHE_CONTEXT_UNSAFE"
+#if IDEEP_PREREQ(3, 9, 0, 0)
+#define ONEDNN_FP8_QCONV_SUPPORTED
+#endif
 
 struct QlinearForwardParams {
   dnnl::matmul primitive;

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1625,7 +1625,11 @@ static at::Tensor _quantized_convolution_onednn(
     func_name, ": dilation should contain ", kSpatialDim, " elements for ",
     kSpatialDim, "D convolution.");
   bool is_fp8 = weight.scalar_type() == c10::ScalarType::Float8_e4m3fn;
+#if IDEEP_PREREQ(3, 9, 0, 0)
+  if (is_fp8 && !cpuinfo_has_x86_amx_fp16()) {
+#else
   if (is_fp8) {
+#endif
     TORCH_CHECK(act_dtype == c10::ScalarType::Float8_e4m3fn,
       func_name, ": expect input tensor to have fp8 data type, but got ", act_dtype);
     TORCH_CHECK(act_zero_point == 0,

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1625,7 +1625,7 @@ static at::Tensor _quantized_convolution_onednn(
     func_name, ": dilation should contain ", kSpatialDim, " elements for ",
     kSpatialDim, "D convolution.");
   bool is_fp8 = weight.scalar_type() == c10::ScalarType::Float8_e4m3fn;
-#if IDEEP_PREREQ(3, 9, 0, 0)
+#ifdef ONEDNN_FP8_QCONV_SUPPORTED
   if (is_fp8 && !cpuinfo_has_x86_amx_fp16()) {
 #else
   if (is_fp8) {

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -539,7 +539,11 @@ at::Tensor _qconv_prepack_onednn(
     dilation = quant_utils::MakeArgForConv1d(dilation, 1);
     kSpatialDim += 1;
   }
+#if IDEEP_PREREQ(3, 9, 0, 0)
+  if (is_fp8 && !cpuinfo_has_x86_amx_fp16()) {
+#else
   if (is_fp8) {
+#endif
     // The current version of oneDNN does not support fp8 conv
     // TODO(weiwen) Remove this when oneDNN supports fp8 conv
     // FP8 convolution is not supported by oneDNN until v3.9

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -544,9 +544,9 @@ at::Tensor _qconv_prepack_onednn(
 #else
   if (is_fp8) {
 #endif
-    // The current version of oneDNN does not support fp8 conv
-    // TODO(weiwen) Remove this when oneDNN supports fp8 conv
-    // FP8 convolution is not supported by oneDNN until v3.9
+    // Fall back when FP8 convolution is not supported by oneDNN:
+    // - For oneDNN versions prior to v3.9, FP8 convolution is unsupported.
+    // - For oneDNN v3.9 and later, FP8 convolution requires AMX_FP16 support.
     return weight;
   }
   auto w_dims = weight.sizes().vec();

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -539,7 +539,7 @@ at::Tensor _qconv_prepack_onednn(
     dilation = quant_utils::MakeArgForConv1d(dilation, 1);
     kSpatialDim += 1;
   }
-#if IDEEP_PREREQ(3, 9, 0, 0)
+#ifdef ONEDNN_FP8_QCONV_SUPPORTED
   if (is_fp8 && !cpuinfo_has_x86_amx_fp16()) {
 #else
   if (is_fp8) {


### PR DESCRIPTION
Fp8 qconv went to ref kernel previously due to lack of support in oneDNN. Now we can use oneDNN primitive for fp8 qconv when oneDNN version >= 3.9 (PyTorch uses 3.10 now and it is guarded by version check).

**Test plan**
Already covered by UT.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01