### PR TITLE
[docs] Fix torch.sparse.mm gradient support documentation

### DIFF
--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -73,13 +73,22 @@ mm = _add_docstr(
     and the (sparse or strided) matrix :attr:`mat2`. Similar to :func:`torch.mm`, if :attr:`mat1` is a
     :math:`(n \times m)` tensor, :attr:`mat2` is a :math:`(m \times p)` tensor, out will be a
     :math:`(n \times p)` tensor.
+
     When :attr:`mat1` is a COO tensor it must have `sparse_dim = 2`.
-    When inputs are COO tensors, this function also supports backward for both inputs.
 
-    Supports both CSR and COO storage formats.
+    Supports both CSR and COO storage formats for :attr:`mat1`.
 
-.. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
+    .. note::
+        **Gradient Support:**
+
+        - **Sparse @ Dense (COO or CSR @ strided):** Backward is supported for both inputs.
+        The sparse input receives a sparse gradient matching its input format (COO→COO, CSR→CSR),
+        while the dense input receives a dense gradient.
+
+        - **Sparse @ Sparse (COO @ COO or CSR @ CSR):** Forward pass is supported, but
+        backward is **not implemented** and will raise a RuntimeError.
+
+        - **Mixed sparse formats (COO @ CSR or CSR @ COO):** Not supported. Will raise a RuntimeError.
 
     This function also additionally accepts an optional :attr:`reduce` argument that allows
     specification of an optional reduction operation, mathematically performs the following operation:

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -82,11 +82,11 @@ mm = _add_docstr(
         **Gradient Support:**
 
         - **Sparse @ Dense (COO or CSR @ strided):** Backward is supported for both inputs.
-        The sparse input receives a sparse gradient matching its input format (COO→COO, CSR→CSR),
-        while the dense input receives a dense gradient.
+          The sparse input receives a sparse gradient matching its input format (COO→COO, CSR→CSR),
+          while the dense input receives a dense gradient.
 
         - **Sparse @ Sparse (COO @ COO or CSR @ CSR):** Forward pass is supported, but
-        backward is **not implemented** and will raise a RuntimeError.
+          backward is **not implemented** and will raise a RuntimeError.
 
         - **Mixed sparse formats (COO @ CSR or CSR @ COO):** Not supported. Will raise a RuntimeError.
 


### PR DESCRIPTION
### What does this PR do?

Fixes the `torch.sparse.mm` documentation to accurately reflect gradient support for COO and CSR sparse matrices.

### Motivation

The `torch.sparse.mm` documentation contains statements that do not match the observed behaviour:

#### Inaccurate Statement

> "This function doesn't support computing derivatives with respect to CSR matrices."

**Observed behaviour:** CSR @ Dense operations **do** support backward pass and return sparse CSR gradients on both CPU and CUDA.

#### Ambiguous Statement

> "When inputs are COO tensors, this function also supports backward for both inputs."

**Observed behaviour:** This is only true for **COO @ Dense**, not **COO @ COO**. The COO @ COO backward pass raises a `RuntimeError` (internal assert failure).
### Changes

- Removed the incorrect claim about CSR derivatives not being supported
- Added a clear "Gradient Support" section documenting:
  - Sparse @ Dense (COO/CSR @ strided): backward supported, sparse gradients returned
  - Sparse @ Sparse (COO @ COO, CSR @ CSR): forward only, backward not implemented
  - Mixed formats (COO @ CSR, CSR @ COO): not supported

### Testing

Verified behaviour locally on:
- PyTorch nightly 2.11.0.dev20260114+cu130, CUDA 13.0
- PyTorch stable 2.9.1+cu130, CUDA 13.0
- Both CPU and CUDA devices

See reproduction colab notebook: [PyTorch_sparse_mm_behaviour.ipynb](https://colab.research.google.com/drive/1xgJgKxQqaxaVB_65OqjttF4OC-m7GYE5?usp=sharing)

### Related Issues

Fixes #172550

Related:
- #41128 — Memory bug for backward on `torch.sparse.mm` (sparse gradient memory issue)
- #86963 — Derivatives with respect to CSR matrices in `torch.sparse.mm`
- #96769 — `sparse.mm` triggers INTERNAL ASSERT FAILED when both inputs are sparse
- #87448 — Sparse tensor semantics discussion (broader gradient sparsity expectations)

---