### PR TITLE
Fix deadlock caused by early return in batch norm backward channels-last kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -1227,16 +1227,12 @@ __global__ void batch_norm_backward_reduce_channels_last_kernel(
   int m_offset = blockIdx.y * blockDim.y + threadIdx.y;
   int c_offset = blockIdx.x * blockDim.x + threadIdx.x;
 
-  if (c_offset >= stride || m_offset >= reduction_size) {
-    return;
-  }
-
   int loop_count = 1 + (reduction_size - 1) / (inner_loop_stride * PARALLEL_LOADS);
   int address_base = m_offset * stride + c_offset;
   int address_increment = inner_loop_stride * stride;
 
-  auto r_mean = mean[c_offset];
-  auto factor = inv_std[c_offset];
+  auto r_mean = (c_offset < stride) ? mean[c_offset] : accscalar_t(0);
+  auto factor = (c_offset < stride) ? inv_std[c_offset] : accscalar_t(0);
 
   for (int i = 0; i < loop_count; i++) {
     accscalar_t x_input[PARALLEL_LOADS];

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7406,6 +7406,26 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last, (0, 2, 3))
         _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_batchnorm_channels_last_backward_no_deadlock(self):
+        # Regression test for channels-last BatchNorm backward deadlock.
+        # This test intentionally does NOT check numerical accuracy.
+        # The test passes as long as backward completes without hanging.
+
+        torch.manual_seed(0)
+
+        x = torch.randn(
+            2, 32, 16, 16,
+            device="cuda",
+            dtype=torch.float32,
+            requires_grad=True,
+        ).to(memory_format=torch.channels_last)
+
+        bn = torch.nn.BatchNorm2d(32).cuda()
+
+        y = bn(x)
+        y.sum().backward()
+
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)
 


### PR DESCRIPTION
### Summary

This PR fixes a deadlock issue in the batch norm backward channels-last kernel on CUDA-style devices, such as MUSA, which port CUDA kernels to run on Moore Threads GPUs.

In CUDA/MUSA kernels, all threads in a block must participate in `__syncthreads()`.  
Early returning some threads before synchronization may cause a hang, as documented in the CUDA C Programming Guide:
https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#synchronization-functions

### Fix

The early return is removed so that all threads participate in synchronization.  
Inactive threads contribute zero to the reduction and do not affect numerical correctness.
