### PR TITLE
Fix `TestGradCollectives.test_all_reduce`

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -421,7 +421,7 @@ class TestGradCollectives(MultiThreadedTestCase):
         y = torch.rand([4], requires_grad=True)
         out = ft_c.all_reduce(x, "sum", dist.group.WORLD)
         (out + y).sum().backward()
-        self.assertIsNone(x.grad)
+        self.assertIsNotNone(x.grad)
 
 
 class TestMakeFx(TestCase):


### PR DESCRIPTION
The test condition is inverted and needs to check for *NOT* `None`.

See https://hud.pytorch.org/pr/pytorch/pytorch/159862#60476017018

Fixes e22d791287d1c00cd11b9229ad15d030224ab4b1 from #93990

cc @kumpera 