### PR TITLE
CUDA Stream Sanitizer fixes

### DIFF
--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -26,10 +26,10 @@ from typing import Any, TypeVar
 
 import torch
 import torch.cuda._gpu_trace as gpu_trace
-from torch.ops import aten
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
 
+aten = torch.ops.aten
 
 DEFAULT_STREAM_ID = 0
 

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -29,6 +29,7 @@ import torch.cuda._gpu_trace as gpu_trace
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
 
+
 aten = torch.ops.aten
 
 DEFAULT_STREAM_ID = 0

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -26,9 +26,9 @@ from typing import Any, TypeVar
 
 import torch
 import torch.cuda._gpu_trace as gpu_trace
+from torch.ops import aten
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
-from torch.ops import aten
 
 
 DEFAULT_STREAM_ID = 0

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -79,6 +79,18 @@ class Access:
     is_output: bool
     stack_trace: traceback.StackSummary
 
+    def format(self, message: io.StringIO):
+        message.write(f"{self.operator}\n{self.type}")
+        if self.aliases:
+            message.write(" argument(s) " + ", ".join(self.aliases))
+            if self.is_output:
+                message.write(", and to")
+        if self.is_output:
+            message.write(" the output")
+        message.write(
+            f"\nWith stack trace:\n{''.join(self.stack_trace.format())}\n"
+        )
+
 
 class SynchronizationError(Exception):
     """Base class for errors detected by CUDA Sanitizer."""
@@ -100,18 +112,6 @@ class UnsynchronizedAccessError(SynchronizationError):
         self.previous_access = previous_access
 
     def __str__(self):
-        def format_access(access: Access):
-            message.write(f"{access.operator}\n{access.type}")
-            if access.aliases:
-                message.write(" argument(s) " + ", ".join(access.aliases))
-                if access.is_output:
-                    message.write(", and to")
-            if access.is_output:
-                message.write(" the output")
-            message.write(
-                f"\nWith stack trace:\n{''.join(access.stack_trace.format())}\n"
-            )
-
         with io.StringIO() as message:
             message.write(
                 textwrap.dedent(
@@ -122,12 +122,12 @@ class UnsynchronizedAccessError(SynchronizationError):
                     """
                 )
             )
-            format_access(self.current_access)
+            self.current_access.format(message)
 
             message.write(
                 f"Previous access by stream {self.previous_access.stream} during kernel:\n"
             )
-            format_access(self.previous_access)
+            self.previous_access.format(message)
 
             if self.allocation_stack_trace:
                 message.write(
@@ -136,6 +136,30 @@ class UnsynchronizedAccessError(SynchronizationError):
                 )
             else:
                 message.write("Trace for tensor allocation not found.")
+            return message.getvalue()
+
+
+class NullTensorAccessError(SynchronizationError):
+    """Stores information about an access of a Tensor without a valid data_ptr."""
+
+    def __init__(
+        self,
+        current_access: Access
+    ):
+        self.current_access = current_access
+
+    def __str__(self):
+        with io.StringIO() as message:
+            message.write(
+                textwrap.dedent(
+                    f"""\
+                    ============================
+                    CSAN detected a Tensor without a valid data_ptr
+                    Access by stream {self.current_access.stream} during kernel:
+                    """
+                )
+            )
+            self.current_access.format(message)
             return message.getvalue()
 
 
@@ -398,6 +422,10 @@ class EventHandler:
                 data_ptr, current_access, self.tensors_accessed.get_write(data_ptr)
             )
             self.tensors_accessed.add_read(data_ptr, current_access)
+            if not data_ptr:
+                error_list.append(
+                    NullTensorAccessError(current_access)
+                )
 
         for data_ptr in read_write:
             self.tensors_accessed.ensure_tensor_exists(data_ptr)
@@ -418,6 +446,10 @@ class EventHandler:
                     data_ptr, current_access, self.tensors_accessed.get_write(data_ptr)
                 )
             self.tensors_accessed.set_write(data_ptr, current_access)
+            if not data_ptr:
+                error_list.append(
+                    NullTensorAccessError(current_access)
+                )
 
         return error_list
 

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -591,6 +591,10 @@ class CUDASanitizerDispatchMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
 
+        # record_stream is not a kernel dispatch, skip it
+        if str(func) == "aten.record_stream.default":
+            return func(*args, **kwargs)
+
         is_factory = bool(FACTORY_FUNCTION_REGEX.match(func._schema.name))
 
         argument_handler = ArgumentHandler()

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -497,7 +497,9 @@ class ArgumentHandler:
         is_output: bool = False,
     ) -> None:
         if isinstance(value, torch.Tensor) and value.is_cuda:
-            data_ptr = value.data_ptr()
+            # data_ptr() is preferred, but distinguish Tensors with null data_ptr()
+            # otherwise two empty Tensors could incorrectly match as a conflict
+            data_ptr = value.data_ptr() if value.data_ptr() else id(value)
             if is_write:
                 self.dataptrs_written.add(data_ptr)
             elif not metadata_only:

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -28,6 +28,7 @@ import torch
 import torch.cuda._gpu_trace as gpu_trace
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
+from torch.ops import aten
 
 
 DEFAULT_STREAM_ID = 0
@@ -594,7 +595,7 @@ class CUDASanitizerDispatchMode(TorchDispatchMode):
             kwargs = {}
 
         # record_stream is not a kernel dispatch, skip it
-        if str(func) == "aten.record_stream.default":
+        if func is aten.record_stream.default:
             return func(*args, **kwargs)
 
         is_factory = bool(FACTORY_FUNCTION_REGEX.match(func._schema.name))


### PR DESCRIPTION
Two issues are fixed here:

- skip operator aten.record_stream.default, otherwise correct uses of tensor.record_stream(stream) are flagged.
- if a Tensor's data_ptr() is 0, track its id() instead to avoid errors in fbgemm using 0-element Tensors as placeholders

This PR replaces #168313 that was blocked by infra issue of pytorchbot PAT and ROCm fork.