### PR TITLE
Cleanup buffer hook after failed export

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -234,10 +234,10 @@ def aot_dispatch_base_graph(
     # (In contrast, strict mode errors on any attribute assignment.)
     mod_when_exporting_non_strict = root_module_when_exporting_non_strict(flat_fn)
     hook = None
+    assigned_buffers: dict[str, str] = {}
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
         # For any buffer that is assigned, we want to associate it to the final proxy node
         # that it is assigned to. This node can then be added as a buffer mutation output.
-        assigned_buffers: dict[str, str] = {}
         hook = register_buffer_assignment_hook(
             mod_when_exporting_non_strict, assigned_buffers
         )


### PR DESCRIPTION
Fixes #172213 

**Issue Summary:**

When ```torch.export.export()``` is called on a model with buffer mutations, it installs a global buffer-assignment hook (```_map_assigned_buffer_to_proxy```) that expects FakeTensor during tracing. If export fails mid-way (e.g., due to data-dependent control flow), this hook is not removed, leaving the original nn.Module in a corrupted state. Subsequent eager-mode forward passes crash with ```AssertionError: assert isinstance(buffer, FakeTensor)``` because the leftover hook is triggered and receives real tensors instead of fake Tensors as expected.


**Proposed Fix:**

Wrap the export tracing logic in a ```try/finally``` block to ensure the buffer-assignment hook is always removed, even when an exception occurs. This fix is applied in two locations: ```torch/export/_trace.py``` (for OSS export via ```_export_to_aten_ir_make_fx```) and ```torch/_functorch/_aot_autograd/graph_capture.py``` (for internal export via ```aot_dispatch_base_graph```). A regression test is added to verify that eager mode works correctly after a failed export attempt.
