### PR TITLE
Allow "store" before or after "gdc_launch" in `test_pdl_template_and_delay`

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15240,14 +15240,14 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             .check("'launch_pdl': True")
             .check("gdc_wait")
             .check("load")
-            .check("gdc_launch")
-            .check("store")
+            .check_dag("gdc_launch")
+            .check_dag("store")
             # second kernel, no need to wait before load
             .check("'launch_pdl': True")
             .check("load")
             .check("gdc_wait")
-            .check("gdc_launch")
-            .check("store")
+            .check_dag("gdc_launch")
+            .check_dag("store")
             # matmul template
             .check_not("'launch_pdl': True")
             .check_not("gdc_wait")


### PR DESCRIPTION
It looks like the kernel generated for `test_pdl_template_and_delay_dynamic_shapes_cuda` places the "store" call before "gdc_launch":
```python
@triton.jit
def triton_red_fused_div_pow_sum_1(in_ptr0, out_ptr1, ks0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
    ...
    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
        ...
        tl.store(out_ptr1 + (r0_1 + ks0*x0), tmp7, r0_mask & xmask)
    tl.extra.cuda.gdc_launch_dependents()
''', device_str='cuda')
```
The base version of this test (without dynamic shapes) in `test_torchinductor.py` expects the "store" call to come afterwards. Replaced the `check` calls with `check_dag` to treat both orders as valid, but can dig for a deeper root cause if this behavior is concerning.

Fixes #172579


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo