### PR TITLE
[BE] Remove unnecessary workarounds

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12681,16 +12681,6 @@ class TestConsistency(TestCaseMPS):
             mps_args = [mps_sample.input] + list(mps_sample.args)
             mps_kwargs = mps_sample.kwargs
 
-            # for tensor_split(), the second tensor arg ("tensor_indices_or_sections") must be on CPU only
-            if op.name == "tensor_split" and isinstance(mps_args[1], torch.Tensor):
-                mps_args[1] = cpu_args[1]
-
-            # Order of ops in index_put is not guaranteed, which can lead to large errors if inputs are
-            # not normalized
-            if op.name == "_unsafe_masked_index_put_accumulate" and dtype in [torch.bfloat16, torch.float16]:
-                mps_args[3] = F.normalize(mps_args[3])
-                cpu_args[3] = F.normalize(cpu_args[3])
-
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
                 cpu_out = op(*cpu_args, **cpu_kwargs)
@@ -12747,16 +12737,6 @@ class TestConsistency(TestCaseMPS):
             cpu_kwargs = cpu_sample.kwargs
             mps_args = [mps_sample.input] + list(mps_sample.args)
             mps_kwargs = mps_sample.kwargs
-
-            # for tensor_split(), the second tensor arg ("tensor_indices_or_sections") must be on CPU only
-            if op.name == "tensor_split" and isinstance(mps_args[1], torch.Tensor):
-                mps_args[1] = cpu_args[1]
-
-            # Order of ops in index_put is not guaranteed, which can lead to large errors if inputs are
-            # not normalized
-            if op.name == "_unsafe_masked_index_put_accumulate" and dtype in [torch.bfloat16, torch.float16]:
-                mps_args[3] = F.normalize(mps_args[3])
-                cpu_args[3] = F.normalize(cpu_args[3])
 
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12885,10 +12885,6 @@ class TestErrorInputs(TestCase):
             mps_args = [mps_sample_input.input] + list(mps_sample_input.args)
             mps_kwargs = mps_sample_input.kwargs
 
-            # for tensor_split(), the second tensor arg ("tensor_indices_or_sections") must be on CPU only
-            if (op.name == "tensor_split" and isinstance(mps_args[1], torch.Tensor)):
-                mps_args[1] = mps_args[1].cpu()
-
             with self.assertRaisesRegex(error_type, error_regex):
                 op(*mps_args, **mps_kwargs)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5442,6 +5442,12 @@ def sample_inputs__unsafe_masked_index_put_accumulate(op_info, device, dtype, re
         masks = [torch.logical_and(idx >= 0, idx < self_shape[i]) for i, idx in enumerate(indices) if idx is not None]
         mask = functools.reduce(torch.logical_and, masks)
         values = make_arg(idx_sizes)
+        if device == 'mps:0' and dtype in [torch.float16, torch.bfloat16]:
+            # TestConsistencyMPS.test_output_match compares CPU to MPS results
+            # Order of operations in GPU index_put_accumulate is not guaranteed,
+            # which can result in significant divergence between sequential and parallel execution
+            # Unless inputs are normalized
+            values = torch.nn.functional.normalize(values)
         yield SampleInput(make_arg(self_shape), mask, indices, values)
 
         masks = [torch.logical_and(idx >= 1, idx < self_shape[i] - 1) for i, idx in enumerate(indices) if idx is not None]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #172591
* #172590
* __->__ #172586

Since migratinig MPS opinfo test to sample from MPS, one no longer need to worry about tensor_split workaround
And move normalization to opinfo generator from test_mps