### PR TITLE
allow constant propagation for detach

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2529,7 +2529,7 @@ class FakeTensorMode(TorchDispatchMode):
             # for detach_ since the underlying data is unchanged.
             and (
                 torch.Tag.inplace_view not in func.tags
-                or func is not aten.detach_.default
+                or func is aten.detach_.default
             )
             and all_constant
             and len(flat_arg_fake_tensors) != 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172589

when some libraries are imported during pre-grad passes, for one of vllm models, we end up executing 
some global code that looks like
```
def inv_softplus(bias):
    if not isinstance(bias, torch.Tensor):
        bias = torch.tensor(bias)  # Creates tensor from scalar
    out = bias.expm1().clamp_min(1e-6).log()
    if out.numel() == 1:
        return out.item()  # Fails with DataDependentOutputException!
    return out
x = {inv_softplus(1.0)}
```
This is end up throwing DataDependentOutputException.

This could can be avoided if constant propagation is not interrupted.  torch.tensor(scalar) internally calls 
detach_() (I do not know why the detach happens here , but because it happens constant propagation 
is not happening on "1.0" since detach_ has the inplace_view tag and Inside
FakeTensorMode.__torch_dispatch__ ops with inplace_view tag skip the constant propagation block

detach does not change constant values so special handling it here. 
```
and (
    torch.Tag.inplace_view not in func.tags
    or func is aten.detach_.default  # Allow detach_ through
)
```

**Why detach_ is safe to special-case**
We dispatch size/stride/numel on the FakeTensor not its constant, so bail on inplace_view.
 Example: fake_a.transpose_(0,1) would mutate fake_a.constant in-place, changing its
shape from (2,3) to (3,2), while fake_a.shape still reports (2,3) → divergence.
However, detach_ is safe: it only mutates requires_grad (not shape/stride/data),
and constants are used purely for their values, not autograd.

