### PR TITLE
Fix: Makes worker shutdown timeout configurable in torchrun

### DIFF
--- a/test/distributed/elastic/agent/server/test/shutdown_timeout_test.py
+++ b/test/distributed/elastic/agent/server/test/shutdown_timeout_test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Owner(s): ["oncall: r2p"]
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import signal
+import tempfile
+import time
+from unittest.mock import MagicMock, Mock, patch
+
+from torch.distributed.elastic.agent.server.api import SimpleElasticAgent, WorkerSpec
+from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent
+from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs
+from torch.distributed.launcher.api import LaunchConfig
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def _sleep_long(duration: int):
+    """Worker function that sleeps for a specified duration."""
+    time.sleep(duration)
+    return int(os.environ["RANK"])
+
+
+class ShutdownTimeoutTest(TestCase):
+    """Tests for the configurable shutdown_timeout feature."""
+
+    def test_launch_config_default_shutdown_timeout(self):
+        config = LaunchConfig(
+            min_nodes=1,
+            max_nodes=1,
+            nproc_per_node=2,
+        )
+        self.assertEqual(config.shutdown_timeout, 30)
+
+    def test_launch_config_custom_shutdown_timeout(self):
+        config = LaunchConfig(
+            min_nodes=1,
+            max_nodes=1,
+            nproc_per_node=2,
+            shutdown_timeout=120,
+        )
+        self.assertEqual(config.shutdown_timeout, 120)
+
+    def test_launch_config_env_var_shutdown_timeout(self):
+        with patch.dict(os.environ, {"TORCH_ELASTIC_SHUTDOWN_TIMEOUT": "600"}):
+            config = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+            )
+            self.assertEqual(config.shutdown_timeout, 600)
+
+    def test_launch_config_explicit_overrides_env(self):
+        with patch.dict(os.environ, {"TORCH_ELASTIC_SHUTDOWN_TIMEOUT": "600"}):
+            config = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+                shutdown_timeout=120,
+            )
+            self.assertEqual(config.shutdown_timeout, 120)
+
+    def test_simple_elastic_agent_receives_shutdown_timeout(self):
+        mock_spec = Mock(spec=WorkerSpec)
+        mock_spec.max_restarts = 3
+
+        agent = SimpleElasticAgent(
+            spec=mock_spec,
+            exit_barrier_timeout=300,
+            shutdown_timeout=180,
+        )
+
+        self.assertEqual(agent._shutdown_timeout, 180)
+
+    def test_simple_elastic_agent_default_shutdown_timeout(self):
+        mock_spec = Mock(spec=WorkerSpec)
+        mock_spec.max_restarts = 3
+
+        agent = SimpleElasticAgent(
+            spec=mock_spec,
+            exit_barrier_timeout=300,
+        )
+
+        self.assertEqual(agent._shutdown_timeout, 30)
+
+    def test_local_elastic_agent_receives_shutdown_timeout(self):
+        mock_spec = Mock(spec=WorkerSpec)
+        mock_spec.max_restarts = 3
+        mock_spec.rdzv_handler = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logs_specs = DefaultLogsSpecs(log_dir=tmpdir)
+
+            agent = LocalElasticAgent(
+                spec=mock_spec,
+                logs_specs=logs_specs,
+                start_method="spawn",
+                exit_barrier_timeout=300,
+                shutdown_timeout=240,
+            )
+
+            self.assertEqual(agent._shutdown_timeout, 240)
+
+    def test_shutdown_method_receives_correct_timeout(self):
+        mock_spec = Mock(spec=WorkerSpec)
+        mock_spec.max_restarts = 3
+        mock_spec.rdzv_handler = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logs_specs = DefaultLogsSpecs(log_dir=tmpdir)
+
+            agent = LocalElasticAgent(
+                spec=mock_spec,
+                logs_specs=logs_specs,
+                start_method="spawn",
+                exit_barrier_timeout=300,
+                shutdown_timeout=150,
+            )
+
+            # Mock the _pcontext to avoid actual process operations
+            mock_pcontext = MagicMock()
+            agent._pcontext = mock_pcontext
+
+            # Call _shutdown directly
+            agent._shutdown(death_sig=signal.SIGTERM, timeout=150)
+
+            # Verify close was called with correct timeout
+            mock_pcontext.close.assert_called_once_with(signal.SIGTERM, 150)
+
+    @patch("torch.distributed.elastic.multiprocessing.api.PContext")
+    def test_pcontext_close_receives_timeout(self, mock_pcontext_class):
+        mock_pcontext = MagicMock()
+        mock_pcontext_class.return_value = mock_pcontext
+
+        # Simulate calling close with a custom timeout
+        mock_pcontext.close(death_sig=signal.SIGTERM, timeout=200)
+
+        # Verify it was called with the correct timeout
+        mock_pcontext.close.assert_called_once_with(
+            death_sig=signal.SIGTERM, timeout=200
+        )
+
+    def test_shutdown_timeout_validation_negative(self):
+        with self.assertRaises(ValueError) as cm:
+            LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+                shutdown_timeout=-5,
+            )
+        self.assertIn("shutdown_timeout must be non-negative", str(cm.exception))
+
+    def test_shutdown_timeout_zero(self):
+        config = LaunchConfig(
+            min_nodes=1,
+            max_nodes=1,
+            nproc_per_node=2,
+            shutdown_timeout=0,
+        )
+        self.assertEqual(config.shutdown_timeout, 0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -112,7 +112,7 @@ class LaunchConfig:
     duplicate_stdout_filters: list[str] | None = None
     duplicate_stderr_filters: list[str] | None = None
     virtual_local_rank: bool = False
-    shutdown_timeout: int = -1
+    shutdown_timeout: int | None = None
 
     def __post_init__(self):
         default_timeout = 900
@@ -135,11 +135,10 @@ class LaunchConfig:
             logger.info("Using default numa options = %r", self.numa_options)
 
         # Set shutdown_timeout from environment variable if not explicitly set
-        if self.shutdown_timeout == -1:
+        if self.shutdown_timeout is None:
             self.shutdown_timeout = int(
                 os.environ.get("TORCH_ELASTIC_SHUTDOWN_TIMEOUT", "30")
             )
-            logger.info("Using shutdown_timeout = %d seconds", self.shutdown_timeout)
         elif self.shutdown_timeout < 0:
             raise ValueError(
                 f"shutdown_timeout must be non-negative, got {self.shutdown_timeout}"
@@ -314,7 +313,7 @@ def launch_agent(
         logs_specs=config.logs_specs,  # type: ignore[arg-type]
         start_method=config.start_method,
         log_line_prefix_template=config.log_line_prefix_template,
-        shutdown_timeout=config.shutdown_timeout,
+        shutdown_timeout=config.shutdown_timeout,  # type: ignore[arg-type]
     )
 
     shutdown_rdzv = True

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -79,6 +79,9 @@ class LaunchConfig:
                            When enabled, LOCAL_RANK is set to 0 for all workers and
                            CUDA_VISIBLE_DEVICES is adjusted so each worker accesses its
                            assigned GPU at device index 0.
+        shutdown_timeout: Time in seconds to wait for graceful shutdown of workers before
+                        sending SIGKILL. Can also be set via TORCH_ELASTIC_SHUTDOWN_TIMEOUT
+                        environment variable. Defaults to 30 seconds.
 
 
     .. note::
@@ -109,6 +112,7 @@ class LaunchConfig:
     duplicate_stdout_filters: list[str] | None = None
     duplicate_stderr_filters: list[str] | None = None
     virtual_local_rank: bool = False
+    shutdown_timeout: int = -1
 
     def __post_init__(self):
         default_timeout = 900
@@ -129,6 +133,17 @@ class LaunchConfig:
         ):
             self.numa_options = get_default_numa_options()
             logger.info("Using default numa options = %r", self.numa_options)
+
+        # Set shutdown_timeout from environment variable if not explicitly set
+        if self.shutdown_timeout == -1:
+            self.shutdown_timeout = int(
+                os.environ.get("TORCH_ELASTIC_SHUTDOWN_TIMEOUT", "30")
+            )
+            logger.info("Using shutdown_timeout = %d seconds", self.shutdown_timeout)
+        elif self.shutdown_timeout < 0:
+            raise ValueError(
+                f"shutdown_timeout must be non-negative, got {self.shutdown_timeout}"
+            )
 
 
 class elastic_launch:
@@ -299,6 +314,7 @@ def launch_agent(
         logs_specs=config.logs_specs,  # type: ignore[arg-type]
         start_method=config.start_method,
         log_line_prefix_template=config.log_line_prefix_template,
+        shutdown_timeout=config.shutdown_timeout,
     )
 
     shutdown_rdzv = True

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -690,7 +690,7 @@ def get_args_parser() -> ArgumentParser:
         "--shutdown_timeout",
         action=env,
         type=int,
-        default=-1,
+        default=None,
         help="Time in seconds to wait for graceful shutdown of worker processes before "
         "sending SIGKILL. If not specified, uses TORCH_ELASTIC_SHUTDOWN_TIMEOUT environment "
         "variable or defaults to 30 seconds.",

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -686,6 +686,17 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--shutdown-timeout",
+        "--shutdown_timeout",
+        action=env,
+        type=int,
+        default=-1,
+        help="Time in seconds to wait for graceful shutdown of worker processes before "
+        "sending SIGKILL. If not specified, uses TORCH_ELASTIC_SHUTDOWN_TIMEOUT environment "
+        "variable or defaults to 30 seconds.",
+    )
+
+    parser.add_argument(
         "--virtual-local-rank",
         "--virtual_local_rank",
         action=check_env,
@@ -915,6 +926,7 @@ def config_from_args(args) -> tuple[LaunchConfig, Callable | str, list[str]]:
         duplicate_stdout_filters=args.duplicate_stdout_filters,
         duplicate_stderr_filters=args.duplicate_stderr_filters,
         virtual_local_rank=args.virtual_local_rank,
+        shutdown_timeout=args.shutdown_timeout,
     )
 
     with_python = not args.no_python


### PR DESCRIPTION
Fixes [#119856](https://github.com/pytorch/pytorch/issues/119856)

Previously, torchrun had a hardcoded 30s timeout between SIGTERM and SIGKILL. This was an issue for large model training where checkpoint saving exceeds 30s, k8s env's with longer `terminationGracePeriodSeconds`, and in SLURM preemption scenarios. The hardcoded timeout caused torchrun to send SIGKILL before workers completed graceful shutdown, even when the orchestrator allowed more time.

The fix adds a new configurable param "--shutdown-timeout", that takes timeout value via CLI args or falls back to `TORCH_ELASTIC_SHUTDOWN_TIMEOUT` env variable. Defaults to 30s otherwise, as it is currently. 

Flows through: CLI → LaunchConfig → LocalElasticAgent → SimpleElasticAgent → PContext.close()

Added unit tests. 

Please review and add anyone else who might be relevant @aivanou @Unturned3 @SandishKumarHN 