### PR TITLE
Add skip_root flag to linalg_vector_norm and foreach_norm

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -470,12 +470,13 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
 std::vector<Tensor> foreach_tensor_norm_slow(
     TensorList tensors,
     const Scalar& ord,
-    std::optional<ScalarType> dtype) {
+    std::optional<ScalarType> dtype,
+    bool skip_root) {
   check_foreach_api_restrictions(tensors);
   std::vector<Tensor> result;
   result.reserve(tensors.size());
   for (const auto& t : tensors) {
-    result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype));
+    result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype, skip_root));
   }
   return result;
 }

--- a/aten/src/ATen/native/ReduceOps.h
+++ b/aten/src/ATen/native/ReduceOps.h
@@ -37,7 +37,7 @@ using reduce_norm_fn =
     void (*)(Tensor&, const Tensor&, const c10::Scalar&, std::optional<int64_t>);
 DECLARE_DISPATCH(reduce_norm_fn, norm_kernel)
 
-using reduce_fn_flag = void(*)(TensorIterator &, const c10::Scalar&);
+using reduce_fn_flag = void(*)(TensorIterator &, const c10::Scalar&, bool skip_root);
 DECLARE_DISPATCH(reduce_fn_flag, norm_stub)
 
 using structured_cum_fn = void (*)(const Tensor&, const Tensor&, int64_t);

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -282,6 +282,38 @@ struct NormOps {
   }
 };
 
+// Like NormOps but skips the final root - returns sum(|x|^p) instead of (sum(|x|^p))^(1/p)
+// Used for skip_root=True in linalg_vector_norm
+template <typename scalar_t, typename acc_t = scalar_t, typename out_t = acc_t>
+struct NormNoRootOps {
+  acc_t norm_;
+
+  inline C10_DEVICE acc_t reduce(acc_t acc, scalar_t data, int64_t /*idx*/) const {
+    return acc + compat_pow(static_cast<acc_t>(std::abs(at::opmath_type<scalar_t>(data))), norm_);
+  }
+
+  inline C10_DEVICE acc_t combine(acc_t a, acc_t b) const {
+    return a + b;
+  }
+
+  inline C10_DEVICE out_t project(acc_t a) const {
+    return a;  // skip the root
+  }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  inline C10_DEVICE acc_t warp_shfl_down(acc_t acc, int offset) const {
+    return WARP_SHFL_DOWN(acc, offset);
+  }
+#endif
+
+  NormNoRootOps(acc_t norm_): norm_(norm_) {
+  }
+};
+
 // This accumulator template is used to calculate the order zero norm of the
 // absolute value of a set of numbers.
 // `scalar_t` is the type of the input and `acc_t` is the type of the accumulated
@@ -377,6 +409,34 @@ struct NormTwoOps {
 
   inline C10_DEVICE out_t project(acc_t a) const {
     return device_sqrt(a);
+  }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  inline C10_DEVICE acc_t warp_shfl_down(acc_t acc, int offset) const {
+    return WARP_SHFL_DOWN(acc, offset);
+  }
+#endif
+};
+
+// Like NormTwoOps but skips the final sqrt - returns sum(|x|^2) instead of sqrt(sum(|x|^2))
+// Used for skip_root=True in linalg_vector_norm
+template <typename scalar_t, typename acc_t = scalar_t, typename out_t = acc_t>
+struct NormTwoNoRootOps {
+  inline C10_DEVICE acc_t reduce(acc_t acc, scalar_t data, int64_t /*idx*/) const {
+    acc_t data_ = abs_if_complex(data, AbsSwitch<acc_t>());
+    return acc + data_ * data_;
+  }
+
+  inline C10_DEVICE acc_t combine(acc_t a, acc_t b) const {
+    return a + b;
+  }
+
+  inline C10_DEVICE out_t project(acc_t a) const {
+    return a;  // skip the sqrt
   }
 
   static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {

--- a/aten/src/ATen/native/cuda/ReduceNormKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceNormKernel.cu
@@ -13,38 +13,47 @@ namespace at::native {
 // This reduction accumulates results as the type `acc_t`. By default, when
 // `scalar_t` is complex, `acc_t` is the downgraded real number type.
 // Otherwise, `acc_t` and `scalar_t` are the same type.
+// When skip_root is true, returns sum(|x|^p) instead of (sum(|x|^p))^(1/p)
 template <typename scalar_t, typename acc_t=typename scalar_value_type<scalar_t>::type, typename out_t=typename scalar_value_type<scalar_t>::type>
-void norm_kernel_cuda_impl(TensorIterator& iter, double p) {
+void norm_kernel_cuda_impl(TensorIterator& iter, double p, bool skip_root) {
   if (p == static_cast<double>(0)) {
     gpu_reduce_kernel<scalar_t, out_t>(iter, NormZeroOps<scalar_t, acc_t, out_t>(), 0);
   } else if (p == static_cast<double>(1)) {
     gpu_reduce_kernel<scalar_t, out_t>(iter, NormOneOps<scalar_t, acc_t, out_t>(), 0);
   } else if (p == static_cast<double>(2)) {
-    gpu_reduce_kernel<scalar_t, out_t>(iter, NormTwoOps<scalar_t, acc_t, out_t>(), 0);
+    if (skip_root) {
+      gpu_reduce_kernel<scalar_t, out_t>(iter, NormTwoNoRootOps<scalar_t, acc_t, out_t>(), 0);
+    } else {
+      gpu_reduce_kernel<scalar_t, out_t>(iter, NormTwoOps<scalar_t, acc_t, out_t>(), 0);
+    }
   } else if (p == static_cast<double>(INFINITY)) {
     gpu_reduce_kernel<scalar_t, out_t>(iter, AbsMaxOps<scalar_t, acc_t, out_t>(), 0);
   } else if (p == static_cast<double>(-INFINITY)) {
     gpu_reduce_kernel<scalar_t, out_t>(iter, AbsMinOps<scalar_t, acc_t, out_t>(), std::numeric_limits<acc_t>::infinity());
   } else {
-    gpu_reduce_kernel<scalar_t, out_t>(iter, NormOps<scalar_t, acc_t, out_t>{acc_t(p)}, 0);
+    if (skip_root) {
+      gpu_reduce_kernel<scalar_t, out_t>(iter, NormNoRootOps<scalar_t, acc_t, out_t>{acc_t(p)}, 0);
+    } else {
+      gpu_reduce_kernel<scalar_t, out_t>(iter, NormOps<scalar_t, acc_t, out_t>{acc_t(p)}, 0);
+    }
   }
 }
 
-void norm_launch_kernel(TensorIterator& iter, double ord) {
+void norm_launch_kernel(TensorIterator& iter, double ord, bool skip_root) {
   if (iter.dtype(0) == kHalf) {
-    return norm_kernel_cuda_impl<at::Half, float>(iter, ord);
+    return norm_kernel_cuda_impl<at::Half, float>(iter, ord, skip_root);
   } else if (iter.input_dtype() == kHalf && iter.dtype(0) == kFloat) {
     // type promotion that does cast and reduction in a single kernel
-    return norm_kernel_cuda_impl<at::Half, float, float>(iter, ord);
+    return norm_kernel_cuda_impl<at::Half, float, float>(iter, ord, skip_root);
   }
   else if(iter.dtype(0) == kBFloat16) {
-    return norm_kernel_cuda_impl<at::BFloat16, float>(iter, ord);
+    return norm_kernel_cuda_impl<at::BFloat16, float>(iter, ord, skip_root);
   } else if (iter.input_dtype() == kBFloat16 && iter.dtype(0) == kFloat) {
     // type promotion that does cast and reduction in a single kernel
-    return norm_kernel_cuda_impl<at::BFloat16, float, float>(iter, ord);
+    return norm_kernel_cuda_impl<at::BFloat16, float, float>(iter, ord, skip_root);
   }
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.input_dtype(), "norm_cuda", [&] {
-    norm_kernel_cuda_impl<scalar_t>(iter, ord);
+    norm_kernel_cuda_impl<scalar_t>(iter, ord, skip_root);
   });
 }
 

--- a/aten/src/ATen/native/cuda/ReduceOps.cpp
+++ b/aten/src/ATen/native/cuda/ReduceOps.cpp
@@ -27,7 +27,7 @@
 namespace at::native {
 namespace {
 
-void norm_kernel_cuda(TensorIterator& iter, const Scalar& val) {
+void norm_kernel_cuda(TensorIterator& iter, const Scalar& val, bool skip_root) {
   double p = 0;
   if (val.isIntegral(false)) {
     p = static_cast<double>(val.to<int64_t>());
@@ -41,7 +41,9 @@ void norm_kernel_cuda(TensorIterator& iter, const Scalar& val) {
     return;
   }
 
-  norm_launch_kernel(iter, p);
+  // skip_root only applies for p-norms where p != inf, -inf, 0, 1
+  bool should_skip_root = skip_root && std::abs(p) != INFINITY && p != 0.0 && p != 1.0;
+  norm_launch_kernel(iter, p, should_skip_root);
 
   if (isComplexType(iter.output().scalar_type())) {
     at::imag(iter.output()).zero_();

--- a/aten/src/ATen/native/cuda/ReduceOps.h
+++ b/aten/src/ATen/native/cuda/ReduceOps.h
@@ -9,7 +9,7 @@ class Scalar;
 
 namespace at::native {
 
-void norm_launch_kernel(TensorIterator &iter, double val);
+void norm_launch_kernel(TensorIterator &iter, double val, bool skip_root);
 void min_launch_kernel(TensorIterator &iter);
 void max_launch_kernel(TensorIterator &iter);
 void aminmax_launch_kernel(TensorIterator &iter);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1134,9 +1134,15 @@ TORCH_IMPL_FUNC(linalg_vector_norm_out_mps)
  OptionalIntArrayRef opt_dim,
  bool keepdim,
  std::optional<ScalarType> opt_dtype,
+ bool skip_root,
  const Tensor& result) {
   impl_func_norm_mps(
       self, self, scalar_ord, opt_dim.value_or(IntArrayRef{}), keepdim, opt_dtype, result, /*cdist=*/false);
+  // If skip_root is requested for p-norms (p != inf, -inf, 0, 1), undo the root
+  auto ord = scalar_ord.toDouble();
+  if (skip_root && std::abs(ord) != std::numeric_limits<double>::infinity() && ord != 0.0 && ord != 1.0) {
+    const_cast<Tensor&>(result).pow_(ord);
+  }
 }
 
 Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, std::optional<int64_t> compute_mode) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11553,7 +11553,7 @@
     CUDA: foreach_tensor_neg_cuda_
   autogen: _foreach_neg.out
 
-- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None, bool skip_root=False) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:
@@ -14499,13 +14499,13 @@
   python_module: linalg
   variants: function
 
-- func: linalg_vector_norm(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- func: linalg_vector_norm(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, bool skip_root=False) -> Tensor
   python_module: linalg
   variants: function
   structured_delegate: linalg_vector_norm.out
   tags: reduction
 
-- func: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, bool skip_root=False, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg
   structured: True
   dispatch:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1457,6 +1457,55 @@ class TestLinalg(TestCase):
                             keepdim,
                             norm_dtype)
 
+    @dtypes(torch.float, torch.double)
+    def test_vector_norm_skip_root(self, device, dtype):
+        # Test that skip_root=True returns sum(|x|^p) instead of (sum(|x|^p))^(1/p)
+        input_sizes = [(10,), (4, 5), (3, 4, 5)]
+        ord_values = [2, 3, 4.5]
+
+        for input_size, ord in product(input_sizes, ord_values):
+            input = make_tensor(input_size, dtype=dtype, device=device, low=0.1, high=2.0)
+
+            # With skip_root=False (default), we get the standard p-norm
+            result_with_root = torch.linalg.vector_norm(input, ord=ord)
+
+            # With skip_root=True, we get sum(|x|^p)
+            result_skip_root = torch.linalg.vector_norm(input, ord=ord, skip_root=True)
+
+            # The relationship should be: result_skip_root = result_with_root ^ ord
+            expected = result_with_root ** ord
+            self.assertEqual(result_skip_root, expected,
+                            msg=f'input.size()={input.size()}, ord={ord}')
+
+        # Test that skip_root has no effect for inf, -inf, 0, 1 norms
+        input = make_tensor((10,), dtype=dtype, device=device, low=0.1, high=2.0)
+        for ord in [float('inf'), float('-inf'), 0, 1]:
+            result_normal = torch.linalg.vector_norm(input, ord=ord)
+            result_skip_root = torch.linalg.vector_norm(input, ord=ord, skip_root=True)
+            self.assertEqual(result_normal, result_skip_root,
+                            msg=f'skip_root should have no effect for ord={ord}')
+
+    @dtypes(torch.float, torch.double)
+    def test_foreach_norm_skip_root(self, device, dtype):
+        # Test that _foreach_norm with skip_root=True returns sum(|x|^p) for each tensor
+        input_sizes = [(10,), (20,), (5, 6)]
+        ord_values = [2, 3]
+
+        for ord in ord_values:
+            tensors = [make_tensor(size, dtype=dtype, device=device, low=0.1, high=2.0)
+                      for size in input_sizes]
+
+            # With skip_root=False (default)
+            results_with_root = torch._foreach_norm(tensors, ord=ord)
+
+            # With skip_root=True
+            results_skip_root = torch._foreach_norm(tensors, ord=ord, skip_root=True)
+
+            # Each result should satisfy: result_skip_root = result_with_root ^ ord
+            for r_root, r_skip in zip(results_with_root, results_skip_root):
+                expected = r_root ** ord
+                self.assertEqual(r_skip, expected, msg=f'ord={ord}')
+
 
     def test_vector_norm_decom_unbacked_checks(self):
         from torch._refs.linalg import _check_vector_norm_args

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1457,54 +1457,51 @@ class TestLinalg(TestCase):
                             keepdim,
                             norm_dtype)
 
-    @dtypes(torch.float, torch.double)
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_vector_norm_skip_root(self, device, dtype):
-        # Test that skip_root=True returns sum(|x|^p) instead of (sum(|x|^p))^(1/p)
-        input_sizes = [(10,), (4, 5), (3, 4, 5)]
-        ord_values = [2, 3, 4.5]
+        # Test skip_root returns sum(|x|^p) instead of (sum(|x|^p))^(1/p)
+        for size, ord in product([(10,), (3, 4, 5)], [2, 3, 4.5]):
+            x = make_tensor(size, dtype=dtype, device=device, low=0.1, high=2.0)
+            result = torch.linalg.vector_norm(x, ord=ord, skip_root=True)
+            expected = x.abs().pow(ord).sum()
+            self.assertEqual(result, expected)
 
-        for input_size, ord in product(input_sizes, ord_values):
-            input = make_tensor(input_size, dtype=dtype, device=device, low=0.1, high=2.0)
+        # Test dim and keepdim
+        x = make_tensor((3, 4, 5), dtype=dtype, device=device, low=0.1, high=2.0)
+        for ord, dim, keepdim in product([2, 3], [0, (0, 2), None], [True, False]):
+            result = torch.linalg.vector_norm(x, ord=ord, dim=dim, keepdim=keepdim, skip_root=True)
+            expected = x.abs().pow(ord).sum(dim=dim, keepdim=keepdim)
+            self.assertEqual(result, expected)
 
-            # With skip_root=False (default), we get the standard p-norm
-            result_with_root = torch.linalg.vector_norm(input, ord=ord)
-
-            # With skip_root=True, we get sum(|x|^p)
-            result_skip_root = torch.linalg.vector_norm(input, ord=ord, skip_root=True)
-
-            # The relationship should be: result_skip_root = result_with_root ^ ord
-            expected = result_with_root ** ord
-            self.assertEqual(result_skip_root, expected,
-                            msg=f'input.size()={input.size()}, ord={ord}')
-
-        # Test that skip_root has no effect for inf, -inf, 0, 1 norms
-        input = make_tensor((10,), dtype=dtype, device=device, low=0.1, high=2.0)
+        # Test skip_root has no effect for inf, -inf, 0, 1
+        x = make_tensor((10,), dtype=dtype, device=device, low=0.1, high=2.0)
         for ord in [float('inf'), float('-inf'), 0, 1]:
-            result_normal = torch.linalg.vector_norm(input, ord=ord)
-            result_skip_root = torch.linalg.vector_norm(input, ord=ord, skip_root=True)
-            self.assertEqual(result_normal, result_skip_root,
-                            msg=f'skip_root should have no effect for ord={ord}')
+            self.assertEqual(
+                torch.linalg.vector_norm(x, ord=ord),
+                torch.linalg.vector_norm(x, ord=ord, skip_root=True))
+
+        # Test 1D fast path (all reduce dims have size 1)
+        x = make_tensor((1, 1, 1), dtype=dtype, device=device, low=0.1, high=2.0)
+        result = torch.linalg.vector_norm(x, ord=2, skip_root=True)
+        self.assertEqual(result, x.abs().pow(2).sum())
+
+    @onlyCUDA
+    @dtypes(torch.half, torch.bfloat16)
+    def test_vector_norm_skip_root_low_precision(self, device, dtype):
+        for size, ord in product([(10,), (4, 5)], [2, 3]):
+            x = make_tensor(size, dtype=dtype, device=device, low=0.1, high=2.0)
+            result = torch.linalg.vector_norm(x, ord=ord, skip_root=True)
+            expected = x.abs().pow(ord).sum()
+            self.assertEqual(result, expected, atol=1e-2, rtol=1e-2)
 
     @dtypes(torch.float, torch.double)
     def test_foreach_norm_skip_root(self, device, dtype):
-        # Test that _foreach_norm with skip_root=True returns sum(|x|^p) for each tensor
-        input_sizes = [(10,), (20,), (5, 6)]
-        ord_values = [2, 3]
-
-        for ord in ord_values:
-            tensors = [make_tensor(size, dtype=dtype, device=device, low=0.1, high=2.0)
-                      for size in input_sizes]
-
-            # With skip_root=False (default)
-            results_with_root = torch._foreach_norm(tensors, ord=ord)
-
-            # With skip_root=True
-            results_skip_root = torch._foreach_norm(tensors, ord=ord, skip_root=True)
-
-            # Each result should satisfy: result_skip_root = result_with_root ^ ord
-            for r_root, r_skip in zip(results_with_root, results_skip_root):
-                expected = r_root ** ord
-                self.assertEqual(r_skip, expected, msg=f'ord={ord}')
+        tensors = [make_tensor(s, dtype=dtype, device=device, low=0.1, high=2.0)
+                   for s in [(10,), (20,), (5, 6)]]
+        for ord in [2, 3]:
+            results = torch._foreach_norm(tensors, ord=ord, skip_root=True)
+            for t, r in zip(tensors, results):
+                self.assertEqual(r, t.abs().pow(ord).sum())
 
 
     def test_vector_norm_decom_unbacked_checks(self):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1325,7 +1325,7 @@
   self: norm_backward(grad, self.to(grad.scalar_type()), p, result, dim, keepdim)
   result: norm_jvp(self_p, self_t, p, result, dim, keepdim)
 
-- name: linalg_vector_norm(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- name: linalg_vector_norm(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, bool skip_root=False) -> Tensor
   self: linalg_vector_norm_backward(grad, self, ord, result, dim, keepdim)
   result: linalg_vector_norm_jvp(self_p, self_t, ord, result, dim, keepdim)
 
@@ -3248,6 +3248,6 @@
 
 # note(crcrpar): forward-mode AD is tricky for a simple string replace to handle:
 #   formula.replace("p", "ord") produces `norm_jvord(self_ord, self_t, ord, result)`
-- name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+- name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None, bool skip_root=False) -> Tensor[]
   self: norm_backward(grads[i], self[i], ord, result[i])
   result: norm_jvp(self_p, self_t, ord, result[i])

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
@@ -1195,7 +1195,7 @@ def flatten(g: jit_utils.GraphContext, input, start_dim, end_dim):
 
 
 @_onnx_symbolic("aten::linalg_vector_norm")
-@symbolic_helper.parse_args("v", "f", "is", "b", "v")
+@symbolic_helper.parse_args("v", "f", "is", "b", "v", "b")
 def linalg_vector_norm(
     g: jit_utils.GraphContext,
     self,
@@ -1203,6 +1203,7 @@ def linalg_vector_norm(
     dim: Sequence[int] | None,
     keepdim: bool,
     dtype,
+    skip_root: bool = False,
 ):
     return symbolic_helper._linalg_vector_norm_helper(g, self, ord, dim, keepdim, dtype)
 

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset18.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset18.py
@@ -260,7 +260,7 @@ def embedding_bag(
 
 
 @_onnx_symbolic("aten::linalg_vector_norm")
-@symbolic_helper.parse_args("v", "f", "is", "b", "v")
+@symbolic_helper.parse_args("v", "f", "is", "b", "v", "b")
 def linalg_vector_norm(
     g: jit_utils.GraphContext,
     self: torch._C.Value,
@@ -268,5 +268,6 @@ def linalg_vector_norm(
     dim: Optional[Sequence[int]],
     keepdim: bool,
     dtype: torch._C.Value,
+    skip_root: bool = False,
 ):
     return symbolic_helper._linalg_vector_norm_helper(g, self, ord, dim, keepdim, dtype)

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -5449,7 +5449,7 @@ def linalg_norm(
 
 
 @_onnx_symbolic("aten::linalg_vector_norm")
-@symbolic_helper.parse_args("v", "f", "is", "b", "v")
+@symbolic_helper.parse_args("v", "f", "is", "b", "v", "b")
 def linalg_vector_norm(
     g: jit_utils.GraphContext,
     self: torch._C.Value,
@@ -5457,6 +5457,7 @@ def linalg_vector_norm(
     dim: Sequence[int] | None,
     keepdim: bool,
     dtype: torch._C.Value,
+    skip_root: bool = False,
 ):
     return symbolic_helper._linalg_vector_norm_helper(g, self, ord, dim, keepdim, dtype)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172620
* #172603
* #172604
* __->__ #172602

Add a skip_root parameter to linalg_vector_norm and _foreach_norm
that skips the root portion of the p-norm computation. When skip_root=True,
the result is sum(|x|^p) instead of (sum(|x|^p))^(1/p).

This enables better numerics for distributed gradient norm computation
by avoiding sqrt -> pow -> sqrt cycles when reducing partial norms.

Authored with Claude.

Dependent on https://github.com/intel/torch-xpu-ops/pull/2746, maybe it's easier to create a new powsum API?

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01