### PR TITLE
Simplify _NormPartial by removing reduce_op branching

### DIFF
--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -59,33 +59,28 @@ class _NormPartial(Partial):
     """
     This placement is used for partial vector norm.
 
-    For p-norms (where p not inf or -inf), the p-norm over n elements computes
-        (sum_i x_i^p)^(1/p)
-    where the sum is from i=1 to n. The reduction op is the p-norm itself.
+    For p-norms (where p not in {inf, -inf, 0, 1}), the p-norm over n elements
+    computes (sum_i x_i^p)^(1/p). After PR 3, inf/-inf/0/1 norms are handled
+    directly by Partial("max"), Partial("min"), or Partial("sum"), so this
+    class is only used for other p-norms.
+
     For example, consider 2 ranks, a (4,) tensor sharded on dim-0, and 2-norm:
         Rank 0: [t1, t2] | Rank 1: [t3, t4]
     After computing 2-norm per gradient (partial placement):
         Rank 0: [sqrt(t1^2 + t2^2)] | Rank 1: [sqrt(t3^2 + t4^2)]
     Converting from partial to replicate wants to ultimately get:
         Rank 0/1: [sqrt(t1^2 + t2^2 + t3^2 + t4^2)]
-    This can be achieved by computing 2-norm on each rank's result. This holds
-    similarly for inf and -inf norm. For 0-norm, the reduction op is sum.
+    This is achieved by raising to power p, summing, then taking pth root.
     """
 
-    norm_type: int | float | str = 2
+    norm_type: int | float = 2
 
-    def __init__(self, norm_type: int | float | str = 2):
-        reduce_op = None
-        if norm_type in (float("inf"), "inf"):
-            reduce_op = "max"
-        elif norm_type in (float("-inf"), "-inf"):
-            reduce_op = "min"
-        elif isinstance(norm_type, (int, float)):
-            reduce_op = "sum"
-        else:
-            raise NotImplementedError(f"Unsupported norm type: {norm_type}")
-
-        super().__init__(reduce_op)
+    def __init__(self, norm_type: int | float = 2):
+        # After PR 3, only p-norms with p not in {inf, -inf, 0, 1} use _NormPartial
+        # So reduce_op is always "sum"
+        if not isinstance(norm_type, (int, float)):
+            raise AssertionError(f"Expected int or float, got {type(norm_type)}")
+        super().__init__("sum")
         object.__setattr__(self, "norm_type", norm_type)
 
     def _partition_value(
@@ -100,19 +95,7 @@ class _NormPartial(Partial):
         One such f(x) is f(x) = x / sqrt(4). This generalizes to d ranks and
         p-norm as f(x) = x / d^(1/p).
         """
-        if self.reduce_op in ("max", "min"):
-            return tensor
-        elif self.reduce_op == "sum":
-            if self.norm_type == 0:
-                raise NotImplementedError(f"Unsupported norm type:: {self.norm_type}")
-            elif self.norm_type == 1:
-                return tensor / mesh.size(mesh_dim)
-            if not isinstance(self.norm_type, (int, float)):
-                raise AssertionError(
-                    f"Expected int or float, got {type(self.norm_type)}"
-                )
-            return tensor / math.pow(mesh.size(mesh_dim), 1 / self.norm_type)
-        raise NotImplementedError(self.reduce_op)
+        return tensor / math.pow(mesh.size(mesh_dim), 1 / self.norm_type)
 
     def _reduce_shard_value(
         self,
@@ -135,24 +118,12 @@ class _NormPartial(Partial):
         return self._post_reduce_transform(reduced_tensor)
 
     def _pre_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
-        if self.reduce_op == "sum":
-            if not isinstance(self.norm_type, (int, float)):
-                raise AssertionError(
-                    f"Expected int or float, got {type(self.norm_type)}"
-                )
-            if self.norm_type != 0 and self.norm_type != 1:
-                return tensor**self.norm_type
-        return tensor
+        # Raise to power p before summing
+        return tensor**self.norm_type
 
     def _post_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
-        if self.reduce_op == "sum":
-            if not isinstance(self.norm_type, (int, float)):
-                raise AssertionError(
-                    f"Expected int or float, got {type(self.norm_type)}"
-                )
-            if self.norm_type != 0 and self.norm_type != 1:
-                return tensor ** (1.0 / self.norm_type)
-        return tensor
+        # Take pth root after summing
+        return tensor ** (1.0 / self.norm_type)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _NormPartial):
@@ -166,11 +137,11 @@ class _NormPartial(Partial):
         """
         machine readable representation of the _NormPartial placement
         """
-        return f"_NormPartial(reduce_op={self.reduce_op}, norm_type={self.norm_type})"
+        return f"_NormPartial(norm_type={self.norm_type})"
 
     def __str__(self) -> str:
         """human readable representation of the _NormPartial placement"""
-        return f"_NormP({self.reduce_op}, {self.norm_type})"
+        return f"_NormP({self.norm_type})"
 
 
 def _infer_reduction_dims(dims_arg: object, ndim: int) -> list[int] | None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172606
* __->__ #172605
* #172604
* #172603
* #172602

After PR 3, inf/-inf/0/1 norms are handled directly by Partial("max"),
Partial("min"), and Partial("sum"). This means _NormPartial is only
used for general p-norms (p > 1, p != inf), so:
- reduce_op is always "sum"
- norm_type is always int | float (not str)
- No need for special cases for 0-norm or 1-norm

Simplified the class by removing these dead code paths.

Authored with Claude.