### PR TITLE
Delete _NormPartial and use reduction_linear=False for p-norms

### DIFF
--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1,13 +1,10 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import math
 from collections.abc import Sequence
-from dataclasses import dataclass
 from enum import Enum
-from typing import cast, Union
+from typing import cast
 
 import torch
-from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import (
     OpSchema,
@@ -44,104 +41,6 @@ class Reduction(Enum):
     NONE = 0
     MEAN = 1
     SUM = 2
-
-
-@dataclass(frozen=True)
-class NormReduction:
-    norm_type: int | float | str
-
-
-ReductionOpType = Union[NormReduction, str]
-
-
-@dataclass(frozen=True)
-class _NormPartial(Partial):
-    """
-    This placement is used for partial vector norm.
-
-    For p-norms (where p not in {inf, -inf, 0, 1}), the p-norm over n elements
-    computes (sum_i x_i^p)^(1/p). After PR 3, inf/-inf/0/1 norms are handled
-    directly by Partial("max"), Partial("min"), or Partial("sum"), so this
-    class is only used for other p-norms.
-
-    For example, consider 2 ranks, a (4,) tensor sharded on dim-0, and 2-norm:
-        Rank 0: [t1, t2] | Rank 1: [t3, t4]
-    After computing 2-norm per gradient (partial placement):
-        Rank 0: [sqrt(t1^2 + t2^2)] | Rank 1: [sqrt(t3^2 + t4^2)]
-    Converting from partial to replicate wants to ultimately get:
-        Rank 0/1: [sqrt(t1^2 + t2^2 + t3^2 + t4^2)]
-    This is achieved by raising to power p, summing, then taking pth root.
-    """
-
-    norm_type: int | float = 2
-
-    def __init__(self, norm_type: int | float = 2):
-        # After PR 3, only p-norms with p not in {inf, -inf, 0, 1} use _NormPartial
-        # So reduce_op is always "sum"
-        if not isinstance(norm_type, (int, float)):
-            raise AssertionError(f"Expected int or float, got {type(norm_type)}")
-        super().__init__("sum")
-        object.__setattr__(self, "norm_type", norm_type)
-
-    def _partition_value(
-        self, tensor: torch.Tensor, mesh: DeviceMesh, mesh_dim: int
-    ) -> torch.Tensor:
-        """
-        For example, consider 4 ranks, a (3,) replicated tensor, and 2-norm:
-            Ranks 0 and 1: sqrt(t1^2 + t2^2 + t3^3)
-        To convert from replicated to partial, we want f(x) such that
-            sqrt(t1^2 + t2^2 + t3^3) = sqrt(4f(t1)^2 + 4f(t2)^2 + 4f(t3)^2)
-                                     = sqrt(4) sqrt(f(t1)^2 + f(t2)^2 + f(t3)^2).
-        One such f(x) is f(x) = x / sqrt(4). This generalizes to d ranks and
-        p-norm as f(x) = x / d^(1/p).
-        """
-        return tensor / math.pow(mesh.size(mesh_dim), 1 / self.norm_type)
-
-    def _reduce_shard_value(
-        self,
-        tensor: torch.Tensor,
-        mesh: DeviceMesh,
-        mesh_dim: int,
-        shard_spec: Placement,
-    ) -> torch.Tensor:
-        if not isinstance(shard_spec, Shard):
-            raise AssertionError(f"Expected Shard, got {type(shard_spec)}")
-        tensor = self._pre_reduce_transform(tensor)
-        reduced_tensor = super()._reduce_shard_value(tensor, mesh, mesh_dim, shard_spec)
-        return self._post_reduce_transform(reduced_tensor)
-
-    def _reduce_value(
-        self, tensor: torch.Tensor, mesh: DeviceMesh, mesh_dim: int
-    ) -> torch.Tensor:
-        tensor = self._pre_reduce_transform(tensor)
-        reduced_tensor = super()._reduce_value(tensor, mesh, mesh_dim)
-        return self._post_reduce_transform(reduced_tensor)
-
-    def _pre_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
-        # Raise to power p before summing
-        return tensor**self.norm_type
-
-    def _post_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
-        # Take pth root after summing
-        return tensor ** (1.0 / self.norm_type)
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, _NormPartial):
-            return False
-        return self.norm_type == other.norm_type
-
-    def __hash__(self) -> int:
-        return 1 + hash(self.norm_type)
-
-    def __repr__(self) -> str:
-        """
-        machine readable representation of the _NormPartial placement
-        """
-        return f"_NormPartial(norm_type={self.norm_type})"
-
-    def __str__(self) -> str:
-        """human readable representation of the _NormPartial placement"""
-        return f"_NormP({self.norm_type})"
 
 
 def _infer_reduction_dims(dims_arg: object, ndim: int) -> list[int] | None:
@@ -218,7 +117,7 @@ def map_placements_after_reduction(
     placements: tuple[Placement, ...],
     reduction_dims: list[int],
     reduction_dims_map: list[int],
-    reduction_op: ReductionOpType,
+    reduction_op: str,
 ) -> tuple[Placement, ...]:
     """
     Map each placement based on the output shape after reduction.
@@ -250,9 +149,7 @@ def map_placements_after_reduction(
     return tuple(new_placements)
 
 
-def get_placement_from_reduction_op(reduction_op: ReductionOpType) -> Placement:
-    if isinstance(reduction_op, NormReduction):
-        return _NormPartial(norm_type=reduction_op.norm_type)
+def get_placement_from_reduction_op(reduction_op: str) -> Placement:
     return Partial(reduction_op)
 
 
@@ -261,7 +158,7 @@ def common_reduction_strategy(
     reduce_dims: list[int],
     keep_dim: bool = False,
     reduction_linear: bool = True,
-    reduction_op: ReductionOpType = "sum",
+    reduction_op: str = "sum",
 ) -> OpStrategy:
     """
     reduction_linear means that the reduction `f` follows this rule:
@@ -442,23 +339,32 @@ def vector_norm_strategy(op_schema: OpSchema) -> OpStrategy:
 
     # For inf/-inf/0/1 norms, use Partial directly instead of NormReduction
     if norm_type in (float("inf"), "inf"):
-        reduction_op: ReductionOpType = "max"
+        reduction_op: str = "max"
+        reduction_linear = True
     elif norm_type in (float("-inf"), "-inf"):
         reduction_op = "min"
-    elif norm_type == 0 or norm_type == 1:
+        reduction_linear = True
+    elif norm_type == 0:
         reduction_op = "sum"
+        reduction_linear = True
+    elif norm_type == 1:
+        reduction_op = "sum"
+        reduction_linear = True
     elif skip_root:
         # For other p-norms with skip_root=True, use Partial(sum) directly
         reduction_op = "sum"
+        reduction_linear = True
     else:
-        # For other p-norms without skip_root, use _NormPartial
-        reduction_op = NormReduction(norm_type)
+        # For other p-norms without skip_root, force an allreduce before the norm
+        # This avoids using _NormPartial and its sqrt -> pow -> sqrt issue
+        reduction_op = "sum"
+        reduction_linear = False
 
     return common_reduction_strategy(
         input_strategy,
         reduce_dims,
         keep_dim=cast(bool, keepdim),
-        reduction_linear=True,
+        reduction_linear=reduction_linear,
         reduction_op=reduction_op,
     )
 
@@ -480,17 +386,25 @@ def foreach_norm_strategy(op_schema: OpSchema) -> TupleStrategy:
 
     # For inf/-inf/0/1 norms, use Partial directly instead of NormReduction
     if norm_type in (float("inf"), "inf"):
-        reduction_op: ReductionOpType = "max"
+        reduction_op: str = "max"
+        reduction_linear = True
     elif norm_type in (float("-inf"), "-inf"):
         reduction_op = "min"
-    elif norm_type == 0 or norm_type == 1:
+        reduction_linear = True
+    elif norm_type == 0:
         reduction_op = "sum"
+        reduction_linear = True
+    elif norm_type == 1:
+        reduction_op = "sum"
+        reduction_linear = True
     elif skip_root:
         # For other p-norms with skip_root=True, use Partial(sum) directly
         reduction_op = "sum"
+        reduction_linear = True
     else:
-        # For other p-norms without skip_root, use _NormPartial
-        reduction_op = NormReduction(norm_type)
+        # For other p-norms without skip_root, force an allreduce before the norm
+        reduction_op = "sum"
+        reduction_linear = False
 
     output_tuple_strategy_children: list[OpStrategy] = []
     for op_strategy in input_tuple_strategy.children:
@@ -500,7 +414,7 @@ def foreach_norm_strategy(op_schema: OpSchema) -> TupleStrategy:
         output_strategy = common_reduction_strategy(
             op_strategy,
             reduce_dims,
-            reduction_linear=True,
+            reduction_linear=reduction_linear,
             reduction_op=reduction_op,
         )
         output_tuple_strategy_children.append(output_strategy)

--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -16,7 +16,6 @@ from torch.distributed.tensor._op_schema import (
     StrategyType,
     TupleStrategy,
 )
-from torch.distributed.tensor._ops._math_ops import _NormPartial
 from torch.distributed.tensor._ops.single_dim_strategy import _ShardingPlaceholder
 from torch.distributed.tensor._ops.utils import (
     generate_redistribute_costs,
@@ -667,21 +666,9 @@ def common_pointwise_strategy(
                     out_placements.append(Shard(new_shard_dim))
             elif isinstance(placement, Partial):
                 is_scalar_arg = any(isinstance(arg, _Number) for arg in args_schema)
-                propagate_partial = False
-
-                # ordering matters here since NormPartial is a subclass of Partial
-                if isinstance(placement, _NormPartial):
-                    # explanation for args_schema[1] >= 0 can be found in summary
-                    # https://github.com/pytorch/pytorch/pull/170035
-                    propagate_partial = (
-                        op in norm_partial_avoidable_redistribute_ops
-                        and args_schema[1] >= 0  # pyre-ignore[unsupported-operation]
-                    )
-
-                elif isinstance(placement, Partial):
-                    propagate_partial = not (
-                        op in p_sum_scalar_redistribute_ops and is_scalar_arg
-                    )
+                propagate_partial = not (
+                    op in p_sum_scalar_redistribute_ops and is_scalar_arg
+                )
 
                 # Check if this partial type should be preserved
                 # preserve_partial="all" preserves any Partial type (used for copy_)
@@ -802,22 +789,10 @@ p_sum_scalar_redistribute_ops = {
     aten.sub_.Tensor,
 }
 
-norm_partial_avoidable_redistribute_ops = {
-    aten.div.Scalar,
-    aten.div_.Scalar,
-    aten.mul.Scalar,
-    aten.mul_.Scalar,
-}
-
 for op in linear_pointwise_ops:
-    if op in norm_partial_avoidable_redistribute_ops:
-        register_op_strategy(
-            op, schema_info=RuntimeSchemaInfo(1, static_kwargkey=["out"])
-        )(linear_pointwise_strategy)
-    else:
-        register_op_strategy(
-            op, schema_info=RuntimeSchemaInfo(static_kwargkey=["out"])
-        )(linear_pointwise_strategy)
+    register_op_strategy(
+        op, schema_info=RuntimeSchemaInfo(static_kwargkey=["out"])
+    )(linear_pointwise_strategy)
 
 for op in partial_preserving_ops:
     register_op_strategy(op, schema_info=RuntimeSchemaInfo(static_kwargkey=["out"]))(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172606
* #172605
* #172604
* #172603
* #172602

This PR removes _NormPartial completely and replaces it with simpler
logic. The key insight is that for p-norms with skip_root=False,
we can use reduction_linear=False to force an allreduce before
computing the norm on the replicated tensor. This avoids the
problematic sqrt→pow→sqrt cycles that _NormPartial had.

Changes:
- Delete _NormPartial, NormReduction, and ReductionOpType
- Update vector_norm_strategy and foreach_norm_strategy:
  - inf/-inf/0/1 norms use Partial directly with reduction_linear=True
  - skip_root=True uses Partial("sum") with reduction_linear=True
  - skip_root=False uses reduction_linear=False to force allreduce
- Update pointwise ops to remove _NormPartial special handling
- Update tests to expect Replicate instead of _NormPartial

This fixes the numerics issues while simplifying the code.

Authored with Claude.