### PR TITLE
Use scripted inputs for PT2 + FoA to handle KJTs + include scripted dummy module

### DIFF
--- a/torch/csrc/export/pt2_archive_constants.h
+++ b/torch/csrc/export/pt2_archive_constants.h
@@ -47,6 +47,8 @@ namespace torch::_export::archive_spec {
   DO(SAMPLE_INPUTS_DIR, "data/sample_inputs/")                                 \
   DO(SAMPLE_INPUTS_FILENAME_FORMAT,                                            \
      "data/sample_inputs/{}.pt") /* {model_name} */                            \
+  DO(TS_SAMPLE_INPUTS_FILENAME_FORMAT,                                         \
+     "extra/{}.forward.sample_input.pt") /* {model_name} */                            \
   /* ExecuTorch artifacts, including PTE files */                              \
   DO(EXECUTORCH_DIR, "data/executorch/")                                       \
   /* extra folder */                                                           \

--- a/torch/nativert/detail/ITree.cpp
+++ b/torch/nativert/detail/ITree.cpp
@@ -326,6 +326,15 @@ class PytreeNodeRegistry {
     registry_.emplace(typeName, nodeDef);
   }
 
+  void registerOrReplaceNode(std::string_view typeName, NodeDef nodeDef) {
+    auto it = registry_.find(std::string{typeName});
+    if (it != registry_.end()) {
+      it->second = nodeDef;
+    } else {
+      registry_.emplace(typeName, nodeDef);
+    }
+  }
+
  private:
   std::unordered_map<std::string, NodeDef> registry_;
 };
@@ -378,6 +387,12 @@ ITreeSpec makeITreeSpec(
 void registerPytreeNode(std::string_view typeName, NodeDef nodeDef) {
   getPytreeNodeRegistry().withLock([&](auto& registry) {
     registry.registerNode(typeName, std::move(nodeDef));
+  });
+}
+
+void registerOrReplacePytreeNode(std::string_view typeName, NodeDef nodeDef) {
+  getPytreeNodeRegistry().withLock([&](auto& registry) {
+    registry.registerOrReplaceNode(typeName, std::move(nodeDef));
   });
 }
 

--- a/torch/nativert/detail/ITree.h
+++ b/torch/nativert/detail/ITree.h
@@ -122,6 +122,12 @@ class ITreeSpec {
 
 void registerPytreeNode(std::string_view typeName, NodeDef nodeDef);
 
+// Register a pytree node, replacing any existing registration with the same name.
+// This is useful for customizing unflatten behavior for types like KeyedJaggedTensor
+// where the default implementation returns a tuple but the caller wants to reconstruct
+// the actual custom class object.
+void registerOrReplacePytreeNode(std::string_view typeName, NodeDef nodeDef);
+
 // Serialized json tree spec should be dumped from treespec_dumps() in
 // torch.utils._pytree directly .
 ITreeSpec itreeSpecLoads(


### PR DESCRIPTION
Summary:
This diff does two things:

1) For PT2 models published with TGIF, we use the torchscripted sample inputs in the extra directory for container warmup in order to allow for deserilaization of KJT types in the inputs. Conveniently, all modules published with PT2 format also save the torchscripted inputs in the extra folder already

2) During publish, add a torchscripted dummy module which has a KJT and JT defined as attributes so that the sigmoid runtime can use the KJT type ptr on the script module to serialize KJT types in the unflattening of the output

Test Plan:
Publish:

```
make -C ~/fbsource/fbcode/minimal_viable_ai/models/pymk/ranking/roo/mid_low_mtml publish-local model_entity_id=2140840078 checkpoint_version=0 2>&1 | tee ~/tgif_publish.log
```
Benchmark individual nets:
```
MODEL_ENTITY_ID=2140840078
SNAPSHOT_ID=4
mkdir -p /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID};

for suffix in .predictor.merge .predictor.remote .predictor.local; do echo ${suffix}; manifold get --parallel ads_storage_fblearner/tree/user/facebook/fblearner/predictor/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}${suffix} /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}${suffix}; done

for suffix in local;
do mkdir -p /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${suffix}_archive; unzip /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.${suffix} -d /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${suffix}_archive; done 

for suffix in merge remote;
do mkdir -p /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${suffix}_archive; unzip /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.${suffix} -d /data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${suffix}_archive; done 

# BENCHMARK
# LOCAL
module_name=local
SAMPLE_INPUT_DIR=/data/users/georgiaphillips/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${module_name}_archive/package/extra

buck2 run mode/opt //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=Benchmark --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.${module_name} --moduleName=${module_name} --submodToDevice="local|cpu"  --benchmarkEnableProfiling=false --disableStaticRuntime=true --doNotRandomizeSampleInputs=true --benchmarkDontRebatchSamples=true --pytorch_predictor_sigmoid_static_dispatch_enable=true --pytorch_predictor_sigmoid_graph_passes_enable=true --pytorch_predictor_runtime_const_folding_enable=true --sampleInputFilePath=${SAMPLE_INPUT_DIR}/${module_name}.forward.sample_input.pt --benchmarkNumIterations=2 --useTgif=true --inputType=pt_scripted

# REMOTE
module_name=remote
SAMPLE_INPUT_DIR=/data/users/georgiaphillips/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${module_name}_archive/archive/extra

buck2 run mode/dev-nosan -c fbcode.nvcc_arch=a100 //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=Benchmark --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.${module_name} --moduleName=${module_name} --submodToDevice="merge|cuda0,remote|cuda0"  --benchmarkEnableProfiling=false --disableStaticRuntime=true --doNotRandomizeSampleInputs=true --benchmarkDontRebatchSamples=true --pytorch_predictor_sigmoid_static_dispatch_enable=true --pytorch_predictor_sigmoid_graph_passes_enable=true --pytorch_predictor_runtime_const_folding_enable=true --sampleInputFilePath=${SAMPLE_INPUT_DIR}/${module_name}.forward.sample_input.pt --useTgif=true --benchmarkNumIterations=2 --inputType=pt_scripted

#MERGE
module_name=merge
SAMPLE_INPUT_DIR=/data/users/georgiaphillips/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${module_name}_archive/archive/extra

buck2 run mode/dev-nosan -c fbcode.nvcc_arch=a100 //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=Benchmark --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.${module_name} --moduleName=${module_name} --submodToDevice="merge|cuda0,remote|cuda0"  --benchmarkEnableProfiling=false --disableStaticRuntime=true --doNotRandomizeSampleInputs=true --benchmarkDontRebatchSamples=true --pytorch_predictor_sigmoid_static_dispatch_enable=true --pytorch_predictor_sigmoid_graph_passes_enable=true --pytorch_predictor_runtime_const_folding_enable=true --sampleInputFilePath=${SAMPLE_INPUT_DIR}/${module_name}.forward.sample_input.pt --useTgif=true --benchmarkNumIterations=2  --inputType=pt_scripted
```

e2e sigrid run:
```
ENABLE_TGIF=true ENABLE_PT2_SIGMOID=true CUDA_VISIBLE_DEVICES=0 GFLAGS_CONFIG_PATH=sigrid/predictor/predictor_x_gflags_tgif_lsr_template BUILD=1 MODEL_ID=2140840078 SNAPSHOT_ID=4 LOCAL_MODEL_DIR=/data/users/georgiaphillips/models/2140840078/4 sh ~/fbsource/fbcode/scripts/dsy842974287/load_model.sh 2>&1 |tee pt2_logs.txt

BUILD=1 sh hpc/inference/scripts/gif/vdd/1_card/launch_gpu_replayer.sh
```

Differential Revision: D90626112


