### PR TITLE
Add dynamo source in args_descs

### DIFF
--- a/torch/_functorch/_aot_autograd/descriptors.py
+++ b/torch/_functorch/_aot_autograd/descriptors.py
@@ -315,6 +315,10 @@ for ease of understanding the data flow:
 """
 
 import dataclasses
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torch._guards import Source
 
 
 # TODO: the is_* predicates are a little suspicious because (1) they're not
@@ -326,7 +330,19 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True)
 class AOTInput:
-    """Describes where an input from an AOTAutograd produced FX graph comes from"""
+    """Describes where an input from an AOTAutograd produced FX graph comes from
+
+    Attributes:
+        source: Optional Dynamo source for this input. When the graph comes from
+            Dynamo, this will be populated with the source that describes where
+            in user code this input originated from. This is useful for deduplication
+            guards and understanding the provenance of inputs.
+    """
+
+    # kw_only=True allows child classes to have non-default fields
+    # repr=False excludes this field from the auto-generated __repr__ to keep
+    # output concise and avoid breaking existing tests/expectations
+    source: "Source | None" = dataclasses.field(default=None, kw_only=True, repr=False)
 
     def expr(self) -> str:
         raise NotImplementedError("Subclasses must implement expr()")


### PR DESCRIPTION
Preserves dynamo source in full_jit torch.compile path. Needed by manual bucketing.

```
import torch
from torch._dynamo.backends.common import aot_autograd
class Encoder(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.layer0 = torch.nn.Linear(3, 3)
        self.layer1 = torch.nn.Linear(3, 3)
    def forward(self, x):
        x = self.layer0(x)
        x = self.layer1(x)
        return x
class M(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.a = torch.nn.Parameter(torch.ones(3, 3))
        self.encoder1 = Encoder()
        self.encoder2 = Encoder()
    def forward(self, x):
        x = self.encoder1(x)
        x = self.encoder2(x)
        x = x + 2 * self.a
        return x
m = M()
def my_backend(gm, example_inputs):

    def fw_compiler(gm, example_inputs):
        print("FWD GRAPH")
        for node in gm.graph.find_nodes(op="placeholder"):
            desc = node.meta.get("desc")
            source = getattr(desc, "source", None)
            if source:
                source = source.name

            print(f"Node: {node.name}, desc: {desc}, source: {source}")
        return gm.forward
    def bw_compiler(gm, example_inputs):
        print("BWD GRAPH")
        return gm.forward
    return aot_autograd(
        fw_compiler=fw_compiler,
        bw_compiler=bw_compiler,
    )(gm, example_inputs)
compiled = torch.compile(m, backend=my_backend)
out = compiled(torch.randn(3, 3))
out.sum().backward()
```