### PR TITLE
Fix PendingUnbackedSymbolNotFound for unbacked SymInts created in __torch_dispatch__

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -690,6 +690,225 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    def _make_unbacked_coord_subclass(self, lib_name, runtime_coord_value, dispatch_fn):
+        """
+        Helper to create a custom op + subclass that returns an unbacked SymInt
+        from inside __torch_dispatch__.
+
+        This simulates how DTensor calls _runtime_compute_coordinate_on_dim
+        inside its dispatch to get mesh coordinates.
+
+        Args:
+            lib_name: Unique library name for the custom op
+            runtime_coord_value: The value the custom op returns at runtime
+            dispatch_fn: Custom dispatch function. Signature: dispatch_fn(func,
+                args, kwargs, unwrap, wrap, get_coord_op) -> result or None
+                (to use default forwarding)
+        """
+        import uuid
+
+        from torch.fx.experimental.symbolic_shapes import _constrain_range_for_size
+        from torch.testing._internal.common_subclass import WrapperTensor
+        from torch.utils._pytree import tree_map
+
+        # Use unique library name to avoid conflicts between test runs
+        unique_lib_name = f"{lib_name}_{uuid.uuid4().hex[:8]}"
+
+        # Define custom op that mimics _runtime_compute_coordinate_on_dim
+        lib = torch.library.Library(unique_lib_name, "DEF")
+
+        lib.define(
+            "get_coord(Tensor x, int max_val) -> SymInt",
+            tags=torch.Tag.pt2_compliant_tag,
+        )
+
+        @torch.library.register_fake(f"{unique_lib_name}::get_coord", lib=lib)
+        def get_coord_fake(x: torch.Tensor, max_val: int):
+            ctx = torch._custom_op.impl.get_ctx()
+            shape_env = ctx._shape_env
+            sz = shape_env.create_unbacked_symint()
+            _constrain_range_for_size(sz, min=0, max=max_val - 1)
+            return sz
+
+        # Capture runtime_coord_value in closure
+        coord_value = runtime_coord_value
+
+        @torch.library.impl(
+            f"{unique_lib_name}::get_coord", "CompositeExplicitAutograd", lib=lib
+        )
+        def get_coord_impl(x: torch.Tensor, max_val: int) -> int:
+            return coord_value
+
+        # Get the op reference
+        get_coord_op = getattr(torch.ops, unique_lib_name).get_coord
+
+        # Subclass that calls the custom op inside __torch_dispatch__
+        class CoordSubclass(WrapperTensor):
+            @classmethod
+            def get_wrapper_properties(cls, t):
+                return t, {}
+
+            def __init__(self, t):
+                self.t = t
+
+            def __repr__(self):
+                return f"CoordSubclass({self.t})"
+
+            def __tensor_flatten__(self):
+                return ["t"], None
+
+            @classmethod
+            def __tensor_unflatten__(
+                cls, inner_tensors, meta, outer_size, outer_stride
+            ):
+                return cls(inner_tensors["t"])
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+
+                def unwrap(e):
+                    return e.t if isinstance(e, CoordSubclass) else e
+
+                def wrap(e):
+                    return CoordSubclass(e) if isinstance(e, torch.Tensor) else e
+
+                # Try custom dispatch first
+                result = dispatch_fn(func, args, kwargs, unwrap, wrap, get_coord_op)
+                if result is not None:
+                    return result
+
+                # Default: forward the op
+                result = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
+                return tree_map(wrap, result)
+
+        # Return both the subclass and the library (caller must hold lib reference)
+        return CoordSubclass, lib
+
+    def test_unbacked_symint_from_custom_op_in_torch_dispatch(self, device):
+        """
+        Test that unbacked SymInts created by custom ops inside __torch_dispatch__
+        are handled correctly.
+
+        This tests the scenario seen with DTensor embedding where:
+        1. Dynamo traces torch.embedding and creates an FX node
+        2. get_fake_value() runs the op with FakeTensors
+        3. The subclass's __torch_dispatch__ calls a custom op that creates unbacked SymInt
+        4. The unbacked SymInt is used for internal computation but doesn't appear in outputs
+        """
+
+        def embedding_dispatch(func, args, kwargs, unwrap, wrap, coord_op):
+            if func is torch.ops.aten.embedding.default:
+                weight = unwrap(args[0])
+                indices = unwrap(args[1])
+                num_shards = 4
+                coord = coord_op(weight, num_shards)
+                torch._check(coord >= 0)
+                torch._check(coord < num_shards)
+                shard_size = weight.size(0) // num_shards
+                offset = coord * shard_size
+                local_weight = weight[offset : offset + shard_size]
+                result = func(local_weight, indices, *args[2:], **kwargs)
+                return wrap(result)
+            return None
+
+        CoordSubclass, lib = self._make_unbacked_coord_subclass(
+            "test_unbacked_ok", runtime_coord_value=0, dispatch_fn=embedding_dispatch
+        )
+
+        def fn(weight, indices):
+            return torch.embedding(weight, indices)
+
+        weight = CoordSubclass(torch.randn(32, 64, device=device))
+        indices = torch.tensor([0, 1, 2, 3], device=device)
+
+        actual = torch.compile(fn, fullgraph=True)(weight, indices)
+        expected = fn(weight, indices)
+        torch.testing.assert_close(actual.t, expected.t)
+
+    def test_unbacked_symint_torch_check_fails_at_runtime(self, device):
+        """
+        Test that torch._check assertions on unbacked SymInts are actually
+        emitted and executed at runtime by having one that fails.
+        """
+
+        def embedding_dispatch(func, args, kwargs, unwrap, wrap, coord_op):
+            if func is torch.ops.aten.embedding.default:
+                weight = unwrap(args[0])
+                indices = unwrap(args[1])
+                num_shards = 4
+                coord = coord_op(weight, num_shards)
+                torch._check(coord >= 0)
+                torch._check(coord < num_shards)
+                shard_size = weight.size(0) // num_shards
+                offset = coord * shard_size
+                local_weight = weight[offset : offset + shard_size]
+                result = func(local_weight, indices, *args[2:], **kwargs)
+                return wrap(result)
+            return None
+
+        # Use runtime_coord_value=4 which violates torch._check(coord < 4)
+        CoordSubclass, lib = self._make_unbacked_coord_subclass(
+            "test_unbacked_fail", runtime_coord_value=4, dispatch_fn=embedding_dispatch
+        )
+
+        def fn(weight, indices):
+            return torch.embedding(weight, indices)
+
+        weight = CoordSubclass(torch.randn(32, 64, device=device))
+        indices = torch.tensor([0, 1, 2, 3], device=device)
+
+        with self.assertRaisesRegex(RuntimeError, ""):
+            compiled = torch.compile(fn, fullgraph=True)
+            compiled(weight, indices)
+
+    def test_unbacked_symint_returned_and_checked(self, device):
+        """
+        Test that when an unbacked SymInt is created inside __torch_dispatch__
+        (acting as a HOP) and returned, it can be checked with torch._check.
+        """
+
+        # Custom dispatch that intercepts mul and returns tensor with unbacked
+        # symint in its shape
+        def mul_dispatch(func, args, kwargs, unwrap, wrap, coord_op):
+            if func is torch.ops.aten.mul.Tensor:
+                x = unwrap(args[0])
+                y = unwrap(args[1])
+
+                # Get unbacked symint inside __torch_dispatch__ (the HOP)
+                num_shards = 4
+                coord = coord_op(x, num_shards)
+
+                # Return a tensor whose shape includes the unbacked symint
+                # This simulates returning the symint from the HOP
+                result = (x * y)[:coord]
+                return wrap(result)
+            return None
+
+        CoordSubclass, lib = self._make_unbacked_coord_subclass(
+            "test_unbacked_return", runtime_coord_value=2, dispatch_fn=mul_dispatch
+        )
+
+        def fn(x, y):
+            # The mul goes through __torch_dispatch__ which creates unbacked symint
+            # and returns it as part of the result shape
+            result = x * y
+
+            # Check the returned shape (which contains unbacked symint)
+            torch._check(result.size(0) >= 0)
+            torch._check(result.size(0) < 4)
+
+            return result
+
+        x = CoordSubclass(torch.randn(8, 16, device=device))
+        y = CoordSubclass(torch.randn(8, 16, device=device))
+
+        # Should compile and run successfully
+        actual = torch.compile(fn, fullgraph=True)(x, y)
+        expected = fn(x, y)
+        torch.testing.assert_close(actual.t, expected.t)
+
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #169552
* __->__ #172615

When a tensor subclass's `__torch_dispatch__` calls a custom op that creates an
unbacked SymInt (e.g., `DTensor` calling `_runtime_compute_coordinate_on_dim`),
Dynamo would raise PendingUnbackedSymbolNotFound because the symbol was created
during `get_fake_value()` evaluation rather than as a traced FX node.

The fix wraps node execution in `get_fake_value()` with
`ignore_fresh_unbacked_symbols()`, so symbols created by ops inside
`__torch_dispatch__` are properly ignored. This removes the need for manual
workarounds in individual ops.

Also adds tests for this scenario using a tensor subclass that calls a custom op
returning unbacked SymInt from within `__torch_dispatch__`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela