### PR TITLE
[vLLM] Fail the benchmark when the results are all zero

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -131,7 +131,9 @@ jobs:
         with:
           repository: pytorch/pytorch-integration-testing
           path: pytorch/pytorch-integration-testing
-          ref: main
+          # ref: main
+          # TESTING, TO BE REMOVED BEFORE LANDING
+          ref: check-vllm-benchmark-result
 
       - name: Check if the device is supported
         run: |
@@ -197,6 +199,16 @@ jobs:
         run: |
           set -eux
           bash .buildkite/performance-benchmarks/scripts/run-performance-benchmarks.sh
+
+      - name: Check the benchmark results
+        env:
+          BENCHMARK_RESULTS: vllm-project/vllm/benchmarks/results
+        run: |
+          set -eux
+
+          # Fail when there is no result or if the metrics are all zero
+          python3 pytorch/pytorch-integration-testing/.github/scripts/check_benchmark_results.py \
+            --benchmark-results "${BENCHMARK_RESULTS}"
 
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -131,9 +131,7 @@ jobs:
         with:
           repository: pytorch/pytorch-integration-testing
           path: pytorch/pytorch-integration-testing
-          # ref: main
-          # TESTING, TO BE REMOVED BEFORE LANDING
-          ref: check-vllm-benchmark-result
+          ref: main
 
       - name: Check if the device is supported
         run: |


### PR DESCRIPTION
Use the same script as https://github.com/pytorch/pytorch-integration-testing/pull/136, but on PyTorch x vLLM nightly benchmark workflow.

After https://github.com/vllm-project/vllm/pull/30975, vLLM bench serve now returns 0 even when it fails. We need to check for this and fail the benchmark job accordingly instead of uploading 0 to the database.

```
============ Serving Benchmark Result ============
Successful requests:                     0
Failed requests:                         200
Maximum request concurrency:             200
Request rate configured (RPS):           16.00
Benchmark duration (s):                  12.50
Total input tokens:                      0
Total generated tokens:                  0
Request throughput (req/s):              0.00
Output token throughput (tok/s):         0.00
Peak output token throughput (tok/s):    0.00
Peak concurrent requests:                0.00
Total token throughput (tok/s):          0.00
---------------Time to First Token----------------
Mean TTFT (ms):                          0.00
Median TTFT (ms):                        0.00
P99 TTFT (ms):                           0.00
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00
Median TPOT (ms):                        0.00
P99 TPOT (ms):                           0.00
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P99 ITL (ms):                            0.00
==================================================
```

While it didn't even generate anything before

### Testing

* Before this change, https://github.com/pytorch/pytorch/actions/runs/21033043941/job/60479807892#step:15:34520 passed where it should fail because the model failed to load
* After this change, https://github.com/pytorch/pytorch/actions/runs/21057616699 failed accordingly