### PR TITLE
Enhance cuDNN tensor shape checks in sdp_utils.cpp to support Blackwell GPUs

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2745,11 +2745,11 @@ class TestSDPACudaOnly(NNTestCase):
                     attn_mask=None, dropout_p=0.0, is_causal=False)
             self.assertEqual(actual.contiguous(), math_ref.contiguous().to(dtype), atol=1e-3, rtol=1e-2)
 
-        # head_dim=192 support on SM 9.0 (Hopper) and SM 10.x (Blackwell) requires cuDNN >= 9.10.0 (91000)
+        # head_dim=192 support on SM 9.0 (Hopper) and SM 10.x (Blackwell) requires cuDNN >= 9.11.0 (91100)
         # This is a special case for DeepSeek model dimensions
         cudnn_version = torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else 0
         device_capability = torch.cuda.get_device_capability()
-        if (device_capability == (9, 0) or device_capability[0] == 10) and cudnn_version >= 91000:
+        if (device_capability == (9, 0) or device_capability[0] == 10) and cudnn_version >= 91100:
             test()
         else:
             with self.assertRaisesRegex(RuntimeError, "No available kernel."):


### PR DESCRIPTION
This PR does following,
- Enhance cuDNN tensor shape checks in sdp_utils.cpp to support head_dim=192 for Blackwell GPUs. 
- Update test cases in test_transformers.py to reflect changes in head_dim limits and add a new test for cuDNN attention with head_dim=192.

Motivation for this change is to enable usage of SDPA CuDNN Attention kernels on Blackwell GPUs (e.g., B200, GB200 etc.) for DeepSeek V3 model training. Without these changes choosing SDPBackend.CUDNN_ATTENTION results in "No available kernel." error.

**Co-authored with @elfiegg**

cc @csarofeen @ptrblck @xwang233 @eqy @nWEIdia