### PR TITLE
Guard mem-eff attention backward when bias grad is requested without bias

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -464,6 +464,9 @@ _efficient_attention_backward(
   }
 
   if (bias_requires_grad) {
+    TORCH_CHECK(
+        bias.has_value(),
+        "bias_requires_grad is true but no bias was provided");
     // force alignment for the last dim
     std::vector<int64_t> sz = bias->sizes().vec();
     int64_t lastDim = sz[sz.size() - 1];


### PR DESCRIPTION
Add a runtime check to avoid dereferencing a missing bias tensor and raise a clear error instead of segfaulting. Add a CUDA test that exercises the invalid input path for the internal SDPA op.

Fixes #172233 
