### PR TITLE
[Inductor] Solve edge case with TMA persistent template ws ptr reuse

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2078,10 +2078,22 @@ class TritonTemplate(KernelTemplate):
 
         def make_kernel_render(out_node, hint_override: Optional[int] = None):
             assert result is not None
+            # Create a new unique name for the workspace arg buffer for each render
+            # to prevent buffer reuse of the same workspace arg
+            kernel_workspace_arg = workspace_arg
+            if workspace_arg is not None:
+                kernel_workspace_arg = WorkspaceArg(
+                    count=workspace_arg.count,
+                    zero_mode=workspace_arg.zero_mode,
+                    device=workspace_arg.device,
+                    outer_name=WorkspaceArg.unique_name(),
+                    inner_name=workspace_arg.inner_name,
+                    dtype=workspace_arg.dtype,
+                )
             kernel = self.kernel_type(
                 kernel_name=str(Placeholder.KERNEL_NAME),
                 output_node=out_node,
-                workspace_arg=workspace_arg,
+                workspace_arg=kernel_workspace_arg,
                 use_jit=False,
                 hint_override=hint_override,
                 tma_store=tma_store,


### PR DESCRIPTION
Differential Revision: D90866894

When using the persistent+tma gemm templates in workloads, there is a rare edge case of the same workspace buffer being reused, where you might encounter something like `workspace_37 = workspace_37; del workspace_37`. This can happen when `make_kernel_render` is called multiple times when the same template is used, leading to the same workspace buffer in the generated output code. This PR addresses this issue by assigning a new inner name to every call of `make_kernel_render`



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo