### PR TITLE
modify noop slice_scatter pass to not throw on symints

### DIFF
--- a/torch/nativert/graph/TensorMeta.h
+++ b/torch/nativert/graph/TensorMeta.h
@@ -55,6 +55,10 @@ class TensorMeta {
     return sizes_.size();
   }
 
+  bool hasSymbolicShape() const {
+    return hasSymbolicShape_;
+  }
+
   int64_t numel() const {
     TORCH_CHECK(!hasSymbolicShape_, "TensorMeta has symbolic shape");
     return numel_;


### PR DESCRIPTION
Summary: slice_scatter op elimination pass was throwing errors on symints, this updates the pass to gracefully handle graphs with symints

Test Plan:
```
buck2 test fbcode//sigmoid/backend/passes:graph_passes_test -- SubgraphRewriterTest.EliminateNoopSliceScatter --run-disabled
```

```
MODEL_ENTITY_ID=2140840078
SNAPSHOT_ID=4

buck2 run mode/opt //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- --loadMode=Benchmark --inputNetFile=/data/users/$USER/models/${MODEL_ENTITY_ID}/${SNAPSHOT_ID}/${MODEL_ENTITY_ID}_${SNAPSHOT_ID}.predictor.${module_name} --moduleName=${module_name} --submodToDevice="local|cpu"  --benchmarkEnableProfiling=false --disableStaticRuntime=true --doNotRandomizeSampleInputs=true --benchmarkDontRebatchSamples=true --pytorch_predictor_sigmoid_static_dispatch_enable=true --pytorch_predictor_sigmoid_graph_passes_enable=true --pytorch_predictor_runtime_const_folding_enable=true --sampleInputFilePath=${SAMPLE_INPUT_DIR}/${module_name}.forward.sample_input.pt --benchmarkNumIterations=2 --useTgif=true --inputType=pt_scripted
```

Differential Revision: D90809751


