### PR TITLE
Build FA3 wheels for linux

### DIFF
--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PYTORCH_ROOT="${PYTORCH_ROOT:-$(cd "$SOURCE_DIR/../.." && pwd)}"
+
+source "${PYTORCH_ROOT}/.ci/pytorch/common_utils.sh"
+FLASH_ATTENTION_DIR="${PYTORCH_ROOT}/third_party/flash-attention"
+FLASH_ATTENTION_HOPPER_DIR="${FLASH_ATTENTION_DIR}/hopper"
+
+if [[ -z "$FA_FINAL_PACKAGE_DIR" ]]; then
+    fatal "FA_FINAL_PACKAGE_DIR must be set"
+fi
+
+if [[ -z "$WHEEL_PLAT" ]]; then
+    fatal "WHEEL_PLAT must be set"
+fi
+
+if [[ ! -d "$FLASH_ATTENTION_HOPPER_DIR" ]]; then
+    fatal "flash attn directory not found $FLASH_ATTENTION_HOPPER_DIR"
+fi
+
+PYTHON="${PYTHON_EXECUTABLE:-python}"
+
+if [[ ! -d "/usr/local/cuda" ]]; then
+    echo "CUDA not found, installing CUDA toolkit for Flash Attention build"
+
+    if command -v dnf &> /dev/null; then
+        dnf install -y wget gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ || true
+        if [[ -d "/opt/rh/gcc-toolset-13" ]]; then
+            export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+            export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH:-}
+        fi
+    fi
+
+    source "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh"
+
+    case "${CUDA_VERSION:-12.6}" in
+        12.6|12.6.*)
+            install_cuda 12.6.3 cuda_12.6.3_560.35.05_linux
+            CCCL_VERSION="12.6.77"
+            ;;
+        13.0|13.0.*)
+            install_cuda 13.0.2 cuda_13.0.2_580.95.05_linux
+            CCCL_VERSION="13.0.85"
+            ;;
+        *)
+            echo "Unsupported CUDA_VERSION: ${CUDA_VERSION}"
+            exit 1
+            ;;
+    esac
+
+    export CUDA_HOME=/usr/local/cuda
+    export PATH=/usr/local/cuda/bin:$PATH
+
+    if [[ ! -f "/usr/local/cuda/include/cuda/std/utility" ]]; then
+        echo "libcu++ headers not found, downloading cuda_cccl package..."
+        CCCL_URL="https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/linux-${arch_path}/cuda_cccl-linux-${arch_path}-${CCCL_VERSION}-archive.tar.xz"
+        wget -q "${CCCL_URL}" -O - | tar -xJ -C /usr/local/cuda --strip-components=1
+    fi
+
+    echo "Checking libcu++ headers:"
+    ls -la /usr/local/cuda/include/cuda/std/utility || echo "WARNING: libcu++ headers still not found!"
+
+    echo "Installed CUDA version:"
+    nvcc --version
+fi
+
+echo "installing dependencies"
+"$PYTHON" -m pip install einops packaging ninja numpy wheel setuptools
+
+export PATH="$(dirname "$PYTHON"):$PATH"
+echo "ninja location: $(which ninja)"
+
+export FLASH_ATTENTION_FORCE_BUILD="${FLASH_ATTENTION_FORCE_BUILD:-TRUE}"
+
+export FLASH_ATTENTION_DISABLE_SPLIT="${FLASH_ATTENTION_DISABLE_SPLIT:-FALSE}"
+export FLASH_ATTENTION_DISABLE_PAGEDKV="${FLASH_ATTENTION_DISABLE_PAGEDKV:-FALSE}"
+export FLASH_ATTENTION_DISABLE_APPENDKV="${FLASH_ATTENTION_DISABLE_APPENDKV:-FALSE}"
+export FLASH_ATTENTION_DISABLE_LOCAL="${FLASH_ATTENTION_DISABLE_LOCAL:-FALSE}"
+export FLASH_ATTENTION_DISABLE_SOFTCAP="${FLASH_ATTENTION_DISABLE_SOFTCAP:-FALSE}"
+export FLASH_ATTENTION_DISABLE_PACKGQA="${FLASH_ATTENTION_DISABLE_PACKGQA:-FALSE}"
+export FLASH_ATTENTION_DISABLE_FP16="${FLASH_ATTENTION_DISABLE_FP16:-FALSE}"
+export FLASH_ATTENTION_DISABLE_FP8="${FLASH_ATTENTION_DISABLE_FP8:-FALSE}"
+export FLASH_ATTENTION_DISABLE_VARLEN="${FLASH_ATTENTION_DISABLE_VARLEN:-FALSE}"
+export FLASH_ATTENTION_DISABLE_CLUSTER="${FLASH_ATTENTION_DISABLE_CLUSTER:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM64="${FLASH_ATTENTION_DISABLE_HDIM64:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM96="${FLASH_ATTENTION_DISABLE_HDIM96:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM128="${FLASH_ATTENTION_DISABLE_HDIM128:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM192="${FLASH_ATTENTION_DISABLE_HDIM192:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM256="${FLASH_ATTENTION_DISABLE_HDIM256:-FALSE}"
+export FLASH_ATTENTION_DISABLE_SM80="${FLASH_ATTENTION_DISABLE_SM80:-FALSE}"
+export FLASH_ATTENTION_ENABLE_VCOLMAJOR="${FLASH_ATTENTION_ENABLE_VCOLMAJOR:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIMDIFF64="${FLASH_ATTENTION_DISABLE_HDIMDIFF64:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIMDIFF192="${FLASH_ATTENTION_DISABLE_HDIMDIFF192:-FALSE}"
+
+export NVCC_THREADS="${NVCC_THREADS:-8}"
+export MAX_JOBS="${MAX_JOBS:-$(nproc)}"
+
+echo "NVCC_THREADS=${NVCC_THREADS}"
+echo "MAX_JOBS=${MAX_JOBS}"
+
+pushd "$FLASH_ATTENTION_HOPPER_DIR"
+
+git config --global --add safe.directory '*'
+git submodule update --init ../csrc/cutlass
+
+if [[ "$(uname -m)" != "aarch64" ]]; then
+    sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version < Version("12.8")/' \
+        "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
+fi
+
+"$PYTHON" setup.py bdist_wheel \
+    -d "$FA_FINAL_PACKAGE_DIR" \
+    -k \
+    --plat-name "manylinux_2_28_${WHEEL_PLAT}"
+
+echo "wheel built: "
+find "$FA_FINAL_PACKAGE_DIR" -name '*.whl' -exec ls -la {} \;
+
+popd

--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -67,6 +67,26 @@ if [[ ! -d "/usr/local/cuda" ]]; then
     ls -la /usr/local/cuda/include/cuda_runtime.h || echo "WARNING: cuda_runtime.h not found"
     ls -la /usr/local/cuda/include/cuda/std/utility || echo "WARNING: libcu++ headers not found"
 
+    if [[ ! -f "/usr/local/cuda/include/cuda/std/utility" ]]; then
+        echo "libcu++ headers missing, downloading CCCL 12.6 package"
+
+        CCCL_VERSION="12.6.77"
+        CCCL_PKG="cuda_cccl-linux-sbsa-${CCCL_VERSION}-archive"
+        CCCL_URL="https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/linux-sbsa/${CCCL_PKG}.tar.xz"
+        echo "Downloading CCCL from: ${CCCL_URL}"
+
+        CCCL_TMP=$(mktemp -d)
+        pushd "${CCCL_TMP}"
+        wget -q "${CCCL_URL}" -O cccl.tar.xz
+        tar xf cccl.tar.xz
+        cp -a "${CCCL_PKG}"/include/* /usr/local/cuda/include/
+        popd
+        rm -rf "${CCCL_TMP}"
+
+        echo "CCCL installed, verifying..."
+        ls -la /usr/local/cuda/include/cuda/std/utility
+    fi
+
     echo "Installed CUDA version:"
     nvcc --version
 fi

--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -42,17 +42,23 @@ if [[ ! -d "/usr/local/cuda" ]]; then
         fi
     fi
 
-    CUDA_INSTALL_DIR=$(mktemp -d)
-    cp "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh" "${CUDA_INSTALL_DIR}/"
-    cp "${PYTORCH_ROOT}/.ci/docker/common/install_nccl.sh" "${CUDA_INSTALL_DIR}/"
-    cp "${PYTORCH_ROOT}/.ci/docker/common/install_cusparselt.sh" "${CUDA_INSTALL_DIR}/"
-    mkdir -p "${CUDA_INSTALL_DIR}/ci_commit_pins"
-    cp "${PYTORCH_ROOT}/.ci/docker/ci_commit_pins"/nccl* "${CUDA_INSTALL_DIR}/ci_commit_pins/" 2>/dev/null || true
+    if [[ "$(uname -m)" == "aarch64" && "${CUDA_VERSION:-12.6}" == "13.0" ]]; then
+        echo "installing CUDA 13.0.0 for ARM"
+        source "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh"
+        install_cuda 13.0.0 cuda_13.0.0_580.65.06_linux
+    else
+        CUDA_INSTALL_DIR=$(mktemp -d)
+        cp "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh" "${CUDA_INSTALL_DIR}/"
+        cp "${PYTORCH_ROOT}/.ci/docker/common/install_nccl.sh" "${CUDA_INSTALL_DIR}/"
+        cp "${PYTORCH_ROOT}/.ci/docker/common/install_cusparselt.sh" "${CUDA_INSTALL_DIR}/"
+        mkdir -p "${CUDA_INSTALL_DIR}/ci_commit_pins"
+        cp "${PYTORCH_ROOT}/.ci/docker/ci_commit_pins"/nccl* "${CUDA_INSTALL_DIR}/ci_commit_pins/" 2>/dev/null || true
 
-    pushd "${CUDA_INSTALL_DIR}"
-    bash ./install_cuda.sh "${CUDA_VERSION:-12.6}"
-    popd
-    rm -rf "${CUDA_INSTALL_DIR}"
+        pushd "${CUDA_INSTALL_DIR}"
+        bash ./install_cuda.sh "${CUDA_VERSION:-12.6}"
+        popd
+        rm -rf "${CUDA_INSTALL_DIR}"
+    fi
 
     export CUDA_HOME=/usr/local/cuda
     export PATH=/usr/local/cuda/bin:$PATH
@@ -60,72 +66,6 @@ if [[ ! -d "/usr/local/cuda" ]]; then
     echo "=== CUDA installation check ==="
     ls -la /usr/local/cuda/include/cuda_runtime.h || echo "WARNING: cuda_runtime.h not found"
     ls -la /usr/local/cuda/include/cuda/std/utility || echo "WARNING: libcu++ headers not found"
-
-    if [[ ! -f "/usr/local/cuda/include/cuda/std/utility" ]]; then
-        echo "libcu++ headers missing, downloading cuda_cccl package..."
-
-        if [[ "$(uname -m)" == "aarch64" ]]; then
-            REDIST_ARCH="linux-sbsa"
-        else
-            REDIST_ARCH="linux-x86_64"
-        fi
-
-        CUDA_MAJOR_MINOR="${CUDA_VERSION:-12.6}"
-        case "${CUDA_MAJOR_MINOR}" in
-            13.0|13.0.*)
-                CCCL_VERSION="13.0.85"
-                ;;
-            12.6|12.6.*)
-                CCCL_VERSION="12.6.77"
-                ;;
-            *)
-                echo "Unknown CUDA version for CCCL: ${CUDA_MAJOR_MINOR}"
-                CCCL_VERSION=""
-                ;;
-        esac
-
-        if [[ -n "${CCCL_VERSION}" ]]; then
-            CCCL_PKG="cuda_cccl-${REDIST_ARCH}-${CCCL_VERSION}-archive"
-            CCCL_URL="https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/${REDIST_ARCH}/${CCCL_PKG}.tar.xz"
-            echo "Downloading CCCL from: ${CCCL_URL}"
-
-            CCCL_TMP=$(mktemp -d)
-            pushd "${CCCL_TMP}"
-            wget -q "${CCCL_URL}" -O cccl.tar.xz
-            tar xf cccl.tar.xz
-
-            echo "=== CCCL package contents ==="
-            find "${CCCL_PKG}" -type d -name "cuda" | head -20
-            find "${CCCL_PKG}" -name "utility" | head -10
-
-            # Copy all include directories
-            if [[ -d "${CCCL_PKG}/include" ]]; then
-                cp -a "${CCCL_PKG}"/include/* /usr/local/cuda/include/
-            fi
-
-            # CCCL 2.x may have libcudacxx headers under lib/cmake or different location
-            # Check for cuda/std in various locations and copy if found
-            for search_dir in "${CCCL_PKG}/lib" "${CCCL_PKG}"; do
-                if [[ -d "${search_dir}" ]]; then
-                    cuda_std_dir=$(find "${search_dir}" -type d -path "*/cuda/std" 2>/dev/null | head -1)
-                    if [[ -n "${cuda_std_dir}" ]]; then
-                        # Found cuda/std, copy the parent cuda directory
-                        cuda_dir=$(dirname "${cuda_std_dir}")
-                        echo "Found libcu++ at: ${cuda_dir}"
-                        mkdir -p /usr/local/cuda/include/cuda
-                        cp -a "${cuda_dir}"/* /usr/local/cuda/include/cuda/
-                        break
-                    fi
-                fi
-            done
-
-            popd
-            rm -rf "${CCCL_TMP}"
-
-            echo "CCCL installed, verifying..."
-            ls -la /usr/local/cuda/include/cuda/std/utility || echo "WARNING: libcu++ still not found after CCCL install"
-        fi
-    fi
 
     echo "Installed CUDA version:"
     nvcc --version

--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -107,10 +107,8 @@ if [[ "${CUDA_VERSION:-12.6}" == 13.* ]]; then
     fi
 fi
 
-if ! [[ "${CUDA_VERSION:-12.6}" == 13.* && "$(uname -m)" == "aarch64" ]]; then
-    sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8")/' \
-        "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
-fi
+sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8")/' \
+    "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
 
 BUILD_DATE=$(date +%Y%m%d)
 if [[ "${WHEEL_PLAT}" == "aarch64" ]]; then

--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -107,13 +107,23 @@ if [[ "${CUDA_VERSION:-12.6}" == 13.* ]]; then
     fi
 fi
 
-sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8")/' \
-    "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
+if ! [[ "${CUDA_VERSION:-12.6}" == 13.* && "$(uname -m)" == "aarch64" ]]; then
+    sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8")/' \
+        "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
+fi
+
+BUILD_DATE=$(date +%Y%m%d)
+if [[ "${WHEEL_PLAT}" == "aarch64" ]]; then
+    ARCH_TAG="arm"
+else
+    ARCH_TAG="x86"
+fi
+export FLASH_ATTN_LOCAL_VERSION="${BUILD_DATE}.cu${CUDA_SHORT}.${ARCH_TAG}"
 
 "$PYTHON" setup.py bdist_wheel \
     -d "$FA_FINAL_PACKAGE_DIR" \
     -k \
-    --plat-name "manylinux_2_28_${WHEEL_PLAT}"
+    --plat-name "${WHEEL_PLAT}"
 
 echo "wheel built: "
 find "$FA_FINAL_PACKAGE_DIR" -name '*.whl' -exec ls -la {} \;

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -1,0 +1,119 @@
+name: Build Flash Attention 3 wheels
+
+on:
+  workflow_dispatch:
+  # TODO: Remove this trigger before merging - only for testing from PR branch
+  pull_request:
+    paths:
+      - .github/workflows/build-flash-attention-wheel.yml
+      - .ci/flash-attention/*.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  build-wheel:
+    name: "Build FA3 ${{ matrix.cuda_version }} ${{ matrix.arch }}"
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ matrix.runner }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cuda_version: "12.6"
+            arch: "x86_64"
+            cuda_short: "126"
+            torch_cuda_arch_list: "8.0;8.6;9.0"
+            docker_image: "pytorch/manylinux2_28-builder:cuda12.6"
+            runner: "linux.12xlarge.memory"
+          - cuda_version: "13.0"
+            arch: "x86_64"
+            cuda_short: "130"
+            torch_cuda_arch_list: "8.0;8.6;9.0;10.0"
+            docker_image: "pytorch/manylinux2_28-builder:cuda13.0"
+            runner: "linux.12xlarge.memory"
+          - cuda_version: "12.6"
+            arch: "aarch64"
+            cuda_short: "126"
+            torch_cuda_arch_list: "9.0"
+            docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
+            runner: "linux.arm64.r7g.12xlarge.memory"
+          - cuda_version: "13.0"
+            arch: "aarch64"
+            cuda_short: "130"
+            torch_cuda_arch_list: "9.0;10.0"
+            docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
+            runner: "linux.arm64.r7g.12xlarge.memory"
+    timeout-minutes: 1440
+    env:
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      CUDA_VERSION: ${{ matrix.cuda_version }}
+      CUDA_SHORT: ${{ matrix.cuda_short }}
+      TORCH_CUDA_ARCH_LIST: ${{ matrix.torch_cuda_arch_list }}
+    steps:
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+          fail-silently: false
+
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          submodules: true
+
+      - name: Setup Linux
+        uses: ./.github/actions/setup-linux
+
+      - name: Pull Docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ env.DOCKER_IMAGE }}
+
+      - name: Build Flash Attention 3 wheel
+        run: |
+          set -x
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+          container_name=$(docker run \
+            --tty \
+            --detach \
+            -v "${GITHUB_WORKSPACE}:/pytorch" \
+            -v "${RUNNER_TEMP}/artifacts:/artifacts" \
+            -w /pytorch \
+            "${DOCKER_IMAGE}"
+          )
+          PYTHON_EXECUTABLE=/opt/python/cp312-cp312/bin/python
+          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" -m pip install \
+            torch --index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+          docker exec -t \
+            -e CUDA_VERSION="${CUDA_VERSION}" \
+            -e TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
+            -e FA_FINAL_PACKAGE_DIR="/artifacts" \
+            -e WHEEL_PLAT="${{ matrix.arch }}" \
+            -e PYTORCH_ROOT="/pytorch" \
+            -e PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
+            -e MAX_JOBS="${{ matrix.arch == 'aarch64' && '4' || '' }}" \
+            -e NVCC_THREADS="${{ matrix.arch == 'aarch64' && '2' || '' }}" \
+            "${container_name}" bash -c \
+            "bash /pytorch/.ci/flash-attention/build.sh"
+          docker exec -t "${container_name}" chown -R 1000:1000 /artifacts
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: flash-attn-3-wheel-cu${{ matrix.cuda_short }}-${{ matrix.arch }}
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/*.whl
+
+      - name: Teardown Linux
+        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        if: always()

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -31,7 +31,6 @@ jobs:
     name: "Build FA3 ${{ matrix.cuda_version }} ${{ matrix.arch }}"
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ matrix.runner }}"
-    environment: ${{ github.event_name == 'workflow_dispatch' && 'pytorchbot-env' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -74,14 +73,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Configure AWS credentials
-        # Only configure AWS for workflow_dispatch with dry_run=false
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
-          aws-region: us-east-1
-          
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -8,6 +8,10 @@ on:
       - .github/workflows/build-flash-attention-wheel.yml
       - .ci/flash-attention/*.sh
 
+permissions:
+  id-token: write
+  contents: read
+  
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
@@ -27,6 +31,7 @@ jobs:
     name: "Build FA3 ${{ matrix.cuda_version }} ${{ matrix.arch }}"
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ matrix.runner }}"
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'pytorchbot-env' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +74,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Configure AWS credentials
+        # Only configure AWS for workflow_dispatch with dry_run=false
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
+          aws-region: us-east-1
+          
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -46,15 +46,19 @@ jobs:
           - cuda_version: "12.6"
             arch: "aarch64"
             cuda_short: "126"
-            torch_cuda_arch_list: "9.0"
+            torch_cuda_arch_list: "8.0;8.6;9.0"
             docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
             runner: "linux.arm64.r7g.12xlarge.memory"
+            max_jobs: "4"
+            nvcc_threads: "2"
           - cuda_version: "13.0"
             arch: "aarch64"
             cuda_short: "130"
             torch_cuda_arch_list: "9.0;10.0"
             docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
             runner: "linux.arm64.r7g.12xlarge.memory"
+            max_jobs: "1"
+            nvcc_threads: "1"
     timeout-minutes: 1440
     env:
       DOCKER_IMAGE: ${{ matrix.docker_image }}
@@ -95,7 +99,7 @@ jobs:
           )
           PYTHON_EXECUTABLE=/opt/python/cp312-cp312/bin/python
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" -m pip install \
-            torch --index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+            torch --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
           docker exec -t \
             -e CUDA_VERSION="${CUDA_VERSION}" \
             -e TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
@@ -103,8 +107,8 @@ jobs:
             -e WHEEL_PLAT="${{ matrix.arch }}" \
             -e PYTORCH_ROOT="/pytorch" \
             -e PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
-            -e MAX_JOBS="${{ matrix.arch == 'aarch64' && '4' || '' }}" \
-            -e NVCC_THREADS="${{ matrix.arch == 'aarch64' && '2' || '' }}" \
+            -e MAX_JOBS="${{ matrix.max_jobs }}" \
+            -e NVCC_THREADS="${{ matrix.nvcc_threads }}" \
             "${container_name}" bash -c \
             "bash /pytorch/.ci/flash-attention/build.sh"
           docker exec -t "${container_name}" chown -R 1000:1000 /artifacts

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   id-token: write
   contents: read
-  
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -127,3 +127,51 @@ jobs:
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
         if: always()
+
+  upload-wheel:
+    name: "Upload FA3 ${{ matrix.cuda_short }} ${{ matrix.arch }}"
+    needs: build-wheel
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cuda_short: "126"
+            arch: "x86_64"
+          - cuda_short: "130"
+            arch: "x86_64"
+          - cuda_short: "126"
+            arch: "aarch64"
+    permissions:
+      id-token: write
+      contents: read
+    container:
+      image: continuumio/miniconda3:4.12.0
+    environment: pytorchbot-env
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure AWS credentials(PyTorch account) for test
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
+          aws-region: us-east-1
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: flash-attn-3-wheel-cu${{ matrix.cuda_short }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/artifacts
+
+      - name: Upload binaries to test index
+        env:
+          PACKAGE_TYPE: wheel
+          UPLOAD_CHANNEL: test
+          UPLOAD_SUBFOLDER: cu${{ matrix.cuda_short }}
+          PKG_DIR: ${{ runner.temp }}/artifacts
+          DRY_RUN: disabled
+        shell: bash
+        run: |
+          set -ex
+          bash .circleci/scripts/binary_upload.sh

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -51,14 +51,6 @@ jobs:
             runner: "linux.arm64.r7g.12xlarge.memory"
             max_jobs: "4"
             nvcc_threads: "2"
-          - cuda_version: "13.0"
-            arch: "aarch64"
-            cuda_short: "130"
-            torch_cuda_arch_list: "9.0;10.0"
-            docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
-            runner: "linux.arm64.r7g.12xlarge.memory"
-            max_jobs: "2"
-            nvcc_threads: "1"
     timeout-minutes: 1440
     env:
       DOCKER_IMAGE: ${{ matrix.docker_image }}

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -57,7 +57,7 @@ jobs:
             torch_cuda_arch_list: "9.0;10.0"
             docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
             runner: "linux.arm64.r7g.12xlarge.memory"
-            max_jobs: "1"
+            max_jobs: "2"
             nvcc_threads: "1"
     timeout-minutes: 1440
     env:
@@ -102,6 +102,7 @@ jobs:
             torch --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
           docker exec -t \
             -e CUDA_VERSION="${CUDA_VERSION}" \
+            -e CUDA_SHORT="${CUDA_SHORT}" \
             -e TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
             -e FA_FINAL_PACKAGE_DIR="/artifacts" \
             -e WHEEL_PLAT="${{ matrix.arch }}" \


### PR DESCRIPTION
Currently, the only way to install FA3 is to build from source, but that process is notoriously difficult (takes 1+ hour, segfaults, timeouts, etc) so we want to build wheels for major CUDA versions on supported PyTorch platforms and hosting them on PyTorch's index. 

This PR has a build script that leverages PyTorch CI to build these wheels. The trigger is manual and the hope is that we can reuse this script to rebuild whenever there are major upstream changes. 

This PR builds wheels for the following environments: 
- CUDA 12.6 + x86
- CUDA 13.0 + x86
- CUDA 12.6 + ARM

CUDA 13.0 + ARM is still a WIP.

The x86 wheels have been tested locally, but we plan on uploading all 3 wheels to PyTorch's test index before doing further testing on various machines/hardwares. 