### PR TITLE
[CD] Update smoke test, enable torch compile testing for py 3.14 and 3.14t

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -247,11 +247,9 @@ def smoke_test_cuda(
                 version = imported_module._extension._check_cuda_version()
             print(f"{module['name']} CUDA: {version}")
 
-    # torch.compile is available on macos-arm64 and Linux for python 3.8-3.13
     if (
         torch_compile_check == "enabled"
-        and sys.version_info < (3, 14, 0)
-        and target_os in ["linux", "linux-aarch64", "macos-arm64", "darwin"]
+        and target_os in ["linux", "linux-aarch64", "macos-arm64", "darwin", "windows"]
     ):
         smoke_test_compile("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -247,10 +247,12 @@ def smoke_test_cuda(
                 version = imported_module._extension._check_cuda_version()
             print(f"{module['name']} CUDA: {version}")
 
-    if (
-        torch_compile_check == "enabled"
-        and target_os in ["linux", "linux-aarch64", "macos-arm64", "darwin"]
-    ):
+    if torch_compile_check == "enabled" and target_os in [
+        "linux",
+        "linux-aarch64",
+        "macos-arm64",
+        "darwin",
+    ]:
         smoke_test_compile("cuda" if torch.cuda.is_available() else "cpu")
 
     if torch.cuda.is_available():

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -249,7 +249,7 @@ def smoke_test_cuda(
 
     if (
         torch_compile_check == "enabled"
-        and target_os in ["linux", "linux-aarch64", "macos-arm64", "darwin", "windows"]
+        and target_os in ["linux", "linux-aarch64", "macos-arm64", "darwin"]
     ):
         smoke_test_compile("cuda" if torch.cuda.is_available() else "cpu")
 


### PR DESCRIPTION
Updates smoke test to run before promotion of binaries and validations

Test: https://github.com/pytorch/test-infra/actions/runs/21076307815

Please note: not enabling for windows for now since windows requires a followup to set path to cl.exe correctly