### PR TITLE
Remove allocator() from MemPool interface.

### DIFF
--- a/aten/src/ATen/cuda/MemPool.cpp
+++ b/aten/src/ATen/cuda/MemPool.cpp
@@ -20,7 +20,7 @@ MemPool::MemPool(
     bool is_user_created,
     bool use_on_oom,
     bool no_split)
-    : allocator_(allocator.get()), is_user_created_(is_user_created) {
+    : is_user_created_(is_user_created) {
   if (is_user_created_) {
     id_ = {0, uid_++};
   } else {
@@ -50,10 +50,6 @@ MemPool::~MemPool() {
 
 MempoolId_t MemPool::id() {
   return id_;
-}
-
-CUDACachingAllocator::CUDAAllocator* MemPool::allocator() {
-  return allocator_;
 }
 
 int MemPool::use_count() {

--- a/aten/src/ATen/cuda/MemPool.h
+++ b/aten/src/ATen/cuda/MemPool.h
@@ -31,7 +31,6 @@ struct TORCH_CUDA_CPP_API MemPool {
   ~MemPool();
 
   MempoolId_t id();
-  c10::cuda::CUDACachingAllocator::CUDAAllocator* allocator();
   int use_count();
   c10::DeviceIndex device();
   static MempoolId_t graph_pool_handle(bool is_user_created = true);
@@ -39,7 +38,6 @@ struct TORCH_CUDA_CPP_API MemPool {
  private:
   static std::atomic<CaptureId_t> uid_;
   static std::atomic<CaptureId_t> uuid_;
-  c10::cuda::CUDACachingAllocator::CUDAAllocator* allocator_;
   bool is_user_created_;
   MempoolId_t id_;
   c10::DeviceIndex device_;

--- a/torch/csrc/cuda/MemPool.cpp
+++ b/torch/csrc/cuda/MemPool.cpp
@@ -25,6 +25,5 @@ void THCPMemPool_init(PyObject* module) {
                 std::move(allocator), is_user_created, use_on_oom, no_split);
           }))
       .def_property_readonly("id", &::at::cuda::MemPool::id)
-      .def_property_readonly("allocator", &::at::cuda::MemPool::allocator)
       .def("use_count", &::at::cuda::MemPool::use_count);
 }


### PR DESCRIPTION
Resolves this request: https://github.com/pytorch/pytorch/pull/171962/changes#r2674543773

It's likely not being used anyway, but CI will confirm.