### PR TITLE
[effect] Fix backwards with AOTAutograd

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -61,7 +61,7 @@ from ._aot_autograd.descriptors import (
 )
 from ._aot_autograd.functional_utils import _is_functional_graph
 from ._aot_autograd.logging_utils import get_aot_graph_name
-from ._aot_autograd.utils import get_cuda_generator_meta_val, is_with_effects
+from ._aot_autograd.utils import get_cuda_generator_meta_val
 from .compile_utils import fx_graph_cse, get_aten_target, raise_getitems
 
 
@@ -333,7 +333,8 @@ def _has_tag_must_be_in_backward(node: fx.Node) -> bool:
 def _must_be_in_forward(node: fx.Node) -> bool:
     if _has_tag_must_be_in_forward(node):
         return True
-    is_mutable = is_with_effects(node) or (
+
+    is_mutable = (
         isinstance(node.target, torch._ops.OpOverload)
         and node.target._schema.is_mutable
     )
@@ -347,7 +348,7 @@ def _must_be_in_forward(node: fx.Node) -> bool:
 def _must_be_in_backward(node: fx.Node) -> bool:
     if _has_tag_must_be_in_backward(node):
         return True
-    is_mutable = is_with_effects(node) or (
+    is_mutable = (
         isinstance(node.target, torch._ops.OpOverload)
         and node.target._schema.is_mutable
     )


### PR DESCRIPTION
The existing code by default marks with_effect nodes as being "must_be_in_forward" and relies on `set_node_meta` to set the backwards with_effect nodes as having the `is_backwards` partitioning tag. However with the AutogradFunction HOO, we overwrite the partitioning tag with the `torch.fx.Interpreter call`. I tried changing the set_node_meta in https://github.com/pytorch/pytorch/pull/172317, but seems like a bunch of other stuff broke (invoke_subgraph, cuda streams..). 

However if we can just properly mark if a token node is in the backwards or forwards, then we can use the logic later down in [`_extract_graph_with_inputs_outputs`](https://github.com/pytorch/pytorch/blob/071bbf6855994e23a9039b95464d54fbe158060c/torch/_functorch/partitioners.py#L245-L256) to determine whether or not the with_effect node is in the forwards/backwards. 

The function [`_is_tangent`](https://github.com/pytorch/pytorch/blob/071bbf6855994e23a9039b95464d54fbe158060c/torch/_functorch/partitioners.py#L290-L291) already properly determines the token input as being a tangent input via matching `tangents` in the name! So the only change we need is just to turn off marking with_effect nodes as being "must_be_in_forward".

I'm also unsure if this `is_backward` metadata issue will affect other things too. Seems like [`checkpointing`](https://github.com/pytorch/pytorch/blob/071bbf6855994e23a9039b95464d54fbe158060c/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py#L56) might use this too? 