### PR TITLE
Fix UserDefinedTupleVariable equality fallback behavior 

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -580,7 +580,7 @@ class FunctionTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
     def test_tuple2(a, b):
         args = [a, b]
         return sub(*args)
-    
+
     @make_test
     def test_tuple_map(a, b):
         t = tuple(map(torch.sin, [a, b]))
@@ -5137,10 +5137,10 @@ class DefaultsTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         def fn(x, my_tuple_1, my_tuple_2):
             """Returns different values based on equality check"""
             if my_tuple_1 != my_tuple_2:
-                return x + 1.0 
+                return x + 1.0
             else:
                 return x - 1.0
-        
+
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         x = torch.randn(1)
         my_tuple_1 = MyTuple([1, -1])
@@ -5148,7 +5148,6 @@ class DefaultsTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         ref_x = fn(x, my_tuple_1, my_tuple_2)
         res_x = opt_fn(x, my_tuple_1, my_tuple_2)
         self.assertEqual(ref_x, res_x)
-       
 
     def test_udf_namedtuple(self):
         class MyTuple(NamedTuple):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1495,13 +1495,6 @@ class NamedTupleVariable(UserDefinedTupleVariable):
             return False
         return True
 
-    def is_python_equal(self, other: Any) -> bool:
-        if isinstance(other, UserDefinedTupleVariable):
-            return super().is_python_equal(other)
-        elif isinstance(other, TupleVariable):
-            return all(a.is_python_equal(b) for (a, b) in zip(self.items, other.items))
-        return False
-
     def call_method(
         self,
         tx: "InstructionTranslator",

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1512,14 +1512,6 @@ class NamedTupleVariable(UserDefinedTupleVariable):
         if self._is_method_overridden(name):
             # Fall back to UserDefinedTupleVariable
             return super().call_method(tx, name, args, kwargs)
-        elif name == "__eq__":
-            if len(args) != 1 or kwargs:
-                raise ValueError("Improper arguments for method.")
-            return ConstantVariable(self.is_python_equal(args[0]))
-        elif name == "__ne__":
-            if len(args) != 1 or kwargs:
-                raise ValueError("Improper arguments for method.")
-            return ConstantVariable(not self.is_python_equal(args[0]))
         elif name == "__setattr__":
             if kwargs or len(args) != 2:
                 raise_args_mismatch(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2590,6 +2590,14 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         assert self._tuple_vt is not None
+        if name == "__eq__":
+            if len(args) != 1 or kwargs:
+                raise ValueError("Improper arguments for method.")
+            return variables.ConstantVariable(self.is_python_equal(args[0]))
+        elif name == "__ne__":
+            if len(args) != 1 or kwargs:
+                raise ValueError("Improper arguments for method.")
+            return variables.ConstantVariable(not self.is_python_equal(args[0]))
         method = self._maybe_get_baseclass_method(name)
         if method in tuple_methods:
             return self._tuple_vt.call_method(tx, name, args, kwargs)


### PR DESCRIPTION
The issue is that UserDefinedTupleVariable was being unwrapped in

```python
method = self._maybe_get_baseclass_method(name)
if method in tuple_methods:
  return self._tuple_vt.call_method(tx, name, args, kwargs)
```
but args was still a UserDefinedTupleVariable not a TupleVariable.

The correct implementation was already in UserDefinedTupleVariable.is_python_equal, so I changed the control flow to call it.

This also allowed NamedTupleVariable to fall back to UserDefinedTupleVariable for the equality check.
Fixes #172666


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo