### PR TITLE
[nativert] implicit fastresizetozero for reused output buffers

### DIFF
--- a/torch/nativert/OVERVIEW.md
+++ b/torch/nativert/OVERVIEW.md
@@ -264,7 +264,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.relu.default", aten_relu, {
     KernelOutput(0) = create_empty_from(in0_t);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::threshold_out(out_t, in0_t, 0, 0);
 });
 ```

--- a/torch/nativert/executor/OpKernel.h
+++ b/torch/nativert/executor/OpKernel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <c10/core/Device.h>
 #include <torch/nativert/executor/ExecutionFrame.h>
 #include <torch/nativert/executor/OpKernelKind.h>
@@ -99,7 +101,9 @@ class OpKernel {
   explicit OpKernel(
       const Node* node,
       OpKernelKind kind = OpKernelKind::kInterpreterFallbackKernel)
-      : node_(node), kind_(kind) {
+      : node_(node),
+        kind_(kind),
+        _outputResized(node->outputs().size(), false) {
     VLOG(1) << "Initializing kernel for node: " << *node_;
   }
 
@@ -152,6 +156,10 @@ class OpKernel {
   const static bool blockingEnabled_;
   // this should be set in the ctor!
   const OpKernelKind kind_;
+  // Tracks which outputs have been resized in the current computeInternal call.
+  // Reset after each computeInternal() call in compute().
+  // Sized to node->outputs().size() in the constructor.
+  mutable std::vector<bool> _outputResized;
 };
 
 } // namespace torch::nativert

--- a/torch/nativert/kernels/GeneratedStaticDispatchKernels.cpp
+++ b/torch/nativert/kernels/GeneratedStaticDispatchKernels.cpp
@@ -39,7 +39,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.absolute.default", aten_absolute_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::absolute_out(self, out);
 })
 
@@ -50,7 +49,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.angle.default", aten_angle_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::angle_out(self, out);
 })
 
@@ -61,7 +59,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sgn.default", aten_sgn_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::sgn_out(out, self);
 })
 
@@ -72,7 +69,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.acos.default", aten_acos_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::acos_out(out, self);
 })
 
@@ -83,7 +79,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.arccos.default", aten_arccos_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::arccos_out(self, out);
 })
 
@@ -96,7 +91,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.add.Tensor", aten_add_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::add_out(out, self, other, alpha);
 })
 
@@ -108,7 +102,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.add.Scalar", aten_add_Scalar, {
     out = create_empty_from(self);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::add_out(out_t, self, other, alpha);
 })
 
@@ -121,7 +114,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten._add_relu.Tensor", aten__add_relu_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::add_relu_out(self, other, alpha, out);
 })
 
@@ -136,7 +128,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.addmv.default", aten_addmv_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::addmv_out(out, self, mat, vec, beta, alpha);
 })
 
@@ -151,7 +142,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.addr.default", aten_addr_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::addr_out(self, vec1, vec2, beta, alpha, out);
 })
 
@@ -164,7 +154,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.all.dim", aten_all_dim, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::all_out(out, self, dim, keepdim);
 })
 
@@ -177,7 +166,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.any.dim", aten_any_dim, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::any_out(out, self, dim, keepdim);
 })
 
@@ -190,7 +178,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.argmax.default", aten_argmax_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::argmax_out(out, self, dim, keepdim);
 })
 
@@ -201,7 +188,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.acosh.default", aten_acosh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::acosh_out(out, self);
 })
 
@@ -212,7 +198,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.asinh.default", aten_asinh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::asinh_out(out, self);
 })
 
@@ -223,7 +208,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.arcsinh.default", aten_arcsinh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::arcsinh_out(self, out);
 })
 
@@ -234,7 +218,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.atanh.default", aten_atanh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::atanh_out(out, self);
 })
 
@@ -245,7 +228,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.arctanh.default", aten_arctanh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::arctanh_out(self, out);
 })
 
@@ -256,7 +238,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.asin.default", aten_asin_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::asin_out(out, self);
 })
 
@@ -267,7 +248,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.arcsin.default", aten_arcsin_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::arcsin_out(self, out);
 })
 
@@ -278,7 +258,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.atan.default", aten_atan_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::atan_out(out, self);
 })
 
@@ -289,7 +268,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.arctan.default", aten_arctan_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::arctan_out(self, out);
 })
 
@@ -304,7 +282,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.baddbmm.default", aten_baddbmm_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::baddbmm_out(out, self, batch1, batch2, beta, alpha);
 })
 
@@ -318,7 +295,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::bitwise_not_out(out, self);
     })
 
@@ -330,7 +306,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.copysign.Tensor", aten_copysign_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::copysign_out(out, self, other);
 })
 
@@ -344,7 +319,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::logical_not_out(self, out);
     })
 
@@ -359,7 +333,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::logical_xor_out(self, other, out);
     })
 
@@ -374,7 +347,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::logical_and_out(self, other, out);
     })
 
@@ -389,7 +361,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::logical_or_out(self, other, out);
     })
 
@@ -400,7 +371,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ceil.default", aten_ceil_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::ceil_out(out, self);
 })
 
@@ -413,7 +383,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.clamp.default", aten_clamp_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::clamp_out(out, self, min, max);
 })
 
@@ -426,7 +395,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.clamp.Tensor", aten_clamp_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::clamp_out(out, self, min, max);
 })
 
@@ -441,7 +409,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::clamp_max_out(out, self, max);
     })
 
@@ -453,7 +420,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.clamp_max.Tensor", aten_clamp_max_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::clamp_max_out(out, self, max);
 })
 
@@ -466,7 +432,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.clip.default", aten_clip_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::clip_out(self, min, max, out);
 })
 
@@ -478,7 +443,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.complex.default", aten_complex_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::complex_out(real, imag, out);
 })
 
@@ -490,7 +454,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.polar.default", aten_polar_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::polar_out(abs, angle, out);
 })
 
@@ -501,7 +464,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.cos.default", aten_cos_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::cos_out(out, self);
 })
 
@@ -512,7 +474,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.cosh.default", aten_cosh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::cosh_out(out, self);
 })
 
@@ -525,7 +486,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.cumprod.default", aten_cumprod_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::cumprod_out(out, self, dim, dtype);
 })
 
@@ -540,7 +500,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.diff.default", aten_diff_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::diff_out(self, n, dim, prepend, append, out);
 })
 
@@ -552,7 +511,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.div.Tensor", aten_div_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::div_out(out, self, other);
 })
 
@@ -565,7 +523,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.div.Tensor_mode", aten_div_Tensor_mode, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::div_out(out, self, other, rounding_mode);
 })
 
@@ -577,7 +534,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.divide.Tensor", aten_divide_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::divide_out(self, other, out);
 })
 
@@ -592,7 +548,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::true_divide_out(self, other, out);
     })
 
@@ -604,7 +559,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.dot.default", aten_dot_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::dot_out(self, tensor, out);
 })
 
@@ -616,7 +570,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.vdot.default", aten_vdot_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::vdot_out(self, other, out);
 })
 
@@ -627,7 +580,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.erf.default", aten_erf_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::erf_out(out, self);
 })
 
@@ -638,7 +590,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.erfc.default", aten_erfc_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::erfc_out(out, self);
 })
 
@@ -649,7 +600,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.exp.default", aten_exp_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::exp_out(out, self);
 })
 
@@ -660,7 +610,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.exp2.default", aten_exp2_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::exp2_out(out, self);
 })
 
@@ -671,7 +620,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.expm1.default", aten_expm1_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::expm1_out(out, self);
 })
 
@@ -682,7 +630,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.floor.default", aten_floor_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::floor_out(out, self);
 })
 
@@ -693,7 +640,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.frac.default", aten_frac_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::frac_out(out, self);
 })
 
@@ -705,7 +651,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.gcd.default", aten_gcd_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::gcd_out(out, self, other);
 })
 
@@ -717,7 +662,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.lcm.default", aten_lcm_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::lcm_out(out, self, other);
 })
 
@@ -734,7 +678,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::index_copy_out(out, self, dim, index, source);
     })
 
@@ -752,7 +695,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::isin_out(out, elements, test_elements, assume_unique, invert);
     })
 
@@ -770,7 +712,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::isin_out(out, elements, test_element, assume_unique, invert);
     })
 
@@ -788,7 +729,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::isin_out(out, element, test_elements, assume_unique, invert);
     })
 
@@ -800,7 +740,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.kron.default", aten_kron_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::kron_out(self, other, out);
 })
 
@@ -812,7 +751,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ldexp.Tensor", aten_ldexp_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::ldexp_out(self, other, out);
 })
 
@@ -823,7 +761,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.log10.default", aten_log10_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::log10_out(out, self);
 })
 
@@ -834,7 +771,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.log1p.default", aten_log1p_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::log1p_out(out, self);
 })
 
@@ -845,7 +781,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.log2.default", aten_log2_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::log2_out(out, self);
 })
 
@@ -860,7 +795,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::logaddexp_out(out, self, other);
     })
 
@@ -875,7 +809,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::logaddexp2_out(out, self, other);
     })
 
@@ -887,7 +820,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.xlogy.Tensor", aten_xlogy_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::xlogy_out(out, self, other);
 })
 
@@ -903,7 +835,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::_log_softmax_out(out, self, dim, half_to_float);
     })
 
@@ -918,7 +849,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::_logcumsumexp_out_cpu(self, dim, out);
     })
 
@@ -933,7 +863,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::logcumsumexp_out(self, dim, out);
     })
 
@@ -948,7 +877,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::matrix_power_out(self, n, out);
     })
 
@@ -960,7 +888,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mm.default", aten_mm_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::mm_out(out, self, mat2);
 })
 
@@ -972,7 +899,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.multiply.Tensor", aten_multiply_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::multiply_out(self, other, out);
 })
 
@@ -984,7 +910,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mv.default", aten_mv_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::mv_out(self, vec, out);
 })
 
@@ -996,7 +921,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mvlgamma.default", aten_mvlgamma_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::mvlgamma_out(self, p, out);
 })
 
@@ -1007,7 +931,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.rad2deg.default", aten_rad2deg_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::rad2deg_out(self, out);
 })
 
@@ -1018,7 +941,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.deg2rad.default", aten_deg2rad_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::deg2rad_out(self, out);
 })
 
@@ -1032,7 +954,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::reciprocal_out(out, self);
     })
 
@@ -1043,7 +964,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.neg.default", aten_neg_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::neg_out(out, self);
 })
 
@@ -1054,7 +974,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.negative.default", aten_negative_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::negative_out(self, out);
 })
 
@@ -1065,7 +984,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.round.default", aten_round_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::round_out(out, self);
 })
 
@@ -1077,7 +995,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.round.decimals", aten_round_decimals, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::round_out(out, self, decimals);
 })
 
@@ -1089,7 +1006,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.gelu.default", aten_gelu_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::gelu_out(out, self, approximate);
 })
 
@@ -1104,7 +1020,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::hardshrink_out(out, self, lambd);
     })
 
@@ -1120,7 +1035,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::hardshrink_backward_out(grad_input, grad_out, self, lambd);
     })
 
@@ -1131,7 +1045,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.rsqrt.default", aten_rsqrt_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::rsqrt_out(out, self);
 })
 
@@ -1142,7 +1055,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.silu.default", aten_silu_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::silu_out(out, self);
 })
 
@@ -1157,7 +1069,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::silu_backward_out(grad_input, grad_output, self);
     })
 
@@ -1168,7 +1079,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mish.default", aten_mish_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::mish_out(out, self);
 })
 
@@ -1179,7 +1089,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sigmoid.default", aten_sigmoid_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::sigmoid_out(out, self);
 })
 
@@ -1190,7 +1099,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sin.default", aten_sin_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::sin_out(out, self);
 })
 
@@ -1201,7 +1109,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sinc.default", aten_sinc_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::sinc_out(out, self);
 })
 
@@ -1212,7 +1119,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sinh.default", aten_sinh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::sinh_out(out, self);
 })
 
@@ -1225,7 +1131,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten._softmax.default", aten__softmax_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::_softmax_out(out, self, dim, half_to_float);
 })
 
@@ -1236,7 +1141,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sqrt.default", aten_sqrt_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::sqrt_out(out, self);
 })
 
@@ -1247,7 +1151,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.square.default", aten_square_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::square_out(self, out);
 })
 
@@ -1259,7 +1162,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.prod.default", aten_prod_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::prod_out(self, dtype, out);
 })
 
@@ -1273,7 +1175,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.prod.dim_int", aten_prod_dim_int, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::prod_out(out, self, dim, keepdim, dtype);
 })
 
@@ -1284,7 +1185,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.tan.default", aten_tan_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::tan_out(out, self);
 })
 
@@ -1295,7 +1195,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.tanh.default", aten_tanh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::tanh_out(out, self);
 })
 
@@ -1311,7 +1210,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::threshold_out(out, self, threshold, value);
     })
 
@@ -1328,7 +1226,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::threshold_backward_out(grad_input, grad_output, self, threshold);
     })
 
@@ -1339,7 +1236,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.trunc.default", aten_trunc_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::trunc_out(out, self);
 })
 
@@ -1350,7 +1246,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.fix.default", aten_fix_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::fix_out(self, out);
 })
 
@@ -1365,7 +1260,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::nuclear_norm_out(self, keepdim, out);
     })
 
@@ -1378,7 +1272,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.subtract.Tensor", aten_subtract_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::subtract_out(self, other, alpha, out);
 })
 
@@ -1393,7 +1286,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::heaviside_out(out, self, values);
     })
 
@@ -1413,7 +1305,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::_addmm_activation_out(
           out, self, mat1, mat2, beta, alpha, use_gelu);
     })
@@ -1432,7 +1323,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::index_add_out(out, self, dim, index, source, alpha);
     })
 
@@ -1446,7 +1336,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.scatter.src", aten_scatter_src, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::scatter_out(out, self, dim, index, src);
 })
 
@@ -1460,7 +1349,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.scatter.value", aten_scatter_value, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::scatter_out(out, self, dim, index, value);
 })
 
@@ -1475,7 +1363,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.scatter.reduce", aten_scatter_reduce, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::scatter_out(out, self, dim, index, src, reduce);
 })
 
@@ -1493,7 +1380,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::scatter_out(out, self, dim, index, value, reduce);
     })
 
@@ -1510,7 +1396,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::scatter_add_out(out, self, dim, index, src);
     })
 
@@ -1530,7 +1415,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::scatter_reduce_out(
           out, self, dim, index, src, reduce, include_self);
     })
@@ -1543,7 +1427,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.eq.Scalar", aten_eq_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::eq_out(out, self, other);
 })
 
@@ -1555,7 +1438,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.eq.Tensor", aten_eq_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::eq_out(out, self, other);
 })
 
@@ -1570,7 +1452,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::bitwise_and_out(out, self, other);
     })
 
@@ -1585,7 +1466,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::bitwise_or_out(out, self, other);
     })
 
@@ -1600,7 +1480,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::bitwise_xor_out(out, self, other);
     })
 
@@ -1615,7 +1494,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::bitwise_left_shift_out(out, self, other);
     })
 
@@ -1630,7 +1508,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::bitwise_right_shift_out(out, self, other);
     })
 
@@ -1642,7 +1519,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.tril.default", aten_tril_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::tril_out(out, self, diagonal);
 })
 
@@ -1654,7 +1530,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.triu.default", aten_triu_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::triu_out(out, self, diagonal);
 })
 
@@ -1665,7 +1540,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.digamma.default", aten_digamma_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::digamma_out(out, self);
 })
 
@@ -1678,7 +1552,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.lerp.Scalar", aten_lerp_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::lerp_out(out, self, end, weight);
 })
 
@@ -1691,7 +1564,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.lerp.Tensor", aten_lerp_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::lerp_out(out, self, end, weight);
 })
 
@@ -1706,7 +1578,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.addbmm.default", aten_addbmm_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::addbmm_out(self, batch1, batch2, beta, alpha, out);
 })
 
@@ -1719,7 +1590,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.cross.default", aten_cross_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::cross_out(self, other, dim, out);
 })
 
@@ -1731,7 +1601,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ne.Scalar", aten_ne_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::ne_out(out, self, other);
 })
 
@@ -1743,7 +1612,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ne.Tensor", aten_ne_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::ne_out(out, self, other);
 })
 
@@ -1755,7 +1623,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ge.Scalar", aten_ge_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::ge_out(out, self, other);
 })
 
@@ -1767,7 +1634,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ge.Tensor", aten_ge_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::ge_out(out, self, other);
 })
 
@@ -1779,7 +1645,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.le.Scalar", aten_le_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::le_out(out, self, other);
 })
 
@@ -1791,7 +1656,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.le.Tensor", aten_le_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::le_out(out, self, other);
 })
 
@@ -1803,7 +1667,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.gt.Scalar", aten_gt_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::gt_out(out, self, other);
 })
 
@@ -1815,7 +1678,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.gt.Tensor", aten_gt_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::gt_out(out, self, other);
 })
 
@@ -1827,7 +1689,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.lt.Scalar", aten_lt_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::lt_out(out, self, other);
 })
 
@@ -1839,7 +1700,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.lt.Tensor", aten_lt_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::lt_out(out, self, other);
 })
 
@@ -1851,7 +1711,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.take.default", aten_take_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::take_out(self, index, out);
 })
 
@@ -1867,7 +1726,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::take_along_dim_out(self, indices, dim, out);
     })
 
@@ -1882,7 +1740,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::masked_select_out_cpu(self, mask, out);
     })
 
@@ -1896,7 +1753,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.gather.default", aten_gather_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::gather_out(out, self, dim, index, sparse_grad);
 })
 
@@ -1910,7 +1766,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.addcmul.default", aten_addcmul_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::addcmul_out(out, self, tensor1, tensor2, value);
 })
 
@@ -1924,7 +1779,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.addcdiv.default", aten_addcdiv_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::addcdiv_out(out, self, tensor1, tensor2, value);
 })
 
@@ -1943,7 +1797,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_solve_triangular_out(
           self, B, upper, left, unitriangular, out);
     })
@@ -1960,7 +1813,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::cholesky_solve_out(self, input2, upper, out);
     })
 
@@ -1975,7 +1827,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::cholesky_inverse_out(self, upper, out);
     })
 
@@ -1987,7 +1838,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.orgqr.default", aten_orgqr_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::orgqr_out(self, input2, out);
 })
 
@@ -2002,7 +1852,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ormqr.default", aten_ormqr_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::ormqr_out(self, input2, input3, left, transpose, out);
 })
 
@@ -2013,7 +1862,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.lgamma.default", aten_lgamma_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::lgamma_out(out, self);
 })
 
@@ -2028,7 +1876,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::polygamma_out(out, n, self);
     })
 
@@ -2039,7 +1886,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.erfinv.default", aten_erfinv_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::erfinv_out(out, self);
 })
 
@@ -2050,7 +1896,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.i0.default", aten_i0_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::i0_out(out, self);
 })
 
@@ -2061,7 +1906,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.signbit.default", aten_signbit_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::signbit_out(out, self);
 })
 
@@ -2073,7 +1917,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.atan2.default", aten_atan2_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::atan2_out(out, self, other);
 })
 
@@ -2085,7 +1928,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.arctan2.default", aten_arctan2_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::arctan2_out(self, other, out);
 })
 
@@ -2099,7 +1941,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.histc.default", aten_histc_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::histogram_histc_out(self, bins, min, max, out);
 })
 
@@ -2111,7 +1952,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.fmod.Tensor", aten_fmod_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::fmod_out(out, self, other);
 })
 
@@ -2123,7 +1963,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.hypot.default", aten_hypot_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::hypot_out(out, self, other);
 })
 
@@ -2135,7 +1974,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.igamma.default", aten_igamma_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::igamma_out(out, self, other);
 })
 
@@ -2147,7 +1985,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.igammac.default", aten_igammac_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::igammac_out(out, self, other);
 })
 
@@ -2162,7 +1999,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::nextafter_out(out, self, other);
     })
 
@@ -2174,7 +2010,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.fmin.default", aten_fmin_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::fmin_out(out, self, other);
 })
 
@@ -2186,7 +2021,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.fmax.default", aten_fmax_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::fmax_out(out, self, other);
 })
 
@@ -2198,7 +2032,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.maximum.default", aten_maximum_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::maximum_out(out, self, other);
 })
 
@@ -2210,7 +2043,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.minimum.default", aten_minimum_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::minimum_out(out, self, other);
 })
 
@@ -2222,7 +2054,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.min.other", aten_min_other, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::min_out(self, other, out);
 })
 
@@ -2238,7 +2069,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.quantile.default", aten_quantile_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::quantile_out(self, q, dim, keepdim, interpolation, out);
 })
 
@@ -2257,7 +2087,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::nanquantile_out(self, q, dim, keepdim, interpolation, out);
     })
 
@@ -2268,7 +2097,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.msort.default", aten_msort_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::msort_out(self, out);
 })
 
@@ -2279,7 +2107,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.all.default", aten_all_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::all_out(out, self);
 })
 
@@ -2290,7 +2117,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.any.default", aten_any_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::any_out(out, self);
 })
 
@@ -2304,7 +2130,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.renorm.default", aten_renorm_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::renorm_out(out, self, p, dim, maxnorm);
 })
 
@@ -2321,7 +2146,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::_convert_indices_from_coo_to_csr_out(out, self, size, out_int32);
     })
 
@@ -2339,7 +2163,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::_convert_indices_from_csr_to_coo_out(
           out, crow_indices, col_indices, out_int32, transpose);
     })
@@ -2353,7 +2176,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mse_loss.default", aten_mse_loss_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::mse_loss_out(out, self, target, reduction);
 })
 
@@ -2373,7 +2195,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::multi_margin_loss_cpu_out(
           self, target, p, margin, weight, reduction, out);
     })
@@ -2391,7 +2212,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::multilabel_margin_loss_out(self, target, reduction, out);
     })
 
@@ -2407,7 +2227,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::soft_margin_loss_out(self, target, reduction, out);
     })
 
@@ -2421,7 +2240,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.elu.default", aten_elu_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::elu_out(out, self, alpha, scale, input_scale);
 })
 
@@ -2441,7 +2259,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::elu_backward_out(
           grad_input,
           grad_output,
@@ -2460,7 +2277,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.glu.default", aten_glu_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::glu_out(out, self, dim);
 })
 
@@ -2474,7 +2290,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::hardsigmoid_out(out, self);
     })
 
@@ -2489,7 +2304,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::hardsigmoid_backward_out(grad_input, grad_output, self);
     })
 
@@ -2502,7 +2316,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.hardtanh.default", aten_hardtanh_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::hardtanh_out(self, min_val, max_val, out);
 })
 
@@ -2516,7 +2329,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::hardswish_out(self, out);
     })
 
@@ -2534,7 +2346,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::leaky_relu_backward_out(
           grad_input, grad_output, self, negative_slope, self_is_result);
     })
@@ -2549,7 +2360,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::log_sigmoid_out(self, out);
     })
 
@@ -2562,7 +2372,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.softplus.default", aten_softplus_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::softplus_out(out, self, beta, threshold);
 })
 
@@ -2580,7 +2389,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::softplus_backward_out(
           grad_input, grad_output, self, beta, threshold);
     })
@@ -2596,7 +2404,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::softshrink_out(out, self, lambd);
     })
 
@@ -2613,7 +2420,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& grad_input = KernelOutput(0).toTensor();
-      fastResizeToZero(grad_input);
       at::cpu::softshrink_backward_out(grad_input, grad_output, self, lambd);
     })
 
@@ -2624,7 +2430,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.isposinf.default", aten_isposinf_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::isposinf_out(out, self);
 })
 
@@ -2635,7 +2440,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.isneginf.default", aten_isneginf_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::isneginf_out(out, self);
 })
 
@@ -2649,7 +2453,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_entr_out(out, self);
     })
 
@@ -2663,7 +2466,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_ndtri_out(out, self);
     })
 
@@ -2677,7 +2479,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_log_ndtr_out(out, self);
     })
 
@@ -2691,7 +2492,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_expm1_out(self, out);
     })
 
@@ -2705,7 +2505,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_exp2_out(self, out);
     })
 
@@ -2719,7 +2518,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_psi_out(self, out);
     })
 
@@ -2733,7 +2531,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_digamma_out(self, out);
     })
 
@@ -2747,7 +2544,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_gammaln_out(self, out);
     })
 
@@ -2761,7 +2557,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_erf_out(self, out);
     })
 
@@ -2775,7 +2570,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_erfc_out(self, out);
     })
 
@@ -2789,7 +2583,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_erfcx_out(out, self);
     })
 
@@ -2803,7 +2596,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_erfinv_out(self, out);
     })
 
@@ -2817,7 +2609,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_ndtr_out(self, out);
     })
 
@@ -2832,7 +2623,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_xlog1py_out(out, self, other);
     })
 
@@ -2847,7 +2637,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_xlogy_out(self, other, out);
     })
 
@@ -2862,7 +2651,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_zeta_out(out, self, other);
     })
 
@@ -2876,7 +2664,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_i0_out(self, out);
     })
 
@@ -2890,7 +2677,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_i0e_out(out, self);
     })
 
@@ -2904,7 +2690,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_i1_out(out, self);
     })
 
@@ -2918,7 +2703,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::special_i1e_out(out, self);
     })
 
@@ -2933,7 +2717,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_polygamma_out(n, self, out);
     })
 
@@ -2947,7 +2730,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_expit_out(self, out);
     })
 
@@ -2961,7 +2743,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_sinc_out(self, out);
     })
 
@@ -2976,7 +2757,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_round_out(self, decimals, out);
     })
 
@@ -2990,7 +2770,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_log1p_out(self, out);
     })
 
@@ -3005,7 +2784,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_gammainc_out(self, other, out);
     })
 
@@ -3020,7 +2798,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_gammaincc_out(self, other, out);
     })
 
@@ -3035,7 +2812,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::special_multigammaln_out(self, p, out);
     })
 
@@ -3051,7 +2827,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::cpu::linalg_cross_out(out, self, other, dim);
     })
 
@@ -3065,7 +2840,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_det_out(A, out);
     })
 
@@ -3080,7 +2854,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_matmul_out(self, other, out);
     })
 
@@ -3094,7 +2867,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_eigvals_out(self, out);
     })
 
@@ -3108,7 +2880,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_inv_out(A, out);
     })
 
@@ -3119,7 +2890,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.inverse.default", aten_inverse_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::inverse_out(self, out);
 })
 
@@ -3131,7 +2901,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.inner.default", aten_inner_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::inner_out(self, other, out);
 })
 
@@ -3143,7 +2912,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.outer.default", aten_outer_default, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::outer_out(self, vec2, out);
 })
 
@@ -3158,7 +2926,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_cond_out(self, p, out);
     })
 
@@ -3174,7 +2941,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_solve_out(A, B, left, out);
     })
 
@@ -3189,7 +2955,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_tensorinv_out(self, ind, out);
     })
 
@@ -3204,7 +2969,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_matrix_power_out(self, n, out);
     })
 

--- a/torch/nativert/kernels/KernelRegistry.cpp
+++ b/torch/nativert/kernels/KernelRegistry.cpp
@@ -294,7 +294,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.remainder.Tensor", aten_remainder_Tensor, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::remainder_out(out, self, KernelInput(1).toTensor());
 })
 
@@ -305,7 +304,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.remainder.Scalar", aten_remainder_Scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::remainder_out(self, KernelInput(1).toScalar(), out);
 })
 
@@ -318,7 +316,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.matmul.default", aten_matmul, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::matmul_out(in0_t, in1_t, out_t);
 })
 
@@ -329,7 +326,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.bmm.default", aten_bmm, {
     KernelOutput(0) = create_empty_from(in0_t);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::bmm_out(out_t, in0_t, in1_t);
 })
 
@@ -340,7 +336,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.abs.default", aten_abs, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::abs_out(in0_t, out_t);
 })
 
@@ -352,7 +347,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mul.Tensor", aten_mul, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::mul_out(out_t, in0_t, in1_t);
 })
 
@@ -364,7 +358,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mul.Scalar", aten_mul_Scalar, {
     KernelOutput(0) = create_empty_from(in0_t, dtype);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   KernelOutput(0) = at::native::mul_out(out_t, in0_t, in1_t);
 })
 
@@ -378,7 +371,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.nan_to_num.default", aten_nan_to_num, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::nan_to_num_out(in0_t, in1_d, in2_d, in3_d, out_t);
 })
 
@@ -390,7 +382,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.leaky_relu.default", aten_leaky_relu, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::leaky_relu_out(out_t, in0_t, in1_s);
 })
 
@@ -400,7 +391,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.relu.default", aten_relu, {
     KernelOutput(0) = create_empty_from(in0_t);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::threshold_out(out_t, in0_t, 0, 0);
 })
 
@@ -432,7 +422,7 @@ REGISTER_CPU_KERNEL("torch.ops.aten.clone.default", aten_clone, {
       KernelOutput(0) = create_empty_from(src, memory_format);
     }
   }
-  auto& out_t = KernelOutput(0).toTensor();
+  auto& out_t = KernelOutputUnsafe(0).toTensor();
   at::native::resize_impl_cpu_(
       out_t.unsafeGetTensorImpl(), src.sizes(), src.strides());
   at::native::copy_(out_t, src, false);
@@ -447,7 +437,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.index.Tensor", aten_index, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::index_out(out_t, in0_t, in1_l);
 })
 
@@ -460,7 +449,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.index_select.default", aten_index_select, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::index_select_out_cpu_(self, dim, index, out);
 })
 
@@ -474,7 +462,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(in0_t, dtype);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       at::cpu::pow_out(
           out_t, KernelInput(0).toTensor(), KernelInput(1).toTensor());
     })
@@ -492,7 +479,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.pow.Scalar", aten_pow_Scalar, {
         at::MemoryFormat::Preserve);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::pow_out(out_t, KernelInput(0).toScalar(), KernelInput(1).toTensor());
 })
 
@@ -512,7 +498,6 @@ REGISTER_CPU_KERNEL(
             at::MemoryFormat::Preserve);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       at::cpu::pow_out(
           out_t, KernelInput(0).toTensor(), KernelInput(1).toScalar());
     })
@@ -529,7 +514,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sum.default", aten_sum_default, {
     KernelOutput(0) = at::cpu::sum(self, dim, keepdim, dtype);
   } else {
     auto& out = KernelOutput(0).toTensor();
-    fastResizeToZero(out);
     at::cpu::sum_out(out, self, dim, keepdim, dtype);
   }
 })
@@ -546,7 +530,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sum.dim_IntList", aten_sum_dim_IntList, {
     KernelOutput(0) = at::cpu::sum(self, dim, keepdim, dtype);
   } else {
     auto& out = KernelOutput(0).toTensor();
-    fastResizeToZero(out);
     at::cpu::sum_out(out, self, dim, keepdim, dtype);
   }
 })
@@ -561,7 +544,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mean.dim", aten_mean_dim, {
         create_empty_from(self, dtype.value_or(self.dtype().toScalarType()));
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::mean_out(out, self, dim, keepdim, dtype);
 })
 
@@ -573,7 +555,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.mean.default", aten_mean_default, {
         create_empty_from(self, dtype.value_or(self.dtype().toScalarType()));
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::mean_out(out, self, /*dim=*/{}, /*keepdim=*/false, dtype);
 })
 
@@ -585,7 +566,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.max.other", aten_max_other, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::max_out(self, other, out);
 })
 
@@ -595,7 +575,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.max.default", aten_max_default, {
     KernelOutput(0) = create_empty_from(self);
   }
   auto& value = KernelOutput(0).toTensor();
-  fastResizeToZero(value);
   at::cpu::amax_out(value, self);
 })
 
@@ -606,7 +585,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sign.Tensor", aten_sign_Tensor, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::sign_out(out_t, in0_t);
 })
 
@@ -617,7 +595,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.log.default", aten_log, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::log_out(out_t, in0_t);
 })
 
@@ -630,7 +607,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sub.Tensor", aten_sub_Tensor, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::sub_out(out_t, in0_t, in1_t, alpha);
 })
 
@@ -644,7 +620,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.sub.Scalar", aten_sub, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::sub_out(out_t, in0_t, in1_t, alpha);
 })
 
@@ -661,7 +636,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       at::cpu::clamp_min_out(out_t, in0_t, in1_s);
     })
 
@@ -674,7 +648,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.argmin.default", aten_argmin, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   if (in0_t.is_contiguous() && dim.has_value()) {
     at::native::c2_argmin_out(out_t, in0_t, dim.value(), keepdim);
     return;
@@ -691,7 +664,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.softmax.int", aten_softmax_int, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   auto half_to_float = in_t.scalar_type() == at::ScalarType::Half &&
       dtype == at::ScalarType::Float;
   at::cpu::_softmax_out(out_t, in_t, dim, half_to_float);
@@ -706,7 +678,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(in0_t);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       const auto in1_s = KernelInput(1).toOptional<at::Scalar>();
       at::cpu::norm_outf(
           in0_t,
@@ -744,7 +715,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ones.default", aten_ones, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::ones_out(size, out_t);
 })
 
@@ -761,7 +731,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.ones_like.default", aten_ones_like, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::ones_out(self.sizes(), out_t);
 })
 
@@ -775,7 +744,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.zeros.default", aten_zeros, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::compositeexplicitautograd::zeros_out(out_t, size);
 })
 
@@ -793,7 +761,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::native::linalg_norm_out(
           self,
           KernelInput(1).toOptional<at::Scalar>(),
@@ -814,7 +781,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.linalg_norm.ord_str", aten_linalg_norm, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::linalg_norm_out(
       self, KernelInput(1).toStringRef(), dim, keepdim, dtype, out);
 })
@@ -828,7 +794,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.cat.default", aten_cat, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::cat_outf(inputs, dim, out);
 })
 
@@ -841,7 +806,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.cumsum.default", aten_cumsum, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::cpu::cumsum_out(out, self, dim, dtype);
 })
 
@@ -852,7 +816,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.nonzero.default", aten_nonzero, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::nonzero_out_cpu(self, out);
 })
 
@@ -867,7 +830,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.addmm.default", aten_addmm, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::cpu::addmm_out(out_t, in0_t, in1_t, in2_t, in3_s, in4_s);
 })
 
@@ -889,7 +851,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.narrow_copy.default", aten_narrow_copy, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::narrow_copy_dense_cpu_out(self, dim, start, length, out);
 })
 
@@ -902,7 +863,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.repeat.default", aten_repeat, {
     return;
   }
   at::Tensor& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::repeat_out(out, self, repeats);
 })
 
@@ -921,8 +881,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.max.dim", aten_max_dim, {
 
   auto& values = KernelOutput(0).toTensor();
   auto& indices = KernelOutput(1).toTensor();
-  fastResizeToZero(values);
-  fastResizeToZero(indices);
   at::cpu::max_out(values, indices, self, dim, keepdim);
 })
 
@@ -972,8 +930,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(in0_t);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
-
       const auto in1_s = KernelInput(1).toOptional<at::Scalar>();
       at::cpu::norm_outf(
           in0_t,
@@ -994,8 +950,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(in0_t);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
-
       const auto in1_s = KernelInput(1).toOptional<at::Scalar>();
       at::cpu::norm_outf(
           in0_t,
@@ -1019,7 +973,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.full_like.default", aten_full_like, {
         in0_t, dtype, layout, device, pin_memory, memory_format);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::resize_(out_t, in0_t.sizes(), std::nullopt);
   at::native::fill_out(out_t, in1_s);
 })
@@ -1034,7 +987,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.linear.default", aten_linear, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::linear_out(out_t, in0_t, in1_t, in2_t);
 })
 
@@ -1047,7 +999,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.where.self", aten_where, {
     KernelOutput(0) = create_empty_from(self);
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::where_self_out(cond, self, other, out);
 })
 
@@ -1058,7 +1009,6 @@ REGISTER_CPU_KERNEL("torch.ops.fb.scale_gradient.default", fb_scale_gradient, {
     KernelOutput(0) = create_empty_from(in_0);
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   out.resize_(in_0.sizes());
   out.copy_(in_0);
 })
@@ -1079,7 +1029,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(weight, at::kFloat);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       at::native::embedding_bag_byte_rowwise_offsets_out(
           out_t,
           weight,
@@ -1109,7 +1058,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(weight, at::kFloat);
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       at::native::embedding_bag_4bit_rowwise_offsets_out(
           out_t,
           weight,
@@ -1134,7 +1082,6 @@ REGISTER_CPU_KERNEL(
       }
 
       auto& out_0 = KernelOutput(0).toTensor();
-      fastResizeToZero(out_0);
 
       KernelInput(1).toCustomClass<LinearPackedParamsBase>()->apply_dynamic_out(
           in_0, out_0, /* reduce_range= */ false);
@@ -1153,7 +1100,6 @@ REGISTER_CPU_KERNEL(
       }
 
       auto& out_0 = KernelOutput(0).toTensor();
-      fastResizeToZero(out_0);
 
       at::native::fbgemm_linear_fp16_weight(
           in_0, weight, bias.value_or(at::Tensor()), out_0);
@@ -1170,7 +1116,6 @@ REGISTER_CPU_KERNEL(
       }
 
       auto& out_0 = KernelOutput(0).toTensor();
-      fastResizeToZero(out_0);
 
       KernelInput(1)
           .toCustomClass<LinearPackedParamsBase>()
@@ -1199,7 +1144,6 @@ REGISTER_CPU_KERNEL(
             std::nullopt);
       }
       auto& out_tensor = KernelOutput(0).toTensor();
-      fastResizeToZero(out_tensor);
       w_prepack->apply_out(in_0, output_scale, output_zero_point, out_tensor);
     })
 
@@ -1210,7 +1154,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.logit.default", aten_logit, {
     KernelOutput(0) = create_empty_from(in0_t);
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::logit_out(in0_t, in1_d, out_t);
 })
 
@@ -1228,7 +1171,6 @@ REGISTER_CPU_KERNEL(
         KernelOutput(0) = create_empty_from(self);
       }
       auto& out = KernelOutput(0).toTensor();
-      fastResizeToZero(out);
       at::slice_scatter_out(out, self, src, dim, start, end, step);
     })
 
@@ -1244,7 +1186,6 @@ REGISTER_CPU_KERNEL(
             weight.suggest_memory_format());
       }
       auto& out_tensor = KernelOutput(0).toTensor();
-      fastResizeToZero(out_tensor);
       at::native::qembeddingbag_byte_unpack_out(out_tensor, weight);
     })
 
@@ -1258,7 +1199,6 @@ REGISTER_CPU_KERNEL(
         return;
       }
       auto& out_tensor = KernelOutput(0).toTensor();
-      fastResizeToZero(out_tensor);
       at::native::qembeddingbag_byte_prepack_out(out_tensor, weight);
     })
 
@@ -1270,7 +1210,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.stack.default", aten_stack, {
     return;
   }
   auto& out_t = KernelOutput(0).toTensor();
-  fastResizeToZero(out_t);
   at::native::_stack_out_cpu(inputs, dim, out_t);
 })
 
@@ -1282,7 +1221,6 @@ REGISTER_CPU_KERNEL("torch.ops.aten.fmod.Scalar", aten_fmod_scalar, {
     return;
   }
   auto& out = KernelOutput(0).toTensor();
-  fastResizeToZero(out);
   at::native::fmod_out(self, other, out);
 })
 
@@ -1320,7 +1258,7 @@ class OpKernel_aten__to_copy : public C10Kernel {
 
   void computeInternal(ExecutionFrame& executionFrame) const final {
     const auto& self = KernelInput(0).toTensor();
-    auto& out = KernelOutput(0);
+    auto& out = KernelOutputUnsafe(0);
 
     // skip if the _to_copy is a no-op
     if (dtype_.has_value() && self.dtype() == dtype_.value() &&
@@ -1404,7 +1342,6 @@ class OpKernel_aten__to_copy : public C10Kernel {
          self.is_non_overlapping_and_dense());
 
     auto& out_t = out.toTensor();
-    fastResizeToZero(out_t);
     at::native::to_copy_out(
         out_t, self, non_blocking_, copy_strides, memory_format);
   }

--- a/torch/nativert/kernels/PrimKernelRegistry.cpp
+++ b/torch/nativert/kernels/PrimKernelRegistry.cpp
@@ -60,8 +60,8 @@ C10_REGISTER_TYPED_CLASS(
 REGISTER_PRIM_KERNEL("prim.ListUnpack", prim_listunpack, {
   RECORD_USER_SCOPE("nativert::OpKernel_prim_listunpack");
   auto inputListRef = KernelInput(0).toListRef();
-  for (const auto& [i, ivalue] : c10::enumerate(inputListRef)) {
-    KernelOutput(i) = ivalue;
+  for (size_t i = 0; i < inputListRef.size(); ++i) {
+    KernelOutput(i) = inputListRef[i];
   }
 })
 
@@ -98,7 +98,6 @@ class OpKernel_variadic_concat : public OpKernel {
         return;
       }
       auto& out_t = KernelOutput(0).toTensor();
-      fastResizeToZero(out_t);
       at::cpu::cat_outf(inputs, dim, out_t);
     }
   }
@@ -143,7 +142,6 @@ class OpKernel_variadic_stack : public OpKernel {
         return;
       }
       auto& out_t = out.toTensor();
-      fastResizeToZero(out_t);
       at::native::_stack_out_cpu(inputs, dim, out_t);
     }
   }

--- a/torch/nativert/kernels/PrimKernelRegistry.h
+++ b/torch/nativert/kernels/PrimKernelRegistry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <utility>
 
 #include <torch/nativert/executor/OpKernel.h>
 #include <torch/nativert/graph/Graph.h>
@@ -9,7 +10,29 @@
 namespace torch::nativert {
 
 #define KernelInput(id) input(id, executionFrame)
-#define KernelOutput(id) output(id, executionFrame)
+// When memory planning is enabled, LayoutManager already handles resize-to-zero
+// (see LayoutManager.cpp ensure_managed_storages), so we skip fastResizeToZero.
+// Always set _outputResized[idx] = true on ANY access (not just when iv is a
+// tensor) to handle kernels that first check isNone(), assign, then access
+// again. Without this, the second access would incorrectly call
+// fastResizeToZero.
+#define KernelOutput(idx)                                             \
+  ([&]() -> c10::IValue& {                                            \
+    if (executionFrame.isManagedValue(node_->outputs()[idx]->id())) { \
+      return output(idx, executionFrame);                             \
+    }                                                                 \
+    c10::IValue& iv = output(idx, executionFrame);                    \
+    /* std::exchange doesn't work with std::vector<bool> */           \
+    bool old = _outputResized[idx];                                   \
+    _outputResized[idx] = true;                                       \
+    if (iv.isTensor() && !old) {                                      \
+      fastResizeToZero(iv.toTensor());                                \
+    }                                                                 \
+    return iv;                                                        \
+  }())
+
+// Bypass auto-resize for special cases (e.g., _to_copy with aliasing)
+#define KernelOutputUnsafe(id) output(id, executionFrame)
 
 TORCH_DECLARE_REGISTRY(PrimKernelRegistry, OpKernel, const Node*);
 


### PR DESCRIPTION
Summary:
i feel this keeps coming up so i ought to attempt to fix it. there are few cases where we actually want ownership over the resizing logic when re-using a buffer from the frame's prev. run.

the memory planner already does this by default in a better way (without adding a bunch of logic to output reads) (https://github.com/pytorch/pytorch/blob/071bbf6855994e23a9039b95464d54fbe158060c/torch/nativert/executor/memory/LayoutManager.cpp#L140) -- but in the even this is disabled, we should have a more foolproof mechanism to enforce resize before reuse.

Test Plan: ci

Differential Revision: D90796423




cc @SherlockNoMad @zhxchen17 @yiming0416