### PR TITLE
[Triton] [Inductor] Configure compilation time and lower the default to 5 minutes.

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -91,7 +91,9 @@ worker_log_path = (
 )
 
 # precompilation timeout
-precompilation_timeout_seconds: int = 60 * 60
+precompilation_timeout_seconds: int = int(
+    os.environ.get("TORCHINDUCTOR_PRECOMPILATION_TIMEOUT_SECONDS", 60 * 5)
+)
 
 # use fx aot graph codegen cache
 fx_graph_cache: bool = Config(


### PR DESCRIPTION
Summary: Control precompilation timeout in an environment variable and default to 5 minutes.

Test Plan: NFC

Differential Revision: D90885280




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo