### PR TITLE
[BE][Type Coverage][AOT_Autograd] Add type coverage to schemas.py

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -162,3 +162,9 @@ matches = "torch/_subclasses/**"
 [sub-config.errors]
 implicit-import = false
 implicit-any = true
+
+[[sub-config]]
+matches = "torch/_functorch/_aot_autograd/schemas.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true

--- a/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
+++ b/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
@@ -78,6 +78,7 @@ class KnapsackEvaluator:
             predecessor_queue = deque(
                 [
                     dependency
+                    # pyrefly: ignore [bad-unpacking]
                     for dependency, v in node_graph.in_edges(node)
                     if dependency not in already_computed
                 ]
@@ -93,6 +94,7 @@ class KnapsackEvaluator:
                     )
                 )
                 # Add predecessors of the predecessor to the queue if they haven't been recomputed yet
+                # pyrefly: ignore [bad-unpacking]
                 for dependency_of_dependency, _ in node_graph.in_edges(dep):
                     if (
                         dependency_of_dependency in already_computed

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -540,7 +540,7 @@ def collect_fw_donated_buffer_idxs(
     fw_ins: list[Optional[FakeTensor]],
     user_fw_outs: list[Optional[FakeTensor]],
     bw_outs: list[Optional[FakeTensor]],
-    saved_tensors: list[FakeTensor],
+    saved_tensors: list[FakeTensor | None],
 ) -> list[int]:
     """
     Checks if the saved tensors are donated buffers, which means a saved tensor is not


### PR DESCRIPTION
Turn on struct type checking for `schema.py` - first step in type coverage for functorch!

### Test
`pyrefly check torch/_functorch/_aot_autograd/schemas.py`

### Output
```
 INFO 0 errors (16 suppressed)
```