### PR TITLE
Better Batch Matmul Codegen

### DIFF
--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -38,12 +38,8 @@ class TestTritonDotReduction(TestCase):
         code = run_and_get_triton_code(f, *example_inputs)
         FileCheck().check_regex(r"triton.*mm.*\.run\(").run(code)
 
-        FileCheck().check_count(
-            "@triton.jit",
-            kernel_count,
-        ).check_count(
-            "tl.dot",
-            dot_count,
+        FileCheck().check_count("@triton.jit", kernel_count, exactly=True).check_count(
+            "tl.dot", dot_count, exactly=True
         ).run(code)
 
     def test_matmul(self):
@@ -152,6 +148,85 @@ class TestTritonDotReduction(TestCase):
 
         self._check_equal(f, (x, y))
         self._check_code(f, (x, y), 1, 1)
+
+    def test_bmm_vertical_fusion(self):
+        def f(x, y):
+            z = torch.bmm(x, y)
+            w = torch.nn.functional.relu(z)
+            v = w + z * z
+            return v
+
+        B, M, K, N = 128, 16, 128, 16
+        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+
+        self._check_equal(f, (x, y))
+        self._check_code(f, (x, y), 1, 1)
+
+    def test_bmm_horizontal_fusion(self):
+        def f(x, y, z, w):
+            bmm1 = torch.bmm(x, y)
+            bmm2 = torch.bmm(z, w)
+            return bmm1 - bmm2 + bmm1 * bmm2
+
+        B, M, K, N = 128, 16, 128, 16
+        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+        z = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
+        w = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+
+        self._check_equal(f, (x, y, z, w))
+        self._check_code(f, (x, y, z, w), 1, 2)
+
+    def test_bmm_fusion_complex1(self):
+        # Out[O[b,i],j] += Input[I[b,i],r] * Weight[W[b],r,j] * Val[b,i]
+        def f(inp, weight, val, I_idx, W_idx, O_idx, out):
+            x = inp[I_idx]  # [B,I,R]
+            y = weight[W_idx]  # [B,R,J]
+            t = torch.einsum("bir,brj,bi->bij", x, y, val)
+            out.index_add_(0, O_idx.reshape(-1), t.reshape(-1, J))
+            return out
+
+        B, I, R, J = 128, 16, 128, 16
+        N_in = 1024
+        N_w = 64
+        N_out = 1024
+
+        inp = rand_strided((N_in, R), (R, 1), device=GPU_TYPE)
+        weight = rand_strided((N_w, R, J), (R * J, J, 1), device=GPU_TYPE)
+        val = rand_strided((B, I), (I, 1), device=GPU_TYPE)
+
+        I_idx = torch.randint(0, N_in, (B, I), device=GPU_TYPE, dtype=torch.int64)
+        W_idx = torch.randint(0, N_w, (B,), device=GPU_TYPE, dtype=torch.int64)
+        O_idx = torch.randint(0, N_out, (B, I), device=GPU_TYPE, dtype=torch.int64)
+
+        out = torch.zeros((N_out, J), device=GPU_TYPE)
+
+        self._check_equal(f, (inp, weight, val, I_idx, W_idx, O_idx, out))
+        self._check_code(f, (inp, weight, val, I_idx, W_idx, O_idx, out), 1, 1)
+
+    def test_bmm_fusion_complex2(self):
+        # out[Ai[g],m,n] += Av[g,m,k,p] * B[Ak[g,p],k,n]
+        def f(Av, B, Ai, Ak, out):
+            Bg = B[Ak]  # [G,P,K,N]
+            Cg = torch.einsum("gmkp,gpkn->gmn", Av, Bg)  # [G,M,N]
+            out.index_add_(0, Ai, Cg)
+            return out
+
+        G, M, K, P, N = 128, 16, 64, 8, 16
+        NB = 1024
+        NA = 512
+
+        Av = rand_strided((G, M, K, P), (M * K * P, K * P, P, 1), device=GPU_TYPE)
+        B = rand_strided((NB, K, N), (K * N, N, 1), device=GPU_TYPE)
+
+        Ai = torch.randint(0, NA, (G,), device=GPU_TYPE, dtype=torch.int64)
+        Ak = torch.randint(0, NB, (G, P), device=GPU_TYPE, dtype=torch.int64)
+
+        out = torch.zeros((NA, M, N), device=GPU_TYPE)
+
+        self._check_equal(f, (Av, B, Ai, Ak, out))
+        self._check_code(f, (Av, B, Ai, Ak, out), 1, 1)
 
     def test_bmm_large_batch_reversed_pid(self):
         def f(x, y):

--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -164,14 +164,10 @@ class TestTritonDotReduction(TestCase):
 
         f = torch.compile(f)
         code = run_and_get_triton_code(f, x, y)
-        
-        FileCheck().check(
-            "zoffset = tl.program_id(0)"
-        ).check(
+
+        FileCheck().check("zoffset = tl.program_id(0)").check(
             "yoffset = tl.program_id(1)"
-        ).check(
-            "xoffset = tl.program_id(2)"
-        ).run(code)
+        ).check("xoffset = tl.program_id(2)").run(code)
 
     def test_bmm_no_z_broadcast(self):
         def f(x, y):
@@ -184,18 +180,13 @@ class TestTritonDotReduction(TestCase):
 
         f = torch.compile(f)
         code = run_and_get_triton_code(f, x, y)
-        
-        FileCheck().check_not(
-            "tl.arange(0, ZBLOCK)[:, None, None, None]"
-        ).check(
+
+        FileCheck().check_not("tl.arange(0, ZBLOCK)[:, None, None, None]").check(
             "tl.arange(0, ZBLOCK)"
-        ).check(
-            "tl.arange(0, YBLOCK)[None, :, None, None]"
-        ).check(
+        ).check("tl.arange(0, YBLOCK)[None, :, None, None]").check(
             "tl.arange(0, XBLOCK)[None, None, :, None]"
-        ).check(
-            "tl.arange(0, R0_BLOCK)[None, None, None, :]"
-        ).run(code)
+        ).check("tl.arange(0, R0_BLOCK)[None, None, None, :]").run(code)
+
 
 if HAS_GPU:
     torch.set_default_device(GPU_TYPE)

--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -233,7 +233,7 @@ class TestTritonDotReduction(TestCase):
             z = torch.bmm(x, y)
             return z
 
-        B, M, K, N = 65537,16,16,16 
+        B, M, K, N = 65537, 16, 16, 16
         x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
         y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
 

--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -187,10 +187,10 @@ class TestTritonDotReduction(TestCase):
             out.index_add_(0, O_idx.reshape(-1), t.reshape(-1, J))
             return out
 
-        B, I, R, J = 128, 16, 128, 16
-        N_in = 1024
+        B, I, R, J = 32, 16, 128, 16
+        N_in = 128
         N_w = 64
-        N_out = 1024
+        N_out = 128
 
         inp = rand_strided((N_in, R), (R, 1), device=GPU_TYPE)
         weight = rand_strided((N_w, R, J), (R * J, J, 1), device=GPU_TYPE)
@@ -214,8 +214,8 @@ class TestTritonDotReduction(TestCase):
             return out
 
         G, M, K, P, N = 128, 16, 64, 8, 16
-        NB = 1024
-        NA = 512
+        NB = 128
+        NA = 128
 
         Av = rand_strided((G, M, K, P), (M * K * P, K * P, P, 1), device=GPU_TYPE)
         B = rand_strided((NB, K, N), (K * N, N, 1), device=GPU_TYPE)
@@ -233,7 +233,7 @@ class TestTritonDotReduction(TestCase):
             z = torch.bmm(x, y)
             return z
 
-        B, M, K, N = 65537, 128, 128, 128
+        B, M, K, N = 65537,16,16,16 
         x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
         y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
 
@@ -249,7 +249,7 @@ class TestTritonDotReduction(TestCase):
             z = torch.bmm(x, y)
             return z
 
-        B, M, K, N = 256, 128, 128, 128
+        B, M, K, N = 128, 16, 128, 16
         x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
         y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5728,7 +5728,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.is_native_matmul
             and entry.tensor_dim == 0
             and self.triton_tensor_ndim() == 4
-        ) :
+        ):
             size = ""
         index_dtype = self.index_dtype
         suffix = f".to({index_dtype})" if index_dtype != "tl.int32" else ""
@@ -5763,7 +5763,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # batch dimension is placed on CUDA gridDim.x (the fastest-varying launch axis).
         # - gridDim.x scales to much larger sizes than gridDim.z (limited to 65536 in CUDA)
         if self.is_native_matmul and self.triton_tensor_ndim() == 4:
-            reversed_pid_map = {0:2, 1:1, 2:0}
+            reversed_pid_map = {0: 2, 1: 1, 2: 0}
             key = f"tl.program_id({reversed_pid_map[entry.grid_dim]})"
 
         pid = entry.pid_cache.get(key, key)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3907,6 +3907,12 @@ class Grid3D(GridExpr):
         self.y_grid = self.ceildiv("ynumel", meta.get("YBLOCK"))
         self.z_grid = self.ceildiv("znumel", meta.get("ZBLOCK"))
 
+class BatchMatmulGrid3D(GridExpr):
+    def generate(self, meta: dict[str, int]) -> None:
+        self.z_grid = self.ceildiv("xnumel", meta.get("XBLOCK"))
+        self.y_grid = self.ceildiv("ynumel", meta.get("YBLOCK"))
+        self.x_grid = self.ceildiv("znumel", meta.get("ZBLOCK"))
+
 
 class Grid2DWithYZOverflow(GridExpr):
     def generate(self, meta: dict[str, int]) -> None:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3907,6 +3907,7 @@ class Grid3D(GridExpr):
         self.y_grid = self.ceildiv("ynumel", meta.get("YBLOCK"))
         self.z_grid = self.ceildiv("znumel", meta.get("ZBLOCK"))
 
+
 class BatchMatmulGrid3D(GridExpr):
     def generate(self, meta: dict[str, int]) -> None:
         self.z_grid = self.ceildiv("xnumel", meta.get("XBLOCK"))


### PR DESCRIPTION
In batch matmul kernels such as `torch.bmm` and `torch.baddbmm`, the batch dimension can become very large.
In native matmul, inductor mapped the batch dimension to `tl.program_id(2)` (i.e. `gridDim.z` in CUDA). Since `gridDim.z` is limited to 65536, this restricts the maximum supported batch size.

This PR introduces two changes:

1. **Move the batch dimension to `gridDim.x`**

   We reverse the program ID mapping from `(z, y, x) = (2, 1, 0)` to `(0, 1, 2)`, placing the batch dimension on `gridDim.x`, which does not have the same limitation. This also consistently shows better performance when `bmm` is fused with other ops.

   ```python
   zoffset = tl.program_id(0) * ZBLOCK
   yoffset = tl.program_id(1) * YBLOCK
   xoffset = tl.program_id(2) * XBLOCK
   ```

2. **Avoid unnecessary broadcasting for `ZBLOCK`**

   Instead of constructing `tl.arange(0, ZBLOCK)[:, None, None, None]`, we use a flat `tl.arange(0, ZBLOCK)`. This is safe because `ZBLOCK` is always set to `1` in native matmul, and it improves performance by ~10%.

   ```python
   zindex = zoffset + tl.arange(0, ZBLOCK)
   yindex = yoffset + tl.arange(0, YBLOCK)[None, :, None, None]
   xindex = xoffset + tl.arange(0, XBLOCK)[None, None, :, None]
   r0_base = tl.arange(0, R0_BLOCK)[None, None, None, :]
   ```

@eellison @PaulZhang12 @shunting314 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo