### PR TITLE
Add Claude Code GitHub Action workflow configuration

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,46 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  claude-code:
+    # Early exit conditions:
+    # 1. Must be pytorch org
+    # 2. Must be triggered by pilot user
+    # 3. Must mention @claude
+    if: |
+      github.repository_owner == 'pytorch' &&
+      contains(fromJSON('["huydhn", "seemethere", "malfet", "ZainRizvi", "jeanschmidt", "atalman", "wdvr", "izaitsevfb", "yangw-dev", "ezyang", "drisspg", "albanD"]'), github.actor) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      )
+    runs-on: ubuntu-latest
+    environment: bedrock
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
+          aws-region: us-east-1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: bedrock
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Adds the ability to mention `@claude` on PyTorch PRs and issues via [claude code action](https://code.claude.com/docs/en/github-actions).

Initially enabled for the pilot group of power users (PT dev infra team + @ezyang, @drisspg, @albanD).

### Infra side

Backed by AWS bedrock, authentication via OIDC which is enabled **only** for the specific Github environment (`bedrock`). The environment is branch-protected (works only for the `main` branch) + claude code action has additional checks that workflow is not modified.


### Security

Verified:
1. [oidc fails](https://github.com/pytorch/pytorch/actions/runs/21081954976/job/60637428742) without environment
2. branch protection works
3. has access to bedrock when run with env
4. claude code action [fails](https://github.com/pytorch/pytorch/actions/runs/21082387606/job/60638815755) when workflow is modified (strictly speaking, not needed, but nice as an additional safety guard)


### Permissions

For the pilot we're restricting "contents" permission to read. Claude can analyze code and answer questions but cannot create branches, commits, or PRs.

 | Permission           | Why needed                                              |
  |----------------------|---------------------------------------------------------|
  | contents: read       | Claude can read files and codebase (no commits/pushes)  |
  | pull-requests: write | Claude can post PR comments, respond to review comments |
  | issues: write        | Claude can post issue comments, respond to questions    |
  | id-token: write      | Enables OIDC token generation for AWS role assumption   |

