### PR TITLE
[invoke_subgraph] Fix invoke_subgraph seq_nr

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -905,6 +905,156 @@ class outer_fn(torch.nn.Module):
         )
 
     @torch._dynamo.config.patch(force_compile_during_fx_trace=True)
+    def test_invoke_subgraph_seq_nr(self):
+        """
+        Test that the seq_nr on the subgraphs and the invoke_subgraph HOP nodes are correct
+        right before we copy metadata from fwd to bwd graph.
+        """
+        from torch._functorch.aot_autograd import aot_function
+        from torch._guards import tracing, TracingContext
+
+        torch._dynamo.reset()
+
+        def inner_fn(x):
+            with torch.fx.traceback.annotate({"test": "test"}):
+                y = x.cos()
+            return y / 2
+
+        compiled_fn = torch.compile(inner_fn, backend="invoke_subgraph")
+
+        def outer_fn(x):
+            y = x + 1
+            z = compiled_fn(y)
+            return z.sum()
+
+        x = torch.randn(3, 3, requires_grad=True)
+
+        # Track forward graph to verify invoke_subgraph appears
+        fw_graph = None
+        bw_graph = None
+
+        def fw_compiler(gm, example_inputs):
+            nonlocal fw_graph
+            fw_graph = gm
+            return gm
+
+        def bw_compiler(gm, example_inputs):
+            nonlocal bw_graph
+            bw_graph = gm
+            return gm
+
+        # we expect to capture two graphs, the first one from aot_autograd in invoke_subgraph backend
+        # This one should have correct seq_nr on the joint graph for inner_fn and copy the metadata.
+        # the second one from actual aot_stage1_graph_capture.
+        tracing_ctx = TracingContext(fake_mode=None)
+        with tracing(tracing_ctx):
+            aot_fn = aot_function(
+                outer_fn,
+                fw_compiler=fw_compiler,
+                bw_compiler=bw_compiler,
+                _disable_torch_fn_metadata_mode=True,
+            )
+
+            # Run forward and backward
+            result = aot_fn(x)
+            result.backward()
+
+        # Check seq_nr ordering for main forward and backward graphs
+        main_groups = torch.fx.traceback._get_ordered_seq_nr_groups(
+            [fw_graph, bw_graph]
+        )
+        self.assertEqual(
+            main_groups,
+            [
+                ["add"],  # seq_nr 21
+                [
+                    "clone",
+                    "getitem",
+                    "getitem_1",
+                    "getitem_2",
+                    "invoke_subgraph",
+                    "invoke_subgraph_1",
+                ],  # seq_nr 22
+                ["expand", "sum_1"],  # seq_nr 23
+            ],
+        )
+
+        # Check seq_nr ordering for inner subgraphs (forward and backward)
+        subgraph_groups = torch.fx.traceback._get_ordered_seq_nr_groups(
+            [fw_graph.repeated_subgraph0, bw_graph.repeated_subgraph1]
+        )
+        self.assertEqual(
+            subgraph_groups,
+            [
+                ["cos", "mul", "neg", "sin"],  # seq_nr 15
+                ["div", "div"],  # seq_nr 16 - both forward and backward have div
+            ],
+        )
+
+        # The annotation is not checked here because we used ignore_comments = True.
+        # The comments here are helpful for human to read and understand the unit test.
+        self.assertExpectedInline(
+            normalize_gm(fw_graph.print_readable(print_output=False)),
+            """
+class GraphModule(torch.nn.Module):
+    def forward(self, primals_1: "f32[3, 3]"):
+        # Annotation: {'seq_nr': 13} No stacktrace found for following nodes
+        add: "f32[3, 3]" = torch.ops.aten.add.Tensor(primals_1, 1);  primals_1 = None
+
+        # Annotation: {'seq_nr': 14} No stacktrace found for following nodes
+        repeated_subgraph0 = self.repeated_subgraph0
+        invoke_subgraph = torch.ops.higher_order.invoke_subgraph(repeated_subgraph0, 'invoke_subgraph_0', add);  repeated_subgraph0 = add = None
+        getitem: "f32[3, 3]" = invoke_subgraph[0]
+        getitem_1: "f32[3, 3]" = invoke_subgraph[1];  invoke_subgraph = None
+
+        # Annotation: {'seq_nr': 15} No stacktrace found for following nodes
+        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
+        return (sum_1, getitem_1)
+
+    class repeated_subgraph0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 3]"):
+            # Annotation: {'test': 'test', 'seq_nr': 9} File: test_modes.py:920 in inner_fn, code: y = x.cos()
+            cos: "f32[3, 3]" = torch.ops.aten.cos.default(arg0_1)
+
+            # Annotation: {'seq_nr': 10} File: test_modes.py:921 in inner_fn, code: return y / 2
+            div: "f32[3, 3]" = torch.ops.aten.div.Tensor(cos, 2);  cos = None
+            return (div, arg0_1)
+        """,  # noqa: B950
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+
+        self.assertExpectedInline(
+            normalize_gm(bw_graph.print_readable(print_output=False)),
+            """
+class GraphModule(torch.nn.Module):
+    def forward(self, getitem_1: "f32[3, 3]", tangents_1: "f32[]"):
+        # Annotation: {'seq_nr': 15} No stacktrace found for following nodes
+        expand: "f32[3, 3]" = torch.ops.aten.expand.default(tangents_1, [3, 3]);  tangents_1 = None
+
+        # Annotation: {'seq_nr': 14} No stacktrace found for following nodes
+        clone: "f32[3, 3]" = torch.ops.aten.clone.default(expand, memory_format = torch.contiguous_format);  expand = None
+        repeated_subgraph1 = self.repeated_subgraph1
+        invoke_subgraph_1 = torch.ops.higher_order.invoke_subgraph(repeated_subgraph1, 'invoke_subgraph_1', getitem_1, clone);  repeated_subgraph1 = getitem_1 = clone = None
+        getitem_2: "f32[3, 3]" = invoke_subgraph_1[0];  invoke_subgraph_1 = None
+        return (getitem_2,)
+
+    class repeated_subgraph1(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 3]", arg1_1: "f32[3, 3]"):
+            # Annotation: {'seq_nr': 10} File: test_modes.py:921 in inner_fn, code: return y / 2
+            div: "f32[3, 3]" = torch.ops.aten.div.Tensor(arg1_1, 2);  arg1_1 = None
+
+            # Annotation: {'test': 'test', 'seq_nr': 9} File: test_modes.py:920 in inner_fn, code: y = x.cos()
+            sin: "f32[3, 3]" = torch.ops.aten.sin.default(arg0_1);  arg0_1 = None
+            neg: "f32[3, 3]" = torch.ops.aten.neg.default(sin);  sin = None
+            mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(div, neg);  div = neg = None
+            return (mul,)
+        """,  # noqa: B950
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+
+    @torch._dynamo.config.patch(force_compile_during_fx_trace=True)
     def test_guard_failure_creates_separate_subgraphs(self):
         """Test that guard failures create separate subgraphs.
 

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -12,10 +12,16 @@
 namespace torch::autograd {
 
 struct TORCH_API Error : public Node {
+  // The Error node should never actually be reached during backprop, so it
+  // doesn't need to increment the global sequence number counter. If it is to
+  // be executed, it should be executed asap and stop the execution, so we set
+  // sequence_nr to the max value.
   Error(std::string msg, edge_list&& next_edges)
-      : Node(std::move(next_edges)), msg(std::move(msg)) {}
+      : Node(/*sequence_nr=*/UINT64_MAX, std::move(next_edges)),
+        msg(std::move(msg)) {}
 
-  Error(std::string msg) : msg(std::move(msg)) {}
+  Error(std::string msg)
+      : Node(/*sequence_nr=*/UINT64_MAX), msg(std::move(msg)) {}
 
   variable_list apply(variable_list&& inputs) override;
   variable_list apply(variable_list&& inputs) const;

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -198,19 +198,12 @@ class TracerBase:
                 if field in current_meta:
                     node.meta[field] = copy.copy(current_meta[field])
 
-            # Here we decrement to account for the sequence_nr having
-            # just been incremented while tracing this lowered aten op.
-            new_seq_nr = torch.autograd._get_sequence_nr() - 1
-            # The sequence_nr increments every time a new autograd Node
-            # is created. During the FWD pass we store the sequence_nr
-            # corresponding to the last autograd Node created on this fx
-            # node's meta.  A single aten op can create multiple autograd
-            # nodes as is the case with in-place foreach ops. During the
-            # BWD pass we retrieve the sequence_nr stored on the current
-            # executing autograd Node. See NOTE [ Sequence Number ].
-            if current_meta.get("in_grad_fn", 0) > 0:
-                annotation_log.debug("seq_nr from current_meta")
-                new_seq_nr = current_meta["grad_fn_seq_nr"][-1]
+            new_seq_nr = _get_seq_nr(node.name)
+            if new_seq_nr is not None:
+                annotation_log.debug(
+                    "Assigning new_seq_nr %s to %s", new_seq_nr, node.name
+                )
+                node.meta["seq_nr"] = new_seq_nr
 
             # See Note [Functionalization View Replay Annotation]
             # Overriding some node meta with the original node meta of the
@@ -218,16 +211,10 @@ class TracerBase:
             replay_node: Node = fx_traceback.get_current_replay_node()
             if replay_node is not None:
                 node.meta["is_functional_regenerated"] = True
-                if "seq_nr" in replay_node.meta:
-                    annotation_log.debug("seq_nr from replay_node")
-                    new_seq_nr = replay_node.meta["seq_nr"]
                 if "custom" in replay_node.meta:
                     node.meta["custom"] = replay_node.meta.get("custom")
                 if "stack_trace" in replay_node.meta:
                     node.stack_trace = replay_node.meta.get("stack_trace")
-
-            annotation_log.debug("Assigning new_seq_nr %s to %s", new_seq_nr, node.name)
-            node.meta["seq_nr"] = new_seq_nr
 
         elif self.module_stack:
             node.meta["nn_module_stack"] = copy.copy(self.module_stack)
@@ -467,6 +454,60 @@ class TracerBase:
         iterator it ** is suppose to work in your custom tracer.
         """
         return Attribute(obj, "keys")()
+
+
+def _get_seq_nr(node_name: str = ""):
+    """
+    Returns the seq_nr node meta for the current proxy node that we're creating.
+    The seq_nr number in node meta is related to but not the same as the "sequence number"
+    in autograd.
+    We use the seq_nr to correlate forward and backward nodes in the traced FX graphs
+    (e.g. in copy_fwd_metadata_to_bw_nodes).
+    The corresponding forward and backward FX graph nodes should have the same seq_nr.
+
+    The ordering of the seq_nr in the graph does not indicate when the node is executed.
+    For example, the nodes in the invoke_subgraph HOP's subgraph may be called multiple
+    times by different HOP nodes, but these nodes only have a single seq_nr, which may be
+    smaller, the same, or larger than the calling HOP.
+
+    `node_name` is the name of the node that we're creating. It is used for logging only.
+    """
+    current_meta: dict[str, Any] = fx_traceback.get_current_meta()
+    new_seq_nr = None
+    # The sequence_nr increments every time a new autograd Node
+    # is created. During the FWD pass we store the sequence_nr
+    # corresponding to the last autograd Node created on this fx
+    # node's meta.  A single aten op can create multiple autograd
+    # nodes as is the case with in-place foreach ops. During the
+    # BWD pass we retrieve the sequence_nr stored on the current
+    # executing autograd Node. See NOTE [ Sequence Number ].
+    if current_meta.get("in_grad_fn", 0) > 0:
+        # This branch is used to get seq_nr for backward nodes
+        annotation_log.debug("%s: seq_nr from current_meta grad_fn_seq_nr", node_name)
+        new_seq_nr = current_meta["grad_fn_seq_nr"][-1]
+
+    elif torch.fx.traceback._is_preserving_node_seq_nr():
+        # Special case where we preserve seq_nr from currently tracing node
+        # Used to preserve seq_nr when re-tracing subgraphs in HOP
+        annotation_log.debug("%s: seq_nr from current_meta seq_nr", node_name)
+        new_seq_nr = current_meta.get("seq_nr")
+    else:
+        # Here we decrement to account for the sequence_nr having
+        # just been incremented while tracing this lowered aten op.
+        # This branch is used to get seq_nr for forward nodes
+        new_seq_nr = torch.autograd._get_sequence_nr() - 1
+
+    if not torch.fx.traceback._is_preserving_node_seq_nr():
+        # See Note [Functionalization View Replay Annotation]
+        # Overriding some node meta with the original node meta of the
+        # regenerated node.
+        replay_node: Node = fx_traceback.get_current_replay_node()
+        if replay_node is not None:
+            if "seq_nr" in replay_node.meta:
+                annotation_log.debug("%s: seq_nr from replay_node", node_name)
+                new_seq_nr = replay_node.meta["seq_nr"]
+
+    return new_seq_nr
 
 
 # used in Proxy object when just appending to the graph while not tracing.

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 import traceback
+from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum
 from typing import Any, Optional, Union
@@ -36,7 +37,10 @@ __all__ = [
 
 current_meta: dict[str, Any] = {}
 current_replay_node: Optional[Node] = None
+# Preserve the node meta fields in torch.fx.proxy._COPY_META_FIELDS
 should_preserve_node_meta = False
+# Preserve the "seq_nr" node meta field
+_should_preserve_node_meta = False
 
 GRADIENT_ACC_SPECIAL_STACK = (
     "Gradient addition node due to multiple use of tensor around:"
@@ -263,6 +267,22 @@ def preserve_node_meta(enable=True):
         current_meta = saved_current_meta
 
 
+@contextmanager
+def _preserve_node_seq_nr(preserve_seq_nr=True):
+    """
+    Temporarily enables or disables the preservation of node.meta["seq_nr"] in the
+    tracing context.
+    """
+    global _should_preserve_node_meta
+    saved = _should_preserve_node_meta
+
+    try:
+        _should_preserve_node_meta = preserve_seq_nr
+        yield
+    finally:
+        _should_preserve_node_meta = saved
+
+
 @compatibility(is_backward_compatible=False)
 def set_stack_trace(stack: list[str]):
     global current_meta
@@ -406,6 +426,10 @@ def has_preserved_node_meta() -> bool:
     return should_preserve_node_meta
 
 
+def _is_preserving_node_seq_nr() -> bool:
+    return _should_preserve_node_meta
+
+
 @compatibility(is_backward_compatible=False)
 @contextmanager
 def set_current_meta(node, pass_name=""):
@@ -505,3 +529,35 @@ def _get_custom_metadata(gm: GraphModule) -> str:
         return custom_metadata
 
     return "\n".join(str(x) for x in helper(gm))
+
+
+def _get_ordered_seq_nr_groups(
+    gm: Union[GraphModule, list[GraphModule]],
+) -> list[list[str]]:
+    """
+    Group call_function nodes by seq_nr, order by seq_nr value,
+    and return a list of lists of node names (sorted alphabetically).
+
+    Args:
+        gm: A single GraphModule or a list of GraphModules to process.
+            When a list is provided, nodes from all graphs are grouped together.
+
+    Returns:
+        A list of lists, where each inner list contains node names that share the same seq_nr,
+        sorted alphabetically. The outer list is ordered by seq_nr value.
+    """
+    # Normalize input to a list
+    if isinstance(gm, GraphModule):
+        gms = [gm]
+    else:
+        gms = gm
+
+    seq_nr_dict: dict[int, list[str]] = defaultdict(list)
+    for graph_module in gms:
+        for node in graph_module.graph.nodes:
+            if node.op == "call_function":
+                seq_nr = node.meta.get("seq_nr")
+                if seq_nr is not None:
+                    seq_nr_dict[seq_nr].append(node.name)
+    # Sort by seq_nr and return list of sorted lists
+    return [sorted(seq_nr_dict[k]) for k in sorted(seq_nr_dict.keys())]


### PR DESCRIPTION
The useful sequence number on invoke_subgraph nodes get lost as we re-trace. In this PR, we add some extra logic to preserve the meaningful sequence number on both the invoke_subgraph HOP node itself as well as the subgraph nodes. 


What we want to achieve:

- The corresponding invoke-subgraph HOP fwd and bwd nodes should have the same seq_nr
- For the subgraph nodes, the backward graph (which is also the joint graph), should preserve the seq_nr and not loose the correct seq_nr during re-trace. 

These two are important because we rely on seq_nr to copy the user annotation from fwd nodes to bwd nodes.


Implementation details:
  - When creating the `Error` autograd node in `_mirror_autograd_meta_to`, we should not increment the global seq_nr counter. We assign `maxint` so if it is to be executed, it should be executed asap and stop the execution.
  - Subgraph node seq_nr preservation: Add a new preserve_node_seq_nr() context manager in torch/fx/traceback.py. When enabled, nodes inherit seq_nr from current_meta instead of using the auto-incremented global counter.
  - Refactored _get_seq_nr(): Extracted seq_nr logic from TracerBase.create_node into a dedicated function that handles three cases: backward nodes (from grad_fn_seq_nr), preserved seq_nr mode (from current_meta), and forward nodes (from global counter).


```
python test/functorch/test_aot_joint_with_descriptors.py -k test_annotate_invoke_subgraph_simple
 python test/dynamo/test_modes.py -k test_invoke_subgraph_seq_nr
 python test/higher_order_ops/test_invoke_subgraph.py
```

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo