### PR TITLE
[Flex] Force last dim contiguous for both flash and triton

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -3504,7 +3504,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             (1, 0, 2, 3),  # Reverse order
             (0, 2, 1, 3),  # Mixed order
             (2, 0, 1, 3),  # Another mixed order
-            (0, 1, 3, 2),  # Non contiguous last dim
         ],
     )
     @common_utils.parametrize("shape", [(2, 1, 128, 16), (4, 2, 64, 16)])
@@ -3558,7 +3557,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @common_utils.parametrize("mode", ["eager", "inductor"])
     @common_utils.parametrize(
         "permute_order",
-        [(0, 1, 2, 3), (1, 0, 2, 3), (0, 2, 1, 3), (2, 0, 1, 3), (0, 1, 3, 2)],
+        [(0, 1, 2, 3), (1, 0, 2, 3), (0, 2, 1, 3), (2, 0, 1, 3)],
     )
     @common_utils.parametrize("shape", [(2, 5, 128, 16), (4, 2, 64, 16)])
     def test_flex_attention_backward_stride_ordering(

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -3504,6 +3504,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             (1, 0, 2, 3),  # Reverse order
             (0, 2, 1, 3),  # Mixed order
             (2, 0, 1, 3),  # Another mixed order
+            (0, 1, 3, 2),  # Non contiguous last dim
         ],
     )
     @common_utils.parametrize("shape", [(2, 1, 128, 16), (4, 2, 64, 16)])
@@ -3543,21 +3544,31 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             func = flex_attention
             out = func(query, key, value)
 
-        out_stride_order = get_stride_order(out.stride())
-        query_stride_order = get_stride_order(query.stride())
+        # We always enforce stride[-1]=1 for attention kernels
+        self.assertEqual(out.stride()[-1], 1, "Output must have contiguous last dim")
 
-        self.assertEqual(
-            out_stride_order,
-            query_stride_order,
-            f"Stride order mismatch: out {out_stride_order}, query {query_stride_order}",
-        )
+        # For permutations that already have contiguous last dim, verify stride order matches
+        if query.stride()[-1] == 1:
+            out_stride_order = get_stride_order(out.stride())
+            query_stride_order = get_stride_order(query.stride())
+            self.assertEqual(
+                out_stride_order,
+                query_stride_order,
+                f"Stride order mismatch: out {out_stride_order}, query {query_stride_order}",
+            )
 
     @supported_platform
     @skip_on_cpu
     @common_utils.parametrize("mode", ["eager", "inductor"])
     @common_utils.parametrize(
         "permute_order",
-        [(0, 1, 2, 3), (1, 0, 2, 3), (0, 2, 1, 3), (2, 0, 1, 3)],
+        [
+            (0, 1, 2, 3),
+            (1, 0, 2, 3),
+            (0, 2, 1, 3),
+            (2, 0, 1, 3),
+            (0, 1, 3, 2),  # Non contiguous last dim
+        ],
     )
     @common_utils.parametrize("shape", [(2, 5, 128, 16), (4, 2, 64, 16)])
     def test_flex_attention_backward_stride_ordering(
@@ -3593,13 +3604,17 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             (key, key.grad, "key"),
             (value, value.grad, "value"),
         ]:
-            input_stride_order = get_stride_order(grad.stride())
-            orig_stride_order = get_stride_order(leaf.stride())
-            self.assertEqual(
-                input_stride_order,
-                orig_stride_order,
-                f"Mode: {mode}, Stride order mismatch for {name}: grad {input_stride_order}, input {orig_stride_order}.",
-            )
+            self.assertIsNotNone(grad, f"Grad {name} should be computed")
+            self.assertFalse(torch.isnan(grad).any(), f"Grad {name} contains NaN")
+
+            if leaf.stride()[-1] == 1:
+                input_stride_order = get_stride_order(grad.stride())
+                orig_stride_order = get_stride_order(leaf.stride())
+                self.assertEqual(
+                    input_stride_order,
+                    orig_stride_order,
+                    f"Mode: {mode}, Stride order mismatch for {name}: grad {input_stride_order}, input {orig_stride_order}.",
+                )
 
     @supported_platform
     def test_non_contiguous_last_dim(self, device):

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -762,9 +762,7 @@ GQA_MQA_BLOCK_MASK_CASES = [
 class TestFlexFlash(InductorTestCase):
     @decorateIf(
         unittest.expectedFailure,
-        lambda params: params["case"].requires_grad
-        and params["case"].dim == 64
-        and IS_SM90,
+        lambda params: params["case"].requires_grad and IS_SM90,
     )
     @dtypes(torch.float16, torch.bfloat16)
     @parametrize("case", SCORE_MOD_CASES, name_fn=score_case_name)
@@ -955,14 +953,12 @@ class TestFlexFlash(InductorTestCase):
         k.requires_grad_(True)
         v.requires_grad_(True)
 
-        flash_vs_triton(q, k, v)
-
-        compiled_fn = torch.compile(flex_attention)
+        compiled_fn = torch.compile(flex_attention, fullgraph=True)
 
         def run_for_profile():
-            q_run, k_run, v_run = (
+            q_run, k_run, v_run = [
                 t.detach().clone().requires_grad_(True) for t in (q, k, v)
-            )
+            ]
             compiled_fn(
                 q_run, k_run, v_run, kernel_options={"BACKEND": "FLASH"}
             ).sum().backward()

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1387,7 +1387,8 @@ def flex_attention_backward_fake_tensor_mode(
     Bq, _, _, qk_head_dim = query.shape
     Bkv, Hkv, seq_len_kv, v_head_dim = value.shape
 
-    grad_query = torch.empty_like(query)
+    grad_query = query.new_empty(query.shape)
+    grad_query = _permute_strides(grad_query, query.stride())
     # zeros_and_scatter creates a contiguous zeros tensor -> contiguous_format
     grad_score_mod_captured = tuple(
         (

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -73,6 +73,16 @@ def _permute_strides(out: torch.Tensor, query_strides: tuple[int, ...]) -> torch
     fill_order = get_fill_order(query_strides)
     assert out.storage_offset() == 0, "Only support storage_offset == 0"
     out_strides = _construct_strides(out.shape, fill_order)
+
+    # Attention kernels require stride[-1]=1 for efficient memory access.
+    # Ensure this by moving last dim to front of fill_order if needed.
+    if out_strides[-1] != 1:
+        last_dim = len(out.shape) - 1
+        fill_order = list(fill_order)
+        fill_order.remove(last_dim)
+        fill_order = [last_dim] + fill_order
+        out_strides = _construct_strides(out.shape, fill_order)
+
     new_out = out.new_empty(out.shape).as_strided(out.shape, out_strides)
     new_out.copy_(out)
     return new_out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172690

# Sumary

Flash requires contiguous last dim. In theory triton would for non contiguous last dim. However, this is an unlikely scenario has q,k,v typically source from head_dim marjoness generating ops. 

We still permute to match the other dims but always enforce last dim contiguous which aligns with other higher performance imlps like those in sdpa

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo