### PR TITLE
[DTensor] Fix _to_copy to reduce Partial before non-linear dtype conversions

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1207,6 +1207,33 @@ class DistBucketizeTest(LocalDTensorTestBase):
             self.assertEqual(result.full_tensor(), expected)
 
 
+class DistToCopyTest(LocalDTensorTestBase):
+    @with_comms
+    def test_to_copy_partial_reduces_for_nonlinear_cast(self):
+        # (reduce_op, target_dtype, expect_partial)
+        cases = [
+            ("sum", torch.int32, False),  # truncation breaks additivity
+            ("sum", torch.bool, False),  # thresholding
+            ("sum", torch.float64, True),  # float→float is safe
+            ("max", torch.int32, True),  # monotonic
+            ("max", torch.bool, False),  # thresholding
+        ]
+        with LocalTensorMode(ranks=self.world_size):
+            mesh = self.build_device_mesh()
+            input_tensor = torch.randn(4, 4, device=self.device_type)
+            for reduce_op, target_dtype, expect_partial in cases:
+                dt = DTensor.from_local(input_tensor, mesh, [Partial(reduce_op)])
+                result = dt.to(target_dtype)
+                p = result.placements[0]
+                if expect_partial:
+                    self.assertTrue(p.is_partial(), f"{reduce_op}→{target_dtype}: {p}")
+                    self.assertEqual(p.reduce_op, reduce_op)
+                else:
+                    self.assertTrue(
+                        p.is_replicate(), f"{reduce_op}→{target_dtype}: {p}"
+                    )
+
+
 class DistArgMaxArgMinTest(DTensorContinuousTestBase):
     world_size = 4
     _ops = [torch.argmax, torch.argmin]

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -121,6 +121,7 @@ def _partial_needs_reduce_for_dtype_cast(
     aten._to_copy.default,
     schema_info=RuntimeSchemaInfo(static_kwargkey=["dtype"]),
     allow_unbacked_sharding=True,
+    allow_uneven_sharding=True,
 )
 def _to_copy_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -102,9 +102,40 @@ register_op_strategy(
 )(propagate_single_input_strategy)
 
 
-register_op_strategy(
-    aten._to_copy.default, schema_info=RuntimeSchemaInfo(static_kwargkey=["dtype"])
-)(propagate_single_input_strategy)
+def _partial_needs_reduce_for_dtype_cast(
+    reduce_op: str,
+    src_dtype: torch.dtype,
+    target_dtype: torch.dtype | None,
+) -> bool:
+    """Return True when reduce_op does not commute with the dtype cast."""
+    if target_dtype is None or src_dtype == target_dtype:
+        return False
+    if target_dtype == torch.bool:
+        return True
+    if reduce_op in ("max", "min"):
+        return False
+    return src_dtype.is_floating_point and not target_dtype.is_floating_point
+
+
+@register_single_dim_strategy(
+    aten._to_copy.default,
+    schema_info=RuntimeSchemaInfo(static_kwargkey=["dtype"]),
+    allow_unbacked_sharding=True,
+)
+def _to_copy_single_dim_strategy(
+    op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    input_meta = cast(TensorMeta, args_schema[0])
+    src_dtype = input_meta.dtype
+    target_dtype = cast(torch.dtype | None, kwargs_schema.get("dtype", None))
+
+    strategies: list[list[Placement | _ShardingPlaceholder]] = []
+    for dim in range(len(input_meta.shape)):
+        strategies.append([_ShardingPlaceholder(dim), _ShardingPlaceholder(dim)])
+    for reduce_op in Partial.ALL_REDUCE_OPS:
+        if not _partial_needs_reduce_for_dtype_cast(reduce_op, src_dtype, target_dtype):
+            strategies.append([Partial(reduce_op), Partial(reduce_op)])
+    return strategies
 
 
 @register_op_strategy(


### PR DESCRIPTION
Fixes #172684
Updated to use single_dim_strategy. 
Type conversion to int/bool on Partial(sum) incorrectly preserved the Partial placement, producing wrong results. trunc(a+b) != trunc(a) + trunc(b).

This adds a custom strategy for _to_copy that checks if the dtype conversion is linear for the reduce operation before preserving Partial.

This PR is offered in support of the Partial correctness stabilization efforts. 