### PR TITLE
[bucketing] Fix reordering in manual bucketing pass

### DIFF
--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -52,7 +52,7 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
     ):
         super().__init__(*args, **kwargs)
         self.node_users = node_users
-        self.wait_to_node_map: dict[fx.Node, fx.Node] = defaultdict()
+        self.node_to_wait_map: dict[fx.Node, fx.Node] = defaultdict()
 
     def _check_recursive_dep(
         self,
@@ -128,7 +128,7 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
                 node_type = node_type + "_wait"
             n.meta["manual_bucket_node_type"] = node_type
             if "wait" in node_type:
-                self.wait_to_node_map[n] = new_wait
+                self.node_to_wait_map[n] = new_wait
 
     def manual_bucket_collectives(self, nodes: list[fx.Node]) -> None:
         """
@@ -237,11 +237,36 @@ class ManualOverlapScheduler(OverlapScheduler):
         """
         Reorder nodes in the FX graph to enforce manual overlap dependencies.
 
-        Enforce:
-        - all_gather_start_i depends on all_gather_wait_(i-1)
-        - reduce_scatter_wait_i must happen before reduce_scatter_start_(i+1)
+        forward graph (all-gathers only):
+            modules are processed in order: module 0, 1, 2, ...
+
+            before reordering:
+            ag_start_0 -> ag_wait_0 -> compute_0 -> ag_start_1 -> ag_wait_1 -> compute_1 -> ...
+
+            Reordering prefetches module i+1's parameters while computing module i
+            It adds dependencies: ag_wait_i should depend on ag_start_(i+1)
+            This enforces ag_start_(i+1) to happen before ag_wait_i so it overlaps with module i's compute
+
+            after reordering:
+            ag_start_0 -> ag_start_1 -> ag_wait_0 -> compute_0 -> ag_wait_1 -> compute_1 -> ...
+
+        backward graph (all-gathers and reduce-scatters):
+            modules are processed in reverse order: module N, N-1, N-2, ...
+
+            before reordering:
+            ag_start_N -> ag_wait_N -> compute_N -> rs_start_N -> rs_wait_N -> ...
+
+            For all-gathers, prefetch module i-1's parameters while computing module i
+            Adds dependencies: ag_wait_i should depend on ag_start_(i-1)
+            So ag_start_(i-1) overlaps with module i's compute
+
+            For reduce-scatters, defer rs_wait_i to happen after rs_start_(i-1)
+            Adds dependencies: rs_wait_i should depend on rs_start_(i-1)
+            So rs_start_i overlaps with module i-1's compute
+
         """
-        delayed_rs_nodes: list[fx.Node] = []
+        delayed_rs_wait_nodes: list[fx.Node] = []
+        current_rs_start_nodes: list[fx.Node] = []
         overlap_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
 
         # Re-initialize after graph modification in _manual_bucket_collectives
@@ -261,19 +286,25 @@ class ManualOverlapScheduler(OverlapScheduler):
                 continue
 
             if node_type == "bucketed_reduce_scatter":
-                # Ensure all delayed waits execute before this reduce_scatter
-                for delayed in delayed_rs_nodes:
-                    self._schedule(delayed)
-                    overlap_deps[delayed].add(node)
-                delayed_rs_nodes.clear()
+                # Collect reduce scatter start nodes (pre_bucket_rs and rs)
+                current_rs_start_nodes.append(node)
 
             elif node_type == "bucketed_reduce_scatter_wait":
-                # Defer until next reduce_scatter
-                delayed_rs_nodes.append(node)
+                # When we see a wait node from a new RS, flush delayed waits
+                # with dependencies on previously collected RS start nodes
+                if current_rs_start_nodes:
+                    for delayed in delayed_rs_wait_nodes:
+                        for rs_start in current_rs_start_nodes:
+                            overlap_deps[delayed].add(rs_start)
+                        self._schedule(delayed)
+                    delayed_rs_wait_nodes.clear()
+                    current_rs_start_nodes.clear()
+                delayed_rs_wait_nodes.append(node)
                 continue
+
             self._schedule(node)
 
-        for delayed in delayed_rs_nodes:
+        for delayed in delayed_rs_wait_nodes:
             self._schedule(delayed)
 
         self.scheduled = OrderedSet(reversed(list(self.scheduled)))
@@ -290,7 +321,7 @@ class ManualOverlapScheduler(OverlapScheduler):
                 # Connect corresponding all_gather_wait -> all_gather edges
                 if picked_ag:
                     for ag in picked_ag:
-                        overlap_deps[self.bucketer.wait_to_node_map[node]].add(ag)
+                        overlap_deps[self.bucketer.node_to_wait_map[node]].add(ag)
                 picked_ag.clear()
             if is_compute_node(node):
                 last_compute = node


### PR DESCRIPTION

Fixes the reordering of reduce-scatter nodes in manual bucketing pass. After `merge_reduce_scatter_bucket()` is done, each bucket will have one `_pre_bucket_reduce_scatter` and one `reduce_scatter`.  During reordering, we should defer reduce_scatter_wait of module i to happen after both `pre_bucket_reduce_scatter` and `reduce_scatter`.

Also misc fixes:

1. Fixes the docstring of `_manual_reorder_graph`
2. Added test for reduce-scatter bucketing and reordering


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo 