### PR TITLE
Docs: add missing NumPy import in tensor example

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -19,6 +19,7 @@ A tensor can be constructed from a Python :class:`list` or sequence using the
     >>> torch.tensor([[1., -1.], [1., -1.]])
     tensor([[ 1.0000, -1.0000],
             [ 1.0000, -1.0000]])
+    >>> import numpy as np
     >>> torch.tensor(np.array([[1, 2, 3], [4, 5, 6]]))
     tensor([[ 1,  2,  3],
             [ 4,  5,  6]])


### PR DESCRIPTION
	•	Problem: Example uses np.array without importing NumPy
	•	Fix: add import numpy as np right before usage
	•	Tests: python -m sphinx -b doctest docs/source docs/_build/doctest