### PR TITLE
[ROCm] Enable test_nccl_errors_nonblocking for ROCm

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -59,7 +59,6 @@ from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     requires_world_size,
     skip_if_lt_x_gpu,
-    skip_if_rocm_multiprocess,
     sm_is_or_higher_than,
     TEST_SKIPS,
     with_dist_debug_levels,
@@ -3814,7 +3813,6 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
     @requires_nccl()
     @requires_nccl_version((2, 4, 0), "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
-    @skip_if_rocm_multiprocess
     @skip_but_pass_in_sandcastle("Test does not pass when run locally")
     def test_nccl_errors_nonblocking(self):
         self._reduce_timeout()


### PR DESCRIPTION
## Summary

Removes the `skip_if_rocm_multiprocess` decorator from `test_nccl_errors_nonblocking`, enabling the test to run on ROCm.

Fixes #168468

## Background

This follows the pattern established in #169698, which enabled the other three tests in `NcclErrorHandlingTest` for ROCm:
- `test_send_recv_non_dense_tensor` (#168467)
- `test_nccl_errors_blocking` (#168469)
- `test_restart_pg_after_error` (#168470)

With this change, all 4 tests in `NcclErrorHandlingTest` are now enabled for ROCm, completing the parent issue #168466.

## Changes

- Removed `@skip_if_rocm_multiprocess` decorator from `test_nccl_errors_nonblocking`
- Removed unused import of `skip_if_rocm_multiprocess`

Note: The `@skip_but_pass_in_sandcastle` decorator remains, as it is platform-agnostic and relates to local vs CI behavior, not ROCm compatibility.

## Test Plan

- [ ] ROCm CI should run `test_nccl_errors_nonblocking` and pass (or skip in sandcastle mode)
- The test behavior is consistent with `test_nccl_errors_blocking` which was already enabled for ROCm in #169698

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @jbschlosser @atulkulk

---
PR authored with assistance from Claude.