### PR TITLE
Identity: avoid non-comparable numbers in SymPy

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -87,6 +87,14 @@ class TestUtils(TestCase):
         result = sympy_subs(expr, {q0: I})
         self.assertTrue(result.has(I))
 
+    def testIdentityComparisonNoRecursion(self):
+        expr = Identity(sympify("0"))
+        try:
+            result = expr >= 0
+        except RecursionError as exc:
+            self.fail(f"Identity comparison should not recurse: {exc}")
+        self.assertIsNotNone(result)
+
     def test_sympy_str(self):
         self.assertEqual(sympy_str(sympify("a+b+c")), "a + b + c")
         self.assertEqual(sympy_str(sympify("a*b+c")), "c + a * b")

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -88,12 +88,22 @@ class TestUtils(TestCase):
         self.assertTrue(result.has(I))
 
     def testIdentityComparisonNoRecursion(self):
-        expr = Identity(sympify("0"))
-        try:
-            result = expr >= 0
-        except RecursionError as exc:
-            self.fail(f"Identity comparison should not recurse: {exc}")
-        self.assertIsNotNone(result)
+        self.assertTrue(Identity(sympify("0")) >= 0)
+        self.assertFalse(Identity(sympify("-6")) >= 0)
+
+    def testIdentityComparableNumbersInMinMax(self):
+        expr = Identity(sympify("-6"))
+        self.assertTrue(expr.is_number)
+        self.assertTrue(expr.is_comparable)
+        self.assertEqual(Max(0, expr), 0)
+
+    def testIdentityEvalfPreservesBitPrecision(self):
+        arg = sympify("1/7")
+        prec = 13
+        expected = arg._eval_evalf(prec)
+        actual = Identity(arg)._eval_evalf(prec)
+        self.assertEqual(actual._prec, expected._prec)
+        self.assertEqual(actual, expected)
 
     def test_sympy_str(self):
         self.assertEqual(sympy_str(sympify("a+b+c")), "a + b + c")

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1334,11 +1334,6 @@ class Identity(sympy.Function):
         # This avoids creating numeric non-comparable Identity(I) terms.
         return bool(self.args[0].is_number and self.args[0].is_comparable)
 
-    @property
-    def is_comparable(self):
-        # Delegate comparability to the wrapped argument.
-        return bool(self.args[0].is_comparable)
-
     def _eval_expand_identity(self, **hints):
         # Removes the identity op.
         return self.args[0]

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1341,6 +1341,13 @@ class Identity(sympy.Function):
     def __int__(self) -> int:
         return int(self.args[0])
 
+    def _eval_evalf(self, prec):
+        # Delegate numeric evaluation so SymPy can compare wrapped constants
+        # (e.g., Identity(-6) in Min/Max simplification paths) without recursion.
+        # `prec` is in bits for _eval_evalf, so delegate through _eval_evalf
+        # (not evalf, which expects decimal digits).
+        return self.args[0]._eval_evalf(prec)
+
     def __float__(self) -> float:
         return float(self.args[0])
 


### PR DESCRIPTION
- Make SymPy Identity numeric only when its argument is comparable, so Identity(I) no longer collapses to I.
- Add a regression test for Min/Max substitution with non‑comparable Identity terms in Inductor.



See https://github.com/pytorch/pytorch/pull/172168

/cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison
