### PR TITLE
Update has_triton to support privateuse1

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -172,6 +172,7 @@ def has_triton() -> bool:
         "xpu": _return_true,
         "cpu": cpu_extra_check,
         "mtia": _return_true,
+        "privateuseone": _return_true,
     }
 
     def is_device_compatible_with_triton() -> bool:


### PR DESCRIPTION
As we are working on Microsoft Maia which uses `privateuse1` to integrate in pytorch, we found `privateuse1` is not included in this `has_triton()` api, which caused issue in FX graphs. This pull request is to fix this. Please kindly help take a look. Thank you very much!


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo