### PR TITLE
use shape_id to inform inputs that must have matching sizes  in support in mark_unbacked. 

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4857,7 +4857,56 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         compiled_func(x3)
         self.assertEqual(counter.frame_count, 2)
 
->>>>>>> Stashed changes
+    def test_duck_shape_id_no_recompile_without_dynamic_indices(self):
+        """
+        Test that passing a tensor without _dynamo_dynamic_indices after
+        compiling with duck_shape_ids does NOT trigger recompilation.
+        The guard on duck_shape_ids only applies when the runtime tensor
+        also has _dynamo_dynamic_indices.
+        """
+        counter = CompileCounter()
+
+        def func(x):
+            return x + 1
+
+        compiled_func = torch.compile(func, backend=counter)
+
+        # First call with duck_shape_id (has _dynamo_dynamic_indices)
+        x1 = torch.rand(4, 3)
+        torch._dynamo.decorators.mark_unbacked(x1, 0, duck_shape_id="batch")
+        compiled_func(x1)
+        self.assertEqual(counter.frame_count, 1)
+
+        # Second call with regular tensor (no _dynamo_dynamic_indices)
+        # Should NOT recompile - guard passes when no _dynamo_dynamic_indices
+        x2 = torch.rand(4, 3)
+        compiled_func(x2)
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_duck_shape_id_recompile_with_different_id(self):
+        """
+        Test that passing a tensor with same _dynamo_dynamic_indices but
+        different duck_shape_id DOES trigger recompilation.
+        """
+        counter = CompileCounter()
+
+        def func(x):
+            return x + 1
+
+        compiled_func = torch.compile(func, backend=counter)
+
+        # First call with duck_shape_id="batch"
+        x1 = torch.rand(4, 3)
+        torch._dynamo.decorators.mark_unbacked(x1, 0, duck_shape_id="batch")
+        compiled_func(x1)
+        self.assertEqual(counter.frame_count, 1)
+
+        # Second call with different duck_shape_id - should recompile
+        x2 = torch.rand(4, 3)
+        torch._dynamo.decorators.mark_unbacked(x2, 0, duck_shape_id="other")
+        compiled_func(x2)
+        self.assertEqual(counter.frame_count, 2)
+
 
 instantiate_parametrized_tests(TestUnbacked)
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4892,6 +4892,7 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         compiled_func(x2)
         self.assertEqual(counter.frame_count, 1)
 
+    @skipIfTorchDynamo("mark_unbacked is not traceable")
     def test_duck_shape_id_recompile_with_different_id(self):
         """
         Test that passing a tensor with same _dynamo_dynamic_indices but

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4865,6 +4865,7 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         compiled_func(x3)
         self.assertEqual(counter.frame_count, 2)
 
+    @skipIfTorchDynamo("mark_unbacked is not traceable")
     def test_duck_shape_id_no_recompile_without_dynamic_indices(self):
         """
         Test that passing a tensor without _dynamo_dynamic_indices after

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4768,9 +4768,9 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         self.assertRaises(GuardOnDataDependentSymNode, lambda: func(torch.tensor([33])))
 
     @skipIfTorchDynamo("mark_unbacked is not traceable")
-    def test_duck_shape_id_unifies_unbacked_symbols(self):
+    def test_shape_id_unifies_unbacked_symbols(self):
         """
-        Test that duck_shape_id parameter in mark_unbacked causes tensors to share
+        Test that shape_id parameter in mark_unbacked causes tensors to share
         the same unbacked symbol, allowing equality comparisons without DDE.
         """
 
@@ -4780,7 +4780,7 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
             else:
                 return x - y
 
-        # Test 1: Without duck_shape_id, comparing unbacked symbols raises DDE
+        # Test 1: Without shape_id, comparing unbacked symbols raises DDE
         x1 = torch.rand(4, 3)
         y1 = torch.rand(4, 3)
         torch._dynamo.decorators.mark_unbacked(x1, 0)
@@ -4791,7 +4791,7 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
             compiled_func = torch.compile(func, fullgraph=True, backend="eager")
             compiled_func(x1, y1)
 
-        # Test 2: With duck_shape_id, same symbol is used - no DDE, fullgraph succeeds
+        # Test 2: With shape_id, same symbol is used - no DDE, fullgraph succeeds
         x2 = torch.rand(4, 3)
         y2 = torch.rand(4, 3)
 
@@ -4802,9 +4802,9 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         self.assertTrue(torch.allclose(result, x2 + y2))
 
     @skipIfTorchDynamo("mark_unbacked is not traceable")
-    def test_duck_shape_id_runtime_assertion_on_mismatch(self):
+    def test_shape_id_runtime_assertion_on_mismatch(self):
         """
-        Test that duck_shape_id with different actual sizes at runtime
+        Test that shape_id with different actual sizes at runtime
         raises an assertion error during tracing. This ensures that duck shaping
         violations are caught rather than silently producing incorrect results.
         """
@@ -4818,27 +4818,27 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         # First, compile with valid inputs (same batch size)
         x1 = torch.rand(4, 3)
         y1 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x1, 0, duck_shape_id="batch")
-        torch._dynamo.decorators.mark_unbacked(y1, 0, duck_shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(x1, 0, shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(y1, 0, shape_id="batch")
         result = compiled_func(x1, y1)
         self.assertTrue(torch.allclose(result, x1 + y1))
 
-        # Now pass tensors with different batch sizes but same duck_shape_id
+        # Now pass tensors with different batch sizes but same shape_id
         # This triggers recompilation, and during tracing the torch._check
         # equality assertion will fail because the sizes don't match
         x2 = torch.rand(4, 3)
         y2 = torch.rand(5, 3)  # Different batch size!
-        torch._dynamo.decorators.mark_unbacked(x2, 0, duck_shape_id="batch")
-        torch._dynamo.decorators.mark_unbacked(y2, 0, duck_shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(x2, 0, shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(y2, 0, shape_id="batch")
 
         # Should raise an AssertionError during guard building because batch sizes don't match
         with self.assertRaises(AssertionError):
             compiled_func(x2, y2)
 
     @skipIfTorchDynamo("mark_unbacked is not traceable")
-    def test_duck_shape_id_recompilation(self):
+    def test_shape_id_recompilation(self):
         """
-        Test that changing _dynamo_duck_shape_ids triggers recompilation.
+        Test that changing _dynamo_shape_ids triggers recompilation.
         """
         counter = CompileCounter()
 
@@ -4847,30 +4847,30 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
 
         compiled_func = torch.compile(func, backend=counter)
 
-        # First call with duck_shape_id
+        # First call with shape_id
         x1 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x1, 0, duck_shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(x1, 0, shape_id="batch")
         compiled_func(x1)
         self.assertEqual(counter.frame_count, 1)
 
-        # Second call with same duck_shape_id - no recompilation
+        # Second call with same shape_id - no recompilation
         x2 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x2, 0, duck_shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(x2, 0, shape_id="batch")
         compiled_func(x2)
         self.assertEqual(counter.frame_count, 1)
 
-        # Third call without duck_shape_id - should recompile
+        # Third call without shape_id - should recompile
         x3 = torch.rand(4, 3)
         torch._dynamo.decorators.mark_unbacked(x3, 0)
         compiled_func(x3)
         self.assertEqual(counter.frame_count, 2)
 
     @skipIfTorchDynamo("mark_unbacked is not traceable")
-    def test_duck_shape_id_no_recompile_without_dynamic_indices(self):
+    def test_shape_id_no_recompile_without_dynamic_indices(self):
         """
         Test that passing a tensor without _dynamo_dynamic_indices after
-        compiling with duck_shape_ids does NOT trigger recompilation.
-        The guard on duck_shape_ids only applies when the runtime tensor
+        compiling with shape_ids does NOT trigger recompilation.
+        The guard on shape_ids only applies when the runtime tensor
         also has _dynamo_dynamic_indices.
         """
         counter = CompileCounter()
@@ -4880,9 +4880,9 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
 
         compiled_func = torch.compile(func, backend=counter)
 
-        # First call with duck_shape_id (has _dynamo_dynamic_indices)
+        # First call with shape_id (has _dynamo_dynamic_indices)
         x1 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x1, 0, duck_shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(x1, 0, shape_id="batch")
         compiled_func(x1)
         self.assertEqual(counter.frame_count, 1)
 
@@ -4893,10 +4893,10 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         self.assertEqual(counter.frame_count, 1)
 
     @skipIfTorchDynamo("mark_unbacked is not traceable")
-    def test_duck_shape_id_recompile_with_different_id(self):
+    def test_shape_id_recompile_with_different_id(self):
         """
         Test that passing a tensor with same _dynamo_dynamic_indices but
-        different duck_shape_id DOES trigger recompilation.
+        different shape_id DOES trigger recompilation.
         """
         counter = CompileCounter()
 
@@ -4905,15 +4905,15 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
 
         compiled_func = torch.compile(func, backend=counter)
 
-        # First call with duck_shape_id="batch"
+        # First call with shape_id="batch"
         x1 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x1, 0, duck_shape_id="batch")
+        torch._dynamo.decorators.mark_unbacked(x1, 0, shape_id="batch")
         compiled_func(x1)
         self.assertEqual(counter.frame_count, 1)
 
-        # Second call with different duck_shape_id - should recompile
+        # Second call with different shape_id - should recompile
         x2 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x2, 0, duck_shape_id="other")
+        torch._dynamo.decorators.mark_unbacked(x2, 0, shape_id="other")
         compiled_func(x2)
         self.assertEqual(counter.frame_count, 2)
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4780,22 +4780,20 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
             else:
                 return x - y
 
-        # # Test 1: Without duck_shape_id, comparing unbacked symbols raises DDE
-        # x1 = torch.rand(4, 3)
-        # y1 = torch.rand(4, 3)
-        # torch._dynamo.decorators.mark_unbacked(x1, 0)
-        # torch._dynamo.decorators.mark_unbacked(y1, 0)
+        # Test 1: Without duck_shape_id, comparing unbacked symbols raises DDE
+        x1 = torch.rand(4, 3)
+        y1 = torch.rand(4, 3)
+        torch._dynamo.decorators.mark_unbacked(x1, 0)
+        torch._dynamo.decorators.mark_unbacked(y1, 0)
 
-        # torch._dynamo.reset()
-        # with self.assertRaises(torch._dynamo.exc.UserError):
-        #     compiled_func = torch.compile(func, fullgraph=True, backend="eager")
-        #     compiled_func(x1, y1)
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.UserError):
+            compiled_func = torch.compile(func, fullgraph=True, backend="eager")
+            compiled_func(x1, y1)
 
         # Test 2: With duck_shape_id, same symbol is used - no DDE, fullgraph succeeds
         x2 = torch.rand(4, 3)
         y2 = torch.rand(4, 3)
-        torch._dynamo.decorators.mark_unbacked(x2, 0, duck_shape_id="batch")
-        torch._dynamo.decorators.mark_unbacked(y2, 0, duck_shape_id="batch")
 
         torch._dynamo.reset()
         compiled_func = torch.compile(func, fullgraph=True, backend="eager")

--- a/torch/_dynamo/_constants.py
+++ b/torch/_dynamo/_constants.py
@@ -1,9 +1,0 @@
-"""
-Shared constants for TorchDynamo internals.
-This module should have no imports from other _dynamo modules to avoid circular dependencies.
-"""
-
-# Field names for tracking dynamic dimension information on tensors
-SHAPE_IDS_FIELD_NAME = "_dynamo_shape_ids"
-UNBACKED_INDICES_FIELD_NAME = "_dynamo_unbacked_indices"
-DYNAMIC_INDICES_FIELD_NAME = "_dynamo_dynamic_indices"

--- a/torch/_dynamo/_constants.py
+++ b/torch/_dynamo/_constants.py
@@ -1,0 +1,9 @@
+"""
+Shared constants for TorchDynamo internals.
+This module should have no imports from other _dynamo modules to avoid circular dependencies.
+"""
+
+# Field names for tracking dynamic dimension information on tensors
+SHAPE_IDS_FIELD_NAME = "_dynamo_shape_ids"
+UNBACKED_INDICES_FIELD_NAME = "_dynamo_unbacked_indices"
+DYNAMIC_INDICES_FIELD_NAME = "_dynamo_dynamic_indices"

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -559,6 +559,7 @@ def mark_unbacked(
     hint_override: Optional[int] = None,
     strict: bool = False,
     specialize_on: Optional[list[Any]] = None,
+    duck_shape_id: Optional[Any] = None,
 ) -> None:
     """
     Mark a tensor as having an unbacked dimension. This changes the semantics of operations:
@@ -576,12 +577,15 @@ def mark_unbacked(
             By default (strict=False), specialization is allowed and will proceed without error.
         specialize_on (Optional[list[Any]], default=None): A list of specialization criteria (e.g., lambdas) for this dimension.
             If provided, Dynamo will generate specialized compiled regions for each criterion in addition to a generic trace.
+        duck_shape_id (Optional[Any], default=None): An optional identifier to group unbacked dimensions together.
+            All unbacked dimensions with the same duck_shape_id will share the same unbacked symbol.
+            This is useful when multiple tensors are known to have the same batch size at runtime.
     """
     if torch.distributed.is_available() and isinstance(
         t, torch.distributed.tensor.DTensor
     ):
         # apply on inner tensor sizes/strides
-        mark_unbacked(t._local_tensor, index)
+        mark_unbacked(t._local_tensor, index, duck_shape_id=duck_shape_id)
     else:
         # You could have copied the mark_dynamic behavior but I'm not convinced
         # it's what you want
@@ -604,8 +608,14 @@ def mark_unbacked(
         if not hasattr(t, "_dynamo_hint_overrides"):
             t._dynamo_hint_overrides = {}
 
+        if not hasattr(t, "_dynamo_duck_shape_ids"):
+            t._dynamo_duck_shape_ids = {}
+
         if hint_override:
             t._dynamo_hint_overrides[index] = hint_override
+
+        if duck_shape_id is not None:
+            t._dynamo_duck_shape_ids[index] = duck_shape_id
 
         # FX tracers don't respect @forbid_in_graph and choke on the following error since it passes in proxies:
         # TypeError: 'Attribute' object does not support item assignment
@@ -618,7 +628,7 @@ def mark_unbacked(
 
     assert isinstance(index, (list, tuple))
     for i in index:
-        mark_unbacked(t, i)
+        mark_unbacked(t, i, duck_shape_id=duck_shape_id)
 
 
 @forbid_in_graph

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -584,7 +584,8 @@ def mark_unbacked(
             If provided, Dynamo will generate specialized compiled regions for each criterion in addition to a generic trace.
         shape_id (Optional[str], default=None): An optional identifier to group unbacked dimensions together.
             All unbacked dimensions with the same shape_id will share the same unbacked symbol. This is useful when multiple tensors
-            are known to have the same batch size at runtime.
+            are known to have the same batch size at runtime. A runtime assertion is added
+            to ensure this property at runtime.
     """
     if torch.distributed.is_available() and isinstance(
         t, torch.distributed.tensor.DTensor

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -609,13 +609,12 @@ def mark_unbacked(
         if not hasattr(t, "_dynamo_hint_overrides"):
             t._dynamo_hint_overrides = {}
 
-        if not hasattr(t, "_dynamo_shape_ids"):
-            t._dynamo_shape_ids = {}
-
         if hint_override:
             t._dynamo_hint_overrides[index] = hint_override
 
         if shape_id is not None:
+            if not hasattr(t, "_dynamo_shape_ids"):
+                t._dynamo_shape_ids = {}
             t._dynamo_shape_ids[index] = shape_id
 
         # FX tracers don't respect @forbid_in_graph and choke on the following error since it passes in proxies:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3086,7 +3086,7 @@ class GuardBuilder(GuardBuilderBase):
                 # Guard on shape_ids when tensor has unbacked indices.
                 # shape_id is only set via mark_unbacked, which sets _dynamo_unbacked_indices.
                 # Empty dict is treated the same as not having the attribute.
-                if shape_ids := getattr(value, "_dynamo_unbacked_indices", None):
+                if shape_ids := getattr(value, "_dynamo_shape_ids", None):
                     code_part = f"((getattr({tensor_name}, '_dynamo_shape_ids', None) == {shape_ids!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"  # noqa: B950
                     code.append(code_part)
                     self.get_guard_manager(guard).add_lambda_guard(

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3082,12 +3082,11 @@ class GuardBuilder(GuardBuilderBase):
                         get_verbose_code_parts(code_part, guard),
                         guard.user_stack,
                     )
+
                 # Guard on shape_ids when tensor has unbacked indices.
                 # shape_id is only set via mark_unbacked, which sets _dynamo_unbacked_indices.
                 # Empty dict is treated the same as not having the attribute.
-                if hasattr(value, "_dynamo_unbacked_indices"):
-                    assert hasattr(value, "_dynamo_shape_ids")
-                    shape_ids = value._dynamo_shape_ids
+                if shape_ids := getattr(value, "_dynamo_unbacked_indices", None):
                     code_part = f"((getattr({tensor_name}, '_dynamo_shape_ids', None) == {shape_ids!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"  # noqa: B950
                     code.append(code_part)
                     self.get_guard_manager(guard).add_lambda_guard(

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -115,6 +115,11 @@ from torch.utils._traceback import format_frame, report_compile_source_on_error
 from torch.utils.weak import TensorWeakRef
 
 from . import config, convert_frame, exc
+from ._constants import (
+    DYNAMIC_INDICES_FIELD_NAME,
+    SHAPE_IDS_FIELD_NAME,
+    UNBACKED_INDICES_FIELD_NAME,
+)
 from .eval_frame import set_guard_error_hook
 from .source import (
     AttrProxySource,
@@ -3061,8 +3066,8 @@ class GuardBuilder(GuardBuilderBase):
             )
 
             if not static:
-                if hasattr(value, "_dynamo_dynamic_indices"):
-                    dynamic_indices = value._dynamo_dynamic_indices
+                if hasattr(value, DYNAMIC_INDICES_FIELD_NAME):
+                    dynamic_indices = getattr(value, DYNAMIC_INDICES_FIELD_NAME)
                     code_part = f"(({tensor_name}._dynamo_dynamic_indices.issubset({dynamic_indices})) if hasattr({tensor_name}, '_dynamo_dynamic_indices') else True)"  # noqa: B950
                     code.append(code_part)
                     self.get_guard_manager(guard).add_dynamic_indices_guard(
@@ -3070,26 +3075,26 @@ class GuardBuilder(GuardBuilderBase):
                         get_verbose_code_parts(code_part, guard),
                         guard.user_stack,
                     )
-                # Guard on duck_shape_ids when tensor has unbacked indices.
-                # duck_shape_id is only set via mark_unbacked, which sets _dynamo_unbacked_indices.
+                # Guard on shape_ids when tensor has unbacked indices.
+                # shape_id is only set via mark_unbacked, which sets _dynamo_unbacked_indices.
                 # Empty dict is treated the same as not having the attribute.
-                if hasattr(value, "_dynamo_unbacked_indices"):
-                    duck_shape_ids = getattr(value, "_dynamo_duck_shape_ids", None)
-                    if duck_shape_ids:
-                        code_part = f"((getattr({tensor_name}, '_dynamo_duck_shape_ids', None) == {duck_shape_ids!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"  # noqa: B950
-                        code.append(code_part)
-                        self.get_guard_manager(guard).add_lambda_guard(
-                            lambda x, expected=duck_shape_ids: (
-                                getattr(x, "_dynamo_duck_shape_ids", None) == expected
-                                if hasattr(x, "_dynamo_unbacked_indices")
-                                else True
-                            ),
-                            get_verbose_code_parts(code_part, guard),
-                            guard.user_stack,
-                        )
+                if hasattr(value, UNBACKED_INDICES_FIELD_NAME):
+                    assert hasattr(value, SHAPE_IDS_FIELD_NAME)
+                    shape_ids = getattr(value, SHAPE_IDS_FIELD_NAME)
+                    code_part = f"((getattr({tensor_name}, {SHAPE_IDS_FIELD_NAME!r}, None) == {shape_ids!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"  # noqa: B950
+                    code.append(code_part)
+                    self.get_guard_manager(guard).add_lambda_guard(
+                        lambda x, expected=shape_ids: (
+                            getattr(x, SHAPE_IDS_FIELD_NAME, None) == expected
+                            if hasattr(x, UNBACKED_INDICES_FIELD_NAME)
+                            else True
+                        ),
+                        get_verbose_code_parts(code_part, guard),
+                        guard.user_stack,
+                    )
                 # In the case of us not having any dynamic dimension indices, we compiled the frame with no chance of
                 # raising for this specific tensor - and any inputs with more dynamic user directives specified must be recompiled.
-                if not hasattr(value, "_dynamo_dynamic_indices") and not hasattr(
+                if not hasattr(value, DYNAMIC_INDICES_FIELD_NAME) and not hasattr(
                     value, "_dynamo_unbacked_indices"
                 ):
                     code_part = (

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3070,6 +3070,23 @@ class GuardBuilder(GuardBuilderBase):
                         get_verbose_code_parts(code_part, guard),
                         guard.user_stack,
                     )
+                    # Guard on duck_shape_ids only when tensor has dynamic indices.
+                    # We only care about symbol unification for unbacked dimensions.
+                    # Empty dict is treated the same as not having the attribute.
+                    # Only check duck_shape_ids if runtime tensor also has _dynamo_dynamic_indices.
+                    duck_shape_ids = getattr(value, "_dynamo_duck_shape_ids", None)
+                    if duck_shape_ids:
+                        code_part = f"((getattr({tensor_name}, '_dynamo_duck_shape_ids', None) == {duck_shape_ids!r}) if hasattr({tensor_name}, '_dynamo_dynamic_indices') else True)"  # noqa: B950
+                        code.append(code_part)
+                        self.get_guard_manager(guard).add_lambda_guard(
+                            lambda x, expected=duck_shape_ids: (
+                                getattr(x, "_dynamo_duck_shape_ids", None) == expected
+                                if hasattr(x, "_dynamo_dynamic_indices")
+                                else True
+                            ),
+                            get_verbose_code_parts(code_part, guard),
+                            guard.user_stack,
+                        )
                 # In the case of us not having any dynamic dimension indices, we compiled the frame with no chance of
                 # raising for this specific tensor - and any inputs with more dynamic user directives specified must be recompiled.
                 else:
@@ -3079,30 +3096,6 @@ class GuardBuilder(GuardBuilderBase):
                     code.append(code_part)
                     self.get_guard_manager(guard).add_no_hasattr_guard(
                         "_dynamo_dynamic_indices",
-                        get_verbose_code_parts(code_part, guard),
-                        guard.user_stack,
-                    )
-
-                # Guard on duck_shape_ids to ensure the same symbol unification happens
-                if hasattr(value, "_dynamo_duck_shape_ids"):
-                    duck_shape_ids = value._dynamo_duck_shape_ids
-                    code_part = f"(getattr({tensor_name}, '_dynamo_duck_shape_ids', None) == {duck_shape_ids!r})"
-                    code.append(code_part)
-                    self.get_guard_manager(guard).add_lambda_guard(
-                        lambda x, expected=duck_shape_ids: getattr(
-                            x, "_dynamo_duck_shape_ids", None
-                        )
-                        == expected,
-                        get_verbose_code_parts(code_part, guard),
-                        guard.user_stack,
-                    )
-                else:
-                    code_part = (
-                        f"hasattr({tensor_name}, '_dynamo_duck_shape_ids') == False"
-                    )
-                    code.append(code_part)
-                    self.get_guard_manager(guard).add_no_hasattr_guard(
-                        "_dynamo_duck_shape_ids",
                         get_verbose_code_parts(code_part, guard),
                         guard.user_stack,
                     )

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3917,6 +3917,7 @@ def _automatic_dynamic(
         view_base_context=view_base_context,
         tensor_source=source,
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
+        duck_shape_ids=getattr(e, "_dynamo_duck_shape_ids", None),
     )
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -95,6 +95,7 @@ from torch.utils._sympy.value_ranges import ValueRanges
 from torch.utils.weak import TensorWeakRef
 
 from .. import config, graph_break_hints, mutation_guard, replay_record, trace_rules
+from .._constants import SHAPE_IDS_FIELD_NAME
 from ..device_interface import get_registered_device_interfaces
 from ..exc import InternalTorchDynamoError, raise_observed_exception, unimplemented
 from ..guards import GuardBuilder, install_guard, make_dupe_guard
@@ -3917,7 +3918,7 @@ def _automatic_dynamic(
         view_base_context=view_base_context,
         tensor_source=source,
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
-        duck_shape_ids=getattr(e, "_dynamo_duck_shape_ids", None),
+        shape_ids=getattr(e, SHAPE_IDS_FIELD_NAME, None),
     )
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -95,7 +95,6 @@ from torch.utils._sympy.value_ranges import ValueRanges
 from torch.utils.weak import TensorWeakRef
 
 from .. import config, graph_break_hints, mutation_guard, replay_record, trace_rules
-from .._constants import SHAPE_IDS_FIELD_NAME
 from ..device_interface import get_registered_device_interfaces
 from ..exc import InternalTorchDynamoError, raise_observed_exception, unimplemented
 from ..guards import GuardBuilder, install_guard, make_dupe_guard
@@ -3918,7 +3917,7 @@ def _automatic_dynamic(
         view_base_context=view_base_context,
         tensor_source=source,
         shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
-        shape_ids=getattr(e, SHAPE_IDS_FIELD_NAME, None),
+        shape_ids=getattr(e, "_dynamo_shape_ids", None),
     )
 
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2158,9 +2158,7 @@ class StatelessSymbolicContext(SymbolicContext, Generic[_P1, _T1]):
     # information on how to allocate symbols when recursively fakeifying the base
     # during view fake-ification.
     view_base_context: Optional[SymbolicContext] = None
-    # Maps dimension index to shape_id. If two unbacked dimensions have the
-    # same shape_id, a torch._check will ensure that shapenv knows they are
-    # always the same. And a runtime assertions will be added to verify that.
+    # Maps dimension index to shape_id.
     shape_ids: Optional[dict[int, Optional[str]]] = None
     # TODO: add storage offset and stride symbolic_context
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3986,9 +3986,10 @@ class ShapeEnv:
             # not be valid.
             self.name_to_node: dict[str, torch.fx.Node] = {}
 
-        # Maps shape_id -> unbacked symbol.
+        # Maps shape_id to the first unbacked symbol allocated for that id.
         # When mark_unbacked is called with a shape_id, we allocate fresh
-        # symbols but add runtime equality checks via torch._check.
+        # symbols but add runtime equality checks via torch._check to ensure
+        # all dims with the same shape_id are treated as the same symbol.
         self._shape_id_to_unbacked_symbol: dict[str, sympy.Expr] = {}
 
     @property


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172716

shape_id: An optional identifier to mark unbacked dimensions that are grouped together.
All unbacked dimensions with the same shape_id will share the same unbacked symbol after
replacement. This is done by Torch checking that they are all the same; runtime assertions
will be added.

This is a special use case, but it is the most common for the prologue function that we want to add to hint at relationships between input unbacked symbols.

Actual use cases:

vLLM default behavior: all inputs that are marked dynamic are actually the same length.
For the TorchBench benchmark, we will assume all inputs with batch_size are dynamic and duck-shaped.

cc @ezyang @EikanWang @jgong5 @wenzhe-nrv @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo