### PR TITLE
[Typing] defualt_value -> defualt_value

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -940,7 +940,7 @@ class Argument:
         name: str,
         type: JitType,
         N: _int | None,
-        defualt_value: Any | None,
+        default_value: Any | None,
         kwarg_only: _bool,
         alias_info: AliasInfo | None,
     ) -> None: ...


### PR DESCRIPTION

Fixes #172724 

torch/aten/src/ATen/core/function_schema.h requires default_value_(std::move(default_value)) and receives defualt_value: Any | None (including typo defualt leading to potential errors in initialization) -> now the typo is removed
