### PR TITLE
[ROCm] Remove redundant @skipIfRocm from test_cudnn_attention_broken_166211

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2924,7 +2924,6 @@ class TestSDPACudaOnly(NNTestCase):
             out = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=0.5)
             out.backward(grad)
 
-    @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_broken_166211(self):
         # https://github.com/pytorch/pytorch/issues/166211#issue-3551350377


### PR DESCRIPTION
## Summary

Removes the redundant `@skipIfRocm` decorator from `test_cudnn_attention_broken_166211`.

Does not fix # 168872, which would be fixed only once hipDnn is properly integrated into PyTorch.

## Analysis

The test has two skip decorators:
```python
@skipIfRocm  # REDUNDANT - removed by this PR
@unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
def test_cudnn_attention_broken_166211(self):
```

The `@skipIfRocm` decorator is redundant because:

1. `PLATFORM_SUPPORTS_CUDNN_ATTENTION` is **explicitly `False` on ROCm** per `common_cuda.py`:
   ```python
   def evaluate_platform_supports_cudnn_attention():
       return (not TEST_WITH_ROCM) and SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
   ```

2. The second decorator already correctly skips the test on ROCm with an accurate message.

## Benefits

- Clearer skip reason: "cudnn Attention is not supported on this system" instead of generic ROCm skip
- Removes redundant code
- Consistent with other cuDNN attention tests in the same file (which don't have `@skipIfRocm`)

## Verification on MI300X

Tested on AMD Instinct MI300X (gfx942) with ROCm 7.1:
- `PLATFORM_SUPPORTS_CUDNN_ATTENTION` evaluates to `False` on ROCm
- Test correctly skips with the cuDNN unavailability message

## Test Plan

- [ ] CI should pass - test remains skipped on ROCm (with clearer message)
- [ ] No functional change on NVIDIA (test behavior unchanged)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @jbschlosser

---
PR authored with assistance from Claude.