### PR TITLE
`_foreach_addcmul.Scalar` fast path for 0d scalar tensor list

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -274,14 +274,14 @@ inline bool _check_tensors_on_device(TensorList tensors, at::Device device) {
 
 // Fast path check for addcmul with value=1 and 0-d tensor broadcast.
 // tensorLists[0]=self, tensorLists[1]=tensor1, tensorLists[2]=tensor2
+// NOTE: Integer tensors are excluded by has_integral_tensor check before
+// calling this.
 inline bool can_use_fast_route_for_fma_broadcast(
     ArrayRef<TensorList> tensorLists) {
   return _check_all_tensors_are_0d_float64(tensorLists[2]) &&
+      _check_tensors_on_device(tensorLists[2], tensorLists[0][0].device()) &&
       _check_tensors_share_device_and_dtype({tensorLists[0], tensorLists[1]}) &&
-      _check_tensors_share_sizes_and_strides(
-             {tensorLists[0], tensorLists[1]}) &&
-      at::isFloatingType(tensorLists[0][0].scalar_type()) &&
-      _check_tensors_on_device(tensorLists[2], tensorLists[0][0].device());
+      _check_tensors_share_sizes_and_strides({tensorLists[0], tensorLists[1]});
 }
 
 using DeviceDtypeKey = std::pair<at::Device, at::ScalarType>;

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -189,7 +189,7 @@ std::vector<Tensor> foreach_pointwise_op_fma_broadcast(
   tensor_lists.emplace_back(tensors2.vec());
   tensor_lists.emplace_back(std::move(vec_res));
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       kHalf,
       kBFloat16,
       input[0].scalar_type(),
@@ -217,7 +217,7 @@ void foreach_pointwise_op_fma_broadcast_(
   tensor_lists.emplace_back(tensors1.vec());
   tensor_lists.emplace_back(tensors2.vec());
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       kHalf,
       kBFloat16,
       input[0].scalar_type(),


### PR DESCRIPTION
# Motivation

One common pattern in optimizer is
```python
for i in range(len(params)):
  params[i].add_(grads[i], alpha=step_sizes[i])
```

Where step_sizes: list[float] is a list of python floats (i.e. fp64) with different values.

Users usually want to use _foreach_add to make it faster. Prior to this PR, we have `_foreach_add.List(Tensor[] self, Tensor[] other, *, Scalar alpha=1) -> Tensor[]`.

However, we want to support:

- a list of different alphas for each tensor
- the alpha should be a 0d tensor to avoid recompile from torch.compile
- avoid `.item()` to support cudagraph
- bitwise equivalence with the python for-loop version of `add_(self, other, alpha)`

I have tried `_foreach_addcmul.ScalarList(Tensor[] self, Tensor[] tensor1, Tensor[] tensor2, Scalar[] scalars) -> Tensor[]`.   However, the issues are: 1) the need to allocate an extra `ones` tensor, which takes some extra memory; 2)`scalars` has to be scalar instead of tensor; 3) this goes through slow path by calling multiple kernels instead of 1 fused foreach kernel.

I have also tried `_foreach_addcmul.Scalar(Tensor[] self, Tensor[] tensor1, Tensor[] tensor2, Scalar value=1) -> Tensor[]`, where `Tensor[] self` is `params`, `Tensor[] tensor1` is `grads`, and `Tensor[] tensor2` is 0d tensors for `step_sizes`. However, it does not bitwisely match numerics of add_. Why? Because `param.add_(grad, alpha=step_size)` becomes `param+step_size*grad`, which uses FMA and has 1 rounding. However, `_foreach_addcmul.Scalar([param], [grad], [step_size], value)` becomes `param+value * (grad*step_size)`, which has 1 rounding from (`tmp=grad*step_size`), and 1 rounding from FMA `param+value*tmp`. This leads to numeric difference.


# Feature
This PR extends existing `func: _foreach_addcmul.Scalar(Tensor[] self, Tensor[] tensor1, Tensor[] tensor2, Scalar value=1) -> Tensor[]` to support fused kernel when tensor2 is a list of float64 scalar tensors. It does not change semantics of the aten op. It just adds a fused kernel for a special case.

Concretely, it additionally supports a fast path when:
- `Tensor[] tensor2` is a list of 0d float64 scalar tensors.
- `Tensor[] self` and `Tensor[] tensors` have the same device, dtype, sizes, and strides.
