### PR TITLE
Fix KeyError in functionalize_rng_ops when RNG op is not needed in backward

### DIFF
--- a/test/test_functionalization_of_rng_ops.py
+++ b/test/test_functionalization_of_rng_ops.py
@@ -319,6 +319,41 @@ class TestFunctionalizationRngOps(TestCase):
         # We can't check accuracy here because rand_like generated different rand numbers than dropout
         aot_fn(x)
 
+    @dtypes(torch.float32)
+    def test_checkpoint_with_unused_rng_in_backward(self, dtype, device):
+        # Test that RNG ops in checkpointed regions that are not needed for
+        # backward computation don't cause KeyError in functionalize_rng_ops.
+        #
+        # This reproduces a bug where rand is used in an additive way:
+        #   rand = torch.rand(...)
+        #   result = x + rand * scale
+        #
+        # The gradient of addition doesn't depend on the VALUE of rand,
+        # only on its shape. So backward doesn't need to recompute rand,
+        # and it gets eliminated from the backward graph by DCE.
+        # But functionalize_rng_ops was assuming all recomputable RNG ops
+        # exist in both forward and backward graphs.
+        from torch.utils.checkpoint import checkpoint
+
+        def g(x):
+            # rand used additively - NOT needed in backward
+            # (gradient of add doesn't depend on the value)
+            # This pattern matches real-world jitter/noise augmentation
+            noise = torch.rand(x.shape[0], 1, device=x.device, dtype=x.dtype)
+            x = x + noise * 1.0
+            return x
+
+        def fn(x):
+            return checkpoint(g, x, use_reentrant=False)
+
+        x = torch.ones(2, 4, device=device, dtype=dtype, requires_grad=True)
+
+        # Use torch.compile to trigger the same code path as the original error
+        compiled_fn = torch.compile(fn, backend="aot_eager")
+        res = compiled_fn(x)
+        # This should not raise KeyError: 'rand' in functionalize_rng_ops
+        res.sum().backward()
+
 
 only_for = ("cuda",)
 instantiate_device_type_tests(TestFunctionalizationRngOps, globals(), only_for=only_for)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1576,6 +1576,11 @@ def functionalize_rng_ops(
             and hasattr(node.target, "tags")
             and torch.Tag.nondeterministic_seeded in node.target.tags
         ):
+            # Skip if the node doesn't exist in both forward and backward graphs.
+            # This can happen when the RNG op's output is not needed for gradient
+            # computation and gets eliminated by dead code elimination.
+            if node.name not in fw_graph_rng_ops or node.name not in bw_graph_rng_ops:
+                continue
             base_node = joint_graph_rng_ops[node.name]
             fw_node = fw_graph_rng_ops[node.name]
             bw_node = bw_graph_rng_ops[node.name]


### PR DESCRIPTION
When using activation checkpointing, an RNG operation (like torch.rand) can be marked for recomputation but not actually needed in the backward graph. This happens when the RNG output flows through operations whose gradients don't depend on the random values (e.g., addition: the gradient of x + noise is 1.0 regardless of noise's value).

The functionalize_rng_ops function assumed all recomputable RNG ops exist in both forward and backward graphs, causing a KeyError when looking up the node in bw_graph_rng_ops. The fix skips RNG nodes that don't exist in both graphs, since there's nothing to functionalize if the op won't be recomputed in backward.

Authored with Claude.
