### PR TITLE
Enable fast path for foreach_addcmul/addcdiv with 0D tensor1

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -506,12 +506,8 @@ struct PointwiseOpScalarListFunctor {
 // The 0D tensor1 value is loaded from device memory once and used as a scalar.
 // Computes: input + alpha * tensor1_val * tensor2 (for addcmul with
 // std::multiplies) or: input + alpha * tensor1_val / tensor2 (for addcdiv with
-// std::divides) 
-template <
-    typename T,
-    int depth,
-    int r_args_depth,
-    int res_arg_index>
+// std::divides)
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct PointwiseOpScalar0dTensorFunctor {
   using opmath_t = at::opmath_type<T>;
   template <typename Op>
@@ -529,8 +525,8 @@ struct PointwiseOpScalar0dTensorFunctor {
         init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
 
     // Load the 0D tensor1 value from device memory (just one element)
-    opmath_t tensor1_val = static_cast<opmath_t>(*reinterpret_cast<const T*>(
-        tl.addresses[1][tensor_loc]));
+    opmath_t tensor1_val = static_cast<opmath_t>(
+        *reinterpret_cast<const T*>(tl.addresses[1][tensor_loc]));
 
     n -= chunk_idx * chunk_size;
     T r_args[r_args_depth][kILP];

--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -501,6 +501,89 @@ struct PointwiseOpScalarListFunctor {
   }
 };
 
+// Functor for pointwise ops where tensor1 is a list of 0D tensors.
+// tensor_lists contains: input, tensor1 (0D), tensor2, [output]
+// The 0D tensor1 value is loaded from device memory once and used as a scalar.
+// Computes: input + alpha * tensor1_val * tensor2 (for addcmul with
+// std::multiplies) or: input + alpha * tensor1_val / tensor2 (for addcdiv with
+// std::divides) 
+template <
+    typename T,
+    int depth,
+    int r_args_depth,
+    int res_arg_index>
+struct PointwiseOpScalar0dTensorFunctor {
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int64_t chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op,
+      opmath_t alpha) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
+
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+
+    // Load the 0D tensor1 value from device memory (just one element)
+    opmath_t tensor1_val = static_cast<opmath_t>(*reinterpret_cast<const T*>(
+        tl.addresses[1][tensor_loc]));
+
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
+
+    // to make things simple, we put aligned case in a different code path
+    // For depth=4: args[0] = input, args[1] = tensor1 (0D), args[2] = tensor2,
+    // args[3] = output For depth=3: args[0] = input, args[1] = tensor1 (0D),
+    // args[2] = tensor2, output = args[0]
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
+        // load input and tensor2 only (tensor1 is already loaded as scalar)
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[2], 0, i_start); // tensor2 is at args[2]
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          // input + alpha * op(tensor1_val, tensor2)
+          r_args[0][ii] = static_cast<T>(
+              static_cast<opmath_t>(r_args[0][ii]) +
+              alpha * op(tensor1_val, static_cast<opmath_t>(r_args[1][ii])));
+        }
+        // store
+        load_store(args[res_arg_index], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
+        // Load input (r_args[0]) and tensor2 (r_args[1])
+        // We need to load from args[0] and args[2] (skipping args[1] which is
+        // 0D tensor)
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          const auto i = i_start + threadIdx.x + ii * blockDim.x;
+          r_args[0][ii] = 0;
+          r_args[1][ii] = 0;
+          if (i < n && i < chunk_size) {
+            r_args[0][ii] = args[0][i];
+            r_args[1][ii] = args[2][i]; // tensor2 is at args[2]
+          }
+        }
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = static_cast<T>(
+              static_cast<opmath_t>(r_args[0][ii]) +
+              alpha * op(tensor1_val, static_cast<opmath_t>(r_args[1][ii])));
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
+};
+
 template <typename T, int depth>
 struct PointwiseOpListFunctor {
   using opmath_t = at::opmath_type<T>;

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -21,6 +21,54 @@
 
 namespace at::native {
 
+// Helper to check if all tensors in a list are 0D (scalar tensors)
+inline bool all_tensors_are_0d(TensorList tensors) {
+  return std::all_of(tensors.begin(), tensors.end(), [](const Tensor& t) {
+    return t.dim() == 0;
+  });
+}
+
+// Helper to check if all tensors have the same dtype as reference
+inline bool all_same_dtype(TensorList tensors, ScalarType dtype) {
+  return std::all_of(tensors.begin(), tensors.end(), [dtype](const Tensor& t) {
+    return t.scalar_type() == dtype;
+  });
+}
+
+// Inplace variant for when tensor1 is a list of 0D tensors (scalars)
+template <template <class> class Op>
+void foreach_pointwise_op_0d_tensor1_(
+    TensorList input,
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+
+  // tensor_lists: input, tensor1 (0D), tensor2
+  tensor_lists.emplace_back(input.vec());
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
+
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      input[0].scalar_type(),
+      "foreach_pointwise_op_0d_tensor1__cuda",
+      [&]() {
+        using opmath_t = at::opmath_type<scalar_t>;
+        multi_tensor_apply<3>(
+            tensor_lists,
+            PointwiseOpScalar0dTensorFunctor<
+                scalar_t,
+                /* depth */ 3,
+                /* r_args_depth */ 2,
+                /* res_arg_index */ 0>(),
+            Op<opmath_t>(),
+            alpha.to<opmath_t>());
+      });
+  increment_version(input);
+}
+
 template <template <class> class Op>
 std::vector<Tensor> foreach_pointwise_op(
     TensorList input,
@@ -55,6 +103,49 @@ std::vector<Tensor> foreach_pointwise_op(
                 /* res_arg_index */ 3>(),
             Op<opmath_t>(),
             scalar.to<opmath_t>());
+      });
+
+  return std::move(tensor_lists[3]);
+}
+
+// Variant for when tensor1 is a list of 0D tensors (scalars)
+// tensor_lists: input, tensor1 (0D), tensor2, output
+// The 0D tensor1 values are loaded from device memory in the functor
+template <template <class> class Op>
+std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
+    TensorList input,
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(input.size());
+  for (const auto& t : input) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
+
+  // tensor_lists: input, tensor1 (0D), tensor2, output
+  tensor_lists.emplace_back(input.vec());
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
+  tensor_lists.emplace_back(std::move(vec_res));
+
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      input[0].scalar_type(),
+      "foreach_pointwise_op_0d_tensor1_cuda",
+      [&]() {
+        using opmath_t = at::opmath_type<scalar_t>;
+        multi_tensor_apply<4>(
+            tensor_lists,
+            PointwiseOpScalar0dTensorFunctor<
+                scalar_t,
+                /* depth */ 4,
+                /* r_args_depth */ 2,
+                /* res_arg_index */ 3>(),
+            Op<opmath_t>(),
+            alpha.to<opmath_t>());
       });
 
   return std::move(tensor_lists[3]);
@@ -163,37 +254,61 @@ std::vector<Tensor> foreach_pointwise_op(
   return std::move(tensor_lists[3]);
 }
 
-#define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                           \
-  std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(              \
-      TensorList input,                                                 \
-      TensorList tensors1,                                              \
-      TensorList tensors2,                                              \
-      const Scalar& scalar) {                                           \
-    check_foreach_api_restrictions(input, tensors1, tensors2);          \
-                                                                        \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) ||     \
-        has_integral_tensor(input, /* includeBool */ true)) {           \
-      return at::native::foreach_tensor_##NAME##_scalar_slow(           \
-          input, tensors1, tensors2, scalar);                           \
-    }                                                                   \
-                                                                        \
-    return foreach_pointwise_op<OP>(input, tensors1, tensors2, scalar); \
-  }                                                                     \
-                                                                        \
-  void foreach_tensor_##NAME##_scalar_cuda_(                            \
-      TensorList input,                                                 \
-      TensorList tensors1,                                              \
-      TensorList tensors2,                                              \
-      const Scalar& scalar) {                                           \
-    check_foreach_api_restrictions(input, tensors1, tensors2);          \
-                                                                        \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) ||     \
-        has_integral_tensor(input, /* includeBool */ true)) {           \
-      return at::native::foreach_tensor_##NAME##_scalar_slow_(          \
-          input, tensors1, tensors2, scalar);                           \
-    }                                                                   \
-                                                                        \
-    foreach_pointwise_op_<OP>(input, tensors1, tensors2, scalar);       \
+#define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                              \
+  std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(                 \
+      TensorList input,                                                    \
+      TensorList tensors1,                                                 \
+      TensorList tensors2,                                                 \
+      const Scalar& scalar) {                                              \
+    check_foreach_api_restrictions(input, tensors1, tensors2);             \
+                                                                           \
+    if (has_integral_tensor(input, /* includeBool */ true)) {              \
+      return at::native::foreach_tensor_##NAME##_scalar_slow(              \
+          input, tensors1, tensors2, scalar);                              \
+    }                                                                      \
+                                                                           \
+    if (can_use_fast_route({input, tensors1, tensors2}, scalar)) {         \
+      return foreach_pointwise_op<OP>(input, tensors1, tensors2, scalar);  \
+    }                                                                      \
+                                                                           \
+    /* Check if we can use 0D tensor1 fast path */                         \
+    if (all_tensors_are_0d(tensors1) &&                                    \
+        all_same_dtype(tensors1, input[0].scalar_type()) &&                \
+        can_use_fast_route({input, tensors2}, scalar)) {                   \
+      return foreach_pointwise_op_0d_tensor1<OP>(                          \
+          input, tensors1, tensors2, scalar);                              \
+    }                                                                      \
+                                                                           \
+    return at::native::foreach_tensor_##NAME##_scalar_slow(                \
+        input, tensors1, tensors2, scalar);                                \
+  }                                                                        \
+                                                                           \
+  void foreach_tensor_##NAME##_scalar_cuda_(                               \
+      TensorList input,                                                    \
+      TensorList tensors1,                                                 \
+      TensorList tensors2,                                                 \
+      const Scalar& scalar) {                                              \
+    check_foreach_api_restrictions(input, tensors1, tensors2);             \
+                                                                           \
+    if (has_integral_tensor(input, /* includeBool */ true)) {              \
+      return at::native::foreach_tensor_##NAME##_scalar_slow_(             \
+          input, tensors1, tensors2, scalar);                              \
+    }                                                                      \
+                                                                           \
+    if (can_use_fast_route({input, tensors1, tensors2}, scalar)) {         \
+      return foreach_pointwise_op_<OP>(input, tensors1, tensors2, scalar); \
+    }                                                                      \
+                                                                           \
+    /* Check if we can use 0D tensor1 fast path */                         \
+    if (all_tensors_are_0d(tensors1) &&                                    \
+        all_same_dtype(tensors1, input[0].scalar_type()) &&                \
+        can_use_fast_route({input, tensors2}, scalar)) {                   \
+      return foreach_pointwise_op_0d_tensor1_<OP>(                         \
+          input, tensors1, tensors2, scalar);                              \
+    }                                                                      \
+                                                                           \
+    return at::native::foreach_tensor_##NAME##_scalar_slow_(               \
+        input, tensors1, tensors2, scalar);                                \
   }
 
 #define FOREACH_POINTWISE_OP_SCALARLIST(NAME, OP)                        \


### PR DESCRIPTION
The foreach pointwise ops (addcmul, addcdiv) fall back to the slow path when tensor1 is a list of 0D tensors because they fail the "same shape" check in can_use_fast_route. This is common in optimizers where scalar tensors are used as multipliers.

This change adds a specialized CUDA functor that loads the 0D tensor1 value from device memory once per tensor and uses it as a scalar in the computation, allowing the fast multi_tensor_apply kernel path to be used instead of falling back to per-tensor operations.

Authored with claude

cc @BoyuanFeng 
