### PR TITLE
added cuda specific condition in common_cuda.py to avoid pytest crash

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -36,7 +36,7 @@ SM90OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_devic
 SM100OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (10, 0))
 SM120OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (12, 0))
 
-IS_THOR = LazyVal(lambda: torch.cuda.is_available() and
+IS_THOR = LazyVal(lambda: torch.cuda.is_available() and torch.version.cuda and
                   ((torch.cuda.get_device_capability() == (11, 0) and int(torch.version.cuda[:2]) >= 13) or
                    (torch.cuda.get_device_capability() == (10, 1) and int(torch.version.cuda[:2]) < 13)))
 IS_JETSON = LazyVal(lambda: torch.cuda.is_available() and (torch.cuda.get_device_capability() in [(7, 2), (8, 7)] or IS_THOR))


### PR DESCRIPTION
While running some pytest on gfx1100 , below was the error found 

``` sh
File "/ML/ext/users/adityaja/src/pytorch/torch/testing/_internal/common_utils.py", line 1491, in wrapped
    return getattr(self._value, name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ML/ext/users/adityaja/src/pytorch/torch/testing/_internal/common_utils.py", line 1488, in wrapped
    self._value = self._cb()
                  ^^^^^^^^^^
  File "/ML/ext/users/adityaja/src/pytorch/torch/testing/_internal/common_cuda.py", line 40, in <lambda>
    ((torch.cuda.get_device_capability() == (11, 0) and int(torch.version.cuda[:2]) >= 13) or
                                                            ~~~~~~~~~~~~~~~~~~^^^^
TypeError: 'NoneType' object is not subscriptable
```

This happend becuase for AMD gfx1100, `torch.cuda.get_device_capability()` returns `(11, 0)` and then it tries to check torch.version.cuda, wihch is not available as this is AMD ROCm platform, Hence added a condition to only run this code if its Cuda specific.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang