### PR TITLE
Fixes error message that instructs user to .detach()

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7628,10 +7628,10 @@ class TestAOTModuleSimplified(AOTTestCase):
         y2 = fn_comp(x2)
         with self.assertRaisesRegex(
             RuntimeError,
-            """
+            r"""
 During the backward, we encountered a tensor subclass where we guessed its
 metadata incorrectly.
-""",  # noqa: F541
+Expected a .* tangent but got a plain Tensor.""",
         ):
             y2.backward(gradient=torch.randn(2, 3))
 

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -54,6 +54,40 @@ from .utils import (
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
 
 
+def _extract_tangent_source_stack_traces(
+    fx_g: torch.fx.GraphModule,
+    fw_metadata: ViewAndMutationMeta,
+) -> None:
+    from .descriptors import PlainAOTOutput, TangentAOTInput
+
+    if not fw_metadata.traced_tangents_descs:
+        return
+
+    output_node = list(fx_g.graph.nodes)[-1]
+    all_outputs = output_node.args[0]
+
+    stack_traces: list[str | None] = []
+    got_one = False
+
+    for desc in fw_metadata.traced_tangents_descs:
+        stack_trace = None
+
+        if isinstance(desc, TangentAOTInput):
+            output_desc = desc.output
+            if isinstance(output_desc, PlainAOTOutput) and output_desc.idx < len(
+                all_outputs
+            ):
+                output_arg = all_outputs[output_desc.idx]
+                if isinstance(output_arg, torch.fx.Node):
+                    stack_trace = output_arg.meta.get("stack_trace", None)
+                    got_one = True
+
+        stack_traces.append(stack_trace)
+
+    if got_one:
+        fw_metadata.tangent_source_stack_traces = stack_traces
+
+
 def _create_graph(
     f: Callable[..., Any],
     args: list[torch.Tensor],
@@ -510,6 +544,9 @@ def aot_dispatch_autograd_graph(
     # Populate fw_metadata with stream indices from the compiled graph
     # NB: This needs to be done after the above stream assignments
     populate_fw_metadata_with_stream_indices(fx_g, fw_metadata)
+
+    # this helps users identify which forward output to call .detach() on.
+    _extract_tangent_source_stack_traces(fx_g, fw_metadata)
 
     fx_g.graph.eliminate_dead_code()
     if not aot_config.disable_functionalization:

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -511,6 +511,12 @@ class ViewAndMutationMeta:
     # This is populated during graph compilation when stream assignments are made
     mutated_inp_stream_indices: Optional[list[Optional[int]]] = None
 
+    # compile ID string (e.g., "1/0") for error messages
+    compile_id_str: str | None = None
+
+    # help users identify where to add .detach() in their code
+    tangent_source_stack_traces: list[str | None] | None = None
+
     def __post_init__(self) -> None:
         # pre-compute the indices of the inputs that are mutated.
         # When keep_input_mutations is set, we don't need to worry about our epilogue


### PR DESCRIPTION
Fixes #172556 


**The conditional distinguishes two different failure modes that need different advice:**

**Expected subclass, got plain Tensor**: This is the common case where users forget to `.detach() `unused outputs. The fix is to call `.detach()`.

**Both are subclasses, metadata mismatch**: This is a subclass implementation issue. The fix is to implement `__coerce_same_metadata_as_tangent__`.