### PR TITLE
docs: fix EMA equation subscript for model weight

### DIFF
--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -1,5 +1,4 @@
-f# torch.optim
-
+# torch.optim
 ```{eval-rst}
 .. automodule:: torch.optim
 ```

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -1,4 +1,4 @@
-# torch.optim
+f# torch.optim
 
 ```{eval-rst}
 .. automodule:: torch.optim
@@ -547,7 +547,7 @@ Decay is a parameter between 0 and 1 that controls how fast the averaged paramet
 {func}`torch.optim.swa_utils.get_ema_multi_avg_fn` returns a function that applies the following EMA equation to the weights:
 
 ```{math}
-W^\textrm{EMA}_{t+1} = \alpha W^\textrm{EMA}_{t} + (1 - \alpha) W^\textrm{model}_t
+W^\textrm{EMA}_{t+1} = \alpha W^\textrm{EMA}_{t} + (1 - \alpha) W^\textrm{model}_{t+1}
 ```
 
 where alpha is the EMA decay.


### PR DESCRIPTION
## Summary
Fixes the EMA equation in the optim.md documentation to use consistent subscripts.

## Problem
The current equation shows:
```
W^{EMA}_{t+1} = α W^{EMA}_{t} + (1 - α) W^{model}_t
```

The subscript on `W^{model}` should be `t+1` to match the EMA weight being computed.

## Fix
Changed to:
```
W^{EMA}_{t+1} = α W^{EMA}_{t} + (1 - α) W^{model}_{t+1}
```

This makes the equation mathematically consistent - when computing the EMA at step t+1, we use the model weights from step t+1.

Fixes #155551