### PR TITLE
[ONNX] Fix export of torch.cdist with dynamic axes

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8970,6 +8970,24 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         y = torch.randn(1, 32, 4)
         self.run_test(Cdist(), input_args=(x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_cdist_dynamic_shape(self):
+        """Test cdist with dynamic input shapes where row_size is None.
+        This tests the optimistic strategy that uses _euclidean_dist for dynamic inputs.
+        """
+        class Cdist(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.cdist(x, y, p=2.0)
+
+        x = torch.randn(5, 3, 3)
+        y = torch.randn(5, 2, 3)
+        # Make the -2 dimension (second-to-last) dynamic
+        self.run_test(
+            Cdist(),
+            input_args=(x, y),
+            dynamic_axes={"x": [0, 1], "y": [0, 1]},
+        )
+
     @skipIfUnsupportedMinOpsetVersion(12)
     def test_crossentropyloss(self):
         for ignore_index in [-100, 1]:

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8972,14 +8972,15 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_cdist_dynamic_axes_script(self):
-        def wrap_cdist(a, b):
-            return torch.cdist(a, b)
+        class CdistModule(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.cdist(a, b)
 
-        script_cdist = torch.jit.script(wrap_cdist)
+        model = torch.jit.script(CdistModule())
         a = torch.randn(10, 3)
         b = torch.randn(10, 3)
         self.run_test(
-            script_cdist,
+            model,
             input_args=(a, b),
             input_names=["a", "b"],
             output_names=["out"],

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -6138,13 +6138,18 @@ def cdist(
     # we unsqueeze both input tensors
     row_size_x1 = symbolic_helper._get_tensor_dim_size(x1, -2)
     row_size_x2 = symbolic_helper._get_tensor_dim_size(x2, -2)
-    assert row_size_x1 is not None
-    assert row_size_x2 is not None
     p_float = symbolic_helper._parse_arg(p, "f")
     compute_mode = symbolic_helper._parse_arg(compute_mode, "i")
     if p_float == 2.0 and (
         compute_mode == 1
-        or (compute_mode is None and row_size_x1 >= 25 and row_size_x2 >= 25)
+        or (
+            compute_mode is None
+            and (
+                row_size_x1 is None
+                or row_size_x2 is None
+                or (row_size_x1 >= 25 and row_size_x2 >= 25)
+            )
+        )
     ):
         return _euclidean_dist(g, x1, x2)
     rank = symbolic_helper._get_tensor_rank(x1)


### PR DESCRIPTION
Fixes #169758

## Summary
This PR fixes a crash when exporting `torch.cdist` to ONNX with dynamic input shapes (e.g., using dynamic_axes).

## Problem
Previously, `symbolic_opset9.py` contained assertions that strictly required static input dimensions. This caused the export to fail immediately when dynamic axes were provided.

##Solution

When inputs have dynamic shapes, the export logic will now default to _euclidean_dist instead of raising an exception.

Regarding the implementation choice: I considered falling back to the standard implementation for dynamic inputs, but that carries a risk of OOM if the dynamic dimensions are large. Therefore, falling back to matrix computation (_euclidean_dist) is the safer, even if it may be slightly slower in worst-case scenarios.