### PR TITLE
Fix incorrect default value for align_corners in interpolate docs

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4654,7 +4654,8 @@ def interpolate(  # noqa: F811
             for out-of-boundary values, making this operation *independent* of input size
             when :attr:`scale_factor` is kept the same. This only has an effect when :attr:`mode`
             is ``'linear'``, ``'bilinear'``, ``'bicubic'`` or ``'trilinear'``.
-            Default: ``False``
+            Default: ``None``. When ``None`` and :attr:`mode` is one of the linear modes,
+            it is treated as ``False``.
         recompute_scale_factor (bool, optional): recompute the scale_factor for use in the
             interpolation calculation. If `recompute_scale_factor` is ``True``, then
             `scale_factor` must be passed in and `scale_factor` is used to compute the


### PR DESCRIPTION
The documentation incorrectly stated the default value for align_corners is False, when it's actually None. Updated to reflect that the default is None, which is treated as False for linear interpolation modes.

Fixes #163266
