### PR TITLE
  Fix instantiate_device_type_tests failing for PrivateUse1 on repeat…

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -747,10 +747,13 @@ def filter_desired_device_types(device_type_test_bases, except_for=None, only_fo
         )
 
     # Replace your privateuse1 backend name with 'privateuse1'
+    # This handles the case where PrivateUse1TestBase.device_type has been
+    # changed from "privateuse1" to the actual backend name (e.g., "openreg")
+    # by setUpClass being called during previous instantiate_device_type_tests calls
     if is_privateuse1_backend_available():
         privateuse1_backend_name = torch._C._get_privateuse1_backend_name()
 
-        def func_replace(x: str):
+        def func_replace(x: str) -> str:
             return x.replace(privateuse1_backend_name, "privateuse1")
 
         except_for = (
@@ -763,14 +766,20 @@ def filter_desired_device_types(device_type_test_bases, except_for=None, only_fo
             if not isinstance(only_for, str)
             else func_replace(only_for)
         )
+    else:
+
+        def func_replace(x: str) -> str:
+            return x
 
     if except_for:
         device_type_test_bases = filter(
-            lambda x: x.device_type not in except_for, device_type_test_bases
+            lambda x: func_replace(x.device_type) not in except_for,
+            device_type_test_bases,
         )
     if only_for:
         device_type_test_bases = filter(
-            lambda x: x.device_type in only_for, device_type_test_bases
+            lambda x: func_replace(x.device_type) in only_for,
+            device_type_test_bases,
         )
 
     return list(device_type_test_bases)


### PR DESCRIPTION
…ed calls

  When instantiate_device_type_tests() is called multiple times with
  only_for or except_for for PrivateUse1 backends, only the first call
  works. This happens because PrivateUse1TestBase.setUpClass() mutates
  the class attribute device_type from privateuse1 to the actual
  backend name (e.g., openreg). Subsequent filtering comparisons fail
  since openreg is not in (privateuse1,).

  Fix by applying func_replace to normalize device_type during filtering,
  using the same function already used to normalize the only_for/except_for
  parameters.

Fixes #172764 

Required for #172318 
