### PR TITLE
[docs] Remove misleading out_dtype=None from bmm, mm, addmm, baddbmm signatures

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -547,7 +547,8 @@ Example::
 add_docstr(
     torch.addmm,
     r"""
-addmm(input, mat1, mat2, out_dtype=None, *, beta=1, alpha=1, out=None) -> Tensor
+addmm(input, mat1, mat2, *, beta=1, alpha=1, out=None) -> Tensor
+addmm(input, mat1, mat2, out_dtype, *, beta=1, alpha=1, out=None) -> Tensor
 
 Performs a matrix multiplication of the matrices :attr:`mat1` and :attr:`mat2`.
 The matrix :attr:`input` is added to the final result.
@@ -1347,7 +1348,8 @@ Example::
 add_docstr(
     torch.baddbmm,
     r"""
-baddbmm(input, batch1, batch2, out_dtype=None, *, beta=1, alpha=1, out=None) -> Tensor
+baddbmm(input, batch1, batch2, *, beta=1, alpha=1, out=None) -> Tensor
+baddbmm(input, batch1, batch2, out_dtype, *, beta=1, alpha=1, out=None) -> Tensor
 
 Performs a batch matrix-matrix product of matrices in :attr:`batch1`
 and :attr:`batch2`.
@@ -1526,7 +1528,8 @@ Example::
 add_docstr(
     torch.bmm,
     r"""
-bmm(input, mat2, out_dtype=None, *, out=None) -> Tensor
+bmm(input, mat2, *, out=None) -> Tensor
+bmm(input, mat2, out_dtype, *, out=None) -> Tensor
 
 Performs a batch matrix-matrix product of matrices stored in :attr:`input`
 and :attr:`mat2`.
@@ -7511,7 +7514,8 @@ Example::
 add_docstr(
     torch.mm,
     r"""
-mm(input, mat2, out_dtype=None, *, out=None) -> Tensor
+mm(input, mat2, *, out=None) -> Tensor
+mm(input, mat2, out_dtype, *, out=None) -> Tensor
 
 Performs a matrix multiplication of the matrices :attr:`input` and :attr:`mat2`.
 


### PR DESCRIPTION
## Summary
Fixes #172751

The documentation for `torch.bmm`, `torch.mm`, `torch.addmm`, and `torch.baddbmm` showed `out_dtype=None` in function signatures, which incorrectly implies that passing `out_dtype=None` explicitly is valid.

However, the actual native functions have two overloads:
1. Base function without `out_dtype` parameter
2. `.dtype` variant with **required** `ScalarType out_dtype`

Passing `out_dtype=None` raises TypeError because no overload accepts `None`.

### Changes
This commit removes `out_dtype=None` from the function signatures:

```diff
- bmm(input, mat2, out_dtype=None, *, out=None) -> Tensor
+ bmm(input, mat2, *, out=None) -> Tensor

- mm(input, mat2, out_dtype=None, *, out=None) -> Tensor
+ mm(input, mat2, *, out=None) -> Tensor

- addmm(input, mat1, mat2, out_dtype=None, *, beta=1, alpha=1, out=None) -> Tensor
+ addmm(input, mat1, mat2, *, beta=1, alpha=1, out=None) -> Tensor

- baddbmm(input, batch1, batch2, out_dtype=None, *, beta=1, alpha=1, out=None) -> Tensor
+ baddbmm(input, batch1, batch2, *, beta=1, alpha=1, out=None) -> Tensor
```

The `out_dtype` parameter remains documented in the Args section which correctly describes it as `(dtype, optional)` and CUDA/XPU-only.

## Test Plan
Verified on **PyTorch 2.11.0a0+gitd803917** with **CUDA 12.8** on **NVIDIA H200**:

| Function | `out_dtype=None` | Without `out_dtype` | Valid `out_dtype` |
|----------|-----------------|---------------------|-------------------|
| `torch.bmm` | ❌ TypeError | ✅ Works | ✅ Works |
| `torch.mm` | ❌ TypeError | ✅ Works | ✅ Works |
| `torch.addmm` | ❌ TypeError | ✅ Works | ✅ Works |
| `torch.baddbmm` | ❌ TypeError | ✅ Works | ✅ Works |

Error message confirms the issue:
```
TypeError: bmm() received an invalid combination of arguments - got (Tensor, Tensor, out_dtype=NoneType), but expected one of:
 * (Tensor input, Tensor mat2, *, Tensor out = None)
 * (Tensor input, Tensor mat2, torch.dtype out_dtype, *, Tensor out = None)
```

cc @ad8e (issue reporter)