### PR TITLE
[serialization] Improve add_safe_globals error message with valid Python syntax

### DIFF
--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -375,11 +375,15 @@ class Unpickler:
                             if len(full_path) > 0 and full_path[0] == "."
                             else builtins_name + full_path
                         )
+                    # Extract just the class/function name for a cleaner suggestion
+                    global_name = full_path.rsplit(".", 1)[-1]
                     raise UnpicklingError(
                         f"Unsupported global: GLOBAL {full_path} was not an allowed global by default. "
-                        f"Please use `torch.serialization.add_safe_globals([{full_path}])` or the "
-                        f"`torch.serialization.safe_globals([{full_path}])` context manager to allowlist this global "
-                        "if you trust this class/function."
+                        f"Please use `torch.serialization.add_safe_globals([{global_name}])` to allowlist "
+                        f"this global if you trust this class/function.\n"
+                        f"You may also need to add `{global_name}` to a tuple along with its module path "
+                        f'if class/function definition does not match the path in the checkpoint:\n'
+                        f'`torch.serialization.add_safe_globals([({global_name}, "{full_path}")])`'
                     )
             elif key[0] == NEWOBJ[0]:
                 args = self.stack.pop()


### PR DESCRIPTION
## Summary

**Fixes #146886**

Improves the error message shown when an unsupported global is encountered during `weights_only=True` loading. The error now shows valid Python code that users can copy-paste.

### Before
```
Please use `torch.serialization.add_safe_globals([__main__.MyClass])` or the
`torch.serialization.safe_globals([__main__.MyClass])` context manager...
```

The syntax `[__main__.MyClass]` is **invalid Python** - users cannot copy-paste this into their code.

### After
```
Please use `torch.serialization.add_safe_globals([MyClass])` to allowlist
this global if you trust this class/function.
You may also need to add `MyClass` to a tuple along with its module path
if class/function definition does not match the path in the checkpoint:
`torch.serialization.add_safe_globals([(MyClass, "__main__.MyClass")])`
```

The new message:
1. Shows just the class name (`MyClass`) which users need to have imported
2. Provides guidance on using the tuple syntax when the module path in the checkpoint differs from the current environment

## Test Plan

Tested on **PyTorch 2.11.0a0+gitd803917** with **Python 3.12**:

```python
import torch

class MyTestClass(torch.Tensor):
    pass

t = MyTestClass(torch.randn(3, 3))
torch.save(t, 'test.pt')

# This fails with improved error message
torch.load('test.pt', weights_only=True)

# This still works correctly
torch.serialization.add_safe_globals([MyTestClass])
torch.load('test.pt', weights_only=True)  # Success!
```

**Old error message:**
```
Please use `torch.serialization.add_safe_globals([__main__.MyTestClass])`...
```

**New error message:**
```
Please use `torch.serialization.add_safe_globals([MyTestClass])` to allowlist this global...
You may also need to add `MyTestClass` to a tuple along with its module path...
`torch.serialization.add_safe_globals([(MyTestClass, "__main__.MyTestClass")])`
```

✅ Error message now shows valid Python
✅ Includes guidance for tuple syntax when needed
✅ Functionality unchanged