### PR TITLE
Remove redundant code from ParamsHash.h

### DIFF
--- a/aten/src/ATen/native/utils/ParamsHash.h
+++ b/aten/src/ATen/native/utils/ParamsHash.h
@@ -60,16 +60,7 @@ struct ParamsWrapper {
     memcpy(&(this->pod), &(other.pod), sizeof(this->pod));
   }
 
-  ParamsWrapper(ParamsWrapper&& other) noexcept {
-    memcpy(&(this->pod), &(other.pod), sizeof(this->pod));
-  }
-
   ParamsWrapper& operator=(const ParamsWrapper& other) noexcept {
-    memcpy(&(this->pod), &(other.pod), sizeof(this->pod));
-    return *this;
-  }
-
-  ParamsWrapper& operator=(ParamsWrapper&& other) noexcept {
     memcpy(&(this->pod), &(other.pod), sizeof(this->pod));
     return *this;
   }
@@ -87,20 +78,9 @@ struct ParamsWrapper {
 // constructors for additional safety
 template <typename ParamsWrapper>
 struct ParamsWrapperHash {
-  // Params must be a POD because we read out its memory
-  // contents as char* when hashing
-  static_assert(
-      std::is_standard_layout_v<decltype(ParamsWrapper::pod)>,
-      "ParamsWrapper cannot wrap non-POD data");
-
   size_t operator()(const ParamsWrapper& params_wrapper) const noexcept {
-    auto ptr = reinterpret_cast<const uint8_t*>(&(params_wrapper.pod));
-    uint32_t value = 0x811C9DC5;
-    for (const auto i : c10::irange(sizeof(params_wrapper.pod))) {
-      value ^= ptr[i];
-      value *= 0x01000193;
-    }
-    return (size_t)value;
+    ParamsHash<decltype(ParamsWrapper::pod)> hasher;
+    return hasher(params_wrapper.pod);
   }
 };
 

--- a/aten/src/ATen/native/utils/ParamsHash.h
+++ b/aten/src/ATen/native/utils/ParamsHash.h
@@ -35,9 +35,7 @@ struct ParamsEqual {
   static_assert(std::is_standard_layout_v<Params>, "Params is not POD");
 
   bool operator()(const Params& a, const Params& b) const noexcept {
-    auto ptr1 = reinterpret_cast<const uint8_t*>(&a);
-    auto ptr2 = reinterpret_cast<const uint8_t*>(&b);
-    return memcmp(ptr1, ptr2, sizeof(Params)) == 0;
+    return memcmp(&a, &b, sizeof(Params)) == 0;
   }
 };
 
@@ -68,9 +66,7 @@ struct ParamsWrapper {
   inline friend bool operator==(
       const ParamsWrapper& lhs,
       const ParamsWrapper& rhs) noexcept {
-    auto ptr1 = reinterpret_cast<const uint8_t*>(&(lhs.pod));
-    auto ptr2 = reinterpret_cast<const uint8_t*>(&(rhs.pod));
-    return memcmp(ptr1, ptr2, sizeof(lhs.pod)) == 0;
+    return memcmp(&lhs.pod, &rhs.pod, sizeof(T)) == 0;
   }
 };
 

--- a/aten/src/ATen/native/utils/ParamsHash.h
+++ b/aten/src/ATen/native/utils/ParamsHash.h
@@ -63,6 +63,9 @@ struct ParamsWrapper {
     return *this;
   }
 
+  ParamsWrapper(ParamsWrapper&& other) = delete;
+  ParamsWrapper& operator=(ParamsWrapper&& other) = delete;
+
   inline friend bool operator==(
       const ParamsWrapper& lhs,
       const ParamsWrapper& rhs) noexcept {


### PR DESCRIPTION
- The move ops were defined identical to the copy ops
- ParamsWrapperHash duplicated the hashing logic from ParamsHash
- memcmp does not require uint8_t* inputs