### PR TITLE
Fix torch.combinations with dynamic shapes (#163759)

### DIFF
--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -21,15 +21,11 @@ namespace {
 
 using namespace at;
 
-// Helper function to create upper triangular mask for combinations.
-// Uses c10::SymInt to support dynamic shapes during tracing/compilation.
-// Fixes https://github.com/pytorch/pytorch/issues/163759
 Tensor _triu_mask(c10::SymInt n, int64_t dims, bool diagonal, TensorOptions opt) {
   // get a mask that has value 1 whose indices satisfies i < j < k < ...
   // or i <= j <= k <= ... (depending on diagonal)
   Tensor range = at::arange(n, opt.dtype(kLong));
   std::vector<Tensor> index_grids = at::meshgrid(std::vector<Tensor>(dims, range), "ij");
-  // Use sym_sizes() instead of sizes() to support symbolic shapes
   Tensor mask = at::full_symint(index_grids[0].sym_sizes(), true, opt.dtype(kBool));
   if(diagonal) {
     for(int64_t i = 0; i < dims - 1; i++) {
@@ -43,12 +39,9 @@ Tensor _triu_mask(c10::SymInt n, int64_t dims, bool diagonal, TensorOptions opt)
   return mask;
 }
 
-// Compute binomial coefficient C(n, r) using SymInt to support symbolic shapes
-// Uses iterative formula: C(n,r) = n*(n-1)*...*(n-r+1) / (r*(r-1)*...*1)
-// For combinations with replacement, computes C(n+r-1, r)
+// Binomial coefficient C(n, r), or C(n+r-1, r) when with_replacement is true.
 c10::SymInt compute_binomial_coeff(c10::SymInt n, int64_t r, bool with_replacement) {
   if (with_replacement) {
-    // C(n+r-1, r) for combinations with replacement
     n = n + (r - 1);
   }
 
@@ -58,8 +51,6 @@ c10::SymInt compute_binomial_coeff(c10::SymInt n, int64_t r, bool with_replaceme
 
   c10::SymInt result(1);
   for (int64_t i = 0; i < r; ++i) {
-    // This division is always exact because the product of (i+1)
-    // consecutive integers is always divisible by (i+1)!
     result = result * (n - i) / (i + 1);
   }
   return result;
@@ -89,25 +80,16 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
   if (r == 0) {
     return at::empty({0}, self.options());
   }
-  // Use sym_size(0) instead of numel() to support dynamic shapes during
-  // tracing/compilation. Since we already checked dim() == 1, sym_size(0)
-  // gives us the same result as sym_numel() but is more explicit.
-  // Fixes https://github.com/pytorch/pytorch/issues/163759
-  c10::SymInt num_elements = self.sym_size(0);
-
-  // Compute expected output size using binomial coefficient
-  // This helps symbolic shape inference understand the output shape
+  c10::SymInt num_elements = self.sym_numel();
   c10::SymInt expected_combinations = compute_binomial_coeff(num_elements, r, with_replacement);
 
   std::vector<Tensor> grids = at::meshgrid(std::vector<Tensor>(r, self), "ij");
   Tensor mask = _triu_mask(num_elements, r, with_replacement, self.options());
   for(Tensor &t : grids) {
     t = t.masked_select(mask);
-    // Assert that masked_select returned the expected size
-    // This helps symbolic shape inference and catches bugs
-    TORCH_INTERNAL_ASSERT(t.sym_size(0) == expected_combinations,
-                          "combinations: unexpected output size from masked_select, "
-                          "got ", t.sym_size(0), " but expected ", expected_combinations);
+    TORCH_SYM_CHECK(t.sym_size(0).sym_eq(expected_combinations),
+                    "combinations: unexpected output size from masked_select, "
+                    "got ", t.sym_size(0), " but expected ", expected_combinations);
   }
   return at::stack(grids, 1);
 }

--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -21,12 +21,16 @@ namespace {
 
 using namespace at;
 
-Tensor _triu_mask(int64_t n, int64_t dims, bool diagonal, TensorOptions opt) {
+// Helper function to create upper triangular mask for combinations.
+// Uses c10::SymInt to support dynamic shapes during tracing/compilation.
+// Fixes https://github.com/pytorch/pytorch/issues/163759
+Tensor _triu_mask(c10::SymInt n, int64_t dims, bool diagonal, TensorOptions opt) {
   // get a mask that has value 1 whose indices satisfies i < j < k < ...
   // or i <= j <= k <= ... (depending on diagonal)
   Tensor range = at::arange(n, opt.dtype(kLong));
   std::vector<Tensor> index_grids = at::meshgrid(std::vector<Tensor>(dims, range), "ij");
-  Tensor mask = at::full(index_grids[0].sizes(), true, opt.dtype(kBool));
+  // Use sym_sizes() instead of sizes() to support symbolic shapes
+  Tensor mask = at::full_symint(index_grids[0].sym_sizes(), true, opt.dtype(kBool));
   if(diagonal) {
     for(int64_t i = 0; i < dims - 1; i++) {
       mask *= index_grids[i] <= index_grids[i+1];
@@ -37,6 +41,28 @@ Tensor _triu_mask(int64_t n, int64_t dims, bool diagonal, TensorOptions opt) {
     }
   }
   return mask;
+}
+
+// Compute binomial coefficient C(n, r) using SymInt to support symbolic shapes
+// Uses iterative formula: C(n,r) = n*(n-1)*...*(n-r+1) / (r*(r-1)*...*1)
+// For combinations with replacement, computes C(n+r-1, r)
+c10::SymInt compute_binomial_coeff(c10::SymInt n, int64_t r, bool with_replacement) {
+  if (with_replacement) {
+    // C(n+r-1, r) for combinations with replacement
+    n = n + (r - 1);
+  }
+
+  if (r == 0) {
+    return c10::SymInt(1);
+  }
+
+  c10::SymInt result(1);
+  for (int64_t i = 0; i < r; ++i) {
+    // This division is always exact because the product of (i+1)
+    // consecutive integers is always divisible by (i+1)!
+    result = result * (n - i) / (i + 1);
+  }
+  return result;
 }
 
 }  // namespace
@@ -63,11 +89,25 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
   if (r == 0) {
     return at::empty({0}, self.options());
   }
-  int64_t num_elements = self.numel();
+  // Use sym_size(0) instead of numel() to support dynamic shapes during
+  // tracing/compilation. Since we already checked dim() == 1, sym_size(0)
+  // gives us the same result as sym_numel() but is more explicit.
+  // Fixes https://github.com/pytorch/pytorch/issues/163759
+  c10::SymInt num_elements = self.sym_size(0);
+
+  // Compute expected output size using binomial coefficient
+  // This helps symbolic shape inference understand the output shape
+  c10::SymInt expected_combinations = compute_binomial_coeff(num_elements, r, with_replacement);
+
   std::vector<Tensor> grids = at::meshgrid(std::vector<Tensor>(r, self), "ij");
   Tensor mask = _triu_mask(num_elements, r, with_replacement, self.options());
   for(Tensor &t : grids) {
     t = t.masked_select(mask);
+    // Assert that masked_select returned the expected size
+    // This helps symbolic shape inference and catches bugs
+    TORCH_INTERNAL_ASSERT(t.sym_size(0) == expected_combinations,
+                          "combinations: unexpected output size from masked_select, "
+                          "got ", t.sym_size(0), " but expected ", expected_combinations);
   }
   return at::stack(grids, 1);
 }


### PR DESCRIPTION
 ### Summary                                                                                          
  Fixes #163759                                                                                        
                                                                                                       
  `torch.combinations` was crashing with a RuntimeError when using `torch.compile(dynamic=True)`       
  because it called `numel()`, which doesn't work with symbolic sizes.                                 
                                                                                                       
  ### What changed                                                                                     
                                                                                                       
  Updated the implementation to use `sym_size(0)` instead of `numel()` and added logic to compute the  expected output size upfront using binomial coefficients. This lets the compiler track shapes properly during symbolic tracing.                                                                    
                                                                                                       
  **aten/src/ATen/native/Itertools.cpp:**                                                              
  - Changed `_triu_mask` to take `c10::SymInt` instead of `int64_t`                                    
  - Updated `combinations` to use `sym_size(0)` for getting the input size                             
  - Added `compute_binomial_coeff` helper that calculates C(n,r) using SymInt arithmetic               
  - Added assertion to verify `masked_select` returns the right size                                   
                                                                                                       
  **test/inductor/test_torchinductor_dynamic_shapes.py:**                                              
  - Added tests for r=1, r=2, r=3, and with_replacement cases                                          
  - Each test verifies the compiled version matches eager mode and works across different input sizes  
                                                                                                       
  ### Why this works                                                                                   
                                                                                                       
  The thing about combinations is that the output size is actually deterministic - it's just C(n,r) for
   regular combinations or C(n+r-1,r) with replacement. By computing this ahead of time with SymInt, we give the compiler enough info to figure out the output shape even though we're still using `masked_select` under the hood (which normally has dynamic output).                                  
                                                                                                       
  ### Testing                                                                                                                                                                                       
  Ran the reproduction case from the issue plus a bunch of variants:                                   
  - Different values of r (1, 2, 3)                                                                    
  - With and without replacement                                                                       
  - Multiple input sizes to make sure dynamic shapes actually work                                     
  - Existing test suite still passes                                                                   
                                                                                                       
  Everything works on CPU.                                                                             
  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo