### PR TITLE
[ROCm] Unifying hipBLASLt architecture lists into common hook methods

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -440,15 +440,7 @@ at::BlasBackend Context::blasPreferredBackend() {
 #ifdef USE_ROCM
     // AMD Instinct targets prefer hipblaslt
     static const bool hipblaslt_preferred = []() {
-      static const std::vector<std::string> archs = {
-          "gfx90a", "gfx942",
-#if ROCM_VERSION >= 60400
-          "gfx1200", "gfx1201",
-#endif
-#if ROCM_VERSION >= 60500
-          "gfx950"
-#endif
-      };
+      const auto& archs = detail::getCUDAHooks().getHipblasltPreferredArchs();
       for (auto index: c10::irange(detail::getCUDAHooks().deviceCount())) {
         if (!detail::getCUDAHooks().isGPUArch(archs, index)) {
           return false;
@@ -470,15 +462,7 @@ at::BlasBackend Context::blasPreferredBackend() {
       {
           return true;
       }
-      static const std::vector<std::string> archs = {
-          "gfx90a", "gfx942",
-#if ROCM_VERSION >= 60300
-          "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
-#endif
-#if ROCM_VERSION >= 70000
-          "gfx950", "gfx1150", "gfx1151"
-#endif
-      };
+      const auto& archs = detail::getCUDAHooks().getHipblasltSupportedArchs();
       for (auto index: c10::irange(detail::getCUDAHooks().deviceCount())) {
         if (!detail::getCUDAHooks().isGPUArch(archs, index)) {
           TORCH_WARN_ONCE(

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -550,6 +550,35 @@ bool CUDAHooks::isGPUArch(const std::vector<std::string>& archs, DeviceIndex dev
   }
   return false;
 }
+
+const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
+  static const std::vector<std::string> archs = {
+    "gfx90a", "gfx942",
+#if ROCM_VERSION >= 60400
+    "gfx1200", "gfx1201",
+#endif
+#if ROCM_VERSION >= 60500
+    "gfx950"
+#endif
+  };
+  return archs;
+}
+
+const std::vector<std::string>& CUDAHooks::getHipblasltSupportedArchs() const {
+  static const std::vector<std::string> archs = {
+    "gfx90a", "gfx942",
+#if ROCM_VERSION >= 60300
+    "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
+#endif
+#if ROCM_VERSION >= 70000
+    "gfx950", "gfx1150", "gfx1151",
+#endif
+#if ROCM_VERSION >= 70200
+    "gfx1250"
+#endif
+  };
+  return archs;
+}
 #endif
 
 void CUDAHooks::deviceSynchronize(DeviceIndex device_index) const {

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -557,7 +557,7 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
 #if ROCM_VERSION >= 60400
     "gfx1200", "gfx1201",
 #endif
-#if ROCM_VERSION >= 60500
+#if ROCM_VERSION >= 70000
     "gfx950"
 #endif
   };

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -65,6 +65,8 @@ struct CUDAHooks : public at::CUDAHooksInterface {
 
 #ifdef USE_ROCM
   bool isGPUArch(const std::vector<std::string>& archs, DeviceIndex device_index = -1) const override;
+  const std::vector<std::string>& getHipblasltPreferredArchs() const override;
+  const std::vector<std::string>& getHipblasltSupportedArchs() const override;
 #endif
   void deviceSynchronize(DeviceIndex device_index) const override;
 };

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -227,6 +227,18 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
   virtual bool isGPUArch(const std::vector<std::string>& /*archs*/, DeviceIndex = -1 /*device_index*/) const {
     TORCH_CHECK(false, "Cannot check GPU arch without ATen_cuda library. ", CUDA_HELP);
   }
+
+  virtual const std::vector<std::string>& getHipblasltPreferredArchs() const {
+    static const std::vector<std::string> empty;
+    TORCH_CHECK(false, "Cannot get hipBLASLt preferred archs without ATen_cuda library. ", CUDA_HELP);
+    return empty;
+  }
+
+  virtual const std::vector<std::string>& getHipblasltSupportedArchs() const {
+    static const std::vector<std::string> empty;
+    TORCH_CHECK(false, "Cannot get hipBLASLt supported archs without ATen_cuda library. ", CUDA_HELP);
+    return empty;
+  }
 #endif
 
   virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -120,15 +120,7 @@ cuda::blas::GEMMAndBiasActivationEpilogue activation_to_gemm_and_blas_arg(Activa
 static bool isGloballyDisabledAddmmCudaLt(const at::Device& device) {
   // When hipBLASLt is not supported on the architecture, return true
   #ifdef USE_ROCM
-  static const std::vector<std::string> archs = {
-        "gfx90a", "gfx942",
-    #if ROCM_VERSION >= 60300
-        "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
-    #endif
-    #if ROCM_VERSION >= 70000
-        "gfx950", "gfx1150", "gfx1151"
-    #endif
-  };
+  const auto& archs = at::detail::getCUDAHooks().getHipblasltSupportedArchs();
   const auto is_hipblas_lt_arch_supported = at::detail::getCUDAHooks().isGPUArch(archs, device.index());
   if (!is_hipblas_lt_arch_supported) {
     return true;


### PR DESCRIPTION
Centralize duplicate hipBLASLt architecture lists from Context.cpp and Blas.cpp into two new CUDAHooks methods:
- getHipblasltPreferredArchs(): Architectures that prefer hipBLASLt
- getHipblasltSupportedArchs(): All architectures that support hipBLASLt

This eliminates code duplication and ensures a single source of truth for architecture support checks.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang