### PR TITLE
[ROCm] Remove obsolete HasSameArgTypes test from cuda_vectorized_test

### DIFF
--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -32,23 +32,6 @@ void reset_buffers() {
   }
 }
 
-#if defined(USE_ROCM) && !defined(_WIN32)
-TEST(TestLoops, HasSameArgTypes) {
-  // This is a compile-time unit test. If this file compiles without error,
-  // then the test passes and during runtime, we just need to return.
-  using namespace at::native::modern::detail;
-  using func1_t = int (*)(float, float);
-  using func2_t = int (*)(bool, float, float);
-  using func3_t = int (*)(float);
-  using func4_t = int (*)();
-  static_assert(has_same_arg_types<func1_t>::value, "func1_t has the same argument types");
-  static_assert(!has_same_arg_types<func2_t>::value, "func2_t does not have the same argument types");
-  static_assert(has_same_arg_types<func3_t>::value, "func3_t has the same argument types");
-  static_assert(has_same_arg_types<func4_t>::value, "func4_t has the same argument types");
-  return;
-}
-#endif
-
 TEST(TestVectorizedMemoryAccess, CanVectorizeUpTo) {
   char *ptr = reinterpret_cast<char *>(buffer1);
 


### PR DESCRIPTION
The HasSameArgTypes test references `at::native::modern::detail::has_same_arg_types`, which was defined in `aten/src/ATen/native/cuda/ROCmLoops.cuh`. This file was deleted in c11bd724fe3 (#120101) when ROCm switched to using the hipified version of `CUDALoops.cuh` instead.

My understanding is that this test should be removed since it's a legacy compile-time check for a code path that no longer exists.

Causes failure in #172775 in [this run](https://github.com/pytorch/pytorch/actions/runs/21153824053/job/60835278003?pr=172775).


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang