### PR TITLE
Fix the step to find merge base in STABLE_SHIM_VERSION 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,7 +108,7 @@ jobs:
     needs: [get-label-type, get-changed-files]
     with:
       timeout: 120
-      runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge"
+      runner: "linux.2xlarge"
       docker-image: ci-image:pytorch-linux-jammy-linter
       # NB: A shallow checkout won't work here because calculate-docker-image requires a full checkout
       # to run git rev-parse HEAD~:.ci/docker when a new image is needed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,6 +119,7 @@ jobs:
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running all other linters"
         if [ "$CHANGED_FILES" = '*' ]; then
+          sleep 7200
           ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY --all-files" .github/scripts/lintrunner.sh
         else
           ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY ${CHANGED_FILES}" .github/scripts/lintrunner.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,7 +108,7 @@ jobs:
     needs: [get-label-type, get-changed-files]
     with:
       timeout: 120
-      runner: "linux.2xlarge"
+      runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge"
       docker-image: ci-image:pytorch-linux-jammy-linter
       # NB: A shallow checkout won't work here because calculate-docker-image requires a full checkout
       # to run git rev-parse HEAD~:.ci/docker when a new image is needed
@@ -119,7 +119,6 @@ jobs:
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running all other linters"
         if [ "$CHANGED_FILES" = '*' ]; then
-          sleep 7200
           ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY --all-files" .github/scripts/lintrunner.sh
         else
           ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY ${CHANGED_FILES}" .github/scripts/lintrunner.sh

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -248,12 +248,11 @@ def get_added_lines(filename: str) -> set[int]:
             ["git", "fetch", "origin", "main"],
             capture_output=True,
             text=True,
-            timeout=180,
+            timeout=300,
         )
         if result.returncode != 0:
             raise RuntimeError(
-                f"Failed to fetch origin. "
-                f"Error: {result.stderr.strip()}"
+                f"Failed to fetch origin. Error: {result.stderr.strip()}"
             )
 
         result = subprocess.run(

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -245,16 +245,16 @@ def get_added_lines(filename: str) -> set[int]:
 
         # Get merge-base with origin/main to check all PR commits
         result = subprocess.run(
-            ["git", "fetch", "origin"],
+            ["git", "fetch", "origin", "main"],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=180,
         )
         if result.returncode != 0:
-            # Just print this as an error, no need to fail the linter here, as
-            # long as we can find the merge base, then this step doesn't matter
-            msg = "Failed to fetch origin: {result.stderr.strip()}"
-            logging.error(msg)
+            raise RuntimeError(
+                f"Failed to fetch origin. "
+                f"Error: {result.stderr.strip()}"
+            )
 
         result = subprocess.run(
             ["git", "merge-base", "HEAD", "origin/main"],

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -248,7 +248,7 @@ def get_added_lines(filename: str) -> set[int]:
             ["git", "fetch", "origin", "main"],
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=600,
         )
         if result.returncode != 0:
             raise RuntimeError(

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -245,6 +245,18 @@ def get_added_lines(filename: str) -> set[int]:
 
         # Get merge-base with origin/main to check all PR commits
         result = subprocess.run(
+            ["git", "fetch", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            # Just print this as an error, no need to fail the linter here, as
+            # long as we can find the merge base, then this step doesn't matter
+            msg = "Failed to fetch origin: {result.stderr.strip()}"
+            logging.error(msg)
+
+        result = subprocess.run(
             ["git", "merge-base", "HEAD", "origin/main"],
             capture_output=True,
             text=True,


### PR DESCRIPTION
This linter starts failing in trunk today https://github.com/pytorch/pytorch/actions/runs/21145313340/job/60809376686#step:16:374, I'm not sure what causes it but the fix would be to run `git fetch origin` before trying to get the merge base.