### PR TITLE
[OpenReg] Register gloo as default distributed backend

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
@@ -17,6 +17,14 @@ torch.utils.rename_privateuse1_backend("openreg")
 torch._register_device_module("openreg", torch_openreg.openreg)
 torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
 
+# Register gloo as the default distributed backend for openreg
+# This is needed for distributed tests to work with the openreg device
+import torch.distributed as dist
+
+
+if hasattr(dist, "Backend") and hasattr(dist.Backend, "default_device_backend_map"):
+    dist.Backend.default_device_backend_map["openreg"] = "gloo"
+
 
 # LITERALINCLUDE START: AUTOLOAD
 def _autoload():


### PR DESCRIPTION
OpenReg was missing distributed backend registration, causing a KeyError when running distributed tests with torch_openreg installed. The test infrastructure looks up the device type in dist.Backend.default_device_backend_map, which failed for openreg.

Since OpenReg is a CPU-based reference implementation, register gloo as its distributed backend.

Fixes #172803 
