### PR TITLE
[CI] Remove ninja version pin from test.sh

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -217,8 +217,7 @@ if [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
 fi
 
 if [[ "$BUILD_ENVIRONMENT" != *-bazel-* ]] ; then
-  # JIT C++ extensions require ninja.
-  pip_install "ninja==1.10.2"
+  # JIT C++ extensions require ninja (installed from requirements-ci.txt).
   # ninja is installed in $HOME/.local/bin, e.g., /var/lib/jenkins/.local/bin for CI user jenkins
   # but this script should be runnable by any user, including root
   export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
The ninja version specified in .ci/pytorch/test.sh was overriding the version pinned in .ci/docker/requirements-ci.txt. This change removes the redundant pin from test.sh, ensuring the version from requirements-ci.txt (1.11.1.4) is used consistently.

This establishes a single source of truth for the ninja version and makes version maintenance easier.

Fixes https://github.com/pytorch/pytorch/issues/172816