### PR TITLE
Do not hardcode `cuda` in `test_warp_softmax_64bit_indexing`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11063,7 +11063,7 @@ class TestNNDeviceType(NNTestCase):
     @largeTensorTest("64GB", "cpu")
     def test_warp_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):
-            x = torch.randn(shape, device="cuda", dtype=torch.float16, requires_grad=True)
+            x = torch.randn(shape, device=device, dtype=torch.float16, requires_grad=True)
             y = F.log_softmax(x, dim=-1, dtype=dtype)
             y.backward(y)
             with torch.no_grad():


### PR DESCRIPTION
Instead of hardcoding `device="cuda"` when creating the input tensor, use the `device` parameter from the test case.


Needed to run tests on XPU builds only.
