### PR TITLE
[inductor] fix strides in lowering for unbind

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1027,8 +1027,6 @@ inductor_skip_exact_stride = {
     "tensordot",
     "tril_indices",
     "triu_indices",
-    "unbind",
-    "unbind_copy",
 }
 
 # Custom replacements for assertEquals, in cases where a difference in value

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -271,10 +271,15 @@ def get_kernel_launch() -> str:
 def clone_preserve_strides_offset(x, device=None):
     if not isinstance(x, torch.Tensor):
         return x
+    device = device or x.device
+    # For 0-element tensors, create a new tensor with correct strides directly
+    # since as_strided from an empty buffer can't preserve non-zero strides
+    if x.numel() == 0:
+        return torch.empty_strided(x.size(), x.stride(), dtype=x.dtype, device=device)
     buffer = torch.as_strided(
         x, (x.untyped_storage().size() // x.element_size(),), (1,), 0
     )
-    if not device:
+    if device == x.device:
         buffer = buffer.clone()
     else:
         buffer = buffer.to(device, copy=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172904
* #172832
* __->__ #172831
* #172516

Summary: Fix strides by using as_strided when strides are available. Previously, backed indices used slice_ + squeeze, but squeeze calls view which creates contiguous strides, losing the original stride information. Falls back to slice_ + squeeze for IR nodes that don't support get_stride() (e.g., SliceView).

Testing: Updated test/inductor/test_torchinductor_opinfo.py to check strides for unbind. Had to make some changes to test helpers:
1. Add to_dtype_preserve_strides helper to preserve strides when converting reference tensors from float32 to lower precision dtypes. Previously .to(dtype) made tensors contiguous. Also handles expanded tensors (zero strides) by falling back to .to().
2. Skip gradient checking when there are no differentiable outputs (e.g., 0-element tensors).
3. Skip exact stride checking for 0-element gradient tensors since compiled backward may produce different but semantically equivalent strides.
4. Fix clone_preserve_strides_offset to handle 0-element tensors by using torch.empty_strided instead of as_strided from an empty buffer, preserving requires_grad.

Co-authored with [Claude Code](https://claude.ai/code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo