### PR TITLE
move RECV right before F/B

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,7 @@
+from torch.distributed.pipelining._schedule_visualizer import get_schedule_ops
+
+schedule_ops = get_schedule_ops(
+    schedule="Interleaved1F1B", pp_degree=2, num_microbatches=4, with_comms=True
+)
+for row in schedule_ops:
+    print(row)


### PR DESCRIPTION
```python
from torch.distributed.pipelining._schedule_visualizer import get_schedule_ops

schedule_ops = get_schedule_ops(
    schedule="Interleaved1F1B", pp_degree=2, num_microbatches=4, with_comms=True
)
for row in schedule_ops:
    print(row)
```

Now returns

```
[0UNSHARD, 2UNSHARD, 0F0, 0SEND_F0, 0F1, 0SEND_F1, 2RECV_F0, 2F0, 2SEND_F0, 2RECV_F1, 2F1, 2SEND_F1, 0F2, 0SEND_F2, 2RECV_B0, 2B0, 2SEND_B0, 0F3, 0SEND_F3, 2RECV_B1, 2B1, 2SEND_B1, 2RECV_F2, 2F2, 2SEND_F2, 0RECV_B0, 0B0, 2RECV_F3, 2F3, 2SEND_F3, 0RECV_B1, 0B1, 2RECV_B2, 2B2, 2SEND_B2, 2RECV_B3, 2B3, 2SEND_B3, 2REDUCE_GRAD, 2RESHARD, 0RECV_B2, 0B2, 0RECV_B3, 0B3, 0REDUCE_GRAD, 0RESHARD]
[1UNSHARD, 3UNSHARD, 1RECV_F0, 1F0, 1SEND_F0, 1RECV_F1, 1F1, 1SEND_F1, 3RECV_F0, 3F0, 3B0, 3SEND_B0, 3RECV_F1, 3F1, 3B1, 3SEND_B1, 1RECV_F2, 1F2, 1SEND_F2, 1RECV_B0, 1B0, 1SEND_B0, 1RECV_F3, 1F3, 1SEND_F3, 1RECV_B1, 1B1, 1SEND_B1, 3RECV_F2, 3F2, 3B2, 3SEND_B2, 3RECV_F3, 3F3, 3B3, 3SEND_B3, 3REDUCE_GRAD, 3RESHARD, 1RECV_B2, 1B2, 1SEND_B2, 1RECV_B3, 1B3, 1SEND_B3, 1REDUCE_GRAD, 1RESHARD]
```

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #172833

