### PR TITLE
[ROCm] Enable test_addmm_sizes on MI300X with relaxed TF32 tolerance

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7611,11 +7611,10 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     def test_addmm_gelu(self, device, dtype):
         self._test_addmm_impl(torch._addmm_activation, "gelu", device, dtype)
 
-    @skipIfRocmArch(MI300_ARCH)
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(*floating_and_complex_types())
-    @tf32_on_and_off(0.005)
-    @reduced_f32_on_and_off(0.005)
+    @tf32_on_and_off(0.05)
+    @reduced_f32_on_and_off(0.05)
     def test_addmm_sizes(self, device, dtype):
         for m in [0, 1, 25]:
             for n in [0, 1, 10]:


### PR DESCRIPTION
## Summary

Remove `@skipIfRocmArch(MI300_ARCH)` decorator and increase TF32/reduced_f32 tolerance from 0.005 to 0.05 for `test_addmm_sizes`.

## Root Cause

MI300X's hipBLASLt produces slightly different results with TF32 enabled compared to NVIDIA GPUs due to different internal precision handling in the matrix multiply operations.

## Changes

- Remove `@skipIfRocmArch(MI300_ARCH)` skip decorator
- Increase `@tf32_on_and_off` tolerance from 0.005 to 0.05
- Increase `@reduced_f32_on_and_off` tolerance from 0.005 to 0.05

The relaxed tolerance (0.05) matches what is already used for the adjacent `test_addmm_gelu` test, which has the same numerical characteristics.

Fixes https://github.com/pytorch/pytorch/issues/168763

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.ai/code)