### PR TITLE
Move ordering of `ComplexWrapper` closer to subclass handling.

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -170,9 +170,9 @@ def _create_wrappers_for_dispatch(needs_autograd: bool) -> list[CompilerWrapper]
     Wrappers that run on every dispatch function
     """
     return [
-        ComplexWrapper(),
         AOTDedupeWrapper(),
         AOTSyntheticBaseWrapper(trace_joint=needs_autograd),
+        ComplexWrapper(),
     ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

