### PR TITLE
[ROCm] Fix AMDSMI UUID retrieval to use correct API

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -936,15 +936,12 @@ def _raw_device_uuid_amdsmi() -> list[str] | None:
             warnings.warn("Cannot get amd device handler", stacklevel=2)
             return None
         try:
-            uuid = amdsmi.amdsmi_get_gpu_asic_info(handler)["asic_serial"][
-                2:
-            ]  # Removes 0x prefix from serial
+            uuid = amdsmi.amdsmi_get_gpu_device_uuid(handler)
         except amdsmi.AmdSmiException:
             warnings.warn("Cannot get uuid for amd device", stacklevel=2)
             return None
-        uuids.append(
-            str(uuid).lower()
-        )  # Lower-case to match expected HIP_VISIBLE_DEVICES uuid input
+        # Lower-case to match expected HIP_VISIBLE_DEVICES uuid input
+        uuids.append(str(uuid).lower())
     return uuids
 
 


### PR DESCRIPTION
## Summary

Fix `_raw_device_uuid_amdsmi()` to use the correct AMDSMI API for retrieving device UUIDs.

**The bug:** The function was using `amdsmi_get_gpu_asic_info()["asic_serial"]` which returns a hardware manufacturing serial number, not the device UUID.

**The fix:** Use `amdsmi_get_gpu_device_uuid()` which returns the actual device UUID matching:
- What `rocminfo` reports
- What users pass via `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES`

This aligns with how the UUID is already correctly retrieved in `tools/stats/monitor.py:424`.

Fixes #169881
Fixes #169878

## Test plan

- [ ] CI should pass `test_raw_amdsmi_device_uuids` and `test_uuid_visible_devices` on ROCm runners
- The tests were previously disabled due to this bug

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.ai/code)