### PR TITLE
[ROCm] Enable test_pdist_norm_large on ROCm

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4078,7 +4078,6 @@ class TestTorchDeviceType(TestCase):
 
     # FIXME: find a test suite for the pdist operator
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "sandcastle OOM with current tpx gpu/re configuration")
-    @skipIfRocm
     @onlyCUDA
     @largeTensorTest('32GB', device='cpu')
     @largeTensorTest('5GB', device='cuda')


### PR DESCRIPTION
## Summary

Remove the `@skipIfRocm` decorator from `test_pdist_norm_large` to enable this test on ROCm.

**Why this should work:**
- The pdist kernel (`aten/src/ATen/native/cuda/DistanceKernel.cu`) is standard CUDA code that works via HIP
- MI300X has 192GB memory, far exceeding the 5GB GPU requirement
- The `@skipIfRocm` was likely a historical skip from when ROCm support was less mature

Fixes #168868

## Test plan

- [ ] CI passes `test_pdist_norm_large` on ROCm runners

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.ai/code)