### PR TITLE
follow factory functions in find_triton_kernels

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -1179,6 +1179,62 @@ class AOTAutogradCacheTests(InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_triton_op_kernel_factory_function(self):
+        """
+        Test that triton kernels returned from factory functions are properly detected.
+
+        i.e., the pattern where a kernel is obtained from a fn like:
+            kernel = get_autotune_kernel()
+            capture_triton(kernel)[grid](...)
+        """
+        from torch._library import capture_triton
+        from torch._library.triton import triton_ops_to_kernels
+
+        @triton.jit
+        def factory_kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            tl.store(x_ptr + offsets, x + 42, mask=mask)
+
+        def get_kernel():
+            """Factory function that returns a triton kernel."""
+            return factory_kernel
+
+        @torch._library.triton_op("test::factory_triton_op", mutates_args=())
+        def factory_triton_op(x: torch.Tensor) -> torch.Tensor:
+            y = x.clone()
+            n_elements = y.numel()
+            kernel = get_kernel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+            capture_triton(kernel)[grid](y, n_elements, BLOCK_SIZE=256)
+            return y
+
+        kernels = triton_ops_to_kernels.get("test::factory_triton_op", [])
+
+        self.assertGreater(
+            len(kernels),
+            0,
+            "we should detect the kernel returned by get_kernel()",
+        )
+
+        kernel_names = [getattr(k, "__name__", str(k)) for k in kernels]
+        self.assertIn(
+            "factory_kernel",
+            kernel_names,
+            f"factory_kernel should be detected, got: {kernel_names}",
+        )
+
+        a = torch.randn(5, device=GPU_TYPE)
+        expected = a.clone() + 42
+        result = torch.ops.test.factory_triton_op(a)
+        self.assertEqual(result, expected)
+
+    @requires_cuda_and_triton
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     def test_triton_op_cache_multiple_ops_invalidation(self):
         @triton.jit
         def my_jit(x):

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -88,11 +88,18 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
                 self.assignments: dict[str, list[ast.expr]] = {}
                 # track function calls
                 self.called_functions: list[str] = []
+                # track return statement expressions
+                self.return_exprs: list[ast.expr] = []
 
             def visit_Assign(self, node: ast.Assign) -> None:
                 for target in node.targets:
                     if isinstance(target, ast.Name):
                         self.assignments.setdefault(target.id, []).append(node.value)
+                self.generic_visit(node)
+
+            def visit_Return(self, node: ast.Return) -> None:
+                if node.value is not None:
+                    self.return_exprs.append(node.value)
                 self.generic_visit(node)
 
             def visit_Call(self, node: ast.Call) -> None:
@@ -131,13 +138,6 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
 
         collector = Visitor()
         collector.visit(tree)
-        closure_vars = inspect.getclosurevars(fn)
-
-        # build combined globals from closure and function's __globals__
-        all_globals: dict[str, Any] = {}
-        all_globals.update(closure_vars.globals)
-        if hasattr(fn, "__globals__"):
-            all_globals.update(fn.__globals__)
 
         def extract_names_from_expr(expr: ast.expr) -> list[str]:
             """Extract all Name references from an AST expression."""
@@ -165,70 +165,62 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
                     return inner
             return None
 
-        def trace_to_global_kernels(
-            name: str, visited: set[str] | None = None
+        def build_namespace(func_obj: object) -> dict[str, Any]:
+            """Build a combined namespace from a function's globals and closures."""
+            if not callable(func_obj) or not hasattr(func_obj, "__code__"):
+                return {}
+            func_closure_vars = inspect.getclosurevars(func_obj)
+            namespace: dict[str, Any] = {}
+            namespace.update(func_closure_vars.builtins)
+            namespace.update(func_closure_vars.globals)
+            namespace.update(func_closure_vars.nonlocals)
+            if hasattr(func_obj, "__globals__"):
+                namespace.update(func_obj.__globals__)
+            return namespace
+
+        all_names = build_namespace(fn)
+
+        def resolve_names_to_kernels(
+            names: list[str],
+            namespace: dict[str, Any],
+            assignments: dict[str, list[ast.expr]] | None = None,
+            visited: set[str] | None = None,
         ) -> list[object]:
             """
-            Trace a name through local assignments back to global triton kernels.
-
-            This handles patterns like:
-                kernel_fn = _my_kernel  # global
-                wrapped = wrapper(kernel_fn)
-                autotuned = autotune(wrapped)
-                capture_triton(autotuned)  # traces back to _my_kernel
+            Resolve a list of names to triton kernels using the given namespace.
             """
             if visited is None:
                 visited = set()
 
-            if name in visited:
-                return []
-
-            visited.add(name)
-
-            # try direct resolution from globals
-            if name in all_globals:
-                kernel = resolve_to_kernel(all_globals[name])
-                if kernel is None:
-                    logger.warning(
-                        "failed to resolve all_globals[%s] to a triton kernel", name
-                    )
-                    return []
-                return [kernel]
-
-            # try closure nonlocals
-            if name in closure_vars.nonlocals:
-                kernel = resolve_to_kernel(closure_vars.nonlocals[name])
-                if kernel is None:
-                    logger.warning(
-                        "failed to resolve closure_vars.nonlocals[%s] to a triton kernel",
-                        name,
-                    )
-                    return []
-                return [kernel]
-
-            # try builtins (this seems unlikely, but for completeness/bc why not)
-            if name in closure_vars.builtins:
-                kernel = resolve_to_kernel(closure_vars.builtins[name])
-                if kernel is None:
-                    logger.warning(
-                        "failed to resolve closure_vars.builtins[%s] to a triton kernel",
-                        name,
-                    )
-                    return []
-                return [kernel]
-
-            # not in globals/nonlocals/builtins, check if it's a local assignment
-            if name not in collector.assignments:
-                logger.warning("%s not in collector.assignments", name)
-                return []
-
-            # trace through assignments - collect all names referenced in RHS
             results: list[object] = []
-            for rhs_expr in collector.assignments[name]:
-                referenced = extract_names_from_expr(rhs_expr)
-                for ref_name in referenced:
-                    traced = trace_to_global_kernels(ref_name, visited)
-                    results.extend(traced)
+            for name in names:
+                if name in visited:
+                    continue
+                visited.add(name)
+
+                if name in namespace:
+                    obj = namespace[name]
+                    kernel = resolve_to_kernel(obj)
+                    if kernel is not None:
+                        results.append(kernel)
+                        continue
+                    # recurse into callables (e.g., factory fn's)
+                    if callable(obj) and hasattr(obj, "__code__"):
+                        nested = find_triton_kernels(obj, visited_fns, depth + 1)
+                        if nested:
+                            results.extend(nested)
+                            continue
+                    logger.warning("failed to resolve %s to a triton kernel", name)
+                elif assignments is not None and name in assignments:
+                    # trace through local assignments
+                    for rhs_expr in assignments[name]:
+                        referenced = extract_names_from_expr(rhs_expr)
+                        traced = resolve_names_to_kernels(
+                            referenced, namespace, assignments, visited
+                        )
+                        results.extend(traced)
+                else:
+                    logger.warning("%s not found in namespace or assignments", name)
 
             return results
 
@@ -236,8 +228,14 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
         resolved: list[object] = []
         seen_ids: set[int] = set()
 
-        for name in collector.triton_kernels:
-            traced_objects = trace_to_global_kernels(name)
+        names_to_resolve: list[str] = list(collector.triton_kernels)
+        for expr in collector.return_exprs:
+            names_to_resolve.extend(extract_names_from_expr(expr))
+
+        for name in names_to_resolve:
+            traced_objects = resolve_names_to_kernels(
+                [name], all_names, collector.assignments
+            )
             for obj in traced_objects:
                 obj_id = id(obj)
                 if obj_id not in seen_ids:
@@ -245,12 +243,7 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
                     resolved.append(obj)
 
         for func_name in collector.called_functions:
-            # try resolving the function from globals or closure
-            func_obj = None
-            if func_name in all_globals:
-                func_obj = all_globals[func_name]
-            elif func_name in closure_vars.nonlocals:
-                func_obj = closure_vars.nonlocals[func_name]
+            func_obj = all_names.get(func_name)
 
             if func_obj is None:
                 from torch._library.custom_ops import OPDEFS


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172879
* __->__ #172876

Summary:
extended get_inner_triton_kernels to trace through factory functions that return triton kernels
    - added visit_Return to AST Visitor to collect return exprs
    - added build_namespace() helper to create combined namespace from function's globals/closures
    - added resolve_names_to_kernels() to unify name resolution logic
    - when a name resolves to a callable (as opposed to a kernel), recursively call find_triton_kernels on it
    - process both capture_triton(kernel) calls and return kernel statements

Test Plan:
pytest test/dynamo/test_aot_autograd_cache.py -k "test_triton_op_"

test/dynamo/test_aot_autograd_cache.py ............                                                                                     [100%]

===================================================== 12 passed, 107 deselected in 14.58s =====================================================

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo