### PR TITLE
[opaque object] support get_attr in inductor

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -24,6 +24,7 @@ from torch._functorch.aot_autograd import (
     aot_export_joint_with_descriptors,
     aot_export_module,
 )
+from torch._inductor.compile_fx import compile_fx
 from torch._library.effects import EffectType
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import (
@@ -2051,7 +2052,6 @@ class GraphModule(torch.nn.Module):
 
     def test_opaque_object_with_inductor_backend(self):
         """Test that opaque objects work correctly with inductor's get_attr handling."""
-        from torch._inductor.compile_fx import compile_fx
 
         class TestModule(torch.nn.Module):
             def __init__(self):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -23,6 +23,7 @@ from torch import device, Tensor
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import defake, dynamo_timed
 from torch._library.fake_class_registry import FakeScriptObject
+from torch._library.opaque_object import is_opaque_type
 from torch._library.utils import get_layout_constraint_tag
 from torch._logging import LazyString, trace_structured
 from torch._prims_common import (
@@ -1412,6 +1413,10 @@ class GraphLowering(torch.fx.Interpreter):
             self.torchbind_constants[target] = value
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)
+        elif is_opaque_type(type(value)):
+            self.torchbind_constants[target] = value  # type: ignore[arg-type]
+            self.constant_reprs[target] = ""
+            return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]
 
         assert isinstance(value, torch.Tensor)
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172890
* #172889
* #172888
* #172887
* #171638
* #171637
* #171636
* #171634
* #172782
* __->__ #172882

Summary:
as opposed to https://github.com/pytorch/pytorch/pull/172810

Test Plan:
pytest test/test_opaque_obj_v2.py -k "test_opaque_object_with_inductor_backend"

test/test_opaque_obj_v2.py .                                                                                                            [100%]

====================================================== 1 passed, 37 deselected in 3.15s =======================================================

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo