### PR TITLE
Fix test_has_main linter dependencies

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -972,7 +972,9 @@ exclude_patterns = [
     'test/test_hub.py',
 ]
 command = [
-    'python3',
+    'uv',
+    'run',
+    '--script',
     'tools/linter/adapters/test_has_main_linter.py',
     '--',
     '@{{PATHSFILE}}',

--- a/tools/linter/adapters/test_has_main_linter.py
+++ b/tools/linter/adapters/test_has_main_linter.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "libcst",
+# ]
+# ///
 """
 This lint verifies that every Python test file (file that matches test_*.py or
 *_test.py in the test folder) has a main block which raises an exception or


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #167577
* #167407
* #167376
* __->__ #172897
* #171918

The TEST_HAS_MAIN linter has an undeclared dependency on libcst.  Previously this was installed as a dependency of usort
via the pyfmt linter.  But as of https://github.com/pytorch/pytorch/pull/172661 libcst is no longer available, causing
lint failures.