### PR TITLE
[Visualizer] Switch to jsdelivr CDN

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1,10 +1,10 @@
 'use strict';
 
-import * as d3 from "https://cdn.skypack.dev/d3@5";
-import {axisLeft} from "https://cdn.skypack.dev/d3-axis@1";
-import {scaleLinear} from "https://cdn.skypack.dev/d3-scale@1";
-import {zoom, zoomIdentity} from "https://cdn.skypack.dev/d3-zoom@1";
-import {brushX} from "https://cdn.skypack.dev/d3-brush@1";
+import * as d3 from "https://cdn.jsdelivr.net/npm/d3@5/+esm";
+import {axisLeft} from "https://cdn.jsdelivr.net/npm/d3-axis@1/+esm";
+import {scaleLinear} from "https://cdn.jsdelivr.net/npm/d3-scale@1/+esm";
+import {zoom, zoomIdentity} from "https://cdn.jsdelivr.net/npm/d3-zoom@1/+esm";
+import {brushX} from "https://cdn.jsdelivr.net/npm/d3-brush@1/+esm";
 
 const schemeTableau10 = [
   '#4e79a7',


### PR DESCRIPTION
Summary:
Switch D3 imports from Skypack CDN to jsdelivr CDN in MemoryViz.js.

Skypack has been experiencing reliability issues, causing FUNCTION_INVOCATION_FAILED errors when loading the memory visualizer. jsdelivr is a more stable alternative.

Test Plan: Ran visualizer manually locally and it worked again

Fixes https://github.com/pytorch/pytorch/issues/172896