### PR TITLE
Fix shape inference bug in mkldnn conv transpose for torch.compile

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -791,7 +791,7 @@ Tensor mkldnn_convolution_transpose_pointwise_meta(
     torch::List<std::optional<at::Scalar>> scalars,
     std::optional<std::string_view> algorithm) {
 
-  std::vector<int64_t> weight_IOHW_sizes = _original_deconv_weight_size(weight_t, groups);
+  std::vector<int64_t> weight_IOHW_sizes = weight_t.is_mkldnn() ? _original_deconv_weight_size(weight_t, groups) : weight_t.sizes().vec();
   int64_t dim = input_t.ndimension() - 2;
   const auto padding_expanded = expand_param_if_needed(padding, "padding", dim);
   const auto stride_expanded = expand_param_if_needed(stride, "stride", dim);

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -544,30 +544,57 @@ class TestMkldnn(TestCase):
     def test_conv_transpose3d(self):
         self._test_conv_transpose_base(dim=3)
 
-    @skipIfTorchDynamo("Test requires dynamo")
     def test_conv_transpose_shape_compile(self):
-        """Regression test for shape inference bug in mkldnn._convolution_transpose.
+        """Regression test for shape inference bug in mkldnn._convolution_transpose_pointwise.
 
         Bug: torch.compile was incorrectly transposing weight dimensions for regular PyTorch
-        tensors, causing wrong output channel prediction (e.g., 3 instead of 8 channels).
+        tensors causing wrong output channel prediction (e.g 3 instead of 8 channels).
         """
-        class M(torch.nn.Module):
+        torch.set_num_threads(1)
+
+        class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.conv_transpose = torch.nn.ConvTranspose2d(3, 8, 3, stride=2, padding=1)
+                # Weight layout: (in_channels, out_channels, kH, kW) - same as nn.ConvTranspose2d
+                self.weight = torch.nn.Parameter(torch.randn(3, 8, 3, 3))  # in=3, out=8
+                self.bias = torch.nn.Parameter(torch.randn(8))
 
             def forward(self, x):
-                return self.conv_transpose(x)
+                # Schema: mkldnn::_convolution_transpose_pointwise(X, W, B, padding, output_padding, stride, dilation, groups, attr, scalars, algorithm)
+                y = torch.ops.mkldnn._convolution_transpose_pointwise.default(
+                    x,
+                    self.weight,
+                    self.bias,
+                    [1, 1],      # padding
+                    [1, 1],      # output_padding
+                    [2, 2],      # stride
+                    [1, 1],      # dilation
+                    1,           # groups
+                    "none",      # attr
+                    [],          # scalars
+                    ""           # algorithm
+                )
+                # Post-ops to prevent trivial elimination
+                y = torch.add(y, 3)
+                y = torch.clamp_min(y, 0)
+                y = torch.clamp_max(y, 6)
+                return torch.div(y, 6)
 
-        mod = M().eval()
+        torch.manual_seed(9150)
+        model = Model().eval()
         x = torch.randn(4, 3, 16, 16)
 
         with torch.no_grad():
-            eager_out = mod(x)
-            compiled_out = torch.compile(mod)(x)
+            torch.manual_seed(9150)
+            eager_out = model(x)
 
+            torch.manual_seed(9150)
+            compiled_model = torch.compile(model, fullgraph=True)
+            compiled_out = compiled_model(x)
+
+            # Bug was shape mismatch eager=(4,8,32,32) compiled=(4,3,32,32)
             self.assertEqual(eager_out.shape, compiled_out.shape)
-            self.assertEqual(eager_out.shape[1], 8)
+            self.assertEqual(eager_out.shape[1], 8)  # Expected output channels
 
     def test_conv2d_legacy_jit_model(self):
         """

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -548,7 +548,7 @@ class TestMkldnn(TestCase):
         """Regression test for shape inference bug in mkldnn._convolution_transpose_pointwise.
 
         Bug: torch.compile was incorrectly transposing weight dimensions for regular PyTorch
-        tensors causing wrong output channel prediction (e.g 3 instead of 8 channels).
+        tensors, causing wrong output channel prediction (e.g., 3 instead of 8 channels).
         """
         torch.set_num_threads(1)
 


### PR DESCRIPTION
Fixes #172711 

Fixes a bug where torch.compile incorrectly predicted output shapes for transposed convolutions using MKLDNN backend. The issue was caused by unconditionally transposing weight dimensions from [Input, Output, Height, W] to [Output, Input, Height, Width], which is only correct for MKLDNN prepacked weights, not regular PyTorch tensors.

This caused compiled models to expect the wrong number of output channels (e.g.  predicting 3 channels when the actual output had 8 channels) leading to assertion failures during execution.

The fix adds proper checks to only transpose weight dimensions when the weight is actually an MKLDNN tensor. Changes were made to both the C++ meta kernel and Python inductor code paths.
Includes a regression test to prevent this issue from happening again.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos