### PR TITLE
fix build for symm mem by setting cmake dependencies

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1046,7 +1046,9 @@ elseif(USE_CUDA)
         "${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp"
     )
     # Add torch_cpu as a dependency to ensure ATen headers are available
-    target_link_libraries(torch_nvshmem PRIVATE torch_cpu)
+    # torch::cudart provides CUDA include directories for .cpp files that include cuda_runtime.h
+    target_link_libraries(torch_nvshmem PRIVATE torch_cpu torch::cudart)
+    target_include_directories(torch_nvshmem PRIVATE ${Caffe2_GPU_INCLUDE})
     set_target_properties(torch_nvshmem PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     target_compile_options(torch_nvshmem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-rdc=true>)
     target_compile_options(torch_nvshmem PRIVATE "-U__CUDA_NO_HALF_OPERATORS__")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1048,7 +1048,6 @@ elseif(USE_CUDA)
     # Add torch_cpu as a dependency to ensure ATen headers are available
     # torch::cudart provides CUDA include directories for .cpp files that include cuda_runtime.h
     target_link_libraries(torch_nvshmem PRIVATE torch_cpu torch::cudart)
-    target_include_directories(torch_nvshmem PRIVATE ${Caffe2_GPU_INCLUDE})
     set_target_properties(torch_nvshmem PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     target_compile_options(torch_nvshmem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-rdc=true>)
     target_compile_options(torch_nvshmem PRIVATE "-U__CUDA_NO_HALF_OPERATORS__")


### PR DESCRIPTION
Without this sometimes (perhaps due to different build order) build fails with 
```
  /home/dev/meta/2_pytorch/torch/csrc/distributed/c10d/cuda/utils.cpp:1:10:
      fatal error: cuda_runtime.h: No such file or directory
          1 | #include <cuda_runtime.h>
            |          ^~~~~~~~~~~~~~~~
      compilation terminated.
      [2/816] Building CXX object
```
authored by claude.
cc @malfet 
      