### PR TITLE
[ROCm][CI] Fix missing /etc/rocm_env.sh error in common.sh

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -5,8 +5,8 @@
 source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
 set -ex -o pipefail
 
-# for ROCm environment variables
-if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
+# for ROCm environment variables (therock builds)
+if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
   # shellcheck disable=SC1091
   source /etc/rocm_env.sh
 fi


### PR DESCRIPTION
## Summary

Fix the CI script failure when `/etc/rocm_env.sh` doesn't exist.

**The bug:** PR #168377 added sourcing of `/etc/rocm_env.sh` for ROCm builds, but the file only exists in therock builds. The condition `[[ "${BUILD_ENVIRONMENT}" == *rocm* ]]` matches all ROCm environments, causing the script to fail with:
```
.ci/pytorch/common.sh: line 11: /etc/rocm_env.sh: No such file or directory
```

**The fix:** Add a file existence check: `[[ -f /etc/rocm_env.sh ]]`

Fixes #170983

## Test Plan

- CI should pass on all ROCm environments (both therock and standard ROCm)
- For therock builds: file exists, gets sourced as before
- For standard ROCm: file doesn't exist, skip sourcing gracefully

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @srinivamd @ethanwee1