### PR TITLE
[Inductor] Guard against zero timing in combo kernel benchmarking

### DIFF
--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -395,9 +395,10 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
         estimated_timing = self.get_event_pairs_min_timing(event_pairs)
 
         # adjust `benchmark_iters` to fit in the maximum benchmarking duration
-        benchmark_iters = max(
-            min(benchmark_iters, int(max_benchmark_duration // estimated_timing)), 1
-        )
+        if estimated_timing > 0:
+            benchmark_iters = max(
+                min(benchmark_iters, int(max_benchmark_duration // estimated_timing)), 1
+            )
 
         # do the memory warmup
         for _ in range(memory_warmup_iters):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172918

If `estimated_timing` is 0 during combo kernel benchmarking, we encounter a division by zero error. So instead we should just stick to the default benchmarking iterations.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo