### PR TITLE
[BE][CI] Remove explicit uv install from lintrunner.sh

### DIFF
--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
-# Use uv to speed up lintrunner init
-python3 -m pip install -U uv==0.8.* setuptools
+# setuptools is needed for lintrunner init
+python3 -m pip install -U setuptools
 
 CACHE_DIRECTORY="/tmp/.lintbin"
 # Try to recover the cached binaries


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #172909
* __->__ #172920

The Docker image already has uv pre-installed (0.9.25), which satisfies
the new uv.toml requirement (>=0.9.21). The explicit install was
downgrading to 0.8.x which caused lintrunner init to fail.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>