### PR TITLE
[MPS] Add device guard for MPS dispatch key

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9607,6 +9607,21 @@ class TestLinalgMPS(TestCaseMPS):
             mean_err = ((res - ref).abs() / ref).mean()
             self.assertLess(mean_err, 0.05)
 
+    def test_solve_triangular_device_check(self):
+        """Test that solve_triangular properly checks for device mismatch.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/142048
+        """
+        a = torch.tensor(
+            [[4, 0, 0], [1, 3, 0], [2, 1, 2]], device="mps", dtype=torch.float32
+        )
+        b = torch.tensor([[2, 3], [4, 5], [6, 7]], device="cpu", dtype=torch.float32)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Expected all tensors to be on the same device"
+        ):
+            torch.linalg.solve_triangular(a, b, upper=False)
+
 
 class TestSDPA(TestCaseMPS):
     def _compare_tensors(self, y, ref):

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -60,6 +60,7 @@ from torchgen.model import (
     FunctionSchema,
     is_cuda_dispatch_key,
     is_generic_dispatch_key,
+    is_mps_dispatch_key,
     is_ufunc_dispatch_key,
     is_xpu_dispatch_key,
     Location,
@@ -209,7 +210,9 @@ def parse_native_yaml_struct(
             use_out_as_primary=True,
             external=False,
             # Only cuda-like devices in tree require device guards
-            device_guard=is_cuda_dispatch_key(k) or is_xpu_dispatch_key(k),
+            device_guard=is_cuda_dispatch_key(k)
+            or is_xpu_dispatch_key(k)
+            or is_mps_dispatch_key(k),
             index=v,
         )
     return ParsedYaml(rs, indices)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -363,6 +363,18 @@ def is_xpu_dispatch_key(dk: DispatchKey) -> bool:
     }
 
 
+# MPS specific dispatch keys
+def is_mps_dispatch_key(dk: DispatchKey) -> bool:
+    return dk in {
+        DispatchKey.MPS,
+        DispatchKey.QuantizedMPS,
+        DispatchKey.SparseMPS,
+        DispatchKey.SparseCsrMPS,
+        DispatchKey.NestedTensorMPS,
+        DispatchKey.AutogradMPS,
+    }
+
+
 # Structured kernel generation is only supported for certain key types;
 # otherwise use old-style
 def is_structured_dispatch_key(dk: DispatchKey) -> bool:
@@ -374,7 +386,11 @@ def is_ufunc_dispatch_key(dk: DispatchKey) -> bool:
     return dk in UFUNC_DISPATCH_KEYS
 
 
-dispatch_device_map = {is_cuda_dispatch_key: "cuda", is_xpu_dispatch_key: "xpu"}
+dispatch_device_map = {
+    is_cuda_dispatch_key: "cuda",
+    is_xpu_dispatch_key: "xpu",
+    is_mps_dispatch_key: "mps",
+}
 
 
 # This is oddly named ScalarType and not DType for symmetry with C++


### PR DESCRIPTION
## Summary

Add `is_mps_dispatch_key()` function to identify MPS dispatch keys and include MPS in device guard generation alongside CUDA and XPU.

This prevents crashes when operations like `solve_triangular` are called with tensors on different devices (e.g., CPU and MPS). Without device guards, MPS operations crash with segmentation faults when mixing CPU and MPS tensors. With this change, a proper `RuntimeError` is raised instead.

Fixes #142048

## Changes

- Add `is_mps_dispatch_key()` function to `torchgen/model.py`
- Include MPS in device guard generation in `torchgen/gen.py`
- Add `dispatch_device_map` entry for MPS
- Add regression test `test_solve_triangular_device_check`

## Test Plan

- Added `test_solve_triangular_device_check` in `test/test_mps.py` that verifies the fix by checking that a `RuntimeError` with message "Expected all tensors to be on the same device" is raised when calling `torch.linalg.solve_triangular` with tensors on different devices.

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen @aditvenk @lezcano

🤖 Authored with assistance from Claude