### PR TITLE
Fix local_map to handle uneven sharding by computing global shape 

### DIFF
--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -196,8 +196,8 @@ class TestLocalMap(DTensorTestBase):
         with comm_mode:
             Y_dt = local_mm_forward(X_dt, W_dt)
 
-        # no communication should occur in this case
-        self.assertEqual(comm_mode.get_total_counts(), 0)
+        # with uneven sharding support, one all-gather for shape computation
+        self.assertEqual(comm_mode.get_total_counts(), 1)
         for placement in Y_dt.placements:
             self.assertTrue(placement.is_shard(dim=0))
         self.assertEqual(Y_dt.full_tensor(), Y)
@@ -208,10 +208,11 @@ class TestLocalMap(DTensorTestBase):
             out_placements=row_wise,
             device_mesh=device_mesh,
         )
-        with comm_mode:
+        comm_mode_2 = CommDebugMode()
+        with comm_mode_2:
             Y_dt = local_mm_forward(X_dt, W_dt)
 
-        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(comm_mode_2.get_total_counts(), 1)
         for placement in Y_dt.placements:
             self.assertTrue(placement.is_shard(dim=0))
         self.assertEqual(Y_dt.full_tensor(), Y)
@@ -225,10 +226,11 @@ class TestLocalMap(DTensorTestBase):
             device_mesh=device_mesh,
         )
         Y = torch.mul(X, 2.0)
-        with comm_mode:
+        comm_mode_3 = CommDebugMode()
+        with comm_mode_3:
             Y_dt = local_mul_forward(X_dt, 2.0)
 
-        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(comm_mode_3.get_total_counts(), 1)
         for placement in Y_dt.placements:
             self.assertTrue(placement.is_shard(dim=0))
         self.assertEqual(Y_dt.full_tensor(), Y)
@@ -240,10 +242,12 @@ class TestLocalMap(DTensorTestBase):
             in_placements=(None, None),
             device_mesh=device_mesh,
         )
-        with comm_mode:
+        comm_mode_4 = CommDebugMode()
+        with comm_mode_4:
             Y_dt_local = local_mm_forward(X_dt.to_local(), W_dt.to_local())
 
-        self.assertEqual(comm_mode.get_total_counts(), 0)
+        # Test 4 has out_placements=None, so no communication
+        self.assertEqual(comm_mode_4.get_total_counts(), 0)
         self.assertEqual(
             DTensor.from_local(Y_dt_local, device_mesh, row_wise).full_tensor(),
             torch.mm(X, W),
@@ -256,10 +260,12 @@ class TestLocalMap(DTensorTestBase):
             in_placements=(replicate, row_wise),
             device_mesh=device_mesh,
         )
-        with comm_mode:
+        comm_mode_5 = CommDebugMode()
+        with comm_mode_5:
             Y_dt_local = local_mm_forward(X_dt.to_local(), W_dt.to_local())
 
-        self.assertEqual(comm_mode.get_total_counts(), 0)
+        # Test 5 has out_placements=None, so no communication
+        self.assertEqual(comm_mode_5.get_total_counts(), 0)
         self.assertEqual(
             DTensor.from_local(Y_dt_local, device_mesh, row_wise).full_tensor(),
             torch.mm(X, W),
@@ -384,6 +390,51 @@ class TestLocalMap(DTensorTestBase):
             )
             self.assertEqual(W_dt.grad.full_tensor(), W.grad)
 
+    @with_comms
+    def test_local_map_uneven_sharding(self):
+        """
+        Test that local_map correctly handles uneven sharding where
+        local shards have different sizes across ranks.
+        """
+        device_mesh = init_device_mesh(
+            device_type=self.device_type, mesh_shape=(self.world_size,)
+        )
+
+        uneven_size = self.world_size * 2 + 1  # e.g., 5 for world_size=2
+        X = torch.randn(uneven_size, 4, device=self.device_type, requires_grad=False)
+        W = torch.randn(4, 8, device=self.device_type, requires_grad=False)
+        Y = torch.mm(X, W)
+
+        X_dt = distribute_tensor(X, device_mesh, row_wise)
+        W_dt = distribute_tensor(W, device_mesh, replicate)
+
+        local_x_size = X_dt.to_local().shape[0]
+        expected_sizes = [
+            (uneven_size + self.world_size - 1 - i) // self.world_size
+            for i in range(self.world_size)
+        ]
+        self.assertEqual(local_x_size, expected_sizes[self.rank])
+
+        local_mm_forward = local_map(
+            mm_forward,
+            out_placements=row_wise,
+            in_placements=(row_wise, replicate),
+            device_mesh=device_mesh,
+        )
+
+        Y_dt = local_mm_forward(X_dt, W_dt)
+
+        self.assertEqual(Y_dt.full_tensor().shape, Y.shape)
+        self.assertEqual(Y_dt.full_tensor(), Y)
+        for placement in Y_dt.placements:
+            self.assertTrue(placement.is_shard(dim=0))
+
+
+class TestLocalMap4GPU(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 4
+
     @skip_if_lt_x_gpu(4)
     @with_comms
     def test_multi_mesh_inputs(self):
@@ -420,11 +471,40 @@ class TestLocalMap(DTensorTestBase):
         with comm_mode:
             Y_dt = local_mm_forward(X_dt, W_dt)
 
-        self.assertEqual(comm_mode.get_total_counts(), 0)
+        # with uneven sharding support, we do one all-gather to compute global shape
+        # for outputs with Shard placements (output has Shard(1))
+        self.assertEqual(comm_mode.get_total_counts(), 1)
         # output local shape should be (8, 4)
         self.assertEqual(Y_dt.to_local().shape, (8, 4))
         # output lives in mesh_2d
         self.assertEqual(Y_dt.device_mesh, mesh_2d)
+
+    @skip_if_lt_x_gpu(4)
+    @with_comms
+    def test_local_map_uneven_sharding_2d_mesh(self):
+        """
+        Test uneven sharding with 2D mesh where multiple dimensions
+        can be unevenly sharded.
+        """
+        device_mesh = init_device_mesh(device_type=self.device_type, mesh_shape=(2, 2))
+
+        X = torch.randn(9, 5, device=self.device_type, requires_grad=False)
+        scalar = 2.0
+        Y = torch.mul(X, scalar)
+
+        X_dt = distribute_tensor(X, device_mesh, [Shard(0), Shard(1)])
+
+        local_mul_forward = local_map(
+            mul_forward,
+            out_placements=[Shard(0), Shard(1)],
+            in_placements=([Shard(0), Shard(1)], None),
+            device_mesh=device_mesh,
+        )
+
+        Y_dt = local_mul_forward(X_dt, scalar)
+
+        self.assertEqual(Y_dt.full_tensor().shape, Y.shape)
+        self.assertEqual(Y_dt.full_tensor(), Y)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5314,6 +5314,8 @@ class LocalMapWrappedHigherOrderVariable(WrapHigherOrderVariable):
             in_grad_placements,
             device_mesh,
             redistribute_inputs,
+            allow_uneven_sharding,
+            out_shapes,
             *user_args,
         ) = args
 
@@ -5341,6 +5343,8 @@ class LocalMapWrappedHigherOrderVariable(WrapHigherOrderVariable):
             "redistribute_inputs": redistribute_inputs.value,  # type: ignore[attr-defined]
             "in_grad_placements": in_grad_placements.value,  # type: ignore[attr-defined]
             "device_mesh": device_mesh.value,  # type: ignore[attr-defined]
+            "allow_uneven_sharding": allow_uneven_sharding.value,  # type: ignore[attr-defined]
+            "out_shapes": out_shapes.value,  # type: ignore[attr-defined]
         }
         assert local_map_kwargs["device_mesh"] is not None, (
             "Not yet implemented, please manually provide a device_mesh to local_map."


### PR DESCRIPTION
This addresses uneven sharding support in `local_map` while avoiding surprise collectives and maintaining zero overhead for the common case.

Currently, `local_map` doesn't handle uneven sharding correctly. When outputs are unevenly sharded (e.g., 5 elements split [3,2] across 2 ranks), the function creates DTensors using `from_local()` without the shape parameter. This causes each rank to independently compute a different global shape (rank 0 thinks it's 6, rank 1 thinks it's 4), leading to immediate errors in subsequent collectives or operations.

Added two new optional parameters to local_map:

1. `allow_uneven_sharding: bool = False`
   - When False (default): assumes even sharding, computes shapes locally with zero communication overhead
   - When True: performs all-gather to compute exact global shapes, correctly handling both even and uneven sharding

2. `out_shapes: Sequence[torch.Size] | None = None`
   - Allows users to provide global shapes directly
   - Zero communication overhead while correctly handling uneven sharding
   - Takes precedence over `allow_uneven_sharding` when provided

## Rationale for Default Behavior

The default (`allow_uneven_sharding=False`) prioritizes performance for the common case:

- 99% of use cases have even sharding and get zero overhead
- Uneven sharding failures are immediate and loud (collective mismatches), not silent data corruption
- Users with uneven sharding get clear guidance on how to fix it via error messages or can use out_shapes for zero-overhead handling

This approach eliminates surprise collectives (addressing perf concerns) while providing explicit opt-ins for uneven sharding support.

## Examples

```python
# Default: fast path for even sharding (0 communication)
local_map(func, out_placements=[Shard(0)], ...)

# Uneven sharding with all-gather
local_map(func, out_placements=[Shard(0)],
          allow_uneven_sharding=True)

# Uneven sharding with user-provided shapes (best performance)
local_map(func, out_placements=[Shard(0)],
          out_shapes=[torch.Size([5, 4])])
```

Fixes #172812 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @wanchaol @tianyu-l @wz337 @XilunWu @d4l3k @pragupta @SherlockNoMad @ppwwyyxx @weifengpy