### PR TITLE
[xpu][fix] Fix wrong signature on XPU memory docs

### DIFF
--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -479,32 +479,31 @@ class _XPUAllocator:
 
 
 class XPUPluggableAllocator(_XPUAllocator):
-    r"""XPU memory allocator loaded from a shared library."""
+    r"""
+    XPU memory allocator loaded dynamically from a shared library.
+
+    This lets users provide custom allocation and free functions implemented
+    in a separate shared library. The allocator is registered and could become
+    available for use via :func:`~torch.xpu.memory.change_current_allocator``.
+
+    Arguments:
+        path_to_lib_file (str):
+            Filesystem path to the shared library file containing the allocation
+            and free functions.
+        alloc_fn_name (str):
+            Name of the allocation function exported from the shared library.
+            The function must have the signature:
+
+                ``void* alloc_fn(size_t size, int device, sycl::queue* queue);``
+
+        free_fn_name (str):
+            Name of the free function exported from the shared library.
+            The function must have the signature:
+
+                ``void free_fn(void* ptr, size_t size, int device, sycl::queue* queue);``
+    """
 
     def __init__(self, path_to_lib_file: str, alloc_fn_name: str, free_fn_name: str):
-        r"""XPU memory allocator loaded dynamically from a shared library.
-
-        This lets users provide custom allocation and free functions implemented
-        in a separate shared library. The allocator is registered through
-        ``torch._C._xpu_customAllocator`` and becomes available for use via
-        ``torch.memory.xpu.change_current_allocator``.
-
-        Arguments:
-            path_to_lib_file (str):
-                Filesystem path to the shared library file containing the allocation
-                and free functions.
-            alloc_fn_name (str):
-                Name of the allocation function exported from the shared library.
-                The function must have the signature:
-
-                    ``void* alloc_fn(size_t size, int device, sycl::queue* queue);``
-
-            free_fn_name (str):
-                Name of the free function exported from the shared library.
-                The function must have the signature:
-
-                    ``void free_fn(void* ptr, size_t size, sycl::queue* queue);``
-        """
         allocator_lib = ctypes.CDLL(path_to_lib_file)
 
         alloc_fn_ptr = getattr(allocator_lib, alloc_fn_name)

--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -484,7 +484,7 @@ class XPUPluggableAllocator(_XPUAllocator):
 
     This lets users provide custom allocation and free functions implemented
     in a separate shared library. The allocator is registered and could become
-    available for use via :func:`~torch.xpu.memory.change_current_allocator``.
+    available for use via :func:`~torch.xpu.memory.change_current_allocator`.
 
     Arguments:
         path_to_lib_file (str):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #172933

# Motivation
This PR mainly does two things:
1. Correct `free_fn`'s signature from void `free_fn(void* ptr, size_t size, sycl::queue* queue);` to `void free_fn(void* ptr, size_t size, int device, sycl::queue* queue);`
2. Refine the description and move it outside of `__init__`, showing more details. The previous docs don't render them, refer to https://docs.pytorch.org/docs/main/generated/torch.xpu.memory.XPUPluggableAllocator.html

# Additional Context
fix https://github.com/pytorch/pytorch/issues/172931