### PR TITLE
[ROCm] Enable test_multi_inp_asm with platform-specific inline assembly

### DIFF
--- a/test/inductor/test_custom_lowering.py
+++ b/test/inductor/test_custom_lowering.py
@@ -134,7 +134,7 @@ class TestCustomLowering(InductorTestCase):
         cls.impl_meta.impl("add_custom", add_custom)
 
         def add_custom_lowering(a, b):
-            if torch.version.hip is not None:
+            if torch.version.hip:
                 # ROCm GCN assembly
                 fn = partial(
                     ops.inline_asm_elementwise,

--- a/test/inductor/test_custom_lowering.py
+++ b/test/inductor/test_custom_lowering.py
@@ -134,7 +134,15 @@ class TestCustomLowering(InductorTestCase):
         cls.impl_meta.impl("add_custom", add_custom)
 
         def add_custom_lowering(a, b):
-            fn = partial(ops.inline_asm_elementwise, asm="add.f32 $0, $1, $2;")
+            if torch.version.hip is not None:
+                # ROCm GCN assembly
+                fn = partial(
+                    ops.inline_asm_elementwise,
+                    asm="v_add_f32 $0, $1, $2",
+                    constraints="=v, v, v",
+                )
+            else:
+                fn = partial(ops.inline_asm_elementwise, asm="add.f32 $0, $1, $2;")
             return make_pointwise(fn)(a, b)
 
         register_lowering(
@@ -223,7 +231,6 @@ class TestCustomLowering(InductorTestCase):
         self.assertEqual(a, b)
 
     @requires_gpu()
-    @skipIfRocm
     @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
     @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
     def test_multi_inp_asm(self):


### PR DESCRIPTION
Fixes #168585

### Overview
This PR enables ROCm/HIP platform support for the `test_multi_inp_asm` test. Previously, this test was skipped on ROCm due to platform-specific inline assembly syntax differences. This PR implements proper platform detection and uses appropriate assembly instructions for each platform.

### Problem
The test used CUDA PTX assembly (`add.f32 $0, $1, $2;`) which is incompatible with ROCm's GCN architecture. ROCm requires GCN assembly syntax with vector register constraints.

### Solution
Added platform-specific inline assembly in the `add_custom_lowering` function:
- **ROCm/HIP**: Uses GCN ISA (`v_add_f32 $0, $1, $2`) with vector register constraints (`"=v, v, v"`)
- **CUDA**: Uses PTX ISA (`add.f32 $0, $1, $2;`) with default register constraints

### Testing
Test now runs and passes on both platforms.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben