### PR TITLE
Bf16 optimized heuristics

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -19,6 +19,16 @@ extern "C" void dgemm_(char *transa, char *transb, int *m, int *n, int *k, doubl
 extern "C" void sgemm_(char *transa, char *transb, int *m, int *n, int *k, float *alpha, const float *a, int *lda, const float *b, int *ldb, float *beta, float *c, int *ldc);
 extern "C" void cgemm_(char *transa, char *transb, int *m, int *n, int *k, void *alpha, const void *a, int *lda, const void *b, int *ldb, void *beta, void *c, int *ldc);
 extern "C" void zgemm_(char *transa, char *transb, int *m, int *n, int *k, void *alpha, const void *a, int *lda, const void *b, int *ldb, void *beta, void *c, int *ldc);
+// BGEMM provides native BF16 GEMM execution (no FP32 up/down conversion),
+// Older SBGEMM paths required BF16 <-> FP32 conversion, adding extra cost.
+#ifdef BLAS_HAS_BGEMM
+extern "C" void bgemm_(char *transa, char *transb, int *m, int *n, int *k,
+                const at::BFloat16 *alpha,
+                const at::BFloat16 *a, int *lda,
+                const at::BFloat16 *b, int *ldb,
+                const at::BFloat16 *beta,
+                at::BFloat16 *c, int *ldc);
+#endif  // BLAS_HAS_BGEMM
 #ifdef BLAS_HAS_SBGEMM
 extern "C" void sbgemm_(char *transa, char *transb, int *m, int *n, int *k,
                 float *alpha,
@@ -351,7 +361,7 @@ void gemm(
 #ifdef __aarch64__
    // MKLDNN also supports ARM for bf16, and the bypass is only
    // currently intended for x86/x86_64.
-   const bool use_bf16_gemv_trans = false;
+   const bool use_bf16_gemv_trans = (m == 1 || n == 1);
 #elif defined(__powerpc__)
    const bool use_bf16_gemv_trans = false;
 #else
@@ -369,15 +379,27 @@ void gemm(
    if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {
       int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
       char transa_ = to_blas(transa), transb_ = to_blas(transb);
-      float alpha_ = alpha, beta_ = beta;
-      int c_size = n_ * m_;
       // C matrix in OpenBLAS sbgemm are of type "float" so we have to convert, copy and copy back.
+#if defined(BLAS_HAS_BGEMM)
+      at::BFloat16 alpha_ = c10::convert<at::BFloat16>(alpha);
+      at::BFloat16 beta_ = c10::convert<at::BFloat16>(beta);
+      bgemm_(&transa_, &transb_,
+             &m_, &n_, &k_,
+             &alpha_,
+             a, &lda_,
+             b, &ldb_,
+             &beta_,
+             c, &ldc_);
+#else
+      // C matrix in OpenBLAS sbgemm are of type "float" so we have to convert, copy and copy back.
+      int c_size = n_ * m_;
       std::vector<float> float_v(c_size, 0.0f);
       for (const auto j : c10::irange(n)) {
         for (const auto i : c10::irange(m)) {
           float_v[j * m_ + i] = c10::convert<float>(c[j * ldc_ + i]);
         }
       }
+      float alpha_ = alpha, beta_ = beta;
       sbgemm_(&transa_, &transb_,
               &m_, &n_, &k_,
               &alpha_,
@@ -390,6 +412,7 @@ void gemm(
           c[j * ldc_ + i] = c10::convert<at::BFloat16>(float_v[j * m_ + i]);
         }
       }
+#endif // defined(BLAS_HAS_BGEMM)
       return;
    }
 #endif

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -161,10 +161,27 @@ mkldnn_gemm(
   bool fp16_usable = std::is_same_v<scalar_t, c10::Half> && use_mkldnn_fp16_matmul();
   bool bf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_bf32_matmul();
   bool tf32_usable = std::is_same_v<scalar_t, float> && use_mkldnn_tf32_matmul();
-  if ( !(bf16_usable || fp16_usable || bf32_usable || tf32_usable) ||
-      (m * n * k <= 16 * 16 * 16) || (alpha == 0.0f)) {
-    return false;
+  if (bf16_usable) {
+  // BF16 heuristic: use BGEMM for GEMV-like or small shapes,
+  // otherwise prefer oneDNN for larger workloads.
+  #if defined(__aarch64__)
+    // Arm-specific BF16 heuristic: avoid oneDNN for GEMV-like or small shapes.
+    if ((m == 1 || n == 1) || (m * n * k <= 786432) || (alpha == 0.0f)) {
+      return false;
+    }
+  #else
+    // Keep existing generic behavior for non-Arm.
+    if ((m * n * k <= 16 * 16 * 16) || (alpha == 0.0f)) {
+      return false;
+    }
+  #endif
+  } else {
+    if (!(fp16_usable || bf32_usable || tf32_usable) ||
+        (m * n * k <= 16 * 16 * 16) || (alpha == 0.0f)) {
+      return false;
+    }
   }
+
 
   ideep::attr_t op_attr;
   // Use mkldnn post ops to perform the add.


### PR DESCRIPTION
**This PR introduces:**
  BGEMM backend integration for BF16 GEMM
  A data-driven decision-tree heuristic for selecting BGEMM vs oneDNN
  Significant CPU inference improvements 
  
  
  
  **OpenBLAS update**
- OpenBLAS version updated to **0.3.31.dev** (this build contains BGEMM kernels for BF16).
- BGEMM vs SBGEMM: BGEMM is a BFloat16-native GEMM kernel that operates directly on BF16 inputs (avoids float32 conversion), improving BF16 GEMM throughput and lowering memory pressure. SBGEMM is the earlier path that required conversion to float and back (extra copy/convert cost). This PR enables BGEMM for BF16 shapes via a small selector+build bump.

**Methodology**
- Forced BGEMM vs oneDNN execution for BF16 GEMM shapes
- Built ground-truth performance dataset
- Trained a decision tree
- Derived a simple rule-based backend heuristic

**Benchmark Setup**

- Model: LLaMA-3.1-8B (BF16)
- Threads: 16
- Instance: c8g.Metal-48xl
- OpenBLAS v0.3.31.dev
- oneDNN v3.12.0
- My changes compared against upstream PyTorch: bfe8c20037dcf9a9169251b35ed8efc6c66476f3


The majority of gains come from improved BF16 GEMM selection.



**Benchmark script and LLAMA evaluation**
 
[Benchmark.py](https://github.com/user-attachments/files/25420164/Benchmark.py)

**• Self CPU total**
* `Short prompt: 486.337s → 97.390s (4.99x faster)`
* `Long prompt (repeated 512x): 951.762s → 486.337s (1.96x faster)`
**• aten::mm self CPU**
* `Short prompt: 329.574s → 69.056s (4.77x faster)`
* `Long prompt: 771.995s → 329.574s (2.34x faster)`

**Evaluation across different shapes**
[bf16_bmm_sweep_benchmark.py](https://github.com/user-attachments/files/26706172/bf16_bmm_sweep_benchmark.py)

 I ran a broader benchmark sweep over **1,296 shapes** across `(B, M, N, K)` and compared the old vs. new heuristic selections, including the before/after timings.

The sweep used:

* `BATCH_SIZES = [1, 8, 64, 128, 256, 512]`
* `M_DIMS = [1, 32, 64, 512, 1024, 2048]`
* `N_DIMS = [1, 32, 64, 512, 1024, 2048]`
* `K_DIMS = [1, 32, 64, 512, 1024, 2048]`

At a high level, the new heuristic reduces total runtime from **234.22s** to **209.90s**, which is an overall **1.12x weighted speedup** on this benchmark set.

The improvement is not uniform across every shape, but it gives strong wins across multiple shape families, not just the `n=1, m=32` cases.

A few representative before/after examples:

* `(b=256, m=32, n=1, k=512)`: **1.4895s -> 0.0035s** (**422.7x faster**)
* `(b=8, m=32, n=1, k=512)`: **0.0463s -> 0.00011s** (**419.6x faster**)
* `(b=64, m=32, n=1, k=512)`: **0.3663s -> 0.00088s** (**414.0x faster**)
* `(b=128, m=32, n=1, k=512)`: **0.7231s -> 0.00177s** (**408.7x faster**)
* `(b=1, m=32, n=1, k=512)`: **0.00564s -> 0.000019s** (**294.4x faster**)

There are also wins on other shape variations, for example:

* `(b=256, m=1, n=64, k=1024)`: **0.1151s -> 0.0021s** (**54.7x faster**)
* `(b=512, m=1, n=32, k=512)`: **0.0282s -> 0.00146s** (**19.3x faster**)
* `(b=512, m=32, n=1024, k=1)`: **0.0716s -> 0.0146s** (**4.9x faster**)
* `(b=128, m=512, n=512, k=1)`: **0.0577s -> 0.0269s** (**2.14x faster**)
* `(b=512, m=2048, n=1, k=1024)`: **0.0716s -> 0.0378s** (**1.89x faster**)

There are also some wins on more balanced shapes, including `m=n=k` examples:

* `(b=512, m=32, n=32, k=32)`: **0.000705s -> 0.000380s** (**1.85x faster**)
* `(b=512, m=64, n=64, k=64)`: **0.00145s -> 0.000558s** (**2.59x faster**)


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01