### PR TITLE
Fix accuracy errors in math backend attention

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2247,7 +2247,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @dtypes(*device_configs["cpu"].dtypes)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes)
     @dtypesIfXPU(*device_configs["xpu"].dtypes)
-    @common_utils.skipIfRocmArch(common_utils.MI200_ARCH)
     def test_autocast(self, device, dtype):
         """Test torch autocast functionality"""
         q = torch.randn(1, 1, 1024, 64, device=device, dtype=dtype).to(torch.float16)

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -278,7 +278,7 @@ def math_attention(
     # for math impl we divide by log(2) because we will multiply by log(2)
 
     return (
-        post_mod_scores.to(query.dtype) @ value.to(query.dtype),
+        (post_mod_scores @ value.to(post_mod_scores.dtype)).to(query.dtype),
         logsumexp / math.log(2),
         max_scores / math.log(2),
     )


### PR DESCRIPTION
The final operation in the math backend attention:
```
scaled attention matrix @ V
```
should be performed in high precision float type and downcast to target float type *afterwards*.

A unit test was disabled for MI200 because of this: https://github.com/pytorch/pytorch/pull/172290
That unit test goes into the math backend attention implementation and compares it to the SDPA attention
(numerical errors pile up in that math backend attention matmul and we get different results that SDPA attention).
The error is very flaky and depends for example on the random seed.

A detail about the fix:

Interestingly we can't just use:
```python
(post_mod_scores @ value).to(query.dtype)
```
(gives `RuntimeError: expected scalar type Float but found Half`), it requires explicit:
```python
(post_mod_scores @ value.to(post_mod_scores.dtype)).to(query.dtype)
```

FInally, a minimal repro if this would ever come back to haunt us:
```python
import torch
from torch.nn.attention.flex_attention import flex_attention
# i=0  # rel dif 0.04
i=73 # rel dif of 4.13
# i=89 # rel dif of 0.23
# i=42 # passes
torch.manual_seed(i)
torch.cuda.manual_seed(i)
# dtype=torch.float32 # assert_close passes
dtype=torch.float16 # assert_close fails
device=torch.device("cuda")
q = torch.randn(1, 1, 1024, 64, device=device, dtype=dtype)
k = torch.randn(1, 1, 1024, 64, device=device, dtype=dtype)
v = torch.randn(1, 1, 1024, 64, device=device, dtype=dtype)
q=q.to(torch.float16)
k=k.to(torch.float16)
v=v.to(torch.float16)
sdpa_output = torch.nn.functional.scaled_dot_product_attention(q, k, v)
flex_output = flex_attention(q, k, v)
torch.testing.assert_close(sdpa_output, flex_output, atol=1e-3, rtol=1e-3)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo