### PR TITLE
fix:https://cdn.skypack.dev/d3@5 cannot reach

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as d3 from "https://cdn.skypack.dev/d3@5";
+import * as d3 from "https://cdn.skypack.dev/d3@7";
 import {axisLeft} from "https://cdn.skypack.dev/d3-axis@1";
 import {scaleLinear} from "https://cdn.skypack.dev/d3-scale@1";
 import {zoom, zoomIdentity} from "https://cdn.skypack.dev/d3-zoom@1";


### PR DESCRIPTION
`https://cdn.skypack.dev/d3@5` can not reach which results to [`snapshot.html`](https://github.com/pytorch/pytorch.github.io/blob/site/assets/images/understanding-gpu-memory-1/snapshot.html) can not be view by chrome. From my test, `https://cdn.skypack.dev/d3@7` is OK.
<img width="542" height="206" alt="image" src="https://github.com/user-attachments/assets/d2e36f01-3bce-4dbb-8896-b71f6bf85948" />
<img width="1320" height="681" alt="image" src="https://github.com/user-attachments/assets/1c30a503-20fa-44dc-9447-8f10cf719f0b" />
<img width="987" height="355" alt="image" src="https://github.com/user-attachments/assets/5e853121-ab76-4f27-8c19-58d438f68e19" />



cc @svekars @sekyondaMeta @AlannaBurke