### PR TITLE
Enable ZVECTOR compilation when building s390x nightly wheels in CI

### DIFF
--- a/.ci/manywheel/build_cpu.sh
+++ b/.ci/manywheel/build_cpu.sh
@@ -44,6 +44,11 @@ if [[ "$ARCH" == "aarch64" ]]; then
     echo "ARM Compute Library enabled for MKLDNN: ACL_ROOT_DIR=/acl"
 fi
 
+if [[ "$ARCH" == "s390x" ]]; then
+    # Build for z15 to enable full ZVECTOR support
+    export CFLAGS="$CFLAGS -march=z15"
+fi
+
 WHEELHOUSE_DIR="wheelhousecpu"
 LIBTORCH_HOUSE_DIR="libtorch_housecpu"
 if [[ -z "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then

--- a/.ci/manywheel/build_libtorch.sh
+++ b/.ci/manywheel/build_libtorch.sh
@@ -118,7 +118,7 @@ fi
     time CMAKE_ARGS=${CMAKE_ARGS[@]} \
         EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
         # TODO: Remove this flag once https://github.com/pytorch/pytorch/issues/55952 is closed
-        CFLAGS='-Wno-deprecated-declarations' \
+        CFLAGS="$CFLAGS -Wno-deprecated-declarations" \
         BUILD_LIBTORCH_CPU_WITH_DEBUG=1 \
         python -m pip install --no-build-isolation -v .
 

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -55,6 +55,10 @@ if [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
   export ATEN_THREADING=NATIVE
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *s390x* ]]; then
+  # Build for z15 to enable full ZVECTOR support
+  export CFLAGS="$CFLAGS -march=z15"
+fi
 
 if ! which conda; then
   # In ROCm CIs, we are doing cross compilation on build machines with


### PR DESCRIPTION
When CFLAGS are set, make sure to not erase previous values but append to them.
