### PR TITLE
[ROCm] Fix AMDSMI UUID retrieval to use correct API

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -937,9 +937,7 @@ def _raw_device_uuid_amdsmi() -> list[str] | None:
             warnings.warn("Cannot get amd device handler", stacklevel=2)
             return None
         try:
-            uuid = amdsmi.amdsmi_get_gpu_asic_info(handler)["asic_serial"][
-                2:
-            ]  # Removes 0x prefix from serial
+            uuid = amdsmi.amdsmi_get_gpu_device_uuid(handler)
         except amdsmi.AmdSmiException:
             warnings.warn("Cannot get uuid for amd device", stacklevel=2)
             return None


### PR DESCRIPTION
## Summary

- Fix `_raw_device_uuid_amdsmi()` to use `amdsmi_get_gpu_device_uuid()` instead of `amdsmi_get_gpu_asic_info()["asic_serial"]`
- The previous API returned hardware serial numbers, not device UUIDs
- This broke UUID-based device selection via `HIP_VISIBLE_DEVICES`

## Background

The function was using the wrong AMDSMI API:
- `asic_serial` returns hardware manufacturing serial numbers (e.g., `0x1234abcd`)
- `amdsmi_get_gpu_device_uuid()` returns actual device UUIDs (e.g., `GPU-9e8d35e3-a134-0fdd-0e01-23811fdbd293`)

The correct API is already used in `tools/stats/monitor.py:424`.

Fixes #169881, #169878

## Test plan

- [ ] `test_raw_amdsmi_device_uuids` - validates PyTorch UUID matches `rocminfo` output
- [ ] `test_uuid_visible_devices` - tests `HIP_VISIBLE_DEVICES` with UUID strings

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.ai/claude-code)