### PR TITLE
[ROCm] Allow overriding AOTriton commit hash via environment variable

### DIFF
--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -24,7 +24,13 @@ if(NOT __AOTRITON_INCLUDED)
       "rocm7.0"
       "rocm7.1"
       )
-  set(__AOTRITON_CI_COMMIT "d34f3b6c824df77d5c5788a2e7555b2398be4b79")
+  # Allow overriding AOTriton commit via environment variable for CI flexibility
+  if(DEFINED ENV{AOTRITON_CI_COMMIT})
+    set(__AOTRITON_CI_COMMIT "$ENV{AOTRITON_CI_COMMIT}")
+    message(STATUS "Using AOTriton commit from environment: ${__AOTRITON_CI_COMMIT}")
+  else()
+    set(__AOTRITON_CI_COMMIT "d34f3b6c824df77d5c5788a2e7555b2398be4b79")
+  endif()
   set(__AOTRITON_SHA256_LIST
       "a3a7e391758b3580c42a1623d11606308ae52115b2a3eba5d1f440586a078391"  # rocm6.2
       "662fc06239c8091f57e13793a4fac0e783241c9f5e86b1701bbb2ba308ef4279"  # rocm6.3


### PR DESCRIPTION
## Summary

- Add support for `AOTRITON_CI_COMMIT` environment variable to override the hardcoded AOTriton git commit hash when building from source
- Enables CI pipelines and developers to test different AOTriton versions without modifying cmake files

## Background

Currently, the AOTriton commit hash is hardcoded in `cmake/External/aotriton.cmake`, making it difficult for CI pipelines to test different versions. This change allows setting `AOTRITON_CI_COMMIT` environment variable to override the default.

**Usage:**
```bash
export AOTRITON_CI_COMMIT=<commit-hash>
export AOTRITON_INSTALL_FROM_SOURCE=1
# Then build PyTorch as usual
```

Fixes #171797

## Test plan

- [ ] Build PyTorch with `AOTRITON_INSTALL_FROM_SOURCE=1` (default commit)
- [ ] Build PyTorch with `AOTRITON_CI_COMMIT=<hash> AOTRITON_INSTALL_FROM_SOURCE=1` (custom commit)
- [ ] Verify status message appears when using custom commit

cc @malfet @seemethere @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

🤖 Generated with [Claude Code](https://claude.ai/claude-code)