### PR TITLE
Opt in files typechecking

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -21,31 +21,12 @@ project-includes = [
     "test/test_utils.py",
 ]
 project-excludes = [
-  # ==== below will be enabled directory by directory ====
-  # ==== to test Pyrefly on a specific directory, simply comment it out ====
   "torch/_inductor/runtime/triton_heuristics.py",
   "torch/_inductor/runtime/triton_helpers.py",
   "torch/_inductor/runtime/halide_helpers.py",
   "torch/utils/data/typing.ipynb",
   "torch/utils/data/dataframes_pipes.ipynb",
   "torch/utils/data/standard_pipes.ipynb",
-  # formatting issues, will turn on after adjusting where suppressions can be
-  # in import statements
-  "torch/distributed/flight_recorder/components/types.py",
-  "torch/linalg/__init__.py",
-  "torch/package/importer.py",
-  "torch/package/_package_pickler.py",
-  "torch/jit/annotations.py",
-  "torch/utils/data/datapipes/_typing.py",
-  "torch/nn/functional.py",
-  "torch/_export/utils.py",
-  "torch/fx/experimental/unification/multipledispatch/__init__.py",
-  "torch/nn/modules/__init__.py",
-  "torch/nn/modules/rnn.py", # only remove when parsing errors are fixed
-  "torch/_inductor/codecache.py",
-  "torch/distributed/elastic/metrics/__init__.py",
-  "torch/_inductor/fx_passes/bucketing.py",
-  # ====
   "torch/onnx/_internal/exporter/_torchlib/ops/nn.py",
   "torch/include/**",
   "torch/csrc/**",

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1141,14 +1141,14 @@ def placeholder_naming_pass(
         if (  # handle targets for custom objects
             spec.kind == InputKind.CUSTOM_OBJ and spec.target in name_map
         ):
-            # pyrefly: ignore [index-error]
+            # pyrefly: ignore [bad-index, index-error]
             spec.target = name_map[spec.target][4:]  # strip obj_ prefix
 
     for spec in export_graph_signature.output_specs:
         if spec.arg.name in name_map:
             spec.arg.name = name_map[spec.arg.name]
         if spec.kind == OutputKind.USER_INPUT_MUTATION and spec.target in name_map:
-            # pyrefly: ignore [index-error]
+            # pyrefly: ignore [bad-index, index-error]
             spec.target = name_map[spec.target]
 
     # rename keys in constants dict for custom objects

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2482,15 +2482,18 @@ end
                                 compile_multiarch_bundle_from_llvm_ir,
                             )
 
+                            # pyrefly: ignore [unbound-name]
                             if not os.path.exists(asm_file):
                                 raise RuntimeError(
                                     f"Multi-arch ROCm compilation requires LLVM IR file, "
+                                    # pyrefly: ignore [unbound-name]
                                     f"but {asm_file} not found. "
                                     f"Ensure asm_type='ll' is captured in triton_heuristics.py"
                                 )
 
                             # Compile for multiple archs and bundle them
                             success = compile_multiarch_bundle_from_llvm_ir(
+                                # pyrefly: ignore [unbound-name]
                                 llvm_ir_path=asm_file,
                                 output_bundle_path=cubin_file,
                                 target_archs=None,
@@ -2605,7 +2608,7 @@ end
                         # Don't use resource.getpagesize() on Windows, as it is a Unix specific package
                         # as seen in https://docs.python.org/2/library/resource.html
                         if _IS_WINDOWS:
-                            from ctypes import (  # type: ignore[attr-defined]
+                            from ctypes import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
                                 byref,
                                 Structure,
                                 windll,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2608,10 +2608,10 @@ end
                         # Don't use resource.getpagesize() on Windows, as it is a Unix specific package
                         # as seen in https://docs.python.org/2/library/resource.html
                         if _IS_WINDOWS:
-                            from ctypes import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
+                            from ctypes import (
                                 byref,
                                 Structure,
-                                windll,
+                                windll,  # pyrefly: ignore [missing-module-attribute]
                             )
                             from ctypes.wintypes import DWORD, LPVOID, WORD
 

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -163,8 +163,8 @@ def bucket_all_gather(
     mode: BucketMode = "default",
 ) -> None:
     if bucket_cap_mb_by_bucket_idx is None:
-        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
-            bucket_cap_mb_by_bucket_idx_default,
+        from torch._inductor.fx_passes.bucketing import (
+            bucket_cap_mb_by_bucket_idx_default,  # pyrefly: ignore [missing-module-attribute]
         )
 
         bucket_cap_mb_by_bucket_idx = bucket_cap_mb_by_bucket_idx_default
@@ -180,8 +180,8 @@ def bucket_reduce_scatter(
     mode: BucketMode = "default",
 ) -> None:
     if bucket_cap_mb_by_bucket_idx is None:
-        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
-            bucket_cap_mb_by_bucket_idx_default,
+        from torch._inductor.fx_passes.bucketing import (
+            bucket_cap_mb_by_bucket_idx_default,  # pyrefly: ignore [missing-module-attribute]
         )
 
         bucket_cap_mb_by_bucket_idx = bucket_cap_mb_by_bucket_idx_default
@@ -440,8 +440,8 @@ def bucket_all_reduce(
     mode: str | None = None,
 ) -> None:
     if bucket_cap_mb_by_bucket_idx is None:
-        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
-            bucket_cap_mb_by_bucket_idx_default,
+        from torch._inductor.fx_passes.bucketing import (
+            bucket_cap_mb_by_bucket_idx_default,  # pyrefly: ignore [missing-module-attribute]
         )
 
         bucket_cap_mb_by_bucket_idx = bucket_cap_mb_by_bucket_idx_default

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -72,6 +72,7 @@ def _schedulable_wait_node(node: torch.fx.Node) -> bool:
     if not isinstance(node.args[0].target, Callable):
         return False
     is_callable: bool = node.args[0].op == "call_function"
+    # pyrefly: ignore [missing-attribute]
     coll: NCCL_COLL = get_collective_type_from_kernel_name(node.args[0].target.name())
     is_collective: bool = coll != NCCL_COLL.UNSUPPORTED
     return is_callable and is_collective
@@ -162,7 +163,7 @@ def bucket_all_gather(
     mode: BucketMode = "default",
 ) -> None:
     if bucket_cap_mb_by_bucket_idx is None:
-        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute
+        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
             bucket_cap_mb_by_bucket_idx_default,
         )
 
@@ -179,7 +180,7 @@ def bucket_reduce_scatter(
     mode: BucketMode = "default",
 ) -> None:
     if bucket_cap_mb_by_bucket_idx is None:
-        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute
+        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
             bucket_cap_mb_by_bucket_idx_default,
         )
 
@@ -439,7 +440,7 @@ def bucket_all_reduce(
     mode: str | None = None,
 ) -> None:
     if bucket_cap_mb_by_bucket_idx is None:
-        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute
+        from torch._inductor.fx_passes.bucketing import (  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
             bucket_cap_mb_by_bucket_idx_default,
         )
 
@@ -853,7 +854,9 @@ def process_collective_bucket(
         # Handle convert_element_type operations (for all_gather)
         node_in = n.args[0]
         if has_mergeable_all_gather_convert_dtype(n):
+            # pyrefly: ignore [bad-argument-type]
             ag_node_to_pre_nodes[n].append(node_in)
+            # pyrefly: ignore [missing-attribute]
             node_in = node_in.args[0]
 
         assert isinstance(node_in, torch.fx.Node)  # Ensure node_in is a Node
@@ -1031,6 +1034,7 @@ def merge_all_gather_bucket(
         ag_merge_fn = all_gather_merge_fn_to_trace_custom_ops  # type: ignore[assignment]
 
     # Process bucket with lazy input collection
+    # pyrefly: ignore [bad-argument-type]
     rank: int = dist.get_rank(_resolve_process_group(group_name))
 
     def create_trace_args(bucket_ins: list[torch.fx.Node]) -> tuple[Any, ...]:

--- a/torch/_subclasses/schema_check_mode.py
+++ b/torch/_subclasses/schema_check_mode.py
@@ -29,7 +29,9 @@ class Aliasing(NamedTuple):
 
 
 # Simplified naming for C++ classes
+# pyrefly: ignore [missing-attribute]
 SchemaArgument = torch._C._SchemaArgument
+# pyrefly: ignore [missing-attribute]
 SchemaArgType = torch._C._SchemaArgType
 SchemaInfo = torch._C._SchemaInfo
 
@@ -124,6 +126,7 @@ class SchemaCheckMode(TorchDispatchMode):
 
         def has_aliased(lhs: Any, rhs: Any) -> bool:
             try:
+                # pyrefly: ignore [missing-attribute]
                 return torch._C._overlaps(lhs, rhs)
             except Exception as exception:
                 if str(exception).startswith("Cannot inspect value of type "):
@@ -186,6 +189,7 @@ class SchemaCheckMode(TorchDispatchMode):
         tuple_out = tree_map(unwrap, tuple_out)
 
         schema_info = SchemaInfo(func._schema)
+        # pyrefly: ignore [missing-attribute]
         schema_info.add_argument_values(pre_arguments)
 
         # Process arguments with outputs
@@ -203,6 +207,7 @@ class SchemaCheckMode(TorchDispatchMode):
                         has_aliased(tuple_out[j], after)
                         and func._schema.name not in unsafe_ops
                     ):
+                        # pyrefly: ignore [missing-attribute]
                         if not schema_info.may_contain_alias(
                             SchemaArgument(SchemaArgType.output, j),
                             SchemaArgument(SchemaArgType.input, i),
@@ -245,6 +250,7 @@ However, we found that `outputs[{str(j)}] is {name}"""
         # Aliasing between outputs
         for i, j in combinations(range(len(func._schema.returns)), 2):
             if has_aliased(tuple_out[i], tuple_out[j]):
+                # pyrefly: ignore [missing-attribute]
                 if not schema_info.may_contain_alias(
                     SchemaArgument(SchemaArgType.output, i),
                     SchemaArgument(SchemaArgType.output, j),

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -7,7 +7,7 @@
 import math
 import os
 from enum import auto, Enum
-from typing import (  # type: ignore[attr-defined]
+from typing import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
     _eval_type,
     Any,
     Generic,
@@ -161,9 +161,11 @@ class Collective(NamedTuple):
 
 class NCCLCall(NamedTuple):
     id: int
+    # pyrefly: ignore [bad-specialization]
     collective_id: Ref[Collective]
     group_id: str
     global_rank: int  # technically Ref[Process] once we have it
+    # pyrefly: ignore [bad-specialization]
     traceback_id: Ref[Traceback]
     collective_type: str
     sizes: list[list[int]]

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -7,8 +7,8 @@
 import math
 import os
 from enum import auto, Enum
-from typing import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
-    _eval_type,
+from typing import (
+    _eval_type,  # pyrefly: ignore [missing-module-attribute]
     Any,
     Generic,
     NamedTuple,

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -38,8 +38,8 @@ from torch._jit_internal import (  # type: ignore[attr-defined]; pyrefly: ignore
     _qualified_name,
     Any,
     BroadcastingList1,
-    BroadcastingList2,
-    BroadcastingList3,
+    BroadcastingList2,  # pyrefly: ignore [missing-module-attribute]
+    BroadcastingList3,  # pyrefly: ignore [missing-module-attribute]
     Dict,
     Future,
     is_await,

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -33,7 +33,7 @@ from torch._C import (
     TupleType,
     UnionType,
 )
-from torch._jit_internal import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
+from torch._jit_internal import (
     _Await,
     _qualified_name,
     Any,

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -33,7 +33,7 @@ from torch._C import (
     TupleType,
     UnionType,
 )
-from torch._jit_internal import (  # type: ignore[attr-defined]
+from torch._jit_internal import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
     _Await,
     _qualified_name,
     Any,
@@ -508,6 +508,7 @@ def try_ann_to_type(ann, loc, rcb=None):
     # Maybe resolve a NamedTuple to a Tuple Type
     if rcb is None:
         rcb = _fake_rcb
+    # pyrefly: ignore [bad-argument-type]
     return torch._C._resolve_type_from_object(ann, loc, rcb)
 
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1,4 +1,4 @@
-from torch._C import (  # type: ignore[attr-defined]  # pyrefly: ignore  # missing-module-attribute
+from torch._C import (  # type: ignore[attr-defined]  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
     _add_docstr,
     _linalg,
     _LinAlgError as LinAlgError,  # pyrefly: ignore  # missing-module-attribute

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1,6 +1,6 @@
-from torch._C import (  # type: ignore[attr-defined]  # pyrefly: ignore  # missing-module-attribute; pyrefly: ignore [missing-module-attribute]
+from torch._C import (
     _add_docstr,
-    _linalg,
+    _linalg,  # pyrefly: ignore [missing-module-attribute]
     _LinAlgError as LinAlgError,  # pyrefly: ignore  # missing-module-attribute
 )
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -8,18 +8,18 @@ from typing import Any as _Any, Optional, TYPE_CHECKING
 
 import torch
 from torch import _VF, sym_int as _sym_int, Tensor
-from torch._C import (  # pyrefly: ignore [missing-module-attribute]
+from torch._C import (
     _add_docstr,
     _infer_size,
-    _ScalingType as ScalingType,
-    _SwizzleType as SwizzleType,
+    _ScalingType as ScalingType,  # pyrefly: ignore [missing-module-attribute]
+    _SwizzleType as SwizzleType,  # pyrefly: ignore [missing-module-attribute]
 )
-from torch._jit_internal import (  # pyrefly: ignore [missing-module-attribute]
+from torch._jit_internal import (
     _overload,
     boolean_dispatch,
     BroadcastingList1,
-    BroadcastingList2,
-    BroadcastingList3,
+    BroadcastingList2,  # pyrefly: ignore [missing-module-attribute]
+    BroadcastingList3,  # pyrefly: ignore [missing-module-attribute]
 )
 from torch._torch_docs import reproducibility_notes, sparse_support_notes, tf32_notes
 from torch.nn import _reduction as _Reduction, grad  # noqa: F401

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -8,13 +8,13 @@ from typing import Any as _Any, Optional, TYPE_CHECKING
 
 import torch
 from torch import _VF, sym_int as _sym_int, Tensor
-from torch._C import (
+from torch._C import (  # pyrefly: ignore [missing-module-attribute]
     _add_docstr,
     _infer_size,
     _ScalingType as ScalingType,
     _SwizzleType as SwizzleType,
 )
-from torch._jit_internal import (
+from torch._jit_internal import (  # pyrefly: ignore [missing-module-attribute]
     _overload,
     boolean_dispatch,
     BroadcastingList1,

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -655,10 +655,12 @@ class RNN(RNNBase):
 
     @overload
     @torch._jit_internal._overload_method  # noqa: F811
+    # pyrefly: ignore [bad-override]
     def forward(
         self,
         input: Tensor,
         hx: Tensor | None = None,
+        # pyrefly: ignore [bad-return]
     ) -> tuple[Tensor, Tensor]:
         pass
 
@@ -668,6 +670,7 @@ class RNN(RNNBase):
         self,
         input: PackedSequence,
         hx: Tensor | None = None,
+        # pyrefly: ignore [bad-return]
     ) -> tuple[PackedSequence, Tensor]:
         pass
 
@@ -740,6 +743,7 @@ class RNN(RNNBase):
             raise AssertionError(f"mode must be RNN_TANH or RNN_RELU, got {self.mode}")
         if batch_sizes is None:
             if self.mode == "RNN_TANH":
+                # pyrefly: ignore [no-matching-overload]
                 result = _VF.rnn_tanh(
                     input,
                     hx,
@@ -752,6 +756,7 @@ class RNN(RNNBase):
                     self.batch_first,
                 )
             else:
+                # pyrefly: ignore [no-matching-overload]
                 result = _VF.rnn_relu(
                     input,
                     hx,
@@ -765,6 +770,7 @@ class RNN(RNNBase):
                 )
         else:
             if self.mode == "RNN_TANH":
+                # pyrefly: ignore [no-matching-overload]
                 result = _VF.rnn_tanh(
                     input,
                     batch_sizes,
@@ -777,6 +783,7 @@ class RNN(RNNBase):
                     self.bidirectional,
                 )
             else:
+                # pyrefly: ignore [no-matching-overload]
                 result = _VF.rnn_relu(
                     input,
                     batch_sizes,
@@ -795,6 +802,7 @@ class RNN(RNNBase):
         if isinstance(orig_input, PackedSequence):
             output_packed = PackedSequence(
                 output,
+                # pyrefly: ignore [bad-argument-type]
                 batch_sizes,
                 sorted_indices,
                 unsorted_indices,
@@ -1021,6 +1029,7 @@ class LSTM(RNNBase):
 
     # In the future, we should prevent mypy from applying contravariance rules here.
     # See torch/nn/modules/module.py::_forward_unimplemented
+    # pyrefly: ignore [bad-override]
     def check_forward_args(
         self,
         input: Tensor,
@@ -1054,10 +1063,12 @@ class LSTM(RNNBase):
     # Same as above, see torch/nn/modules/module.py::_forward_unimplemented
     @overload  # type: ignore[override]
     @torch._jit_internal._overload_method  # noqa: F811
+    # pyrefly: ignore [bad-override]
     def forward(
         self,
         input: Tensor,
         hx: tuple[Tensor, Tensor] | None = None,
+        # pyrefly: ignore [bad-return]
     ) -> tuple[Tensor, tuple[Tensor, Tensor]]:  # noqa: F811
         pass
 
@@ -1068,6 +1079,7 @@ class LSTM(RNNBase):
         self,
         input: PackedSequence,
         hx: tuple[Tensor, Tensor] | None = None,
+        # pyrefly: ignore [bad-return]
     ) -> tuple[PackedSequence, tuple[Tensor, Tensor]]:  # noqa: F811
         pass
 
@@ -1153,6 +1165,7 @@ class LSTM(RNNBase):
                 hx = self.permute_hidden(hx, sorted_indices)
 
         if batch_sizes is None:
+            # pyrefly: ignore [no-matching-overload]
             result = _VF.lstm(
                 input,
                 hx,
@@ -1165,6 +1178,7 @@ class LSTM(RNNBase):
                 self.batch_first,
             )
         else:
+            # pyrefly: ignore [no-matching-overload]
             result = _VF.lstm(
                 input,
                 batch_sizes,
@@ -1182,6 +1196,7 @@ class LSTM(RNNBase):
         if isinstance(orig_input, PackedSequence):
             output_packed = PackedSequence(
                 output,
+                # pyrefly: ignore [bad-argument-type]
                 batch_sizes,
                 sorted_indices,
                 unsorted_indices,
@@ -1350,10 +1365,12 @@ class GRU(RNNBase):
 
     @overload  # type: ignore[override]
     @torch._jit_internal._overload_method  # noqa: F811
+    # pyrefly: ignore [bad-override]
     def forward(
         self,
         input: Tensor,
         hx: Tensor | None = None,
+        # pyrefly: ignore [bad-return]
     ) -> tuple[Tensor, Tensor]:  # noqa: F811
         pass
 
@@ -1363,6 +1380,7 @@ class GRU(RNNBase):
         self,
         input: PackedSequence,
         hx: Tensor | None = None,
+        # pyrefly: ignore [bad-return]
     ) -> tuple[PackedSequence, Tensor]:  # noqa: F811
         pass
 
@@ -1427,6 +1445,7 @@ class GRU(RNNBase):
 
         self.check_forward_args(input, hx, batch_sizes)
         if batch_sizes is None:
+            # pyrefly: ignore [no-matching-overload]
             result = _VF.gru(
                 input,
                 hx,
@@ -1439,6 +1458,7 @@ class GRU(RNNBase):
                 self.batch_first,
             )
         else:
+            # pyrefly: ignore [no-matching-overload]
             result = _VF.gru(
                 input,
                 batch_sizes,
@@ -1457,6 +1477,7 @@ class GRU(RNNBase):
         if isinstance(orig_input, PackedSequence):
             output_packed = PackedSequence(
                 output,
+                # pyrefly: ignore [bad-argument-type]
                 batch_sizes,
                 sorted_indices,
                 unsorted_indices,

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -1,10 +1,8 @@
-# mypy: allow-untyped-defs
-# pyrefly: ignore [missing-module-attribute]
 import sys
-from pickle import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
-    _compat_pickle,
-    _extension_registry,
-    _getattribute,
+from pickle import (
+    _compat_pickle,  # pyrefly: ignore [missing-module-attribute]
+    _extension_registry,  # pyrefly: ignore [missing-module-attribute]
+    _getattribute,  # pyrefly: ignore [missing-module-attribute]
     _Pickler,
     EXT1,
     EXT2,

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 # pyrefly: ignore [missing-module-attribute]
 import sys
-from pickle import (  # type: ignore[attr-defined]
+from pickle import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
     _compat_pickle,
     _extension_registry,
     _getattribute,

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC, abstractmethod
 
 # pyrefly: ignore [missing-module-attribute]
-from pickle import (  # type: ignore[attr-defined]
+from pickle import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
     _getattribute,
     _Pickler,
     whichmodule as _pickle_whichmodule,  # pyrefly: ignore  # missing-module-attribute

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from pickle import (
     _getattribute,  # pyrefly: ignore [missing-module-attribute]
     _Pickler,
-    whichmodule as _pickle_whichmodule,  # pyrefly: ignore  # missing-module-attribute
+    whichmodule as _pickle_whichmodule,  # pyrefly: ignore [missing-module-attribute]
 )
 from types import ModuleType
 from typing import Any

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -1,12 +1,9 @@
-# mypy: allow-untyped-defs
 import importlib
 import logging
 import sys
 from abc import ABC, abstractmethod
-
-# pyrefly: ignore [missing-module-attribute]
-from pickle import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
-    _getattribute,
+from pickle import (
+    _getattribute,  # pyrefly: ignore [missing-module-attribute]
     _Pickler,
     whichmodule as _pickle_whichmodule,  # pyrefly: ignore  # missing-module-attribute
 )

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -14,11 +14,11 @@ from abc import ABCMeta
 from collections.abc import Iterator
 
 # TODO: Use TypeAlias when Python 3.6 is deprecated
-from typing import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
-    _eval_type,
-    _GenericAlias,
-    _tp_cache,
-    _type_check,
+from typing import (
+    _eval_type,  # pyrefly: ignore [missing-module-attribute]
+    _GenericAlias,  # pyrefly: ignore [missing-module-attribute]
+    _tp_cache,  # pyrefly: ignore [missing-module-attribute]
+    _type_check,  # pyrefly: ignore [missing-module-attribute]
     _type_repr,
     Any,
     ForwardRef,

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -14,7 +14,7 @@ from abc import ABCMeta
 from collections.abc import Iterator
 
 # TODO: Use TypeAlias when Python 3.6 is deprecated
-from typing import (  # type: ignore[attr-defined]
+from typing import (  # type: ignore[attr-defined]; pyrefly: ignore [missing-module-attribute]
     _eval_type,
     _GenericAlias,
     _tp_cache,

--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -263,6 +263,7 @@ def memory_snapshot(
     """
     if not is_initialized():
         return []
+    # pyrefly: ignore [missing-attribute]
     return torch._C._xpu_memorySnapshot(mempool_id)["segments"]
 
 
@@ -349,6 +350,7 @@ def _snapshot(device: Device = None, augment_with_fx_traces: bool = False):
     Returns:
         The Snapshot dictionary object
     """
+    # pyrefly: ignore [missing-attribute]
     s = torch._C._xpu_memorySnapshot(None)
     if augment_with_fx_traces:
         s = _augment_memory_snapshot_stack_traces(s)  # type: ignore[assignment, arg-type]
@@ -457,6 +459,7 @@ def _record_memory_history(
 
             Defaults to ``None`` (record all actions).
     """
+    # pyrefly: ignore [missing-attribute]
     torch._C._xpu_recordMemoryHistory(
         enabled,
         context,


### PR DESCRIPTION
These files were excluded due to a mismatch in how usort and pyrefly expected the suppression comments to be formatted. 

With a recent usort upgrade, we can now typecheck these files without issue. 


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo