### PR TITLE
ci: Set resolution-strategy to lowest for uv

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -61,6 +61,7 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -21,6 +21,7 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -28,6 +28,7 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -33,6 +33,7 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     # Check out pytorch with fetch depth 0
     - name: Check file changes

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -54,6 +54,7 @@ runs:
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     - name: Install pip
       shell: bash

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -29,6 +29,7 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     - name: Zip artifacts for upload
       if: runner.os != 'Windows'

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -42,6 +42,7 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         python-version: 3.12
+        resolution-strategy: lowest
 
     - name: Print Inputs
       shell: bash

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           python-version: 3.12
           activate-environment: true
+          resolution-strategy: lowest
 
       - name: Install build artifacts
         shell: bash

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -49,6 +49,7 @@ jobs:
           python-version: 3.12
           activate-environment: true
           ignore-empty-workdir: true
+          resolution-strategy: lowest
 
       - name: Checkout pytorch-integration-testing repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #172972

If we don't specify this we will constantly hammer the Github API in
order to figure out the latest release which results in Github API rate
limits.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>