### PR TITLE
[tlparse] Extract log file prefix

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -57,6 +57,8 @@ LOG_TRACE_HANDLER: Optional["LazyTraceHandler"] = None
 
 GET_DTRACE_STRUCTURED = False
 
+LOG_PREFIX = "dedicated_log_torch_trace_"
+
 
 @dataclass
 class LogRegistry:
@@ -1253,7 +1255,7 @@ class LazyTraceHandler(logging.StreamHandler):
                 self.stream = tempfile.NamedTemporaryFile(  # noqa: SIM115
                     mode="w+",
                     suffix=".log",
-                    prefix=f"dedicated_log_torch_trace_{ranksuffix}",
+                    prefix=LOG_PREFIX + ranksuffix,
                     dir=self.root_dir,
                     delete=False,
                 )


### PR DESCRIPTION
Summary: Extracting the log prefix as a global so that we can use it in other places

Test Plan: CI

Differential Revision: D91147911


