### PR TITLE
ci: Use test-infra setup-uv wrapper

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -58,9 +58,9 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -18,9 +18,9 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -25,9 +25,9 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - uses: nick-fields/retry@v3.0.0
       name: Setup dependencies

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -30,9 +30,9 @@ runs:
 
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     # Check out pytorch with fetch depth 0
     - name: Check file changes

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -50,10 +50,10 @@ runs:
         fi
 
     - name: Install uv
-      uses: astral-sh/setup-uv@374b9305c53f17cee51e793c1234cdb1897489d5 # v7
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - name: Install pip
       shell: bash

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -26,9 +26,9 @@ runs:
     # Always set up uv and zip files first (needed for S3, reusable for GHA fallback)
     - name: Setup uv
       if: runner.os != 'Windows'
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - name: Zip artifacts for upload
       if: runner.os != 'Windows'

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -39,9 +39,9 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - name: Print Inputs
       shell: bash

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -82,10 +82,10 @@ jobs:
           name: ${{ inputs.build_environment }}
           s3-bucket: gha-artifacts
 
-      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+      - uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
-          python-version: 3.12
-          activate-environment: true
+          python-version: "3.12"
+          activate-environment: "true"
 
       - name: Install build artifacts
         shell: bash

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -44,11 +44,11 @@ jobs:
       torch_cuda_arch_list: '8.0 8.9 9.0 10.0'
       build_environment: linux-jammy-cuda12.9-py3.12-gcc11
     steps:
-      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+      - uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
-          python-version: 3.12
-          activate-environment: true
-          ignore-empty-workdir: true
+          python-version: "3.12"
+          activate-environment: "true"
+          ignore-empty-workdir: "true"
 
       - name: Checkout pytorch-integration-testing repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #172974

Migrate all setup-uv calls to use the centralized wrapper action
from test-infra which pins an explicit uv version, avoiding
GitHub API calls that cause rate limit issues at PyTorch's CI scale.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>