### PR TITLE
[CI] Collect eager performance when benchmarking vLLM

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -178,7 +178,8 @@ jobs:
             --from-benchmark-configs-dir vllm-benchmarks/benchmarks \
             --to-benchmark-configs-dir ../../vllm-project/vllm/.buildkite/performance-benchmarks/tests \
             --models "${MODELS}" \
-            --device "${DEVICE_NAME}"
+            --device "${DEVICE_NAME}" \
+            --include-eager-mode
           popd
 
           pushd vllm-project/vllm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #172979

Summary: With https://github.com/pytorch/pytorch-integration-testing/pull/135 landed, now we can collect eager performance when benchmarking vLLM.