### PR TITLE
[inductor] Materialize IR nodes in kwargs for FXIR

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -1238,6 +1238,21 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         args = (torch.randn((12, 14), device=self.device),)
         self.check(TestModule(), args, ds)
 
+    def test_extern_kernel_irnode_kwargs(self):
+        """
+        Test that IR nodes passed as kwargs to extern kernels are properly materialized.
+        """
+
+        class TestModule(torch.nn.Module):
+            def forward(self, data, offsets):
+                return torch.segment_reduce(data, "sum", offsets=offsets)
+
+        length = 10
+        data = torch.randn(length, device=self.device)
+        offsets = torch.tensor([0, 3, 7, length], dtype=torch.int64, device=self.device)
+
+        self.check(TestModule(), (data, offsets))
+
 
 class TestReplaceFloorDiv(InductorTestCase):
     """

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1108,7 +1108,11 @@ class FxConverter:
 
         # Get the result buffer.
         # Some kernels write to a pre-existing output tensor via the "out" kwarg.
-        kwargs = kernel.kwargs.copy()
+        # Materialize any IR nodes in kwargs to FX nodes (e.g., TensorBox -> Tensor).
+        kwargs = {
+            k: self._generate_buffer(v) if isinstance(v, ir.IRNode) else v
+            for k, v in kernel.kwargs.items()
+        }
 
         result_buffer: Optional[str] = None
         if isinstance(kernel, ir.ExternKernelOut):


### PR DESCRIPTION
Summary:
Encountering error `RuntimeError: aten::segment_reduce() Expected a value of type 'Optional[Tensor]' for argument 'lengths' but instead found type 'TensorBox'.`

Fix by calling `_generate_buffer` on kwargs, similar to what's done for args.

Test Plan:
Added test:
```
buck2 run mode/dev-nosan  fbcode//caffe2/test/inductor:fxir_backend -- -r test_extern_kernel_irnode_kwargs
```
passes with change: P2137468168, fails without change P2137468535

Error for op info test case no longer fails due to type error, instead fails with `UnsupportedOperatorException`:
```
OPINFO_TEST_CASE="_segment_reduce+offsets; 6; 0; tensor, f64x5x5x5; str, prod; dict, axis=int, 1; dict, unsafe=bool, False; dict, initial=int, 2; dict, offsets=tensor, i64x5x5" buck run mode/{opt,mtia,inplace} mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e_user_defined
```

Differential Revision: D90643762




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo