### PR TITLE
Enable triggering s390x nightly wheels build with ciflow/s390x label

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -22,6 +22,7 @@ LABEL_CIFLOW_BINARIES = "ciflow/binaries"
 LABEL_CIFLOW_PERIODIC = "ciflow/periodic"
 LABEL_CIFLOW_BINARIES_LIBTORCH = "ciflow/binaries_libtorch"
 LABEL_CIFLOW_BINARIES_WHEEL = "ciflow/binaries_wheel"
+LABEL_CIFLOW_S390 = "ciflow/s390"
 
 
 @dataclass
@@ -263,7 +264,11 @@ S390X_BINARY_BUILD_WORKFLOWS = [
             OperatingSystem.LINUX_S390X
         ),
         ciflow_config=CIFlowConfig(
-            labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
+            labels={
+                LABEL_CIFLOW_BINARIES,
+                LABEL_CIFLOW_BINARIES_WHEEL,
+                LABEL_CIFLOW_S390,
+            },
             isolated_workflow=True,
         ),
     ),

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -16,6 +16,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
       - 'ciflow/binaries/*'
       - 'ciflow/binaries_wheel/*'
+      - 'ciflow/s390/*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Enable triggering s390x nightly wheels build with ciflow/s390x label.

Nightly builds use different build script. Trigger these builds when triggering other s390x CI workflows to increase coverage of such test CI runs.