### PR TITLE
[MPS] Add gcd (greatest common divisor) support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -379,6 +379,20 @@ struct igammac_functor {
   }
 };
 
+struct gcd_functor {
+  template <typename T>
+  inline T operator()(T a, T b) {
+    a = a >= 0 ? a : -a;
+    b = b >= 0 ? b : -b;
+    while (b != 0) {
+      T t = b;
+      b = a % b;
+      a = t;
+    }
+    return a;
+  }
+};
+
 #define REGISTER_INTEGER_BINARY_OP(NAME)  \
   REGISTER_BINARY_OP(NAME, long, long);   \
   REGISTER_BINARY_OP(NAME, int, int);     \
@@ -461,6 +475,7 @@ REGISTER_OPMATH_FLOAT_BINARY_OP(fmod);
 REGISTER_INTEGER_BINARY_OP(fmod);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igamma);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igammac);
+REGISTER_INTEGER_BINARY_OP(gcd);
 REGISTER_BINARY_ALPHA_OP(add_alpha, long, long, long);
 REGISTER_BINARY_ALPHA_OP(add_alpha, int, int, int);
 REGISTER_BINARY_ALPHA_OP(add_alpha, float, float, float);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -222,6 +222,10 @@ static void hypot_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "hypot");
 }
 
+static void gcd_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "gcd");
+}
+
 REGISTER_DISPATCH(fmax_stub, &fmax_mps_kernel)
 REGISTER_DISPATCH(fmin_stub, &fmin_mps_kernel)
 REGISTER_DISPATCH(maximum_stub, &maximum_mps_kernel)
@@ -254,4 +258,5 @@ REGISTER_DISPATCH(remainder_stub, &remainder_mps_kernel)
 REGISTER_DISPATCH(igamma_stub, &igamma_mps_kernel)
 REGISTER_DISPATCH(igammac_stub, &igammac_mps_kernel)
 REGISTER_DISPATCH(hypot_stub, &hypot_mps_kernel)
+REGISTER_DISPATCH(gcd_stub, &gcd_mps_kernel)
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2877,7 +2877,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: gcd_out
+    CPU, CUDA, MPS: gcd_out
   tags: pointwise
 
 - func: gcd(Tensor self, Tensor other) -> Tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15342,11 +15342,6 @@ op_db: list[OpInfo] = [
                                      'TestBinaryUfuncs',
                                      'test_reference_numerics_small_values',
                                      dtypes=(torch.int8,)),
-                        # NotImplementedError: The operator 'aten::gcd.out' is not currently implemented for the MPS device
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
                     )),
     BinaryUfuncInfo('isclose',
                     ref=np.isclose,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -314,7 +314,6 @@ if torch.backends.mps.is_available():
             "put": None,
             "cholesky_solve": None,
             "frexp": None,
-            "gcd": None,
             "geqrf": None,
             "nn.functional.grid_sample": None,  # Unsupported Border padding mode
             "hash_tensor": None,


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for the `gcd` (greatest common divisor) operation on Apple Silicon.

## Changes
- Added `gcd_functor` in `BinaryKernel.metal` with iterative Euclidean algorithm
- Registered gcd kernel for integer types in Metal shader
- Added `gcd_mps_kernel` dispatch in `BinaryKernel.mm`
- Updated `native_functions.yaml` to include MPS in `gcd.out` dispatch

## Test Plan
```python
import torch
a = torch.tensor([12, 24, 36], device='mps')
b = torch.tensor([8, 16, 48], device='mps')
result = torch.gcd(a, b)
print(result)  # Expected: tensor([4, 8, 12], device='mps:0')

# Test with negative numbers
a = torch.tensor([-12, 24, -36], device='mps')
b = torch.tensor([8, -16, -48], device='mps')
result = torch.gcd(a, b)
print(result)  # Expected: tensor([4, 8, 12], device='mps:0')
```

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen
