### PR TITLE
[MPS] Add lcm (least common multiple) support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -379,6 +379,41 @@ struct igammac_functor {
   }
 };
 
+struct gcd_functor {
+  template <typename T>
+  inline T operator()(T a, T b) {
+    a = a >= 0 ? a : -a;
+    b = b >= 0 ? b : -b;
+    while (b != 0) {
+      T t = b;
+      b = a % b;
+      a = t;
+    }
+    return a;
+  }
+};
+
+struct lcm_functor {
+  template <typename T>
+  inline T operator()(T a, T b) {
+    T abs_a = a >= 0 ? a : -a;
+    T abs_b = b >= 0 ? b : -b;
+    if (abs_a == 0 || abs_b == 0) {
+      return 0;
+    }
+    // Calculate gcd
+    T ga = abs_a;
+    T gb = abs_b;
+    while (gb != 0) {
+      T t = gb;
+      gb = ga % gb;
+      ga = t;
+    }
+    // lcm = |a| / gcd * |b| to avoid overflow
+    return (abs_a / ga) * abs_b;
+  }
+};
+
 #define REGISTER_INTEGER_BINARY_OP(NAME)  \
   REGISTER_BINARY_OP(NAME, long, long);   \
   REGISTER_BINARY_OP(NAME, int, int);     \
@@ -461,6 +496,8 @@ REGISTER_OPMATH_FLOAT_BINARY_OP(fmod);
 REGISTER_INTEGER_BINARY_OP(fmod);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igamma);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igammac);
+REGISTER_INTEGER_BINARY_OP(gcd);
+REGISTER_INTEGER_BINARY_OP(lcm);
 REGISTER_BINARY_ALPHA_OP(add_alpha, long, long, long);
 REGISTER_BINARY_ALPHA_OP(add_alpha, int, int, int);
 REGISTER_BINARY_ALPHA_OP(add_alpha, float, float, float);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -222,6 +222,14 @@ static void hypot_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "hypot");
 }
 
+static void gcd_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "gcd");
+}
+
+static void lcm_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "lcm");
+}
+
 REGISTER_DISPATCH(fmax_stub, &fmax_mps_kernel)
 REGISTER_DISPATCH(fmin_stub, &fmin_mps_kernel)
 REGISTER_DISPATCH(maximum_stub, &maximum_mps_kernel)
@@ -254,4 +262,6 @@ REGISTER_DISPATCH(remainder_stub, &remainder_mps_kernel)
 REGISTER_DISPATCH(igamma_stub, &igamma_mps_kernel)
 REGISTER_DISPATCH(igammac_stub, &igammac_mps_kernel)
 REGISTER_DISPATCH(hypot_stub, &hypot_mps_kernel)
+REGISTER_DISPATCH(gcd_stub, &gcd_mps_kernel)
+REGISTER_DISPATCH(lcm_stub, &lcm_mps_kernel)
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2877,7 +2877,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: gcd_out
+    CPU, CUDA, MPS: gcd_out
   tags: pointwise
 
 - func: gcd(Tensor self, Tensor other) -> Tensor
@@ -2893,7 +2893,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: lcm_out
+    CPU, CUDA, MPS: lcm_out
   tags: pointwise
 
 - func: lcm(Tensor self, Tensor other) -> Tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15184,13 +15184,6 @@ op_db: list[OpInfo] = [
                     ref=np.lcm,
                     dtypes=integral_types_and(),
                     supports_autograd=False,
-                    skips=(
-                        # The operator 'aten::lcm.out' is not currently implemented for the MPS device.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-                    ),
                     supports_rhs_python_scalar=False),
     BinaryUfuncInfo('gcd',
                     ref=np.gcd,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -324,7 +324,6 @@ if torch.backends.mps.is_available():
             "index_reduceamax": None,
             "index_reduceamin": None,
             # "kthvalue": None,
-            "lcm": None,
             "linalg.cond": None,
             "linalg.eigh": None,
             "linalg.eigvalsh": None,


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for the `lcm` (least common multiple) operation on Apple Silicon. Also includes `gcd` as lcm depends on it internally.

## Changes
- Added `gcd_functor` and `lcm_functor` in `BinaryKernel.metal`
- Registered gcd and lcm kernels for integer types in Metal shader
- Added `gcd_mps_kernel` and `lcm_mps_kernel` dispatch in `BinaryKernel.mm`
- Updated `native_functions.yaml` to include MPS in `gcd.out` and `lcm.out` dispatch

## Test Plan
```python
import torch

# Test lcm basic functionality
a = torch.tensor([12, 24, 36], device='mps')
b = torch.tensor([8, 16, 48], device='mps')
result = torch.lcm(a, b)
expected = torch.tensor([24, 48, 144])
assert torch.equal(result.cpu(), expected)

# Test lcm with zeros
a = torch.tensor([0, 5, 10], device='mps')
b = torch.tensor([3, 0, 15], device='mps')
result = torch.lcm(a, b)
expected = torch.tensor([0, 0, 30])
assert torch.equal(result.cpu(), expected)

# Test lcm with negative numbers
a = torch.tensor([-12, 24, -36], device='mps')
b = torch.tensor([8, -16, -48], device='mps')
result = torch.lcm(a, b)
expected = torch.tensor([24, 48, 144])
assert torch.equal(result.cpu(), expected)

# Test gcd basic functionality
a = torch.tensor([12, 24, 36], device='mps')
b = torch.tensor([8, 16, 48], device='mps')
result = torch.gcd(a, b)
expected = torch.tensor([4, 8, 12])
assert torch.equal(result.cpu(), expected)

print('All tests passed!')
```

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen
