### PR TITLE
[MPS] Add logspace support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3732,6 +3732,7 @@
   dispatch:
     CPU, Meta: logspace_out
     CUDA: logspace_cuda_out
+    MPS: logspace_mps_out
 
 - func: logspace.Tensor_Tensor_out(Tensor start, Tensor end, int steps, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
   category_override: factory

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -307,7 +307,6 @@ if torch.backends.mps.is_available():
         # Those ops are not expected to work
         UNIMPLEMENTED_XFAILLIST: dict[str, Optional[list]] = {
             # Failures due to lack of op implementation on MPS backend
-            "logspace": None,
             "logspacetensor_overload": None,
             "linalg.eig": None,
             "linalg.eigvals": None,
@@ -440,7 +439,6 @@ if torch.backends.mps.is_available():
             ],
         }
         UNIMPLEMENTED_XFAILLIST_SPARSE: dict[str, Optional[list]] = {
-            "logspace": None,
             "logspacetensor_overload": None,
             "linalg.eig": None,
             "linalg.eigvals": None,


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for the `logspace` operation on Apple Silicon.

## Changes
- Added `LogspaceCachedGraph` struct for MPSGraph caching
- Implemented `logspace_mps_out` function using MPSGraph power operation
- Updated `native_functions.yaml` to include MPS in `logspace.out` dispatch
- Added `logspace_native.h` include

## Test Plan
```python
import torch

# Test logspace basic functionality (base 10)
result = torch.logspace(0, 2, 5, device='mps')
expected = torch.tensor([1., 3.1623, 10., 31.6228, 100.])
assert torch.allclose(result.cpu(), expected, rtol=1e-3)

# Test logspace with base 2
result = torch.logspace(0, 4, 5, base=2, device='mps')
expected = torch.tensor([1., 2., 4., 8., 16.])
assert torch.allclose(result.cpu(), expected, rtol=1e-3)

# Test logspace with negative exponents
result = torch.logspace(-2, 2, 5, device='mps')
expected = torch.tensor([0.01, 0.1, 1., 10., 100.])
assert torch.allclose(result.cpu(), expected, rtol=1e-3)

# Test logspace with single step
result = torch.logspace(1, 2, 1, device='mps')
expected = torch.tensor([10.])
assert torch.allclose(result.cpu(), expected, rtol=1e-3)

# Test logspace with zero steps
result = torch.logspace(0, 1, 0, device='mps')
assert result.numel() == 0

print('All tests passed!')
```

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen
