### PR TITLE
[MPS] Add MPS support for take operation

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9484,11 +9484,13 @@
 - func: take.out(Tensor self, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, CUDA: take_out
+    MPS: take_out_mps
 
 - func: take(Tensor self, Tensor index) -> Tensor
   variants: method, function
   dispatch:
     CPU, CUDA: take
+    MPS: take_mps
 
 - func: take_along_dim.out(Tensor self, Tensor indices, int? dim=None, *, Tensor(a!) out) -> Tensor(a!)
 


### PR DESCRIPTION
## Summary
This PR adds MPS (Apple Silicon) support for torch.take and torch.take with out= parameter.

## Implementation
- Added take_mps and take_out_mps functions in Indexing.mm
- Uses the existing index_select_out_mps by flattening the input tensor and selecting along dimension 0
- Updated native_functions.yaml to register MPS dispatch for:
  - take.out
  - take

## Motivation
The take operation is useful for advanced indexing workflows:
- Data preprocessing and sampling in bioinformatics pipelines
- Random access patterns in machine learning data loaders
- Enables full MPS acceleration for tensor indexing operations

## Test Plan
Added test_take in test_mps.py covering:
- Various tensor shapes (1D, 2D, 3D, 4D)
- Different index sizes
- Empty indices edge case
- Both int64 and int32 index dtypes
- Testing both functional and out= parameter variants

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen
