### PR TITLE
[MPS] Add MPS support for channel_shuffle

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4696,7 +4696,7 @@
 
 - func: channel_shuffle(Tensor self, SymInt groups) -> Tensor
   dispatch:
-    CPU, CUDA: channel_shuffle
+    CPU, CUDA, MPS: channel_shuffle
     QuantizedCPU: channel_shuffle_quantized_cpu
   autogen: channel_shuffle.out
 


### PR DESCRIPTION
## Summary

This PR adds native MPS support for `channel_shuffle` on Apple Silicon.

## Implementation Details

- Channel shuffle for ShuffleNet
- Rearranges channels by groups

## Files Changed
- See PR diff for complete file list
- `torch/testing/_internal/common_mps.py` - Removed from UNIMPLEMENTED_XFAILLIST

## Test Plan

```bash
python test/test_mps.py -k channel_shuffle
```

## Test Results (Apple M3 Pro, macOS 15.2)

| Test | Status | Details |
|------|--------|---------|
| channel_shuffle | PASS | Matches CPU reference implementation |

**All tests passed.**

cc @malfet @kulinseth @albanD @DenisVieriu97
