### PR TITLE
[MPS] Add nonzero_static support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -40,6 +40,7 @@
 #include <ATen/ops/masked_select_native.h>
 #include <ATen/ops/nonzero.h>
 #include <ATen/ops/nonzero_native.h>
+#include <ATen/ops/nonzero_static_native.h>
 #include <ATen/ops/view_as_real.h>
 #endif
 
@@ -433,6 +434,78 @@ Tensor nonzero_mps(const Tensor& self) {
 
   Tensor out = at::empty({0}, self.options().dtype(kLong));
   return nonzero_out_mps(self, out);
+}
+
+Tensor& nonzero_static_out_mps(
+    const Tensor& self,
+    int64_t size,
+    int64_t fill_value,
+    Tensor& result) {
+  // Check if `size` is not negative
+  TORCH_CHECK(
+      size >= 0, "nonzero_static: 'size' must be an non-negative integer");
+  TORCH_CHECK(
+      result.scalar_type() == kLong,
+      "nonzero_static: Expected out tensor to have scalar type Long "
+      "but got scalar type ",
+      result.scalar_type());
+
+  int64_t ndim = self.dim();
+  if (result.dim() != 2 || result.size(0) != size || result.size(1) != ndim) {
+    at::native::resize_output(result, {size, ndim});
+  }
+  // Verify that the output tensor is resized to expected size=(size, ndim)
+  TORCH_CHECK(
+      result.dim() == 2,
+      "nonzero_static: Expected out tensor to be a 2D tensor but got a ",
+      result.dim(),
+      "D tensor");
+  TORCH_CHECK(
+      result.size(0) == size && result.size(1) == ndim,
+      "nonzero_static: Expected out tensor to have Size([",
+      size,
+      ", ",
+      ndim,
+      "]) but got Size([",
+      result.size(0),
+      ", ",
+      result.size(1),
+      "]) ");
+  at::assert_no_internal_overlap(result);
+  at::assert_no_overlap(result, self);
+
+  // Return earlier if either dim is 0
+  if (result.size(0) == 0 || result.size(1) == 0) {
+    return result;
+  }
+
+  // Delegate call to regular nonzero to get a data-dependent output
+  auto dyn_result = nonzero_mps(self);
+  int64_t num_nonzeros = dyn_result.size(0);
+  int64_t copy_len = std::min(size, num_nonzeros);
+  // Copy the dynamic result to the fixed-size tensor
+  result.narrow(0, 0, copy_len).copy_(dyn_result.narrow(0, 0, copy_len));
+  if (size > copy_len) {
+    // Pad result with `fill_value`
+    result.narrow(0, copy_len, size - copy_len).fill_(fill_value);
+  }
+  return result;
+}
+
+Tensor nonzero_static_mps(
+    const Tensor& self,
+    int64_t size,
+    int64_t fill_value) {
+  // Check if `size` is not negative
+  TORCH_CHECK(
+      size >= 0, "nonzero_static: 'size' must be an non-negative integer");
+  // Allocate fixed-size out tensor
+  int64_t ndim = self.dim();
+  auto result = at::empty(
+      {size, ndim},
+      at::TensorOptions().dtype(at::ScalarType::Long).device(at::kMPS));
+  nonzero_static_out_mps(self, size, fill_value, result);
+  return result;
 }
 
 Tensor masked_select_mps(const Tensor& self, const Tensor& mask) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9566,12 +9566,14 @@
   dispatch:
     CPU: nonzero_static_out_cpu
     CUDA: nonzero_static_out_cuda
+    MPS: nonzero_static_out_mps
 
 - func: nonzero_static(Tensor self, *, SymInt size, int fill_value=-1) -> Tensor
   variants: method, function
   dispatch:
     CPU: nonzero_static_cpu
     CUDA: nonzero_static_cuda
+    MPS: nonzero_static_mps
 
 - func: nonzero_numpy(Tensor self) -> Tensor[]
   variants: method, function

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -402,7 +402,6 @@ if torch.backends.mps.is_available():
             "linalg.matrix_rankhermitian": None,
             "linalg.pinvhermitian": None,
             "linalg.pinvsingular": None,  # Missing `aten::linalg_qr.out`.
-            "nonzero_static": None,
             # MPS: input sizes must be divisible by output sizes
             "nn.functional.adaptive_avg_pool1d": None,
             "nn.functional.adaptive_avg_pool2d": None,


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for the nonzero_static operation.

## Changes
- Add nonzero_static_mps and nonzero_static_out_mps implementations in Indexing.mm
- Register MPS dispatch for nonzero_static and nonzero_static.out in native_functions.yaml
- Remove nonzero_static from UNIMPLEMENTED_XFAILLIST in common_mps.py to enable automatic testing

## Implementation Details
The implementation follows the same pattern as the CPU version:
1. Call nonzero_mps to get dynamic-sized result
2. Copy relevant portion to fixed-size output
3. Pad remaining entries with fill_value

This approach reuses the existing MPS nonzero implementation and avoids code duplication.

## Test Plan
Existing tests for nonzero_static will now run on MPS (previously excluded).

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen
