### PR TITLE
[MPS] Add frexp support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Frexp.metal
+++ b/aten/src/ATen/native/mps/kernels/Frexp.metal
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// frexp kernel - decomposes floating point numbers into mantissa and exponent
+// mantissa = frexp(x, &exponent) where x = mantissa * 2^exponent
+// mantissa is in range [0.5, 1.0) or 0 for x = 0
+
+template <typename T>
+kernel void frexp_kernel(
+    device const T* input [[buffer(0)]],
+    device T* mantissa [[buffer(1)]],
+    device int* exponent [[buffer(2)]],
+    uint index [[thread_position_in_grid]]) {
+  T x = input[index];
+  int exp;
+  T mant = frexp(x, &exp);
+  mantissa[index] = mant;
+  exponent[index] = exp;
+}
+
+#define REGISTER_FREXP_KERNEL(DTYPE)                                        \
+  template [[host_name("frexp_kernel_" #DTYPE)]] kernel void frexp_kernel<DTYPE>( \
+      device const DTYPE* input [[buffer(0)]],                              \
+      device DTYPE* mantissa [[buffer(1)]],                                 \
+      device int* exponent [[buffer(2)]],                                   \
+      uint index [[thread_position_in_grid]])
+
+REGISTER_FREXP_KERNEL(float);
+REGISTER_FREXP_KERNEL(half);
+// Note: bfloat16 may need special handling as Metal's frexp might not support it directly

--- a/aten/src/ATen/native/mps/operations/Frexp.mm
+++ b/aten/src/ATen/native/mps/operations/Frexp.mm
@@ -1,0 +1,73 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/TensorIterator.h>
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/UnaryOps.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <fmt/format.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/frexp_native.h>
+#endif
+
+namespace at::native {
+
+using namespace mps;
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Frexp_metallib.h>
+#endif
+
+static void frexp_kernel_mps(TensorIteratorBase& iter) {
+  TORCH_CHECK(iter.ntensors() == 3, "frexp expects 3 tensors (2 outputs + 1 input)");
+
+  Tensor mantissa = iter.output(0);
+  Tensor exponent = iter.output(1);
+  const Tensor& self = iter.input(0);
+
+  if (self.numel() == 0) {
+    return;
+  }
+
+  TORCH_CHECK(at::isFloatingType(self.scalar_type()),
+              "frexp_mps: only floating-point types are supported, got ", self.scalar_type());
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+
+      std::string kernel_name = fmt::format("frexp_kernel_{}", scalarToMetalTypeString(self));
+      id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(kernel_name);
+
+      [computeEncoder setComputePipelineState:pso];
+
+      Tensor self_contiguous = self.contiguous();
+      Tensor mantissa_contiguous = mantissa.contiguous();
+      Tensor exponent_contiguous = exponent.contiguous();
+
+      mtl_setBuffer(computeEncoder, self_contiguous, 0);
+      mtl_setBuffer(computeEncoder, mantissa_contiguous, 1);
+      mtl_setBuffer(computeEncoder, exponent_contiguous, 2);
+
+      uint64_t numThreads = self.numel();
+      mtl_dispatch1DJob(computeEncoder, pso, numThreads);
+
+      if (!mantissa.is_contiguous()) {
+        mantissa.copy_(mantissa_contiguous);
+      }
+      if (!exponent.is_contiguous()) {
+        exponent.copy_(exponent_contiguous);
+      }
+    }
+  });
+}
+
+REGISTER_DISPATCH(frexp_stub, &frexp_kernel_mps);
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7054,7 +7054,7 @@
 
 - func: frexp.Tensor_out(Tensor self, *, Tensor(a!) mantissa, Tensor(b!) exponent) -> (Tensor(a!) mantissa, Tensor(b!) exponent)
   dispatch:
-    CPU, CUDA: frexp_out
+    CPU, CUDA, MPS: frexp_out
   tags: pointwise
 
 # Deprecated (v.1.12)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -313,7 +313,6 @@ if torch.backends.mps.is_available():
             "linalg.eigvals": None,
             "put": None,
             "cholesky_solve": None,
-            "frexp": None,
             "gcd": None,
             "geqrf": None,
             "nn.functional.grid_sample": None,  # Unsupported Border padding mode


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for the frexp operation which decomposes floating-point numbers into mantissa and exponent components.

## Changes
- Add Metal kernel Frexp.metal with frexp_kernel for float and half types
- Add Objective-C++ implementation Frexp.mm with frexp_kernel_mps
- Register MPS dispatch for frexp.Tensor_out in native_functions.yaml
- Remove frexp from UNIMPLEMENTED_XFAILLIST in common_mps.py

## Implementation Details
The Metal kernel uses the native frexp() function available in Metal Shading Language.

frexp returns two values:
- mantissa: floating-point value in range [0.5, 1.0) or 0
- exponent: integer such that input = mantissa * 2^exponent

## Test Plan
Existing tests for frexp will now run on MPS.

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen
