### PR TITLE
[MPS] Add put_ operation support

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Put.metal
+++ b/aten/src/ATen/native/mps/kernels/Put.metal
@@ -1,0 +1,138 @@
+#include <c10/metal/atomic.h>
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T>
+kernel void put_kernel(
+    device T* output [[buffer(0)]],
+    constant T* source [[buffer(1)]],
+    constant int64_t* indices [[buffer(2)]],
+    constant int64_t& numel [[buffer(3)]],
+    constant int64_t& output_numel [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid >= (uint)numel) {
+    return;
+  }
+  
+  int64_t idx = indices[tid];
+  // Wrap negative indices
+  if (idx < 0) {
+    idx += output_numel;
+  }
+  
+  // Bounds check
+  if (idx >= 0 && idx < output_numel) {
+    output[idx] = source[tid];
+  }
+}
+
+// Accumulate kernel using AtomicType for all supported types
+template <typename T>
+kernel void put_accumulate_kernel(
+    device c10::metal::AtomicType_t<T>* output [[buffer(0)]],
+    constant T* source [[buffer(1)]],
+    constant int64_t* indices [[buffer(2)]],
+    constant int64_t& numel [[buffer(3)]],
+    constant int64_t& output_numel [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid >= (uint)numel) {
+    return;
+  }
+  
+  int64_t idx = indices[tid];
+  // Wrap negative indices
+  if (idx < 0) {
+    idx += output_numel;
+  }
+  
+  // Bounds check
+  if (idx >= 0 && idx < output_numel) {
+    c10::metal::AtomicType<T>::atomic_add(&output[idx], source[tid]);
+  }
+}
+
+// Non-atomic accumulate for types that don't support atomics
+template <typename T>
+kernel void put_accumulate_serial_kernel(
+    device T* output [[buffer(0)]],
+    constant T* source [[buffer(1)]],
+    constant int64_t* indices [[buffer(2)]],
+    constant int64_t& numel [[buffer(3)]],
+    constant int64_t& output_numel [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  // This kernel runs with 1 thread only
+  if (tid != 0) {
+    return;
+  }
+  
+  for (int64_t i = 0; i < numel; i++) {
+    int64_t idx = indices[i];
+    // Wrap negative indices
+    if (idx < 0) {
+      idx += output_numel;
+    }
+    
+    // Bounds check
+    if (idx >= 0 && idx < output_numel) {
+      output[idx] += source[i];
+    }
+  }
+}
+
+#define INSTANTIATE_PUT(TYPE) \
+  template [[host_name("put_" #TYPE)]] \
+  kernel void put_kernel<TYPE>( \
+      device TYPE*, constant TYPE*, constant int64_t*, \
+      constant int64_t&, constant int64_t&, uint);
+
+#define INSTANTIATE_PUT_ACCUMULATE(TYPE) \
+  template [[host_name("put_accumulate_" #TYPE)]] \
+  kernel void put_accumulate_kernel<TYPE>( \
+      device c10::metal::AtomicType_t<TYPE>*, constant TYPE*, constant int64_t*, \
+      constant int64_t&, constant int64_t&, uint);
+
+#define INSTANTIATE_PUT_ACCUMULATE_SERIAL(TYPE) \
+  template [[host_name("put_accumulate_serial_" #TYPE)]] \
+  kernel void put_accumulate_serial_kernel<TYPE>( \
+      device TYPE*, constant TYPE*, constant int64_t*, \
+      constant int64_t&, constant int64_t&, uint);
+
+// Basic types
+INSTANTIATE_PUT(float)
+INSTANTIATE_PUT(half)
+INSTANTIATE_PUT(bfloat)
+INSTANTIATE_PUT(int)
+INSTANTIATE_PUT(uint)
+INSTANTIATE_PUT(short)
+INSTANTIATE_PUT(ushort)
+INSTANTIATE_PUT(char)
+INSTANTIATE_PUT(uchar)
+INSTANTIATE_PUT(bool)
+INSTANTIATE_PUT(long)
+INSTANTIATE_PUT(ulong)
+
+// Accumulate with AtomicType support for all numeric types
+INSTANTIATE_PUT_ACCUMULATE(float)
+INSTANTIATE_PUT_ACCUMULATE(half)
+INSTANTIATE_PUT_ACCUMULATE(bfloat)
+INSTANTIATE_PUT_ACCUMULATE(int)
+INSTANTIATE_PUT_ACCUMULATE(uint)
+INSTANTIATE_PUT_ACCUMULATE(short)
+INSTANTIATE_PUT_ACCUMULATE(ushort)
+INSTANTIATE_PUT_ACCUMULATE(char)
+INSTANTIATE_PUT_ACCUMULATE(uchar)
+INSTANTIATE_PUT_ACCUMULATE(long)
+INSTANTIATE_PUT_ACCUMULATE(ulong)
+
+// Serial fallback for types without native atomic support
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(float)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(half)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(bfloat)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(int)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(uint)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(short)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(ushort)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(char)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(uchar)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(long)
+INSTANTIATE_PUT_ACCUMULATE_SERIAL(ulong)

--- a/aten/src/ATen/native/mps/operations/Put.mm
+++ b/aten/src/ATen/native/mps/operations/Put.mm
@@ -1,0 +1,98 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/TensorIterator.h>
+#include <ATen/native/IndexKernel.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/put_native.h>
+#endif
+
+namespace at::native {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Put_metallib.h>
+#endif
+
+namespace mps {
+
+static void put_kernel_mps_impl(
+    TensorIterator& iter,
+    const TensorBase& self,
+    const bool accumulate) {
+  using namespace mps;
+
+  if (iter.numel() == 0) {
+    return;
+  }
+
+  // Get the source tensor and index tensor from the iterator
+  // iter has 2 inputs: source, index (reshaped)
+  const auto& source = iter.tensor(0);
+  const auto& index = iter.tensor(1);
+
+  TORCH_CHECK(
+      index.scalar_type() == ScalarType::Long,
+      "put_(): Expected a long tensor for index, but got ",
+      index.scalar_type());
+
+  // Make contiguous copies
+  auto source_contiguous = source.contiguous();
+  auto index_contiguous = index.contiguous();
+  
+  // Self needs to be flattened conceptually, but we operate on it directly
+  auto self_contiguous = self.contiguous();
+  
+  MPSStream* stream = getCurrentMPSStream();
+  
+  @autoreleasepool {
+    id<MTLComputePipelineState> pso = nil;
+    
+    std::string scalar_type = scalarToMetalTypeString(source);
+    
+    if (accumulate) {
+      // Use AtomicType-based accumulate kernel for all types
+      pso = lib.getPipelineStateForFunc("put_accumulate_" + scalar_type);
+    } else {
+      pso = lib.getPipelineStateForFunc("put_" + scalar_type);
+    }
+    
+    id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+    [encoder setComputePipelineState:pso];
+    
+    // Set buffers
+    // Buffer 0: output (self)
+    mtl_setBuffer(encoder, self_contiguous, 0);
+    // Buffer 1: source
+    mtl_setBuffer(encoder, source_contiguous, 1);
+    // Buffer 2: indices
+    mtl_setBuffer(encoder, index_contiguous, 2);
+    // Buffer 3: numel (number of elements to put)
+    int64_t numel = iter.numel();
+    [encoder setBytes:&numel length:sizeof(int64_t) atIndex:3];
+    // Buffer 4: output_numel (size of self)
+    int64_t output_numel = self.numel();
+    [encoder setBytes:&output_numel length:sizeof(int64_t) atIndex:4];
+    
+    // Dispatch - parallel execution for all modes (AtomicType handles all types)
+    mtl_dispatch1DJob(encoder, pso, numel);
+    
+    stream->synchronize(SyncType::COMMIT);
+  }
+}
+
+} // namespace mps
+
+void put_kernel_mps(
+    TensorIterator& iter,
+    const TensorBase& self,
+    const bool accumulate) {
+  mps::put_kernel_mps_impl(iter, self, accumulate);
+}
+
+REGISTER_DISPATCH(put_stub, &put_kernel_mps)
+
+} // namespace at::native

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -311,7 +311,6 @@ if torch.backends.mps.is_available():
             "logspacetensor_overload": None,
             "linalg.eig": None,
             "linalg.eigvals": None,
-            "put": None,
             "cholesky_solve": None,
             "frexp": None,
             "gcd": None,
@@ -442,7 +441,6 @@ if torch.backends.mps.is_available():
             "logspacetensor_overload": None,
             "linalg.eig": None,
             "linalg.eigvals": None,
-            "put": None,
         }
 
         if MACOS_VERSION < 15.0:


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for the `put_` operation using Metal kernels.

## Implementation Details
- Creates a Metal kernel for non-accumulate mode (parallel execution)
- Creates atomic accumulate kernels for float and int types  
- Creates a serial accumulate kernel for other types without atomic support
- Registers with `put_stub` dispatch

The `put_` operation writes values from a source tensor to a destination tensor at specified flat indices.

## Test Plan
This implementation enables automatic testing by removing `put` from `UNIMPLEMENTED_XFAILLIST` and `UNIMPLEMENTED_XFAILLIST_SPARSE` in `common_mps.py`.

cc @malfet @kulinseth