### PR TITLE
[MPS] Add pdist support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -245,7 +245,7 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
 Tensor _pdist_forward(const Tensor& self, const double p) {
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.device().type();
-  TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU, "_pdist_forward only supports CPU, XPU and CUDA devices, got: ", device);
+  TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU || device == kMPS, "_pdist_forward only supports CPU, XPU, CUDA and MPS devices, got: ", device);
   Tensor result = at::empty({0}, self.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   if (self.size(0) <= 1) {
     result.resize_({0});

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -266,7 +266,7 @@ Tensor _pdist_backward(const Tensor& grad, const Tensor& self, const double p, c
   TORCH_CHECK(self.is_contiguous(), "_pdist_backward requires self to be contiguous");
   TORCH_CHECK(pdist.is_contiguous(), "_pdist_backward requires pdist to be contiguous");
   auto device = self.device().type();
-  TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU, "_pdist_backward only supports CPU, XPU and CUDA devices, got: ", device);
+  TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU || device == kMPS, "_pdist_backward only supports CPU, XPU, CUDA and MPS devices, got: ", device);
   Tensor result = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   pdist_backward_stub(device, result, grad, self, p, pdist);
   return result;

--- a/aten/src/ATen/native/mps/operations/Pdist.mm
+++ b/aten/src/ATen/native/mps/operations/Pdist.mm
@@ -6,9 +6,12 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_cdist_backward.h>
 #include <ATen/ops/_cdist_forward.h>
+#include <ATen/ops/_pdist_backward_native.h>
 #include <ATen/ops/_pdist_forward_native.h>
 #include <ATen/ops/triu_indices.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at::native {
@@ -40,6 +43,44 @@ static void pdist_forward_kernel_mps_impl(
   result.copy_(full_distances.index({row_indices, col_indices}));
 }
 
+static void pdist_backward_kernel_mps_impl(
+    Tensor& result,
+    const Tensor& grad,
+    const Tensor& self,
+    const double p,
+    const Tensor& pdist) {
+
+  int64_t n = self.size(0);
+
+  if (n <= 1) {
+    result.zero_();
+    return;
+  }
+
+  // Create a full n x n gradient matrix from the upper triangular gradient
+  Tensor full_grad = at::zeros({n, n}, grad.options());
+
+  // Get upper triangular indices
+  auto indices = at::triu_indices(n, n, 1, self.options().dtype(kLong).device(self.device()));
+  auto row_indices = indices[0];
+  auto col_indices = indices[1];
+
+  // Fill upper triangular part
+  full_grad.index_put_({row_indices, col_indices}, grad);
+
+  // Make symmetric (lower triangular = upper triangular transpose)
+  full_grad = full_grad + full_grad.transpose(0, 1);
+
+  // Reconstruct full distance matrix
+  Tensor full_distances = at::_cdist_forward(self, self, p, std::nullopt);
+
+  // Use cdist backward to compute gradients
+  // cdist_backward gives gradient w.r.t. x1 when x1 == x2
+  Tensor grad_self = at::_cdist_backward(full_grad, self, self, p, full_distances);
+
+  result.copy_(grad_self);
+}
+
 } // namespace mps
 
 void pdist_forward_kernel_mps(
@@ -49,6 +90,16 @@ void pdist_forward_kernel_mps(
   mps::pdist_forward_kernel_mps_impl(result, self, p);
 }
 
+void pdist_backward_kernel_mps(
+    Tensor& result,
+    const Tensor& grad,
+    const Tensor& self,
+    const double p,
+    const Tensor& pdist) {
+  mps::pdist_backward_kernel_mps_impl(result, grad, self, p, pdist);
+}
+
 REGISTER_DISPATCH(pdist_forward_stub, &pdist_forward_kernel_mps)
+REGISTER_DISPATCH(pdist_backward_stub, &pdist_backward_kernel_mps)
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Pdist.mm
+++ b/aten/src/ATen/native/mps/operations/Pdist.mm
@@ -1,0 +1,54 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/Distance.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_cdist_forward.h>
+#include <ATen/ops/_pdist_forward_native.h>
+#include <ATen/ops/triu_indices.h>
+#endif
+
+namespace at::native {
+namespace mps {
+
+// pdist implementation for MPS
+// We leverage the existing cdist implementation and extract the upper triangular part
+static void pdist_forward_kernel_mps_impl(
+    Tensor& result,
+    const Tensor& self,
+    const double p) {
+
+  int64_t n = self.size(0);
+
+  // Compute full distance matrix using cdist
+  // cdist(self, self) gives us an n x n matrix of all pairwise distances
+  Tensor full_distances = at::_cdist_forward(self, self, p, std::nullopt);
+
+  // Extract upper triangular indices (excluding diagonal)
+  // The result should be of size n*(n-1)/2
+  auto indices = at::triu_indices(n, n, 1, self.options().dtype(kLong).device(self.device()));
+
+  // Get row and column indices
+  auto row_indices = indices[0];
+  auto col_indices = indices[1];
+
+  // Extract the upper triangular elements
+  // full_distances[row_indices, col_indices]
+  result.copy_(full_distances.index({row_indices, col_indices}));
+}
+
+} // namespace mps
+
+void pdist_forward_kernel_mps(
+    Tensor& result,
+    const Tensor& self,
+    const double p) {
+  mps::pdist_forward_kernel_mps_impl(result, self, p);
+}
+
+REGISTER_DISPATCH(pdist_forward_stub, &pdist_forward_kernel_mps)
+
+} // namespace at::native

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -529,7 +529,6 @@ if torch.backends.mps.is_available():
             "nn.functional.padreflect": [torch.bool],
             "nn.functional.padreplicate": [torch.bool],
             "nn.functional.padreplicate_negative": [torch.bool],
-            "nn.functional.pdist": None,
             "nn.functional.relu": [torch.bool],
             "nn.functional.rrelu": None,
             "nn.functional.silu": [


### PR DESCRIPTION
## Summary

This PR adds native MPS support for `pdist` on Apple Silicon.

## Implementation Details

- Pairwise distance computation
- Supports various p-norms

## Files Changed
- See PR diff for complete file list
- `torch/testing/_internal/common_mps.py` - Removed from UNIMPLEMENTED_XFAILLIST

## Test Plan

```bash
python test/test_mps.py -k pdist
```

## Test Results (Apple M3 Pro, macOS 15.2)

| Test | Status | Details |
|------|--------|---------|
| pdist | PASS | Matches CPU reference implementation |

**All tests passed.**

cc @malfet @kulinseth @albanD @DenisVieriu97
