### PR TITLE
[MPS] Add nn.functional.rrelu support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12333,12 +12333,14 @@
   dispatch:
     CPU: rrelu_with_noise_out_cpu
     CUDA: rrelu_with_noise_out_cuda
+    MPS: rrelu_with_noise_out_mps
 
 - func: rrelu_with_noise(Tensor self, Tensor(b!) noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
   python_module: nn
   dispatch:
     CPU: rrelu_with_noise_cpu
     CUDA: rrelu_with_noise_cuda
+    MPS: rrelu_with_noise_mps
   tags: nondeterministic_seeded
   autogen: rrelu_with_noise_functional
 
@@ -12354,6 +12356,7 @@
   dispatch:
     CPU: rrelu_with_noise_cpu_
     CUDA: rrelu_with_noise_cuda_
+    MPS: rrelu_with_noise_mps_
 
 - func: softplus.out(Tensor self, Scalar beta=1, Scalar threshold=20, *, Tensor(a!) out) -> Tensor(a!)
   structured: True

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -352,7 +352,6 @@ if torch.backends.mps.is_available():
             "nn.functional.multi_margin_loss": None,
             "nn.functional.multilabel_margin_loss": None,
             "nn.functional.pdist": None,
-            "nn.functional.rrelu": None,
             "nn.functional.norm": None,
             "ormqr": None,
             "pca_lowrank": None,


### PR DESCRIPTION
## Summary
This PR adds MPS support for the rrelu (randomized leaky ReLU) operation.

## Implementation Details
In **training mode**:
- Generates random slopes uniformly sampled from [lower, upper] for negative values
- Uses uniform distribution for noise tensor
- Implements using at::where for efficient element-wise selection

In **eval mode**:
- Uses average of lower and upper as fixed negative slope
- Delegates to existing leaky_relu implementation

## Test Plan
- Automatic tests via test_mps.py (nn.functional.rrelu removed from UNIMPLEMENTED_XFAILLIST)

cc @malfet