### PR TITLE
[MPS] Add geometric distribution support

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9062,6 +9062,7 @@
   variants: method
   dispatch:
     CPU, CUDA: geometric_
+    MPS: geometric_mps_
 
   # wrappers for TH functions
   autogen: geometric, geometric.out

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -386,8 +386,6 @@ if torch.backends.mps.is_available():
             "segment_reduce_": None,
             "_upsample_bilinear2d_aa": [torch.uint8],  # uint8 is for CPU only
             "_upsample_bicubic2d_aa": [torch.uint8],  # uint8 is for CPU only
-            "geometric": None,
-            "geometric_": None,
             "cdouble": None,
             "double": None,
             "log_softmaxwith_dtype": [


### PR DESCRIPTION
This PR adds MPS support for the geometric distribution using inverse transform sampling: floor(log(1-U) / log(1-p)) + 1. Test Plan: Automatic tests via test_mps.py. cc @malfet