### PR TITLE
Add Triton forward kernel varlen support and batch invariance tests

### DIFF
--- a/torch/_inductor/_numeric_utils.py
+++ b/torch/_inductor/_numeric_utils.py
@@ -1,0 +1,87 @@
+import random
+from contextlib import contextmanager
+
+import torch
+
+
+@contextmanager
+def random_seed(seed: int):
+    state = random.getstate()
+    random.seed(seed)
+    try:
+        yield
+    finally:
+        random.setstate(state)
+
+
+def clone_args(args):
+    return [
+        arg.detach().clone().requires_grad_(arg.requires_grad)
+        if isinstance(arg, torch.Tensor)
+        else arg
+        for arg in args
+    ]
+
+
+def assert_batch_invariance(fn, batch_ids_in, batch_ids_out, args, *, rtol=0, atol=0):
+    """Assert that fn produces batch-invariant results.
+
+    Args:
+        fn: Function to test
+        batch_ids_in: Tuple of batch dimension indices for input args (None for non-batched args)
+        batch_ids_out: Int or tuple of batch dimension indices for outputs
+        args: Input arguments to fn
+        rtol: Relative tolerance for comparison (default 0 for bitwise equality)
+        atol: Absolute tolerance for comparison (default 0 for bitwise equality)
+    """
+    batch_size = next(
+        iter(
+            arg.shape[batch_id]
+            for arg, batch_id in zip(args, batch_ids_in)
+            if batch_id is not None
+        )
+    )
+    device = next(
+        iter(
+            arg.device
+            for arg, batch_id in zip(args, batch_ids_in)
+            if batch_id is not None
+        )
+    )
+
+    def index_at(arg, idx, value):
+        if idx is None:
+            return arg
+        assert value.max().item() < arg.shape[idx]
+        return arg[tuple([slice(None) if i != idx else value for i in range(arg.ndim)])]
+
+    def compare_tensors(a, b):
+        if rtol == 0 and atol == 0:
+            return torch.equal(a, b)
+        else:
+            return torch.allclose(a, b, rtol=rtol, atol=atol)
+
+    ref_result = fn(*clone_args(args))
+    with random_seed(0):
+        for _ in range(3):
+            num = random.randint(1, batch_size)
+            selection = torch.tensor(
+                [random.randint(0, batch_size - 1) for _ in range(num)], device=device
+            )
+            batch_result = fn(
+                *[
+                    index_at(arg, batch_id, selection)
+                    for arg, batch_id in zip(args, batch_ids_in)
+                ]
+            )
+            if type(batch_ids_out) is int:
+                assert compare_tensors(
+                    index_at(ref_result, batch_ids_out, selection), batch_result
+                ), f"Batch invariance failed with rtol={rtol}, atol={atol}"
+            else:
+                for ref, batch, batch_id in zip(
+                    ref_result, batch_result, batch_ids_out
+                ):
+                    assert compare_tensors(index_at(ref, batch_id, selection), batch), (
+                        f"Batch invariance failed with rtol={rtol}, atol={atol}"
+                    )

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -318,6 +318,8 @@ def flex_attention(
             mask_mod_other_buffers,
         )
 
+    has_varlen_offsets = q_offsets is not None and kv_offsets is not None
+
     (
         query,
         key,
@@ -330,6 +332,10 @@ def flex_attention(
         q_indices,
         full_q_num_blocks,
         full_q_indices,
+        kv_offsets,
+        kv_limits,
+        q_offsets,
+        q_limits,
     ) = maybe_realize(
         [
             query,
@@ -343,15 +349,22 @@ def flex_attention(
             q_indices,
             full_q_num_blocks,
             full_q_indices,
+            kv_offsets,
+            kv_limits,
+            q_offsets,
+            q_limits,
         ]
     )
 
-    if _use_flex_flash_attention(
-        subgraph,
-        mask_graph,
-        kernel_options,
-        num_score_mod_placeholders=len(placeholder_inps),
-        backend=backend,
+    if (
+        _use_flex_flash_attention(
+            subgraph,
+            mask_graph,
+            kernel_options,
+            num_score_mod_placeholders=len(placeholder_inps),
+            backend=backend,
+        )
+        and not has_varlen_offsets
     ):
         return create_flex_flash_attention_kernel(
             query,
@@ -439,6 +452,29 @@ def flex_attention(
             empty(0, device=query.get_device()) for _ in range(2)
         )
 
+    # Setup variable-length offsets and logical sequence lengths
+    (
+        q_offsets,
+        kv_offsets,
+        q_limits,
+        kv_limits,
+        logical_seq_len_q,
+        logical_seq_len_kv,
+        logical_q_len_buf,
+        logical_kv_len_buf,
+    ) = _setup_varlen_offsets(
+        q_offsets,
+        kv_offsets,
+        q_limits,
+        kv_limits,
+        seq_len_q,
+        seq_len_kv,
+        block_mask_q_length,
+        block_mask_kv_length,
+        query.get_device(),
+        kernel_options,
+    )
+
     set_head_dim_values(kernel_options, qk_head_dim, v_head_dim, V.graph.sizevars)
 
     choices: list[Any] = []
@@ -520,6 +556,12 @@ def flex_attention(
                 kv_indices,
                 full_kv_num_blocks,
                 full_kv_indices,
+                q_offsets,
+                kv_offsets,
+                q_limits,
+                kv_limits,
+                logical_q_len_buf,
+                logical_kv_len_buf,
             ],
             layout=layout,
             subgraphs=[
@@ -530,7 +572,9 @@ def flex_attention(
                 logsumexp,
                 max_scores,
             ],
-            call_sizes=query.get_size(),
+            # Use logical sequence length for grid calculation
+            # For varlen, this is the padded iteration space, not physical tensor size
+            call_sizes=[Bq, Hq, logical_seq_len_q, qk_head_dim],
             **cur_kernel_options,
         )
         if error is not None and len(configs) == 1:
@@ -546,6 +590,12 @@ def flex_attention(
             kv_indices,
             full_kv_num_blocks,
             full_kv_indices,
+            q_offsets,
+            kv_offsets,
+            q_limits,
+            kv_limits,
+            logical_q_len_buf,
+            logical_kv_len_buf,
         ]
         + list(score_mod_other_buffers)
         + list(mask_mod_other_buffers)
@@ -555,6 +605,7 @@ def flex_attention(
         6: create_indices_fake,
         7: create_num_blocks_fake_generator(full_kv_indices),
         8: create_indices_fake,
+        # q_offsets and kv_offsets at indices 9 and 10 don't need special generators
     }
 
     out = autotune_select_algorithm(

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -247,6 +247,10 @@ def create_flex_decoding_kernel(*args, **kwargs):
 
     kernel_options.setdefault("SM_SCALE", scale)
     kernel_options.setdefault("SPLIT_KV", get_split_k(B, Hkv, seq_len_kv))
+    # Flex decoding doesn't support varlen, so HAS_OFFSETS is always False
+    kernel_options.setdefault("HAS_OFFSETS", False)
+    # Create empty KV_OFFSETS tensor for non-varlen (required by forward_inner signature)
+    kv_offsets = empty(0, device=query.get_device(), dtype=torch.int32)
     MAX_SPLIT_KV = kernel_options["SPLIT_KV"]
 
     # create config dependent intermediate buffers
@@ -377,6 +381,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
                 kv_indices,
                 full_kv_num_blocks,
                 full_kv_indices,
+                kv_offsets,
             ],
             layout=layout_acc,
             subgraphs=[
@@ -406,6 +411,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
             kv_indices,
             full_kv_num_blocks,
             full_kv_indices,
+            kv_offsets,
         ]
         + filtered_score_mod_buffers
         + filtered_mask_mod_buffers
@@ -416,6 +422,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
         6: create_indices_fake,
         7: create_num_blocks_fake_generator(full_kv_indices),
         8: create_indices_fake,
+        # kv_offsets at index 9 doesn't need special generator (empty tensor)
     }
 
     buf_ACC = autotune_select_algorithm(

--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -1,10 +1,13 @@
 
 
+
 # Common Imports
 @triton.jit
 def forward_block_mn(
     {{gen_argdefs()}},
     q, K, V, desc_k, desc_v, Q_LEN, KV_LEN,
+    # Logical sequence lengths for mask_mod bounds (may differ from Q_LEN/KV_LEN for varlen)
+    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
     # accumulated values
     acc, l_i, m_i,
     # Offsets
@@ -46,9 +49,12 @@ def forward_block_mn(
     # ~~~~~~~~~~~~~~~~~~~ Apply score modification  ~~~~~~~~~~~~~~~~~~~
     # If this is the last block of a non divisible seqlen, we still need to load [BLOCK_M, BLOCK_N] elements,
     # which is larger than the actual number of elements. To avoid access memory out of bound,
-    # we need to mask out the elements that are out of Q_LEN & KV_LEN.
-    m = get_bounded_indices(offs_m, Q_LEN if CHECK_BLOCK_BOUNDARY else None)
-    n = get_bounded_indices(offs_n, KV_LEN if CHECK_BLOCK_BOUNDARY else None)
+    # we need to mask out the elements that are out of the sequence length.
+    # For varlen, use LOGICAL_Q/KV_LEN (logical iteration space) for mask_mod bounds,
+    # since mask_mod captures tensors sized for the logical space.
+    # For non-varlen, LOGICAL_Q/KV_LEN == Q/KV_LEN (physical tensor size).
+    m = get_bounded_indices(offs_m, LOGICAL_Q_LEN if CHECK_BLOCK_BOUNDARY else None)
+    n = get_bounded_indices(offs_n, LOGICAL_KV_LEN if CHECK_BLOCK_BOUNDARY else None)
 
     {{ modification(
         subgraph_number=0,
@@ -62,8 +68,10 @@ def forward_block_mn(
     ) | indent_except_first(1) }}
 
     if CHECK_BLOCK_BOUNDARY:
-        # Mask out the elements that are out of the KV_LEN for non divisible seqlen.
-        post_mod_scores = tl.where(offs_n < KV_LEN, post_mod_scores, float("-inf"))
+        # Mask out the elements that are out of the logical sequence length.
+        # For varlen, offs_n uses logical positions which can exceed physical KV_LEN,
+        # so we use LOGICAL_KV_LEN for bounds checking.
+        post_mod_scores = tl.where(offs_n < LOGICAL_KV_LEN, post_mod_scores, float("-inf"))
 
     if not IS_FULL_BLOCKS:
         {{ modification(
@@ -77,7 +85,7 @@ def forward_block_mn(
         ) | indent_except_first(2) }}
 
         if CHECK_BLOCK_BOUNDARY:
-            mask_mod_output = tl.where(offs_n < KV_LEN, mask_mod_output, False)
+            mask_mod_output = tl.where(offs_n < LOGICAL_KV_LEN, mask_mod_output, False)
         # apply mask for partially unmasked blocks
         post_mod_scores = tl.where(mask_mod_output, post_mod_scores, float("-inf"))
 
@@ -123,14 +131,19 @@ def forward_block_mn(
 def forward_inner(
     {{gen_argdefs()}},
     q, K, V,
+    KV_OFFSETS,
     desc_k, desc_v, Q_LEN, KV_LEN,
+    # Logical sequence lengths for mask_mod bounds (may differ from Q_LEN/KV_LEN for varlen)
+    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
     # accumulated values
     acc, l_i, m_i,
     # Offsets used as inputs to score_mod & mask_mod
     # of size [BLOCK_M, BLOCK_N] or scalar.
-    off_z, off_h, offs_m, offs_n,
+    off_z, off_h, sparse_idx_hq, offs_m, offs_n,
     # Offsets needed for TMA loads
-    kv_start,
+    kv_start, first_kv_block_idx,
+    # Initial kv_offset for physical memory access (logical + offset = physical)
+    kv_offset,
     # blocksparse data
     kv_indices, kv_num_blocks,
     # start kv and end kv block
@@ -149,7 +162,14 @@ def forward_inner(
     if PRESCALE_QK:
         q = (q * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
 
-    kv_offset = 0
+    # Track current sparse block index for varlen offset updates
+    current_sparse_block_idx = first_kv_block_idx
+    {%- if HAS_OFFSETS %}
+    stride_kv_offsets_z = {{stride("KV_OFFSETS", 0)}}
+    stride_kv_offsets_h = {{stride("KV_OFFSETS", 1)}}
+    # Track current kv_offset for pointer adjustments when crossing sparse block boundaries
+    current_kv_offset = kv_offset
+    {%- endif %}
 
     # loop over k, v and update accumulator until block_n_end
     for start_n in range(block_n_start, block_n_end):
@@ -158,6 +178,7 @@ def forward_inner(
             acc, l_i, m_i = forward_block_mn(
                 {{gen_argdefs()}},
                 q, K, V, desc_k, desc_v, Q_LEN, KV_LEN,
+                LOGICAL_Q_LEN, LOGICAL_KV_LEN,
                 # accumulated values
                 acc, l_i, m_i,
                 # Offsets
@@ -178,6 +199,7 @@ def forward_inner(
             acc, l_i, m_i = forward_block_mn(
                 {{gen_argdefs()}},
                 q, K, V, desc_k, desc_v, Q_LEN, KV_LEN,
+                LOGICAL_Q_LEN, LOGICAL_KV_LEN,
                 # accumulated values
                 acc, l_i, m_i,
                 # Offsets
@@ -201,5 +223,19 @@ def forward_inner(
         offs_n = offs_n + offset
         kv_offset += offset
 
+        # Update sparse block index and adjust kv_offset for physical offset change when crossing sparse block boundaries
+        {%- if HAS_OFFSETS %}
+        # Check if we crossed a sparse block boundary
+        if (start_n + 1) % SPARSE_KV_MULTIPLE == 0:
+            current_sparse_block_idx += 1
+            # Load new offset for the next sparse block
+            new_kv_offset_ptr = KV_OFFSETS + off_z * stride_kv_offsets_z + sparse_idx_hq * stride_kv_offsets_h + current_sparse_block_idx
+            new_kv_offset = tl.load(new_kv_offset_ptr).to(INDEX_DTYPE)
+            # Adjust kv_offset for the change in physical offset
+            # When crossing document boundaries, physical memory is not contiguous
+            offset_diff = new_kv_offset - current_kv_offset
+            kv_offset += offset_diff
+            current_kv_offset = new_kv_offset
+        {%- endif %}
 
     return acc, l_i, m_i

--- a/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
@@ -1,4 +1,4 @@
-{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX", "Q_OFFSETS", "KV_OFFSETS", "Q_LIMITS", "KV_LIMITS", "LOGICAL_Q_LEN_BUF", "LOGICAL_KV_LEN_BUF")}}
     # Sub notation for this kernel:
     #
     # Q: Query, K: Key, V: Value
@@ -42,6 +42,17 @@
     Q_LEN = {{size("Q", 2)}}
     ZKV = {{size("K", 0)}}
     KV_LEN = {{size("K", 2)}}
+
+    # Compute logical sequence lengths (for mask_mod bounds checking)
+    # For varlen, these are loaded from scalar tensors to avoid constexpr recompilation
+    # For non-varlen, logical lengths equal physical lengths
+    {%- if HAS_OFFSETS %}
+    LOGICAL_Q_LEN = tl.load(LOGICAL_Q_LEN_BUF).to(INDEX_DTYPE)
+    LOGICAL_KV_LEN = tl.load(LOGICAL_KV_LEN_BUF).to(INDEX_DTYPE)
+    {%- else %}
+    LOGICAL_Q_LEN = Q_LEN
+    LOGICAL_KV_LEN = KV_LEN
+    {%- endif %}
 
     MATMUL_PRECISION = Q.dtype.element_ty
 
@@ -115,38 +126,72 @@
     sparse_kv_num_blks_offset = sparse_hz_offset * stride_kv_num_blks_h + q_start // SPARSE_Q_MULTIPLE
     sparse_kv_idx_offset = sparse_hz_offset * stride_kv_idx_h + (q_start // SPARSE_Q_MULTIPLE) * stride_kv_idx_m  # noqa: B950
 
+    # Load Q offset and limit for variable-length sequences
+    # offset: translates logical pos to physical pos for memory access
+    # limit: number of valid positions in this block
+    {%- if HAS_OFFSETS %}
+    stride_q_offsets_z = {{stride("Q_OFFSETS", 0)}}
+    stride_q_offsets_h = {{stride("Q_OFFSETS", 1)}}
+    q_sparse_block_idx = q_start // SPARSE_Q_MULTIPLE
+    q_offset_ptr = Q_OFFSETS + off_zq * stride_q_offsets_z + sparse_idx_hq * stride_q_offsets_h + q_sparse_block_idx
+    q_offset = tl.load(q_offset_ptr).to(INDEX_DTYPE)
+    stride_q_limits_z = {{stride("Q_LIMITS", 0)}}
+    stride_q_limits_h = {{stride("Q_LIMITS", 1)}}
+    q_limit_ptr = Q_LIMITS + off_zq * stride_q_limits_z + sparse_idx_hq * stride_q_limits_h + q_sparse_block_idx
+    q_limit = tl.load(q_limit_ptr).to(INDEX_DTYPE)
+    {%- else %}
+    q_offset = 0
+    q_limit = BLOCK_M
+    {%- endif %}
+
+    # Logical Q positions (used for mask_mod/score_mod)
+    offs_m = q_start * BLOCK_M + tl.arange(0, BLOCK_M)
+    # Physical Q positions (used for memory access)
+    offs_m_physical = offs_m + q_offset
+
     {%- if USE_TMA %}
     q = tl.load_tensor_descriptor(
         desc_q,
-        [(q_start * BLOCK_M).to(tl.int32), 0],
+        [(offs_m_physical[0]).to(tl.int32), 0],
     )
     {%- else %}
-    offs_m = q_start * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_k = tl.arange(0, QK_HEAD_DIM_ROUNDED)
-    q = load_checked_2d(Q, offs_m, offs_k, stride_qm, stride_qk, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM)
+    q = load_checked_2d(Q, offs_m_physical, offs_k, stride_qm, stride_qk, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM)
     {%- endif %}
 
     # ~~~~~~~~~~~~~~ normal blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # We don't know anything "special" about these blocks, so we need to apply
     # both score_mod and mask_mod to it
     kv_indices = KV_IDX + sparse_kv_idx_offset
-    kv_start = tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE # first kv block we're loading
     kv_num_blocks = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
     block_n_end = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
 
+    # Load first kv block index and kv_offset for variable-length sequences
+    # Note: even if kv_num_blocks = 0, the load is safe (allocated memory), and the value is ignored
+    first_kv_block_idx = tl.load(kv_indices)  # sparse block index
+    kv_start = first_kv_block_idx * SPARSE_KV_BLOCK_SIZE  # first kv block we're loading (logical)
+    {%- if HAS_OFFSETS %}
+    stride_kv_offsets_z = {{stride("KV_OFFSETS", 0)}}
+    stride_kv_offsets_h = {{stride("KV_OFFSETS", 1)}}
+    kv_offset_ptr = KV_OFFSETS + off_zq * stride_kv_offsets_z + sparse_idx_hq * stride_kv_offsets_h + first_kv_block_idx
+    kv_offset = tl.load(kv_offset_ptr).to(INDEX_DTYPE)
+    {%- else %}
+    kv_offset = 0
+    {%- endif %}
 
-    # K and V pointers will be passed directly to forward_inner
-
+    # Logical KV positions (used for mask_mod/score_mod)
     offs_n = kv_start + tl.arange(0, BLOCK_N)
-
 
     acc, l_i, m_i = forward_inner(
         {{gen_argdefs()}},
         q, K, V,
+        KV_OFFSETS,
         desc_k, desc_v, Q_LEN, KV_LEN,
+        LOGICAL_Q_LEN, LOGICAL_KV_LEN,
         acc, l_i, m_i,
-        off_zq, off_hq, offs_m[:, None], offs_n[None, :],
-        kv_start,
+        off_zq, off_hq, sparse_idx_hq, offs_m[:, None], offs_n[None, :],
+        kv_start, first_kv_block_idx,
+        kv_offset,
         kv_indices, kv_num_blocks,
         0, block_n_end,
         MATMUL_PRECISION,
@@ -160,19 +205,31 @@
     if HAS_FULL_BLOCKS:
         # FULL_KV_IDX and FULL_KV_NUM_BLKS are always contiguous.
         kv_indices = FULL_KV_IDX + sparse_kv_idx_offset
-        kv_start = tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE # first kv block we're loading
+        first_full_kv_block_idx = tl.load(kv_indices)  # sparse block index
+        kv_start = first_full_kv_block_idx * SPARSE_KV_BLOCK_SIZE  # first kv block we're loading (logical)
         kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
         block_n_end = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
-        # K and V pointers will be passed directly to forward_inner
+
+        {%- if HAS_OFFSETS %}
+        kv_offset_ptr_full = KV_OFFSETS + off_zq * stride_kv_offsets_z + sparse_idx_hq * stride_kv_offsets_h + first_full_kv_block_idx
+        kv_offset_full = tl.load(kv_offset_ptr_full).to(INDEX_DTYPE)
+        {%- else %}
+        kv_offset_full = 0
+        {%- endif %}
+
+        # Logical KV positions (used for mask_mod/score_mod)
         offs_n = kv_start + tl.arange(0, BLOCK_N)
 
         acc, l_i, m_i = forward_inner(
             {{gen_argdefs()}},
             q, K, V,
+            KV_OFFSETS,
             desc_k, desc_v, Q_LEN, KV_LEN,
+            LOGICAL_Q_LEN, LOGICAL_KV_LEN,
             acc, l_i, m_i,
-            off_zq, off_hq, offs_m[:, None], offs_n[None, :],
-            kv_start,
+            off_zq, off_hq, sparse_idx_hq, offs_m[:, None], offs_n[None, :],
+            kv_start, first_full_kv_block_idx,
+            kv_offset_full,
             kv_indices, kv_num_blocks,
             0, block_n_end,
             MATMUL_PRECISION,
@@ -189,27 +246,46 @@
     acc = acc / l_i[:, None]
     idx_zq = tl.program_id(1).to(INDEX_DTYPE)
     idx_hq = tl.program_id(2).to(INDEX_DTYPE)
-    idx_m = offs_m[:, None].to(INDEX_DTYPE)
+    # For output storage, use physical positions when offsets are enabled
+    # This ensures output is stored at the correct physical memory locations
+    idx_m = offs_m_physical[:, None].to(INDEX_DTYPE)
     idx_d = tl.arange(0, V_HEAD_DIM_ROUNDED)[None, :].to(INDEX_DTYPE)
 
+    # Mask for output storage: must be within Q_LEN AND within block's valid limit
+    {%- if HAS_OFFSETS %}
+    # Local position within sparse block (not just thread block)
+    # This is needed because q_limit is for the entire sparse block, not the thread block
+    local_m_1d = ((q_start % SPARSE_Q_MULTIPLE) * BLOCK_M + tl.arange(0, BLOCK_M)).to(INDEX_DTYPE)
+    local_m_2d = local_m_1d[:, None]
+    mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM) & (local_m_2d < q_limit)
+    {%- else %}
     mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM)
+    {%- endif %}
 
     tl.static_assert(acc.shape == [BLOCK_M, V_HEAD_DIM_ROUNDED])
     {{store_output(("idx_zq", "idx_hq", "idx_m", "idx_d"), "acc", "mask", val_shape=("BLOCK_M", "V_HEAD_DIM_ROUNDED"))}}
 
     if OUTPUT_LOGSUMEXP:
         off_hz = off_zq * HQ + off_hq
-        l_ptrs = LSE + off_hz * Q_LEN + offs_m
+        # Use physical positions for LSE storage
+        l_ptrs = LSE + off_hz * Q_LEN + offs_m_physical
         lse = m_i + tl.math.log2(l_i)
-        if IS_DIVISIBLE:
-            tl.store(l_ptrs, lse)
-        else:
-            tl.store(l_ptrs, lse, mask=offs_m < Q_LEN)
+        # Mask must check both physical bounds and block limit
+        {%- if HAS_OFFSETS %}
+        lse_mask = (offs_m_physical < Q_LEN) & (local_m_1d < q_limit)
+        {%- else %}
+        lse_mask = offs_m_physical < Q_LEN
+        {%- endif %}
+        tl.store(l_ptrs, lse, mask=lse_mask)
 
     if OUTPUT_MAX:
         off_hz = off_zq * HQ + off_hq
-        max_ptrs = MAX + off_hz * Q_LEN + offs_m
-        if IS_DIVISIBLE:
-            tl.store(max_ptrs, m_i)
-        else:
-            tl.store(max_ptrs, m_i, mask=offs_m < Q_LEN)
+        # Use physical positions for MAX storage
+        max_ptrs = MAX + off_hz * Q_LEN + offs_m_physical
+        # Mask must check both physical bounds and block limit
+        {%- if HAS_OFFSETS %}
+        max_mask = (offs_m_physical < Q_LEN) & (local_m_1d < q_limit)
+        {%- else %}
+        max_mask = offs_m_physical < Q_LEN
+        {%- endif %}
+        tl.store(max_ptrs, m_i, mask=max_mask)

--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -1,4 +1,4 @@
-    {{def_kernel("Q", "K", "V", "M", "L", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+    {{def_kernel("Q", "K", "V", "M", "L", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX", "KV_OFFSETS")}}
     # Sub notation for this kernel:
     # Q: Query, K: Key, V: Value
     # reduction buffers: M rowmax across local KV split, L local sumexp across local KV split
@@ -161,15 +161,24 @@
     )
     {%- endif %}
 
+    # kv_offset = 0 for non-varlen (local var needed for loop-carried variable type compatibility)
+    kv_offset = 0
+
     acc, l_i, m_i = forward_inner(
         {{gen_argdefs()}},
-        q, K, V, desc_k, desc_v, Q_LEN, KV_LEN,
-        # accumulatd values
+        q, K, V,
+        KV_OFFSETS,
+        desc_k, desc_v, Q_LEN, KV_LEN,
+        Q_LEN, KV_LEN,  # LOGICAL_Q_LEN, LOGICAL_KV_LEN (same as physical for non-varlen)
+        # accumulated values
         acc, l_i, m_i,
-        #offsets
-        off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
-        off_n,
-        #block sparse data
+        # offsets for score_mod/mask_mod
+        off_z, offs_hq[:, None], sparse_idx_h, offs_m[:, None], offs_n[None, :],
+        # kv_start, first_kv_block_idx (first_kv_block_idx unused when HAS_OFFSETS=False)
+        off_n, 0,
+        # kv_offset
+        kv_offset,
+        # block sparse data
         kv_indices, kv_num_blocks,
         block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
         MATMUL_PRECISION,
@@ -196,15 +205,24 @@
 
         offs_n = tl.arange(0, BLOCK_N) + off_n
 
+        # Reset kv_offset for full blocks section
+        kv_offset = 0
+
         acc, l_i, m_i = forward_inner(
             {{gen_argdefs()}},
-            q, K, V, desc_k, desc_v, Q_LEN, KV_LEN,
-            # accumulatd values
+            q, K, V,
+            KV_OFFSETS,
+            desc_k, desc_v, Q_LEN, KV_LEN,
+            Q_LEN, KV_LEN,  # LOGICAL_Q_LEN, LOGICAL_KV_LEN (same as physical for non-varlen)
+            # accumulated values
             acc, l_i, m_i,
-            #offsets
-            off_z, offs_hq[:, None], offs_m[:, None], offs_n[None, :],
-            off_n,
-            #block sparse data
+            # offsets for score_mod/mask_mod
+            off_z, offs_hq[:, None], sparse_idx_h, offs_m[:, None], offs_n[None, :],
+            # kv_start, first_kv_block_idx (first_kv_block_idx unused when HAS_OFFSETS=False)
+            off_n, 0,
+            # kv_offset
+            kv_offset,
+            # block sparse data
             kv_indices, kv_num_blocks,
             block_n_start, block_n_end if block_n_end <= block_n_last_valid else block_n_last_valid,
             MATMUL_PRECISION,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173020
* #173019
* __->__ #173018
* #173016

Update the forward Triton kernel templates to handle variable-length
sequences via HAS_OFFSETS conditionals:
- flex_attention.py.jinja: Load Q/KV offsets and limits per block,
  compute logical vs physical positions, mask output storage by limits
- common.py.jinja: Update forward_block_mn and forward_inner to use
  LOGICAL_Q/KV_LEN for mask_mod bounds, track sparse block boundaries

Add _setup_varlen_offsets() helper to convert offset/limit tensors into
kernel inputs and compute logical sequence lengths for grid calculation.

Add assert_batch_invariance utility in _numeric_utils.py for verifying
that attention results are identical regardless of batch composition.

Add forward tests:
- test_varlen_block_mask_forward: End-to-end forward kernel test
- test_varlen_block_mask_batch_invariance: Verify batch-invariant outputs