### PR TITLE
Add Triton backward kernel varlen support and backward test

### DIFF
--- a/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
@@ -1,4 +1,4 @@
-{{def_kernel("Q", "K", "V", "LSE", "DELTA", "DO", "DQ", "DV", "KV_NUM_BLKS", "KV_IDX", "Q_NUM_BLKS", "Q_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX")}}
+{{def_kernel("Q", "K", "V", "LSE", "DELTA", "DO", "DQ", "DV", "KV_NUM_BLKS", "KV_IDX", "Q_NUM_BLKS", "Q_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "Q_OFFSETS", "KV_OFFSETS", "Q_LIMITS", "KV_LIMITS", "LOGICAL_Q_LEN_BUF", "LOGICAL_KV_LEN_BUF")}}
     # Sub notation for this kernel:
     #
     # Q: Query, K: Key, V: Value
@@ -49,11 +49,24 @@
     ZKV = {{size("K", 0)}}
     KV_LEN = {{size("K", 2)}}
 
+    # Compute logical sequence lengths (for mask_mod bounds checking and grid iteration)
+    # For varlen, these are loaded from scalar tensors to avoid constexpr recompilation
+    # For non-varlen, logical lengths equal physical lengths
+    {%- if HAS_OFFSETS %}
+    LOGICAL_Q_LEN = tl.load(LOGICAL_Q_LEN_BUF).to(INDEX_DTYPE)
+    LOGICAL_KV_LEN = tl.load(LOGICAL_KV_LEN_BUF).to(INDEX_DTYPE)
+    {%- else %}
+    LOGICAL_Q_LEN = Q_LEN
+    LOGICAL_KV_LEN = KV_LEN
+    {%- endif %}
+
     MATMUL_PRECISION = Q.dtype.element_ty
 
     pid = tl.program_id(0).to(INDEX_DTYPE)
-    NUM_KV_BLOCKS = tl.cdiv(KV_LEN, BLOCK_N1)
-    NUM_Q_BLOCKS = tl.cdiv(Q_LEN, BLOCK_M2)
+    # For varlen, use logical sequence lengths for grid iteration
+    # (logical = padded to block boundaries, physical = actual data size)
+    NUM_KV_BLOCKS = tl.cdiv(LOGICAL_KV_LEN, BLOCK_N1)
+    NUM_Q_BLOCKS = tl.cdiv(LOGICAL_Q_LEN, BLOCK_M2)
 
     off_zq = tl.program_id(1).to(INDEX_DTYPE) # q batch idx
     off_hkv = tl.program_id(2).to(INDEX_DTYPE) # kv head idx
@@ -115,39 +128,76 @@
         dq = tl.zeros([BLOCK_M2, QK_HEAD_DIM_ROUNDED], dtype=tl.float32)
 
         start_m2 = start_m2_block * BLOCK_M2
+        # Logical Q positions (used for mask_mod/score_mod)
         offs_m2 = start_m2 + tl.arange(0, BLOCK_M2)
 
+        # Load Q offset and limit for variable-length sequences
+        {%- if HAS_OFFSETS %}
+        stride_q_offsets_z = {{stride("Q_OFFSETS", 0)}}
+        stride_q_offsets_h = {{stride("Q_OFFSETS", 1)}}
+        q_sparse_block_idx = start_m2_block // SPARSE_Q_MULTIPLE
+        q_offset_ptr = Q_OFFSETS + off_zq * stride_q_offsets_z + sparse_idx_hq2 * stride_q_offsets_h + q_sparse_block_idx
+        q_offset = tl.load(q_offset_ptr).to(INDEX_DTYPE)
+        stride_q_limits_z = {{stride("Q_LIMITS", 0)}}
+        stride_q_limits_h = {{stride("Q_LIMITS", 1)}}
+        q_limit_ptr = Q_LIMITS + off_zq * stride_q_limits_z + sparse_idx_hq2 * stride_q_limits_h + q_sparse_block_idx
+        q_limit = tl.load(q_limit_ptr).to(INDEX_DTYPE)
+        {%- else %}
+        q_offset = 0
+        q_limit = BLOCK_M2
+        {%- endif %}
+
+        # Physical Q positions (used for memory access)
+        offs_m2_physical = offs_m2 + q_offset
+
         # load Q and do: they stay in SRAM throughout the inner loop.
-        q = load_checked_2d(Q2, offs_m2, offs_k, stride_qm, stride_qd, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM)
-        do = load_checked_2d(DO2, offs_m2, offs_v, stride_dom, stride_dod, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM)
+        q = load_checked_2d(Q2, offs_m2_physical, offs_k, stride_qm, stride_qd, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, QK_HEAD_DIM)
+        do = load_checked_2d(DO2, offs_m2_physical, offs_v, stride_dom, stride_dod, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM)
 
         if PRESCALE_QK:
             q = (q * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
 
+        # LSE and Delta are stored at physical positions, so use offs_m2_physical
         if IS_DIVISIBLE:
-            Di = tl.load(DELTA2 + offs_m2)
-            lse = tl.load(LSE2 + offs_m2)
+            Di = tl.load(DELTA2 + offs_m2_physical)
+            lse = tl.load(LSE2 + offs_m2_physical)
         else:
-            Di = tl.load(DELTA2 + offs_m2, mask=offs_m2 < Q_LEN)
-            lse = tl.load(LSE2 + offs_m2, mask=offs_m2 < Q_LEN)
+            Di = tl.load(DELTA2 + offs_m2_physical, mask=offs_m2_physical < Q_LEN)
+            lse = tl.load(LSE2 + offs_m2_physical, mask=offs_m2_physical < Q_LEN)
         lse = tl.where(lse == -float("inf"), 0.0, lse)
         lse = lse[:, None]
 
         # ~~~~~~~~~~~ fully unmasked blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # KV_IDX and KV_NUM_BLKS are always contiguous.
         kv_indices = KV_IDX + sparse_kv_idx_offset
-        kv_start = tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE # first kv block we're loading
+        first_kv_block_idx = tl.load(kv_indices)  # sparse block index
+        kv_start = first_kv_block_idx * SPARSE_KV_BLOCK_SIZE # first kv block we're loading (logical)
         sparse_kv_num_blocks = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
 
+        # Load KV offset for variable-length sequences
+        {%- if HAS_OFFSETS %}
+        stride_kv_offsets_z = {{stride("KV_OFFSETS", 0)}}
+        stride_kv_offsets_h = {{stride("KV_OFFSETS", 1)}}
+        kv_offset_ptr = KV_OFFSETS + off_zq * stride_kv_offsets_z + sparse_idx_hq2 * stride_kv_offsets_h + first_kv_block_idx
+        kv_offset = tl.load(kv_offset_ptr).to(INDEX_DTYPE)
+        {%- else %}
+        kv_offset = 0
+        {%- endif %}
+
+        # Logical KV positions (used for mask_mod/score_mod)
         offs_n2 = kv_start + tl.arange(0, BLOCK_N2)
+
         dq = bwd_dq_inner(
             {{gen_argdefs()}},
-            K, V,
+            K, V, KV_OFFSETS, KV_LIMITS,
             dq, q, do, Di, lse,
-            off_zq, off_hq2, offs_m2, offs_n2,
+            off_zq, off_hq2, sparse_idx_hq2, offs_m2, offs_n2,
+            kv_start, first_kv_block_idx,
+            kv_offset,
             stride_kn, stride_kd, stride_vn, stride_vd,
             kv_indices, sparse_kv_num_blocks,
             MATMUL_PRECISION,
+            LOGICAL_Q_LEN, LOGICAL_KV_LEN,
             IS_FULL_BLOCKS=False,
         )
 
@@ -155,28 +205,50 @@
             # ~~~~~~~~~~~ partial unmasked blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             # FULL_KV_IDX and FULL_KV_NUM_BLKS are always contiguous.
             kv_indices = FULL_KV_IDX + sparse_kv_idx_offset
-            kv_start = tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE # first kv block we're loading
+            first_full_kv_block_idx = tl.load(kv_indices)  # sparse block index
+            kv_start = first_full_kv_block_idx * SPARSE_KV_BLOCK_SIZE # first kv block we're loading (logical)
             sparse_kv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
 
+            {%- if HAS_OFFSETS %}
+            kv_offset_ptr_full = KV_OFFSETS + off_zq * stride_kv_offsets_z + sparse_idx_hq2 * stride_kv_offsets_h + first_full_kv_block_idx
+            kv_offset_full = tl.load(kv_offset_ptr_full).to(INDEX_DTYPE)
+            {%- else %}
+            kv_offset_full = 0
+            {%- endif %}
+
+            # Logical KV positions (used for mask_mod/score_mod)
             offs_n2 = kv_start + tl.arange(0, BLOCK_N2)
+
             dq = bwd_dq_inner(
                 {{gen_argdefs()}},
-                K, V,
+                K, V, KV_OFFSETS, KV_LIMITS,
                 dq, q, do, Di, lse,
-                off_zq, off_hq2, offs_m2, offs_n2,
+                off_zq, off_hq2, sparse_idx_hq2, offs_m2, offs_n2,
+                kv_start, first_full_kv_block_idx,
+                kv_offset_full,
                 stride_kn, stride_kd, stride_vn, stride_vd,
                 kv_indices, sparse_kv_num_blocks,
                 MATMUL_PRECISION,
+                LOGICAL_Q_LEN, LOGICAL_KV_LEN,
                 IS_FULL_BLOCKS=True,
             )
 
-        # Write back dQ.
-        dq_ptrs = DQ2 + offs_m2[:, None] * stride_dqm + offs_k[None, :] * stride_dqd
+        # Write back dQ at physical positions (using offset for varlen support)
+        dq_ptrs = DQ2 + offs_m2_physical[:, None] * stride_dqm + offs_k[None, :] * stride_dqd
         dq *= SM_SCALE
+        # For varlen, also check local position against q_limit to mask out invalid positions
+        {%- if HAS_OFFSETS %}
+        # Local position within sparse block (not just thread block)
+        # This is needed because q_limit is for the entire sparse block, not the thread block
+        local_m2 = (start_m2_block % SPARSE_Q_MULTIPLE) * BLOCK_M2 + tl.arange(0, BLOCK_M2)
+        dq_mask = (offs_m2_physical[:, None] < Q_LEN) & (offs_k[None, :] < QK_HEAD_DIM) & (local_m2[:, None] < q_limit)
+        tl.store(dq_ptrs, dq, mask=dq_mask)
+        {%- else %}
         if IS_DIVISIBLE and SAFE_HEAD_DIM:
             tl.store(dq_ptrs, dq)
         else:
-            tl.store(dq_ptrs, dq, mask=(offs_m2[:, None] < Q_LEN) & (offs_k[None, :] < QK_HEAD_DIM))
+            tl.store(dq_ptrs, dq, mask=(offs_m2_physical[:, None] < Q_LEN) & (offs_k[None, :] < QK_HEAD_DIM))
+        {%- endif %}
     else:
         # THIS BLOCK DOES DK & DV
         SPARSE_Q_MULTIPLE = (SPARSE_Q_BLOCK_SIZE // BLOCK_M1)
@@ -193,11 +265,33 @@
         dk = tl.zeros([BLOCK_N1, QK_HEAD_DIM_ROUNDED], dtype=tl.float32)
 
         start_n1 = pid * BLOCK_N1
+        # Logical KV positions (used for mask_mod/score_mod)
         offs_n1 = start_n1 + tl.arange(0, BLOCK_N1)
 
+        # Load KV offset and limit for variable-length sequences
+        {%- if HAS_OFFSETS %}
+        stride_kv_offsets_z = {{stride("KV_OFFSETS", 0)}}
+        stride_kv_offsets_h = {{stride("KV_OFFSETS", 1)}}
+        kv_sparse_block_idx = pid // SPARSE_KV_MULTIPLE
+        # Note: For DK/DV, we use off_hkv for the head index since we iterate over KV heads
+        kv_offset_ptr = KV_OFFSETS + off_zq * stride_kv_offsets_z + (off_hkv % SPARSE_HQ) * stride_kv_offsets_h + kv_sparse_block_idx
+        kv_offset_dkdv = tl.load(kv_offset_ptr).to(INDEX_DTYPE)
+        stride_kv_limits_z = {{stride("KV_LIMITS", 0)}}
+        stride_kv_limits_h = {{stride("KV_LIMITS", 1)}}
+        kv_limit_ptr = KV_LIMITS + off_zq * stride_kv_limits_z + (off_hkv % SPARSE_HQ) * stride_kv_limits_h + kv_sparse_block_idx
+        kv_limit_dkdv = tl.load(kv_limit_ptr).to(INDEX_DTYPE)
+        {%- else %}
+        kv_offset_dkdv = 0
+        kv_limit_dkdv = BLOCK_N1
+        {%- endif %}
+
+        # Physical KV positions (used for memory access)
+        offs_n1_physical = offs_n1 + kv_offset_dkdv
+
         # load K and V: they stay in SRAM throughout the inner loop.
-        k = load_checked_2d(K, offs_n1, offs_k, stride_kn, stride_kd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, QK_HEAD_DIM)
-        v = load_checked_2d(V, offs_n1, offs_v, stride_vn, stride_vd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
+        # Use physical indices for memory access
+        k = load_checked_2d(K, offs_n1_physical, offs_k, stride_kn, stride_kd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, QK_HEAD_DIM)
+        v = load_checked_2d(V, offs_n1_physical, offs_v, stride_vn, stride_vd, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
 
         if PRESCALE_QK:
             k = (k * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
@@ -227,18 +321,34 @@
             # ~~~~~~~~~~~~~~~ fully unmasked blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             # Q_IDX and Q_NUM_BLKS are always contiguous.
             q_indices = Q_IDX + sparse_q_idx_offset
-            q_start = tl.load(q_indices) * SPARSE_Q_BLOCK_SIZE # first q block we're loading
+            first_q_block_idx = tl.load(q_indices)  # sparse block index
+            q_start = first_q_block_idx * SPARSE_Q_BLOCK_SIZE # first q block we're loading (logical)
             sparse_q_num_blocks = tl.load(Q_NUM_BLKS + sparse_q_num_blks_offset)
 
+            # Load Q offset for variable-length sequences
+            {%- if HAS_OFFSETS %}
+            stride_q_offsets_z = {{stride("Q_OFFSETS", 0)}}
+            stride_q_offsets_h = {{stride("Q_OFFSETS", 1)}}
+            q_offset_ptr = Q_OFFSETS + off_zq * stride_q_offsets_z + sparse_idx_hq1 * stride_q_offsets_h + first_q_block_idx
+            q_offset_dkdv = tl.load(q_offset_ptr).to(INDEX_DTYPE)
+            {%- else %}
+            q_offset_dkdv = 0
+            {%- endif %}
+
+            # Logical Q positions (used for mask_mod/score_mod)
             offs_m1 = q_start + tl.arange(0, BLOCK_M1)
+
             dk, dv = bwd_dkdv_inner(
                 {{gen_argdefs()}},
-                Q1, DO1, DELTA1, LSE1,
+                Q1, DO1, DELTA1, LSE1, Q_OFFSETS, Q_LIMITS,
                 dk, dv, k, v,
-                off_zq, off_hq1, offs_n1, offs_m1,
+                off_zq, off_hq1, sparse_idx_hq1, offs_n1, offs_m1,
+                q_start, first_q_block_idx,
+                q_offset_dkdv,
                 stride_qm, stride_qd, stride_dom, stride_dod,
                 q_indices, sparse_q_num_blocks,
                 MATMUL_PRECISION,
+                LOGICAL_Q_LEN, LOGICAL_KV_LEN,
                 IS_FULL_BLOCKS=False,
             )
 
@@ -247,39 +357,66 @@
                 # ~~~~~~~~~~~~~~~ fully unmasked blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 # FULL_Q_IDX and FULL_Q_NUM_BLKS are always contiguous.
                 q_indices = FULL_Q_IDX + sparse_q_idx_offset
-                q_start = tl.load(q_indices) * SPARSE_Q_BLOCK_SIZE # first q block we're loading
+                first_full_q_block_idx = tl.load(q_indices)  # sparse block index
+                q_start = first_full_q_block_idx * SPARSE_Q_BLOCK_SIZE # first q block we're loading (logical)
                 sparse_q_num_blocks = tl.load(FULL_Q_NUM_BLKS + sparse_q_num_blks_offset)
 
+                {%- if HAS_OFFSETS %}
+                q_offset_ptr_full = Q_OFFSETS + off_zq * stride_q_offsets_z + sparse_idx_hq1 * stride_q_offsets_h + first_full_q_block_idx
+                q_offset_dkdv_full = tl.load(q_offset_ptr_full).to(INDEX_DTYPE)
+                {%- else %}
+                q_offset_dkdv_full = 0
+                {%- endif %}
+
+                # Logical Q positions (used for mask_mod/score_mod)
                 offs_m1 = q_start + tl.arange(0, BLOCK_M1)
+
                 dk, dv = bwd_dkdv_inner(
                     {{gen_argdefs()}},
-                    Q1, DO1, DELTA1, LSE1,
+                    Q1, DO1, DELTA1, LSE1, Q_OFFSETS, Q_LIMITS,
                     dk, dv, k, v,
-                    off_zq, off_hq1, offs_n1, offs_m1,
+                    off_zq, off_hq1, sparse_idx_hq1, offs_n1, offs_m1,
+                    q_start, first_full_q_block_idx,
+                    q_offset_dkdv_full,
                     stride_qm, stride_qd, stride_dom, stride_dod,
                     q_indices, sparse_q_num_blocks,
                     MATMUL_PRECISION,
+                    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
                     IS_FULL_BLOCKS=True,
                 )
 
-        # Write back dV and dK.
-        dv_ptrs = DV + offs_n1[:, None] * stride_dvm + offs_v[None, :] * stride_dvd
+        # Write back dV and dK at physical positions (using offset for varlen support)
+        dv_ptrs = DV + offs_n1_physical[:, None] * stride_dvm + offs_v[None, :] * stride_dvd
 
-        index_n = offs_n1[:, None]
+        # Use physical positions for storage masks
+        index_n = offs_n1_physical[:, None]
         index_k = offs_k[None, :]
         index_v = offs_v[None, :]
 
+        # For varlen, also check local position against kv_limit to mask out invalid positions
+        {%- if HAS_OFFSETS %}
+        # Local position within sparse block (not just thread block)
+        # This is needed because kv_limit is for the entire sparse block, not the thread block
+        local_n1 = (pid % SPARSE_KV_MULTIPLE) * BLOCK_N1 + tl.arange(0, BLOCK_N1)
+        dv_mask = (index_n < KV_LEN) & (index_v < V_HEAD_DIM) & (local_n1[:, None] < kv_limit_dkdv)
+        tl.store(dv_ptrs, dv, mask=dv_mask)
+        {%- else %}
         if IS_DIVISIBLE and SAFE_HEAD_DIM:
             tl.store(dv_ptrs, dv)
         else:
             tl.store(dv_ptrs, dv, mask=(index_n < KV_LEN) & (index_v < V_HEAD_DIM))
+        {%- endif %}
 
         dk *= SM_SCALE
 
+        {%- if HAS_OFFSETS %}
+        mask = (index_n < KV_LEN) & (index_k < QK_HEAD_DIM) & (local_n1[:, None] < kv_limit_dkdv)
+        {%- else %}
         if SAFE_HEAD_DIM:
             mask = index_n < KV_LEN
         else:
             mask = (index_n < KV_LEN) & (index_k < QK_HEAD_DIM)
+        {%- endif %}
 
         # first compute broadcasted dk of shape [Bq, Hkv, KV_LEN, V_HEAD_DIM]
         # then reduce to dk of shape [Bkv, Hkv, KV_LEN, V_HEAD_DIM]
@@ -289,12 +426,17 @@
 @triton.jit
 def bwd_dq_inner(
     {{gen_argdefs()}},
-    K, V,  # pointers
+    K, V, KV_OFFSETS, KV_LIMITS,  # pointers
     dq, q, do, Di, lse,
-    off_z, off_hq, offs_m2, offs_n2,
+    off_z, off_hq, sparse_idx_hq, offs_m2, offs_n2,
+    # Offsets needed for memory access
+    kv_start, first_kv_block_idx,
+    kv_offset,
     stride_kn, stride_kd, stride_vn, stride_vd,
     kv_indices, sparse_kv_num_blocks,
     MATMUL_PRECISION,
+    # Logical sequence lengths for mask_mod bounds (may differ from Q_LEN/KV_LEN for varlen)
+    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
     IS_FULL_BLOCKS,
 ):
     {{gen_defines() | indent_except_first(1) }}
@@ -306,22 +448,55 @@ def bwd_dq_inner(
     offs_k = tl.arange(0, QK_HEAD_DIM_ROUNDED)
     offs_v = tl.arange(0, V_HEAD_DIM_ROUNDED)
 
-    kT_ptrs = K + offs_n2[None, :] * stride_kn + offs_k[:, None] * stride_kd
-    vT_ptrs = V + offs_n2[None, :] * stride_vn + offs_v[:, None] * stride_vd
+    # Physical KV positions for memory access (logical + offset = physical)
+    kv_base_offset = kv_start + kv_offset
+    offs_n2_physical = kv_base_offset + tl.arange(0, BLOCK_N2)
+
+    # Use physical indices for memory access
+    kT_ptrs = K + offs_n2_physical[None, :] * stride_kn + offs_k[:, None] * stride_kd
+    vT_ptrs = V + offs_n2_physical[None, :] * stride_vn + offs_v[:, None] * stride_vd
     # BLOCK_M2 must be a multiple of BLOCK_N2, otherwise the code wouldn't work.
     tl.static_assert(BLOCK_M2 % BLOCK_N2 == 0)
 
+    # For varlen, use logical length for iteration limit since we iterate over logical blocks
+    {%- if HAS_OFFSETS %}
+    hi = tl.minimum(sparse_kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(LOGICAL_KV_LEN, BLOCK_N2), 1))
+    {%- else %}
     hi = tl.minimum(sparse_kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N2), 1))
+    {%- endif %}
+
+    # Track current sparse block index for loading kv_limit
+    current_sparse_block_idx = first_kv_block_idx
+
+    {%- if HAS_OFFSETS %}
+    stride_kv_limits_z = {{stride("KV_LIMITS", 0)}}
+    stride_kv_limits_h = {{stride("KV_LIMITS", 1)}}
+    stride_kv_offsets_z = {{stride("KV_OFFSETS", 0)}}
+    stride_kv_offsets_h = {{stride("KV_OFFSETS", 1)}}
+    # Track current kv_offset for pointer adjustments when crossing sparse block boundaries
+    current_kv_offset = kv_offset
+    {%- else %}
+    current_kv_offset = 0
+    {%- endif %}
 
     for start_n in range(0, hi):
+        # Load kv_limit for current KV block (for varlen masking)
+        {%- if HAS_OFFSETS %}
+        kv_limit_ptr = KV_LIMITS + off_z * stride_kv_limits_z + sparse_idx_hq * stride_kv_limits_h + current_sparse_block_idx
+        kv_limit = tl.load(kv_limit_ptr).to(INDEX_DTYPE)
+        {%- else %}
+        kv_limit = BLOCK_N2
+        {%- endif %}
+
         dq = bwd_dq_block_mn(
             {{gen_argdefs()}},
             dq, q, kT_ptrs, vT_ptrs, do, Di, lse, Q_LEN, KV_LEN,
+            LOGICAL_Q_LEN, LOGICAL_KV_LEN,
             off_z, off_hq, offs_m2, offs_n2, offs_k, offs_v,
             stride_kn, stride_kd, stride_vn, stride_vd,
             kv_indices, sparse_kv_num_blocks,
             MATMUL_PRECISION, RCP_LN2,
-            IS_FULL_BLOCKS,
+            IS_FULL_BLOCKS, kv_limit, current_kv_offset,
         )
 
         # Increment pointers.
@@ -335,6 +510,22 @@ def bwd_dq_inner(
 
         offs_n2 += offset
 
+        # Update sparse block index and adjust pointers for offset change
+        {%- if HAS_OFFSETS %}
+        # Check if we crossed a sparse block boundary
+        if (start_n + 1) % SPARSE_KV_MULTIPLE == 0:
+            current_sparse_block_idx += 1
+            # Load new offset for the next sparse block
+            new_kv_offset_ptr = KV_OFFSETS + off_z * stride_kv_offsets_z + sparse_idx_hq * stride_kv_offsets_h + current_sparse_block_idx
+            new_kv_offset = tl.load(new_kv_offset_ptr).to(INDEX_DTYPE)
+            # Adjust pointers for the change in physical offset
+            # When crossing document boundaries, physical memory is not contiguous
+            offset_diff = new_kv_offset - current_kv_offset
+            kT_ptrs += offset_diff * stride_kn
+            vT_ptrs += offset_diff * stride_vn
+            current_kv_offset = new_kv_offset
+        {%- endif %}
+
     return dq
 
 
@@ -342,25 +533,43 @@ def bwd_dq_inner(
 def bwd_dq_block_mn(
     {{gen_argdefs()}},
     dq, q, kT_ptrs, vT_ptrs, do, Di, lse, Q_LEN, KV_LEN,
+    # Logical sequence lengths for mask_mod bounds (may differ from Q_LEN/KV_LEN for varlen)
+    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
     off_z, off_hq, offs_m2, offs_n2, offs_k, offs_v,
     stride_kn, stride_kd, stride_vn, stride_vd,
     kv_indices, sparse_kv_num_blocks,
     MATMUL_PRECISION, RCP_LN2,
-    IS_FULL_BLOCKS,
+    IS_FULL_BLOCKS, kv_limit, kv_offset,
 ):
     {{gen_defines() | indent_except_first(1)}}
 
     # NB reversed order to since K is transposed
+    # For varlen, use physical positions for bounds checking since kT_ptrs was computed with physical offsets
+    {%- if HAS_OFFSETS %}
+    # Compute physical KV positions from logical positions + offset
+    offs_n2_physical = offs_n2 + kv_offset
+    kT = load_checked_2d(kT_ptrs, offs_k, offs_n2_physical, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, KV_LEN)
+    {%- else %}
     kT = load_checked_2d(kT_ptrs, offs_k, offs_n2, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, KV_LEN)
+    {%- endif %}
     qk = tl.dot(q, kT, input_precision=FLOAT32_PRECISION)
     if not PRESCALE_QK:
         qk *= SM_SCALE
     # ~~~~~~~~~~~~~~~~~~~ Apply score modification  ~~~~~~~~~~~~~~~~~~~
     pre_mod_scores = qk
+    # Use global indices for score_mod/mask_mod
+    # For varlen, use logical lengths since these are logical positions
+    {%- if HAS_OFFSETS %}
+    n = get_bounded_indices(offs_n2[None, :], LOGICAL_KV_LEN if not IS_DIVISIBLE else None)
+    # The boundary check is done for the outer loop, but here it's possible since we're iterating across N dim
+    # that the M reads out of bounds for the PIDS spanning the Q_LEN boundary
+    m = get_bounded_indices(offs_m2[:, None], LOGICAL_Q_LEN if not IS_DIVISIBLE else None)
+    {%- else %}
     n = get_bounded_indices(offs_n2[None, :], KV_LEN if not IS_DIVISIBLE else None)
     # The boundary check is done for the outer loop, but here it's possible since we're iterating across N dim
     # that the M reads out of bounds for the PIDS spanning the Q_LEN boundary
     m = get_bounded_indices(offs_m2[:, None], Q_LEN if not IS_DIVISIBLE else None)
+    {%- endif %}
 
     {{ modification(
         subgraph_number=0,
@@ -379,8 +588,19 @@ def bwd_dq_block_mn(
     Example: lambda x, *_: 1 / score, this NaN would propagate regardless of other masking
     We only need to do this on the m1 dim since these elements take part in the final reduction
     for DQ #}
+    # For varlen, use logical lengths since offs_n2 contains logical positions
+    {%- if HAS_OFFSETS %}
+    if not IS_DIVISIBLE:
+        post_mod_scores = tl.where(offs_n2[None, :] < LOGICAL_KV_LEN, post_mod_scores, float("-inf"))
+    {%- else %}
     if not IS_DIVISIBLE:
         post_mod_scores = tl.where(offs_n2[None, :] < KV_LEN, post_mod_scores, float("-inf"))
+    {%- endif %}
+
+    # Note: For DQ computation with varlen, we DON'T need to mask based on kv_limit here
+    # because the sparse block structure already ensures document isolation. The kv_limit
+    # is only needed for storage masking, not computation masking (unlike DK/DV which
+    # iterates over Q blocks from potentially different documents).
 
     if not IS_FULL_BLOCKS:
         {{ modification(
@@ -401,7 +621,12 @@ def bwd_dq_block_mn(
     p = tl.math.exp2(post_mod_scores - lse)
     # Compute dP and dS.
     # NB reversed order to since V is transposed
+    # For varlen, use physical positions for bounds checking since vT_ptrs was computed with physical offsets
+    {%- if HAS_OFFSETS %}
+    vT = load_checked_2d(vT_ptrs, offs_v, offs_n2_physical, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, V_HEAD_DIM, KV_LEN)
+    {%- else %}
     vT = load_checked_2d(vT_ptrs, offs_v, offs_n2, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, V_HEAD_DIM, KV_LEN)
+    {%- endif %}
 
     dp = tl.dot(do, vT, input_precision=FLOAT32_PRECISION)
     ds = p * (dp - Di[:, None])
@@ -417,12 +642,25 @@ def bwd_dq_block_mn(
         grad_score_mod="ds"
     ) | indent_except_first(1) }}
     {# See Note Selective masking DQ #}
+    # For varlen, use logical lengths since offs_n2 contains logical positions
+    {%- if HAS_OFFSETS %}
+    if not IS_DIVISIBLE:
+        grad_scores = tl.where(offs_n2[None, :] < LOGICAL_KV_LEN, grad_scores, 0.0)
+    {%- else %}
     if not IS_DIVISIBLE:
         grad_scores = tl.where(offs_n2[None, :] < KV_LEN, grad_scores, 0.0)
+    {%- endif %}
+
+    # Note: For DQ computation with varlen, kv_limit masking is not needed here
+    # because the sparse block structure already ensures document isolation.
 
     # ~~~~~~~~~~~~~~~~~~~ Apply other buffer grad writes ~~~~~~~~~~~~~
     if WRITE_DQ:
+        {%- if HAS_OFFSETS %}
+        scatter_mask = (offs_m2[:, None] < LOGICAL_Q_LEN) & (offs_n2[None, :] < LOGICAL_KV_LEN)
+        {%- else %}
         scatter_mask = (offs_m2[:, None] < Q_LEN ) & (offs_n2[None, :] < KV_LEN)
+        {%- endif %}
         {{ modification(
             subgraph_number=3,
             output_name=None,
@@ -451,12 +689,17 @@ def bwd_dq_block_mn(
 @triton.jit
 def bwd_dkdv_inner(
     {{gen_argdefs()}},
-    Q, DO, DELTA, LSE, # pointers
+    Q, DO, DELTA, LSE, Q_OFFSETS, Q_LIMITS, # pointers
     dk, dv, k, v,
-    off_z, off_hq, offs_n1, offs_m1,
+    off_z, off_hq, sparse_idx_hq, offs_n1, offs_m1,
+    # Offsets needed for memory access
+    q_start, first_q_block_idx,
+    q_offset,
     stride_qm, stride_qd, stride_dom, stride_dod,
     q_indices, sparse_q_num_blocks,
     MATMUL_PRECISION,
+    # Logical sequence lengths for mask_mod bounds (may differ from Q_LEN/KV_LEN for varlen)
+    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
     IS_FULL_BLOCKS,
 ):
     {{gen_defines() | indent_except_first(1) }}
@@ -468,24 +711,55 @@ def bwd_dkdv_inner(
     offs_k = tl.arange(0, QK_HEAD_DIM_ROUNDED)
     offs_v = tl.arange(0, V_HEAD_DIM_ROUNDED)
 
-    qT_ptrs = Q + offs_m1[None, :] * stride_qm + offs_k[:, None] * stride_qd
-    do_ptrs = DO + offs_m1[:, None] * stride_dom + offs_v[None, :] * stride_dod
+    # Physical Q positions for memory access (logical + offset = physical)
+    q_base_offset = q_start + q_offset
+    offs_m1_physical = q_base_offset + tl.arange(0, BLOCK_M1)
+
+    # Use physical indices for memory access
+    qT_ptrs = Q + offs_m1_physical[None, :] * stride_qm + offs_k[:, None] * stride_qd
+    do_ptrs = DO + offs_m1_physical[:, None] * stride_dom + offs_v[None, :] * stride_dod
     # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
     tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
 
     # The minimum is needed to handle the case where we run with a super large
     # SPARSE_BLOCK_SIZE (i.e. no block-mask!)
+    # For varlen, use logical length for iteration limit since we iterate over logical blocks
+    {%- if HAS_OFFSETS %}
+    hi = tl.minimum(sparse_q_num_blocks * SPARSE_Q_MULTIPLE, tl.maximum(tl.cdiv(LOGICAL_Q_LEN, BLOCK_M1), 1))
+    {%- else %}
     hi = tl.minimum(sparse_q_num_blocks * SPARSE_Q_MULTIPLE, tl.maximum(tl.cdiv(Q_LEN, BLOCK_M1), 1))
+    {%- endif %}
+
+    # Track current sparse block index for loading q_limit
+    current_sparse_block_idx = first_q_block_idx
+
+    {%- if HAS_OFFSETS %}
+    stride_q_limits_z = {{stride("Q_LIMITS", 0)}}
+    stride_q_limits_h = {{stride("Q_LIMITS", 1)}}
+    stride_q_offsets_z = {{stride("Q_OFFSETS", 0)}}
+    stride_q_offsets_h = {{stride("Q_OFFSETS", 1)}}
+    # Track current q_offset for pointer adjustments when crossing sparse block boundaries
+    current_q_offset = q_offset
+    {%- endif %}
 
     for start_m in range(0, hi):
+        # Load q_limit for current Q block (for varlen masking)
+        {%- if HAS_OFFSETS %}
+        q_limit_ptr = Q_LIMITS + off_z * stride_q_limits_z + sparse_idx_hq * stride_q_limits_h + current_sparse_block_idx
+        q_limit = tl.load(q_limit_ptr).to(INDEX_DTYPE)
+        {%- else %}
+        q_limit = BLOCK_M1
+        {%- endif %}
+
         dk, dv = bwd_dkdv_block_mn(
             {{gen_argdefs()}},
             dk, dv, qT_ptrs, k, v, do_ptrs, DELTA, LSE, Q_LEN, KV_LEN,
-            off_z, off_hq, offs_n1, offs_m1, offs_k, offs_v,
+            off_z, off_hq, offs_n1, offs_m1, offs_m1_physical, offs_k, offs_v,
             stride_qm, stride_qd, stride_dom, stride_dod,
             q_indices, sparse_q_num_blocks,
             MATMUL_PRECISION, RCP_LN2,
-            IS_FULL_BLOCKS,
+            IS_FULL_BLOCKS, q_limit, start_m,
+            LOGICAL_Q_LEN, LOGICAL_KV_LEN,
         )
         # Increment pointers.
         offset = get_offset_for_next_block(
@@ -496,6 +770,24 @@ def bwd_dkdv_inner(
         qT_ptrs += offset * stride_qm
         do_ptrs += offset * stride_dom
         offs_m1 += offset
+        offs_m1_physical += offset
+
+        # Update sparse block index and adjust pointers for offset change
+        {%- if HAS_OFFSETS %}
+        # Check if we crossed a sparse block boundary
+        if (start_m + 1) % SPARSE_Q_MULTIPLE == 0:
+            current_sparse_block_idx += 1
+            # Load new offset for the next sparse block
+            new_q_offset_ptr = Q_OFFSETS + off_z * stride_q_offsets_z + sparse_idx_hq * stride_q_offsets_h + current_sparse_block_idx
+            new_q_offset = tl.load(new_q_offset_ptr).to(INDEX_DTYPE)
+            # Adjust pointers for the change in physical offset
+            # When crossing document boundaries, physical memory is not contiguous
+            offset_diff = new_q_offset - current_q_offset
+            qT_ptrs += offset_diff * stride_qm
+            do_ptrs += offset_diff * stride_dom
+            offs_m1_physical += offset_diff
+            current_q_offset = new_q_offset
+        {%- endif %}
 
     return dk, dv
 
@@ -504,30 +796,53 @@ def bwd_dkdv_inner(
 def bwd_dkdv_block_mn(
     {{gen_argdefs()}},
     dk, dv, qT_ptrs, k, v, do_ptrs, DELTA, LSE, Q_LEN, KV_LEN,
-    off_z, off_hq, offs_n1, offs_m1, offs_k, offs_v,
+    off_z, off_hq, offs_n1, offs_m1, offs_m1_physical, offs_k, offs_v,
     stride_qm, stride_qd, stride_dom, stride_dod,
     q_indices, sparse_q_num_blocks,
     MATMUL_PRECISION, RCP_LN2,
-    IS_FULL_BLOCKS,
+    IS_FULL_BLOCKS, q_limit, start_m,
+    # Logical sequence lengths for mask_mod bounds (may differ from Q_LEN/KV_LEN for varlen)
+    LOGICAL_Q_LEN, LOGICAL_KV_LEN,
 ):
     {{gen_defines() | indent_except_first(1) }}
 
+    # Local position within sparse block (not just thread block)
+    # This is needed because q_limit is for the entire sparse block, not the thread block
+    SPARSE_Q_MULTIPLE_LOCAL: tl.constexpr = (SPARSE_Q_BLOCK_SIZE // BLOCK_M1)
+    local_m1 = (start_m % SPARSE_Q_MULTIPLE_LOCAL) * BLOCK_M1 + tl.arange(0, BLOCK_M1)
+
     # NB reversed order since Q is transposed
+    # Use physical positions for bounds checking since qT_ptrs was computed with physical offsets
+    # For varlen, check against Q_LEN (physical tensor size) using offs_m1_physical
+    {%- if HAS_OFFSETS %}
+    qT = load_checked_2d(qT_ptrs, offs_k, offs_m1_physical, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, Q_LEN)
+    {%- else %}
     qT = load_checked_2d(qT_ptrs, offs_k, offs_m1, None, None, SAFE_HEAD_DIM, IS_DIVISIBLE, QK_HEAD_DIM, Q_LEN)
+    {%- endif %}
     # Load LSE before computing qk to reduce pipeline stall.
+    # LSE is stored at physical positions, so use offs_m1_physical
     if IS_DIVISIBLE:
-        lse = tl.load(LSE + offs_m1)
+        lse = tl.load(LSE + offs_m1_physical)
     else:
-        lse = tl.load(LSE + offs_m1, mask=offs_m1 < Q_LEN)
+        lse = tl.load(LSE + offs_m1_physical, mask=offs_m1_physical < Q_LEN)
     lse = tl.where(lse == -float("inf"), 0.0, lse)
     qkT = tl.dot(k, qT, input_precision=FLOAT32_PRECISION)
     if not PRESCALE_QK:
         qkT *= SM_SCALE
     # ~~~~~~~~~~~~~~~~~~~ Apply score modification  ~~~~~~~~~~~~~~~~~~~
+    # Use global indices for score_mod/mask_mod
+    # For varlen, use logical lengths since these are logical positions
+    {%- if HAS_OFFSETS %}
+    m = get_bounded_indices(offs_m1[None, :], LOGICAL_Q_LEN if not IS_DIVISIBLE else None)
+    # The boundary check is done for the outer loop, but here it's possible since we're iterating across M dim
+    # that the n reads out of bounds for the PIDS spanning the KV_LEN boundary
+    n = get_bounded_indices(offs_n1[:, None], LOGICAL_KV_LEN if not IS_DIVISIBLE else None)
+    {%- else %}
     m = get_bounded_indices(offs_m1[None, :], Q_LEN if not IS_DIVISIBLE else None)
     # The boundary check is done for the outer loop, but here it's possible since we're iterating across M dim
     # that the n reads out of bounds for the PIDS spanning the KV_LEN boundary
     n = get_bounded_indices(offs_n1[:, None], KV_LEN if not IS_DIVISIBLE else None)
+    {%- endif %}
 
     pre_mod_scores = qkT
     {{ modification(
@@ -546,8 +861,19 @@ def bwd_dkdv_block_mn(
     Example: lambda x, *_: 1 / score, this NaN would propagate regardless of other masking
     We only need to do this on the m1 dim since these elements take part in the final reduction
     for DK/DV #}
+    # For varlen, use logical lengths since offs_m1 contains logical positions
+    {%- if HAS_OFFSETS %}
+    if not IS_DIVISIBLE:
+        post_mod_scores = tl.where(offs_m1[None, :] < LOGICAL_Q_LEN, post_mod_scores, float("-inf"))
+    {%- else %}
     if not IS_DIVISIBLE:
         post_mod_scores = tl.where(offs_m1[None, :] < Q_LEN, post_mod_scores, float("-inf"))
+    {%- endif %}
+
+    # For varlen, mask out positions beyond q_limit (to prevent data from other documents leaking in)
+    {%- if HAS_OFFSETS %}
+    post_mod_scores = tl.where(local_m1[None, :] < q_limit, post_mod_scores, float("-inf"))
+    {%- endif %}
 
     if not IS_FULL_BLOCKS:
         {{ modification(
@@ -564,14 +890,20 @@ def bwd_dkdv_block_mn(
     if not PRESCALE_QK:
         post_mod_scores *= RCP_LN2
     pT = tl.math.exp2(post_mod_scores - lse[None, :])
+    # For varlen, use physical positions for bounds checking since do_ptrs was computed with physical offsets
+    {%- if HAS_OFFSETS %}
+    do = load_checked_2d(do_ptrs, offs_m1_physical, offs_v, None, None, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM)
+    {%- else %}
     do = load_checked_2d(do_ptrs, offs_m1, offs_v, None, None, IS_DIVISIBLE, SAFE_HEAD_DIM, Q_LEN, V_HEAD_DIM)
+    {%- endif %}
     # Compute dV.
     ppT = pT
     dv += tl.dot(ppT.to(MATMUL_PRECISION), do, input_precision=FLOAT32_PRECISION)
+    # Delta is stored at physical positions, so use offs_m1_physical
     if IS_DIVISIBLE:
-        Di = tl.load(DELTA + offs_m1)
+        Di = tl.load(DELTA + offs_m1_physical)
     else:
-        Di = tl.load(DELTA + offs_m1, mask=offs_m1 < Q_LEN)
+        Di = tl.load(DELTA + offs_m1_physical, mask=offs_m1_physical < Q_LEN)
     # Compute dP and dS.
     dpT = tl.dot(v, tl.trans(do), input_precision=FLOAT32_PRECISION)
     dsT = pT * (dpT - Di[None, :])
@@ -588,8 +920,19 @@ def bwd_dkdv_block_mn(
     ) | indent_except_first(1) }}
 
     {# See Note: Selective masking DK/DV#}
+    # For varlen, use logical lengths since offs_m1 contains logical positions
+    {%- if HAS_OFFSETS %}
+    if not IS_DIVISIBLE:
+        grad_scores = tl.where(offs_m1[None, :] < LOGICAL_Q_LEN, grad_scores, 0.0)
+    {%- else %}
     if not IS_DIVISIBLE:
         grad_scores = tl.where(offs_m1[None, :] < Q_LEN, grad_scores, 0.0)
+    {%- endif %}
+
+    # For varlen, mask out positions beyond q_limit
+    {%- if HAS_OFFSETS %}
+    grad_scores = tl.where(local_m1[None, :] < q_limit, grad_scores, 0.0)
+    {%- endif %}
 
     # ~~~~~~~~~~~~~~~~~~~ Apply other buffer grad writes ~~~~~~~~~~~~~
     if not WRITE_DQ:
@@ -597,7 +940,12 @@ def bwd_dkdv_block_mn(
         idx_h = off_hq
         idx_m = m
         idx_n = n
+        {%- if HAS_OFFSETS %}
+        scatter_mask = (offs_m1[None, :] < LOGICAL_Q_LEN) & (offs_n1[:, None] < LOGICAL_KV_LEN)
+        scatter_mask = scatter_mask & (local_m1[None, :] < q_limit)
+        {%- else %}
         scatter_mask = (offs_m1[None, :] < Q_LEN) & (offs_n1[:, None] < KV_LEN)
+        {%- endif %}
         {{ modification(
             subgraph_number=3,
             output_name=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Adds support for variable-length sequences in the backward pass of
flex_attention. The backward template now handles HAS_OFFSETS
conditionals for loading Q/KV offsets and limits, and uses logical
sequence lengths for grid iteration.

Key changes:
- flex_backwards.py.jinja: Add HAS_OFFSETS conditionals for backward
  pass, including Q_OFFSETS/KV_OFFSETS/Q_LIMITS/KV_LIMITS inputs and
  LOGICAL_Q/KV_LEN computation
- flex_attention.py: Update backward path to call _setup_varlen_offsets
  and include offset tensors in input_nodes, use logical sequence
  lengths for call_sizes
- flex_attention.py (nn/attention): Fix validation to allow physical
  tensor sizes smaller than logical block_mask sizes in varlen mode

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo