### PR TITLE
[DO NOT REBASE][ROCm][inductor] New Inductor benchmarker based on torch profiler.

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -119,10 +119,10 @@ jobs:
     needs: linux-jammy-rocm-py3_10-inductor-benchmark-build
     with:
       build-environment: ${{ needs.linux-jammy-rocm-py3_10-inductor-benchmark-build.outputs.build-environment }}
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-maxautotune-true-freezing_cudagraphs-true
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-inductor-benchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-inductor-benchmark-build.outputs.test-matrix }}
-      timeout-minutes: 720
+      timeout-minutes: 1440
       # Disable monitor in perf tests for more investigation
       disable-monitor: true
       monitor-log-interval: 10

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -476,7 +476,7 @@ pipeline_max_autotune_gemm = (
 # use torch profiler to benchmark kernels during autotuning
 # when enabled, this takes precedence over use_experimental_benchmarker
 use_torch_profiler_benchmarker: bool = Config(
-    default=False,
+    default=True,
     env_name_force="TORCHINDUCTOR_USE_TORCH_PROFILER_BENCHMARKER",
     justknob="pytorch/inductor:use_torch_profiler_benchmarker",
 )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -473,6 +473,14 @@ pipeline_max_autotune_gemm = (
     os.environ.get("TORCHINDUCTOR_PIPELINE_GEMM_AUTOTUNING") == "1"
 )
 
+# use torch profiler to benchmark kernels during autotuning
+# when enabled, this takes precedence over use_experimental_benchmarker
+use_torch_profiler_benchmarker: bool = Config(
+    default=False,
+    env_name_force="TORCHINDUCTOR_USE_TORCH_PROFILER_BENCHMARKER",
+    justknob="pytorch/inductor:use_torch_profiler_benchmarker",
+)
+
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -476,7 +476,7 @@ pipeline_max_autotune_gemm = (
 # use torch profiler to benchmark kernels during autotuning
 # when enabled, this takes precedence over use_experimental_benchmarker
 use_torch_profiler_benchmarker: bool = Config(
-    default=True,
+    default=False,
     env_name_force="TORCHINDUCTOR_USE_TORCH_PROFILER_BENCHMARKER",
     justknob="pytorch/inductor:use_torch_profiler_benchmarker",
 )

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -12,12 +12,19 @@ import torch
 import torch._inductor.config as inductor_config
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import counters, dynamo_timed
+from torch._inductor.config import (
+    use_experimental_benchmarker,
+    use_torch_profiler_benchmarker,
+)
 from torch.utils._debug_mode import DebugMode
 
 
 logger = torch._logging.getArtifactLogger(__name__, "benchmarking")
 use_experimental_benchmarker = (
     inductor_config.use_experimental_benchmarker and torch.cuda.is_available()
+)
+use_torch_profiler_benchmarker = (
+    use_torch_profiler_benchmarker and torch.cuda.is_available()
 )
 
 
@@ -291,6 +298,113 @@ class TritonBenchmarker(Benchmarker):
         return self.triton_do_bench(_callable, **kwargs, return_mode="median")
 
 
+class TorchProfilerBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
+    """Benchmarker that uses torch.profiler for GPU kernel benchmarking."""
+
+    @time_and_count
+    def benchmark_gpu(  # type: ignore[override]
+        self: Self,
+        _callable: Callable[[], Any],
+        warmup: int = 25,
+        rep: int = 100,
+        return_mode: str = "mean",
+        grad_to_none: Optional[list[torch.Tensor]] = None,
+        **kwargs: Any,
+    ) -> float:
+        """Benchmark a GPU callable using torch.profiler.
+
+        Arguments:
+        - _callable: The callable to benchmark.
+
+        Keyword Arguments:
+        - warmup: Optionally, the number of warmup iterations to run before benchmarking.
+        - rep: Optionally, the number of iterations to run during benchmarking.
+        - return_mode: Return mode for benchmark results. Options are "min", "mean" (default), 
+        or "max".
+        - grad_to_none: Optionally, a list of tensors whose gradients should be cleared
+        before each benchmark iteration.
+        - **kwargs: Additional kwargs that may be passed to the fallback.
+
+        Returns:
+        - The runtime of `_callable` in milliseconds, computed according to return_mode.
+        """
+        # we don't want any outside errors propagating into benchmarking
+        torch.cuda.synchronize()
+
+        # warmup `_callable` (and catches any failures in the process)
+        _callable()
+        torch.cuda.synchronize()
+
+        # create cache flush buffer: 256 MB = 256 * 1024 * 1024 bytes
+        # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
+        buffer_size_bytes = 256 * 1024 * 1024
+        buffer = torch.empty(buffer_size_bytes // 4, dtype=torch.int, device="cuda")
+        buffer.zero_()
+
+        # additional warmup with cache flushing
+        for _ in range(warmup):
+            # Clear gradients before timing (matches triton.testing.do_bench)
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            buffer.zero_()
+            _callable()
+        torch.cuda.synchronize()
+
+        # benchmark with profiler
+        timings = []
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CUDA],
+            record_shapes=False,
+        ) as prof:
+            for _ in range(rep):
+                # Clear gradients before timing (matches triton.testing.do_bench)
+                if grad_to_none is not None:
+                    for x in grad_to_none:
+                        x.grad = None
+                buffer.zero_()
+                _callable()
+        torch.cuda.synchronize()
+        
+        # Extract CUDA kernel time from profiler events
+        # First, try to find Triton kernels (kernel names starting with "triton_")
+        triton_kernel_time_us = sum(
+            event.device_time_total
+            for event in prof.key_averages()
+            if event.device_type == torch.profiler.DeviceType.CUDA
+            and event.key.startswith("triton_")
+        )
+        
+        # If no Triton kernels found, fall back to GEMM kernels
+        # - "Cijk" prefix: ROCm/HIP GEMM kernels (rocBLAS/Tensile)
+        # - Contains "gemm": CUDA cuBLAS/cuDNN GEMM kernels
+        # NOTE: This fallback path is not well tested at this time and may need refinement
+        if triton_kernel_time_us == 0:
+            triton_kernel_time_us = sum(
+                event.device_time_total
+                for event in prof.key_averages()
+                if event.device_type == torch.profiler.DeviceType.CUDA
+                and (event.key.startswith("Cijk") or "gemm" in event.key.lower())
+            )
+        
+        # Convert to milliseconds and compute the average time per iteration
+        avg_time_ms = (triton_kernel_time_us / rep) / 1000.0
+
+        # explicitly delete the buffer, sometimes helps memory
+        # footprint metrics in OSS Inductor performance benchmarks
+        del buffer
+
+        # Return based on the requested mode
+        # Note: For profiler-based benchmarking, we return the mean time per iteration
+        # min/max modes are kept for API compatibility but return the mean
+        if return_mode in ("min", "mean", "max"):
+            return avg_time_ms
+        else:
+            raise ValueError(
+                f"Unsupported return_mode: {return_mode}. Use 'min', 'mean', or 'max'."
+            )
+
+
 class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
     @cached_property
     def L2_cache_size(self: Self) -> int:
@@ -440,5 +554,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
 
 
 benchmarker = (
-    InductorBenchmarker() if use_experimental_benchmarker else TritonBenchmarker()
+    TorchProfilerBenchmarker()
+    if use_torch_profiler_benchmarker
+    else (InductorBenchmarker() if use_experimental_benchmarker else TritonBenchmarker())
 )

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -294,116 +294,6 @@ class TritonBenchmarker(Benchmarker):
         return self.triton_do_bench(_callable, **kwargs, return_mode="median")
 
 
-class TorchProfilerBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
-    """Benchmarker that uses torch.profiler for GPU kernel benchmarking."""
-
-    @time_and_count
-    def benchmark_gpu(  # type: ignore[override]
-        self: Self,
-        _callable: Callable[[], Any],
-        warmup: int = 25,
-        rep: int = 100,
-        return_mode: str = "mean",
-        grad_to_none: Optional[list[torch.Tensor]] = None,
-        **kwargs: Any,
-    ) -> float:
-        """Benchmark a GPU callable using torch.profiler.
-
-        Arguments:
-        - _callable: The callable to benchmark.
-
-        Keyword Arguments:
-        - warmup: Optionally, the number of warmup iterations to run before benchmarking.
-        - rep: Optionally, the number of iterations to run during benchmarking.
-        - return_mode: Return mode for benchmark results. Options are "min", "mean" (default),
-        or "max".
-        - grad_to_none: Optionally, a list of tensors whose gradients should be cleared
-        before each benchmark iteration.
-        - **kwargs: Additional kwargs that may be passed to the fallback.
-
-        Returns:
-        - The runtime of `_callable` in milliseconds, computed according to return_mode.
-        """
-        # we don't want any outside errors propagating into benchmarking
-        torch.cuda.synchronize()
-
-        # warmup `_callable` (and catches any failures in the process)
-        _callable()
-        torch.cuda.synchronize()
-
-        # create cache flush buffer: 256 MB = 256 * 1024 * 1024 bytes
-        # NOTE: This is the same buffer size as Triton's do_bench
-        # For AMD, there are better outcomes on short duration kernels (<20 us)
-        # when buffer size is set to the Infinity cache (LLC) instead of L2.
-        # LLC cache size is not a supported field in PyTorchdevice properties.
-        # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
-        buffer_size_bytes = 256 * 1024 * 1024
-        buffer = torch.empty(buffer_size_bytes // 4, dtype=torch.int, device="cuda")
-        buffer.zero_()
-
-        # additional warmup with cache flushing
-        for _ in range(warmup):
-            # Clear gradients before timing (matches triton.testing.do_bench)
-            if grad_to_none is not None:
-                for x in grad_to_none:
-                    x.grad = None
-            buffer.zero_()
-            _callable()
-        torch.cuda.synchronize()
-
-        # benchmark with profiler
-        with torch.profiler.profile(
-            activities=[torch.profiler.ProfilerActivity.CUDA],
-            record_shapes=False,
-        ) as prof:
-            for _ in range(rep):
-                # Clear gradients before timing (matches triton.testing.do_bench)
-                if grad_to_none is not None:
-                    for x in grad_to_none:
-                        x.grad = None
-                buffer.zero_()
-                _callable()
-        torch.cuda.synchronize()
-
-        # Extract CUDA kernel time from profiler events
-        # First, try to find Triton kernels (kernel names starting with "triton_")
-        triton_kernel_time_us = sum(
-            event.device_time_total
-            for event in prof.key_averages()
-            if event.device_type == torch.profiler.DeviceType.CUDA
-            and event.key.startswith("triton_")
-        )
-
-        # If no Triton kernels found, fall back to GEMM kernels from other backends
-        # - "Cijk" prefix: rocBLAS/hipBLASLt GEMM kernels (rocBLAS/Tensile)
-        # - Contains "gemm": CK GEMM kernels
-        # NOTE: This fallback path is not well tested at this time and may need refinement
-        if triton_kernel_time_us == 0:
-            triton_kernel_time_us = sum(
-                event.device_time_total
-                for event in prof.key_averages()
-                if event.device_type == torch.profiler.DeviceType.CUDA
-                and (event.key.startswith("Cijk") or "gemm" in event.key.lower())
-            )
-
-        # Convert to milliseconds and compute the average time per iteration
-        avg_time_ms = (triton_kernel_time_us / rep) / 1000.0
-
-        # explicitly delete the buffer, sometimes helps memory
-        # footprint metrics in OSS Inductor performance benchmarks
-        del buffer
-
-        # Return based on the requested mode
-        # Note: For profiler-based benchmarking, we return the mean time per iteration
-        # min/max modes are kept for API compatibility but return the mean
-        if return_mode in ("min", "mean", "max"):
-            return avg_time_ms
-        else:
-            raise ValueError(
-                f"Unsupported return_mode: {return_mode}. Use 'min', 'mean', or 'max'."
-            )
-
-
 class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
     @cached_property
     def L2_cache_size(self: Self) -> int:
@@ -549,6 +439,138 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
         else:
             raise ValueError(
                 f"Unsupported return_mode: {return_mode}. Use 'min' or 'all'."
+            )
+
+
+class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
+    """Benchmarker that uses torch.profiler for GPU kernel benchmarking."""
+
+    @time_and_count
+    def benchmark_gpu(  # type: ignore[override]
+        self: Self,
+        _callable: Callable[[], Any],
+        estimation_iters: int = 5,
+        memory_warmup_iters: int = 100,
+        benchmark_iters: int = 100,
+        max_benchmark_duration: int = 25,
+        return_mode: str = "mean",
+        grad_to_none: Optional[list[torch.Tensor]] = None,
+        **kwargs: Any,
+    ) -> float:
+        """Benchmark a GPU callable using torch.profiler.
+
+        Arguments:
+        - _callable: The callable to benchmark.
+
+        Keyword Arguments:
+        - estimation_iters: Optionally, the number of iterations to run `_callable`
+        during runtime estimation.
+        - memory_warmup_iters: Optionally, the number of iterations to flush the L2
+        cache before starting benchmarking.
+        - benchmark_iters: Optionally, the number of iterations to run `_callable`
+        during the benchmarking.
+        - max_benchmark_duration: Optionally, the maximum duration of the benchmarking,
+        in milliseconds.
+        - return_mode: Return mode for benchmark results. Options are "min", "mean" (default),
+        or "max".
+        - grad_to_none: Optionally, a list of tensors whose gradients should be cleared
+        before each benchmark iteration.
+        - **kwargs: Additional kwargs that may be passed to the fallback.
+
+        Returns:
+        - The runtime of `_callable` in milliseconds, computed according to return_mode.
+        """
+        # we don't want any outside errors propagating into benchmarking
+        torch.cuda.synchronize()
+
+        # warmup `_callable` (and catches any failures in the process)
+        _callable()
+        torch.cuda.synchronize()
+
+        # create cache flush buffer: 256 MB = 256 * 1024 * 1024 bytes
+        # NOTE: This is the same buffer size as Triton's do_bench
+        # For AMD, there are better outcomes on short duration kernels (<20 us)
+        # when buffer size is set to the Infinity cache (LLC) instead of L2.
+        # LLC cache size is not a supported field in PyTorchdevice properties.
+        # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
+        if torch.version.hip:
+            buffer_size_bytes = 256 * 1024 * 1024
+        else:
+            buffer_size_bytes = self.L2_cache_size
+        buffer = torch.empty(buffer_size_bytes // 4, dtype=torch.int, device="cuda")
+        buffer.zero_()
+
+        # estimate the runtime of `_callable`
+        event_pairs = self.get_event_pairs(estimation_iters)
+        for start_event, end_event in event_pairs:
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            buffer.zero_()
+            start_event.record()
+            _callable()
+            end_event.record()
+        torch.cuda.synchronize()
+        estimated_timing = self.get_event_pairs_min_timing(event_pairs)
+
+        # adjust `benchmark_iters` to fit in the maximum benchmarking duration
+        benchmark_iters = max(
+            min(benchmark_iters, int(max_benchmark_duration // estimated_timing)), 1
+        )
+
+        # do the memory warmup
+        for _ in range(memory_warmup_iters):
+            buffer.zero_()
+
+        # benchmark with profiler
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CUDA],
+            record_shapes=False,
+        ) as prof:
+            for _ in range(benchmark_iters):
+                if grad_to_none is not None:
+                    for x in grad_to_none:
+                        x.grad = None
+                buffer.zero_()
+                _callable()
+        torch.cuda.synchronize()
+
+        # Extract CUDA kernel time from profiler events
+        # First, try to find Triton kernels (kernel names starting with "triton_")
+        triton_kernel_time_us = sum(
+            event.device_time_total
+            for event in prof.key_averages()
+            if event.device_type == torch.profiler.DeviceType.CUDA
+            and event.key.startswith("triton_")
+        )
+
+        # If no Triton kernels found, fall back to GEMM kernels from other backends
+        # - "Cijk" prefix: rocBLAS/hipBLASLt GEMM kernels (rocBLAS/Tensile)
+        # - Contains "gemm": CK GEMM kernels
+        # NOTE: This fallback path is not well tested at this time and may need refinement
+        if triton_kernel_time_us == 0:
+            triton_kernel_time_us = sum(
+                event.device_time_total
+                for event in prof.key_averages()
+                if event.device_type == torch.profiler.DeviceType.CUDA
+                and (event.key.startswith("Cijk") or "gemm" in event.key.lower())
+            )
+
+        # Convert to milliseconds and compute the average time per iteration
+        avg_time_ms = (triton_kernel_time_us / benchmark_iters) / 1000.0
+
+        # explicitly delete the buffer, sometimes helps memory
+        # footprint metrics in OSS Inductor performance benchmarks
+        del buffer
+
+        # Return based on the requested mode
+        # Note: For profiler-based benchmarking, we return the mean time per iteration
+        # min/max modes are kept for API compatibility but return the mean
+        if return_mode in ("min", "mean", "max"):
+            return avg_time_ms
+        else:
+            raise ValueError(
+                f"Unsupported return_mode: {return_mode}. Use 'min', 'mean', or 'max'."
             )
 
 


### PR DESCRIPTION
A new benchmarker method for timing Inductor kernels during autotuning.

Improves selection of optimal kernels on ROCm platforms.

Very similar to experimental Inductor benchmarker, but using Torch profiler to obtain timings instead of hipEvents (which seems to be inaccurate when measuring the time on small Inductor-Triton kernels).

May also benefit NVIDIA, but not tested on that platform as of yet.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos