### PR TITLE
[MPS] Add _aminmax support for Apple Silicon (deprecated API)

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -11,10 +11,12 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_aminmax_native.h>
 #include <ATen/ops/_cdist_forward_native.h>
 #include <ATen/ops/all_native.h>
 #include <ATen/ops/amax_native.h>
 #include <ATen/ops/amin_native.h>
+#include <ATen/ops/aminmax.h>
 #include <ATen/ops/aminmax_native.h>
 #include <ATen/ops/any_native.h>
 #include <ATen/ops/argmax_native.h>
@@ -1060,6 +1062,19 @@ TORCH_IMPL_FUNC(aminmax_out_mps)
                     max_t,
                     MPSReductionType::AMAX,
                     "aminmax_out_mps_max");
+}
+
+// DEPRECATED: _aminmax is deprecated, use aminmax instead
+std::tuple<Tensor, Tensor> _aminmax_all_mps(const Tensor& self) {
+  TORCH_WARN_ONCE("_aminmax is deprecated as of PyTorch 1.11 and will be removed in a future release. Use aminmax instead."
+                  " This warning will only appear once per process.");
+  return at::aminmax(self);
+}
+
+std::tuple<Tensor, Tensor> _aminmax_mps(const Tensor& self, int64_t dim, bool keepdim) {
+  TORCH_WARN_ONCE("_aminmax is deprecated as of PyTorch 1.11 and will be removed in a future release. Use aminmax instead."
+                  " This warning will only appear once per process.");
+  return at::aminmax(self, dim, keepdim);
 }
 
 Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3868,12 +3868,14 @@
 - func: _aminmax(Tensor self) -> (Tensor, Tensor)
   dispatch:
     CPU, CUDA: _aminmax_all
+    MPS: _aminmax_all_mps
   autogen: _aminmax.out
 
 # DEPRECATED: Use torch.aminmax instead
 - func: _aminmax.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
   dispatch:
     CPU, CUDA: _aminmax
+    MPS: _aminmax_mps
   autogen: _aminmax.dim_out
 
 - func: aminmax(Tensor self, *, int? dim=None, bool keepdim=False) -> (Tensor min, Tensor max)


### PR DESCRIPTION
## Summary
This PR adds MPS support for the deprecated `_aminmax` operations by delegating to the `aminmax` function which already has MPS support.

## Implementation Details
Both variants are implemented:
- `_aminmax_all_mps`: reduces over all dimensions
- `_aminmax_mps`: reduces over a specific dimension with keepdim

These functions emit a deprecation warning consistent with the CPU/CUDA implementations, directing users to use `aminmax` instead.

## Changes
- `aten/src/ATen/native/mps/operations/ReduceOps.mm`: Added `_aminmax_all_mps` and `_aminmax_mps` functions
- `aten/src/ATen/native/native_functions.yaml`: Added MPS dispatch for `_aminmax` and `_aminmax.dim`

cc @malfet @kulinseth