### PR TITLE
[pytorch] Fix RMSNorm eps documentation to match opmath behavior

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -357,7 +357,10 @@ class RMSNorm(Module):
 
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
-        eps: a value added to the denominator for numerical stability. Default: ``torch.finfo(x.dtype).eps``
+        eps: a value added to the denominator for numerical stability. If not specified,
+            uses the machine epsilon of the computation (opmath) type: fp16/bf16 and
+            fp32 inputs use ``torch.finfo(torch.float32).eps``, while fp64 inputs use
+            ``torch.finfo(torch.float64).eps``.
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
 


### PR DESCRIPTION
Summary:
The RMSNorm documentation incorrectly stated that the default epsilon is `torch.finfo(x.dtype).eps`. However, since #142848  (January 2025), the implementation uses `toOpMathType()` to determine the computation type before computing epsilon.

For fp16/bf16 inputs, computation is done in fp32, so the default epsilon is `torch.finfo(torch.float32).eps`, not the input dtype's epsilon. This is a significant difference.

Note: LayerNorm and GroupNorm do not need similar updates because they use a hardcoded default of `eps=1e-5` rather than a dtype-dependent epsilon.

Test Plan: Documentation-only change. The implementation behavior is already correct and tested by PyTorch CI tests for RMSNorm.

Reviewed By: jfix71

Differential Revision: D91174010


