### PR TITLE
[MPS] Add adaptive_max_pool3d support for Apple Silicon

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12518,6 +12518,7 @@
   dispatch:
     CPU: adaptive_max_pool3d_out_cpu
     CUDA: adaptive_max_pool3d_out_cuda
+    MPS: adaptive_max_pool3d_out_mps
 
 # Return: (Tensor output, Tensor indices)
 - func: adaptive_max_pool3d(Tensor self, int[3] output_size) -> (Tensor, Tensor)
@@ -12530,6 +12531,7 @@
   dispatch:
     CPU: adaptive_max_pool3d_backward_out_cpu
     CUDA: adaptive_max_pool3d_backward_out_cuda
+    MPS: adaptive_max_pool3d_backward_out_mps
 
 - func: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor
   python_module: nn


### PR DESCRIPTION
## Summary
This PR adds MPS (Metal Performance Shaders) support for adaptive_max_pool3d and adaptive_max_pool3d_backward operations.

## Implementation Details
The implementation follows the same pattern as adaptive_max_pool2d_mps:
- Calculate appropriate kernel sizes and strides based on input/output dimensions
- Delegate to max_pool3d_with_indices which already has MPS support

This enables 3D adaptive max pooling operations to run natively on Apple Silicon GPUs instead of falling back to CPU.

## Functions Added
- adaptive_max_pool3d_out_mps
- adaptive_max_pool3d_backward_out_mps
- set_kernel_params_3d helper function

## Testing
The implementation reuses the existing max_pool3d_with_indices MPS kernel which is already well-tested.

cc @kulinseth @albanD @malfet @DenisVieriu97 @razarmehr
