### PR TITLE
Fix stride mismatch in householder_product_backward

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1019,7 +1019,6 @@ inductor_skip_exact_stride = {
     "nn.functional.linear",
     "nn.functional.max_pool2d",
     "nn.functional.unfold",
-    "ormqr",
     "polar",
     "prod",
     "qr",

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5638,6 +5638,14 @@ std::tuple<Tensor, Tensor> householder_product_backward(
   // excluding the main diagonal, hence the gradient is also lower-triangular.
   input_grad.tril_(-1);
 
+  // Match input strides if different.
+  if (!input_grad.strides().equals(input_.strides())) {
+    auto new_grad =
+        input_grad.new_empty_strided(input_.sizes(), input_.strides());
+    new_grad.copy_(input_grad);
+    input_grad = std::move(new_grad);
+  }
+
   return std::make_tuple(std::move(input_grad), std::move(tau_grad));
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173045

Summary: Surfaced by an inductor test when checking strides for ormqr: When tracing householder_product_backward with FakeTensor (used by AOT autograd/inductor), the function takes a path using cat() to construct the input gradient. During functionalization, the subsequent tril_(-1) operation becomes tril(), which produces contiguous output with different strides than the original input.

Fix by adding stride correction after tril_(-1) to preserve the original input's strides when they differ; uses new_empty_strided + copy_ to properly replicate the input's stride pattern while preserving the computed gradient values. Using new_empty_strided (instead of at::empty_strided) ensures composite compliance by preserving the tensor subclass type.

Testing: Enabled stride comparison for ormqr in test/inductor/test_torchinductor_opinfo.py

Co-Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo