### PR TITLE
[MPS] Add support for adaptive_max_pool3d forward and backward

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12518,6 +12518,7 @@
   dispatch:
     CPU: adaptive_max_pool3d_out_cpu
     CUDA: adaptive_max_pool3d_out_cuda
+    MPS: adaptive_max_pool3d_out_mps
 
 # Return: (Tensor output, Tensor indices)
 - func: adaptive_max_pool3d(Tensor self, int[3] output_size) -> (Tensor, Tensor)
@@ -12530,6 +12531,7 @@
   dispatch:
     CPU: adaptive_max_pool3d_backward_out_cpu
     CUDA: adaptive_max_pool3d_backward_out_cuda
+    MPS: adaptive_max_pool3d_backward_out_mps
 
 - func: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor
   python_module: nn


### PR DESCRIPTION
## Summary
This PR adds MPS backend support for adaptive_max_pool3d and adaptive_max_pool3d_backward.

## Implementation Details
- Adds set_kernel_params_3d helper function to compute kernel sizes and strides for 3D adaptive pooling
- Implements TORCH_IMPL_FUNC(adaptive_max_pool3d_out_mps) using max_pool3d_with_indices
- Implements TORCH_IMPL_FUNC(adaptive_max_pool3d_backward_out_mps) using max_pool3d_with_indices_backward
- Follows the same pattern as the existing adaptive_max_pool2d implementation

## Changes
- aten/src/ATen/native/native_functions.yaml: Added MPS dispatch for structured ops
- aten/src/ATen/native/mps/operations/AdaptivePooling.mm: Added implementation
- test/test_mps.py: Added test_adaptive_max_pool3d_simple test

## Test Plan
- Added comprehensive tests covering both 4D and 5D input tensors
- Tests include forward pass, backward pass, and indices validation
- Tests compare MPS results against CPU reference

Closes https://github.com/pytorch/pytorch/issues/141287
