### PR TITLE
Fix critical null pointer bug in TransformerEncoder

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9629,6 +9629,22 @@ class TestNNDeviceType(NNTestCase):
             transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6).to(device)
             _test_module_empty_input(self, transformer_encoder, input, check_size=False)
 
+    def test_TransformerEncoder_num_layers_validation(self):
+        """Test that TransformerEncoder raises ValueError for invalid num_layers."""
+        encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+
+        # Test num_layers = 0
+        with self.assertRaisesRegex(ValueError, "num_layers must be a positive integer"):
+            nn.TransformerEncoder(encoder_layer, num_layers=0)
+
+        # Test num_layers < 0
+        with self.assertRaisesRegex(ValueError, "num_layers must be a positive integer"):
+            nn.TransformerEncoder(encoder_layer, num_layers=-1)
+
+        # Test valid num_layers = 1 (should not raise)
+        transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=1)
+        self.assertEqual(len(transformer_encoder.layers), 1)
+
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
     @expectedFailureMPS   # Float64 is not supported
     @onlyNativeDeviceTypes

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -358,6 +358,14 @@ class TransformerEncoder(Module):
     ) -> None:
         super().__init__()
         torch._C._log_api_usage_once(f"torch.nn.modules.{self.__class__.__name__}")
+        
+        # Validate num_layers parameter
+        if num_layers <= 0:
+            raise ValueError(
+                f"num_layers must be a positive integer, but got {num_layers}. "
+                f"TransformerEncoder requires at least 1 layer to function properly."
+            )
+        
         self.layers = _get_clones(encoder_layer, num_layers)
         self.num_layers = num_layers
         self.norm = norm
@@ -445,6 +453,14 @@ class TransformerEncoder(Module):
 
         output = src
         convert_to_nested = False
+        
+        # Validate that layers list is not empty before accessing first layer
+        if not self.layers:
+            raise RuntimeError(
+                f"TransformerEncoder has no layers. Expected at least 1 layer, "
+                f"but got {len(self.layers)} layers. Please ensure num_layers > 0."
+            )
+        
         first_layer = self.layers[0]
         src_key_padding_mask_for_layers = src_key_padding_mask
         why_not_sparsity_fast_path = ""


### PR DESCRIPTION
This PR adds validation to prevent IndexError when TransformerEncoder is created with invalid num_layers parameter.
### Problem
When TransformerEncoder is created with num_layers=0 or a negative value, it would cause a cryptic IndexError when accessing self.layers[0] in the forward pass:
```
encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)encoder = nn.TransformerEncoder(encoder_layer, num_layers=0)  # No error hereencoder(input)  # IndexError: list index out of range
```

### Solution
Added constructor validation to raise a clear ValueError with a helpful message:
```
if num_layers <= 0:    raise ValueError(        f"num_layers must be a positive integer, but got {num_layers}. "        "TransformerEncoder requires at least 1 layer to function properly."    )
```
### Changes
torch/nn/modules/transformer.py: Added num_layers validation in constructor
test/test_nn.py: Added test test_TransformerEncoder_num_layers_validation

Fixes #165312
