### PR TITLE
Fix pandas/numpy binary incompatibility breaking test_dataloader and test_datapipe

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -141,8 +141,8 @@ numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
 numpy==2.1.2; python_version >= "3.13" and python_version < "3.14"
 numpy==2.3.4; python_version >= "3.14"
 
-pandas==2.0.3; python_version < "3.12"
-pandas==2.2.3; python_version >= "3.12" and python_version < "3.14"
+pandas==2.0.3; python_version < "3.11"
+pandas==2.2.3; python_version >= "3.11" and python_version < "3.14"
 pandas==2.3.3; python_version >= "3.14"
 
 #onnxruntime


### PR DESCRIPTION
Fixes #173059 

 Bump pandas to 2.2.3 for Python 3.11 to fix numpy binary incompatibility.

  pandas 2.0.3 wheels on PyPI were rebuilt with numpy 2.x ABI (96-byte dtype),
  causing `ValueError: numpy.dtype size changed` errors when running with
  numpy 1.26.2 (88-byte dtype) on Python 3.11.

  This affected tests importing pandas (test_dataloader, test_datapipe).

  **Change:**
  - `pandas==2.0.3` now only applies to Python < 3.11 (was < 3.12)
  - `pandas==2.2.3` now applies to Python 3.11+ (was 3.12+)


cc @andrewkho @divyanshk @VitalyFedyunin @dzhulgakov @scotts @cyyever @janeyx99 