### PR TITLE
avoid small macro conflict with windows.h

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -208,8 +208,8 @@ struct ShareableHandle {
 };
 
 struct StreamSegmentSize {
-  StreamSegmentSize(cudaStream_t s, bool small, size_t sz)
-      : stream(s), is_small_pool(small), total_size(sz) {}
+  StreamSegmentSize(cudaStream_t s, bool is_small, size_t sz)
+      : stream(s), is_small_pool(is_small), total_size(sz) {}
   cudaStream_t stream;
   bool is_small_pool;
   size_t total_size;


### PR DESCRIPTION
Unfortunately "small" is a macro in `C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\shared\rpcndr.h:#define small char`. `rpcndr.h` is included indirectly via `windows.h` so it's not possible to not include this on Windows. Simply renaming "small" to something else like "is_small" to avoid the collision fixes the issue.

This problem was discovered when I updated libtorch from 2.9.1 to 2.10.0 for my codebase.
