### PR TITLE
[Makefile] Clean up non-existent script calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ NIGHTLY_TOOL_OPTS := pull
 
 .PHONY: all
 all:
-	@cmake -S . -B build $(shell $(PYTHON) ./scripts/get_python_cmake_flags.py) && \
-		cmake --build build --parallel --
 
 .PHONY: triton
 triton:


### PR DESCRIPTION
Since commit 91602a92548d ("Cleanup old caffe2 scripts (#158475)") remove scripts/get_python_cmake_flags.py.

