### PR TITLE
Disable Triton convolution templates for non-1x1 kernels

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -578,6 +578,9 @@ def convolution(
         and is_ones(dilation)
         and not transposed
         and is_zeros(output_padding)
+        # Triton conv templates only work correctly for 1x1 kernels due to loop unrolling issues
+        # See https://github.com/triton-lang/triton/issues/1254
+        and is_ones(kernel_shape)
         # there are some odd models where this check fails (e.g. shufflenet_v2_x1_0)
         and V.graph.sizevars.statically_known_equals(in_chan * groups, x.get_size()[1])  # type: ignore[arg-type]
     ):


### PR DESCRIPTION
The Triton convolution template produces incorrect results for kernels larger than 1x1 due to loop unrolling issues in Triton (triton#1254).

This change restricts Triton conv templates to 1x1 kernels only, falling back to ATen convolution for larger kernels which produces correct results.

Fixes test_convolution1 in test/inductor/test_select_algorithm.py which was failing with 84.7% mismatched elements and max error of 132.3.

Fixes #173068 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo