### PR TITLE
[docs] Clarify torch.as_tensor signature: dtype and device are keyword-only

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -993,7 +993,7 @@ Example::
 add_docstr(
     torch.as_tensor,
     r"""
-as_tensor(data: Any, dtype: Optional[dtype] = None, device: Optional[DeviceLikeType]) -> Tensor
+as_tensor(data: Any, *, dtype: Optional[dtype] = None, device: Optional[DeviceLikeType]) -> Tensor
 
 Converts :attr:`data` into a tensor, sharing data and preserving autograd
 history if possible.


### PR DESCRIPTION
## Summary

**Fixes #173027**

The documentation for `torch.as_tensor` shows the signature as:
```python
as_tensor(data, dtype=None, device=None)
```

This implies that `dtype` and `device` can be passed as positional arguments, but they are actually **keyword-only**. Attempting to use positional arguments results in:
```
TypeError: as_tensor() takes 1 positional argument but 2 were given
```

## Fix

Updated the signature to use the standard Python asterisk (`*`) syntax:
```python
as_tensor(data, *, dtype=None, device=None)
```

This clearly indicates that arguments after `data` must be passed as keyword arguments.

## Test Plan

Documentation change only - no functional code changes.

cc @svekars @sekyondaMeta @AlannaBurke