### PR TITLE
[ONNX] Raise an error if there are duplicated input/output names

### DIFF
--- a/torch/onnx/_internal/exporter/_ir_passes.py
+++ b/torch/onnx/_internal/exporter/_ir_passes.py
@@ -20,13 +20,32 @@ logger = logging.getLogger(__name__)
 
 
 def rename_inputs(model: ir.Model, new_names: Sequence[str]) -> None:
-    # TODO: Ensure the names do not have duplicates
+    unique_names = frozenset(new_names)
+    if len(unique_names) != len(new_names):
+        seen = set()
+        duplicates = []
+        for name in new_names:
+            if name in seen:
+                duplicates.append(name)
+            seen.add(name)
+        raise ValueError(f"Input names cannot be duplicated: {duplicates}")
+
     for input, new_name in zip(model.graph.inputs, new_names):
         input.metadata_props["pkg.torch.onnx.original_node_name"] = str(input.name)
         input.name = new_name
 
 
 def rename_outputs(model: ir.Model, new_names: Sequence[str]) -> None:
+    unique_names = frozenset(new_names)
+    if len(unique_names) != len(new_names):
+        seen = set()
+        duplicates = []
+        for name in new_names:
+            if name in seen:
+                duplicates.append(name)
+            seen.add(name)
+        raise ValueError(f"Output names cannot be duplicated: {duplicates}")
+
     for output, new_name in zip(model.graph.outputs, new_names):
         output.metadata_props["pkg.torch.onnx.original_node_name"] = str(output.name)
         output.name = new_name


### PR DESCRIPTION
This pull request adds validation to prevent duplicate input and output names when renaming model inputs and outputs in the ONNX exporter. If duplicate names are detected, a clear error is raised to help users avoid accidental naming conflicts.

Validation improvements:

* Added duplicate name checks in the `rename_inputs` function, raising a `ValueError` with details if duplicates are found.
* Added duplicate name checks in the `rename_outputs` function, raising a `ValueError` with details if duplicates are found.

cc @titaiwangms