### PR TITLE
[ROCm] Fix Triton 3.6 accuracy regression in inductor pipelining

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4954,8 +4954,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
                     )
                     # Conditionalize pipelining on HIP for Triton due to
-                    # reports of numerical inaccuracies on older Triton
-                    if torch.version.hip and get_triton_version() > (3, 2):
+                    # reports of numerical inaccuracies on older Triton (<=3.2)
+                    # and Triton 3.6+ (see issue #169378)
+                    triton_ver = get_triton_version()
+                    if torch.version.hip and triton_ver > (3, 2) and triton_ver < (3, 6):
                         num_stages = ", num_stages = 2"
                     else:
                         num_stages = ""


### PR DESCRIPTION
## Summary

Disable loop pipelining (`num_stages=2`) for Triton 3.6+ on HIP due to numerical inaccuracies in reduction operations. This is similar to the issues seen with Triton <=3.2, so pipelining now only remains enabled for Triton 3.3-3.5 where it works correctly.

Fixes #169378

## Test plan

- CI validation on `linux.rocm.gpu.gfx942.1` (MI300X) with `rocm-periodic-dynamo-benchmarks-test`
- The affected model `convnextv2_nano.fcmae_ft_in22k_in1k` should pass accuracy checks

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben

🤖 Generated with [Claude Code](https://claude.ai/code)