### PR TITLE
[inductor][control_deps] support nonflat args

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -115,6 +115,66 @@ class TestControlDeps(InductorTestCase):
                 "extern_kernels.mm", 2, exactly=True
             ).check("del buf0").run(code[0])
 
+    @config.patch(reorder_for_locality=False)
+    @requires_gpu()
+    def test_control_deps_with_nested_args(self):
+        """Test control_deps with operations that have nested args (e.g., torch.cat)."""
+
+        def fn(a, b, c):
+            x = a + 1
+            y = b * 2
+            # torch.cat has nested args: (List[Tensor], dim)
+            cat_result = torch.cat([x, y], dim=0)
+            z = cat_result + c
+            return z
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            # Find the cat node which has nested args
+            cat_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.cat.default
+            )
+            assert len(cat_nodes) == 1, f"Expected 1 cat node, got {len(cat_nodes)}"
+            cat_node = cat_nodes[0]
+
+            # Verify it has nested args (list of tensors)
+            assert isinstance(cat_node.args[0], (list, tuple)), (
+                f"Expected nested args, got {type(cat_node.args[0])}"
+            )
+
+            # Find a node that comes before cat to use as dependency
+            add_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.add.Tensor
+            )
+            # Use the first add node (x = a + 1)
+            dep_node = add_nodes[0]
+
+            deps_map = {cat_node: OrderedSet([dep_node])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+
+            # Verify control_deps was created
+            control_deps_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.higher_order.control_deps
+            )
+            assert len(control_deps_nodes) == 1
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            a = torch.rand([128, 64], device=GPU_TYPE)
+            b = torch.rand([128, 64], device=GPU_TYPE)
+            c = torch.rand([256, 64], device=GPU_TYPE)
+
+            compiled_fn = torch.compile(fn)
+            result = compiled_fn(a, b, c)
+
+            expected = fn(a, b, c)
+            torch.testing.assert_close(result, expected)
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CUDA_AND_TRITON:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173100
* __->__ #173083


The problem:

the "overlap" node can be cat or triton_kernel that has some non-flat fx.Nodes , e.g. `cat([node0, node1])`

Supporting subgraph extraction for it.

Test:
python test/inductor/test_control_deps.py -k test_control_deps_with_nested_args

Example of the graph:
```
class <lambda>(torch.nn.Module):
    def forward(self, arg0_1: "f32[128, 64]", arg1_1: "f32[128, 64]", arg2_1: "f32[256, 64]"):
        # File: /data/users/ivankobzarev/j/pytorch/test/inductor/test_control_deps.py:124 in fn, code: x = a + 1
        add: "f32[128, 64]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None

        # File: /data/users/ivankobzarev/j/pytorch/test/inductor/test_control_deps.py:125 in fn, code: y = b * 2
        mul: "f32[128, 64]" = torch.ops.aten.mul.Tensor(arg1_1, 2);  arg1_1 = None

        # No stacktrace found for following nodes
        subgraph_cat = self.subgraph_cat

        # File: /data/users/ivankobzarev/j/pytorch/test/inductor/test_control_deps.py:127 in fn, code: cat_result = torch.cat([x, y], dim=0)
        cat: "f32[256, 64]" = torch.ops.higher_order.control_deps((add,), subgraph_cat, add, mul);  add = subgraph_cat = mul = None

        # File: /data/users/ivankobzarev/j/pytorch/test/inductor/test_control_deps.py:128 in fn, code: z = cat_result + c
        add_1: "f32[256, 64]" = torch.ops.aten.add.Tensor(cat, arg2_1);  cat = arg2_1 = None
        return (add_1,)

    class subgraph_cat(torch.nn.Module):
        def forward(self, arg_0: "f32[128, 64]", arg_1: "f32[128, 64]"):
            # File: /data/users/ivankobzarev/j/pytorch/test/inductor/test_control_deps.py:127 in fn, code: cat_result = torch.cat([x, y], dim=0)
            cat_default: "f32[256, 64]" = torch.ops.aten.cat.default([arg_0, arg_1]);  arg_0 = arg_1 = None
            return cat_default
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo