### PR TITLE
[Inductor] Fix pickling issue of workspace arg for tma templates in async-pipelined autotuning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4094,13 +4094,6 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune):
         "test_non_contiguous_input_mm_plus_mm": "Flaky on trunk",
         "test_autotune_device_guard": "Flaky on trunk",
         "test_template_bad_epilogue_fusion": "Benchmarking path is different",
-        # XPU specific skips due to lack of multiprocess tensor reduction support (issue #170636)
-        "test_max_autotune_addmm_persistent_tma": "No XPU implementation for multiprocess tensor reduction",
-        "test_max_autotune_regular_mm_persistent_tma": "No XPU implementation for multiprocess tensor reduction",
-        "test_max_autotune_regular_mm_persistent_tma_strided": "No XPU implementation for multiprocess tensor reduction",
-        "test_max_autotune_addmm_tma_dynamic_outer_dim": "No XPU implementation for multiprocess tensor reduction",
-        "test_max_autotune_regular_mm_tma_dynamic_outer_dim": "No XPU implementation for multiprocess tensor reduction",
-        # END XPU specific skips
     }
 
     @classmethod

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -601,8 +601,13 @@ class CPUDeviceBenchmarkMixin:
 
 
 class TritonBenchmarkRequest(BenchmarkRequest):
-    # Important: Instances of this class have to be serializable
-    # across process boundaries. Do not put CUDA Tensors in here!
+    """
+    Represents a standalone benchmark request for a Triton Template.
+
+    Important: Instances of this class have to be serializable
+    across process boundaries. Do not put CUDA Tensors in here!
+    """
+
     def __init__(
         self,
         kernel_name: str,
@@ -618,6 +623,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         matrix_instr_nonkdim: int = 0,  # only used for hip to choose the shape of mfma instruction.
         waves_per_eu: int = 0,  # only used for hip to schedule waves per execution unit
         kpack: int = 0,  # ROCm specific gemm parameter
+        workspace_size: Optional[int] = None,  # size of workspace buffer in bytes
+        workspace_zero_fill: bool = False,  # whether to zero-fill workspace
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
         self.module_path = module_path
@@ -629,6 +636,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.matrix_instr_nonkdim = matrix_instr_nonkdim
         self.waves_per_eu = waves_per_eu
         self.kpack = kpack
+        self.workspace_size = workspace_size
+        self.workspace_zero_fill = workspace_zero_fill
 
     def make_run_fn(
         self, *input_tensors: torch.Tensor, out: torch.Tensor
@@ -642,6 +651,23 @@ class TritonBenchmarkRequest(BenchmarkRequest):
 
         run_method = getattr(mod, self.kernel_name).run
         extra_args = list(self.extra_args)
+
+        # Recreate workspace tensor if needed (for TMA templates)
+        # The workspace tensor couldn't be pickled, so we recreate it here
+        # It should be inserted before the grid values (last 3 elements)
+        if self.workspace_size is not None:
+            from torch._inductor.select_algorithm import WORKSPACE_ARG_PLACEHOLDER
+
+            workspace_tensor = torch.empty(
+                (self.workspace_size,),
+                dtype=torch.uint8,
+                device=out.device,
+            )
+            if self.workspace_zero_fill:
+                workspace_tensor.zero_()
+            workspace_index = extra_args.index(WORKSPACE_ARG_PLACEHOLDER)
+            extra_args[workspace_index] = workspace_tensor
+
         run_method.__self__.with_bandwidth_info = False
 
         # Newer version of triton add warmup argument to JITFunction.run.


### PR DESCRIPTION
Summary: Solve compat issue between persistent + tma templates and async pipelined autotuning

Test Plan: `buck2 run mode/opt caffe2/test/inductor:max_autotune`

Differential Revision: D91235285




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo