### PR TITLE
[docs] Clarify that F.embedding weight must be 2-D tensor

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2481,7 +2481,7 @@ def embedding(
 
     Args:
         input (LongTensor): Tensor containing indices into the embedding matrix
-        weight (Tensor): The embedding matrix with number of rows equal to the maximum possible index + 1,
+        weight (Tensor): The embedding matrix (must be 2-D) with number of rows equal to the maximum possible index + 1,
             and number of columns equal to the embedding size
         padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the gradient;
                                      therefore, the embedding vector at :attr:`padding_idx` is not updated during training,


### PR DESCRIPTION
## Summary

This PR clarifies in the documentation that the `weight` parameter for `torch.nn.functional.embedding` must be a 2-D tensor.

## Issue

Fixes #89361

## Changes

Updated the `weight` parameter description in `torch.nn.functional.embedding` from:
> `weight (Tensor): The embedding matrix with number of rows equal to the maximum possible index + 1, and number of columns equal to the embedding size`

To:
> `weight (Tensor): The embedding matrix (must be 2-D) with number of rows equal to the maximum possible index + 1, and number of columns equal to the embedding size`

## Rationale

While the documentation already implied 2-D by mentioning "rows" and "columns", explicitly stating the requirement helps users avoid confusion. As noted in issue #89361, PyTorch versions prior to 1.12 allowed 1D weight tensors, but current versions correctly require 2-D weight. Making this requirement explicit in the documentation helps users understand the expected input format.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki