### PR TITLE
build FA3 wheels for Linux

### DIFF
--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PYTORCH_ROOT="${PYTORCH_ROOT:-$(cd "$SOURCE_DIR/../.." && pwd)}"
+
+source "${PYTORCH_ROOT}/.ci/pytorch/common_utils.sh"
+FLASH_ATTENTION_DIR="${PYTORCH_ROOT}/third_party/flash-attention"
+FLASH_ATTENTION_HOPPER_DIR="${FLASH_ATTENTION_DIR}/hopper"
+
+if [[ -z "$FA_FINAL_PACKAGE_DIR" ]]; then
+    fatal "FA_FINAL_PACKAGE_DIR must be set"
+fi
+
+if [[ -z "$WHEEL_PLAT" ]]; then
+    fatal "WHEEL_PLAT must be set"
+fi
+
+if [[ ! -d "$FLASH_ATTENTION_HOPPER_DIR" ]]; then
+    fatal "flash attn directory not found $FLASH_ATTENTION_HOPPER_DIR"
+fi
+
+PYTHON="${PYTHON_EXECUTABLE:-python}"
+
+if [[ "$(uname -m)" == "aarch64" ]]; then
+    if command -v dnf &> /dev/null; then
+        dnf install -y \
+            wget \
+            perl \
+            make \
+            xz \
+            bzip2 \
+            gcc-toolset-13-gcc \
+            gcc-toolset-13-gcc-c++ \
+            || true
+        if [[ -d "/opt/rh/gcc-toolset-13" ]]; then
+            export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+            export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH:-}
+        fi
+    fi
+
+    source "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh"
+    if [[ "${CUDA_VERSION:-12.6}" == "13.0" ]]; then
+        echo "installing CUDA 13.0.0 for ARM"
+        # install_cuda 13.0.0 cuda_13.0.0_580.65.06_linux
+        install_cuda 13.0.2 cuda_13.0.2_580.95.05_linux
+    else
+        echo "installing CUDA 12.6.3 for ARM"
+        install_cuda 12.6.3 cuda_12.6.3_560.35.05_linux
+    fi
+
+    export CUDA_HOME=/usr/local/cuda
+    export PATH=/usr/local/cuda/bin:$PATH
+
+    echo "installed CUDA version:"
+    nvcc --version
+fi
+
+echo "installing dependencies"
+"$PYTHON" -m pip install einops packaging ninja numpy wheel setuptools
+
+export PATH="$(dirname "$PYTHON"):$PATH"
+echo "ninja location: $(which ninja)"
+
+export FLASH_ATTENTION_FORCE_BUILD="${FLASH_ATTENTION_FORCE_BUILD:-TRUE}"
+
+export FLASH_ATTENTION_DISABLE_SPLIT="${FLASH_ATTENTION_DISABLE_SPLIT:-FALSE}"
+export FLASH_ATTENTION_DISABLE_PAGEDKV="${FLASH_ATTENTION_DISABLE_PAGEDKV:-FALSE}"
+export FLASH_ATTENTION_DISABLE_APPENDKV="${FLASH_ATTENTION_DISABLE_APPENDKV:-FALSE}"
+export FLASH_ATTENTION_DISABLE_LOCAL="${FLASH_ATTENTION_DISABLE_LOCAL:-FALSE}"
+export FLASH_ATTENTION_DISABLE_SOFTCAP="${FLASH_ATTENTION_DISABLE_SOFTCAP:-FALSE}"
+export FLASH_ATTENTION_DISABLE_PACKGQA="${FLASH_ATTENTION_DISABLE_PACKGQA:-FALSE}"
+export FLASH_ATTENTION_DISABLE_FP16="${FLASH_ATTENTION_DISABLE_FP16:-FALSE}"
+export FLASH_ATTENTION_DISABLE_FP8="${FLASH_ATTENTION_DISABLE_FP8:-FALSE}"
+export FLASH_ATTENTION_DISABLE_VARLEN="${FLASH_ATTENTION_DISABLE_VARLEN:-FALSE}"
+export FLASH_ATTENTION_DISABLE_CLUSTER="${FLASH_ATTENTION_DISABLE_CLUSTER:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM64="${FLASH_ATTENTION_DISABLE_HDIM64:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM96="${FLASH_ATTENTION_DISABLE_HDIM96:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM128="${FLASH_ATTENTION_DISABLE_HDIM128:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM192="${FLASH_ATTENTION_DISABLE_HDIM192:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIM256="${FLASH_ATTENTION_DISABLE_HDIM256:-FALSE}"
+export FLASH_ATTENTION_DISABLE_SM80="${FLASH_ATTENTION_DISABLE_SM80:-FALSE}"
+export FLASH_ATTENTION_ENABLE_VCOLMAJOR="${FLASH_ATTENTION_ENABLE_VCOLMAJOR:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIMDIFF64="${FLASH_ATTENTION_DISABLE_HDIMDIFF64:-FALSE}"
+export FLASH_ATTENTION_DISABLE_HDIMDIFF192="${FLASH_ATTENTION_DISABLE_HDIMDIFF192:-FALSE}"
+
+export NVCC_THREADS="${NVCC_THREADS:-8}"
+export MAX_JOBS="${MAX_JOBS:-$(nproc)}"
+
+echo "NVCC_THREADS=${NVCC_THREADS}"
+echo "MAX_JOBS=${MAX_JOBS}"
+
+pushd "$FLASH_ATTENTION_HOPPER_DIR"
+
+git config --global --add safe.directory '*'
+git submodule update --init ../csrc/cutlass
+
+if [[ "${CUDA_VERSION:-12.6}" == 13.* ]]; then
+    CCCL_INCLUDE="/usr/local/cuda/include/cccl"
+    if [[ -d "${CCCL_INCLUDE}" ]]; then
+        echo "Adding CCCL include path: ${CCCL_INCLUDE}"
+        export CPLUS_INCLUDE_PATH="${CCCL_INCLUDE}${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"
+        export C_INCLUDE_PATH="${CCCL_INCLUDE}${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+    else
+        echo "WARNING: CCCL include directory not found at ${CCCL_INCLUDE}"
+    fi
+fi
+
+sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8")/' \
+    "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
+
+BUILD_DATE=$(date +%Y%m%d)
+if [[ "${WHEEL_PLAT}" == "aarch64" ]]; then
+    ARCH_TAG="arm"
+else
+    ARCH_TAG="x86"
+fi
+export FLASH_ATTN_LOCAL_VERSION="${BUILD_DATE}.cu${CUDA_SHORT}.${ARCH_TAG}"
+
+"$PYTHON" setup.py bdist_wheel \
+    -d "$FA_FINAL_PACKAGE_DIR" \
+    -k \
+    --plat-name "${WHEEL_PLAT}"
+
+echo "wheel built: "
+find "$FA_FINAL_PACKAGE_DIR" -name '*.whl' -exec ls -la {} \;
+
+popd

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -1,0 +1,122 @@
+name: Build Flash Attention 3 wheels
+
+on:
+  workflow_dispatch:
+  # TODO: Remove this trigger before merging - only for testing from PR branch
+  pull_request:
+    paths:
+      - .github/workflows/build-flash-attention-wheel.yml
+      - .ci/flash-attention/*.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  build-wheel:
+    name: "Build FA3 ${{ matrix.cuda_version }} ${{ matrix.arch }}"
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ matrix.runner }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cuda_version: "12.6"
+            arch: "x86_64"
+            cuda_short: "126"
+            torch_cuda_arch_list: "8.0;8.6;9.0"
+            docker_image: "pytorch/manylinux2_28-builder:cuda12.6"
+            runner: "linux.12xlarge.memory"
+          - cuda_version: "13.0"
+            arch: "x86_64"
+            cuda_short: "130"
+            torch_cuda_arch_list: "8.0;8.6;9.0;10.0"
+            docker_image: "pytorch/manylinux2_28-builder:cuda13.0"
+            runner: "linux.12xlarge.memory"
+          - cuda_version: "12.6"
+            arch: "aarch64"
+            cuda_short: "126"
+            torch_cuda_arch_list: "8.0;8.6;9.0"
+            docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
+            runner: "linux.arm64.r7g.12xlarge.memory"
+            max_jobs: "4"
+            nvcc_threads: "2"
+    timeout-minutes: 1440
+    env:
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      CUDA_VERSION: ${{ matrix.cuda_version }}
+      CUDA_SHORT: ${{ matrix.cuda_short }}
+      TORCH_CUDA_ARCH_LIST: ${{ matrix.torch_cuda_arch_list }}
+    steps:
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+          fail-silently: false
+
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          submodules: true
+
+      - name: Setup Linux
+        uses: ./.github/actions/setup-linux
+
+      - name: Pull Docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ env.DOCKER_IMAGE }}
+
+      # - name: Configure AWS credentials environment pytorchbot-env
+
+      - name: Build Flash Attention 3 wheel
+        run: |
+          set -x
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+          container_name=$(docker run \
+            --tty \
+            --detach \
+            -v "${GITHUB_WORKSPACE}:/pytorch" \
+            -v "${RUNNER_TEMP}/artifacts:/artifacts" \
+            -w /pytorch \
+            "${DOCKER_IMAGE}"
+          )
+          PYTHON_EXECUTABLE=/opt/python/cp312-cp312/bin/python
+          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" -m pip install \
+            torch --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+          docker exec -t \
+            -e CUDA_VERSION="${CUDA_VERSION}" \
+            -e CUDA_SHORT="${CUDA_SHORT}" \
+            -e TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
+            -e FA_FINAL_PACKAGE_DIR="/artifacts" \
+            -e WHEEL_PLAT="${{ matrix.arch }}" \
+            -e PYTORCH_ROOT="/pytorch" \
+            -e PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
+            -e MAX_JOBS="${{ matrix.max_jobs }}" \
+            -e NVCC_THREADS="${{ matrix.nvcc_threads }}" \
+            "${container_name}" bash -c \
+            "bash /pytorch/.ci/flash-attention/build.sh"
+          docker exec -t "${container_name}" chown -R 1000:1000 /artifacts
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: flash-attn-3-wheel-cu${{ matrix.cuda_short }}-${{ matrix.arch }}
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/*.whl
+
+      - name: Teardown Linux
+        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        if: always()

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -9,8 +9,8 @@ on:
       - .ci/flash-attention/*.sh
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   id-token: write


### PR DESCRIPTION
Currently, the only way to install FA3 is to build from source, but that process is notoriously difficult (takes 1+ hour, segfaults, timeouts, etc) so we want to build wheels for major CUDA versions on supported PyTorch platforms and hosting them on PyTorch's index.

This PR has a build script that leverages PyTorch CI to build these wheels. The trigger is manual and the hope is that we can reuse this script to rebuild whenever there are major upstream changes.

This PR builds wheels for the following environments:

- CUDA 12.6 + x86
- CUDA 13.0 + x86
- CUDA 12.6 + ARM

CUDA 13.0 + ARM is still a WIP.

The x86 wheels have been tested locally, but we plan on uploading all 3 wheels to PyTorch's test index before doing further testing on various machines/hardwares.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173098
* __->__ #173095

