### PR TITLE
[ROCm] Replace __gfxXXX__ preprocessor checks with __builtin_amdgcn_processor_is() for SPIR-V

### DIFF
--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -344,11 +344,12 @@ inline __device__ void gpuAtomicAddNoReturn(at::BFloat16 *address, at::BFloat16 
  */
 #if defined(USE_ROCM)
 inline __device__ void gpuAtomicAddNoReturn(float *address, float val) {
-#if defined(__gfx908__)
-  atomicAddNoRet(address, val);
-#else
-  (void)unsafeAtomicAdd(address, val);
-#endif
+  // Use runtime check for SPIR-V compatibility
+  if (__builtin_amdgcn_processor_is("gfx908")) {
+    atomicAddNoRet(address, val);
+  } else {
+    (void)unsafeAtomicAdd(address, val);
+  }
 }
 inline __device__ void gpuAtomicAddNoReturn(double *address, double val) { (void)unsafeAtomicAdd(address, val); }
 #else

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -517,7 +517,8 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t* self_data_start, int64_t index, int64_t numel, const scalar_t * src_data) const {
-#if (defined(__gfx942__) || defined(__gfx950__))
+#if defined(USE_ROCM)
+    // opportunistic_fastAtomicAdd has internal arch checks for SPIR-V compatibility
     opportunistic_fastAtomicAdd(self_data_start, index, numel, *src_data);
 #else
     fastAtomicAdd(self_data_start, index, numel, *src_data, true);

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -187,28 +187,31 @@ template <int vec_size, typename scalar_t>
 __device__ aligned_vector<scalar_t, vec_size> load_vector(const scalar_t *base_ptr, uint32_t offset) {
   using vec_t = aligned_vector<scalar_t, vec_size>;
   auto *from = reinterpret_cast<const vec_t *>(base_ptr);
-#if defined(USE_ROCM) && defined(__gfx942__)
-  using longx2 = __attribute__((__vector_size__(4*sizeof(int)))) int;
-  if constexpr (sizeof(vec_t) == sizeof(int)) {
-   union {
-     vec_t v;
-     int   i;
-   } tmpt = { .i = __builtin_nontemporal_load(reinterpret_cast<const int *>(&(from[offset]))) };
-   return tmpt.v;
-  }
-  else if constexpr (sizeof(vec_t) == sizeof(long)) {
-   union {
-     vec_t v;
-     long   i;
-   } tmpt = { .i = __builtin_nontemporal_load(reinterpret_cast<const long *>(&(from[offset]))) };
-   return tmpt.v;
-  }
-  else if constexpr (sizeof(vec_t) == sizeof(longx2)) {
-   union {
-     vec_t v;
-     longx2  i;
-   } tmpt = { .i = __builtin_nontemporal_load(reinterpret_cast<const longx2 *>(&(from[offset]))) };
-   return tmpt.v;
+#if defined(USE_ROCM)
+  // Use runtime check for SPIR-V compatibility
+  if (__builtin_amdgcn_processor_is("gfx942")) {
+    using longx2 = __attribute__((__vector_size__(4*sizeof(int)))) int;
+    if constexpr (sizeof(vec_t) == sizeof(int)) {
+      union {
+        vec_t v;
+        int   i;
+      } tmpt = { .i = __builtin_nontemporal_load(reinterpret_cast<const int *>(&(from[offset]))) };
+      return tmpt.v;
+    }
+    else if constexpr (sizeof(vec_t) == sizeof(long)) {
+      union {
+        vec_t v;
+        long   i;
+      } tmpt = { .i = __builtin_nontemporal_load(reinterpret_cast<const long *>(&(from[offset]))) };
+      return tmpt.v;
+    }
+    else if constexpr (sizeof(vec_t) == sizeof(longx2)) {
+      union {
+        vec_t v;
+        longx2  i;
+      } tmpt = { .i = __builtin_nontemporal_load(reinterpret_cast<const longx2 *>(&(from[offset]))) };
+      return tmpt.v;
+    }
   }
 #endif
   return from[offset];

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -32,7 +32,8 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t* self_data_start, int64_t index, int64_t numel, const scalar_t * src_data) const {
-#if (defined(__gfx942__) || defined(__gfx950__))
+#if defined(USE_ROCM)
+    // opportunistic_fastAtomicAdd has internal arch checks for SPIR-V compatibility
     opportunistic_fastAtomicAdd(self_data_start, index, numel, *src_data);
 #else
     fastAtomicAdd(self_data_start, index, numel, *src_data, true);

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -140,8 +140,11 @@ WelfordDataLN cuWelfordOnlineSum(
     U delta = val - curr_sum.mean;
     U new_count = curr_sum.count + 1.f;
 //Due to low CU count, we run into accuracy issues on gfx90a with `__builtin_amdgcn_rcpf`
-#if defined(USE_ROCM) && !defined(__gfx90a__) && defined(USE_LAYERNORM_FAST_RECIPROCAL)
-    U new_mean = curr_sum.mean + delta * __builtin_amdgcn_rcpf(new_count);
+#if defined(USE_ROCM) && defined(USE_LAYERNORM_FAST_RECIPROCAL)
+    // Use runtime check for SPIR-V compatibility: fast reciprocal on all archs except gfx90a
+    U new_mean = (!__builtin_amdgcn_processor_is("gfx90a") && __builtin_amdgcn_is_invocable(__builtin_amdgcn_rcpf))
+        ? curr_sum.mean + delta * __builtin_amdgcn_rcpf(new_count)
+        : curr_sum.mean + delta * (1.f/new_count);
 #else
     U new_mean = curr_sum.mean + delta * (1.f/new_count); //proper division is slow, this is less accurate but noticeably faster
 #endif
@@ -163,8 +166,11 @@ WelfordDataLN cuWelfordCombine(
     U mean, sigma2;
     if (count > decltype(dataB.count){0}) {
 //Due to low CU count, we run into accuracy issues on gfx90a with `__builtin_amdgcn_rcpf`
-#if defined(USE_ROCM) && !defined(__gfx90a__) && defined(USE_LAYERNORM_FAST_RECIPROCAL)
-      auto coef = __builtin_amdgcn_rcpf(count);
+#if defined(USE_ROCM) && defined(USE_LAYERNORM_FAST_RECIPROCAL)
+      // Use runtime check for SPIR-V compatibility: fast reciprocal on all archs except gfx90a
+      auto coef = (!__builtin_amdgcn_processor_is("gfx90a") && __builtin_amdgcn_is_invocable(__builtin_amdgcn_rcpf))
+          ? __builtin_amdgcn_rcpf(count)
+          : 1.f/count;
 #else
       auto coef = 1.f/count; //NB we don't use --use_fast_math, but this is emulation, 1./count goes to intrinsic, `* coef` is multiplication, instead of slow fp division
 #endif

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp
@@ -14,11 +14,14 @@ __launch_bounds__(MaxThreadPerBlock, MinBlockPerCu)
 #endif
     __global__ void kentry_pt(Args... args)
 {
-#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
-    Kernel{}(args...);
-#else
-    CUDA_KERNEL_ASSERT(false && "Fatal! Attempting to call a CK SDPA kernel on unsupported hardware");
-#endif
+    // Use runtime check for SPIR-V compatibility
+    if (__builtin_amdgcn_processor_is("gfx90a") ||
+        __builtin_amdgcn_processor_is("gfx942") ||
+        __builtin_amdgcn_processor_is("gfx950")) {
+        Kernel{}(args...);
+    } else {
+        CUDA_KERNEL_ASSERT(false && "Fatal! Attempting to call a CK SDPA kernel on unsupported hardware");
+    }
 }
 
 


### PR DESCRIPTION
## Summary

This PR replaces compile-time GPU architecture preprocessor macros (like `__gfx942__`, `__gfx950__`, etc.) with runtime checks using the new `__builtin_amdgcn_processor_is()` and `__builtin_amdgcn_is_invocable()` builtins.

**Why this is needed:**

When compiling for SPIR-V with `--offload-arch=amdgcnspirv`, the target GPU architecture is not known at compile time. The `__gfxXXX__` macros are not defined, so code paths guarded by these macros would be excluded entirely. By using runtime checks instead, all code paths are compiled into the SPIR-V binary and selected at runtime when the concrete target is known.

Reference: https://rocm.docs.amd.com/projects/llvm-project/en/develop/conceptual/spirv.html

## Changes

**Files modified:**
- `aten/src/ATen/cuda/Atomic.cuh` - `gpuAtomicAddNoReturn` for gfx908
- `aten/src/ATen/native/cuda/KernelUtils.cuh`:
  - `preview_unsafeAtomicAdd` functions (gfx942 atomic intrinsics)
  - `cmtdStore` inline assembly selection (gfx1250)
  - `opportunistic_fastAtomicAdd` - now always available with internal arch check
- `aten/src/ATen/native/cuda/MemoryAccess.cuh` - `load_vector` nontemporal loads (gfx942)
- `aten/src/ATen/native/cuda/layer_norm_kernel.cu` - fast reciprocal (except gfx90a)
- `aten/src/ATen/native/cuda/Indexing.cu` - `ReduceAdd` call site
- `aten/src/ATen/native/cuda/ScatterGatherKernel.cu` - `ReduceAdd` call site
- `aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp` - CK kernel entry point

**Conversion pattern:**
```cpp
// Before (compile-time)
#if defined(__gfx942__)
    use_fast_path();
#else
    use_fallback();
#endif

// After (runtime)
if (__builtin_amdgcn_processor_is("gfx942")) {
    use_fast_path();
} else {
    use_fallback();
}
```

**Not converted** (more complex refactoring needed):
- `CUDALoops.cuh` - constexpr variable selection
- `int4mm.cu` - macro affecting static_asserts
- `ck_types.h` - macros affecting CK header parsing

## Test Plan

- [ ] ROCm CI passes (builds and tests on MI300X)
- Existing ROCm tests should pass - runtime behavior is unchanged for direct arch compilation
- SPIR-V compilation should now include all arch-specific code paths

Fixes #172467

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @lakhinderwalia

🤖 Generated with [Claude Code](https://claude.ai/code)