### PR TITLE
[Athena op coverage] Implement addmv

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -649,6 +649,7 @@
     CUDA: addmv_out_cuda
     MPS: addmv_out_mps
     XPU: addmv_out_xpu
+    MTIA: addmv_out_mtia
     SparseCsrCPU: addmv_out_sparse_compressed
     SparseCsrCUDA: addmv_out_sparse_compressed_cuda
 


### PR DESCRIPTION
Summary:
- Added host runtime implementation for `addmv`, similar to existing ops such as `addmm`.
- Added registration and CI tests

Test Plan:
Eager mode:
`buck2 run fbcode//mode/opt fbcode//glow/fba/tests:run_kernel -- --kernel addmv -eager --config 'input=64;m=64;n=128;dtype=fp32'  --cmp cpu`

Athena CI:
`buck2 test fbcode//mode/opt fbcode//glow/fba/tests:test_kernel_eager_ci_athena_re -- 'test_addmv' --run-disabled`
File changed: fbcode//glow/fba/tests/test_kernel_eager_ci.py
Buck UI: https://www.internalfb.com/buck2/e9229b10-c436-4823-9466-f998520e8fa4
Test UI: https://www.internalfb.com/intern/testinfra/testrun/17169973721042277
Network: Up: 2.9KiB  Down: 69KiB  (reSessionID-b222339c-f69e-41db-bef1-a0f488561e7a)
Executing actions. Remaining     0/2             
Command: test.                                                                                                        
Time elapsed: 51.3s
Tests finished: Pass 4. Fail 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0

Iris CI:
`buck2 test fbcode//mode/opt fbcode//glow/fba/tests:test_kernel_eager_ci_iris -- 'test_addmv' --run-disabled`
Buck UI: https://www.internalfb.com/buck2/d3f7a695-5359-4045-9f43-855457d10421
Test UI: https://www.internalfb.com/intern/testinfra/testrun/562950429843370
Network: Up: 227MiB  Down: 1.6GiB  (reSessionID-d0c9fb52-83d0-4afc-a103-36b148f0a305)
Loading targets.   Remaining     0/1                         
Analyzing targets. Remaining     0/6298                      
Executing actions. Remaining     0/52991                     
Command: test.     Finished 84 local, 17614 cache (99% hit)                                                           
Time elapsed: 2:29.7s
Tests finished: Pass 3. Fail 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0

Differential Revision: D91169410


