### PR TITLE
[ROCm] Test fixes to create tensor size based on warp_size for AMD GPUs 

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -22,8 +22,8 @@ except ImportError:
     TRITON_AVAILABLE = False
 
 
-def get_warp_size(device=torch.device("cuda")):
-    dev_props = DeviceProperties.create(device)
+def get_warp_size():
+    dev_props = DeviceProperties.create(torch.device(GPU_TYPE))
     return dev_props.warp_size
 
 
@@ -66,7 +66,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
         super().setUp()
 
         self.model = Foo().to(GPU_TYPE)
-        M = 4096 if torch.version.hip is not None and get_warp_size() > 32 else 2048
+        M = 4096 if get_warp_size() > 32 else 2048
         self.inputs = torch.ones((M, 1), device=GPU_TYPE)
         self.orig_reorder_method = memory.reorder_for_peak_memory
 

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -6,8 +6,8 @@ import torch
 from torch._C import FileCheck
 from torch._dynamo.utils import same
 from torch._inductor import config, memory
-from torch._inductor.test_case import TestCase
 from torch._inductor.runtime.hints import DeviceProperties
+from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
 from torch.testing._internal.common_utils import serialTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
@@ -20,10 +20,11 @@ try:
     TRITON_AVAILABLE = True
 except ImportError:
     TRITON_AVAILABLE = False
-def get_warp_size(device=torch.device("cuda")):    
+
+
+def get_warp_size(device=torch.device("cuda")):
     dev_props = DeviceProperties.create(device)
     return dev_props.warp_size
-
 
 
 class Foo(torch.nn.Module):

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -8,8 +8,8 @@ import torch._inductor.config as inductor_config
 import torch.nn.functional as F
 from torch._dynamo.utils import same
 from torch._inductor import metrics, utils
-from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.runtime.hints import DeviceProperties
+from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
@@ -21,9 +21,10 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
-def get_warp_size(device=torch.device("cuda")):    
+def get_warp_size(device=torch.device("cuda")):
     dev_props = DeviceProperties.create(device)
     return dev_props.warp_size
+
 
 class TestBase(TestCase):
     def setUp(self):
@@ -191,7 +192,11 @@ class MixOrderReductionTest(TestBase):
         def f(x):
             return x.sum(dim=-1), x.sum(dim=0)
 
-        M = 32768 * 1024 if torch.version.hip is not None and get_warp_size() > 32 else 32768 * 256
+        M = (
+            32768 * 1024
+            if torch.version.hip is not None and get_warp_size() > 32
+            else 32768 * 256
+        )
         x = torch.randn(M, 2, dtype=torch.float, device=GPU_TYPE)
         self.check_numeric(f, (x,))
         # We don't do mix order reduction for split redutions

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -21,8 +21,8 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
-def get_warp_size(device=torch.device("cuda")):
-    dev_props = DeviceProperties.create(device)
+def get_warp_size():
+    dev_props = DeviceProperties.create(torch.device(GPU_TYPE))
     return dev_props.warp_size
 
 
@@ -192,11 +192,7 @@ class MixOrderReductionTest(TestBase):
         def f(x):
             return x.sum(dim=-1), x.sum(dim=0)
 
-        M = (
-            32768 * 1024
-            if torch.version.hip is not None and get_warp_size() > 32
-            else 32768 * 256
-        )
+        M = 32768 * 1024 if get_warp_size() > 32 else 32768 * 256
         x = torch.randn(M, 2, dtype=torch.float, device=GPU_TYPE)
         self.check_numeric(f, (x,))
         # We don't do mix order reduction for split redutions

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -8,9 +8,9 @@ import torch._inductor.config as inductor_config
 import torch.nn.functional as F
 from torch._dynamo.utils import same
 from torch._inductor import metrics, utils
-from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import is_warp_size_64
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -19,11 +19,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
-
-
-def get_warp_size():
-    dev_props = DeviceProperties.create(torch.device(GPU_TYPE))
-    return dev_props.warp_size
 
 
 class TestBase(TestCase):
@@ -192,7 +187,7 @@ class MixOrderReductionTest(TestBase):
         def f(x):
             return x.sum(dim=-1), x.sum(dim=0)
 
-        M = 32768 * 1024 if get_warp_size() > 32 else 32768 * 256
+        M = 32768 * 1024 if is_warp_size_64(torch.device(GPU_TYPE)) else 32768 * 256
         x = torch.randn(M, 2, dtype=torch.float, device=GPU_TYPE)
         self.check_numeric(f, (x,))
         # We don't do mix order reduction for split redutions

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -155,9 +155,10 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 
-def get_warp_size(device=torch.device("cuda")):    
+def get_warp_size(device=torch.device("cuda")):
     dev_props = DeviceProperties.create(device)
     return dev_props.warp_size
+
 
 HAS_AVX2 = "fbgemm" in torch.backends.quantized.supported_engines
 
@@ -16649,7 +16650,9 @@ if RUN_GPU:
         def test_donated_buffer_inplace(self):
             batch_size = 32
             seq_length = 50
-            hidden_size = 512 if torch.version.hip is not None and get_warp_size() > 32 else 256
+            hidden_size = (
+                512 if torch.version.hip is not None and get_warp_size() > 32 else 256
+            )
 
             inp = torch.randn(
                 batch_size,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -155,8 +155,8 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 
-def get_warp_size(device=torch.device("cuda")):
-    dev_props = DeviceProperties.create(device)
+def get_warp_size():
+    dev_props = DeviceProperties.create(torch.device(GPU_TYPE))
     return dev_props.warp_size
 
 
@@ -16650,9 +16650,7 @@ if RUN_GPU:
         def test_donated_buffer_inplace(self):
             batch_size = 32
             seq_length = 50
-            hidden_size = (
-                512 if torch.version.hip is not None and get_warp_size() > 32 else 256
-            )
+            hidden_size = 512 if get_warp_size() > 32 else 256
 
             inp = torch.randn(
                 batch_size,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -53,10 +53,10 @@ from torch._inductor.aoti_eager import (
     load_aoti_eager_cache,
 )
 from torch._inductor.codegen.common import DataTypePropagation, OptimizationContext
-from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import (
     add_scheduler_init_hook,
+    is_warp_size_64,
     run_and_get_code,
     run_and_get_cpp_code,
     run_and_get_kernels,
@@ -153,11 +153,6 @@ from torch.testing._internal.triton_utils import (
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
-
-
-def get_warp_size():
-    dev_props = DeviceProperties.create(torch.device(GPU_TYPE))
-    return dev_props.warp_size
 
 
 HAS_AVX2 = "fbgemm" in torch.backends.quantized.supported_engines
@@ -16650,7 +16645,7 @@ if RUN_GPU:
         def test_donated_buffer_inplace(self):
             batch_size = 32
             seq_length = 50
-            hidden_size = 512 if get_warp_size() > 32 else 256
+            hidden_size = 512 if is_warp_size_64(torch.device(GPU_TYPE)) else 256
 
             inp = torch.randn(
                 batch_size,

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -14,7 +14,7 @@ from torch._dynamo.debug_utils import InputReader
 from torch._inductor import config
 from torch._inductor.choices import InductorChoices
 from torch._inductor.codegen.triton import FixedTritonConfig
-from torch._inductor.runtime.hints import TRITON_MAX_BLOCK, DeviceProperties
+from torch._inductor.runtime.hints import DeviceProperties, TRITON_MAX_BLOCK
 from torch._inductor.runtime.runtime_utils import get_max_y_grid, is_power_of_2
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
@@ -86,9 +86,10 @@ TMA_TEST_XFAIL = dict.fromkeys(
 )
 
 
-def get_warp_size(device=torch.device("cuda")):    
+def get_warp_size(device=torch.device("cuda")):
     dev_props = DeviceProperties.create(device)
     return dev_props.warp_size
+
 
 class BlockDescriptorTestBase(InductorTestCase):
     block_descriptor_constructor_str = "tl.make_block_ptr"
@@ -531,10 +532,18 @@ class CommonTemplate:
         """
         Tests a reduction kernel.
         """
-        if view_size == (2, 3 * max_block) and torch.version.hip is not None and get_warp_size() > 32:
+        if (
+            view_size == (2, 3 * max_block)
+            and torch.version.hip is not None
+            and get_warp_size() > 32
+        ):
             view_size = (4, 6 * max_block)
 
-        if view_size == (128, 128) and torch.version.hip is not None and get_warp_size() > 32:
+        if (
+            view_size == (128, 128)
+            and torch.version.hip is not None
+            and get_warp_size() > 32
+        ):
             view_size = (256, 256)
 
         if self.device == "cpu" and all(
@@ -813,7 +822,11 @@ class CommonTemplate:
         Tests 2D reduction kernels. These arise from "odd" shapes which are not
         expressible with a 1D block pointer.
         """
-        if reduction_op == torch.sum and torch.version.hip is not None and get_warp_size() > 32:
+        if (
+            reduction_op == torch.sum
+            and torch.version.hip is not None
+            and get_warp_size() > 32
+        ):
             view_size = (513, 513) if view_size == (129, 129) else view_size
         view = self._discontiguous_tensor(view_size, self.device)
 
@@ -854,7 +867,11 @@ class CommonTemplate:
         doesn't generate a block pointer. Since tiling welford reductions depends on
         the block pointer analysis, those cases would fall back to 1D.
         """
-        if torch.version.hip is not None and get_warp_size() > 32 and expected_num_triton_kernels == 2:
+        if (
+            torch.version.hip is not None
+            and get_warp_size() > 32
+            and expected_num_triton_kernels == 2
+        ):
             size = (256, 256)
         view = self._discontiguous_tensor(size, self.device)
 

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -86,8 +86,8 @@ TMA_TEST_XFAIL = dict.fromkeys(
 )
 
 
-def get_warp_size(device=torch.device("cuda")):
-    dev_props = DeviceProperties.create(device)
+def get_warp_size():
+    dev_props = DeviceProperties.create(torch.device(GPU_TYPE))
     return dev_props.warp_size
 
 
@@ -532,18 +532,10 @@ class CommonTemplate:
         """
         Tests a reduction kernel.
         """
-        if (
-            view_size == (2, 3 * max_block)
-            and torch.version.hip is not None
-            and get_warp_size() > 32
-        ):
+        if view_size == (2, 3 * max_block) and get_warp_size() > 32:
             view_size = (4, 6 * max_block)
 
-        if (
-            view_size == (128, 128)
-            and torch.version.hip is not None
-            and get_warp_size() > 32
-        ):
+        if view_size == (128, 128) and get_warp_size() > 32:
             view_size = (256, 256)
 
         if self.device == "cpu" and all(
@@ -822,11 +814,7 @@ class CommonTemplate:
         Tests 2D reduction kernels. These arise from "odd" shapes which are not
         expressible with a 1D block pointer.
         """
-        if (
-            reduction_op == torch.sum
-            and torch.version.hip is not None
-            and get_warp_size() > 32
-        ):
+        if reduction_op == torch.sum and get_warp_size() > 32:
             view_size = (513, 513) if view_size == (129, 129) else view_size
         view = self._discontiguous_tensor(view_size, self.device)
 
@@ -867,11 +855,7 @@ class CommonTemplate:
         doesn't generate a block pointer. Since tiling welford reductions depends on
         the block pointer analysis, those cases would fall back to 1D.
         """
-        if (
-            torch.version.hip is not None
-            and get_warp_size() > 32
-            and expected_num_triton_kernels == 2
-        ):
+        if get_warp_size() > 32 and expected_num_triton_kernels == 2:
             size = (256, 256)
         view = self._discontiguous_tensor(size, self.device)
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1662,8 +1662,11 @@ class DelayReplaceLine(DeferredLineBase):
 
 @functools.cache
 def is_warp_size_64(device: torch.device) -> bool:
-    prop = DeviceProperties.create(device)
-    return prop.warp_size == 64
+    if isinstance(device, torch.device("cuda")):
+        prop = DeviceProperties.create(device)
+        return prop.warp_size == 64
+    else:
+        return False
 
 
 @functools.cache

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1661,6 +1661,12 @@ class DelayReplaceLine(DeferredLineBase):
 
 
 @functools.cache
+def is_warp_size_64(device: torch.device) -> bool:
+    prop = DeviceProperties.create(device)
+    return prop.warp_size == 64
+
+
+@functools.cache
 def is_big_gpu(index_or_device: Union[int, torch.device] = 0) -> bool:
     if isinstance(index_or_device, torch.device):
         device = index_or_device

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1662,7 +1662,7 @@ class DelayReplaceLine(DeferredLineBase):
 
 @functools.cache
 def is_warp_size_64(device: torch.device) -> bool:
-    if isinstance(device, torch.device("cuda")):
+    if device == torch.device("cuda"):
         prop = DeviceProperties.create(device)
         return prop.warp_size == 64
     else:


### PR DESCRIPTION
This PR changes the tensor sizes in the tests based on the warp_size.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben