### PR TITLE
Fix expected recipes in `TestFP8LoweringCUDA.test_main_loop_scaling`

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -967,14 +967,20 @@ class TestFP8Lowering(TestCase):
             )
 
         # Verify that Inductor chooses the correct scaling recipes
+        check_scale_recipe_a = (
+            ScalingType.BlockWise1x128.value
+            if (am, ak) == (1, 128)
+            else ScalingType.BlockWise128x128.value
+        )
         FileCheck().check(
-            f"SCALE_RECIPE_A : tl.constexpr = {ScalingType.BlockWise1x128.value}"
+            f"SCALE_RECIPE_A : tl.constexpr = {check_scale_recipe_a}"
         ).run(code[0])
 
-        if (bn, bk) == (1, 128):
-            check_scale_recipe_b = ScalingType.BlockWise1x128.value
-        else:
-            check_scale_recipe_b = ScalingType.BlockWise128x128.value
+        check_scale_recipe_b = (
+            ScalingType.BlockWise1x128.value
+            if (bn, bk) == (1, 128)
+            else ScalingType.BlockWise128x128.value
+        )
         FileCheck().check(
             f"SCALE_RECIPE_B : tl.constexpr = {check_scale_recipe_b}"
         ).run(code[0])


### PR DESCRIPTION
Select expected recipe A/B accordingly to m/n/k values.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo