### PR TITLE
Update mps.rst with correct minimum version for MacOS

### DIFF
--- a/docs/source/notes/mps.rst
+++ b/docs/source/notes/mps.rst
@@ -22,7 +22,7 @@ To get started, simply move your Tensor and Module to the ``mps`` device:
             print("MPS not available because the current PyTorch install was not "
                   "built with MPS enabled.")
         else:
-            print("MPS not available because the current MacOS version is not 12.3+ "
+            print("MPS not available because the current MacOS version is not 14.0+ "
                   "and/or you do not have an MPS-enabled device on this machine.")
 
     else:


### PR DESCRIPTION
Fixes #ISSUE_NUMBER - N/A, trivial docs update so no issue created.

From what I understand the minimum version has been 14.0+ since v2.8.0 so the documentation should reflect this.