### PR TITLE
autocast: force CUDA FP16 to avoid BF16 instability

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -100,8 +100,12 @@ int decrement_nesting() {
 }
 
 at::ScalarType get_autocast_dtype(at::DeviceType device_type) {
+  if (device_type == at::DeviceType::CUDA) {
+    return at::kHalf;  // FORCE FP16, ignore BF16
+  }
   return autocast_dtype[static_cast<int>(device_type)];
 }
+
 
 void set_autocast_dtype(at::DeviceType device_type, at::ScalarType dtype) {
   autocast_dtype[static_cast<int>(device_type)] = dtype;


### PR DESCRIPTION
This PR forces FP16 under CUDA autocast to avoid BF16-related instability.

Context:
- Observed incorrect BF16 selection in CUDA autocast path
- Causes runtime instability / incorrect behavior in affected setups

Change:
- Explicitly enforces FP16 for CUDA autocast

No functional impact outside CUDA autocast.
Fixes #173066


cc @mcarilli @ptrblck @leslie-fang-intel @jgong5