### PR TITLE
[DTensor][BE] redistribute to replicate in from_local backward for partial target type

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -234,7 +234,7 @@ class DTensorTest(DTensorTestBase):
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
-        # Test 1: Shard -> Shard (no redistribution needed in backward)
+        # Test 1: Shard(fwd) - Shard(grad_output) - Shard(grad_input): no redistribution needed in backward
         with comm_mode:
             local_tensor = torch.randn(
                 3, 3, device=self.device_type, requires_grad=True
@@ -249,7 +249,7 @@ class DTensorTest(DTensorTestBase):
         # Gradient should flow back without redistribution
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
-        # Test 2: Replicate -> Replicate (no redistribution needed in backward)
+        # Test 2: Replicate(fwd) - Replicate(grad_output) - Replicate(grad_input): no redistribution needed in backward
         comm_mode = CommDebugMode()
         with comm_mode:
             local_tensor = torch.randn(
@@ -268,8 +268,28 @@ class DTensorTest(DTensorTestBase):
         # Gradient should flow back without redistribution
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
-        # Test 3: Partial -> Replicate (gradient normalized to Replicate)
-        # When forward placement is Partial, backward should redistribute to Replicate
+        # Test 3: Replicate(fwd) - Partial(grad_output) - Replicate(grad_input): gradient redistributed to Replicate
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            local_tensor = torch.randn(
+                3, 3, device=self.device_type, requires_grad=True
+            )
+            dt = DTensor.from_local(local_tensor, device_mesh, [Replicate()])
+            output = dt * 2
+            # Manually create a Partial gradient to simulate grad coming from a reduce operation
+            grad = DTensor.from_local(
+                torch.ones(3, 3, device=self.device_type), device_mesh, [Partial()]
+            )
+            output.backward(grad)
+            # The gradient should be redistributed from Partial to Replicate
+            # Since grad was Partial with ones, after all-reduce it becomes world_size * ones
+            # Then multiplied by 2 from the backward of (dt * 2)
+            expected_grad = torch.ones(3, 3) * 2 * self.world_size
+            self.assertEqual(local_tensor.grad, expected_grad)
+        # Verify that an all-reduce happened for the Partial -> Replicate case
+        self.assertEqual(comm_mode.get_comm_counts()[c10d_functional.all_reduce], 1)
+
+        # Test 4: Partial(fwd) - Partial(grad_output) - Replicate(grad_input): gradient redistributed to Replicate
         comm_mode = CommDebugMode()
         with comm_mode:
             local_tensor = torch.randn(
@@ -289,6 +309,29 @@ class DTensorTest(DTensorTestBase):
 
         # Verify that an all-reduce happened for the Partial -> Replicate case
         self.assertEqual(comm_mode.get_comm_counts()[c10d_functional.all_reduce], 1)
+
+        # Test 5: Partial(fwd) - Replicate(grad_output) - Replicate(grad_input): no redistribution needed in backward
+        # When forward was Partial but grad_output is already Replicate, no redistribution is needed
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            local_tensor = torch.randn(
+                3, 3, device=self.device_type, requires_grad=True
+            )
+            dt = DTensor.from_local(local_tensor, device_mesh, [Partial()])
+            output = dt * 2
+            # Grad output is already Replicate
+            grad = DTensor.from_local(
+                torch.ones(3, 3, device=self.device_type),
+                device_mesh,
+                [Replicate()],
+                run_check=False,
+            )
+            output.backward(grad)
+            # The gradient is already Replicate which matches the normalized target (Partial->Replicate)
+            # So no redistribution should happen
+            self.assertEqual(local_tensor.grad, torch.ones(3, 3) * 2)
+        # Gradient should flow back without redistribution since grad is already Replicate
+        self.assertEqual(comm_mode.get_total_counts(), 0)
 
     @with_comms
     def test_from_local_uneven_sharding(self):

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -419,7 +419,15 @@ class DTensor(torch.Tensor):
         .. note:: ``from_local`` is differentiable, the `requires_grad` of the created
             `DTensor` object will depend on if `local_tensor` requires_grad or not.
 
+        .. note:: During backward, if the target placement is :class:`Partial`, we always
+            redistribute to :class:`Replicate` instead. This means:
 
+            - For backward ``Replicate`` -> ``Partial``, we do ``Replicate`` -> ``Replicate``
+            - For backward ``Partial`` -> ``Partial``, we do ``Partial`` -> ``Replicate``
+
+            Redistributing to ``Replicate`` in the ``Partial`` -> ``Partial`` case may not be the
+            most efficient option, but we choose to do so to avoid ambiguity and provide clearer
+            gradient semantics to users.
         """
         # `local_tensor` argument cannot be DTensor
         if isinstance(local_tensor, DTensor):

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -206,20 +206,22 @@ class _FromTorchTensor(torch.autograd.Function):
         # reshard to the placement when creating DistributedTensor
         # so that the gradient layout matches, and we could return
         # local gradients directly
-        if grad_output.placements != forward_input_placements:
-            current_spec = grad_output._spec
+        normalized_placements: list[Placement] = []
+        # if forward placement is partial, we always redistribute grad_input to Replicate:
+        # Partial(fwd) - Replicate(grad_output) - Replicate(grad_input): no redistribution needed
+        # Partial(fwd) - Partial(grad_output) - Replicate(grad_input): redistribute Partial to Replicate
 
-            # if target gradient placement is partial, we always redistribute to replicate, this means
-            # for backward replicate -> partial, we do replicate -> replicate
-            # for backward partial -> partial, we do partial -> replicate.
-            # For partial -> partial, redistributing to replicate might not be efficient but we choose to do so to avoid ambiguity
-            normalized_placements: list[Placement] = []
-            for current, target in zip(
-                current_spec.placements, forward_input_placements
-            ):
-                if target.is_partial():
-                    normalized_placements.append(Replicate())
+        # The second case is BC breaking:
+        # was: Partial(fwd) - Partial(grad_output) - Partial(grad_input)
+        # now: Partial(fwd) - Partial(grad_output) - Replicate(grad_input)
+        for current, target in zip(grad_output.placements, forward_input_placements):
+            if target.is_partial():
+                normalized_placements.append(Replicate())
+            else:
+                normalized_placements.append(target)
 
+        if grad_output.placements != tuple(normalized_placements):
+            current_spec: DTensorSpec = grad_output._spec
             target_spec = DTensorSpec(
                 forward_input_device_mesh,
                 tuple(normalized_placements),
@@ -419,15 +421,22 @@ class DTensor(torch.Tensor):
         .. note:: ``from_local`` is differentiable, the `requires_grad` of the created
             `DTensor` object will depend on if `local_tensor` requires_grad or not.
 
-        .. note:: During backward, if the target placement is :class:`Partial`, we always
-            redistribute the gradient to :class:`Replicate` instead. This means:
+        .. note:: During backward, ``from_local`` provides the following gradient placement
+            guarantees. For each mesh dimension, the gradient placement maps as follows:
 
-            - For backward ``Replicate`` -> ``Partial``, we do ``Replicate`` -> ``Replicate``
-            - For backward ``Partial`` -> ``Partial``, we do ``Partial`` -> ``Replicate``
+            +---------------------+--------------------+
+            | Forward Placement   | Gradient Placement |
+            +=====================+====================+
+            | ``Shard``           | ``Shard``          |
+            +---------------------+--------------------+
+            | ``Replicate``       | ``Replicate``      |
+            +---------------------+--------------------+
+            | ``Partial``         | ``Replicate``      |
+            +---------------------+--------------------+
 
-            Redistributing to ``Replicate`` in the ``Partial`` -> ``Partial`` case may not be the
-            most efficient option, but we choose to do so to avoid ambiguity and provide clearer
-            gradient semantics to users.
+            When the forward placement is :class:`Partial`, we always redistribute the gradient
+            to :class:`Replicate` instead of keeping it :class:`Partial`. This may not be the most
+            efficient option, but it avoids ambiguity and provides clearer gradient semantics to users.
         """
         # `local_tensor` argument cannot be DTensor
         if isinstance(local_tensor, DTensor):

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -420,7 +420,7 @@ class DTensor(torch.Tensor):
             `DTensor` object will depend on if `local_tensor` requires_grad or not.
 
         .. note:: During backward, if the target placement is :class:`Partial`, we always
-            redistribute to :class:`Replicate` instead. This means:
+            redistribute the gradient to :class:`Replicate` instead. This means:
 
             - For backward ``Replicate`` -> ``Partial``, we do ``Replicate`` -> ``Replicate``
             - For backward ``Partial`` -> ``Partial``, we do ``Partial`` -> ``Replicate``


### PR DESCRIPTION
follow up per this [comment](https://github.com/pytorch/pytorch/pull/170147#discussion_r2616173713) 

**Motivation:** If in `from_local` forward placement is Partial, user could get either Partial or Replicate gradients depending on what the incoming gradient placement is(if incoming gradient is Replicate, we keep Replicate; if incoming gradient is Partial, we keep Partial). This is not ideal as it's not 1-1 mapping and introduces ambiguity. 

**Change in this PR:** if incoming gradient is Partial, we redistribute the Partial to Replicate. As a result, users will always get Replicate gradient when forward is Partial. 

This behavior aligned with our future plan to add Reduced/Unreduced type: If forward is partial, backward is Replicate(now)/Reduced(later). 

Also added unit test for `from_local` backward to cover the 5 possible cases:
| `from_local` forward | grad_output | grad_input |
|-----|-----|-----|
| Shard | Shard | Shard |
| Replicate | Replicate | Replicate | 
| Replicate | Partial | Replicate | 
| Partial | Replicate | Replicate(now) / Reduced(later) | 
| Partial | Partial | Replicate(now) / Reduced(later) | 
```
python3 test/distributed/tensor/test_dtensor.py -k test_from_local_backward
```