### PR TITLE
[pytorch] avoid unnecessary recursion for load_state_dict()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2603,6 +2603,15 @@ class Module:
                         for k, v in local_state_dict.items()
                         if k.startswith(child_prefix)
                     }
+                    # skip recursion if child_state_dict is empty, and there is no pre/post
+                    # hooks registered in child, and not in strict mode.
+                    if (
+                        len(child_state_dict) == 0
+                        and len(child._load_state_dict_pre_hooks) == 0
+                        and len(child._load_state_dict_post_hooks) == 0
+                        and not strict
+                    ):
+                        continue
                     load(child, child_state_dict, child_prefix)  # noqa: F821
 
             # Note that the hook can modify missing_keys and unexpected_keys.


### PR DESCRIPTION
Summary: avoid unnecessary recursion in load_state_dict()

Test Plan:
before
```
[gpu_model_runner.py:3921] Model loading took 41.75 GiB memory and 616.724681 seconds
```
after
```
[gpu_model_runner.py:3921] Model loading took 41.75 GiB memory and 236.296068 seconds
```

Reviewed By: luccafong

Differential Revision: D91287523

@diff-train-skip-merge

