### PR TITLE
[ROCm]Enable and fix AOT inductor tests

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_cuda import (
     CDNA2OrLater,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     requires_triton_ptxas_compat,
     SM80OrLater,
@@ -1312,8 +1313,8 @@ class AOTInductorTestsTemplate:
         )
 
     @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FP8,
-        "FP8 is only supported on H100+, SM >= 8.9 and MI300+ devices",
+        not PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
+        "scaled_grouped_mm is only supported on SM90 and MI300+ devices",
     )
     @skipIfXpu
     def test_scaled_grouped_mm(self):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -40,7 +40,6 @@ from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import (
     CDNA2OrLater,
-    IS_SM90,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
@@ -48,7 +47,11 @@ from torch.testing._internal.common_cuda import (
     SM80OrLater,
     tf32_on_and_off,
 )
-from torch.testing._internal.common_device_type import _has_sufficient_memory, e4m3_type
+from torch.testing._internal.common_device_type import (
+    _has_sufficient_memory,
+    e4m3_type,
+    e5m2_type,
+)
 from torch.testing._internal.common_quantization import (
     _group_quantize_tensor,
     skip_if_no_torchvision,
@@ -1309,8 +1312,8 @@ class AOTInductorTestsTemplate:
         )
 
     @unittest.skipIf(
-        TEST_WITH_ROCM or not IS_SM90,
-        "scaled_grouped_mm is only supported on SM90",
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM >= 8.9 and MI300+ devices",
     )
     @skipIfXpu
     def test_scaled_grouped_mm(self):
@@ -1357,13 +1360,13 @@ class AOTInductorTestsTemplate:
         x_fp16 = torch.randn(
             num_groups, batch_size, in_features, dtype=dtype, device=device
         )
-        x_fp8 = x_fp16.to(torch.float8_e4m3fn)
+        x_fp8 = x_fp16.to(e4m3_type)
 
         # Create FP8 weight tensor - concatenated and transposed
         weight_fp16 = torch.randn(
             total_out_features, in_features, dtype=dtype, device=device
         )
-        weight_fp8 = weight_fp16.to(torch.float8_e4m3fn)
+        weight_fp8 = weight_fp16.to(e4m3_type)
 
         # Create scales
         scale_a = torch.ones(num_groups, batch_size, device=device, dtype=torch.float32)
@@ -4895,7 +4898,6 @@ class AOTInductorTestsTemplate:
 
         self.check_model(m, inputs)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
@@ -4916,12 +4918,8 @@ class AOTInductorTestsTemplate:
 
         inputs = []
         for dtype in (
-            torch.float8_e4m3fn,
-            torch.float8_e5m2,
-            # FP8 funz are for AMD
-            # see https://github.com/pytorch/pytorch/issues/126734
-            # torch.float8_e4m3fnuz,
-            # torch.float8_e5m2fnuz,
+            e4m3_type,  # float8_e4m3fn (CUDA) or float8_e4m3fnuz (ROCm)
+            e5m2_type,  # float8_e5m2 (CUDA) or float8_e5m2fnuz (ROCm)
         ):
             inputs.append(torch.ones(8, 8, 8, dtype=dtype, device=self.device))
         dim0 = Dim("s0", min=2, max=1024)


### PR DESCRIPTION
Fixes #168564
Fixes #168565

This PR enables and fixes AOT Inductor tests to run on ROCm devices by fixing platform-specific dtype handling and removing outdated skip decorators.

### Changes Made
1. `test_scaled_grouped_mm`:
Test was hardcoding `torch.float8_e4m3fn` (CUDA format) instead of using platform-aware dtypes.

2. `test_runtime_checks_fp8`:
Test had blanket @skipIfRocm decorator and hardcoded CUDA FP8 type.
Use e4m3_type and e5m2_type for platform-agnostic FP8 dtypes.

### Fix: 
- Use `e4m3_type` helper that auto-selects correct FP8 format:
  - **CUDA**: `torch.float8_e4m3fn`
  - **ROCm**: `torch.float8_e4m3fnuz` (unsigned zero format)
- Removed redundant device checks that were already handled by skip decorator

### Testing:
Test now passes on ROCm MI300 Platform.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben