### PR TITLE
[CUDA] Fix adaptive pooling integer overflows that result in illegal memory accesses

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -570,7 +570,9 @@ namespace {
         if (output.numel() == 0) {
           return;
         }
-
+        
+        // Check if no integer overflow can happen during the output pointer calculation
+        TORCH_CHECK(grid_x * osizeH * osizeW <= std::numeric_limits<int32_t>::max(), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
         AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
             input_.scalar_type(), "adaptive_avg_pool2d_cuda", [&] {
               const scalar_t *input_data = input_.const_data_ptr<scalar_t>();

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -570,7 +570,7 @@ namespace {
         if (output.numel() == 0) {
           return;
         }
-        
+
         // Check if no integer overflow can happen during the output pointer calculation
         TORCH_CHECK(grid_x * osizeH * osizeW <= std::numeric_limits<int32_t>::max(), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
         AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -230,7 +230,9 @@ const Tensor& indices) {
     int64_t istrideD = input.stride(0);
     int64_t istrideH = input.stride(1);
     int64_t istrideW = input.stride(2);
-
+            
+      // Check if no integer overflow can happen during the output pointer calculation
+    TORCH_CHECK(sizeD * osizeH * osizeW <= std::numeric_limits<int32_t>::max(), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
     AT_DISPATCH_FLOATING_TYPES_AND2(
         kHalf, kBFloat16, input.scalar_type(), "adaptive_max_pool2d_cuda", [&] {
           const scalar_t* input_data = input.const_data_ptr<scalar_t>();
@@ -275,7 +277,9 @@ const Tensor& indices) {
     int64_t istrideD = isizeH * isizeW;
     int64_t istrideH = input_.stride(2);
     int64_t istrideW = input_.stride(3);
-
+            
+    // Check if no integer overflow can happen during the output pointer calculation
+    TORCH_CHECK(sizeB * sizeD * osizeH * osizeW <= std::numeric_limits<int32_t>::max(), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
     AT_DISPATCH_FLOATING_TYPES_AND2(
         kHalf,
         kBFloat16,

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -230,7 +230,7 @@ const Tensor& indices) {
     int64_t istrideD = input.stride(0);
     int64_t istrideH = input.stride(1);
     int64_t istrideW = input.stride(2);
-            
+
       // Check if no integer overflow can happen during the output pointer calculation
     TORCH_CHECK(sizeD * osizeH * osizeW <= std::numeric_limits<int32_t>::max(), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
     AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -277,7 +277,7 @@ const Tensor& indices) {
     int64_t istrideD = isizeH * isizeW;
     int64_t istrideH = input_.stride(2);
     int64_t istrideW = input_.stride(3);
-            
+
     // Check if no integer overflow can happen during the output pointer calculation
     TORCH_CHECK(sizeB * sizeD * osizeH * osizeW <= std::numeric_limits<int32_t>::max(), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
     AT_DISPATCH_FLOATING_TYPES_AND2(

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -585,8 +585,9 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "expected dimensions"):
             torch.ops.aten.adaptive_max_pool3d_backward(grad_output, input, indices)
 
+    @largeTensorTest("26GB") # conservative estimate ~4GiB input + ~4GiB output + ~16GiB indices
     def test_adaptive_max_pooling_integer_overflow(self, device):
-        input = torch.randn((8193, 512, 512), dtype=torch.half, device=device)
+        input = torch.ones((8193, 512, 512), dtype=torch.half, device=device)
         max_pool = torch.nn.AdaptiveMaxPool2d((512, 512))
 
         try:
@@ -594,19 +595,19 @@ class TestPoolingNNDeviceType(NNTestCase):
         except RuntimeError as e:
             self.assertRegex(str(e), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
         else:
-            self.assertEqual(out, input)
+            self.assertEqual(out[0,:,:], input[0,:,:])
 
-
+    @largeTensorTest("9GB")
     def test_adaptive_avg_pooling_integer_overflow(self, device):
-        input = torch.randn((8193, 512, 512), dtype=torch.half, device=device)
+        input = torch.ones((8193, 512, 512), dtype=torch.half, device=device)
         avg_pool = torch.nn.AdaptiveAvgPool2d((512, 512))
-        
+
         try:
             out = avg_pool(input)
         except RuntimeError as e:
             self.assertRegex(str(e), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
         else:
-            self.assertEqual(out, input)
+            self.assertEqual(out[0,:,:], input[0,:,:])
 
     @expectedFailureMPS  # Op not implemented
     @onlyNativeDeviceTypes

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -366,6 +366,18 @@ class TestPoolingNN(NNTestCase):
         self.assertFalse(torch.isnan(out).any())
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_adaptive_avg_pooling_integer_overflow(self):
+        input = torch.randn((8193, 512, 512), dtype=torch.half, device="cuda")
+        avg_pool = torch.nn.AdaptiveAvgPool2d((512, 512))
+        
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Adaptive Pooling does not support output sizes larger than INT32_MAX"
+        ):
+            out = avg_pool(input)
+            out[0,0,0] = 1.0
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_adaptive_avg_pooling_nhwc_overflow(self):
         input = torch.randint(
             -256, 256, (20, 32, 256, 256), dtype=torch.half, device="cuda"
@@ -584,6 +596,18 @@ class TestPoolingNNDeviceType(NNTestCase):
         indices = torch.ones(1, 2, 3, 3, dtype=torch.long, device=device)
         with self.assertRaisesRegex(RuntimeError, "expected dimensions"):
             torch.ops.aten.adaptive_max_pool3d_backward(grad_output, input, indices)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_adaptive_max_pooling_integer_overflow(self):
+        input = torch.randn((8193, 512, 512), dtype=torch.half, device="cuda")
+        max_pool = torch.nn.AdaptiveMaxPool2d((512, 512))
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Adaptive Pooling does not support output sizes larger than INT32_MAX"
+        ):
+            out = max_pool(input)
+            out[0,0,0] = 1.0
 
     @expectedFailureMPS  # Op not implemented
     @onlyNativeDeviceTypes

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize as parametrize_test,
     run_tests,
+    serialTest,
     set_default_dtype,
     skipIfTorchDynamo,
     slowTest,
@@ -585,7 +586,10 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "expected dimensions"):
             torch.ops.aten.adaptive_max_pool3d_backward(grad_output, input, indices)
 
-    @largeTensorTest("26GB") # conservative estimate ~4GiB input + ~4GiB output + ~16GiB indices
+    @serialTest()
+    @largeTensorTest(
+        "26GB"
+    )  # conservative estimate ~4GiB input + ~4GiB output + ~16GiB indices
     def test_adaptive_max_pooling_integer_overflow(self, device):
         input = torch.ones((8193, 512, 512), dtype=torch.half, device=device)
         max_pool = torch.nn.AdaptiveMaxPool2d((512, 512))
@@ -593,9 +597,12 @@ class TestPoolingNNDeviceType(NNTestCase):
         try:
             out = max_pool(input)
         except RuntimeError as e:
-            self.assertRegex(str(e), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
+            self.assertRegex(
+                str(e),
+                "Adaptive Pooling does not support output sizes larger than INT32_MAX",
+            )
         else:
-            self.assertEqual(out[0,:,:], input[0,:,:])
+            self.assertEqual(out[0, :, :], input[0, :, :])
 
     @largeTensorTest("9GB")
     def test_adaptive_avg_pooling_integer_overflow(self, device):
@@ -605,9 +612,12 @@ class TestPoolingNNDeviceType(NNTestCase):
         try:
             out = avg_pool(input)
         except RuntimeError as e:
-            self.assertRegex(str(e), "Adaptive Pooling does not support output sizes larger than INT32_MAX")
+            self.assertRegex(
+                str(e),
+                "Adaptive Pooling does not support output sizes larger than INT32_MAX",
+            )
         else:
-            self.assertEqual(out[0,:,:], input[0,:,:])
+            self.assertEqual(out[0, :, :], input[0, :, :])
 
     @expectedFailureMPS  # Op not implemented
     @onlyNativeDeviceTypes


### PR DESCRIPTION
Assert before launching the kernel that no integer overflow (nor the subsequent memory error) will occur during output pointer calculation.

Fixes issues https://github.com/pytorch/pytorch/issues/145349 and https://github.com/pytorch/pytorch/issues/145453.