### PR TITLE
Fix bucketize nan inductor

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1214,7 +1214,9 @@ class CudaReproTests(TestCase):
         def fn_mixed(x, thresholds, right):
             return torch.bucketize(x, thresholds, right=right)
 
-        mixed_values = torch.tensor([0.3, float("nan"), 0.6, float("nan"), 0.1], device="cuda")
+        mixed_values = torch.tensor(
+            [0.3, float("nan"), 0.6, float("nan"), 0.1], device="cuda"
+        )
         for right in [True, False]:
             torch._dynamo.reset()
             expected = fn_mixed(mixed_values, thresholds, right)


### PR DESCRIPTION
## Summary

Fixes inconsistent results for `torch.bucketize` when handling NaN values between Eager and Inductor modes on CUDA.

**The bug:** When `torch.bucketize` receives NaN values (e.g., from `torch.rsqrt` of negative numbers):
- Eager mode correctly returns `len(boundaries)` (placing NaN in the last bucket)
- Inductor mode incorrectly returned `0`

**Root cause:** The Triton binary search used direct comparisons (`values > x`) which return `False` for NaN, causing the search to always go left.

**The fix:** Use negated comparisons (`~(x >= values)`) to match the eager C++ implementation in `Bucketization.cpp`.

## Test plan

- Added comprehensive test `test_bucketize_nan_values` covering NaN, rsqrt-produced NaN, mixed values, and infinity

Fixes #173133

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos