### PR TITLE
[inductor][overlap] early exit if no collectives in graph

### DIFF
--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1417,6 +1417,9 @@ def schedule_overlap_bucketing(
             Uses minimum of absolute and ratio limits when both are specified.
         enable_fusion_regions: Enable fusion region detection and cost estimation for fusible ops.
     """
+    if not any(is_wait_tensor(n) for n in gm.graph.nodes):
+        return gm
+
     trace_structured(
         "artifact",
         metadata_fn=lambda: {
@@ -1460,6 +1463,9 @@ def schedule_overlap_bucketing_from_inductor_configs(
     Reads configuration from torch._inductor.config.aten_distributed_optimizations
     and calls schedule_overlap_bucketing with those settings.
     """
+    if not any(is_wait_tensor(n) for n in gm.graph.nodes):
+        return gm
+
     from torch._inductor import config
 
     dist_opts = config.aten_distributed_optimizations


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173174


When overlap_scheduling is set as a post_grad_custom_pass - it is applied to all subgraphs and logs empty artifacts into tlparse.

Adding early return to not apply it if there are no wait_tensors => no collectives in the graph


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo