### PR TITLE
Make autograd use zeros_like for Python dispatch of  DTensor

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2865,6 +2865,14 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     refresh_layout_policy();
   }
 
+  void set_python_custom_zeros_like(bool custom_zeros_like) {
+    python_custom_zeros_like_ = custom_zeros_like;
+  }
+
+  bool python_custom_zeros_like() const {
+    return python_custom_zeros_like_;
+  }
+
  protected:
   void refresh_sizes_strides_policy() {
     if (has_symbolic_sizes_strides_) {
@@ -2965,6 +2973,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         static_cast<uint8_t>(SizesStridesPolicy::Default);
     python_custom_device_ = false;
     python_custom_layout_ = false;
+    python_custom_zeros_like_ = false;
     custom_device_ = false;
     custom_layout_ = false;
     device_policy_ = false;
@@ -3061,6 +3070,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   // Call into Python for layout()
   bool python_custom_layout_ : 1;
+
+  // subclasses like DTensor that need zeros_like() to be used
+  // when materializing undefined gradients, to preserve the subclass type.
+  bool python_custom_zeros_like_ : 1;
 
   // The set of DispatchKeys which describe this tensor.  NB: this
   // does NOT include Autograd (historically, it did, but

--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1710,6 +1710,60 @@ class TestDTensorCompileE2E(DTensorTestBase):
             for dt_chunk, tensor_chunk in zip(result, expected):
                 self.assertEqual(dt_chunk.full_tensor(), tensor_chunk)
 
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_compile_dtensor_unused_output_backward(self):
+        # test for https://github.com/pytorch/pytorch/issues/173123
+        mesh = self.build_device_mesh()
+
+        class MultiOutputOp(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                return x * 2, y * 3
+
+            @staticmethod
+            def backward(ctx, grad1, grad2):
+                return grad1 * 2, grad2 * 3
+
+        w = DTensor.from_local(
+            torch.randn(4, 4, device=self.device_type),
+            mesh,
+            [Replicate()],
+            run_check=False,
+        )
+
+        def fn(x, y):
+            h1, h2 = x @ w, y @ w
+            out1, out2 = MultiOutputOp.apply(h1, h2)
+            return out1.sum()
+
+        x_local = torch.randn(4, 4, device=self.device_type)
+        y_local = torch.randn(4, 4, device=self.device_type)
+
+        x_ref = DTensor.from_local(
+            x_local.clone().requires_grad_(True), mesh, [Replicate()], run_check=False
+        )
+        y_ref = DTensor.from_local(
+            y_local.clone().requires_grad_(True), mesh, [Replicate()], run_check=False
+        )
+        ref = fn(x_ref, y_ref)
+
+        x = DTensor.from_local(
+            x_local.clone().requires_grad_(True), mesh, [Replicate()], run_check=False
+        )
+        y = DTensor.from_local(
+            y_local.clone().requires_grad_(True), mesh, [Replicate()], run_check=False
+        )
+        res = torch.compile(fn)(x, y)
+
+        self.assertEqual(res, ref)
+
+        ref.backward()
+        res.backward()
+
+        self.assertEqual(x.grad, x_ref.grad)
+        self.assertEqual(y.grad, y_ref.grad)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -769,15 +769,16 @@ static void _wrap_outputs(
     } else {
       if (is_executable) {
         // If one of the grad outputs is undefined, a correctly-shaped zeros
-        // should be used instead. For NJT and Python dispatch subclasses (e.g.
-        // DTensor), zeros_like() must be used to preserve the tensor type.
+        // should be used instead. For NJT and tensor subclasses that set
+        // python_custom_zeros_like (e.g. DTensor), zeros_like() must be used
+        // to preserve the tensor type.
         bool is_differentiable =
             (non_differentiable.count(wrapped_output->unsafeGetTensorImpl()) ==
                  0 &&
              isDifferentiableType(wrapped_output->scalar_type()));
         bool use_zeros_like = is_differentiable && num_outputs > 1 &&
             (wrapped_output->is_nested() ||
-             wrapped_output->unsafeGetTensorImpl()->is_python_dispatch());
+             wrapped_output->unsafeGetTensorImpl()->python_custom_zeros_like());
         self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);
       }
       PyTuple_SetItem(outputs, i, THPVariable_Wrap(wrapped_output.value()));

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -769,14 +769,15 @@ static void _wrap_outputs(
     } else {
       if (is_executable) {
         // If one of the grad outputs is undefined, a correctly-shaped zeros
-        // should be used instead. To construct these for NJT, zeros_like() must
-        // be used until we have factory function support.
+        // should be used instead. For NJT and Python dispatch subclasses (e.g.
+        // DTensor), zeros_like() must be used to preserve the tensor type.
         bool is_differentiable =
             (non_differentiable.count(wrapped_output->unsafeGetTensorImpl()) ==
                  0 &&
              isDifferentiableType(wrapped_output->scalar_type()));
-        bool use_zeros_like =
-            is_differentiable && num_outputs > 1 && wrapped_output->is_nested();
+        bool use_zeros_like = is_differentiable && num_outputs > 1 &&
+            (wrapped_output->is_nested() ||
+             wrapped_output->unsafeGetTensorImpl()->is_python_dispatch());
         self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);
       }
       PyTuple_SetItem(outputs, i, THPVariable_Wrap(wrapped_output.value()));

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1716,6 +1716,7 @@ static PyObject* THPVariable_dtensor_new(
       extra_dispatch_keys);
   tensor.set_requires_grad(requires_grad);
   tensor.unsafeGetTensorImpl()->set_python_dispatch(true);
+  tensor.unsafeGetTensorImpl()->set_python_custom_zeros_like(true);
   py::object py_tensor = py::reinterpret_steal<py::object>(
       THPVariable_WrapWithType(std::move(tensor), (PyTypeObject*)cls));
   py_tensor.attr(dtensor_interned_strings._spec) = spec;


### PR DESCRIPTION
Fixes #173123 

When a multi output autograd.Function has an unused output then autograd should materialize a zero gradient for it. 
It chooses between `zeros_like` which preserves tensor type  and `zeros_symint` which creates plain tensor. 

Previously, only nested tensors got `zeros_like`. 

This fix adds `DTensor` to that condition. Now the mismatch does not happen.

Added a test too.

cc @wanchaol @tianyu-l @wz337 @XilunWu @d4l3k @pragupta @SherlockNoMad @ppwwyyxx