### PR TITLE
[ROCm] Skip test_index on MI300X due to timeout

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -17,7 +17,12 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor._sharding_prop import ShardingPropagator
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import MI200_ARCH, run_tests, skipIfRocmArch
+from torch.testing._internal.common_utils import (
+    MI200_ARCH,
+    MI300_ARCH,
+    run_tests,
+    skipIfRocmArch,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorConverter,
@@ -609,7 +614,7 @@ class DistTensorOpsTest(DTensorTestBase):
             self.assertEqual(output_dt.placements, [Shard(gather_dim)])
             self.assertEqual(output_dt.full_tensor(), global_output)
 
-    @skipIfRocmArch(MI200_ARCH)
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH)
     @with_comms
     def test_index(self):
         meshes = [


### PR DESCRIPTION
## Summary

Skip `DistTensorOpsTest.test_index` on MI300 architecture (gfx942) in addition to MI200. The test times out after 300 seconds on MI300X.

Fixes #171119

## Background

The test was disabled after [#171051](https://github.com/pytorch/pytorch/pull/171051) updated the slow tests list. The test already had `@skipIfRocmArch(MI200_ARCH)` decorator; this PR extends it to also skip on MI300X (`MI300_ARCH`) until the underlying performance issue is resolved.

## Changes

- Added `MI300_ARCH` import to test file
- Extended `@skipIfRocmArch(MI200_ARCH)` to `@skipIfRocmArch(MI200_ARCH + MI300_ARCH)`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

---
PR authored with assistance from Claude.