### PR TITLE
Updated foreach_norm to accept dim and keepdim arguments. 

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -472,19 +472,6 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
 
 std::vector<Tensor> foreach_tensor_norm_slow(
     TensorList tensors,
-    const Scalar& ord,
-    std::optional<ScalarType> dtype) {
-  check_foreach_api_restrictions(tensors);
-  std::vector<Tensor> result;
-  result.reserve(tensors.size());
-  for (const auto& t : tensors) {
-    result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype));
-  }
-  return result;
-}
-
-std::vector<Tensor> foreach_tensor_norm_slow(
-    TensorList tensors,
     at::IntArrayRef dim,
     bool keepdim,
     const Scalar& ord,
@@ -514,6 +501,39 @@ std::vector<Tensor> foreach_tensor_norm_slow(
           "_foreach_norm cannot compute the infinity norm on an empty tensor because the operation does not have an identity");
     }
     result.emplace_back(at::linalg_vector_norm(t, ord, dim, keepdim, dtype));
+  }
+  return result;
+}
+
+std::vector<Tensor> foreach_tensor_norm_slow(
+    TensorList tensors,
+    const Scalar& ord,
+    std::optional<ScalarType> dtype) {
+  check_foreach_api_restrictions(tensors);
+
+  // Extract ord value to check for infinity
+  const auto p = [&]() -> double {
+    if (ord.isIntegral(false)) {
+      return ord.to<int64_t>();
+    } else if (ord.isFloatingPoint()) {
+      return ord.to<double>();
+    } else {
+      TORCH_CHECK(
+          false, "foreach_tensor_norm_slow expects ord to be integer or float");
+    }
+  }();
+
+  std::vector<Tensor> result;
+  result.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    // If the tensor is empty and norm == infinity, we cannot compute the norm
+    // because the operation does not have an identity
+    if (p == std::numeric_limits<double>::infinity()) {
+      TORCH_SYM_CHECK(
+          t.sym_numel().sym_gt(0),
+          "_foreach_norm cannot compute the infinity norm on an empty tensor because the operation does not have an identity");
+    }
+    result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype));
   }
   return result;
 }

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -473,9 +473,22 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
 std::vector<Tensor> foreach_tensor_norm_slow(
     TensorList tensors,
     const Scalar& ord,
-    std::optional<ScalarType> dtype,
-    at::OptionalIntArrayRef dim,
-    bool keepdim) {
+    std::optional<ScalarType> dtype) {
+  check_foreach_api_restrictions(tensors);
+  std::vector<Tensor> result;
+  result.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype));
+  }
+  return result;
+}
+
+std::vector<Tensor> foreach_tensor_norm_slow(
+    TensorList tensors,
+    at::IntArrayRef dim,
+    bool keepdim,
+    const Scalar& ord,
+    std::optional<ScalarType> dtype) {
   check_foreach_api_restrictions(tensors);
 
   // Extract ord value to check for infinity

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -503,6 +503,21 @@ std::vector<Tensor> foreach_tensor_norm_slow(
   return result;
 }
 
+std::vector<Tensor> foreach_tensor_norm_dim_slow(
+    TensorList tensors,
+    const Scalar& ord,
+    at::OptionalIntArrayRef dim,
+    bool keepdim,
+    std::optional<ScalarType> dtype) {
+  check_foreach_api_restrictions(tensors);
+  std::vector<Tensor> result;
+  result.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    result.emplace_back(at::linalg_vector_norm(t, ord, dim, keepdim, dtype));
+  }
+  return result;
+}
+
 std::vector<Tensor> foreach_tensor_powsum_slow(
     TensorList tensors,
     const Scalar& ord,

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -473,7 +473,9 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
 std::vector<Tensor> foreach_tensor_norm_slow(
     TensorList tensors,
     const Scalar& ord,
-    std::optional<ScalarType> dtype) {
+    std::optional<ScalarType> dtype,
+    at::OptionalIntArrayRef dim,
+    bool keepdim) {
   check_foreach_api_restrictions(tensors);
 
   // Extract ord value to check for infinity
@@ -498,21 +500,6 @@ std::vector<Tensor> foreach_tensor_norm_slow(
           t.sym_numel().sym_gt(0),
           "_foreach_norm cannot compute the infinity norm on an empty tensor because the operation does not have an identity");
     }
-    result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype));
-  }
-  return result;
-}
-
-std::vector<Tensor> foreach_tensor_norm_dim_slow(
-    TensorList tensors,
-    const Scalar& ord,
-    at::OptionalIntArrayRef dim,
-    bool keepdim,
-    std::optional<ScalarType> dtype) {
-  check_foreach_api_restrictions(tensors);
-  std::vector<Tensor> result;
-  result.reserve(tensors.size());
-  for (const auto& t : tensors) {
     result.emplace_back(at::linalg_vector_norm(t, ord, dim, keepdim, dtype));
   }
   return result;

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -397,104 +397,6 @@ inline void check_foreach_norm_dtype(
 }
 } // anonymous namespace
 
-// template <
-//     typename T,
-//     NormType norm_type,
-//     typename out_t,
-//     int depth = 1,
-//     int r_args_depth = 1,
-//     int res_arg_index = 0>
-// struct LpNormDimFunctor {
-//   using out_opmath_t = typename at::opmath_type<out_t>;
-  
-//   __device__ __forceinline__ void operator()(
-//       int64_t /*unused_chunk_size*/,
-//       TensorListDimMetadata<depth>& tl,
-//       out_opmath_t* output_per_tensor_ptr,
-//       const int max_output_per_tensor) {
-    
-   
-//     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-//     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-//     const auto num_rows = tl.num_rows[tensor_loc];
-//     const auto num_cols = tl.num_cols[tensor_loc];
-//     const auto row_stride = tl.row_stride[tensor_loc]; 
-//     const auto reduce_dim = tl.reduce_dim;
-//     ///
-//     int n_norm_elements_per_chunk = 16;  // Each block handles 16 rows (row_norm) or cols (col_norm)
-//     const int row_start = chunk_idx * n_norm_elements_per_chunk;  // first row of this chunk
-//     // Each warp (32 threads) handles one row (or col)
-//     const int row = row_start + threadIdx.y;
-//     ///
-
-//     T* data = (T*)tl.addresses[0][tensor_loc];
-    
-//     __shared__ out_opmath_t s_vals[512];  // 512 = blockDim.x * blockDim.y
-//     out_opmath_t val = out_opmath_t(0);
-//     // out_opmath_t vals[kILP];
-//     // T r_x[kILP];
-//     // for (int64_t i = 0; i < kILP; i++) {
-//     //   vals[i] = out_opmath_t(0);
-//     //   r_x[i] = T(0);
-//     // }
-    
-//     if (reduce_dim == 1) {  // want to change this to a constexpr
-//       // Reduce across columns - row norm
-//       T* row_ptr = data + row * row_stride;
-      
-//       for (int64_t i = threadIdx.x; i < num_cols; i += blockDim.x) {
-//         const auto elem = static_cast<out_opmath_t>(row_ptr[i]);
-//         if constexpr (norm_type == NormType::LInf) {
-//           val = max_propagate_nan(val, ::abs(elem));
-//         } else {
-//           val += norm_type == NormType::L1 ? ::abs(elem) : elem * elem;
-//         }
-//       }
-//     } else {
-//       // Reduce across rows - column norm  
-//       // Each block handles one column, threads iterate over rows
-//       int64_t col_idx = row;
-      
-//       for (int64_t i = threadIdx.x; i < num_rows; i += blockDim.x) {
-//         const auto elem = static_cast<out_opmath_t>(data[i * row_stride + col_idx]);
-//         if constexpr (norm_type == NormType::LInf) {
-//           val = max_propagate_nan(val, ::abs(elem));
-//         } else {
-//           val += norm_type == NormType::L1 ? ::abs(elem) : elem * elem;
-//         }
-//       }
-//     }
-
-//     int64_t block_row = threadIdx.y * blockDim.x;
-//     int64_t block_elem = block_row + threadIdx.x;
-//     s_vals[block_elem] = val;
-    
-//     // Block reduction
-//     __syncthreads();
-//     for (int64_t s = blockDim.x / 2; s > 0; s >>= 1) {
-//       if (threadIdx.x < s)
-//       {
-//         if constexpr (norm_type == NormType::LInf) {
-//           s_vals[block_elem] = max_propagate_nan(s_vals[block_elem], s_vals[block_elem + s]);
-//         } else {
-//           s_vals[block_elem] += s_vals[block_elem + s];
-//         } 
-//       }
-//       __syncthreads();
-//     }
-    
-//     if (threadIdx.x == 0 && row < max_output_per_tensor) {
-//       auto final_val = s_vals[block_elem];
-//       // Apply sqrt for L2 norm
-//       if constexpr (norm_type == NormType::L2) {
-//         final_val = ::sqrt(final_val);
-//       }
-//       // Write directly to output (no cleanup needed for simple rows/cols)
-//       output_per_tensor_ptr[(tl.start_tensor_this_launch + tensor_loc) * max_output_per_tensor + row] = final_val;
-//     }
-//   }
-// };
-
 
 template <
     typename T,
@@ -535,66 +437,60 @@ struct LpNormDimFunctor {
             
     T* data = (T*)tl.addresses[0][tensor_loc];
 
-    // Row norms time is dominated by the number of kernel launch's
-    // so multiple rows are calculated per warp to reduce the number of kernel launches. 
-    constexpr int ROWS_PER_CHUNK = 128;
-    constexpr int WARPS_PER_BLOCK = 16;
-    constexpr int ROWS_PER_WARP = ROWS_PER_CHUNK / WARPS_PER_BLOCK;  // 8
+    constexpr int ROWS_PER_CHUNK = 16;
     
     const int chunk_row_start = chunk_idx * ROWS_PER_CHUNK;
     
-    for (int r = 0; r < ROWS_PER_WARP; r++) {
-      const int row = chunk_row_start + warp_id * ROWS_PER_WARP + r;
+    const int row = chunk_row_start + warp_id;
       
-      if (row >= num_rows) continue;
+    if (row >= num_rows) return;
+    
+    out_opmath_t val = out_opmath_t(0);
+    T* row_ptr = data + row * row_stride;
+    
+    if (num_cols % kILP == 0 && is_aligned(row_ptr)) {
+      // fast path using Instruction-Level Parallelism (ILP) 
+      out_opmath_t vals[kILP] = {0};
+      T r_x[kILP];
       
-      out_opmath_t val = out_opmath_t(0);
-      T* row_ptr = data + row * row_stride;
-      
-      if (num_cols % kILP == 0 && is_aligned(row_ptr)) {
-        // fast path using Instruction-Level Parallelism (ILP) 
-        out_opmath_t vals[kILP] = {0};
-        T r_x[kILP];
-        
-        for (int64_t i_start = lane; i_start * kILP < num_cols; i_start += blockDim.x) {
-          load_store(r_x, row_ptr, 0, i_start);
-          #pragma unroll
-          for (int ii = 0; ii < kILP; ii++) {
-            const auto elem = static_cast<out_opmath_t>(r_x[ii]);
-            if constexpr (norm_type == NormType::LInf) {
-              vals[ii] = max_propagate_nan(vals[ii], ::abs(elem));
-            } else {
-              vals[ii] += norm_type == NormType::L1 ? ::abs(elem) : elem * elem;
-            }
-          }
-        }
-        
+      for (int64_t i_start = lane; i_start * kILP < num_cols; i_start += blockDim.x) {
+        load_store(r_x, row_ptr, 0, i_start);
+        #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
+          const auto elem = static_cast<out_opmath_t>(r_x[ii]);
           if constexpr (norm_type == NormType::LInf) {
-            val = max_propagate_nan(val, vals[ii]);
+            vals[ii] = max_propagate_nan(vals[ii], ::abs(elem));
           } else {
-            val += vals[ii];
-          }
-        }
-      } else {
-        for (int64_t i = lane; i < num_cols; i += 32) {
-          const auto elem = static_cast<out_opmath_t>(row_ptr[i]);
-          if constexpr (norm_type == NormType::LInf) {
-            val = max_propagate_nan(val, ::abs(elem));
-          } else {
-            val += norm_type == NormType::L1 ? ::abs(elem) : elem * elem;
+            vals[ii] += norm_type == NormType::L1 ? ::abs(elem) : elem * elem;
           }
         }
       }
       
-      val = warpReduce(val);
-      
-      if (lane == 0) {
-        if constexpr (norm_type == NormType::L2) {
-          val = ::sqrt(val);
+      for (int ii = 0; ii < kILP; ii++) {
+        if constexpr (norm_type == NormType::LInf) {
+          val = max_propagate_nan(val, vals[ii]);
+        } else {
+          val += vals[ii];
         }
-        output_per_tensor_ptr[(tl.start_tensor_this_launch + tensor_loc) * max_num_output_per_tensor + row] = val;
       }
+    } else {
+      for (int64_t i = lane; i < num_cols; i += 32) {
+        const auto elem = static_cast<out_opmath_t>(row_ptr[i]);
+        if constexpr (norm_type == NormType::LInf) {
+          val = max_propagate_nan(val, ::abs(elem));
+        } else {
+          val += norm_type == NormType::L1 ? ::abs(elem) : elem * elem;
+        }
+      }
+    }
+    
+    val = warpReduce(val);
+    
+    if (lane == 0) {
+      if constexpr (norm_type == NormType::L2) {
+        val = ::sqrt(val);
+      }
+      output_per_tensor_ptr[(tl.start_tensor_this_launch + tensor_loc) * max_num_output_per_tensor + row] = val;
     }
   }
 
@@ -612,10 +508,8 @@ struct LpNormDimFunctor {
     const int lane = threadIdx.x;
       
     T* data = (T*)tl.addresses[0][tensor_loc];
-  
-    // Col norms time is dominated by memory time not kernel launches
-    // so only one col is calculated per warp to increase compute per block time. 
-    constexpr int COLS_PER_CHUNK = 16;  // Just blockDim.y, no multiplier
+
+    constexpr int COLS_PER_CHUNK = 16;
     
     const int chunk_col_start = chunk_idx * COLS_PER_CHUNK;
     const int col = chunk_col_start + warp_id;

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -658,6 +658,23 @@ std::vector<Tensor> foreach_tensor_powsum_cuda(
       /*support_infinity=*/false>(tensors, p, dtype);
 }
 
+std::vector<Tensor> foreach_tensor_norm_dim_cuda(
+    TensorList tensors,
+    const Scalar& ord,
+    OptionalIntArrayRef dim,
+    bool keepdim,
+    std::optional<ScalarType> dtype) {
+  // For the dim/keepdim variant, we fall back to slow path
+  // because the CUDA optimization is designed for full tensor reduction
+  // When reducing over specific dimensions, the tensor structure is different
+  std::vector<Tensor> result;
+  result.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    result.push_back(t[0]);
+  }
+  return result;
+}
+
 #undef AT_DISPATCH_OUT_DTYPES
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -612,7 +612,7 @@ std::vector<Tensor> foreach_tensor_norm_cuda(
   }
   if (!can_use_fast_route(tensors) || has_int_or_complex ||
       !(p == static_cast<double>(1) || p == static_cast<double>(2) ||
-        p == std::numeric_limits<double>::infinity())) {
+        p == std::numeric_limits<double>::infinity()) || dim.has_value()) {
     return foreach_tensor_norm_slow(tensors, ord, dtype, dim, keepdim);
   }
   check_foreach_norm_dtype(

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -673,34 +673,34 @@ std::vector<Tensor> foreach_tensor_norm_cuda(
               if (reduce_dim == tensors_dim - 1) { // row norm
                 reduce_dim = 1;
                 if (p == static_cast<double>(1)) {
-                  multi_tensor_apply_dim<2>(
+                  multi_tensor_apply_dim(
                       tensor_lists,
                       reduce_dim,
                       LpNormDimFunctor<scalar_t, NormType::L1, out_t, 1>());
                 } else if (p == static_cast<double>(2)) {
-                  multi_tensor_apply_dim<2>(
+                  multi_tensor_apply_dim(
                       tensor_lists,
                       reduce_dim,
                       LpNormDimFunctor<scalar_t, NormType::L2, out_t, 1>());
                 } else {
-                  multi_tensor_apply_dim<2>(
+                  multi_tensor_apply_dim(
                       tensor_lists,
                       reduce_dim,
                       LpNormDimFunctor<scalar_t, NormType::LInf, out_t, 1>());
                 }
               } else { // col norm
                 if (p == static_cast<double>(1)) {
-                  multi_tensor_apply_dim<2>(
+                  multi_tensor_apply_dim(
                       tensor_lists,
                       reduce_dim,
                       LpNormDimFunctor<scalar_t, NormType::L1, out_t, 0>());
                 } else if (p == static_cast<double>(2)) {
-                  multi_tensor_apply_dim<2>(
+                  multi_tensor_apply_dim(
                       tensor_lists,
                       reduce_dim,
                       LpNormDimFunctor<scalar_t, NormType::L2, out_t, 0>());
                 } else {
-                  multi_tensor_apply_dim<2>(
+                  multi_tensor_apply_dim(
                       tensor_lists,
                       reduce_dim,
                       LpNormDimFunctor<scalar_t, NormType::LInf, out_t, 0>());

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -623,8 +623,8 @@ std::vector<Tensor> _foreach_norm_cuda_with_dim(
     }
   }
 
-  auto tensor_lists =
-      std::vector<std::vector<Tensor>>{input_tensors, output_tensors};
+  auto tensor_lists = std::vector<std::vector<Tensor>>{
+      std::move(input_tensors), output_tensors};
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -428,14 +428,9 @@ void multi_tensor_apply_dim(
           tensor_lists[d][t].const_data_ptr();
     }
     loc_tensor_info++;
-
-    // Row norms time is dominated by the number of kernel launches
-    // so multiple rows are calculated per warp to reduce the number of kernel launches. 
-    // Col norms time is dominated by memory time not kernel launches
-    // so only one col is calculated per warp to increase compute per block time. 
-    bool reduce_dim_is_row = reduce_dim == 1; 
-    int outer_dim_size = reduce_dim_is_row ? tensor.size(0) : tensor.size(1);
-    const int CHUNK_SIZE = reduce_dim_is_row ? 8*kBlockSizeDim.y: kBlockSizeDim.y;  // 128 : 16
+ 
+    int outer_dim_size = reduce_dim == 1 ? tensor.size(0) : tensor.size(1);
+    const int CHUNK_SIZE = kBlockSizeDim.y;  //   reduce_dim_is_row ? kBlockSizeDim.y: kBlockSizeDim.y;  // 128 : 16
     const int64_t num_chunks_per_tensor = (outer_dim_size + CHUNK_SIZE - 1) / CHUNK_SIZE; 
     for (int64_t idx = 0; idx < num_chunks_per_tensor; idx++) {
       tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -425,10 +425,10 @@ void multi_tensor_apply_dim(
     tensorListMeta.prod_of_other_dim[loc_tensor_info] = c10::multiply_integers(
         tensor.sizes().begin(), tensor.sizes().end() - 2);
 
-    for (int d = 0; d < depth; d++) {
-      tensorListMeta.addresses[d][loc_tensor_info] =
-          tensor_lists[d][t].const_data_ptr();
-    }
+    tensorListMeta.addresses[0][loc_tensor_info] =
+        tensor_lists[0][t].const_data_ptr();
+    tensorListMeta.addresses[1][loc_tensor_info] =
+        tensor_lists[1][t].mutable_data_ptr();
     loc_tensor_info++;
 
     int outer_dim_size =

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -429,9 +429,14 @@ void multi_tensor_apply_dim(
     }
     loc_tensor_info++;
 
-    int outer_dim_size = reduce_dim == 1 ? tensor.size(0) : tensor.size(1);
-    const int CHUNK_SIZE = (reduce_dim == 1) ? 128 : 16;
-    const int64_t num_chunks_per_tensor = (outer_dim_size + CHUNK_SIZE - 1) / CHUNK_SIZE;  // 16 rows per chunk. 
+    // Row norms time is dominated by the number of kernel launches
+    // so multiple rows are calculated per warp to reduce the number of kernel launches. 
+    // Col norms time is dominated by memory time not kernel launches
+    // so only one col is calculated per warp to increase compute per block time. 
+    bool reduce_dim_is_row = reduce_dim == 1; 
+    int outer_dim_size = reduce_dim_is_row ? tensor.size(0) : tensor.size(1);
+    const int CHUNK_SIZE = reduce_dim_is_row ? 8*kBlockSizeDim.y: kBlockSizeDim.y;  // 128 : 16
+    const int64_t num_chunks_per_tensor = (outer_dim_size + CHUNK_SIZE - 1) / CHUNK_SIZE; 
     for (int64_t idx = 0; idx < num_chunks_per_tensor; idx++) {
       tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
       tensorListMeta.block_to_chunk[loc_block_info] = idx;

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -430,7 +430,8 @@ void multi_tensor_apply_dim(
     loc_tensor_info++;
 
     int outer_dim_size = reduce_dim == 1 ? tensor.size(0) : tensor.size(1);
-    const int64_t num_chunks_per_tensor = (outer_dim_size + 15) / 16;  // 16 rows per chunk. 
+    const int CHUNK_SIZE = (reduce_dim == 1) ? 128 : 16;
+    const int64_t num_chunks_per_tensor = (outer_dim_size + CHUNK_SIZE - 1) / CHUNK_SIZE;  // 16 rows per chunk. 
     for (int64_t idx = 0; idx < num_chunks_per_tensor; idx++) {
       tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
       tensorListMeta.block_to_chunk[loc_block_info] = idx;

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -468,6 +468,8 @@ void multi_tensor_apply_dim(
               tensorListMeta.num_rows[loc_tensor_info - 1];
           tensorListMeta.num_cols[0] =
               tensorListMeta.num_cols[loc_tensor_info - 1];
+          tensorListMeta.prod_of_other_dim[0] =
+              tensorListMeta.prod_of_other_dim[loc_tensor_info - 1];
           for (int d = 0; d < depth; d++) {
             tensorListMeta.addresses[d][0] =
                 tensorListMeta.addresses[d][loc_tensor_info - 1];

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -393,12 +393,13 @@ void multi_tensor_apply_for_fused_optimizer(
   }
 }
 
-template <int depth, typename T, typename... ArgTypes>
+template <typename T, typename... ArgTypes>
 void multi_tensor_apply_dim(
     std::vector<std::vector<at::Tensor>>& tensor_lists,
     int reduce_dim, // 0 = reduce rows, 1 = reduce cols
     T callable,
     ArgTypes... args) {
+  constexpr int depth = 2; // 1 input and 1 output tensor list.
   TORCH_CHECK(
       tensor_lists.size() == depth,
       "Number of tensor lists has to match the depth.");

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11567,6 +11567,14 @@
     MTIA: foreach_tensor_norm_mtia
   autogen: _foreach_norm.Scalar_out
 
+- func: _foreach_norm.dim(Tensor[] self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor[]
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: foreach_tensor_norm_dim_slow
+    CUDA: foreach_tensor_norm_dim_cuda
+  autogen: _foreach_norm.dim_out
+
 # Like _foreach_norm but returns sum(|x|^ord) without the final root
 - func: _foreach_powsum.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
   device_check: NoCheck

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11558,7 +11558,7 @@
     CUDA: foreach_tensor_neg_cuda_
   autogen: _foreach_neg.out
 
-- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None, int[1]? dim=None, bool keepdim=False) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:
@@ -11566,14 +11566,6 @@
     CUDA: foreach_tensor_norm_cuda
     MTIA: foreach_tensor_norm_mtia
   autogen: _foreach_norm.Scalar_out
-
-- func: _foreach_norm.dim(Tensor[] self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor[]
-  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
-  variants: function
-  dispatch:
-    CompositeExplicitAutograd: foreach_tensor_norm_dim_slow
-    CUDA: foreach_tensor_norm_dim_cuda
-  autogen: _foreach_norm.dim_out
 
 # Like _foreach_norm but returns sum(|x|^ord) without the final root
 - func: _foreach_powsum.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11558,7 +11558,7 @@
     CUDA: foreach_tensor_neg_cuda_
   autogen: _foreach_neg.out
 
-- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None, int[1]? dim=None, bool keepdim=False) -> Tensor[]
+- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:
@@ -11566,6 +11566,14 @@
     CUDA: foreach_tensor_norm_cuda
     MTIA: foreach_tensor_norm_mtia
   autogen: _foreach_norm.Scalar_out
+
+  - func: _foreach_norm.dim(Tensor[] self, int[1] dim, bool keepdim=False, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: foreach_tensor_norm_slow
+    CUDA: foreach_tensor_norm_cuda
+  autogen: _foreach_norm.dim_out
 
 # Like _foreach_norm but returns sum(|x|^ord) without the final root
 - func: _foreach_powsum.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11567,7 +11567,7 @@
     MTIA: foreach_tensor_norm_mtia
   autogen: _foreach_norm.Scalar_out
 
-  - func: _foreach_norm.dim(Tensor[] self, int[1] dim, bool keepdim=False, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+- func: _foreach_norm.dim(Tensor[] self, int[1] dim, bool keepdim=False, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -296,6 +296,8 @@ aten::_foreach_neg.out
 aten::_foreach_neg_
 aten::_foreach_norm.Scalar
 aten::_foreach_norm.Scalar_out
+aten::_foreach_norm.dim
+aten::_foreach_norm.dim_out
 aten::_foreach_pow.List
 aten::_foreach_pow.List_out
 aten::_foreach_pow.Scalar

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3248,6 +3248,10 @@
 
 # note(crcrpar): forward-mode AD is tricky for a simple string replace to handle:
 #   formula.replace("p", "ord") produces `norm_jvord(self_ord, self_t, ord, result)`
-- name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None, int[1]? dim=None, bool keepdim=False) -> Tensor[]
+- name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
   self: norm_backward(grads[i], self[i], ord, result[i])
   result: norm_jvp(self_p, self_t, ord, result[i])
+
+- name: _foreach_norm.dim(Tensor[] self, int[1] dim, bool keepdim=False, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+  self: norm_backward(grads[i], self[i], ord, result[i], dim, keepdim)
+  result: norm_jvp(self_p, self_t, ord, result[i], dim, keepdim)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3248,6 +3248,6 @@
 
 # note(crcrpar): forward-mode AD is tricky for a simple string replace to handle:
 #   formula.replace("p", "ord") produces `norm_jvord(self_ord, self_t, ord, result)`
-- name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None) -> Tensor[]
+- name: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2, ScalarType? dtype=None, int[1]? dim=None, bool keepdim=False) -> Tensor[]
   self: norm_backward(grads[i], self[i], ord, result[i])
   result: norm_jvp(self_p, self_t, ord, result[i])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -19,6 +19,7 @@ from torch._ops import OpOverload
 from torch._prims import _prim_elementwise_meta, ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND
 from torch._prims_common import (
     BoolLike,
+    canonicalize_dims,
     corresponding_complex_dtype,
     corresponding_real_dtype,
     elementwise_dtypes,
@@ -8432,6 +8433,30 @@ def meta_foreach_norm(tensors, ord=2, dtype=None):
         if out_dtype.is_complex:
             out_dtype = corresponding_real_dtype(out_dtype)
         results.append(t.new_empty((), dtype=out_dtype))
+    return results
+
+
+@register_meta(aten._foreach_norm.dim)
+def meta_foreach_norm_dim(tensors, dim, keepdim=False, ord=2, dtype=None):
+    if float(ord) == float("inf"):
+        for t in tensors:
+            torch._check(
+                t.numel() > 0,
+                lambda: "_foreach_norm cannot compute infinity norm on empty tensor",
+            )
+    results = []
+    for t in tensors:
+        out_dtype = dtype if dtype is not None else t.dtype
+        if out_dtype.is_complex:
+            out_dtype = corresponding_real_dtype(out_dtype)
+        cdims = canonicalize_dims(t.ndim, dim)
+        if keepdim:
+            new_shape = list(t.shape)
+            for d in cdims:
+                new_shape[d] = 1
+        else:
+            new_shape = [s for d, s in enumerate(t.shape) if d not in cdims]
+        results.append(t.new_empty(new_shape, dtype=out_dtype))
     return results
 
 

--- a/torch/_refs/linalg/__init__.py
+++ b/torch/_refs/linalg/__init__.py
@@ -10,6 +10,7 @@ import torch._refs as refs
 import torch._refs.linalg as linalg
 from torch import Tensor
 from torch._prims_common import (
+    canonicalize_dims,
     check_fp_or_complex,
     check_is_matrix,
     Dim,
@@ -183,7 +184,8 @@ def vector_norm(
             elif dim is None:
                 return to_result_dtype(x).flatten()[0]
             else:
-                new_shape = [s for d, s in enumerate(x.shape) if d not in dim]
+                cdims = canonicalize_dims(x.ndim, dim)
+                new_shape = [s for d, s in enumerate(x.shape) if d not in cdims]
                 return to_result_dtype(x.view(new_shape)).contiguous()
 
         if not (is_ord_even and utils.is_float_dtype(x.dtype)):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9951,6 +9951,41 @@ class foreach_norm_sample_func(foreach_inputs_sample_func):
                 disable_fastpath = False
             yield ForeachSampleInput(input, ord=ord, disable_fastpath=disable_fastpath, dtype=out_dtype)
 
+        # Test dim argument with sample inputs interspersed with empty tensors
+        # and test higher dimensional tensor
+        # Use fewer combinations for autodiff tests
+        ords = (2,) if requires_grad else (1, 2, float('inf'))
+        keepdims = (False,) if requires_grad else (True, False)
+        dims = (-1, -2)
+        higher_dims = (True, False)
+        for ord, keepdim, dim, higher_dim in product(
+            ords,
+            keepdims,
+            dims,
+            higher_dims,
+        ):
+            if higher_dim:
+                if dtype not in floating_types_and(torch.half, torch.bfloat16):
+                    continue
+                input = [torch.randn((i, 2 * i, 3 * i, 4 * i),
+                                     device=device,
+                                     dtype=dtype,
+                                     requires_grad=requires_grad)
+                         for i in range(1, 5)]
+            else:
+                # linalg.vector_norm cannot compute the inf norm on an empty tensor because the operation does not have an identity
+                _foreach_inputs_kwargs["intersperse_empty_tensors"] = ord != float('inf')
+                input = sample_inputs_foreach(None, device, dtype, 20, zero_size=False, **_foreach_inputs_kwargs)
+
+            disable_fastpath = dtype not in floating_types_and(torch.half, torch.bfloat16)
+            yield ForeachSampleInput(
+                input,
+                ord=ord,
+                dim=[dim],
+                keepdim=keepdim,
+                disable_fastpath=disable_fastpath,
+            )
+
         # Also test nan propagation with a single tensor, but skip autograd testing
         if not requires_grad:
             nan_inputs = [

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9974,7 +9974,8 @@ class foreach_norm_sample_func(foreach_inputs_sample_func):
                          for i in range(1, 5)]
             else:
                 # linalg.vector_norm cannot compute the inf norm on an empty tensor because the operation does not have an identity
-                _foreach_inputs_kwargs["intersperse_empty_tensors"] = ord != float('inf')
+                # empty tensors have dim() == 1 thus dim = -2 does not work if they are in the list.
+                _foreach_inputs_kwargs["intersperse_empty_tensors"] = ord != float('inf') and dim != -2
                 input = sample_inputs_foreach(None, device, dtype, 20, zero_size=False, **_foreach_inputs_kwargs)
 
             disable_fastpath = dtype not in floating_types_and(torch.half, torch.bfloat16)


### PR DESCRIPTION
Related:
  #133367
 
Updated foreach_norm to accept dim and keepdim arguments.    
This implementation:
`row_norm = torch._foreach_norm(tensor_list, dim=-1, keepdim=True)`
and 
`col_norm = torch._foreach_norm(tensor_list, dim=-2, keepdim=True)`
produce the same output as 
`row_norm = [torch.linalg.vector_norm(t, dim=-1, keepdim=true) for t in tensor_list]`
and 
`col_norm = [torch.linalg.vector_norm(t, dim=-2, keepdim=true) for t in tensor_list]`

In this implementation, only row and column norms (`dim` in `[-1, len(tensors)-1, len(tensors)-2, -2]`) use the fast path kernel. Otherwise, a slow path is called and the norms are calculated 1 at a time (see ForeachOpsKernels.cpp). Each tensor in tensor_list can be an arbitrary number of dimension, but if the `t.dim()` are not all the same within the tensor list, then the slow path is called.   

Below is some runtime analysis comparing the foreach_norm implementation vs list comprehension implementation. These are computed for the 2-norm, but the results are similar for 1 and infinity norms. From the foreach_norm runtime, $fnr$, and the list comprehension runtime, $lcr$, The relative runtime , $rr$, is computed as

$rr = \frac{fnr}{lcr} \cdot 100\\% $

The runtimes were compared to each other for 4 different tensor list:
`small = [torch.randn((768, 4), device=device, dtype=dtype) for _ in range(100)]`
`medium = [torch.randn(1024, 1024, device='cuda', dtype=dtype) for _ in range(50)]`
`large = [torch.randn(2048, 2048, device=device, dtype=dtype) for _ in range(50)]`
and 
```
mixed = [
  *[torch.randn(3, 768, 1, device=device, dtype=dtype) for _ in range(50)],
  *[torch.randn(4, 768, 768, device=device, dtype=dtype) for _ in range(24)],
  *[torch.randn(5, 768, 3072, device=device, dtype=dtype) for _ in range(12)],
  *[torch.randn(6, 3072, 768, device=device, dtype=dtype) for _ in range(12)],
  ]
```
and the reported relative runtimes is from an average of 50 runs on each tensor list. 
| | relative runtime | speedup
|---|---|---|
| row_norm small| 32.2% | 3.121x  
| col_norm small | 30.3% | 3.328x 
| row_norm medium| 33.4% | 3.009x 
| col_norm medium | 31.4% | 3.226x
| row_norm large| 39.8% | 2.516x
| col_norm large | 67.0% | 1.494x
| row_norm mixed| 48.0% | 2.097x
| col_norm mixed | 75.7% | 1.328x
 
 (updated to reflect changes on February 12, 2026)
 
 @janeyx99 

