### PR TITLE
[dynamo] Fix property setter on MutableMapping subclasses

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1557,6 +1557,85 @@ class FunctionTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreaks):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    def test_mutable_mapping_property_setter_nested(self):
+        """Test that property setters work correctly on nested MutableMapping objects.
+
+        This tests the fix for a bug where property setters on newly created
+        MutableMapping objects would fail when accessing nested objects.
+        The issue was that property.__set__ is a slot wrapper (not a Python function),
+        so Dynamo wasn't tracing the property setter (fset), causing the setter code
+        to run on uninitialized example objects.
+
+        See: https://github.com/pytorch/pytorch/issues/172000
+        """
+        from collections.abc import MutableMapping
+
+        class Container(MutableMapping):
+            def __init__(self, data=None, batch_size=None):
+                self._data = data if data is not None else {}
+                self._batch_size = batch_size if batch_size is not None else ()
+                self._names = None
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __setitem__(self, key, value):
+                self._data[key] = value
+
+            def __delitem__(self, key):
+                del self._data[key]
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def __len__(self):
+                return len(self._data)
+
+            @property
+            def batch_size(self):
+                return self._batch_size
+
+            @property
+            def names(self):
+                return self._names
+
+            @names.setter
+            def names(self, value):
+                self._set_names(value)
+
+            def _set_names(self, value):
+                self._names = value
+                for item in self._data.values():
+                    if isinstance(item, Container):
+                        child_size = len(item.batch_size)
+                        item._names = list(value) + [None] * (child_size - len(value))
+
+        # Test that both direct method call and property setter work identically
+        @torch.compile(backend="eager", fullgraph=True)
+        def using_method(x):
+            nested = Container({"b": x}, (3,))
+            root = Container({"nested": nested}, (3,))
+            root._set_names(["time"])
+            return root, x + 1
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def using_property_setter(x):
+            nested = Container({"b": x}, (3,))
+            root = Container({"nested": nested}, (3,))
+            root.names = ["time"]
+            return root, x + 1
+
+        x = torch.tensor(2.0)
+
+        # Both should work without error
+        result_method, _ = using_method(x)
+        self.assertEqual(result_method._names, ["time"])
+        self.assertEqual(result_method["nested"]._names, ["time"])
+
+        result_property, _ = using_property_setter(x)
+        self.assertEqual(result_property._names, ["time"])
+        self.assertEqual(result_property["nested"]._names, ["time"])
+
     def _test_default_dict_helper(self, factory):
         dd = collections.defaultdict(factory)
         param = torch.nn.Parameter(torch.ones([2, 2]))

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2712,6 +2712,44 @@ class MutableMappingVariable(UserDefinedObjectVariable):
         super().__init__(value, **kwargs)
         self.generic_dict_vt = ConstDictVariable({})
 
+    def method_setattr_standard(
+        self,
+        tx: "InstructionTranslator",
+        name: VariableTracker,
+        value: VariableTracker,
+        directly_update_dict: bool = False,
+    ) -> VariableTracker:
+        """Override to handle property setters on MutableMapping subclasses.
+
+        This is needed because property.__set__ is a slot wrapper (C function),
+        not a Python function, so the base class's try_get_descritor_and_setter_py_func
+        returns None for properties. But property.fset IS a Python function we can trace.
+
+        Without this, property setters on newly created MutableMapping objects fail
+        when accessing nested objects (which haven't been initialized yet on the
+        example value). By tracing the fset, we capture the setter logic in the graph
+        instead of running it on uninitialized example objects.
+
+        TODO(compiler): This fix is scoped to MutableMapping only because tracing
+        property setters on ALL UserDefinedObjectVariable can cause failures when
+        the fset calls untraceable C++ functions (e.g., pybind functions). Ideally,
+        this should be extended to all user-defined classes with a graceful fallback
+        when tracing the fset hits an untraceable function.
+        See: https://github.com/pytorch/pytorch/issues/172000
+        """
+        if isinstance(name, variables.ConstantVariable) and isinstance(name.value, str):
+            name_str = name.value
+            descriptor = inspect.getattr_static(type(self.value), name_str, None)
+            if isinstance(descriptor, property) and descriptor.fset is not None:
+                fset_source = None
+                if self.cls_source:
+                    desc_source = self.get_source_by_walking_mro(name_str)
+                    fset_source = AttrSource(desc_source, "fset")
+                fset_vt = VariableTracker.build(tx, descriptor.fset, fset_source)
+                return fset_vt.call_function(tx, [self, value], {})
+
+        return super().method_setattr_standard(tx, name, value, directly_update_dict)
+
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         # A common pattern in the init code of MutableMapping objects is to
         # update the __dict__ attribute. To prevent graph break, we directly


### PR DESCRIPTION
# [dynamo] Fix property setter on MutableMapping subclasses

Closes #172000

## Summary

When a compiled function creates nested `MutableMapping` instances and uses a property setter that accesses nested objects, Dynamo fails with `AttributeError` because property setters weren't being traced correctly. This PR fixes the issue by properly tracing property setter functions on `MutableMapping` subclasses.

## Problem

Property setters were not being traced correctly because `property.__set__` is a slot wrapper (C function), not a Python function. When Dynamo encountered a property setter like `obj.names = value`, it would:

1. Skip tracing the property's `fset` function (since `try_get_descritor_and_setter_py_func` returns `None` for properties)
2. Defer to a `STORE_ATTR` bytecode at runtime
3. Run the setter code on uninitialized example objects
4. Fail when the setter accessed nested objects that were missing attributes

This caused an asymmetry where `obj._set_names(value)` worked but `obj.names = value` failed, even though they execute identical code.

## Solution

Added an override of `method_setattr_standard` in `MutableMappingVariable` that:

1. Checks if the attribute being set corresponds to a property descriptor with an `fset` function
2. If so, traces the `fset` function directly (similar to how property getters call `fget` in `var_getattr`)
3. Otherwise delegates to the parent class implementation

### Why scoped to MutableMapping only?

This fix is intentionally scoped to `MutableMapping` subclasses only. Applying it broadly to all user-defined objects can cause failures when property setters call untraceable C++ pybind functions. By limiting the scope, we fix the original bug while avoiding potential regressions.

A broader fix would require Dynamo to gracefully fall back when tracing a property setter's `fset` hits an untraceable function.

## Test

Added `test_mutable_mapping_property_setter_nested` that verifies both direct method calls and property setters work identically on nested `MutableMapping` objects.

## Workaround (for users on older PyTorch versions)

Call methods directly instead of using property setters:

```python
# Instead of:
obj.names = ["time"]

# Use:
obj._set_names(["time"])
```

This workaround was applied in TensorDict: https://github.com/pytorch/tensordict/pull/1521


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo