### PR TITLE
Fixed call of cudssMatrixCreateCsr for CUDA 13.0

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -757,7 +757,7 @@ void _apply_sparse_csr_linear_solve(
     auto CUDA_R_TYP = std::is_same_v<scalar_t, double> ? CUDA_R_64F : CUDA_R_32F;
     TORCH_CUDSS_CHECK(cudssMatrixCreateDn(&b_mt, b.size(0), 1, b.size(0), b_ptr, CUDA_R_TYP, CUDSS_LAYOUT_COL_MAJOR));
     TORCH_CUDSS_CHECK(cudssMatrixCreateDn(&x_mt, x.size(0), 1, x.size(0), x_ptr, CUDA_R_TYP, CUDSS_LAYOUT_COL_MAJOR));
-    TORCH_CUDSS_CHECK(cudssMatrixCreateCsr(&A_mt, A.size(0), A.size(1),  A._nnz(), rowOffsets, rowOffsets + crow.size(0), colIndices, values_ptr, CUDA_R_32I, CUDA_R_TYP, CUDSS_MTYPE_GENERAL, CUDSS_MVIEW_FULL, CUDSS_BASE_ZERO));
+    TORCH_CUDSS_CHECK(cudssMatrixCreateCsr(&A_mt, A.size(0), A.size(1),  A._nnz(), rowOffsets, nullptr, colIndices, values_ptr, CUDA_R_32I, CUDA_R_TYP, CUDSS_MTYPE_GENERAL, CUDSS_MVIEW_FULL, CUDSS_BASE_ZERO));
   }));
   TORCH_CUDSS_CHECK(cudssExecute(handle, CUDSS_PHASE_ANALYSIS, config, cudss_data, A_mt, x_mt, b_mt));
   TORCH_CUDSS_CHECK(cudssExecute(handle, CUDSS_PHASE_FACTORIZATION, config, cudss_data, A_mt, x_mt, b_mt));


### PR DESCRIPTION
Function cudssMatrixCreateCsr provides interface for both 3-array CSR and 4-array CSR. By passing 6th parameter rowEnd other than nullptr function assumes 4-array CSR which is currently unsupported. Therefore currently the only valid value of 6-th parameter is nullptr. The original code worked in CUDA 12.x because function did not read that parameter at all. However in CUDA 13.0 they added check for NULL and if anything different is passed, function returns CUDSS_STATUS_NOT_SUPPORTED.

For more information see the official documentation: https://docs.nvidia.com/cuda/archive/13.0.0/cudss/functions.html#cudssmatrixcreatecsr
