### PR TITLE
[ONNX] Remove the fallback option

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -65,9 +65,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
     def assert_export(
         self, *args, strategy: str | None = "TorchExportNonStrictStrategy", **kwargs
     ):
-        onnx_program = torch.onnx.export(
-            *args, **kwargs, dynamo=True, fallback=False, verbose=False
-        )
+        onnx_program = torch.onnx.export(*args, **kwargs, dynamo=True, verbose=False)
         assert onnx_program is not None
         onnx_testing.assert_onnx_program(onnx_program, strategy=strategy)
         return onnx_program
@@ -413,7 +411,6 @@ class TestExportAPIDynamo(common_utils.TestCase):
             Mod(),
             (torch.randn(3, 4),),
             dynamo=True,
-            fallback=False,
         )
         self.assertFalse(torch.onnx.is_in_onnx_export())
 

--- a/test/onnx/exporter/test_exportable_module.py
+++ b/test/onnx/exporter/test_exportable_module.py
@@ -187,15 +187,9 @@ class TestExportableModule(common_utils.TestCase):
 
         # This test verifies that to_onnx returns an ONNXProgram
         # The actual export functionality is tested elsewhere
-        try:
-            onnx_program = model.to_onnx(dynamo=True, fallback=False)
-            self.assertIsNotNone(onnx_program)
-            self.assertIsInstance(onnx_program, torch.onnx.ONNXProgram)
-        except Exception as e:
-            # If export fails for environmental reasons, skip this test
-            # The important part is that the method exists and calls export
-            if "dynamo" not in str(e).lower():
-                raise
+        onnx_program = model.to_onnx()
+        self.assertIsNotNone(onnx_program)
+        self.assertIsInstance(onnx_program, torch.onnx.ONNXProgram)
 
     def test_exportable_module_is_nn_module(self):
         """Test that ExportableModule is a proper nn.Module."""

--- a/test/onnx/exporter/test_hf_models_e2e.py
+++ b/test/onnx/exporter/test_hf_models_e2e.py
@@ -19,7 +19,6 @@ class DynamoExporterHfModelsTest(common_utils.TestCase):
             args,
             kwargs=kwargs,
             dynamo=True,
-            fallback=False,
             verbose=False,
             **options,
         )

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -24,7 +24,6 @@ class _WithExport:
             args,
             kwargs=kwargs,
             dynamo=True,
-            fallback=False,
             verbose=False,
             **options,
         )

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -424,7 +424,6 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             args,
             kwargs=kwargs,
             dynamo=True,
-            fallback=False,
             verbose=False,
             **options,
         )

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -84,7 +84,6 @@ def export(
     profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
-    fallback: bool = False,
     # BC options
     export_params: bool = True,
     keep_initializers_as_inputs: bool = False,
@@ -157,9 +156,6 @@ def export(
             This is useful for debugging the exporter. This option is only valid when dynamo is True.
         artifacts_dir: The directory to save the debugging artifacts like the report and the serialized
             exported program. This option is only valid when dynamo is True.
-        fallback: Whether to fallback to the TorchScript exporter if the dynamo exporter fails.
-            This option is only valid when dynamo is True. When fallback is enabled, It is
-            recommended to set dynamic_axes even when dynamic_shapes is provided.
         export_params: **When ``f`` is specified**: If false, parameters (weights) will not be exported.
 
             You can also leave it unspecified and use the returned :class:`torch.onnx.ONNXProgram`
@@ -177,8 +173,7 @@ def export(
             You can also leave it unspecified and use the returned :class:`torch.onnx.ONNXProgram`
             to control how initializers are treated when serializing the model.
         dynamic_axes:
-            Prefer specifying ``dynamic_shapes`` when ``dynamo=True`` and when ``fallback``
-            is not enabled.
+            Deprecated: Prefer specifying ``dynamic_shapes`` when ``dynamo=True``.
 
             By default the exported model will have the shapes of all input and output tensors
             set to exactly match those given in ``args``. To specify axes of tensors as
@@ -271,15 +266,17 @@ def export(
         :class:`torch.onnx.ONNXProgram` if dynamo is True, otherwise None.
 
     .. versionchanged:: 2.6
-        *training* is now deprecated. Instead, set the training mode of the model before exporting.
-        *operator_export_type* is now deprecated. Only ONNX is supported.
-        *do_constant_folding* is now deprecated. It is always enabled.
-        *export_modules_as_functions* is now deprecated.
-        *autograd_inlining* is now deprecated.
+        ``training`` is now deprecated. Instead, set the training mode of the model before exporting.
+        ``operator_export_type`` is now deprecated. Only ONNX is supported.
+        ``do_constant_folding`` is now deprecated. It is always enabled.
+        ``export_modules_as_functions`` is now deprecated.
+        ``autograd_inlining`` is now deprecated.
     .. versionchanged:: 2.7
-        *optimize* is now True by default.
+        ``optimize`` is now True by default.
     .. versionchanged:: 2.9
-        *dynamo* is now True by default.
+        ``dynamo`` is now True by default.
+    .. versionchanged:: 2.11
+        ``fallback`` option has been removed.
     """
     if dynamo is True or isinstance(
         model, (torch.export.ExportedProgram, ExportableModule)
@@ -288,15 +285,6 @@ def export(
 
         if isinstance(args, torch.Tensor):
             args = (args,)
-        # Prepare legacy export parameters for potential fallback
-        legacy_export_kwargs = {
-            "training": training,
-            "operator_export_type": operator_export_type,
-            "do_constant_folding": do_constant_folding,
-            "custom_opsets": custom_opsets,
-            "export_modules_as_functions": export_modules_as_functions,
-            "autograd_inlining": autograd_inlining,
-        }
 
         return _compat.export_compat(
             model,
@@ -319,8 +307,6 @@ def export(
             profile=profile,
             dump_exported_program=dump_exported_program,
             artifacts_dir=artifacts_dir,
-            fallback=fallback,
-            legacy_export_kwargs=legacy_export_kwargs,
         )
     else:
         import warnings

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -68,8 +68,6 @@ def export_compat(
     profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
-    # Legacy export parameters for fallback
-    legacy_export_kwargs: dict[str, Any] | None = None,
 ) -> _onnx_program.ONNXProgram:
     if opset_version is None:
         opset_version = onnx_constants.ONNX_DEFAULT_OPSET

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -12,7 +12,7 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 from torch.onnx import _constants as onnx_constants
-from torch.onnx._internal._lazy_import import onnx, onnx_ir as ir, onnxscript_apis
+from torch.onnx._internal._lazy_import import onnx, onnxscript_apis
 from torch.onnx._internal.exporter import (
     _constants,
     _core,
@@ -68,7 +68,6 @@ def export_compat(
     profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
-    fallback: bool = False,
     # Legacy export parameters for fallback
     legacy_export_kwargs: dict[str, Any] | None = None,
 ) -> _onnx_program.ONNXProgram:
@@ -162,67 +161,22 @@ def export_compat(
                 # register_op places the op in the front of all onnx variants,
                 # so we reverse the list to maintain the order of the custom ops provided
                 registry.register_op(torch_op, op, is_complex=False)
-    try:
-        onnx_program = _core.export(
-            model,
-            args,
-            kwargs,
-            registry=registry,
-            dynamic_shapes=dynamic_shapes_with_export_dim,
-            input_names=input_names,
-            output_names=output_names,
-            profile=profile,
-            report=report,
-            verify=verify,
-            dump_exported_program=dump_exported_program,
-            artifacts_dir=artifacts_dir,
-            verbose=verbose,
-        )
 
-    except Exception as e:
-        if fallback:
-            if verbose is not False:
-                print(
-                    "[torch.onnx] Falling back to legacy torch.onnx.export due "
-                    f"to the following error: {e}",
-                )
-            if f is None:
-                raise TypeError("f must be provided when fallback is enabled") from e
-            if dynamic_shapes is not None and dynamic_axes is None:
-                if input_names is None:
-                    raise ValueError(
-                        "Failed to convert dynamic_shapes to dynamic_axes. "
-                        "Either input_names or dynamic_axes must be provided "
-                        "when dynamic is requested in fallback"
-                    ) from e
-                dynamic_axes = _dynamic_shapes.from_dynamic_shapes_to_dynamic_axes(
-                    dynamic_shapes=dynamic_shapes, input_names=input_names, exception=e
-                )
-            # Use the legacy export kwargs prepared in __init__.py
-            if legacy_export_kwargs is None:
-                legacy_export_kwargs = {}
-
-            torch.onnx.utils.export(
-                model,  # type: ignore[arg-type]
-                args,
-                f,  # type: ignore[arg-type]
-                kwargs=kwargs,
-                export_params=export_params,
-                input_names=input_names,
-                output_names=output_names,
-                opset_version=opset_version,
-                dynamic_axes=dynamic_axes,
-                keep_initializers_as_inputs=keep_initializers_as_inputs,
-                **legacy_export_kwargs,
-            )
-            onnx_program = _onnx_program.ONNXProgram(ir.load(f), None)
-
-            # NOTE: It it's falling back to the legacy exporter, we don't need to
-            # optimize the model, so we return it here. Users can still optimize
-            # the model using the optimize() if they want.
-            return onnx_program
-        else:
-            raise
+    onnx_program = _core.export(
+        model,
+        args,
+        kwargs,
+        registry=registry,
+        dynamic_shapes=dynamic_shapes_with_export_dim,
+        input_names=input_names,
+        output_names=output_names,
+        profile=profile,
+        report=report,
+        verify=verify,
+        dump_exported_program=dump_exported_program,
+        artifacts_dir=artifacts_dir,
+        verbose=verbose,
+    )
 
     if need_axis_mapping and dynamic_shapes is not None:
         onnx_program._rename_dynamic_axes(dynamic_shapes)


### PR DESCRIPTION
Remove the fallback option because it was overly complicated, required different inputs, and produced different models that hides errors from the new exporter. Instead, we encourage users to implement the fallback logic, if needed.

cc @titaiwangms