### PR TITLE
Documentation Fix: Typo in torch_compiler export.md

### DIFF
--- a/docs/source/user_guide/torch_compiler/export.md
+++ b/docs/source/user_guide/torch_compiler/export.md
@@ -16,7 +16,7 @@ mystnb:
 
 {func}`torch.export.export` takes a {class}`torch.nn.Module` and produces a traced graph
 representing only the Tensor computation of the function in an Ahead-of-Time
-(AOT) fashion, which can subsequently be executed with different outputs or
+(AOT) fashion, which can subsequently be executed with different inputs or
 serialized.
 
 ```{code-cell}


### PR DESCRIPTION
(AOT) fashion, which can subsequently be executed with different outputs to (AOT) fashion, which can subsequently be executed with different inputs

Fixes #173097
