### PR TITLE
[dynamo] Fix GPU memory leak in backend override

### DIFF
--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -27,17 +27,25 @@ def lookup_backend_with_mode(backend_str: str) -> Any:
     import torch
 
     from .backends.registry import lookup_backend
+    from .eval_frame import cached_backends
 
+    backend: Any = None
     if ":" in backend_str:
         parts = backend_str.split(":", 1)
         backend_name, mode = parts[0], parts[1]
 
         if backend_name == "inductor" and mode in _INDUCTOR_MODES:
-            return torch._TorchCompileInductorWrapper(
+            backend = torch._TorchCompileInductorWrapper(
                 mode=mode, options=None, dynamic=None
             )
 
-    return lookup_backend(backend_str)
+    if backend is None:
+        backend = lookup_backend(backend_str)
+
+    # Register the backend so its reset() is called during torch._dynamo.reset()
+    assert backend is not None, "Invalid override backend: " + backend_str
+    cached_backends.setdefault(id(backend), backend)
+    return backend
 
 
 class GraphIdFilter:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173198

Summary: Register override backends to cached_backends so that they are cleaned up properly later one.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo

Differential Revision: [D91351690](https://our.internmc.facebook.com/intern/diff/D91351690)