### PR TITLE
[inductor] Fix stride computation for zero-size tensors

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -997,7 +997,6 @@ inductor_one_sample["xpu"] = {
 # TODO: Fix these so strides match.
 inductor_skip_exact_stride = {
     "complex",
-    "empty_permuted",
     "fft.irfftn",
     "fft.irfft2",
     "linalg.diagonal",

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3974,14 +3974,14 @@ class FlexibleLayout(Layout):
 
     allow_indexing = False
 
-    # WARNING!  This doesn't handle zero size tensors correctly
     @staticmethod
     def contiguous_strides(sizes: Sequence[int]) -> list[Expr]:
         if len(sizes) == 0:
             return []
         reversed_strides = [sympy.S.One]
         for size in reversed(sizes[1:]):
-            reversed_strides.append(size * reversed_strides[-1])
+            # Use Max(size, 1) to handle zero-size tensors correctly
+            reversed_strides.append(sympy.Max(size, 1) * reversed_strides[-1])
         return list(reversed(reversed_strides))
 
     @staticmethod
@@ -3998,7 +3998,8 @@ class FlexibleLayout(Layout):
 
         for i in order:
             strides[i] = next_stride
-            next_stride = next_stride * sizes[i]
+            # Use Max(sizes[i], 1) to handle zero-size tensors correctly
+            next_stride = next_stride * sympy.Max(sizes[i], 1)
         return strides
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173206

Summary: FlexibleLayout.contiguous_strides and fill_ordered were not handling
zero-size tensors correctly, causing strides to become 0 when any
dimension size is 0. This led to stride mismatches between inductor
and eager for operations like empty_permuted.

The fix uses sympy.Max(size, 1) instead of just size when computing
the stride multiplier, matching the behavior of make_contiguous_strides_for
in torch/_prims_common which uses sym_max(l, 1) for the same reason.

Testing: Compare strides for empty_permute in test/inductor/test_torchinductor_opinfo.py.

Co-authored-by: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo