### PR TITLE
[FA3 wheel] build cuda 13 x ARM + submodule bump

### DIFF
--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -43,7 +43,6 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
     source "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh"
     if [[ "${CUDA_VERSION:-12.6}" == "13.0" ]]; then
         echo "installing CUDA 13.0.0 for ARM"
-        # install_cuda 13.0.0 cuda_13.0.0_580.65.06_linux
         install_cuda 13.0.2 cuda_13.0.2_580.95.05_linux
     else
         echo "installing CUDA 12.6.3 for ARM"

--- a/.github/workflows/build-flash-attention-wheel.yml
+++ b/.github/workflows/build-flash-attention-wheel.yml
@@ -55,6 +55,14 @@ jobs:
             runner: "linux.arm64.r7g.12xlarge.memory"
             max_jobs: "4"
             nvcc_threads: "2"
+          - cuda_version: "13.0"
+            arch: "aarch64"
+            cuda_short: "130"
+            torch_cuda_arch_list: "9.0;10.0"
+            docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
+            runner: "linux.arm64.r7g.12xlarge.memory"
+            max_jobs: "4"
+            nvcc_threads: "2"
     timeout-minutes: 1440
     env:
       DOCKER_IMAGE: ${{ matrix.docker_image }}


### PR DESCRIPTION
Bumping FA3 submodule to latest commit to build CUDA 13.0 x ARM wheel. v2.8.3 seems to have a bug that leads to a seg fault when compiling one of the hdim kernels.
