### PR TITLE
[MPS] Add MPS support for gcd and lcm operations

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -379,6 +379,40 @@ struct igammac_functor {
   }
 };
 
+struct gcd_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    T x = a >= 0 ? a : -a;
+    T y = b >= 0 ? b : -b;
+    while (x != 0) {
+      T c = x;
+      x = y % x;
+      y = c;
+    }
+    return y;
+  }
+};
+
+struct lcm_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    // Calculate gcd
+    T x = a >= 0 ? a : -a;
+    T y = b >= 0 ? b : -b;
+    T orig_y = y;
+    while (x != 0) {
+      T c = x;
+      x = y % x;
+      y = c;
+    }
+    T g = y;
+    // lcm = |a / gcd * b| to avoid overflow
+    T abs_a = a >= 0 ? a : -a;
+    T abs_b = b >= 0 ? b : -b;
+    return (g == 0) ? 0 : (abs_a / g * abs_b);
+  }
+};
+
 #define REGISTER_INTEGER_BINARY_OP(NAME)  \
   REGISTER_BINARY_OP(NAME, long, long);   \
   REGISTER_BINARY_OP(NAME, int, int);     \
@@ -461,6 +495,8 @@ REGISTER_OPMATH_FLOAT_BINARY_OP(fmod);
 REGISTER_INTEGER_BINARY_OP(fmod);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igamma);
 REGISTER_OPMATH_FLOAT_BINARY_OP(igammac);
+REGISTER_INTEGER_BINARY_OP(gcd);
+REGISTER_INTEGER_BINARY_OP(lcm);
 REGISTER_BINARY_ALPHA_OP(add_alpha, long, long, long);
 REGISTER_BINARY_ALPHA_OP(add_alpha, int, int, int);
 REGISTER_BINARY_ALPHA_OP(add_alpha, float, float, float);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -222,6 +222,14 @@ static void hypot_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "hypot");
 }
 
+static void gcd_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "gcd");
+}
+
+static void lcm_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "lcm");
+}
+
 REGISTER_DISPATCH(fmax_stub, &fmax_mps_kernel)
 REGISTER_DISPATCH(fmin_stub, &fmin_mps_kernel)
 REGISTER_DISPATCH(maximum_stub, &maximum_mps_kernel)
@@ -254,4 +262,6 @@ REGISTER_DISPATCH(remainder_stub, &remainder_mps_kernel)
 REGISTER_DISPATCH(igamma_stub, &igamma_mps_kernel)
 REGISTER_DISPATCH(igammac_stub, &igammac_mps_kernel)
 REGISTER_DISPATCH(hypot_stub, &hypot_mps_kernel)
+REGISTER_DISPATCH(gcd_stub, &gcd_mps_kernel)
+REGISTER_DISPATCH(lcm_stub, &lcm_mps_kernel)
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2877,7 +2877,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: gcd_out
+    CPU, CUDA, MPS: gcd_out
   tags: pointwise
 
 - func: gcd(Tensor self, Tensor other) -> Tensor
@@ -2893,7 +2893,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: lcm_out
+    CPU, CUDA, MPS: lcm_out
   tags: pointwise
 
 - func: lcm(Tensor self, Tensor other) -> Tensor


### PR DESCRIPTION
## Summary
This adds MPS backend support for the greatest common divisor (gcd) and least common multiple (lcm) operations on integer tensors.

## Implementation Details
The implementation uses the Euclidean algorithm for gcd and computes lcm as |a / gcd(a,b) * b| to avoid overflow.

Both operations are registered for all integer types (long, int, short, uchar, char, bool) via the existing binary kernel infrastructure.

## Test Plan
```python
import torch

# Test gcd on MPS
a = torch.tensor([12, 15, 8], dtype=torch.int64, device='mps')
b = torch.tensor([8, 25, 12], dtype=torch.int64, device='mps')
print(f'gcd({a.tolist()}, {b.tolist()}) = {torch.gcd(a, b).tolist()}')
# Expected: [4, 5, 4]

# Test lcm on MPS
print(f'lcm({a.tolist()}, {b.tolist()}) = {torch.lcm(a, b).tolist()}')
# Expected: [24, 75, 24]
```

cc @malfet @kulinseth