### PR TITLE
Fix with_effects and FunctionalTensorMode composition

### DIFF
--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -1114,7 +1114,6 @@ def forward(self, tangents_1, tangents_token):
             )
 
     def test_with_effects_through_functional_tensor_mode(self):
-        """Test that with_effects can flow through FunctionalTensorMode."""
         from torch._subclasses.functional_tensor import (
             FunctionalTensor,
             FunctionalTensorMode,

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -193,20 +193,19 @@ with_effects.fallthrough(DispatchKey.AutogradCPU)
 with_effects.fallthrough(DispatchKey.AutogradCUDA)
 
 
-# handle with_effects when FunctionalTensorMode is active.
-# this is needed when regional inductor compiles a graph that already contains
-# with_effects nodes (from a prev. functionalization pass).
-@with_effects.py_impl(FunctionalTensorMode)
+@with_effects.py_functionalize_impl
 def with_effects_functional(
-    mode,
+    ctx,
     token: torch.Tensor,
     op: torch._ops.OpOverload,
     *args: tuple[Any, ...],
     **kwargs: dict[str, Any],
 ) -> tuple[torch.Tensor, ...]:
-    with mode:
-        result = with_effects_dense(token, op, *args, **kwargs)
-        return result
+    # with_effects is already functional, so just re-emit it.
+    unwrapped_token, unwrapped_args, unwrapped_kwargs = ctx.unwrap_tensors([token, args, kwargs])
+    with ctx.redispatch_to_next():
+        result = with_effects(unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs)
+    return ctx.wrap_tensors(result)
 
 
 def _get_schema(op, args, kwargs: Optional[dict] = None) -> torch.FunctionSchema:

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -11,7 +11,6 @@ from torch._library.effects import EffectType
 from torch._library.utils import RegistrationHandle
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch._subclasses.functional_tensor import FunctionalTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -202,7 +201,9 @@ def with_effects_functional(
     **kwargs: dict[str, Any],
 ) -> tuple[torch.Tensor, ...]:
     # with_effects is already functional, so just re-emit it.
-    unwrapped_token, unwrapped_args, unwrapped_kwargs = ctx.unwrap_tensors([token, args, kwargs])
+    unwrapped_token, unwrapped_args, unwrapped_kwargs = ctx.unwrap_tensors(
+        [token, args, kwargs]
+    )
     with ctx.redispatch_to_next():
         result = with_effects(unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs)
     return ctx.wrap_tensors(result)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173234

1. FunctionalTensorMode registrations should use py_functionalize_impl
2. We just want to unwrap, emit the with_effects, and re-wrap: this is
   the formula for all operations that are already "functional".
   with_effects is always considered to already be functional.

Test Plan:
`pytest test/higher_order_ops/test_with_effects.py -v -k test_with_effects_through_functional_tensor_mode`