### PR TITLE
Initialize output_per_tensor with lowest() instead of zeros

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -155,10 +155,10 @@ std::vector<Tensor> foreach_tensor_max_cuda(TensorList tensors) {
     }
   }
   const auto options = tensors[0].options();
-  
+
   // Initialize output_per_tensor with lowest value
   Tensor output_per_tensor;
-  
+
   std::vector<at::Tensor> vec_res;
   vec_res.reserve(ntensors);
   for (const auto i : c10::irange(ntensors)) {
@@ -185,7 +185,7 @@ std::vector<Tensor> foreach_tensor_max_cuda(TensorList tensors) {
             {static_cast<int64_t>(ntensors) * max_chunks_per_tensor},
             std::numeric_limits<scalar_t>::lowest(),
             options);
-        
+
         multi_tensor_apply<1>(
             tensor_lists,
             LpMaxFunctor<scalar_t>(),

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1022,7 +1022,6 @@ class TestForeach(TestCase):
             )
         self.assertEqual(expect, actual, equal_nan=False)
 
-    @onlyCUDA
     @dtypes(*floating_types_and(torch.half, torch.bfloat16))
     def test_foreach_max_with_different_tensor_sizes_and_negative_values(self, device, dtype):
         # Small tensor with all negative values

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1023,18 +1023,20 @@ class TestForeach(TestCase):
         self.assertEqual(expect, actual, equal_nan=False)
 
     @dtypes(*floating_types_and(torch.half, torch.bfloat16))
-    def test_foreach_max_with_different_tensor_sizes_and_negative_values(self, device, dtype):
+    def test_foreach_max_with_different_tensor_sizes_and_negative_values(
+        self, device, dtype
+    ):
         # Small tensor with all negative values
         x = torch.rand(4, device=device, dtype=dtype) * (-5)
         # Large tensor with positive values
         y = torch.rand(1024, 1024, device=device, dtype=dtype)
-        
+
         result = torch._foreach_max([x, y])
-        
+
         # Verify x's max is the actual max of x (a negative number)
         expected_x_max = x.max()
         expected_y_max = y.max()
-        
+
         self.assertEqual(result[0], expected_x_max)
         self.assertEqual(result[1], expected_y_max)
 


### PR DESCRIPTION
Correctly initialized the output tensor with lowest possible values for foreach_max. Added tests.
Fixes #173210
