### PR TITLE
[CUDA] Use c10::cuda::compat::exp instead of std::exp

### DIFF
--- a/aten/src/ATen/native/cuda/ActivationGluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGluKernel.cu
@@ -29,7 +29,7 @@ void glu_kernel(TensorIteratorBase& iter) {
           const opmath_t a = a_;
           const opmath_t b = b_;
           const opmath_t one = opmath_t(1);
-          const opmath_t sigmoid = one / (one + std::exp(-b));
+          const opmath_t sigmoid = one / (one + c10::cuda::compat::exp(-b));
           return a * sigmoid;
         });
       });
@@ -53,7 +53,7 @@ void glu_jvp_kernel(TensorIteratorBase& iter) {
               const opmath_t db = db_;
               const opmath_t one = opmath_t(1);
 
-              const opmath_t sig_b = one / (one + std::exp(-b));
+              const opmath_t sig_b = one / (one + c10::cuda::compat::exp(-b));
               return (da * sig_b + res * (db - sig_b * db));
             });
       });
@@ -97,7 +97,7 @@ __global__ void glu_backward_kernel(
   const opmath_t gO_val = gO[offsets[2]];
 
   const auto one = opmath_t(1);
-  const opmath_t sigmoid = one / (one + std::exp(-b));
+  const opmath_t sigmoid = one / (one + c10::cuda::compat::exp(-b));
 
   auto* gA = gI + offsets[0];
   *gA = sigmoid * gO_val;

--- a/aten/src/ATen/native/cuda/ActivationGluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGluKernel.cu
@@ -28,7 +28,7 @@ void glu_kernel(TensorIteratorBase& iter) {
         gpu_kernel(iter, [] GPU_LAMBDA(scalar_t a_, scalar_t b_) -> scalar_t {
           const opmath_t a = a_;
           const opmath_t b = b_;
-          const opmath_t one = opmath_t(1);
+          constexpr opmath_t one = opmath_t(1);
           const opmath_t sigmoid = one / (one + c10::cuda::compat::exp(-b));
           return a * sigmoid;
         });
@@ -51,7 +51,7 @@ void glu_jvp_kernel(TensorIteratorBase& iter) {
               const opmath_t b = b_;
               const opmath_t da = da_;
               const opmath_t db = db_;
-              const opmath_t one = opmath_t(1);
+              constexpr opmath_t one = opmath_t(1);
 
               const opmath_t sig_b = one / (one + c10::cuda::compat::exp(-b));
               return (da * sig_b + res * (db - sig_b * db));
@@ -96,7 +96,7 @@ __global__ void glu_backward_kernel(
   const opmath_t b = *byte_offset(I + offsets[1], I_byte_offset);
   const opmath_t gO_val = gO[offsets[2]];
 
-  const auto one = opmath_t(1);
+  constexpr auto one = opmath_t(1);
   const opmath_t sigmoid = one / (one + c10::cuda::compat::exp(-b));
 
   auto* gA = gI + offsets[0];


### PR DESCRIPTION
This should be a little more efficient IMO (not tested, but c10 should be optimized for cuda if I'm not mistaken, please correct me if this is different)