### PR TITLE
[CUDA] Fix TORCH_CHECK_INDEX

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1828,7 +1828,7 @@ ForwardIt find_bound(ForwardIt first, ForwardIt last, const T& value) {
 
 Tensor index_select_sparse_cuda(const Tensor& self, int64_t dim, const Tensor& index) {
   const auto ndim = self.dim();
-  TORCH_CHECK_INDEX(ndim, "index_select() cannot be applied to a 0-dim tensor.");
+  TORCH_CHECK_INDEX(ndim > 0, "index_select() cannot be applied to a 0-dim tensor.");
   TORCH_CHECK_INDEX(
       index.dim() == 1 && index.dtype() == at::kLong && index.options().layout() == at::kStrided,
       "index_select() argument index must be 1-D strided (non-sparse) long-tensor.");


### PR DESCRIPTION
TORCH_CHECK_INDEX requires a condition as a first argument (I'm not an expert for indexing, so please correct me if I'm wrong) and considering the error message it should be required that ndim > 0 (and as of what I found I guess that the named condition in first place has the "correct" one and not the "wrong" one so ndim > 0 and not ndim < 0, but please correct me if that's wrong, I just want to report this and fix the bug, but indexing is not my main field)