### PR TITLE
[dynamo] Handle DeviceMesh wrapped in FakeScriptObject

### DIFF
--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -365,9 +365,11 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         )
 
     def as_python_constant(self) -> Any:
-        if is_opaque_value_type(
-            type(self.value.real_obj)  # pyrefly: ignore[missing-attribute]
-        ):
+        real_obj_type = type(self.value.real_obj)  # pyrefly: ignore[missing-attribute]
+        # Allow both value types and reference types (like DeviceMesh) to be used
+        # as python constants. Reference types are typically immutable objects
+        # that can be safely baked into the traced graph.
+        if is_opaque_value_type(real_obj_type) or is_opaque_reference_type(real_obj_type):
             return self.value.real_obj  # pyrefly: ignore[missing-attribute]
         return super().as_python_constant()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* #173282
* #173281
* #173280
* #173279
* #173278
* #173277
* #173276
* #173275
* #173274
* #173273
* #173272
* #173271
* #173270
* #173269
* #173268
* #173266
* __->__ #173265
* #173264
* #173263
* #173262

When tracing with fake distributed mode, DeviceMesh objects may be
wrapped in FakeScriptObject. This commit updates the handling to:

1. DeviceMeshVariable.is_device_mesh() now detects FakeScriptObject
   wrapping a DeviceMesh
2. DeviceMeshVariable.__init__() extracts the real DeviceMesh from
   the wrapper
3. TorchScriptObjectVariable.as_python_constant() now allows reference
   types (like DeviceMesh) to be used as Python constants

This ensures attribute access and method calls work properly on
DeviceMesh objects during fake distributed tracing.

Authored with Claude.