### PR TITLE
[dynamo] Handle non-GetItemSource inputs in functional export

### DIFF
--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -845,11 +845,13 @@ def _dynamo_graph_capture_for_export(
             ]
 
             # Create input order mapping from dynamo's internal order to user order
+            # Only consider inputs that come from user args (GetItemSource).
+            # Other inputs like ProcessGroup from method calls are not positional.
             graph_input_order: dict[int, int] = {}
             for inp in graph_inputs:
                 source = graph_inputs[inp]
-                assert isinstance(source, torch._dynamo.source.GetItemSource), source
-                graph_input_order[source.index] = len(graph_input_order)
+                if isinstance(source, torch._dynamo.source.GetItemSource):
+                    graph_input_order[source.index] = len(graph_input_order)
 
             for real_idx, graph_idx in graph_input_order.items():
                 flat_inputs[real_idx] = example_inputs[graph_idx]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* #173282
* #173281
* #173280
* #173279
* #173278
* #173277
* #173276
* #173275
* #173274
* #173273
* #173272
* #173271
* #173270
* #173269
* __->__ #173268
* #173266
* #173265
* #173264
* #173263
* #173262

With ProcessGroup now lifted as graph inputs, the graph may contain
inputs that don't come from user args (e.g., ProcessGroup from method
calls like DeviceMesh.get_group()). These inputs have MethodCallSource
rather than GetItemSource.

This commit updates the input ordering logic to only consider
GetItemSource inputs for positional argument mapping, skipping
other input types.

Authored with Claude.