### PR TITLE
[distributed] Register DeviceMesh members for opaque type handling

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3000,7 +3000,28 @@ if hasattr(torch._C, "_c10d_init"):
     import torch.distributed
 
     if torch.distributed.is_available():
-        from torch._library.opaque_object import register_opaque_type
+        from torch._library.opaque_object import MemberType, register_opaque_type
 
         register_opaque_type(torch.distributed.ProcessGroup, typ="reference")
-        register_opaque_type(torch.distributed.DeviceMesh, typ="reference")
+        register_opaque_type(
+            torch.distributed.DeviceMesh,
+            typ="reference",
+            members={
+                # Attributes accessed via var_getattr in DeviceMeshVariable
+                "ndim": MemberType.USE_REAL,
+                "device_type": MemberType.USE_REAL,
+                "mesh_dim_names": MemberType.USE_REAL,
+                # Methods accessed via call_method in DeviceMeshVariable
+                "size": MemberType.USE_REAL,
+                "get_coordinate": MemberType.USE_REAL,
+                "get_rank": MemberType.USE_REAL,
+                "get_local_rank": MemberType.USE_REAL,
+                "get_group": MemberType.USE_REAL,
+                "_is_current_rank_part_of_mesh": MemberType.USE_REAL,
+                "_flatten": MemberType.USE_REAL,
+                "_sym_get_coordinate": MemberType.USE_REAL,
+                # Dunder methods for equality comparison
+                "__eq__": MemberType.USE_REAL,
+                "__hash__": MemberType.USE_REAL,
+            },
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* #173282
* #173281
* #173280
* #173279
* #173278
* #173277
* #173276
* #173275
* #173274
* #173273
* __->__ #173272
* #173271
* #173270
* #173269
* #173268
* #173266
* #173265
* #173264
* #173263
* #173262

Registers DeviceMesh with explicit member configuration using
MemberType.USE_REAL for attributes and methods accessed during tracing.

This includes:
- Attributes: ndim, device_type, mesh_dim_names
- Methods: size, get_coordinate, get_rank, get_local_rank, get_group,
  _is_current_rank_part_of_mesh, _flatten, _sym_get_coordinate
- Dunder methods: __eq__, __hash__

This configuration ensures proper handling when DeviceMesh is treated
as an opaque reference type during fake distributed tracing.

Authored with Claude.