### PR TITLE
Fix IndexError when args list contains empty strings

### DIFF
--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -183,7 +183,7 @@ def _get_entrypoint_name(entrypoint: Callable | str | None, args: list[Any]) -> 
         return entrypoint.__name__  # type: ignore[union-attr]
     elif isinstance(entrypoint, str):
         if entrypoint == sys.executable:
-            return next((arg for arg in args if arg[0] != "-"), "")
+            return next((arg for arg in args if arg and arg[0] != "-"), "")
         else:
             return entrypoint
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* #173282
* #173281
* #173280
* #173279
* #173278
* #173277
* #173276
* #173275
* #173274
* __->__ #173273
* #173272
* #173271
* #173270
* #173269
* #173268
* #173266
* #173265
* #173264
* #173263
* #173262

When determining the entrypoint name, the code iterates through args
looking for the first non-flag argument. If an empty string is in the
args list, accessing arg[0] raises an IndexError.

Add a check for empty strings before accessing the first character.

Co-authored-by: Claude