### PR TITLE
Add workaround for opaque objects missing meta val

### DIFF
--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1016,10 +1016,13 @@ def check_input_alias_and_mutation_return_outputs(
     Union[tuple[Any, ...], list[Any]],
 ]:
     def _get_example_value(n):
-        if not isinstance(n, torch.fx.Node):
-            return n
-        else:
-            return n.meta["val"] if "val" in n.meta else n.meta["example_value"]
+        try:
+            if not isinstance(n, torch.fx.Node):
+                return n
+            else:
+                return n.meta["val"] if "val" in n.meta else n.meta["example_value"]
+        except Exception as e:
+            return "dumb workaround for opaque objects not having meta val"
 
     fake_args = [
         _get_example_value(n)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* #173282
* #173281
* #173280
* #173279
* #173278
* __->__ #173277
* #173276
* #173275
* #173274
* #173273
* #173272
* #173271
* #173270
* #173269
* #173268
* #173266
* #173265
* #173264
* #173263
* #173262

When checking for input aliasing and mutations, _get_example_value()
may encounter nodes that don't have 'val' or 'example_value' in their
meta dict. This can happen with opaque objects.

Return a placeholder string instead of raising to allow compilation
to proceed.

Co-authored-by: Claude