### PR TITLE
[GraphPickler] Add profiler and higher_order ops to safe ops filter

### DIFF
--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -39,6 +39,8 @@ def _ops_filter_safe(name: str) -> bool:
             "torch.ops.fbgemm",
             "torch.ops.c10d",
             "torch.ops.device_mesh",
+            "torch.ops.profiler",
+            "torch.ops.higher_order",
         )
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* #173282
* #173281
* #173280
* #173279
* __->__ #173278
* #173277
* #173276
* #173275
* #173274
* #173273
* #173272
* #173271
* #173270
* #173269
* #173268
* #173266
* #173265
* #173264
* #173263
* #173262

Add torch.ops.profiler and torch.ops.higher_order to the list of
pickle-safe ops. These ops are built-in PyTorch ops that can be
safely unpickled on any machine with PyTorch installed.

This enables GraphPickler to serialize graphs containing profiler
ops (like _record_function_enter/exit) and higher order operators.

Authored with Claude.