### PR TITLE
[effects] Add with_effects implementations for functional tensor modes

### DIFF
--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
+from torch._functorch.pyfunctorch import TransformType
 from torch._higher_order_ops.print import print as hop_print
 from torch._higher_order_ops.torchbind import call_torchbind
 from torch._library.custom_ops import CustomOpDef
@@ -11,6 +12,7 @@ from torch._library.effects import EffectType
 from torch._library.utils import RegistrationHandle
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.functional_tensor import FunctionalTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,
@@ -186,6 +188,82 @@ def with_effects_proxy(
     )
     result = track_tensor_tree(out, out_proxy, constant=None, tracer=mode.tracer)
     return result
+
+
+@with_effects.py_impl(FunctionalTensorMode)
+def with_effects_functional(
+    mode,
+    token: torch.Tensor,
+    op: torch._ops.OpOverload,
+    *args: tuple[Any, ...],
+    **kwargs: dict[str, Any],
+) -> tuple[torch.Tensor, ...]:
+    """
+    Handle with_effects under FunctionalTensorMode. This is needed when
+    executing a pre-compiled FX graph that contains explicit with_effects
+    calls. We unwrap the functional tensors, execute the op, and wrap
+    the results.
+    """
+    from torch._subclasses.functional_tensor import PythonFunctionalizeAPI
+
+    ctx = PythonFunctionalizeAPI()
+
+    unwrapped_token = ctx.unwrap_tensors([token])[0]
+    unwrapped_args = ctx.unwrap_tensors(args)
+    unwrapped_kwargs = ctx.unwrap_tensors(kwargs)  # type: ignore[arg-type]
+
+    with ctx.redispatch_to_next():
+        result = with_effects(unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs)
+
+    return ctx.wrap_tensors(result)
+
+
+@with_effects.py_impl(TransformType.Functionalize)
+def with_effects_functionalize(
+    interpreter,
+    token: torch.Tensor,
+    op: torch._ops.OpOverload,
+    *args: tuple[Any, ...],
+    **kwargs: dict[str, Any],
+) -> tuple[torch.Tensor, ...]:
+    """
+    Handle with_effects under the functorch Functionalize transform
+    (e.g., via torch.func.functionalize). We unwrap the functorch functional
+    tensors, execute with_effects, and wrap the results.
+
+    This uses the C-level _unwrap_functional_tensor and _wrap_functional_tensor
+    functions which handle the functorch-level wrappers (different from
+    PythonFunctionalizeAPI which handles FunctionalTensorMode).
+    """
+    from torch._C._functorch import (
+        _unwrap_functional_tensor,
+        _wrap_functional_tensor,
+    )
+
+    reapply_views = interpreter.functionalize_add_back_views()
+    func_level = interpreter.level()
+
+    def unwrap(t):
+        if isinstance(t, torch.Tensor) and torch._is_functional_tensor(t):
+            torch._sync(t)
+            return _unwrap_functional_tensor(t, reapply_views)
+        return t
+
+    def wrap(t):
+        if isinstance(t, torch.Tensor) and not torch._is_functional_tensor(t):
+            return _wrap_functional_tensor(t, func_level)
+        return t
+
+    unwrapped_token = unwrap(token)
+    unwrapped_args = pytree.tree_map(unwrap, args)
+    unwrapped_kwargs = pytree.tree_map(unwrap, kwargs)
+
+    with interpreter.lower():
+        result = with_effects(
+            unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs
+        )
+
+    return pytree.tree_map(wrap, result)
 
 
 with_effects.fallthrough(DispatchKey.AutogradCPU)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173283
* __->__ #173282
* #173281
* #173280
* #173279
* #173278
* #173277
* #173276
* #173275
* #173274
* #173273
* #173272
* #173271
* #173270
* #173269
* #173268
* #173266
* #173265
* #173264
* #173263
* #173262

Add two new implementations for the with_effects HigherOrderOperator to
support executing pre-compiled FX graphs that contain explicit with_effects
calls under functional tensor modes:

1. with_effects_functional (FunctionalTensorMode): Handles with_effects
   when running under FunctionalTensorMode (a TorchDispatchMode). Uses
   PythonFunctionalizeAPI to unwrap/wrap tensors and redispatches.

2. with_effects_functionalize (TransformType.Functionalize): Handles
   with_effects when running under the functorch Functionalize transform
   (e.g., via torch.func.functionalize). Uses C-level _unwrap_functional_tensor
   and _wrap_functional_tensor to handle the functorch-level wrappers.

These are needed because when a pre-compiled graph containing with_effects
is executed, it may be wrapped in functionalization layers that need to
properly unwrap inputs and wrap outputs.

Authored with Claude.