### PR TITLE
[fx] Remove ops whitelist from GraphPickler, allow all ops by default

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -76,7 +76,6 @@ class CustomCompiledFunction(torch._dynamo.aot_compile.SerializableCallable):
         import sympy
 
         from torch._subclasses import FakeTensorMode
-        from torch.fx._graph_pickler import Options
 
         state = fn.__dict__.copy()
         graph_reducer_override = GraphPickler.reducer_override
@@ -93,7 +92,7 @@ class CustomCompiledFunction(torch._dynamo.aot_compile.SerializableCallable):
             return graph_reducer_override(self, obj)
 
         with patch.object(GraphPickler, "reducer_override", _graph_reducer_override):
-            state["gm"] = GraphPickler.dumps(state["gm"], Options(ops_filter=None))
+            state["gm"] = GraphPickler.dumps(state["gm"])
         return pickle.dumps(state)
 
     @classmethod

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -25,36 +25,14 @@ from torch.utils._mode_utils import no_dispatch
 _SymNodeT = TypeVar("_SymNodeT", torch.SymInt, torch.SymFloat)
 
 
-def _ops_filter_safe(name: str) -> bool:
-    """
-    An ops filter which allows pickle-safe ops. Pickle-safe ops are built-in
-    ones where it will be possible to unpickle on any machine which has PyTorch.
-    """
-    # TODO: This list is pretty pessimistic right now. What's the full list?
-    return name.startswith(
-        (
-            "torch.ops.aten",
-            "torch.ops.fbgemm",
-        )
-    )
-
-
-@dataclasses.dataclass
-class Options:
-    # A filter for which ops will cause the pickler to raise a
-    # BypassFxGraphCache exception. If None then all ops are allowed.
-    ops_filter: Optional[Callable[[str], bool]] = _ops_filter_safe
-
-
 class GraphPickler(pickle.Pickler):
     """
     GraphPickler is a Pickler which helps pickling fx graph - in particular
     GraphModule.
     """
 
-    def __init__(self, file: io.BytesIO, options: Optional[Options] = None) -> None:
+    def __init__(self, file: io.BytesIO) -> None:
         super().__init__(file)
-        self.options = options or Options()
 
         # This abomination is so we can pass external decoding state to the
         # unpickler functions. We serialize _unpickle_state as a persistent
@@ -118,12 +96,12 @@ class GraphPickler(pickle.Pickler):
             return None
 
     @classmethod
-    def dumps(cls, obj: object, options: Optional[Options] = None) -> bytes:
+    def dumps(cls, obj: object) -> bytes:
         """
         Pickle an object.
         """
         with io.BytesIO() as stream:
-            pickler = cls(stream, options)
+            pickler = cls(stream)
             pickler.dump(obj)
             return stream.getvalue()
 
@@ -349,11 +327,11 @@ class _GraphModulePickleData:
         tuple[Self, _UnpickleStateToken],
     ]:
         return cls.unpickle, (
-            cls(obj, pickler.options),
+            cls(obj),
             pickler._unpickle_state,
         )
 
-    def __init__(self, gm: torch.fx.GraphModule, options: Options) -> None:
+    def __init__(self, gm: torch.fx.GraphModule) -> None:
         # Need to do this to ensure the code is created for later pickling.
         if isinstance(gm, torch.fx._lazy_graph_module._LazyGraphModule):
             _python_code = gm._real_recompile()
@@ -361,7 +339,7 @@ class _GraphModulePickleData:
             _python_code = gm.recompile()
         self.gm_dict = gm.__dict__.copy()
         del self.gm_dict["_graph"]
-        self.graph = _GraphPickleData(gm._graph, options)
+        self.graph = _GraphPickleData(gm._graph)
 
     def unpickle(self, unpickle_state: _UnpickleState) -> torch.fx.GraphModule:
         gm = torch.fx.GraphModule.__new__(torch.fx.GraphModule)
@@ -383,7 +361,6 @@ class _NodePickleData:
         self,
         node: torch.fx.Node,
         mapping: dict[torch.fx.Node, "_NodePickleData"],
-        options: Options,
     ) -> None:
         self.args = pytree.tree_map_only(torch.fx.Node, lambda n: mapping[n], node.args)
         self.kwargs = pytree.tree_map_only(
@@ -392,7 +369,7 @@ class _NodePickleData:
         # -- self.graph = node.graph
         self.name = node.name
         self.op = node.op
-        self.target = _OpPickleData.pickle(node.target, options)
+        self.target = _OpPickleData.pickle(node.target)
         # self.input_nodes = node._input_nodes
         # self.users = node.users
         self.type = node.type
@@ -427,11 +404,11 @@ class _OpPickleData:
     def reduce_helper(
         cls, pickler: GraphPickler, op: object
     ) -> tuple[Callable[[_UnpickleState], object], tuple[_UnpickleStateToken]]:
-        result = cls.pickle(op, pickler.options)
+        result = cls.pickle(op)
         return (result.unpickle, (pickler._unpickle_state,))
 
     @classmethod
-    def pickle(cls, op: object, options: Options) -> "_OpPickleData":
+    def pickle(cls, op: object) -> "_OpPickleData":
         if isinstance(op, str):
             return _OpStrPickleData(op)
 
@@ -444,29 +421,15 @@ class _OpPickleData:
         name = torch.fx.Node._pretty_print_target(op)
 
         if isinstance(op, torch._ops.OpOverload):
-            return cls._pickle_op(name, _OpOverloadPickleData, options)
+            return _OpOverloadPickleData(name)
         elif isinstance(op, torch._ops.OpOverloadPacket):
-            return cls._pickle_op(name, _OpOverloadPacketPickleData, options)
+            return _OpOverloadPacketPickleData(name)
         elif name.startswith(_OpFunctionPickleData.SUPPORTED_ROOTS):
             root, detail = name.split(".", 1)
             return _OpFunctionPickleData(root, detail)
         else:
             # TODO: raise a BypassFxGraphCache so we will just bypass this one...
             raise NotImplementedError(f"TARGET: {type(op)} {op} {name}")
-
-    @staticmethod
-    def _pickle_op(
-        name: str,
-        datacls: Union[
-            type["_OpOverloadPickleData"], type["_OpOverloadPacketPickleData"]
-        ],
-        options: Options,
-    ) -> "_OpPickleData":
-        if (ops_filter := options.ops_filter) and not ops_filter(name):
-            from torch._inductor.codecache import BypassFxGraphCache
-
-            raise BypassFxGraphCache(f"Unable to pickle non-standard op: {name}")
-        return datacls(name)
 
     @abstractmethod
     def unpickle(self, unpickle_state: _UnpickleState) -> object:
@@ -574,13 +537,13 @@ class _OpFunctionPickleData(_OpPickleData):
 
 
 class _GraphPickleData:
-    def __init__(self, graph: torch.fx.Graph, options: Options) -> None:
+    def __init__(self, graph: torch.fx.Graph) -> None:
         self.tracer_cls = graph._tracer_cls
         self.tracer_extras = graph._tracer_extras
 
         nodes: dict[torch.fx.Node, _NodePickleData] = {}
         for node in graph.nodes:
-            nodes[node] = _NodePickleData(node, nodes, options)
+            nodes[node] = _NodePickleData(node, nodes)
         self.nodes = tuple(nodes.values())
         self._codegen = graph._codegen
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173285

Remove _ops_filter_safe, the Options class, and all related filtering
infrastructure. All ops are now assumed to be serializable.

The whitelist approach (only allowing torch.ops.aten and torch.ops.fbgemm)
was overly pessimistic and created friction without meaningfully improving
correctness. In practice, unpicklable custom ops are rare, and the whitelist
just accumulated prefixes over time (e.g., ops.sixlib, ops.msl). Since
someone could always add a non-serializable op to a whitelisted namespace
anyway, the static check provided limited value.

Also cleaned up RegionalOutputCode which was using _ops_filter_safe as its
default and passing it through to GraphPickler.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela