### PR TITLE
[CUDA] Fix potential error in lt_two structure for CUDA backward kernels

### DIFF
--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -49,9 +49,10 @@ struct dists {
 
   // Special case backward when p is less than two
   struct lt_two {
-    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) {
-      return (dist == 0.0 || (diff == 0.0 && p < 1)) ? 0 : (sign(diff) * std::pow(std::abs(diff), p - 1) * grad / std::pow(dist, p - 1));
-    }
+    static __forceinline__ __device__ void inc(...) { }
+    static __forceinline__ __device__ scalar_t finish(...) { return agg; }
+    static __forceinline__ __device__ void agg(...) { }
+    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return (dist == 0.0 || (diff == 0.0 && p < 1)) ? 0 : (sign(diff) * std::pow(std::abs(diff), p - 1) * grad / std::pow(dist, p - 1));
   };
 
   // Two norm

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -53,6 +53,7 @@ struct dists {
     static __forceinline__ __device__ scalar_t finish(...) { return agg; }
     static __forceinline__ __device__ void agg(...) { }
     static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return (dist == 0.0 || (diff == 0.0 && p < 1)) ? 0 : (sign(diff) * std::pow(std::abs(diff), p - 1) * grad / std::pow(dist, p - 1));
+    }
   };
 
   // Two norm


### PR DESCRIPTION
Added dummy inc, finish, and agg methods (fixes #173290) to lt_two to satisfy template requirements in pdist_backward_kernel_cuda_impl and cdist_backward_kernel_cuda_impl. This ensures compilation succeeds while keeping the special backward formula for p < 2.0 (> 1.0).

I'm not quite sure about this fix, I just saw this potential issue from looking at the code, so I'd like to ask a reviewer (in best case an expert for this topic) for feedback please because maybe I'm mistaken.
