### PR TITLE
[MPS] Native Metal kernel for Poisson distribution

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -694,3 +694,120 @@ kernel void dirichlet_grad(
 REGISTER_DIRICHLET_GRAD(float);
 REGISTER_DIRICHLET_GRAD(half);
 REGISTER_DIRICHLET_GRAD(bfloat);
+
+// ============================================================================
+// Poisson Distribution
+// Knuth algorithm for small lambda, Hoermann (1993) PTRD for large lambda.
+// Adapted from aten/src/ATen/native/Distributions.cpp sample_poisson(), which
+// is itself adapted from NumPy's distributions.c.
+//
+// Copyright 2005 Robert Kern (robert.kern@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ============================================================================
+constant constexpr int POISSON_RANDOMS_STRIDE = 32;
+
+inline int sample_poisson_knuth(
+    float lambda,
+    long seed,
+    long base,
+    thread int& rng_idx) {
+  float enlam = ::metal::precise::exp(-lambda);
+  int x = 0;
+  float prod = 1.0f;
+  bool done = false;
+  do {
+    prod *= c10::metal::rand(seed, base + rng_idx++);
+    done = (prod <= enlam);
+    if (!done) {
+      x += 1;
+    }
+  } while (!done);
+  return x;
+}
+
+inline int sample_poisson_hormann(
+    float lambda,
+    long seed,
+    long base,
+    thread int& rng_idx) {
+  float slam = ::metal::precise::sqrt(lambda);
+  float loglam = ::metal::precise::log(lambda);
+  float b = 0.931f + 2.53f * slam;
+  float a = -0.059f + 0.02483f * b;
+  float invalpha = 1.1239f + 1.1328f / (b - 3.4f);
+  float vr = 0.9277f - 3.6224f / (b - 2.0f);
+
+  while (true) {
+    float u = c10::metal::rand(seed, base + rng_idx++) - 0.5f;
+    // v in (0, 1] so log(v) is finite (matches standard_gamma's rand pattern).
+    float v = 1.0f - c10::metal::rand(seed, base + rng_idx++);
+    float us = 0.5f - abs(u);
+    float k = floor((2.0f * a / us + b) * u + lambda + 0.43f);
+
+    if (k < 0.0f)
+      continue;
+    if ((us >= 0.07f) && (v <= vr))
+      return int(k);
+    if ((us < 0.013f) && (v > us))
+      continue;
+
+    if ((::metal::precise::log(v) + ::metal::precise::log(invalpha) -
+         ::metal::precise::log(a / (us * us) + b)) <=
+        (-lambda + k * loglam - c10::metal::log_gamma(k + 1.0f))) {
+      return int(k);
+    }
+  }
+}
+
+template <typename T>
+kernel void poisson_kernel(
+    device T* output [[buffer(0)]],
+    device const T* lambda_in [[buffer(1)]],
+    constant long2& seed_base_offset [[buffer(2)]],
+    uint tid [[thread_position_in_grid]]) {
+  float lambda = static_cast<float>(lambda_in[tid]);
+  long base =
+      seed_base_offset.y + static_cast<long>(tid) * POISSON_RANDOMS_STRIDE;
+  long seed = seed_base_offset.x;
+  int rng_idx = 0;
+
+  // Mirrors CPU sample_poisson() (Distributions.cpp). CPU rejects lambda < 0
+  // via TORCH_CHECK; we can't do that on-device, and NaN / +inf would make
+  // both rejection loops below run forever, so any non-finite or
+  // non-positive lambda short-circuits to 0.
+  int result = 0;
+  if (lambda > 0.0f && isfinite(lambda)) {
+    result = lambda < 10.0f
+        ? sample_poisson_knuth(lambda, seed, base, rng_idx)
+        : sample_poisson_hormann(lambda, seed, base, rng_idx);
+  }
+
+  output[tid] = static_cast<T>(result);
+}
+
+#define REGISTER_POISSON(DTYPE)             \
+  template [[host_name("poisson_" #DTYPE)]] \
+  kernel void poisson_kernel<DTYPE>(        \
+      device DTYPE*, device const DTYPE*, constant long2&, uint)
+
+REGISTER_POISSON(float);
+REGISTER_POISSON(half);
+REGISTER_POISSON(bfloat);

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -21,6 +21,7 @@
 #include <ATen/ops/bernoulli_native.h>
 #include <ATen/ops/clamp.h>
 #include <ATen/ops/cumsum.h>
+#include <ATen/ops/poisson_native.h>
 #include <ATen/ops/rand.h>
 #include <ATen/ops/randperm.h>
 #include <ATen/ops/randperm_native.h>
@@ -358,6 +359,46 @@ Tensor _s_gamma_mps(const Tensor& alpha, std::optional<Generator> gen) {
         auto computeEncoder = stream->commandEncoder();
         [computeEncoder setComputePipelineState:pso];
         mtl_setArgs(computeEncoder, ret, alpha_contig, std::array<long, 2>{seed, base_offset});
+        mtl_dispatch1DJob(computeEncoder, pso, ret.numel());
+      }
+    });
+  }
+
+  return ret;
+}
+
+Tensor _s_poisson_mps(const Tensor& lambda, std::optional<Generator> gen) {
+  if (lambda.numel() == 0) {
+    return at::empty_like(lambda);
+  }
+
+  using namespace mps;
+
+  auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
+  auto stream = getCurrentMPSStream();
+  Tensor ret = at::empty_like(lambda, lambda.options(), at::MemoryFormat::Contiguous);
+  auto lambda_contig = lambda.contiguous();
+
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc("poisson_" + scalarToMetalTypeString(ret));
+
+    int64_t seed;
+    int64_t base_offset;
+    // Each thread may consume up to POISSON_RANDOMS_STRIDE random numbers
+    constexpr int64_t POISSON_RANDOMS_STRIDE = 32;
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(mps_gen->mutex_);
+      seed = static_cast<int64_t>(mps_gen->current_seed());
+      base_offset = static_cast<int64_t>(mps_gen->get_offset());
+      mps_gen->set_offset(base_offset + POISSON_RANDOMS_STRIDE * ret.numel());
+    }
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder, ret, lambda_contig, std::array<long, 2>{seed, base_offset});
         mtl_dispatch1DJob(computeEncoder, pso, ret.numel());
       }
     });

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6548,6 +6548,7 @@
   dispatch:
     CPU: _s_poisson_cpu
     CUDA: _s_poisson_cuda
+    MPS: _s_poisson_mps
   tags: nondeterministic_seeded
   autogen: poisson.out
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8814,6 +8814,57 @@ class TestMPS(TestCaseMPS):
             a = torch.empty(32_000, device="mps", dtype=dtype).exponential_()
             self.assertTrue((a != 0).all())
 
+    @parametrize("dtype", [torch.float32])
+    def test_poisson(self, dtype):
+        """Test poisson on MPS matches expected statistical properties and CPU."""
+        n_samples = 10000
+
+        # Cover both code paths in the Metal kernel: Knuth for lambda < 10,
+        # Hoermann PTRD for lambda >= 10.
+        for rate_val in [0.5, 1.0, 5.0, 10.0, 50.0]:
+            rate_mps = torch.full((n_samples,), rate_val, device='mps', dtype=dtype)
+            rate_cpu = rate_mps.cpu()
+            samples_mps = torch.poisson(rate_mps)
+            samples_cpu = torch.poisson(rate_cpu)
+
+            self.assertTrue((samples_mps >= 0).all(),
+                            f"Poisson samples should be non-negative for rate={rate_val}")
+
+            mps_f = samples_mps.float()
+            self.assertTrue(torch.allclose(mps_f, mps_f.floor()),
+                            f"Poisson samples should be integers for rate={rate_val}")
+
+            # Theoretical Poisson has mean == var == rate. Sampling error on
+            # n=10k is roughly sqrt(rate / n); compare MPS to CPU within a few
+            # standard errors so we catch implementation drift without being
+            # flaky on legitimate RNG noise.
+            tol_mean = max(0.1, 5.0 * (rate_val / n_samples) ** 0.5)
+            tol_var = max(0.2, 5.0 * rate_val * (2.0 / n_samples) ** 0.5)
+
+            mps_mean = mps_f.mean().item()
+            cpu_mean = samples_cpu.float().mean().item()
+            self.assertAlmostEqual(mps_mean, rate_val, delta=tol_mean,
+                                   msg=f"MPS mean should match rate={rate_val}")
+            self.assertAlmostEqual(mps_mean, cpu_mean, delta=tol_mean,
+                                   msg=f"MPS mean should match CPU mean for rate={rate_val}")
+
+            mps_var = mps_f.var(unbiased=False).item()
+            cpu_var = samples_cpu.float().var(unbiased=False).item()
+            self.assertAlmostEqual(mps_var, rate_val, delta=tol_var,
+                                   msg=f"MPS variance should match rate={rate_val}")
+            self.assertAlmostEqual(mps_var, cpu_var, delta=tol_var,
+                                   msg=f"MPS variance should match CPU variance for rate={rate_val}")
+
+        # Test zero rate
+        zero_rate = torch.zeros(100, device='mps', dtype=dtype)
+        zero_samples = torch.poisson(zero_rate)
+        self.assertTrue((zero_samples == 0).all(), "Poisson(0) should return all zeros")
+
+        # Test empty tensor
+        empty_rate = torch.empty(0, device='mps', dtype=dtype)
+        empty_samples = torch.poisson(empty_rate)
+        self.assertEqual(empty_samples.numel(), 0)
+
     def test_distributions(self):
         ops = [
             ("normal_", lambda t: t.normal_(0, 1), []),


### PR DESCRIPTION
## Summary
Implements a native MPS Metal kernel for Poisson distribution sampling, eliminating the CPU fallback for `torch.poisson` on Apple Silicon.

**Operator implemented:**
- `poisson` — Poisson distribution sampling (Knuth for λ < 10, Hörmann (1993) PTRD rejection for λ ≥ 10)

**Note:** `_standard_gamma` / `_standard_gamma_grad` are already on `main` (#179228 by @malfet), and `_sample_dirichlet` is being added separately in #184085. This PR is scoped to Poisson only.

## Motivation

Requested by the bioinformatics community for MPS acceleration on Apple Silicon:

### CellBender
[CellBender](https://github.com/broadinstitute/CellBender) removes ambient RNA from single-cell RNA-seq data using Poisson/Dirichlet variational inference.
- broadinstitute/CellBender#149, broadinstitute/CellBender#171

### Cell2location
[Cell2location](https://github.com/BayraktarLab/cell2location) is a Bayesian model for spatial transcriptomics (Pyro, GammaPoisson) — Poisson is the missing MPS op.
- BayraktarLab/cell2location#221, #406, #408, #252, #206

Without a native Poisson kernel these workflows fall back to CPU on Apple Silicon.

## Implementation

### Poisson kernel (`Distributions.metal`)
- Draws through `c10::metal::rand` / `c10::metal::randn` with a per-thread RNG offset stride (matches the existing `standard_gamma` pattern)
- Knuth algorithm for λ < 10, Hörmann (1993) PTRD rejection for λ ≥ 10
- `::metal::precise::` math and `c10::metal::log_gamma` for numerical stability
- Non-finite / non-positive λ short-circuits to 0 on-device (the device-side equivalent of the CPU's host `TORCH_CHECK(lambda >= 0)`), since a `NaN`/`+inf` λ would otherwise spin the rejection loops forever and hang the GPU
- Supports float32, float16, bfloat16

### RNG management
Follows the `dispatch_sync_with_rethrow` + `std::array<long, 2>{seed, base_offset}` pattern established by `_s_gamma_mps` (#179228), advancing the generator offset by `POISSON_RANDOMS_STRIDE * numel`.

## Changes
- `aten/src/ATen/native/mps/kernels/Distributions.metal` — Poisson Metal kernel
- `aten/src/ATen/native/mps/operations/Distributions.mm` — `_s_poisson_mps` host wrapper
- `aten/src/ATen/native/native_functions.yaml` — MPS dispatch entry for `poisson`
- `test/test_mps.py` — statistical validation against the CPU implementation

Addresses: https://github.com/pytorch/pytorch/issues/77764

Authored with assistance from Claude.

cc @malfet @kulinseth @kurtamohler @Skylion007
