### PR TITLE
Clarify DDP usage in build_stage example

### DIFF
--- a/docs/source/distributed.pipelining.md
+++ b/docs/source/distributed.pipelining.md
@@ -318,6 +318,7 @@ modification to the `stage_mod`, you can use a functional version of the
 from torch.distributed.pipelining import build_stage
 from torch.nn.parallel import DistributedDataParallel
 
+# DistributedDataParallel (DDP) is an nn.Module wrapper, so it can be passed to build_stage.
 dp_mod = DistributedDataParallel(stage_mod)
 info = pipe.info()
 stage = build_stage(dp_mod, stage_idx, info, device, group)

--- a/docs/source/distributed.pipelining.md
+++ b/docs/source/distributed.pipelining.md
@@ -318,7 +318,7 @@ modification to the `stage_mod`, you can use a functional version of the
 from torch.distributed.pipelining import build_stage
 from torch.nn.parallel import DistributedDataParallel
 
-# DistributedDataParallel (DDP) is an nn.Module wrapper, so it can be passed to build_stage.
+# DistributedDataParallel (DDP) returns an nn.Module subclass, so it can be passed to build_stage.
 dp_mod = DistributedDataParallel(stage_mod)
 info = pipe.info()
 stage = build_stage(dp_mod, stage_idx, info, device, group)


### PR DESCRIPTION
Fixes pytorch#152849

Clarifies that build_stage expects an nn.Module, and documents how
DistributedDataParallel should be applied in a pipeline-parallel setup.


cc @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk