### PR TITLE
Fix MSVC warnings with all warnings enabled 

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -435,7 +435,7 @@ struct TORCH_API FunctionSchema {
   std::optional<int> argumentIndexWithName(std::string_view name) const {
     for (const auto i : c10::irange(arguments().size())) {
       if(name == arguments()[i].name())
-        return i;
+        return static_cast<int>(i);
     }
     return std::nullopt;
   }

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -680,19 +680,19 @@ class CompiledNodeArgs {
 
     auto hook_id = _compiler.emplace_cpp_tensor_pre_hook(std::move(wrapper));
     collect_size(hook_id);
-    _node_call.cpp_tensor_pre_hooks.emplace_back(hook_id, idx);
+    _node_call.cpp_tensor_pre_hooks.emplace_back(static_cast<int>(hook_id), static_cast<int>(idx));
   }
 
   void add_pre_hook(c10::SafePyObject&& obj) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
     collect_size(fn_id);
-    _node_call.pre_hooks.emplace_back(fn_id);
+    _node_call.pre_hooks.emplace_back(static_cast<int>(fn_id));
   }
 
   void add_post_hook(c10::SafePyObject&& obj) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
     collect_size(fn_id);
-    _node_call.post_hooks.emplace_back(fn_id);
+    _node_call.post_hooks.emplace_back(static_cast<int>(fn_id));
   }
 
   void add_post_acc_grad_hook(c10::SafePyObject&& obj) {

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -698,7 +698,7 @@ class CompiledNodeArgs {
   void add_post_acc_grad_hook(c10::SafePyObject&& obj) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
     collect_size(fn_id);
-    _node_call.post_acc_grad_hooks.emplace_back(fn_id);
+    _node_call.post_acc_grad_hooks.emplace_back(static_cast<int>(fn_id));
   }
 
   // Need to template the size_t to silence internal 32-bit build errors due to

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -233,7 +233,7 @@ struct TensorArgs {
       it = _args.emplace(impl, TensorArg(_next_id++)).first;
       inputs.emplace_back(tensor);
       if (active_node_call_idx.has_value()) {
-        input_origins.emplace_back(active_node_call_idx.value());
+        input_origins.emplace_back(static_cast<uint32_t>(active_node_call_idx.value()));
       }
     }
     return it->second;

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -663,7 +663,7 @@ class CompiledNodeArgs {
   void add_tensor_pre_hook(c10::SafePyObject&& obj, int index) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
     collect_size(fn_id);
-    _node_call.tensor_pre_hooks.emplace_back(fn_id, index);
+    _node_call.tensor_pre_hooks.emplace_back(static_cast<int>(fn_id), static_cast<int>(index));
   }
 
   void add_cpp_single_tensor_pre_hook(

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -302,7 +302,7 @@ struct LiftedIValueArgs {
   void add(const at::IValue* iv) {
     args.emplace_back(iv);
     if (active_node_call_idx.has_value()) {
-      args_origins.emplace_back(active_node_call_idx.value());
+      args_origins.emplace_back(static_cast<uint32_t>(active_node_call_idx.value()));
     }
   }
 

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -326,7 +326,7 @@ struct AutogradCompilerCall {
     all_size_inputs.emplace_back(
         default_dyn_type, s.guard_int(__FILE__, __LINE__));
     if (active_node_call_idx.has_value()) {
-      size_input_origins.emplace_back(active_node_call_idx.value());
+      size_input_origins.emplace_back(static_cast<uint32_t>(active_node_call_idx.value()));
     }
   }
 


### PR DESCRIPTION
Fixes MSVC triggering C4267 warnings when all warnings are enabled. Due to various signed / unsigned mismatches.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @xmfan @aditvenk