### PR TITLE
[BE][MPS] Adjust cdist tolerances

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13135,7 +13135,12 @@ op_db: list[OpInfo] = [
            skips=(
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
-               DecorateInfo(toleranceOverride({torch.float16: tol(atol=1e-3, rtol=2e-2)}), 'TestConsistency', device_type='mps'),
+               DecorateInfo(toleranceOverride(
+                   {
+                       torch.float16: tol(atol=1e-3, rtol=2e-2),
+                       torch.float32: tol(atol=1.6e-5, rtol=1.6e-6),
+                   }),
+                   'TestConsistency', device_type='mps'),
            )),
     UnaryUfuncInfo('ceil',
                    ref=np.ceil,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173328
* #173327
* __->__ #173326

It passes in CI, but on local runs on M4 it fails with
```
Mismatched elements: 1 / 150 (0.7%)
Greatest absolute difference: 1.5139579772949219e-05 at index (1, 3, 3) (up to 1e-05 allowed)
Greatest relative difference: 1.506664830230875e-05 at index (1, 3, 3) (up to 1.3e-06 allowed)
```