### PR TITLE
[BE] Remove nextafter from list of imprecise ops

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12615,7 +12615,6 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.softmin',
         'cross', 'linalg.cross',
         'prod', 'masked.prod',
-        'nextafter',
         'native_layer_norm',
         'nn.functional.layer_norm',
         'nn.functional.interpolate',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173328
* __->__ #173327
* #173326

It's implemented via Metal shader, so it should be as precise as its CPU conuterpart