### PR TITLE
[xpu][utils] Add a helper function to XPU for code reuse

### DIFF
--- a/aten/src/ATen/xpu/XPUUtils.h
+++ b/aten/src/ATen/xpu/XPUUtils.h
@@ -11,7 +11,9 @@ inline bool check_device(ArrayRef<Tensor> ts) {
   }
   Device curDevice = Device(kXPU, current_device());
   for (const Tensor& t : ts) {
-    if (t.device() != curDevice) return false;
+    if (t.device() != curDevice) {
+      return false;
+    }
   }
   return true;
 }

--- a/aten/src/ATen/xpu/XPUUtils.h
+++ b/aten/src/ATen/xpu/XPUUtils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <ATen/xpu/XPUContext.h>
+
+namespace at::xpu {
+
+// Check if every tensor in a list of tensors matches the current device.
+inline bool check_device(ArrayRef<Tensor> ts) {
+  if (ts.empty()) {
+    return true;
+  }
+  Device curDevice = Device(kXPU, current_device());
+  for (const Tensor& t : ts) {
+    if (t.device() != curDevice) return false;
+  }
+  return true;
+}
+
+} // namespace at::xpu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173333

# Motivation
This PR would like to introduce the helper `check_device` that helps us reduce the code duplication in torch-xpu-ops, such as:
https://github.com/intel/torch-xpu-ops/blob/45e4ded8947fc412b615e3f156857f6e38805274/src/ATen/native/sparse/xpu/SparseTensorMath.cpp#L34-L44
and 
https://github.com/intel/torch-xpu-ops/blob/45e4ded8947fc412b615e3f156857f6e38805274/src/ATen/native/sparse/xpu/sycl/SparseTensorMathKernels.cpp#L212-L222
CUDA has a similar utility helper in 
https://github.com/pytorch/pytorch/blob/ad5a78268395989006af147ac9eab66393170573/aten/src/ATen/cuda/CUDAUtils.h#L9-L18

