### PR TITLE
[TEST] Fix `test_signal_window` as `scipy.signal.get_window` no longer accepts size 0

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2847,7 +2847,7 @@ class TestTensorCreation(TestCase):
             with self.assertRaisesRegex(RuntimeError, r'floating point'):
                 torch_method(3, dtype=dtype)
             return
-        for size in [0, 1, 2, 5, 10, 50, 100, 1024, 2048]:
+        for size in [1, 2, 5, 10, 50, 100, 1024, 2048]:
             for periodic in [True, False]:
                 res = torch_method(
                     size,
@@ -2896,7 +2896,7 @@ class TestTensorCreation(TestCase):
             with self.assertRaisesRegex(RuntimeError, r'floating point'):
                 torch_method(3, dtype=dtype)
             return
-        for size in [0, 1, 2, 5, 10, 50, 100, 1024, 2048]:
+        for size in [1, 2, 5, 10, 50, 100, 1024, 2048]:
             for periodic in [True, False]:
                 res = torch_method(size, sym=not periodic, **kwargs, device=device, dtype=dtype)
                 # NB: scipy always returns a float64 result


### PR DESCRIPTION
`scipy.signal.get_window` [no longer accepts size 0](https://github.com/scipy/scipy/blob/b9f97fedd9fde02616bd9c74f6cf6c360b86e0ab/scipy/signal/windows/_windows.py#L2540-L2541) since https://github.com/scipy/scipy/pull/23518 has landed. The changes in SciPy break a couple of test cases in `test_tensor_creation_ops.py`.