### PR TITLE
[Test] Remove duplicate `binary_ufuncs_and_refs` variable

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -50,7 +50,6 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_methods_invocations import (
     binary_ufuncs,
-    binary_ufuncs_and_refs,
     generate_elementwise_binary_broadcasting_tensors,
     generate_elementwise_binary_extremal_value_tensors,
     generate_elementwise_binary_large_value_tensors,
@@ -505,7 +504,7 @@ class TestBinaryUfuncs(TestCase):
     # NOTE: because the cross-product of all possible type promotion tests is huge, this
     #   just spot checks some handwritten cases.
     # NOTE: It may be possible to refactor this test into something simpler
-    @ops(binary_ufuncs_and_refs, dtypes=OpDTypes.none)
+    @ops(binary_ufuncs, dtypes=OpDTypes.none)
     def test_type_promotion(self, device, op):
         supported_dtypes = op.supported_dtypes(torch.device(device).type)
         make_lhs = partial(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -27149,7 +27149,6 @@ python_ref_db += opinfo.definitions.python_ref_db
 ops_and_refs = op_db + python_ref_db
 unary_ufuncs = [op for op in ops_and_refs if isinstance(op, UnaryUfuncInfo)]
 binary_ufuncs = [op for op in ops_and_refs if isinstance(op, BinaryUfuncInfo)]
-binary_ufuncs_and_refs = tuple(op for op in ops_and_refs if isinstance(op, BinaryUfuncInfo))
 spectral_funcs = [op for op in ops_and_refs if isinstance(op, SpectralFuncInfo)]
 sparse_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse]
 sparse_csr_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse_csr]


### PR DESCRIPTION
## Summary

This PR removes the `binary_ufuncs_and_refs` variable that is literally a duplicate of `binary_ufuncs`.

## Changes

1. **torch/testing/_internal/common_methods_invocations.py**: Removed the line defining `binary_ufuncs_and_refs` as it creates an identical list/tuple as `binary_ufuncs`
2. **test/test_binary_ufuncs.py**: Updated the single usage to directly use `binary_ufuncs` instead

## Motivation

Both variables were defined identically:
```python
binary_ufuncs = [op for op in ops_and_refs if isinstance(op, BinaryUfuncInfo)]
binary_ufuncs_and_refs = tuple(op for op in ops_and_refs if isinstance(op, BinaryUfuncInfo))
```

The only difference was the container type (list vs tuple), but since both are iterable and used in the same contexts, this distinction is unnecessary and creates confusion.

## Test Plan

- Existing tests should continue to pass
- The `test_type_promotion` test in `test_binary_ufuncs.py` now uses `binary_ufuncs` directly