### PR TITLE
[benchmark] Update CUTLASS instantiation level based on device capability

### DIFF
--- a/benchmarks/inductor_backends/cutlass.py
+++ b/benchmarks/inductor_backends/cutlass.py
@@ -77,7 +77,7 @@ CUTLASS_INSTANTIATION_LEVELS = [
     "0",
     # "1111",
     # "2222",
-    "3332",
+    "3332" if torch.cuda.get_device_capability() != (10, 0) else "3432",
     # "9992",
 ]
 


### PR DESCRIPTION
Set level to 4 when the capability is (10, 0).

As 3 would not satisfy the condition of https://github.com/NVIDIA/cutlass/blob/9fba3195f96db261ce802761505cb167f1cee370/python/cutlass_library/sm100_utils.py#L624-L637.