### PR TITLE
Update IS_THOR check for rocm

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -36,7 +36,7 @@ SM90OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_devic
 SM100OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (10, 0))
 SM120OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (12, 0))
 
-IS_THOR = LazyVal(lambda: torch.cuda.is_available() and
+IS_THOR = LazyVal(lambda: torch.cuda.is_available() and torch.version.cuda is not None and
                   ((torch.cuda.get_device_capability() == (11, 0) and int(torch.version.cuda[:2]) >= 13) or
                    (torch.cuda.get_device_capability() == (10, 1) and int(torch.version.cuda[:2]) < 13)))
 IS_JETSON = LazyVal(lambda: torch.cuda.is_available() and (torch.cuda.get_device_capability() in [(7, 2), (8, 7)] or IS_THOR))


### PR DESCRIPTION
Commit 8fa4d2def6465795689c486a72361c7d263efde7 updated the IS_THOR check to use `torch.version.cuda` object, however since it's undefined on rocm the check fails. Update it to account for this case too. Tested on Radeon Pro V710

Original error was:

```
test/export/test_unflatten_training_ir.py F                                                      [100%]

=============================================== FAILURES ===============================================
____________ TrainingIRUnflattenTestUnflatten.test_assert_tensor_metadata_stack_training_ir ____________
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 3363, in wrapper
    method(*args, **kwargs)
  File "/root/pytorch/test/export/testing.py", line 238, in _fn
    from . import test_export
  File "/root/pytorch/test/export/test_export.py", line 540, in <module>
    class TestExport(TestCase):
  File "/root/pytorch/test/export/test_export.py", line 17055, in TestExport
    @xfailIfDistributedNotSupported
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/torch/testing/_internal/common_cuda.py", line 428, in xfailIfDistributedNotSupported
    return func if not (IS_MACOS or IS_JETSON) else unittest.expectedFailure(func)
                                    ^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 1492, in wrapped
    return getattr(self._value, name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 1489, in wrapped
    self._value = self._cb()
                  ^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/torch/testing/_internal/common_cuda.py", line 40, in <lambda>
    ((torch.cuda.get_device_capability() == (11, 0) and int(torch.version.cuda[:2]) >= 13) or
                                                            ~~~~~~~~~~~~~~~~~~^^^^
TypeError: 'NoneType' object is not subscriptable

To execute this test, run the following from the base repo dir:
    python test/export/test_unflatten_training_ir.py TrainingIRUnflattenTestUnflatten.test_assert_tensor_metadata_stack_training_ir
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang