### PR TITLE
[inductor][triton] BlockPatternMatch improvements

### DIFF
--- a/torch/_inductor/codegen/block_analysis.py
+++ b/torch/_inductor/codegen/block_analysis.py
@@ -6,7 +6,7 @@ from typing import Optional
 import sympy
 from sympy import Expr, Symbol
 
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import Identity, FloorDiv, ModularIndexing
 
 from ..utils import sympy_dot, sympy_subs
 from ..virtualized import V
@@ -53,7 +53,11 @@ class BlockPatternMatcher:
     @staticmethod
     def _preprocess(expr: Expr) -> Expr:
         # Remove any Identity nodes, e.g. expand x + (5 * y) to x + 5 * y.
-        return expr.expand(identity=True)
+        # Disable mul and multinomial as those expansions affect op trees:
+        # e.g. sympy expects to match Mul(a, b), but expansion has simplified
+        # to Add(...). Even though they may be algebraically equivalent,
+        # sympy `match` performs structural pattern matching
+        return expr.expand(mul=False, multinomial=False, identity=True)
 
     @classmethod
     def match_mod_div_block_expr(
@@ -66,6 +70,11 @@ class BlockPatternMatcher:
         """
         Matches modular indexing expressions, converting them to implied block dimensions and strides.
         See triton.py for more information.
+
+        Warning: this function requires that `index`, `numel` and any other sympy
+        expression does not have precomputed replacements since otherwise block
+        pattern matching may fail.
+        See [Note: Precomputed replacements with BlockPatternMatch]
         """
         index = cls._preprocess(index)
 
@@ -135,16 +144,13 @@ class BlockPatternMatcher:
             if stride not in match:
                 match[stride] = sympy.S.Zero
 
-        sizevars = V.graph.sizevars
-
-        def get_match(expr: Expr) -> Expr:
-            return sizevars.lookup_precomputed_size(match[expr])
-
         # Replace wildcards with matched expressions.
-        dims = [dims[0]] + [get_match(dim) for dim in dims[1:]]
-        strides = [get_match(stride) for stride in strides]
+        dims = [dims[0]] + [match[ dim ] for dim in dims[1:]]
+        strides = [match[ stride ] for stride in strides]
         slice_numels = cls.get_slice_numels(dims)
         block_index_exprs = [sympy_subs(expr, match) for expr in block_index_exprs]
+
+        sizevars = V.graph.sizevars
 
         # The leading dimension is not directly matched in our expression.
         # We solve for it by dividing the range tree numel by the product of
@@ -157,12 +163,8 @@ class BlockPatternMatcher:
         # Sanity check that we can recover the index from the matched subexpressions.
         matched_index = sympy_dot(strides, block_index_exprs)
         assert sizevars.statically_known_equals(
-            # New precomputed replacements may be generated when the `get_match` function
-            # above is called, but the `index` that is being matched has not been updated.
-            # So remove them when checking for equivalence e.g. if ps0=3*s0 and
-            # index=3*s0*expr, matched_index=ps0*expr, then index == matched_index
-            sizevars.remove_precomputed_replacements(matched_index),
-            sizevars.remove_precomputed_replacements(index),
+            matched_index,
+            index,
         ), textwrap.dedent(
             f"""
             Invalid match!

--- a/torch/_inductor/codegen/block_analysis.py
+++ b/torch/_inductor/codegen/block_analysis.py
@@ -6,7 +6,7 @@ from typing import Optional
 import sympy
 from sympy import Expr, Symbol
 
-from torch.utils._sympy.functions import Identity, FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
 from ..utils import sympy_dot, sympy_subs
 from ..virtualized import V
@@ -145,8 +145,8 @@ class BlockPatternMatcher:
                 match[stride] = sympy.S.Zero
 
         # Replace wildcards with matched expressions.
-        dims = [dims[0]] + [match[ dim ] for dim in dims[1:]]
-        strides = [match[ stride ] for stride in strides]
+        dims = [dims[0]] + [match[dim] for dim in dims[1:]]
+        strides = [match[stride] for stride in strides]
         slice_numels = cls.get_slice_numels(dims)
         block_index_exprs = [sympy_subs(expr, match) for expr in block_index_exprs]
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2955,7 +2955,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     match_mod_div_block,
                 ):
                     factored_index_expr = BlockPatternMatcher.factor_index_expr(
-                        expr, range_tree
+                        expr, range_tree.symbol()
                     )
                     match = match_func(factored_index_expr, range_tree)
                     if match is not None:

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -312,6 +312,13 @@ class FloorDiv(sympy.Function):
 
         return None
 
+    def _eval_is_nonnegative(self) -> bool | None:
+        # pyrefly: ignore [missing-attribute]
+        p, q = self.args[:2]
+        if all([p.is_integer, q.is_integer, p.is_nonnegative, q.is_nonnegative]):
+            return True
+        return None
+
 
 class ModularIndexing(sympy.Function):
     """


### PR DESCRIPTION
1. Stop `BlockPatternMatch._preprocess` from expanding certain expressions since expansion can prevent matches. For the ModDiv pattern shown below, it is required that the denominator of rindex//(d1 * ... * d(N-1)) matches with the product of the dimension sizes in the indexing expression. However if the denominator is `sympy.expand`ed prior to matching, the computed product d0x... xd(N-1) may not match the denominator structurally e.g. x0*(2 + x1) = 2*x0 + 3*x1 algebraically, but structurally they're different. sympy uses structural matching i.e. if the former x0 * (2 + x1) (Mul(x0, 2 + x1)),  is kept in the index, a match would occur, but if the latter 2*x + 3*x is kept (Add(2*x, 3*x))), a match will fail.
```
                   sN * ((rindex//(d1 * ... * d(N-1))))
                       + s1 * ModularIndexing(rindex, 1, d1)
                       + ...
                       + s(N-1) * ModularIndexing(rindex, d1 * ... * d(N-2), d(N-1))
```
2. When dynamic shapes are in use, there may be precomputed replacements in an indexing expression. However sympy cannot determine the equivalence of e.g. (rindex // p0) + ModularIndexing(rindex, 1, s1) + ModularIndexing(rindex, s1, s2), p0  = s0 * s1. The match requires that sympy knows p0 = s0 * s1, but sympy is unaware of this. This PR removes precomputed sizes prior to matching to avoid these types of examples
3. `FloorDiv` can determine if the result is non-negative if both inputs are integers and non-negative. So `_eval_is_non_negative` is defined. Currently it returns `None` for all inputs. 
4. The above changes fix a test case that does not terminate when `BlockPatternMatch`ing (it takes atleast an hour locally): `test_torchinductor.py.CommonTemplate.test_low_memory_max_poollow_memory_max_pool` when run with `use_block_ptr` and `use_tensor_descriptor`


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo