### PR TITLE
Simplify_ zipfile_ syntax

### DIFF
--- a/torch/export/experimental/__init__.py
+++ b/torch/export/experimental/__init__.py
@@ -403,9 +403,7 @@ class _ExportPackage:
             )
         base_directory = os.path.dirname(pt2_path)
         package_name = os.path.basename(pt2_path)[:-4]
-        with (
-            zipfile.ZipFile(pt2_path, "r") as zip_ref,
-        ):
+        with zipfile.ZipFile(pt2_path, "r") as zip_ref:
             zip_ref.extractall(base_directory)
 
         example_inputs_map: dict[str, int] | None = (


### PR DESCRIPTION
While the current syntax is valid Python 3.10+, it is typically reserved for managing multiple context managers simultaneously. Using it for a single object adds unnecessary nesting and visual noise.

By reverting to the standard with zipfile.ZipFile(...) as zip_ref: syntax, we:

**Improve Readability:** The code is more concise and easier to scan.

Follow PEP 8: Matches the standard style for single-resource management.

**Maintain Consistency:** Aligns this block with other standard file-handling operations in the codebase.
