### PR TITLE
tools: avoid duplicate entries when merging VS Code list settings

### DIFF
--- a/tools/vscode_settings.py
+++ b/tools/vscode_settings.py
@@ -26,7 +26,10 @@ def deep_update(d: dict, u: dict) -> dict:  # type: ignore[type-arg]
         if isinstance(v, dict):
             d[k] = deep_update(d.get(k, {}), v)
         elif isinstance(v, list):
-            d[k] = d.get(k, []) + v
+            existing = d.get(k, [])
+            if isinstance(existing, list):
+                # preserve order, avoid duplicates
+                d[k] = list(dict.fromkeys(existing + v))
         else:
             d[k] = v
     return d


### PR DESCRIPTION
This PR improves the `tools/vscode_settings.py` utility by making the settings merge behavior safer and more predictable.


Changes:
    - prevent unintended duplication when merging list-based VS Code settings
    - Improve resilience when existing `.vscode/settings.json` contains unexpected or partial structures
    - Keep behavior backward-compatible while making the merge idempotent