### PR TITLE
Fix coordinate descent tuner incorrectly re-running on warm cache

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -459,20 +459,22 @@ class CachingAutotuner(KernelInterface):
         )
         self.autotune_cache_info = autotune_cache_info
         # I.e. there was an autotune cache hit
-        if len(cached_configs) == 1 and len(configs) > 1:
+        if len(cached_configs) == 1:
             best_config = cached_configs[0]
+            found_by_coordesc = getattr(best_config, "found_by_coordesc", False)
             # Grab the best compiled config, if it's in the list of available ones
             best_config_hash = triton_config_to_hashable(best_config)
 
             for compile_result in self.compile_results:
                 if triton_config_to_hashable(compile_result.config) == best_config_hash:
+                    compile_result.config.found_by_coordesc = found_by_coordesc
                     self.compile_results = [compile_result]
                     return
 
             # If the best config isn't in our list of compile results,
             # it's likely because it was found by coordesc after the cache
             # already saved
-            if best_config.found_by_coordesc:
+            if found_by_coordesc:
                 with dynamo_timed("CachingAutotuner.slow_precompile_config"):
                     if self.fn.fn is None:
                         self.fn = reload_kernel_from_src().fn
@@ -1202,6 +1204,9 @@ class CachingAutotuner(KernelInterface):
             self.save_cache_hook(
                 launcher.config,
                 self.autotune_time_taken_ns,
+                found_by_coordesc=self.inductor_meta.get(
+                    "coordinate_descent_tuning", False
+                ),
                 triton_cache_hash=launcher.cache_hash,
             )
 


### PR DESCRIPTION
## Summary

Fixes #172819

`CachingAutotuner.recheck_autotune_cache` has two bugs that cause coordinate descent tuning to re-run on warm cache hits, negating much of the benefit of caching when using `max-autotune` mode.

1. The guard `len(configs) > 1` skips the cache-hit block when there is exactly one config. This means the single config never gets marked with the cached `found_by_coordesc` value, so `run()` re-triggers coordinate descent.

2. When the cached best config matches an existing compile result, `found_by_coordesc` is not propagated from the cached config to the compile result's config. Since `run()` checks `self.launchers[0].config.found_by_coordesc` (which is the compile result's config, a different object), the flag is missing and coordinate descent re-runs.

The fix changes `> 1` to `>= 1` and propagates `compile_result.config.found_by_coordesc = best_config.found_by_coordesc` when narrowing to the matched compile result.

## Test plan

- [x] `python test/inductor/test_coordinate_descent_tuner.py`
- [x] `python test/inductor/test_triton_heuristics.py` — added 4 new tests for `recheck_autotune_cache`
- [x] `python test/inductor/test_codecache.py -k autotune`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos