### PR TITLE
add hasattr check when print 'triton not found' warning

### DIFF
--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 try:
     from triton.runtime.jit import JITFunction as _JITFunction
 except ImportError:
-    if any(x is not None for x in [torch.version.cuda, torch.version.hip, torch.version.xpu]):
+    if any(getattr(torch.version, attr, None) is not None for attr in ["cuda", "hip", "xpu"]):
         log.warning("triton not found; flop counting will not work for triton kernels")
     _JITFunction = NoneType
 


### PR DESCRIPTION
Summary:
D90903684 is breaking our torchstream tests and this should fix it.
see https://www.internalfb.com/intern/test/562950222982678.

Test Plan: buck test -j 18 fbsource//arvr/mode/mac-arm/opt fbcode//frl/ctrl/src2-main/platform/torchstream_ctrl/torchstream_ctrl/prod/tests:test_modules-arvr -- --exact 'fbcode//frl/ctrl/src2-main/platform/torchstream_ctrl/torchstream_ctrl/prod/tests:test_modules-arvr - test_ptq_compatibility (torchstream_ctrl.prod.tests.test_modules.Test_TdsBlock)' --stress-runs 20 --record-results

Reviewed By: ogbiggles

Differential Revision: D91038779


Regression caused by https://github.com/pytorch/pytorch/pull/172614