### PR TITLE
[ROCm][CI] Use MI350 test runners

### DIFF
--- a/.github/workflows/trunk-rocm-mi300.yml
+++ b/.github/workflows/trunk-rocm-mi300.yml
@@ -55,15 +55,15 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1.test" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1.test" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1.test" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1.test" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1.test" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1.test" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx942.4.test" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx942.4.test" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx942.4.test" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -1,4 +1,4 @@
-name: trunk-rocm-mi300
+name: trunk-rocm-sandbox
 
 on:
   push:

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -5,7 +5,7 @@ on:
     workflows:
       - pull
       - trunk
-      - trunk-rocm-mi300
+      - trunk-rocm-sandbox
       - periodic
       - periodic-rocm-mi200
       - periodic-rocm-mi300


### PR DESCRIPTION
This PR uses the `trunk-rocm-sandbox` workflow to test the new MI350 CI runners to catch any infra issues ahead of https://github.com/pytorch/pytorch/pull/173209


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang