### PR TITLE
Handle OutputNode in get_buf_bytes for MultiOutputLayout

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1131,6 +1131,8 @@ class BaseSchedulerNode:
                     users = self.scheduler.name_to_buf[buf.get_name()].users
                     tot = 0
                     for user in users:
+                        if isinstance(user.node, OutputNode):
+                            continue
                         assert isinstance(user.node, BaseSchedulerNode)
                         if isinstance(user.node.node, MultiOutput):
                             for sched_buf in user.node.get_outputs():


### PR DESCRIPTION
The get_buf_bytes function can fail with an AssertionError when calculating sizes for a buffer with MultiOutputLayout if one of its users is an OutputNode. This occurs because the loop asserts that user.node must be a BaseSchedulerNode but does not account for OutputNode users.

This change fixes the issue by ensuring [OutputNode](http://_vscodecontentref_/10) users are skipped when calculating buffer sizes for `MultiOutputLayout` nodes, preventing the assertion failure.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo