### PR TITLE
[dynamo] patch out LazyConstants

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -38,7 +38,7 @@ update_hint_regression,compile_time_instruction_count,1645000000,0.1
 
 
 
-sum_floordiv_regression,compile_time_instruction_count,4500834211,0.1
+sum_floordiv_regression,compile_time_instruction_count,3636000000,0.1
 
 
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -216,7 +216,7 @@ Unsupported context manager
   Hint: If the context manager seems like it should be supported (e.g. torch.set_grad_enabled), then it may be the case that it was created outside the compiled region, which Dynamo does not support. Supported context managers can cross graph break boundaries only if they are local non-closure variables, or are intermediate values.
   Hint: File an issue to PyTorch. Simple context managers can potentially be supported, but note that context managers can't be supported in general
 
-  Developer debug context: Attempted SETUP_WITH/BEFORE_WITH/LOAD_SPECIAL on LazyVariableTracker(unrealized: <class 'int'>)
+  Developer debug context: Attempted SETUP_WITH/BEFORE_WITH/LOAD_SPECIAL on LazyVariableTracker(realized: ConstantVariable(int: 3))
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0142.html
 

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -518,4 +518,6 @@ class LazyConstantVariableTests(TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    pass
+    # FIXME re-enable tests once LazyConstant compile time problems are fixed
+    # run_tests()

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -1,13 +1,16 @@
 # Owner(s): ["module: dynamo"]
 
 import keyword
+import unittest
 
 import torch
 import torch._dynamo
-from torch._dynamo.test_case import TestCase
+from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import CompileCounter, same
 
 
+# FIXME: re-enable LazyConstantVariable once compile time issues have been resolved
+@unittest.skip("temporarily disabled")
 class LazyConstantVariableTests(TestCase):
     def _assert_compile_count(self, fn, arg_sets, expected_frames):
         counter = CompileCounter()
@@ -518,6 +521,4 @@ class LazyConstantVariableTests(TestCase):
 
 
 if __name__ == "__main__":
-    pass
-    # FIXME re-enable tests once LazyConstant compile time problems are fixed
-    # run_tests()
+    run_tests()

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -4,7 +4,7 @@ import keyword
 
 import torch
 import torch._dynamo
-from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.test_case import TestCase
 from torch._dynamo.testing import CompileCounter, same
 
 

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -73,8 +73,9 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
 
     @staticmethod
     def create(value: Any, source: Any, **options: Any) -> VariableTracker:
-        if type(value) in LazyConstantVariable.supported_types:
-            return LazyConstantVariable.create(value, source, **options)
+        # FIXME: re-enable LazyConstantVariable once compile time issues have been resolved
+        # if type(value) in LazyConstantVariable.supported_types:
+        #     return LazyConstantVariable.create(value, source, **options)
         return LazyVariableTracker(LazyCache(value, source), source=source, **options)
 
     def __init__(self, _cache: LazyCache, **kwargs: Any) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173410

Disables LazyConstants due to compile time regressions introduced by https://github.com/pytorch/pytorch/pull/169513

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo