### PR TITLE
[NATIVE] [CUDA] OpaqueType specialisation for performance improvements

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -122,6 +122,9 @@ void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, co
 // The kernels are templated on an opaque, self-aligned type of the correct
 // size to avoid redundant kernels for different types of the same size.
 template <int N> struct alignas(N) OpaqueType { char data[N]; };
+template <> struct alignas(1) OpaqueType<1> { uint8_t data; };
+template <> struct alignas(2) OpaqueType<2> { uint16_t data; };
+template <> struct alignas(4) OpaqueType<4> { uint32_t data; };
 
 template <typename scalar_t>
 void index_fill_kernel_impl(


### PR DESCRIPTION
This PR should (potentially) reduce inefficient register allocation at OpaqueTypes just like in #167094 by @YyWangCS (credits to you 👍 ) in IndexKernel.cu by adding native integer types instead of char data[N] for (potentially) better performance. I've not tested it out, but as of the logic of the code, I'm pretty confident that this should be the same case in IndexKernel.cu, but please review because there are several minor differences in usage of OpaqueType I already found out which (IMO) aren't relevant for this change, e.g. the note says "// The kernels are templated on an opaque, self-aligned type of the correct
// size to avoid redundant kernels for different types of the same size." which should be the same with my fix as it just then uses the specialised type, but I'm not quite sure as it isn't tested and it could theoretically cause problems (considering e.g. warp divergence which could theoretically be relevant in different uint types used (but I'm really not sure about this one and I don't really think that this could be a problem in that special case, but please correct me if I'm mistaken)) and also considering the further usage it (I'm pretty confident that this all shouldn't cause any problems, but I just can't guarantee anything as it's not tested and just from the code).