### PR TITLE
Skip Windows cross-compilation Test if WINDOWS_CUDA_HOME is not set

### DIFF
--- a/test/inductor/test_aoti_cross_compile_windows.py
+++ b/test/inductor/test_aoti_cross_compile_windows.py
@@ -80,7 +80,10 @@ class WindowsCrossCompilationTestFramework:
 
             if is_fbcode():
                 raise unittest.SkipTest("requires x86_64-w64-mingw32-gcc")
-
+            if "WINDOWS_CUDA_HOME" not in os.environ:
+                raise unittest.SkipTest(
+                    "Skip Windows cross-compilation test because WINDOWS_CUDA_HOME is not set"
+                )            
             self.assertTrue("WINDOWS_CUDA_HOME" in os.environ)
 
             with torch.no_grad():


### PR DESCRIPTION
The Windows cross-compilation test for AOTInductor currently fails with
an assertion error if the `WINDOWS_CUDA_HOME` environment variable is
not set.

This change ensures the test is skipped if `WINDOWS_CUDA_HOME` is
missing by checking for the environment variable before asserting its
presence. This prevents test failures in environments where
`WINDOWS_CUDA_HOME` is not configured, while keeping the assertion for
cases where the test is expected to run.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo