### PR TITLE
[NATIVE] [CUDA] Switch order of blocked reduce in reduction_template.cuh

### DIFF
--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -222,7 +222,6 @@ struct ReduceJitOp {
       value = thread_reduce<${output_vec_size}>(input_slice);
     }
 
-    
     if (config.should_block_x_reduce()) {
       value = block_x_reduce<${output_vec_size}>(value, shared_memory);
     }

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -222,11 +222,13 @@ struct ReduceJitOp {
       value = thread_reduce<${output_vec_size}>(input_slice);
     }
 
-    if (config.should_block_y_reduce()) {
-      value = block_y_reduce<${output_vec_size}>(value, shared_memory);
-    }
+    
     if (config.should_block_x_reduce()) {
       value = block_x_reduce<${output_vec_size}>(value, shared_memory);
+    }
+
+    if (config.should_block_y_reduce()) {
+      value = block_y_reduce<${output_vec_size}>(value, shared_memory);
     }
 
     using out_ptr_vec_t = Array<out_scalar_t*, ${output_vec_size}>;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -229,7 +229,6 @@ struct ReduceJitOp {
     if (config.should_block_y_reduce()) {
       value = block_y_reduce<${output_vec_size}>(value, shared_memory);
     }
-
     using out_ptr_vec_t = Array<out_scalar_t*, ${output_vec_size}>;
     using offset_vec_t = Array<uint32_t, ${output_vec_size}>;
     offset_vec_t base_offsets;


### PR DESCRIPTION
This PR references #165178 (credits to @PaulZhang12 for the nice fix 👍 ) and aims to improve numerics in reduction_template.cuh as well. I've not tested it, but I'm pretty sure that this has a positive effect as this change was already confirmed in Reduce.cuh and reduction_template.cuh contains basically the same contents (if I'm not mistaken). Please review this exactly nevertheless as I am not quite sure, especially because Reduce.cuh originally contained "__syncthreads();" as well which was then removed via #165178, but which wasn't / isn't included in the template (while the other changes out of the PR weren't made to the template, so the template didn't contain "__syncthreads();" despite the PR, so maybe there is any mistake I make when looking at the code as it wasn't tested and it's just a code analysis). Please correct me if I'm mistaken anywhere, so please review, thanks! 👍 