### PR TITLE
[map] fix accidently specializing mapped dim

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5084,17 +5084,17 @@ class <lambda>(torch.nn.Module):
 
             body_graph_0 = self.body_graph_0
             map_impl = torch.ops.higher_order.map_impl(body_graph_0, [cos], [arg1_1]);  body_graph_0 = None
-            getitem_2: "f32[2, 2]" = map_impl[0];  map_impl = None
+            getitem: "f32[2, 2]" = map_impl[0];  map_impl = None
 
-            sum_1: "f32[]" = torch.ops.aten.sum.default(getitem_2);  getitem_2 = None
+            sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
 
             add: "f32[2, 2]" = torch.ops.aten.add.Tensor(cos, sum_1);  sum_1 = None
 
             body_graph_1 = self.body_graph_1
             map_impl_1 = torch.ops.higher_order.map_impl(body_graph_1, [cos], [arg1_1]);  body_graph_1 = cos = arg1_1 = None
-            getitem_5: "f32[2, 2]" = map_impl_1[0];  map_impl_1 = None
+            getitem_1: "f32[2, 2]" = map_impl_1[0];  map_impl_1 = None
 
-            sum_2: "f32[]" = torch.ops.aten.sum.default(getitem_5);  getitem_5 = None
+            sum_2: "f32[]" = torch.ops.aten.sum.default(getitem_1);  getitem_1 = None
 
             add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(add, sum_2);  add = sum_2 = None
             return (add_1,)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5149,9 +5149,9 @@ class <lambda>(torch.nn.Module):
 
         body_graph_0 = self.body_graph_0
         map_impl = torch.ops.higher_order.map_impl(body_graph_0, [cos], [arg1_1]);  body_graph_0 = arg1_1 = None
-        getitem_2: "f32[2, 2]" = map_impl[0];  map_impl = None
+        getitem: "f32[2, 2]" = map_impl[0];  map_impl = None
 
-        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem_2);  getitem_2 = None
+        sum_1: "f32[]" = torch.ops.aten.sum.default(getitem);  getitem = None
         add: "f32[2, 2]" = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
         return (
             add,  # PlainAOTOutput(idx=0)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -7390,13 +7390,11 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             gm.code.strip(),
             """\
 def forward(self, pred_1, x_1):
-    unbind = torch.ops.aten.unbind.int(x_1)
-    getitem = unbind[0];  getitem = None
-    getitem_1 = unbind[1];  unbind = getitem_1 = None
+    select_copy = torch.ops.aten.select_copy.int(x_1, 0, 0);  select_copy = None
     body_graph_0 = self.body_graph_0
     map_impl = torch.ops.higher_order.map_impl(body_graph_0, [x_1], [pred_1]);  body_graph_0 = x_1 = pred_1 = None
-    getitem_2 = map_impl[0];  map_impl = None
-    return getitem_2""",
+    getitem = map_impl[0];  map_impl = None
+    return getitem""",
         )
         self.assertExpectedInline(
             gm.body_graph_0.code.strip(),

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -210,9 +210,31 @@ class MapAutogradOp(torch.autograd.Function):
         return None, None, *fill_none_with_masks(grads, grads_tensor_masks)
 
 
+def _broadcast_to_batch(output, batch_size):
+    """Expand each tensor in output pytree to include batch dimension.
+
+    Note: Although outputs are flattened in the compiled path (via torch.compile),
+    users may call map_impl directly with pytree outputs, so we support pytrees
+    for backward compatibility.
+    """
+
+    def expand_with_batch(t):
+        if t is None:
+            return None
+        if isinstance(t, torch.Tensor):
+            return t.unsqueeze(0).expand(batch_size, *t.shape).clone()
+        return t
+
+    return pytree.tree_map(expand_with_batch, output)
+
+
 def trace_map(proxy_mode, func_overload, f, xs, pos_args):
+    from torch._higher_order_ops.utils import first_slice_copy
+
     with disable_proxy_modes_tracing():
-        example_input = _unstack_pytree(xs)[0]
+        # Use first_slice_copy instead of _unstack_pytree to avoid
+        # iterating over batch dim, which would guard on symbolic sizes.
+        example_input = pytree.tree_map(first_slice_copy, xs)
 
         body_graph = f
 
@@ -254,20 +276,38 @@ def map_proxy_torch_dispatch_mode(mode, f, xs, args):
 
 @map_impl.py_impl(FakeTensorMode)
 def map_fake_tensor_mode(mode, f, xs, args):
+    from torch._higher_order_ops.utils import first_slice_copy
+
     with mode:
-        return map_dense(f, xs, args)
+        # Use first_slice_copy instead of _unstack_pytree to avoid
+        # iterating over batch dim, which would guard on symbolic sizes.
+        first_row = pytree.tree_map(first_slice_copy, xs)
+        example_output = f(*first_row, *args)
+
+        flat_xs, _ = pytree.tree_flatten(xs)
+        batch_size = flat_xs[0].shape[0]
+
+        return _broadcast_to_batch(example_output, batch_size)
 
 
 @map_impl.py_functionalize_impl
 def map_functionalize(ctx, f, xs, pos_args):
-    from torch._higher_order_ops.utils import _check_alias_and_mutation
+    from torch._higher_order_ops.utils import (
+        _check_alias_and_mutation,
+        first_slice_copy,
+    )
 
     unwrapped_xs = ctx.unwrap_tensors(xs)
     unwrapped_args = ctx.unwrap_tensors(pos_args)
     wrapped_fn = ctx.functionalize(_maybe_run_with_interpreter(f))
 
     with ctx.redispatch_to_next():
-        example_inputs = (*_unstack_pytree(unwrapped_xs)[0], *unwrapped_args)
+        # Use first_slice_copy instead of _unstack_pytree to avoid
+        # iterating over batch dim, which would guard on symbolic sizes.
+        example_inputs = (
+            *pytree.tree_map(first_slice_copy, unwrapped_xs),
+            *unwrapped_args,
+        )
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
         _check_alias_and_mutation(f, example_inputs, "map", pre_dispatch)
         map_return = map_impl(wrapped_fn, unwrapped_xs, unwrapped_args)

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -220,7 +220,12 @@ def _broadcast_to_batch(output, batch_size):
 
     def expand_with_batch(t):
         if isinstance(t, torch.Tensor):
-            return t.unsqueeze(0).expand(batch_size, *t.shape).clone()
+            # Use contiguous_format to match torch.stack behavior
+            return (
+                t.unsqueeze(0)
+                .expand(batch_size, *t.shape)
+                .clone(memory_format=torch.contiguous_format)
+            )
         return t
 
     return pytree.tree_map(expand_with_batch, output)

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -219,8 +219,6 @@ def _broadcast_to_batch(output, batch_size):
     """
 
     def expand_with_batch(t):
-        if t is None:
-            return None
         if isinstance(t, torch.Tensor):
             return t.unsqueeze(0).expand(batch_size, *t.shape).clone()
         return t


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173432

_unstack_pytree calls zip(*tensors) that accidentally triggers specialization. Change to _first_slice_copy and make it consistent with scan.
