### PR TITLE
enable RNG on GPU

### DIFF
--- a/aten/src/ATen/core/Generator.cpp
+++ b/aten/src/ATen/core/Generator.cpp
@@ -17,6 +17,10 @@ void Generator::graphsafe_set_state(const Generator& new_state) {
   this->impl_->graphsafe_set_state(new_state.getIntrusivePtr());
 }
 
+void Generator::set_current_tensor_seed(const at::Tensor& seed) {
+  impl_->set_current_tensor_seed(seed.getIntrusivePtr());
+}
+
 Generator Generator::graphsafe_get_state() const {
   return Generator(this->impl_->graphsafe_get_state());
 }

--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -87,6 +87,7 @@ struct TORCH_API Generator {
   }
 
   void set_current_seed(uint64_t seed) { impl_->set_current_seed(seed); }
+  void set_current_tensor_seed(const at::Tensor& seed);
   // Sets the offset of Generator state to the desired offset. This is currently
   // supported for only Philox based Generators, i.e., CUDA and MPS.
   void set_offset(uint64_t offset) { impl_->set_offset(offset); }

--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.h
@@ -102,6 +102,10 @@ struct CUDAGeneratorState : public c10::intrusive_ptr_target {
   at::TensorBase seed_extragraph_;
   at::TensorBase offset_extragraph_;
 
+  at::TensorBase tensor_seed_;
+  at::TensorBase tensor_offset_;
+  bool is_seed_tensor_ = false;
+
   CUDAGeneratorState(
       uint64_t seed = default_rng_seed_val,
       uint64_t philox_offset_per_thread = 0,
@@ -133,6 +137,7 @@ struct TORCH_CUDA_CPP_API CUDAGeneratorImpl : public c10::GeneratorImpl {
   // CUDAGeneratorImpl methods
   std::shared_ptr<CUDAGeneratorImpl> clone() const;
   void set_current_seed(uint64_t seed) override;
+  void set_current_tensor_seed(c10::intrusive_ptr<c10::TensorImpl> seed) override;
   void set_offset(uint64_t offset) override;
   uint64_t get_offset() const override;
   uint64_t current_seed() const override;

--- a/aten/src/ATen/cuda/detail/PhiloxCudaStateRaw.cuh
+++ b/aten/src/ATen/cuda/detail/PhiloxCudaStateRaw.cuh
@@ -26,6 +26,16 @@ struct PhiloxCudaState {
     captured_ = true;
   }
 
+  PhiloxCudaState(int64_t* seed,
+                  int64_t* offset,
+                  uint64_t increment,
+                  bool use_atomic)
+    : increment_(increment), use_atomic_(use_atomic) {
+    seed_.ptr = seed;
+    offset_.ptr = offset;
+    captured_ = true;
+  }
+
   // Public members, directly accessible by at::cuda::philox::unpack.
   // If we made them private with getters/setters, the getters/setters
   // would have to be __device__, and we can't declare __device__ in ATen.
@@ -38,6 +48,8 @@ struct PhiloxCudaState {
   Payload offset_{};
   uint64_t offset_intragraph_ = 0;
   bool captured_ = false;
+  uint64_t increment_ = 0;
+  bool use_atomic_ = false;
 };
 
 } // namespace at

--- a/c10/core/GeneratorImpl.h
+++ b/c10/core/GeneratorImpl.h
@@ -68,6 +68,11 @@ struct C10_API GeneratorImpl : public c10::intrusive_ptr_target {
 
   // Common methods for all generators
   virtual void set_current_seed(uint64_t seed) = 0;
+  virtual void set_current_tensor_seed(
+      c10::intrusive_ptr<c10::TensorImpl> seed) {
+    TORCH_CHECK(
+        false, "set_current_tensor_seed is not implemented for this generator");
+  }
   virtual void set_offset(uint64_t offset) = 0;
   virtual uint64_t get_offset() const = 0;
   virtual uint64_t current_seed() const = 0;


### PR DESCRIPTION
This PR modifies `torch.Generator.manual_seed` so that it also accepts Tensors in addition to integers. This way, we can avoid CPU calls when using `Generator`.

Simple prototype:

```python
import torch
seed = torch.tensor(1, device="cuda")
gen = torch.Generator(device="cuda").manual_seed(seed)

result = torch.rand([3, 4], generator=gen, device="cuda")

gen2 = torch.Generator(device="cuda").manual_seed(1)
expected = torch.rand([3, 4], generator=gen2, device="cuda")

print("result:", result)
print("expected:", expected)
print("equal:", torch.equal(result, expected))
```