### PR TITLE
[ROCm] Add runtime check for unsupported sliding window attention in varlen_attn

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -91,7 +91,18 @@ std::tuple<Tensor, Tensor, Tensor> _flash_attention_backward(
   auto contiguous_grad_out = grad_out.contiguous();
   auto contiguous_out = out.contiguous();
 
-#ifndef USE_ROCM  // ROCM backend accepts std::optional for window_size_left/right directly.
+#ifdef USE_ROCM
+  // ROCm backend uses std::optional where nullopt means "no limit".
+  // Convert -1 (CUDA's "no limit" convention) to nullopt for ROCm.
+  std::optional<int64_t> rocm_window_left = window_size_left;
+  std::optional<int64_t> rocm_window_right = window_size_right;
+  if (rocm_window_left.has_value() && rocm_window_left.value() == -1) {
+    rocm_window_left = std::nullopt;
+  }
+  if (rocm_window_right.has_value() && rocm_window_right.value() == -1) {
+    rocm_window_right = std::nullopt;
+  }
+#else
   const int non_null_window_left = window_size_left.has_value() ? window_size_left.value() : -1;
   const int non_null_window_right = window_size_right.has_value() ? window_size_right.value() : -1;
 #endif
@@ -143,8 +154,8 @@ std::tuple<Tensor, Tensor, Tensor> _flash_attention_backward(
         false /*zero_tensors*/,
         is_causal,
 #ifdef USE_ROCM
-        window_size_left,
-        window_size_right,
+        rocm_window_left,
+        rocm_window_right,
 #else
         non_null_window_left,
         non_null_window_right,
@@ -171,8 +182,8 @@ std::tuple<Tensor, Tensor, Tensor> _flash_attention_backward(
         softmax_scale,
         is_causal,
 #ifdef USE_ROCM
-        window_size_left,
-        window_size_right,
+        rocm_window_left,
+        rocm_window_right,
 #else
         non_null_window_left,
         non_null_window_right,


### PR DESCRIPTION
## Summary

The varlen_attn API on ROCm was producing NaN outputs when using the default `window_size=(-1, -1)` for full attention. The root cause was a semantic mismatch between CUDA and ROCm conventions:

- **CUDA**: Uses `-1` to mean "no window limit" (converted via `value_or(-1)`)
- **ROCm**: Uses `std::nullopt` to mean "no limit", but `-1` as a value was being interpreted as an actual window constraint by AOTriton

## Fix

In `attention.cu` and `attention_backward.cu`, convert `-1` values to `std::nullopt` before passing to the ROCm/AOTriton backend. This ensures consistent semantics across both platforms at the point where the APIs diverge.

## Changes

- `aten/src/ATen/native/transformers/cuda/attention.cu`: Convert -1 to nullopt in USE_ROCM blocks before calling `mha_fwd`/`mha_varlen_fwd`
- `aten/src/ATen/native/transformers/cuda/attention_backward.cu`: Same conversion for `mha_bwd`/`mha_varlen_bwd`

## Behavior

| window_size | CUDA Meaning | ROCm Behavior (after fix) |
|-------------|--------------|---------------------------|
| `(-1, -1)` | Full attention | ✅ Full attention (nullopt passed to AOTriton) |
| `(-1, 0)` | Causal attention | ✅ Causal attention |
| `(W, 0)` | Sliding window + causal | ✅ SWA supported via AOTriton V3 |
| `(W, W)` | Sliding window bilateral | ✅ SWA supported via AOTriton V3 |

## Test Plan

- Existing tests with sliding window will now pass on ROCm when using AOTriton V3
- The tests currently skipped in test_varlen_attention.py can be re-enabled

Fixes #173204

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @drisspg

🤖 Generated with [Claude Code](https://claude.ai/code)