### PR TITLE
[test] Enable FSDPv2 tests (_composable/fsdp) for PrivateUse1 devices

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import (
     TEST_CUDA,
     TEST_HPU,
     TEST_XPU,
+    TEST_PRIVATEUSE1,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
@@ -256,14 +257,14 @@ class TestFullyShardMemory(FSDPTest):
     def _get_peak_active_memory_mb(self) -> int:
         mem_stats = torch.get_device_module(device_type).memory_stats()
 
-        if TEST_CUDA or TEST_XPU:
+        if TEST_CUDA or TEST_XPU or TEST_PRIVATEUSE1:
             return round(mem_stats["active_bytes.all.peak"] / 1e6)
         if TEST_HPU:
             return round(mem_stats["MaxInUse"] / 1e6)
 
     def _get_curr_active_memory_mb(self) -> int:
         mem_stats = torch.get_device_module(device_type).memory_stats()
-        if TEST_CUDA or TEST_XPU:
+        if TEST_CUDA or TEST_XPU or TEST_PRIVATEUSE1:
             return round(mem_stats["active_bytes.all.current"] / 1e6)
         if TEST_HPU:
             return round(mem_stats["InUse"] / 1e6)

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -141,14 +141,14 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
             )
         else:
             model = model.cpu()
-            model = model.cuda()
+            model = model.to(device_type)
             self.assertTrue(
                 sd["weight"]._local_tensor.untyped_storage().data_ptr()
                 != model.weight._local_tensor.untyped_storage().data_ptr()
             )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.rand(mlp_dim, mlp_dim, device="cuda")
+        inp = torch.rand(mlp_dim, mlp_dim, device=device_type.type)
         for _ in range(5):
             optim.zero_grad()
             loss = model(inp).sum()

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -426,7 +426,6 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             in (2, 3)
         ):
             return
-        assert test_device_type in ("cuda", "hpu", "xpu", "cpu"), f"{test_device_type}"
         torch.manual_seed(42)
         vocab_size = 1024
         model_args = ModelArgs(

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -49,6 +49,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_TSAN,
     TEST_XPU,
     TestCase,
+    TEST_PRIVATEUSE1,
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
     _install_threaded_pg,
@@ -228,6 +229,8 @@ def skip_if_lt_x_gpu(x):
             if TEST_HPU and torch.hpu.device_count() >= x:
                 return func(*args, **kwargs)
             if TEST_XPU and torch.xpu.device_count() >= x:
+                return func(*args, **kwargs)
+            if TEST_PRIVATEUSE1 and torch.accelerator.device_count() >= x:
                 return func(*args, **kwargs)
             test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -63,6 +63,8 @@ from torch.testing._internal.common_utils import (
     TEST_CUDA,
     TEST_HPU,
     TEST_XPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
 )
 from torch.utils._triton import has_triton
 
@@ -80,6 +82,10 @@ elif TEST_XPU:
     DEVICE_TYPE = "xpu"
     DISTRIBUTED_BACKEND = "xccl"
     DEVICE_COUNT = torch.xpu.device_count()
+elif TEST_PRIVATEUSE1:
+    DEVICE_TYPE = TEST_PRIVATEUSE1_DEVICE_TYPE
+    DISTRIBUTED_BACKEND = TEST_PRIVATEUSE1_DEVICE_TYPE
+    DEVICE_COUNT = torch.accelerator.device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1258,7 +1264,7 @@ class FSDPTest(MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if TEST_CUDA or TEST_XPU or TEST_PRIVATEUSE1:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5527,14 +5527,16 @@ def dtype_name(dtype):
 
 @functools.lru_cache
 def get_cycles_per_ms() -> float:
-    """Measure and return approximate number of cycles per millisecond for torch.cuda._sleep
+    """Measure and return approximate number of cycles per millisecond for module._sleep
     """
 
     def measure() -> float:
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
+        device_type = torch.accelerator.current_accelerator(check_available=True)
+        device_module = torch.get_device_module(device_type)
+        start = device_module.Event(enable_timing=True)
+        end = device_module.Event(enable_timing=True)
         start.record()
-        torch.cuda._sleep(1000000)
+        device_module._sleep(1000000)
         end.record()
         end.synchronize()
         cycles_per_ms = 1000000 / start.elapsed_time(end)


### PR DESCRIPTION
## Summary
Enable FSDPv2 tests  (_composable/fsdp) to run natively on PrivateUse1 devices.

## Changes
- Add PrivateUse1 devices support in FSDP test infrastructure 
- Use `torch.accelerator` API for device-agnostic operations