### PR TITLE
[Inductor] Fix buffer reuse when TTIR mutation analysis fails

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1229,6 +1229,7 @@ def _(
     grid: list["TritonGridType"],
     tma_descriptor_metadata: TMADescriptorMetadata,
     kwargs: dict[str, Any],
+    tensors_to_clone_hint: Optional[list[str]] = None,
 ) -> None:
     return None
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7166,6 +7166,7 @@ class UserDefinedTritonKernel(ExternKernel):
         grid: Any,
         tma_descriptor_metadata: dict[str, Any],
         kernel_args: dict[str, Any],
+        tensors_to_clone_hint: Optional[list[str]] = None,
     ) -> None:
         inputs: list[IRNode] = []
         kwargs: dict[str, IRNode] = {}
@@ -7213,6 +7214,7 @@ class UserDefinedTritonKernel(ExternKernel):
                 kernel,
                 {**kernel_args, **autotuned_kwargs},
                 tma_descriptor_metadata,
+                tensors_to_clone_hint=tensors_to_clone_hint,
             )
         ]
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7445,6 +7445,7 @@ def triton_kernel_wrap_(
     grid,
     tma_descriptor_metadata,
     kwargs,
+    tensors_to_clone_hint=None,
 ):
     from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
@@ -7454,6 +7455,7 @@ def triton_kernel_wrap_(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kernel_args={**kwargs, **constant_args},
+        tensors_to_clone_hint=tensors_to_clone_hint,
     )
     return {key: val for key, val in kwargs.items() if isinstance(val, TensorBox)}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173485

When ttir analysis fails to identify mutated tensors in a Triton kernel, the inductor currently falls back to conservatively marking all tensor inputs as mutated. This prevents buffer reuse optimization, causing significant unnecessary memory allocation.

This PR fixes the issue by propagating the existing `tensors_to_clone` parameter from `triton_kernel_wrapper_functional` through to `identify_mutated_tensors`, where it serves as a fallback when ttir analysis raises an exception.

for this `test_triton_kernel_reinplace_same_tensor_in_out` test case peak memory reduced from 1.8GB -> 746.6MB

before fix
```python
class Runner:
    def __init__(self, partitions):
        self.partitions = partitions

    def recursively_apply_fns(self, fns):
        new_callables = []
        for fn, c in zip(fns, self.partitions):
            new_callables.append(fn(c))
        self.partitions = new_callables

    def call(self, args):
        x_1, = args
        args.clear()
        assert_size_stride(x_1, (30000000, ), (1, ))
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            buf0 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [getitem_12], Original ATen: []
            # [Provenance debug handles] triton_poi_fused_0:1
            stream0 = get_raw_stream(0)
            triton_poi_fused_0.run(buf0, 30000000, stream=stream0)
            buf3 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:2
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf3, 30000000, stream=stream0)
            buf4 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:3
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf4, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:4
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf3, buf4, 30000000, 29297, 1, 1, stream=stream0)
            buf8 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_2:5
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_2.run(buf3, buf4, buf8, 30000000, stream=stream0)
            buf9 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:6
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf9, 30000000, stream=stream0)
            buf10 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:7
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf10, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:8
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf9, buf10, 30000000, 29297, 1, 1, stream=stream0)
            buf14 = buf8; del buf8  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:9
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf14, buf9, 30000000, stream=stream0)
            buf15 = buf14; del buf14  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:10
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf15, buf10, 30000000, stream=stream0)
            buf16 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:11
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf16, 30000000, stream=stream0)
            buf17 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:12
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf17, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:13
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf16, buf17, 30000000, 29297, 1, 1, stream=stream0)
            buf21 = buf15; del buf15  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:14
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf21, buf16, 30000000, stream=stream0)
            buf22 = buf21; del buf21  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:15
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf22, buf17, 30000000, stream=stream0)
            buf23 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:16
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf23, 30000000, stream=stream0)
            buf24 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:17
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf24, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:18
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf23, buf24, 30000000, 29297, 1, 1, stream=stream0)
            buf28 = buf22; del buf22  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:19
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf28, buf23, 30000000, stream=stream0)
            buf29 = buf28; del buf28  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:20
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf29, buf24, 30000000, stream=stream0)
            buf30 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:21
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf30, 30000000, stream=stream0)
            buf31 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:22
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf31, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:23
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf30, buf31, 30000000, 29297, 1, 1, stream=stream0)
            buf35 = buf29; del buf29  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:24
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf35, buf30, 30000000, stream=stream0)
            buf36 = buf35; del buf35  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:25
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf36, buf31, 30000000, stream=stream0)
            buf37 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:26
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf37, 30000000, stream=stream0)
            buf38 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:27
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf38, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:28
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf37, buf38, 30000000, 29297, 1, 1, stream=stream0)
            buf42 = buf36; del buf36  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:29
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf42, buf37, 30000000, stream=stream0)
            buf43 = buf42; del buf42  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:30
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf43, buf38, 30000000, stream=stream0)
            buf44 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:31
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf44, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:32
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf0, buf44, 30000000, 29297, 1, 1, stream=stream0)
            del buf10
            del buf16
            del buf17
            del buf23
            del buf24
            del buf3
            del buf30
            del buf31
            del buf37
            del buf38
            del buf4
            del buf9
            del x_1
            buf48 = buf43; del buf43  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: []
            # [Provenance debug handles] triton_poi_fused_as_strided_3:33
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf48, buf0, 30000000, stream=stream0)
            del buf0
            buf49 = buf48; del buf48  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:34
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf49, buf44, 30000000, stream=stream0)
            del buf44
        return (buf49, )
```

Before fix `buf3` deleted at the very end 
```python
del buf3
del buf30
del buf31
```
After fix:
```python
class Runner:
    def __init__(self, partitions):
        self.partitions = partitions

    def recursively_apply_fns(self, fns):
        new_callables = []
        for fn, c in zip(fns, self.partitions):
            new_callables.append(fn(c))
        self.partitions = new_callables

    def call(self, args):
        x_1, = args
        args.clear()
        assert_size_stride(x_1, (30000000, ), (1, ))
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            buf0 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [getitem_12], Original ATen: []
            # [Provenance debug handles] triton_poi_fused_0:1
            stream0 = get_raw_stream(0)
            triton_poi_fused_0.run(buf0, 30000000, stream=stream0)
            buf3 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:2
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf3, 30000000, stream=stream0)
            buf4 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:3
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf4, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:4
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf3, buf4, 30000000, 29297, 1, 1, stream=stream0)
            buf7 = empty_strided_cuda((30000000, ), (1, ), torch.float32)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_2:5
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_2.run(buf3, buf4, buf7, 30000000, stream=stream0)
            buf8 = buf4; del buf4  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:6
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf8, 30000000, stream=stream0)
            buf9 = buf3; del buf3  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:7
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf9, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:8
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf8, buf9, 30000000, 29297, 1, 1, stream=stream0)
            buf12 = buf7; del buf7  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:9
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf12, buf8, 30000000, stream=stream0)
            buf13 = buf12; del buf12  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:10
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf13, buf9, 30000000, stream=stream0)
            buf14 = buf9; del buf9  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:11
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf14, 30000000, stream=stream0)
            buf15 = buf8; del buf8  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:12
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf15, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:13
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf14, buf15, 30000000, 29297, 1, 1, stream=stream0)
            buf18 = buf13; del buf13  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:14
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf18, buf14, 30000000, stream=stream0)
            buf19 = buf18; del buf18  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:15
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf19, buf15, 30000000, stream=stream0)
            buf20 = buf15; del buf15  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:16
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf20, 30000000, stream=stream0)
            buf21 = buf14; del buf14  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:17
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf21, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:18
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf20, buf21, 30000000, 29297, 1, 1, stream=stream0)
            buf24 = buf19; del buf19  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:19
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf24, buf20, 30000000, stream=stream0)
            buf25 = buf24; del buf24  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:20
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf25, buf21, 30000000, stream=stream0)
            buf26 = buf21; del buf21  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:21
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf26, 30000000, stream=stream0)
            buf27 = buf20; del buf20  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:22
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf27, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:23
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf26, buf27, 30000000, 29297, 1, 1, stream=stream0)
            buf30 = buf25; del buf25  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:24
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf30, buf26, 30000000, stream=stream0)
            buf31 = buf30; del buf30  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:25
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf31, buf27, 30000000, stream=stream0)
            buf32 = buf27; del buf27  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:26
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf32, 30000000, stream=stream0)
            buf33 = buf26; del buf26  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:27
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf33, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:28
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf32, buf33, 30000000, 29297, 1, 1, stream=stream0)
            buf36 = buf31; del buf31  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:29
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf36, buf32, 30000000, stream=stream0)
            del buf32
            buf37 = buf36; del buf36  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_3:30
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_3.run(buf37, buf33, 30000000, stream=stream0)
            buf38 = buf33; del buf33  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided, aten.clone]
            # [Provenance debug handles] triton_poi_fused_as_strided_clone_1:31
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_clone_1.run(buf0, buf38, 30000000, stream=stream0)
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] dual_output_kernel_with_inline_asm_0:32
            stream0 = get_raw_stream(0)
            dual_output_kernel_with_inline_asm_0.run(x_1, buf0, buf38, 30000000, 29297, 1, 1, stream=stream0)
            del buf0
            del x_1
            buf40 = buf37; del buf37  # reuse
            # Topologically Sorted Source Nodes: [], Original ATen: [aten.as_strided]
            # [Provenance debug handles] triton_poi_fused_as_strided_4:33
            stream0 = get_raw_stream(0)
            triton_poi_fused_as_strided_4.run(buf40, buf38, 30000000, stream=stream0)
            del buf38
        return (buf40, )

```

after fix `buf3` immediately deleted
```python
del buf3  # reuse
dual_output_kernel_with_inline_asm_0.run(x_1, buf8, buf9, ...)
```
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos

Differential Revision: [D91551912](https://our.internmc.facebook.com/intern/diff/D91551912)