### PR TITLE
[ROCm] Enable test_ldl_solve for ROCm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9972,7 +9972,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
-    @skipCUDAIfRocm
     @dtypes(*floating_and_complex_types())
     def test_ldl_solve(self, device, dtype):
         from torch.testing._internal.common_utils import random_hermitian_pd_matrix


### PR DESCRIPTION
## Summary
Removes `@skipCUDAIfRocm` decorator from `test_ldl_solve` to enable the test on ROCm devices.

## Rationale
The LDL factorization (`torch.linalg.ldl_factor_ex`) and solve (`torch.linalg.ldl_solve`) operations are supported on ROCm via the MAGMA backend, which is the same backend used for CUDA. The test already has `@skipCUDAIfNoMagma` decorator ensuring MAGMA availability, so there's no technical reason to skip this test on ROCm.

This is a simple stale skip removal - the underlying LAPACK/MAGMA operations work correctly on ROCm.

## Test Details
- **Test**: `test_ldl_solve` in `test/test_linalg.py`
- **Line**: ~9975
- **Change**: Remove `@skipCUDAIfRocm` decorator

Fixes #168771

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang