### PR TITLE
[inductor][sampling] propagate kernel precompilation times to feedback savers

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3248,7 +3248,9 @@ class TestTuningProcessPool(TestCase):
         # Create a simple feedback saver function
         feedback_calls = []
 
-        def simple_feedback_saver(timings, name, input_nodes, choices, profiled_time):
+        def simple_feedback_saver(
+            timings, name, input_nodes, choices, profiled_time, precompile_times
+        ):
             feedback_calls.append(
                 {
                     "name": name,
@@ -3267,7 +3269,9 @@ class TestTuningProcessPool(TestCase):
         self.assertEqual(cache.feedback_saver_fns[0], simple_feedback_saver)
 
         # Test that we can add multiple feedback savers
-        def another_feedback_saver(timings, name, input_nodes, choices, profiled_time):
+        def another_feedback_saver(
+            timings, name, input_nodes, choices, profiled_time, precompile_times
+        ):
             pass
 
         add_feedback_saver(another_feedback_saver)
@@ -3281,10 +3285,14 @@ class TestTuningProcessPool(TestCase):
         from torch._inductor.select_algorithm import get_algorithm_selector_cache
 
         # Add some feedback savers first
-        def feedback_saver1(timings, name, input_nodes, choices, profiled_time):
+        def feedback_saver1(
+            timings, name, input_nodes, choices, profiled_time, precompile_times
+        ):
             pass
 
-        def feedback_saver2(timings, name, input_nodes, choices, profiled_time):
+        def feedback_saver2(
+            timings, name, input_nodes, choices, profiled_time, precompile_times
+        ):
             pass
 
         add_feedback_saver(feedback_saver1)
@@ -3307,7 +3315,9 @@ class TestTuningProcessPool(TestCase):
 
         feedback_calls = []
 
-        def test_feedback_saver(timings, name, input_nodes, choices, profiled_time):
+        def test_feedback_saver(
+            timings, name, input_nodes, choices, profiled_time, precompile_times
+        ):
             # Store information about the call for verification
             feedback_calls.append(
                 {

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -286,6 +286,8 @@ class AutoHeuristicSelectAlgorithm(AutoHeuristic):
             name: str,
             input_nodes: list[Any],
             choices: list[ChoiceCaller],
+            profiled_time: Callable[[], dict[ChoiceCaller, float]],
+            precompile_times: dict[ChoiceCaller, float],
         ) -> None:
             current_inputs_key = create_inputs_key(input_nodes)
             if current_inputs_key != ah_inputs_key:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2683,6 +2683,7 @@ def create_precompile_key(
 # input_nodes: list of input ir.py Nodes
 # choices: list of choices
 # profiled time: Callable that returns a dict mapping from choices to the profiled time
+# precompile_times: mapping from choices to their precompilation time in seconds
 FeedbackFunction = Callable[
     [
         dict[ChoiceCaller, float],
@@ -2690,6 +2691,7 @@ FeedbackFunction = Callable[
         list[Any],
         list[ChoiceCaller],
         Callable[[], dict[ChoiceCaller, float]],
+        dict[ChoiceCaller, float],
     ],
     None,
 ]
@@ -2765,7 +2767,7 @@ class AlgorithmSelectorCache(PersistentCache):
         # no guarantee that the first lowering for a given key will also be the
         # first to benchmark it. share a single precompilation function for all lowerings
         # of a particular key
-        self.precompile_cache: dict[str, Callable[[], None]] = {}
+        self.precompile_cache: dict[str, Callable[[], dict[ChoiceCaller, float]]] = {}
         # cache for prescreening results to ensure deterministic candidate selection
         self.prescreening_cache: dict[str, OrderedSet[str]] = {}
         # list of callbacks that are called after benchmarking
@@ -3144,9 +3146,9 @@ class AlgorithmSelectorCache(PersistentCache):
                 log_pt2_compile_event=True,
                 dynamo_compile_column_us="compile_time_autotune_time_us",
             ):
-                precompile_fn()
+                precompile_times = precompile_fn()
         else:
-            precompile_fn()
+            precompile_times = precompile_fn()
 
         precompile_elapse = time.time() - precompile_start_ts
         log.debug("Precompilation elapsed time: %.02fs", precompile_elapse)
@@ -3292,6 +3294,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 input_nodes,
                 choices,
                 profiler_bench_function,
+                precompile_times,
             )
 
         return timings
@@ -3314,14 +3317,14 @@ class AlgorithmSelectorCache(PersistentCache):
         name: str,
         inputs_key: str,
         precompilation_timeout_seconds: Optional[int] = 60 * 60,
-    ) -> Callable[[], None]:
+    ) -> Callable[[], dict[ChoiceCaller, float]]:
         """
         Returns a function that precompiles the given choices.
         """
         log.debug("Starting precompilation")
 
-        def no_op(*args, **kwargs):
-            return
+        def no_op(*args, **kwargs) -> dict[ChoiceCaller, float]:
+            return {}
 
         if (
             precompilation_timeout_seconds is None
@@ -3435,7 +3438,12 @@ class AlgorithmSelectorCache(PersistentCache):
 
         @functools.cache
         @restore_stdout_stderr()
-        def wait_on_futures():
+        def wait_on_futures() -> dict[ChoiceCaller, float]:
+            """Wait for all precompilation futures to complete.
+
+            Returns:
+                Dict mapping each choice to its precompilation time in seconds.
+            """
             log.debug("Waiting on futures")
             counters["inductor"]["select_algorithm_precompile"] += 1
             exceptions: list[tuple[ChoiceCaller, BaseException]] = []
@@ -3495,6 +3503,13 @@ class AlgorithmSelectorCache(PersistentCache):
             if not config.pipeline_max_autotune_gemm:
                 # pyrefly: ignore [missing-attribute]
                 executor.shutdown(wait=True)
+
+            # Build and return dict mapping choices to their precompilation times
+            precompile_times: dict[ChoiceCaller, float] = {}
+            for future, choice in futures.items():
+                if future in elapsed_times:
+                    precompile_times[choice] = elapsed_times[future]
+            return precompile_times
 
         self.precompile_cache[precompile_key] = wait_on_futures
 


### PR DESCRIPTION
Summary:
## Summary

Propagates kernel precompilation timing data through the autotuning feedback system and adds a new `precompile_time_ms` field to the AutotuneMetrics03 logging schema.

## Changes

- Modify `AlgorithmSelectorCache.autotune` to capture and return precompilation times from `wait_on_futures()`
- Update `FeedbackFunction` type signature to include `precompile_times: dict[ChoiceCaller, float]` parameter
- Update all feedback saver implementations to accept the new `precompile_times` parameter:
  - `autoheuristic.py`: AutoHeuristic feedback saver
  - `extractor.py`: Sampling extractor
  - `mm_full_sample.py`: Full MM sampling
  - `mm_sample.py`: MM sampling
  - `recorder.py`: Lookup table recorder
  - `tuneexp.py`: Tuning experiments script
- Add `precompile_time_ms` field to AutotuneMetrics03 thrift schema
- Convert precompilation times from seconds to milliseconds when logging
- Update test fixtures to match new function signatures

## Details

The precompilation phase compiles all kernel choices before benchmarking. Previously, timing for individual kernel compilations was tracked internally but not exposed. This change propagates these timings through the feedback mechanism so they can be logged and analyzed alongside benchmark results.

The new `precompile_time_ms` field in the logging schema enables analysis of compilation overhead for different kernel configurations, which is valuable for understanding autotuning performance characteristics.

Test Plan:
Run the autotuning feedback saver tests:
```
buck test fbcode//caffe2/test/inductor:test_max_autotune -- --test-filter "*feedback*"
```

Run the extractor validation tests:
```
buck test fbcode//deeplearning/aot_inductor/benchmark/sampling:test_extractor_validation
```




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

@diff-train-skip-merge
@bypass-github-export-checks
