### PR TITLE
[Test][Fix] Cast `supported` from `tuple` to `set`

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1104,7 +1104,7 @@ class ops(_TestParametrizer):
                 dtypes = set(op.supported_dtypes(device_cls.device_type))
             elif self.opinfo_dtypes == OpDTypes.any_one:
                 # Tries to pick a dtype that supports both forward or backward
-                supported = op.supported_dtypes(device_cls.device_type)
+                supported = set(op.supported_dtypes(device_cls.device_type))
                 supported_backward = op.supported_backward_dtypes(
                     device_cls.device_type
                 )


### PR DESCRIPTION
https://github.com/pytorch/pytorch/blob/fbdc163dde6ead830d622bb7a13174091ebe4c53/torch/testing/_internal/opinfo/core.py#L1565-L1572

Here `supported` is a `_dispatch_dtypes` (`tuple`), and `supported_backward` is a `set`. And tuple hasn't `intersection()` method.

https://github.com/pytorch/pytorch/blob/fbdc163dde6ead830d622bb7a13174091ebe4c53/torch/testing/_internal/common_device_type.py#L1096-L1102