### PR TITLE
[ROCm] group_gemm perf: Add new kernel for all K equal cases

### DIFF
--- a/aten/src/ATen/native/hip/ck_group_gemm.hip
+++ b/aten/src/ATen/native/hip/ck_group_gemm.hip
@@ -13,6 +13,7 @@
 #include <ck/tensor_operation/gpu/device/tensor_layout.hpp>
 #include <ck/tensor_operation/gpu/device/gemm_specialization.hpp>
 #include <ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_splitk_xdl_cshuffle_two_stage.hpp>
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp"
 #include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
 #include <ck/utility/tuple.hpp>
 
@@ -31,7 +32,54 @@ namespace CkTypes {
 }
 
 template <typename ALayout, typename BLayout, typename DataType>
-using GroupedGemmKernel = ck::tensor_operation::device::DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage<
+using GroupedGemmXdlSplit = ck::tensor_operation::device::DeviceGroupedGemmXdlSplitKCShuffle<
+    ALayout,                                 // Layout for A
+    BLayout,                                 // Layout for B
+    ck::Tuple<>,                             // DsLayout
+    ck::tensor_layout::gemm::RowMajor,       // ELayout/CLayout
+    DataType,                                // A type
+    DataType,                                // B type
+    CkTypes::F32,                            // Accumulator type
+    DataType,                                // CShuffle type
+    ck::Tuple<>,                             // Ds type
+    DataType,                                // E type
+    CkTypes::PassThrough,                    // Elementwise functors
+    CkTypes::PassThrough,
+    CkTypes::PassThrough,
+    ck::tensor_operation::device::GemmSpecialization::MNKPadding,
+    1,                                       // NumGemmKPrefetchStage
+    256,                                     // BlockSize
+    256,                                     // MPerBlock
+    128,                                     // NPerBlock
+    32,                                      // KPerBlock
+    8,                                       // AK1
+    8,                                       // BK1
+    32,                                      // MPerXDL
+    32,                                      // NPerXDL
+    4,                                       // MXdlPerWave
+    2,                                       // NXdlPerWave
+    S<1,4,64,1>,                             // ABlockTransferThreadClusterLengths_K0_M_K1
+    S<0,2,1,3>,                              // ABlockTransferThreadClusterArrangeOrder
+    S<0,2,1,3>,                              // ABlockTransferSrcAccessOrder
+    3,                                       // ABlockTransferSrcVectorDim
+    8,                                       // ABlockTransferSrcScalarPerVector
+    8,                                       // ABlockTransferDstScalarPerVector_K1
+    1,                                       // ABlockLdsExtraM
+    S<1,4,64,1>,                             // BBlockTransferThreadClusterLengths_K0_N_K1
+    S<0,2,1,3>,                              // BBlockTransferThreadClusterArrangeOrder
+    S<0,2,1,3>,                              // BBlockTransferSrcAccessOrder
+    3,                                       // BBlockTransferSrcVectorDim
+    8,                                       // BBlockTransferSrcScalarPerVector
+    8,                                       // BBlockTransferDstScalarPerVector_K1
+    1,                                       // BBlockLdsExtraN
+    1,                                       // CShuffleMXdlPerWavePerShuffle
+    1,                                       // CShuffleNXdlPerWavePerShuffle
+    S<1,32,1,8>,                             // CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
+    4                                        // CDEBlockTransferScalarPerVector_NPerBlock
+>;
+
+template <typename ALayout, typename BLayout, typename DataType>
+using GroupedGemmMultipleDSplit = ck::tensor_operation::device::DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage<
     ALayout, BLayout, ck::Tuple<>, ck::tensor_layout::gemm::RowMajor,
     DataType, DataType, CkTypes::F32, DataType, ck::Tuple<>, DataType,
     CkTypes::PassThrough, CkTypes::PassThrough, CkTypes::PassThrough,
@@ -52,7 +100,6 @@ void launch_grouped_bgemm_ck_impl_dispatch(
     const std::optional<at::Tensor>& offs,
     at::Tensor& out)
 {
-    using DeviceOp = GroupedGemmKernel<ALayout, BLayout, DataType>;
     using PassThrough = CkTypes::PassThrough;
 
     std::vector<ck::tensor_operation::device::GemmDesc> gemm_descs;
@@ -381,27 +428,51 @@ void launch_grouped_bgemm_ck_impl_dispatch(
     // Initialize d_ptrs with the correct size
     std::vector<std::array<const void*, 0>> d_ptrs(p_a_ptrs.size());
 
-    static DeviceOp gemm_instance;
-    auto argument = gemm_instance.MakeArgument(
-        p_a_ptrs, p_b_ptrs, d_ptrs, p_e_ptrs,
-        gemm_descs, PassThrough{}, PassThrough{}, PassThrough{}
-    );
-    TORCH_INTERNAL_ASSERT(gemm_instance.IsSupportedArgument(argument),
-        "CK Group GEMM: argument unsupported (shape/strides/type config)");
-    size_t arg_buf_size = gemm_instance.GetDeviceKernelArgSize(&argument);
-    size_t ws_size = gemm_instance.GetWorkSpaceSize(&argument);
+    bool all_K_equal = true;
+    ck::index_t base_K = gemm_descs.empty() ? 0 : gemm_descs[0].K_;
+    for (const auto& desc : gemm_descs) {
+        if (desc.K_ != base_K) {
+           all_K_equal = false;
+           break;
+       }
+    }
 
-    void* gemm_arg_buf = c10::cuda::CUDACachingAllocator::raw_alloc(arg_buf_size);
-    void* ws_buf = c10::cuda::CUDACachingAllocator::raw_alloc(ws_size);
+    auto run_gemm = [](auto& gemm_instance, auto& argument) {
+        TORCH_INTERNAL_ASSERT(gemm_instance.IsSupportedArgument(argument),
+            "CK Group GEMM: argument unsupported (shape/strides/type config)");
+        size_t arg_buf_size = gemm_instance.GetDeviceKernelArgSize(&argument);
+        size_t ws_size = gemm_instance.GetWorkSpaceSize(&argument);
 
-    gemm_instance.SetDeviceKernelArgs(&argument, gemm_arg_buf);
-    gemm_instance.SetWorkSpacePointer(&argument, ws_buf);
+        void* gemm_arg_buf = c10::cuda::CUDACachingAllocator::raw_alloc(arg_buf_size);
+        void* ws_buf = c10::cuda::CUDACachingAllocator::raw_alloc(ws_size);
 
-    auto invoker = gemm_instance.MakeInvoker();
-    hipStream_t stream = c10::cuda::getCurrentCUDAStream();
-    invoker.Run(argument, {stream});
-    c10::cuda::CUDACachingAllocator::raw_delete(gemm_arg_buf);
-    c10::cuda::CUDACachingAllocator::raw_delete(ws_buf);
+        gemm_instance.SetDeviceKernelArgs(&argument, gemm_arg_buf);
+        gemm_instance.SetWorkSpacePointer(&argument, ws_buf);
+
+        auto invoker = gemm_instance.MakeInvoker();
+        hipStream_t stream = c10::cuda::getCurrentCUDAStream();
+        invoker.Run(argument, {stream});
+        c10::cuda::CUDACachingAllocator::raw_delete(gemm_arg_buf);
+        c10::cuda::CUDACachingAllocator::raw_delete(ws_buf);
+    };
+
+    if (all_K_equal) {
+        using DeviceOp = GroupedGemmXdlSplit<ALayout, BLayout, DataType>;
+        static DeviceOp gemm_instance;
+        auto argument = gemm_instance.MakeArgument(
+            p_a_ptrs, p_b_ptrs, d_ptrs, p_e_ptrs,
+            gemm_descs, PassThrough{}, PassThrough{}, PassThrough{}
+        );
+        run_gemm(gemm_instance, argument);
+    } else {
+        using DeviceOp = GroupedGemmMultipleDSplit<ALayout, BLayout, DataType>;
+        static DeviceOp gemm_instance;
+        auto argument = gemm_instance.MakeArgument(
+            p_a_ptrs, p_b_ptrs, d_ptrs, p_e_ptrs,
+            gemm_descs, PassThrough{}, PassThrough{}, PassThrough{}
+        );
+        run_gemm(gemm_instance, argument);
+    }
 }
 
 void group_gemm_ck(
@@ -473,3 +544,4 @@ void group_gemm_ck(
 } // namespace detail
 } // namespace hip
 } // namespace at
+

--- a/aten/src/ATen/native/hip/ck_group_gemm.hip
+++ b/aten/src/ATen/native/hip/ck_group_gemm.hip
@@ -13,7 +13,7 @@
 #include <ck/tensor_operation/gpu/device/tensor_layout.hpp>
 #include <ck/tensor_operation/gpu/device/gemm_specialization.hpp>
 #include <ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_splitk_xdl_cshuffle_two_stage.hpp>
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp"
+#include <ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp>
 #include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
 #include <ck/utility/tuple.hpp>
 

--- a/aten/src/ATen/native/hip/ck_group_gemm.hip
+++ b/aten/src/ATen/native/hip/ck_group_gemm.hip
@@ -544,4 +544,3 @@ void group_gemm_ck(
 } // namespace detail
 } // namespace hip
 } // namespace at
-

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -711,43 +711,55 @@ class TestMatmulCuda(InductorTestCase):
             self.assertEqual(C, C_ref)
 
     @skipCUDAIfNotRocm
-    def test_grouped_gemm_rocm_ck_flag(self):
-        CK_HINT = "kernel_grouped_gemm_xdl_splitk"
+    def test_grouped_gemm_rocm_ck_flag_and_k_variants(self):
+        CK_EQUAL_K_HINT = "DeviceGroupedGemmXdlSplitKCShuffle"
+        CK_UNEQUAL_K_HINT = "DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage"
         HIPBLASLT_HINT = "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs"
 
-        def uses_ck(kernels: set[str]) -> bool:
-            return any(CK_HINT in k for k in kernels)
+        def has_ck_kernel(kernels: set[str], hint: str) -> bool:
+            return any(hint in k for k in kernels)
 
         def uses_hipblaslt(kernels: set[str]) -> bool:
             return any(HIPBLASLT_HINT in k for k in kernels)
 
-        def run_grouped_mm():
+        def run_grouped_mm(equal_k: bool):
             device = "cuda"
             dtype = torch.bfloat16
-            # row-major 3d-3d
-            G, M, N, K = 4, 16, 32, 64
-            a = torch.randn(G, M, K, device=device, dtype=dtype)
-            b = torch.randn(G, N, K, device=device, dtype=dtype)
-            # 3d-3d grouped GEMM: [G, M, K] @ [G, K, N]
-            out = F.grouped_mm(a, b.transpose(-2, -1), out_dtype=dtype)
-            return out
+            if equal_k:
+                # 3d-3d grouped GEMM with identical K for all groups
+                G, M, N, K = 4, 16, 32, 64
+                a = torch.randn(G, M, K, device=device, dtype=dtype)
+                b = torch.randn(G, N, K, device=device, dtype=dtype)
+                return F.grouped_mm(a, b.transpose(-2, -1), out_dtype=dtype)
 
-        def collect_kernel_names():
+            # 2d-2d grouped GEMM with non-uniform offs, i.e. per-group K is not equal
+            M, N = 16, 32
+            offs = torch.tensor([64, 136], device=device, dtype=torch.int32)
+            K_total = offs[-1].item()
+            a = torch.randn(M, K_total, device=device, dtype=dtype)
+            b = torch.randn(N, K_total, device=device, dtype=dtype)
+            return F.grouped_mm(a, b.transpose(-2, -1), offs=offs, out_dtype=dtype)
+
+        def collect_kernel_names(equal_k: bool):
             kernels = set()
             with profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
                 record_shapes=False,
                 with_stack=False,
             ) as prof:
-                run_grouped_mm()
+                run_grouped_mm(equal_k=equal_k)
             for evt in prof.key_averages(group_by_input_shape=False):
                 kernels.add(evt.key)
             return kernels
 
         with rocm_group_gemm_ck_env(None):
-            self.assertTrue(uses_hipblaslt(collect_kernel_names()))
+            self.assertTrue(uses_hipblaslt(collect_kernel_names(equal_k=True)))
         with rocm_group_gemm_ck_env("1"):
-            self.assertTrue(uses_ck(collect_kernel_names()))
+            ck_equal_kernels = collect_kernel_names(equal_k=True)
+            self.assertTrue(has_ck_kernel(ck_equal_kernels, CK_EQUAL_K_HINT))
+
+            ck_unequal_kernels = collect_kernel_names(equal_k=False)
+            self.assertTrue(has_ck_kernel(ck_unequal_kernels, CK_UNEQUAL_K_HINT))
 
     @onlyCUDA
     @parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])


### PR DESCRIPTION
Use DeviceGroupedGemmXdlSplitKCShuffle when all GEMM groups have equal K dimensions for improved performance. Fall back to DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage otherwise.



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang