### PR TITLE
Add support DDP native mixed_precision in replicate()

### DIFF
--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -143,7 +143,8 @@ class _ReplicateState(_State):
 
         self._ddp.require_backward_grad_sync = not self._no_sync
         results = self._ddp._pre_forward(*args, **kwargs)
-        self._ddp._active_ddp_module = self._ddp
+        if not self._ddp._use_python_reducer:
+            self._ddp._active_ddp_module = self._ddp
         if not should_init:
             return results
 
@@ -165,6 +166,7 @@ class _ReplicateState(_State):
         input: tuple[torch.Tensor],
         output: torch.Tensor,
     ) -> torch.Tensor:
+        self._ddp._active_ddp_module = None
         return self._ddp._post_forward(output)
 
 


### PR DESCRIPTION
## Motivation
Although DDP already supports [native mixed precision](https://github.com/pytorch/pytorch/blob/main/torch/nn/parallel/distributed.py#L671), native mixed precision does not work well with `replicate`. This is because DDP injects some [mixed precision-related forward_pre_hooks](https://github.com/pytorch/pytorch/blob/main/torch/nn/parallel/distributed.py#L912-L922) into the original module, but `replicate` constructs a new `_param_list` object and passes it to DDP, which results in these hooks not being properly injected into the original module. Additionally, `replicate` does not handle buffers, which may need to be synchronized.

## Changes
- Pass the original module to DDP instead of the `_params_list` object, and ignore parameters not in `_params_list` via `module._ddp_params_and_buffers_to_ignore`
- Due to lazy initialization, it is necessary to manually call the newly registered forward_pre_hooks of DDP (i.e., `_reconstruct_dtensor` and `_root_copy_hook`) during the first forward pass
- To ensure the correct calling order, `state.forward_post_hook` is registered in `state.forward_pre_hook` instead of in `replicate()`
- The `device_mesh` parameter is [handled  internally](https://github.com/pytorch/pytorch/blob/main/torch/nn/parallel/distributed.py#L701-L720) by DDP rather than by the `replicate` function (for compatibility with `TP`)
- Correctly set the `DDP._active_ddp_module` attribute.