### PR TITLE
Fix native_channel_shuffle FPE crash on CUDA when groups=0

### DIFF
--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -73,8 +73,17 @@ Tensor channel_shuffle(const Tensor& self, int64_t groups) {
 }
 
 Tensor math_channel_shuffle(const Tensor& self, int64_t groups) {
+  TORCH_CHECK(self.dim() > 2,
+              "channel_shuffle expects input with > 2 dims, but got input with sizes ",
+              self.sizes());
   int64_t b = self.size(0);
   int64_t c = self.size(1);
+  TORCH_CHECK(groups > 0,
+              "Number of groups to divide channels in must be positive.",
+              " Value of groups:", groups);
+  TORCH_CHECK((c % groups) == 0,
+              "Number of channels must be divisible by groups. Got ",
+              c, " channels and ", groups, " groups.");
   int64_t oc = c / groups;
 
   auto input_reshaped = self.view({b, groups, oc, -1});

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6735,28 +6735,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             groups = 2
             torch.native_channel_shuffle(input_tensor, groups)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_native_channel_shuffle_cuda_input_checks(self):
-        # Test that CUDA path also raises proper errors instead of crashing with FPE
-        # See https://github.com/pytorch/pytorch/issues/173500
-        input_tensor = torch.rand([1, 4, 10, 10], device='cuda')
-
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Number of groups to divide channels in must be positive.*"):
-            groups = 0
-            torch.native_channel_shuffle(input_tensor, groups)
-
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Number of channels must be divisible by groups.*"):
-            groups = 3
-            torch.native_channel_shuffle(input_tensor, groups)
-
-        with self.assertRaisesRegex(RuntimeError,
-                                    "channel_shuffle expects input with > 2 dims,.*"):
-            input_tensor = torch.rand([1, 2], device='cuda')
-            groups = 2
-            torch.native_channel_shuffle(input_tensor, groups)
-
     @skipIfTorchDynamo("TorchDynamo fails here for unknown reasons")
     def test_native_channel_shuffle_return_alias_of_self(self):
         groups = 3

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6735,6 +6735,28 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             groups = 2
             torch.native_channel_shuffle(input_tensor, groups)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_native_channel_shuffle_cuda_input_checks(self):
+        # Test that CUDA path also raises proper errors instead of crashing with FPE
+        # See https://github.com/pytorch/pytorch/issues/173500
+        input_tensor = torch.rand([1, 4, 10, 10], device='cuda')
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of groups to divide channels in must be positive.*"):
+            groups = 0
+            torch.native_channel_shuffle(input_tensor, groups)
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of channels must be divisible by groups.*"):
+            groups = 3
+            torch.native_channel_shuffle(input_tensor, groups)
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    "channel_shuffle expects input with > 2 dims,.*"):
+            input_tensor = torch.rand([1, 2], device='cuda')
+            groups = 2
+            torch.native_channel_shuffle(input_tensor, groups)
+
     @skipIfTorchDynamo("TorchDynamo fails here for unknown reasons")
     def test_native_channel_shuffle_return_alias_of_self(self):
         groups = 3

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9365,6 +9365,31 @@ def sample_inputs_channel_shuffle(op_info, device, dtype, requires_grad, **kwarg
         for shape, groups in shapes_groups
     )
 
+
+def error_inputs_channel_shuffle(op_info, device, **kwargs):
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32)
+
+    # groups=0 should raise error
+    yield ErrorInput(
+        SampleInput(make_arg((1, 4, 10, 10)), args=(0,)),
+        error_type=RuntimeError,
+        error_regex="Number of groups to divide channels in must be positive",
+    )
+
+    # channels not divisible by groups
+    yield ErrorInput(
+        SampleInput(make_arg((1, 4, 10, 10)), args=(3,)),
+        error_type=RuntimeError,
+        error_regex="Number of channels must be divisible by groups",
+    )
+
+    # input with <= 2 dims
+    yield ErrorInput(
+        SampleInput(make_arg((1, 4)), args=(2,)),
+        error_type=RuntimeError,
+        error_regex="channel_shuffle expects input with > 2 dims",
+    )
+
 def sample_inputs_binary_cross_entropy(op_info, device, dtype, requires_grad, logits=False, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype)
     # Lower bounds must be greater than 'eps' defined in gradcheck.py::gradgradcheck() -> eps
@@ -22988,6 +23013,7 @@ op_db: list[OpInfo] = [
     OpInfo(
         "nn.functional.channel_shuffle",
         sample_inputs_func=sample_inputs_channel_shuffle,
+        error_inputs_func=error_inputs_channel_shuffle,
         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
         supports_out=False,
         supports_forward_ad=True,


### PR DESCRIPTION
Fixes #173500

`math_channel_shuffle` was missing input validation, causing FPE on CUDA when `groups=0`.

Added the same checks that exist in `channel_shuffle_cpu`.