### PR TITLE
[CPU][AArch64] - enable jit softmax from oneDNN

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -311,6 +311,14 @@ TORCH_IMPL_FUNC(softmax_cpu_out)
     return;
   }
 
+  #if AT_MKLDNN_ENABLED() && defined(__aarch64__)
+      if(input.is_mkldnn()){
+        auto y = at::native::mkldnn_softmax(input, dim, half_to_float);
+        output.copy_(y);
+        return;
+      }
+  #endif  // if AT_MKLDNN_ENABLED() && defined(__aarch64__)
+
   auto input_ = input.contiguous();
   int64_t dim_ = maybe_wrap_dim(dim, input_.dim());
 


### PR DESCRIPTION
Plug Softmax to use oneDNN jit kernels.

Evaluated the performance against a micro benchmark over aws c8g 16xlarge with number of threads set to 1, 16, and 64 for data type bf16 and float32 separately.


Softmax Speedup Summary (benchmarked on Neoverse V2) 

Speedup = Current implementation / JIT oneDNN

| Threads | DType     | Shape          | Rows   | Softmax Dim | Speedup |
|---------|-----------|----------------|--------|-------------|---------|
| 64      | float32   | [32, 1024]     | 32     | 1024        | 0.60× |
| 64      | float32   | [32, 4096]     | 32     | 4096        | 0.73× |
| 64      | float32   | [32, 16384]    | 32     | 16384       | 0.93× |
| 64      | float32   | [32,4096,4096] | 131072 | 4096        | 0.92× |
| 64      | bfloat16  | [32, 1024]     | 32     | 1024        | 0.64× |
| 64      | bfloat16  | [32, 4096]     | 32     | 4096        | 0.78× |
| 64      | bfloat16  | [32, 16384]    | 32     | 16384       | 0.98× |
| 64      | bfloat16  | [32,4096,4096] | 131072 | 4096        | 1.08× |
| 1       | float32   | [32, 1024]     | 32     | 1024        | 1.25× |
| 1       | float32   | [32, 4096]     | 32     | 4096        | 1.42× |
| 1       | float32   | [32, 16384]    | 32     | 16384       | 1.46× |
| 1       | float32   | [32,4096,4096] | 131072 | 4096        | 1.22× |
| 1       | bfloat16  | [32, 1024]     | 32     | 1024        | 1.18× |
| 1       | bfloat16  | [32, 4096]     | 32     | 4096        | 1.29× |
| 1       | bfloat16  | [32, 16384]    | 32     | 16384       | 1.26× |
| 1       | bfloat16  | [32,4096,4096] | 131072 | 4096        | 1.24× |
| 16      | float32   | [32, 1024]     | 32     | 1024        | 0.61× |
| 16      | float32   | [32, 4096]     | 32     | 4096        | 0.88× |
| 16      | float32   | [32, 16384]    | 32     | 16384       | 1.23× |
| 16      | float32   | [32,4096,4096] | 131072 | 4096        | 0.98× |
| 16      | bfloat16  | [32, 1024]     | 32     | 1024        | 0.62× |
| 16      | bfloat16  | [32, 4096]     | 32     | 4096        | 0.88× |
| 16      | bfloat16  | [32, 16384]    | 32     | 16384       | 1.13× |
| 16      | bfloat16  | [32,4096,4096] | 131072 | 4096        | 1.16× |



cc: @aditew01 @robert-hardwick 

