### PR TITLE
Remove unnecessary warning

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2238,7 +2238,7 @@ def forward(self, arg0_1, arg1_1):
         ):
             self._compile_and_capture(fwd_bwd_with_rng, True, (x,))
 
-    def test_ac_rematerialize_with_no_annotations_warns_and_returns_unchanged(self):
+    def test_ac_rematerialize_with_no_annotations_returns_unchanged(self):
         x = torch.randn(4, 4, requires_grad=True)
 
         def fwd_bwd(x):
@@ -2248,21 +2248,7 @@ def forward(self, arg0_1, arg1_1):
             loss = z.sum()
             return _grad(loss, x)[0]
 
-        # Without backward annotations, the pass should warn and return unchanged
-        # We verify this by checking that remat_using_tags=True produces the same
-        # graph as remat_using_tags=False (i.e., no recomputation happens)
-        import warnings
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result_with, gm_with = self._compile_and_capture(fwd_bwd, True, (x,))
-
-            # Check warning was issued
-            self.assertTrue(
-                any("no backward region" in str(warning.message) for warning in w),
-                f"Expected warning about no backward region, got: {[str(warning.message) for warning in w]}",
-            )
-
+        result_with, gm_with = self._compile_and_capture(fwd_bwd, True, (x,))
         # Get the graph without the pass for comparison
         result_without, gm_without = self._compile_and_capture(fwd_bwd, False, (x,))
 

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -2,8 +2,6 @@
 AC rematerialize pass: Duplicates checkpointed nodes for backward, then DCE removes unused forward versions.
 """
 
-import warnings
-
 import torch
 import torch.fx as fx
 from torch._functorch import config
@@ -57,16 +55,11 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
             bwd_start = idx
 
     if bwd_start is None:
-        warnings.warn(
-            "remat_using_tags_for_fwd_loss_bwd_graph: Graph has recomputable ops but no backward region. "
-            "This may indicate a forward-only graph (e.g., from nested compilation) or missing backward annotations. "
-            "Returning graph unchanged."
-        )
         return gm
 
     if has_recomputable_rng_ops(gm):
         raise RuntimeError(
-            "Activation checkpoint rematerializing in `forward-loss-backward` graph does not support RNG ops "
+            "Activation checkpoint rematerializing in forward-loss-backward graph does not support RNG ops "
             "in checkpointed regions. Please move RNG operations outside "
             "of checkpoint regions, or use joint graph mode (where partitioner handles RNG)."
         )

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -59,7 +59,7 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     if has_recomputable_rng_ops(gm):
         raise RuntimeError(
-            "Activation checkpoint rematerializing in forward-loss-backward graph does not support RNG ops "
+            "Activation checkpoint rematerializing in `forward-loss-backward` graph does not support RNG ops "
             "in checkpointed regions. Please move RNG operations outside "
             "of checkpoint regions, or use joint graph mode (where partitioner handles RNG)."
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173528

The warning is bit spammy when used in purely eval context because it is actually hard to distinguish between fwd + bwd graph vs purely fwd graph. One potential improvement here could be that we should tag the very first backward node via dynamo (like when we trace autograd.grad in dynamo) so that we know if we are in the fwd + bwd VS fwd graph. But for now, we just silently return unchanged gm when there is no backward annotation. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo