### PR TITLE
Fix _foreach_copy_ with mixed destination dtypes

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -420,8 +420,14 @@ void foreach_tensor_copy_list_kernel_cuda_(
         std::all_of(
             src.cbegin(),
             src.cend(),
-            [&](const auto& t) -> bool {
+            [&src](const auto& t) -> bool {
               return t.dtype() == src[0].dtype();
+            }) &&
+        std::all_of(
+            self.cbegin(),
+            self.cend(),
+            [&self](const auto& t) -> bool {
+              return t.dtype() == self[0].dtype();
             }) &&
         _check_tensors_share_sizes_and_strides({self, src}))) {
     return at::native::foreach_tensor_copy_list_kernel_slow_(

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1528,6 +1528,46 @@ class TestForeach(TestCase):
                     self.assertTrue(torch.equal(t, ref_t))
 
     @onlyCUDA
+    @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
+    def test_foreach_copy_with_mixed_dtypes_within_tensor(self, device, dtype, op):
+        foreach_copy_ = ForeachFuncWrapper(op.inplace_variant)
+
+        for sample in op.sample_inputs(
+            device, dtype, noncontiguous=False, allow_higher_dtype_scalars=True
+        ):
+            if len(sample.input) < 2:
+                continue
+
+            dtypes = [torch.float32, torch.bfloat16, torch.float16]
+            uniform_tensors = [t.clone() for t in sample.input]
+            mixed_tensors = [
+                t.clone().to(dtype)
+                for t, dtype in zip(sample.input, itertools.cycle(dtypes))
+            ]
+
+            uniform_dst = [torch.empty_like(t) for t in uniform_tensors]
+            out = foreach_copy_(
+                (uniform_dst, mixed_tensors), is_cuda=True, expect_fastpath=False
+            )
+            out_ref = [
+                torch.empty_like(t1).copy_(t2)
+                for t1, t2 in zip(uniform_tensors, mixed_tensors)
+            ]
+            for t, ref_t in zip(out, out_ref):
+                self.assertTrue(torch.equal(t, ref_t))
+
+            mixed_dst = [torch.empty_like(t) for t in mixed_tensors]
+            out = foreach_copy_(
+                (mixed_dst, uniform_tensors), is_cuda=True, expect_fastpath=False
+            )
+            out_ref = [
+                torch.empty_like(t1).copy_(t2)
+                for t1, t2 in zip(mixed_tensors, uniform_tensors)
+            ]
+            for t, ref_t in zip(out, out_ref):
+                self.assertTrue(torch.equal(t, ref_t))
+
+    @onlyCUDA
     @serialTest()
     @largeTensorTest("40GB", device="cuda")
     def test_foreach_copy_with_multi_dtypes_large_input(self):


### PR DESCRIPTION
_foreach_copy_ chooses between a slow and a fast path depending on the src and dst parameters like type and alignment.

The existing implementation did not check for the type of tensors in the dst tensorlist and would choose the fast-path kernel based on the type of the first tensor. This leads to incorrect outputs when not all tensors in dst are the same type.

This commit fixes the issue by falling back to the slow path.

Fixes #173383
