### PR TITLE
Add flags to pyrefly script

### DIFF
--- a/tools/linter/adapters/pyrefly_linter.py
+++ b/tools/linter/adapters/pyrefly_linter.py
@@ -141,6 +141,8 @@ def in_github_actions() -> bool:
 def check_files(
     code: str,
     config: str,
+    remove_unused_ignores: bool,
+    suppress: bool
 ) -> list[LintMessage]:
     try:
         pyrefly_commands = [
@@ -150,6 +152,10 @@ def check_files(
             config,
             "--output-format=json",
         ]
+        if remove_unused_ignores:
+            pyrefly_commands.append("--remove-unused-ignores")
+        if suppress:
+            pyrefly_commands.append("--suppress-errors")
         proc = run_command(
             [*pyrefly_commands],
             extra_env={},
@@ -265,6 +271,16 @@ def main() -> None:
         required=True,
         help="path to an mypy .ini config file",
     )
+    parser.add_argument(
+        "--remove-unused-ignores",
+        action="store_true",
+        help="clean up unused ignores",
+    )
+    parser.add_argument(
+        "--suppress",
+        action="store_true",
+        help="add suppressions",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -274,7 +290,7 @@ def main() -> None:
     )
 
     lint_messages = check_pyrefly_installed(args.code) + check_files(
-        args.code, args.config
+        args.code, args.config, args.remove_unused_ignores, args.suppress
     )
     for lint_message in lint_messages:
         print(json.dumps(lint_message._asdict()), flush=True)

--- a/tools/linter/adapters/pyrefly_linter.py
+++ b/tools/linter/adapters/pyrefly_linter.py
@@ -139,10 +139,7 @@ def in_github_actions() -> bool:
 
 
 def check_files(
-    code: str,
-    config: str,
-    remove_unused_ignores: bool,
-    suppress: bool
+    code: str, config: str, remove_unused_ignores: bool, suppress: bool
 ) -> list[LintMessage]:
     try:
         pyrefly_commands = [


### PR DESCRIPTION
There have been some changes to how lintrunner and adapter scripts are run, adding pyrefly arguments to add / remove suppressions so we can use these flags with the same `uv` setup that is used when the check is done in CI. 


