### PR TITLE
Fix macosx wheel metadata

### DIFF
--- a/.ci/wheel/build_wheel.sh
+++ b/.ci/wheel/build_wheel.sh
@@ -39,7 +39,8 @@ else
 fi
 
 echo "Building for Python: $desired_python Version: $build_version Build: $build_number"
-python_nodot="$(echo $desired_python | tr -d m.u)"
+python_tag="cp$(echo $desired_python | tr -d m.ut)"
+abi_tag="cp$(echo $desired_python | tr -d .)"
 
 # Version: setup.py uses $PYTORCH_BUILD_VERSION.post$PYTORCH_BUILD_NUMBER if
 # PYTORCH_BUILD_NUMBER > 1
@@ -100,7 +101,7 @@ mac_version='macosx-11.0-arm64'
 libtorch_arch='arm64'
 
 # Create a consistent wheel package name to rename the wheel to
-wheel_filename_new="${TORCH_PACKAGE_NAME}-${build_version}${build_number_prefix}-cp${python_nodot}-none-${mac_version//[-,.]/_}.whl"
+wheel_filename_new="${TORCH_PACKAGE_NAME}-${build_version}${build_number_prefix}-${python_tag}-${abi_tag}-${mac_version//[-,.]/_}.whl"
 
 ###########################################################
 
@@ -133,17 +134,14 @@ case $desired_python in
     3.14t)
         echo "Using 3.14 deps"
         NUMPY_PINNED_VERSION="==2.1.0"
-        RENAME_WHEEL=false
         ;;
     3.14)
         echo "Using 3.14t deps"
         NUMPY_PINNED_VERSION="==2.1.0"
-        RENAME_WHEEL=false
         ;;
     3.13t)
         echo "Using 3.13t deps"
         NUMPY_PINNED_VERSION="==2.1.0"
-        RENAME_WHEEL=false
         ;;
     3.13)
         echo "Using 3.13 deps"

--- a/.ci/wheel/build_wheel.sh
+++ b/.ci/wheel/build_wheel.sh
@@ -96,7 +96,7 @@ fi
 whl_tmp_dir="${MAC_PACKAGE_WORK_DIR}/dist"
 mkdir -p "$whl_tmp_dir"
 
-mac_version='macosx-11_0-arm64'
+mac_version='macosx-11.0-arm64'
 libtorch_arch='arm64'
 
 # Create a consistent wheel package name to rename the wheel to

--- a/.ci/wheel/build_wheel.sh
+++ b/.ci/wheel/build_wheel.sh
@@ -100,7 +100,7 @@ mac_version='macosx-11.0-arm64'
 libtorch_arch='arm64'
 
 # Create a consistent wheel package name to rename the wheel to
-wheel_filename_new="${TORCH_PACKAGE_NAME}-${build_version}${build_number_prefix}-cp${python_nodot}-none-${mac_version//[-,]/_}.whl"
+wheel_filename_new="${TORCH_PACKAGE_NAME}-${build_version}${build_number_prefix}-cp${python_nodot}-none-${mac_version//[-,.]/_}.whl"
 
 ###########################################################
 
@@ -132,19 +132,16 @@ RENAME_WHEEL=true
 case $desired_python in
     3.14t)
         echo "Using 3.14 deps"
-        mac_version='macosx-11.0-arm64'
         NUMPY_PINNED_VERSION="==2.1.0"
         RENAME_WHEEL=false
         ;;
     3.14)
         echo "Using 3.14t deps"
-        mac_version='macosx-11.0-arm64'
         NUMPY_PINNED_VERSION="==2.1.0"
         RENAME_WHEEL=false
         ;;
     3.13t)
         echo "Using 3.13t deps"
-        mac_version='macosx-11.0-arm64'
         NUMPY_PINNED_VERSION="==2.1.0"
         RENAME_WHEEL=false
         ;;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #173666
* __->__ #173541

Setting _PYTHON_HOST_PLATFORM=macosx-11_0-arm64 will make setuptools
interpret this version as 110=int("11_0") and leads to a wrong
version in wheel metadata.

Fixes https://github.com/pytorch/pytorch/issues/173475