### PR TITLE
[BE][Functorch] Add type hints to torch/_functorch files pt 3

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -152,7 +152,7 @@ implicit-any = true
 
 
 [[sub-config]]
-matches = "torch/_functorch/_aot_autograd/collect_metadata_analysis.py"
+matches = "torch/_functorch/autograd_function.py"
 [sub-config.errors]
 implicit-import = false
 implicit-any = true

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4390,12 +4390,13 @@ class AutogradFunctionApplyVariable(VariableTracker):
         with enable_python_dispatcher():
             with tx.output.fake_mode:
                 fwd_freevars_args = [_get_fake_value(arg) for arg in fwd_freevars]
-                fake_args = (
+
+                example_value = autograd_function_apply(
                     tx.output.nn_modules[fwd_node.node.name],
                     tx.output.nn_modules[bwd_node.node.name],
                     *fwd_freevars_args,
+                    **kwargs_for_fn,
                 )
-                example_value = autograd_function_apply(*fake_args, **kwargs_for_fn)
 
         flat_variable = add_call_function(
             tx, autograd_function_apply, p_args, kwargs_for_fn, example_value

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -47,8 +47,8 @@ class CustomFunctionHigherOrderOperator(HigherOrderOperator):
     def __call__(
         self,
         autograd_function: type[torch.autograd.Function],
-        *args: Any,
-        **kwargs: Any,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> Any:
         # When custom_function_call is done dispatching through functorch,
         # it should just invoke the autograd.Function. This is consistent
@@ -861,11 +861,11 @@ autograd_function_apply = AutogradFunctionApply()
 
 class DynamoAutogradFunctionTraceHelper:
     @staticmethod
-    def fwd_trace_helper(orig_fwd: Callable[..., Any]) -> Callable[..., Any]:
+    def fwd_trace_helper(orig_fwd: Callable[_P, Any]) -> Callable[_P, Any]:
         # autograd.Function forward does more than just running the forward method. Most
         # of this logic is in C++. Here, we rewrite that functionality in python and let
         # Dynamo trace it.
-        def inner(*args: Any, **kwargs: Any) -> Any:
+        def inner(*args: _P.args, **kwargs: _P.kwargs) -> Any:
             with torch.no_grad():
                 outs = orig_fwd(*args, **kwargs)
 

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -1,5 +1,7 @@
-# mypy: allow-untyped-defs
-from typing import NamedTuple
+from __future__ import annotations
+
+from typing import Any, NamedTuple, TYPE_CHECKING
+from typing_extensions import ParamSpec, TypeVar
 
 import torch
 import torch.utils._pytree as pytree
@@ -22,6 +24,15 @@ from torch._ops import HigherOrderOperator
 from torch.autograd.forward_ad import _set_fwd_grad_enabled
 
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    from torch._functorch.pyfunctorch import FuncTorchInterpreter, VmapInterpreter
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
 # autograd.Function technically runs before the regular PyTorch dispatcher.
 # This is how features like autocast and torch_dispatch (e.g. PythonTLSSnapshot)
 # work with it. One day we might decide to change this, but until then,
@@ -33,7 +44,12 @@ class CustomFunctionHigherOrderOperator(HigherOrderOperator):
     def __init__(self) -> None:
         super().__init__("custom_function_call")
 
-    def __call__(self, autograd_function, *args, **kwargs):
+    def __call__(
+        self,
+        autograd_function: type[torch.autograd.Function],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
         # When custom_function_call is done dispatching through functorch,
         # it should just invoke the autograd.Function. This is consistent
         # with the autograd.Function behavior of being invoked before the
@@ -88,17 +104,25 @@ custom_function_call = CustomFunctionHigherOrderOperator()
 # and apply it.
 @custom_function_call.py_impl(TransformType.Grad)
 @custom_function_call.py_impl(TransformType.Jvp)
-def custom_function_call_grad(interpreter, autograd_function, *operands):
+def custom_function_call_grad(
+    interpreter: FuncTorchInterpreter,
+    autograd_function: type[torch.autograd.Function],
+    *operands: Any,
+) -> Any:
     Generated = generate_single_level_function(interpreter, autograd_function)
     with enable_single_level_autograd_function():
+        # pyrefly: ignore [missing-attribute]
         flat_out = Generated.apply(*operands)
     return flat_out
 
 
-def generate_single_level_function(interpreter, autograd_function):
+def generate_single_level_function(
+    interpreter: FuncTorchInterpreter,
+    autograd_function: type[torch.autograd.Function],
+) -> type[torch.autograd.function._SingleLevelFunction]:
     level = interpreter.level()
 
-    def forward(*operands):
+    def forward(*operands: Any) -> Any:
         unwrapped_operands = pytree.tree_map_only(
             torch.Tensor, lambda x: _unwrap_for_grad(x, level), operands
         )
@@ -111,23 +135,23 @@ def generate_single_level_function(interpreter, autograd_function):
             )
 
         # See NOTE [mark_dirty object identity check]
-        def wrap_fn(output):
+        def wrap_fn(output: torch.Tensor) -> torch.Tensor:
             return _wrap_for_grad(output, level)
 
         return wrap_outputs_maintaining_identity(
             unwrapped_output, unwrapped_operands, operands, wrap_fn
         )
 
-    def setup_context(ctx, inputs, output):
+    def setup_context(ctx: Any, inputs: Any, output: Any) -> Any:
         return autograd_function.setup_context(ctx, inputs, output)
 
     # backward is only used if the transform is TransformType.Grad
-    def backward(ctx, *grads):
+    def backward(ctx: Any, *grads: Any) -> Any:
         result = autograd_function.backward(ctx, *grads)
         return result
 
     # jvp is only used if the transform is TransformType.Jvp
-    def jvp(ctx, *tangents):
+    def jvp(ctx: Any, *tangents: Any) -> Any:
         result = autograd_function.jvp(ctx, *tangents)
         return result
 
@@ -166,8 +190,12 @@ NO_OUT_DIMS = "not specified"
 # to have the same object identity as the input.
 # Mode-only functorch will greatly simplify this logic.
 def wrap_outputs_maintaining_identity(
-    outputs, unwrapped_inputs, orig_inputs, wrap_fn, out_dims=NO_OUT_DIMS
-):
+    outputs: Any,
+    unwrapped_inputs: Any,
+    orig_inputs: Any,
+    wrap_fn: Callable[..., Any],
+    out_dims: Any = NO_OUT_DIMS,
+) -> Any:
     flat_unwrapped_inputs = pytree.arg_tree_leaves(*unwrapped_inputs)
     flat_orig_inputs = pytree.arg_tree_leaves(*orig_inputs)
 
@@ -181,6 +209,7 @@ def wrap_outputs_maintaining_identity(
 
     out_dims_specified = out_dims != NO_OUT_DIMS
 
+    flat_out_dims = None
     if out_dims_specified:
         flat_out_dims = _broadcast_to_and_flatten(out_dims, spec)
         # _broadcast_to_and_flatten returns None if it is unable to broadcast.
@@ -205,7 +234,8 @@ def wrap_outputs_maintaining_identity(
             result.append(unwrapped_input_to_orig_input[id(output)])
             continue
         if out_dims_specified:
-            result.append(wrap_fn(output, flat_out_dims[i]))  # type: ignore[possibly-undefined, index]
+            assert flat_out_dims is not None
+            result.append(wrap_fn(output, flat_out_dims[i]))
         else:
             result.append(wrap_fn(output))
 
@@ -259,11 +289,13 @@ class VmapInfo(NamedTuple):
     randomness: str
 
 
-def has_overridden_vmap_rule(autograd_function):
+def has_overridden_vmap_rule(
+    autograd_function: type[torch.autograd.Function],
+) -> bool:
     return autograd_function.vmap is not torch.autograd.Function.vmap
 
 
-def validate_vmap_returns_tuple_of_two_elements(result):
+def validate_vmap_returns_tuple_of_two_elements(result: Any) -> None:
     base_error_msg = (
         "Expected the vmap staticmethod to have two returns, an output "
         "and out_dims with pytree structure compatible with the output. "
@@ -275,7 +307,12 @@ def validate_vmap_returns_tuple_of_two_elements(result):
 
 
 @custom_function_call.py_impl(TransformType.Vmap)
-def custom_function_call_vmap(interpreter, autograd_function, *operands, **kwargs):
+def custom_function_call_vmap(
+    interpreter: VmapInterpreter,
+    autograd_function: type[torch.autograd.Function],
+    *operands: Any,
+    **kwargs: Any,
+) -> Any:
     if any(
         isinstance(val, torch.Tensor)
         for val in torch.utils._pytree.tree_flatten(kwargs)[0]
@@ -319,8 +356,12 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands, **kwarg
 
 
 def custom_function_call_vmap_helper(
-    interpreter, vmap_function, op, *operands, **kwargs
-):
+    interpreter: VmapInterpreter,
+    vmap_function: Callable[..., Any],
+    op: Any,
+    *operands: Any,
+    **kwargs: Any,
+) -> Any:
     current_level = interpreter.level()
     info = VmapInfo(
         batch_size=interpreter.batch_size(),
@@ -330,7 +371,7 @@ def custom_function_call_vmap_helper(
     # or the torch.library.register_vmap case.
     autograd_function_case = isinstance(op, torch.autograd.function.FunctionMeta)
 
-    def lower_to_next():
+    def lower_to_next() -> Any:
         if autograd_function_case:
             return interpreter.lower()
         else:
@@ -355,7 +396,7 @@ def custom_function_call_vmap_helper(
     unwrapped_output, out_dims = result
 
     # See NOTE [mark_dirty object identity check]
-    def wrap_fn(output, out_dim):
+    def wrap_fn(output: torch.Tensor, out_dim: int | None) -> torch.Tensor:
         return (
             output
             if out_dim is None
@@ -367,7 +408,7 @@ def custom_function_call_vmap_helper(
     )
 
 
-def unpack_outputs(outputs):
+def unpack_outputs(outputs: tuple[Any, ...]) -> tuple[Any, Any]:
     out_dims = outputs[-1]
     if isinstance(out_dims, tuple):
         outputs = outputs[:-1]
@@ -376,10 +417,17 @@ def unpack_outputs(outputs):
     return outputs, out_dims
 
 
-def custom_function_call_vmap_generate_rule(interpreter, autograd_function, *operands):
+def custom_function_call_vmap_generate_rule(
+    interpreter: VmapInterpreter,
+    autograd_function: type[torch.autograd.Function],
+    *operands: Any,
+) -> Any:
     unwrapped_operands, in_dims = unwrap_batched(operands, interpreter.level())
     vmapped_function = vmapify_autograd_function(
-        autograd_function, in_dims, interpreter.batch_size(), interpreter.randomness()
+        autograd_function,
+        in_dims,
+        interpreter.batch_size(),
+        interpreter.randomness(),
     )
     with interpreter.lower():
         outputs = custom_function_call(vmapped_function, *unwrapped_operands)
@@ -391,13 +439,21 @@ def custom_function_call_vmap_generate_rule(interpreter, autograd_function, *ope
 
 @custom_function_call.py_impl(TransformType.Functionalize)
 def custom_function_call_functionalize(
-    interpreter, autograd_function, generate_vmap_rule, *operands
-):
+    interpreter: FuncTorchInterpreter,
+    autograd_function: type[torch.autograd.Function],
+    generate_vmap_rule: bool,
+    *operands: Any,
+) -> Any:
     raise RuntimeError("NYI: Functionalize rule for custom_function_call")
 
 
-def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness):
-    def forward(*operands):
+def vmapify_autograd_function(
+    autograd_function: type[torch.autograd.Function],
+    in_dims: Any,
+    batch_size: int,
+    randomness: str,
+) -> type[torch.autograd.Function]:
+    def forward(*operands: Any) -> Any:
         outputs, out_dims = restore_vmap(
             autograd_function.forward, in_dims, batch_size, randomness
         )(*operands)
@@ -406,11 +462,11 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
         else:
             return *outputs, out_dims
 
-    def setup_context(ctx, inputs, outputs):
+    def setup_context(ctx: Any, inputs: Any, outputs: Any) -> None:
         outputs, out_dims = unpack_outputs(outputs)
         key = id(Generated)
 
-        def inner(inputs, outputs):
+        def inner(inputs: Any, outputs: Any) -> None:
             # wrapped_ctx.save_for_backward will:
             # - unwrap batchedtensors into (tensor, bdim)
             # - save_for_backward(*unwrapped_tensors)
@@ -447,10 +503,10 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
             ctx._pt_out_dims = {}
         ctx._pt_out_dims.update({key: out_dims})
 
-    def jvp(ctx, *tangents):
+    def jvp(ctx: Any, *tangents: Any) -> Any:
         key = id(Generated)
 
-        def jvp_no_context(saved_tensors, tangents):
+        def jvp_no_context(saved_tensors: Any, tangents: Any) -> Any:
             wrapped_ctx = CtxWithSavedTensors(ctx, saved_tensors)
             return autograd_function.jvp(wrapped_ctx, *tangents)
 
@@ -470,7 +526,7 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
         else:
             return *result, None
 
-    def backward(ctx, *grad_outputs):
+    def backward(ctx: Any, *grad_outputs: Any) -> Any:
         key = id(Generated)
         grad_outputs_ = grad_outputs[:-1]
         grad_outputs_in_dims = ctx._pt_out_dims[key]
@@ -483,7 +539,7 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
             for grad_output, in_dim in zip(grad_outputs_, grad_outputs_in_dims)
         )
 
-        def backward_no_context(inputs):
+        def backward_no_context(inputs: Any) -> Any:
             saved_tensors, grad_outputs = inputs
             wrapped_ctx = CtxWithSavedTensors(ctx, saved_tensors)
             return autograd_function.backward(wrapped_ctx, *grad_outputs)
@@ -517,7 +573,7 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
 
 # tangents might be None, so we need to replace
 # the corresponding in_dims with None.
-def get_tangents_in_dims(input_dims, tangents):
+def get_tangents_in_dims(input_dims: Any, tangents: tuple[Any, ...]) -> Any:
     flat_in_dims, spec = pytree.tree_flatten(input_dims)
     flat_tangents = pytree.arg_tree_leaves(*tangents)
     result = [
@@ -583,7 +639,7 @@ def get_tangents_in_dims(input_dims, tangents):
 class WrappedCtx:
     _pt_reserved_attrs: tuple[str, ...] = ("_pt_reserved_attrs", "_pt_inner_ctx")
 
-    def __init__(self, ctx):
+    def __init__(self, ctx: Any) -> None:
         if not isinstance(ctx, WrappedCtx):
             reserved_attrs = type(self)._pt_reserved_attrs
             for name in reserved_attrs:
@@ -596,10 +652,10 @@ class WrappedCtx:
                 )
         self._pt_inner_ctx = ctx
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._pt_inner_ctx, name)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name in type(self)._pt_reserved_attrs:
             self.__dict__[name] = value
             return
@@ -610,12 +666,12 @@ class WrappedCtx:
 class CtxWithSavedTensors(WrappedCtx):
     _pt_reserved_attrs = ("_pt_new_saved_tensors", *WrappedCtx._pt_reserved_attrs)
 
-    def __init__(self, ctx, new_saved_tensors):
+    def __init__(self, ctx: Any, new_saved_tensors: Sequence[torch.Tensor]) -> None:
         super().__init__(ctx)
         self._pt_new_saved_tensors = new_saved_tensors
 
     @property
-    def saved_tensors(self):
+    def saved_tensors(self) -> Sequence[torch.Tensor]:
         return self._pt_new_saved_tensors
 
 
@@ -626,29 +682,29 @@ class CtxCustomSave(WrappedCtx):
         *WrappedCtx._pt_reserved_attrs,
     )
 
-    def __init__(self, ctx, current_level):
+    def __init__(self, ctx: Any, current_level: int) -> None:
         super().__init__(ctx)
-        self._pt_saved_tensors_bdims = ()
+        self._pt_saved_tensors_bdims: tuple[Any, ...] = ()
         self._pt_current_level = current_level
 
-    def save_for_backward(self, *tensors):
+    def save_for_backward(self, *tensors: torch.Tensor) -> None:
         unwrapped_tensors, bdims = unwrap_batched(tensors, self._pt_current_level)
         self._pt_inner_ctx.save_for_backward(*unwrapped_tensors)
         self._pt_saved_tensors_bdims = bdims
 
-    def save_for_forward(self, *tensors):
+    def save_for_forward(self, *tensors: torch.Tensor) -> None:
         unwrapped_tensors, bdims = unwrap_batched(tensors, self._pt_current_level)
         self._pt_inner_ctx.save_for_forward(*unwrapped_tensors)
         self._pt_saved_tensors_bdims = bdims
 
 
 def reductify(
-    grad_input,
-    grad_input_bdim,
-    input_bdim,
-    batch_size,
-    target_shape_without_bdim_to_reduce_to=None,
-):
+    grad_input: torch.Tensor | tuple[torch.Tensor, ...],
+    grad_input_bdim: int | tuple[int, ...],
+    input_bdim: int | tuple[int, ...],
+    batch_size: int,
+    target_shape_without_bdim_to_reduce_to: Any = None,
+) -> tuple[Any, ...]:
     if not isinstance(grad_input, tuple):
         grad_input = (grad_input,)
     if not isinstance(grad_input_bdim, tuple):
@@ -671,12 +727,12 @@ def reductify(
 
 
 def reductify_leaf(
-    grad_input,
-    grad_input_bdim,
-    input_bdim,
-    batch_size,
-    target_shape_without_bdim_to_reduce_to=None,
-):
+    grad_input: torch.Tensor | None,
+    grad_input_bdim: int | None,
+    input_bdim: int | None,
+    batch_size: int,
+    target_shape_without_bdim_to_reduce_to: Any = None,
+) -> torch.Tensor | None:
     if grad_input is None:
         return None
 
@@ -729,8 +785,11 @@ def reductify_leaf(
     return grad_input
 
 
-def autograd_function_forward_rewritten(original_forward, original_setup_context):
-    def new_forward(ctx, *args, **kwargs):
+def autograd_function_forward_rewritten(
+    original_forward: Callable[_P, _R],
+    original_setup_context: Callable[..., Any],
+) -> Callable[..., _R]:
+    def new_forward(ctx: Any, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         output = original_forward(*args, **kwargs)
         original_setup_context(ctx, args, output)
         return output
@@ -742,15 +801,21 @@ class AutogradFunctionApply(HigherOrderOperator):
     def __init__(self) -> None:
         super().__init__("autograd_function_apply")
 
-    def __call__(self, fwd, bwd, *fwd_args, **fwd_kwargs):
-        saved_values = None
+    def __call__(
+        self,
+        fwd: torch.fx.GraphModule,
+        bwd: torch.fx.GraphModule,
+        *fwd_args: Any,
+        **fwd_kwargs: Any,
+    ) -> Any:
+        saved_values: Iterable[Any] | None = None
         non_differentiable_idx = fwd_kwargs["non_differentiable_idx"]
         saved_for_backward_idx = fwd_kwargs["saved_for_backward_idx"]
 
         class ApplyTemplate(torch.autograd.Function):
             @staticmethod
             # pyrefly: ignore [bad-override]
-            def forward(ctx, *args):
+            def forward(ctx: Any, *args: Any) -> Any:
                 nonlocal saved_values
 
                 # The Interpreter here is required to propagate metadata
@@ -780,12 +845,12 @@ class AutogradFunctionApply(HigherOrderOperator):
                 return output
 
             @staticmethod
-            def backward(ctx, *grad):
+            def backward(ctx: Any, *grad: Any) -> Any:
                 # The Interpreter here is required to propagate metadata
                 # from the dynamo graph body to the local_map graph body.
                 # This is required for fx_traceback.annotate for work.
 
-                # pyrefly: ignore [not-iterable]
+                assert saved_values is not None
                 return torch.fx.Interpreter(bwd).run(*grad, *saved_values)
 
         return ApplyTemplate.apply(*fwd_args)
@@ -796,11 +861,11 @@ autograd_function_apply = AutogradFunctionApply()
 
 class DynamoAutogradFunctionTraceHelper:
     @staticmethod
-    def fwd_trace_helper(orig_fwd):
+    def fwd_trace_helper(orig_fwd: Callable[..., Any]) -> Callable[..., Any]:
         # autograd.Function forward does more than just running the forward method. Most
         # of this logic is in C++. Here, we rewrite that functionality in python and let
         # Dynamo trace it.
-        def inner(*args, **kwargs):
+        def inner(*args: Any, **kwargs: Any) -> Any:
             with torch.no_grad():
                 outs = orig_fwd(*args, **kwargs)
 

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 """
 The APIs in this file are exposed as `functorch.*`. They are thin wrappers
 around the torch.func.* APIs that have deprecation warnings -- we're trying
@@ -8,20 +7,28 @@ NB: We don't use *args, **kwargs in the signatures because that changes the
 documentation.
 """
 
+from __future__ import annotations
+
 import textwrap
 import warnings
-from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any, TYPE_CHECKING
 
 import torch._functorch.apis as apis
 import torch._functorch.eager_transforms as _impl
 import torch._functorch.make_functional as _nn_impl
 import torch.nn as nn
-from torch._functorch.eager_transforms import argnums_t
-from torch._functorch.vmap import in_dims_t, out_dims_t
 
 
-def get_warning(api, new_api=None, replace_newlines=False):
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch._functorch.eager_transforms import argnums_t
+    from torch._functorch.vmap import in_dims_t, out_dims_t
+
+
+def get_warning(
+    api: str, new_api: str | None = None, replace_newlines: bool = False
+) -> str:
     if new_api is None:
         new_api = f"torch.func.{api}"
     warning = (
@@ -37,12 +44,16 @@ def get_warning(api, new_api=None, replace_newlines=False):
     return warning
 
 
-def warn_deprecated(api, new_api=None):
+def warn_deprecated(api: str, new_api: str | None = None) -> None:
     warning = get_warning(api, new_api, replace_newlines=True)
     warnings.warn(warning, FutureWarning, stacklevel=3)
 
 
-def setup_docs(functorch_api, torch_func_api=None, new_api_name=None):
+def setup_docs(
+    functorch_api: Callable[..., Any],
+    torch_func_api: Callable[..., Any] | None = None,
+    new_api_name: str | None = None,
+) -> None:
     api_name = functorch_api.__name__
     if torch_func_api is None:
         torch_func_api = getattr(_impl, api_name)
@@ -57,54 +68,56 @@ def setup_docs(functorch_api, torch_func_api=None, new_api_name=None):
 
 
 def vmap(
-    func: Callable,
+    func: Callable[..., Any],
     in_dims: in_dims_t = 0,
     out_dims: out_dims_t = 0,
     randomness: str = "error",
     *,
-    chunk_size=None,
-) -> Callable:
+    chunk_size: int | None = None,
+) -> Callable[..., Any]:
     warn_deprecated("vmap", "torch.vmap")
     return apis.vmap(func, in_dims, out_dims, randomness, chunk_size=chunk_size)
 
 
-def grad(func: Callable, argnums: argnums_t = 0, has_aux: bool = False) -> Callable:
+def grad(
+    func: Callable[..., Any], argnums: argnums_t = 0, has_aux: bool = False
+) -> Callable[..., Any]:
     warn_deprecated("grad")
     return apis.grad(func, argnums, has_aux)
 
 
 def grad_and_value(
-    func: Callable, argnums: argnums_t = 0, has_aux: bool = False
-) -> Callable:
+    func: Callable[..., Any], argnums: argnums_t = 0, has_aux: bool = False
+) -> Callable[..., Any]:
     warn_deprecated("grad_and_value")
     return apis.grad_and_value(func, argnums, has_aux)
 
 
-def vjp(func: Callable, *primals, has_aux: bool = False):
+def vjp(func: Callable[..., Any], *primals: Any, has_aux: bool = False) -> Any:
     warn_deprecated("vjp")
     return _impl.vjp(func, *primals, has_aux=has_aux)
 
 
 def jvp(
-    func: Callable,
+    func: Callable[..., Any],
     primals: Any,
     tangents: Any,
     *,
     strict: bool = False,
     has_aux: bool = False,
-):
+) -> Any:
     warn_deprecated("jvp")
     return _impl.jvp(func, primals, tangents, strict=strict, has_aux=has_aux)
 
 
 def jacrev(
-    func: Callable,
-    argnums: Union[int, tuple[int, ...]] = 0,
+    func: Callable[..., Any],
+    argnums: int | tuple[int, ...] = 0,
     *,
-    has_aux=False,
-    chunk_size: Optional[int] = None,
-    _preallocate_and_copy=False,
-):
+    has_aux: bool = False,
+    chunk_size: int | None = None,
+    _preallocate_and_copy: bool = False,
+) -> Callable[..., Any]:
     warn_deprecated("jacrev")
     return _impl.jacrev(
         func,
@@ -116,39 +129,41 @@ def jacrev(
 
 
 def jacfwd(
-    func: Callable,
+    func: Callable[..., Any],
     argnums: argnums_t = 0,
     has_aux: bool = False,
     *,
     randomness: str = "error",
-):
+) -> Callable[..., Any]:
     warn_deprecated("jacfwd")
     return _impl.jacfwd(func, argnums, has_aux, randomness=randomness)
 
 
-def hessian(func, argnums=0):
+def hessian(func: Callable[..., Any], argnums: int = 0) -> Callable[..., Any]:
     warn_deprecated("hessian")
     return _impl.hessian(func, argnums=argnums)
 
 
-def functionalize(func: Callable, *, remove: str = "mutations") -> Callable:
+def functionalize(
+    func: Callable[..., Any], *, remove: str = "mutations"
+) -> Callable[..., Any]:
     warn_deprecated("functionalize")
     return _impl.functionalize(func, remove=remove)
 
 
-def make_functional(model: nn.Module, disable_autograd_tracking: bool = False):
+def make_functional(model: nn.Module, disable_autograd_tracking: bool = False) -> Any:
     warn_deprecated("make_functional", "torch.func.functional_call")
     return _nn_impl.make_functional(model, disable_autograd_tracking)
 
 
 def make_functional_with_buffers(
     model: nn.Module, disable_autograd_tracking: bool = False
-):
+) -> Any:
     warn_deprecated("make_functional_with_buffers", "torch.func.functional_call")
     return _nn_impl.make_functional_with_buffers(model, disable_autograd_tracking)
 
 
-def combine_state_for_ensemble(models):
+def combine_state_for_ensemble(models: list[nn.Module]) -> Any:
     warn_deprecated("combine_state_for_ensemble", "torch.func.stack_module_state")
     return _nn_impl.combine_state_for_ensemble(models)
 

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -1424,7 +1424,7 @@ def grad_and_value_impl(
     has_aux: bool,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-) -> tuple[Any, tuple[Any, Any]] | tuple[Any, Any]:
+) -> tuple[Any, Any]:
     with grad_increment_nesting() as level:
         output, aux, grad_input = None, None, None
         # See NOTE [grad and vjp interaction with no_grad]

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -1,6 +1,7 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -10,14 +11,14 @@ from torch._functorch.utils import exposed_in
 
 @exposed_in("torch.func")
 def functional_call(
-    module: "torch.nn.Module",
-    parameter_and_buffer_dicts: Union[dict[str, Tensor], Sequence[dict[str, Tensor]]],
-    args: Optional[Union[Any, tuple]] = None,
-    kwargs: Optional[dict[str, Any]] = None,
+    module: torch.nn.Module,
+    parameter_and_buffer_dicts: dict[str, Tensor] | Sequence[dict[str, Tensor]],
+    args: Any | tuple[Any, ...] | None = None,
+    kwargs: dict[str, Any] | None = None,
     *,
     tie_weights: bool = True,
     strict: bool = False,
-):
+) -> Any:
     r"""Performs a functional call on the module by replacing the module parameters
     and buffers with the provided ones.
 
@@ -162,7 +163,7 @@ def functional_call(
 
 @exposed_in("torch.func")
 def stack_module_state(
-    models: Union[Sequence[nn.Module], nn.ModuleList],
+    models: Sequence[nn.Module] | nn.ModuleList,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """stack_module_state(models) -> params, buffers
 
@@ -249,7 +250,7 @@ def stack_module_state(
 
 
 def construct_stacked_leaf(
-    tensors: Union[tuple[Tensor, ...], list[Tensor]], name: str
+    tensors: tuple[Tensor, ...] | list[Tensor], name: str
 ) -> Tensor:
     all_requires_grad = all(t.requires_grad for t in tensors)
     none_requires_grad = all(not t.requires_grad for t in tensors)

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -13,7 +13,7 @@ from torch._functorch.utils import exposed_in
 def functional_call(
     module: torch.nn.Module,
     parameter_and_buffer_dicts: dict[str, Tensor] | Sequence[dict[str, Tensor]],
-    args: Any | tuple[Any, ...] | None = None,
+    args: Any = None,
     kwargs: dict[str, Any] | None = None,
     *,
     tie_weights: bool = True,

--- a/torch/_functorch/make_functional.py
+++ b/torch/_functorch/make_functional.py
@@ -1,19 +1,22 @@
-# mypy: allow-untyped-defs
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import copy
-from collections.abc import Callable, Iterable, Sequence
-from typing import Any, NoReturn, Union
+from typing import Any, NoReturn, TYPE_CHECKING
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn.utils._named_member_accessor import NamedMemberAccessor
 
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
 
 # Utilities to make nn.Module "functional"
 # In particular the goal is to be able to provide a function that takes as input
@@ -31,8 +34,8 @@ def raise_parameter_tying_error() -> NoReturn:
 
 
 def create_names_map(
-    named_params: Union[dict[str, Tensor], Iterable[tuple[str, Tensor]]],
-    tied_named_params: Union[dict[str, Tensor], Iterable[tuple[str, Tensor]]],
+    named_params: dict[str, Tensor] | Iterable[tuple[str, Tensor]],
+    tied_named_params: dict[str, Tensor] | Iterable[tuple[str, Tensor]],
 ) -> dict[str, list[str]]:
     """
     named_params is a dictionary of tensors: {'A': A, 'B': B}
@@ -42,22 +45,18 @@ def create_names_map(
     This function creates a mapping from the names in named_params to the
     names in tied_named_params: {'A': ['A'], 'B': ['B', 'B_tied']}.
     """
-    # pyrefly: ignore [no-matching-overload]
-    named_params = dict(named_params)
-    # pyrefly: ignore [no-matching-overload]
-    tied_named_params = dict(tied_named_params)
+    named_params_dict = dict(named_params)
+    tied_named_params_dict = dict(tied_named_params)
 
-    tensors_dict_keys = set(named_params.keys())
-    tied_tensors_dict_keys = set(tied_named_params.keys())
+    tensors_dict_keys = set(named_params_dict.keys())
+    tied_tensors_dict_keys = set(tied_named_params_dict.keys())
     assert tensors_dict_keys.issubset(tied_tensors_dict_keys)
 
     tensor_to_mapping: dict[Tensor, tuple[str, list[str]]] = {}
-    for key, tensor in named_params.items():
-        # pyrefly: ignore [unsupported-operation]
+    for key, tensor in named_params_dict.items():
         tensor_to_mapping[tensor] = (key, [])
-    for key, tensor in tied_named_params.items():
+    for key, tensor in tied_named_params_dict.items():
         assert tensor in tensor_to_mapping
-        # pyrefly: ignore [bad-argument-type]
         tensor_to_mapping[tensor][1].append(key)
     return dict(tensor_to_mapping.values())
 
@@ -168,7 +167,9 @@ def load_state(
     return model
 
 
-def make_functional_deprecated_v1(model: nn.Module):
+def make_functional_deprecated_v1(
+    model: nn.Module,
+) -> tuple[tuple[Tensor, ...], Callable[..., Any], tuple[str, ...]]:
     """make_functional_deprecated_v1(model) -> weights, func, weight_names
 
     Given an nn.Module, make_functional_deprecated_v1 extracts the state (weights)
@@ -202,7 +203,7 @@ def make_functional_deprecated_v1(model: nn.Module):
         )
     weights, descriptors, _ = extract_weights(model)
 
-    def fun(weights, data):
+    def fun(weights: tuple[Tensor, ...], data: tuple[Any, ...]) -> Any:
         mutable_model = copy.deepcopy(model)
         load_weights(mutable_model, descriptors, weights)
         return mutable_model(*data)
@@ -210,7 +211,15 @@ def make_functional_deprecated_v1(model: nn.Module):
     return weights, fun, descriptors
 
 
-def make_functional_with_buffers_deprecated_v1(model: nn.Module):
+def make_functional_with_buffers_deprecated_v1(
+    model: nn.Module,
+) -> tuple[
+    tuple[Tensor, ...],
+    tuple[Tensor, ...],
+    Callable[..., Any],
+    tuple[str, ...],
+    tuple[str, ...],
+]:
     """make_functional_with_buffers_deprecated_v1(model) -> weights, buffers, func, weight_names, buffer_names
 
     Given an nn.Module, make_functional_with_buffers_deprecated_v1 extracts the state (weights and buffers)
@@ -238,7 +247,11 @@ def make_functional_with_buffers_deprecated_v1(model: nn.Module):
     weights, weight_descriptors, _ = extract_weights(model)
     buffers, buf_descriptors, _ = extract_buffers(model)
 
-    def fun(weights, buffers, data):
+    def fun(
+        weights: tuple[Tensor, ...],
+        buffers: tuple[Tensor, ...],
+        data: tuple[Any, ...],
+    ) -> Any:
         mutable_model = copy.deepcopy(model)
         load_weights(mutable_model, weight_descriptors, weights)
         load_buffers(mutable_model, buf_descriptors, buffers)
@@ -271,7 +284,7 @@ class FunctionalModuleWithBuffers(nn.Module):
     @staticmethod
     def _create_from(
         model: nn.Module, disable_autograd_tracking: bool = False
-    ) -> tuple["FunctionalModuleWithBuffers", tuple[Tensor, ...], tuple[Tensor, ...]]:
+    ) -> tuple[FunctionalModuleWithBuffers, tuple[Tensor, ...], tuple[Tensor, ...]]:
         # TODO: We don't need to copy the model to create a stateless copy
         model_copy = copy.deepcopy(model)
         params, param_names, param_names_map = extract_weights(model_copy)
@@ -288,7 +301,11 @@ class FunctionalModuleWithBuffers(nn.Module):
         )
 
     def forward(
-        self, params: Iterable[Tensor], buffers: Iterable[Tensor], *args, **kwargs
+        self,
+        params: Iterable[Tensor],
+        buffers: Iterable[Tensor],
+        *args: Any,
+        **kwargs: Any,
     ) -> Any:
         # Temporarily load the state back onto self.stateless_model
         old_state = _swap_state(
@@ -322,7 +339,7 @@ class FunctionalModule(nn.Module):
     @staticmethod
     def _create_from(
         model: nn.Module, disable_autograd_tracking: bool = False
-    ) -> tuple["FunctionalModule", tuple[Tensor, ...]]:
+    ) -> tuple[FunctionalModule, tuple[Tensor, ...]]:
         # TODO: We don't need to copy the model to create a stateless copy
         model_copy = copy.deepcopy(model)
         params, param_names, names_map = extract_weights(model_copy)
@@ -331,7 +348,7 @@ class FunctionalModule(nn.Module):
                 param.requires_grad_(False)
         return FunctionalModule(model_copy, param_names, names_map), params
 
-    def forward(self, params: Iterable[Tensor], *args, **kwargs) -> Any:
+    def forward(self, params: Iterable[Tensor], *args: Any, **kwargs: Any) -> Any:
         # Temporarily load the state back onto self.stateless_model
         old_state = _swap_state(self.stateless_model, self.names_map, params)
         try:
@@ -550,10 +567,12 @@ def combine_state_for_ensemble(
 
 def functional_init(
     model_class: type[nn.Module],
-    ensemble_shape: Union[tuple[()], tuple[int, ...]] = (),
+    ensemble_shape: tuple[()] | tuple[int, ...] = (),
     device: torch.types.Device = "cpu",
-):
-    def wrapped(*args, **kwargs):
+) -> Callable[..., tuple[tuple[Tensor, ...], Callable[..., Any], tuple[str, ...]]]:
+    def wrapped(
+        *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Tensor, ...], Callable[..., Any], tuple[str, ...]]:
         if len(ensemble_shape) >= 2:
             raise ValueError("NYI: ensemble_shape with more than 1 element")
         if len(ensemble_shape) == 0:
@@ -577,10 +596,31 @@ def functional_init(
 
 def functional_init_with_buffers(
     model_class: type[nn.Module],
-    ensemble_shape: Union[tuple[()], tuple[int, ...]] = (),
+    ensemble_shape: tuple[()] | tuple[int, ...] = (),
     device: torch.types.Device = "cpu",
-):
-    def wrapped(*args, **kwargs):
+) -> Callable[
+    ...,
+    tuple[
+        tuple[Tensor, ...],
+        tuple[Tensor, ...],
+        Callable[..., Any],
+        tuple[str, ...],
+        tuple[str, ...],
+    ]
+    | tuple[tuple[Tensor, ...], Callable[..., Any], tuple[str, ...]],
+]:
+    def wrapped(
+        *args: Any, **kwargs: Any
+    ) -> (
+        tuple[
+            tuple[Tensor, ...],
+            tuple[Tensor, ...],
+            Callable[..., Any],
+            tuple[str, ...],
+            tuple[str, ...],
+        ]
+        | tuple[tuple[Tensor, ...], Callable[..., Any], tuple[str, ...]]
+    ):
         if len(ensemble_shape) >= 2:
             raise ValueError("NYI: ensemble_shape with more than 1 element")
         if len(ensemble_shape) == 0:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1,4 +1,5 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import copy
 import functools
 import hashlib
@@ -14,7 +15,7 @@ import warnings
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch._inductor.inductor_prims
@@ -71,6 +72,7 @@ from .compile_utils import fx_graph_cse, get_aten_target, raise_getitems
 
 
 if TYPE_CHECKING:
+    import networkx as nx
     import sympy
 
 
@@ -91,19 +93,19 @@ class OpTypes:
     view_ops: OrderedSet[Callable]
     recomputable_ops: OrderedSet[Callable]
 
-    def is_fusible(self, node: fx.Node):
+    def is_fusible(self, node: fx.Node) -> bool:
         return get_aten_target(node) in self.fusible_ops
 
-    def is_compute_intensive(self, node: fx.Node):
+    def is_compute_intensive(self, node: fx.Node) -> bool:
         return get_aten_target(node) in self.compute_intensive_ops
 
-    def is_random(self, node: fx.Node):
+    def is_random(self, node: fx.Node) -> bool:
         return get_aten_target(node) in self.random_ops
 
-    def is_view(self, node: fx.Node):
+    def is_view(self, node: fx.Node) -> bool:
         return get_aten_target(node) in self.view_ops
 
-    def is_recomputable(self, node: fx.Node):
+    def is_recomputable(self, node: fx.Node) -> bool:
         return get_aten_target(node) in self.recomputable_ops
 
 
@@ -182,12 +184,12 @@ def sym_node_size(node: fx.Node) -> int:
 
 
 class InvalidNodeBase:
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Invalid Node"
 
 
 # Run DCE while overriding the definition of is_impure_node
-def is_not_collective(node):
+def is_not_collective(node: fx.Node) -> bool:
     return getattr(node.target, "namespace", None) != "_c10d_functional"
 
 
@@ -199,7 +201,7 @@ def _extract_graph_with_inputs_outputs(
     inputs: list[fx.Node],
     outputs: list[fx.Node],
     outputs_descs: list[AOTOutput],
-    subgraph: Optional[str] = None,
+    subgraph: str | None = None,
     ignore_must_be_in_fw_bw: bool = False,
 ) -> fx.Graph:
     """
@@ -362,7 +364,7 @@ def _must_be_in_backward(node: fx.Node) -> bool:
 
 
 def _extract_fwd_bwd_outputs(
-    joint_module: fx.GraphModule, *, num_fwd_outputs
+    joint_module: fx.GraphModule, *, num_fwd_outputs: int
 ) -> tuple[list[fx.Node], list[fx.Node], list[AOTOutput], list[AOTOutput]]:
     outputs = pytree.arg_tree_leaves(
         *(node.args for node in joint_module.graph.find_nodes(op="output"))
@@ -379,7 +381,7 @@ def _extract_fwd_bwd_outputs(
     return fwd_outputs, bwd_outputs, fwd_outputs_descs, bwd_outputs_descs
 
 
-def _remove_by_name(saved_values: list[fx.Node], name: str):
+def _remove_by_name(saved_values: list[fx.Node], name: str) -> None:
     for saved_value in saved_values:
         if saved_value.name == name:
             saved_values.remove(saved_value)
@@ -387,7 +389,7 @@ def _remove_by_name(saved_values: list[fx.Node], name: str):
 
 
 def find_first_sym_node(
-    fwd_module_outputs: Union[list[fx.Node], tuple[fx.Node, ...]],
+    fwd_module_outputs: list[fx.Node] | tuple[fx.Node, ...],
 ) -> int:
     idx = len(fwd_module_outputs)
     for i in range(len(fwd_module_outputs) - 1, -1, -1):
@@ -403,7 +405,7 @@ def calculate_quantization_scaling(
     max: float = 57344.0,
     min: float = 1e-12,
     position: int = 0,
-):
+) -> torch.fx.Node:
     with graph.inserting_after(node):
         abs_node = graph.call_function(
             torch.ops.aten.abs.default,
@@ -856,7 +858,7 @@ def enable_activation_quantization(
     saved_values: list[fx.Node],
     fwd_module: fx.GraphModule,
     bwd_module: fx.GraphModule,
-    static_lifetime_input_nodes: Optional[OrderedSet[fx.Node]] = None,
+    static_lifetime_input_nodes: OrderedSet[fx.Node] | None = None,
 ) -> None:
     if (
         inductor_config.post_grad_fusion_options.get(
@@ -905,7 +907,7 @@ def _extract_fwd_bwd_modules(
     saved_sym_nodes: list[fx.Node],
     *,
     num_fwd_outputs: int,
-    static_lifetime_input_nodes: Optional[OrderedSet[fx.Node]] = None,
+    static_lifetime_input_nodes: OrderedSet[fx.Node] | None = None,
 ) -> tuple[fx.GraphModule, fx.GraphModule]:
     fwd_outputs, bwd_outputs, fwd_outputs_descs, bwd_outputs_descs = (
         _extract_fwd_bwd_outputs(joint_module, num_fwd_outputs=num_fwd_outputs)
@@ -1062,11 +1064,11 @@ def _extract_fwd_bwd_modules(
 
 def default_partition(
     joint_module: fx.GraphModule,
-    _joint_inputs,
+    _joint_inputs: Any,
     *,
-    num_fwd_outputs,
-    static_lifetime_input_indices: Optional[list[int]] = None,
-    static_lifetime_input_nodes: Optional[OrderedSet[fx.Node]] = None,
+    num_fwd_outputs: int,
+    static_lifetime_input_indices: list[int] | None = None,
+    static_lifetime_input_nodes: OrderedSet[fx.Node] | None = None,
 ) -> tuple[fx.GraphModule, fx.GraphModule]:
     """
     Partitions the :attr:`joint_module` in a manner that closely resembles the
@@ -1141,18 +1143,18 @@ def default_partition(
 
     distributed_enabled = torch.distributed.is_available()
 
-    def is_tensor(node):
+    def is_tensor(node: fx.Node) -> bool:
         return "tensor_meta" in node.meta or isinstance(
             node.meta.get("val"), torch._subclasses.FakeTensor
         )
 
-    def is_multi_output(node):
+    def is_multi_output(node: fx.Node) -> bool:
         return (
             all(user.target == operator.getitem for user in node.users)
             and len(node.users) > 0
         )
 
-    def is_impure(node):
+    def is_impure(node: fx.Node) -> bool:
         # wait tensor is an "impure" op according to DCE's definition of impure
         # (see is_impure in torch/fx/node.py), but it survives past
         # functionalization and can be safely dup'd and reordered under the
@@ -1280,12 +1282,12 @@ def default_partition(
 INT_INF = int(1e6)
 
 
-def _tensor_nbytes(numel: int, dtype) -> int:
+def _tensor_nbytes(numel: int, dtype: torch.dtype) -> int:
     return numel * dtype.itemsize
 
 
 def _size_of(node: fx.Node) -> int:
-    def object_nbytes(x) -> int:
+    def object_nbytes(x: object) -> int:
         if not isinstance(x, torch.Tensor):
             return 0
         return _tensor_nbytes(size_hint(x.numel(), fallback=4096), x.dtype)
@@ -1313,7 +1315,7 @@ def _size_of(node: fx.Node) -> int:
 
 
 # Used for some investigative purposes
-def _count_ops(graph: fx.Graph):
+def _count_ops(graph: fx.Graph) -> None:
     from collections import defaultdict
 
     cnt: dict[str, int] = defaultdict(int)
@@ -1324,8 +1326,8 @@ def _count_ops(graph: fx.Graph):
 
 
 @functools.cache
-def pointwise_ops():
-    ops = []
+def pointwise_ops() -> list[torch._ops.OpOverloadPacket]:
+    ops: list[torch._ops.OpOverloadPacket] = []
     for attr_name in dir(torch.ops.aten):
         opoverloadpacket = getattr(torch.ops.aten, attr_name)
         if not isinstance(opoverloadpacket, torch._ops.OpOverloadPacket):
@@ -1341,7 +1343,9 @@ def pointwise_ops():
     return ops
 
 
-def sort_depths(args, depth_map: dict[fx.Node, int]) -> list[tuple[fx.Node, int]]:
+def sort_depths(
+    args: tuple[Any, ...], depth_map: dict[fx.Node, int]
+) -> list[tuple[fx.Node, int]]:
     arg_depths = {
         arg: depth_map[arg] for arg in args if isinstance(arg, torch.fx.node.Node)
     }
@@ -1380,7 +1384,7 @@ def reordering_to_mimic_autograd_engine(gm: fx.GraphModule) -> fx.GraphModule:
 
     order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
 
-    def insert_node_in_graph(node):
+    def insert_node_in_graph(node: fx.Node) -> None:
         cur_nodes = [node]
         insertable_nodes: OrderedSet[fx.Node] = OrderedSet()
         while len(cur_nodes) > 0:
@@ -1435,7 +1439,7 @@ def apply_graphsafe_rng_functionalization(
     rng_count: int,
     last_fwd_input: torch.fx.Node,
     last_bwd_input: torch.fx.Node,
-):
+) -> tuple[torch.fx.Node, torch.fx.Node]:
     """
     Note [CUDA Graph Safe RNG Functionalization]
 
@@ -1546,8 +1550,8 @@ def functionalize_rng_ops(
     # Unique id to generate name
     uid = itertools.count()
 
-    def get_rng_ops(gmod):
-        random_nodes = {}
+    def get_rng_ops(gmod: fx.GraphModule) -> dict[str, fx.Node]:
+        random_nodes: dict[str, fx.Node] = {}
         for node in gmod.graph.nodes:
             if (
                 node.op == "call_function"
@@ -1557,7 +1561,7 @@ def functionalize_rng_ops(
                 random_nodes[node.name] = node
         return random_nodes
 
-    def get_device(node) -> Optional[torch.device]:
+    def get_device(node: fx.Node) -> torch.device | None:
         """
         Check the example value of the node outputs to find the device type.
         """
@@ -1575,7 +1579,7 @@ def functionalize_rng_ops(
 
         return torch.device("cpu")
 
-    def get_sample_rng_state(device: Optional[torch.device]):
+    def get_sample_rng_state(device: torch.device | None) -> torch.Tensor:
         from torch._guards import detect_fake_mode  # noqa: F401
 
         fake_mode = detect_fake_mode()
@@ -1775,10 +1779,11 @@ def force_save_bw_mutation_src(joint_module: fx.GraphModule) -> None:
             break
 
 
-def is_getitem_of_multi_output(node):
+def is_getitem_of_multi_output(node: fx.Node) -> bool:
     if node.target != operator.getitem:
         return False
     parent = node.args[0]
+    assert type(parent) is fx.Node
     return "tensor_meta" not in parent.meta and node.op == "call_function"
 
 
@@ -1842,8 +1847,8 @@ def solve_min_cut(
     joint_graph: fx.Graph,
     node_info: NodeInfo,
     min_cut_options: MinCutOptions,
-    dont_ban: Optional[OrderedSet[fx.Node]] = None,
-):
+    dont_ban: OrderedSet[fx.Node] | None = None,
+) -> tuple[list[fx.Node], OrderedSet[fx.Node]]:
     if dont_ban is None:
         dont_ban = OrderedSet()
     op_types = get_default_op_list()
@@ -1859,15 +1864,18 @@ def solve_min_cut(
         )
         log.info("Ops banned from re-materialization: %s", ops_ignored)
 
-    def can_fuse_into_auto_functionalized(a, b):
+    def can_fuse_into_auto_functionalized(a: fx.Node, b: fx.Node) -> bool:
         if b.target != torch.ops.higher_order.auto_functionalized:
             return False
         mutable_op = b.args[0]
         (
             mutable_arg_names,
             _,
-        ) = torch._higher_order_ops.auto_functionalize.get_mutable_args(mutable_op)
-        for name in mutable_arg_names:
+        ) = torch._higher_order_ops.auto_functionalize.get_mutable_args(
+            # pyrefly: ignore[bad-argument-type]
+            mutable_op
+        )
+        for name in mutable_arg_names:  # pyrefly: ignore [not-iterable]
             arg = b.kwargs[name]
             if a is arg:
                 return True
@@ -1876,17 +1884,19 @@ def solve_min_cut(
                     return True
         return False
 
-    def can_fuse_into_triton_kernel_wrapper_functional(a, b):
+    def can_fuse_into_triton_kernel_wrapper_functional(a: fx.Node, b: fx.Node) -> bool:
         if b.target != torch.ops.higher_order.triton_kernel_wrapper_functional:
             return False
         mutable_arg_names = b.kwargs["tensors_to_clone"]
-        for name in mutable_arg_names:
-            arg = b.kwargs["kwargs"][name]
+        for name in mutable_arg_names:  # pyrefly: ignore [not-iterable]
+            kwargs: Any = b.kwargs["kwargs"]
+            assert kwargs is not None
+            arg = kwargs[name]
             if a is arg:
                 return True
         return False
 
-    def is_fusible(a, b):
+    def is_fusible(a: fx.Node, b: fx.Node) -> bool:
         # We can perform "memory fusion" into a cat, but cat cannot be a
         # producer to a fusion
         if get_aten_target(b) == aten.cat:
@@ -1897,7 +1907,7 @@ def solve_min_cut(
             return True
         if (
             a.target is operator.getitem
-            and a.args[0].target
+            and a.args[0].target  # pyrefly: ignore [missing-attribute]
             is torch.ops.higher_order.triton_kernel_wrapper_functional
         ):
             # if a is the output of a user triton kernel,
@@ -1912,7 +1922,7 @@ def solve_min_cut(
             "Need networkx installed to perform smart recomputation heuristics"
         ) from e
 
-    def is_materialized_backwards(node):
+    def is_materialized_backwards(node: fx.Node) -> bool:
         if op_types.is_view(node):
             return False
         cur_nodes = OrderedSet([node])
@@ -1926,7 +1936,7 @@ def solve_min_cut(
 
         return False
 
-    def should_ban_recomputation(node) -> Optional[str]:
+    def should_ban_recomputation(node: fx.Node) -> str | None:
         """Returns reason string if node should be banned from recomputation, None otherwise."""
         if node.op != "call_function":
             return None
@@ -1965,7 +1975,10 @@ def solve_min_cut(
         # modification appears to have made this heuristic a lot less critical
         # for performance.
         # NB: As of PR #121692, this hack no longer seems necessary.
-        if node.dist_from_bw < 1000 and node.dist_from_bw > config.max_dist_from_bw:
+        if (
+            # pyrefly: ignore [missing-attribute]
+            node.dist_from_bw < 1000 and node.dist_from_bw > config.max_dist_from_bw
+        ):
             return "too far from backward"
 
         # If the output of an op is 4x smaller (arbitrary choice),
@@ -1982,15 +1995,15 @@ def solve_min_cut(
                 return "reduction op"
         return None
 
-    def is_materialized(node):
+    def is_materialized(node: fx.Node) -> bool:
         if node.op == "placeholder":
             return True
 
         return not all(is_fusible(node, user) for user in node.users)
 
     def get_node_weight(
-        node, static_lifetime_input_nodes
-    ) -> tuple[float, Optional[str]]:
+        node: fx.Node, static_lifetime_input_nodes: OrderedSet[fx.Node]
+    ) -> tuple[float, str | None]:
         """Returns (weight, cannot_save_reason).
 
         cannot_save_reason is None for finite weights, or a string explaining
@@ -2019,7 +2032,10 @@ def solve_min_cut(
 
         # Heuristic to bias towards nodes closer to the backwards pass
         # Complete guess about current value
-        mem_sz = int(mem_sz * (1.1 ** max(min(node.dist_from_bw, 100), 1)))
+        mem_sz = int(
+            # pyrefly: ignore [missing-attribute]
+            mem_sz * (1.1 ** max(min(node.dist_from_bw, 100), 1))
+        )
         if is_materialized(node):
             return mem_sz, None
         else:
@@ -2028,7 +2044,7 @@ def solve_min_cut(
     nx_graph = nx.DiGraph()
     banned_nodes: OrderedSet[fx.Node] = OrderedSet()
 
-    def ban_recomputation_if_allowed(node, reason: str = ""):
+    def ban_recomputation_if_allowed(node: fx.Node, reason: str = "") -> bool:
         if op_types.is_view(node):
             return False
         if node in dont_ban:
@@ -2276,8 +2292,8 @@ def solve_min_cut(
         structured_tracing_enabled = bool(trace_log.handlers)
 
         # Dump the FX graph for debugging
-        fx_graph_file: Optional[str] = None
-        fx_graph_str: Optional[str] = None
+        fx_graph_file: str | None = None
+        fx_graph_str: str | None = None
         joint_module = joint_graph.owning_module
         try:
             fx_graph_str = (
@@ -2454,8 +2470,8 @@ def solve_min_cut(
 
 
 def _find_infinite_capacity_path(
-    nx_graph,
-) -> Optional[list[tuple[str, str, str]]]:
+    nx_graph: nx.DiGraph[str, dict[str, Any]],
+) -> list[tuple[str, str, str]] | None:
     """BFS from source to sink following only infinite-capacity edges.
 
     Returns a list of (from_node, to_node, reason) tuples representing the path,
@@ -2501,7 +2517,9 @@ def _get_unique_path(base_name: str, extension: str) -> str:
     return f"{base_name}_{counter}{extension}"
 
 
-def visualize_min_cut_graph(nx_graph) -> tuple[Optional[str], Optional[str]]:
+def visualize_min_cut_graph(
+    nx_graph: nx.DiGraph[str, dict[str, Any]],
+) -> tuple[str | None, str | None]:
     """Visualize the min-cut graph to an SVG file.
 
     Returns (path_to_svg, svg_content) tuple. Both are None if pydot is unavailable.
@@ -2706,8 +2724,8 @@ def get_default_op_list() -> OpTypes:
     )
 
 
-def get_name_to_node(graph: fx.Graph):
-    name_to_node = {}
+def get_name_to_node(graph: fx.Graph) -> dict[str, fx.Node]:
+    name_to_node: dict[str, fx.Node] = {}
     for node in graph.nodes:
         name_to_node[node.name] = node
     return name_to_node
@@ -2768,7 +2786,7 @@ from torch.utils._mode_utils import no_dispatch
 def _remove_symbols_without_guarding(x: torch.Tensor, fallback: int) -> torch.Tensor:
     shape = list(x.shape)
 
-    def realize_symbol(d):
+    def realize_symbol(d: torch.SymInt | int) -> int:
         return size_hint(d, fallback=fallback)
 
     shape = [realize_symbol(s) for s in shape]
@@ -2776,10 +2794,10 @@ def _remove_symbols_without_guarding(x: torch.Tensor, fallback: int) -> torch.Te
     return x.new_empty_strided(shape, stride=stride)
 
 
-def estimate_runtime(node):
+def estimate_runtime(node: fx.Node) -> float:
     RUNTIME_MODE = config.activation_memory_budget_runtime_estimator
 
-    def materialize_arg(x):
+    def materialize_arg(x: Any) -> Any:
         if isinstance(x, fx.Node) and isinstance(x.meta["val"], torch.Tensor):
             return _remove_symbols_without_guarding(x.meta["val"], fallback=4096)
         elif isinstance(x, fx.Node) and isinstance(x.meta["val"], torch.SymInt):
@@ -2799,6 +2817,7 @@ def estimate_runtime(node):
             from torch._inductor.runtime.benchmarking import benchmarker
 
             args, kwargs = pytree.tree_map(materialize_arg, (node.args, node.kwargs))
+            # pyrefly: ignore[not-callable]
             ms = benchmarker.benchmark_gpu(lambda: node.target(*args, **kwargs))
             return ms
 
@@ -2808,6 +2827,7 @@ def estimate_runtime(node):
 
         args, kwargs = pytree.tree_map(materialize_arg, (node.args, node.kwargs))
         with FlopCounterMode(display=False) as mode:
+            # pyrefly: ignore[not-callable]
             node.target(*args, **kwargs)
         counted_flops = mode.get_total_flops()
         return max(counted_flops, 1)
@@ -2822,7 +2842,7 @@ def estimate_runtime(node):
 def choose_saved_values_set(
     joint_graph: fx.Graph,
     node_info: NodeInfo,
-    memory_budget=1,
+    memory_budget: float = 1,
 ) -> list[fx.Node]:
     if memory_budget > 1 or memory_budget < 0:
         raise RuntimeError(
@@ -2865,10 +2885,10 @@ def choose_saved_values_set(
     if max_act_size <= min_act_size:
         return runtime_optimized_saved_values
 
-    def get_normalized_size(sz):
+    def get_normalized_size(sz: float) -> float:
         return (sz / 1e9) / (max_act_size - min_act_size)
 
-    def get_mem_ratio(activations: list[fx.Node]):
+    def get_mem_ratio(activations: list[fx.Node]) -> float:
         return (estimate_activations_size(activations) - min_act_size) / (
             max_act_size - min_act_size
         )
@@ -2943,7 +2963,9 @@ def choose_saved_values_set(
     ]
     from torch.utils._mode_utils import no_dispatch
 
-    def get_saved_values_knapsack(memory_budget, node_info, joint_graph):
+    def get_saved_values_knapsack(
+        memory_budget: float, node_info: NodeInfo, joint_graph: fx.Graph
+    ) -> tuple[list[fx.Node], float]:
         with no_dispatch():
             (
                 expected_runtime,
@@ -2991,7 +3013,7 @@ def choose_saved_values_set(
 
     if config.visualize_memory_budget_pareto:
 
-        def estimate_for_budget(b):
+        def estimate_for_budget(b: float) -> tuple[float, float, float]:
             saved_values, expected_runtime = get_saved_values_knapsack(
                 b, node_info=node_info, joint_graph=joint_graph
             )
@@ -3069,11 +3091,11 @@ def choose_saved_values_set(
 
 def _sync_decision_cross_ranks(
     joint_graph: torch.fx.Graph, saved_values: list[torch.fx.Node]
-):
+) -> list[torch.fx.Node]:
     # use the same policy across different GPUs
     from torch._subclasses.fake_tensor import unset_fake_temporarily
 
-    def has_collectives(joint_graph):
+    def has_collectives(joint_graph: torch.fx.Graph) -> bool:
         for node in joint_graph.nodes:
             if isinstance(
                 node.target, torch._ops.OpOverload
@@ -3081,7 +3103,7 @@ def _sync_decision_cross_ranks(
                 return True
         return False
 
-    def has_same_nodes(joint_graph):
+    def has_same_nodes(joint_graph: torch.fx.Graph) -> bool:
         # proxy to check if the graph is the same across different GPUs.
         # We only consider the name and order of nodes. A more robust way
         # would be to check the hash of the whole graph (disregarding input shapes),
@@ -3148,7 +3170,9 @@ def _sync_decision_cross_ranks(
     return saved_values
 
 
-def thread_graphsafe_rng_from_hops(module, is_backward):
+def thread_graphsafe_rng_from_hops(
+    module: fx.GraphModule, is_backward: bool
+) -> fx.GraphModule:
     """
     Graph-safe RNG lets torch.compile use CUDA Graphs for graphs with RNG ops.
     For graphs without HOPs, the partitioner adds placeholder nodes
@@ -3228,7 +3252,11 @@ def thread_graphsafe_rng_from_hops(module, is_backward):
     return module
 
 
-def classify_nodes(joint_module, static_lifetime_input_indices, num_fwd_outputs):
+def classify_nodes(
+    joint_module: fx.GraphModule,
+    static_lifetime_input_indices: list[int],
+    num_fwd_outputs: int,
+) -> NodeInfo:
     name_to_node = get_name_to_node(joint_module.graph)
     required_bw_nodes: OrderedSet[fx.Node] = OrderedSet()
     for node in joint_module.graph.nodes:
@@ -3291,11 +3319,11 @@ def classify_nodes(joint_module, static_lifetime_input_indices, num_fwd_outputs)
 
 def min_cut_rematerialization_partition(
     joint_module: fx.GraphModule,
-    _joint_inputs,
-    compiler="inductor",
+    _joint_inputs: Any,
+    compiler: str = "inductor",
     *,
-    num_fwd_outputs,
-    static_lifetime_input_indices: Optional[list[int]] = None,
+    num_fwd_outputs: int,
+    static_lifetime_input_indices: list[int] | None = None,
 ) -> tuple[fx.GraphModule, fx.GraphModule]:
     """
     Partitions the joint graph such that the backward recomputes the forward.
@@ -3464,9 +3492,9 @@ def draw_graph(
     fname: str,
     figname: str = "fx_graph",
     clear_meta: bool = True,
-    prog: Optional[Union[str, list[str]]] = None,
+    prog: str | list[str] | None = None,
     parse_stack_trace: bool = False,
-    dot_graph_shape: Optional[str] = None,
+    dot_graph_shape: str | None = None,
 ) -> None:
     if clear_meta:
         new_graph = copy.deepcopy(traced.graph)

--- a/torch/_functorch/pyfunctorch.py
+++ b/torch/_functorch/pyfunctorch.py
@@ -1,8 +1,9 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import contextlib
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
@@ -18,6 +19,10 @@ from torch._C._functorch import (
     TransformType,
 )
 from torch.autograd.forward_ad import _set_fwd_grad_enabled
+
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 """
@@ -53,41 +58,41 @@ interpreter then invokes.
 #
 # Keep the methods in sync with aten/src/ATen/functorch/Interpreter.h
 class FuncTorchInterpreter(ABC):
-    def __init__(self, cptr: Any):
+    def __init__(self, cptr: Any) -> None:
         self._cptr = cptr
 
     # Process an operation. eg for vmap, this is invoking a batching rule.
     # Conceptually this is analogous to Interpreter::process in C++
     @abstractmethod
-    def process(self, op, args, kwargs):
+    def process(self, op: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         pass
 
     # lower an operation from this Interpreter to the next Interpreter on the stack.
     # Concretely, this involves temporarily popping the current Interpreter.
     # Conceptually this is analogous to Interpreter::sendToNextInterpreter in C++
-    def lower(self):
+    def lower(self) -> contextlib.AbstractContextManager[Any]:
         return temporarily_pop_interpreter_stack()
 
-    def level(self):
+    def level(self) -> int:
         return self._cptr.level()
 
-    def key(self):
+    def key(self) -> TransformType:
         return self._cptr.key()
 
-    def get_state(self):
+    def get_state(self) -> tuple[Any, ...]:
         raise NotImplementedError
 
-    def check_state(self, state):
+    def check_state(self, state: tuple[Any, ...]) -> bool:
         return state == self.get_state()
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         state.pop("_cptr", None)
         return state
 
 
 @contextlib.contextmanager
-def temporarily_pop_interpreter_stack():
+def temporarily_pop_interpreter_stack() -> Generator[None, None, None]:
     try:
         saved = pop_dynamic_layer_stack()
         yield
@@ -96,8 +101,8 @@ def temporarily_pop_interpreter_stack():
 
 
 @contextlib.contextmanager
-def temporarily_clear_interpreter_stack():
-    stack = []
+def temporarily_clear_interpreter_stack() -> Generator[list[Any], None, None]:
+    stack: list[Any] = []
     try:
         while torch._C._functorch.peek_interpreter_stack() is not None:
             stack.append(pop_dynamic_layer_stack())
@@ -108,8 +113,12 @@ def temporarily_clear_interpreter_stack():
 
 
 @contextlib.contextmanager
-def temporarily_restore_interpreter_stack(stack):
-    pushed = []
+def temporarily_restore_interpreter_stack(
+    stack: list[Any] | None,
+) -> Generator[None, None, None]:
+    pushed: list[Any] = []
+    if stack is None:
+        return
     try:
         for s in reversed(stack):
             push_dynamic_layer_stack(s)
@@ -123,7 +132,7 @@ def temporarily_restore_interpreter_stack(stack):
 
 
 class VmapInterpreter(FuncTorchInterpreter):
-    def __init__(self, cdata: CInterpreter):
+    def __init__(self, cdata: CInterpreter) -> None:
         assert cdata.key() == TransformType.Vmap
         # NOTE: [Interpreter cdata vs cptr]
         # cdata is a generic CInterpreter. We wrap it in a CVmapInterpreterPtr
@@ -132,17 +141,17 @@ class VmapInterpreter(FuncTorchInterpreter):
 
     @cached_property
     # pyrefly: ignore [bad-override]
-    def _cptr(self):
+    def _cptr(self) -> CVmapInterpreterPtr:
         return CVmapInterpreterPtr(self._cdata)
 
-    def process(self, op, args, kwargs):
+    def process(self, op: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         kernel = op.functorch_table[TransformType.Vmap]
         return kernel(self, *args, **kwargs)
 
-    def batch_size(self):
+    def batch_size(self) -> int:
         return self._cptr.batchSize()
 
-    def randomness(self):
+    def randomness(self) -> str:
         typ = self._cptr.randomness()
         if typ == RandomnessType.Error:
             return "error"
@@ -152,12 +161,14 @@ class VmapInterpreter(FuncTorchInterpreter):
             return "different"
         raise RuntimeError(f"Unknown RandomnessType: {typ}")
 
-    def get_state(self):
+    def get_state(self) -> tuple[Any, ...]:
         return (self.key().name, self.level(), self.randomness())
 
 
 @contextlib.contextmanager
-def nested(*contexts):
+def nested(
+    *contexts: contextlib.AbstractContextManager[Any],
+) -> Generator[tuple[contextlib.AbstractContextManager[Any], ...], None, None]:
     with contextlib.ExitStack() as stack:
         for ctx in contexts:
             stack.enter_context(ctx)
@@ -165,23 +176,25 @@ def nested(*contexts):
 
 
 class GradInterpreter(FuncTorchInterpreter):
-    def __init__(self, cdata: CInterpreter):
+    def __init__(self, cdata: CInterpreter) -> None:
         assert cdata.key() == TransformType.Grad
         # See NOTE: [Interpreter cdata vs cptr]
         self._cdata = cdata
 
     @cached_property
     # pyrefly: ignore [bad-override]
-    def _cptr(self):
+    def _cptr(self) -> CGradInterpreterPtr:
         return CGradInterpreterPtr(self._cdata)
 
-    def lift(self, args, kwargs):
+    def lift(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = pytree.tree_map_only(
             torch.Tensor, self._cptr.lift, [args, kwargs]
         )
         return args, kwargs
 
-    def process(self, op, args, kwargs):
+    def process(self, op: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         kernel = op.functorch_table[TransformType.Grad]
         args, kwargs = self.lift(args, kwargs)
         return kernel(self, *args, **kwargs)
@@ -189,37 +202,39 @@ class GradInterpreter(FuncTorchInterpreter):
     # GradInterpreter has custom lower because of the no_grad interaction
     # See NOTE [grad and vjp interaction with no_grad]
     # This logic is mirrored from C++ GradInterpreterPtr::sendToNextInterpreter
-    def lower(self):
+    def lower(self) -> contextlib.AbstractContextManager[Any]:
         prev_grad_mode = self.prev_grad_mode()
         if not prev_grad_mode:
             return nested(torch.no_grad(), super().lower())
         return super().lower()
 
-    def prev_grad_mode(self):
+    def prev_grad_mode(self) -> bool:
         return self._cptr.prevGradMode()
 
-    def get_state(self):
+    def get_state(self) -> tuple[Any, ...]:
         return (self.key().name, self.level(), self.prev_grad_mode())
 
 
 class JvpInterpreter(FuncTorchInterpreter):
-    def __init__(self, cdata: CInterpreter):
+    def __init__(self, cdata: CInterpreter) -> None:
         assert cdata.key() == TransformType.Jvp
         # See NOTE: [Interpreter cdata vs cptr]
         self._cdata = cdata
 
     @cached_property
     # pyrefly: ignore [bad-override]
-    def _cptr(self):
+    def _cptr(self) -> CJvpInterpreterPtr:
         return CJvpInterpreterPtr(self._cdata)
 
-    def lift(self, args, kwargs):
+    def lift(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = pytree.tree_map_only(
             torch.Tensor, self._cptr.lift, [args, kwargs]
         )
         return args, kwargs
 
-    def process(self, op, args, kwargs):
+    def process(self, op: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         kernel = op.functorch_table[TransformType.Jvp]
         args, kwargs = self.lift(args, kwargs)
         return kernel(self, *args, **kwargs)
@@ -227,37 +242,37 @@ class JvpInterpreter(FuncTorchInterpreter):
     # Jvp has custom lower because of the no_fwd_grad interaction
     # See NOTE [grad and vjp interaction with no_grad] for related info.
     # This logic is mirrored from C++ JvpInterpreterPtr::sendToNextInterpreter
-    def lower(self):
+    def lower(self) -> contextlib.AbstractContextManager[Any]:
         prev_fwd_grad_mode = self.prev_fwd_grad_mode()
         if not prev_fwd_grad_mode:
             return nested(_set_fwd_grad_enabled(False), super().lower())
         return super().lower()
 
-    def prev_fwd_grad_mode(self):
+    def prev_fwd_grad_mode(self) -> bool:
         return self._cptr.prevFwdGradMode()
 
-    def get_state(self):
+    def get_state(self) -> tuple[Any, ...]:
         return (self.key().name, self.level(), self.prev_fwd_grad_mode())
 
 
 class FunctionalizeInterpreter(FuncTorchInterpreter):
-    def __init__(self, cdata: CInterpreter):
+    def __init__(self, cdata: CInterpreter) -> None:
         assert cdata.key() == TransformType.Functionalize
         self._cdata = cdata
 
     @cached_property
     # pyrefly: ignore [bad-override]
-    def _cptr(self):
+    def _cptr(self) -> CFunctionalizeInterpreterPtr:
         return CFunctionalizeInterpreterPtr(self._cdata)
 
-    def process(self, op, args, kwargs):
+    def process(self, op: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         kernel = op.functorch_table[TransformType.Functionalize]
         return kernel(self, *args, **kwargs)
 
-    def functionalize_add_back_views(self):
+    def functionalize_add_back_views(self) -> bool:
         return self._cptr.functionalizeAddBackViews()
 
-    def get_state(self):
+    def get_state(self) -> tuple[Any, ...]:
         return (self.key().name, self.level())
 
 
@@ -303,7 +318,7 @@ def compare_functorch_state(states: list[tuple[Any, ...]]) -> bool:
     )
 
 
-def dispatch_functorch(op, args, kwargs):
+def dispatch_functorch(op: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
     interpreter = retrieve_current_functorch_interpreter()
     # In traditional PyTorch operators, DispatchKey::FuncTorchTensorWrapper's
     # unwrap_dead_tensors fallback handles unwrapping dead tensor wrappers.

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2219,6 +2219,7 @@ def partition_fn(
                 joint_inputs,
                 compiler="inductor",
                 static_lifetime_input_indices=static_lifetime_input_indices,
+                # pyrefly: ignore[bad-argument-type]
                 **kwargs,
             )
     else:

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -782,7 +782,13 @@ class CustomOpDef:
                 def wrapped_func(keyset, *args, **kwargs):
                     interpreter = retrieve_current_functorch_interpreter()
                     return custom_function_call_vmap_helper(
-                        interpreter, self._vmap_fn, self._opoverload, *args, **kwargs
+                        # pyrefly: ignore[bad-argument-type]
+                        interpreter,
+                        # pyrefly: ignore[bad-argument-type]
+                        self._vmap_fn,
+                        self._opoverload,
+                        *args,
+                        **kwargs,
                     )
 
                 self._lib.impl(

--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -470,6 +470,7 @@ class _PTRRLoadBalancer(_LoadBalancer):
         indices = indices[ptrr_indices].view(B, -1)  # (B, qkv_size)
 
         if restore:
+            # pyrefly: ignore[missing-argument]
             indices = torch.vmap(torch.argsort)(indices)
 
         return indices

--- a/torch/library.py
+++ b/torch/library.py
@@ -1468,7 +1468,12 @@ def register_vmap(
         def wrapped_func(keyset, *args, **kwargs):
             interpreter = retrieve_current_functorch_interpreter()
             return custom_function_call_vmap_helper(
-                interpreter, func, op, *args, **kwargs
+                # pyrefly: ignore[bad-argument-type]
+                interpreter,
+                func,
+                op,
+                *args,
+                **kwargs,
             )
 
         lib.impl(opname, wrapped_func, "FuncTorchBatched", with_keyset=True)


### PR DESCRIPTION
Add comprehensive type annotations to 7 files in torch/_functorch that were previously missing type coverage. Each file now passes pyrefly check with stricter sub-config settings (implicit-any=true).

Files updated:

apis.py
autograd_function.py
deprecated.py
functional_call.py
make_functional.py
partitioners.py
pyfunctorch.py


Authored with help of Claude Code

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo