### PR TITLE
Fix: skip redundant precision emulation casts to avoid Triton PassManager crash [AI assisted Fix]

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -678,8 +678,16 @@ def make_pointwise(
                     out = load(index)
                     inp_dtype = inputs[inp_index].get_dtype()
                     if emulate_precision_casts and inp_dtype in low_pr_fp:
-                        downcast = ops.to_dtype(out, inp_dtype, use_compute_types=False)
-                        out = ops.to_dtype(downcast, inp_dtype)
+                        # Check if this value already has precision emulation applied.
+                        # If so, skip to avoid redundant bf16->fp32->bf16->fp32 chains
+                        # that can crash Triton's PassManager.
+                        already_emulated = getattr(out, "_precision_emulated", False)
+                        if not already_emulated:
+                            downcast = ops.to_dtype(
+                                out, inp_dtype, use_compute_types=False
+                            )
+                            out = ops.to_dtype(downcast, inp_dtype)
+                            out._precision_emulated = True
                     inputs_loaded.append(out)
 
                 out = fn(*inputs_loaded)
@@ -687,7 +695,10 @@ def make_pointwise(
                     # fp16/bf16 kernels are computed in fp32. Casting down to fp16/bf16 here,
                     # then upcasting again, to emulate casts that eager would do.
                     downcast = ops.to_dtype(out, dtype, use_compute_types=False)
-                    return ops.to_dtype(downcast, dtype)
+                    out = ops.to_dtype(downcast, dtype)
+                    # Mark output as precision-emulated so subsequent operations
+                    # don't add redundant input casts.
+                    out._precision_emulated = True
                 return out
 
         if not override_device:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -631,6 +631,10 @@ def make_pointwise(
     allow_alpha=False,
     triton_fallback=None,
 ):
+    """
+    Create a pointwise operation wrapper that applies a function element-wise across tensors.
+    """
+
     def inner(*inputs: TensorBox, alpha=None):
         if triton_fallback is not None and any(
             isinstance(inp, IRNode) and is_triton(inp) for inp in inputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173547

**Note: this seems reasonable to me i vet for the change**

**changes summary**
When emulate_precision_casts=True is enabled with bf16/fp16 tensors, the inductor was generating redundant type conversion chains (bf16→fp32→bf16→fp32→...) that crash Triton 3.6.0's PassManager during the make_ttgir phase.
before this PR some generated code samples where
```
    tmp53 = tmp52 * tmp47
    tmp54 = tmp53.to(tl.bfloat16)
    tmp55 = tmp54.to(tl.float32)
    tmp56 = tmp55.to(tl.bfloat16)
    tmp57 = tmp56.to(tl.float32)
    tmp59 = tmp58.to(tl.bfloat16)
    tmp60 = tmp59.to(tl.float32)
 ```
 this patter does not exist anymore ! 

Root cause: Both input and output precision emulation casts were being applied without tracking whether a value had already been cast. When an operation's output (which gets an output cast) becomes the input to another operation, it would receive another input cast, creating ever-longer conversion chains.

Fix: Track values that have already been precision-emulated using a _precision_emulated attribute. Skip input casts for values that already have this marker, and mark output-cast values so subsequent operations don't re-cast them.


I asked 
**is this mathematically true that if i already did the conversion then it become redundant**

AI

Yes, it's mathematically correct. Here's the proof:

Given:
- bf16(x) = truncate/round fp32 value x to bfloat16 precision
- fp32(y) = represent bf16 value y in float32 (lossless, every bf16 is exactly representable in fp32)

Key insight:
- fp32 → bf16 is lossy (reduces precision)
- bf16 → fp32 is lossless (exact representation)

Proof:

```
Let x be any fp32 value.
Step 1: bf16(x)           → rounds/truncates to bf16 precision
Step 2: fp32(bf16(x))     → same value, just in fp32 representation (lossless)
Step 3: bf16(fp32(bf16(x))) = bf16(x)   → already at bf16 precision, no change
Step 4: fp32(bf16(x))     → same as step 2
```

Therefore:

```fp32(bf16(fp32(bf16(x)))) ≡ fp32(bf16(x))```

The second bf16→fp32 pair is a no-op because:

- After the first bf16(x), the value has exactly bf16 precision
- Converting to fp32 doesn't add precision back (it's still "bf16 precision in fp32 container")
- Converting back to bf16 doesn't lose anything new (it's already at bf16 precision)
- Converting to fp32 again is the same as step 2

So yes, skipping redundant conversions is mathematically sound and preserves numerical correctness.
Fix https://github.com/pytorch/pytorch/issues/163874
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo