### PR TITLE
[RFC] Annotation Evaluation Error

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -585,7 +585,14 @@ def createResolutionCallbackForClassMethods(cls: type) -> Callable[[str], Any]:
     # Skip built-ins, as they do not have global scope nor type hints
     # Needed to support `enum.Enum` derived classes in Python-3.11
     # That adds `_new_member_` property which is an alias to `__new__`
-    fns = [fn for fn in fns if not inspect.isbuiltin(fn) and hasattr(fn, "__globals__")]
+    # Skip __annotate__ added by PEP 649 for deferred annotation evaluation
+    fns = [
+        fn
+        for fn in fns
+        if not inspect.isbuiltin(fn)
+        and hasattr(fn, "__globals__")
+        and fn.__name__ != "__annotate__"
+    ]
     captures = {}
 
     for fn in fns:


### PR DESCRIPTION
Summary:
When running dlrm in 3.14 I ran into this [crash](https://www.internalfb.com/phabricator/paste/view/P2139564584).

Python 3.14 implements PEP 649 deferred annotation evaluation. There is a strange interplay with when annotation functions are being evaluated and when they are calling `createResolutionCallbackForClassMethods`. The best I could think of was to just skip these annotation functions.

Test Plan: ci

Differential Revision: D91241734


