### PR TITLE
Update claude.md with coding style guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,23 @@ entirely.
 
 Disclose that the PR was authored with Claude.
 
+# Coding Style Guidelines
+
+Follow these rules for all code changes in this repository:
+
+- Minimize comments; code should be self-explanatory and self-documenting.
+- Prefer clear abstractions over helper functions.
+- Don't make trivial one-off helper functions.
+- State management should be explicit. For example, there should be a clear class definition
+  for an object in Python that has all of the members: don't dynamically `setattr` a field on an
+  object and then dynamically `getattr` the field on the object.
+- Match existing code style and architectural patterns.
+- Assume the reader has familiarity with PyTorch. They may not be the expert
+  on the code that is being read, but they should have some experience in the
+  area.
+
+If uncertain, choose the simpler, more concise implementation.
+
 # Dynamo Config
 
 Use `torch._dynamo.config.patch` for temporarily changing config. It can be used as a decorator on test methods or as a context manager:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ Disclose that the PR was authored with Claude.
 Follow these rules for all code changes in this repository:
 
 - Minimize comments; be concise; code should be self-explanatory and self-documenting.
-- Don't make trivial one-off helper functions.
+- Don't make trivial (1-2 LOC) helper functions that are only used once unless
+  it significantly improves code readability.
 - Prefer clear abstractions. State management should be explicit.
   For example, if managing state in a Python class: there should be a clear
   class definition that has all of the members: don't dynamically `setattr`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Disclose that the PR was authored with Claude.
 Follow these rules for all code changes in this repository:
 
 - Minimize comments; be concise; code should be self-explanatory and self-documenting.
+- Comments should be useful, for example, comments that remind the reader about
+  some global context that is non-obvious and can't be inferred locally.
 - Don't make trivial (1-2 LOC) helper functions that are only used once unless
   it significantly improves code readability.
 - Prefer clear abstractions. State management should be explicit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,12 @@ Disclose that the PR was authored with Claude.
 
 Follow these rules for all code changes in this repository:
 
-- Minimize comments; code should be self-explanatory and self-documenting.
-- Prefer clear abstractions over helper functions.
+- Minimize comments; be concise; code should be self-explanatory and self-documenting.
 - Don't make trivial one-off helper functions.
-- State management should be explicit. For example, there should be a clear class definition
-  for an object in Python that has all of the members: don't dynamically `setattr` a field on an
-  object and then dynamically `getattr` the field on the object.
+- Prefer clear abstractions. State management should be explicit.
+  For example, if managing state in a Python class: there should be a clear
+  class definition that has all of the members: don't dynamically `setattr`
+  a field on an object and then dynamically `getattr` the field on the object.
 - Match existing code style and architectural patterns.
 - Assume the reader has familiarity with PyTorch. They may not be the expert
   on the code that is being read, but they should have some experience in the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173549

My main opposition to claude-authored PRs is that extra commetns and
fluff distract from what the code is doing and this adds significant
review overhead.

I added some initial coding sytle guidelines. We'll see how well these
work. Feel free to keep updating.