### PR TITLE
[bucketing] Filter all-gathers and reduce-scatters by checking their recursive ancestors and users

### DIFF
--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -267,6 +267,54 @@ def is_wait_tensor_from_all_gather_into_tensor(node: torch.fx.Node) -> bool:
     return is_wait_tensor(node) and is_all_gather_into_tensor(node.args[0])  # type: ignore[arg-type]
 
 
+def is_fsdp_all_gather(
+    node: torch.fx.Node,
+    all_node_ancestors: dict[torch.fx.Node, OrderedSet[torch.fx.Node]],
+) -> bool:
+    """
+    Check if the node is a FSDP-related all_gather by its recursive ancestors.
+    On the path from the all-gather to its originate placeholder, there should not be any compute node
+    So there should be ONLY ONE placeholder in its recursive ancestors.
+    """
+    if not is_all_gather_into_tensor(node):
+        return False
+
+    seen_placeholders = 0
+    for ancestor in all_node_ancestors[node]:
+        if ancestor.op == "placeholder":
+            seen_placeholders += 1
+
+    return seen_placeholders == 1
+
+
+def is_fsdp_reduce_scatter(node: torch.fx.Node) -> bool:
+    """
+    Check if a reduce_scatter node is FSDP-related by verifying its output flows
+    directly to graph outputs through only unary ops (e.g., to_copy, wait).
+    """
+    if not is_reduce_scatter_tensor(node):
+        return False
+
+    visited: OrderedSet[torch.fx.Node] = OrderedSet()
+    stack = [node]
+
+    while stack:
+        curr = stack.pop()
+        if curr in visited:
+            continue
+        visited.add(curr)
+
+        for user in curr.users:
+            if user.op == "output":
+                continue
+            # Non-unary op means computation with external data
+            if len(user.all_input_nodes) != 1:
+                return False
+            stack.append(user)
+
+    return True
+
+
 def collect_node_descendants(
     graph: torch.fx.Graph,
 ) -> dict[torch.fx.Node, OrderedSet[torch.fx.Node]]:


### PR DESCRIPTION
This PR uses a better way to check whether an all-gather or a reduce-scatter in the graph comes from FSDP.

For a FSDP-related all-gather node, check its recursive ancestors up to placeholders, there should not be any compute node. So the recursive ancestors should contain only ONE placeholder

For a FSDP-related reduce-scatter node, check its recursive users down to outputs, there should not be any compute node. So recursive users inputs should not contain placeholder nodes. 

verified in torchtitan simple fsdp experiments:
```
CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.name simple_fsdp.llama3 --compile.enable --job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config --compile.backend "aot_eager" --compile.graph_passes "transformer_block_bucketing" --training.steps 200
```

profiling results for comm-compute overlap FSDP=8
<img width="1671" height="107" alt="Screenshot 2026-01-30 at 4 29 14 PM" src="https://github.com/user-attachments/assets/af4dbc04-cdaf-4087-bffc-19db9a0956c2" />


profiling results for comm-compute overlap FSDP=4, TP=2
<img width="1574" height="203" alt="Screenshot 2026-01-30 at 4 35 15 PM" src="https://github.com/user-attachments/assets/f3f33cee-2eba-452f-9c7b-9d2d707e7fd2" />



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo