### PR TITLE
Add foreach_groups optimization to _pre_bucket_all_gather

### DIFF
--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -59,6 +59,41 @@ def _ar_group_key(node: torch.fx.Node) -> tuple[str, str, torch.dtype]:
     return (group_name, reduce_op, dtype)
 
 
+def _compute_foreach_groups(
+    ag_ins: list[torch.Tensor],
+    out_dtypes: list[torch.dtype],  # type: ignore[name-defined]
+) -> list[int] | None:
+    """
+    Compute groups of indices that have the same src/dst dtype and shape.
+
+    Groups tensors by (src_dtype, dst_dtype, shape) to avoid falling back to the foreach slow path.
+
+    Returns a flat list with -1 as group delimiter, or None if only one group exists.
+    For example, groups [[0, 2], [1]] would be encoded as [0, 2, -1, 1].
+    """
+    from torch.fx.experimental.symbolic_shapes import size_hint
+
+    groups: defaultdict[tuple[torch.dtype, torch.dtype, tuple[int, ...]], list[int]] = (
+        defaultdict(list)
+    )
+    for i, (ag_in, out_dtype) in enumerate(zip(ag_ins, out_dtypes)):
+        shape = tuple(size_hint(s) for s in ag_in.shape)
+        key = (ag_in.dtype, out_dtype, shape)
+        groups[key].append(i)
+
+    if len(groups) <= 1:
+        return None
+
+    # Encode as flat list with -1 as delimiter
+    result: list[int] = []
+    for i, group_indices in enumerate(groups.values()):
+        result.extend(group_indices)
+        if i < len(groups) - 1:
+            result.append(-1)
+
+    return result
+
+
 def _schedulable_wait_node(node: torch.fx.Node) -> bool:
     """
     Add additional check on if the wait node is schedulable
@@ -561,6 +596,7 @@ def _pre_bucket_all_gather(
         int
     ],  # dtype enum values, that inputs are converted to before all_gather
     rank: int,
+    foreach_group_indices: list[int] | None = None,
 ) -> torch.Tensor:
     """
     Pre-bucket all gather operation.
@@ -572,6 +608,8 @@ def _pre_bucket_all_gather(
         dtype: Target dtype for the bucket
         out_dtype_ints: Dtype enum values for each input
         rank: Current rank
+        foreach_group_indices: Optional flat list of grouped indices with -1 as delimiter.
+            E.g., [0, 2, -1, 1] means groups [[0, 2], [1]].
     """
     # Convert int indices back to torch.dtype
     out_dtypes = [_ALL_DTYPES[d] for d in out_dtype_ints]
@@ -596,24 +634,28 @@ def _pre_bucket_all_gather(
     ]
     ag_ins_flattened = [ag_in.reshape(-1) for ag_in in ag_ins]
 
-    # Group foreach_copy calls by same src/dst dtype and numel for better performance
-    # At runtime tensors are concrete so we can use numel() directly
-    # TODO: pre-compute groups, but custom ops don't support list[list[int]]
-    groups: defaultdict[tuple[torch.dtype, torch.dtype, int], list[int]] = defaultdict(
-        list
-    )
-    for i, (ag_in, out_dtype) in enumerate(zip(ag_ins_flattened, out_dtypes)):
-        key = (ag_in.dtype, out_dtype, ag_in.numel())
-        groups[key].append(i)
+    # Parse pre-computed groups from flat list with -1 delimiters
+    if foreach_group_indices is not None:
+        groups_list: list[list[int]] = []
+        current_group: list[int] = []
+        for idx in foreach_group_indices:
+            if idx == -1:
+                if current_group:
+                    groups_list.append(current_group)
+                    current_group = []
+            else:
+                current_group.append(idx)
+        # Add last group if not empty
+        if current_group:
+            groups_list.append(current_group)
 
-    if len(groups) > 1:
-        # Multiple groups - call foreach_copy_ per group for better performance
-        for group_indices in groups.values():
+        # Call foreach_copy_ per group
+        for group_indices in groups_list:
             group_dsts = [foreach_copy_dsts_typed[idx] for idx in group_indices]
             group_srcs = [ag_ins_flattened[idx] for idx in group_indices]
             torch._foreach_copy_(group_dsts, group_srcs)
     else:
-        # Single group - call foreach_copy_ once
+        # No grouping provided - single foreach_copy_ call
         torch._foreach_copy_(foreach_copy_dsts_typed, ag_ins_flattened)
     return new_ag_out
 
@@ -625,6 +667,7 @@ def _pre_bucket_all_gather_fake(
     dtype: torch.dtype,  # type: ignore[name-defined]
     out_dtype_ints: list[int],
     rank: int,
+    foreach_group_indices: list[int] | None = None,
 ) -> torch.Tensor:
     out_dtypes = [_ALL_DTYPES[d] for d in out_dtype_ints]
     ins_split_sizes_bytes = [
@@ -670,6 +713,9 @@ def all_gather_merge_fn_to_trace_custom_ops(
     # TODO: custom ops support list[dtype] input
     out_dtype_ints = [_ALL_DTYPES.index(dt) for dt in out_dtypes]
 
+    # Pre-compute foreach groups for better foreach_copy_ performance
+    foreach_group_indices = _compute_foreach_groups(ag_ins, out_dtypes)
+
     new_ag_out = torch.ops.bucketing._pre_bucket_all_gather(
         ag_ins,
         group_size,
@@ -677,6 +723,7 @@ def all_gather_merge_fn_to_trace_custom_ops(
         dtype,
         out_dtype_ints,
         rank,
+        foreach_group_indices,
     )
     new_ag_in = new_ag_out.narrow(0, ag_input_numel * rank, ag_input_numel)
     wait_tensor = torch.ops.c10d_functional.wait_tensor(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173554
* #172951

Groups tensors by (src_dtype, dst_dtype, numel) at runtime to avoid `foreach_copy` falling back to individual kernels per input.

Works around https://github.com/pytorch/pytorch/issues/173383

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo