### PR TITLE
[ROCm] Resolve build issue due to flatbuffers version

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1792,8 +1792,8 @@ if(USE_ROCM)
     endif()
   endif()
   # Since PyTorch files contain HIP headers, this is also needed to capture the includes.
-  # ROCM_INCLUDE_DIRS is defined in LoadHIP.cmake
-  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE} ${ROCM_INCLUDE_DIRS})
+  # ROCM_INCLUDE_DIRS is defined in LoadHIP.cmake and added as SYSTEM includes in cmake/Dependencies.cmake
+  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE})
   target_include_directories(torch_hip INTERFACE $<INSTALL_INTERFACE:include>)
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1101,6 +1101,12 @@ if(USE_ROCM)
   else()
     caffe2_update_option(USE_ROCM OFF)
   endif()
+
+  # Add ROCm includes as SYSTEM includes (lower priority than regular includes).
+  # This ensures third_party vendored headers take precedence over ROCm headers.
+  if(USE_ROCM AND ROCM_INCLUDE_DIRS)
+    include_directories(SYSTEM ${ROCM_INCLUDE_DIRS})
+  endif()
 endif()
 
 # ---[ NCCL


### PR DESCRIPTION
When building PyTorch with the latest 7.11.0 ROCm tarballs (not wheels), the ROCm SDK headers in /opt/rocm-7.11.0/include were being searched before PyTorch's vendored third-party headers. This caused build failures when ROCm ships newer versions of libraries than what PyTorch's generated code expects (e.g., flatbuffers 25.x vs 24.x).

Error snippet:
```
In file included from /app/pytorch/torch/csrc/jit/mobile/flatbuffer_loader.cpp:55:
/app/pytorch/torch/csrc/jit/serialization/mobile_bytecode_generated.h:11:41: error: static assertion failed: Non-compatible flatbuffers version included
   11 | static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
```
New rocm include headers location:
```
    40  -I/app/pytorch/build/third_party/onnx
    41  -I/app/pytorch/third_party/flatbuffers/include
    42  -isystem /opt/rocm-7.11.0/include
    43  -isystem /app/pytorch/build/third_party/gloo
    44  -isystem /app/pytorch/cmake/../third_party/gloo
```

Old:
```
I/app/pytorch/build -I/app/pytorch -I/opt/rocm-7.11.0/include
...
I/app/pytorch/third_party/flatbuffers/include -isystem 
```
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang