### PR TITLE
[precompile] Serialize triton kernel side table for bundled AOT artifacts

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1617,6 +1617,75 @@ from user code:
             c10d.destroy_process_group()
 
 
+class TestTritonKernelSerialization(torch._inductor.test_case.TestCase):
+    """Tests for triton kernel side table serialization."""
+
+    def test_kernel_side_table_serialization_roundtrip(self):
+        """
+        Test that the kernel_side_table is properly serialized and restored.
+
+        This test verifies that when we serialize the triton kernel side table
+        and then clear it (simulating a new process), deserialization properly
+        restores the kernels so they can be looked up by index.
+
+        Without this fix, deserialization in a new process would fail with:
+            AssertionError: Kernel index X not found in id_to_kernel
+        """
+        from torch._dynamo.aot_compile_types import (
+            _deserialize_triton_kernel,
+            _serialize_triton_kernel,
+        )
+        from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+
+        # Create a mock kernel-like object that mimics triton JITFunction structure.
+        # Triton JITFunction has a `fn` attribute pointing to the wrapped function.
+        class MockTritonKernel:
+            def __init__(self, fn):
+                self.fn = fn
+
+        # Use a real importable function (torch.sin) as the wrapped function
+        mock_kernel = MockTritonKernel(torch.sin)
+
+        # Add the kernel to the side table (this is what dynamo does during tracing)
+        kernel_idx = kernel_side_table.add_kernel(mock_kernel)
+
+        # Add some constant args too
+        const_args = {"BLOCK_SIZE": 128, "num_warps": 4}
+        const_args_idx = kernel_side_table.add_constant_args(const_args)
+
+        # Simulate serialization: capture the kernel side table state
+        triton_kernels = {}
+        triton_constant_args = {}
+        for idx, kernel in kernel_side_table.id_to_kernel.items():
+            triton_kernels[idx] = _serialize_triton_kernel(kernel)
+        for idx, args in kernel_side_table.constant_args.items():
+            triton_constant_args[idx] = args
+
+        # Simulate a new process by clearing the side table
+        kernel_side_table.reset_table()
+
+        # Verify the table is empty - looking up the kernel should fail
+        with self.assertRaisesRegex(AssertionError, "not found in id_to_kernel"):
+            kernel_side_table.get_kernel(kernel_idx)
+
+        # Simulate deserialization: restore the kernel side table
+        for idx, kernel_info in triton_kernels.items():
+            restored_kernel = _deserialize_triton_kernel(kernel_info)
+            kernel_side_table.id_to_kernel[idx] = restored_kernel
+            kernel_side_table.kernel_to_id[restored_kernel] = idx
+
+        for idx, args in triton_constant_args.items():
+            kernel_side_table.constant_args[idx] = args
+
+        # Now the kernel lookup should succeed
+        restored = kernel_side_table.get_kernel(kernel_idx)
+        # The restored kernel is torch.sin (the underlying function), not the mock wrapper
+        self.assertIs(restored, torch.sin)
+
+        # Constant args should also be restored
+        self.assertEqual(kernel_side_table.constant_args[const_args_idx], const_args)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1654,12 +1654,11 @@ class TestTritonKernelSerialization(torch._inductor.test_case.TestCase):
         const_args_idx = kernel_side_table.add_constant_args(const_args)
 
         # Simulate serialization: capture the kernel side table state
-        triton_kernels = {}
-        triton_constant_args = {}
-        for idx, kernel in kernel_side_table.id_to_kernel.items():
-            triton_kernels[idx] = _serialize_triton_kernel(kernel)
-        for idx, args in kernel_side_table.constant_args.items():
-            triton_constant_args[idx] = args
+        triton_kernels = {
+            idx: _serialize_triton_kernel(kernel)
+            for idx, kernel in kernel_side_table.id_to_kernel.items()
+        }
+        triton_constant_args = dict(kernel_side_table.constant_args)
 
         # Simulate a new process by clearing the side table
         kernel_side_table.reset_table()

--- a/torch/_dynamo/aot_compile_types.py
+++ b/torch/_dynamo/aot_compile_types.py
@@ -1,8 +1,76 @@
 import abc
+import importlib
 import pickle
 from typing import Any
 
 import torch
+
+
+def _serialize_triton_kernel(kernel: Any) -> tuple[str, str]:
+    """
+    Serialize a triton kernel by extracting its module path and function name.
+    Returns (module_path, function_name) tuple.
+
+    Triton JITFunction objects contain unpicklable _thread.RLock objects, so we
+    serialize the import path instead and reimport on load.
+
+    Raises:
+        RuntimeError: If the kernel cannot be serialized (missing attributes).
+    """
+    fn = getattr(kernel, "fn", None)
+    if fn is None:
+        raise RuntimeError(
+            f"Kernel {kernel} has no 'fn' attribute. "
+            f"Cannot serialize for precompilation."
+        )
+    module_path = getattr(fn, "__module__", None)
+    func_name = getattr(fn, "__name__", None)
+    if module_path is None or func_name is None:
+        raise RuntimeError(
+            f"Kernel fn missing __module__ or __name__: "
+            f"module={module_path}, name={func_name}. "
+            f"Cannot serialize for precompilation."
+        )
+    return (module_path, func_name)
+
+
+def _deserialize_triton_kernel(kernel_info: tuple[str, str]) -> Any:
+    """
+    Deserialize a triton kernel by reimporting from its module.
+    kernel_info is (module_path, function_name) tuple.
+    """
+    module_path, func_name = kernel_info
+    module = importlib.import_module(module_path)
+    kernel = getattr(module, func_name)
+    return kernel
+
+
+# Note: [Triton Kernel Side Table Serialization]
+#
+# When dynamo captures user-defined triton kernels, it creates FX graph nodes
+# (triton_kernel_wrapper_mutation/functional) with a `kernel_idx` parameter that
+# references the global `kernel_side_table` in triton_kernel_wrap.py. This side
+# table maps integer indices to actual triton kernel objects.
+#
+# For kernels that go through inductor's codegen path, this is fine - inductor
+# looks up the kernel from the side table at codegen time and embeds the kernel
+# source code directly into the generated wrapper. The compiled code doesn't
+# need the side table at runtime.
+#
+# However, not all triton kernels go through inductor codegen. When using
+# regional_inductor, only annotated regions are compiled by inductor. Triton
+# kernels outside these regions are executed via the FX interpreter, which
+# calls the higher-order op directly and needs the kernel to be in the side
+# table at runtime.
+#
+# When serializing/deserializing bundled AOT artifacts across process boundaries,
+# the kernel_side_table is empty in the new process, causing:
+#   AssertionError: Kernel index X not found in id_to_kernel
+#
+# To fix this, we capture the kernel_side_table state during serialization and
+# restore it during deserialization. Kernels are serialized by their import path
+# (module_path, function_name) since triton JITFunction objects contain
+# unpicklable RLock objects.
 
 
 class SerializableCallable(abc.ABC):
@@ -46,8 +114,24 @@ class BundledAOTAutogradSerializableCallable(SerializableCallable):
     def serialize_compile_artifacts(
         cls, fn: "BundledAOTAutogradSerializableCallable"
     ) -> bytes:
+        from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+
+        # See Note: [Triton Kernel Side Table Serialization]
+        # Capture triton kernel side table state BEFORE serialization.
+        triton_kernels: dict[int, tuple[str, str]] = {}
+        triton_constant_args: dict[int, dict[str, Any]] = {}
+
+        for idx, kernel in kernel_side_table.id_to_kernel.items():
+            triton_kernels[idx] = _serialize_triton_kernel(kernel)
+
+        for idx, args in kernel_side_table.constant_args.items():
+            triton_constant_args[idx] = args
+
         with torch._functorch.config.patch("bundled_autograd_cache", True):
-            result = pickle.dumps(fn.compiled_fn.serialize())
+            serialized_entry = fn.compiled_fn.serialize()
+            # Bundle the triton kernel side table with the serialized entry
+            bundle = (serialized_entry, triton_kernels, triton_constant_args)
+            result = pickle.dumps(bundle)
             return result
 
     @classmethod
@@ -55,8 +139,31 @@ class BundledAOTAutogradSerializableCallable(SerializableCallable):
         from torch._functorch._aot_autograd.aot_autograd_result import (
             deserialize_bundled_cache_entry,
         )
+        from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
-        entry = pickle.loads(data)
+        bundle = pickle.loads(data)
+
+        # Handle both old format (just entry) and new format (entry, kernels, const_args)
+        if isinstance(bundle, tuple) and len(bundle) == 3:
+            entry, triton_kernels, triton_constant_args = bundle
+        else:
+            # Backwards compatibility with old serialized artifacts
+            entry = bundle
+            triton_kernels = {}
+            triton_constant_args = {}
+
+        # See Note: [Triton Kernel Side Table Serialization]
+        # Restore triton kernel side table BEFORE deserializing the compiled function.
+        # The compiled function may reference kernels by index if any triton kernels
+        # don't go through inductor codegen (e.g., triton kernels outside of
+        # regional_inductor compiled regions).
+        for idx, kernel_info in triton_kernels.items():
+            kernel = _deserialize_triton_kernel(kernel_info)
+            kernel_side_table.id_to_kernel[idx] = kernel
+            kernel_side_table.kernel_to_id[kernel] = idx
+
+        for idx, args in triton_constant_args.items():
+            kernel_side_table.constant_args[idx] = args
 
         compiled_fn = deserialize_bundled_cache_entry(entry)
         return cls(compiled_fn)

--- a/torch/_dynamo/aot_compile_types.py
+++ b/torch/_dynamo/aot_compile_types.py
@@ -118,14 +118,13 @@ class BundledAOTAutogradSerializableCallable(SerializableCallable):
 
         # See Note: [Triton Kernel Side Table Serialization]
         # Capture triton kernel side table state BEFORE serialization.
-        triton_kernels: dict[int, tuple[str, str]] = {}
-        triton_constant_args: dict[int, dict[str, Any]] = {}
-
-        for idx, kernel in kernel_side_table.id_to_kernel.items():
-            triton_kernels[idx] = _serialize_triton_kernel(kernel)
-
-        for idx, args in kernel_side_table.constant_args.items():
-            triton_constant_args[idx] = args
+        triton_kernels: dict[int, tuple[str, str]] = {
+            idx: _serialize_triton_kernel(kernel)
+            for idx, kernel in kernel_side_table.id_to_kernel.items()
+        }
+        triton_constant_args: dict[int, dict[str, Any]] = dict(
+            kernel_side_table.constant_args
+        )
 
         with torch._functorch.config.patch("bundled_autograd_cache", True):
             serialized_entry = fn.compiled_fn.serialize()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173667
* __->__ #173556

When serializing bundled AOT artifacts across process boundaries, the
kernel_side_table in triton_kernel_wrap.py is empty in the new process,
causing "Kernel index X not found in id_to_kernel" errors for triton
kernels that don't go through inductor codegen (e.g., kernels outside
regional_inductor compiled regions).

This change captures and restores the kernel_side_table state during
serialization/deserialization. Triton kernels are serialized by their
import path (module_path, function_name) since JITFunction objects
contain unpicklable RLock objects.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo