### PR TITLE
[Profiler] Add callback mechanism for export_chrome_trace

### DIFF
--- a/test/profiler/test_profiler_utilization_hook.py
+++ b/test/profiler/test_profiler_utilization_hook.py
@@ -1,3 +1,4 @@
+# Owner(s): ["module: profiler"]
 """
 Test the profiler export_chrome_trace callback mechanism.
 """

--- a/test/profiler/test_profiler_utilization_hook.py
+++ b/test/profiler/test_profiler_utilization_hook.py
@@ -1,0 +1,125 @@
+"""
+Test the profiler export_chrome_trace callback mechanism.
+"""
+
+import json
+import os
+import tempfile
+
+import torch
+from torch.profiler import register_export_chrome_trace_callback, _export_chrome_trace_callbacks
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestExportChromeTraceCallbacks(TestCase):
+    """Test the export_chrome_trace callback mechanism."""
+
+    def setUp(self):
+        # Clear callbacks before each test
+        _export_chrome_trace_callbacks.clear()
+
+    def tearDown(self):
+        _export_chrome_trace_callbacks.clear()
+
+    def test_callback_registration(self):
+        """Test that callbacks can be registered and removed."""
+        from torch.profiler import unregister_export_chrome_trace_callback
+
+        def my_callback(data):
+            return data
+
+        self.assertEqual(len(_export_chrome_trace_callbacks), 0)
+        register_export_chrome_trace_callback(my_callback)
+        self.assertEqual(len(_export_chrome_trace_callbacks), 1)
+
+        # Test unregister works
+        unregister_export_chrome_trace_callback(my_callback)
+        self.assertEqual(len(_export_chrome_trace_callbacks), 0)
+
+    def test_callback_modifies_trace(self):
+        """Test that registered callbacks modify the trace."""
+        from torch.profiler import profile, ProfilerActivity
+
+        def add_marker(data):
+            data["test_marker"] = "callback_ran"
+            return data
+
+        register_export_chrome_trace_callback(add_marker)
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+
+        try:
+            with profile(activities=[ProfilerActivity.CPU]) as prof:
+                x = torch.randn(10, 10)
+                _ = x + x
+
+            prof.export_chrome_trace(trace_path)
+
+            with open(trace_path) as f:
+                data = json.load(f)
+
+            self.assertEqual(data.get("test_marker"), "callback_ran")
+
+        finally:
+            os.unlink(trace_path)
+
+    def test_multiple_callbacks_run_in_order(self):
+        """Test that multiple callbacks run in registration order."""
+        from torch.profiler import profile, ProfilerActivity
+
+        def add_first(data):
+            data["order"] = ["first"]
+            return data
+
+        def add_second(data):
+            data["order"].append("second")
+            return data
+
+        register_export_chrome_trace_callback(add_first)
+        register_export_chrome_trace_callback(add_second)
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+
+        try:
+            with profile(activities=[ProfilerActivity.CPU]) as prof:
+                x = torch.randn(10, 10)
+                _ = x + x
+
+            prof.export_chrome_trace(trace_path)
+
+            with open(trace_path) as f:
+                data = json.load(f)
+
+            self.assertEqual(data.get("order"), ["first", "second"])
+
+        finally:
+            os.unlink(trace_path)
+
+    def test_no_callbacks_no_error(self):
+        """Test that export works with no callbacks registered."""
+        from torch.profiler import profile, ProfilerActivity
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+
+        try:
+            with profile(activities=[ProfilerActivity.CPU]) as prof:
+                x = torch.randn(10, 10)
+                _ = x + x
+
+            # Should not raise
+            prof.export_chrome_trace(trace_path)
+
+            # Trace should be valid
+            with open(trace_path) as f:
+                data = json.load(f)
+            self.assertIn("traceEvents", data)
+
+        finally:
+            os.unlink(trace_path)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -19,13 +19,16 @@ from torch.autograd.profiler import KinetoStepTracker, record_function
 from torch.optim.optimizer import Optimizer, register_optimizer_step_post_hook
 
 from .profiler import (
+    _export_chrome_trace_callbacks,
     _KinetoProfile,
     ExecutionTraceObserver,
     profile,
     ProfilerAction,
+    register_export_chrome_trace_callback,
     schedule,
     supported_activities,
     tensorboard_trace_handler,
+    unregister_export_chrome_trace_callback,
 )
 
 
@@ -40,6 +43,7 @@ __all__ = [
     "DeviceType",
     "record_function",
     "ExecutionTraceObserver",
+    "register_export_chrome_trace_callback",
 ]
 
 from . import itt

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -74,6 +74,8 @@ def unregister_export_chrome_trace_callback(callback: Callable[[dict], dict]) ->
     """Remove a previously registered export_chrome_trace callback."""
     if callback in _export_chrome_trace_callbacks:
         _export_chrome_trace_callbacks.remove(callback)
+
+
 PROFILER_STEP_NAME = "ProfilerStep"
 
 _WARNINGS_SHOWN = set()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173551
* __->__ #173561

Add a public API for registering callbacks that run when export_chrome_trace()
is called. This allows other components (like inductor) to augment traces
with custom annotations without coupling the profiler to those components.

API:
  torch.profiler.register_export_chrome_trace_callback(fn)

The callback receives trace data as a dict and returns the modified data.
Multiple callbacks run in registration order. Exceptions are caught and
logged as warnings to avoid breaking trace export.

Co-Authored-By: Claude (global.anthropic.claude-opus-4-5-20251101-v1:0) <noreply@anthropic.com>