### PR TITLE
[DTensor] single-dim expander raises clear inplace error

### DIFF
--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -399,7 +399,7 @@ def expand_to_full_mesh_op_strategy(
     input_args_strategy = args_strategy + kwargs_strategy
     all_strategies = []
     # Track input placements if we skip strategies due to inplace placement mismatch
-    blocking_inplace_input_placements = None
+    blocking_inplace_input_placements: tuple[Placement, ...] | None = None
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
         # Track how many non-None output specs we've seen (for output_tensor_meta indexing).

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -398,6 +398,8 @@ def expand_to_full_mesh_op_strategy(
     kwargs_strategy = op_schema.kwargs_strategy
     input_args_strategy = args_strategy + kwargs_strategy
     all_strategies = []
+    # Track input placements if we skip strategies due to inplace placement mismatch
+    blocking_inplace_input_placements = None
     for strategy_comb in strategy_combs:
         spec_list: list[DTensorSpec | None] = []
         # Track how many non-None output specs we've seen (for output_tensor_meta indexing).
@@ -451,6 +453,8 @@ def expand_to_full_mesh_op_strategy(
         if inplace_op and self_spec.placements != input_specs[0].placements:
             # if it's inplace op, we would only allow the OpSpec to be added when the
             # input_spec matches the first argument's runtime sharding, otherwise we skip
+            if blocking_inplace_input_placements is None:
+                blocking_inplace_input_placements = self_spec.placements
             continue
 
         # For out= variant ops, output placement must match the "out" kwarg's placement
@@ -501,6 +505,18 @@ def expand_to_full_mesh_op_strategy(
             redistribute_cost=redistribute_cost,
         )
         all_strategies.append(strategy)
+
+    # If all strategies were filtered out due to inplace placement mismatch,
+    # raise a clear error message instead of returning an empty OpStrategy
+    # (which would later cause a cryptic "min() arg is an empty sequence" error)
+    if not all_strategies and blocking_inplace_input_placements is not None:
+        raise RuntimeError(
+            f"{op_schema.op}: in-place operations that require placement changes "
+            f"are not supported. The input has placement {blocking_inplace_input_placements}, "
+            f"but no valid strategy preserves this placement. "
+            f"Please use the out-of-place version of this operation instead."
+        )
+
     return OpStrategy(all_strategies)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173614
* #172278
* #173567
* __->__ #173572
* #172479

Inplace ops for dtensor have a restriction: you're not allowed to
redistribute the 'inplace' tensor.  This means in some cases, sharding
propagation has to fail becuase the inplace input is not compatible with
any of the possible sharding strategies.

This PR makes sure this case raises the expected informative error
rather than a confusing error about selecting min cost over an
empty sharding strategies list.