### PR TITLE
Disable ROCM jobs on trunk

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -295,7 +295,10 @@ jobs:
     secrets: inherit
 
   linux-jammy-rocm-py3_10-build:
-    if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/trunk') || (needs.job-filter.outputs.jobs != '' && contains(needs.job-filter.outputs.jobs, ' linux-jammy-rocm-py3.10 ')) }}
+    #NS: Trunk jobs should run on both PR if ciflow/trunk is added an on trunk
+    # But https://github.com/pytorch/pytorch/pull/165674 always skips them on trunk
+    if: 0
+    # if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/trunk') || (needs.job-filter.outputs.jobs != '' && contains(needs.job-filter.outputs.jobs, ' linux-jammy-rocm-py3.10 ')) }}
     name: linux-jammy-rocm-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173573

They way they were added by https://github.com/pytorch/pytorch/pull/165674 makes signal from this jobs only visible on PR, but skipped when actually pushed to trunk, see https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=trunk%20%2F%20linux-jammy-rocm which avoids usual latency monitoring, but creates a very confusing pattern, when `broken on trunk` status is never applied to those jobs

This deficiency was highlighted in late Nov 2025, but still not fix as of late Jan 2026 as of almost

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang