### PR TITLE
Fix Handle RuntimeError in FxGraphCachePickler.dumps() for unpickleable pybind11 objects[AI generated]

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2866,7 +2866,7 @@ class TestFxGraphCacheHashing(TestCase):
 
     def test_non_pybind11_runtime_error_propagates(self):
         """
-        Test that non-pybind11 RuntimeErrors are NOT caught and propagate up.
+        Test that RuntimeErrors not matching pybind11 pickle pattern propagate up.
         """
 
         class OtherRuntimeErrorObject:

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -656,6 +656,47 @@ class TestInductorDynamic(TestCase):
         self.assertEqual(ref1, res1)
 
     @onlyOn(GPU_TYPE)
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    def test_sympy_infinity_bounds_in_persistent_reduction(self):
+        """
+        Regression test for sympy Infinity bounds handling in should_use_persistent_reduction.
+
+        When bound_sympy() returns infinity bounds for dynamic reduction dimensions,
+        the inductor compiler should handle them correctly without attempting to
+        convert infinity to an integer.
+
+        Previously this would fail with: AttributeError: 'Infinity' object has no attribute '_mpf_'
+        """
+
+        def fn(arg0, arg2, arg3):
+            t0 = arg0
+            t2 = torch.nn.functional.layer_norm(t0, (1024, 10))
+            t3 = arg2
+            t4 = t3.contiguous().view((67, 1024, 5))
+            t5 = torch.nn.functional.conv1d(t2, t4, stride=1, padding=0)
+            t6 = arg3
+            t7 = torch.sqrt(t6)
+            t14 = torch.nn.functional.group_norm(t7, 1)
+            t15 = (((t5) - t14) - t5) - t5
+            return t15
+
+        arg0 = torch.rand(
+            [65, 1024, 10], dtype=torch.float32, device=GPU_TYPE, requires_grad=True
+        )
+        arg2 = torch.rand(
+            [134, 4, 640], dtype=torch.float32, device=GPU_TYPE, requires_grad=True
+        )
+        arg3 = torch.rand(
+            [65, 67, 6], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+        )
+
+        compiled_fn = torch.compile(fn, fullgraph=True, dynamic=True)
+        out_compiled = compiled_fn(arg0, arg2, arg3)
+        # Test backward pass as well - this is where the bug manifested
+        out_compiled.sum().backward()
+
+    @onlyOn(GPU_TYPE)
     def test_pad_dynamic(self, device):
         def get_same_padding(x: int, k: int, s: int, d: int):
             return max((math.ceil(x / s) - 1) * s + (k - 1) * d + 1 - x, 0)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -656,47 +656,6 @@ class TestInductorDynamic(TestCase):
         self.assertEqual(ref1, res1)
 
     @onlyOn(GPU_TYPE)
-    @torch._dynamo.config.patch(capture_scalar_outputs=True)
-    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
-    def test_sympy_infinity_bounds_in_persistent_reduction(self):
-        """
-        Regression test for sympy Infinity bounds handling in should_use_persistent_reduction.
-
-        When bound_sympy() returns infinity bounds for dynamic reduction dimensions,
-        the inductor compiler should handle them correctly without attempting to
-        convert infinity to an integer.
-
-        Previously this would fail with: AttributeError: 'Infinity' object has no attribute '_mpf_'
-        """
-
-        def fn(arg0, arg2, arg3):
-            t0 = arg0
-            t2 = torch.nn.functional.layer_norm(t0, (1024, 10))
-            t3 = arg2
-            t4 = t3.contiguous().view((67, 1024, 5))
-            t5 = torch.nn.functional.conv1d(t2, t4, stride=1, padding=0)
-            t6 = arg3
-            t7 = torch.sqrt(t6)
-            t14 = torch.nn.functional.group_norm(t7, 1)
-            t15 = (((t5) - t14) - t5) - t5
-            return t15
-
-        arg0 = torch.rand(
-            [65, 1024, 10], dtype=torch.float32, device=GPU_TYPE, requires_grad=True
-        )
-        arg2 = torch.rand(
-            [134, 4, 640], dtype=torch.float32, device=GPU_TYPE, requires_grad=True
-        )
-        arg3 = torch.rand(
-            [65, 67, 6], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
-        )
-
-        compiled_fn = torch.compile(fn, fullgraph=True, dynamic=True)
-        out_compiled = compiled_fn(arg0, arg2, arg3)
-        # Test backward pass as well - this is where the bug manifested
-        out_compiled.sum().backward()
-
-    @onlyOn(GPU_TYPE)
     def test_pad_dynamic(self, device):
         def get_same_padding(x: int, k: int, s: int, d: int):
             return max((math.ceil(x / s) - 1) * s + (k - 1) * d + 1 - x, 0)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -625,8 +625,15 @@ class FxGraphCachePickler(pickle.Pickler):
         try:
             self.dump(obj)
             return self._stream.getvalue()
-        except (TypeError, AttributeError, pickle.PicklingError, ValueError) as e:
+        except (
+            TypeError,
+            AttributeError,
+            pickle.PicklingError,
+            ValueError,
+            RuntimeError,
+        ) as e:
             # Some configs options may not pickle.
+            # RuntimeError can be raised by pybind11 for non-pickleable objects.
             log.warning("Failed to pickle cache key", exc_info=True)
             raise BypassFxGraphCache("Failed to pickle cache key") from e
         finally:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -630,9 +630,9 @@ class FxGraphCachePickler(pickle.Pickler):
             log.warning("Failed to pickle cache key", exc_info=True)
             raise BypassFxGraphCache("Failed to pickle cache key") from e
         except RuntimeError as e:
-            # pybind11 raises RuntimeError when trying to pickle non-pickleable
-            # objects (e.g., OpOverload._op which is a C++ function pointer).
-            if "pybind11" in str(e):
+            # pybind11 raises RuntimeError with message like:
+            # "<pybind11_builtins... object at 0x...> is not pickleable."
+            if "pybind11" in str(e) and "is not pickleable" in str(e):
                 log.warning("Failed to pickle cache key", exc_info=True)
                 raise BypassFxGraphCache("Failed to pickle cache key") from e
             raise


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173577
* #172534

When `torch.compile` encounters certain graph configurations during backward pass,
`OpOverload` objects (containing unpickleable pybind11 `_op` C++ function pointers)
may end up in the FxGraphCache pickle stream via ShapeEnv.tracked_fakes.
This causes compilation to crash instead of gracefully bypassing the cache.

This PR catches `RuntimeError` exceptions that match pybind11's pickle failure
pattern ("pybind11" in error message) and converts them to `BypassFxGraphCache`,
allowing compilation to proceed without caching. Other RuntimeErrors propagate normally.

those are not trivial to support pickle for according to AI

address https://github.com/pytorch/pytorch/issues/164682

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo