### PR TITLE
[CI] Permantently skip flaky ROCM inductor test

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -225,6 +225,12 @@ if TEST_WITH_ROCM:
     # Tensors are not alike
     inductor_skips["cuda"]["logcumsumexp"] = {f32}
     inductor_skips["cuda"]["special.modified_bessel_i1"] = {f64}
+    # https://github.com/pytorch/pytorch/issues/140383
+    inductor_skips["cuda"]["nn.functional.glu"] = {f16}
+    # https://github.com/pytorch/pytorch/issues/147058
+    inductor_skips["cuda"]["nn.functional.interpolate.linear"] = {f16}
+    # https://github.com/pytorch/pytorch/issues/147047
+    inductor_skips["cuda"]["sub"] = {f16}
 
 inductor_skips["xpu"] = {}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173579

As `Platform: inductor` skips it for both CUDA and ROCM

Also, we should not really have open skip-test issues from 2024

Fixes  https://github.com/pytorch/pytorch/issues/140383 , https://github.com/pytorch/pytorch/issues/147058 , https://github.com/pytorch/pytorch/issues/147047

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben