### PR TITLE
[BE] Update sccache from 0.10 to 0.13

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,11 +9,12 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.10.0
+  git clone https://github.com/mozilla/sccache -b v0.13.0
   cd sccache
   echo "Building sccache"
-  cargo build --release
+  cargo build --release --features="dist-client dist-server"
   cp target/release/sccache /opt/cache/bin
+  cp target/release/sccache-dist /opt/cache/bin
   echo "Cleaning up"
   cd ..
   rm -rf sccache

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -3,22 +3,21 @@
 set -ex
 
 install_ubuntu() {
-  echo "Preparing to build sccache from source"
-  apt-get update
-  # libssl-dev will not work as it is upgraded to libssl3 in Ubuntu-22.04.
-  # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
-  apt-get install -y cargo
+  echo "Installing pkg-config and libssl-dev"
+  apt-get update && apt-get install -y pkg-config libssl-dev curl
+  echo "Installing rust"
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
   echo "Checking out sccache repo"
   git clone https://github.com/mozilla/sccache -b v0.13.0
   cd sccache
   echo "Building sccache"
-  cargo build --release --features="dist-client dist-server"
+  . "$HOME/.cargo/env" && cargo build --release --features="dist-client dist-server"
   cp target/release/sccache /opt/cache/bin
   cp target/release/sccache-dist /opt/cache/bin
   echo "Cleaning up"
   cd ..
-  rm -rf sccache
-  apt-get remove -y cargo rustc
+  rm -rf sccache .cargo
+  apt-get remove -y pkg-config libssl-dev
   apt-get autoclean && apt-get clean
 
   echo "Downloading old sccache binary from S3 repo for PCH builds"

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -10,6 +10,8 @@ install_ubuntu() {
   echo "Checking out sccache repo"
   git clone https://github.com/mozilla/sccache -b v0.13.0
   cd sccache
+  echo "Patch dist build on aarch64"
+  sed -i '/all(target_os = "linux", target_arch = "x86_64"),/{ p; s/x86_64/aarch64/; }' src/bin/sccache-dist/main.rs
   echo "Building sccache"
   . "$HOME/.cargo/env" && cargo build --release --features="dist-client dist-server"
   cp target/release/sccache /opt/cache/bin

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -294,8 +294,10 @@ else
     # set only when building other architectures
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  && "$BUILD_ENVIRONMENT" != *xla* && "$BUILD_ENVIRONMENT" != *riscv64* ]]; then
-      if [[ "$ANACONDA_PYTHON_VERSION" = "3.10" || "$ANACONDA_PYTHON_VERSION" = "3.11" ]]; then
+      # TODO: Remove me and may be just focus on numpy-2.x testing
+      if [[ "$ANACONDA_PYTHON_VERSION" =~ ^3\.1[0-2]$ ]]; then
         # Install numpy-2.0.2 for builds which are backward compatible with 1.X
+        # In relality it's only needed for numpy_2_x and vllm shards (where vllm depends on numpy-2)
         python -mpip install numpy==2.0.2
       fi
 

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -294,8 +294,10 @@ else
     # set only when building other architectures
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  && "$BUILD_ENVIRONMENT" != *xla* && "$BUILD_ENVIRONMENT" != *riscv64* ]]; then
-      # Install numpy-2.0.2 for builds which are backward compatible with 1.X
-      python -mpip install numpy==2.0.2
+      if [[ "$ANACONDA_PYTHON_VERSION" = "3.10" || "$ANACONDA_PYTHON_VERSION" = "3.11" ]]; then
+        # Install numpy-2.0.2 for builds which are backward compatible with 1.X
+        python -mpip install numpy==2.0.2
+      fi
 
       WERROR=1 python setup.py clean
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173581

Also build with distributed build feature (will not be used by default, but will be present all the same)
Instal more modern version of rust to be able to build it
Also, tweak build rule a bit, in order no to downgrade cmake for Python-3.13+ builds to numpy-2.0.2