### PR TITLE
[Distributed] Extract and restore distributed topology in fx_graph_runnable

### DIFF
--- a/test/distributed/test_distributed_topology_repro.py
+++ b/test/distributed/test_distributed_topology_repro.py
@@ -1,0 +1,143 @@
+"""
+Tests for distributed topology extraction and repro generation.
+
+This tests Goal 1: When running with tlparse and distributed, correctly set up
+the right mesh that existed during the run, with FakeProcesses support.
+"""
+
+import io
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestDistributedTopologyRepro(TestCase):
+    """Test distributed topology extraction and fx_graph_runnable generation."""
+
+    def setUp(self):
+        # Initialize fake distributed if not already initialized
+        if not dist.is_initialized():
+            from torch.testing._internal.distributed.fake_pg import FakeStore
+
+            store = FakeStore()
+            dist.init_process_group(backend="fake", rank=0, world_size=4, store=store)
+            self._initialized_dist = True
+        else:
+            self._initialized_dist = False
+
+    def tearDown(self):
+        if self._initialized_dist and dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_extract_distributed_topology_with_collectives(self):
+        """Test that distributed topology is correctly extracted from a graph with collectives."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch._dynamo.repro.after_aot import _extract_distributed_topology
+
+        def f(x):
+            return torch.ops._c10d_functional.all_reduce(x, "sum", "default")
+
+        with FakeTensorMode():
+            fake_x = torch.randn(4, 4)
+            gm = make_fx(f)(fake_x)
+
+        topology = _extract_distributed_topology(gm)
+
+        self.assertTrue(topology["has_distributed_ops"])
+        self.assertIn("default", topology["process_groups"])
+        self.assertEqual(topology["process_groups"]["default"]["size"], 4)
+        self.assertEqual(topology["process_groups"]["default"]["rank"], 0)
+
+    def test_extract_distributed_topology_no_collectives(self):
+        """Test that topology extraction works for graphs without collectives."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch._dynamo.repro.after_aot import _extract_distributed_topology
+
+        def f(x):
+            return x * 2
+
+        with FakeTensorMode():
+            fake_x = torch.randn(4, 4)
+            gm = make_fx(f)(fake_x)
+
+        topology = _extract_distributed_topology(gm)
+
+        self.assertFalse(topology["has_distributed_ops"])
+        self.assertEqual(topology["process_groups"], {})
+
+    def test_generate_distributed_init_code(self):
+        """Test that distributed init code is generated correctly."""
+        from torch._dynamo.repro.after_aot import _generate_distributed_init_code
+
+        topology = {
+            "has_distributed_ops": True,
+            "process_groups": {
+                "default": {"size": 8, "rank": 2},
+            },
+            "device_meshes": [],
+        }
+
+        code = _generate_distributed_init_code(topology, use_fake_processes=True)
+
+        # Check that the code contains expected elements
+        self.assertIn("FakeStore", code)
+        self.assertIn("dist.init_process_group", code)
+        self.assertIn('backend="fake"', code)
+        self.assertIn("REPRO_RANK", code)
+        self.assertIn("REPRO_WORLD_SIZE", code)
+        # Check that it uses the correct world size from topology
+        self.assertIn('"8"', code)
+
+    def test_generate_distributed_init_code_with_device_mesh(self):
+        """Test that DeviceMesh setup code is generated when meshes are present."""
+        from torch._dynamo.repro.after_aot import _generate_distributed_init_code
+
+        topology = {
+            "has_distributed_ops": True,
+            "process_groups": {"default": {"size": 4, "rank": 0}},
+            "device_meshes": [
+                {
+                    "device_type": "cuda",
+                    "mesh": [[0, 1], [2, 3]],
+                    "mesh_dim_names": ("dp", "tp"),
+                }
+            ],
+        }
+
+        code = _generate_distributed_init_code(topology, use_fake_processes=True)
+
+        self.assertIn("DeviceMesh", code)
+        self.assertIn('"cuda"', code)
+        self.assertIn("[[0, 1], [2, 3]]", code)
+        self.assertIn("('dp', 'tp')", code)
+
+    def test_save_graph_repro_with_distributed(self):
+        """Test that save_graph_repro generates proper repro with distributed ops."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch._dynamo.repro.after_aot import save_graph_repro
+
+        def f(x):
+            return torch.ops._c10d_functional.all_reduce(x, "sum", "default")
+
+        with FakeTensorMode():
+            fake_x = torch.randn(4, 4)
+            gm = make_fx(f)(fake_x)
+
+        fd = io.StringIO()
+        save_graph_repro(fd, gm, [fake_x], "inductor")
+        repro_code = fd.getvalue()
+
+        # Check that the repro includes distributed setup
+        self.assertIn("import torch.distributed as dist", repro_code)
+        self.assertIn("FakeStore", repro_code)
+        self.assertIn("dist.init_process_group", repro_code)
+        self.assertIn("dist.destroy_process_group", repro_code)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1274,6 +1274,20 @@ class _InProcessFxCompile(FxCompile):
                 payload_fn=lambda: runnable_graph_str,
             )
 
+            # Log distributed topology if present
+            dist_topology = torch._dynamo.repro.after_aot._extract_distributed_topology(
+                gm
+            )
+            if dist_topology["has_distributed_ops"]:
+                trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "distributed_topology",
+                        "encoding": "json",
+                    },
+                    payload_fn=lambda: dist_topology,
+                )
+
             V.debug.fx_graph(gm, example_inputs)
             # TODO: Should we actually dump this?  It should be redundant with the aot
             # structured logs...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173589
* #173586
* #173585
* __->__ #173584

When running with tlparse and distributed, the fx_graph_runnable repro
now correctly captures and restores the distributed topology that
existed during the original run.

Changes:
- Add _extract_distributed_topology() to capture process group configs
  (rank, world_size) and DeviceMesh topology from the compiled graph
- Add _generate_distributed_init_code() to generate proper distributed
  initialization code with the correct topology
- Log distributed_topology as a JSON artifact to tlparse
- Support FakeProcesses for single-GPU debugging via environment
  variables: USE_REAL_DISTRIBUTED, REPRO_RANK, REPRO_WORLD_SIZE

This allows users to reproduce distributed compilation issues on a
single GPU by using the fake backend with the correct topology.

Co-Authored-By: Claude <noreply@anthropic.com>