### PR TITLE
[BE] Remove Python-2.6.9 copy-pasta

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -26,12 +26,6 @@ ADD ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh && rm install_openssl.sh
 
 
-# remove unnecessary python versions
-RUN rm -rf /opt/python/cp26-cp26m /opt/_internal/cpython-2.6.9-ucs2
-RUN rm -rf /opt/python/cp26-cp26mu /opt/_internal/cpython-2.6.9-ucs4
-RUN rm -rf /opt/python/cp33-cp33m /opt/_internal/cpython-3.3.6
-RUN rm -rf /opt/python/cp34-cp34m /opt/_internal/cpython-3.4.6
-
 FROM base as cuda
 ARG BASE_CUDA_VERSION=12.6
 # Install CUDA

--- a/.ci/docker/manywheel/Dockerfile_2_28_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_2_28_aarch64
@@ -76,10 +76,6 @@ RUN bash ./install_acl.sh && rm install_acl.sh
 FROM base as final
 
 # remove unnecessary python versions
-RUN rm -rf /opt/python/cp26-cp26m /opt/_internal/cpython-2.6.9-ucs2
-RUN rm -rf /opt/python/cp26-cp26mu /opt/_internal/cpython-2.6.9-ucs4
-RUN rm -rf /opt/python/cp33-cp33m /opt/_internal/cpython-3.3.6
-RUN rm -rf /opt/python/cp34-cp34m /opt/_internal/cpython-3.4.6
 COPY --from=openblas     /opt/OpenBLAS/  /opt/OpenBLAS/
 COPY --from=arm_compute /acl /acl
 ENV LD_LIBRARY_PATH=/opt/OpenBLAS/lib:/acl/build/:$LD_LIBRARY_PATH

--- a/.ci/docker/manywheel/Dockerfile_cuda_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_cuda_aarch64
@@ -60,11 +60,6 @@ RUN bash ./install_openssl.sh && rm install_openssl.sh
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 
 FROM openssl as final
-# remove unnecessary python versions
-RUN rm -rf /opt/python/cp26-cp26m /opt/_internal/cpython-2.6.9-ucs2
-RUN rm -rf /opt/python/cp26-cp26mu /opt/_internal/cpython-2.6.9-ucs4
-RUN rm -rf /opt/python/cp33-cp33m /opt/_internal/cpython-3.3.6
-RUN rm -rf /opt/python/cp34-cp34m /opt/_internal/cpython-3.4.6
 
 FROM base as cuda
 ARG BASE_CUDA_VERSION


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173588
* #173587

I'm surprised it survived in so many files all the way into 2026
Oldest cpython supported in manylinux2_28 are 3.8:
```
% docker run --rm quay.io/pypa/manylinux_2_28_aarch64 ls -l /opt/python    
total 0
lrwxrwxrwx 1 root root 30 Jan 23 20:20 cp310-cp310 -> /opt/_internal/cpython-3.10.19
lrwxrwxrwx 1 root root 30 Jan 23 20:20 cp311-cp311 -> /opt/_internal/cpython-3.11.14
lrwxrwxrwx 1 root root 30 Jan 23 20:20 cp312-cp312 -> /opt/_internal/cpython-3.12.12
lrwxrwxrwx 1 root root 30 Jan 23 20:20 cp313-cp313 -> /opt/_internal/cpython-3.13.11
lrwxrwxrwx 1 root root 36 Jan 23 20:20 cp313-cp313t -> /opt/_internal/cpython-3.13.11-nogil
lrwxrwxrwx 1 root root 29 Jan 23 20:21 cp314-cp314 -> /opt/_internal/cpython-3.14.2
lrwxrwxrwx 1 root root 35 Jan 23 20:21 cp314-cp314t -> /opt/_internal/cpython-3.14.2-nogil
lrwxrwxrwx 1 root root 29 Jan 23 20:21 cp38-cp38 -> /opt/_internal/cpython-3.8.20
lrwxrwxrwx 1 root root 29 Jan 23 20:21 cp39-cp39 -> /opt/_internal/cpython-3.9.25
lrwxrwxrwx 1 root root 33 Jan 23 20:21 pp311-pypy311_pp73 -> /opt/_internal/pp311-pypy311_pp73
```