### PR TITLE
[DTensor] update add_backward benchmark to avoid redisribute

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
@@ -5,7 +5,7 @@ from benchmark_base import BenchmarkBase
 import torch
 from torch.distributed._tensor import DTensor, Partial, Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
-
+from torch.distributed.tensor._utils import ExplicitRedistributionContext
 
 class BenchmarkDTensorDispatch(BenchmarkBase):
     def __init__(self, operator, world_size) -> None:
@@ -84,14 +84,14 @@ class BenchmarkAddBackward(BenchmarkDTensorDispatch):
     def _prepare_once(self) -> None:
         super()._prepare_once()
         self.a = DTensor.from_local(
-            torch.ones(2, 512, device=self.device(), requires_grad=True),
+            torch.ones(512, 512, device=self.device(), requires_grad=True),
             self.mesh,
-            [Shard(0)],
+            [Replicate()],
         )
         self.b = DTensor.from_local(
-            torch.ones(512, 2, device=self.device(), requires_grad=True),
+            torch.ones(512, 512, device=self.device(), requires_grad=True),
             self.mesh,
-            [Shard(1)],
+            [Replicate()],
         )
 
     def _work(self) -> None:

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/dtensor.py
@@ -5,7 +5,7 @@ from benchmark_base import BenchmarkBase
 import torch
 from torch.distributed._tensor import DTensor, Partial, Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
-from torch.distributed.tensor._utils import ExplicitRedistributionContext
+
 
 class BenchmarkDTensorDispatch(BenchmarkBase):
     def __init__(self, operator, world_size) -> None:

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -102,7 +102,7 @@ dtensor_dispatch_collectives,instruction_count,25300000,0.1
 
 
 
-dtensor_dispatch_add_backward,instruction_count,626000,0.1
+dtensor_dispatch_add_backward,instruction_count,346201,0.1
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173436
* #172610
* __->__ #173593

Benchmark focuses on dispatch time.

Also, the shapes didn't make sense for add previously, fixed them

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo