### PR TITLE
[CI][BE] Return better error when unimplemented dtype

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12685,13 +12685,14 @@ class TestConsistency(TestCaseMPS):
                 # TODO: Handle list inputs later
                 if not isinstance(mps_out, torch.Tensor):
                     raise
+                if mps_sample.input.dtype not in [torch.float16, torch.bfloat16]:
+                    raise
 
-                if mps_sample.input.dtype in [torch.float16, torch.bfloat16]:
-                    # Often CPU ops are not implemented for low precision dtypes
-                    # In that case, upcast to higher precision and try again
-                    cpu_sample = transform_opinfo_sample_to_cpu(mps_sample, dtype=torch.float32)
-                    cpu_out = op(cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs)
-                    cpu_out = cpu_out.to(dtype=mps_out.dtype)
+                # Often CPU ops are not implemented for low precision dtypes
+                # In that case, upcast to higher precision and try again
+                cpu_sample = transform_opinfo_sample_to_cpu(mps_sample, dtype=torch.float32)
+                cpu_out = op(cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs)
+                cpu_out = cpu_out.to(dtype=mps_out.dtype)
 
         return mps_out, cpu_out, cpu_sample
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #173600
* __->__ #173596

If CPU lacks implementation for dtype, and this type is not lower precision float, re-reaise unimplemented error
Otherwise test will fail anyway with
```
UnboundLocalError: cannot access local variable 'cpu_out' where it is not associated with a value
```

After this fix it fails with a much more actionable error, for example
```
Exception: "gcd_cpu" not implemented for 'Bool'
```