### PR TITLE
test: add a tearDown method to the TestSelectAlgorithm class

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -85,6 +85,11 @@ class TestSelectAlgorithm(TestCase):
         # Clear preprocessing functions to ensure clean state
         select_algorithm.clear_preprocessing_fns()
 
+    def tearDown(self):
+        super().tearDown()
+        V.choices_handler = None
+        select_algorithm.clear_preprocessing_fns()
+
     @patches
     def test_linear_relu(self):
         @torch.compile


### PR DESCRIPTION
The test `test_extern_kernel_benchmark_valid_timing` failed when run as part of its test suite but passed in isolation. This is a classic test isolation problem, meaning one test modified a global setting that was not reset, causing a later test to fail.

In this case, the test `test_convolution_as_mm_triton_only` uses `V.set_choices_handler(...)` to install a custom handler. This handler deliberately limits Inductor's algorithm choices to test a specific scenario, which has the side effect of skipping the autotuning process for that test. Since `V.choices_handler` is effectively a global setting, it remained active after `test_convolution_as_mm_triton_only` finished.

Consequently, when `test_extern_kernel_benchmark_valid_timing` was run later in the suite, this handler was still active, causing autotuning to be skipped. This directly caused its assertion, `self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)`, to fail. Another test, `test_preprocessing_single_choice`, similarly modifies global state via `select_algorithm.add_preprocessing_fn`.

```
  File "torch/test/inductor/test_select_algorithm.py", line 605, in test_extern_kernel_benchmark_valid_timing
    self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
  File "torch/torch/_dynamo/test_case.py", line 113, in assertEqual
    return super().assertEqual(x, y, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "torch/testing/_internal/common_utils.py", line 4360, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Scalars are not equal!

Expected 1 but got 0.
Absolute difference: 1
Relative difference: 1.0
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo