### PR TITLE
[pytorch] Fix expandable segments IPC handle type propagation

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -75,6 +75,7 @@ list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_reportMemoryUsage_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_allocatorTraceTracker_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_stream_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_caching_allocator_ipc_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_vectorized_test.cu)
 if(CAFFE2_USE_CUDNN)
   list(APPEND ATen_CUDA_TEST_SRCS

--- a/aten/src/ATen/test/cuda_allocator_test.cpp
+++ b/aten/src/ATen/test/cuda_allocator_test.cpp
@@ -12,7 +12,7 @@ std::unordered_map<void*, size_t> allocation_sizes;
 
 void* logging_malloc(size_t size, int device, cudaStream_t stream) {
     void* ptr;
-    cudaMalloc(&ptr, size);
+    C10_CUDA_CHECK(cudaMalloc(&ptr, size));
     allocation_sizes[ptr] = size;
     return ptr;
 }
@@ -25,7 +25,7 @@ void logging_free(void* ptr, size_t size, int device, cudaStream_t stream) {
     } else {
       throw std::runtime_error("free of unknown ptr");
     }
-    cudaFree(ptr);
+    C10_CUDA_CHECK(cudaFree(ptr));
     allocation_sizes.erase(ptr);
 }
 

--- a/aten/src/ATen/test/cuda_caching_allocator_ipc_test.cpp
+++ b/aten/src/ATen/test/cuda_caching_allocator_ipc_test.cpp
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/PeerToPeerAccess.h>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <cstdlib>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+// Compatibility definitions for CUDA versions < 12.3
+#if CUDA_VERSION < 12030
+#define CU_MEM_HANDLE_TYPE_FABRIC ((CUmemAllocationHandleType)0x8ULL)
+#define CU_IPC_HANDLE_SIZE 64
+typedef struct CUmemFabricHandle_st {
+  unsigned char data[CU_IPC_HANDLE_SIZE];
+} CUmemFabricHandle_v1;
+typedef CUmemFabricHandle_v1 CUmemFabricHandle;
+#define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED \
+  ((CUdevice_attribute)128)
+#endif
+
+#if !defined(USE_ROCM) && !defined(_WIN32)
+#include <c10/cuda/driver_api.h>
+
+using namespace c10::cuda::CUDACachingAllocator;
+
+class ExpandableSegmentsIPCTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True", 1);
+    setenv("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC", "1", 1);
+
+    int deviceCount = 0;
+    cudaGetDeviceCount(&deviceCount);
+    if (deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices available";
+    }
+    cudaSetDevice(0);
+
+    c10::cuda::CUDACachingAllocator::init(deviceCount);
+    c10::cuda::detail::init_p2p_access_cache(deviceCount);
+  }
+};
+
+// Test that expandable segments allocations have valid IPC handle types
+// (either FABRIC or POSIX_FD, but never NONE)
+TEST_F(ExpandableSegmentsIPCTest, AllocationHasValidIPCHandleType) {
+  auto allocator = get();
+  if (allocator == nullptr) {
+    GTEST_SKIP() << "CUDACachingAllocator not available";
+  }
+
+  ASSERT_EQ(CUDAAllocatorConfig::expandable_segments(), true);
+
+  auto* driver = c10::cuda::DriverAPI::get();
+  CUdevice device;
+  CUresult deviceResult = driver->cuDeviceGet_(&device, 0);
+  ASSERT_EQ(deviceResult, CUDA_SUCCESS) << "Failed to get CUDA device";
+
+  int fabricSupported = 0;
+#if CUDA_VERSION < 12030
+  fabricSupported = 0;
+#else
+  CUresult attrResult = driver->cuDeviceGetAttribute_(
+      &fabricSupported,
+      CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+      device);
+  // CUDA_ERROR_INVALID_VALUE means the driver doesn't recognize this attribute
+  // (driver older than CUDA 12.3), so fabric is not supported
+  if (attrResult == CUDA_ERROR_INVALID_VALUE) {
+    fabricSupported = 0;
+  } else {
+    ASSERT_EQ(attrResult, CUDA_SUCCESS)
+        << "Failed to query FABRIC support attribute";
+  }
+#endif
+
+  CUmemAllocationHandleType expectedHandleType;
+#if CUDA_VERSION > 12040
+  if (fabricSupported) {
+    expectedHandleType = CU_MEM_HANDLE_TYPE_FABRIC;
+  } else {
+    expectedHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  }
+#else
+  expectedHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+#endif
+
+  constexpr size_t allocSize = 1024 * 1024;  // 1MB
+  void* ptr = allocator->raw_alloc(allocSize);
+  ASSERT_NE(ptr, nullptr) << "Failed to allocate memory";
+
+  CUmemGenericAllocationHandle handle;
+  CUresult retainResult = driver->cuMemRetainAllocationHandle_(&handle, ptr);
+  ASSERT_EQ(retainResult, CUDA_SUCCESS);
+
+  CUmemAllocationProp prop = {};
+  CUresult propResult =
+      driver->cuMemGetAllocationPropertiesFromHandle_(&prop, handle);
+  ASSERT_EQ(propResult, CUDA_SUCCESS)
+      << "Failed to get allocation properties";
+
+  EXPECT_EQ(prop.requestedHandleTypes, expectedHandleType)
+      << "Handle type mismatch. Expected: " << expectedHandleType
+      << " (POSIX_FILE_DESCRIPTOR=1, FABRIC=8), got: "
+      << prop.requestedHandleTypes
+      << ". CUDA_VERSION=" << CUDA_VERSION
+      << ", fabricSupported=" << fabricSupported;
+
+  allocator->raw_delete(ptr);
+}
+
+// Test that allocation can be exported to shareable handle
+TEST_F(ExpandableSegmentsIPCTest, AllocationCanBeExported) {
+  auto allocator = get();
+  if (allocator == nullptr) {
+    GTEST_SKIP() << "CUDACachingAllocator not available";
+  }
+
+  constexpr size_t allocSize = 1024 * 1024;  // 1MB
+
+  void* ptr = allocator->raw_alloc(allocSize);
+  ASSERT_NE(ptr, nullptr) << "Failed to allocate memory";
+
+  auto* driver = c10::cuda::DriverAPI::get();
+  CUmemGenericAllocationHandle handle;
+  CUresult retainResult = driver->cuMemRetainAllocationHandle_(&handle, ptr);
+
+  if (retainResult == CUDA_SUCCESS) {
+    CUmemAllocationProp prop = {};
+    CUresult propResult =
+        driver->cuMemGetAllocationPropertiesFromHandle_(&prop, handle);
+    ASSERT_EQ(propResult, CUDA_SUCCESS);
+
+    if (prop.requestedHandleTypes != 0) {
+      CUmemAllocationHandleType exportType =
+          (prop.requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC)
+              ? CU_MEM_HANDLE_TYPE_FABRIC
+              : CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+      // Try to export - this should succeed with the fix
+      if (exportType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+        int fd = -1;
+        CUresult exportResult = driver->cuMemExportToShareableHandle_(
+            &fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+        EXPECT_EQ(exportResult, CUDA_SUCCESS)
+            << "Failed to export to POSIX_FILE_DESCRIPTOR handle";
+        if (exportResult == CUDA_SUCCESS && fd >= 0) {
+          close(fd);
+        }
+      } else {
+        CUmemFabricHandle fabricHandle = {};
+        CUresult exportResult = driver->cuMemExportToShareableHandle_(
+            &fabricHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+        EXPECT_EQ(exportResult, CUDA_SUCCESS)
+            << "Failed to export to FABRIC handle";
+      }
+    }
+  }
+
+  allocator->raw_delete(ptr);
+}
+
+#endif // !defined(USE_ROCM) && !defined(_WIN32)

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -18,6 +18,7 @@
 #include <c10/util/static_tracepoint.h>
 
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+#include <c10/cuda/PeerToPeerAccess.h>
 #include <c10/cuda/driver_api.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -404,20 +405,46 @@ struct ExpandableSegment {
       return rangeFromHandles(begin, end);
     }
 
-    // if the handle type is not specified, try to use fabric handle first.
-    // if it fails, use posix file handle
-    if (CUDAAllocatorConfig::expandable_segments_handle_type() ==
-        Expandable_Segments_Handle_Type::UNSPECIFIED) {
-      CUDAAllocatorConfig::set_expandable_segments_handle_type(
-          Expandable_Segments_Handle_Type::FABRIC_HANDLE);
-      auto output = map(range);
-      if (output.ptr != nullptr) {
-        return output;
+    // In fbcode, IPC handle types for expandable segments are disabled by
+    // default because some jobs were failing (see
+    // https://github.com/pytorch/pytorch/pull/132890), but can be explicitly
+    // enabled via environment variable when IPC functionality is required
+    // (e.g., for multi-process communication with CTran). In non-fbcode
+    // builds, IPC handle types are enabled by default.
+#ifdef FBCODE_CAFFE2
+    static const bool default_enable_ipc = false;
+#else
+    static const bool default_enable_ipc = true;
+#endif
+    static const bool enable_ipc_handles =
+        c10::utils::check_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC")
+            .value_or(default_enable_ipc);
+
+    // Determine IPC handle type upfront based on config and device capability.
+    // Must check FABRIC support at runtime because CUDA silently accepts
+    // FABRIC handle type on non-FABRIC devices during cuMemCreate, but later
+    // cuMemExportToShareableHandle fails with "invalid argument".
+    if (enable_ipc_handles) {
+      switch (CUDAAllocatorConfig::expandable_segments_handle_type()) {
+        case Expandable_Segments_Handle_Type::UNSPECIFIED:
+          // Auto-detect based on device capability
+          handle_type_ = cuda::get_fabric_access(device_)
+              ? Expandable_Segments_Handle_Type::FABRIC_HANDLE
+              : Expandable_Segments_Handle_Type::POSIX_FD;
+          break;
+        case Expandable_Segments_Handle_Type::FABRIC_HANDLE:
+          // User explicitly requested FABRIC - validate device support
+          TORCH_CHECK(
+              cuda::get_fabric_access(device_),
+              "FABRIC handle type configured but device ",
+              device_,
+              " does not support fabric access");
+          handle_type_ = Expandable_Segments_Handle_Type::FABRIC_HANDLE;
+          break;
+        case Expandable_Segments_Handle_Type::POSIX_FD:
+          handle_type_ = Expandable_Segments_Handle_Type::POSIX_FD;
+          break;
       }
-      // if fabric handle is not supported, use posix file handle.
-      CUDAAllocatorConfig::set_expandable_segments_handle_type(
-          Expandable_Segments_Handle_Type::POSIX_FD);
-      return map(range);
     }
 
     if (end > handles_.size()) {
@@ -428,26 +455,11 @@ struct ExpandableSegment {
       CUmemGenericAllocationHandle handle = 0;
       CUmemAllocationProp prop = {};
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-      // In fbcode, IPC handle types for expandable segments are disabled by
-      // default because some jobs were failing (see
-      // https://github.com/pytorch/pytorch/pull/132890), but can be explicitly
-      // enabled via environment variable when IPC functionality is required
-      // (e.g., for multi-process communication with CTran). In non-fbcode
-      // builds, IPC handle types are enabled by default.
-#ifdef FBCODE_CAFFE2
-      static const bool default_enable_ipc = false;
-#else
-      static const bool default_enable_ipc = true;
-#endif
-      static const bool enable_ipc_handles =
-          c10::utils::check_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC")
-              .value_or(default_enable_ipc);
       if (enable_ipc_handles) {
-        if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
-            Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
-          prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-        } else {
+        if (handle_type_ == Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
           prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+        } else {
+          prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
         }
       }
       int flag = 0;
@@ -472,21 +484,8 @@ struct ExpandableSegment {
           }
           trimHandles();
           return rangeFromHandles(begin, begin);
-        } else if (
-            CUDAAllocatorConfig::expandable_segments_handle_type() ==
-            Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
-          // we are testing if we can use fabric handle.
-          // if we can, we will use it.
-          // if we can't, we will use posix file handle.
-          // so we should not return an error here.
-          // in practice, we can get CUDA_ERROR_NOT_SUPPORTED or
-          // CUDA_ERROR_NOT_PERMITTED to be safe, any non out-of-memory error is
-          // considered as the handle type is not supported. if the handle type
-          // is not supported, return a null range to indicate it.
-          return SegmentRange(nullptr, 0);
-        } else {
-          C10_CUDA_DRIVER_CHECK(status);
         }
+        C10_CUDA_DRIVER_CHECK(status);
       }
       handles_.at(i) = Handle{handle, std::nullopt};
     }
@@ -525,13 +524,13 @@ struct ExpandableSegment {
     header.pid = getpid();
     header.segment_size = segment_size_;
     header.num_handles = end - begin;
+    header.handle_type = handle_type_;
 
     buf.write(reinterpret_cast<const char*>(&header), sizeof(ShareHeader));
     for (auto i : c10::irange(begin, end)) {
       // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       auto& handle = handles_.at(i).value();
-      if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
-          Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+      if (handle_type_ != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
         if (!handle.shareable_handle) {
           int fd = 0;
           C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemExportToShareableHandle_(
@@ -572,6 +571,7 @@ struct ExpandableSegment {
     buf.read(reinterpret_cast<char*>(&header), sizeof(ShareHeader));
     auto segment = std::make_unique<ExpandableSegment>(
         device, std::nullopt, header.segment_size, std::move(peers));
+    segment->handle_type_ = header.handle_type;
 // older build setups (e.g. multiwheels) do not have this syscall, added 2020
 // but the kernel on the system might still support it.
 #ifndef SYS_pidfd_open
@@ -580,8 +580,7 @@ struct ExpandableSegment {
 #ifndef SYS_pidfd_getfd
 #define SYS_pidfd_getfd 438
 #endif
-    if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
-        Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+    if (header.handle_type != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
       auto pidfd = syscall(SYS_pidfd_open, header.pid, 0);
       TORCH_CHECK(
           pidfd != -1 || errno != ENOSYS,
@@ -775,11 +774,15 @@ struct ExpandableSegment {
     pid_t pid;
     size_t segment_size;
     size_t num_handles;
+    Expandable_Segments_Handle_Type handle_type;
   };
   std::vector<std::optional<Handle>> handles_;
   // devices on which this memory should be mapped in addition
   // to the device where the physical memory lives (device_).
   std::vector<c10::DeviceIndex> peers_;
+  // handle type of the expandable segment; recorded for IPC share.
+  Expandable_Segments_Handle_Type handle_type_ =
+      Expandable_Segments_Handle_Type::UNSPECIFIED;
 };
 #else
 struct ExpandableSegment {

--- a/test/distributed/test_p2p_ipc.py
+++ b/test/distributed/test_p2p_ipc.py
@@ -12,7 +12,7 @@ from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
     requires_cuda_p2p_access,
     run_tests,
-    skipIfRocm,
+    TEST_WITH_ROCM,
 )
 
 
@@ -84,8 +84,9 @@ class P2PIpcTest(MultiProcContinuousTest):
         """Test P2P IPC with regular cudaMalloc allocations."""
         self._test_p2p_ipc_impl()
 
-    @unittest.skip("Requires fix for expandable segments IPC handle type propagation")
-    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
+    @unittest.skipIf(
+        TEST_WITH_ROCM, "expandable_segments mode is not supported on ROCm"
+    )
     def test_p2p_ipc_expandable_segments(self) -> None:
         """
         Test P2P IPC with expandable segments enabled.


### PR DESCRIPTION
Summary:
## Problem:

Fix IPC failures when FABRIC handle type is configured but not supported by the device. CUDA silently accepts FABRIC handle type requests on non-FABRIC devices during cuMemCreate, but later cuMemExportToShareableHandle fails with "invalid argument".

## Additional refactoring when applying the fix:

The original implementation used a recursive try-fallback pattern that:
1. Tried FABRIC handle type first by modifying global config
2. If allocation failed, recursively called `map()` with POSIX_FD
3. Modified global config (`set_expandable_segments_handle_type()`) based on per-device checks, which is incorrect since `get_fabric_access()` is per-device

Refactored the IPC handle type logic to:

1. **Determine handle type upfront** - All IPC handle type checking now happens once at the beginning of `map()`, before the allocation loop
2. **Use switch-based logic** with clear per-config behavior:
   - `UNSPECIFIED`: Auto-detect using `cuda::get_fabric_access(device_)` 
   - `FABRIC_HANDLE`: Validate device support with `TORCH_CHECK`, error if unsupported
   - `POSIX_FD`: Use POSIX_FD directly
3. **Store result in instance variable** - The decided `handle_type_` is stored per-segment, not in global config
4. **Propagate via ShareHeader** - The actual handle type used during segment creation is propagated during IPC sharing, ensuring receivers import using the correct handle type

Differential Revision: D90907675


