### PR TITLE
Fix  Skip loop split optimization when nodes have mismatched var_ranges[ AI assisted]

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5000,6 +5000,7 @@ class CppScheduling(BaseScheduling):
         div_expr_ = None
         match_div = False
         matched_node = None
+        matched_index_size = None
 
         # Collect node info for later compatibility check
         node_bodies: list[tuple[Any, Any]] = []
@@ -5036,6 +5037,7 @@ class CppScheduling(BaseScheduling):
                         split_number = div_expr.args[1]
                         match_div = True
                         matched_node = node
+                        matched_index_size = index_size
 
         # Only one node contains a division, and the split dimension is contiguous in all other indexing_exprs.
         if not match_div:
@@ -5045,12 +5047,6 @@ class CppScheduling(BaseScheduling):
         # (same number of index dimensions). If not, bail out to avoid incompatible
         # var_ranges after loop split which would cause assertion failures in
         # simplify_and_reorder or codegen_functions.
-        assert matched_node is not None
-        matched_index_size = None
-        for node, ((index_size, _), original_body, _) in node_bodies:
-            if node == matched_node:
-                matched_index_size = index_size
-                break
         assert matched_index_size is not None
         matched_num_dims = len(matched_index_size)
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5001,9 +5001,14 @@ class CppScheduling(BaseScheduling):
         match_div = False
         matched_node = None
 
+        # Collect node info for later compatibility check
+        node_bodies: list[tuple[Any, Any]] = []
+
         for node in nodes:
             assert isinstance(node.node, ir.ComputedBuffer)
-            _, original_body, _ = node.node.get_default_sizes_body()
+            sizes_body = node.node.get_default_sizes_body()
+            node_bodies.append((node, sizes_body))
+            (index_size, _), original_body, _ = sizes_body
             for name, expr in original_body.indexing_exprs.items():
                 if not isinstance(expr, sympy.Expr):
                     continue
@@ -5035,6 +5040,25 @@ class CppScheduling(BaseScheduling):
         # Only one node contains a division, and the split dimension is contiguous in all other indexing_exprs.
         if not match_div:
             return nodes
+
+        # Check if all nodes have split_var in their iter_vars and have compatible sizes
+        # (same number of index dimensions). If not, bail out to avoid incompatible
+        # var_ranges after loop split which would cause assertion failures in
+        # simplify_and_reorder or codegen_functions.
+        assert matched_node is not None
+        matched_index_size = None
+        for node, ((index_size, _), original_body, _) in node_bodies:
+            if node == matched_node:
+                matched_index_size = index_size
+                break
+        assert matched_index_size is not None
+        matched_num_dims = len(matched_index_size)
+
+        for node, ((index_size, _), original_body, _) in node_bodies:
+            if split_var not in original_body.iter_vars:
+                return nodes
+            if len(index_size) != matched_num_dims:
+                return nodes
 
         extra_indexing_constraints = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173685
* #173684
* __->__ #173607

Note: **Fixed by AI waitng for experts to review**

**Summary**
The try_loop_split function in cpp codegen was causing an assertion failure when nodes in a fused group had different numbers of index dimensions.

**Root Cause**
When applying loop split optimization, the function captures extra_indexing_constraints from the matched_node (the node containing the FloorDiv expression) and passes it to all other nodes. However, when nodes have different numbers of index dimensions, the resulting var_ranges after loop split will differ (e.g., {y0: 7, y1: 32} vs {y0: 0, y1: 32, y2: 14}), causing the assertion expected_var_ranges == extra_indexing_ranges to fail in simplify_and_reorder.

**Fix:**
Added a compatibility check that bails out of the loop split optimization early if any node :
 1. Does not have split_var in its iter_vars
 2. Has a different number of index dimensions than matched_node
This ensures all nodes in the group have compatible loop structures before applying the optimization.

Before fix: AssertionError: ({y0: 0, y1: 32, y2: 14}, {y0: 7, y1: 32})
After fix: ✅ eager success, ✅ compile success
Fix https://github.com/pytorch/pytorch/issues/164428
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo