### PR TITLE
[BE] Setup HF cache for vLLM benchmark

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -38,6 +38,8 @@ jobs:
     container:
       image: ${{ inputs.docker_image }}
       options: --gpus all --ipc=host --tty
+      volumes:
+        - /mnt/hf_cache:/mnt/hf_cache
     steps:
       - name: Install system dependencies
         run: |
@@ -188,6 +190,7 @@ jobs:
         working-directory: vllm-project/vllm
         env:
           HF_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
+          HF_HOME: /mnt/hf_cache
           # vLLM-related environment variables
           ENGINE_VERSION: v1
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -191,6 +191,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
           HF_HOME: /mnt/hf_cache
+          TRANSFORMERS_OFFLINE: 1
           # vLLM-related environment variables
           ENGINE_VERSION: v1
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1


### PR DESCRIPTION
The local cache directory is created in https://github.com/meta-pytorch/pytorch-gha-infra/pull/920

### Testing

* Empty cache
    * Smoke https://github.com/pytorch/pytorch/actions/runs/21422576551/job/61715584075
    * All models https://github.com/pytorch/pytorch/actions/runs/21503151885
* Cached
    * Smoke https://github.com/pytorch/pytorch/actions/runs/21422576551/job/61726702614
    * All models
