### PR TITLE
[einops] Don't register einops ops with `allow_in_graph`

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -442,6 +442,8 @@ test_einops() {
   time python test/run_test.py --einops --verbose --upload-artifacts-while-running
   pip install einops==0.8.1
   time python test/run_test.py --einops --verbose --upload-artifacts-while-running
+  pip install einops==0.8.2
+  time python test/run_test.py --einops --verbose --upload-artifacts-while-running
   assert_git_not_dirty
 }
 

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -195,10 +195,6 @@ print(normalize_gm(graph.print_readable(print_output=False)))
         ["reduce", "repeat", "pack", "unpack", "einsum", "rearrange"],
         name_fn=lambda f: f,
     )
-    # @parametrize("flag", [True, False], name_fn=lambda f: f)
-    # @unittest.skipIf(
-    #     einops_version_sanitized != "0.6.1", "Skipping for einops != 0.6.1"
-    # )
     def test_einops_method(self, method):
         flag = einops.__version__ >= "0.8.2"
         if not hasattr(einops, method):

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -1,12 +1,11 @@
 # Owner(s): ["module: dynamo"]
 import importlib
+import os
 import subprocess
 import sys
 import unittest
 
 import torch
-import torch._dynamo.config
-import torch._dynamo.test_case
 from torch import nn
 from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_utils import (
@@ -146,6 +145,86 @@ with torch.compiler.set_stance("fail_on_recompile"):
     z = compiled_fn(x)
 """
         subprocess.check_output([sys.executable, "-c", script])
+
+    def _run_in_subprocess(self, flag, method, einops_method, snippet):
+        # run in a different process
+        script = f"""
+import torch
+from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm
+
+import einops
+
+backend = EagerAndRecordGraphs()
+
+def f(x):
+    {snippet}
+    return y.sin()
+
+x = torch.randn(3, 4, 5)
+expected = f(x)
+got = torch.compile(f, backend=backend, fullgraph=True)(x)
+
+assert torch.allclose(expected, got)
+assert len(backend.graphs) == 1, len(backend.graphs)
+graph = backend.graphs[0]
+print(normalize_gm(graph.print_readable(print_output=False)))
+"""
+        script = script.strip()
+        try:
+            output = (
+                subprocess.check_output(
+                    [sys.executable, "-c", script],
+                    stderr=subprocess.STDOUT,
+                    cwd=os.path.dirname(os.path.realpath(__file__)),
+                )
+                .decode("utf-8")
+                .strip()
+            )
+        except subprocess.CalledProcessError as e:
+            self.fail(
+                msg=(f"Subprocess exception {method}:\n" + e.output.decode("utf-8"))
+            )
+        else:
+            if flag:
+                self.assertNotIn(einops_method, output)
+            else:
+                self.assertIn(einops_method, output)
+
+    @parametrize(
+        "method",
+        ["reduce", "repeat", "pack", "unpack", "einsum", "rearrange"],
+        name_fn=lambda f: f,
+    )
+    # @parametrize("flag", [True, False], name_fn=lambda f: f)
+    # @unittest.skipIf(
+    #     einops_version_sanitized != "0.6.1", "Skipping for einops != 0.6.1"
+    # )
+    def test_einops_method(self, method):
+        flag = einops.__version__ >= "0.8.2"
+        if not hasattr(einops, method):
+            self.skipTest(f"Needs einops.{method}")
+
+        if method == "reduce":
+            einops_method = f"einops_einops_{method}"
+            snippet = "y = einops.reduce(x, 'a b c -> a b', 'min')"
+        elif method == "repeat":
+            einops_method = f"einops_einops_{method}"
+            snippet = "y = einops.repeat(x, 'a b c -> a b c d', d=2)"
+        elif method == "rearrange":
+            einops_method = f"einops_einops_{method}"
+            snippet = "y = einops.rearrange(x, 'a b c -> a c b')"
+        elif method == "einsum":
+            einops_method = f"einops_einops_{method}"
+            snippet = "y = einops.einsum(x, 'a b c -> a c b')"
+        elif method == "pack":
+            einops_method = f"einops_packing_{method}"
+            snippet = "y, meta = einops.pack([x], '* b')"
+        elif method == "unpack":
+            einops_method = f"einops_packing_{method}"
+            snippet = "x_packed, meta = einops.pack([x], '* b'); y = einops.unpack(x_packed, meta, '* b')[0]"
+        else:
+            self.fail(method)
+        self._run_in_subprocess(flag, method, einops_method, snippet)
 
 
 instantiate_parametrized_tests(

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -830,7 +830,7 @@ def _allow_in_graph_einops() -> None:
         if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
             # trigger backend registration up front to avoid a later guard failure
             # that would otherwise cause a recompilation
-            einops.einops.get_backend(torch.tensor(1))
+            einops.rearrange("i -> i", torch.tensor(1))
 
         # einops 0.8.2+ don't need explicit allow_in_graph calls
         return

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -826,6 +826,15 @@ def mark_static_address(t: Any, guard: bool = False) -> None:
 def _allow_in_graph_einops() -> None:
     import einops
 
+    if einops.__version__ >= "0.8.2":
+        if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
+            # trigger backend registration up front to avoid a later guard failure
+            # that would otherwise cause a recompilation
+            einops.einops.get_backend(torch.tensor(1))
+
+        # einops 0.8.2+ don't need explicit allow_in_graph calls
+        return
+
     try:
         # requires einops > 0.6.1, torch >= 2.0
         from einops._torch_specific import (  # type: ignore[attr-defined]  # noqa: F401

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -830,7 +830,7 @@ def _allow_in_graph_einops() -> None:
         if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
             # trigger backend registration up front to avoid a later guard failure
             # that would otherwise cause a recompilation
-            einops.rearrange("i -> i", torch.tensor(1))
+            einops.rearrange(torch.randn(1), "i -> i")
 
         # einops 0.8.2+ don't need explicit allow_in_graph calls
         return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #173611

Starting with einops 0.8.2, einops do not need to be registered with `allow_in_graph`. This means Dynamo will be able to trace through its ops to produce a graph with only PyTorch operations.

Relevant PRs:
* https://github.com/pytorch/pytorch/pull/155310
* https://github.com/arogozhnikov/einops/pull/394

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos