### PR TITLE
[typing] Fix type hints for grad_outputs/grad_tensors to allow None in sequence

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -15,7 +15,12 @@ from typing import cast, Optional, Union
 import torch
 from torch import _vmap_internals
 from torch.overrides import handle_torch_function, has_torch_function, is_tensor_like
-from torch.types import _size, _TensorOrTensors, _TensorOrTensorsOrGradEdge
+from torch.types import (
+    _size,
+    _TensorOrTensors,
+    _TensorOrTensorsOrGradEdge,
+    _TensorOrTensorsOrNone,
+)
 
 from . import forward_ad, functional, graph
 from .anomaly_mode import detect_anomaly, set_detect_anomaly
@@ -241,7 +246,7 @@ def _make_grads(
 
 
 def _tensor_or_tensors_to_tuple(
-    tensors: Optional[_TensorOrTensors], length: int
+    tensors: Optional[_TensorOrTensorsOrNone], length: int
 ) -> tuple[_OptionalTensor, ...]:
     if tensors is None:
         return (None,) * length
@@ -252,10 +257,10 @@ def _tensor_or_tensors_to_tuple(
 
 def backward(
     tensors: _TensorOrTensorsOrGradEdge,
-    grad_tensors: Optional[_TensorOrTensors] = None,
+    grad_tensors: Optional[_TensorOrTensorsOrNone] = None,
     retain_graph: Optional[bool] = None,
     create_graph: bool = False,
-    grad_variables: Optional[_TensorOrTensors] = None,
+    grad_variables: Optional[_TensorOrTensorsOrNone] = None,
     inputs: Optional[_TensorOrTensorsOrGradEdge] = None,
 ) -> None:
     r"""Compute the sum of gradients of given tensors with respect to graph leaves.
@@ -392,7 +397,7 @@ def backward(
 def grad(
     outputs: _TensorOrTensorsOrGradEdge,
     inputs: _TensorOrTensorsOrGradEdge,
-    grad_outputs: Optional[_TensorOrTensors] = None,
+    grad_outputs: Optional[_TensorOrTensorsOrNone] = None,
     retain_graph: Optional[bool] = None,
     create_graph: bool = False,
     only_inputs: bool = True,

--- a/torch/types.py
+++ b/torch/types.py
@@ -39,6 +39,8 @@ __all__ = ["Number", "Device", "FileLike", "Storage"]
 # Convenience aliases for common composite types that we need
 # to talk about in PyTorch
 _TensorOrTensors: TypeAlias = Tensor | Sequence[Tensor]  # noqa: PYI047
+# Like _TensorOrTensors but allows None values in the sequence (e.g., for grad_outputs)
+_TensorOrTensorsOrNone: TypeAlias = Tensor | Sequence[Tensor | None]  # noqa: PYI047
 _TensorOrTensorsOrGradEdge: TypeAlias = Union[  # noqa: PYI047
     Tensor,
     Sequence[Tensor],


### PR DESCRIPTION
## Summary

Fixes #164298

The documentation for `torch.autograd.grad` and `torch.autograd.backward` states that `grad_outputs`/`grad_tensors` can contain `None` values for scalar Tensors or ones that don't require grad. However, the type hints only allowed `Tensor` values in the sequence, which caused type checkers to flag valid code as errors.

## Changes

1. **Added new type alias** `_TensorOrTensorsOrNone` in `torch/types.py`:
   ```python
   _TensorOrTensorsOrNone: TypeAlias = Tensor | Sequence[Tensor | None]
   ```

2. **Updated type hints** in `torch/autograd/__init__.py`:
   - `grad_outputs` in `torch.autograd.grad`
   - `grad_tensors` in `torch.autograd.backward`
   - `grad_variables` in `torch.autograd.backward` (deprecated parameter)
   - `_tensor_or_tensors_to_tuple` helper function

## Example

This code is valid and now type-checks correctly:
```python
import torch

x = torch.randn(3, requires_grad=True)
y = x.sum()  # scalar output
z = x * 2   # non-scalar output

# None is valid for scalar outputs
grads = torch.autograd.grad([y, z], [x], grad_outputs=[None, torch.ones(3)])
```

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @xmfan @bobrenjc93 @lolpack @maggiemoss @ndmitchell @kinto0 @samwgoldman