### PR TITLE
[docs] Remove misleading GLU activation image

### DIFF
--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -47,7 +47,9 @@ functions = [
     torch.nn.Tanh(),
     torch.nn.Tanhshrink(),
     torch.nn.Threshold(0, 0.5),
-    torch.nn.GLU(),
+    # Note: GLU is not included because it requires splitting the input tensor
+    # into two halves (a, b) and computing a * sigmoid(b). A simple 1D input-output
+    # plot doesn't meaningfully represent this behavior.
 ]
 
 
@@ -56,12 +58,8 @@ def plot_function(function, **args):
     Plot a function on the current plot. The additional arguments may
     be used to specify color, alpha, etc.
     """
-    if isinstance(function, torch.nn.GLU):
-        xrange = torch.arange(-7.0, 7.0, 0.01).unsqueeze(1).repeat(1, 2)
-        x = xrange.numpy()[:, 0]
-    else:
-        xrange = torch.arange(-7.0, 7.0, 0.01)  # We need to go beyond 6 for ReLU6
-        x = xrange.numpy()
+    xrange = torch.arange(-7.0, 7.0, 0.01)  # We need to go beyond 6 for ReLU6
+    x = xrange.numpy()
     y = function(xrange).detach().numpy()
     plt.plot(x, y, **args)
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -747,8 +747,6 @@ class GLU(Module):
           dimensions
         - Output: :math:`(\ast_1, M, \ast_2)` where :math:`M=N/2`
 
-    .. image:: ../scripts/activation_images/GLU.png
-
     Examples::
 
         >>> m = nn.GLU()


### PR DESCRIPTION
## Summary
The GLU (Gated Linear Unit) documentation referenced an activation plot that was generated by passing identical values for both halves of the input tensor. Since GLU computes `a * sigmoid(b)` where `a` and `b` are the split halves, when `a = b = x` the result is `x * sigmoid(x)`, which is exactly SiLU.

This caused the GLU plot to look identical to SiLU, which is misleading since GLU is fundamentally different - it operates on two input halves rather than being a simple single-input activation function.

## Changes
1. Removed the misleading image reference from the GLU docstring in `torch/nn/modules/activation.py`
2. Removed GLU from the `build_activation_images.py` script since a simple 1D input-output plot doesn't meaningfully represent GLU's behavior
3. Cleaned up the now-unused GLU special case code in `plot_function()`

## Test Plan
Documentation-only change. No functional code changes.

Fixes #167240

cc @svekars @sekyondaMeta @AlannaBurke @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki