### PR TITLE
Use type-appropriate default tolerances in test assertions

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -517,7 +517,8 @@ class TestCommon(TestCase):
             cuda_results = sample.output_process_fn_grad(cuda_results)
             cpu_results = cpu_sample.output_process_fn_grad(cpu_results)
 
-            atol, rtol = None, None
+            atol = None if torch.xpu.is_available() else 0
+            rtol = None if torch.xpu.is_available() else 0
             if dtype.is_floating_point or dtype.is_complex:
                 atol, rtol = 1e-3, 1e-3
             self.assertEqual(cuda_results, cpu_results, atol=atol, rtol=rtol)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -517,7 +517,7 @@ class TestCommon(TestCase):
             cuda_results = sample.output_process_fn_grad(cuda_results)
             cpu_results = cpu_sample.output_process_fn_grad(cpu_results)
 
-            atol, rtol = 0, 0
+            atol, rtol = None, None
             if dtype.is_floating_point or dtype.is_complex:
                 atol, rtol = 1e-3, 1e-3
             self.assertEqual(cuda_results, cpu_results, atol=atol, rtol=rtol)


### PR DESCRIPTION
This pull request makes a small change to the test code to improve how tolerance values are handled during comparisons. It sets the default values of atol and rtol to None instead of zero, so that self.assertEqual will automatically use the appropriate tolerance for the data type, which is more suitable for non-floating-point and non-complex types.

- Testing improvement:
  * Updated `test_compare_cpu` in `test/test_ops.py` to initialize `atol` and `rtol` as `None` rather than `0`, ensuring correct behavior when these tolerances are not needed.

