### PR TITLE
[DTensor] add ImplicitRedistributionError

### DIFF
--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -30,6 +30,7 @@ from torch.distributed.tensor._utils import (
     compute_local_shape_and_global_offset,
     compute_local_tensor_info,
     ExplicitRedistributionContext,
+    ImplicitRedistributionError,
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import (
@@ -1719,7 +1720,9 @@ class TestExplicitRedistribute(LocalTensorTestBase):
 
             # explicit redistribute works too
             with ExplicitRedistributionContext():
-                with self.assertRaisesRegex(RuntimeError, "Implicit redistribution"):
+                with self.assertRaisesRegex(
+                    ImplicitRedistributionError, "Implicit redistribution"
+                ):
                     torch.matmul(dx, dA)
             with ExplicitRedistributionContext(mode="warn"):
                 with self.assertLogs(
@@ -1750,7 +1753,9 @@ class TestExplicitRedistribute(LocalTensorTestBase):
                 loss = dY.sum()
 
                 # we now see the error during backwards
-                with self.assertRaisesRegex(RuntimeError, "Implicit redistribution"):
+                with self.assertRaisesRegex(
+                    ImplicitRedistributionError, "Implicit redistribution"
+                ):
                     loss.backward(retain_graph=True)
 
                 with ExplicitRedistributionContext(strict=False):
@@ -1762,7 +1767,9 @@ class TestExplicitRedistribute(LocalTensorTestBase):
                     loss.backward(retain_graph=True)
 
                 # and re-enable
-                with self.assertRaisesRegex(RuntimeError, "Implicit redistribution"):
+                with self.assertRaisesRegex(
+                    ImplicitRedistributionError, "Implicit redistribution"
+                ):
                     loss.backward(retain_graph=True)
 
 

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -26,6 +26,10 @@ from torch.distributed.tensor.placement_types import (
 logger = logging.getLogger(__name__)
 
 
+class ImplicitRedistributionError(Exception):
+    """Raised when implicit redistribution occurs within ExplicitRedistributionContext."""
+
+
 def _format_implicit_redistribution_msg(schema: OpSchema) -> str:
     return f"Implicit redistribution occurred for {schema} while ExplicitRedistributionContext was active"
 
@@ -75,7 +79,7 @@ class ExplicitRedistributionContext:
                     allowed = redistribute_cost(src_spec, dst_spec) <= 0
             if not allowed:
                 if instance._raise_on_redistribution:
-                    raise RuntimeError(redistribution_msg)
+                    raise ImplicitRedistributionError(redistribution_msg)
                 else:
                     logger.warning(redistribution_msg)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173625

ExplicitRedistributionContext now raises ImplicitRedistributionError
instead of RuntimeError when implicit redistribution occurs

Will this break six?