### PR TITLE
Remove visualizing and estimating peak mem, put scheduler nodes under config

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3024,23 +3024,25 @@ class Scheduler:
 
                     align_runtime_estimations_across_all_distributed_ranks(self.nodes)
 
-            from torch._logging import trace_structured
+            # pyrefly: ignore [unbound-name]
+            if config_comms.reorder_sink_verbose_logging:
+                from torch._logging import trace_structured
 
-            trace_structured(
-                "artifact",
-                metadata_fn=lambda: {
-                    "name": "scheduler_nodes_before_comm_overlap",
-                    "encoding": "string",
-                },
-                payload_fn=lambda: "\n\n".join(
-                    [
-                        f"snode[{i}]"
-                        + n.debug_str()
-                        + f" buffer_names:{n.get_buffer_names()}"
-                        for i, n in enumerate(self.nodes)
-                    ]
-                ),
-            )
+                trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "scheduler_nodes_before_comm_overlap",
+                        "encoding": "string",
+                    },
+                    payload_fn=lambda: "\n\n".join(
+                        [
+                            f"snode[{i}]"
+                            + n.debug_str()
+                            + f" buffer_names:{n.get_buffer_names()}"
+                            for i, n in enumerate(self.nodes)
+                        ]
+                    ),
+                )
             self.nodes = comms.reorder_compute_and_comm_for_overlap(self.nodes)
         self.process_grouped_nodes()
 


### PR DESCRIPTION
Summary: The visualize and estimate peak mem part is mainly for logging purpose and costly, we thus remove them. For `scheduler_nodes_before_comm_overlap`, we only enable it when corresponding config is set

Test Plan:
Without this change:
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-aps-train-1027125464-f1027133211?job_attempt=0&version=0&tab=summary

Compile time event: https://fburl.com/c0atgucp

With this change: 

https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-aps-train-1027075794-f1027080395?job_attempt=0&version=0&tab=summary

Compile time event: https://fburl.com/dkfo5gbw

Time cost of `Scheduler.__init__` of forward is reduced 8m39s from 2m49s
Time cost of `Scheduler.__init__` of backward is reduced 4m29s from 2m47s

Differential Revision: D91102802




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo