### PR TITLE
[xpu][inductor] enable tensor descriptor on xpu

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2262,10 +2262,13 @@ class TMACompatibilityChecker:
         if self.force:
             return True
         if not (
-            V.graph.get_current_device_or_throw().type == "cuda"
-            and torch.cuda.get_device_capability()[0] >= 9
+            (
+                V.graph.get_current_device_or_throw().type == "cuda"
+                and torch.cuda.get_device_capability()[0] >= 9
+                and config.assume_aligned_inputs
+            )
+            or V.graph.get_current_device_or_throw().type == "xpu"
             and config.triton.use_tensor_descriptor
-            and config.assume_aligned_inputs
             and has_triton_stable_tma_api()
             # For CUDA The base ptr needs to be aligned
         ):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1716,7 +1716,7 @@ class triton:
     #   assume_aligned_inputs to also be enabled
     # TMA descriptors are only going to be generated if the above conditions
     # can be satisfied, along with any existing requirements for index expressions
-    use_tensor_descriptor = True if torch.version.xpu else False
+    use_tensor_descriptor = False
 
     # (Experimental)
     # Whether to allow reordering tensor descriptor matches with descending

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1716,7 +1716,7 @@ class triton:
     #   assume_aligned_inputs to also be enabled
     # TMA descriptors are only going to be generated if the above conditions
     # can be satisfied, along with any existing requirements for index expressions
-    use_tensor_descriptor = False
+    use_tensor_descriptor = True if torch.version.xpu else False
 
     # (Experimental)
     # Whether to allow reordering tensor descriptor matches with descending


### PR DESCRIPTION
XPU devices can use tensor descriptor API. I will set it as default after triton fix related issue https://github.com/intel/intel-xpu-backend-for-triton/issues/5947

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo