### PR TITLE
[xpu][feat][1/3] Add blockwise FP8 support for scaled_mm_v2

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/xpu/Blas.h>
 #include <ATen/xpu/XPUScaledBlas.h>
 #include <torch/library.h>
+#include <functional>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -73,14 +74,49 @@ bool is_rowwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
       scale.is_contiguous());
 }
 
+bool is_blockwise_1x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  // For 1x128 blockwise scaling:
+  // scale shape: [outer_dim x K // 128], stride: [1, outer_dim]
+  int64_t outer_dim = t.size(0);
+  int64_t K = t.size(1);
+  return (
+      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
+      scale.dim() == 2 && scale.size(0) == outer_dim &&
+      scale.size(1) == at::ceil_div<int64_t>(K, 128) &&
+      scale.stride(0) == 1 &&
+      (scale.stride(1) == outer_dim || (scale.size(1) == 1 && scale.stride(1) == 1)));
+}
+
+bool is_blockwise_128x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  // For 128x128 blockwise scaling:
+  // scale shape: [round_up(K // 128, 4), outer_dim // 128], stride: [1, round_up(K // 128, 4)]
+  int64_t outer_dim = t.size(0);
+  int64_t K = t.size(1);
+  int64_t k_blocks = at::round_up<int64_t>(at::ceil_div<int64_t>(K, 128), 4);
+  return (
+      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
+      scale.dim() == 2 && scale.size(0) == k_blocks &&
+      scale.size(1) == at::ceil_div<int64_t>(outer_dim, 128) &&
+      scale.stride(0) == 1 &&
+      (scale.stride(1) == k_blocks || (scale.size(1) == 1 && scale.stride(1) == 1)));
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
     ScalingType desired_scaling) {
-  auto result = desired_scaling == ScalingType::TensorWise
-      ? is_tensorwise_scaling(t, scale)
-      : is_rowwise_scaling(t, scale);
-  return result;
+  switch (desired_scaling) {
+    case ScalingType::TensorWise:
+      return is_tensorwise_scaling(t, scale);
+    case ScalingType::RowWise:
+      return is_rowwise_scaling(t, scale);
+    case ScalingType::BlockWise1x128:
+      return is_blockwise_1x128_scaling(t, scale);
+    case ScalingType::BlockWise128x128:
+      return is_blockwise_128x128_scaling(t, scale);
+    default:
+      return false;
+  }
 }
 
 std::pair<ScalingType, ScalingType> get_joint_scaling(
@@ -104,6 +140,24 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ", 1) and scale_b should be (1, ",
       b.size(1),
       "), and both should be contiguous.\n"
+      "- For BlockWise 1x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1), 128),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0), 128),
+      ", ",
+      b.size(1),
+      "), and both should be outer-dim-major.\n"
+      "- For BlockWise 128x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
+      ceil_div<int64_t>(a.size(0), 128),
+      ", ",
+      ceil_div<int64_t>(a.size(1), 128),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0), 128),
+      ", ",
+      ceil_div<int64_t>(b.size(1), 128),
+      "), and both should be near-inner-dim-major.\n"
       "Got a.dtype()=",
       a.scalar_type(),
       ", scale_a.dtype()=",
@@ -223,10 +277,15 @@ Tensor& _scaled_mm_out_xpu(
 
   // List of supported datatypes for XPU with oneDNN:
   // https://uxlfoundation.github.io/oneDNN/dev_guide_matmul.html#data-types
+  // List of supported BlockWise pairs for FP8:
+  // https://docs.nvidia.com/cuda/cublas/#element-1d-and-128x128-2d-block-scaling-for-fp8-data-types
   auto [scaling_choice_a, scaling_choice_b] = get_joint_scaling(
       {
           std::make_pair(ScalingType::TensorWise, ScalingType::TensorWise),
           std::make_pair(ScalingType::RowWise, ScalingType::RowWise),
+          std::make_pair(ScalingType::BlockWise128x128, ScalingType::BlockWise1x128),
+          std::make_pair(ScalingType::BlockWise1x128, ScalingType::BlockWise128x128),
+          std::make_pair(ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
       },
       mat1,
       mat2,
@@ -364,7 +423,7 @@ namespace scaled_blas = at::native::scaled;
 using scaled_blas::convert_int_to_enum;
 using scaled_blas::ScaledGemmImplementation;
 
-std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 2>
+std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 5>
     scale_kernel_dispatch = {{
         {"tensorwise_tensorwise",
          scaled_blas::check_tensorwise_recipe,
@@ -372,7 +431,15 @@ std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 2>
         {"rowwise_rowwise",
          scaled_blas::check_rowwise_recipe,
          ScaledGemmImplementation::ROWWISE_ROWWISE},
-
+        {"block_1x128_128x128",
+         std::bind(scaled_blas::check_deepseek_recipe, ScalingType::BlockWise1x128, ScalingType::BlockWise128x128, _1, _2, _3, _4, _5, _6),
+         ScaledGemmImplementation::BLOCK_1x128_128x128},
+        {"block_128x128_1x128",
+         std::bind(scaled_blas::check_deepseek_recipe, ScalingType::BlockWise128x128, ScalingType::BlockWise1x128, _1, _2, _3, _4, _5, _6),
+         ScaledGemmImplementation::BLOCK_128x128_1x128},
+        {"block_1x128_1x128",
+         std::bind(scaled_blas::check_deepseek_recipe, ScalingType::BlockWise1x128, ScalingType::BlockWise1x128, _1, _2, _3, _4, _5, _6),
+         ScaledGemmImplementation::BLOCK_1x128_1x128},
     }};
 
 Tensor& _scaled_tensorwise_tensorwise(
@@ -463,6 +530,257 @@ Tensor& _scaled_rowwise_rowwise(
 
   auto scaling_choice_a = ScalingType::RowWise;
   auto scaling_choice_b = ScalingType::RowWise;
+
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out);
+
+  return out;
+}
+
+Tensor& _scaled_block1x128_block1x128(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    const bool use_fast_accum,
+    Tensor& out) {
+  // Restrictions:
+  // A, B are FP8, scales are fp32, shape K//128
+  // As: [M x K // 128], stride: [1, M]
+  // Bs: [N x K // 128], stride: [1, N]
+
+  // check types
+  TORCH_CHECK_VALUE(
+      isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
+      "mat_a and mat_b must be fp8 types, got: ",
+      mat_a.scalar_type(),
+      mat_b.scalar_type());
+
+  const int64_t M = mat_a.sizes()[0];
+  const int64_t K = mat_a.sizes()[1];
+  const int64_t N = mat_b.sizes()[1];
+
+  // scale_a shape
+  TORCH_CHECK_VALUE(
+      scale_a.size(0) == M &&
+          scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
+          scale_a.scalar_type() == kFloat,
+      "scale_a must have shape ",
+      M,
+      " x ",
+      ceil_div<int64_t>(K, 128),
+      " Float elements, got ",
+      scale_a.sizes());
+  // scale_a stride
+  TORCH_CHECK_VALUE(
+      scale_a.stride(0) == 1 &&
+          (scale_a.stride(1) == M ||
+           (scale_a.size(1) == 1 && scale_b.stride(1) == 1)),
+      "scale_a strides must be (",
+      1,
+      ", ",
+      M,
+      "); got: ",
+      scale_a.strides());
+
+  // scale_b shape
+  TORCH_CHECK_VALUE(
+      scale_b.size(0) == N &&
+          scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
+          scale_b.scalar_type() == kFloat,
+      "scale_b must have shape ",
+      N,
+      " x ",
+      ceil_div<int64_t>(K, 128),
+      " Float elements, got ",
+      scale_b.sizes());
+  // scale_b stride
+  TORCH_CHECK_VALUE(
+      scale_b.stride(0) == 1 &&
+          (scale_b.stride(1) == N ||
+           (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
+      "scale_b strides must be (",
+      1,
+      ", ",
+      N,
+      "); got: ",
+      scale_a.strides());
+
+  auto scaling_choice_a = ScalingType::BlockWise1x128;
+  auto scaling_choice_b = ScalingType::BlockWise1x128;
+
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out);
+
+  return out;
+}
+
+Tensor& _scaled_block128x128_block1x128(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    const bool use_fast_accum,
+    Tensor& out) {
+  // Restrictions:
+  // A: [M, K], B: [K, N] are FP8, scales are fp32
+  // As: [round_up(K // 128, 4), M // 128], stride: [M // 128, 1]
+  // Bs: [N x K // 128], stride: [1, N]
+  TORCH_CHECK_VALUE(
+      isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
+      "mat_a and mat_b must be fp8 types, got: ",
+      mat_a.scalar_type(),
+      mat_b.scalar_type());
+
+  const int64_t M = mat_a.sizes()[0];
+  const int64_t K = mat_a.sizes()[1];
+  const int64_t N = mat_b.sizes()[1];
+
+  // scale_a shape
+  TORCH_CHECK_VALUE(
+      scale_a.size(0) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) &&
+          scale_a.size(1) == ceil_div<int64_t>(M, 128) &&
+          scale_a.scalar_type() == kFloat,
+      "scale_a must have shape ",
+      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      " x ",
+      ceil_div<int64_t>(M, 128),
+      " Float elements, got ",
+      scale_a.sizes());
+  // scale_a stride
+  TORCH_CHECK_VALUE(
+      scale_a.stride(0) == 1 &&
+          (scale_a.stride(1) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) ||
+           (scale_a.size(1) == 1 && scale_a.stride(1) == 1)),
+      "scale_a must have strides (1, ",
+      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      "); got ",
+      scale_b.strides());
+
+  // scale_b shape
+  TORCH_CHECK_VALUE(
+      scale_b.size(0) == N &&
+          scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
+          scale_b.scalar_type() == kFloat,
+      "scale_b must have shape ",
+      N,
+      " x ",
+      ceil_div<int64_t>(K, 128),
+      " Float elements, got ",
+      scale_b.sizes());
+  // scale_b stride
+  TORCH_CHECK_VALUE(
+      scale_b.stride(0) == 1 &&
+          (scale_b.stride(1) == N ||
+           (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
+      "scale_b must have strides (1, ",
+      N,
+      "); got ",
+      scale_b.strides());
+
+  auto scaling_choice_a = ScalingType::BlockWise128x128;
+  auto scaling_choice_b = ScalingType::BlockWise1x128;
+
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out);
+
+  return out;
+}
+
+Tensor& _scaled_block1x128_block128x128(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const c10::ScalarType out_dtype,
+    const bool use_fast_accum,
+    Tensor& out) {
+  // Restrictions:
+  // A: [M, K], B: [K, N] are FP8, scales are fp32
+  // As: [M x K // 128], stride: [1, M]
+  // Bs: [round_up(K // 128, 4) x N // 128], stride: [1, N // 128]
+  TORCH_CHECK_VALUE(
+      isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
+      "mat_a and mat_b must be fp8 types, got: ",
+      mat_a.scalar_type(),
+      mat_b.scalar_type());
+
+  int64_t M = mat_a.size(0);
+  int64_t K = mat_a.size(1);
+  int64_t N = mat_b.size(1);
+
+  // scale_a shape
+  TORCH_CHECK_VALUE(
+      scale_a.size(0) == M &&
+          scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
+          scale_a.scalar_type() == kFloat,
+      "scale_a must have shape ",
+      M,
+      " x ",
+      ceil_div<int64_t>(K, 128),
+      " Float elements, got ",
+      scale_a.sizes());
+  // scale_a stride
+  TORCH_CHECK_VALUE(
+      scale_a.stride(0) == 1 &&
+          (scale_a.stride(1) == M ||
+           (scale_a.size(1) == 1 && scale_a.stride(1) == 1)),
+      "scale_a must have strides (1, ",
+      M,
+      "); got ",
+      scale_b.strides());
+  // scale_b shape
+  TORCH_CHECK_VALUE(
+      scale_b.size(0) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) &&
+          scale_b.size(1) == ceil_div<int64_t>(N, 128) &&
+          scale_b.scalar_type() == kFloat,
+      "scale_b must have shape ",
+      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      " x ",
+      ceil_div<int64_t>(N, 128),
+      " Float elements, got ",
+      scale_b.sizes());
+  // scale_b stride
+  TORCH_CHECK_VALUE(
+      scale_b.stride(0) == 1 &&
+          (scale_b.stride(1) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) ||
+           (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
+      "scale_b must have strides (1, ",
+      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      "); got ",
+      scale_b.strides());
+
+  auto scaling_choice_a = ScalingType::BlockWise1x128;
+  auto scaling_choice_b = ScalingType::BlockWise128x128;
 
   _scaled_gemm(
       mat_a,
@@ -665,6 +983,24 @@ Tensor& _scaled_mm_xpu_v2_out(
       ", 1) and scale_b should be (1, ",
       mat_b.size(1),
       "), and both should be contiguous.\n"
+      "- For BlockWise 1x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
+      mat_a.size(0),
+      ", ",
+      ceil_div<int64_t>(mat_a.size(1), 128),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(mat_b.size(0), 128),
+      ", ",
+      mat_b.size(1),
+      "), and both should be outer-dim-major.\n"
+      "- For BlockWise 128x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
+      ceil_div<int64_t>(mat_a.size(0), 128),
+      ", ",
+      ceil_div<int64_t>(mat_a.size(1), 128),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(mat_b.size(0), 128),
+      ", ",
+      ceil_div<int64_t>(mat_b.size(1), 128),
+      "), and both should be near-inner-dim-major (with 16-byte aligned strides).\n"
       "Got mat_a.dtype()=",
       mat_a.scalar_type(),
       ", scale_a[0].dtype()=",
@@ -700,6 +1036,36 @@ Tensor& _scaled_mm_xpu_v2_out(
         out);
   } else if (gemm_impl == ScaledGemmImplementation::ROWWISE_ROWWISE) {
     return _scaled_rowwise_rowwise(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        out);
+  } else if (gemm_impl == ScaledGemmImplementation::BLOCK_128x128_1x128) {
+    return _scaled_block128x128_block1x128(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        out);
+  } else if (gemm_impl == ScaledGemmImplementation::BLOCK_1x128_128x128) {
+    return _scaled_block1x128_block128x128(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        out);
+  } else if (gemm_impl == ScaledGemmImplementation::BLOCK_1x128_1x128) {
+    return _scaled_block1x128_block1x128(
         mat_a,
         mat_b,
         scale_a[0],

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -74,7 +74,6 @@ bool is_rowwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
       scale.is_contiguous());
 }
 
-
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -44,22 +44,31 @@ using at::blas::SwizzleType;
 
 namespace {
 /*
- * Scaling Type Determination:
- * ---------------------------
- * Conditions and corresponding Scaling Types:
+ * Scaling Type Determination (XPU):
+ * -------------------------------------------
+ * All scale tensors must be float32.
+ * API shapes match CUDA for portability (Same shape [n, k], but strides may
+ * differ). CUDA uses col-major because of swizzling purpose, but XPU expects
+ * row-major order for oneDNN.
  *
- * - If scale tensor is `Float8_e8m0fnu` or `Float8_e4m3fn`:
- *   - Returns BlockWise (with additional size checks).
+ * For matrix A [M, K] and scale_a:
+ *   - TensorWise:      scale_a is a singleton (numel==1)
+ *   - RowWise:         scale_a has shape [M, 1]
+ *   - BlockWise1x128:  scale_a has shape [M, K//128]
+ *   - BlockWise128x128: scale_a has shape [M//128, K//128]
  *
- * - Else if scale.numel() == 1:
- *   - Returns TensorWise.
+ * For matrix B [K, N] and scale_b:
+ *   - TensorWise:      scale_b is a singleton (numel==1)
+ *   - RowWise:         scale_b has shape [1, N]
+ *   - BlockWise1x128:  scale_b has shape [K//128, N]
+ *   - BlockWise128x128: scale_b has shape [K//128, N//128]
  *
- * - Else if scale.dim() == 2 && scale.size(0) == outer_dim && scale.size(1) ==
- * 1:
- *   - Returns RowWise.
- *
- * - Otherwise:
- *   - Returns Error.
+ * Supported (A, B) scaling combinations:
+ *   - (TensorWise, TensorWise)
+ *   - (RowWise, RowWise)
+ *   - (BlockWise128x128, BlockWise1x128)  -- DeepSeek-style
+ *   - (BlockWise1x128, BlockWise128x128)
+ *   - (BlockWise1x128, BlockWise1x128)
  */
 
 bool is_tensorwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
@@ -74,6 +83,34 @@ bool is_rowwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
       scale.is_contiguous());
 }
 
+// Scale shape checks for blockwise scaling.
+// For a matrix t [rows, cols]:
+//   BlockWise1x128:   scale has shape [rows, ceil_div(cols, 128)]
+//   BlockWise128x128: scale has shape [ceil_div(rows, 128), ceil_div(cols,
+//   128)]
+// These shapes match CUDA's convention.
+// XPU accepts both row-major (contiguous) and column-major strides,
+// since it internally calls .contiguous() for oneDNN. CUDA requires
+// specific strides for cuBLAS swizzling; XPU is more permissive but
+// still validates that strides form a valid contiguous layout.
+bool is_blockwise_1x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  return (
+      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
+      scale.dim() == 2 && scale.size(0) == t.size(0) &&
+      scale.size(1) == ceil_div<int64_t>(t.size(1), 128) &&
+      (scale.is_contiguous() || scale.t().is_contiguous()));
+}
+
+bool is_blockwise_128x128_scaling(
+    const at::Tensor& t,
+    const at::Tensor& scale) {
+  return (
+      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
+      scale.dim() == 2 && scale.size(0) == ceil_div<int64_t>(t.size(0), 128) &&
+      scale.size(1) == ceil_div<int64_t>(t.size(1), 128) &&
+      (scale.is_contiguous() || scale.t().is_contiguous()));
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
@@ -83,6 +120,10 @@ bool is_desired_scaling(
       return is_tensorwise_scaling(t, scale);
     case ScalingType::RowWise:
       return is_rowwise_scaling(t, scale);
+    case ScalingType::BlockWise1x128:
+      return is_blockwise_1x128_scaling(t, scale);
+    case ScalingType::BlockWise128x128:
+      return is_blockwise_128x128_scaling(t, scale);
     default:
       return false;
   }
@@ -95,6 +136,11 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
     const at::Tensor& scale_a,
     const at::Tensor& scale_b) {
   for (auto [lhs, rhs] : options) {
+    // Use the same b.t()/scale_b.t() convention as CUDA v1.
+    // For b=[K,N]: b.t()=[N,K], scale_b.t() is checked against [N,K].
+    // This gives API shapes matching CUDA:
+    //   1x128:   scale_b = [K//128, N]
+    //   128x128: scale_b = [K//128, N//128]
     if (is_desired_scaling(a, scale_a, lhs) &&
         is_desired_scaling(b.t(), scale_b.t(), rhs)) {
       return {lhs, rhs};
@@ -108,7 +154,25 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       a.size(0),
       ", 1) and scale_b should be (1, ",
       b.size(1),
-      "), and both should be contiguous.\n"
+      "), and both should be contiguous.\n",
+      "- For BlockWise 1x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1), 128),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0), 128),
+      ", ",
+      b.size(1),
+      ").\n"
+      "- For BlockWise 128x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
+      ceil_div<int64_t>(a.size(0), 128),
+      ", ",
+      ceil_div<int64_t>(a.size(1), 128),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0), 128),
+      ", ",
+      ceil_div<int64_t>(b.size(1), 128),
+      ").\n"
       "Got a.dtype()=",
       a.scalar_type(),
       ", scale_a.dtype()=",
@@ -165,30 +229,32 @@ Tensor& _scaled_gemm(
 } // namespace
 
 // Computes matrix multiply + bias while applying scaling to input and output
-// matrices Scales are only applicable when matrices are of Float8 type and
-// assumed to be equal to 1.0 by default. If output matrix type is 16 or 32-bit
-// type, scale_result is not applied. Known limitations:
+// matrices. Scales are only applicable when matrices are of Float8 type.
+// Scale tensors must be float32 with stride(1)==1 for blockwise modes.
+// Known limitations:
 //  - Only works if mat1 is row-major and mat2 is column-major
-//  - Only works if matrices sizes are divisible by 32
-//  - If 1-dimensional tensors are used then scale_a should be size =
-//  mat1.size(0)
-//    and scale_b should have size = to mat2.size(1)
+//  - Only works if matrices sizes are divisible by 16
 //  Arguments:
-//    - `mat1`: the first operand of the matrix multiply, can be type
-//    `torch.float8_e4m3fn` or `torch.float8_e5m2`
-//    - `mat2`: the second operand of the matrix multiply, can be type
-//    `torch.float8_e4m3fn` or `torch.float8_e5m2`
-//    - `bias`: the bias, can be type `torch.float16` or `torch.bfloat16`
-//    - `out_dtype`: the output dtype, can either be a float8 or a higher
-//    precision floating point type
-//    - `scale_a`: a tensor with the inverse scale of `mat1`, whose
-//    shape/strides/dtype depend on the scaling scheme
-//    - `scale_b`: a tensor with the inverse scale of `mat2`, whose
-//    shape/strides/dtype depend on the scaling scheme
-//    - `scale_result`: a scalar tensor with the scale of the output, only
-//    utilized if the output is a float8 type
-//    - `use_fast_accum`: Not applicable for XPU. For now, it should always be
-//    false.
+//    - `mat1`: the first operand [M, K], type `torch.float8_e4m3fn` or
+//    `torch.float8_e5m2`
+//    - `mat2`: the second operand [K, N], type `torch.float8_e4m3fn` or
+//    `torch.float8_e5m2`
+//    - `bias`: optional bias of size N, type `torch.float16`, `torch.bfloat16`,
+//    or `torch.float32`
+//    - `out_dtype`: the output dtype
+//    - `scale_a`: inverse scale of `mat1`; shape depends on scaling scheme:
+//        TensorWise: scalar tensor;
+//        RowWise: [M, 1];
+//        BlockWise1x128: [M, K//128];
+//        BlockWise128x128: [M//128, K//128]
+//    - `scale_b`: inverse scale of `mat2`; shape depends on scaling scheme:
+//        TensorWise: scalar tensor;
+//        RowWise: [1, N];
+//        BlockWise1x128: [K//128, N];
+//        BlockWise128x128: [K//128, N//128]
+//    - `scale_result`: a scalar tensor with the scale of the output (not
+//    currently supported on XPU)
+//    - `use_fast_accum`: not supported on XPU, silently ignored
 //    - `out`: a reference to the output tensor
 
 Tensor& _scaled_mm_out_xpu(
@@ -527,22 +593,9 @@ Tensor& _scaled_block1x128_block1x128(
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
     Tensor& out) {
-  // A: [M, K], B: [K, N] are FP8, scales are fp32
-  //
-  //          |  shape    | stride
-  //  --------|-----------|--------
-  //  A       | [M, K]    | row-major
-  //  B       | [K, N]    | col-major
-  //
-  // Scale layout vs CUDA:
-  //   CUDA (col-major, mirrors cuBLAS col-major A/B convention):
-  //     scale_a: [M, K//128]   stride (1, M)   <- scale_a[:,kb] contiguous
-  //     scale_b: [N, K//128]   stride (1, N)   <- scale_b[:,kb] contiguous
-  //   XPU (row-major, PyTorch-native convention):
-  //     scale_a: [M, K//128]   stride (K//128, 1)
-  //     scale_b: [K//128, N]   stride (N, 1)
+  //   scale_a: [M, K//128]
+  //   scale_b: [N, K//128]
 
-  // check types
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -553,7 +606,6 @@ Tensor& _scaled_block1x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a: [M, K//128], row-major stride (K//128, 1)
   TORCH_CHECK_VALUE(
       scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
@@ -563,26 +615,23 @@ Tensor& _scaled_block1x128_block1x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  TORCH_CHECK_VALUE(
-      scale_a.stride(1) == 1,
-      "scale_a must be row-major (stride(1) == 1); got: ",
-      scale_a.strides());
 
-  // scale_b: [K//128, N], row-major stride (N, 1) — same K//128 x N grid as
-  // CUDA's [N, K//128], axes swapped to match row-major layout
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
-      ceil_div<int64_t>(K, 128),
-      " x ",
       N,
+      " x ",
+      ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_b.sizes());
-  TORCH_CHECK_VALUE(
-      scale_b.stride(1) == 1,
-      "scale_b must be row-major (stride(1) == 1); got: ",
-      scale_b.strides());
+
+  // Convert to oneDNN row-major layout:
+  //   scale_a [M, K//128] → no transpose, just contiguous
+  //   scale_b [N, K//128] → transpose to [K//128, N], then contiguous
+  auto sa = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
+  auto sb_t = scale_b.t();
+  auto sb = sb_t.is_contiguous() ? sb_t : sb_t.contiguous();
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;
   auto scaling_choice_b = ScalingType::BlockWise1x128;
@@ -590,8 +639,8 @@ Tensor& _scaled_block1x128_block1x128(
   _scaled_gemm(
       mat_a,
       mat_b,
-      scale_a,
-      scale_b,
+      sa,
+      sb,
       scaling_choice_a,
       scaling_choice_b,
       bias,
@@ -610,20 +659,8 @@ Tensor& _scaled_block128x128_block1x128(
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
     Tensor& out) {
-  // A: [M, K], B: [K, N] are FP8, scales are fp32
-  //
-  //          |  shape    | stride
-  //  --------|-----------|--------
-  //  A       | [M, K]    | row-major
-  //  B       | [K, N]    | col-major
-  //
-  // Scale layout vs CUDA:
-  //   CUDA (col-major, mirrors cuBLAS col-major A/B convention):
-  //     scale_a: [round_up(K//128,4), M//128]  stride (1, round_up(K//128,4))
-  //     scale_b: [N, K//128]                   stride (1, N)
-  //   XPU (row-major, PyTorch-native convention, no L4 padding):
-  //     scale_a: [M//128, K//128]  stride (K//128, 1)
-  //     scale_b: [K//128, N]       stride (N, 1)
+  //   scale_a: [K//128, M//128]
+  //   scale_b: [N, K//128]
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -634,37 +671,34 @@ Tensor& _scaled_block128x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a: [M//128, K//128], row-major stride (K//128, 1)
   TORCH_CHECK_VALUE(
-      scale_a.size(0) == ceil_div<int64_t>(M, 128) &&
-          scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_a.size(0) == ceil_div<int64_t>(K, 128) &&
+          scale_a.size(1) == ceil_div<int64_t>(M, 128) &&
           scale_a.scalar_type() == kFloat,
       "scale_a must have shape ",
-      ceil_div<int64_t>(M, 128),
-      " x ",
       ceil_div<int64_t>(K, 128),
+      " x ",
+      ceil_div<int64_t>(M, 128),
       " Float elements, got ",
       scale_a.sizes());
-  TORCH_CHECK_VALUE(
-      scale_a.stride(1) == 1,
-      "scale_a must be row-major (stride(1) == 1); got: ",
-      scale_a.strides());
 
-  // scale_b: [K//128, N], row-major stride (N, 1) — same K//128 x N grid as
-  // CUDA's [N, K//128], axes swapped to match row-major layout
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
-      ceil_div<int64_t>(K, 128),
-      " x ",
       N,
+      " x ",
+      ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_b.sizes());
-  TORCH_CHECK_VALUE(
-      scale_b.stride(1) == 1,
-      "scale_b must be row-major (stride(1) == 1); got: ",
-      scale_b.strides());
+
+  // Convert to oneDNN row-major layout:
+  //   scale_a [K//128, M//128] → transpose to [M//128, K//128], then contiguous
+  //   scale_b [N, K//128] → transpose to [K//128, N], then contiguous
+  auto sa_t = scale_a.t();
+  auto sa = sa_t.is_contiguous() ? sa_t : sa_t.contiguous();
+  auto sb_t = scale_b.t();
+  auto sb = sb_t.is_contiguous() ? sb_t : sb_t.contiguous();
 
   auto scaling_choice_a = ScalingType::BlockWise128x128;
   auto scaling_choice_b = ScalingType::BlockWise1x128;
@@ -672,8 +706,8 @@ Tensor& _scaled_block128x128_block1x128(
   _scaled_gemm(
       mat_a,
       mat_b,
-      scale_a,
-      scale_b,
+      sa,
+      sb,
       scaling_choice_a,
       scaling_choice_b,
       bias,
@@ -692,20 +726,8 @@ Tensor& _scaled_block1x128_block128x128(
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
     Tensor& out) {
-  // A: [M, K], B: [K, N] are FP8, scales are fp32
-  //
-  //          |  shape    | stride
-  //  --------|-----------|--------
-  //  A       | [M, K]    | row-major
-  //  B       | [K, N]    | col-major
-  //
-  // Scale layout vs CUDA:
-  //   CUDA (col-major, mirrors cuBLAS col-major A/B convention):
-  //     scale_a: [M, K//128]                   stride (1, M)
-  //     scale_b: [round_up(K//128,4), N//128]  stride (1, round_up(K//128,4))
-  //   XPU (row-major, PyTorch-native convention, no L4 padding):
-  //     scale_a: [M, K//128]       stride (K//128, 1)
-  //     scale_b: [K//128, N//128]  stride (N//128, 1)
+  //   scale_a: [M, K//128]
+  //   scale_b: [K//128, N//128]
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -716,7 +738,6 @@ Tensor& _scaled_block1x128_block128x128(
   int64_t K = mat_a.size(1);
   int64_t N = mat_b.size(1);
 
-  // scale_a: [M, K//128], row-major stride (K//128, 1)
   TORCH_CHECK_VALUE(
       scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
@@ -726,12 +747,7 @@ Tensor& _scaled_block1x128_block128x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  TORCH_CHECK_VALUE(
-      scale_a.stride(1) == 1,
-      "scale_a must be row-major (stride(1) == 1); got: ",
-      scale_a.strides());
-  // scale_b: [K//128, N//128], row-major stride (N//128, 1) — no L4 padding vs
-  // CUDA's [round_up(K//128, 4), N//128]
+
   TORCH_CHECK_VALUE(
       scale_b.size(0) == ceil_div<int64_t>(K, 128) &&
           scale_b.size(1) == ceil_div<int64_t>(N, 128) &&
@@ -742,10 +758,12 @@ Tensor& _scaled_block1x128_block128x128(
       ceil_div<int64_t>(N, 128),
       " Float elements, got ",
       scale_b.sizes());
-  TORCH_CHECK_VALUE(
-      scale_b.stride(1) == 1,
-      "scale_b must be row-major (stride(1) == 1); got: ",
-      scale_b.strides());
+
+  // Convert to oneDNN row-major layout:
+  //   scale_a [M, K//128] → no transpose, just contiguous
+  //   scale_b [K//128, N//128] → no transpose, just contiguous
+  auto sa = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
+  auto sb = scale_b.is_contiguous() ? scale_b : scale_b.contiguous();
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;
   auto scaling_choice_b = ScalingType::BlockWise128x128;
@@ -753,8 +771,8 @@ Tensor& _scaled_block1x128_block128x128(
   _scaled_gemm(
       mat_a,
       mat_b,
-      scale_a,
-      scale_b,
+      sa,
+      sb,
       scaling_choice_a,
       scaling_choice_b,
       bias,
@@ -956,19 +974,19 @@ Tensor& _scaled_mm_xpu_v2_out(
       ", ",
       ceil_div<int64_t>(mat_a.size(1), 128),
       ") and scale_b should be (",
-      ceil_div<int64_t>(mat_b.size(0), 128),
-      ", ",
       mat_b.size(1),
-      "), and both should be outer-dim-major.\n"
-      "- For BlockWise 128x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
-      ceil_div<int64_t>(mat_a.size(0), 128),
       ", ",
+      ceil_div<int64_t>(mat_b.size(0), 128),
+      ").\n"
+      "- For BlockWise 128x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
       ceil_div<int64_t>(mat_a.size(1), 128),
+      ", ",
+      ceil_div<int64_t>(mat_a.size(0), 128),
       ") and scale_b should be (",
       ceil_div<int64_t>(mat_b.size(0), 128),
       ", ",
       ceil_div<int64_t>(mat_b.size(1), 128),
-      "), and both should be near-inner-dim-major (with 16-byte aligned strides).\n"
+      ").\n"
       "Got mat_a.dtype()=",
       mat_a.scalar_type(),
       ", scale_a[0].dtype()=",
@@ -991,7 +1009,6 @@ Tensor& _scaled_mm_xpu_v2_out(
 
   auto bias_ = bias.value_or(Tensor());
 
-  // dispatch to appropriate lower-level calls for error checking & execution
   if (gemm_impl == ScaledGemmImplementation::TENSORWISE_TENSORWISE) {
     return _scaled_tensorwise_tensorwise(
         mat_a,

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -528,6 +528,21 @@ Tensor& _scaled_block1x128_block1x128(
     const bool use_fast_accum,
     Tensor& out) {
   // A: [M, K], B: [K, N] are FP8, scales are fp32
+  //
+  //          |  shape    | stride
+  //  --------|-----------|--------
+  //  A       | [M, K]    | row-major
+  //  B       | [K, N]    | col-major
+  //
+  // Scale layout vs CUDA:
+  //            |  CUDA shape   | CUDA stride | XPU shape   | XPU stride
+  //  ----------|---------------|-------------|-------------|------------
+  //  scale_a   | [M, K//128]   | (1, M)      | [M, K//128] | (K//128, 1)
+  //  scale_b   | [N, K//128]   | (1, N)      | [K//128, N] | (N, 1)
+  //
+  // Both represent the same K//128 x N grid of scale values.
+  // CUDA orders scale_b axes as [N, K//128] col-major;
+  // XPU uses [K//128, N] row-major.
 
   // check types
   TORCH_CHECK_VALUE(
@@ -540,7 +555,7 @@ Tensor& _scaled_block1x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a shape: [M, K//128]
+  // scale_a: [M, K//128], row-major stride (K//128, 1)
   TORCH_CHECK_VALUE(
       scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
@@ -550,13 +565,13 @@ Tensor& _scaled_block1x128_block1x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  // scale_a stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
       scale_a.stride(1) == 1,
-      "scale_a must be K-contiguous (stride(1) == 1); got: ",
+      "scale_a must be row-major (stride(1) == 1); got: ",
       scale_a.strides());
 
-  // scale_b shape: [K//128, N]
+  // scale_b: [K//128, N], row-major stride (N, 1) — same K//128 x N grid as
+  // CUDA's [N, K//128], axes swapped to match row-major layout
   TORCH_CHECK_VALUE(
       scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
           scale_b.scalar_type() == kFloat,
@@ -566,10 +581,9 @@ Tensor& _scaled_block1x128_block1x128(
       N,
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride: K-contiguous (stride(0) can vary, stride(1) == 1)
   TORCH_CHECK_VALUE(
       scale_b.stride(1) == 1,
-      "scale_b must be K-contiguous (stride(1) == 1); got: ",
+      "scale_b must be row-major (stride(1) == 1); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;
@@ -599,11 +613,20 @@ Tensor& _scaled_block128x128_block1x128(
     const bool use_fast_accum,
     Tensor& out) {
   // A: [M, K], B: [K, N] are FP8, scales are fp32
-
-  // [Note:] Unlike cuBLAS, XPU does not use L4 padding nor swizzling
-  // XPU uses natural scale shapes that match matrix dimensions:
-  // A: [M, K] -> scale_a: [M//128, K//128]
-  // B: [K, N] -> scale_b: [K//128, N]
+  //
+  //          |  shape    | stride
+  //  --------|-----------|--------
+  //  A       | [M, K]    | row-major
+  //  B       | [K, N]    | col-major
+  //
+  // Scale layout vs CUDA:
+  //   CUDA (col-major, scale_a L4-padded on K-block dim):
+  //     scale_a: [round_up(K//128,4), M//128]  stride (1, round_up(K//128,4))
+  //     scale_b: [N, K//128]                   stride (1, N)
+  //   XPU (row-major, no L4 padding):
+  //     scale_a: [M//128, K//128]  stride (K//128, 1)
+  //     scale_b: [K//128, N]       stride (N, 1)
+  // scale_b: same K//128 x N values; axis order differs per backend.
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -614,7 +637,7 @@ Tensor& _scaled_block128x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a shape: [M//128, K//128]
+  // scale_a: [M//128, K//128], row-major stride (K//128, 1)
   TORCH_CHECK_VALUE(
       scale_a.size(0) == ceil_div<int64_t>(M, 128) &&
           scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
@@ -625,13 +648,13 @@ Tensor& _scaled_block128x128_block1x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  // scale_a stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
       scale_a.stride(1) == 1,
-      "scale_a must be K-contiguous (stride(1) == 1); got: ",
+      "scale_a must be row-major (stride(1) == 1); got: ",
       scale_a.strides());
 
-  // scale_b shape: [K//128, N].
+  // scale_b: [K//128, N], row-major stride (N, 1) — same K//128 x N grid as
+  // CUDA's [N, K//128], axes swapped to match row-major layout
   TORCH_CHECK_VALUE(
       scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
           scale_b.scalar_type() == kFloat,
@@ -641,11 +664,9 @@ Tensor& _scaled_block128x128_block1x128(
       N,
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride:
-  // Note that this is different with CUDA. CUDA has col-major scales.
   TORCH_CHECK_VALUE(
       scale_b.stride(1) == 1,
-      "scale_b must be K-contiguous (stride(1) == 1); got: ",
+      "scale_b must be row-major (stride(1) == 1); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise128x128;
@@ -674,14 +695,21 @@ Tensor& _scaled_block1x128_block128x128(
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
     Tensor& out) {
-  // Restrictions:
   // A: [M, K], B: [K, N] are FP8, scales are fp32
-  // As: [M x K // 128]
-  // Bs: [K // 128 x N // 128]
-
-  // XPU uses natural scale shapes that match matrix dimensions:
-  // A: [M, K] -> scale_a: [M, K//128]
-  // B: [K, N] -> scale_b: [K//128, N//128]
+  //
+  //          |  shape    | stride
+  //  --------|-----------|--------
+  //  A       | [M, K]    | row-major
+  //  B       | [K, N]    | col-major
+  //
+  // Scale layout vs CUDA:
+  //   CUDA (col-major, scale_b L4-padded on K-block dim):
+  //     scale_a: [M, K//128]                   stride (1, M)
+  //     scale_b: [round_up(K//128,4), N//128]  stride (1, round_up(K//128,4))
+  //   XPU (row-major, no L4 padding):
+  //     scale_a: [M, K//128]       stride (K//128, 1)
+  //     scale_b: [K//128, N//128]  stride (N//128, 1)
+  // scale_a: same [M, K//128] shape; CUDA col-major stride, XPU row-major.
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -692,7 +720,7 @@ Tensor& _scaled_block1x128_block128x128(
   int64_t K = mat_a.size(1);
   int64_t N = mat_b.size(1);
 
-  // scale_a shape: [M, K//128]
+  // scale_a: [M, K//128], row-major stride (K//128, 1)
   TORCH_CHECK_VALUE(
       scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
@@ -702,12 +730,12 @@ Tensor& _scaled_block1x128_block128x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  // scale_a stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
       scale_a.stride(1) == 1,
-      "scale_a must be K-contiguous (stride(1) == 1); got: ",
+      "scale_a must be row-major (stride(1) == 1); got: ",
       scale_a.strides());
-  // scale_b shape: [K//128, N//128]
+  // scale_b: [K//128, N//128], row-major stride (N//128, 1) — no L4 padding vs
+  // CUDA's [round_up(K//128, 4), N//128]
   TORCH_CHECK_VALUE(
       scale_b.size(0) == ceil_div<int64_t>(K, 128) &&
           scale_b.size(1) == ceil_div<int64_t>(N, 128) &&
@@ -718,10 +746,9 @@ Tensor& _scaled_block1x128_block128x128(
       ceil_div<int64_t>(N, 128),
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
       scale_b.stride(1) == 1,
-      "scale_b must be K-contiguous (stride(1) == 1); got: ",
+      "scale_b must be row-major (stride(1) == 1); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -74,32 +74,6 @@ bool is_rowwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
       scale.is_contiguous());
 }
 
-bool is_blockwise_1x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
-  // For 1x128 blockwise scaling:
-  // scale shape: [outer_dim x K // 128], stride: [1, outer_dim]
-  int64_t outer_dim = t.size(0);
-  int64_t K = t.size(1);
-  return (
-      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
-      scale.dim() == 2 && scale.size(0) == outer_dim &&
-      scale.size(1) == at::ceil_div<int64_t>(K, 128) &&
-      scale.stride(0) == 1 &&
-      (scale.stride(1) == outer_dim || (scale.size(1) == 1 && scale.stride(1) == 1)));
-}
-
-bool is_blockwise_128x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
-  // For 128x128 blockwise scaling:
-  // scale shape: [round_up(K // 128, 4), outer_dim // 128], stride: [1, round_up(K // 128, 4)]
-  int64_t outer_dim = t.size(0);
-  int64_t K = t.size(1);
-  int64_t k_blocks = at::round_up<int64_t>(at::ceil_div<int64_t>(K, 128), 4);
-  return (
-      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
-      scale.dim() == 2 && scale.size(0) == k_blocks &&
-      scale.size(1) == at::ceil_div<int64_t>(outer_dim, 128) &&
-      scale.stride(0) == 1 &&
-      (scale.stride(1) == k_blocks || (scale.size(1) == 1 && scale.stride(1) == 1)));
-}
 
 bool is_desired_scaling(
     const at::Tensor& t,
@@ -110,10 +84,6 @@ bool is_desired_scaling(
       return is_tensorwise_scaling(t, scale);
     case ScalingType::RowWise:
       return is_rowwise_scaling(t, scale);
-    case ScalingType::BlockWise1x128:
-      return is_blockwise_1x128_scaling(t, scale);
-    case ScalingType::BlockWise128x128:
-      return is_blockwise_128x128_scaling(t, scale);
     default:
       return false;
   }
@@ -140,24 +110,6 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ", 1) and scale_b should be (1, ",
       b.size(1),
       "), and both should be contiguous.\n"
-      "- For BlockWise 1x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
-      a.size(0),
-      ", ",
-      ceil_div<int64_t>(a.size(1), 128),
-      ") and scale_b should be (",
-      ceil_div<int64_t>(b.size(0), 128),
-      ", ",
-      b.size(1),
-      "), and both should be outer-dim-major.\n"
-      "- For BlockWise 128x128 scaling, a and b should be float8, scales should be float, scale_a should be (",
-      ceil_div<int64_t>(a.size(0), 128),
-      ", ",
-      ceil_div<int64_t>(a.size(1), 128),
-      ") and scale_b should be (",
-      ceil_div<int64_t>(b.size(0), 128),
-      ", ",
-      ceil_div<int64_t>(b.size(1), 128),
-      "), and both should be near-inner-dim-major.\n"
       "Got a.dtype()=",
       a.scalar_type(),
       ", scale_a.dtype()=",
@@ -277,15 +229,10 @@ Tensor& _scaled_mm_out_xpu(
 
   // List of supported datatypes for XPU with oneDNN:
   // https://uxlfoundation.github.io/oneDNN/dev_guide_matmul.html#data-types
-  // List of supported BlockWise pairs for FP8:
-  // https://docs.nvidia.com/cuda/cublas/#element-1d-and-128x128-2d-block-scaling-for-fp8-data-types
   auto [scaling_choice_a, scaling_choice_b] = get_joint_scaling(
       {
           std::make_pair(ScalingType::TensorWise, ScalingType::TensorWise),
           std::make_pair(ScalingType::RowWise, ScalingType::RowWise),
-          std::make_pair(ScalingType::BlockWise128x128, ScalingType::BlockWise1x128),
-          std::make_pair(ScalingType::BlockWise1x128, ScalingType::BlockWise128x128),
-          std::make_pair(ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
       },
       mat1,
       mat2,

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -631,7 +631,7 @@ Tensor& _scaled_block128x128_block1x128(
       "scale_a must be K-contiguous (stride(1) == 1); got: ",
       scale_a.strides());
 
-  // scale_b shape: [K//128, N] - natural shape matching B [K, N]
+  // scale_b shape: [K//128, N].
   TORCH_CHECK_VALUE(
       scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
           scale_b.scalar_type() == kFloat,
@@ -641,7 +641,8 @@ Tensor& _scaled_block128x128_block1x128(
       N,
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride: K-contiguous (stride(1) == 1)
+  // scale_b stride:
+  // Note that this is different with CUDA. CUDA has col-major scales.
   TORCH_CHECK_VALUE(
       scale_b.stride(1) == 1,
       "scale_b must be K-contiguous (stride(1) == 1); got: ",

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -527,8 +527,7 @@ Tensor& _scaled_block1x128_block1x128(
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
     Tensor& out) {
-  // Restrictions:
-  // A, B are FP8, scales are fp32, shape K//128
+  // A: [M, K], B: [K, N] are FP8, scales are fp32
 
   // check types
   TORCH_CHECK_VALUE(
@@ -599,7 +598,6 @@ Tensor& _scaled_block128x128_block1x128(
     const c10::ScalarType out_dtype,
     const bool use_fast_accum,
     Tensor& out) {
-  // Restrictions:
   // A: [M, K], B: [K, N] are FP8, scales are fp32
 
   // [Note:] Unlike cuBLAS, XPU does not use L4 padding nor swizzling

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -535,14 +535,12 @@ Tensor& _scaled_block1x128_block1x128(
   //  B       | [K, N]    | col-major
   //
   // Scale layout vs CUDA:
-  //            |  CUDA shape   | CUDA stride | XPU shape   | XPU stride
-  //  ----------|---------------|-------------|-------------|------------
-  //  scale_a   | [M, K//128]   | (1, M)      | [M, K//128] | (K//128, 1)
-  //  scale_b   | [N, K//128]   | (1, N)      | [K//128, N] | (N, 1)
-  //
-  // Both represent the same K//128 x N grid of scale values.
-  // CUDA orders scale_b axes as [N, K//128] col-major;
-  // XPU uses [K//128, N] row-major.
+  //   CUDA (col-major, mirrors cuBLAS col-major A/B convention):
+  //     scale_a: [M, K//128]   stride (1, M)   <- scale_a[:,kb] contiguous
+  //     scale_b: [N, K//128]   stride (1, N)   <- scale_b[:,kb] contiguous
+  //   XPU (row-major, PyTorch-native convention):
+  //     scale_a: [M, K//128]   stride (K//128, 1)
+  //     scale_b: [K//128, N]   stride (N, 1)
 
   // check types
   TORCH_CHECK_VALUE(
@@ -620,13 +618,12 @@ Tensor& _scaled_block128x128_block1x128(
   //  B       | [K, N]    | col-major
   //
   // Scale layout vs CUDA:
-  //   CUDA (col-major, scale_a L4-padded on K-block dim):
+  //   CUDA (col-major, mirrors cuBLAS col-major A/B convention):
   //     scale_a: [round_up(K//128,4), M//128]  stride (1, round_up(K//128,4))
   //     scale_b: [N, K//128]                   stride (1, N)
-  //   XPU (row-major, no L4 padding):
+  //   XPU (row-major, PyTorch-native convention, no L4 padding):
   //     scale_a: [M//128, K//128]  stride (K//128, 1)
   //     scale_b: [K//128, N]       stride (N, 1)
-  // scale_b: same K//128 x N values; axis order differs per backend.
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -703,13 +700,12 @@ Tensor& _scaled_block1x128_block128x128(
   //  B       | [K, N]    | col-major
   //
   // Scale layout vs CUDA:
-  //   CUDA (col-major, scale_b L4-padded on K-block dim):
+  //   CUDA (col-major, mirrors cuBLAS col-major A/B convention):
   //     scale_a: [M, K//128]                   stride (1, M)
   //     scale_b: [round_up(K//128,4), N//128]  stride (1, round_up(K//128,4))
-  //   XPU (row-major, no L4 padding):
+  //   XPU (row-major, PyTorch-native convention, no L4 padding):
   //     scale_a: [M, K//128]       stride (K//128, 1)
   //     scale_b: [K//128, N//128]  stride (N//128, 1)
-  // scale_a: same [M, K//128] shape; CUDA col-major stride, XPU row-major.
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -541,7 +541,7 @@ Tensor& _scaled_block1x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a shape
+  // scale_a shape: [M, K//128]
   TORCH_CHECK_VALUE(
       scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
@@ -551,36 +551,26 @@ Tensor& _scaled_block1x128_block1x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  // scale_a stride
+  // scale_a stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
-      scale_a.stride(0) == 1 &&
-          (scale_a.stride(1) == M ||
-           (scale_a.size(1) == 1 && scale_b.stride(1) == 1)),
-      "scale_a strides must be (",
-      1,
-      ", ",
-      M,
-      "); got: ",
+      scale_a.stride(1) == 1,
+      "scale_a must be K-contiguous (stride(1) == 1); got: ",
       scale_a.strides());
 
-  // scale_b shape
+  // scale_b shape: [K//128, N]
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
-      N,
-      " x ",
       ceil_div<int64_t>(K, 128),
+      " x ",
+      N,
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride
+  // scale_b stride: K-contiguous (stride(0) can vary, stride(1) == 1)
   TORCH_CHECK_VALUE(
-      scale_b.stride(0) == 1 &&
-          (scale_b.stride(1) == N ||
-           (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
-      "scale_b strides must be (1, ",
-      N,
-      "); got: ",
+      scale_b.stride(1) == 1,
+      "scale_b must be K-contiguous (stride(1) == 1); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;
@@ -613,11 +603,9 @@ Tensor& _scaled_block128x128_block1x128(
   // A: [M, K], B: [K, N] are FP8, scales are fp32
 
   // [Note:] Unlike cuBLAS, XPU does not use L4 padding nor swizzling
-  // However, XPU needs the scale shape to match cuBLAS, so we keep the same
-  // shape here. This makes XPU `scale` an additional reshape before oneDNN's
-  // call. See aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp's
-  // `spec.normalize()` for detail.
-  // We keep the frontend the same with CUDA to make it easier to align
+  // XPU uses natural scale shapes that match matrix dimensions:
+  // A: [M, K] -> scale_a: [M//128, K//128]
+  // B: [K, N] -> scale_b: [K//128, N]
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -628,45 +616,37 @@ Tensor& _scaled_block128x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a shape: [K//128, M//128] with column-major stride
+  // scale_a shape: [M//128, K//128]
   TORCH_CHECK_VALUE(
-      scale_a.size(0) == ceil_div<int64_t>(K, 128) &&
-          scale_a.size(1) == ceil_div<int64_t>(M, 128) &&
+      scale_a.size(0) == ceil_div<int64_t>(M, 128) &&
+          scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
       "scale_a must have shape ",
-      ceil_div<int64_t>(K, 128),
-      " x ",
       ceil_div<int64_t>(M, 128),
+      " x ",
+      ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  // scale_a stride
+  // scale_a stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
-      scale_a.stride(0) == 1 &&
-          (scale_a.stride(1) == ceil_div<int64_t>(K, 128) ||
-           (scale_a.size(1) == 1 && scale_a.stride(1) == 1)),
-      "scale_a must have strides (1, ",
-      ceil_div<int64_t>(K, 128),
-      "); got ",
+      scale_a.stride(1) == 1,
+      "scale_a must be K-contiguous (stride(1) == 1); got: ",
       scale_a.strides());
 
-  // scale_b shape
+  // scale_b shape: [K//128, N] - natural shape matching B [K, N]
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_b.size(0) == ceil_div<int64_t>(K, 128) && scale_b.size(1) == N &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
-      N,
-      " x ",
       ceil_div<int64_t>(K, 128),
+      " x ",
+      N,
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride: column-major [1, N]
+  // scale_b stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
-      scale_b.stride(0) == 1 &&
-          (scale_b.stride(1) == N ||
-           (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
-      "scale_b strides must be (1, ",
-      N,
-      "); got: ",
+      scale_b.stride(1) == 1,
+      "scale_b must be K-contiguous (stride(1) == 1); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise128x128;
@@ -700,12 +680,9 @@ Tensor& _scaled_block1x128_block128x128(
   // As: [M x K // 128]
   // Bs: [K // 128 x N // 128]
 
-  // [Note:] Unlike cuBLAS, XPU does not use L4 padding nor swizzling
-  // However, XPU needs the scale shape to match cuBLAS, so we keep the same
-  // shape here. This makes XPU `scale` an additional reshape before oneDNN's
-  // call. See aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp's
-  // `spec.normalize()` for detail.
-  // We keep the frontend the same with CUDA to make it easier to align
+  // XPU uses natural scale shapes that match matrix dimensions:
+  // A: [M, K] -> scale_a: [M, K//128]
+  // B: [K, N] -> scale_b: [K//128, N//128]
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -716,7 +693,7 @@ Tensor& _scaled_block1x128_block128x128(
   int64_t K = mat_a.size(1);
   int64_t N = mat_b.size(1);
 
-  // scale_a shape
+  // scale_a shape: [M, K//128]
   TORCH_CHECK_VALUE(
       scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
@@ -726,16 +703,12 @@ Tensor& _scaled_block1x128_block128x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_a.sizes());
-  // scale_a stride
+  // scale_a stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
-      scale_a.stride(0) == 1 &&
-          (scale_a.stride(1) == M ||
-           (scale_a.size(1) == 1 && scale_a.stride(1) == 1)),
-      "scale_a must have strides (1, ",
-      M,
-      "); got ",
-      scale_b.strides());
-  // scale_b shape
+      scale_a.stride(1) == 1,
+      "scale_a must be K-contiguous (stride(1) == 1); got: ",
+      scale_a.strides());
+  // scale_b shape: [K//128, N//128]
   TORCH_CHECK_VALUE(
       scale_b.size(0) == ceil_div<int64_t>(K, 128) &&
           scale_b.size(1) == ceil_div<int64_t>(N, 128) &&
@@ -746,14 +719,10 @@ Tensor& _scaled_block1x128_block128x128(
       ceil_div<int64_t>(N, 128),
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride
+  // scale_b stride: K-contiguous (stride(1) == 1)
   TORCH_CHECK_VALUE(
-      scale_b.stride(0) == 1 &&
-          (scale_b.stride(1) == ceil_div<int64_t>(K, 128) ||
-           (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
-      "scale_b must have strides (1, ",
-      ceil_div<int64_t>(K, 128),
-      "); got ",
+      scale_b.stride(1) == 1,
+      "scale_b must be K-contiguous (stride(1) == 1); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -378,13 +378,40 @@ std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 5>
          scaled_blas::check_rowwise_recipe,
          ScaledGemmImplementation::ROWWISE_ROWWISE},
         {"block_1x128_128x128",
-         std::bind(scaled_blas::check_deepseek_recipe, ScalingType::BlockWise1x128, ScalingType::BlockWise128x128, _1, _2, _3, _4, _5, _6),
+         std::bind(
+             scaled_blas::check_deepseek_recipe,
+             ScalingType::BlockWise1x128,
+             ScalingType::BlockWise128x128,
+             _1,
+             _2,
+             _3,
+             _4,
+             _5,
+             _6),
          ScaledGemmImplementation::BLOCK_1x128_128x128},
         {"block_128x128_1x128",
-         std::bind(scaled_blas::check_deepseek_recipe, ScalingType::BlockWise128x128, ScalingType::BlockWise1x128, _1, _2, _3, _4, _5, _6),
+         std::bind(
+             scaled_blas::check_deepseek_recipe,
+             ScalingType::BlockWise128x128,
+             ScalingType::BlockWise1x128,
+             _1,
+             _2,
+             _3,
+             _4,
+             _5,
+             _6),
          ScaledGemmImplementation::BLOCK_128x128_1x128},
         {"block_1x128_1x128",
-         std::bind(scaled_blas::check_deepseek_recipe, ScalingType::BlockWise1x128, ScalingType::BlockWise1x128, _1, _2, _3, _4, _5, _6),
+         std::bind(
+             scaled_blas::check_deepseek_recipe,
+             ScalingType::BlockWise1x128,
+             ScalingType::BlockWise1x128,
+             _1,
+             _2,
+             _3,
+             _4,
+             _5,
+             _6),
          ScaledGemmImplementation::BLOCK_1x128_1x128},
     }};
 
@@ -502,8 +529,6 @@ Tensor& _scaled_block1x128_block1x128(
     Tensor& out) {
   // Restrictions:
   // A, B are FP8, scales are fp32, shape K//128
-  // As: [M x K // 128], stride: [1, M]
-  // Bs: [N x K // 128], stride: [1, N]
 
   // check types
   TORCH_CHECK_VALUE(
@@ -518,8 +543,7 @@ Tensor& _scaled_block1x128_block1x128(
 
   // scale_a shape
   TORCH_CHECK_VALUE(
-      scale_a.size(0) == M &&
-          scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
       "scale_a must have shape ",
       M,
@@ -541,8 +565,7 @@ Tensor& _scaled_block1x128_block1x128(
 
   // scale_b shape
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == N &&
-          scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
       N,
@@ -555,12 +578,10 @@ Tensor& _scaled_block1x128_block1x128(
       scale_b.stride(0) == 1 &&
           (scale_b.stride(1) == N ||
            (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
-      "scale_b strides must be (",
-      1,
-      ", ",
+      "scale_b strides must be (1, ",
       N,
       "); got: ",
-      scale_a.strides());
+      scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise1x128;
   auto scaling_choice_b = ScalingType::BlockWise1x128;
@@ -590,8 +611,13 @@ Tensor& _scaled_block128x128_block1x128(
     Tensor& out) {
   // Restrictions:
   // A: [M, K], B: [K, N] are FP8, scales are fp32
-  // As: [round_up(K // 128, 4), M // 128], stride: [M // 128, 1]
-  // Bs: [N x K // 128], stride: [1, N]
+
+  // [Note:] Unlike cuBLAS, XPU does not use L4 padding nor swizzling
+  // However, XPU needs the scale shape to match cuBLAS, so we keep the same
+  // shape here. This makes XPU `scale` an additional reshape before oneDNN's
+  // call. See aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp's
+  // `spec.normalize()` for detail.
+  // We keep the frontend the same with CUDA to make it easier to align
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -602,13 +628,13 @@ Tensor& _scaled_block128x128_block1x128(
   const int64_t K = mat_a.sizes()[1];
   const int64_t N = mat_b.sizes()[1];
 
-  // scale_a shape
+  // scale_a shape: [K//128, M//128] with column-major stride
   TORCH_CHECK_VALUE(
-      scale_a.size(0) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) &&
+      scale_a.size(0) == ceil_div<int64_t>(K, 128) &&
           scale_a.size(1) == ceil_div<int64_t>(M, 128) &&
           scale_a.scalar_type() == kFloat,
       "scale_a must have shape ",
-      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      ceil_div<int64_t>(K, 128),
       " x ",
       ceil_div<int64_t>(M, 128),
       " Float elements, got ",
@@ -616,17 +642,16 @@ Tensor& _scaled_block128x128_block1x128(
   // scale_a stride
   TORCH_CHECK_VALUE(
       scale_a.stride(0) == 1 &&
-          (scale_a.stride(1) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) ||
+          (scale_a.stride(1) == ceil_div<int64_t>(K, 128) ||
            (scale_a.size(1) == 1 && scale_a.stride(1) == 1)),
       "scale_a must have strides (1, ",
-      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      ceil_div<int64_t>(K, 128),
       "); got ",
-      scale_b.strides());
+      scale_a.strides());
 
   // scale_b shape
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == N &&
-          scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_b.size(0) == N && scale_b.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
       N,
@@ -634,14 +659,14 @@ Tensor& _scaled_block128x128_block1x128(
       ceil_div<int64_t>(K, 128),
       " Float elements, got ",
       scale_b.sizes());
-  // scale_b stride
+  // scale_b stride: column-major [1, N]
   TORCH_CHECK_VALUE(
       scale_b.stride(0) == 1 &&
           (scale_b.stride(1) == N ||
            (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
-      "scale_b must have strides (1, ",
+      "scale_b strides must be (1, ",
       N,
-      "); got ",
+      "); got: ",
       scale_b.strides());
 
   auto scaling_choice_a = ScalingType::BlockWise128x128;
@@ -672,8 +697,15 @@ Tensor& _scaled_block1x128_block128x128(
     Tensor& out) {
   // Restrictions:
   // A: [M, K], B: [K, N] are FP8, scales are fp32
-  // As: [M x K // 128], stride: [1, M]
-  // Bs: [round_up(K // 128, 4) x N // 128], stride: [1, N // 128]
+  // As: [M x K // 128]
+  // Bs: [K // 128 x N // 128]
+
+  // [Note:] Unlike cuBLAS, XPU does not use L4 padding nor swizzling
+  // However, XPU needs the scale shape to match cuBLAS, so we keep the same
+  // shape here. This makes XPU `scale` an additional reshape before oneDNN's
+  // call. See aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp's
+  // `spec.normalize()` for detail.
+  // We keep the frontend the same with CUDA to make it easier to align
   TORCH_CHECK_VALUE(
       isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()),
       "mat_a and mat_b must be fp8 types, got: ",
@@ -686,8 +718,7 @@ Tensor& _scaled_block1x128_block128x128(
 
   // scale_a shape
   TORCH_CHECK_VALUE(
-      scale_a.size(0) == M &&
-          scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
+      scale_a.size(0) == M && scale_a.size(1) == ceil_div<int64_t>(K, 128) &&
           scale_a.scalar_type() == kFloat,
       "scale_a must have shape ",
       M,
@@ -706,11 +737,11 @@ Tensor& _scaled_block1x128_block128x128(
       scale_b.strides());
   // scale_b shape
   TORCH_CHECK_VALUE(
-      scale_b.size(0) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) &&
+      scale_b.size(0) == ceil_div<int64_t>(K, 128) &&
           scale_b.size(1) == ceil_div<int64_t>(N, 128) &&
           scale_b.scalar_type() == kFloat,
       "scale_b must have shape ",
-      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      ceil_div<int64_t>(K, 128),
       " x ",
       ceil_div<int64_t>(N, 128),
       " Float elements, got ",
@@ -718,10 +749,10 @@ Tensor& _scaled_block1x128_block128x128(
   // scale_b stride
   TORCH_CHECK_VALUE(
       scale_b.stride(0) == 1 &&
-          (scale_b.stride(1) == round_up<int64_t>(ceil_div<int64_t>(K, 128), 4) ||
+          (scale_b.stride(1) == ceil_div<int64_t>(K, 128) ||
            (scale_b.size(1) == 1 && scale_b.stride(1) == 1)),
       "scale_b must have strides (1, ",
-      round_up<int64_t>(ceil_div<int64_t>(K, 128), 4),
+      ceil_div<int64_t>(K, 128),
       "); got ",
       scale_b.strides());
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -1,10 +1,10 @@
 #include <ATen/BlasBackend.h>
 #include <ATen/Tensor.h>
+#include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>
-#include <c10/core/ScalarType.h>
-
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+#include <c10/core/ScalarType.h>
 
 #include <oneapi/dnnl/dnnl.hpp>
 
@@ -339,8 +339,6 @@ struct ScaleSpec {
   dnnl::memory::data_type dtype;
 
   // Helper to compute expected number of elements for scale tensors
-  // arg_type: "src" for SRC (groups pattern {1, X}),
-  // "wei" for WEIGHTS (groups pattern {X, 1})
   int64_t expected_numel(
       int64_t outer_dim,
       int64_t inner_dim,
@@ -360,29 +358,51 @@ struct ScaleSpec {
         arg_type,
         "'");
 
-    // For rowwise: SRC groups={1, K}, WEI groups={K, 1}
-    TORCH_INTERNAL_ASSERT(
-        (groups == dnnl::memory::dims{1, inner_dim} ||
-         groups == dnnl::memory::dims{inner_dim, 1}),
-        "The groups must be either {1, inner_dim} or {inner_dim, 1}. But got ",
-        groups,
-        ".");
-    return outer_dim;
-  }
+    int64_t group_m = groups[0];
+    int64_t group_k = groups[1];
 
-  // Normalize an incoming scale tensor to contiguous storage and appropriate
-  // dtype/view
-  at::Tensor normalize(const at::Tensor& scale) const {
+    // For RowWise: groups={1, K} for SRC, {K, 1} for WEI
+    //     This gives outer_dim scales (M for SRC, N for WEI)
+    // For blockwise 1x128: groups = {1, 128} for SRC, {128, 1} for WEI
+    //     scale shape: [outer_dim, ceil_div(inner_dim, 128)]
+    if (group_m == 1 && group_k > 1) {
+      return outer_dim * at::ceil_div(inner_dim, group_k);
+    } else if (group_m > 1 && group_k == 1) {
+      return outer_dim * at::ceil_div(inner_dim, group_m);
+    }
+
+    // For blockwise 128x128: groups = {128, 128}
+    // scale shape: [ceil_div(inner_dim, 128), ceil_div(outer_dim, 128)]
+    // Note: XPU/oneDNN does not use L4 padding unlike CUDA cuBLAS.
+    // So it won't have something like
+    // `round_up<int64_t>(ceil_div<int64_t>(K, 128), 4)`
+    if (group_m > 1 && group_k > 1) {
+      return at::ceil_div(outer_dim, group_m) *
+          at::ceil_div(inner_dim, group_k);
+    }
+
     TORCH_INTERNAL_ASSERT(
-        dtype == dnnl::memory::data_type::f32,
-        "tensor scale currently must be f32, but got scale dtype: ",
-        scale.scalar_type());
-    return scale.to(at::kFloat).contiguous();
+        false,
+        "Unexpected groups configuration: ",
+        groups,
+        " for arg_type: ",
+        arg_type);
+    return 0;
   }
 };
 
 // This function defines how to set scales mask and groups according to:
-// https://github.com/uxlfoundation/oneDNN/blob/main/tests/benchdnn/doc/knobs_attr.md#--attr-scales
+// - Official API:
+// https://uxlfoundation.github.io/oneDNN/struct_dnnl_primitive_attr-2.html
+// - Quantization Guide:
+// https://uxlfoundation.github.io/oneDNN/dev_guide_attributes_quantization.html
+//
+// The mask and groups parameters work together:
+// - mask=0: per-tensor (single scale for whole tensor)
+// - mask=(1<<0)|(1<<1): scale varies along both dimensions
+// - groups: block sizes for grouping,
+// e.g., {128, 1} means 128 elements grouped on dim0
+//
 // The returned value will be used in
 // `set_scales(arg, mask, groups, data_type)`.
 inline ScaleSpec make_scale_spec(
@@ -396,26 +416,55 @@ inline ScaleSpec make_scale_spec(
       "Expected arg_type to be 'src' or 'wei', but got '",
       arg_type,
       "'");
-  TORCH_INTERNAL_ASSERT(
-      (scaling_type == at::blas::ScalingType::TensorWise ||
-       scaling_type == at::blas::ScalingType::RowWise),
-      "Currently only support scaling_type for TensorWise or RowWise");
-  int64_t dim = K; // Currently only K is used for grouping
+
   bool is_src = (arg_type == "src");
-  if (scaling_type == at::blas::ScalingType::TensorWise) {
-    // Scale tensorwise. The same as `--attr-scales=common`.
-    // mask=0 : scale whole tensor
-    // groups={}: indicates that there is only one group for scaling
-    return {0, {}, dnnl::memory::data_type::f32};
-  } else {
-    // (scaling_type == at::blas::ScalingType::RowWise)
-    // Scale RowWise. The same as `--attr-scales=per_dim_01`.
-    // mask={(1 << 0) | (1 << 1)}: Scale on both dim0 and dim1
-    // SRC: groups={1, K}, WEIGHTS: groups={K, 1}
-    return {
-        (1 << 0) | (1 << 1),
-        is_src ? dnnl::memory::dims{1, dim} : dnnl::memory::dims{dim, 1},
-        dnnl::memory::data_type::f32};
+
+  switch (scaling_type) {
+    case at::blas::ScalingType::TensorWise: {
+      // Scale tensorwise. The same as `--attr-scales=common`.
+      // mask=0: scale whole tensor, groups={}: no grouping needed
+      return {0, {}, dnnl::memory::data_type::f32};
+    }
+
+    case at::blas::ScalingType::RowWise: {
+      // Scale RowWise using block-wise style groups to achieve
+      // per-column scaling.
+      //   SRC: groups={1, K} -> one scale per row (M scales)
+      //   WEI: groups={K, 1} -> one scale per column (N scales)
+      return {
+          (1 << 0) | (1 << 1),
+          is_src ? dnnl::memory::dims{1, K} : dnnl::memory::dims{K, 1},
+          dnnl::memory::data_type::f32};
+    }
+
+    case at::blas::ScalingType::BlockWise1x128: {
+      // Blockwise 1x128 scaling (DeepSeek style)
+      // For SRC (A): scale shape [M, ceil_div(K, 128)], groups = {1, 128}
+      // For WEI (B): scale shape [ceil_div(K, 128), N], groups = {128, 1}
+      // mask={(1 << 0) | (1 << 1)}: Scale on both dim0 and dim1
+      return {
+          (1 << 0) | (1 << 1),
+          is_src ? dnnl::memory::dims{1, 128} : dnnl::memory::dims{128, 1},
+          dnnl::memory::data_type::f32};
+    }
+
+    case at::blas::ScalingType::BlockWise128x128: {
+      // Blockwise 128x128 scaling (2D block scaling)
+      // For SRC (A): scale shape [M // 128, K // 128], groups = {128, 128}
+      // For WEI (B): scale shape [K // 128, N // 128], groups = {128, 128}
+      // mask={(1 << 0) | (1 << 1)}: Scale on both dim0 and dim1
+      return {
+          (1 << 0) | (1 << 1),
+          dnnl::memory::dims{128, 128},
+          dnnl::memory::data_type::f32};
+    }
+
+    default:
+      TORCH_INTERNAL_ASSERT(
+          false,
+          "Unsupported scaling_type: ",
+          static_cast<int>(scaling_type),
+          ". Currently only support TensorWise, RowWise, BlockWise1x128, and BlockWise128x128");
   }
 }
 
@@ -442,15 +491,10 @@ sycl::event scaled_matmul(
   const int64_t K = mat1.size(1);
   const int64_t N = mat2.size(1);
 
-  // 1.1 Create memory descriptor
+  // 1.1 Create memory descriptors
   dnnl::memory::desc src_md = get_onednn_md(mat1);
   dnnl::memory::desc weights_md = get_onednn_md(mat2);
   dnnl::memory::desc dst_md = get_onednn_md(result);
-
-  // scale_a and scale_b has already be checked in `is_desired_scaling()` call.
-  // So we could directly get their memory desc and set later.
-  dnnl::memory::desc scale_a_md = get_onednn_md(scale_a);
-  dnnl::memory::desc scale_b_md = get_onednn_md(scale_b);
 
   dnnl::memory::desc bias_md;
   bool with_bias = bias.has_value();
@@ -514,20 +558,20 @@ sycl::event scaled_matmul(
         make_onednn_memory(bias_md, engine, possible_reshaped_bias.data_ptr());
   }
 
-  // Prepare runtime scale memories (flat 1-D views) using the specs
-  auto make_scale_mem_from_spec = [&](const ScaleSpec& spec,
-                                      int64_t expected_numel,
-                                      const at::Tensor& scale_tensor) {
-    at::Tensor prepared = spec.normalize(scale_tensor);
+  // Prepare scale memory for oneDNN.
+  auto make_scale_mem_from_spec =
+      [&](const ScaleSpec& spec,
+          int64_t expected_numel,
+          const at::Tensor& scale_tensor) -> dnnl::memory {
     TORCH_CHECK(
-        prepared.numel() == expected_numel,
+        scale_tensor.numel() == expected_numel,
         "Scale buffer length mismatch. Expected ",
         expected_numel,
         ", got ",
-        prepared.numel());
+        scale_tensor.numel());
     dnnl::memory::desc scale_md(
-        {prepared.numel()}, spec.dtype, dnnl::memory::format_tag::x);
-    return make_onednn_memory(scale_md, engine, prepared.data_ptr());
+        {scale_tensor.numel()}, spec.dtype, dnnl::memory::format_tag::x);
+    return make_onednn_memory(scale_md, engine, scale_tensor.data_ptr());
   };
 
   auto scratchpad =
@@ -543,20 +587,23 @@ sycl::event scaled_matmul(
     args.insert({DNNL_ARG_BIAS, b_usr_m});
   }
 
-  // Attach runtime scales using specs
   auto src_sc_mem = make_scale_mem_from_spec(
       src_spec, src_spec.expected_numel(M, K, "src"), scale_a);
+
   auto wei_sc_mem = make_scale_mem_from_spec(
       wei_spec, wei_spec.expected_numel(N, K, "wei"), scale_b);
+
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, src_sc_mem});
   args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, wei_sc_mem});
+
+  at::Tensor dst_scale_tensor;
   if (with_dst_scale) {
     // Bind single f32 scalar as DST scale
-    at::Tensor dst_scale_f32 = scale_result->to(at::kFloat).contiguous();
+    dst_scale_tensor = scale_result->to(at::kFloat).contiguous();
     dnnl::memory::desc dst_sc_md(
         {1}, dnnl::memory::data_type::f32, dnnl::memory::format_tag::x);
     auto dst_sc_mem =
-        make_onednn_memory(dst_sc_md, engine, dst_scale_f32.data_ptr());
+        make_onednn_memory(dst_sc_md, engine, dst_scale_tensor.data_ptr());
     args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, dst_sc_mem});
   }
 

--- a/aten/src/ATen/xpu/XPUScaledBlas.cpp
+++ b/aten/src/ATen/xpu/XPUScaledBlas.cpp
@@ -121,7 +121,9 @@ bool check_rowwise_recipe(
 
 /**
  * Both inputs must be fp8
- * A, B must only have 1 scale each, A: {Blockwise_1x128 (float), B: {Blockwise_128x128 (float)
+ * A, B must only have 1 scale each,
+ * A: {Blockwise_1x128 (float),
+ * B: {Blockwise_128x128 (float)
  * or other DeepSeek-style blockwise scaling combinations
  */
 bool check_deepseek_recipe(

--- a/aten/src/ATen/xpu/XPUScaledBlas.h
+++ b/aten/src/ATen/xpu/XPUScaledBlas.h
@@ -59,6 +59,9 @@ enum class ScaledGemmImplementation {
   NONE = 0,
   TENSORWISE_TENSORWISE = 1,
   ROWWISE_ROWWISE = 2,
+  BLOCK_128x128_1x128 = 3,
+  BLOCK_1x128_128x128 = 4,
+  BLOCK_1x128_1x128 = 5,
 };
 
 /**
@@ -85,6 +88,16 @@ bool check_tensorwise_recipe(
     ArrayRef<Tensor>&);
 
 bool check_rowwise_recipe(
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&,
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&);
+
+bool check_deepseek_recipe(
+    ScalingType,
+    ScalingType,
     c10::ScalarType,
     std::vector<ScalingType>&,
     ArrayRef<Tensor>&,


### PR DESCRIPTION
This PR adds the `block_1x128_128x128`, `block_128x128_1x128` and `block_1x128_1x128` for `scaled_mm_v2` for xpu.

It does the following:
1. Adds the scaled_mm v2 frontend API in ScaledBlas.cpp
2. Adds the oneDNN backend in QMatMul.cpp

The oneDNN fp8 blockwise supports relies on the oneDNN > v3.11, a dedicated oneDNN upgrade is needed for the functionalit and is not included in this PR. However, it doesn't affect the overall build. The full feature will be enabled only after oneDNN upgrade is done.

# PR Stack:
- https://github.com/pytorch/pytorch/pull/176064 : Enables full tests for XPU
- https://github.com/pytorch/pytorch/pull/176043 : Contains the scaled_mm v1 version.
- https://github.com/pytorch/pytorch/pull/173630 : <- **Contains oneDNN backend code and scaled_mm v2 frontend, should be merged first.**

cc: @liangan1 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey 
