### PR TITLE
[MPS] Implement geqrf stub for MPS

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -20,3 +20,8 @@ struct UnpackPivotsParams {
   uint32_t pivots_batch_stride;
   uint32_t dim_size;
 };
+
+struct GeqrfParams {
+  uint32_t m;  // rows
+  uint32_t n;  // cols
+};

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9755,12 +9755,12 @@
 
 - func: geqrf.a(Tensor self, *, Tensor(a!) a, Tensor(b!) tau) -> (Tensor(a!) a, Tensor(b!) tau)
   dispatch:
-    CPU, CUDA: geqrf_out
+    CPU, CUDA, MPS: geqrf_out
 
 - func: geqrf(Tensor self) -> (Tensor a, Tensor tau)
   variants: method, function
   dispatch:
-    CPU, CUDA: geqrf
+    CPU, CUDA, MPS: geqrf
 
 # orgqr, alias for linalg_householder_product
 - func: orgqr(Tensor self, Tensor input2) -> Tensor
@@ -14682,7 +14682,7 @@
   python_module: linalg
   structured: True
   dispatch:
-    CPU, CUDA: linalg_qr_out
+    CPU, CUDA, MPS: linalg_qr_out
 
 - func: linalg_matrix_power(Tensor self, int n) -> Tensor
   python_module: linalg

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -60,6 +60,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_cumprod(AtenTensorHandle self, i
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_cumsum(AtenTensorHandle self, int64_t dim, int32_t* dtype, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_exponential(AtenTensorHandle self, double lambd, AtenGeneratorHandle* generator, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_fill__Scalar(AtenTensorHandle self, double value);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_geqrf(AtenTensorHandle self, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_hann_window(int64_t window_length, int32_t* dtype, int32_t* layout, int32_t* device, int32_t device_index_, int32_t* pin_memory, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_histc(AtenTensorHandle self, int64_t bins, double min, double max, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_histogram_bin_ct(AtenTensorHandle self, int64_t bins, const double** range, int64_t range_len_, AtenTensorHandle* weight, int32_t density, AtenTensorHandle* ret0, AtenTensorHandle* ret1);

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -315,7 +315,6 @@ if torch.backends.mps.is_available():
             "cholesky_solve": None,
             "frexp": None,
             "gcd": None,
-            "geqrf": None,
             "nn.functional.grid_sample": None,  # Unsupported Border padding mode
             "hash_tensor": None,
             "heaviside": None,
@@ -336,7 +335,6 @@ if torch.backends.mps.is_available():
             "linalg.matrix_norm": [torch.float32],
             "linalg.norm": [torch.float32],
             "linalg.normsubgradients_at_zero": [torch.float32],
-            "linalg.qr": None,
             "linalg.svdvals": None,
             "masked.median": None,
             "matrix_exp": None,
@@ -551,7 +549,6 @@ if torch.backends.mps.is_available():
             "ormqr": None,
             "pca_lowrank": None,
             "pow": [torch.bool],
-            "qr": None,
             "remainder": [torch.bool],
             "rounddecimals_0": [
                 torch.uint8,


### PR DESCRIPTION
Implements geqrf stub for MPS. Relates to suggestion from @kurtamohler in https://github.com/pytorch/pytorch/pull/172536#pullrequestreview-3699221494_

Combined with the existing `linalg.householder_product` implementation, enables full QR decomposition via `torch.linalg.qr` on MPS, requested in (https://github.com/pytorch/pytorch/issues/154052)


Note: This implementation necessitated a CPU fallback in orgqr_stub_impl() in LinearAlgebra.mm for matrices larger than 32x32, which can't sync across threadgroups, leading to race condition issues. I believe this should be fixable in future by using one threadgroup per matrix there, but this PR provides a working foundation in the meantime.


For full QR decomposition, offers incremental performance gains for larger batches.

M4 Max (16 core CPU, 40 core GPU):
<img width="658" height="452" alt="image" src="https://github.com/user-attachments/assets/413e7c4b-9ebe-44de-9145-6fecacae7a19" />
