### PR TITLE
[ROCm] Fix cholesky_solve backward nondeterminism in gradcheck

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13237,6 +13237,9 @@ op_db: list[OpInfo] = [
            check_batched_gradgrad=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
+           # ROCm hipSOLVER has nondeterministic backward for complex types
+           # https://github.com/pytorch/pytorch/issues/164193
+           gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            gradcheck_wrapper=lambda *args, **kwargs: gradcheck_wrapper_triangular_input(*args, idx=1, **kwargs),
            decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
            skips=(


### PR DESCRIPTION
## Summary
  ROCm's hipSOLVER exhibits nondeterministic behavior in backward passes for complex types, causing gradcheck to fail with 'backward is not reentrant' errors.

  This adds GRADCHECK_NONDET_TOL (1e-12) to allow small numerical differences in gradient reentrance checks, following the pattern used by other ops with similar nondeterminism (addmm, mm, etc).

  Split from #170964 as requested by @jeffdaily.

  Fixes: https://github.com/pytorch/pytorch/issues/164193

  cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

  ## Test plan
  - Existing CI tests should pass
  - The affected test test_linalg_cholesky_solve_cuda_complex128 will now pass on ROCm