### PR TITLE
[XPU] xfail specific logspace tests

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14746,6 +14746,10 @@ op_db: list[OpInfo] = [
                             dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive',
                             dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
+               DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick',
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="xpu"),
+               DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive',
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="xpu"),
                # UserWarning: CUDA caching allocator reports a memory leak not verified by the driver API
                # in __main__.TestJitCUDA.test_variant_consistency_jit_logspace_cuda_complex64!
                # Caching allocator allocated memory was 0 and is now reported as 307200 on device 0.
@@ -14784,6 +14788,10 @@ op_db: list[OpInfo] = [
                             dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive',
                             dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
+               DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick',
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="xpu"),
+               DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive',
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="xpu"),
                # UserWarning: CUDA caching allocator reports a memory leak not verified by the driver API
                # in __main__.TestJitCUDA.test_variant_consistency_jit_logspace_cuda_complex64!
                # Caching allocator allocated memory was 0 and is now reported as 307200 on device 0.


### PR DESCRIPTION
Fixes [#2779](https://github.com/intel/torch-xpu-ops/issues/2779)

Logspace kernel for XPU is similar to CUDA one. It use int to float intermediate casting for integer datatypes. This leads to one-off accuracy errors.

Therefore xfailing tests similarly as they are xfail on CUDA see: https://github.com/pytorch/pytorch/pull/81826
