### PR TITLE
[docs] Clarify normalization formulas to specify what E[x] and Var[x] are computed over

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -291,8 +291,16 @@ class BatchNorm1d(_BatchNorm):
 
         y = \frac{x - \mathrm{E}[x]}{\sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension over
-    the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per channel over
+    the mini-batch and spatial dimensions. For input shape `(N, C)` or `(N, C, L)`:
+
+    .. code-block:: python
+
+        # Equivalent computation for (N, C, L) input:
+        mean = input.mean(dim=(0, 2))  # shape: (C,)
+        var = input.var(dim=(0, 2), correction=0)  # shape: (C,)
+
+    :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the number of features or channels of the input). By default, the
     elements of :math:`\gamma` are set to 1 and the elements of :math:`\beta` are set to 0.
     At train time in the forward pass, the variance is calculated via the biased estimator,
@@ -402,8 +410,16 @@ class BatchNorm2d(_BatchNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension over
-    the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per channel over
+    the mini-batch and spatial dimensions. For input shape `(N, C, H, W)`:
+
+    .. code-block:: python
+
+        # Equivalent computation:
+        mean = input.mean(dim=(0, 2, 3))  # shape: (C,)
+        var = input.var(dim=(0, 2, 3), correction=0)  # shape: (C,)
+
+    :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the input size). By default, the elements of :math:`\gamma` are set
     to 1 and the elements of :math:`\beta` are set to 0. At train time in the forward pass, the
     standard-deviation is calculated via the biased estimator, equivalent to
@@ -512,8 +528,16 @@ class BatchNorm3d(_BatchNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension over
-    the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per channel over
+    the mini-batch and spatial dimensions. For input shape `(N, C, D, H, W)`:
+
+    .. code-block:: python
+
+        # Equivalent computation:
+        mean = input.mean(dim=(0, 2, 3, 4))  # shape: (C,)
+        var = input.var(dim=(0, 2, 3, 4), correction=0)  # shape: (C,)
+
+    :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the input size). By default, the elements of :math:`\gamma` are set
     to 1 and the elements of :math:`\beta` are set to 0. At train time in the forward pass, the
     standard-deviation is calculated via the biased estimator, equivalent to
@@ -623,8 +647,18 @@ class SyncBatchNorm(_BatchNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension over all
-    mini-batches of the same process groups. :math:`\gamma` and :math:`\beta`
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per channel over
+    all mini-batches of the same process groups and spatial dimensions. For a 4D input
+    `(N, C, H, W)`, this is conceptually equivalent to gathering all inputs across the
+    process group and computing:
+
+    .. code-block:: python
+
+        # Equivalent computation (after gathering across processes):
+        mean = gathered_input.mean(dim=(0, 2, 3))  # shape: (C,)
+        var = gathered_input.var(dim=(0, 2, 3), correction=0)  # shape: (C,)
+
+    :math:`\gamma` and :math:`\beta`
     are learnable parameter vectors of size `C` (where `C` is the input size).
     By default, the elements of :math:`\gamma` are sampled from
     :math:`\mathcal{U}(0, 1)` and the elements of :math:`\beta` are set to 0.

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -137,8 +137,16 @@ class InstanceNorm1d(_InstanceNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension separately
-    for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per instance, per channel
+    over the spatial dimensions. For input shape `(N, C, L)`:
+
+    .. code-block:: python
+
+        # Equivalent computation (for each instance n and channel c):
+        mean = input.mean(dim=2)  # shape: (N, C)
+        var = input.var(dim=2, correction=0)  # shape: (N, C)
+
+    :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the number of features or channels of the input) if :attr:`affine` is ``True``.
     The variance is calculated via the biased estimator, equivalent to
     `torch.var(input, correction=0)`.
@@ -252,8 +260,16 @@ class InstanceNorm2d(_InstanceNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension separately
-    for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per instance, per channel
+    over the spatial dimensions. For input shape `(N, C, H, W)`:
+
+    .. code-block:: python
+
+        # Equivalent computation (for each instance n and channel c):
+        mean = input.mean(dim=(2, 3))  # shape: (N, C)
+        var = input.var(dim=(2, 3), correction=0)  # shape: (N, C)
+
+    :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the input size) if :attr:`affine` is ``True``.
     The standard-deviation is calculated via the biased estimator, equivalent to
     `torch.var(input, correction=0)`.
@@ -368,8 +384,16 @@ class InstanceNorm3d(_InstanceNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension separately
-    for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
+    where :math:`\mathrm{E}[x]` and :math:`\mathrm{Var}[x]` are computed per instance, per channel
+    over the spatial dimensions. For input shape `(N, C, D, H, W)`:
+
+    .. code-block:: python
+
+        # Equivalent computation (for each instance n and channel c):
+        mean = input.mean(dim=(2, 3, 4))  # shape: (N, C)
+        var = input.var(dim=(2, 3, 4), correction=0)  # shape: (N, C)
+
+    :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size C (where C is the input size) if :attr:`affine` is ``True``.
     The standard-deviation is calculated via the biased estimator, equivalent to
     `torch.var(input, correction=0)`.


### PR DESCRIPTION
## Summary
The documentation for BatchNorm, InstanceNorm, LayerNorm, and GroupNorm all use the same formula:

```
y = (x - E[x]) / sqrt(Var[x] + ε) * γ + β
```

However, they compute mean and variance over different dimensions, which wasn't immediately clear from the formulas alone.

## Changes
This PR clarifies each formula by explicitly stating what the statistics are computed over:

- **BatchNorm**: `E[x]` and `Var[x]` are computed per channel over the mini-batch and spatial dimensions
- **InstanceNorm**: `E[x]` and `Var[x]` are computed per instance, per channel over the spatial dimensions  
- **LayerNorm**: `E[x]` and `Var[x]` are computed over the last D dimensions (normalized_shape)
- **GroupNorm**: `E[x]` and `Var[x]` are computed per instance, per group over the channels within each group and spatial dimensions

## Motivation
This makes the differences between the normalization layers clearer at a glance, without needing to read multiple paragraphs of text. The original issue noted that the identical formulas were confusing since they don't represent what dimensions the statistics are computed over.

## Test Plan
Documentation-only change. No functional code changes.

Fixes #140640

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki