### PR TITLE
Return NotImplemented for incompatible types in cuda.Stream.__eq__

### DIFF
--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -114,7 +114,7 @@ class Stream(torch._C._CudaStreamBase):
     def __eq__(self, o) -> bool:
         if isinstance(o, Stream):
             return super().__eq__(o)
-        return False
+        return NotImplemented
 
     def __hash__(self):
         return hash((self.cuda_stream, self.device))


### PR DESCRIPTION
This allows Python to try the reflected operation on the other operand. Without this, third party libraries cannot implement equality with PyTorch streams in a symmetric way:

```python
import torch

class MyStream:
  def __init__(self, handle: int):
    self._handle = handle

  def __eq__(self, other):
    if isinstance(other, torch.Stream):
      return self._handle == other.cuda_stream
    # [...]

s1 = torch.cuda.Stream()
s2 = MyStream(s1.cuda_stream)
assert s2 == s1  # succeeds
assert s1 == s2  # fails with the current behavior
```

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia