### PR TITLE
[triton] Downgrade kernel resolution logs from WARNING to DEBUG

### DIFF
--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -227,7 +227,7 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
                             if nested:
                                 results.extend(nested)
                                 continue
-                    logger.warning("failed to resolve %s to a triton kernel", name)
+                    logger.debug("failed to resolve %s to a triton kernel", name)
                 elif assignments is not None and name in assignments:
                     # trace through local assignments
                     for rhs_expr in assignments[name]:
@@ -237,7 +237,7 @@ def get_inner_triton_kernels(fn: Callable[..., Any]) -> list[object]:
                         )
                         results.extend(traced)
                 else:
-                    logger.warning("%s not found in namespace or assignments", name)
+                    logger.debug("%s not found in namespace or assignments", name)
 
             return results
 


### PR DESCRIPTION
Summary:
The `get_inner_triton_kernels` function is explicitly documented as "best
effort" - it parses AST to find triton kernels but name resolution failures
are expected (not all names are kernels). These WARNING logs were causing
noise on every torch import when modules using `triton_op` are loaded.

Changed to DEBUG to match similar diagnostic messages in the same function
(e.g., lines 67-70, 287-289) while keeping them available for developers
debugging kernel resolution.

Authored with help from Claude. 

At the moment we get this logs 

 {F1985013202}

Test Plan: Import torch and verify no spurious warnings appear from triton.py

Differential Revision: D91409600


