### PR TITLE
upgrade lintrunner from 0.2.7 to 0.2.11

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -287,9 +287,9 @@ unittest-xml-reporting<=3.2.0,>=2.0.0
 #test that import:
 
 #lintrunner is supported on aarch64-linux only from 0.12.4 version
-lintrunner==0.12.7
+lintrunner==0.12.11
 #Description: all about linters!
-#Pinned versions: 0.12.7
+#Pinned versions: 0.12.11
 #test that import:
 
 redis>=4.0.0


### PR DESCRIPTION
On riscv64, installing lintrunner 0.12.7 from sdist fails because its build dependency maturin<0.13 cannot be installed:

pip install "maturin>=0.12,<0.13" fails with:
BackendUnavailable: Cannot import 'setuptools.build_meta'

This can be reproduced on x86 also.

Upgrading to maturin >= 1.0 (as done in lintrunner 0.12.11) resolves the issue.

