### PR TITLE
[RISCV] disable cuda-bingings on riscv64 CI

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -397,7 +397,7 @@ tlparse==0.4.0
 filelock==3.20.3
 #Description: required for inductor testing
 
-cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x" and platform_system != "Darwin"
+cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. Note "Any fix in the latest bindings would be backported to the prior major version" means that only the newest version of cuda-bindings will get fixes. Depending on the latest version of 12.x is okay because all 12.y versions will be supported via "CUDA minor version compatibility". Pytorch builds against 13.z versions of cuda toolkit work with 12.x versions of cuda-bindings as well because newer drivers work with old toolkits.
 #test that import: test_cuda.py
 


### PR DESCRIPTION
cuda-bindings is currently gated on riscv64 because there is no supported CUDA toolchain or installable Python package available for this architecture.

Attempting to resolve cuda-bindings on riscv64 results in install-time failures, even when CUDA is explicitly disabled at build time.

This change disables cuda-bindings on riscv64 for now, and it can be re-enabled once official CUDA support or a working packaging path becomes available.


