### PR TITLE
    [Profiler] Add callback mechanism for export_chrome_trace

### DIFF
--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -26,6 +26,10 @@
 .. autofunction:: torch.profiler.schedule
 
 .. autofunction:: torch.profiler.tensorboard_trace_handler
+
+.. autofunction:: torch.profiler.register_export_chrome_trace_callback
+
+.. autofunction:: torch.profiler.unregister_export_chrome_trace_callback
 ```
 
 ## Intel Instrumentation and Tracing Technology APIs

--- a/test/profiler/test_profiler_utilization_hook.py
+++ b/test/profiler/test_profiler_utilization_hook.py
@@ -1,0 +1,126 @@
+# Owner(s): ["module: profiler"]
+"""
+Test the profiler export_chrome_trace callback mechanism.
+"""
+
+import json
+import os
+import tempfile
+
+import torch
+from torch.profiler import register_export_chrome_trace_callback, _export_chrome_trace_callbacks
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestExportChromeTraceCallbacks(TestCase):
+    """Test the export_chrome_trace callback mechanism."""
+
+    def setUp(self):
+        # Clear callbacks before each test
+        _export_chrome_trace_callbacks.clear()
+
+    def tearDown(self):
+        _export_chrome_trace_callbacks.clear()
+
+    def test_callback_registration(self):
+        """Test that callbacks can be registered and removed."""
+        from torch.profiler import unregister_export_chrome_trace_callback
+
+        def my_callback(data):
+            return data
+
+        self.assertEqual(len(_export_chrome_trace_callbacks), 0)
+        register_export_chrome_trace_callback(my_callback)
+        self.assertEqual(len(_export_chrome_trace_callbacks), 1)
+
+        # Test unregister works
+        unregister_export_chrome_trace_callback(my_callback)
+        self.assertEqual(len(_export_chrome_trace_callbacks), 0)
+
+    def test_callback_modifies_trace(self):
+        """Test that registered callbacks modify the trace."""
+        from torch.profiler import profile, ProfilerActivity
+
+        def add_marker(data):
+            data["test_marker"] = "callback_ran"
+            return data
+
+        register_export_chrome_trace_callback(add_marker)
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+
+        try:
+            with profile(activities=[ProfilerActivity.CPU]) as prof:
+                x = torch.randn(10, 10)
+                _ = x + x
+
+            prof.export_chrome_trace(trace_path)
+
+            with open(trace_path) as f:
+                data = json.load(f)
+
+            self.assertEqual(data.get("test_marker"), "callback_ran")
+
+        finally:
+            os.unlink(trace_path)
+
+    def test_multiple_callbacks_run_in_order(self):
+        """Test that multiple callbacks run in registration order."""
+        from torch.profiler import profile, ProfilerActivity
+
+        def add_first(data):
+            data["order"] = ["first"]
+            return data
+
+        def add_second(data):
+            data["order"].append("second")
+            return data
+
+        register_export_chrome_trace_callback(add_first)
+        register_export_chrome_trace_callback(add_second)
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+
+        try:
+            with profile(activities=[ProfilerActivity.CPU]) as prof:
+                x = torch.randn(10, 10)
+                _ = x + x
+
+            prof.export_chrome_trace(trace_path)
+
+            with open(trace_path) as f:
+                data = json.load(f)
+
+            self.assertEqual(data.get("order"), ["first", "second"])
+
+        finally:
+            os.unlink(trace_path)
+
+    def test_no_callbacks_no_error(self):
+        """Test that export works with no callbacks registered."""
+        from torch.profiler import profile, ProfilerActivity
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+
+        try:
+            with profile(activities=[ProfilerActivity.CPU]) as prof:
+                x = torch.randn(10, 10)
+                _ = x + x
+
+            # Should not raise
+            prof.export_chrome_trace(trace_path)
+
+            # Trace should be valid
+            with open(trace_path) as f:
+                data = json.load(f)
+            self.assertIn("traceEvents", data)
+
+        finally:
+            os.unlink(trace_path)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/profiler/test_profiler_utilization_hook.py
+++ b/test/profiler/test_profiler_utilization_hook.py
@@ -8,7 +8,10 @@ import os
 import tempfile
 
 import torch
-from torch.profiler import register_export_chrome_trace_callback, _export_chrome_trace_callbacks
+from torch.profiler import (
+    _export_chrome_trace_callbacks,
+    register_export_chrome_trace_callback,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "record_function",
     "ExecutionTraceObserver",
     "register_export_chrome_trace_callback",
+    "unregister_export_chrome_trace_callback",
 ]
 
 from . import itt

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -19,13 +19,16 @@ from torch.autograd.profiler import KinetoStepTracker, record_function
 from torch.optim.optimizer import Optimizer, register_optimizer_step_post_hook
 
 from .profiler import (
+    _export_chrome_trace_callbacks,
     _KinetoProfile,
     ExecutionTraceObserver,
     profile,
     ProfilerAction,
+    register_export_chrome_trace_callback,
     schedule,
     supported_activities,
     tensorboard_trace_handler,
+    unregister_export_chrome_trace_callback,
 )
 
 
@@ -40,6 +43,7 @@ __all__ = [
     "DeviceType",
     "record_function",
     "ExecutionTraceObserver",
+    "register_export_chrome_trace_callback",
 ]
 
 from . import itt

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -35,7 +35,47 @@ __all__ = [
     "tensorboard_trace_handler",
     "profile",
     "ExecutionTraceObserver",
+    "register_export_chrome_trace_callback",
 ]
+
+# Callbacks to run when export_chrome_trace is called.
+# Each callback takes trace data (dict) and returns modified trace data.
+_export_chrome_trace_callbacks: list[Callable[[dict], dict]] = []
+
+
+def register_export_chrome_trace_callback(
+    callback: Callable[[dict], dict]
+) -> Callable[[dict], dict]:
+    """
+    Register a callback to be run when export_chrome_trace() is called.
+
+    The callback receives the trace data as a dict and should return the
+    (potentially modified) trace data. Callbacks are run in registration order.
+
+    Returns the callback (for use with unregister_export_chrome_trace_callback).
+
+    Example::
+
+        def add_custom_annotation(data):
+            for event in data["traceEvents"]:
+                if event.get("cat") == "kernel":
+                    event["args"]["custom"] = "value"
+            return data
+
+        torch.profiler.register_export_chrome_trace_callback(add_custom_annotation)
+        # Later, to remove:
+        torch.profiler.unregister_export_chrome_trace_callback(add_custom_annotation)
+    """
+    _export_chrome_trace_callbacks.append(callback)
+    return callback
+
+
+def unregister_export_chrome_trace_callback(callback: Callable[[dict], dict]) -> None:
+    """Remove a previously registered export_chrome_trace callback."""
+    if callback in _export_chrome_trace_callbacks:
+        _export_chrome_trace_callbacks.remove(callback)
+
+
 PROFILER_STEP_NAME = "ProfilerStep"
 
 _WARNINGS_SHOWN = set()
@@ -279,6 +319,9 @@ class _KinetoProfile:
         """
         Exports the collected trace in Chrome JSON format. If kineto is enabled, only
         last cycle in schedule is exported.
+
+        Any callbacks registered via ``register_export_chrome_trace_callback()``
+        will be executed to augment the trace before saving.
         """
         if self.profiler is None:
             raise AssertionError(
@@ -287,11 +330,36 @@ class _KinetoProfile:
         if path.endswith(".gz"):
             with tempfile.NamedTemporaryFile("w+b", suffix=".json") as fp:
                 retvalue = self.profiler.export_chrome_trace(fp.name)
+                # Run callbacks on the uncompressed trace
+                self._run_export_callbacks(fp.name)
                 with open(fp.name, "rb") as fin, gzip.open(path, "wb") as fout:
                     fout.writelines(fin)
             return retvalue
         else:
-            return self.profiler.export_chrome_trace(path)
+            retvalue = self.profiler.export_chrome_trace(path)
+            # Run callbacks on the trace
+            self._run_export_callbacks(path)
+            return retvalue
+
+    def _run_export_callbacks(self, path: str) -> None:
+        """Run registered export callbacks on the trace file."""
+        if not _export_chrome_trace_callbacks:
+            return
+
+        try:
+            with open(path) as f:
+                data = json.load(f)
+
+            for callback in _export_chrome_trace_callbacks:
+                data = callback(data)
+
+            with open(path, "w") as f:
+                json.dump(data, f)
+        except Exception as e:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Profiler export callback failed: %s", e
+            )
 
     def export_stacks(self, path: str, metric: str = "self_cpu_time_total"):
         """Save stack traces to a file

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -36,6 +36,7 @@ __all__ = [
     "profile",
     "ExecutionTraceObserver",
     "register_export_chrome_trace_callback",
+    "unregister_export_chrome_trace_callback",
 ]
 
 # Callbacks to run when export_chrome_trace is called.
@@ -44,7 +45,7 @@ _export_chrome_trace_callbacks: list[Callable[[dict], dict]] = []
 
 
 def register_export_chrome_trace_callback(
-    callback: Callable[[dict], dict]
+    callback: Callable[[dict], dict],
 ) -> Callable[[dict], dict]:
     """
     Register a callback to be run when export_chrome_trace() is called.
@@ -61,6 +62,7 @@ def register_export_chrome_trace_callback(
                 if event.get("cat") == "kernel":
                     event["args"]["custom"] = "value"
             return data
+
 
         torch.profiler.register_export_chrome_trace_callback(add_custom_annotation)
         # Later, to remove:
@@ -357,6 +359,7 @@ class _KinetoProfile:
                 json.dump(data, f)
         except Exception as e:
             import logging
+
             logging.getLogger(__name__).warning(
                 "Profiler export callback failed: %s", e
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173665
* __->__ #173664

Add a public API for registering callbacks that run when export_chrome_trace()
is called. This allows other components (like inductor) to augment traces
with custom annotations without coupling the profiler to those components.

API:
 torch.profiler.register_export_chrome_trace_callback(fn)

The callback receives trace data as a dict and returns the modified data.
Multiple callbacks run in registration order. Exceptions are caught and
logged as warnings to avoid breaking trace export.

authored with cluade code