### PR TITLE
[Inductor] Add profiler utilization annotations with FLOPS/bandwidth metrics

### DIFF
--- a/test/inductor/test_profile_utilization.py
+++ b/test/inductor/test_profile_utilization.py
@@ -1,0 +1,312 @@
+# Owner(s): ["module: inductor"]
+"""
+Tests for profiler utilization annotations.
+
+Tests:
+1. Unit tests for annotation functions (no GPU needed)
+2. Integration tests for profiler with GPU kernels
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+from torch._inductor import config as inductor_config
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+
+
+class TestUtilizationAnnotations(TestCase):
+    """Unit tests for utilization annotation functions (no GPU needed)."""
+
+    def test_basic_annotation(self):
+        """Test utilization annotations are added correctly."""
+        from torch._inductor.analysis.profile_analysis import add_utilization_annotations
+
+        trace_data = {
+            "traceEvents": [
+                {"name": "kernel", "cat": "kernel", "dur": 100,
+                 "args": {"kernel_flop": 2e9, "kernel_num_gb": 0.1}},
+            ],
+            "deviceProperties": [{"id": 0, "name": "NVIDIA H100"}],
+        }
+
+        result = add_utilization_annotations(trace_data, device_name="NVIDIA H100")
+        args = result["traceEvents"][0]["args"]
+
+        self.assertIn("achieved_flops_percent", args)
+        self.assertIn("achieved_bandwidth_percent", args)
+        # Utilization should be between 10% and 95%
+        self.assertGreaterEqual(args["achieved_flops_percent"], 0)
+        self.assertLessEqual(args["achieved_flops_percent"], 95)
+
+    def test_skips_non_kernel_events(self):
+        """Test that cpu_op events are not annotated."""
+        from torch._inductor.analysis.profile_analysis import add_utilization_annotations
+
+        trace_data = {
+            "traceEvents": [
+                {"name": "cpu_op", "cat": "cpu_op", "dur": 100,
+                 "args": {"kernel_flop": 1e9, "kernel_num_gb": 0.1}},
+            ],
+            "deviceProperties": [{"id": 0, "name": "NVIDIA H100"}],
+        }
+
+        result = add_utilization_annotations(trace_data, device_name="NVIDIA H100")
+        self.assertNotIn("achieved_flops_percent", result["traceEvents"][0]["args"])
+
+    def test_handles_missing_metrics(self):
+        """Test that events without flop/bandwidth info are handled gracefully."""
+        from torch._inductor.analysis.profile_analysis import add_utilization_annotations
+
+        trace_data = {
+            "traceEvents": [{"name": "kernel", "cat": "kernel", "dur": 100, "args": {}}],
+            "deviceProperties": [{"id": 0, "name": "NVIDIA H100"}],
+        }
+
+        result = add_utilization_annotations(trace_data, device_name="NVIDIA H100")
+        self.assertNotIn("achieved_flops_percent", result["traceEvents"][0]["args"])
+
+
+class TestProfilerCallbacks(TestCase):
+    """Test the profiler callback mechanism."""
+
+    def setUp(self):
+        from torch._inductor.analysis.profile_analysis import clear_profiler_export_callbacks
+        clear_profiler_export_callbacks()
+
+    def tearDown(self):
+        from torch._inductor.analysis.profile_analysis import clear_profiler_export_callbacks
+        clear_profiler_export_callbacks()
+
+    def test_callback_registration_and_execution(self):
+        """Test callbacks are registered and run in order."""
+        from torch._inductor.analysis.profile_analysis import (
+            register_profiler_export_callback,
+            run_profiler_export_callbacks,
+            _profiler_export_callbacks,
+        )
+
+        results = []
+        register_profiler_export_callback(lambda d: (results.append(1), d)[1])
+        register_profiler_export_callback(lambda d: (results.append(2), d)[1])
+
+        self.assertEqual(len(_profiler_export_callbacks), 2)
+
+        run_profiler_export_callbacks({"traceEvents": []})
+        self.assertEqual(results, [1, 2])
+
+
+class ProfilerIntegrationBase(TestCase):
+    """Base class for profiler integration tests with common setup/teardown."""
+
+    def setUp(self):
+        fd, self.trace_path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+
+    def tearDown(self):
+        if os.path.exists(self.trace_path):
+            os.unlink(self.trace_path)
+
+    def profile_and_get_kernels(self, fn, iterations=3):
+        """Profile a function and return kernel events with utilization."""
+        from torch.profiler import profile, ProfilerActivity
+
+        with profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+            record_shapes=True,
+        ) as prof:
+            for _ in range(iterations):
+                fn()
+            torch.cuda.synchronize()
+
+        prof.export_chrome_trace(self.trace_path)
+
+        with open(self.trace_path) as f:
+            data = json.load(f)
+
+        return [
+            e for e in data["traceEvents"]
+            if e.get("cat") == "kernel"
+            and ("achieved_flops_percent" in e.get("args", {})
+                 or "achieved_bandwidth_percent" in e.get("args", {}))
+        ]
+
+    def assert_reasonable_utilization(self, kernel_events, min_util=10, max_util=95, check_flops=None):
+        """Assert at least one kernel achieves reasonable utilization (10-95%).
+
+        Args:
+            kernel_events: List of kernel events from trace
+            min_util: Minimum utilization percentage
+            max_util: Maximum utilization percentage
+            check_flops: If True, assert FLOPS metrics exist. If False, assert they don't.
+                        If None, don't check for FLOPS presence.
+        """
+        self.assertGreater(len(kernel_events), 0, "No kernel events with utilization found")
+
+        max_flop = max(e["args"].get("achieved_flops_percent", 0) for e in kernel_events)
+        max_bw = max(e["args"].get("achieved_bandwidth_percent", 0) for e in kernel_events)
+
+        if check_flops is True:
+            self.assertGreater(max_flop, 0, "Expected FLOPS metrics but none found")
+        elif check_flops is False:
+            self.assertEqual(max_flop, 0, f"Expected no FLOPS metrics but got {max_flop:.1f}%")
+
+        self.assertTrue(
+            max_flop >= min_util or max_bw >= min_util,
+            f"Utilization too low: FLOPS={max_flop:.1f}%, BW={max_bw:.1f}%"
+        )
+        self.assertLessEqual(
+            max(max_flop, max_bw), max_util,
+            f"Utilization too high: FLOPS={max_flop:.1f}%, BW={max_bw:.1f}%"
+        )
+
+
+@unittest.skipUnless(HAS_GPU, "requires GPU")
+class TestCublasUtilization(ProfilerIntegrationBase):
+    """Test cuBLAS GEMM achieves reasonable utilization."""
+
+    def test_gemm_utilization(self):
+        """Test GEMM achieves reasonable FLOPS or bandwidth utilization."""
+        size = 2048
+        a = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float32)
+        b = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float32)
+
+        # Warmup
+        for _ in range(3):
+            torch.mm(a, b)
+        torch.cuda.synchronize()
+
+        kernels = self.profile_and_get_kernels(lambda: torch.mm(a, b))
+        self.assert_reasonable_utilization(kernels, min_util=20)
+
+
+@unittest.skipUnless(HAS_GPU, "requires GPU")
+class TestInductorUtilization(ProfilerIntegrationBase):
+    """Test Inductor-generated kernels achieve reasonable utilization."""
+
+    def test_pointwise_bandwidth(self):
+        """Test pointwise ops achieve reasonable bandwidth utilization."""
+        @torch.compile
+        def pointwise(a, b):
+            return a + b * 2.0
+
+        size = 10_000_000
+        a = torch.randn(size, device=GPU_TYPE, dtype=torch.float32)
+        b = torch.randn(size, device=GPU_TYPE, dtype=torch.float32)
+
+        # Warmup
+        for _ in range(3):
+            pointwise(a, b)
+        torch.cuda.synchronize()
+
+        kernels = self.profile_and_get_kernels(lambda: pointwise(a, b))
+        self.assert_reasonable_utilization(kernels, min_util=10)
+
+    def test_fused_kernel_bandwidth_exact(self):
+        """Test fused kernels report correct bandwidth (deterministic)."""
+        @torch.compile
+        def fused(x):
+            return torch.relu(torch.sigmoid(x)) + 1.0
+
+        size = 10_000_000  # 40MB at fp32
+        x = torch.randn(size, device=GPU_TYPE, dtype=torch.float32)
+
+        for _ in range(3):
+            fused(x)
+        torch.cuda.synchronize()
+
+        kernels = self.profile_and_get_kernels(lambda: fused(x))
+        self.assertGreater(len(kernels), 0)
+
+        # Fused kernel: read 40MB + write 40MB = 80MB = 0.08GB exactly
+        # (10M elements * 4 bytes * 2 for read+write)
+        expected_gb = 10_000_000 * 4 * 2 / 1e9  # 0.08 GB
+        for e in kernels:
+            kernel_num_gb = e["args"].get("kernel_num_gb", 0)
+            if kernel_num_gb > 0:
+                self.assertEqual(kernel_num_gb, expected_gb)
+
+
+@unittest.skipUnless(HAS_GPU, "requires GPU")
+@inductor_config.patch(force_disable_caches=True, max_autotune_gemm_backends="TRITON")
+class TestTritonGemmUtilization(ProfilerIntegrationBase):
+    """Test Triton GEMM with max-autotune achieves reasonable utilization."""
+
+    def test_triton_gemm_utilization(self):
+        """Test max-autotune Triton GEMM achieves reasonable utilization."""
+        @torch.compile(mode="max-autotune-no-cudagraphs")
+        def triton_mm(a, b):
+            return torch.mm(a, b)
+
+        size = 2048
+        a = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float32)
+        b = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float32)
+
+        # Warmup (includes autotuning)
+        for _ in range(3):
+            triton_mm(a, b)
+        torch.cuda.synchronize()
+
+        kernels = self.profile_and_get_kernels(lambda: triton_mm(a, b))
+        self.assert_reasonable_utilization(kernels, min_util=10)
+
+
+@unittest.skipUnless(HAS_GPU, "requires GPU")
+class TestRooflineMetrics(ProfilerIntegrationBase):
+    """Test roofline classification (compute-bound vs memory-bound)."""
+
+    def test_large_gemm_is_compute_bound(self):
+        """Test large GEMM has high arithmetic intensity."""
+        size = 4096
+        a = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float32)
+        b = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float32)
+
+        for _ in range(3):
+            torch.mm(a, b)
+        torch.cuda.synchronize()
+
+        kernels = self.profile_and_get_kernels(lambda: torch.mm(a, b))
+
+        # Find GEMM kernels (high FLOP count)
+        gemm_kernels = [e for e in kernels if e["args"].get("kernel_flop", 0) > 1e10]
+        self.assertGreater(len(gemm_kernels), 0, "No GEMM kernels found")
+
+        for e in gemm_kernels:
+            arith_intensity = e["args"].get("arithmetic_intensity", 0)
+            self.assertGreater(
+                arith_intensity, 50,
+                f"Expected high arithmetic intensity, got {arith_intensity:.1f}"
+            )
+
+    def test_pointwise_is_memory_bound(self):
+        """Test pointwise ops have low arithmetic intensity."""
+        @torch.compile
+        def add_op(a, b):
+            return a + b
+
+        size = 10_000_000
+        a = torch.randn(size, device=GPU_TYPE, dtype=torch.float32)
+        b = torch.randn(size, device=GPU_TYPE, dtype=torch.float32)
+
+        for _ in range(3):
+            add_op(a, b)
+        torch.cuda.synchronize()
+
+        kernels = self.profile_and_get_kernels(lambda: add_op(a, b))
+
+        memory_bound = [e for e in kernels if e["args"].get("roofline_bound") == "memory"]
+        self.assertGreater(len(memory_bound), 0, "No memory-bound kernels found")
+
+        for e in memory_bound:
+            arith_intensity = e["args"].get("arithmetic_intensity", 0)
+            self.assertLess(
+                arith_intensity, 10,
+                f"Expected low arithmetic intensity, got {arith_intensity:.1f}"
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -28,6 +28,25 @@ class DeviceInfo:
 # TODO investigate profiler support for tf32 and allow device to report correct number when it's turned on.
 _device_mapping: dict[str, DeviceInfo] = {
     # Source:
+    # @lint-ignore https://www.nvidia.com/en-us/data-center/h200/
+    "NVIDIA H200": DeviceInfo(
+        # Same compute as H100, more memory and bandwidth
+        tops={
+            torch.float64: 67.0,
+            torch.float32: 67.5,
+            "torch.tf32": 989.0,
+            torch.bfloat16: 1979.0,
+            torch.float16: 1979.0,
+            torch.float8_e8m0fnu: 3958.0,
+            torch.float8_e4m3fnuz: 3958.0,
+            torch.float8_e5m2: 3958.0,
+            torch.float8_e5m2fnuz: 3958.0,
+            torch.int8: 3958.0,
+        },
+        dram_bw_gbs=4800,  # 4.8 TB/s HBM3e
+        dram_gb=141,
+    ),
+    # Source:
     # @lint-ignore https://www.nvidia.com/en-us/data-center/h100/
     "NVIDIA H100": DeviceInfo(
         tops={

--- a/torch/_inductor/analysis/profile_analysis.py
+++ b/torch/_inductor/analysis/profile_analysis.py
@@ -729,6 +729,274 @@ class ParseException(RuntimeError):
     pass
 
 
+def add_utilization_annotations(
+    data: dict[str, Any],
+    device_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Add achieved_flops_percent, achieved_bandwidth_percent, and roofline metrics to trace events.
+
+    This function augments a Chrome trace with performance utilization metrics by:
+    1. First ensuring kernel_flop and kernel_num_gb are present (via _augment_trace_helper)
+    2. Computing achieved FLOPS% and bandwidth% based on device peak specs
+    3. Computing roofline metrics (arithmetic intensity, roofline efficiency)
+
+    Args:
+        data: Chrome trace data (dict with "traceEvents" key)
+        device_name: Optional device name to use for looking up peak specs.
+                    If None, will try to use PyTorch's device query APIs or
+                    infer from trace's deviceProperties.
+
+    Returns:
+        The augmented trace data with utilization and roofline metrics added to kernel events.
+
+    Roofline metrics added:
+        - arithmetic_intensity: FLOP/byte ratio for the kernel
+        - roofline_ceiling_tflops: Theoretical max performance for this kernel
+        - roofline_bound: "memory" or "compute" indicating the limiting factor
+        - roofline_efficiency_percent: Actual performance / roofline ceiling
+    """
+    # First ensure we have kernel_flop and kernel_num_gb
+    data = _augment_trace_helper(data)
+
+    # Try to get device specs from PyTorch's APIs first (most accurate)
+    peak_tflops_by_dtype: dict[torch.dtype, float] = {}
+    peak_bw_gbps: Optional[float] = None
+
+    try:
+        from torch._inductor.utils import get_device_tflops, get_gpu_dram_gbps
+
+        if torch.cuda.is_available():
+            peak_bw_gbps = get_gpu_dram_gbps()
+            for dt in [torch.float32, torch.float16, torch.bfloat16, torch.float64]:
+                try:
+                    peak_tflops_by_dtype[dt] = get_device_tflops(dt)
+                except Exception:
+                    pass
+    except ImportError:
+        pass
+
+    # Fall back to device_info lookup if PyTorch APIs didn't work
+    device_info = None
+    if not peak_tflops_by_dtype or peak_bw_gbps is None:
+        if device_name is not None:
+            device_info = lookup_device_info(device_name)
+        elif "deviceProperties" in data and len(data["deviceProperties"]) > 0:
+            for dev_prop in data["deviceProperties"]:
+                if "name" in dev_prop:
+                    device_info = lookup_device_info(dev_prop["name"])
+                    if device_info is not None:
+                        break
+
+        if device_info is not None:
+            if not peak_tflops_by_dtype:
+                peak_tflops_by_dtype = {
+                    k: v for k, v in device_info.tops.items() if isinstance(k, torch.dtype)
+                }
+            if peak_bw_gbps is None:
+                peak_bw_gbps = device_info.dram_bw_gbs
+
+    if not peak_tflops_by_dtype or peak_bw_gbps is None:
+        log.warning(
+            "Could not determine device specs for utilization annotations. "
+            "Ensure CUDA is available or specify device_name."
+        )
+        return data
+
+    # Add utilization annotations to CUDA kernel events only
+    # CPU ops with kernel metadata are skipped - they represent the CPU-side launch,
+    # not the actual GPU execution where utilization matters
+    for event in data["traceEvents"]:
+        cat = event.get("cat", "")
+
+        # Skip events that don't have duration or args
+        if "args" not in event or "dur" not in event:
+            continue
+
+        # Only process kernel events (GPU-side)
+        if cat != "kernel":
+            continue
+
+        dur = event["dur"]  # microseconds
+        if dur == 0:
+            continue
+
+        # Get kernel metrics
+        kernel_flop = event["args"].get("kernel_flop", 0)
+        kernel_num_gb = event["args"].get("kernel_num_gb", 0)
+
+        # Determine dtype for this event
+        event_dtype: Optional[torch.dtype] = None
+        # Try to infer from event's input types
+        if "Input type" in event["args"]:
+            input_types = event["args"]["Input type"]
+            if isinstance(input_types, list) and len(input_types) > 0:
+                type_str = input_types[0]
+                if type_str in _dtype_map:
+                    event_dtype = _dtype_map[type_str]
+        # Try from kernel name
+        if event_dtype is None:
+            name = event.get("name", "")
+            if "bfloat16" in name:
+                event_dtype = torch.bfloat16
+            elif "float16" in name:
+                event_dtype = torch.float16
+            else:
+                event_dtype = torch.float32  # Default
+
+        # Get peak performance for dtype
+        peak_tflops = peak_tflops_by_dtype.get(event_dtype, 0)
+        peak_flops = peak_tflops * 1e12  # Convert to FLOPS
+        peak_bw = peak_bw_gbps * 1e9  # Convert to bytes/s
+
+        # Calculate achieved FLOPS%
+        op_flops = 0
+        if kernel_flop != 0:
+            op_flops = kernel_flop / (dur / 1e6)  # FLOPS/s
+            if peak_tflops > 0:
+                achieved_flops_pct = 100 * op_flops / peak_flops
+                event["args"]["achieved_flops_percent"] = achieved_flops_pct
+
+        # Calculate achieved bandwidth%
+        op_bw = 0
+        if kernel_num_gb != 0:
+            op_bw = kernel_num_gb * 1e9 / (dur / 1e6)  # bytes/s
+            achieved_bw_pct = 100 * op_bw / peak_bw
+            event["args"]["achieved_bandwidth_percent"] = achieved_bw_pct
+
+        # Calculate roofline metrics
+        if kernel_num_gb > 0 and peak_tflops > 0:
+            # Ridge point: where compute and memory ceilings meet (used internally)
+            ridge_point = peak_flops / peak_bw
+
+            if kernel_flop > 0:
+                # Standard roofline: kernel has both FLOPS and memory access
+                # Arithmetic intensity (FLOP/byte)
+                arith_intensity = kernel_flop / (kernel_num_gb * 1e9)
+                event["args"]["arithmetic_intensity"] = arith_intensity
+
+                # Roofline ceiling: theoretical max performance for this kernel
+                # min(peak_flops, peak_bandwidth * arithmetic_intensity)
+                roofline_ceiling = min(peak_flops, peak_bw * arith_intensity)
+                event["args"]["roofline_ceiling_tflops"] = roofline_ceiling / 1e12
+
+                # Roofline efficiency: actual vs theoretical max
+                roofline_efficiency = 100 * op_flops / roofline_ceiling
+                event["args"]["roofline_efficiency_percent"] = roofline_efficiency
+
+                # Bound type: is this kernel memory-bound or compute-bound on roofline?
+                if arith_intensity < ridge_point:
+                    event["args"]["roofline_bound"] = "memory"
+                else:
+                    event["args"]["roofline_bound"] = "compute"
+            else:
+                # Purely memory-bound kernel (no FLOPS tracked, only memory access)
+                # These are always memory-bound with arithmetic intensity ~0
+                event["args"]["arithmetic_intensity"] = 0.0
+                event["args"]["roofline_bound"] = "memory"
+                # For purely memory-bound, roofline efficiency = achieved bandwidth
+                event["args"]["roofline_efficiency_percent"] = achieved_bw_pct
+
+    return data
+
+
+def augment_trace_file(
+    input_path: str,
+    output_path: Optional[str] = None,
+    device_name: Optional[str] = None,
+    dtype: Optional[Union[torch.dtype, str]] = None,
+    add_utilization: bool = True,
+) -> str:
+    """
+    Augment a Chrome trace file with FLOPS, bandwidth, and utilization annotations.
+
+    This is a convenience function for augmenting trace files with performance metrics.
+    It can be used as a post-processing step after profiler.export_chrome_trace().
+
+    Args:
+        input_path: Path to the input Chrome trace JSON file.
+        output_path: Path to write the augmented trace. If None, overwrites input_path.
+        device_name: Optional device name for utilization calculations.
+        dtype: Optional dtype for FLOPS calculations.
+        add_utilization: If True, also adds achieved_flops_percent and
+                        achieved_bandwidth_percent. Requires device info.
+
+    Returns:
+        The path to the output file.
+
+    Example:
+        >>> from torch.profiler import profile, ProfilerActivity
+        >>> with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        ...     # Do some work
+        ...     pass
+        >>> prof.export_chrome_trace("trace.json")
+        >>> # Now augment the trace with utilization metrics
+        >>> from torch._inductor.analysis.profile_analysis import augment_trace_file
+        >>> augment_trace_file("trace.json", device_name="NVIDIA H100")
+    """
+    with open(input_path) as f:
+        data = json.load(f)
+
+    # Always run basic augmentation
+    data = _augment_trace_helper(data)
+
+    # Optionally add utilization annotations
+    if add_utilization:
+        data = add_utilization_annotations(data, device_name=device_name, dtype=dtype)
+
+    # Write output
+    if output_path is None:
+        output_path = input_path
+
+    with open(output_path, "w") as f:
+        json.dump(data, f)
+
+    return output_path
+
+
+# Legacy callback functions for backwards compatibility
+# New code should use torch.profiler.register_export_chrome_trace_callback
+_profiler_export_callbacks: list[Callable[[dict[str, Any]], dict[str, Any]]] = []
+
+
+def register_profiler_export_callback(
+    callback: Callable[[dict[str, Any]], dict[str, Any]]
+) -> None:
+    """
+    Register a callback to run before profiler trace export.
+
+    .. deprecated::
+        Use torch.profiler.register_export_chrome_trace_callback() instead.
+    """
+    _profiler_export_callbacks.append(callback)
+
+
+def clear_profiler_export_callbacks() -> None:
+    """Remove all registered profiler export callbacks (for testing)."""
+    _profiler_export_callbacks.clear()
+
+
+def run_profiler_export_callbacks(data: dict[str, Any]) -> dict[str, Any]:
+    """Run all registered profiler export callbacks on the trace data."""
+    for callback in _profiler_export_callbacks:
+        try:
+            data = callback(data)
+        except Exception as e:
+            log.warning("Profiler export callback failed: %s", e)
+    return data
+
+
+def _default_utilization_callback(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Default callback that adds utilization annotations to profiler traces.
+
+    This callback is automatically registered with the profiler when this module
+    is imported. It detects the device from trace metadata and adds FLOPS/bandwidth
+    utilization metrics to kernel events.
+    """
+    return add_utilization_annotations(data)
+
+
 def main() -> None:
     """
     Main function for the profile analysis script.
@@ -817,6 +1085,26 @@ input files to combine.",
 
         combined.dump(output_file)
         print(f"Successfully combined {', '.join(input_files)} into {output_file}")
+
+
+# Register the default utilization callback with the profiler.
+# This enables automatic FLOPS/bandwidth utilization annotations in profiler traces.
+# lru_cache ensures we only register once per process.
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _register_profiler_callback() -> None:
+    try:
+        from torch.profiler import register_export_chrome_trace_callback
+
+        register_export_chrome_trace_callback(_default_utilization_callback)
+    except ImportError:
+        # Profiler not available (e.g., minimal build)
+        pass
+
+
+_register_profiler_callback()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173665
* #173664

Add utilization analysis for profiler traces:

1. Core functionality (profile_analysis.py):
   - add_utilization_annotations(): Adds achieved_flops_percent, achieved_bandwidth_percent
   - Roofline metrics: arithmetic_intensity, roofline_bound, roofline_ceiling_tflops
   - Auto-registers callback with profiler via lru_cache
   - Uses PyTorch's get_device_tflops()/get_gpu_dram_gbps() with device_info fallback

2. Bandwidth estimation fix (simd.py):
   - Rewrote estimate_kernel_num_bytes() to use actual read_writes from fused nodes
   - Properly excludes kernel-local buffers eliminated through fusion
   - Correctly handles in_out_ptr buffers (counts read + write separately)

3. DebugAutotuner fix (triton_heuristics.py):
   - Call kernel with profiler support even when benchmark results are cached

4. Device info:
   - Added NVIDIA H200 (4.8 TB/s HBM3e, 141GB)

written with claude code

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos