### PR TITLE
[DYNAMO] Change trigger to trigger.name

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -231,8 +231,16 @@ def test_reinplace_counters_use_trigger_name_not_enum_value(self):
     expected_bytes_key = "missed_bytes_AUTO_FUNC_V1"
 
     # Verify the keys exist with the correct format
-    self.assertIn(expected_tensor_key, ReinplaceCounters._values, f"Expected key {expected_tensor_key} not found")
-    self.assertIn(expected_bytes_key, ReinplaceCounters._values, f"Expected key {expected_bytes_key} not found")
+    self.assertIn(
+        expected_tensor_key,
+        ReinplaceCounters._values,
+        f"Expected key {expected_tensor_key} not found",
+    )
+    self.assertIn(
+        expected_bytes_key,
+        ReinplaceCounters._values,
+        f"Expected key {expected_bytes_key} not found",
+    )
 
     # Verify the values are correct
     self.assertEqual(ReinplaceCounters._values[expected_tensor_key], 2)
@@ -246,7 +254,11 @@ def test_reinplace_counters_use_trigger_name_not_enum_value(self):
     ReinplaceCounters.add_missed_opportunities(trigger2, 3)
 
     expected_key2 = "missed_tensors_TRITON_OPS"
-    self.assertIn(expected_key2, ReinplaceCounters._values, f"Expected key {expected_key2} not found")
+    self.assertIn(
+        expected_key2,
+        ReinplaceCounters._values,
+        f"Expected key {expected_key2} not found",
+    )
     self.assertEqual(ReinplaceCounters._values[expected_key2], 3)
 
     # Verify the old key doesn't exist
@@ -254,7 +266,10 @@ def test_reinplace_counters_use_trigger_name_not_enum_value(self):
 
     # Test edge case: check that we don't use the enum integer value
     # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
-    self.assertNotIn(f"missed_tensors_{trigger.value}", ReinplaceCounters._values, "Should not use enum value (integer) in key, should use trigger.name instead")
+    self.assertNotIn(f"missed_tensors_{trigger.value}",
+        ReinplaceCounters._values,
+        "Should not use enum value (integer) in key, should use trigger.name instead",
+    )
 
 
 class TestModel(torch.nn.Module):

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -215,50 +215,46 @@ class TestUtils(TestCase):
 def test_reinplace_counters_use_trigger_name_not_enum_value(self):
     """Test that ReinplaceCounters uses trigger.name in dictionary keys instead of the enum value"""
     from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger
-    
+
     # Clear any existing state
     ReinplaceCounters.clear()
-    
+
     # Test with AUTO_FUNC_V1 trigger
     trigger = ReInplaceTrigger.AUTO_FUNC_V1
-    
+
     # Add some values
     ReinplaceCounters.add_missed_opportunities(trigger, 2)
     ReinplaceCounters.add_missed_bytes(trigger, 512)
-    
+
     # Check that the dictionary keys use the trigger name, not the enum value
     expected_tensor_key = "missed_tensors_AUTO_FUNC_V1"
     expected_bytes_key = "missed_bytes_AUTO_FUNC_V1"
-    
+
     # Verify the keys exist with the correct format
-    self.assertIn(expected_tensor_key, ReinplaceCounters._values, 
-                  f"Expected key {expected_tensor_key} not found")
-    self.assertIn(expected_bytes_key, ReinplaceCounters._values, 
-                  f"Expected key {expected_bytes_key} not found")
-    
+    self.assertIn(expected_tensor_key, ReinplaceCounters._values, f"Expected key {expected_tensor_key} not found")
+    self.assertIn(expected_bytes_key, ReinplaceCounters._values, f"Expected key {expected_bytes_key} not found")
+
     # Verify the values are correct
     self.assertEqual(ReinplaceCounters._values[expected_tensor_key], 2)
     self.assertEqual(ReinplaceCounters._values[expected_bytes_key], 512)
-    
+
     # Clear for next test
     ReinplaceCounters.clear()
-    
+
     # Test with a different trigger to ensure it's not hardcoded
     trigger2 = ReInplaceTrigger.TRITON_OPS
     ReinplaceCounters.add_missed_opportunities(trigger2, 3)
-    
+
     expected_key2 = "missed_tensors_TRITON_OPS"
-    self.assertIn(expected_key2, ReinplaceCounters._values, 
-                  f"Expected key {expected_key2} not found")
+    self.assertIn(expected_key2, ReinplaceCounters._values, f"Expected key {expected_key2} not found")
     self.assertEqual(ReinplaceCounters._values[expected_key2], 3)
-    
+
     # Verify the old key doesn't exist
     self.assertNotIn("missed_tensors_AUTO_FUNC_V1", ReinplaceCounters._values)
-    
+
     # Test edge case: check that we don't use the enum integer value
     # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
-    self.assertNotIn(f"missed_tensors_{trigger.value}", ReinplaceCounters._values,
-                     "Should not use enum value (integer) in key, should use trigger.name instead")
+    self.assertNotIn(f"missed_tensors_{trigger.value}", ReinplaceCounters._values, "Should not use enum value (integer) in key, should use trigger.name instead")
 
 
 class TestModel(torch.nn.Module):

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -212,6 +212,51 @@ class TestUtils(TestCase):
         fn(x)
         self.assertEqual(traced_code_lists, [])
 
+def test_reinplace_counters_use_trigger_name_not_enum_value(self):
+    """Test that ReinplaceCounters uses trigger.name in dictionary keys instead of the enum value"""
+    from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger
+    
+    # Clear any existing state
+    ReinplaceCounters.clear()
+    
+    # Test with AUTO_FUNC_V1 trigger
+    trigger = ReInplaceTrigger.AUTO_FUNC_V1
+    
+    # Add some values
+    ReinplaceCounters.add_missed_opportunities(trigger, 2)
+    ReinplaceCounters.add_missed_bytes(trigger, 512)
+    
+    # Check that the dictionary keys use the trigger name, not the enum value
+    expected_tensor_key = "missed_tensors_AUTO_FUNC_V1"
+    expected_bytes_key = "missed_bytes_AUTO_FUNC_V1"
+    
+    # Verify the keys exist with the correct format
+    assert expected_tensor_key in ReinplaceCounters._values, f"Expected key {expected_tensor_key} not found"
+    assert expected_bytes_key in ReinplaceCounters._values, f"Expected key {expected_bytes_key} not found"
+    
+    # Verify the values are correct
+    assert ReinplaceCounters._values[expected_tensor_key] == 2
+    assert ReinplaceCounters._values[expected_bytes_key] == 512
+    
+    # Clear for next test
+    ReinplaceCounters.clear()
+    
+    # Test with a different trigger to ensure it's not hardcoded
+    trigger2 = ReInplaceTrigger.TRITON_OPS
+    ReinplaceCounters.add_missed_opportunities(trigger2, 3)
+    
+    expected_key2 = "missed_tensors_TRITON_OPS"
+    assert expected_key2 in ReinplaceCounters._values, f"Expected key {expected_key2} not found"
+    assert ReinplaceCounters._values[expected_key2] == 3
+    
+    # Verify the old key doesn't exist
+    assert "missed_tensors_AUTO_FUNC_V1" not in ReinplaceCounters._values
+    
+    # Test edge case: check that we don't use the enum integer value
+    # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
+    assert f"missed_tensors_{trigger.value}" not in ReinplaceCounters._values, \
+        "Should not use enum value (integer) in key, should use trigger.name instead"
+
 
 class TestModel(torch.nn.Module):
     def __init__(self):

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -266,7 +266,8 @@ def test_reinplace_counters_use_trigger_name_not_enum_value(self):
 
     # Test edge case: check that we don't use the enum integer value
     # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
-    self.assertNotIn(f"missed_tensors_{trigger.value}",
+    self.assertNotIn(
+        f"missed_tensors_{trigger.value}",
         ReinplaceCounters._values,
         "Should not use enum value (integer) in key, should use trigger.name instead",
     )

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -213,65 +213,65 @@ class TestUtils(TestCase):
         self.assertEqual(traced_code_lists, [])
 
 
-def test_reinplace_counters_use_trigger_name_not_enum_value(self):
-    """Test that ReinplaceCounters uses trigger.name in dictionary keys instead of the enum value"""
-    from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger
+    def test_reinplace_counters_use_trigger_name_not_enum_value(self):
+        """Test that ReinplaceCounters uses trigger.name in dictionary keys instead of the enum value"""
+        from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger
 
-    # Clear any existing state
-    ReinplaceCounters.clear()
+        # Clear any existing state
+        ReinplaceCounters.clear()
 
-    # Test with AUTO_FUNC_V1 trigger
-    trigger = ReInplaceTrigger.AUTO_FUNC_V1
+        # Test with AUTO_FUNC_V1 trigger
+        trigger = ReInplaceTrigger.AUTO_FUNC_V1
 
-    # Add some values
-    ReinplaceCounters.add_missed_opportunities(trigger, 2)
-    ReinplaceCounters.add_missed_bytes(trigger, 512)
+        # Add some values
+        ReinplaceCounters.add_missed_opportunities(trigger, 2)
+        ReinplaceCounters.add_missed_bytes(trigger, 512)
 
-    # Check that the dictionary keys use the trigger name, not the enum value
-    expected_tensor_key = "missed_tensors_AUTO_FUNC_V1"
-    expected_bytes_key = "missed_bytes_AUTO_FUNC_V1"
+        # Check that the dictionary keys use the trigger name, not the enum value
+        expected_tensor_key = "missed_tensors_AUTO_FUNC_V1"
+        expected_bytes_key = "missed_bytes_AUTO_FUNC_V1"
 
-    # Verify the keys exist with the correct format
-    self.assertIn(
-        expected_tensor_key,
-        ReinplaceCounters._values,
-        f"Expected key {expected_tensor_key} not found",
-    )
-    self.assertIn(
-        expected_bytes_key,
-        ReinplaceCounters._values,
-        f"Expected key {expected_bytes_key} not found",
-    )
+        # Verify the keys exist with the correct format
+        self.assertIn(
+            expected_tensor_key,
+            ReinplaceCounters._values,
+            f"Expected key {expected_tensor_key} not found",
+        )
+        self.assertIn(
+            expected_bytes_key,
+            ReinplaceCounters._values,
+            f"Expected key {expected_bytes_key} not found",
+        )
 
-    # Verify the values are correct
-    self.assertEqual(ReinplaceCounters._values[expected_tensor_key], 2)
-    self.assertEqual(ReinplaceCounters._values[expected_bytes_key], 512)
+        # Verify the values are correct
+        self.assertEqual(ReinplaceCounters._values[expected_tensor_key], 2)
+        self.assertEqual(ReinplaceCounters._values[expected_bytes_key], 512)
 
-    # Clear for next test
-    ReinplaceCounters.clear()
+        # Clear for next test
+        ReinplaceCounters.clear()
 
-    # Test with a different trigger to ensure it's not hardcoded
-    trigger2 = ReInplaceTrigger.TRITON_OPS
-    ReinplaceCounters.add_missed_opportunities(trigger2, 3)
+        # Test with a different trigger to ensure it's not hardcoded
+        trigger2 = ReInplaceTrigger.TRITON_OPS
+        ReinplaceCounters.add_missed_opportunities(trigger2, 3)
 
-    expected_key2 = "missed_tensors_TRITON_OPS"
-    self.assertIn(
-        expected_key2,
-        ReinplaceCounters._values,
-        f"Expected key {expected_key2} not found",
-    )
-    self.assertEqual(ReinplaceCounters._values[expected_key2], 3)
+        expected_key2 = "missed_tensors_TRITON_OPS"
+        self.assertIn(
+            expected_key2,
+            ReinplaceCounters._values,
+            f"Expected key {expected_key2} not found",
+        )
+        self.assertEqual(ReinplaceCounters._values[expected_key2], 3)
 
-    # Verify the old key doesn't exist
-    self.assertNotIn("missed_tensors_AUTO_FUNC_V1", ReinplaceCounters._values)
+        # Verify the old key doesn't exist
+        self.assertNotIn("missed_tensors_AUTO_FUNC_V1", ReinplaceCounters._values)
 
-    # Test edge case: check that we don't use the enum integer value
-    # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
-    self.assertNotIn(
-        f"missed_tensors_{trigger.value}",
-        ReinplaceCounters._values,
-        "Should not use enum value (integer) in key, should use trigger.name instead",
-    )
+        # Test edge case: check that we don't use the enum integer value
+        # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
+        self.assertNotIn(
+            f"missed_tensors_{trigger.value}",
+            ReinplaceCounters._values,
+            "Should not use enum value (integer) in key, should use trigger.name instead",
+        )
 
 
 class TestModel(torch.nn.Module):

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -212,7 +212,6 @@ class TestUtils(TestCase):
         fn(x)
         self.assertEqual(traced_code_lists, [])
 
-
     def test_reinplace_counters_use_trigger_name_not_enum_value(self):
         """Test that ReinplaceCounters uses trigger.name in dictionary keys instead of the enum value"""
         from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -212,6 +212,7 @@ class TestUtils(TestCase):
         fn(x)
         self.assertEqual(traced_code_lists, [])
 
+
 def test_reinplace_counters_use_trigger_name_not_enum_value(self):
     """Test that ReinplaceCounters uses trigger.name in dictionary keys instead of the enum value"""
     from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -231,12 +231,14 @@ def test_reinplace_counters_use_trigger_name_not_enum_value(self):
     expected_bytes_key = "missed_bytes_AUTO_FUNC_V1"
     
     # Verify the keys exist with the correct format
-    assert expected_tensor_key in ReinplaceCounters._values, f"Expected key {expected_tensor_key} not found"
-    assert expected_bytes_key in ReinplaceCounters._values, f"Expected key {expected_bytes_key} not found"
+    self.assertIn(expected_tensor_key, ReinplaceCounters._values, 
+                  f"Expected key {expected_tensor_key} not found")
+    self.assertIn(expected_bytes_key, ReinplaceCounters._values, 
+                  f"Expected key {expected_bytes_key} not found")
     
     # Verify the values are correct
-    assert ReinplaceCounters._values[expected_tensor_key] == 2
-    assert ReinplaceCounters._values[expected_bytes_key] == 512
+    self.assertEqual(ReinplaceCounters._values[expected_tensor_key], 2)
+    self.assertEqual(ReinplaceCounters._values[expected_bytes_key], 512)
     
     # Clear for next test
     ReinplaceCounters.clear()
@@ -246,16 +248,17 @@ def test_reinplace_counters_use_trigger_name_not_enum_value(self):
     ReinplaceCounters.add_missed_opportunities(trigger2, 3)
     
     expected_key2 = "missed_tensors_TRITON_OPS"
-    assert expected_key2 in ReinplaceCounters._values, f"Expected key {expected_key2} not found"
-    assert ReinplaceCounters._values[expected_key2] == 3
+    self.assertIn(expected_key2, ReinplaceCounters._values, 
+                  f"Expected key {expected_key2} not found")
+    self.assertEqual(ReinplaceCounters._values[expected_key2], 3)
     
     # Verify the old key doesn't exist
-    assert "missed_tensors_AUTO_FUNC_V1" not in ReinplaceCounters._values
+    self.assertNotIn("missed_tensors_AUTO_FUNC_V1", ReinplaceCounters._values)
     
     # Test edge case: check that we don't use the enum integer value
     # ReInplaceTrigger.AUTO_FUNC_V1 has value 1, so we verify "missed_tensors_1" doesn't exist
-    assert f"missed_tensors_{trigger.value}" not in ReinplaceCounters._values, \
-        "Should not use enum value (integer) in key, should use trigger.name instead"
+    self.assertNotIn(f"missed_tensors_{trigger.value}", ReinplaceCounters._values,
+                     "Should not use enum value (integer) in key, should use trigger.name instead")
 
 
 class TestModel(torch.nn.Module):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -207,7 +207,7 @@ class ReinplaceCounters:
     @classmethod
     def add_missed_opportunities(cls, trigger: ReInplaceTrigger, count: int) -> None:
         if count != 0:
-            cls._values[f"missed_tensors_{trigger}"] += count
+            cls._values[f"missed_tensors_{trigger.name}"] += count
 
     @classmethod
     def clear(cls) -> None:
@@ -217,7 +217,7 @@ class ReinplaceCounters:
     def get_total_missed(cls) -> int:
         sum = 0
         for trigger in ReInplaceTrigger:
-            sum += cls._values.get(f"missed_tensors_{trigger}", 0)
+            sum += cls._values.get(f"missed_tensors_{trigger.name}", 0)
         return sum
 
     @classmethod


### PR DESCRIPTION
I'm not quite sure about this fix and it's not tested (just from looking at the code), so please correct me if I'm mistaken, but shouldn't it be trigger.name in order to be consistent with sum += cls._values.get(f"missed_bytes_{trigger.name}", 0)? Thanks!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos