### PR TITLE
[FA3] pass max_q and max_k for varlen attn

### DIFF
--- a/torch/nn/attention/_fa3.py
+++ b/torch/nn/attention/_fa3.py
@@ -249,6 +249,8 @@ def _fa3_run_forward(
     value: torch.Tensor,
     cu_seq_q: torch.Tensor | None,
     cu_seq_k: torch.Tensor | None,
+    max_q: int,
+    max_k: int,
     scale: float | None,
     is_causal: bool,
     window_size_left: int | None,
@@ -292,8 +294,8 @@ def _fa3_run_forward(
         None,  # cu_seqlens_k_new
         None,  # seqused_q
         seqused_k,  # seqused_k
-        None,  # max_seqlen_q
-        None,  # max_seqlen_k
+        max_q,  # max_seqlen_q
+        max_k,  # max_seqlen_k
         None,  # page_table,
         None,  # kv_batch_idx,
         None,  # leftpad_k,
@@ -420,6 +422,8 @@ def _fa3_flash_attention_forward_impl(
         value,
         cum_seq_q,
         cum_seq_k,
+        max_q,
+        max_k,
         scale,
         is_causal,
         window_size_left,


### PR DESCRIPTION
Fixes error below: 

```
    File "/home/liangel/local/pytorch/torch/nn/attention/_fa3.py", line 417, in _fa3_flash_attention_forward_impl
      out, lse = _fa3_run_forward(
                 ^^^^^^^^^^^^^^^^^
    File "/home/liangel/local/pytorch/torch/nn/attention/_fa3.py", line 282, in _fa3_run_forward
      out, softmax_lse, out_accum, softmax_lse_accum = _FA3_CUDA_FWD(
                                                       ^^^^^^^^^^^^^^
    File "/home/liangel/local/pytorch/torch/_ops.py", line 1258, in __call__
      return self._op(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
    RuntimeError: mha_fwd, /pytorch/third_party/flash-attention/hopper/flash_api_stable.cpp:814, 
                           max_seqlen_q must be provided if cu_seqlens_q is provided
```

`_fa3_flash_attention_forward_impl` has `max_q` and `max_k` params passed in from `varlen_attn` so we should continue passing these down to the kernel call. 

Tests: 
added basic functionality test for varlen to `test_fa3.py`. correctness tests can stay in `test_varlen_attention.py`.