### PR TITLE
[inductor] Add test for libdevice.pow type mismatch bug

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -690,6 +690,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipCPUIf(True, "Triton codegen bug only affects GPU")
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_scalar_outputs": True})
     @unittest.expectedFailure
@@ -700,15 +701,18 @@ class TestUnbackedSymints(InductorTestCase):
         Reproducer: sqrt returns float32, but exponent is float64 from sympy.
         This caused: KeyError: (triton.language.float32, triton.language.float64)
 
-        Note: We use exponent 10 instead of larger values (e.g., 70) to avoid
-        a separate overflow issue in TruncToInt which converts to int32.
-        The type mismatch fix is validated regardless of exponent size.
+        The bug only triggers with a NON-INTEGER float exponent (like 2.5).
+        Integer exponents (like 10.0) are printed differently and don't trigger
+        the type mismatch.
         """
         import math
 
         def fn(x):
+            # sqrt(x.size(0)) creates OpaqueUnaryFn_sqrt -> printed as float32
+            # **2.5 creates FloatPow with sympy.Float(2.5) -> printed as float64
+            # This causes: KeyError: (triton.language.float32, triton.language.float64)
             r = math.sqrt(x.size(0))
-            r = r**10
+            r = r**2.5  # Non-integer exponent is required to trigger the bug
             return torch.tensor(math.trunc(r), dtype=torch.float64, device=device)
 
         example_inputs = (torch.randn(4, device=device),)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173685
* __->__ #173684
* #173607

Summary:
Add a test that reproduces the Triton compilation error when libdevice.pow
receives mismatched float32/float64 argument types.

The bug occurs when:
- sqrt returns float32 (from _helper_sqrt)
- exponent is float64 (from _print_Float)

This causes: KeyError: (triton.language.float32, triton.language.float64)

Test Plan:
Run the test and verify it fails with the expected error:
python -m pytest test/inductor/test_unbacked_symints.py -k test_triton_pow_type_mismatch -xvs

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo