### PR TITLE
Fixing ParallelGraphExecutor hangs during load_net_predictor benchmark runs.

### DIFF
--- a/torch/nativert/executor/ParallelGraphExecutor.cpp
+++ b/torch/nativert/executor/ParallelGraphExecutor.cpp
@@ -23,8 +23,16 @@ ThreadPoolExecutor::~ThreadPoolExecutor() {
 
 C10_ALWAYS_INLINE moodycamel::ProducerToken& ThreadPoolExecutor::ptok() {
   // NOLINTNEXTLINE(misc-use-internal-linkage)
-  thread_local moodycamel::ProducerToken ptok(*work_);
-  return ptok;
+  thread_local moodycamel::ProducerToken* pTokPtr = nullptr;
+  thread_local moodycamel::ConcurrentQueue<Work>* associatedQueue = nullptr;
+
+  // Check if token exists AND is for the current queue
+  if (pTokPtr == nullptr || associatedQueue != work_.get()) {
+    delete pTokPtr;
+    pTokPtr = new moodycamel::ProducerToken(*work_);
+    associatedQueue = work_.get();
+  }
+  return *pTokPtr;
 }
 
 C10_ALWAYS_INLINE moodycamel::ConsumerToken& ThreadPoolExecutor::ctok() {
@@ -125,6 +133,10 @@ void ThreadPoolExecutor::stop() {
     auto tmp = moodycamel::ConcurrentQueue<Work>();
     work_->swap(tmp);
   }
+}
+
+size_t ThreadPoolExecutor::queueSizeApprox() const {
+  return work_->size_approx();
 }
 
 void ThreadPoolExecutor::run(

--- a/torch/nativert/executor/ParallelGraphExecutor.h
+++ b/torch/nativert/executor/ParallelGraphExecutor.h
@@ -79,6 +79,9 @@ class ThreadPoolExecutor {
   C10_ALWAYS_INLINE moodycamel::ProducerToken& ptok();
   C10_ALWAYS_INLINE moodycamel::ConsumerToken& ctok();
 
+  // Returns approximate queue size. Useful for testing.
+  size_t queueSizeApprox() const;
+
  private:
   void loop();
 


### PR DESCRIPTION
Summary:
1. During producer token issue, we have to check if the thread is associated with the same queue.
2. Otherwise, during consecutive inference runs, main thead's thread local producer token ends up pointing to wrong queue.
3. The fix does not fix/support concurrent executions of graph. Only fixes consecutive execution of graphs. 
4. We can support the concurrent case later, if that is a valid execution pattern for low level runtime. But we may have to re-think the some of the design decisions in that case.


More details in the following doc;


https://docs.google.com/document/d/1batmENxBF6CswgoYHBqwYFnJHSw9-b0N2bbNDAYfKTQ/edit?usp=sharing

Test Plan:
New UT.

without the fix;

`buck test fbcode//sigmoid/inference/test_cpu:ThreadPoolExecutorTest`
`File changed: fbsource//xplat/caffe2/torch/nativert/executor/ParallelGraphExecutor.cpp`
`File changed: fbcode//caffe2/torch/nativert/executor/ParallelGraphExecutor.cpp`
`✗ Fail: fbcode//sigmoid/inference/test_cpu:ThreadPoolExecutorTest - ThreadPoolExecutorTest.SequentialQueueOperations (0.0s)`
`Note: Google Test filter = ThreadPoolExecutorTest.SequentialQueueOperations`
`[==========] Running 1 test from 1 test suite.`
`[----------] Global test environment set-up.`
`[----------] 1 test from ThreadPoolExecutorTest`
`[ RUN      ] ThreadPoolExecutorTest.SequentialQueueOperations`
`fbcode/sigmoid/inference/test_cpu/ThreadPoolExecutorTest.cpp:63: Failure`
`Expected equality of these values:`
  `executor1->queueSizeApprox()`
    `Which is: 15`
  `kWorkUnitsExecutor1`
    `Which is: 5`
`Executor 1 should have 5 work units`

`fbcode/sigmoid/inference/test_cpu/ThreadPoolExecutorTest.cpp:65: Failure`
`Expected equality of these values:`
  `executor2->queueSizeApprox()`
    `Which is: 0`
  `kWorkUnitsExecutor2`
    `Which is: 10`
`Executor 2 should have 10 work units`

`[  FAILED  ] ThreadPoolExecutorTest.SequentialQueueOperations (0 ms)`
`[----------] 1 test from ThreadPoolExecutorTest (0 ms total)`

`[----------] Global test environment tear-down`
`[==========] 1 test from 1 test suite ran. (0 ms total)`
`[  PASSED  ] 0 tests.`
`[  FAILED  ] 1 test, listed below:`
`[  FAILED  ] ThreadPoolExecutorTest.SequentialQueueOperations`

 `1 FAILED TEST`

`Buck UI: https://www.internalfb.com/buck2/398c1a62-5d65-45d5-a0b9-0d24d43f988c`
`Test UI: https://www.internalfb.com/intern/testinfra/testrun/7881299676160850`
`Network: Up: 1.3MiB  Down: 0B  (reSessionID-726eaaa9-789e-4a4f-a19d-d0edc753b8cf)`
`Executing actions. Remaining     0/20                                                                                                                                                                                                  26.0s exec time total`
`Command: test.     Finished 10 local`
`Time elapsed: 29.9s`
`Test execution completed but the tests failed`
`Tests finished: Pass 0. Fail 1. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`
`1 TESTS FAILED`
  `✗ fbcode//sigmoid/inference/test_cpu:ThreadPoolExecutorTest - ThreadPoolExecutorTest.SequentialQueueOperations`

`Run $ fdb buck test <args> to debug fbcode//sigmoid/inference/test_cpu:ThreadPoolExecutorTest - ThreadPoolExecutorTest.SequentialQueueOperations`
      `^^^ just prefix your previous command! ($ fdb !!)`
`Learn more at https://fburl.com/fdb`


with the Fix;

buck test fbcode//sigmoid/inference/test_cpu:ThreadPoolExecutorTest
File changed: fbcode//sigmoid/inference/test_cpu/ThreadPoolExecutorTest.cpp
Buck UI: https://www.internalfb.com/buck2/aff67d9a-0112-408c-8aac-3761e740eef5
Test UI: https://www.internalfb.com/intern/testinfra/testrun/14073748980861114
Network: Up: 290KiB  Down: 0B  (reSessionID-bdf65b7e-07fe-4b15-aee2-15a34f3c2fd7)
Executing actions. Remaining     0/4                                                                                                                                                                                                   11.4s exec time total
Command: test.     Finished 2 local
Time elapsed: 26.4s
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0

Differential Revision: D91237639


