### PR TITLE
ProcessGroupNCCL: use lowest rank as split color

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -682,27 +682,6 @@ size_t hashTensors(const std::vector<at::Tensor>& tensors) {
   return hash;
 }
 
-// NCCL uses Non-negative int to represent in-group according to API
-// requirement. We take a list of ranks and generate a hash value based on the
-// list and ensure its range of 32-bit int.
-int genNcclSplitColor(const std::vector<int>& ranks) {
-  // Combine the hash values using a simple reducer (std::hash + fold)
-  std::size_t combined_hash = std::accumulate(
-      ranks.begin(),
-      ranks.end(),
-      std::size_t(0),
-      [](std::size_t acc, int rank) {
-        return acc ^
-            (std::hash<int>{}(rank) + 0x9e3779b9 + (acc << 6) + (acc >> 2));
-      });
-
-  // max positive value of int32_t
-  constexpr int32_t max_c_int = std::numeric_limits<int32_t>::max();
-  int color = static_cast<int>(
-      std::abs(static_cast<int64_t>(combined_hash)) % max_c_int);
-  return color;
-}
-
 // Default value: 30 minutes
 int nccl_nonblocking_timeout() {
   static int timeout = -2; // -2 means not initialized

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -240,7 +240,6 @@ static std::map<at::ScalarType, ncclDataType_t> ncclDataType = {
 };
 
 TORCH_API size_t hashTensors(const std::vector<at::Tensor>& tensors);
-TORCH_API int genNcclSplitColor(const std::vector<int>& ranks);
 TORCH_API std::string getNcclVersion();
 TORCH_API std::tuple<int, int, int> getNcclVersionTuple();
 TORCH_API int getNcclVersionNumber();

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1306,8 +1306,10 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::split(
   ncclOpts->split_from =
       c10::intrusive_ptr<ProcessGroupNCCL>::unsafe_reclaim_from_nonowning(this);
   ncclOpts->global_ranks_in_group = std::move(globalRanksInGroup);
-  auto color = genNcclSplitColor(ranks);
-  ncclOpts->split_color = color;
+  // We use the lowest rank in the group as the split_color as each rank can
+  // only participate in one group.
+  // This value must be non-negative int32 and all ranks are.
+  ncclOpts->split_color = *std::min_element(ranks.cbegin(), ranks.cend());
   auto pg = c10::make_intrusive<ProcessGroupNCCL>(
       store->clone(), groupRank, ranks.size(), ncclOpts);
 #ifdef NCCL_COMM_DESCRIPTION


### PR DESCRIPTION
This fixes hash collisions when using NCCL split by using the lowest rank as a split color. This is safe as each rank in a split can only participate in a single sub partition/group so the lowest rank is guaranteed to be unique per group and consistent across all workers in that group.

https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#creating-more-communicators

When porting this to C++ the hash logic changed and resulted in a higher incidence of hash collisions as compared to the old logic. https://github.com/pytorch/pytorch/blame/c6986ca2e125a0fc4decb9dd006cb31a8e8db19f/torch/distributed/distributed_c10d.py#L4668C5-L4668C25

Test plan:

CI

rank IDs:

```
 [1474, 1475] and [1984, 1985]
```