### PR TITLE
[ROCm] Skip linalg tests when MAGMA is not available

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2482,7 +2482,8 @@ class TestLinalg(TestCase):
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
-    @skipCUDAIfNoMagma
+    @skipCUDAIfNoCusolver
+    @skipIf(TEST_WITH_ROCM and _get_magma_version() is None, "ROCm requires MAGMA for this test")
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):
         """Test CUDA eigenvector decoding with known ground truth, including batching."""

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2482,7 +2482,6 @@ class TestLinalg(TestCase):
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
-    @skipCUDAIfNoCusolver
     @skipIf(TEST_WITH_ROCM and _get_magma_version() is None, "ROCm requires MAGMA for this test")
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2482,6 +2482,7 @@ class TestLinalg(TestCase):
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
+    @skipCUDAIfNoMagma
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):
         """Test CUDA eigenvector decoding with known ground truth, including batching."""
@@ -7205,6 +7206,7 @@ class TestLinalg(TestCase):
     def test_lobpcg_basic(self, device, dtype):
         self._test_lobpcg_method(device, dtype, 'basic')
 
+    @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.double)
     def test_lobpcg_ortho(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7210,11 +7210,7 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @dtypes(torch.double)
     def test_lobpcg_ortho(self, device, dtype):
-        if torch.version.hip:
-            torch.backends.cuda.preferred_linalg_library('magma')
         self._test_lobpcg_method(device, dtype, 'ortho')
-        if torch.version.hip:
-            torch.backends.cuda.preferred_linalg_library('default')
 
     def _test_lobpcg_method(self, device, dtype, method):
         from torch.testing._internal.common_utils import random_symmetric_pd_matrix, random_sparse_pd_matrix

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2482,7 +2482,7 @@ class TestLinalg(TestCase):
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
-    @skipIf(TEST_WITH_ROCM and _get_magma_version() is None, "ROCm requires MAGMA for this test")
+    @skipIf(TEST_WITH_ROCM and _get_magma_version() is None, "ROCm hipsolver backend does not currently support eig")
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):
         """Test CUDA eigenvector decoding with known ground truth, including batching."""

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2482,7 +2482,7 @@ class TestLinalg(TestCase):
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
-    @skipIf(TEST_WITH_ROCM and _get_magma_version() is None, "ROCm hipsolver backend does not currently support eig")
+    @skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "ROCm hipsolver backend does not currently support eig")
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):
         """Test CUDA eigenvector decoding with known ground truth, including batching."""

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7206,7 +7206,6 @@ class TestLinalg(TestCase):
     def test_lobpcg_basic(self, device, dtype):
         self._test_lobpcg_method(device, dtype, 'basic')
 
-    @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.double)
     def test_lobpcg_ortho(self, device, dtype):


### PR DESCRIPTION
Unskipping 1 UT that passes when magma is not available and skipping 2 UT's that ROCm's hipsolver backend does not currently support
Tests affected:
- `test_eig_cuda_complex_eigenvectors` (float32 and float64 variants)
- `test_lobpcg_ortho`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang