### PR TITLE
[inductor][testing][BE] Fix flaky test_dropout_deterministic

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9456,11 +9456,13 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
                 x = torch.ones(1024, device=self.device, dtype=torch.float32)
 
+                random.seed(1234)
                 torch.manual_seed(1234)
                 a0 = fn(x).clone()
                 a1 = fn(x).clone()
                 a2 = fn(x).clone()
 
+                random.seed(1234)
                 torch.manual_seed(1234)
                 b0 = fn(x).clone()
                 b1 = fn(x).clone()
@@ -9485,11 +9487,13 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
             x = torch.ones(1024, device=self.device, dtype=torch.float32)
 
+            random.seed(1234)
             torch.manual_seed(1234)
             a0 = fn(x)[0].clone()
             a1 = fn(x)[0].clone()
             a2 = fn(x)[0].clone()
 
+            random.seed(1234)
             torch.manual_seed(1234)
             b0 = fn(x)[0].clone()
             b1 = fn(x)[0].clone()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173690

Summary: I actually don't think this is the problem; I can't repro this failure locally and the related "rand_like" test uses the same pattern and is not marked as flaky. But some of the other tests in this file set both random seeds, so why not give it a try?

Fixes: https://github.com/pytorch/pytorch/issues/133025

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo