### PR TITLE
Say explicitly when any lint command fails.

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -408,6 +408,7 @@ def lint(ctx, *, lintrunner_args, apply_patches, **kwargs):
     if write_json_output:
         Path(tee_file).write_text(json_output_all + json_output_changed)
     if lint_found:
+        click.secho("Lint failed!", fg="red")
         raise SystemExit(1)
 
 


### PR DESCRIPTION
Explicitly say that lint failed when it did, by making sure the last line doesn't state that there are no lint issues.
```
# Rest of output
ok No lint issues.
Lint failed!
```
