### PR TITLE
[inductor][testing][BE] Fix test_mm_triton_kernel_benchmark

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -194,6 +194,9 @@ class TestKernelBenchmark(TestCase):
     @config.patch(
         max_autotune=True, max_autotune_gemm_backends="TRITON", shape_padding=False
     )
+    @unittest.skipIf(
+        not IS_BIG_GPU, "Skipping triton backend only since not big GPU (not enough SM)"
+    )
     @fresh_cache()
     def test_mm_triton_kernel_benchmark(self):
         M = 2048


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173696

Summary: Looks like this test is failing intermittently; logs indicate OOMs; seems it needs the same decorator as the adjacent test.

Fixes: https://github.com/pytorch/pytorch/issues/118346

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo