### PR TITLE
test: clear computation cache in LazyGraphExecutorTest

### DIFF
--- a/test/cpp/lazy/test_lazy_graph_executor.cpp
+++ b/test/cpp/lazy/test_lazy_graph_executor.cpp
@@ -13,6 +13,7 @@ class LazyGraphExecutorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     executor_ = LazyGraphExecutor::Get();
+    executor_->ClearComputationCache();
   }
 
   using CachedComputationType = LazyGraphExecutor::CachedComputation;


### PR DESCRIPTION
Under  an specific order `LazyGraphExecutorTest.TestClearComputationCache`. Other tests likely populate the cache.
```
[----------] 2 tests from LazyGraphExecutorTest
[ RUN      ] LazyGraphExecutorTest.TestClearComputationCache
torch/test/cpp/lazy/test_lazy_graph_executor.cpp:54: Failure
Expected equality of these values:
  executor_->GetComputationCache()->Numel()
    Which is: 1024
  1
[  FAILED  ] LazyGraphExecutorTest.TestClearComputationCache (101 ms)
```
To ensure test isolation, I added a call to `ClearComputationCache()` in the `SetUp()` method of the `LazyGraphExecutorTest ` fixture.
