### PR TITLE
Issue #172987 - Leveraging Unified Memory for MPS Tensors on Apple Silicone

### DIFF
--- a/aten/src/ATen/mps/EmptyTensor.cpp
+++ b/aten/src/ATen/mps/EmptyTensor.cpp
@@ -39,7 +39,14 @@ TensorBase empty_mps(
 
     check_size_nonnegative(size);
 
+#if defined(MPS_SUPPORT_TENSORS_UNIFIED_MEMORY) && MPS_SUPPORT_TENSORS_UNIFIED_MEMORY
+    // APPLE TODO: this should check if device supports unified memory
+    auto* allocator = at::mps::GetMPSAllocator(/* useSharedAllocator = */ true);
+#else
     auto* allocator = at::mps::GetMPSAllocator();
+#endif
+
+    TORCH_INTERNAL_ASSERT(allocator != nullptr);
     int64_t nelements = c10::multiply_integers(size);
     auto dtype = dtype_or_default(dtype_opt);
     TORCH_CHECK_TYPE(dtype != ScalarType::Double, MPS_ERROR_DOUBLE_NOT_SUPPORTED);

--- a/aten/src/ATen/mps/EmptyTensor.cpp
+++ b/aten/src/ATen/mps/EmptyTensor.cpp
@@ -39,12 +39,7 @@ TensorBase empty_mps(
 
     check_size_nonnegative(size);
 
-#if defined(MPS_SUPPORT_TENSORS_UNIFIED_MEMORY) && MPS_SUPPORT_TENSORS_UNIFIED_MEMORY
-    // APPLE TODO: this should check if device supports unified memory
     auto* allocator = at::mps::GetMPSAllocator(/* useSharedAllocator = */ true);
-#else
-    auto* allocator = at::mps::GetMPSAllocator();
-#endif
 
     TORCH_INTERNAL_ASSERT(allocator != nullptr);
     int64_t nelements = c10::multiply_integers(size);

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -195,7 +195,6 @@ struct HeapBlock {
     if (buf) {
       updateAvailableSize();
       n_buffers++;
-      TORCH_INTERNAL_ASSERT([buf storageMode] == MTLStorageModeShared);
     }
     return buf;
   }

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <ATen/mps/MPSAllocatorInterface.h>
+#include <ATen/mps/MPSDevice.h>
 #include <ATen/mps/MPSEvent.h>
 #include <ATen/mps/MPSStream.h>
 
@@ -194,6 +195,9 @@ struct HeapBlock {
     if (buf) {
       updateAvailableSize();
       n_buffers++;
+#if defined(MPS_SUPPORT_TENSORS_UNIFIED_MEMORY) && MPS_SUPPORT_TENSORS_UNIFIED_MEMORY
+      TORCH_INTERNAL_ASSERT([buf storageMode] == MTLStorageModeShared);
+#endif
     }
     return buf;
   }

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -195,9 +195,7 @@ struct HeapBlock {
     if (buf) {
       updateAvailableSize();
       n_buffers++;
-#if defined(MPS_SUPPORT_TENSORS_UNIFIED_MEMORY) && MPS_SUPPORT_TENSORS_UNIFIED_MEMORY
       TORCH_INTERNAL_ASSERT([buf storageMode] == MTLStorageModeShared);
-#endif
     }
     return buf;
   }

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -14,6 +14,8 @@ typedef id<MTLDevice> MTLDevice_t;
 typedef void* MTLDevice_t;
 #endif
 
+#define MPS_SUPPORT_TENSORS_UNIFIED_MEMORY 1
+
 namespace at::mps {
 
 // Helper enum to check if a MPSGraph op is supported in a given macOS version

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -14,8 +14,6 @@ typedef id<MTLDevice> MTLDevice_t;
 typedef void* MTLDevice_t;
 #endif
 
-#define MPS_SUPPORT_TENSORS_UNIFIED_MEMORY 1
-
 namespace at::mps {
 
 // Helper enum to check if a MPSGraph op is supported in a given macOS version

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -1,15 +1,18 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSDevice.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_copy_from_and_resize_native.h>
 #include <ATen/ops/_copy_from_native.h>
+#include <ATen/ops/from_blob.h>
 #include <ATen/ops/imag.h>
 #include <ATen/ops/neg.h>
 #include <ATen/ops/real.h>
 #include <ATen/ops/view_as_real.h>
 #include <ATen/ops/zeros_like.h>
+#include <cstring>
 
 namespace at::native {
 namespace mps {
@@ -79,6 +82,10 @@ static void copy_cast_mps(at::Tensor& dst,
 }
 
 static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking) {
+  // Ensure  src_ and dst_ tensors reside in unified memory and belong to correct devices
+  TORCH_INTERNAL_ASSERT(src_.device().type() == at::kMPS);
+  TORCH_INTERNAL_ASSERT(dst_.device().type() == at::kCPU);
+
   auto sameMemFormat =
       src_.is_contiguous(dst_.suggest_memory_format()) && dst_.is_contiguous(dst_.suggest_memory_format());
 
@@ -105,21 +112,71 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
 
   id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
   size_t dst_tensor_nbytes = dst.nbytes();
+  const void* host_dst = static_cast<const char*>(dst.storage().data()) + dst.storage_offset() * dst.itemsize();
 
   @autoreleasepool {
     MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
     NSUInteger alignedLength = 0;
 
-    const void* host_dst = static_cast<const char*>(dst.storage().data()) + dst.storage_offset() * dst.itemsize();
     void* alignedPtr = pageAlignedBlockPtr(host_dst, (NSUInteger)dst_tensor_nbytes, &alignedLength);
     NSUInteger destOffset = (uintptr_t(host_dst) - uintptr_t(alignedPtr));
     // 4 bytes alignment required on macos for blits.
-    TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned blit request");
+    TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned copy request");
 
     id<MTLBuffer> destBuffer = [device newBufferWithBytesNoCopy:alignedPtr
                                                          length:alignedLength
                                                         options:options
                                                     deallocator:nil];
+
+#if defined(MPS_SUPPORT_TENSORS_UNIFIED_MEMORY) && MPS_SUPPORT_TENSORS_UNIFIED_MEMORY
+    // Both src and dst tensors have MTLBuffer backing in shared storage
+    // we can memcpy directly between their contents pointers and avoid encoding
+    // a Metal blit.
+
+    TORCH_INTERNAL_ASSERT(sourceBuffer.storageMode == MTLStorageModeShared);
+
+    // Ensure any GPU work that produced `sourceBuffer` is finished and
+    // the contents are visible to the CPU.
+    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+
+    const void* src_ptr = static_cast<const char*>((void*)[sourceBuffer contents]) + storage_byte_offset;
+    void* dst_ptr = static_cast<char*>((void*)[destBuffer contents]) + destOffset;
+
+    // Handle logical metadata differences negation/conjugation
+    // if these differ we must manually apply the transform before copying.
+    const bool needs_conj = src_.is_conj() != dst.is_conj();
+    const bool needs_neg = src_.is_neg() != dst.is_neg();
+    const bool needs_type_conv = src_.dtype() != dst.dtype();
+
+    if (!needs_type_conv && !needs_conj && !needs_neg) {
+      // Same element type and no conjugation/negation metadata differences
+      if (dst_ptr != src_ptr) {
+        // a plain memcpy is sufficient
+        memcpy(dst_ptr, src_ptr, dst_tensor_nbytes);
+      } else {
+        // pointers are identical, nothing to do
+      }
+    } else {
+      // Create a CPU tensor view over the shared buffer and perform any
+      // required conjugation/negation and dtype conversion on the CPU,
+      // then copy into the destination.
+      Tensor src_cpu_view = at::from_blob(const_cast<void*>(src_ptr),
+                                          src.sizes(),
+                                          src.strides(),
+                                          at::TensorOptions().dtype(src_.dtype()).device(at::kCPU));
+      Tensor tmp = src_cpu_view;
+      if (needs_conj) {
+        tmp = tmp.conj();
+      }
+      if (needs_neg) {
+        tmp = at::neg(tmp);
+      }
+      if (needs_type_conv) {
+        tmp = tmp.to(dst.dtype());
+      }
+      dst.copy_(tmp, non_blocking);
+    }
+#else
     id<MTLBuffer> maybeCastedSourceBuffer = sourceBuffer;
     Tensor maybeCastedSource;
     bool needsBlit = true;
@@ -148,8 +205,10 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
       stream->copy_and_sync(
           maybeCastedSourceBuffer, destBuffer, size_to_copy, storage_byte_offset, destOffset, non_blocking, profile_id);
     }
+#endif
     [destBuffer release];
   }
+
   if (!dst.is_same(dst_)) {
     dst_.copy_(dst, non_blocking);
   }
@@ -176,21 +235,78 @@ static void copy_to_mps_stride_contig(at::Tensor& dst, const at::Tensor& src, bo
 
     void* alignedPtr = pageAlignedBlockPtr(host_src, (NSUInteger)size_to_copy, &alignedLength);
     sourceOffset = uintptr_t(host_src) - uintptr_t(alignedPtr);
+    // 4 bytes alignment required on macos for blits.
+    TORCH_INTERNAL_ASSERT(sourceOffset % 4 == 0, "Unaligned copy request");
+
     id<MTLBuffer> sourceBuffer = [device newBufferWithBytesNoCopy:alignedPtr
                                                            length:alignedLength
                                                           options:options
                                                       deallocator:nil];
 
+#if defined(MPS_SUPPORT_TENSORS_UNIFIED_MEMORY) && MPS_SUPPORT_TENSORS_UNIFIED_MEMORY
+    // Both src and dst tensors have MTLBuffer backing in shared storage
+    // we can memcpy directly between their contents pointers and avoid encoding
+    // a Metal blit.
+
+    TORCH_INTERNAL_ASSERT(destBuffer.storageMode == MTLStorageModeShared);
+
+    // Both buffers are shared; copy CPU-visible memory directly.
+    const void* src_ptr = static_cast<const char*>((void*)[sourceBuffer contents]) + sourceOffset;
+    void* dst_ptr = static_cast<char*>((void*)[destBuffer contents]) + dst_byte_offset;
+
+    // Handle logical metadata differences negation/conjugation
+    // if these differ we must manually apply the transform before copying.
+    const bool needs_conj = src.is_conj() != dst.is_conj();
+    const bool needs_neg = src.is_neg() != dst.is_neg();
+    const bool needs_type_conv = src.dtype() != dst.dtype();
+
+    if (!needs_type_conv && !needs_conj && !needs_neg) {
+      // Same element type and no conjugation/negation metadata differences
+      if (dst_ptr != src_ptr) {
+        // a plain memcpy is sufficient
+        memcpy(dst_ptr, src_ptr, size_to_copy);
+      } else {
+        // pointers are identical, nothing to do
+      }
+    } else {
+      // Create a CPU tensor view over the shared buffer and perform any
+      // required conjugation/negation and dtype conversion on the CPU,
+      // then make it contiguous and memcopy into the destination.
+      Tensor tmp = src;
+      if (needs_conj) {
+        tmp = tmp.conj();
+      }
+      if (needs_neg) {
+        tmp = at::neg(tmp);
+      }
+      if (needs_type_conv) {
+        tmp = tmp.to(dst.dtype());
+      }
+      tmp = tmp.contiguous();
+      const void* tmp_ptr = static_cast<const char*>(tmp.storage().data()) + tmp.storage_offset() * tmp.itemsize();
+      if (dst_ptr != tmp_ptr) {
+        memcpy(dst_ptr, tmp_ptr, size_to_copy);
+      }
+    }
+
+    // Ensure the device sees the updated shared memory before any GPU work
+    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+#else
     uint64_t profile_id =
         getMPSProfiler().beginProfileCopy(sourceBuffer, destBuffer, src, dst, size_to_copy, non_blocking);
 
     stream->copy_and_sync(
         sourceBuffer, destBuffer, size_to_copy, sourceOffset, dst_byte_offset, non_blocking, profile_id);
+#endif
     [sourceBuffer release];
   }
 }
 
 static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking) {
+  // Ensure  src_ and dst_ tensors reside in unified memory and belong to correct devices
+  TORCH_INTERNAL_ASSERT(src_.device().type() == at::kCPU);
+  TORCH_INTERNAL_ASSERT(dst_.device().type() == at::kMPS);
+
   // Typecast to dst_ if needed and expand, which is a no-op
   Tensor src = (src_.dtype() != dst_.dtype() ? src_.to(dst_.dtype()) : src_).expand_as(dst_);
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -182,6 +182,7 @@ static void dispatch_index_kernel(TensorIteratorBase& iter,
                    ndim_nindiees,
                    mpsStream->getErrorBuffer());
     mtl_dispatch1DJob(computeEncoder, indexSelectPSO, serial ? 1 : iter.numel());
+    mpsStream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
 }
 

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -116,6 +116,7 @@ Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& ste
       feeds[cachedGraph->multiplyTensor] = getMPSGraphTensorFromScalar(stream, stepScalar);
 
       runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
     }
 
     if (!needs_gather) {
@@ -176,6 +177,7 @@ Tensor& range_mps_out(const Scalar& start, const Scalar& end, const Scalar& step
       feeds[cachedGraph->multiplyTensor] = getMPSGraphTensorFromScalar(stream, stepScalar);
 
       runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
     }
 
     if (!needs_gather) {
@@ -243,6 +245,7 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
       feeds[cachedGraph->multiplyTensor] = getMPSGraphTensorFromScalar(stream, multiplyScalar);
 
       runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
     }
 
     if (!result.is_contiguous()) {

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -24,6 +24,7 @@
 #include <ATen/SparseCsrTensorUtils.h>
 #include <ATen/TracerMode.h>
 #include <ATen/dlpack.h>
+#include <ATen/mps/MPSStream.h>
 #include <c10/core/Backend.h>
 #include <c10/core/DispatchKeySet.h>
 #include <c10/core/Layout.h>
@@ -444,6 +445,12 @@ Tensor internal_new_from_data(
               inferred_scalar_type,
               tensor.dtype().itemsize(),
               data);
+
+          // APPLE TODO: IS THIS VALID??
+          // MPS tensors reside in unified memory, flush CPU writes to GPU
+          if (device.type() == DeviceType::MPS) {
+            ::at::mps::getDefaultMPSStream()->synchronize(::at::mps::SyncType::COMMIT_AND_WAIT);
+          }
         }
       }
     }


### PR DESCRIPTION
  * Allocating all CPU/MPS tensors on unified memory instead of device private memory
  * Modified copy_from_mps_ and copy_to_mps_stride_conting with the following:
    - Avoid backing buffer MPS <--> CPU blit
    - Instead perform a Unified Mem <--> Unified Mem memcpy
    - Add memory synchronization since tensors now reside in shared memory
    - Perform aliasing using at::from_blob and newBufferWithBytesNoCopy and update owner device
    - Manually perform negation/conjugation since memcpy does not automatically carry that information along
  * TODO:
    - Resolve remaining failures of tests_mps.py (0.22%)

Fixes #172987 
