### PR TITLE
[Inductor] Fix fx_graph_runnable with single quotes in envvar

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -61,11 +61,29 @@ def forward(self, x_1):
     """,  # NOQA: B950
         )
 
-    @patch.dict(os.environ, {"TORCHINDUCTOR_MAX_AUTOTUNE": "1", "TEST_ENV": "1"})
+    @patch.dict(
+        os.environ,
+        {
+            "TORCHINDUCTOR_MAX_AUTOTUNE": "1",
+            "TEST_ENV": "1",
+            "TORCHINDUCTOR_ENV_SINGLE_QUOTES": "inductor_'env'",
+            "TORCHINDUCTOR_ENV_DOUBLE_QUOTES": 'inductor_"env"',
+        },
+    )
     def test_generate_env_vars_string(self):
         env_strings = generate_env_vars_string()
         self.assertIn(
             """os.environ['TORCHINDUCTOR_MAX_AUTOTUNE'] = '1'
+""",
+            env_strings,
+        )
+        self.assertIn(
+            """os.environ['TORCHINDUCTOR_ENV_SINGLE_QUOTES'] = 'inductor_"env"'
+""",
+            env_strings,
+        )
+        self.assertIn(
+            """os.environ['TORCHINDUCTOR_ENV_DOUBLE_QUOTES'] = 'inductor_"env"'
 """,
             env_strings,
         )

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -297,7 +297,7 @@ def generate_env_vars_string(*, stable_output: bool = False) -> str:
         return any(string in key for string in allow_list) and key not in skip_list
 
     config_lines = [
-        f"os.environ['{key}'] = '{value}'"
+        f"""os.environ['{key}'] = '{value.replace("'", '"')}'"""
         for key, value in os.environ.items()
         if filter(key)
     ]


### PR DESCRIPTION
Differential Revision: D91716888

Sometimes, envvars in the fx graph runnable can contain strings, such as `os.environ["TORCH_COMPILE_DYNAMIC_SOURCES"] = `L['input'][0],L['weight']``

Do this to ensure that the fx graph runnable doesn't crash during running


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo