### PR TITLE
[inductor][testing][BE] Fix test_comprehensive_linalg_lu_cuda_float32

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -991,6 +991,7 @@ inductor_skip_exact_stride = {
     "fft.irfft2",
     "linalg.diagonal",
     "linalg.eigvals",  # Fails for ROCM
+    "linalg.lu",
     "linalg.lu_factor",
     "linalg.matrix_norm",
     "linalg.norm",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173705

Summary: This test is failing the stride comparision (which was only recently added). Looks like I missed allow-listing this one.

Fixes: https://github.com/pytorch/pytorch/issues/137684

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo