### PR TITLE
Fix STD_CUDA_CHECK libtorch agnostic tests on RoCM

### DIFF
--- a/test/cpp_extensions/libtorch_agn_2_10_extension/csrc/test_std_cuda_check.cu
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/csrc/test_std_cuda_check.cu
@@ -33,7 +33,9 @@ void test_std_cuda_kernel_launch_check_success() {
 void test_std_cuda_kernel_launch_check_error() {
   // Launch a kernel with invalid configuration
   // Using more blocks than allowed (2^31) will trigger a launch error
-  invalid_kernel<<<2147483648, 1>>>(0);
+  // HIP does not error on invalid grid size, but errrors on invalid block size
+
+  invalid_kernel<<<2147483648, 2048>>>(0);
 
   STD_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/test/cpp_extensions/libtorch_agn_2_10_extension/csrc/test_std_cuda_check.cu
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/csrc/test_std_cuda_check.cu
@@ -33,7 +33,7 @@ void test_std_cuda_kernel_launch_check_success() {
 void test_std_cuda_kernel_launch_check_error() {
   // Launch a kernel with invalid configuration
   // Using more blocks than allowed (2^31) will trigger a launch error
-  // HIP does not error on invalid grid size, but errrors on invalid block size
+  // HIP does not error on invalid grid size, but errors on invalid block size
 
   invalid_kernel<<<2147483648, 2048>>>(0);
 

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -1231,7 +1231,6 @@ class TestLibtorchAgnostic(TestCase):
 
     @skipIfTorchVersionLessThan(2, 10)
     @onlyCUDA
-    @skipIfRocm(msg="TODO: @mikaylagawarecki fix after branch cut")
     @parametrize("show_cpp_stacktraces", [False, True])
     def test_std_cuda_check_error(self, device, show_cpp_stacktraces):
         """Test that STD_CUDA_CHECK throws std::runtime_error with CUDA error message.
@@ -1403,7 +1402,6 @@ except RuntimeError as e:
     @skipIfTorchVersionLessThan(2, 10)
     @onlyCUDA
     @parametrize("show_cpp_stacktraces", [False, True])
-    @skipIfRocm(msg="TODO: @mikaylagawarecki fix after branch cut")
     @unittest.skipIf(
         _get_torch_cuda_version() >= (13, 0), "To be resolved after branch cut"
     )

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_utils import (
     install_cpp_extension,
     parametrize,
     run_tests,
-    skipIfRocm,
     skipIfTorchDynamo,
     skipIfWindows,
     TestCase,


### PR DESCRIPTION
empirically observed that invalid grid size did not seem to throw for hip whereas invalid block would error

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173711



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang