### PR TITLE
[dynamo][aoti][BE] Add streams::synchronize_event op for AOTI compatibility

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2466,6 +2466,7 @@ make_fallback(aten.randint)
 # TODO: mlazos reevaluate if we want to codegen something different
 make_fallback(torch.ops.streams.record_event.default)
 make_fallback(torch.ops.streams.wait_event.default)
+make_fallback(torch.ops.streams.synchronize_event.default)
 
 
 @register_lowering(aten.rand)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173730

Summary: Event.synchronize() was traced as a call_method instead of a
proper torch.ops call. During torch.export (used by AOTI), method
calls on external objects are dropped while proper ops survive. This
caused synchronize to be missing from generated AOTI code, creating a
race condition where non-blocking D2H copies weren't waited for.

Add a new streams::synchronize_event custom op following the pattern
of record_event and wait_event, ensuring Event.synchronize() survives
the export path.

Testing: `python test/inductor/test_aot_inductor.py -k test_copy_non_blocking_is_pinned_cuda`
(I was able to repro intermittent failures locally; after change was unable to repro)

Fixes: https://github.com/pytorch/pytorch/issues/164858

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98