### PR TITLE
removing allow_tf32 from pytorch inductor

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -35,13 +35,13 @@ class TestSDPAPatternRewriterTemplate(TestCase):
     use_static_shapes = True
 
     def setUp(self):
-        self.prev_tf32 = torch.backends.cuda.matmul.allow_tf32
-        torch.backends.cuda.matmul.allow_tf32 = True
+        self.prev_tf32 = torch.backends.cuda.matmul.fp32_precision
+        torch.backends.cuda.matmul.fp32_precision = "tf32"
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
-        torch.backends.cuda.matmul.allow_tf32 = self.prev_tf32
+        torch.backends.cuda.matmul.fp32_precision = self.prev_tf32
 
     def _clone_inputs(self, inputs):
         def clone(x):
@@ -1233,8 +1233,8 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         @skipIfXpu(msg="FIXME: ENable for XPU")
         def test_skip_non_tf32(self):
             try:
-                orig = torch.backends.cuda.matmul.allow_tf32
-                torch.backends.cuda.matmul.allow_tf32 = False
+                orig = torch.backends.cuda.matmul.fp32_precision
+                torch.backends.cuda.matmul.fp32_precision = "ieee"
 
                 class Model(torch.nn.Module):
                     def __init__(self):
@@ -1265,7 +1265,7 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
                 self.assertEqual(out, func(*test_inputs))
 
             finally:
-                torch.backends.cuda.matmul.allow_tf32 = orig
+                torch.backends.cuda.matmul.fp32_precision = orig
 
     class SDPAPatternRewriterGpuDynamicTests(SDPAPatternRewriterGpuTests):
         use_static_shapes = False

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -69,7 +69,7 @@ def patches(fn):
     def wrapped(*args, **kwargs):
         counters.clear()
         torch.manual_seed(12345)
-        assert not torch.backends.cuda.matmul.allow_tf32, (
+        assert torch.backends.cuda.matmul.fp32_precision != "tf32", (
             "correctness testing is allergic to tf32"
         )
         return fn(*args, **kwargs)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -78,6 +78,9 @@ if HAS_GPU:
     STRING_CONSTANT_C: tl.constexpr = tl.constexpr("CONSTANT_C")
     BOOL_CONSTANT_C: tl.constexpr = tl.constexpr(True)
     FLOAT_CONSTANT_C = tl.constexpr(3.14)  # intentionally un-annotated
+    # Compute at module level to avoid dynamo tracing issue with
+    # torch.backends.cuda.matmul.fp32_precision getter
+    USE_TF32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
 
     if hasattr(triton, "constexpr_function"):
 
@@ -4261,7 +4264,7 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
                 w.stride(1),
                 z.stride(0),
                 z.stride(1),
-                ALLOW_TF32=torch.backends.cuda.matmul.fp32_precision == "tf32",
+                ALLOW_TF32=USE_TF32,
             )
             return z
 

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -4261,7 +4261,7 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
                 w.stride(1),
                 z.stride(0),
                 z.stride(1),
-                ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+                ALLOW_TF32=torch.backends.cuda.matmul.fp32_precision == "tf32",
             )
             return z
 

--- a/torch/_inductor/autoheuristic/autoheuristic_utils.py
+++ b/torch/_inductor/autoheuristic/autoheuristic_utils.py
@@ -336,5 +336,5 @@ def context_add_strides(context: AHContext, name: str, stride: tuple[int, ...]) 
 def context_add_using_tf32(context: AHContext, dtype: torch.dtype) -> None:
     using_tf32 = "not_float_32"
     if dtype == torch.float32:
-        using_tf32 = torch.backends.cuda.matmul.matmul.fp32_precision == "tf32"
+        using_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
     context.add_feature("using_tf32", using_tf32, is_categorical=True)

--- a/torch/_inductor/autoheuristic/autoheuristic_utils.py
+++ b/torch/_inductor/autoheuristic/autoheuristic_utils.py
@@ -336,5 +336,5 @@ def context_add_strides(context: AHContext, name: str, stride: tuple[int, ...]) 
 def context_add_using_tf32(context: AHContext, dtype: torch.dtype) -> None:
     using_tf32 = "not_float_32"
     if dtype == torch.float32:
-        using_tf32 = torch.backends.cuda.matmul.allow_tf32
+        using_tf32 = torch.backends.cuda.matmul.matmul.fp32_precision == "tf32"
     context.add_feature("using_tf32", using_tf32, is_categorical=True)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -315,7 +315,7 @@ def _step_logger() -> Callable[..., None]:
 def _warn_tf32_disabled() -> None:
     if (
         torch.cuda.is_available()
-        and not torch.backends.cuda.matmul.fp32_precision == "tf32"
+        and torch.backends.cuda.matmul.fp32_precision != "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
     ):
         warnings.warn(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -315,7 +315,7 @@ def _step_logger() -> Callable[..., None]:
 def _warn_tf32_disabled() -> None:
     if (
         torch.cuda.is_available()
-        and not torch.backends.cuda.matmul.fp32_precision=="tf32"
+        and not torch.backends.cuda.matmul.fp32_precision == "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
     ):
         warnings.warn(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -315,7 +315,7 @@ def _step_logger() -> Callable[..., None]:
 def _warn_tf32_disabled() -> None:
     if (
         torch.cuda.is_available()
-        and not torch.backends.cuda.matmul.allow_tf32
+        and not torch.backends.cuda.matmul.fp32_precision=="tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
     ):
         warnings.warn(

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -710,7 +710,7 @@ def _sfdp_replacement_24(query, key, value, attention_mask):
 def _warn_tf32_disabled() -> None:
     if (
         torch.cuda.is_available()
-        and not torch.backends.cuda.matmul.allow_tf32
+        and torch.backends.cuda.matmul.fp32_precision != "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
     ):
         warnings.warn(
@@ -733,7 +733,7 @@ def _sfdp_params_check(match):
     if (
         query.device.type == "cuda"
         and query.dtype == torch.float32
-        and not torch.backends.cuda.matmul.allow_tf32
+        and torch.backends.cuda.matmul.fp32_precision != "tf32"
     ):
         _warn_tf32_disabled()
         return False

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -348,7 +348,7 @@ def should_pad_bench_key(
     tf32_key = (
         None
         if mat1.dtype != torch.float32
-        else torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32
+        else torch.backends.cuda.matmul.fp32_precision=="tf32" or torch.backends.mkldnn.fp32_precision=="tf32"
     )
 
     def fmt_pad(name: str) -> str | None:

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -349,7 +349,7 @@ def should_pad_bench_key(
         None
         if mat1.dtype != torch.float32
         else torch.backends.cuda.matmul.fp32_precision == "tf32"
-        or torch.backends.mkldnn.fp32_precision == "tf32"
+        or torch.backends.mkldnn.allow_tf32
     )
 
     def fmt_pad(name: str) -> str | None:

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -349,7 +349,7 @@ def should_pad_bench_key(
         None
         if mat1.dtype != torch.float32
         else torch.backends.cuda.matmul.fp32_precision == "tf32"
-        or torch.backends.mkldnn.allow_tf32
+        or torch.backends.mkldnn.fp32_precision == "tf32"
     )
 
     def fmt_pad(name: str) -> str | None:

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -348,7 +348,8 @@ def should_pad_bench_key(
     tf32_key = (
         None
         if mat1.dtype != torch.float32
-        else torch.backends.cuda.matmul.fp32_precision=="tf32" or torch.backends.mkldnn.fp32_precision=="tf32"
+        else torch.backends.cuda.matmul.fp32_precision == "tf32"
+        or torch.backends.mkldnn.fp32_precision == "tf32"
     )
 
     def fmt_pad(name: str) -> str | None:

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,7 +613,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,
@@ -636,7 +636,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,7 +613,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(torch.backends.cuda, "fp32_precision", None)
+                    ALLOW_TF32=getattr(torch.backends.cuda.matmul, "fp32_precision", None)
                     == "tf32"
                     or getattr(torch.backends.cudnn, "allow_tf32", False),
                     num_stages=cfg.num_stages,
@@ -638,7 +638,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(torch.backends.cuda, "fp32_precision", None)
+                    ALLOW_TF32=getattr(torch.backends.cuda.matmul, "fp32_precision", None)
                     == "tf32"
                     or getattr(torch.backends.cudnn, "allow_tf32", False),
                     num_stages=cfg.num_stages,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,8 +613,9 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(torch.backends.cuda, 'fp32_precision', None) == "tf32" or 
-          getattr(torch.backends.cudnn, 'allow_tf32', False),
+                    ALLOW_TF32=getattr(torch.backends.cuda, "fp32_precision", None)
+                    == "tf32"
+                    or getattr(torch.backends.cudnn, "allow_tf32", False),
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,
@@ -637,8 +638,9 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(torch.backends.cuda, 'fp32_precision', None) == "tf32" or 
-          getattr(torch.backends.cudnn, 'allow_tf32', False),
+                    ALLOW_TF32=getattr(torch.backends.cuda, "fp32_precision", None)
+                    == "tf32"
+                    or getattr(torch.backends.cudnn, "allow_tf32", False),
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,7 +613,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision== "tf32",
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,
@@ -636,7 +636,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision== "tf32",
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,7 +613,9 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(torch.backends.cuda.matmul, "fp32_precision", None)
+                    ALLOW_TF32=getattr(
+                        torch.backends.cuda.matmul, "fp32_precision", None
+                    )
                     == "tf32"
                     or getattr(torch.backends.cudnn, "allow_tf32", False),
                     num_stages=cfg.num_stages,
@@ -638,9 +640,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(torch.backends.cuda.matmul, "fp32_precision", None)
-                    == "tf32"
-                    or getattr(torch.backends.cudnn, "allow_tf32", False),
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,7 +613,8 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
+                    ALLOW_TF32=getattr(torch.backends.cuda, 'fp32_precision', None) == "tf32" or 
+          getattr(torch.backends.cudnn, 'allow_tf32', False),
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,
@@ -636,7 +637,8 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
+                    ALLOW_TF32=getattr(torch.backends.cuda, 'fp32_precision', None) == "tf32" or 
+          getattr(torch.backends.cudnn, 'allow_tf32', False),
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -613,11 +613,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=getattr(
-                        torch.backends.cuda.matmul, "fp32_precision", None
-                    )
-                    == "tf32"
-                    or getattr(torch.backends.cudnn, "allow_tf32", False),
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision== "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,
@@ -640,7 +636,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=is_ones(kernel_shape),
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
+                    ALLOW_TF32=torch.backends.cudnn.fp32_precision== "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=cfg.num_warps,
                     **cfg.kwargs,

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -61,8 +61,5 @@ def should_pad_params_encoder(
         mat2_exclude_padding_time=should_exclude_padding_time(match, "mat2"),
         tf32=False
         if mat1.dtype != torch.float32
-        else bool(
-            torch.backends.cuda.matmul.fp32_precision == "tf32"
-            or torch.backends.mkldnn.allow_tf32
-        ),
+        else bool(torch.backends.mkldnn.fp32_precision == "tf32"),
     )

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -61,5 +61,8 @@ def should_pad_params_encoder(
         mat2_exclude_padding_time=should_exclude_padding_time(match, "mat2"),
         tf32=False
         if mat1.dtype != torch.float32
-        else bool(torch.backends.cuda.matmul.fp32_precision == "tf32" or torch.backends.mkldnn.fp32_precision == "tf32"),
+        else bool(
+            torch.backends.cuda.matmul.fp32_precision == "tf32"
+            or torch.backends.mkldnn.fp32_precision == "tf32"
+        ),
     )

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -61,5 +61,5 @@ def should_pad_params_encoder(
         mat2_exclude_padding_time=should_exclude_padding_time(match, "mat2"),
         tf32=False
         if mat1.dtype != torch.float32
-        else bool(torch.backends.mkldnn.fp32_precision == "tf32"),
+        else bool(torch.backends.cuda.matmul.fp32_precision == "tf32" or torch.backends.mkldnn.fp32_precision == "tf32"),
     )

--- a/torch/_inductor/runtime/caching/encoders.py
+++ b/torch/_inductor/runtime/caching/encoders.py
@@ -62,6 +62,7 @@ def should_pad_params_encoder(
         tf32=False
         if mat1.dtype != torch.float32
         else bool(
-            torch.backends.cuda.matmul.allow_tf32 or torch.backends.mkldnn.allow_tf32
+            torch.backends.cuda.matmul.fp32_precision == "tf32"
+            or torch.backends.mkldnn.allow_tf32
         ),
     )

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1852,7 +1852,7 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         assert isinstance(kernel_inputs, MMKernelInputs)
         m, n, k = kernel_inputs.mnk_symbolic()
         # Calculate allow_tf32
-        allow_tf32 = torch.backends.cuda.matmul.allow_tf32 and (
+        allow_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32" and (
             not inductor_config.force_same_precision
             or ((m % 16) == 0 and (n % 16) == 0 and (k % 8) == 0)
         )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2751,7 +2751,9 @@ def get_device_tflops(dtype: torch.dtype) -> float:
     We don't want to throw errors in this function. First check to see if the device is in device_info.py,
     then fall back to the inaccurate triton estimation.
     """
-    ds_tops = datasheet_tops(dtype, is_tf32=torch.backends.cuda.matmul.allow_tf32)
+    ds_tops = datasheet_tops(
+        dtype, is_tf32=torch.backends.cuda.matmul.fp32_precision == "tf32"
+    )
     if ds_tops is not None:
         return ds_tops
 
@@ -2772,7 +2774,7 @@ def get_device_tflops(dtype: torch.dtype) -> float:
         if dtype in (torch.float16, torch.bfloat16) and SM80OrLater:
             return get_max_tensorcore_tflops(dtype, sm_clock)
 
-        if torch.backends.cuda.matmul.allow_tf32:
+        if torch.backends.cuda.matmul.fp32_precision == "tf32":
             return get_max_tensorcore_tflops(torch.float32, sm_clock)
         else:
             return get_max_simd_tflops(torch.float32, sm_clock)
@@ -2780,7 +2782,7 @@ def get_device_tflops(dtype: torch.dtype) -> float:
         if dtype in (torch.float16, torch.bfloat16) and SM80OrLater:
             return get_max_tensorcore_tflops(dtype)
 
-        if torch.backends.cuda.matmul.allow_tf32:
+        if torch.backends.cuda.matmul.fp32_precision == "tf32":
             return get_max_tensorcore_tflops(torch.float32)
         else:
             return get_max_simd_tflops(torch.float32)

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -246,4 +246,5 @@ enabled: bool
 deterministic: bool
 benchmark: bool
 allow_tf32: bool
+fp32_precision: str
 benchmark_limit: int

--- a/torch/backends/mkldnn/__init__.py
+++ b/torch/backends/mkldnn/__init__.py
@@ -134,5 +134,6 @@ if TYPE_CHECKING:
     enabled: ContextProp
     deterministic: ContextProp
     allow_tf32: ContextProp
+    fp32_precision: str
 
 sys.modules[__name__] = MkldnnModule(sys.modules[__name__], __name__)


### PR DESCRIPTION
fixes #166387

As pytorch moved to [new API](https://docs.pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices) for tf32, many like transformer started using them.

It seems pytorch inductor is still using old allow_tf32, so when new API is invoked and read happens for old API we see error like 
ERROR: PyTorch is checking whether allow_tf32_new is enabled for cuBlas matmul,Current status indicate that you have used mix of the legacy and new APIs to set the TF32 status for cublas matmul. We suggest only using the new API to set the TF32 flag. See also: https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices

My PR is addressing this by using new API in inductor.

currently I have only made changes pytorch issue lined above and transofrmer, you can see traceback in [comment](https://github.com/huggingface/transformers/issues/42371#issuecomment-3730137367) section here, https://github.com/huggingface/transformers/issues/42371

Can I can start changing more allow allow_tf32 in inductor

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos