### PR TITLE
[aoti][testing][BE] Fix test_upper_bound_i64

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7411,6 +7411,7 @@ class AOTInductorTestsTemplate:
         # the output should have int type
         self.check_model(Model2(), (x,))
 
+    @unittest.skipIf(not IS_BIG_GPU, "Test requires large GPU memory")
     def test_upper_bound_i64(self):
         class Model(torch.nn.Module):
             def forward(self, x, y):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173733

Recent failure logs show this test is flaky because of OOMs: https://hud.pytorch.org/tests/testInfo?name=test_upper_bound_i64_cuda&suite=AOTInductorTestABICompatibleGpu&file=inductor%2Ftest_aot_inductor.py
Is this the right decorator?

Fixes: https://github.com/pytorch/pytorch/issues/159860

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo