### PR TITLE
Add a `additional_meta` arg to gm.print_readable()

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -23,7 +23,7 @@ torch.fx.graph.Graph.node_copy(self, node: torch.fx.node.Node, arg_transform: Ca
 torch.fx.graph.Graph.output(self, result: 'Argument', type_expr: Optional[Any] = None)
 torch.fx.graph.Graph.placeholder(self, name: str, type_expr: Optional[Any] = None, default_value: Any) -> torch.fx.node.Node
 torch.fx.graph.Graph.print_tabular(self)
-torch.fx.graph.Graph.python_code(self, root_module: str, verbose: bool = False, include_stride: bool = False, include_device: bool = False, colored: bool = False, expanded_def: bool = False, record_func: bool = False) -> torch.fx.graph.PythonCode
+torch.fx.graph.Graph.python_code(self, root_module: str, verbose: bool = False, include_stride: bool = False, include_device: bool = False, colored: bool = False, expanded_def: bool = False, record_func: bool = False, additional_meta: Optional[List[str]] = None) -> torch.fx.graph.PythonCode
 torch.fx.graph_module.GraphModule.__init__(self, root: Union[torch.nn.modules.module.Module, Dict[str, Any]], graph: torch.fx.graph.Graph, class_name: str = 'GraphModule')
 torch.fx.graph_module.GraphModule.add_submodule(self, target: str, m: torch.nn.modules.module.Module) -> bool
 torch.fx.graph_module.GraphModule.delete_all_unused_submodules(self) -> None

--- a/test/test_fx_graph_print.py
+++ b/test/test_fx_graph_print.py
@@ -1,0 +1,230 @@
+# Owner(s): ["module: fx"]
+
+import torch
+from torch.fx import symbolic_trace
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestFxGraphPrint(TestCase):
+    """Tests for GraphModule.print_readable() with additional_meta."""
+
+    def test_print_readable_with_list_of_meta_keys(self):
+        """Test print_readable with a list of meta keys to include."""
+
+        def forward(x):
+            return torch.sin(x) + torch.cos(x)
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Manually add some meta keys to nodes for testing
+        call_fn_idx = 0
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta["my_custom_key"] = f"value_{call_fn_idx}"
+                node.meta["another_key"] = call_fn_idx * 10
+                call_fn_idx += 1
+
+        output = gm.print_readable(
+            print_output=False, additional_meta=["my_custom_key", "another_key"]
+        )
+
+        # The actual meta values should appear in the generated code
+        self.assertIn("my_custom_key: value_0", output)
+        self.assertIn("another_key: 0", output)
+        self.assertIn("my_custom_key: value_1", output)
+        self.assertIn("another_key: 10", output)
+        self.assertIn("my_custom_key: value_2", output)
+        self.assertIn("another_key: 20", output)
+
+    def test_print_readable_with_list_missing_keys(self):
+        """Test print_readable with a list containing keys that don't exist in meta."""
+
+        def forward(x):
+            return torch.sin(x)
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Add only one key
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta["existing_key"] = "exists"
+
+        output = gm.print_readable(
+            print_output=False,
+            additional_meta=["existing_key", "nonexistent_key"],
+        )
+
+        # Only existing_key should appear
+        self.assertIn("existing_key: exists", output)
+        self.assertNotIn("nonexistent_key", output)
+
+    def test_print_readable_with_seq_nr(self):
+        """Test print_readable with seq_nr in node.meta."""
+
+        def forward(x):
+            y = torch.sin(x)
+            z = torch.cos(x)
+            return y + z
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Manually set seq_nr for testing (normally set during tracing)
+        seq_nr = 0
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta["seq_nr"] = seq_nr
+                seq_nr += 1
+
+        output = gm.print_readable(print_output=False, additional_meta=["seq_nr"])
+
+        # seq_nr values should appear in the generated code
+        self.assertIn("seq_nr: 0", output)
+        self.assertIn("seq_nr: 1", output)
+        self.assertIn("seq_nr: 2", output)
+
+    def test_print_readable_none_annotation(self):
+        """Test print_readable with additional_meta=None (default behavior)."""
+
+        def forward(x):
+            return torch.sin(x)
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Default behavior - no custom annotation
+        output = gm.print_readable(print_output=False, additional_meta=None)
+
+        # Should still work without errors
+        self.assertIn("sin", output)
+
+    def test_print_readable_with_nested_modules(self):
+        """Test print_readable with nested GraphModules."""
+
+        class Inner(torch.nn.Module):
+            def forward(self, x):
+                return torch.relu(x)
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = Inner()
+
+            def forward(self, x):
+                return self.inner(torch.sin(x))
+
+        model = Outer()
+        traced = symbolic_trace(model)
+
+        # Add meta to nodes
+        for node in traced.graph.nodes:
+            if node.op == "call_function":
+                node.meta["layer"] = "outer"
+
+        output = traced.print_readable(print_output=False, additional_meta=["layer"])
+
+        self.assertIn("layer: outer", output)
+
+    def test_print_readable_additional_meta_ordering(self):
+        """Test that additional_meta appears before other meta info in the comment."""
+
+        def forward(x):
+            return torch.sin(x)
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Add custom meta that would also appear via annotation
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta["custom"] = {"test": "value"}
+                node.meta["my_key"] = "my_value"
+
+        output = gm.print_readable(print_output=False, additional_meta=["my_key"])
+
+        # The additional_meta should appear before the custom annotation
+        for line in output.split("\n"):
+            if "my_key: my_value" in line and "Annotation:" in line:
+                my_key_pos = line.find("my_key: my_value")
+                annotation_pos = line.find("Annotation:")
+                self.assertLess(
+                    my_key_pos,
+                    annotation_pos,
+                    "additional_meta should appear before Annotation",
+                )
+                break
+
+    def test_print_readable_with_empty_list(self):
+        """Test print_readable with an empty list of meta keys."""
+
+        def forward(x):
+            return torch.sin(x)
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Empty list should not add any annotation
+        output = gm.print_readable(print_output=False, additional_meta=[])
+
+        # Should work without errors
+        self.assertIn("sin", output)
+
+    def test_print_readable_multiple_meta_keys_formatting(self):
+        """Test that multiple meta keys are formatted correctly with commas."""
+
+        def forward(x):
+            return torch.sin(x)
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta["key1"] = "val1"
+                node.meta["key2"] = "val2"
+                node.meta["key3"] = "val3"
+
+        output = gm.print_readable(
+            print_output=False, additional_meta=["key1", "key2", "key3"]
+        )
+
+        # All three keys should appear comma-separated
+        self.assertIn("key1: val1", output)
+        self.assertIn("key2: val2", output)
+        self.assertIn("key3: val3", output)
+        # Check comma separation
+        self.assertIn(", ", output)
+
+    def test_print_readable_seq_nr_with_multiple_ops(self):
+        """Test print_readable with seq_nr across multiple different operations."""
+
+        def forward(x):
+            a = torch.sin(x)
+            b = torch.cos(x)
+            c = torch.relu(a + b)
+            return c
+
+        x = torch.randn(3)
+        gm = make_fx(forward)(x)
+
+        # Manually set seq_nr
+        seq_nr = 100
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta["seq_nr"] = seq_nr
+                seq_nr += 1
+
+        output = gm.print_readable(print_output=False, additional_meta=["seq_nr"])
+
+        # Check that seq_nr values appear
+        self.assertIn("seq_nr: 100", output)
+        self.assertIn("seq_nr: 101", output)
+        self.assertIn("seq_nr: 102", output)
+        self.assertIn("seq_nr: 103", output)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -461,6 +461,7 @@ class CodeGen:
         # Render each argument on its own line
         expanded_def: bool = False,
         record_func: bool = False,
+        additional_meta: Optional[list[str]] = None,
     ) -> PythonCode:
         free_vars: list[str] = []
         body: list[str] = []
@@ -650,6 +651,15 @@ class CodeGen:
             nonlocal prev_summary_str
 
             if node.op not in {"placeholder", "output"}:
+                additional_meta_str = ""
+                if additional_meta:
+                    parts = []
+                    for key in additional_meta:
+                        if key in node.meta:
+                            parts.append(f"{key}: {node.meta[key]}")
+                    if parts:
+                        additional_meta_str = f"# {', '.join(parts)} "
+
                 annotation_str = ""
                 annotation = node.meta.get("custom", {})
                 annotation_trunc = {}
@@ -684,7 +694,7 @@ class CodeGen:
                     elif ac_graph_id is not None:
                         maybe_recompute_info = f" ac_graph_id: {str(ac_graph_id)}"
 
-                summary_str = f"\n{dim(f'#{annotation_str}{maybe_recompute_info} {stack_trace_str}')}\n"
+                summary_str = f"\n{dim(f'{additional_meta_str}#{annotation_str}{maybe_recompute_info} {stack_trace_str}')}\n"
 
                 if summary_str != prev_summary_str:
                     prev_summary_str = summary_str
@@ -1889,6 +1899,7 @@ class Graph:
         colored: bool = False,
         expanded_def: bool = False,
         record_func: bool = False,
+        additional_meta: Optional[list[str]] = None,
     ) -> PythonCode:
         """
         Turn this ``Graph`` into valid Python code.
@@ -1957,6 +1968,7 @@ class Graph:
                 colored=colored,
                 expanded_def=expanded_def,
                 record_func=record_func,
+                additional_meta=additional_meta,
             )
 
     def _python_code(
@@ -1970,6 +1982,7 @@ class Graph:
         colored: bool = False,
         expanded_def: bool = False,
         record_func: bool = False,
+        additional_meta: Optional[list[str]] = None,
     ) -> PythonCode:
         return self._codegen._gen_python_code(
             self.nodes,
@@ -1981,6 +1994,7 @@ class Graph:
             colored=colored,
             expanded_def=expanded_def,
             record_func=record_func,
+            additional_meta=additional_meta,
         )
 
     def __str__(self) -> str:

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -323,6 +323,7 @@ def _print_readable(
     include_device=False,
     colored=False,
     expanded_def=False,
+    additional_meta=None,
 ):
     graph = module.graph
     if graph is None or not isinstance(graph, torch.fx.Graph):
@@ -335,6 +336,7 @@ def _print_readable(
         include_device=include_device,
         colored=colored,
         expanded_def=expanded_def,
+        additional_meta=additional_meta,
     )
     module_code = verbose_python_code.src
     module_code = module_code.lstrip("\n")
@@ -352,6 +354,7 @@ def _print_readable(
                     include_stride=include_stride,
                     include_device=include_device,
                     colored=colored,
+                    additional_meta=additional_meta,
                 )
             )
     submodule_code = "\n".join(submodule_code_list)
@@ -1058,9 +1061,16 @@ class {module_name}(torch.nn.Module):
         # but may result in less-readable output.
         fast_sympy_print: bool = False,
         expanded_def: bool = False,
+        additional_meta: Optional[list[str]] = None,
     ):
         """
-        Return the Python code generated for current GraphModule and its children GraphModules
+        Return the Python code generated for current GraphModule and its children GraphModules.
+
+        Args:
+            additional_meta: Optional list of meta keys to include in the output.
+                For each key in the list, if it exists in node.meta, its value
+                will be shown in the format "key: value".
+                Example: `print_readable(additional_meta=["seq_nr"])`.
         """
         ctx_mgr = contextlib.ExitStack()
         with ctx_mgr:
@@ -1080,6 +1090,7 @@ class {module_name}(torch.nn.Module):
                 include_device,
                 colored,
                 expanded_def,
+                additional_meta,
             )
             return r
 


### PR DESCRIPTION
Example usages:

 you can see the fwd/bwd by doing `gm.print_readable(addtional_meta=["partitioner_tag"])`. 

You can view `seq_nr` by doing `gm.print_readable(addtional_meta=["seq_nr"])`. 



Example output from `graph_module.print_readable(info=["seq_nr", "partitioner_tag"])` :

<img width="1179" height="307" alt="Screenshot 2026-01-28 at 4 42 20 PM" src="https://github.com/user-attachments/assets/ef2e3689-7849-4845-b05f-517e5b4c0719" />

```
class inner_f(torch.nn.Module):
    def forward(self, primals, tangents):
        primals_1: "f32[4, 3]"; tangents_1: "f32[4, 3]"; 

        primals_1, tangents_1, = fx_pytree.tree_flatten_spec([primals, tangents], self._in_spec)
        # seq_nr: 5, partitioner_tag: is_forward # Annotation: {'pp_stage': 0} File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1022 in _unpermute, code: out_unpermuted = out.new_empty(input_shape)
        new_empty: "f32[5, 3]" = torch.ops.aten.new_empty.default(primals_1, [5, 3], pin_memory = False)

        # seq_nr: 6, partitioner_tag: is_forward # Annotation: {'pp_stage': 0} File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1023 in _unpermute, code: out_unpermuted[permuted_indices, :] = out
        _tensor_constant0: "i64[4]" = self._tensor_constant0
        index_put: "f32[5, 3]" = torch.ops.aten.index_put.default(new_empty, [_tensor_constant0], primals_1);  new_empty = _tensor_constant0 = primals_1 = None

        # seq_nr: 7, partitioner_tag: is_forward # Annotation: {'pp_stage': 0} File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1024 in _unpermute, code: out = out_unpermuted[:-1]
        slice_2: "f32[4, 3]" = torch.ops.aten.slice.Tensor(index_put, 0, 0, -1);  index_put = None

        # seq_nr: 8, partitioner_tag: is_forward # File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1038 in forward, code: return routed_output.cos()
        cos: "f32[4, 3]" = torch.ops.aten.cos.default(slice_2)

        # seq_nr: 8, partitioner_tag: is_backward # File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1038 in forward, code: return routed_output.cos()
        sin: "f32[4, 3]" = torch.ops.aten.sin.default(slice_2);  slice_2 = None
        neg: "f32[4, 3]" = torch.ops.aten.neg.default(sin);  sin = None
        mul: "f32[4, 3]" = torch.ops.aten.mul.Tensor(tangents_1, neg);  tangents_1 = neg = None

        # seq_nr: 7, partitioner_tag: is_backward # Annotation: {'pp_stage': 0} File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1024 in _unpermute, code: out = out_unpermuted[:-1]
        slice_backward: "f32[5, 3]" = torch.ops.aten.slice_backward.default(mul, [5, 3], 0, 0, -1, 1);  mul = None

        # seq_nr: 6, partitioner_tag: is_backward # Annotation: {'pp_stage': 0} File: /data/users/shangdiy/pytorch/test/functorch/test_aot_joint_with_descriptors.py:1023 in _unpermute, code: out_unpermuted[permuted_indices, :] = out
        _tensor_constant0_1: "i64[4]" = self._tensor_constant0
        index: "f32[4, 3]" = torch.ops.aten.index.Tensor(slice_backward, [_tensor_constant0_1]);  slice_backward = _tensor_constant0_1 = None
        return pytree.tree_unflatten([cos, index], self._out_spec)
```
