### PR TITLE
[inductor][testing][BE] fix test_linear_and_cel_max_autotune

### DIFF
--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -254,7 +254,9 @@ class InplacePaddingTest(TestCase):
 
     # Enable Max-Autotune to repro this test failure:
     #   https://github.com/pytorch/pytorch/pull/140249#issuecomment-2556079406
+    @requires_cuda_with_enough_memory(2e10)
     @inductor_config.patch(max_autotune=True)
+    @serialTest()
     def test_linear_and_cel_max_autotune(self):
         self.test_linear_and_cel()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173735

This test is failing with CUDA out of memory. I guess we need the decorator on the calling method too?

Fixes: https://github.com/pytorch/pytorch/issues/145359

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo