### PR TITLE
[BE] Bye bye TorchFix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # NOTE: **Mirror any changes** to this file the [tool.ruff] config in pyproject.toml
 # before we can fully move to use ruff
 enable-extensions = G
-select = B,C,E,F,G,P,SIM1,SIM911,T4,W,B9,TOR0,TOR1,TOR2,TOR9
+select = B,C,E,F,G,P,SIM1,SIM911,T4,W,B9
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
@@ -18,16 +18,7 @@ ignore =
     # SIM104 is already covered by pyupgrade ruff
     SIM104,
     # flake8-simplify code styles
-    SIM102,SIM103,SIM106,SIM112,
-    # TorchFix codes that don't make sense for PyTorch itself:
-    # removed and deprecated PyTorch functions.
-    TOR001,TOR101,
-    # TODO(kit1980): fix all TOR102 issues
-    # `torch.load` without `weights_only` parameter is unsafe
-    TOR102,
-    # TODO(kit1980): resolve all TOR003 issues
-    # pass `use_reentrant` explicitly to `checkpoint`.
-    TOR003
+    SIM102,SIM103,SIM106,SIM112
 per-file-ignores =
     __init__.py: F401
     test/**: F821
@@ -38,26 +29,8 @@ per-file-ignores =
     test/dynamo/test_higher_order_ops.py: B950
     test/dynamo/test_error_messages.py: B950
     torch/testing/_internal/dynamo_test_failures.py: B950
-    # TOR901 is only for test, we want to ignore it for everything else.
-    # It's not easy to configure this without affecting other per-file-ignores,
-    # so we explicitly list every file where it's violated outside of test.
-    torch/__init__.py: F401,TOR901
-    torch/_custom_op/impl.py: TOR901
-    torch/_export/serde/upgrade.py: TOR901
-    torch/_functorch/predispatch.py: TOR901
-    torch/_functorch/vmap.py: TOR901
-    torch/_inductor/test_operators.py: TOR901
-    torch/_library/abstract_impl.py: TOR901
-    torch/_meta_registrations.py: TOR901
-    torch/_prims/__init__.py: F401,TOR901
-    torch/_prims/rng_prims.py: TOR901
-    torch/ao/quantization/fx/_decomposed.py: TOR901
-    torch/distributed/_functional_collectives.py: TOR901
-    torch/distributed/_spmd/data_parallel.py: TOR901
-    torch/distributed/_tensor/_collective_utils.py: TOR901
-    # This is a full package that happen to live within the test
-    # folder, so ok to skip
-    test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py: TOR901
+    torch/__init__.py: F401
+    torch/_prims/__init__.py: F401
 optional-ascii-coding = True
 exclude =
     ./.git,

--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -11,7 +11,6 @@
 #   "mccabe==0.7.0",
 #   "pycodestyle==2.14.0",
 #   "pyflakes==3.4.0",
-#   "torchfix==0.4.0 ; python_version >= '3.10' and python_version < '3.13'",
 #   "setuptools",
 # ]
 # ///


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173736

It was helpful in many ways, but repo has not been maintained for quite some time and is archived now, see https://github.com/meta-pytorch/torchfix