### PR TITLE
[ROCm] Enable scaled group mm on gfx950 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,8 +940,8 @@ cmake_dependent_option(
   OFF)
 
 
-IF(USE_ROCM AND "gfx942" IN_LIST PYTORCH_ROCM_ARCH)
-  message(WARNING "Setting USE_MSLK for gfx942 to ON by default, doing ROCM build")
+IF(USE_ROCM AND ("gfx942" IN_LIST PYTORCH_ROCM_ARCH OR "gfx950" IN_LIST PYTORCH_ROCM_ARCH))
+  message(WARNING "Setting USE_MSLK for gfx942/gfx950 to ON by default, doing ROCM build")
   set(USE_MSLK_DEFAULT ON)
 elseif(USE_CUDA AND "$ENV{TORCH_CUDA_ARCH_LIST}" MATCHES "10.0" AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8 AND NOT WIN32)
   message(STATUS "Setting USE_MSLK to ON by default , doing CUDA build for SM100a")

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -347,13 +347,14 @@ IF(USE_MSLK)
         list(PREPEND MSLK_EXTRA_HIPCC_FLAGS -mllvm -amdgpu-coerce-illegal-types=1)
       endif()
 
-    # Only compile for gfx942 for now.
-    # This is rather hacky, I could not figure out a clean solution :(
+    # Only compile for gfx942 and gfx950.
     set(HIP_CLANG_FLAGS_ORIGINAL ${HIP_CLANG_FLAGS})
     string(REGEX REPLACE "--offload-arch=[^ ]*" "" FILTERED_HIP_CLANG_FLAGS "${HIP_CLANG_FLAGS}")
-    if("gfx942" IN_LIST PYTORCH_ROCM_ARCH)
-      list(APPEND FILTERED_HIP_CLANG_FLAGS --offload-arch=gfx942;)
-    endif()
+    foreach(ARCH gfx942 gfx950)
+      if(${ARCH} IN_LIST PYTORCH_ROCM_ARCH)
+        list(APPEND FILTERED_HIP_CLANG_FLAGS --offload-arch=${ARCH})
+      endif()
+    endforeach()
     set(HIP_CLANG_FLAGS ${FILTERED_HIP_CLANG_FLAGS})
 
     hip_add_library(

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -71,7 +71,7 @@ if TEST_CUDA:
     _IS_SM8X = torch.cuda.get_device_capability(0)[0] == 8
 
 f8_msg = "FP8 is only supported on H100+, SM 8.9 and MI300+ and XPU devices"
-f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300+ devices"
+f8_grouped_msg = "FP8 grouped is only supported on SM90 and MI300/MI350 devices"
 mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 mxfp8_grouped_mm_skip_msg = "MXFP8 grouped GEMM is only supported when PyTorch is built with USE_MSLK=1 on SM100+"
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8168,11 +8168,24 @@ def _meta_grouped_mm_common(
     # aten/src/ATen/native/cuda/Blas.cpp.
 
     if scaled:
-        fp8_dtype = torch.float8_e4m3fnuz if torch.version.hip else torch.float8_e4m3fn
-        torch._check(
-            mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
-            lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",  # noqa: B950
-        )
+        if torch.version.hip:
+            allowed_fp8 = {torch.float8_e4m3fnuz, torch.float8_e4m3fn}
+            torch._check(
+                mat_a.dtype in allowed_fp8 and mat_b.dtype in allowed_fp8,
+                lambda: (
+                    f"Expected inputs of E4M3 FP8 type on ROCm "
+                    f"but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}."
+                ),
+            )
+        else:
+            fp8_dtype = torch.float8_e4m3fn
+            torch._check(
+                mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
+                lambda: (
+                    f"Expected inputs of E4M3 FP8 type but got "
+                    f"mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}."
+                ),
+            )
     else:
         torch._check(
             mat_a.dtype == torch.bfloat16 and mat_b.dtype == torch.bfloat16,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8168,24 +8168,17 @@ def _meta_grouped_mm_common(
     # aten/src/ATen/native/cuda/Blas.cpp.
 
     if scaled:
-        if torch.version.hip:
-            allowed_fp8 = {torch.float8_e4m3fnuz, torch.float8_e4m3fn}
-            torch._check(
-                mat_a.dtype in allowed_fp8 and mat_b.dtype in allowed_fp8,
-                lambda: (
-                    f"Expected inputs of E4M3 FP8 type on ROCm "
-                    f"but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}."
-                ),
-            )
-        else:
-            fp8_dtype = torch.float8_e4m3fn
-            torch._check(
-                mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
-                lambda: (
-                    f"Expected inputs of E4M3 FP8 type but got "
-                    f"mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}."
-                ),
-            )
+        fp8_dtype = torch.float8_e4m3fn
+        if (
+            torch.version.hip
+            and torch.cuda.is_available()
+            and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        ):
+            fp8_dtype = torch.float8_e4m3fnuz
+        torch._check(
+            mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
+            lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",  # noqa: B950
+        )
     else:
         torch._check(
             mat_a.dtype == torch.bfloat16 and mat_b.dtype == torch.bfloat16,

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -151,7 +151,7 @@ def evaluate_platform_supports_fp8_grouped_gemm():
         if torch.version.hip:
             if "USE_MSLK" not in torch.__config__.show():
                 return False
-            archs = ['gfx942']
+            archs = ['gfx942', 'gfx950']
             for arch in archs:
                 if arch in torch.cuda.get_device_properties(0).gcnArchName:
                     return True


### PR DESCRIPTION
Update CMakeLists.txt to compile for both gfx942 and gfx950.
Add architecture-specific dtype checks (gfx942: e4m3fnuz).
Update test skip messages and platform checks to include gfx950.
Fixed inductor test  AOTInductorTestABICompatibleGpu.test_scaled_grouped_mm_cuda

Test command : PYTORCH_TEST_WITH_ROCM=1 python test/test_scaled_matmul_cuda.py -v -k test_scaled_grouped_gemm

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang