### PR TITLE
[linalg] Fix segfault in matrix_exp_backward with scalar input

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2757,6 +2757,9 @@ Tensor backward_analytic_function_of_a_matrix(
     const Tensor& self, const Tensor& grad,
     const func_t& function_of_a_matrix
   ) {
+  TORCH_CHECK(
+      self.dim() >= 2,
+      "backward_analytic_function_of_a_matrix: The input tensor must have at least 2 dimensions.");
   auto self_transposed = self.mH();
   auto self_transposed_sizes = self_transposed.sizes().vec();
   self_transposed_sizes[self.dim() - 2] <<= 1;

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4212,6 +4212,9 @@ static Tensor differential_analytic_matrix_function(
 ) {
   // Given an analytic matrix function, this computes the differential (forward
   // AD) or the adjoint of the differential (backward AD)
+  TORCH_CHECK(
+      self.dim() >= 2,
+      "differential_analytic_matrix_function: The input tensor must have at least 2 dimensions.");
   auto A = adjoint ? self.transpose(-2, -1).conj() : self;
   auto meta_grad_sizes = A.sym_sizes().vec();
   meta_grad_sizes[A.dim() - 2] *= 2;


### PR DESCRIPTION
## Summary

Fixes #173624

`torch.ops.aten.matrix_exp_backward` crashes with a segmentation fault when given a scalar tensor (0-dimensional) as input, instead of raising a proper error.

**Root cause:** The helper functions `backward_analytic_function_of_a_matrix` and `differential_analytic_matrix_function` access `self.dim() - 2` and `self.dim() - 1` as vector indices without validating input dimensions first. For 0-dim tensors, this results in negative indices causing undefined behavior.

**Fix:** Add defensive `TORCH_CHECK` validations at the beginning of both functions to ensure the input tensor has at least 2 dimensions.

## Test plan

Existing test `test_matrix_exp_backward_input_validation` in `test/test_linalg.py` covers this case:
```python
scalar_tensor = torch.tensor(1.0, dtype=dtype, device=device)
grad_1d = torch.randn(1, dtype=dtype, device=device)
with self.assertRaisesRegex(RuntimeError, "must have at least 2 dimensions"):
    torch.ops.aten.matrix_exp_backward(scalar_tensor, grad_1d)
```