### PR TITLE
[inductor][testing][BE] fix test_unbacked_symint

### DIFF
--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -134,7 +134,10 @@ class TestMemoryPlanning(TestCase):
 
         # check allocation is done after the unbacked symint is computed
         FileCheck().check("auto u0 = u0_raw;").check(
-            "const int64_t int_array_2[] = {10L, 8L*u0, 32L};"
+            # Shows up as one of the following:
+            #   const int64_t int_array_2[] = {10L, 8L*u0, 32L};
+            #   const int64_t int_array_2[] = {10L, 8L*u0, 32L};
+            "[] = {10L, 8L*u0, 32L};"
         ).check("AtenTensorHandle pool0_handle;").check(
             "aoti_torch_empty_strided(3, int_array_2, int_array_3"
         ).run(code)

--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -136,7 +136,7 @@ class TestMemoryPlanning(TestCase):
         FileCheck().check("auto u0 = u0_raw;").check(
             # Shows up as one of the following:
             #   const int64_t int_array_2[] = {10L, 8L*u0, 32L};
-            #   const int64_t int_array_2[] = {10L, 8L*u0, 32L};
+            #   const int64_t int_array_3[] = {10L, 8L*u0, 32L};
             "[] = {10L, 8L*u0, 32L};"
         ).check("AtenTensorHandle pool0_handle;").check(
             "aoti_torch_empty_strided(3, int_array_2, int_array_3"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173753

Summary: Looks like this test is flaky because the generated variable name isn't reliable. Just massage the string we look for.

Fixes: https://github.com/pytorch/pytorch/issues/168171

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo