### PR TITLE
[NVIDIA] DGX Spark: Fix wrong computing capabilities replacement in cmake

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -138,7 +138,8 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
     string(REGEX MATCHALL "[0-9]+\\.[0-9]+" compute_capabilities "${compute_capabilities}")
 
     if(run_result EQUAL 0)
-      string(REPLACE "2.1" "2.1(2.0)" compute_capabilities "${compute_capabilities}")
+      # Only replace "2.1" to "2.1(2.0)", skip "12.1"
+      string(REGEX REPLACE "(^|[^0-9])2\\.1([^0-9]|$)" "\\12.1(2.0)\\2" compute_capabilities "${compute_capabilities}")
       set(CUDA_GPU_DETECT_OUTPUT ${compute_capabilities}
         CACHE INTERNAL "Returned GPU architectures from detect_gpus tool" FORCE)
     endif()


### PR DESCRIPTION
Nvidia DGX Spark [0] has computing-cap = 12.1, however, due to an incorrect replacement (2.1 -> 2.1(2.0)), 12.1 has been replaced with 12.1(2.0), which will incorrectly set the nvcc parameter:

    $ nvcc ... -gencode arch=compute_20,code=sm_121
    nvcc fatal   : Unsupported gpu architecture 'compute_20'

[0] https://docs.nvidia.com/dgx/dgx-spark/