### PR TITLE
[inductor][testing][BE] Fix test_equivalent_template_code

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -292,7 +292,12 @@ if HAS_GPU_AND_TRITON:
             return code, code2
 
         @fresh_cache()
-        @config.patch(max_autotune_gemm_backends="TRITON")
+        @config.patch(
+            {
+                "max_autotune_gemm_backends": "TRITON",
+                "benchmark_epilogue_fusion": False,
+            }
+        )
         def test_equivalent_template_code(self):
             code, code2 = self._equivalent_output_code_impl(256)
             for out_code in [code, code2]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173755

Summary: This test is flaky and disabled. looks like it's because autotuning sometimes chooses not to do the epilog tuning. Turning off benchmark_epilogue_fusion seems to fix.

Fixes: https://github.com/pytorch/pytorch/issues/166601

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo