### PR TITLE
[pallas backend] more passing gpu tests after jax 0.9

### DIFF
--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -215,7 +215,7 @@ class PallasTestsMixin:
     def test_sqrt(self):
         """Test sqrt operation."""
         if self.DEVICE == "cuda":
-            self.skipTest("sqrt not supported in Pallas GPU (Mosaic) backend")
+            self.skipTest("sqrt primitive not implemented in Pallas Mosaic GPU")
 
         def fn(x):
             return torch.sqrt(x)
@@ -242,8 +242,6 @@ class PallasTestsMixin:
 
     def test_abs_neg(self):
         """Test abs and neg operations."""
-        if self.DEVICE == "cuda":
-            self.skipTest("abs not supported in Pallas GPU (Mosaic) backend")
 
         def fn(x):
             return torch.abs(-x)
@@ -388,8 +386,6 @@ class PallasTestsMixin:
 
     def test_contiguous_index_validation(self):
         """Test that contiguous index validation works correctly end-to-end."""
-        if self.DEVICE == "cuda":
-            self.skipTest("sin not supported in Pallas GPU (Mosaic) backend")
 
         # Test 1: Contiguous operations should work
         def contiguous_add(a, b):
@@ -472,8 +468,6 @@ class PallasTestsMixin:
 
     def test_strided_2d_pallas(self):
         """Test strided access on 2D tensors."""
-        if self.DEVICE == "cuda":
-            self.skipTest("strided access not supported in Pallas GPU (Mosaic) backend")
 
         def fn(x):
             # Simple operation on 2D tensor
@@ -488,10 +482,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_1d(self):
         """Test 1D non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_1d = torch.arange(256, dtype=torch.float32, device=self.DEVICE)
@@ -501,10 +491,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_2d_row_stride(self):
         """Test 2D row-strided input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -514,10 +500,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_2d_col_stride(self):
         """Test 2D col-strided input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -527,10 +509,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_2d_both_stride(self):
         """Test 2D both-strided input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -540,10 +518,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_2d_transpose(self):
         """Test 2D transposed input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -553,10 +527,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_3d(self):
         """Test 3D non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_3d = torch.randn(8, 8, 8, device=self.DEVICE)
@@ -566,10 +536,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_permuted(self):
         """Test permuted non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_3d = torch.randn(8, 8, 8, device=self.DEVICE)
@@ -579,10 +545,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_channels_last(self):
         """Test channels-last (NHWC) non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         x = torch.randn(2, 3, 4, 5, device=self.DEVICE).to(
@@ -593,10 +555,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_diagonal(self):
         """Test diagonal (large stride) non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -606,10 +564,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_as_strided(self):
         """Test as_strided (custom layout) non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_flat = torch.randn(256, device=self.DEVICE)
@@ -619,10 +573,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_select_stride(self):
         """Test select then stride on non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -631,10 +581,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_unsqueeze(self):
         """Test unsqueeze on strided non-contiguous input patterns."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         base_2d = torch.randn(32, 32, device=self.DEVICE)
@@ -643,10 +589,6 @@ class PallasTestsMixin:
 
     def test_stride_non_contiguous_dtypes(self):
         """Test non-contiguous patterns with various dtypes."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda x: x * 2.0 + 1.0)
 
         for dtype in [torch.float64, torch.int32, torch.complex64]:
@@ -678,10 +620,6 @@ class PallasTestsMixin:
 
     def test_stride_multiple_inputs(self):
         """Test multiple strided inputs and broadcasting."""
-        if self.DEVICE == "cuda":
-            self.skipTest(
-                "non-contiguous access not supported in Pallas GPU (Mosaic) backend"
-            )
         compiled = self._compile(lambda a, b, c: a * b + c)
 
         # Use separate base tensors to create strided inputs with the SAME stride pattern
@@ -947,8 +885,6 @@ class PallasTestsMixin:
 
     def test_sign(self):
         """Test sign operation."""
-        if self.DEVICE == "cuda":
-            self.skipTest("sign not supported in Pallas GPU (Mosaic) backend")
 
         def fn(x):
             return torch.sign(x)
@@ -963,7 +899,7 @@ class PallasTestsMixin:
     def test_reciprocal(self):
         """Test reciprocal operation."""
         if self.DEVICE == "cuda":
-            self.skipTest("reciprocal not supported in Pallas GPU (Mosaic) backend")
+            self.skipTest("integer_pow primitive not implemented in Pallas Mosaic GPU")
 
         def fn(x):
             return torch.reciprocal(x)
@@ -977,8 +913,6 @@ class PallasTestsMixin:
 
     def test_square(self):
         """Test square operation."""
-        if self.DEVICE == "cuda":
-            self.skipTest("square not supported in Pallas GPU (Mosaic) backend")
 
         def fn(x):
             return torch.square(x)
@@ -992,8 +926,6 @@ class PallasTestsMixin:
 
     def test_erf(self):
         """Test erf operation."""
-        if self.DEVICE == "cuda":
-            self.skipTest("erf not supported in Pallas GPU (Mosaic) backend")
 
         def fn(x):
             return torch.erf(x)
@@ -1007,8 +939,6 @@ class PallasTestsMixin:
 
     def test_atan2(self):
         """Test atan2 operation."""
-        if self.DEVICE == "cuda":
-            self.skipTest("atan2 not supported in Pallas GPU (Mosaic) backend")
 
         def fn(a, b):
             return torch.atan2(a, b)
@@ -1049,8 +979,6 @@ class PallasTestsMixin:
 
     def test_min_reduction(self):
         """Test min reduction."""
-        if self.DEVICE == "cuda":
-            self.skipTest("min reduction not supported in Pallas GPU (Mosaic) backend")
 
         def fn(x):
             return x.min()
@@ -1065,7 +993,7 @@ class PallasTestsMixin:
     def test_prod_reduction(self):
         """Test prod reduction."""
         if self.DEVICE == "cuda":
-            self.skipTest("prod reduction not supported in Pallas GPU (Mosaic) backend")
+            self.skipTest("reduce_prod primitive not implemented in Pallas Mosaic GPU")
 
         def fn(x):
             # Use smaller values to avoid overflow


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #173756



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo