### PR TITLE
[c10d] Re-enable nonblocking API mode

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1050,12 +1050,14 @@ bool ProcessGroupNCCL::useNonblocking() {
     useNonblocking_ = nbEnv;
   }
   // 3rd priority: automatically use nonblocking if we are in eager init mode
-  // Note: this automatic selection is disabled in torch 2.7.1 to work around a
-  // hang in NCCL 2.26 in non-blocking mode. We can revisit if NCCL fixes the
-  // bug. See https://github.com/pytorch/pytorch/issues/153960
-  // else if (getBoundDeviceId()) {
-  //   useNonblocking_ = true;
-  // }
+  // Note: this automatic selection was once disabled in torch 2.7.1 to work
+  // around a hang in NCCL 2.26 in non-blocking mode. See
+  // https://github.com/pytorch/pytorch/issues/153960. The cause was NCCL
+  // requiring thread-exclusive access to the communicator. PR #170424 added
+  // that in torch 2.10.
+  else if (getBoundDeviceId()) {
+    useNonblocking_ = true;
+  }
   // 4th priority: otherwise, nonblocking = false to preserve old behavior
   else {
     useNonblocking_ = false;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173758

https://github.com/pytorch/pytorch/pull/170424 added thread-safe access to NCCL communicator. 
Trying to re-enable nonblocking API mode **under eager init**.

cc @stas00 @RohitRathore1