### PR TITLE
[XPU] Enable the test case in dlpack, skip the unsupported test case

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -30,7 +30,9 @@ from torch.utils.dlpack import DLDeviceType, from_dlpack, to_dlpack
 
 
 device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+    acc.type
+    if (acc := torch.accelerator.current_accelerator(check_available=True))
+    else "cpu"
 )
 
 # Wraps a tensor, exposing only DLPack methods:

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -9,8 +9,8 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
-    onlyOn,
     onlyNativeDeviceTypes,
+    onlyOn,
     skipCUDAIfNotRocm,
     skipMeta,
     skipXPUIf,
@@ -280,7 +280,9 @@ class TestTorchDlPack(TestCase):
                 return capsule
 
         # CUDA-based tests runs on non-default streams
-        with torch.get_device_module(device_type).stream(torch.get_device_module(device_type).default_stream()):
+        with torch.get_device_module(device_type).stream(
+                torch.get_device_module(device_type).default_stream()
+        ):
             x = DLPackTensor(make_tensor((5,), dtype=torch.float32, device=device))
             from_dlpack(x)
 
@@ -299,7 +301,9 @@ class TestTorchDlPack(TestCase):
             x = torch.zeros(1, device=device)
             if torch.cuda.is_available():
                 torch.cuda._sleep(2**20)
-            self.assertTrue(torch.get_device_module(device_type).default_stream().query())
+            self.assertTrue(
+                torch.get_device_module(device_type).default_stream().query()
+            )
             # ROCm uses stream 0 for default stream, CUDA uses stream 1
             default_stream_id = 0 if torch.version.hip else 1
             x.__dlpack__(stream=default_stream_id)
@@ -819,7 +823,9 @@ class TestTorchDlPack(TestCase):
         )
 
         # Run the comprehensive C++ test
-        module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda") or device.startswith("xpu"))
+        module.test_dlpack_exchange_api(
+            tensor, api_capsule, device.startswith("cuda") or device.startswith("xpu")
+        )
 
     @skipMeta
     @onlyOn(["xpu", "cuda"])

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -9,11 +9,11 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
+    onlyOn,
     onlyNativeDeviceTypes,
     skipCUDAIfNotRocm,
     skipMeta,
     skipXPUIf,
-    onlyGPU,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -114,7 +114,7 @@ class TestTorchDlPack(TestCase):
         return z
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_dlpack_conversion_with_streams(self, device, dtype):
         # Create a stream where the tensor will reside
@@ -126,7 +126,7 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(z, x)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @dtypes(
         torch.float8_e5m2,
         torch.float8_e5m2fnuz,
@@ -259,7 +259,7 @@ class TestTorchDlPack(TestCase):
             raise AssertionError(f"dtype mismatch: {x.dtype} != {y.dtype}")
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2793")
     def test_dlpack_default_stream(self, device):
         class DLPackTensor:
@@ -285,7 +285,7 @@ class TestTorchDlPack(TestCase):
             from_dlpack(x)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2793")
     def test_dlpack_convert_default_stream(self, device):
         # tests run on non-default stream, so _sleep call
@@ -315,7 +315,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=object())
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     def test_dlpack_cuda_per_thread_stream(self, device):
         # Test whether we raise an error if we are trying to use per-thread default
@@ -335,7 +335,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=2)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     @skipCUDAIfNotRocm
     def test_dlpack_invalid_rocm_streams(self, device):
@@ -350,7 +350,7 @@ class TestTorchDlPack(TestCase):
         test(x, stream=1)
         test(x, stream=2)
 
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     @skipMeta
     def test_dlpack_invalid_cuda_streams(self, device):
@@ -373,7 +373,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=0)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @deviceCountAtLeast(2)
     def test_dlpack_tensor_on_different_device(self, devices):
         dev0, dev1 = devices[:2]
@@ -523,7 +523,7 @@ class TestTorchDlPack(TestCase):
             self.assertNotEqual(inp.data_ptr(), out.data_ptr())
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     def test_copy(self, device):
         # Force-copy same device tensor.
         self._test_from_dlpack(device, copy=True)
@@ -533,7 +533,7 @@ class TestTorchDlPack(TestCase):
         self._test_from_dlpack(device, out_device="cpu", copy=True)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     def test_no_copy(self, device):
         # No copy, since tensor lives in the same device.
         self._test_from_dlpack(device)
@@ -542,7 +542,7 @@ class TestTorchDlPack(TestCase):
         self._test_from_dlpack(device, out_device=device, copy=False)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2797")
     def test_needs_copy_error(self, device):
         with self.assertRaisesRegex(ValueError, r"cannot move .* tensor from .*"):
@@ -822,7 +822,7 @@ class TestTorchDlPack(TestCase):
         module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda") or device.startswith("xpu"))
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2798")
     def test_numpy_cross_device_transfer(self, device):
         """Test cross-device transfer from NumPy (CPU) to PyTorch (CUDA).
@@ -873,7 +873,7 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(np_array2[0], 999)
 
     @skipMeta
-    @onlyGPU
+    @onlyOn(["xpu", "cuda"])
     @deviceCountAtLeast(2)
     def test_numpy_cross_device_multi_gpu(self, devices):
         """Test cross-device transfer to specific CUDA devices (cuda:0, cuda:1, etc)."""

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -578,7 +578,6 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyNativeDeviceTypes
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2788")
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it
@@ -805,6 +804,7 @@ class TestTorchDlPack(TestCase):
             functions=["test_dlpack_exchange_api"],
             verbose=False,
             with_cuda=device.startswith("cuda"),
+            with_sycl=device.startswith("xpu"),
         )
 
         # Run the comprehensive C++ test

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -35,6 +35,7 @@ device_type = (
     else "cpu"
 )
 
+
 # Wraps a tensor, exposing only DLPack methods:
 #    - __dlpack__
 #    - __dlpack_device__

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_device_type import (
     onlyNativeDeviceTypes,
     skipCUDAIfNotRocm,
     skipMeta,
+    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -281,7 +281,7 @@ class TestTorchDlPack(TestCase):
 
         # CUDA-based tests runs on non-default streams
         with torch.get_device_module(device_type).stream(
-                torch.get_device_module(device_type).default_stream()
+            torch.get_device_module(device_type).default_stream()
         ):
             x = DLPackTensor(make_tensor((5,), dtype=torch.float32, device=device))
             from_dlpack(x)
@@ -824,7 +824,7 @@ class TestTorchDlPack(TestCase):
 
         # Run the comprehensive C++ test
         module.test_dlpack_exchange_api(
-            tensor, api_capsule, device.startswith("cuda") or device.startswith("xpu")
+            tensor, api_capsule, device.startswith(("cuda", "xpu"))
         )
 
     @skipMeta

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -101,8 +101,9 @@ class TestTorchDlPack(TestCase):
             # DLPack protocol that establishes correct stream order
             # does not behave as expected on Jetson
             stream.synchronize()
-        stream = torch.cuda.Stream()
-        with torch.cuda.stream(stream):
+        stream = torch.Stream()
+        acc = torch.accelerator.current_accelerator()
+        with torch.get_device_module(acc).stream(stream):
             z = from_dlpack(x)
         stream.synchronize()
         return z
@@ -576,6 +577,7 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyNativeDeviceTypes
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2788")
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIfNotRocm,
     skipMeta,
     skipXPUIf,
+    onlyGPU,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -113,6 +114,7 @@ class TestTorchDlPack(TestCase):
         return z
 
     @skipMeta
+    @onlyGPU
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_dlpack_conversion_with_streams(self, device, dtype):
         # Create a stream where the tensor will reside
@@ -124,6 +126,7 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(z, x)
 
     @skipMeta
+    @onlyGPU
     @dtypes(
         torch.float8_e5m2,
         torch.float8_e5m2fnuz,
@@ -256,7 +259,7 @@ class TestTorchDlPack(TestCase):
             raise AssertionError(f"dtype mismatch: {x.dtype} != {y.dtype}")
 
     @skipMeta
-    @onlyCUDA
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2793")
     def test_dlpack_default_stream(self, device):
         class DLPackTensor:
@@ -282,7 +285,7 @@ class TestTorchDlPack(TestCase):
             from_dlpack(x)
 
     @skipMeta
-    @onlyCUDA
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2793")
     def test_dlpack_convert_default_stream(self, device):
         # tests run on non-default stream, so _sleep call
@@ -312,7 +315,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=object())
 
     @skipMeta
-    @onlyCUDA
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     def test_dlpack_cuda_per_thread_stream(self, device):
         # Test whether we raise an error if we are trying to use per-thread default
@@ -332,7 +335,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=2)
 
     @skipMeta
-    @onlyCUDA
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     @skipCUDAIfNotRocm
     def test_dlpack_invalid_rocm_streams(self, device):
@@ -347,7 +350,7 @@ class TestTorchDlPack(TestCase):
         test(x, stream=1)
         test(x, stream=2)
 
-    @onlyCUDA
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     @skipMeta
     def test_dlpack_invalid_cuda_streams(self, device):
@@ -370,6 +373,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=0)
 
     @skipMeta
+    @onlyGPU
     @deviceCountAtLeast(2)
     def test_dlpack_tensor_on_different_device(self, devices):
         dev0, dev1 = devices[:2]
@@ -519,6 +523,7 @@ class TestTorchDlPack(TestCase):
             self.assertNotEqual(inp.data_ptr(), out.data_ptr())
 
     @skipMeta
+    @onlyGPU
     def test_copy(self, device):
         # Force-copy same device tensor.
         self._test_from_dlpack(device, copy=True)
@@ -528,6 +533,7 @@ class TestTorchDlPack(TestCase):
         self._test_from_dlpack(device, out_device="cpu", copy=True)
 
     @skipMeta
+    @onlyGPU
     def test_no_copy(self, device):
         # No copy, since tensor lives in the same device.
         self._test_from_dlpack(device)
@@ -536,7 +542,7 @@ class TestTorchDlPack(TestCase):
         self._test_from_dlpack(device, out_device=device, copy=False)
 
     @skipMeta
-    @onlyCUDA
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2797")
     def test_needs_copy_error(self, device):
         with self.assertRaisesRegex(ValueError, r"cannot move .* tensor from .*"):
@@ -816,6 +822,7 @@ class TestTorchDlPack(TestCase):
         module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda") or device.startswith("xpu"))
 
     @skipMeta
+    @onlyGPU
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2798")
     def test_numpy_cross_device_transfer(self, device):
         """Test cross-device transfer from NumPy (CPU) to PyTorch (CUDA).
@@ -866,6 +873,7 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(np_array2[0], 999)
 
     @skipMeta
+    @onlyGPU
     @deviceCountAtLeast(2)
     def test_numpy_cross_device_multi_gpu(self, devices):
         """Test cross-device transfer to specific CUDA devices (cuda:0, cuda:1, etc)."""

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -816,6 +816,7 @@ class TestTorchDlPack(TestCase):
         module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda") or device.startswith("xpu"))
 
     @skipMeta
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2798")
     def test_numpy_cross_device_transfer(self, device):
         """Test cross-device transfer from NumPy (CPU) to PyTorch (CUDA).
 

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -262,8 +262,7 @@ class TestTorchDlPack(TestCase):
             raise AssertionError(f"dtype mismatch: {x.dtype} != {y.dtype}")
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2793")
+    @onlyCUDA
     def test_dlpack_default_stream(self, device):
         class DLPackTensor:
             def __init__(self, tensor):
@@ -290,8 +289,7 @@ class TestTorchDlPack(TestCase):
             from_dlpack(x)
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2793")
+    @onlyCUDA
     def test_dlpack_convert_default_stream(self, device):
         # tests run on non-default stream, so _sleep call
         # below will run on a non-default stream, causing
@@ -300,7 +298,7 @@ class TestTorchDlPack(TestCase):
         # run _sleep call on a non-default stream, causing
         # default stream to wait due to inserted syncs
         side_stream = torch.Stream()
-        with torch.get_device_module(device_type).stream(side_stream):
+        with side_stream:
             x = torch.zeros(1, device=device)
             if torch.cuda.is_available():
                 torch.cuda._sleep(2**20)
@@ -322,8 +320,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=object())
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
+    @onlyCUDA
     def test_dlpack_cuda_per_thread_stream(self, device):
         # Test whether we raise an error if we are trying to use per-thread default
         # stream, which is currently not supported by PyTorch.
@@ -342,8 +339,7 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=2)
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
+    @onlyCUDA
     @skipCUDAIfNotRocm
     def test_dlpack_invalid_rocm_streams(self, device):
         # Test that we correctly raise errors on unsupported ROCm streams.
@@ -357,9 +353,8 @@ class TestTorchDlPack(TestCase):
         test(x, stream=1)
         test(x, stream=2)
 
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2796")
     @skipMeta
+    @onlyCUDA
     def test_dlpack_invalid_cuda_streams(self, device):
         x = make_tensor((5,), dtype=torch.float32, device=device)
 

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -512,7 +512,7 @@ class TestTorchDlPack(TestCase):
             self.assertNotEqual(inp.data_ptr(), out.data_ptr())
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
+    @onlyCUDA
     def test_copy(self, device):
         # Force-copy same device tensor.
         self._test_from_dlpack(device, copy=True)
@@ -887,7 +887,9 @@ class TestTorchDlPack(TestCase):
         self.assertNotEqual(t0.device, t1.device)
 
 
-instantiate_device_type_tests(TestTorchDlPack, globals(), allow_mps=True, allow_xpu=True)
+instantiate_device_type_tests(
+    TestTorchDlPack, globals(), allow_mps=True, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -217,7 +217,7 @@ class TestTorchDlPack(TestCase):
         # in the current stream to make sure that it was correctly populated.
         with stream_a:
             x = make_tensor((5,), dtype=dtype, device=device) + 1
-            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
+            z = torch.from_dlpack(x.__dlpack__(stream=stream_b))
             stream_a.synchronize()
         stream_b.synchronize()
         self.assertEqual(z, x)
@@ -238,7 +238,7 @@ class TestTorchDlPack(TestCase):
         with stream_a:
             x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
             x = x.view(dtype)
-            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
+            z = torch.from_dlpack(x.__dlpack__(stream=stream_b))
             stream_a.synchronize()
         stream_b.synchronize()
         self.assertEqual(z.view(torch.uint8), x.view(torch.uint8))

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -597,7 +597,6 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyNativeDeviceTypes
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2788")
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
     onlyOn,
     skipCUDAIfNotRocm,
     skipMeta,
+    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -577,6 +578,7 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyNativeDeviceTypes
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/3074")
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -224,12 +224,12 @@ class TestTorchDlPack(TestCase):
         torch.float4_e2m1fn_x2,
     )
     def test_dlpack_conversion_with_diff_streams_narrow_precision(self, device, dtype):
-        stream_a = torch.Stream()
-        stream_b = torch.Stream()
-        with stream_a:
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
+        with torch.cuda.stream(stream_a):
             x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
             x = x.view(dtype)
-            z = torch.from_dlpack(x.__dlpack__(stream=stream_b))
+            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
             stream_a.synchronize()
         stream_b.synchronize()
         self.assertEqual(z.view(torch.uint8), x.view(torch.uint8))
@@ -803,13 +803,10 @@ class TestTorchDlPack(TestCase):
             functions=["test_dlpack_exchange_api"],
             verbose=False,
             with_cuda=device.startswith("cuda"),
-            with_sycl=device.startswith("xpu"),
         )
 
         # Run the comprehensive C++ test
-        module.test_dlpack_exchange_api(
-            tensor, api_capsule, device.startswith(("cuda", "xpu"))
-        )
+        module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda"))
 
     @skipMeta
     @onlyCUDA

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -13,7 +13,6 @@ from torch.testing._internal.common_device_type import (
     onlyOn,
     skipCUDAIfNotRocm,
     skipMeta,
-    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -27,13 +26,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.utils.dlpack import DLDeviceType, from_dlpack, to_dlpack
-
-
-device_type = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
-)
 
 
 # Wraps a tensor, exposing only DLPack methods:
@@ -208,15 +200,15 @@ class TestTorchDlPack(TestCase):
     @onlyCUDA
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_dlpack_conversion_with_diff_streams(self, device, dtype):
-        stream_a = torch.Stream()
-        stream_b = torch.Stream()
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
         # DLPack protocol helps establish a correct stream order
         # (hence data dependency) at the exchange boundary.
         # the `tensor.__dlpack__` method will insert a synchronization event
         # in the current stream to make sure that it was correctly populated.
-        with stream_a:
+        with torch.cuda.stream(stream_a):
             x = make_tensor((5,), dtype=dtype, device=device) + 1
-            z = torch.from_dlpack(x.__dlpack__(stream=stream_b))
+            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
             stream_a.synchronize()
         stream_b.synchronize()
         self.assertEqual(z, x)
@@ -282,9 +274,7 @@ class TestTorchDlPack(TestCase):
                 return capsule
 
         # CUDA-based tests runs on non-default streams
-        with torch.get_device_module(device_type).stream(
-            torch.get_device_module(device_type).default_stream()
-        ):
+        with torch.cuda.stream(torch.cuda.default_stream()):
             x = DLPackTensor(make_tensor((5,), dtype=torch.float32, device=device))
             from_dlpack(x)
 
@@ -294,22 +284,19 @@ class TestTorchDlPack(TestCase):
         # tests run on non-default stream, so _sleep call
         # below will run on a non-default stream, causing
         # default stream to wait due to inserted syncs
-        torch.get_device_module(device_type).default_stream().synchronize()
+        torch.cuda.default_stream().synchronize()
         # run _sleep call on a non-default stream, causing
         # default stream to wait due to inserted syncs
-        side_stream = torch.Stream()
-        with side_stream:
+        side_stream = torch.cuda.Stream()
+        with torch.cuda.stream(side_stream):
             x = torch.zeros(1, device=device)
-            if torch.cuda.is_available():
-                torch.cuda._sleep(2**20)
-            self.assertTrue(
-                torch.get_device_module(device_type).default_stream().query()
-            )
+            torch.cuda._sleep(2**20)
+            self.assertTrue(torch.cuda.default_stream().query())
             # ROCm uses stream 0 for default stream, CUDA uses stream 1
             default_stream_id = 0 if torch.version.hip else 1
             x.__dlpack__(stream=default_stream_id)
         # check that the default stream has work (a pending cudaStreamWaitEvent)
-        self.assertFalse(torch.get_device_module(device_type).default_stream().query())
+        self.assertFalse(torch.cuda.default_stream().query())
 
     @skipMeta
     @onlyNativeDeviceTypes
@@ -386,7 +373,7 @@ class TestTorchDlPack(TestCase):
         with self.assertRaisesRegex(
             BufferError, r"Can't export tensors on a different CUDA device"
         ):
-            with torch.get_device_module(device_type).device(dev1):
+            with torch.device(dev1):
                 x.__dlpack__()
 
     # TODO: add interchange tests once NumPy 1.22 (dlpack support) is required
@@ -544,8 +531,7 @@ class TestTorchDlPack(TestCase):
         self._test_from_dlpack(device, out_device=device, copy=False)
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2797")
+    @onlyCUDA
     def test_needs_copy_error(self, device):
         with self.assertRaisesRegex(ValueError, r"cannot move .* tensor from .*"):
             self._test_from_dlpack(device, out_device="cpu", copy=False)
@@ -826,8 +812,7 @@ class TestTorchDlPack(TestCase):
         )
 
     @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2798")
+    @onlyCUDA
     def test_numpy_cross_device_transfer(self, device):
         """Test cross-device transfer from NumPy (CPU) to PyTorch (CUDA).
 
@@ -845,12 +830,12 @@ class TestTorchDlPack(TestCase):
 
         # Test 1: copy=None (default) - should allow copy for cross-device
         t1 = from_dlpack(np_array, device=device)
-        self.assertEqual(t1.device.type, device_type)
+        self.assertEqual(t1.device.type, "cuda")
         self.assertEqual(t1, expected)
 
         # Test 2: copy=True - explicit copy
         t2 = from_dlpack(np_array, device=device, copy=True)
-        self.assertEqual(t2.device.type, device_type)
+        self.assertEqual(t2.device.type, "cuda")
         self.assertEqual(t2, expected)
 
         # Test 3: copy=False - should raise ValueError (can't do cross-device without copy)
@@ -860,10 +845,10 @@ class TestTorchDlPack(TestCase):
             from_dlpack(np_array, device=device, copy=False)
 
         # Test 4: device as string vs torch.device object (both should work)
-        t_str = from_dlpack(np_array, device=device_type)
-        t_obj = from_dlpack(np_array, device=torch.device(device_type))
-        self.assertEqual(t_str.device.type, device_type)
-        self.assertEqual(t_obj.device.type, device_type)
+        t_str = from_dlpack(np_array, device="cuda")
+        t_obj = from_dlpack(np_array, device=torch.device("cuda"))
+        self.assertEqual(t_str.device.type, "cuda")
+        self.assertEqual(t_obj.device.type, "cuda")
         self.assertEqual(t_str, t_obj)
 
         # Test 5: Regression - CPU -> CPU should still be zero-copy (share memory)
@@ -902,7 +887,7 @@ class TestTorchDlPack(TestCase):
         self.assertNotEqual(t0.device, t1.device)
 
 
-instantiate_device_type_tests(TestTorchDlPack, globals(), allow_mps=True)
+instantiate_device_type_tests(TestTorchDlPack, globals(), allow_mps=True, allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -9,6 +9,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
+    onlyOn,
     onlyNativeDeviceTypes,
     onlyOn,
     skipCUDAIfNotRocm,

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -9,7 +9,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
-    onlyOn,
     onlyNativeDeviceTypes,
     onlyOn,
     skipCUDAIfNotRocm,

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -111,7 +111,8 @@ class TestTorchDlPack(TestCase):
             # does not behave as expected on Jetson
             stream.synchronize()
         stream = torch.Stream()
-        with stream:
+        acc = torch.accelerator.current_accelerator()
+        with torch.get_device_module(acc).stream(stream):
             z = from_dlpack(x)
         stream.synchronize()
         return z
@@ -596,6 +597,7 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyNativeDeviceTypes
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2788")
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -524,6 +524,7 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyOn(["xpu", "cuda"])
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/3077")
     def test_no_copy(self, device):
         # No copy, since tensor lives in the same device.
         self._test_from_dlpack(device)

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -803,10 +803,13 @@ class TestTorchDlPack(TestCase):
             functions=["test_dlpack_exchange_api"],
             verbose=False,
             with_cuda=device.startswith("cuda"),
+            with_sycl=device.startswith("xpu"),
         )
 
         # Run the comprehensive C++ test
-        module.test_dlpack_exchange_api(tensor, api_capsule, device.startswith("cuda"))
+        module.test_dlpack_exchange_api(
+            tensor, api_capsule, device.startswith(("cuda", "xpu"))
+        )
 
     @skipMeta
     @onlyCUDA

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -111,8 +111,7 @@ class TestTorchDlPack(TestCase):
             # does not behave as expected on Jetson
             stream.synchronize()
         stream = torch.Stream()
-        acc = torch.accelerator.current_accelerator()
-        with torch.get_device_module(acc).stream(stream):
+        with stream:
             z = from_dlpack(x)
         stream.synchronize()
         return z

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -13,7 +13,6 @@ from torch.testing._internal.common_device_type import (
     onlyOn,
     skipCUDAIfNotRocm,
     skipMeta,
-    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -123,7 +122,7 @@ class TestTorchDlPack(TestCase):
     def test_dlpack_conversion_with_streams(self, device, dtype):
         # Create a stream where the tensor will reside
         stream = torch.Stream()
-        with stream:
+        with torch.get_device_module(device_type).stream(stream):
             # Do an operation in the actual stream
             x = make_tensor((5,), dtype=dtype, device=device) + 1
         z = self._dlpack_conversion_with_streams(stream, x)
@@ -141,7 +140,7 @@ class TestTorchDlPack(TestCase):
     )
     def test_dlpack_conversion_with_streams_narrow_precision(self, device, dtype):
         stream = torch.Stream()
-        with stream:
+        with torch.get_device_module(device_type).stream(stream):
             x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
             x = x.view(dtype)
         z = self._dlpack_conversion_with_streams(stream, x)
@@ -215,7 +214,7 @@ class TestTorchDlPack(TestCase):
         # (hence data dependency) at the exchange boundary.
         # the `tensor.__dlpack__` method will insert a synchronization event
         # in the current stream to make sure that it was correctly populated.
-        with stream_a:
+        with torch.get_device_module(device_type).stream(stream_a):
             x = make_tensor((5,), dtype=dtype, device=device) + 1
             z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
             stream_a.synchronize()
@@ -235,7 +234,7 @@ class TestTorchDlPack(TestCase):
     def test_dlpack_conversion_with_diff_streams_narrow_precision(self, device, dtype):
         stream_a = torch.Stream()
         stream_b = torch.Stream()
-        with stream_a:
+        with torch.get_device_module(device_type).stream(stream_a):
             x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
             x = x.view(dtype)
             z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
     onlyOn,
     skipCUDAIfNotRocm,
     skipMeta,
+    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -122,7 +123,7 @@ class TestTorchDlPack(TestCase):
     def test_dlpack_conversion_with_streams(self, device, dtype):
         # Create a stream where the tensor will reside
         stream = torch.Stream()
-        with torch.get_device_module(device_type).stream(stream):
+        with stream:
             # Do an operation in the actual stream
             x = make_tensor((5,), dtype=dtype, device=device) + 1
         z = self._dlpack_conversion_with_streams(stream, x)
@@ -140,7 +141,7 @@ class TestTorchDlPack(TestCase):
     )
     def test_dlpack_conversion_with_streams_narrow_precision(self, device, dtype):
         stream = torch.Stream()
-        with torch.get_device_module(device_type).stream(stream):
+        with stream:
             x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
             x = x.view(dtype)
         z = self._dlpack_conversion_with_streams(stream, x)
@@ -214,7 +215,7 @@ class TestTorchDlPack(TestCase):
         # (hence data dependency) at the exchange boundary.
         # the `tensor.__dlpack__` method will insert a synchronization event
         # in the current stream to make sure that it was correctly populated.
-        with torch.get_device_module(device_type).stream(stream_a):
+        with stream_a:
             x = make_tensor((5,), dtype=dtype, device=device) + 1
             z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
             stream_a.synchronize()
@@ -234,7 +235,7 @@ class TestTorchDlPack(TestCase):
     def test_dlpack_conversion_with_diff_streams_narrow_precision(self, device, dtype):
         stream_a = torch.Stream()
         stream_b = torch.Stream()
-        with torch.get_device_module(device_type).stream(stream_a):
+        with stream_a:
             x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
             x = x.view(dtype)
             z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1678,10 +1678,6 @@ def onlyXPU(fn):
     return onlyOn("xpu")(fn)
 
 
-def onlyGPU(fn):
-    return onlyOn("cuda")(fn) or onlyOn("xpu")(fn)
-
-
 def onlyHPU(fn):
     return onlyOn("hpu")(fn)
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1677,6 +1677,9 @@ def onlyMPS(fn):
 def onlyXPU(fn):
     return onlyOn("xpu")(fn)
 
+def onlyGPU(fn):
+    return onlyOn("cuda")(fn) or onlyOn("xpu")(fn)
+
 
 def onlyHPU(fn):
     return onlyOn("hpu")(fn)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1677,6 +1677,7 @@ def onlyMPS(fn):
 def onlyXPU(fn):
     return onlyOn("xpu")(fn)
 
+
 def onlyGPU(fn):
     return onlyOn("cuda")(fn) or onlyOn("xpu")(fn)
 


### PR DESCRIPTION
# Description
Port dlpack tests to Intel GPU
We could enable Intel GPU with following methods and try the best to keep the original code styles:

# Changes
1. Get device type with from accelerator and get device type helper method


# Notify
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @ezyang @msaroufim @dcci @chenyang78 @mingfeima @sanchitintel @ashokei @jingxu10 @jerryzh168 @ipiszy @muchulee8 @aakhundov @coconutruben @gujinghui @fengyuan14 @guangyey