### PR TITLE
[logging] Support registration of components/artifacts in TORCH_LOGS

### DIFF
--- a/test/custom_backend/mock_backend/setup.py
+++ b/test/custom_backend/mock_backend/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+
+setup(
+    name="torch_mock_backend",
+    packages=["torch_mock_backend"],
+    entry_points={
+        "torch.backends": [
+            "device_backend = torch_mock_backend:_autoload",
+        ],
+    },
+)

--- a/test/custom_backend/mock_backend/torch_mock_backend/__init__.py
+++ b/test/custom_backend/mock_backend/torch_mock_backend/__init__.py
@@ -1,0 +1,5 @@
+from . import logger_registration
+
+
+def _autoload():
+    pass

--- a/test/custom_backend/mock_backend/torch_mock_backend/logger_registration.py
+++ b/test/custom_backend/mock_backend/torch_mock_backend/logger_registration.py
@@ -1,0 +1,18 @@
+from torch._logging._internal import getArtifactLogger, register_artifact, register_log
+
+
+register_log("test_component", ["torch_mock_backend.logger_registration"])
+register_artifact(
+    "test_artifact",
+    "torch mock backend artifact.",
+)
+
+
+def test_logger():
+    import logging
+
+    commponent_logger = logging.getLogger(__name__)
+    commponent_logger.info("custom backend component info log")
+
+    artifact_logger = getArtifactLogger(__name__, "test_artifact")
+    artifact_logger.info("custom backend artifact info log")

--- a/test/test_log_registration.py
+++ b/test/test_log_registration.py
@@ -1,0 +1,13 @@
+# Owner(s): ["module: PrivateUse1"]
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestDeviceBackendLogging(TestCase):
+    def test_log(self):
+        from torch_mock_backend.logger_registration import test_logger
+
+        test_logger()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2935,12 +2935,6 @@ def _constrain_as_size(
     torch.sym_constrain_range_for_size(symbol, min=min, max=max)
 
 
-from torch import _logging
-
-
-_logging._init_logs()
-
-
 def _import_device_backends():
     """
     Leverage the Python plugin mechanism to load out-of-the-tree device extensions.
@@ -3002,3 +2996,9 @@ def _as_tensor_fullprec(t):
 # an autoloaded backend are defined
 if _is_device_backend_autoload_enabled():
     _import_device_backends()
+
+
+from torch import _logging
+
+
+_logging._init_logs()


### PR DESCRIPTION
Resolves #173759
1. Moved the TORCH_LOGS validation block downstream of the import backends statement.

2. Ensures that the logging registry is fully extensible by backends before the environment variables are parsed.