### PR TITLE
[BE] Decorate `to_blas` function with `[[maybe_unused]]`

### DIFF
--- a/aten/src/ATen/native/TransposeType.h
+++ b/aten/src/ATen/native/TransposeType.h
@@ -13,7 +13,7 @@ enum class TransposeType {
 };
 
 // Transforms TransposeType into the BLAS / LAPACK format
-static inline char to_blas(TransposeType trans) {
+[[maybe_unused]] static inline char to_blas(TransposeType trans) {
   switch (trans) {
     case TransposeType::Transpose: return 'T';
     case TransposeType::NoTranspose: return 'N';


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #173764
* __->__ #173763

Fixes `unused function 'to_blas'` warning when compiling native/cuda/BatchLinearAlgebraEig.cu with clang-15