### PR TITLE
[BE] Add explicit copy construction to `c10::Backend::Options`

### DIFF
--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -40,6 +40,7 @@ class TORCH_API Backend : public torch::CustomClassHolder {
         std::chrono::milliseconds timeout = kBackendDefaultTimeout)
         : timeout(timeout), backend(std::move(backend)) {}
     ~Options() override = default;
+    Options(const Options&) = default;
 
     std::chrono::milliseconds timeout;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173764
* #173763

Fixes following compilation warning
```
/var/lib/jenkins/workspace/torch/csrc/distributed/c10d/Backend.hpp:42:5: error: definition of implicit copy constructor for 'Options' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated-copy-with-dtor]
    ~Options() override = default;
    ^
/var/lib/jenkins/workspace/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp:518:5: note: in implicit copy constructor for 'c10d::Backend::Options' first required here
    Options(const Options&) = default;
    ^
/var/lib/jenkins/workspace/torch/csrc/distributed/c10d/init.cpp:3523:20: note: in defaulted copy constructor for 'c10d::ProcessGroupNCCL::Options' first required here
            return ::c10d::ProcessGroupNCCL::Options(self);
```