### PR TITLE
[c10] Add cuMemRetainAllocationHandle and cuMemGetAllocationPropertiesFromHandle to DriverAPI

### DIFF
--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -49,20 +49,23 @@
 // newer version of the function with different behavior, potentially breaking
 // PyTorch.
 
-#define C10_LIBCUDA_DRIVER_API_REQUIRED(_) \
-  _(cuDeviceGetAttribute, 12000)           \
-  _(cuMemAddressReserve, 12000)            \
-  _(cuMemRelease, 12000)                   \
-  _(cuMemMap, 12000)                       \
-  _(cuMemAddressFree, 12000)               \
-  _(cuMemSetAccess, 12000)                 \
-  _(cuMemUnmap, 12000)                     \
-  _(cuMemCreate, 12000)                    \
-  _(cuMemGetAllocationGranularity, 12000)  \
-  _(cuMemExportToShareableHandle, 12000)   \
-  _(cuMemImportFromShareableHandle, 12000) \
-  _(cuMemsetD32Async, 12000)               \
-  _(cuStreamWriteValue32, 12000)           \
+#define C10_LIBCUDA_DRIVER_API_REQUIRED(_)         \
+  _(cuDeviceGet, 12000)                            \
+  _(cuDeviceGetAttribute, 12000)                   \
+  _(cuMemAddressReserve, 12000)                    \
+  _(cuMemRelease, 12000)                           \
+  _(cuMemMap, 12000)                               \
+  _(cuMemAddressFree, 12000)                       \
+  _(cuMemSetAccess, 12000)                         \
+  _(cuMemUnmap, 12000)                             \
+  _(cuMemCreate, 12000)                            \
+  _(cuMemGetAllocationGranularity, 12000)          \
+  _(cuMemExportToShareableHandle, 12000)           \
+  _(cuMemImportFromShareableHandle, 12000)         \
+  _(cuMemRetainAllocationHandle, 12000)            \
+  _(cuMemGetAllocationPropertiesFromHandle, 12000) \
+  _(cuMemsetD32Async, 12000)                       \
+  _(cuStreamWriteValue32, 12000)                   \
   _(cuGetErrorString, 12000)
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
@@ -76,7 +79,6 @@
   _(cuGreenCtxDestroy, 12080)              \
   _(cuGreenCtxStreamCreate, 12080)         \
   _(cuDevSmResourceSplitByCount, 12080)    \
-  _(cuDeviceGet, 12080)                    \
   _(cuDeviceGetDevResource, 12080)         \
   _(cuDevResourceGenerateDesc, 12080)      \
   _(cuMulticastAddDevice, 12030)           \

--- a/test/distributed/test_p2p_ipc.py
+++ b/test/distributed/test_p2p_ipc.py
@@ -3,11 +3,17 @@
 # To run:
 # python test/distributed/test_p2p_ipc.py
 
+import os
+import unittest
 
 import torch
 from torch.multiprocessing.reductions import reduce_tensor
 from torch.testing._internal.common_distributed import MultiProcContinuousTest
-from torch.testing._internal.common_utils import requires_cuda_p2p_access, run_tests
+from torch.testing._internal.common_utils import (
+    requires_cuda_p2p_access,
+    run_tests,
+    skipIfRocm,
+)
 
 
 # So that tests are written in device-agnostic way
@@ -30,21 +36,27 @@ class P2PIpcTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    def test_p2p_ipc(self) -> None:
+    def _test_p2p_ipc_impl(self, tensor_size: int = 2333) -> None:
         """
+        Core P2P IPC test implementation.
+
         Test that cross-process P2P access works, by reducing a tensor,
         and then constructing a new tensor from the reduced tensor,
         while modifying the 6-th argument.
 
         This test is here to help stabilize the P2P share mechanism,
         preventing bc-breakage.
+
+        Args:
+            tensor_size: Size of the tensor to allocate. Larger sizes are needed
+                        to trigger expandable segment allocation.
         """
         self._init_device()
 
         tensor: torch.Tensor
 
         if self.rank == 0:
-            tensor = torch.randn(2333, device=self.device)
+            tensor = torch.randn(tensor_size, device=self.device)
             tensor_meta = reduce_tensor(tensor)
             torch.distributed.broadcast_object_list([tensor_meta], src=0)
         else:
@@ -67,6 +79,38 @@ class P2PIpcTest(MultiProcContinuousTest):
         assert tensor.allclose(tensor, 1)
 
         torch.distributed.barrier()
+
+    def test_p2p_ipc(self) -> None:
+        """Test P2P IPC with regular cudaMalloc allocations."""
+        self._test_p2p_ipc_impl()
+
+    @unittest.skip("Requires fix for expandable segments IPC handle type propagation")
+    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
+    def test_p2p_ipc_expandable_segments(self) -> None:
+        """
+        Test P2P IPC with expandable segments enabled.
+
+        This exercises the SHAREABLE_CUDA_EXPANDABLE_SEGMENT path in
+        CUDACachingAllocator::shareIpcHandle() which uses
+        cuMemExportToShareableHandle() instead of cudaIpcGetMemHandle().
+        """
+        # Enable IPC handles for expandable segments (disabled by default in fbcode)
+        os.environ["TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC"] = "1"
+
+        # Set expandable segments BEFORE any CUDA allocation
+        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+
+        # Clear existing cached memory to force new allocations from expandable segments
+        torch.cuda.empty_cache()
+
+        # Use a larger tensor size (8MB) to ensure expandable segment allocation
+        # Default segment size is 2MB, so this will trigger segment creation
+        self._test_p2p_ipc_impl(tensor_size=2 * 1024 * 1024)
+
+    @classmethod
+    def tearDownClass(cls):
+        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+        super().tearDownClass()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Add CUDA driver API functions needed for IPC memory handle operations to the
DriverAPI wrapper. Also moves cuDeviceGet from optional (CUDA 12080+) to
required API.

Differential Revision: D91753579


