### PR TITLE
Fix COW materialization in XPU GEMM ops

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -350,8 +350,8 @@ class Attr {
             dnnl::query::exec_arg_md,
             DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1);
 
-        binary_m = at::native::onednn::make_onednn_memory(
-            md, engine, binary.data_ptr());
+        binary_m = at::native::onednn::make_onednn_memory_readonly(
+            md, engine, binary.const_data_ptr());
 
         args.insert(
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binary_m});

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -350,8 +350,8 @@ class Attr {
             dnnl::query::exec_arg_md,
             DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1);
 
-        binary_m = at::native::onednn::make_onednn_memory_readonly(
-            md, engine, binary.const_data_ptr());
+        binary_m = at::native::onednn::make_onednn_memory(
+            md, engine, usm_ro(binary));
 
         args.insert(
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binary_m});

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -138,13 +138,13 @@ sycl::event convolution(
   dnnl::memory src_m, weight_m, dst_m, bia_m;
   at::Tensor src_blocked, weight_blocked, dst_blocked = dst;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  weight_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
+  src_m = make_onednn_memory_readonly(src_md, engine, src.const_data_ptr());
+  weight_m = make_onednn_memory_readonly(weight_md, engine, weight.const_data_ptr());
   dst_m = make_onednn_memory(dst_md, engine, dst.data_ptr());
 
   std::unordered_map<int, dnnl::memory> args;
   if (bia.defined()) {
-    bia_m = make_onednn_memory(bia_md, engine, bia.data_ptr());
+    bia_m = make_onednn_memory_readonly(bia_md, engine, bia.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, bia_m});
   }
   auto expected_dst_md = conv_fwd_pd.dst_desc();
@@ -247,8 +247,8 @@ sycl::event convolution_backward_weights(
   at::Tensor expected_src, expected_diff_dst, expected_diff_weight;
   dnnl::memory src_m, diff_dst_m, diff_weight_m;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
+  src_m = make_onednn_memory_readonly(src_md, engine, src.const_data_ptr());
+  diff_dst_m = make_onednn_memory_readonly(dst_md, engine, diff_dst.const_data_ptr());
   diff_weight_m = make_onednn_memory(weight_md, engine, diff_weight.data_ptr());
 
   // insert args
@@ -355,8 +355,8 @@ sycl::event convolution_backward_data(
   dnnl::memory diff_dst_m, wei_m, diff_src_m;
 
   diff_src_m = make_onednn_memory(src_md, engine, diff_src.data_ptr());
-  wei_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
+  wei_m = make_onednn_memory_readonly(weight_md, engine, weight.const_data_ptr());
+  diff_dst_m = make_onednn_memory_readonly(dst_md, engine, diff_dst.const_data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -208,8 +208,8 @@ sycl::event deconvolution(
   dnnl::memory src_m, weight_m, dst_m, bia_m;
   at::Tensor src_blocked, weight_blocked, dst_blocked = dst;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  weight_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
+  src_m = make_onednn_memory_readonly(src_md, engine, src.const_data_ptr());
+  weight_m = make_onednn_memory_readonly(weight_md, engine, weight.const_data_ptr());
   dst_m = make_onednn_memory(dst_md, engine, dst.data_ptr());
 
   std::unordered_map<int, dnnl::memory> args;
@@ -218,7 +218,7 @@ sycl::event deconvolution(
   args.insert({DNNL_ARG_DST, dst_m});
 
   if (bia.defined()) {
-    auto bia_m = make_onednn_memory(bia_md, engine, bia.data_ptr());
+    auto bia_m = make_onednn_memory_readonly(bia_md, engine, bia.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, bia_m});
   }
   if (attr.with_binary())
@@ -311,8 +311,8 @@ sycl::event deconvolution_backward_data(
   dnnl::memory diff_dst_m, wei_m, diff_src_m;
 
   diff_src_m = make_onednn_memory(src_md, engine, diff_src.data_ptr());
-  wei_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
+  wei_m = make_onednn_memory_readonly(weight_md, engine, weight.const_data_ptr());
+  diff_dst_m = make_onednn_memory_readonly(dst_md, engine, diff_dst.const_data_ptr());
 
   // insert args
   std::unordered_map<int, dnnl::memory> args;
@@ -407,8 +407,8 @@ sycl::event deconvolution_backward_weights(
   // create bwd dnnl::memory
   dnnl::memory src_m, diff_dst_m, diff_weight_m;
 
-  src_m = make_onednn_memory(src_md, engine, src.data_ptr());
-  diff_dst_m = make_onednn_memory(dst_md, engine, diff_dst.data_ptr());
+  src_m = make_onednn_memory_readonly(src_md, engine, src.const_data_ptr());
+  diff_dst_m = make_onednn_memory_readonly(dst_md, engine, diff_dst.const_data_ptr());
   diff_weight_m = make_onednn_memory(weight_md, engine, diff_weight.data_ptr());
 
   // insert args

--- a/aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h
@@ -259,10 +259,10 @@ class primitive_ext : public primitive {
     }
   }
 
-  template <typename M>
-  void set_attribute(int slot, int arg_class, void* handle, M constructor) {
+  template <typename USM, typename M>
+  void set_attribute(int slot, int arg_class, USM handle, M constructor) {
     if (mem_arg_cache[slot])
-      mem_arg_cache[slot].set_data_handle(handle);
+      mem_arg_cache[slot].set_data_handle(handle.raw());
     else {
       mem_arg_cache[slot] = constructor();
       c_args[slot].arg = arg_class;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -223,9 +223,9 @@
       dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
       // STEP4: create memory
-      auto m1_usr_m = make_onednn_memory_readonly(m1_usr_md, engine, m1.const_data_ptr());
-      auto m2_usr_m = make_onednn_memory_readonly(m2_usr_md, engine, m2.const_data_ptr());
-      auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
+      auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, usm_ro(m1));
+      auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, usm_ro(m2));
+      auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, usm_rw(dst));
 
       auto expected_m1_md = matmul_pd.src_desc();
       auto expected_m2_md = matmul_pd.weights_desc();
@@ -243,14 +243,14 @@
           m1.options().dtype(at::kByte),
           std::nullopt);
       auto scratchpad_memory = make_onednn_memory(
-          matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+          matmul_pd.scratchpad_desc(), engine, usm_rw(scratchpad_tensor));
       args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
 
       args.insert({DNNL_ARG_SRC, m1_m});
       args.insert({DNNL_ARG_WEIGHTS, m2_m});
       args.insert({DNNL_ARG_DST, dst_m});
       if (with_bias) {
-        auto bias_m = make_onednn_memory_readonly(bias_md, engine, b.const_data_ptr());
+        auto bias_m = make_onednn_memory(bias_md, engine, usm_ro(b));
         args.insert({DNNL_ARG_BIAS, bias_m});
       }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -1,266 +1,266 @@
 
-    #include <c10/xpu/XPUFunctions.h>
+#include <c10/xpu/XPUFunctions.h>
 
-    #include <ATen/ATen.h>
-    #include <ATen/record_function.h>
+#include <ATen/ATen.h>
+#include <ATen/record_function.h>
 
-    #include <Attr.h>
-    #include <Utils.h>
+#include <Attr.h>
+#include <Utils.h>
 
-    #include <c10/core/ScalarType.h>
-    #include <oneapi/dnnl/dnnl.hpp>
+#include <c10/core/ScalarType.h>
+#include <oneapi/dnnl/dnnl.hpp>
 
-    namespace at::native::onednn {
+namespace at::native::onednn {
 
-    sycl::event matmul(
-        at::Tensor& result,
-        const at::Tensor& mat1,
-        const at::Tensor& mat2,
-        const at::Tensor& b_raw,
-        bool m2_trans,
-        Attr attr,
-        const std::vector<sycl::event>& deps) {
-      // m2_trans means mat2 is transposed from the nn.Linear perspective.
-      // m2_trans==true means mat2 is [k, n] layout.
-      // m2_trans==false means mat2 is [n, k] layout, aka, the default layout in
-      // nn.Linear.
-      int64_t dims = result.dim();
+sycl::event matmul(
+    at::Tensor& result,
+    const at::Tensor& mat1,
+    const at::Tensor& mat2,
+    const at::Tensor& b_raw,
+    bool m2_trans,
+    Attr attr,
+    const std::vector<sycl::event>& deps) {
+  // m2_trans means mat2 is transposed from the nn.Linear perspective.
+  // m2_trans==true means mat2 is [k, n] layout.
+  // m2_trans==false means mat2 is [n, k] layout, aka, the default layout in
+  // nn.Linear.
+  int64_t dims = result.dim();
+  TORCH_CHECK(
+      dims == 2 || dims == 3,
+      "oneDNN matmul only works with 2D or 3D, got ",
+      dims);
+  TORCH_CHECK(
+      dims == mat1.dim() && dims == mat2.dim(),
+      "oneDNN input matrixes must have the same ranks");
+  TORCH_CHECK(result.defined(), "oneDNN matmul result should be defined");
+
+  auto& engine = GpuEngineManager::Instance().get_engine();
+  auto& stream = GpuStreamManager::Instance().get_stream();
+
+  at::Tensor m1 = mat1;
+  at::Tensor m2 = mat2;
+
+  undo_broadcast_on_batch(m1, m2);
+
+  m1 = is_onednn_matmul_strides(m1) ? m1 : m1.contiguous();
+  m2 = is_onednn_matmul_strides(m2) ? m2 : m2.contiguous();
+  at::Tensor dst =
+      is_onednn_matmul_strides(result) ? result : result.contiguous();
+
+  int64_t m = dst.size(-2);
+  int64_t n = dst.size(-1);
+  int64_t k = m1.size(-1);
+  int64_t mb = 1;
+
+  if (dims == 3) {
+    mb = dst.size(0);
+    TORCH_CHECK(
+        mb == mat1.size(0) && mb == mat2.size(0),
+        "batch size mismatch, dst mb: ",
+        mb,
+        "m1 mb",
+        mat1.size(0),
+        " m2 mb: ",
+        mat2.size(0));
+  }
+
+  // validate bias and make it compatible with oneDNN implementation
+  bool with_bias = false;
+  at::Tensor b = b_raw;
+  if (b.defined()) {
+    with_bias = true;
+    if (b.dim() == 1) {
       TORCH_CHECK(
-          dims == 2 || dims == 3,
-          "oneDNN matmul only works with 2D or 3D, got ",
-          dims);
+          b.size(0) == n || b.size(0) == 1,
+          "matmul supports [n] or [1] when bias dim is 1 ...");
+      if (b.size(0) == 0) {
+        with_bias = false;
+      } else if (m1.dim() == 3) {
+        b = b.expand({mb, m, n}).contiguous();
+      } else if (m1.dim() == 2) {
+        b = b.expand({1, n}).contiguous();
+      }
+    } else if (b.dim() == 2) {
       TORCH_CHECK(
-          dims == mat1.dim() && dims == mat2.dim(),
-          "oneDNN input matrixes must have the same ranks");
-      TORCH_CHECK(result.defined(), "oneDNN matmul result should be defined");
-
-      auto& engine = GpuEngineManager::Instance().get_engine();
-      auto& stream = GpuStreamManager::Instance().get_stream();
-
-      at::Tensor m1 = mat1;
-      at::Tensor m2 = mat2;
-
-      undo_broadcast_on_batch(m1, m2);
-
-      m1 = is_onednn_matmul_strides(m1) ? m1 : m1.contiguous();
-      m2 = is_onednn_matmul_strides(m2) ? m2 : m2.contiguous();
-      at::Tensor dst =
-          is_onednn_matmul_strides(result) ? result : result.contiguous();
-
-      int64_t m = dst.size(-2);
-      int64_t n = dst.size(-1);
-      int64_t k = m1.size(-1);
-      int64_t mb = 1;
-
-      if (dims == 3) {
-        mb = dst.size(0);
-        TORCH_CHECK(
-            mb == mat1.size(0) && mb == mat2.size(0),
-            "batch size mismatch, dst mb: ",
-            mb,
-            "m1 mb",
-            mat1.size(0),
-            " m2 mb: ",
-            mat2.size(0));
-      }
-
-      // validate bias and make it compatible with oneDNN implementation
-      bool with_bias = false;
-      at::Tensor b = b_raw;
-      if (b.defined()) {
-        with_bias = true;
-        if (b.dim() == 1) {
-          TORCH_CHECK(
-              b.size(0) == n || b.size(0) == 1,
-              "matmul supports [n] or [1] when bias dim is 1 ...");
-          if (b.size(0) == 0) {
-            with_bias = false;
-          } else if (m1.dim() == 3) {
-            b = b.expand({mb, m, n}).contiguous();
-          } else if (m1.dim() == 2) {
-            b = b.expand({1, n}).contiguous();
-          }
-        } else if (b.dim() == 2) {
-          TORCH_CHECK(
-              (b.size(0) == m && b.size(1) == n) ||
-                  (b.size(0) == 1 && b.size(1) == n) ||
-                  (b.size(0) == m && b.size(1) == 1) ||
-                  (b.size(0) == 1 && b.size(1) == 1),
-              "matmul supports [m, n] or [1, n] or [m, 1] or [1, 1] when bias dim is 2 ...");
-          if (b.size(0) == 1 && b.size(1) == 1)
-            b = b.expand({1, n}).contiguous();
-        } else if (b.dim() == 3) {
-          TORCH_CHECK(
-              at::are_expandable({mb, m, n}, b.sizes()),
-              "matmul bias must be expandable to:",
-              dst.sizes(),
-              " but got:",
-              b.sizes());
-          b = b.expand({mb, m, n}).contiguous();
-        } else if (b.dim() == 0) {
-          TORCH_CHECK(
-              b.numel() == 1, "matmul supports 1 numel when bias dim is [] ...");
-          if (m1.dim() == 3) {
-            b = b.expand({mb, m, n}).contiguous();
-          } else {
-            b = b.expand({1, n}).contiguous();
-          }
-        } else {
-          TORCH_CHECK(0, "unsupported bias dim in matmul ...");
-        }
-      }
-
-      b = b.contiguous(); // avoid reorder 2 times
-
-      // xpu matmul support both ab/ba shape for m2 tensor, we don't check any more
-      auto m1_usr_dt = get_onednn_dtype_include_double(m1);
-      auto m2_usr_dt = get_onednn_dtype_include_double(m2);
-      auto dst_usr_dt = get_onednn_dtype_include_double(dst);
-
-      auto m1_dt = m1_usr_dt;
-      auto m2_dt = m2_usr_dt;
-      auto dst_dt = dst_usr_dt;
-      dnnl::memory::data_type bias_dt;
-
-      dnnl::memory::desc m1_md, m1_usr_md, m1_any_md;
-      dnnl::memory::desc m2_md, m2_usr_md, m2_any_md;
-      dnnl::memory::desc dst_md, dst_usr_md, dst_any_md;
-      dnnl::memory::desc bias_md;
-
-      // Naive Master weight
-      if (m1_dt == dnnl::memory::data_type::bf16 &&
-          m2_dt == dnnl::memory::data_type::f32) {
-        m2_dt = dnnl::memory::data_type::bf16;
-        dst_dt = dnnl::memory::data_type::bf16;
-      } else if (
-          m1_dt == dnnl::memory::data_type::f32 &&
-          m2_dt == dnnl::memory::data_type::bf16) {
-        m1_dt = dnnl::memory::data_type::bf16;
-        dst_dt = dnnl::memory::data_type::bf16;
-      }
-
-      dnnl::memory::dims m1_dims, m2_dims, dst_dims, bias_dims;
-      dnnl::memory::dims m1_strides, m2_strides, dst_strides, bias_strides;
-      if (dims == 2) {
-        m1_dims = {m, k};
-        m2_dims = {k, n};
-        dst_dims = {m, n};
-
-        m1_strides = {m1.stride(0), m1.stride(1)};
-        if (m2_trans) {
-          m2_strides = {m2.stride(0), m2.stride(1)};
-        } else {
-          m2_strides = {m2.stride(1), m2.stride(0)};
-        }
-        dst_strides = {dst.stride(0), dst.stride(1)};
+          (b.size(0) == m && b.size(1) == n) ||
+              (b.size(0) == 1 && b.size(1) == n) ||
+              (b.size(0) == m && b.size(1) == 1) ||
+              (b.size(0) == 1 && b.size(1) == 1),
+          "matmul supports [m, n] or [1, n] or [m, 1] or [1, 1] when bias dim is 2 ...");
+      if (b.size(0) == 1 && b.size(1) == 1)
+        b = b.expand({1, n}).contiguous();
+    } else if (b.dim() == 3) {
+      TORCH_CHECK(
+          at::are_expandable({mb, m, n}, b.sizes()),
+          "matmul bias must be expandable to:",
+          dst.sizes(),
+          " but got:",
+          b.sizes());
+      b = b.expand({mb, m, n}).contiguous();
+    } else if (b.dim() == 0) {
+      TORCH_CHECK(
+          b.numel() == 1, "matmul supports 1 numel when bias dim is [] ...");
+      if (m1.dim() == 3) {
+        b = b.expand({mb, m, n}).contiguous();
       } else {
-        m1_dims = {m1.size(0), m, k};
-        m2_dims = {m2.size(0), k, n};
-        dst_dims = {mb, m, n};
-
-        m1_strides = {m1.stride(0), m1.stride(1), m1.stride(2)};
-        if (m2_trans) {
-          m2_strides = {m2.stride(0), m2.stride(1), m2.stride(2)};
-        } else {
-          m2_strides = {m2.stride(0), m2.stride(2), m2.stride(1)};
-        }
-        dst_strides = {dst.stride(0), dst.stride(1), dst.stride(2)};
+        b = b.expand({1, n}).contiguous();
       }
-
-      if (with_bias) {
-        bias_dims = get_onednn_dims(b);
-        bias_dt = get_onednn_dtype_include_double(b);
-        bias_strides = get_onednn_strides(b);
-      }
-
-      dnnl::post_ops po = attr.extract_post_ops(dst);
-
-      std::unordered_map<int, dnnl::memory> args;
-      dnnl::matmul matmul_p;
-      dnnl::matmul::primitive_desc matmul_pd;
-
-      // STEP1: create memory desc
-      m1_md = dnnl::memory::desc(m1_dims, m1_dt, m1_strides);
-      m2_md = dnnl::memory::desc(m2_dims, m2_dt, m2_strides);
-      dst_md = dnnl::memory::desc(dst_dims, dst_dt, dst_strides);
-
-      // STEP2: creat attribute
-      dnnl::primitive_attr pattr;
-      pattr.set_post_ops(po);
-
-    #if ONEDNN_SUPPORT_DETERMINISTIC
-      if (at::globalContext().deterministicAlgorithms() ||
-          at::globalContext().deterministicMkldnn())
-        pattr.set_deterministic(true);
-    #endif
-
-      // scratchpad
-      pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-
-      if (m1_dt == dnnl::memory::data_type::f32) {
-        bool allow_tf32 = at::globalContext().allowTF32OneDNN();
-        if (allow_tf32) {
-          pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
-        } else {
-          pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
-        }
-      }
-
-      // STEP3: create primitive
-      if (with_bias) {
-        bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);
-        matmul_pd = dnnl::matmul::primitive_desc(
-            engine, m1_md, m2_md, bias_md, dst_md, pattr);
-      } else {
-        matmul_pd =
-            dnnl::matmul::primitive_desc(engine, m1_md, m2_md, dst_md, pattr);
-      }
-
-      matmul_p = dnnl::matmul(matmul_pd);
-
-      m1_usr_md = dnnl::memory::desc(m1_dims, m1_usr_dt, m1_strides);
-      m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
-      dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
-
-      // STEP4: create memory
-      auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, usm_ro(m1));
-      auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, usm_ro(m2));
-      auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, usm_rw(dst));
-
-      auto expected_m1_md = matmul_pd.src_desc();
-      auto expected_m2_md = matmul_pd.weights_desc();
-      auto expected_dst_md = matmul_pd.dst_desc();
-
-      dnnl::memory m1_m = m1_usr_m, m2_m = m2_usr_m, dst_m = dst_usr_m;
-      at::Tensor m1_, m2_, dst_;
-
-      if (attr.with_binary())
-        attr.construct_post_binary(matmul_pd, args);
-
-      size_t scratchpad_size = matmul_pd.scratchpad_desc().get_size();
-      at::Tensor scratchpad_tensor = at::empty(
-          {static_cast<int64_t>(scratchpad_size)},
-          m1.options().dtype(at::kByte),
-          std::nullopt);
-      auto scratchpad_memory = make_onednn_memory(
-          matmul_pd.scratchpad_desc(), engine, usm_rw(scratchpad_tensor));
-      args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
-
-      args.insert({DNNL_ARG_SRC, m1_m});
-      args.insert({DNNL_ARG_WEIGHTS, m2_m});
-      args.insert({DNNL_ARG_DST, dst_m});
-      if (with_bias) {
-        auto bias_m = make_onednn_memory(bias_md, engine, usm_ro(b));
-        args.insert({DNNL_ARG_BIAS, bias_m});
-      }
-
-      sycl::event matmul_event =
-          dnnl::sycl_interop::execute(matmul_p, stream, args, deps);
-
-      if (!dst.is_same(result))
-        result.copy_(dst);
-
-      return matmul_event;
+    } else {
+      TORCH_CHECK(0, "unsupported bias dim in matmul ...");
     }
+  }
 
-    } // namespace at::native::onednn
+  b = b.contiguous(); // avoid reorder 2 times
+
+  // xpu matmul support both ab/ba shape for m2 tensor, we don't check any more
+  auto m1_usr_dt = get_onednn_dtype_include_double(m1);
+  auto m2_usr_dt = get_onednn_dtype_include_double(m2);
+  auto dst_usr_dt = get_onednn_dtype_include_double(dst);
+
+  auto m1_dt = m1_usr_dt;
+  auto m2_dt = m2_usr_dt;
+  auto dst_dt = dst_usr_dt;
+  dnnl::memory::data_type bias_dt;
+
+  dnnl::memory::desc m1_md, m1_usr_md, m1_any_md;
+  dnnl::memory::desc m2_md, m2_usr_md, m2_any_md;
+  dnnl::memory::desc dst_md, dst_usr_md, dst_any_md;
+  dnnl::memory::desc bias_md;
+
+  // Naive Master weight
+  if (m1_dt == dnnl::memory::data_type::bf16 &&
+      m2_dt == dnnl::memory::data_type::f32) {
+    m2_dt = dnnl::memory::data_type::bf16;
+    dst_dt = dnnl::memory::data_type::bf16;
+  } else if (
+      m1_dt == dnnl::memory::data_type::f32 &&
+      m2_dt == dnnl::memory::data_type::bf16) {
+    m1_dt = dnnl::memory::data_type::bf16;
+    dst_dt = dnnl::memory::data_type::bf16;
+  }
+
+  dnnl::memory::dims m1_dims, m2_dims, dst_dims, bias_dims;
+  dnnl::memory::dims m1_strides, m2_strides, dst_strides, bias_strides;
+  if (dims == 2) {
+    m1_dims = {m, k};
+    m2_dims = {k, n};
+    dst_dims = {m, n};
+
+    m1_strides = {m1.stride(0), m1.stride(1)};
+    if (m2_trans) {
+      m2_strides = {m2.stride(0), m2.stride(1)};
+    } else {
+      m2_strides = {m2.stride(1), m2.stride(0)};
+    }
+    dst_strides = {dst.stride(0), dst.stride(1)};
+  } else {
+    m1_dims = {m1.size(0), m, k};
+    m2_dims = {m2.size(0), k, n};
+    dst_dims = {mb, m, n};
+
+    m1_strides = {m1.stride(0), m1.stride(1), m1.stride(2)};
+    if (m2_trans) {
+      m2_strides = {m2.stride(0), m2.stride(1), m2.stride(2)};
+    } else {
+      m2_strides = {m2.stride(0), m2.stride(2), m2.stride(1)};
+    }
+    dst_strides = {dst.stride(0), dst.stride(1), dst.stride(2)};
+  }
+
+  if (with_bias) {
+    bias_dims = get_onednn_dims(b);
+    bias_dt = get_onednn_dtype_include_double(b);
+    bias_strides = get_onednn_strides(b);
+  }
+
+  dnnl::post_ops po = attr.extract_post_ops(dst);
+
+  std::unordered_map<int, dnnl::memory> args;
+  dnnl::matmul matmul_p;
+  dnnl::matmul::primitive_desc matmul_pd;
+
+  // STEP1: create memory desc
+  m1_md = dnnl::memory::desc(m1_dims, m1_dt, m1_strides);
+  m2_md = dnnl::memory::desc(m2_dims, m2_dt, m2_strides);
+  dst_md = dnnl::memory::desc(dst_dims, dst_dt, dst_strides);
+
+  // STEP2: creat attribute
+  dnnl::primitive_attr pattr;
+  pattr.set_post_ops(po);
+
+#if ONEDNN_SUPPORT_DETERMINISTIC
+  if (at::globalContext().deterministicAlgorithms() ||
+      at::globalContext().deterministicMkldnn())
+    pattr.set_deterministic(true);
+#endif
+
+  // scratchpad
+  pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+  if (m1_dt == dnnl::memory::data_type::f32) {
+    bool allow_tf32 = at::globalContext().allowTF32OneDNN();
+    if (allow_tf32) {
+      pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
+    } else {
+      pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
+    }
+  }
+
+  // STEP3: create primitive
+  if (with_bias) {
+    bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);
+    matmul_pd = dnnl::matmul::primitive_desc(
+        engine, m1_md, m2_md, bias_md, dst_md, pattr);
+  } else {
+    matmul_pd =
+        dnnl::matmul::primitive_desc(engine, m1_md, m2_md, dst_md, pattr);
+  }
+
+  matmul_p = dnnl::matmul(matmul_pd);
+
+  m1_usr_md = dnnl::memory::desc(m1_dims, m1_usr_dt, m1_strides);
+  m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
+  dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
+
+  // STEP4: create memory
+  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, usm_ro(m1));
+  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, usm_ro(m2));
+  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, usm_rw(dst));
+
+  auto expected_m1_md = matmul_pd.src_desc();
+  auto expected_m2_md = matmul_pd.weights_desc();
+  auto expected_dst_md = matmul_pd.dst_desc();
+
+  dnnl::memory m1_m = m1_usr_m, m2_m = m2_usr_m, dst_m = dst_usr_m;
+  at::Tensor m1_, m2_, dst_;
+
+  if (attr.with_binary())
+    attr.construct_post_binary(matmul_pd, args);
+
+  size_t scratchpad_size = matmul_pd.scratchpad_desc().get_size();
+  at::Tensor scratchpad_tensor = at::empty(
+      {static_cast<int64_t>(scratchpad_size)},
+      m1.options().dtype(at::kByte),
+      std::nullopt);
+  auto scratchpad_memory = make_onednn_memory(
+      matmul_pd.scratchpad_desc(), engine, usm_rw(scratchpad_tensor));
+  args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
+
+  args.insert({DNNL_ARG_SRC, m1_m});
+  args.insert({DNNL_ARG_WEIGHTS, m2_m});
+  args.insert({DNNL_ARG_DST, dst_m});
+  if (with_bias) {
+    auto bias_m = make_onednn_memory(bias_md, engine, usm_ro(b));
+    args.insert({DNNL_ARG_BIAS, bias_m});
+  }
+
+  sycl::event matmul_event =
+      dnnl::sycl_interop::execute(matmul_p, stream, args, deps);
+
+  if (!dst.is_same(result))
+    result.copy_(dst);
+
+  return matmul_event;
+}
+
+} // namespace at::native::onednn

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -205,7 +205,7 @@ sycl::event matmul(
       pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
     }
   }
-
+  
   // STEP3: create primitive
   if (with_bias) {
     bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);
@@ -223,8 +223,8 @@ sycl::event matmul(
   dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
   // STEP4: create memory
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
+  auto m1_usr_m = make_onednn_memory_readonly(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory_readonly(m2_usr_md, engine, m2.const_data_ptr());
   auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
 
   auto expected_m1_md = matmul_pd.src_desc();

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -205,7 +205,7 @@ sycl::event matmul(
       pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
     }
   }
-  
+
   // STEP3: create primitive
   if (with_bias) {
     bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -1,266 +1,266 @@
 
-#include <c10/xpu/XPUFunctions.h>
+    #include <c10/xpu/XPUFunctions.h>
 
-#include <ATen/ATen.h>
-#include <ATen/record_function.h>
+    #include <ATen/ATen.h>
+    #include <ATen/record_function.h>
 
-#include <Attr.h>
-#include <Utils.h>
+    #include <Attr.h>
+    #include <Utils.h>
 
-#include <c10/core/ScalarType.h>
-#include <oneapi/dnnl/dnnl.hpp>
+    #include <c10/core/ScalarType.h>
+    #include <oneapi/dnnl/dnnl.hpp>
 
-namespace at::native::onednn {
+    namespace at::native::onednn {
 
-sycl::event matmul(
-    at::Tensor& result,
-    const at::Tensor& mat1,
-    const at::Tensor& mat2,
-    const at::Tensor& b_raw,
-    bool m2_trans,
-    Attr attr,
-    const std::vector<sycl::event>& deps) {
-  // m2_trans means mat2 is transposed from the nn.Linear perspective.
-  // m2_trans==true means mat2 is [k, n] layout.
-  // m2_trans==false means mat2 is [n, k] layout, aka, the default layout in
-  // nn.Linear.
-  int64_t dims = result.dim();
-  TORCH_CHECK(
-      dims == 2 || dims == 3,
-      "oneDNN matmul only works with 2D or 3D, got ",
-      dims);
-  TORCH_CHECK(
-      dims == mat1.dim() && dims == mat2.dim(),
-      "oneDNN input matrixes must have the same ranks");
-  TORCH_CHECK(result.defined(), "oneDNN matmul result should be defined");
-
-  auto& engine = GpuEngineManager::Instance().get_engine();
-  auto& stream = GpuStreamManager::Instance().get_stream();
-
-  at::Tensor m1 = mat1;
-  at::Tensor m2 = mat2;
-
-  undo_broadcast_on_batch(m1, m2);
-
-  m1 = is_onednn_matmul_strides(m1) ? m1 : m1.contiguous();
-  m2 = is_onednn_matmul_strides(m2) ? m2 : m2.contiguous();
-  at::Tensor dst =
-      is_onednn_matmul_strides(result) ? result : result.contiguous();
-
-  int64_t m = dst.size(-2);
-  int64_t n = dst.size(-1);
-  int64_t k = m1.size(-1);
-  int64_t mb = 1;
-
-  if (dims == 3) {
-    mb = dst.size(0);
-    TORCH_CHECK(
-        mb == mat1.size(0) && mb == mat2.size(0),
-        "batch size mismatch, dst mb: ",
-        mb,
-        "m1 mb",
-        mat1.size(0),
-        " m2 mb: ",
-        mat2.size(0));
-  }
-
-  // validate bias and make it compatible with oneDNN implementation
-  bool with_bias = false;
-  at::Tensor b = b_raw;
-  if (b.defined()) {
-    with_bias = true;
-    if (b.dim() == 1) {
+    sycl::event matmul(
+        at::Tensor& result,
+        const at::Tensor& mat1,
+        const at::Tensor& mat2,
+        const at::Tensor& b_raw,
+        bool m2_trans,
+        Attr attr,
+        const std::vector<sycl::event>& deps) {
+      // m2_trans means mat2 is transposed from the nn.Linear perspective.
+      // m2_trans==true means mat2 is [k, n] layout.
+      // m2_trans==false means mat2 is [n, k] layout, aka, the default layout in
+      // nn.Linear.
+      int64_t dims = result.dim();
       TORCH_CHECK(
-          b.size(0) == n || b.size(0) == 1,
-          "matmul supports [n] or [1] when bias dim is 1 ...");
-      if (b.size(0) == 0) {
-        with_bias = false;
-      } else if (m1.dim() == 3) {
-        b = b.expand({mb, m, n}).contiguous();
-      } else if (m1.dim() == 2) {
-        b = b.expand({1, n}).contiguous();
+          dims == 2 || dims == 3,
+          "oneDNN matmul only works with 2D or 3D, got ",
+          dims);
+      TORCH_CHECK(
+          dims == mat1.dim() && dims == mat2.dim(),
+          "oneDNN input matrixes must have the same ranks");
+      TORCH_CHECK(result.defined(), "oneDNN matmul result should be defined");
+
+      auto& engine = GpuEngineManager::Instance().get_engine();
+      auto& stream = GpuStreamManager::Instance().get_stream();
+
+      at::Tensor m1 = mat1;
+      at::Tensor m2 = mat2;
+
+      undo_broadcast_on_batch(m1, m2);
+
+      m1 = is_onednn_matmul_strides(m1) ? m1 : m1.contiguous();
+      m2 = is_onednn_matmul_strides(m2) ? m2 : m2.contiguous();
+      at::Tensor dst =
+          is_onednn_matmul_strides(result) ? result : result.contiguous();
+
+      int64_t m = dst.size(-2);
+      int64_t n = dst.size(-1);
+      int64_t k = m1.size(-1);
+      int64_t mb = 1;
+
+      if (dims == 3) {
+        mb = dst.size(0);
+        TORCH_CHECK(
+            mb == mat1.size(0) && mb == mat2.size(0),
+            "batch size mismatch, dst mb: ",
+            mb,
+            "m1 mb",
+            mat1.size(0),
+            " m2 mb: ",
+            mat2.size(0));
       }
-    } else if (b.dim() == 2) {
-      TORCH_CHECK(
-          (b.size(0) == m && b.size(1) == n) ||
-              (b.size(0) == 1 && b.size(1) == n) ||
-              (b.size(0) == m && b.size(1) == 1) ||
-              (b.size(0) == 1 && b.size(1) == 1),
-          "matmul supports [m, n] or [1, n] or [m, 1] or [1, 1] when bias dim is 2 ...");
-      if (b.size(0) == 1 && b.size(1) == 1)
-        b = b.expand({1, n}).contiguous();
-    } else if (b.dim() == 3) {
-      TORCH_CHECK(
-          at::are_expandable({mb, m, n}, b.sizes()),
-          "matmul bias must be expandable to:",
-          dst.sizes(),
-          " but got:",
-          b.sizes());
-      b = b.expand({mb, m, n}).contiguous();
-    } else if (b.dim() == 0) {
-      TORCH_CHECK(
-          b.numel() == 1, "matmul supports 1 numel when bias dim is [] ...");
-      if (m1.dim() == 3) {
-        b = b.expand({mb, m, n}).contiguous();
+
+      // validate bias and make it compatible with oneDNN implementation
+      bool with_bias = false;
+      at::Tensor b = b_raw;
+      if (b.defined()) {
+        with_bias = true;
+        if (b.dim() == 1) {
+          TORCH_CHECK(
+              b.size(0) == n || b.size(0) == 1,
+              "matmul supports [n] or [1] when bias dim is 1 ...");
+          if (b.size(0) == 0) {
+            with_bias = false;
+          } else if (m1.dim() == 3) {
+            b = b.expand({mb, m, n}).contiguous();
+          } else if (m1.dim() == 2) {
+            b = b.expand({1, n}).contiguous();
+          }
+        } else if (b.dim() == 2) {
+          TORCH_CHECK(
+              (b.size(0) == m && b.size(1) == n) ||
+                  (b.size(0) == 1 && b.size(1) == n) ||
+                  (b.size(0) == m && b.size(1) == 1) ||
+                  (b.size(0) == 1 && b.size(1) == 1),
+              "matmul supports [m, n] or [1, n] or [m, 1] or [1, 1] when bias dim is 2 ...");
+          if (b.size(0) == 1 && b.size(1) == 1)
+            b = b.expand({1, n}).contiguous();
+        } else if (b.dim() == 3) {
+          TORCH_CHECK(
+              at::are_expandable({mb, m, n}, b.sizes()),
+              "matmul bias must be expandable to:",
+              dst.sizes(),
+              " but got:",
+              b.sizes());
+          b = b.expand({mb, m, n}).contiguous();
+        } else if (b.dim() == 0) {
+          TORCH_CHECK(
+              b.numel() == 1, "matmul supports 1 numel when bias dim is [] ...");
+          if (m1.dim() == 3) {
+            b = b.expand({mb, m, n}).contiguous();
+          } else {
+            b = b.expand({1, n}).contiguous();
+          }
+        } else {
+          TORCH_CHECK(0, "unsupported bias dim in matmul ...");
+        }
+      }
+
+      b = b.contiguous(); // avoid reorder 2 times
+
+      // xpu matmul support both ab/ba shape for m2 tensor, we don't check any more
+      auto m1_usr_dt = get_onednn_dtype_include_double(m1);
+      auto m2_usr_dt = get_onednn_dtype_include_double(m2);
+      auto dst_usr_dt = get_onednn_dtype_include_double(dst);
+
+      auto m1_dt = m1_usr_dt;
+      auto m2_dt = m2_usr_dt;
+      auto dst_dt = dst_usr_dt;
+      dnnl::memory::data_type bias_dt;
+
+      dnnl::memory::desc m1_md, m1_usr_md, m1_any_md;
+      dnnl::memory::desc m2_md, m2_usr_md, m2_any_md;
+      dnnl::memory::desc dst_md, dst_usr_md, dst_any_md;
+      dnnl::memory::desc bias_md;
+
+      // Naive Master weight
+      if (m1_dt == dnnl::memory::data_type::bf16 &&
+          m2_dt == dnnl::memory::data_type::f32) {
+        m2_dt = dnnl::memory::data_type::bf16;
+        dst_dt = dnnl::memory::data_type::bf16;
+      } else if (
+          m1_dt == dnnl::memory::data_type::f32 &&
+          m2_dt == dnnl::memory::data_type::bf16) {
+        m1_dt = dnnl::memory::data_type::bf16;
+        dst_dt = dnnl::memory::data_type::bf16;
+      }
+
+      dnnl::memory::dims m1_dims, m2_dims, dst_dims, bias_dims;
+      dnnl::memory::dims m1_strides, m2_strides, dst_strides, bias_strides;
+      if (dims == 2) {
+        m1_dims = {m, k};
+        m2_dims = {k, n};
+        dst_dims = {m, n};
+
+        m1_strides = {m1.stride(0), m1.stride(1)};
+        if (m2_trans) {
+          m2_strides = {m2.stride(0), m2.stride(1)};
+        } else {
+          m2_strides = {m2.stride(1), m2.stride(0)};
+        }
+        dst_strides = {dst.stride(0), dst.stride(1)};
       } else {
-        b = b.expand({1, n}).contiguous();
+        m1_dims = {m1.size(0), m, k};
+        m2_dims = {m2.size(0), k, n};
+        dst_dims = {mb, m, n};
+
+        m1_strides = {m1.stride(0), m1.stride(1), m1.stride(2)};
+        if (m2_trans) {
+          m2_strides = {m2.stride(0), m2.stride(1), m2.stride(2)};
+        } else {
+          m2_strides = {m2.stride(0), m2.stride(2), m2.stride(1)};
+        }
+        dst_strides = {dst.stride(0), dst.stride(1), dst.stride(2)};
       }
-    } else {
-      TORCH_CHECK(0, "unsupported bias dim in matmul ...");
+
+      if (with_bias) {
+        bias_dims = get_onednn_dims(b);
+        bias_dt = get_onednn_dtype_include_double(b);
+        bias_strides = get_onednn_strides(b);
+      }
+
+      dnnl::post_ops po = attr.extract_post_ops(dst);
+
+      std::unordered_map<int, dnnl::memory> args;
+      dnnl::matmul matmul_p;
+      dnnl::matmul::primitive_desc matmul_pd;
+
+      // STEP1: create memory desc
+      m1_md = dnnl::memory::desc(m1_dims, m1_dt, m1_strides);
+      m2_md = dnnl::memory::desc(m2_dims, m2_dt, m2_strides);
+      dst_md = dnnl::memory::desc(dst_dims, dst_dt, dst_strides);
+
+      // STEP2: creat attribute
+      dnnl::primitive_attr pattr;
+      pattr.set_post_ops(po);
+
+    #if ONEDNN_SUPPORT_DETERMINISTIC
+      if (at::globalContext().deterministicAlgorithms() ||
+          at::globalContext().deterministicMkldnn())
+        pattr.set_deterministic(true);
+    #endif
+
+      // scratchpad
+      pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+      if (m1_dt == dnnl::memory::data_type::f32) {
+        bool allow_tf32 = at::globalContext().allowTF32OneDNN();
+        if (allow_tf32) {
+          pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
+        } else {
+          pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
+        }
+      }
+
+      // STEP3: create primitive
+      if (with_bias) {
+        bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);
+        matmul_pd = dnnl::matmul::primitive_desc(
+            engine, m1_md, m2_md, bias_md, dst_md, pattr);
+      } else {
+        matmul_pd =
+            dnnl::matmul::primitive_desc(engine, m1_md, m2_md, dst_md, pattr);
+      }
+
+      matmul_p = dnnl::matmul(matmul_pd);
+
+      m1_usr_md = dnnl::memory::desc(m1_dims, m1_usr_dt, m1_strides);
+      m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
+      dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
+
+      // STEP4: create memory
+      auto m1_usr_m = make_onednn_memory_readonly(m1_usr_md, engine, m1.const_data_ptr());
+      auto m2_usr_m = make_onednn_memory_readonly(m2_usr_md, engine, m2.const_data_ptr());
+      auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
+
+      auto expected_m1_md = matmul_pd.src_desc();
+      auto expected_m2_md = matmul_pd.weights_desc();
+      auto expected_dst_md = matmul_pd.dst_desc();
+
+      dnnl::memory m1_m = m1_usr_m, m2_m = m2_usr_m, dst_m = dst_usr_m;
+      at::Tensor m1_, m2_, dst_;
+
+      if (attr.with_binary())
+        attr.construct_post_binary(matmul_pd, args);
+
+      size_t scratchpad_size = matmul_pd.scratchpad_desc().get_size();
+      at::Tensor scratchpad_tensor = at::empty(
+          {static_cast<int64_t>(scratchpad_size)},
+          m1.options().dtype(at::kByte),
+          std::nullopt);
+      auto scratchpad_memory = make_onednn_memory(
+          matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
+
+      args.insert({DNNL_ARG_SRC, m1_m});
+      args.insert({DNNL_ARG_WEIGHTS, m2_m});
+      args.insert({DNNL_ARG_DST, dst_m});
+      if (with_bias) {
+        auto bias_m = make_onednn_memory_readonly(bias_md, engine, b.const_data_ptr());
+        args.insert({DNNL_ARG_BIAS, bias_m});
+      }
+
+      sycl::event matmul_event =
+          dnnl::sycl_interop::execute(matmul_p, stream, args, deps);
+
+      if (!dst.is_same(result))
+        result.copy_(dst);
+
+      return matmul_event;
     }
-  }
 
-  b = b.contiguous(); // avoid reorder 2 times
-
-  // xpu matmul support both ab/ba shape for m2 tensor, we don't check any more
-  auto m1_usr_dt = get_onednn_dtype_include_double(m1);
-  auto m2_usr_dt = get_onednn_dtype_include_double(m2);
-  auto dst_usr_dt = get_onednn_dtype_include_double(dst);
-
-  auto m1_dt = m1_usr_dt;
-  auto m2_dt = m2_usr_dt;
-  auto dst_dt = dst_usr_dt;
-  dnnl::memory::data_type bias_dt;
-
-  dnnl::memory::desc m1_md, m1_usr_md, m1_any_md;
-  dnnl::memory::desc m2_md, m2_usr_md, m2_any_md;
-  dnnl::memory::desc dst_md, dst_usr_md, dst_any_md;
-  dnnl::memory::desc bias_md;
-
-  // Naive Master weight
-  if (m1_dt == dnnl::memory::data_type::bf16 &&
-      m2_dt == dnnl::memory::data_type::f32) {
-    m2_dt = dnnl::memory::data_type::bf16;
-    dst_dt = dnnl::memory::data_type::bf16;
-  } else if (
-      m1_dt == dnnl::memory::data_type::f32 &&
-      m2_dt == dnnl::memory::data_type::bf16) {
-    m1_dt = dnnl::memory::data_type::bf16;
-    dst_dt = dnnl::memory::data_type::bf16;
-  }
-
-  dnnl::memory::dims m1_dims, m2_dims, dst_dims, bias_dims;
-  dnnl::memory::dims m1_strides, m2_strides, dst_strides, bias_strides;
-  if (dims == 2) {
-    m1_dims = {m, k};
-    m2_dims = {k, n};
-    dst_dims = {m, n};
-
-    m1_strides = {m1.stride(0), m1.stride(1)};
-    if (m2_trans) {
-      m2_strides = {m2.stride(0), m2.stride(1)};
-    } else {
-      m2_strides = {m2.stride(1), m2.stride(0)};
-    }
-    dst_strides = {dst.stride(0), dst.stride(1)};
-  } else {
-    m1_dims = {m1.size(0), m, k};
-    m2_dims = {m2.size(0), k, n};
-    dst_dims = {mb, m, n};
-
-    m1_strides = {m1.stride(0), m1.stride(1), m1.stride(2)};
-    if (m2_trans) {
-      m2_strides = {m2.stride(0), m2.stride(1), m2.stride(2)};
-    } else {
-      m2_strides = {m2.stride(0), m2.stride(2), m2.stride(1)};
-    }
-    dst_strides = {dst.stride(0), dst.stride(1), dst.stride(2)};
-  }
-
-  if (with_bias) {
-    bias_dims = get_onednn_dims(b);
-    bias_dt = get_onednn_dtype_include_double(b);
-    bias_strides = get_onednn_strides(b);
-  }
-
-  dnnl::post_ops po = attr.extract_post_ops(dst);
-
-  std::unordered_map<int, dnnl::memory> args;
-  dnnl::matmul matmul_p;
-  dnnl::matmul::primitive_desc matmul_pd;
-
-  // STEP1: create memory desc
-  m1_md = dnnl::memory::desc(m1_dims, m1_dt, m1_strides);
-  m2_md = dnnl::memory::desc(m2_dims, m2_dt, m2_strides);
-  dst_md = dnnl::memory::desc(dst_dims, dst_dt, dst_strides);
-
-  // STEP2: creat attribute
-  dnnl::primitive_attr pattr;
-  pattr.set_post_ops(po);
-
-#if ONEDNN_SUPPORT_DETERMINISTIC
-  if (at::globalContext().deterministicAlgorithms() ||
-      at::globalContext().deterministicMkldnn())
-    pattr.set_deterministic(true);
-#endif
-
-  // scratchpad
-  pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-
-  if (m1_dt == dnnl::memory::data_type::f32) {
-    bool allow_tf32 = at::globalContext().allowTF32OneDNN();
-    if (allow_tf32) {
-      pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
-    } else {
-      pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
-    }
-  }
-
-  // STEP3: create primitive
-  if (with_bias) {
-    bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);
-    matmul_pd = dnnl::matmul::primitive_desc(
-        engine, m1_md, m2_md, bias_md, dst_md, pattr);
-  } else {
-    matmul_pd =
-        dnnl::matmul::primitive_desc(engine, m1_md, m2_md, dst_md, pattr);
-  }
-
-  matmul_p = dnnl::matmul(matmul_pd);
-
-  m1_usr_md = dnnl::memory::desc(m1_dims, m1_usr_dt, m1_strides);
-  m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
-  dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
-
-  // STEP4: create memory
-  auto m1_usr_m = make_onednn_memory_readonly(m1_usr_md, engine, m1.const_data_ptr());
-  auto m2_usr_m = make_onednn_memory_readonly(m2_usr_md, engine, m2.const_data_ptr());
-  auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
-
-  auto expected_m1_md = matmul_pd.src_desc();
-  auto expected_m2_md = matmul_pd.weights_desc();
-  auto expected_dst_md = matmul_pd.dst_desc();
-
-  dnnl::memory m1_m = m1_usr_m, m2_m = m2_usr_m, dst_m = dst_usr_m;
-  at::Tensor m1_, m2_, dst_;
-
-  if (attr.with_binary())
-    attr.construct_post_binary(matmul_pd, args);
-
-  size_t scratchpad_size = matmul_pd.scratchpad_desc().get_size();
-  at::Tensor scratchpad_tensor = at::empty(
-      {static_cast<int64_t>(scratchpad_size)},
-      m1.options().dtype(at::kByte),
-      std::nullopt);
-  auto scratchpad_memory = make_onednn_memory(
-      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
-  args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
-
-  args.insert({DNNL_ARG_SRC, m1_m});
-  args.insert({DNNL_ARG_WEIGHTS, m2_m});
-  args.insert({DNNL_ARG_DST, dst_m});
-  if (with_bias) {
-    auto bias_m = make_onednn_memory(bias_md, engine, b.data_ptr());
-    args.insert({DNNL_ARG_BIAS, bias_m});
-  }
-
-  sycl::event matmul_event =
-      dnnl::sycl_interop::execute(matmul_p, stream, args, deps);
-
-  if (!dst.is_same(result))
-    result.copy_(dst);
-
-  return matmul_event;
-}
-
-} // namespace at::native::onednn
+    } // namespace at::native::onednn

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -180,11 +180,11 @@ at::Tensor quantized_convolution(
 
   dnnl::memory src_m, weight_m, output_m, bias_m;
 
-  src_m = make_onednn_memory(src_md, engine, act.data_ptr());
+  src_m = make_onednn_memory_readonly(src_md, engine, act.const_data_ptr());
   output_m = make_onednn_memory(output_md, engine, output.data_ptr());
-  weight_m = make_onednn_memory(weight_md, engine, weight.data_ptr());
+  weight_m = make_onednn_memory_readonly(weight_md, engine, weight.const_data_ptr());
   if (bias.has_value()) {
-    bias_m = make_onednn_memory(bias_md, engine, bias.value().data_ptr());
+    bias_m = make_onednn_memory_readonly(bias_md, engine, bias.value().const_data_ptr());
   }
 
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -261,8 +261,8 @@ void quantized_matmul(
   m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
   dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
+  auto m1_usr_m = make_onednn_memory_readonly(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory_readonly(m2_usr_md, engine, m2.const_data_ptr());
   auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
 
   auto expected_m1_md = matmul_pd.src_desc();
@@ -286,7 +286,7 @@ void quantized_matmul(
   args.insert({DNNL_ARG_WEIGHTS, m2_m});
   args.insert({DNNL_ARG_DST, dst_m});
   if (b.defined()) {
-    auto b_m = make_onednn_memory(b_md, engine, b.data_ptr());
+    auto b_m = make_onednn_memory_readonly(b_md, engine, b.const_data_ptr());
     args.insert({DNNL_ARG_BIAS, b_m});
   }
 
@@ -499,13 +499,13 @@ sycl::event scaled_matmul(
   // 2. Prepare memory
 
   // Create memory
-  auto src_usr_m = make_onednn_memory(src_md, engine, mat1.data_ptr());
-  auto weights_usr_m = make_onednn_memory(weights_md, engine, mat2.data_ptr());
+  auto src_usr_m = make_onednn_memory_readonly(src_md, engine, mat1.const_data_ptr());
+  auto weights_usr_m = make_onednn_memory_readonly(weights_md, engine, mat2.const_data_ptr());
   auto dst_usr_m = make_onednn_memory(dst_md, engine, result.data_ptr());
   dnnl::memory b_usr_m;
   if (with_bias) {
     b_usr_m =
-        make_onednn_memory(bias_md, engine, possible_reshaped_bias.data_ptr());
+        make_onednn_memory_readonly(bias_md, engine, possible_reshaped_bias.const_data_ptr());
   }
 
   // Prepare runtime scale memories (flat 1-D views) using the specs

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -10,26 +10,35 @@ namespace at::native::onednn {
 dnnl::memory make_onednn_memory(
     dnnl::memory::desc md,
     dnnl::engine& engine,
-    void* ptr) {
+    ReadWriteUSM mem) {
   return dnnl::sycl_interop::make_memory(
       md,
       engine,
       dnnl::sycl_interop::memory_kind::usm,
-      ptr == nullptr ? DNNL_MEMORY_ALLOCATE : ptr);
+      mem.ptr ? mem.ptr : DNNL_MEMORY_ALLOCATE);
 }
 
-dnnl::memory make_onednn_memory_readonly(
+dnnl::memory make_onednn_memory(
     dnnl::memory::desc md,
     dnnl::engine& engine,
-    const void* ptr) {
-  TORCH_CHECK(ptr, "oneDNN readonly: null data_ptr");
-
-  // oneDNN requires void*, const_cast avoids COW materialization.
+    ReadOnlyUSM mem) {
   return dnnl::sycl_interop::make_memory(
       md,
       engine,
       dnnl::sycl_interop::memory_kind::usm,
-      const_cast<void*>(ptr));
+      const_cast<void*>(mem.ptr));
+}
+
+dnnl::memory make_onednn_memory(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    AllocUSM) {
+
+  return dnnl::sycl_interop::make_memory(
+      md,
+      engine,
+      dnnl::sycl_interop::memory_kind::usm,
+      DNNL_MEMORY_ALLOCATE);
 }
 
 dnnl::memory::format_tag get_dnnl_default_format(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -317,7 +317,7 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   if (tensor.storage_offset() > 0) {
     // currently onednn asks 64 byte alignment
     constexpr int alignment_byte = 64;
-    if (reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignment_byte > 0)
+    if (reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) % alignment_byte > 0)
       return false;
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -17,6 +17,20 @@ dnnl::memory make_onednn_memory(
       dnnl::sycl_interop::memory_kind::usm,
       ptr == nullptr ? DNNL_MEMORY_ALLOCATE : ptr);
 }
+// Use this helper for all read-only inputs (src, bias, binary) passed to oneDNN.
+// Do NOT use data_ptr() for inputs here.
+// Using mutable pointers may trigger COW materialization and break COW tests.
+// Only destination tensors should use writable memory.
+dnnl::memory make_onednn_memory_readonly(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    const void* ptr) {
+  return dnnl::sycl_interop::make_memory(
+      md,
+      engine,
+      dnnl::sycl_interop::memory_kind::usm,
+      const_cast<void*>(ptr));
+}
 
 dnnl::memory::format_tag get_dnnl_default_format(
     int ndims,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -17,14 +17,14 @@ dnnl::memory make_onednn_memory(
       dnnl::sycl_interop::memory_kind::usm,
       ptr == nullptr ? DNNL_MEMORY_ALLOCATE : ptr);
 }
-// Use this helper for all read-only inputs (src, bias, binary) passed to oneDNN.
-// Do NOT use data_ptr() for inputs here.
-// Using mutable pointers may trigger COW materialization and break COW tests.
-// Only destination tensors should use writable memory.
+
 dnnl::memory make_onednn_memory_readonly(
     dnnl::memory::desc md,
     dnnl::engine& engine,
     const void* ptr) {
+  TORCH_CHECK(ptr, "oneDNN readonly: null data_ptr");
+
+  // oneDNN requires void*, const_cast avoids COW materialization.
   return dnnl::sycl_interop::make_memory(
       md,
       engine,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -121,7 +121,7 @@ dnnl::memory dnnl_memory_from_host_scalar(
                      .device(kXPU);
   holder = at::empty({1}, options).fill_(host_value);
   dnnl::memory::desc md = get_onednn_md(holder);
-  dnnl::memory mem = make_onednn_memory(md, engine, holder.data_ptr());
+  dnnl::memory mem = make_onednn_memory(md, engine, usm_rw(holder));
   return mem;
 }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
@@ -66,8 +66,8 @@ void woq_matmul_int4_impl(
 
   // create usr memory
   auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
-  auto scale_usr_m = make_onednn_memory(scale_usr_md, engine, scale.data_ptr());
-  auto zp_usr_m = make_onednn_memory(zp_usr_md, engine, zp.data_ptr());
+  auto scale_usr_m = make_onednn_memory_readonly(scale_usr_md, engine, scale.const_data_ptr());
+  auto zp_usr_m = make_onednn_memory_readonly(zp_usr_md, engine, zp.const_data_ptr());
 
   // Construct md for primitive creation
   // The xxx_md describes what kinds of matmul the oneDNN does.
@@ -109,8 +109,8 @@ void woq_matmul_int4_impl(
   dnnl::matmul matmul_p;
   dnnl::matmul::primitive_desc matmul_pd;
 
-  auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
-  auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
+  auto m1_usr_m = make_onednn_memory_readonly(m1_usr_md, engine, m1.const_data_ptr());
+  auto m2_usr_m = make_onednn_memory_readonly(m2_usr_md, engine, m2.const_data_ptr());
 
   void* handle_b = m2_usr_m.get_data_handle();
   // reinterpret m2_usr_memory as u4
@@ -264,8 +264,8 @@ void woq_matmul_int4_impl_cache(
       DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
       scale.data_ptr(),
       [&]() {
-        return make_onednn_memory(
-            get_onednn_md(scale), engine, scale.data_ptr());
+        return make_onednn_memory_readonly(
+            get_onednn_md(scale), engine, scale.const_data_ptr());
       });
 
   // set zp_md for asymmetric quantization

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
@@ -13,16 +13,18 @@
 
 namespace at::native::onednn {
 
+// For read-write outputs (use data_ptr()).
 TORCH_XPU_API dnnl::memory make_onednn_memory(
     dnnl::memory::desc md,
     dnnl::engine& engine,
     void* ptr);
 
+// For read-only inputs (use const_data_ptr()).
 TORCH_XPU_API dnnl::memory make_onednn_memory_readonly(
     dnnl::memory::desc md,
     dnnl::engine& engine,
     const void* ptr);
-
+    
 // Keep non-static and non-inline
 bool set_onednn_verbose(int level);
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
@@ -18,6 +18,11 @@ TORCH_XPU_API dnnl::memory make_onednn_memory(
     dnnl::engine& engine,
     void* ptr);
 
+TORCH_XPU_API dnnl::memory make_onednn_memory_readonly(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    const void* ptr);
+
 // Keep non-static and non-inline
 bool set_onednn_verbose(int level);
 


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/2248

This PR adds strongly-typed USM wrappers in the XPU oneDNN backend
to prevent unintended COW materialization.

It replaces raw void* handles with explicit read-only and read-write types,
so input tensors cannot be bound as mutable buffers by mistake.
@pytorchbot label "topic: not user facing"

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01