### PR TITLE
[xpu][fix] Skip exact stride for XPU due to layout optimization

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1025,9 +1025,10 @@ inductor_skip_exact_stride = {
 # tensor strides compared to eager mode, so exact stride checks are relaxed
 # for certain ops.
 inductor_skip_exact_stride_xpu = {
+    "nn.functional.conv2d",
+    "nn.functional.conv_transpose2d",
     "nn.functional.max_unpool2d",
     "nn.functional.max_unpool2d.grad",
-    "nn.functional.conv_transpose2d",
 }
 
 # Custom replacements for assertEquals, in cases where a difference in value

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1021,6 +1021,15 @@ inductor_skip_exact_stride = {
     "unbind_copy",
 }
 
+# On XPU, Inductor may apply additional layout optimizations that can change
+# tensor strides compared to eager mode, so exact stride checks are relaxed
+# for certain ops.
+inductor_skip_exact_stride_xpu = {
+    "nn.functional.max_unpool2d",
+    "nn.functional.max_unpool2d.grad",
+    "nn.functional.conv_transpose2d",
+}
+
 # Custom replacements for assertEquals, in cases where a difference in value
 # may not indicate correctness.
 
@@ -1392,6 +1401,9 @@ class TestInductorOpInfo(TestCase):
 
                         # Call the appropriate check method based on device type
                         exact_stride = op_name not in inductor_skip_exact_stride
+                        # XPU has additional layout optimizations that change strides differently from eager mode.
+                        if exact_stride and GPU_TYPE == "xpu":
+                            exact_stride = op_name not in inductor_skip_exact_stride_xpu
                         if device_type == GPU_TYPE:
                             self.check_model_gpu(
                                 fn,

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1029,6 +1029,7 @@ inductor_skip_exact_stride_xpu = {
     "nn.functional.conv_transpose2d",
     "nn.functional.max_unpool2d",
     "nn.functional.max_unpool2d.grad",
+    "nn.functional.rms_norm",
 }
 
 # Custom replacements for assertEquals, in cases where a difference in value


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173784

# Motivation
This PR https://github.com/pytorch/pytorch/pull/172516 introduces exact stride checks in test_torchinductor_opinfo.py. These checks are currently stricter on XPU, which makes XPU CI red. 

On XPU, Inductor may apply additional layout optimizations compared to CUDA, which can legitimately change tensor strides relative to eager mode. As a result, enforcing exact stride equality with eager is not always appropriate on XPU, and the exact stride checks need to be relaxed for certain ops.

For example, during `GraphLowering`, XPU uses different heuristics than CUDA to decide whether and how to apply layout optimizations:
https://github.com/pytorch/pytorch/blob/6579652dc1ec00059b7f732870ee34428525dfef/torch/_inductor/graph.py#L662-L691

Additionally, even in eager mode, XPU exhibits different layout behavior compared to CUDA. A notable example is convolution:
- On XPU: channel-first input → channel-first output; channel-last input → channel-last output
- On CUDA: output is always channel-first, regardless of input layout

Given these differences, XPU currently maintains an additional skip list to exempt certain ops (mainly leverage oneDNN) from exact stride checks, allowing valid XPU-specific layout transformations while preserving test correctness.

# Additional Context
Fix https://github.com/pytorch/pytorch/issues/173472
Fix https://github.com/pytorch/pytorch/issues/173471
Fix https://github.com/pytorch/pytorch/issues/173465
Fix https://github.com/pytorch/pytorch/issues/173464
Fix https://github.com/pytorch/pytorch/issues/173364
Fix https://github.com/pytorch/pytorch/issues/173363
Fix https://github.com/pytorch/pytorch/issues/173354
Fix https://github.com/pytorch/pytorch/issues/173353
Fix https://github.com/pytorch/pytorch/issues/173351
Fix https://github.com/pytorch/pytorch/issues/173345
Fix https://github.com/pytorch/pytorch/issues/173341
Fix https://github.com/pytorch/pytorch/issues/173340
Fix https://github.com/pytorch/pytorch/issues/173339


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo