### PR TITLE
Fix linalg pinv

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -143,6 +143,23 @@ class CPUReproTests(TestCase):
         self.assertEqual(len(actual), 1)
         torch.testing.assert_close(actual[0], expected[0])
 
+    @unittest.skipUnless(torch._C.has_lapack, "LAPACK not available")
+    def test_linalg_pinv_rcond_tensor_shape(self):
+        def fn(x, rcond):
+            return torch.linalg.pinv(x, rcond=rcond)
+
+        x = torch.randn(8, 3, dtype=torch.float64)
+        rcond = torch.tensor([0.1], dtype=torch.float64)
+
+        expected = fn(x, rcond)
+
+        compiled = torch.compile(fn, backend="inductor")
+        actual = compiled(x, rcond)
+
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertEqual(actual.shape, torch.Size([3, 8]))
+        torch.testing.assert_close(actual, expected)
+
     @skipIfRocm
     def test_conv_stride_constraints(self):
         for fmt in [torch.contiguous_format, torch.channels_last]:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1549,6 +1549,25 @@ def _linalg_svd_meta(
     return U, S, V
 
 
+@register_meta([aten.linalg_pinv.atol_rtol_tensor])
+@out_wrapper()
+def linalg_pinv_meta(
+    self: Tensor,
+    *,
+    atol: Tensor | None = None,
+    rtol: Tensor | None = None,
+    hermitian: bool = False,
+) -> Tensor:
+    checkIsMatrix(self, "linalg.pinv")
+    checkFloatingOrComplex(self, "linalg.pinv")
+
+    # output shape is the transpose of input shape
+    output_shape = list(self.shape)
+    output_shape[-2], output_shape[-1] = output_shape[-1], output_shape[-2]
+
+    return self.new_empty(output_shape)
+
+
 def _linalg_broadcast_batch_dims(
     arg1: Tensor,
     arg2: Tensor,


### PR DESCRIPTION
Fixes #173052


### Summary:

- Fixes `torch.linalg.pinv` returns inconsistent output shapes between eager and inductor backends when rcond is a tensor with shape [1].
- Register meta function for shape inference

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo