### PR TITLE
Add rdna specific exception msg for TestNNDeviceTypeCUDA.test_cross_e…

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12616,7 +12616,8 @@ if __name__ == '__main__':
         # CUDA says "device-side assert triggered", ROCm says "unspecified launch failure"
         has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
         has_hip_assert = 'HIP error' in stderr and 'launch failure' in stderr
-        self.assertTrue(has_cuda_assert or has_hip_assert,
+        has_hip_rdna_assert = 'HSA_STATUS_ERROR_EXCEPTION' in stderr and 'hardware exception' in stderr
+        self.assertTrue(has_cuda_assert or has_hip_assert or has_hip_rdna_assert,
                         f"Expected device assert error in stderr, got: {stderr}")
 
 


### PR DESCRIPTION
…ntropy_loss_2d_out_of_bounds_class_index

Full exception msg on RDNA (gfx1100) looks next:
```
:0:rocdevice.cpp            :3580: 4165352498983 us:
Callback: Queue 0x7186a0e00000 aborting with error :
HSA_STATUS_ERROR_EXCEPTION:
An HSAIL operation resulted in a hardware exception.
code: 0x1016
```