### PR TITLE
Add single-level NVFP4 to scaled_mm_v2 tracing

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6859,7 +6859,9 @@ def _check_scaled_mm_sizes_v2(
                 and recipe_b[0] == ScalingType.BlockWise1x32
             )
 
-        def is_nv_single_level(recipe_a: list[ScalingType], recipe_b: list[ScalingType]):
+        def is_nv_single_level(
+            recipe_a: list[ScalingType], recipe_b: list[ScalingType]
+        ):
             return (
                 len(recipe_a) == 1
                 and len(recipe_b) == 1

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6859,6 +6859,14 @@ def _check_scaled_mm_sizes_v2(
                 and recipe_b[0] == ScalingType.BlockWise1x32
             )
 
+        def is_nv_single_level(recipe_a: list[ScalingType], recipe_b: list[ScalingType]):
+            return (
+                len(recipe_a) == 1
+                and len(recipe_b) == 1
+                and recipe_a[0] == ScalingType.BlockWise1x16
+                and recipe_b[0] == ScalingType.BlockWise1x16
+            )
+
         def is_nv(recipe_a: list[ScalingType], recipe_b: list[ScalingType]):
             return (
                 len(recipe_a) == 2
@@ -7034,6 +7042,23 @@ def _check_scaled_mm_sizes_v2(
                     f"and scale_b must have {expected_scale_b_elems} (got: {scale_b[0].numel()}). Scales must "
                     f"have types {torch.float8_e8m0fnu} (for self: {scale_a[0].dtype}, mat_b: {scale_b[0].dtype}) "
                     f"Must have swizzle type {expected_swizzle} (got self: {swizzle_a[0]}, mat_b: {swizzle_b[0]})"
+                ),
+            )
+        elif is_nv_single_level(scale_recipe_a, scale_recipe_b):
+            expected_scale_a_elems = round_up(M, 128) * round_up(ceil_div(K, 16), 4)
+            expected_scale_b_elems = round_up(N, 128) * round_up(ceil_div(K, 16), 4)
+            expected_swizzle = SwizzleType.SWIZZLE_32_4_4
+            torch._check(
+                scale_a[0].numel() == expected_scale_a_elems
+                and scale_a[0].dtype == torch.float8_e4m3fn
+                and scale_b[0].numel() == expected_scale_b_elems
+                and scale_b[0].dtype == torch.float8_e4m3fn
+                and swizzle_a[0] == expected_swizzle
+                and swizzle_b[0] == expected_swizzle,
+                lambda: (
+                    f"for single-level NV scaling scale_a must have {expected_scale_a_elems} (got: {scale_a[0].numel()}) "
+                    f"and scale_b must have {expected_scale_b_elems} (got: {scale_b[0].numel()}). Must have "
+                    f"swizzle type {expected_swizzle} (got self: {swizzle_a[0]}, mat_b: {swizzle_b[0]})"
                 ),
             )
         elif is_nv(scale_recipe_a, scale_recipe_b):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9036,6 +9036,28 @@ def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
                     torch.bfloat16,  # out_dtype
                 )
             )
+            # Single-level NVFP4
+            # [M, K] -> [M, K // 2]
+            # [K, N] -> [K // 2, N]
+            mat1_fp4 = _bfloat16_to_float4_e2m1fn_x2(mat1.to(torch.bfloat16))
+            mat2_fp4 = _bfloat16_to_float4_e2m1fn_x2(mat2.to(torch.bfloat16).t()).t()
+            scale1 = make_scale((M, K // 16)).to(torch.float8_e4m3fn)
+            scale2 = make_scale((K // 16, N)).to(torch.float8_e4m3fn)
+            samples.append(
+                SampleInput(
+                    mat1_fp4,
+                    mat2_fp4,
+                    [scale1, ],
+                    [ScalingType.BlockWise1x16, ],
+                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    [scale2, ],
+                    [ScalingType.BlockWise1x16, ],
+                    [SwizzleType.SWIZZLE_32_4_4, ],
+                    None,  # bias
+                    torch.bfloat16,  # out_dtype
+                )
+            )
+
             # NVFP4
             # [M, K] -> [M, K // 2]
             # [K, N] -> [K // 2, N]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #173806

Summary:

Some people (notably torchao) may want to use single-level NVFP4 (as-in
no second-level-scale) - extend checking support to cover this and allow
compilation to work.

Signed-off-by: Simon Layton <simonlayton@meta.com>