### PR TITLE
[fx] Respect __getstate__ in GraphPickler for GraphModule serialization

### DIFF
--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -559,7 +559,10 @@ class _GraphModulePickleData:
             _python_code = gm._real_recompile()
         else:
             _python_code = gm.recompile()
-        self.gm_dict = gm.__dict__.copy()
+        if hasattr(gm, "__getstate__"):
+            self.gm_dict = gm.__getstate__()
+        else:
+            self.gm_dict = gm.__dict__.copy()
         del self.gm_dict["_graph"]
         self.graph = _GraphPickleData(gm._graph, options)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173767
* #173801
* #173771
* __->__ #173809

_GraphModulePickleData was directly copying gm.__dict__ which bypasses
any custom __getstate__ methods defined on GraphModule subclasses. This
could cause serialization failures when subclasses need to filter out
unpicklable attributes.

Now we call __getstate__() when available, which allows GraphModule
subclasses to properly control their serialization behavior.

Co-authored-by: Claude <noreplyanthropic.com>