### PR TITLE
select_algorithm.py produces json during mm, admm, etc. tuning.

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -7718,7 +7718,9 @@ class TestLearnableBiases(InductorTestCase):
                             self.assertEqual(choice["Hkv"], expected_Hkv)
                             self.assertEqual(choice["seq_len_q"], expected_seq_len_q)
                             self.assertEqual(choice["seq_len_kv"], expected_seq_len_kv)
-                            self.assertEqual(choice["qk_head_dim"], expected_qk_head_dim)
+                            self.assertEqual(
+                                choice["qk_head_dim"], expected_qk_head_dim
+                            )
                             self.assertEqual(choice["v_head_dim"], expected_v_head_dim)
 
                             if kernel_type == "forward":

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -7659,22 +7659,39 @@ class TestLearnableBiases(InductorTestCase):
                 self.assertIsInstance(log_data, list)
                 self.assertEqual(len(log_data), 2)
 
-                keys_seen = [next(iter(entry.keys())) for entry in log_data]
+                # Check that we have both forward and backward entries
+                kernel_types_seen = [entry["kernel_type"] for entry in log_data]
+                self.assertIn("forward", kernel_types_seen)
+                self.assertIn("backward", kernel_types_seen)
 
-                expected_fwd_key = "('forward', 1, 2, 2, 128, 128, 64, 64)"
-                expected_bwd_key = "('backward', 1, 2, 2, 128, 128, 64, 64)"
-
-                self.assertIn(expected_fwd_key, keys_seen)
-                self.assertIn(expected_bwd_key, keys_seen)
+                # Expected values from the test inputs
+                expected_query_shape = "[1, 2, 128, 64]"
+                expected_key_shape = "[1, 2, 128, 64]"
+                expected_value_shape = "[1, 2, 128, 64]"
+                expected_B = 1
+                expected_Hq = 2
+                expected_Hkv = 2
+                expected_seq_len_q = 128
+                expected_seq_len_kv = 128
+                expected_qk_head_dim = 64
+                expected_v_head_dim = 64
 
                 for entry in log_data:
                     self.assertIsInstance(entry, dict)
-                    self.assertEqual(len(entry), 1)
+                    # New format has: query_shape, key_shape, value_shape, kernel_type, choices
+                    self.assertIn("kernel_type", entry)
+                    self.assertIn("choices", entry)
+                    self.assertIn("query_shape", entry)
+                    self.assertIn("key_shape", entry)
+                    self.assertIn("value_shape", entry)
 
-                    dims_key = next(iter(entry.keys()))
-                    choices = entry[dims_key]
+                    # Check shape values
+                    self.assertEqual(entry["query_shape"], expected_query_shape)
+                    self.assertEqual(entry["key_shape"], expected_key_shape)
+                    self.assertEqual(entry["value_shape"], expected_value_shape)
 
-                    kernel_type = eval(dims_key)[0]
+                    kernel_type = entry["kernel_type"]
+                    choices = entry["choices"]
 
                     self.assertIsInstance(choices, list)
                     self.assertGreater(len(choices), 0)
@@ -7686,6 +7703,23 @@ class TestLearnableBiases(InductorTestCase):
                         if choice["type"] == "triton":
                             self.assertIn("num_warps", choice)
                             self.assertIn("num_stages", choice)
+
+                            # Check numerical values in each choice
+                            self.assertIn("B", choice)
+                            self.assertIn("Hq", choice)
+                            self.assertIn("Hkv", choice)
+                            self.assertIn("seq_len_q", choice)
+                            self.assertIn("seq_len_kv", choice)
+                            self.assertIn("qk_head_dim", choice)
+                            self.assertIn("v_head_dim", choice)
+
+                            self.assertEqual(choice["B"], expected_B)
+                            self.assertEqual(choice["Hq"], expected_Hq)
+                            self.assertEqual(choice["Hkv"], expected_Hkv)
+                            self.assertEqual(choice["seq_len_q"], expected_seq_len_q)
+                            self.assertEqual(choice["seq_len_kv"], expected_seq_len_kv)
+                            self.assertEqual(choice["qk_head_dim"], expected_qk_head_dim)
+                            self.assertEqual(choice["v_head_dim"], expected_v_head_dim)
 
                             if kernel_type == "forward":
                                 self.assertIn("BLOCK_M", choice)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2784,6 +2784,83 @@ def filter_choices_by_desc_regex(choices: list[ChoiceCaller]) -> list[ChoiceCall
     return choices
 
 
+def _classify_kernel_operation(
+    name: str, choices: list[ChoiceCaller], input_nodes
+) -> str:
+    """
+    Classify the operation type for logging and filtering purposes.
+    Returns one of: "mm", "conv", "flex", or "other"
+    
+    This is more robust than simple string matching as it:
+    1. Checks template types from choices
+    2. Uses input shape patterns
+    3. Falls back to exact name matching (not substring)
+    """
+    # First, try to classify from choice types
+    if choices:
+        for choice in choices:
+            if isinstance(choice, TritonTemplateCaller):
+                # Extract template name (e.g., "mm" from "mm_1", "convolution2d" from "convolution2d_3")
+                template_name = choice.name.rsplit("_", 1)[0]
+                
+                # Check known template patterns
+                if template_name in ("mm", "bmm", "mm_persistent_tma", "grouped_mm", 
+                                    "scaled_grouped_mm", "mm_plus_mm",
+                                    "blackwell_ws_persistent_device_tma",
+                                    "scaled_mm_device_tma_main_loop_scaling"):
+                    return "mm"
+                elif template_name in ("convolution2d", "convolution3d"):
+                    return "conv"
+                elif template_name.startswith("flex_"):
+                    return "flex"
+                    
+            elif isinstance(choice, ExternKernelChoice):
+                # Check extern kernel names
+                choice_name = choice.name
+                if choice_name in ("mm", "bmm", "addmm", "baddbmm", "_int_mm", "_scaled_mm"):
+                    return "mm"
+                elif "conv" in choice_name:
+                    return "conv"
+    
+    # Second, use input shape heuristics for additional validation
+    if len(input_nodes) >= 2:
+        try:
+            input_0_shape = input_nodes[0].get_size()
+            input_1_shape = input_nodes[1].get_size()
+            
+            # Matrix multiplication patterns
+            if len(input_0_shape) == 2 and len(input_1_shape) == 2:
+                return "mm"
+            elif len(input_0_shape) == 3 and len(input_1_shape) == 3:
+                return "mm"  # bmm
+                
+            # Convolution patterns: input NCHW/NCDHW, weight OIHW/OIDHW
+            elif len(input_0_shape) in (4, 5) and len(input_1_shape) in (4, 5):
+                # Could be conv or flex_attention, prefer template name if available
+                if len(input_0_shape) == 4 and len(input_1_shape) == 4:
+                    # Check if it looks like conv (channel dims match)
+                    # Conv: input[N,C,H,W] @ weight[O,C,kH,kW] where input[1] == weight[1]
+                    try:
+                        if input_0_shape[1] == input_1_shape[1]:
+                            return "conv"
+                    except (IndexError, TypeError):
+                        pass
+                        
+        except (ValueError, IndexError, AttributeError):
+            pass
+    
+    # Last resort: exact name matching (not substring to avoid false positives)
+    name_lower = name.lower()
+    if name_lower in ("mm", "bmm", "addmm", "baddbmm"):
+        return "mm"
+    elif name_lower in ("convolution", "convolution2d", "convolution3d", "conv2d", "conv3d"):
+        return "conv"
+    elif name_lower.startswith("flex_"):
+        return "flex"
+    
+    return "other"
+
+
 class AlgorithmSelectorCache(PersistentCache):
     """
     A persistent cache for algorithm selection results used in autotuning of GEMMs
@@ -2888,41 +2965,6 @@ class AlgorithmSelectorCache(PersistentCache):
             return_multi_template = False
 
         # TODO - assert that we have not mutating kernels here
-
-        if mm_file_name := get_mm_log_filename():
-            # Only log for MM-like operations (not flex_attention, etc.)
-            # MM operations have 2D inputs, flex_attention has 4D
-            if "mm" in name and len(input_nodes) >= 2:
-                try:
-                    M, K = input_nodes[-2].get_size()[:2]
-                    N = input_nodes[-1].get_size()[-1]
-                    append_to_log(
-                        mm_file_name, {"invoke": str((M, K, N)), "kernel_type": name}
-                    )
-                except (ValueError, IndexError):
-                    # Skip logging if inputs don't match MM pattern
-                    pass
-
-        if conv_file_name := get_conv_log_filename():
-            # Only log for convolution operations
-            if "conv" in name and len(input_nodes) >= 2:
-                try:
-                    # Extract conv dimensions: input shape [N, C, H, W] or [N, C, H, W, D]
-                    x_size = input_nodes[0].get_size()
-                    w_size = input_nodes[1].get_size()
-                    append_to_log(
-                        conv_file_name,
-                        {
-                            "invoke": {
-                                "input_shape": str(x_size),
-                                "weight_shape": str(w_size),
-                            },
-                            "kernel_type": name,
-                        },
-                    )
-                except (ValueError, IndexError):
-                    # Skip logging if inputs don't match conv pattern
-                    pass
 
         if len(choices) == 0:
             raise self.create_no_valid_choices(name, "No choices exist for backend.")
@@ -4196,6 +4238,119 @@ class AlgorithmSelectorCache(PersistentCache):
         return pruned_choices
 
     @staticmethod
+    def maybe_log_mm_results(
+        name: str, input_nodes: list[ir.IRNode], timings: dict[ChoiceCaller, float]
+    ) -> None:
+        """Log matrix multiplication autotuning results."""
+        mm_filename = get_mm_log_filename()
+        if not mm_filename:
+            return
+        
+        # Classify operation to ensure it's actually an MM operation
+        choices_list = list(timings.keys())
+        operation_type = _classify_kernel_operation(name, choices_list, input_nodes)
+        if operation_type != "mm":
+            return
+        
+        if len(input_nodes) < 2:
+            return
+        
+        M, K = input_nodes[-2].get_size()[:2]
+        N = input_nodes[-1].get_size()[-1]
+        
+        def get_choice_info(choice):
+            if isinstance(choice, ExternKernelCaller):
+                return {"type": "cublas", "time": timings[choice]}
+            
+            if isinstance(choice, TritonTemplateCaller):
+                info = choice.info_dict()
+                tile = info["tile_shape"]
+                
+                tile_vals = eval(tile)  # type: ignore[arg-type]
+                BLOCK_M = tile_vals[0]
+                BLOCK_K = tile_vals[1]
+                BLOCK_N = tile_vals[2]
+                
+                return {
+                    "type": "triton",
+                    "time": timings[choice],
+                    "BLOCK_M": BLOCK_M,
+                    "BLOCK_K": BLOCK_K,
+                    "BLOCK_N": BLOCK_N,
+                    "num_stages": info["num_stages"],
+                    "num_warps": info["num_warps"],
+                    "waves_per_eu": info.get("waves_per_eu", 0),
+                    "matrix_instr_nonkdim": info.get("matrix_instr_nonkdim", 0),
+                    "kpack": info.get("kpack", 2),
+                }
+            return None
+        
+        out_dict = {
+            str((M, K, N)): [get_choice_info(choice) for choice in timings],
+            "kernel_type": name,
+        }
+        
+        append_to_log(mm_filename, out_dict)
+
+    @staticmethod
+    def maybe_log_conv_results(
+        name: str, input_nodes: list[ir.IRNode], timings: dict[ChoiceCaller, float]
+    ) -> None:
+        """Log convolution autotuning results."""
+        conv_filename = get_conv_log_filename()
+        if not conv_filename:
+            return
+        
+        # Classify operation to ensure it's actually a conv operation
+        choices_list = list(timings.keys())
+        operation_type = _classify_kernel_operation(name, choices_list, input_nodes)
+        if operation_type != "conv":
+            return
+        
+        if len(input_nodes) < 2:
+            return
+        
+        x_size = input_nodes[0].get_size()
+        w_size = input_nodes[1].get_size()
+        
+        def get_conv_choice_info(choice):
+            if choice not in timings:
+                return None
+            info = choice.info_dict()
+            
+            # Start with timing and backend type
+            result = {
+                "time": timings[choice],
+                "backend": info.get("backend", "unknown"),
+            }
+            
+            # Add all parameters from info_dict
+            for key, value in info.items():
+                if key != "backend":  # Already added
+                    # Convert non-serializable types to strings
+                    try:
+                        import json
+                        json.dumps(value)  # Test if serializable
+                        result[key] = value
+                    except (TypeError, ValueError):
+                        result[key] = str(value)
+            
+            return result
+        
+        out_dict = {
+            "input_shape": str(x_size),
+            "weight_shape": str(w_size),
+            "choices": [
+                get_conv_choice_info(choice)
+                for choice in timings
+                if get_conv_choice_info(choice) is not None
+            ],
+            "kernel_type": name,
+        }
+        
+        append_to_log(conv_filename, out_dict)
+
+    @staticmethod
     def get_flex_attention_choice_info(
         choice: ChoiceCaller, timings: dict[ChoiceCaller, float]
     ) -> dict[str, Any]:
@@ -4358,103 +4513,9 @@ class AlgorithmSelectorCache(PersistentCache):
 
         best = top_k[0]
 
-        def get_choice_info(choice):
-            if isinstance(choice, torch._inductor.select_algorithm.ExternKernelCaller):
-                return {"type": "cublas", "time": timings[choice]}
-
-            assert isinstance(
-                choice, torch._inductor.select_algorithm.TritonTemplateCaller
-            )
-
-            info = choice.info_dict()
-            tile = info["tile_shape"]
-
-            tile_vals = eval(tile)  # type: ignore[arg-type]
-            BLOCK_M = tile_vals[0]
-            BLOCK_K = tile_vals[1]
-            BLOCK_N = tile_vals[2]
-
-            return {
-                "type": "triton",
-                "time": timings[choice],
-                "BLOCK_M": BLOCK_M,
-                "BLOCK_K": BLOCK_K,
-                "BLOCK_N": BLOCK_N,
-                "num_stages": info["num_stages"],
-                "num_warps": info["num_warps"],
-                "waves_per_eu": info.get("waves_per_eu", 0),
-                "matrix_instr_nonkdim": info.get("matrix_instr_nonkdim", 0),
-                "kpack": info.get("kpack", 2),
-            }
-
-        mm_filename = get_mm_log_filename()
-        if mm_filename and "mm" in name:
-            # Only log for MM-like operations (not flex_attention, etc.)
-            try:
-                M, K = input_nodes[-2].get_size()[:2]
-                N = input_nodes[-1].get_size()[-1]
-
-                out_dict = {
-                    str((M, K, N)): [get_choice_info(choice) for choice in timings],
-                    "kernel_type": name,
-                }
-
-                append_to_log(mm_filename, out_dict)
-            except (ValueError, IndexError):
-                # Skip logging if inputs don't match MM pattern
-                pass
-
-        conv_filename = get_conv_log_filename()
-        if conv_filename and "conv" in name:
-            # Log convolution operations with detailed tuning results
-            try:
-                x_size = input_nodes[0].get_size()
-                w_size = input_nodes[1].get_size()
-
-                def get_conv_choice_info(choice):
-                    if choice not in timings:
-                        return None
-                    info = choice.info_dict()
-
-                    # Start with timing and backend type
-                    result = {
-                        "time": timings[choice],
-                        "backend": info.get("backend", "unknown"),
-                    }
-
-                    # Add all parameters from info_dict
-                    # This includes BLOCK_K, BLOCK_M, BLOCK_N, GROUPS, KERNEL_H, KERNEL_W,
-                    # PADDING_H, PADDING_W, STRIDE_H, STRIDE_W, UNROLL, kpack,
-                    # matrix_instr_nonkdim, waves_per_eu, num_stages, num_warps, etc.
-                    for key, value in info.items():
-                        if key != "backend":  # Already added
-                            # Convert non-serializable types to strings
-                            try:
-                                import json
-
-                                json.dumps(value)  # Test if serializable
-                                result[key] = value
-                            except (TypeError, ValueError):
-                                result[key] = str(value)
-
-                    return result
-
-                out_dict = {
-                    "input_shape": str(x_size),
-                    "weight_shape": str(w_size),
-                    "choices": [
-                        get_conv_choice_info(choice)
-                        for choice in timings
-                        if get_conv_choice_info(choice) is not None
-                    ],
-                    "kernel_type": name,
-                }
-
-                append_to_log(conv_filename, out_dict)
-            except (ValueError, IndexError):
-                # Skip logging if inputs don't match conv pattern
-                pass
-
+        # Log autotuning results for each operation type
+        AlgorithmSelectorCache.maybe_log_mm_results(name, input_nodes, timings)
+        AlgorithmSelectorCache.maybe_log_conv_results(name, input_nodes, timings)
         AlgorithmSelectorCache.maybe_log_flex_attention_results(
             name, input_nodes, timings
         )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2171,12 +2171,19 @@ class TritonTemplate(KernelTemplate):
 
         # Convolution-specific parameters to include in logging
         CONV_TUNABLE_KEYS = [
-            "KERNEL_H", "KERNEL_W", "KERNEL_D",
-            "STRIDE_H", "STRIDE_W", "STRIDE_D",
-            "PADDING_H", "PADDING_W", "PADDING_D",
-            "GROUPS", "UNROLL",
+            "KERNEL_H",
+            "KERNEL_W",
+            "KERNEL_D",
+            "STRIDE_H",
+            "STRIDE_W",
+            "STRIDE_D",
+            "PADDING_H",
+            "PADDING_W",
+            "PADDING_D",
+            "GROUPS",
+            "UNROLL",
         ]
-        
+
         return TritonTemplateCaller(
             kernel_hash_name,
             codegen_input_nodes,
@@ -2205,11 +2212,7 @@ class TritonTemplate(KernelTemplate):
                     for k in AlgorithmSelectorCache.FLEX_ATTENTION_TUNABLE_KEYS
                     if k in kwargs
                 },
-                **{
-                    k: kwargs[k]
-                    for k in CONV_TUNABLE_KEYS
-                    if k in kwargs
-                },
+                **{k: kwargs[k] for k in CONV_TUNABLE_KEYS if k in kwargs},
             },
             mutated_inputs=mutated_inputs,
             workspace_arg=workspace_arg,
@@ -4260,7 +4263,7 @@ class AlgorithmSelectorCache(PersistentCache):
             if "backward" in name
             else ("decode" if "decoding" in name else "forward")
         )
-        
+
         # Create shape info dictionary
         shape_info = {
             "kernel_type": kernel_type,
@@ -4274,15 +4277,17 @@ class AlgorithmSelectorCache(PersistentCache):
         }
 
         sorted_choices = sorted(timings, key=timings.__getitem__)
-        
+
         # Include shape info in each choice
         choices_with_shapes = []
         for choice in sorted_choices:
-            choice_info = AlgorithmSelectorCache.get_flex_attention_choice_info(choice, timings)
+            choice_info = AlgorithmSelectorCache.get_flex_attention_choice_info(
+                choice, timings
+            )
             # Merge shape info with choice info
             choice_info.update(shape_info)
             choices_with_shapes.append(choice_info)
-        
+
         out_dict = {
             "query_shape": str(query_size),
             "key_shape": str(key_size),
@@ -4410,13 +4415,13 @@ class AlgorithmSelectorCache(PersistentCache):
                     if choice not in timings:
                         return None
                     info = choice.info_dict()
-                    
+
                     # Start with timing and backend type
                     result = {
                         "time": timings[choice],
                         "backend": info.get("backend", "unknown"),
                     }
-                    
+
                     # Add all parameters from info_dict
                     # This includes BLOCK_K, BLOCK_M, BLOCK_N, GROUPS, KERNEL_H, KERNEL_W,
                     # PADDING_H, PADDING_W, STRIDE_H, STRIDE_W, UNROLL, kpack,
@@ -4426,11 +4431,12 @@ class AlgorithmSelectorCache(PersistentCache):
                             # Convert non-serializable types to strings
                             try:
                                 import json
+
                                 json.dumps(value)  # Test if serializable
                                 result[key] = value
                             except (TypeError, ValueError):
                                 result[key] = str(value)
-                    
+
                     return result
 
                 out_dict = {

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2871,7 +2871,9 @@ class AlgorithmSelectorCache(PersistentCache):
                 try:
                     M, K = input_nodes[-2].get_size()[:2]
                     N = input_nodes[-1].get_size()[-1]
-                    append_to_log(mm_file_name, {"invoke": str((M, K, N)), "kernel_type": name})
+                    append_to_log(
+                        mm_file_name, {"invoke": str((M, K, N)), "kernel_type": name}
+                    )
                 except (ValueError, IndexError):
                     # Skip logging if inputs don't match MM pattern
                     pass
@@ -4174,7 +4176,8 @@ class AlgorithmSelectorCache(PersistentCache):
         name: str, input_nodes: list[ir.IRNode], timings: dict[ChoiceCaller, float]
     ) -> None:
         flex_attention_filename = get_flex_attention_log_filename()
-        if not flex_attention_filename or "flex_attention" not in name:
+        # Support both flex_attention and flex_decoding
+        if not flex_attention_filename or ("flex_attention" not in name and "flex_decoding" not in name):
             return
 
         if len(input_nodes) < 3:
@@ -4192,7 +4195,7 @@ class AlgorithmSelectorCache(PersistentCache):
         seq_len_kv = key_size[2]
         v_head_dim = value_size[3]
 
-        kernel_type = "backward" if "backward" in name else "forward"
+        kernel_type = "backward" if "backward" in name else ("decode" if "decoding" in name else "forward")
         dims_key = str(
             (
                 kernel_type,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2867,7 +2867,7 @@ class AlgorithmSelectorCache(PersistentCache):
         if mm_file_name := get_mm_log_filename():
             M, K = input_nodes[-2].get_size()[:2]
             N = input_nodes[-1].get_size()[-1]
-            append_to_log(mm_file_name, {"invoke": str((M, K, N))})
+            append_to_log(mm_file_name, {"invoke": str((M, K, N)), "kernel_type": name})
 
         if len(choices) == 0:
             raise self.create_no_valid_choices(name, "No choices exist for backend.")
@@ -4300,7 +4300,10 @@ class AlgorithmSelectorCache(PersistentCache):
             M, K = input_nodes[-2].get_size()[:2]
             N = input_nodes[-1].get_size()[-1]
 
-            out_dict = {str((M, K, N)): [get_choice_info(choice) for choice in timings]}
+            out_dict = {
+                str((M, K, N)): [get_choice_info(choice) for choice in timings],
+                "kernel_type": name,
+            }
 
             append_to_log(mm_filename, out_dict)
 


### PR DESCRIPTION
Added the kernel name type into the json data produced during templated autotuning.
```json
{
   "invoke": "(4096, 4096, 4096)",
   "kernel_type": "mm" // THIS IS NEW
},
...
```
This makes downstream analysis of templated autotuning easier.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo