### PR TITLE
[inductor][testing][BE] fix test_comprehensive_pca_lowrank_cuda_float32

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1008,6 +1008,7 @@ inductor_skip_exact_stride = {
     "nn.functional.max_pool2d",
     "nn.functional.unfold",
     "ormqr",
+    "pca_lowrank",
     "polar",
     "prod",
     "qr",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173817

Summary: I missed excluding this op from the allow-list (that I recently added) because the test has been disabled due to a bug that was fixed a while ago. Adding to the list and re-enabling this test.

Fixes: https://github.com/pytorch/pytorch/issues/139828

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo