### PR TITLE
Allow claude bot react to bot queries

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -78,7 +78,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           # We filter by github.actor at workflow level, there is no point of filtering here as well
-          allowed_bots: "*"  
+          allowed_bots: "*"
           claude_args: "--model global.anthropic.claude-opus-4-5-20251101-v1:0"
           settings: '{"alwaysThinkingEnabled": true}'
           use_bedrock: "true"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -77,9 +77,11 @@ jobs:
         if: steps.fork-check.outputs.is_fork != 'true'
         uses: anthropics/claude-code-action@v1
         with:
-          use_bedrock: "true"
+          # We filter by github.actor at workflow level, there is no point of filtering here as well
+          allowed_bots: "*"  
           claude_args: "--model global.anthropic.claude-opus-4-5-20251101-v1:0"
           settings: '{"alwaysThinkingEnabled": true}'
+          use_bedrock: "true"
 
       - name: Upload usage metrics
         if: steps.fork-check.outputs.is_fork != 'true'


### PR DESCRIPTION
Currently we filter by github.actor in the workflow:

```
    if: |
      github.repository_owner == 'pytorch' &&
      contains(fromJSON('["huydhn", "seemethere", "malfet", "ZainRizvi", "jeanschmidt", "atalman", "wdvr", "izaitsevfb", "yangw-dev", "ezyang", "drisspg", "albanD", "pytorch-auto-revert[bot]", "janeyx99"]'), github.actor) &&
      (
        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
      )
```

Claude bot, by default, does not react to bot requests. But, it is reasonable to accept that claude bot should react to bots we allow in the if statement.

If we decide in the future to remove the github.actor filtering on who can run claude bot, we can then filter by bot names if we feel the need to.