### PR TITLE
[ROCm] Consider -1 as "default" value for both window sizes

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -100,6 +100,10 @@ calculate_swa(std::optional<int64_t> window_size_left,
     needs_swa = true;
     window_left = window_size_left.value_or(window_left);
     window_right = window_size_right.value_or(window_right);
+    // If both windows are set to -1, this is a "Default" value use case. no SWA
+    if(window_left == -1 && window_right == -1) {
+        return std::make_tuple(false/*needs_swa*/, 0, 0);
+    }
   }
   return std::make_tuple(needs_swa, window_left, window_right);
 #else


### PR DESCRIPTION
ROCm implementation of SWA considers -1 a special value. However, having both left and right equal to negative one needs to be treated as a default no-op scenario. This change looks for this and returns.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang