### PR TITLE
[inductor][testing][BE] Fix test_repeated_calling

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3484,7 +3484,7 @@ class AOTInductorTestsTemplate:
         segments = torch.cuda.memory._snapshot()["segments"]
         self.assertTrue(
             any(seg["requested_size"] == 400 for seg in segments),
-            f"Expected segment with size 400, got: {[s["requested_size"] for s in segments]}",
+            f"Expected segment with size 400, got: {[s['requested_size'] for s in segments]}",
         )
 
     def test_view_outputs(self):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3482,7 +3482,10 @@ class AOTInductorTestsTemplate:
         finally:
             torch.cuda.memory._record_memory_history(False)
         segments = torch.cuda.memory._snapshot()["segments"]
-        self.assertEqual(segments[0]["requested_size"], 400)
+        self.assertTrue(
+            any(seg["requested_size"] == 400 for seg in segments),
+            f"Expected segment with size 400, got: {[s["requested_size"] for s in segments]}",
+        )
 
     def test_view_outputs(self):
         class Model(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173822

This test fails intermittently in CI but I cannot reproduce locally.
I suspect the issue is that `segments[0]` may not be the segment
created by this test if other tests have allocated memory that
appears earlier in the snapshot. Search for a segment with the
expected size rather than assuming it's at index 0.

Co-authored-by: Claude

Fixes: https://github.com/pytorch/pytorch/issues/146185

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo