### PR TITLE
Fix NaN propagation in pdist

### DIFF
--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -34,7 +34,11 @@ struct dists {
 
   // Zero norm
   struct zero {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) { agg += std::isnan(diff) ? diff : (diff != static_cast<scalar_t>(0.0)); }
+    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) {
+      // cannot use min(ceil(abs(diff)), 1) because std::min does
+      // not guarantee NaN propagation (and does not work on ROCm)
+      agg += std::isnan(diff) ? diff : (diff != static_cast<scalar_t>(0.0));
+    }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
   };

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -37,7 +37,7 @@ struct dists {
     static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) {
       // cannot use min(ceil(abs(diff)), 1) because std::min does
       // not guarantee NaN propagation (and does not work on ROCm)
-      agg += std::isnan(diff) ? diff : (diff != static_cast<scalar_t>(0.0));
+      agg += (diff != diff) ? diff : (diff != static_cast<scalar_t>(0.0));
     }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -36,8 +36,11 @@ struct dists {
   // Zero norm
   struct zero {
     static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) {
-      // std::min does not guarantee NaN propagation so we need an explicit check
-      agg += at::_isnan(diff) ? diff : std::min(std::ceil(std::abs(diff)), static_cast<scalar_t>(1.0));
+      if (diff != diff) { // NaN
+        agg = diff;
+      } else if (diff != 0.0) {
+        agg += 1.0;
+      }
     }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -34,7 +34,7 @@ struct dists {
 
   // Zero norm
   struct zero {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) { agg += diff != 0.0; }
+    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) { agg += std::min(std::ceil(std::abs(diff)), static_cast<scalar_t>(1.0)); }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
   };

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -34,7 +34,14 @@ struct dists {
 
   // Zero norm
   struct zero {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) { agg += std::min(std::ceil(std::abs(diff)), static_cast<scalar_t>(1.0)); }
+    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) {
+#ifndef USE_ROCM
+      // This expression correctly handles nan propagation but causes failures in the ROCm CI
+      agg += std::min(std::ceil(std::abs(diff)), static_cast<scalar_t>(1.0));
+#else
+      agg += diff != 0.0;
+#endif // USE_ROCM
+    }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
   };

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -9,6 +9,7 @@
 #include <ATen/native/cuda/block_reduce.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
 #include <ATen/native/Distance.h>
+#include <ATen/NumericUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -35,9 +36,8 @@ struct dists {
   // Zero norm
   struct zero {
     static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) {
-      // cannot use min(ceil(abs(diff)), 1) because std::min does
-      // not guarantee NaN propagation (and does not work on ROCm)
-      agg += (diff != diff) ? diff : (diff != static_cast<scalar_t>(0.0));
+      // std::min does not guarantee NaN propagation so we need an explicit check
+      agg += at::_isnan(diff) ? diff : std::min(std::ceil(std::abs(diff)), static_cast<scalar_t>(1.0));
     }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -34,14 +34,7 @@ struct dists {
 
   // Zero norm
   struct zero {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) {
-#ifndef USE_ROCM
-      // This expression correctly handles nan propagation but causes failures in the ROCm CI
-      agg += std::min(std::ceil(std::abs(diff)), static_cast<scalar_t>(1.0));
-#else
-      agg += diff != 0.0;
-#endif // USE_ROCM
-    }
+    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t /*p*/) { agg += std::isnan(diff) ? diff : (diff != static_cast<scalar_t>(0.0)); }
     static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
     static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
   };

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5457,6 +5457,13 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             # just run a single backward, as gradcheck/gradgradcheck is expensive here
             output.sum().backward()
 
+    # test for issue reported in https://github.com/pytorch/pytorch/issues/173799
+    def test_pdist_inf_nan_propagation(self):
+        x = torch.empty((2, 2), dtype=torch.float64).fill_(float("inf"))
+        for device in device_():
+            result = F.pdist(x.to(device), p=0.0)
+            self.assertTrue(torch.isnan(result).item(), "Expected NaN in pdist output")
+
     def test_cosine_embedding_loss_with_diff_type(self):
         for device in device_():
             input1 = torch.tensor([[2, 3, 4], [6, 2, 4]], dtype=torch.double, device=device)


### PR DESCRIPTION
Updated the CUDA implementation to explicitly check for NaN when computing the L0 norm.

We cannot use the CPU implementation directly due to a longstanding ROCm bug where `std::min` and `std::max` don't correctly propagate nans.

Fixes #173799