### PR TITLE
[CI] Update onnxscript version to 0.6.0

### DIFF
--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -20,8 +20,6 @@ pip_install \
 
 pip_install coloredlogs packaging
 pip_install onnxruntime==1.23.1
-pip_install onnx-ir==0.1.15
-pip_install onnxscript==0.6.0
 
 # Cache the transformers model to be used later by ONNX tests. We need to run the transformers
 # package to download the model. By default, the model is cached at ~/.cache/huggingface/hub/

--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -21,7 +21,7 @@ pip_install \
 pip_install coloredlogs packaging
 pip_install onnxruntime==1.23.1
 pip_install onnx-ir==0.1.15
-pip_install onnxscript==0.5.4
+pip_install onnxscript==0.6.0
 
 # Cache the transformers model to be used later by ONNX tests. We need to run the transformers
 # package to download the model. By default, the model is cached at ~/.cache/huggingface/hub/

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -345,7 +345,7 @@ onnx==1.20.0
 #Pinned versions:
 #test that import:
 
-onnxscript==0.5.4
+onnxscript==0.6.0
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:

--- a/test/onnx/torchlib/test_ops.py
+++ b/test/onnx/torchlib/test_ops.py
@@ -151,7 +151,9 @@ def run_test_output_match(
     onnx_function = torchlib_op_info.op
     input_wrangler = torchlib_op_info.input_wrangler
     if (
-        not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.op_signature)
+        not ops_test_common.dtype_op_schema_compatible(
+            dtype, onnx_function.op_signature
+        )
         and dtype not in COMPLEX_TYPES
     ):
         test_suite.skipTest(

--- a/test/onnx/torchlib/test_ops.py
+++ b/test/onnx/torchlib/test_ops.py
@@ -151,12 +151,12 @@ def run_test_output_match(
     onnx_function = torchlib_op_info.op
     input_wrangler = torchlib_op_info.input_wrangler
     if (
-        not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.op_schema)
+        not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.op_signature)
         and dtype not in COMPLEX_TYPES
     ):
         test_suite.skipTest(
             f"dtype '{dtype}' is not supported by the op '{op.name}'. "
-            f"Type constraints: {onnx_function.op_schema.type_constraints}"
+            f"Type constraints: {onnx_function.op_signature.params}"
         )
 
     # Obtain the tolerance for the op

--- a/torch/onnx/_internal/_lazy_import.py
+++ b/torch/onnx/_internal/_lazy_import.py
@@ -30,10 +30,10 @@ if TYPE_CHECKING:
     import onnx
     import onnx_ir  # type: ignore[import-untyped, import-not-found]
     import onnxscript
-    import onnxscript._framework_apis.torch_2_9 as onnxscript_apis
+    import onnxscript._framework_apis.torch_2_11 as onnxscript_apis
 
 else:
     onnx = _LazyModule("onnx")
     onnx_ir = _LazyModule("onnx_ir")
     onnxscript = _LazyModule("onnxscript")
-    onnxscript_apis = _LazyModule("onnxscript._framework_apis.torch_2_9")
+    onnxscript_apis = _LazyModule("onnxscript._framework_apis.torch_2_11")


### PR DESCRIPTION
Also updated test logic, as OpSchema was replaced by OpSignature for onnx functions.

Required for https://github.com/pytorch/pytorch/pull/165083

cc @titaiwangms