### PR TITLE
[inductor][testing][BE] Improve test_mixed_mm_exhaustive

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -377,22 +377,21 @@ class TestPatternMatcher(TestCase):
         }
     )
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
-    def test_mixed_mm_exhaustive_dtypes(self):
+    @parametrize("dtype_left", (torch.float16, torch.float32, torch.bfloat16))
+    @parametrize("dtype_right", (torch.int8, torch.uint8))
+    def test_mixed_mm_exhaustive(self, dtype_left, dtype_right):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
 
-        dtypes_left = [torch.float16, torch.float32, torch.bfloat16]
-        dtypes_right = [torch.int8, torch.uint8]
         dtype_ranges = {torch.uint8: (0, 255), torch.int8: (-128, 127)}
-        for dtype_left, dtype_right in itertools.product(dtypes_left, dtypes_right):
-            low, high = dtype_ranges[dtype_right]
-            args = (
-                torch.randn(256, 256, dtype=dtype_left, device=GPU_TYPE),
-                torch.randint(
-                    low, high, (256, 256), dtype=dtype_right, device=GPU_TYPE
-                ),
-            )
-            self._test_mixed_impl(fn, args, True, False, rtol=0.16, atol=1e-4)
+        low, high = dtype_ranges[dtype_right]
+        args = (
+            torch.randn(256, 256, dtype=dtype_left, device=GPU_TYPE),
+            torch.randint(
+                low, high, (256, 256), dtype=dtype_right, device=GPU_TYPE
+            ),
+        )
+        self._test_mixed_impl(fn, args, True, False, rtol=0.16, atol=1e-4)
 
     @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: inductor"]
 import copy
-import itertools
 import os
 import unittest
 from collections.abc import Callable
@@ -387,9 +386,7 @@ class TestPatternMatcher(TestCase):
         low, high = dtype_ranges[dtype_right]
         args = (
             torch.randn(256, 256, dtype=dtype_left, device=GPU_TYPE),
-            torch.randint(
-                low, high, (256, 256), dtype=dtype_right, device=GPU_TYPE
-            ),
+            torch.randint(low, high, (256, 256), dtype=dtype_right, device=GPU_TYPE),
         )
         self._test_mixed_impl(fn, args, True, False, rtol=0.16, atol=1e-4)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173829

Summary: This test is failing intermittently in CI, but it's actually 6 tests in one and it's difficult to tell what's failing. Split it out into 6 different tests using the @parametrize decorator.

Fixes: https://github.com/pytorch/pytorch/issues/147853

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo