### PR TITLE
[inductor][testing][BE] Fix test_subclass to actually call capture_triton

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -3737,8 +3737,8 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
 
             def grid(meta):
                 return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-                capture_triton(add_kernel)[grid](x, y, output, n_elements, 16)
 
+            capture_triton(add_kernel)[grid](x, y, output, n_elements, 16)
             return output
 
         def f(x, y):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173831

The capture_triton call was incorrectly placed inside the grid function
after the return statement, making it dead code. This caused the test
to return uninitialized memory and fail intermittently.

Co-authored-by: Claude

Fixes: https://github.com/pytorch/pytorch/issues/160447

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo