### PR TITLE
[fx] Allow symbolic tracing of HigherOrderOperators that don't take callable args

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -4468,6 +4468,75 @@ event=aten::add node=add stack_trace=a = s + self.c
 event={kernel_event} node=add stack_trace=a = s + self.c"""
             )
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_graph_module_with_hop_serialization(self):
+        """
+        Test that a GraphModule containing HigherOrderOperators that don't take
+        callable arguments can be serialized and deserialized via __reduce__.
+
+        HOPs like triton_kernel_wrapper_functional don't take function arguments,
+        so they can be symbolically traced during deserialization without needing
+        special handling.
+        """
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            kernel_side_table,
+            triton_kernel_wrapper_functional,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+        from torch.testing._internal.triton_utils import mul2_kernel
+
+        kernel_side_table.reset_table()
+
+        def f(x, output):
+            out = triton_kernel_wrapper_functional(
+                kernel_idx=kernel_side_table.add_kernel(mul2_kernel),
+                constant_args_idx=kernel_side_table.add_constant_args(
+                    {"n_elements": output.numel(), "BLOCK_SIZE": 16}
+                ),
+                grid=[(x.numel(),)],
+                tma_descriptor_metadata={},
+                kwargs={
+                    "in_ptr0": x,
+                    "out_ptr": output,
+                },
+                tensors_to_clone=["in_ptr0", "out_ptr"],
+            )
+            return out["out_ptr"]
+
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        with fake_mode:
+            t1 = torch.randn(5)
+            t2 = torch.randn(5)
+        gm = make_fx(f, tracing_mode="fake")(t1, t2)
+
+        self.assertTrue(
+            any(
+                node.target == torch.ops.higher_order.triton_kernel_wrapper_functional
+                for node in gm.graph.nodes
+                if node.op == "call_function"
+            ),
+            "Graph should contain triton_kernel_wrapper_functional",
+        )
+
+        from torch._functorch._aot_autograd.aot_autograd_result import (
+            SerializedGraphModule,
+        )
+
+        serialized = SerializedGraphModule(gm)
+        deserialized = serialized.deserialize()
+
+        self.assertIsInstance(deserialized, torch.fx.GraphModule)
+        self.assertTrue(
+            any(
+                node.target == torch.ops.higher_order.triton_kernel_wrapper_functional
+                for node in deserialized.graph.nodes
+                if node.op == "call_function"
+            ),
+            "Deserialized graph should contain triton_kernel_wrapper_functional",
+        )
+
 
 def run_getitem_target():
     from torch.fx._symbolic_trace import _wrapped_methods_to_patch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173839
* #173801
* #173771
* #173810

For more context, see discussion in https://github.com/pytorch/pytorch/pull/173767

TL;DR
1) Important internal model uses triton_kernel_wrapper_functional HOP
2) Precompile needs to serialize/deserialize graph modules that contain these hops
3) `GraphModule.__reduce__` uses symbolic trace to rehydrate
4) Symbolic trace and HOPs don't compose 

Previously, `Proxy.__torch_function__` unconditionally raised a RuntimeError for
all HigherOrderOperators, preventing symbolic tracing through any HOP. This caused
issues when deserializing GraphModules containing HOPs like
`triton_kernel_wrapper_functional` via `__reduce__`, since deserialization uses
symbolic tracing to reconstruct the graph.

This change makes the behavior more nuanced: HOPs that take callable arguments
(like `cond`, `while_loop`, `map_impl`, etc.) still raise because they require
special tracing to handle their subgraphs. HOPs that don't take callable arguments
(like `triton_kernel_wrapper_functional`) are now traced normally as
`call_function` nodes.

This enables serialization/deserialization of GraphModules containing non-callable
HOPs without requiring changes to the GraphPickler infrastructure.

PR authored with Claude.