### PR TITLE
Warn wrong custom ops by default

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13645,11 +13645,27 @@ fn
             with torch._functorch.config.patch(
                 check_custom_op_aliasing=True, error_on_custom_op_aliasing=False
             ):
-                with self.assertWarnsRegex(
-                    UserWarning,
-                    "The output of this custom operator \(1\) must not also be an input",
-                ):
+                import warnings
+
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
                     _ = compiled_fn(x)
+                    aliasing_warnings = [
+                        x for x in w if "may not alias any inputs" in str(x.message)
+                    ]
+                    self.assertEqual(len(aliasing_warnings), 1)
+                    msg = str(aliasing_warnings[0].message)
+                    self.assertEqual(
+                        msg,
+                        "mylib::alias_op2 (with implementation in ???): "
+                        "The output of this custom operator (1) must not also be an input "
+                        "to this custom operator and (2) may not alias any inputs to this "
+                        "custom operator or other returns. The most common way to trigger "
+                        "this error is if we have y = custom_op(x) and y and x are the same "
+                        "Tensor. Please instead return a clone of the offending output "
+                        "tensor(s) (e.g. return x.clone()) or refactor the custom operator "
+                        "to not return y. This will become an error in PyTorch 2.12 or later.",
+                    )
 
 
 class MiscTestsPyTree(torch._inductor.test_case.TestCase):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13642,30 +13642,30 @@ fn
             x = torch.randn(10, 10)
             compiled_fn = torch.compile(fn, fullgraph=True, backend="inductor")
             # Use error_on_custom_op_aliasing=False to emit warnings instead of errors
-            with torch._functorch.config.patch(
-                check_custom_op_aliasing=True, error_on_custom_op_aliasing=False
+            with (
+                torch._functorch.config.patch(
+                    check_custom_op_aliasing=True, error_on_custom_op_aliasing=False
+                ),
+                warnings.catch_warnings(record=True) as w,
             ):
-                import warnings
-
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
-                    _ = compiled_fn(x)
-                    aliasing_warnings = [
-                        x for x in w if "may not alias any inputs" in str(x.message)
-                    ]
-                    self.assertEqual(len(aliasing_warnings), 1)
-                    msg = str(aliasing_warnings[0].message)
-                    self.assertEqual(
-                        msg,
-                        "mylib::alias_op2 (with implementation in ???): "
-                        "The output of this custom operator (1) must not also be an input "
-                        "to this custom operator and (2) may not alias any inputs to this "
-                        "custom operator or other returns. The most common way to trigger "
-                        "this error is if we have y = custom_op(x) and y and x are the same "
-                        "Tensor. Please instead return a clone of the offending output "
-                        "tensor(s) (e.g. return x.clone()) or refactor the custom operator "
-                        "to not return y. This will become an error in PyTorch 2.12 or later.",
-                    )
+                warnings.simplefilter("always")
+                _ = compiled_fn(x)
+                aliasing_warnings = [
+                    x for x in w if "may not alias any inputs" in str(x.message)
+                ]
+                self.assertEqual(len(aliasing_warnings), 1)
+                msg = str(aliasing_warnings[0].message)
+                self.assertEqual(
+                    msg,
+                    "mylib::alias_op2 (with implementation in ???): "
+                    "The output of this custom operator (1) must not also be an input "
+                    "to this custom operator and (2) may not alias any inputs to this "
+                    "custom operator or other returns. The most common way to trigger "
+                    "this error is if we have y = custom_op(x) and y and x are the same "
+                    "Tensor. Please instead return a clone of the offending output "
+                    "tensor(s) (e.g. return x.clone()) or refactor the custom operator "
+                    "to not return y. This will become an error in PyTorch 2.12 or later.",
+                )
 
 
 class MiscTestsPyTree(torch._inductor.test_case.TestCase):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13664,7 +13664,7 @@ fn
                     "this error is if we have y = custom_op(x) and y and x are the same "
                     "Tensor. Please instead return a clone of the offending output "
                     "tensor(s) (e.g. return x.clone()) or refactor the custom operator "
-                    "to not return y. This will become an error in PyTorch 2.12 or later.",
+                    "to not return y. This is deprecated and will become an error in PyTorch 2.12.",
                 )
 
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -332,7 +332,7 @@ def _check_custom_op_aliasing(name, args, kwargs, result):
         if config.error_on_custom_op_aliasing:
             raise
         else:
-            msg = f"{e} This will become an error in PyTorch 2.12 or later."
+            msg = f"{e} This is deprecated and will become an error in PyTorch 2.12."
             warnings.warn(msg, UserWarning, stacklevel=3)
 
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -332,7 +332,8 @@ def _check_custom_op_aliasing(name, args, kwargs, result):
         if config.error_on_custom_op_aliasing:
             raise
         else:
-            warnings.warn(str(e), UserWarning, stacklevel=3)
+            msg = f"{e} This will become an error in PyTorch 2.12 or later."
+            warnings.warn(msg, UserWarning, stacklevel=3)
 
 
 @functools.lru_cache(None)

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -92,8 +92,9 @@ autograd_cache_normalize_inputs = not is_fbcode()
 #   - When True: Raises RuntimeError on aliasing violations.
 #   - When False: Emits UserWarning on aliasing violations.
 #
-# Currently error_on_custom_op_aliasing is True only in CI,
-# but in 2.12, we should enable them everywhere.
+# Deprecated: Custom ops returning aliased outputs is deprecated and will
+# become an error in PyTorch 2.12. Currently error_on_custom_op_aliasing
+# is True only in CI.
 check_custom_op_aliasing = True
 error_on_custom_op_aliasing = bool(os.getenv("CI"))
 

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -92,8 +92,9 @@ autograd_cache_normalize_inputs = not is_fbcode()
 #   - When True: Raises RuntimeError on aliasing violations.
 #   - When False: Emits UserWarning on aliasing violations.
 #
-# Currently both are only enabled in CI, but eventually we should enable them everywhere.
-check_custom_op_aliasing = bool(os.getenv("CI"))
+# Currently error_on_custom_op_aliasing is True only in CI,
+# but in 2.12, we should enable them everywhere.
+check_custom_op_aliasing = True
 error_on_custom_op_aliasing = bool(os.getenv("CI"))
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #173844

By 2.12, we want to error on custom ops that have wrong schemas. In the meanwhile, we will be helping internal users to fix their custom ops.   


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo