### PR TITLE
[pyrefly] Add type coverage for torch/_dynamo core modules (1/4)

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -86,7 +86,7 @@ class AOTCompilePickler(pickle.Pickler):
         return _.__closure__[0]
 
     @classmethod
-    def _unpickle_bound_method(cls, func: Callable, base: object) -> types.MethodType:
+    def _unpickle_bound_method(cls, func: Callable[..., Any], base: object) -> types.MethodType:
         return types.MethodType(func, base)
 
     @classmethod

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -197,7 +197,7 @@ def allow_in_graph(fn):  # type: ignore[no-untyped-def]
     return fn
 
 
-def _check_mutually_exclusive_decorators(fn: Callable, decorator_name: str) -> None:
+def _check_mutually_exclusive_decorators(fn: Callable[..., Any], decorator_name: str) -> None:
     mutually_exclusive = {
         "leaf_function": trace_rules.is_leaf_function,
         "nonstrict_trace": trace_rules.is_nonstrict_trace_callable,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173855
* #173854
* #173853
* __->__ #173852

Fix empty container annotations and Callable type parameters:
- aot_compile.py, bytecode_analysis.py, bytecode_transformation.py
- code_context.py, compiled_autograd.py, convert_frame.py
- debug_utils.py, decorators.py, eval_frame.py, exc.py

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @xmfan @aditvenk