### PR TITLE
[pyrefly] Add type coverage for torch/_dynamo misc modules (3/4)

### DIFF
--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -419,6 +419,7 @@ if "__compile_source__" in globals():
                 # pyrefly: ignore [missing-attribute]
                 kernel._fn_name
                 if isinstance(kernel, JITFunction)
+                # pyrefly: ignore [missing-attribute]
                 else kernel.fn._fn_name
             )
             fn_name = fn_name.split(".")[-1]
@@ -793,6 +794,7 @@ def repro_common(
     nop_reader = NopInputReader()
     load_args(nop_reader)
 
+    # pyrefly: ignore [bad-context-manager]
     with tqdm(desc="Loading inputs", total=nop_reader.total) as pbar:
         input_reader = InputReader(save_dir=options.save_dir, pbar=pbar)
         load_args(input_reader)
@@ -883,6 +885,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
     # It is certainly faster though!  It probably makes sense to let the
     # user specify the offload strategy.
 
+    # pyrefly: ignore [bad-context-manager]
     with tqdm(desc="Compiling"):
         compiled = compile_fx_inner(mod, args)
     total = counters["inductor"]["intermediate_hooks"]
@@ -903,7 +906,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
     new_args = clone_inputs(args)
     with (
         intermediate_hook(save_hook),
-        tqdm(desc="Saving inductor intermediates", total=total) as pbar,
+        tqdm(desc="Saving inductor intermediates", total=total) as pbar,  # pyrefly: ignore [bad-context-manager]
     ):
         assert not isinstance(compiled, str)
         compiled(new_args)  # type: ignore[arg-type]
@@ -930,7 +933,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
         new_args = clone_inputs(args)
         with (
             intermediate_hook(check_hook),
-            tqdm(desc="Checking inductor determinism", total=total) as pbar,
+            tqdm(desc="Checking inductor determinism", total=total) as pbar,  # pyrefly: ignore [bad-context-manager]
         ):
             compiled(new_args)  # type: ignore[arg-type]
             assert not new_args
@@ -952,6 +955,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
     # parameters/buffers on the module
     if not options.skip_saving_float64_intermediates:
         new_mod, new_args = cast_to_fp64(copy.deepcopy(mod), clone_inputs(args))  # type: ignore[arg-type]
+        # pyrefly: ignore [bad-context-manager]
         with tqdm(desc="Saving float64 intermediates", total=total) as pbar:
             WriterInterp(new_mod, "float64").boxed_run(new_args)
         assert not new_args
@@ -973,6 +977,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
 
     if not options.skip_check_deterministic:
         new_mod, new_args = cast_to_fp64(copy.deepcopy(mod), clone_inputs(args))  # type: ignore[arg-type]
+        # pyrefly: ignore [bad-context-manager]
         with tqdm(desc="Checking float64 determinism", total=total) as pbar:
             ExactReaderInterp(new_mod).boxed_run(new_args)
             assert not new_args
@@ -1005,6 +1010,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
                 pbar.update(1)
             return r
 
+    # pyrefly: ignore [bad-context-manager]
     with tqdm(desc="Checking divergence", total=total) as pbar:
         ReaderInterp(mod).boxed_run(args)
     assert not args

--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -290,6 +290,7 @@ def repro_load_args(load_args: Any, save_dir: Optional[str]) -> tuple[Any]:
     nop_reader = NopInputReader()
     load_args(nop_reader)
 
+    # pyrefly: ignore [bad-context-manager]
     with tqdm(desc="Loading inputs", total=nop_reader.total) as pbar:
         input_reader = InputReader(save_dir=save_dir, pbar=pbar)
         load_args(input_reader)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Fix empty container annotations and missing import ignores:
- polyfills/pytree.py, polyfills/sys.py, polyfills/traceback.py
- repro/after_aot.py, repro/aoti.py
- test_case.py, test_minifier_common.py
- backends/distributed.py

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98