### PR TITLE
[TEST][SDPA] Fix pattern_matcher test assert condition to allow cuDNN SDPA

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1814,38 +1814,44 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         fwd_graph = aot_graphs[0]
         op1 = torch.ops.aten._scaled_dot_product_flash_attention.default
         op2 = torch.ops.aten._scaled_dot_product_cudnn_attention.default
-        self.assertTrue(
+        try:
+            self.assertTrue(
             count_ops(
                 fwd_graph,
                 [],
                 freq=1,
                 op=op1,
             )
-            or count_ops(
+            )
+        except AssertionError:
+            count_ops(
                 fwd_graph,
                 [],
                 freq=1,
                 op=op2,
             )
-        )
         bwd_graph = aot_graphs[1]
         # Check that sin is not recomputed in the backward graph - checks percolate tags
         self.assertTrue(count_ops(bwd_graph, [], freq=0, op=torch.ops.aten.sin.default))
         # Check that the sdpa op is recomputed in the backward graph
-        self.assertTrue(
-            count_ops(
-                bwd_graph,
-                [],
-                freq=1,
-                op=op1,
-            )
-            or count_ops(
+        try:
+            self.assertTrue(
+                count_ops(
+                    bwd_graph,
+                    [],
+                    freq=1,
+                    op=op1,
+                )
+                )
+        except AssertionError:
+            self.assertTrue(
+                count_ops(
                 bwd_graph,
                 [],
                 freq=1,
                 op=op2,
             )
-        )
+            )
 
     @requires_distributed()
     @requires_cuda_and_triton

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1812,50 +1812,25 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         opt_fn(*args1).sum().backward()
 
         fwd_graph = aot_graphs[0]
-        op1 = torch.ops.aten._scaled_dot_product_flash_attention.default
-        op2 = torch.ops.aten._scaled_dot_product_cudnn_attention.default
-        # Use a try-except as count_ops internally asserts the expected freq matches actual count
-        try:
-            self.assertTrue(
-                count_ops(
-                    fwd_graph,
-                    [],
-                    freq=1,
-                    op=op1,
-                )
-            )
-        except AssertionError:
-            self.assertTrue(
-                count_ops(
-                    fwd_graph,
-                    [],
-                    freq=1,
-                    op=op2,
-                )
-            )
+        # Determine which fused attention backend is expected based on the
+        # prioritization logic in sdp_utils.cpp:check_prefer_cudnn_attention.
+        dprops = torch.cuda.get_device_properties(device)
+        cudnn_version = (
+            torch.backends.cudnn.version()
+            if torch.backends.cudnn.is_available()
+            else 0
+        )
+        prefer_cudnn = cudnn_version > 91500 and dprops.major in (9, 10) and dprops.minor in (0, 3)
+        if prefer_cudnn:
+            sdpa_op = torch.ops.aten._scaled_dot_product_cudnn_attention.default
+        else:
+            sdpa_op = torch.ops.aten._scaled_dot_product_flash_attention.default
+        self.assertTrue(count_ops(fwd_graph, [], freq=1, op=sdpa_op))
         bwd_graph = aot_graphs[1]
         # Check that sin is not recomputed in the backward graph - checks percolate tags
         self.assertTrue(count_ops(bwd_graph, [], freq=0, op=torch.ops.aten.sin.default))
         # Check that the sdpa op is recomputed in the backward graph
-        # Same use of try-except as above
-        try:
-            self.assertTrue(
-                count_ops(
-                    bwd_graph,
-                    [],
-                    freq=1,
-                    op=op1,
-                )
-            )
-        except AssertionError:
-            self.assertTrue(
-                count_ops(
-                    bwd_graph,
-                    [],
-                    freq=1,
-                    op=op2,
-                )
-            )
+        self.assertTrue(count_ops(bwd_graph, [], freq=1, op=sdpa_op))
 
     @requires_distributed()
     @requires_cuda_and_triton

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1816,19 +1816,21 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         op2 = torch.ops.aten._scaled_dot_product_cudnn_attention.default
         try:
             self.assertTrue(
-            count_ops(
-                fwd_graph,
-                [],
-                freq=1,
-                op=op1,
-            )
+                count_ops(
+                    fwd_graph,
+                    [],
+                    freq=1,
+                    op=op1,
+                )
             )
         except AssertionError:
-            count_ops(
-                fwd_graph,
-                [],
-                freq=1,
-                op=op2,
+            self.assertTrue(
+                count_ops(
+                    fwd_graph,
+                    [],
+                    freq=1,
+                    op=op2,
+                )
             )
         bwd_graph = aot_graphs[1]
         # Check that sin is not recomputed in the backward graph - checks percolate tags
@@ -1842,15 +1844,15 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                     freq=1,
                     op=op1,
                 )
-                )
+            )
         except AssertionError:
             self.assertTrue(
                 count_ops(
-                bwd_graph,
-                [],
-                freq=1,
-                op=op2,
-            )
+                    bwd_graph,
+                    [],
+                    freq=1,
+                    op=op2,
+                )
             )
 
     @requires_distributed()

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1816,11 +1816,11 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         # prioritization logic in sdp_utils.cpp:check_prefer_cudnn_attention.
         dprops = torch.cuda.get_device_properties(device)
         cudnn_version = (
-            torch.backends.cudnn.version()
-            if torch.backends.cudnn.is_available()
-            else 0
+            torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else 0
         )
-        prefer_cudnn = cudnn_version > 91500 and dprops.major in (9, 10) and dprops.minor in (0, 3)
+        prefer_cudnn = (
+            cudnn_version > 91500 and dprops.major in (9, 10) and dprops.minor in (0, 3)
+        )
         if prefer_cudnn:
             sdpa_op = torch.ops.aten._scaled_dot_product_cudnn_attention.default
         else:

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1814,6 +1814,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         fwd_graph = aot_graphs[0]
         op1 = torch.ops.aten._scaled_dot_product_flash_attention.default
         op2 = torch.ops.aten._scaled_dot_product_cudnn_attention.default
+        # Use a try-except as count_ops internally asserts the expected freq matches actual count
         try:
             self.assertTrue(
                 count_ops(
@@ -1836,6 +1837,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         # Check that sin is not recomputed in the backward graph - checks percolate tags
         self.assertTrue(count_ops(bwd_graph, [], freq=0, op=torch.ops.aten.sin.default))
         # Check that the sdpa op is recomputed in the backward graph
+        # Same use of try-except as above
         try:
             self.assertTrue(
                 count_ops(


### PR DESCRIPTION
`count` seems to fail an assert if the passed `freq` doesn't exactly match the observed frequency and we want to allow either Flash or cuDNN here

cc @csarofeen @ptrblck @xwang233 @nWEIdia @msaroufim @jerryzh168 @tinglvv @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo