### PR TITLE
Fix: Correctly pass type to is_opaque_type in _inductor/ir.py

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9466,7 +9466,7 @@ class TorchBindObject(NonTensorObj):
         # Returns the sum of all tensors in the flattened object
         real_script_obj = self.get_real_obj()
 
-        if is_opaque_type(real_script_obj):
+        if is_opaque_type(type(real_script_obj)):
             return 0
 
         assert hasattr(real_script_obj, "__obj_flatten__")


### PR DESCRIPTION
Description:

This PR resolves an AssertionError occurring within PyTorch Inductor's opaque object handling, specifically in the get_buf_bytes method.

Problem:

An AssertionError was raised because hasattr(real_script_obj, "obj_flatten") failed. Upon investigation, the root cause was identified in the preceding if is_opaque_type(real_script_obj): check. The is_opaque_type function is designed to check if a type is opaque. However, it was being called with real_script_obj, which is an instance of an object, not the type itself. This led to incorrect branching, causing the subsequent assertion to fail when obj_flatten was not found on the instance.

Solution:

The fix involves passing the type of real_script_obj to is_opaque_type by changing is_opaque_type(real_script_obj) to is_opaque_type(type(real_script_obj)).

The change is in third_party/py/torch/_inductor/ir.py around line 9469

Failing Trace 
```
Traceback (most recent call last):
File "/<embedded stdlib>/unittest/case.py", line 58, in testPartExecutor
yield
File "/<embedded stdlib>/unittest/case.py", line 634, in run
self._callTestMethod(testMethod)
File "/<embedded stdlib>/unittest/case.py", line 589, in _callTestMethod
if method() is not None:
^^^^^^^^
File "py/torch/testing/_internal/common_utils.py", line 3365, in wrapper
method(*args, **kwargs)
File "py/torch/test/test_opaque_obj_v2.py", line 2083, in test_multiple_opaque_objects_in_backward
result = compiled_fn(x2, rng1, rng2)
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "py/torch/_dynamo/eval_frame.py", line 998, in compile_wrapper
raise e.remove_dynamo_frames() from None # see TORCHDYNAMO_VERBOSE=1
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/compile_fx.py", line 1018, in _compile_fx_inner
raise InductorError(e, currentframe()).with_traceback(
File "py/torch/_inductor/compile_fx.py", line 1014, in _compile_fx_inner
mb_compiled_graph = fx_codegen_and_compile(
^^^^^^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/compile_fx.py", line 1790, in fx_codegen_and_compile
return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/compile_fx.py", line 1604, in codegen_and_compile
num_bytes, nodes_num_elem, node_runtimes = graph.count_bytes()
^^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/graph.py", line 2412, in count_bytes
num_bytes = node.get_read_write_buffers_sizes()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<string>", line 6, in get_read_write_buffers_sizes_cache_on_self
File "py/torch/_inductor/scheduler.py", line 999, in get_read_write_buffers_sizes
return self.get_read_write_buffers_sizes_impl(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/scheduler.py", line 1019, in get_read_write_buffers_sizes_impl
self.get_read_write_buffer_accesses(
File "py/torch/_inductor/scheduler.py", line 1160, in get_read_write_buffer_accesses
buf_bytes = get_buf_bytes(buf)
^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/scheduler.py", line 1129, in get_buf_bytes
return buf.get_buf_bytes()
^^^^^^^^^^^^^^^^^^^
File "py/torch/_inductor/ir.py", line 9472, in get_buf_bytes
assert hasattr(real_script_obj, "obj_flatten")
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch._inductor.exc.InductorError: AssertionError:

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

To execute this test, run the following from the base repo dir:
PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/test_opaque_obj_v2.py TestOpaqueObject.test_multiple_opaque_objects_in_backward

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo