### PR TITLE
[pyrefly] Fix bare Callable types in torch/_dynamo (1/4)

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -86,7 +86,7 @@ class AOTCompilePickler(pickle.Pickler):
         return _.__closure__[0]
 
     @classmethod
-    def _unpickle_bound_method(cls, func: Callable, base: object) -> types.MethodType:
+    def _unpickle_bound_method(cls, func: Callable[..., Any], base: object) -> types.MethodType:
         return types.MethodType(func, base)
 
     @classmethod

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -197,7 +197,7 @@ def allow_in_graph(fn):  # type: ignore[no-untyped-def]
     return fn
 
 
-def _check_mutually_exclusive_decorators(fn: Callable, decorator_name: str) -> None:
+def _check_mutually_exclusive_decorators(fn: Callable[..., Any], decorator_name: str) -> None:
     mutually_exclusive = {
         "leaf_function": trace_rules.is_leaf_function,
         "nonstrict_trace": trace_rules.is_nonstrict_trace_callable,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173868
* #173867
* __->__ #173866

Add type parameters to bare Callable annotations:
- aot_compile.py: _unpickle_bound_method
- decorators.py: _check_mutually_exclusive_decorators

Authored with Claude.