### PR TITLE
[pyrefly] Fix type annotations in torch/_dynamo (2/4)

### DIFF
--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -678,8 +678,8 @@ class _DynamoBytecodeCodeGen(torch.fx.graph.CodeGen):
     def __init__(
         self,
         orig_arg_names: list[str],
-        dynamo_bytecode_flatten: Callable,
-        dynamo_bytecode_unflatten: Callable,
+        dynamo_bytecode_flatten: Callable[..., Any],
+        dynamo_bytecode_unflatten: Callable[..., Any],
     ) -> None:
         super().__init__()
         self.orig_arg_names = orig_arg_names

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2708,7 +2708,7 @@ class GuardBuilder(GuardBuilderBase):
                 names: dict[str, tuple[int, int]] = {}
                 source_pairs: list[tuple[Source, Source]] = []
                 derived_equalities: list[  # type: ignore[type-arg]
-                    tuple[Source, Union[Source, Symbol], Callable]
+                    tuple[Source, Source | Symbol, Callable[..., Any]]
                 ] = []
                 phantom_symbols: dict[str, Symbol] = {}
                 relaxed_sources: set[Source] = set()
@@ -4567,8 +4567,8 @@ def format_user_stack_trace(
 def get_guard_fail_reason_helper(
     guard_manager: GuardManagerWrapper,
     f_locals: dict[str, object],
-    compile_id: Optional[CompileId],
-    backend: Optional[Callable],
+    compile_id: CompileId | None,
+    backend: Callable[..., Any] | None,
 ) -> str:
     """
     Return the reason why `guard_manager` failed.
@@ -4675,7 +4675,7 @@ def get_guard_fail_reason(
     code: types.CodeType,
     f_locals: dict[str, object],
     compile_id: CompileId,
-    backend: Callable,
+    backend: Callable[..., Any],
     skip_logging: bool = False,
 ) -> str:
     if isinstance(guard_manager, DeletedGuardManagerWrapper):
@@ -4701,9 +4701,9 @@ def get_guard_fail_reason(
 
 
 def get_and_maybe_log_recompilation_reasons(
-    cache_entry: Optional[CacheEntry],
+    cache_entry: CacheEntry | None,
     frame: DynamoFrameType,
-    backend: Callable,
+    backend: Callable[..., Any],
     skip_logging: bool = False,
 ) -> list[str]:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

- Replace bare Callable with Callable[..., Any]
- Convert Union[X, Y] to X | Y syntax
- Convert Optional[X] to X | None syntax

Files: guards.py, functional_export.py

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo