### PR TITLE
[DTensor RNG][BC Breaking] Change DTensor Philox seed and offset from int to tensor

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -678,16 +678,17 @@ class DistTensorRandomOpTest(DTensorTestBase):
         (which uses uint64 view) and then re-setting it would fail with:
         OverflowError: can't convert negative int to unsigned
 
-        The fix ensures the seed getter uses uint64 view, preventing negative
-        values from appearing when the high bit is set.
+        The fix ensures the seed getter returns a tensor, preventing any
+        int conversion issues when the high bit is set.
         """
         from torch.distributed.tensor._random import _PhiloxState
 
         state = torch.zeros(16, dtype=torch.uint8, device="cpu")
         philox = _PhiloxState(state)
-        test_seed = 2**63 + 42  # This has the sign bit set when viewed as int64
+        # Create a seed with the sign bit set (valid uint64, negative as int64)
+        test_seed = torch.tensor([2**63 + 42], dtype=torch.uint64)
         philox.seed = test_seed
-        philox.seed = philox.seed
+        philox.seed = philox.seed.clone()
 
 
 class DistTensorRandomOpsTest3D(DTensorTestBase):


### PR DESCRIPTION
When tracing a DTensor random op, it involves tracing the RNG state in `OffsetBasedRNGTracker`. However the `.item()` call in the `_PhiloxState` is not fake tensor friendly. 

In this PR, we remove the `.item()` call in `_PhiloxState` so that the getter and setter of `seed` and `offset` directly interact with Tensors and it is more tracing friendly.

`_LocalPhiloxState` in `_LocalOffsetBasedRNGTracker` has a similar pattern that we could potentially get rid of the `.item()` call. Right now we don't trace local tensor, so PR keeps it unchanged but makes sure it's compatible with the new `_PhiloxState`