### PR TITLE
[docs] Fix tensordot formula indexing errors

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1255,8 +1255,8 @@ def tensordot(  # noqa: F811
     respectively, :func:`~torch.tensordot` computes
 
     .. math::
-        r_{i_0,...,i_{m-d}, i_d,...,i_n}
-          = \sum_{k_0,...,k_{d-1}} a_{i_0,...,i_{m-d},k_0,...,k_{d-1}} \times b_{k_0,...,k_{d-1}, i_d,...,i_n}.
+        r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}}
+          = \sum_{k_1,...,k_d} a_{i_1,...,i_{m-d},k_1,...,k_d} \times b_{k_1,...,k_d, j_1,...,j_{n-d}}.
 
     When called with :attr:`dims` of the list form, the given dimensions will be contracted
     in place of the last :math:`d` of :attr:`a` and the first :math:`d` of :math:`b`. The sizes


### PR DESCRIPTION
## Summary
Fixes #173879

The original `tensordot` formula had several indexing issues:

1. Tensor `a` has `m` dimensions but formula had `m+1` indices
2. Tensor `b` has `n` dimensions but formula had `n+1` indices  
3. Result `r` should have `m+n-2d` dimensions but had `m+n-2d+2` indices
4. Index names were reused (e.g., `i_d` appeared in both `a` and `b` indices when `m=n`)

## Changes

Updated the formula from:
```math
r_{i_0,...,i_{m-d}, i_d,...,i_n} = \sum_{k_0,...,k_{d-1}} a_{i_0,...,i_{m-d},k_0,...,k_{d-1}} \times b_{k_0,...,k_{d-1}, i_d,...,i_n}
```

To:
```math
r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}} = \sum_{k_1,...,k_d} a_{i_1,...,i_{m-d},k_1,...,k_d} \times b_{k_1,...,k_d, j_1,...,j_{n-d}}
```

**Key improvements:**
- Use `i` for indices from tensor `a`, `j` for indices from tensor `b` (avoids name collision)
- Start indexing at 1 (common math convention) to simplify notation
- Fix the number of indices to match actual tensor dimensions

## Verification

Example with `m=n=3`, `d=2` (from the docs):
- **Before**: `r_{i_0, i_2, i_3}` (3 indices for a 2D result - wrong)
- **After**: `r_{i_1, j_1}` (2 indices for a 2D result - correct)

cc @svekars @sekyondaMeta @AlannaBurke @ValerianRey