### PR TITLE
[docs] Clarify scatter/gather index supports int32 and int64

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4450,9 +4450,9 @@ Reducing with the addition operation is the same as using
 
 Args:
     dim (int): the axis along which to index
-    index (LongTensor): the indices of elements to scatter, can be either empty
-        or of the same dimensionality as ``src``. When empty, the operation
-        returns ``self`` unchanged.
+    index (Tensor): the indices of elements to scatter. Must have dtype ``torch.int32`` or
+        ``torch.int64``. Can be either empty or of the same dimensionality as ``src``.
+        When empty, the operation returns ``self`` unchanged.
     src (Tensor): the source element(s) to scatter.
 
 Keyword args:
@@ -4548,9 +4548,9 @@ Note:
 
 Args:
     dim (int): the axis along which to index
-    index (LongTensor): the indices of elements to scatter and add, can be
-        either empty or of the same dimensionality as ``src``. When empty, the
-        operation returns ``self`` unchanged.
+    index (Tensor): the indices of elements to scatter and add. Must have dtype ``torch.int32``
+        or ``torch.int64``. Can be either empty or of the same dimensionality as ``src``.
+        When empty, the operation returns ``self`` unchanged.
     src (Tensor): the source elements to scatter and add
 
 Example::
@@ -4610,7 +4610,8 @@ Note:
 
 Args:
     dim (int): the axis along which to index
-    index (LongTensor): the indices of elements to scatter and reduce.
+    index (Tensor): the indices of elements to scatter and reduce. Must have dtype
+        ``torch.int32`` or ``torch.int64``.
     src (Tensor): the source elements to scatter and reduce
     reduce (str): the reduction operation to apply for non-unique indices
         (:obj:`"sum"`, :obj:`"prod"`, :obj:`"mean"`, :obj:`"amax"`, :obj:`"amin"`)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4594,7 +4594,7 @@ without further error checking.
 Args:
     input (Tensor): the source tensor
     dim (int): the axis along which to index
-    index (LongTensor): the indices of elements to gather
+    index (Tensor): the indices of elements to gather. Must have dtype ``torch.int32`` or ``torch.int64``.
 
 Keyword arguments:
     sparse_grad (bool, optional): If ``True``, gradient w.r.t. :attr:`input` will be a sparse tensor.


### PR DESCRIPTION
## Summary
Fixes #162711

The documentation for `scatter_`, `scatter_add_`, `scatter_reduce_`, and `gather` previously used `LongTensor` for the index parameter, implying only `int64` was supported. Since PyTorch 2.8, `int32` is also supported for the index tensor.

## Changes

Updated the documentation for:
- `torch.gather`
- `torch.Tensor.scatter_`
- `torch.Tensor.scatter_add_`
- `torch.Tensor.scatter_reduce_`

Changed the index parameter type from `LongTensor` to `Tensor` with an explicit note that dtype must be `torch.int32` or `torch.int64`.

## Example
The issue reported that this code fails on PyTorch 2.7.1 but works on 2.8+:

```python
import torch
input = torch.arange(240).reshape([2, 3, 2, 4, 5]).type(torch.int32)
index = torch.ones([2, 1, 2, 3, 4], dtype=torch.int32)  # int32 now supported
src = torch.full([2, 10, 3, 10, 6], -99, dtype=torch.int32)
result = input.scatter(3, index, src=src, reduce="add")
```

cc @svekars @sekyondaMeta @AlannaBurke @Enigmatisms