### PR TITLE
[docs] Clarify RMSNorm eps parameter default behavior

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -365,10 +365,10 @@ class RMSNorm(Module):
 
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
-        eps: a value added to the denominator for numerical stability. If not specified,
-            uses the machine epsilon of the computation (opmath) type: fp16/bf16 and
-            fp32 inputs use ``torch.finfo(torch.float32).eps``, while fp64 inputs use
-            ``torch.finfo(torch.float64).eps``.
+        eps (float, optional): a value added to the denominator for numerical stability.
+            If not specified, uses the machine epsilon of the computation (opmath) type:
+            fp16/bf16 and fp32 inputs use ``torch.finfo(torch.float32).eps``, while fp64
+            inputs use ``torch.finfo(torch.float64).eps``. Default: ``None``
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
 


### PR DESCRIPTION
## Summary
Fixes #155527

The `RMSNorm` documentation was inconsistent between the docstring and function signature:
- **Docstring**: `eps: ... Default: torch.finfo(x.dtype).eps`
- **Signature**: `eps: float | None = None`

This was confusing because the actual behavior is that `eps=None` gets dynamically converted to `torch.finfo(x.dtype).eps` at runtime based on the input dtype.

## Changes

Updated the documentation to clearly state:
- `eps` is `(float, optional)`
- Default is `None`
- When `None`, uses `torch.finfo(x.dtype).eps`

This matches the function signature and clarifies the dynamic runtime behavior.

cc @svekars @sekyondaMeta @AlannaBurke @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @DongGeun123 @spzala