### PR TITLE
[docs] Fix RNN example to support backward pass

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -503,27 +503,27 @@ class RNN(RNNBase):
         # Efficient implementation equivalent to the following with bidirectional=False
         rnn = nn.RNN(input_size, hidden_size, num_layers)
         params = dict(rnn.named_parameters())
-        def forward(x, hx=None, batch_first=False):
+        def forward(x, h_t_minus_1=None, batch_first=False):
             if batch_first:
                 x = x.transpose(0, 1)
             seq_len, batch_size, _ = x.size()
-            if hx is None:
-                hx = torch.zeros(rnn.num_layers, batch_size, rnn.hidden_size)
-            h_t_minus_1 = hx.clone()
-            h_t = hx.clone()
+            if h_t_minus_1 is None:
+                h_t_minus_1 = torch.zeros(rnn.num_layers, batch_size, rnn.hidden_size)
             output = []
             for t in range(seq_len):
+                h_t = []
                 for layer in range(rnn.num_layers):
                     input_t = x[t] if layer == 0 else h_t[layer - 1]
-                    h_t[layer] = torch.tanh(
+                    h_t.append(torch.tanh(
                         input_t @ params[f"weight_ih_l{layer}"].T
                         + h_t_minus_1[layer] @ params[f"weight_hh_l{layer}"].T
                         + params[f"bias_hh_l{layer}"]
                         + params[f"bias_ih_l{layer}"]
-                    )
-                output.append(h_t[-1].clone())
-                h_t_minus_1 = h_t.clone()
+                    ))
+                output.append(h_t[-1])
+                h_t_minus_1 = h_t
             output = torch.stack(output)
+            h_t = torch.stack(h_t)
             if batch_first:
                 output = output.transpose(0, 1)
             return output, h_t


### PR DESCRIPTION
## Summary
Fixes #165621

The RNN docstring includes an example implementation that shows how the forward pass works internally. However, this example code used in-place tensor operations that broke the computation graph, causing gradients to not propagate correctly during `backward()`.

## Problem

The original code:
```python
h_t_minus_1 = hx.clone()
h_t = hx.clone()
for t in range(seq_len):
    for layer in range(rnn.num_layers):
        h_t[layer] = torch.tanh(...)  # in-place modification
    output.append(h_t[-1].clone())
    h_t_minus_1 = h_t.clone()
```

The `.clone()` calls and in-place `h_t[layer] = ...` operations disconnected the computation graph.

## Solution

Changed to build hidden states as a list and stack at the end:
```python
for t in range(seq_len):
    h_t = []  # fresh list each timestep
    for layer in range(rnn.num_layers):
        h_t.append(torch.tanh(...))  # append instead of in-place
    output.append(h_t[-1])
    h_t_minus_1 = h_t
output = torch.stack(output)
h_t = torch.stack(h_t)
```

This preserves the computation graph for autograd.

cc @svekars @sekyondaMeta @AlannaBurke @mikaylagawarecki @student868