### PR TITLE
[do-not-review] deeply nested modules getattr caching CI runs

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/deep_nested_module.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/deep_nested_module.py
@@ -1,0 +1,86 @@
+import sys
+
+from benchmark_base import BenchmarkBase
+
+import torch
+import torch.nn as nn
+from torch._inductor.utils import fresh_cache
+
+
+class DeepNestedModule(nn.Module):
+    """A deeply nested module chain (depth-wise, not width-wise).
+
+    This tests the performance of tracing deeply nested nn.Module hierarchies,
+    which exercises AttrSource creation with long dotted member paths like
+    "child.child.child.linear.weight".
+    """
+
+    def __init__(self, depth=40):
+        super().__init__()
+        self.depth = depth
+        if depth > 0:
+            self.child = DeepNestedModule(depth - 1)
+            self.linear = nn.Linear(10, 10)
+        else:
+            self.linear = nn.Linear(10, 10)
+
+    def forward(self, x):
+        if self.depth > 0:
+            x = self.child(x)
+        return self.linear(x)
+
+
+class Benchmark(BenchmarkBase):
+    def __init__(
+        self,
+        ModuleClass,
+        depth=40,
+        backend="eager",
+        is_gpu=False,
+        dynamic=False,
+    ):
+        self.ModuleClass = ModuleClass
+        self.depth = depth
+        self._name = f"{ModuleClass.__name__}_depth{depth}"
+        self._is_gpu = is_gpu
+
+        super().__init__(
+            category="basic",
+            backend=backend,
+            device="cuda" if self._is_gpu else "cpu",
+            dynamic=dynamic,
+        )
+
+    def name(self):
+        prefix = f"{self.category()}_{self._name}_{self.backend()}"
+        return prefix
+
+    def _prepare_once(self):
+        self.m = self.ModuleClass(depth=self.depth)
+        torch.set_float32_matmul_precision("high")
+        self.input = torch.ones(1, 10, device=self.device())
+
+    def _prepare(self):
+        torch._dynamo.reset()
+
+    def _work(self):
+        with fresh_cache():
+            opt_m = torch.compile(backend=self.backend(), dynamic=self.is_dynamic())(
+                self.m.cuda() if self._is_gpu else self.m
+            )
+            opt_m(self.input)
+
+
+def main():
+    result_path = sys.argv[1]
+    benchmarks = [
+        Benchmark(DeepNestedModule, depth=40),
+    ]
+    for b in benchmarks:
+        b.enable_compile_time_instruction_count().collect_all().append_results(
+            result_path
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -86,6 +86,10 @@ basic_NestedModule_eager,compile_time_instruction_count,6307000000,0.1
 
 
 
+basic_DeepNestedModule_depth40_eager,compile_time_instruction_count,1505000000,0.1
+
+
+
 basic_InlineMod_eager,compile_time_instruction_count,8536000000,0.1
 
 

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -161,6 +161,9 @@ def reset() -> None:
         TensorifyState.clear()
         torch._dynamo.utils.warn_once_cache.clear()
         torch._C._autograd._saved_tensors_hooks_set_tracing(False)
+        from .source import _clear_attr_source_cache
+
+        _clear_attr_source_cache()
 
         # Reset cudagraph trees unconditionally since they are global state
         # not tied to a specific backend instance


### PR DESCRIPTION
Add deep nested module instruction count benchmark

Add a benchmark that tests compilation performance for deeply nested
nn.Module hierarchies (single chain of parent-child modules, depth=40).
This exercises AttrSource creation with long dotted member paths like
"child.child.child...linear.weight".

Baseline instruction count: 1,776,000,000

Authored with Claude.

Cache AttrSource objects to avoid O(n^2) creation for deeply nested modules

When tracing deeply nested nn.Module hierarchies, AttrSource objects are
created with long dotted member paths like "child.child.child...linear.weight".
The __post_init__ method recursively splits these paths, creating intermediate
AttrSource objects. Without caching, this leads to O(n^2) object creation
for depth n, as the same intermediate objects are recreated many times.

This change adds object interning for AttrSource via __new__ that caches
objects by (base, member) key. On cache hits, the existing object is
returned and __post_init__ skips re-initialization.

For a depth=40 nested module:
- Full __post_init__ calls reduced by 93%
- Instruction count reduced from 1,776M to 1,505M (15% improvement)

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo