### PR TITLE
Cache AttrSource objects to avoid O(n^2) creation for deeply nested modules

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -86,7 +86,7 @@ basic_NestedModule_eager,compile_time_instruction_count,6307000000,0.1
 
 
 
-basic_DeepNestedModule_depth40_eager,compile_time_instruction_count,1776000000,0.1
+basic_DeepNestedModule_depth40_eager,compile_time_instruction_count,1505000000,0.1
 
 
 

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -161,6 +161,9 @@ def reset() -> None:
         TensorifyState.clear()
         torch._dynamo.utils.warn_once_cache.clear()
         torch._C._autograd._saved_tensors_hooks_set_tracing(False)
+        from .source import _clear_attr_source_cache
+
+        _clear_attr_source_cache()
 
         # Reset cudagraph trees unconditionally since they are global state
         # not tied to a specific backend instance


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #173892
* #173891

When tracing deeply nested nn.Module hierarchies, AttrSource objects are
created with long dotted member paths like "child.child.child...linear.weight".
The __post_init__ method recursively splits these paths, creating intermediate
AttrSource objects. Without caching, this leads to O(n^2) object creation
for depth n, as the same intermediate objects are recreated many times.

This change adds object interning for AttrSource via __new__ that caches
objects by (base, member) key. On cache hits, the existing object is
returned and __post_init__ skips re-initialization.

```
  Subtracting depth=1 baseline (77M) to isolate the depth-dependent cost:                                                                                                                                                                       
  ┌───────┬────────────────────────────────┬───────────┬───────────────────────────────┬───────────┬─────────────────────────────────┬─────────────┐                                                                                            
  │ Depth │ __post_init__ (before → after) │ Reduction │ Instructions (before → after) │ Reduction │ Δ Instructions (before → after) │ Δ Reduction │                                                                                            
  ├───────┼────────────────────────────────┼───────────┼───────────────────────────────┼───────────┼─────────────────────────────────┼─────────────┤                                                                                            
  │   1   │            106 → 63            │    41%    │           77M → 77M           │    0%     │             0M → 0M             │      —      │                                                                                            
  ├───────┼────────────────────────────────┼───────────┼───────────────────────────────┼───────────┼─────────────────────────────────┼─────────────┤                                                                                            
  │  10   │          1,291 → 558           │    57%    │          333M → 331M          │    1%     │           256M → 254M           │     1%      │                                                                                            
  ├───────┼────────────────────────────────┼───────────┼───────────────────────────────┼───────────┼─────────────────────────────────┼─────────────┤                                                                                            
  │  17   │         3,594 → 1,167          │    68%    │          568M → 552M          │    3%     │           491M → 475M           │     3%      │                                                                                            
  ├───────┼────────────────────────────────┼───────────┼───────────────────────────────┼───────────┼─────────────────────────────────┼─────────────┤                                                                                            
  │  20   │         5,141 → 1,488          │    71%    │          682M → 655M          │    4%     │           605M → 578M           │     4%      │                                                                                            
  ├───────┼────────────────────────────────┼───────────┼───────────────────────────────┼───────────┼─────────────────────────────────┼─────────────┤                                                                                            
  │  30   │         13,591 → 2,818         │    79%    │        1,136M → 1,026M        │    10%    │          1,059M → 949M          │     10%     │                                                                                            
  ├───────┼────────────────────────────────┼───────────┼───────────────────────────────┼───────────┼─────────────────────────────────┼─────────────┤                                                                                            
  │  40   │         28,641 → 4,548         │    84%    │        1,739M → 1,455M        │    16%    │         1,662M → 1,378M         │     17%     │                                                                                            
  └───────┴────────────────────────────────┴───────────┴───────────────────────────────┴───────────┴─────────────────────────────────┴─────────────┘                                                                                            
  The "Δ Instructions" column shows the depth-dependent overhead after removing the fixed ~77M baseline cost. The reduction percentages remain similar, confirming the improvement scales with depth.  
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo