### PR TITLE
Fix tensordot documentation

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1274,7 +1274,7 @@ def tensordot(  # noqa: F811
     When called with a non-negative integer argument :attr:`dims` = :math:`d`, and
     the number of dimensions of :attr:`a` and :attr:`b` is :math:`m` and :math:`n`,
     respectively, :func:`~torch.tensordot` computes the tensor :math:`r` of shape
-    ``a.shape[:m-d] + b.shape[d:]`` given by:
+    ``a.shape[:-dims] + b.shape[dims:]`` given by:
 
     .. math::
         r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}}

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1276,8 +1276,8 @@ def tensordot(  # noqa: F811
     respectively, :func:`~torch.tensordot` computes
 
     .. math::
-        r_{i_0,...,i_{m-d}, i_d,...,i_n}
-          = \sum_{k_0,...,k_{d-1}} a_{i_0,...,i_{m-d},k_0,...,k_{d-1}} \times b_{k_0,...,k_{d-1}, i_d,...,i_n}.
+        r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}}
+          = \sum_{k_1,...,k_d} a_{i_1,...,i_{m-d},k_1,...,k_d} \times b_{k_1,...,k_d, j_1,...,j_{n-d}}.
 
     When called with :attr:`dims` of the list form, the given dimensions will be contracted
     in place of the last :math:`d` of :attr:`a` and the first :math:`d` of :math:`b`. The sizes

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1273,7 +1273,8 @@ def tensordot(  # noqa: F811
 
     When called with a non-negative integer argument :attr:`dims` = :math:`d`, and
     the number of dimensions of :attr:`a` and :attr:`b` is :math:`m` and :math:`n`,
-    respectively, :func:`~torch.tensordot` computes
+    respectively, :func:`~torch.tensordot` computes the tensor :math:`r` of shape
+    ``a.shape[:m-d] + b.shape[d:]`` given by:
 
     .. math::
         r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}}


### PR DESCRIPTION
This fixes #173879 by using the proposed formula and indicating the shape of the result.

Examples showing that the shape indication is correct:
```python
>>> import torch
>>> a = torch.randn(2, 3, 4, 5, 6)
>>> b = torch.randn(5, 6, 7)
>>> torch.tensordot(a, b, dims=2).shape
torch.Size([2, 3, 4, 7])
>>> a.shape[:-2]
torch.Size([2, 3, 4])
>>> b.shape[2:]
torch.Size([7])

>>> a = torch.randn(2, 3, 4)
>>> b = torch.randn(2, 3, 4, 5, 6)
>>> torch.tensordot(a, b, dims=3).shape
torch.Size([5, 6])
>>> a.shape[:-3]
torch.Size([])
>>> b.shape[3:]
torch.Size([5, 6])
```