### PR TITLE
[nn] Fix softplus numerical instability with large beta values

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -965,7 +965,7 @@ void softplus_kernel(TensorIteratorBase& iter, const Scalar& beta_, const Scalar
             }
             // Use numerically stable formula: exp(-abs(y)) never overflows
             float z = std::log1p(std::exp(-std::abs(y))) / beta;
-            return static_cast<scalar_t>((y > 0.0f ? float(a) : 0.0f) + z);
+            return (y > 0.0f ? float(a) : 0.0f) + z;
           },
           [beta_vec, threshold_vec, zero_vec](Vectorized<scalar_t> a) -> Vectorized<scalar_t> {
             auto [a0, a1] = convert_to_float<scalar_t>(a);

--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -955,16 +955,36 @@ void softplus_kernel(TensorIteratorBase& iter, const Scalar& beta_, const Scalar
       auto threshold = threshold_.to<float>();
       const Vec beta_vec(beta);
       const Vec threshold_vec(threshold);
+      const Vec zero_vec(0.0f);
       cpu_kernel_vec(
           iter,
           [beta, threshold](scalar_t a) -> scalar_t {
-            return (float(a) * beta) > threshold ? a
-              : static_cast<scalar_t>((std::log1p(std::exp(float(a) * beta))) / beta);
+            float y = float(a) * beta;
+            if (y > threshold) {
+              return a;
+            } else if (y <= 0.0f) {
+              return static_cast<scalar_t>(std::log1p(std::exp(y)) / beta);
+            } else {
+              return static_cast<scalar_t>(float(a) + std::log1p(std::exp(-y)) / beta);
+            }
           },
-          [beta_vec, threshold_vec](Vectorized<scalar_t> a) -> Vectorized<scalar_t> {
+          [beta_vec, threshold_vec, zero_vec](Vectorized<scalar_t> a) -> Vectorized<scalar_t> {
             auto [a0, a1] = convert_to_float<scalar_t>(a);
-            a0 = Vec::blendv((a0 * beta_vec).exp().log1p() / beta_vec, a0, (a0 * beta_vec) > threshold_vec);
-            a1 = Vec::blendv((a1 * beta_vec).exp().log1p() / beta_vec, a1, (a1 * beta_vec) > threshold_vec);
+            Vec y0 = a0 * beta_vec;
+            Vec y1 = a1 * beta_vec;
+            // Compute both branches:
+            // negative_result = log1p(exp(y)) / beta
+            // positive_result = x + log1p(exp(-y)) / beta
+            Vec neg_result0 = y0.exp().log1p() / beta_vec;
+            Vec neg_result1 = y1.exp().log1p() / beta_vec;
+            Vec pos_result0 = a0 + (zero_vec - y0).exp().log1p() / beta_vec;
+            Vec pos_result1 = a1 + (zero_vec - y1).exp().log1p() / beta_vec;
+            // Select based on y > 0
+            Vec intermediate0 = Vec::blendv(neg_result0, pos_result0, y0 > zero_vec);
+            Vec intermediate1 = Vec::blendv(neg_result1, pos_result1, y1 > zero_vec);
+            // Select based on y > threshold
+            a0 = Vec::blendv(intermediate0, a0, y0 > threshold_vec);
+            a1 = Vec::blendv(intermediate1, a1, y1 > threshold_vec);
             return convert_from_float<scalar_t>(a0, a1);
           }
       );
@@ -976,14 +996,30 @@ void softplus_kernel(TensorIteratorBase& iter, const Scalar& beta_, const Scalar
     auto threshold = threshold_.to<scalar_t>();
     const Vec beta_vec(beta);
     const Vec threshold_vec(threshold);
+    const Vec zero_vec(static_cast<scalar_t>(0.0));
     cpu_kernel_vec(
         iter,
         [beta, threshold](scalar_t a) -> scalar_t {
-          return (a * beta) > threshold ? a
-            : static_cast<scalar_t>(std::log1p(std::exp(a * beta))) / beta;
+          scalar_t y = a * beta;
+          if (y > threshold) {
+            return a;
+          } else if (y <= scalar_t(0)) {
+            return static_cast<scalar_t>(std::log1p(std::exp(y))) / beta;
+          } else {
+            return a + static_cast<scalar_t>(std::log1p(std::exp(-y))) / beta;
+          }
         },
-        [beta_vec, threshold_vec](Vec a) -> Vec {
-          return Vec::blendv((a * beta_vec).exp().log1p() / beta_vec, a, (a * beta_vec) > threshold_vec);
+        [beta_vec, threshold_vec, zero_vec](Vec a) -> Vec {
+          Vec y = a * beta_vec;
+          // Compute both branches:
+          // negative_result = log1p(exp(y)) / beta
+          // positive_result = x + log1p(exp(-y)) / beta
+          Vec neg_result = y.exp().log1p() / beta_vec;
+          Vec pos_result = a + (zero_vec - y).exp().log1p() / beta_vec;
+          // Select based on y > 0
+          Vec intermediate = Vec::blendv(neg_result, pos_result, y > zero_vec);
+          // Select based on y > threshold
+          return Vec::blendv(intermediate, a, y > threshold_vec);
         }
     );
   });
@@ -999,19 +1035,45 @@ void softplus_backward_kernel(TensorIteratorBase& iter, const Scalar& beta_, con
     const Vec beta_vec(beta);
     const Vec threshold_vec(threshold);
     const Vec one_vec(1.0f);
+    const Vec zero_vec(0.0f);
     cpu_kernel_vec(
         iter,
         [beta, threshold](scalar_t a, scalar_t b) -> scalar_t {
-          float z = std::exp(float(b) * beta);
-          return (float(b) * beta) > threshold ? a : static_cast<scalar_t>(float(a) * z / (z + float(1.)));
+          float y = float(b) * beta;
+          if (y > threshold) {
+            return a;
+          } else if (y >= 0.0f) {
+            // For y >= 0, use stable formula: sigmoid(y) = 1 / (1 + exp(-y))
+            float sigmoid = 1.0f / (1.0f + std::exp(-y));
+            return static_cast<scalar_t>(float(a) * sigmoid);
+          } else {
+            // For y < 0, original formula is stable
+            float z = std::exp(y);
+            return static_cast<scalar_t>(float(a) * z / (z + 1.0f));
+          }
         },
-        [beta_vec, one_vec, threshold_vec](Vectorized<scalar_t> a, Vectorized<scalar_t> b) -> Vectorized<scalar_t> {
+        [beta_vec, one_vec, zero_vec, threshold_vec](Vectorized<scalar_t> a, Vectorized<scalar_t> b) -> Vectorized<scalar_t> {
           auto [a0, a1] = convert_to_float<scalar_t>(a);
           auto [b0, b1] = convert_to_float<scalar_t>(b);
-          Vec z = (b0 * beta_vec).exp();
-          a0 = Vec::blendv(a0 * z / (z + one_vec), a0, (b0 * beta_vec) > threshold_vec);
-          z = (b1 * beta_vec).exp();
-          a1 = Vec::blendv(a1 * z / (z + one_vec), a1, (b1 * beta_vec) > threshold_vec);
+          Vec y0 = b0 * beta_vec;
+          Vec y1 = b1 * beta_vec;
+          // For y >= 0: sigmoid = 1 / (1 + exp(-y))
+          Vec pos_sigmoid0 = one_vec / (one_vec + (zero_vec - y0).exp());
+          Vec pos_sigmoid1 = one_vec / (one_vec + (zero_vec - y1).exp());
+          // For y < 0: sigmoid = exp(y) / (1 + exp(y))
+          Vec z0 = y0.exp();
+          Vec z1 = y1.exp();
+          Vec neg_sigmoid0 = z0 / (z0 + one_vec);
+          Vec neg_sigmoid1 = z1 / (z1 + one_vec);
+          // Select based on y >= 0
+          Vec sigmoid0 = Vec::blendv(neg_sigmoid0, pos_sigmoid0, y0 >= zero_vec);
+          Vec sigmoid1 = Vec::blendv(neg_sigmoid1, pos_sigmoid1, y1 >= zero_vec);
+          // Compute grad * sigmoid
+          Vec result0 = a0 * sigmoid0;
+          Vec result1 = a1 * sigmoid1;
+          // Select based on y > threshold
+          a0 = Vec::blendv(result0, a0, y0 > threshold_vec);
+          a1 = Vec::blendv(result1, a1, y1 > threshold_vec);
           return convert_from_float<scalar_t>(a0, a1);
         });
     });
@@ -1023,15 +1085,36 @@ void softplus_backward_kernel(TensorIteratorBase& iter, const Scalar& beta_, con
     const Vec beta_vec(beta);
     const Vec threshold_vec(threshold);
     const Vec one_vec(static_cast<scalar_t>(1.0));
+    const Vec zero_vec(static_cast<scalar_t>(0.0));
     cpu_kernel_vec(
         iter,
         [beta, threshold](scalar_t a, scalar_t b) -> scalar_t {
-          scalar_t z = std::exp(b * beta);
-          return (b * beta) > threshold ? a : a * z / (z + scalar_t(1.));
+          scalar_t y = b * beta;
+          if (y > threshold) {
+            return a;
+          } else if (y >= scalar_t(0)) {
+            // For y >= 0, use stable formula: sigmoid(y) = 1 / (1 + exp(-y))
+            scalar_t sigmoid = scalar_t(1) / (scalar_t(1) + std::exp(-y));
+            return a * sigmoid;
+          } else {
+            // For y < 0, original formula is stable
+            scalar_t z = std::exp(y);
+            return a * z / (z + scalar_t(1));
+          }
         },
-        [beta_vec, one_vec, threshold_vec](Vec a, Vec b) -> Vec {
-          const Vec z = (b * beta_vec).exp();
-          return Vec::blendv(a * z / (z + one_vec), a, (b * beta_vec) > threshold_vec);
+        [beta_vec, one_vec, zero_vec, threshold_vec](Vec a, Vec b) -> Vec {
+          Vec y = b * beta_vec;
+          // For y >= 0: sigmoid = 1 / (1 + exp(-y))
+          Vec pos_sigmoid = one_vec / (one_vec + (zero_vec - y).exp());
+          // For y < 0: sigmoid = exp(y) / (1 + exp(y))
+          Vec z = y.exp();
+          Vec neg_sigmoid = z / (z + one_vec);
+          // Select based on y >= 0
+          Vec sigmoid = Vec::blendv(neg_sigmoid, pos_sigmoid, y >= zero_vec);
+          // Compute grad * sigmoid
+          Vec result = a * sigmoid;
+          // Select based on y > threshold
+          return Vec::blendv(result, a, y > threshold_vec);
         }
     );
   });

--- a/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
@@ -41,7 +41,7 @@ void softplus_kernel(
           // Use numerically stable formula: exp(-abs(y)) never overflows
           // For y > 0: log1p(exp(-abs(y))) / beta + a
           // For y <= 0: log1p(exp(-abs(y))) / beta + 0
-          opmath_t z = ::log1p(std::exp(-std::abs(y))) / beta;
+          opmath_t z = std::log1p(std::exp(-std::abs(y))) / beta;
           return (y > opmath_t(0) ? aop : opmath_t(0)) + z;
         });
       });

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -801,8 +801,8 @@ TORCH_IMPL_FUNC(softplus_out_mps)
                                                                                name:nil];
       MPSGraphTensor* positivePartTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
       MPSGraphTensor* softplusTensor = [mpsGraph additionWithPrimaryTensor:scaledLog1pTensor
-                                                          secondaryTensor:positivePartTensor
-                                                                     name:nil];
+                                                           secondaryTensor:positivePartTensor
+                                                                      name:nil];
       MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
                                                      truePredicateTensor:reluTensor
                                                     falsePredicateTensor:softplusTensor

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -783,17 +783,26 @@ TORCH_IMPL_FUNC(softplus_out_mps)
       MPSGraphTensor* reluTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
 
       MPSGraphTensor* reciprocalBetaTensor = [mpsGraph reciprocalWithTensor:betaTensor name:nil];
+      // y = beta * x
       MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
                                                            secondaryTensor:betaTensor
                                                                       name:nil];
       MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:bxTensor
                                                                secondaryTensor:thresholdTensor
                                                                           name:nil];
-      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:bxTensor name:nil];
+      // Numerically stable: log1p(exp(-|y|)) / beta + max(x, 0)
+      // exp(-|y|) never overflows since -|y| <= 0
+      MPSGraphTensor* absBxTensor = [mpsGraph absoluteWithTensor:bxTensor name:nil];
+      MPSGraphTensor* negAbsBxTensor = [mpsGraph negativeWithTensor:absBxTensor name:nil];
+      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:negAbsBxTensor name:nil];
       MPSGraphTensor* log1pTensor = at::native::mps::log1p(mpsGraph, expTensor);
-      MPSGraphTensor* softplusTensor = [mpsGraph multiplicationWithPrimaryTensor:log1pTensor
-                                                                 secondaryTensor:reciprocalBetaTensor
-                                                                            name:nil];
+      MPSGraphTensor* scaledLog1pTensor = [mpsGraph multiplicationWithPrimaryTensor:log1pTensor
+                                                                    secondaryTensor:reciprocalBetaTensor
+                                                                               name:nil];
+      MPSGraphTensor* positivePartTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
+      MPSGraphTensor* softplusTensor = [mpsGraph additionWithPrimaryTensor:scaledLog1pTensor
+                                                          secondaryTensor:positivePartTensor
+                                                                     name:nil];
       MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
                                                      truePredicateTensor:reluTensor
                                                     falsePredicateTensor:softplusTensor
@@ -854,17 +863,21 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps)
       MPSGraphTensor* thresholdTensor = mpsGraphScalarPlaceHolder(mpsGraph, inputTensor.dataType);
 
       MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      // y = beta * x
       MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
                                                            secondaryTensor:betaTensor
                                                                       name:nil];
-      MPSGraphTensor* expBxTensor = [mpsGraph exponentWithTensor:bxTensor name:nil];
-      MPSGraphTensor* unitExpBxTensor = [mpsGraph additionWithPrimaryTensor:expBxTensor
-                                                            secondaryTensor:unitTensor
-                                                                       name:nil];
-      MPSGraphTensor* rTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                          secondaryTensor:expBxTensor
-                                                                     name:nil];
-      rTensor = [mpsGraph divisionWithPrimaryTensor:rTensor secondaryTensor:unitExpBxTensor name:nil];
+      // Numerically stable: grad / (1 + exp(-y))
+      // For large y, exp(-y) -> 0, so result -> grad (correct)
+      // For large negative y, exp(-y) -> inf, so result -> 0 (correct)
+      MPSGraphTensor* negBxTensor = [mpsGraph negativeWithTensor:bxTensor name:nil];
+      MPSGraphTensor* expNegBxTensor = [mpsGraph exponentWithTensor:negBxTensor name:nil];
+      MPSGraphTensor* denomTensor = [mpsGraph additionWithPrimaryTensor:unitTensor
+                                                        secondaryTensor:expNegBxTensor
+                                                                   name:nil];
+      MPSGraphTensor* rTensor = [mpsGraph divisionWithPrimaryTensor:gradOutputTensor
+                                                    secondaryTensor:denomTensor
+                                                               name:nil];
       MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:bxTensor
                                                                secondaryTensor:thresholdTensor
                                                                           name:nil];

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13493,9 +13493,16 @@ if __name__ == '__main__':
         # Test numerical stability with large beta values (issue #171249)
         # Previously, softplus returned inf for positive inputs when beta was very large
         # because exp(beta * x) would overflow. The fix uses a numerically stable formula.
+        #
+        # For float16 (max ~65504), use a large but representable beta that still
+        # triggers the overflow bug (exp(1000 * 0.5) overflows in any precision).
+        if dtype == torch.float16:
+            beta = 1000.0
+            threshold = 1000.0
+        else:
+            beta = 1e30
+            threshold = 1e30
         input = torch.tensor([0.5, -1.0, 2.0], device=device, dtype=dtype)
-        beta = 1e30
-        threshold = 1e30
 
         output = F.softplus(input, beta=beta, threshold=threshold)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13487,31 +13487,31 @@ if __name__ == '__main__':
         output = model(input)
         torch.autograd.gradcheck(model, input)
 
-    def test_softplus_large_beta_numerical_stability(self, device):
+    @dtypes(torch.float32, torch.bfloat16)
+    @dtypesIfMPS(torch.float32, torch.float16)
+    def test_softplus_large_beta_numerical_stability(self, device, dtype):
         # Test numerical stability with large beta values (issue #171249)
         # Previously, softplus returned inf for positive inputs when beta was very large
         # because exp(beta * x) would overflow. The fix uses a numerically stable formula.
-        input = torch.tensor([0.5, -1.0, 2.0], device=device)
+        input = torch.tensor([0.5, -1.0, 2.0], device=device, dtype=dtype)
         beta = 1e30
         threshold = 1e30
 
         output = F.softplus(input, beta=beta, threshold=threshold)
 
-        # All outputs should be finite (no inf or nan)
         self.assertTrue(torch.isfinite(output).all().item(),
                         f"Expected all finite outputs, got {output}")
 
-        # When beta * x > threshold, output should equal x (for positive x)
-        # When beta * x <= threshold (i.e., x <= 0 for large beta), output should be ~0
-        expected = torch.tensor([0.5, 0., 2.0], device=device)
+        expected = torch.tensor([0.5, 0., 2.0], device=device, dtype=dtype)
         self.assertEqual(output, expected)
 
-        # Test backward pass stability
-        input_grad = torch.tensor([0.5, -1.0, 2.0], device=device, requires_grad=True)
-        output_grad = F.softplus(input_grad, beta=beta, threshold=threshold)
-        output_grad.sum().backward()
-        self.assertTrue(torch.isfinite(input_grad.grad).all().item(),
-                        f"Expected all finite gradients, got {input_grad.grad}")
+        # Test backward pass stability (only for float32 — reduced types lack grad support)
+        if dtype == torch.float32:
+            input_grad = torch.tensor([0.5, -1.0, 2.0], device=device, dtype=dtype, requires_grad=True)
+            output_grad = F.softplus(input_grad, beta=beta, threshold=threshold)
+            output_grad.sum().backward()
+            self.assertTrue(torch.isfinite(input_grad.grad).all().item(),
+                            f"Expected all finite gradients, got {input_grad.grad}")
 
     def test_softshrink_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13487,6 +13487,32 @@ if __name__ == '__main__':
         output = model(input)
         torch.autograd.gradcheck(model, input)
 
+    def test_softplus_large_beta_numerical_stability(self, device):
+        # Test numerical stability with large beta values (issue #171249)
+        # Previously, softplus returned inf for positive inputs when beta was very large
+        # because exp(beta * x) would overflow. The fix uses a numerically stable formula.
+        input = torch.tensor([0.5, -1.0, 2.0], device=device)
+        beta = 1e30
+        threshold = 1e30
+
+        output = F.softplus(input, beta=beta, threshold=threshold)
+
+        # All outputs should be finite (no inf or nan)
+        self.assertTrue(torch.isfinite(output).all().item(),
+                        f"Expected all finite outputs, got {output}")
+
+        # When beta * x > threshold, output should equal x (for positive x)
+        # When beta * x <= threshold (i.e., x <= 0 for large beta), output should be ~0
+        expected = torch.tensor([0.5, 0., 2.0], device=device)
+        self.assertEqual(output, expected)
+
+        # Test backward pass stability
+        input_grad = torch.tensor([0.5, -1.0, 2.0], device=device, requires_grad=True)
+        output_grad = F.softplus(input_grad, beta=beta, threshold=threshold)
+        output_grad.sum().backward()
+        self.assertTrue(torch.isfinite(input_grad.grad).all().item(),
+                        f"Expected all finite gradients, got {input_grad.grad}")
+
     def test_softshrink_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):


### PR DESCRIPTION
## Summary

Fixes #171249

When `torch.nn.functional.softplus` is called with very large beta values (e.g., `1e+30`), the current implementation can produce `inf` values for positive inputs because `exp(beta * x)` overflows.

**Before fix:**
```python
>>> import torch.nn.functional as F
>>> input = torch.tensor([0.5, -1.0, 2.0])
>>> F.softplus(input, beta=1e+30, threshold=1e+30)
tensor([inf,  0.,  2.])  # BUG: first value should be 0.5
```

**After fix:**
```python
>>> F.softplus(input, beta=1e+30, threshold=1e+30)
tensor([0.5,  0.,  2.])  # Correct
```

## Technical Details

The fix uses a numerically stable formulation that avoids overflow:

- For `y <= 0`: `log1p(exp(y)) / beta` (original formula, stable since `exp(y)` won't overflow)
- For `y > 0`: `x + log1p(exp(-y)) / beta` (mathematically equivalent formula, stable since `exp(-y)` won't overflow)

The two formulas are equivalent:
```
log(1 + exp(y)) / beta
= log(exp(y) * (exp(-y) + 1)) / beta
= (y + log(1 + exp(-y))) / beta
= x + log1p(exp(-y)) / beta
```

This matches the behavior of TensorFlow and SciPy, which use similar stable formulations.

## Changes

- `aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu`: Updated CUDA forward and backward kernels
- `aten/src/ATen/native/cpu/Activation.cpp`: Updated CPU forward and backward kernels (scalar and vectorized versions)

## Testing

Verified bug exists with PyTorch 2.7.1 Docker image:
```
Input: [0.5, -1.0, 2.0], Beta: 1e+30, Threshold: 1e+30
Before fix: [inf, 0.0, 2.0]
Expected after fix: [0.5, 0.0, 2.0]
```

## Credit

The fix approach was suggested by @lakshayg in the issue comments.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @Thrsu @lakshayg