### PR TITLE
[TEST] A couple of test enhancements and improvements

### DIFF
--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -22,7 +22,7 @@ if not c10d.is_available() or not c10d.is_nccl_available():
 
 
 import torch.distributed as dist
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     init_multigpu_helper,
     MultiProcContinuousTest,
@@ -245,11 +245,11 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl_version((2, 24), "Need NCCL 2.24+ for Float8")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @skip_but_pass_in_sandcastle_if(
+        not PLATFORM_SUPPORTS_FP8, "Float8 requires sm >= 90"
+    )
     def test_allreduce_float8(self):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
-        if not sm_is_or_higher_than(device, 9, 0):
-            self.skipTest("Float8 requires sm >= 90")
-
         numel = 1024
         tensor = torch.ones(numel, dtype=torch.float32, device=device).to(
             torch.float8_e4m3fn
@@ -915,11 +915,11 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
 
     @requires_nccl_version((2, 24), "Need NCCL 2.24+ for Float8")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    @skip_but_pass_in_sandcastle_if(
+        not PLATFORM_SUPPORTS_FP8, "Float8 requires sm >= 90"
+    )
     def test_reduce_scatter_float8(self):
         device = torch.device("cuda", self.rank_to_GPU[self.rank][0])
-        if not sm_is_or_higher_than(device, 9, 0):
-            self.skipTest("Float8 requires sm >= 90")
-
         numel = 1024
         output_tensor = torch.zeros(numel, dtype=torch.float32, device=device).to(
             torch.float8_e5m2

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -28,7 +28,6 @@ from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl,
     requires_nccl_version,
-    sm_is_or_higher_than,
 )
 from torch.testing._internal.common_utils import (
     run_tests,

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -967,8 +967,12 @@ class TestFP8Lowering(TestCase):
             )
 
         # Verify that Inductor chooses the correct scaling recipes
+        if (am, ak) == (1, 128):
+            check_scale_recipe_a = ScalingType.BlockWise1x128.value
+        else:
+            check_scale_recipe_a = ScalingType.BlockWise128x128.value
         FileCheck().check(
-            f"SCALE_RECIPE_A : tl.constexpr = {ScalingType.BlockWise1x128.value}"
+            f"SCALE_RECIPE_A : tl.constexpr = {check_scale_recipe_a}"
         ).run(code[0])
 
         if (bn, bk) == (1, 128):


### PR DESCRIPTION
Per title. 

This improves the skips and fixes the `test/inductor/test_fp8.py::TestFP8LoweringCUDA::test_main_loop_scaling` which fails with:
```
RuntimeError: Expected to find "SCALE_RECIPE_A : tl.constexpr = 4" but did not find it
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo