### PR TITLE
[PU1] Add allows_shallow_copy_to in StorageExtraMeta

### DIFF
--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -23,7 +23,11 @@ C10_API void warnDeprecatedDataPtr();
 // Currently used only for storing a custom error message
 // used when throwing an exception when data_ptr is accessed.
 struct C10_API StorageExtraMeta {
+  virtual ~StorageExtraMeta() = default;
   std::optional<std::string> custom_data_ptr_error_msg_ = std::nullopt;
+  virtual bool allows_shallow_copy_to(c10::DispatchKeySet dest) const {
+    return false;
+  }
 };
 
 // A storage represents the underlying backing data buffer for a
@@ -283,6 +287,10 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
       extra_meta_ = std::make_unique<StorageExtraMeta>();
     }
     return *extra_meta_;
+  }
+
+  void set_extra_meta(std::unique_ptr<StorageExtraMeta> extra_meta) {
+    extra_meta_ = std::move(extra_meta);
   }
 
   [[noreturn]] void throw_data_ptr_access_error() const;

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_storage.py
@@ -31,6 +31,16 @@ class TestStorage(TestCase):
         self.assertTrue(rewrapped_a.is_pinned())
         self.assertNotEqual(pinned_a.data_ptr(), rewrapped_a.data_ptr())
 
+    def test_set_data_cpu_to_openreg(self):
+        """Test cpu_tensor.data = openreg_tensor"""
+        cpu_tensor = torch.randn(2, 3, device="cpu")
+        openreg_tensor = torch.randn(2, 3, device="openreg")
+
+        cpu_tensor.data = openreg_tensor
+
+        self.assertEqual(cpu_tensor.device.type, "openreg")
+        self.assertEqual(cpu_tensor.data_ptr(), openreg_tensor.data_ptr())
+
 
 class TestSerialization(TestCase):
     def test_serialization(self):

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -485,8 +485,15 @@ void VariableHooks::set_data(
   // `var.set_data(new_data)` shallow-copies all non-autograd TensorImpl fields
   // from `new_data` to `var`. It requires that `new_data` and `var` have
   // compatible tensor type.
+  bool compatible = _has_compatible_shallow_copy_type(self, new_data);
+  if (!compatible && new_data.has_storage()) {
+    compatible = new_data.storage()
+                     .unsafeGetStorageImpl()
+                     ->get_extra_meta()
+                     .allows_shallow_copy_to(self.key_set());
+  }
   TORCH_CHECK(
-      _has_compatible_shallow_copy_type(self, new_data),
+      compatible,
       "Attempted to call `variable.set_data(tensor)`, but `variable` and `tensor` have incompatible tensor type.");
 
   TORCH_CHECK(


### PR DESCRIPTION
Refer to #173021

Adding a new method `allows_shallow_copy_to` within `StorageExtraMeta` for PU1 device.

cc @fffrog 