### PR TITLE
XPU: async dist.all_reduce wait ensure collective completion(#173897)

### DIFF
--- a/torch/distributed/algorithms/join.py
+++ b/torch/distributed/algorithms/join.py
@@ -336,6 +336,12 @@ class Join:
         # Schedule an all-reduce to indicate that the caller has not yet joined
         ones = torch.ones(1, device=device)
         work = dist.all_reduce(ones, group=process_group, async_op=True)
+        if (
+            work is not None
+            and isinstance(device, torch.device)
+            and "xpu" == device.type
+        ):
+            work.wait()
 
         if join_config.throw_on_early_termination:
             # Check if uneven inputs have been detected


### PR DESCRIPTION
XPU: async dist.all_reduce execution torch.xpu.synchronize doesn't ensure collective completion so need to use work object wait to ensure collective completion.

Fixes #[173897](https://github.com/pytorch/pytorch/issues/173897)

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168