### PR TITLE
Remove duplicate Jinja2 requirement in CI dependencies

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -411,6 +411,5 @@ tqdm>=4.66.0
 #Description: progress bar library required for dynamo benchmarks
 #test that import: benchmarks/dynamo/*
 
-Jinja2==3.1.6
 aiohttp==3.13.3
 #Description: required for torch.distributed.debug


### PR DESCRIPTION
  Remove duplicate Jinja2 requirement in CI dependencies                                                                         
                                                                                                                                 
  Fixes  #173918                                                                                          
                                                                                                                                 
  Summary                                                                                                                                                                                                                                                   
  The .ci/docker/requirements-ci.txt file contained two entries for Jinja2 with different casing (jinja2==3.1.6 on line 304 and  
  Jinja2==3.1.6 on line 414). Since Python package names are case-insensitive, these entries are functionally identical. This                 PR removes the duplicate entry.                                                       
                                                                                                                                 
  Changes                                                                                                                                                                                                                                         
  Removed Jinja2==3.1.6 from line 414 while keeping the original jinja2==3.1.6 entry at line 304.                                
                                                                                                                                 
  Testing                                                                                                                                                                                                                                               
  Verified that pip treats package names case-insensitively and installs Jinja2 only once regardless of multiple entries with    
  different casing in requirements.txt.                                                                                          
                                                                                                                                 
  Impact                                                                                                                         
  No functional change                                                  
  Improves code quality
  
  @pytorchbot label "topic: not user facing"