### PR TITLE
[ROCm] Enable and Fix flaky test_dont_aggressively_write_assert

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4971,8 +4971,11 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         # there is no backed assert on them. The reason this is ok is
         # because dynamo will only skip the assert statement, but not
         # the instructions before it.
+
+        # The code generation can non-deterministically use either form
+        generated_code = str(graph.code).strip().replace(".gt(0)", " > 0")
         self.assertExpectedInline(
-            str(graph.code).strip(),
+            generated_code,
             """\
 def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
     l_x_ = L_x_


### PR DESCRIPTION
Fixes #156570

The test `test_dont_aggressively_write_assert` was failing intermittently with the following error:

```
AssertionError: "def [178 chars]sum_1 > 0;  sum_1 = None..." != "def [178 chars]sum_1.gt(0);  sum_1 = None..."
-     gt_1 = sum_1 > 0;  sum_1 = None
?                 ^^^
+     gt_1 = sum_1.gt(0);  sum_1 = None
?                 ^^^^ +
```

PyTorch's code generation non-deterministically produces either:
- Operator form: `sum_1 > 0`
- Method form: `sum_1.gt(0)`

Both forms are semantically equivalent, but the exact string comparison in `assertExpectedInline` would fail when the representation changed.

### Solution

Normalize the generated code by converting `.gt(0)` to ` > 0` before comparison:

### Testing
Test passes consistently.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela