### PR TITLE
Register QuantizedXPU dispatch key

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -961,7 +961,7 @@
   dispatch:
     ZeroTensor, CPU, CUDA, MTIA, MPS: as_strided_tensorimpl
     Meta: as_strided_tensorimpl_meta_symint
-    QuantizedCPU, QuantizedCUDA: as_strided_qtensorimpl
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: as_strided_qtensorimpl
   device_check: NoCheck
   device_guard: False
   tags: core
@@ -2433,7 +2433,7 @@
     SparseMeta: empty_sparse_symint
     SparseCsrCPU, SparseCsrCUDA: empty_sparse_compressed
     SparseCsrMeta: empty_sparse_compressed_symint
-    QuantizedCPU, QuantizedCUDA, QuantizedMeta: empty_unknown_quantized
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU, QuantizedMeta: empty_unknown_quantized
   tags: core
 
 - func: empty_permuted(SymInt[] size, int[] physical_layout, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
@@ -2483,7 +2483,7 @@
 - func: _empty_affine_quantized(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0, MemoryFormat? memory_format=contiguous_format) -> Tensor
   dispatch:
     CPU: empty_affine_quantized_other_backends_stub
-    QuantizedCPU, QuantizedCUDA: empty_affine_quantized
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: empty_affine_quantized
   autogen: _empty_affine_quantized.out
 
 # it's a factory function receiving a tensor argument, thus overriding explicitly
@@ -7146,7 +7146,7 @@
     SparseCPU, SparseCUDA, SparseMPS: clone_sparse
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: clone_sparse_compressed
     MkldnnCPU: mkldnn_clone
-    QuantizedCPU, QuantizedCUDA: quantized_clone
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: quantized_clone
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: clone_nested
   autogen: clone.out
   tags: [core, pointwise]
@@ -7931,7 +7931,7 @@
   variants: function, method
   dispatch:
     CPU, CUDA: dequantize_cpu_or_cuda
-    QuantizedCPU, QuantizedCUDA: dequantize_quantized
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: dequantize_quantized
   autogen: dequantize.self_out
 
 - func: dequantize.tensors(Tensor[] tensors) -> Tensor[]
@@ -7943,12 +7943,12 @@
 - func: q_scale(Tensor self) -> float
   variants: function, method
   dispatch:
-    QuantizedCPU, QuantizedCUDA: q_scale_quant
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: q_scale_quant
 
 - func: q_zero_point(Tensor self) -> int
   variants: function, method
   dispatch:
-    QuantizedCPU, QuantizedCUDA: q_zero_point_quant
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: q_zero_point_quant
 
 - func: q_per_channel_scales(Tensor self) -> Tensor
   variants: function, method
@@ -7990,7 +7990,7 @@
 - func: qscheme(Tensor self) -> QScheme
   variants: method
   dispatch:
-    QuantizedCPU, QuantizedCUDA: qscheme_quant
+    QuantizedCPU, QuantizedCUDA, QuantizedXPU: qscheme_quant
 
 - func: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -8422,7 +8422,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA: view
+    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, QuantizedXPU, MPS, MTIA: view
     MkldnnCPU: mkldnn_view
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: view_nested
   tags: core

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -18,7 +18,6 @@ from torch.testing._internal.common_device_type import (
     skipLazy,
     skipMeta,
     skipXLA,
-    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1140,10 +1140,6 @@ class TestViewOps(TestCase):
 
 
 class TestOldViewOps(TestCase):
-    @skipXPUIf(
-        True,
-        "NotImplementedError with test_ravel, https://github.com/intel/torch-xpu-ops/issues/2358",
-    )
     def test_ravel(self, device):
         def _test_ravel(tensors, size, nc=False):
             for src in tensors:
@@ -1304,10 +1300,6 @@ class TestOldViewOps(TestCase):
             RuntimeError, lambda: x.reshape_as(torch.rand(10, device=device))
         )
 
-    @skipXPUIf(
-        True,
-        "NotImplementedError with test_flatten,https://github.com/intel/torch-xpu-ops/issues/2358",
-    )
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
         zero_dim_tensor = torch.tensor(123, device=device)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -308,6 +308,7 @@ dispatch_keys = [
     DispatchKey.SparseCsrMPS,
     DispatchKey.QuantizedCPU,
     DispatchKey.QuantizedCUDA,
+    DispatchKey.QuantizedXPU,
     DispatchKey.CompositeImplicitAutograd,
     DispatchKey.CompositeImplicitAutogradNestedTensor,
     DispatchKey.CompositeExplicitAutograd,


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2358

This PR adds `QuantizedXPU` dispatch key support to enable quantized tensors on XPU. 

The root cause of failures in _TestOldViewOpsXPU.test_flatten_xpu_ and _TestOldViewOpsXPU.test_ravel_xpu_ was missing `QuantizedXPU` dispatch support. These tests are parametrized to use both normal and quantized tensors, and XPU couldn't create quantized tensor.

Minimal issue reproduction:
```Python
import torch
torch._empty_affine_quantized([2], dtype=torch.quint8, device="xpu")
```