### PR TITLE
Also fix typo in test after fixing error message in functorch test

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -5211,7 +5211,7 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(
             AssertionError,
-            "Combin_fn received wrong number of arguments.*",
+            "Combine_fn received wrong number of arguments.*",
         ):
             associative_scan(fct_wrong_pytree, inp, 0, combine_mode="generic")
 


### PR DESCRIPTION
Which started to fail after https://github.com/pytorch/pytorch/pull/172480 that fixed similar typo in assert expression