### PR TITLE
Replace unused attention tensor from SDPA op return values with an empty tensor for better performance

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -58,7 +58,6 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
     MPSGraphTensor* vTensor = nil;
     MPSGraphTensor* maskTensor = nil;
     MPSGraphTensor* outputTensor = nil;
-    MPSGraphTensor* attnTensor = nil;
   };
   const auto macOS15_0_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
   int64_t batchSize = query.size(0);
@@ -67,7 +66,6 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   int64_t headSize = query.size(3);
   int64_t maxSeqLength = key.size(2);
   auto out = at::empty({batchSize, num_head, qSize, headSize}, query.options());
-  auto attn = at::empty({batchSize, num_head, qSize, maxSeqLength}, query.options());
   auto scale_factor = sdp::calculate_scale(query, scale).expect_float();
   @autoreleasepool {
     auto mkey = __func__ + getTensorsStringKey({query, key, value}) + ":" + std::to_string(is_causal) + ":" +
@@ -131,13 +129,11 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
           graph->kTensor = kTensor;
           graph->vTensor = vTensor;
           graph->outputTensor = castMPSTensor(mpsGraph, output, qTensor.dataType);
-          graph->attnTensor = castMPSTensor(mpsGraph, sm, qTensor.dataType);
         });
     auto qPlaceholder = Placeholder(cachedGraph->qTensor, query);
     auto kPlaceholder = Placeholder(cachedGraph->kTensor, key);
     auto vPlaceholder = Placeholder(cachedGraph->vTensor, value);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor, out);
-    auto attnPlaceholder = Placeholder(cachedGraph->attnTensor, attn);
     NSDictionary* feeds = nil;
     if (!attn_mask) {
       feeds = dictionaryFromPlaceholders(qPlaceholder, kPlaceholder, vPlaceholder);
@@ -145,18 +141,13 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
       auto mPlaceholder = Placeholder(cachedGraph->maskTensor, *attn_mask);
       feeds = dictionaryFromPlaceholders(qPlaceholder, kPlaceholder, vPlaceholder, mPlaceholder);
     }
-    NSDictionary* outs = dictionaryFromPlaceholders(outputPlaceholder, attnPlaceholder);
+    NSDictionary* outs = dictionaryFromPlaceholders(outputPlaceholder);
     runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outs);
   }
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  auto final_attn = unsqueezed ? (orig_query.dim() == 3 ? attn.squeeze(0) : [&]{
-    std::vector<int64_t> shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
-    shape.insert(shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
-    return attn.view(shape);
-  }()) : attn;
-
-  return {std::move(final_out), std::move(final_attn)};
+  // Return empty tensor for attention weights - they are not used by the caller
+  return {std::move(final_out), at::Tensor()};
 }
 
 // Vector mode (One–pass variant)
@@ -187,7 +178,6 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
   uint v_seq_stride = v_.stride(2);
 
   auto out = at::empty({batchSize, num_head, qSize, headSize}, q_.options());
-  auto attn = at::empty({batchSize, num_head, qSize, maxSeqLength}, q_.options());
   auto scale_factor = sdp::calculate_scale(q_, scale).expect_float();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
@@ -226,13 +216,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
   });
   // reshape back to original dimension
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  auto final_attn = unsqueezed ? (orig_query.dim() == 3 ? attn.squeeze(0) : [&]{
-    std::vector<int64_t> shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
-    shape.insert(shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
-    return attn.view(shape);
-  }()) : attn;
-
-  return {std::move(final_out), std::move(final_attn)};
+  // Return empty tensor for attention weights - they are not used by the caller
+  return {std::move(final_out), at::Tensor()};
 }
 
 // Vector mode (Two–pass variant)
@@ -317,7 +302,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
   });
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  return {std::move(final_out), std::move(intermediate)};
+  // Return empty tensor for attention weights - they are not used by the caller
+  return {std::move(final_out), at::Tensor()};
 }
 
 // Implementation 3: Full attention mode
@@ -418,7 +404,8 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
   });
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  return {std::move(final_out), std::move(final_out)};
+  // Return empty tensor for attention weights - they are not used by the caller
+  return {std::move(final_out), at::Tensor()};
 }
 
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& query,

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -146,8 +146,9 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   }
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  // Return empty tensor for attention weights - they are not used by the caller
-  return {std::move(final_out), at::Tensor()};
+  // Return empty tensor with correct shape for attention weights - they are not used by the caller
+  auto attn_weights = at::empty({batchSize, num_head, qSize, maxSeqLength}, query.options());
+  return {std::move(final_out), std::move(attn_weights)};
 }
 
 // Vector mode (One–pass variant)
@@ -216,8 +217,9 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
   });
   // reshape back to original dimension
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  // Return empty tensor for attention weights - they are not used by the caller
-  return {std::move(final_out), at::Tensor()};
+  // Return empty tensor with correct shape for attention weights - they are not used by the caller
+  auto attn_weights = at::empty({batchSize, num_head, qSize, maxSeqLength}, q_.options());
+  return {std::move(final_out), std::move(attn_weights)};
 }
 
 // Vector mode (Two–pass variant)
@@ -302,8 +304,9 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
   });
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  // Return empty tensor for attention weights - they are not used by the caller
-  return {std::move(final_out), at::Tensor()};
+  // Return empty tensor with correct shape for attention weights - they are not used by the caller
+  auto attn_weights = at::empty({batchSize, num_heads, seq_len_q, N}, q_.options());
+  return {std::move(final_out), std::move(attn_weights)};
 }
 
 // Implementation 3: Full attention mode
@@ -404,8 +407,9 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
   });
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  // Return empty tensor for attention weights - they are not used by the caller
-  return {std::move(final_out), at::Tensor()};
+  // Return empty tensor with correct shape for attention weights - they are not used by the caller
+  auto attn_weights = at::empty({batchSize, num_heads, qL, kL}, q_.options());
+  return {std::move(final_out), std::move(attn_weights)};
 }
 
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& query,


### PR DESCRIPTION
Fixes: #175873

Currently the SDPA op in MPS backend returns a second tensor to satisfy the function signature. However argument never gets used for any purpose as it is explicitly dropped by the only callers in Attention.cpp L809 and L820 where only the first returned object is used for both cases:

`return std::get<0>(at::_scaled_dot_product_attention_math_for_mps(  ...`

By not forcing the graph to return the attention tensor explicitly one should see speedups in O(10%) across various sizes and shapes, depending on the device and input data type. A naive scan of the op level speedups for an M2 Max on MacOS26 resulting from this change:

```
# Configurations: (batch, num_heads, seq_len, head_dim)
--- SDPA Benchmarks ---
Configuration                                 Baseline (ms)   New (ms)        Change                        
--------------------------------------------------------------------------------------------------------------
SDPA(1, 12, 1024, 64)                        
  Non-causal:                                 1.7881          1.2695          1.41x
  Causal:                                     2.1025          1.4654          1.43x
SDPA(1, 12, 2048, 64)                        
  Non-causal:                                 8.5264          6.0076          1.42x
  Causal:                                     8.4796          6.0682          1.40x
SDPA(1, 12, 512, 64)                         
  Non-causal:                                 0.3709          0.3145          1.18x
  Causal:                                     0.3852          0.3341          1.15x
SDPA(1, 8, 128, 64)                          
  Non-causal:                                 0.1115          0.1013          1.10x
  Causal:                                     0.1113          0.1009          1.10x
SDPA(1, 8, 256, 64)                          
  Non-causal:                                 0.1256          0.1175          1.07x
  Causal:                                     0.1242          0.1071          1.16x
SDPA(1, 8, 512, 128)                         
  Non-causal:                                 0.3821          0.3352          1.14x
  Causal:                                     0.4013          0.3477          1.15x
SDPA(1, 8, 512, 32)                          
  Non-causal:                                 0.2573          0.2032          1.27x
  Causal:                                     0.2387          0.1996          1.20x
SDPA(1, 8, 512, 64)                          
  Non-causal:                                 0.2691          0.2267          1.19x
  Causal:                                     0.2814          0.2429          1.16x
```

This improvement carries over to the network level as well (diluted by the other ops in the network of course). Using Qwen3-8B from huggingface in BF16 to measure time to first token inference with an input prompt of ~4000 tokens:

```
Network                            Baseline (ms)                 New (ms)               Speedup
-----------------------------------------------------------------------------------------------
Qwen3-8B BFloat16                  13766.95                      12869.74               1.07x
```

Likely saves some memory too not having to write the potentially large attention tensor just for it to get ditched. These benefits should carry to other hardware and data types.

cc @jerryzh168 @kulinseth @malfet @DenisVieriu97 @aditvenk