### PR TITLE
Fixes LazyConvTranspose modules when used with torch.compile(dynamic=True)

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -21,7 +21,7 @@ import torch.nn.functional as F
 from torch._dynamo.debug_utils import same_two_models
 from torch._dynamo.eval_frame import unsupported
 from torch._dynamo.mutation_guard import GenerationTracker
-from torch._dynamo.testing import expectedFailureDynamic, same
+from torch._dynamo.testing import same
 from torch._dynamo.utils import ifdynstaticdefault
 from torch._dynamo.variables.torch_function import TensorWithTFOverrideVariable
 from torch.nn.modules.lazy import LazyModuleMixin
@@ -1511,8 +1511,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.op_count, 1)
         self.assertTrue(torch._dynamo.testing.same(out1, out2))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module1(self):
         input_shape = (16, 3, 6, 7, 8)
 
@@ -1581,8 +1579,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         )
         self.assertEqual(cnt.frame_count, 1, "No guards should have triggered.")
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module2(self):
         # Test FX graph 'call_module' works well if argument is lazy module
         m = LazyMLP()
@@ -1594,8 +1590,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module4(self):
         m = LazyMLP()
         x = torch.rand([10, 10])
@@ -1612,8 +1606,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         except RuntimeError:
             self.assertIn("must have same reduction dim", traceback.format_exc())
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module5(self):
         # Test lazy module works well with list/tuple input
         m = LazyModuleWithListInput()
@@ -1623,8 +1615,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module6(self):
         # Test new lazy submodule in lazy module's initialize_parameters
         m = LazyModuleWithLazySubmodule()
@@ -1634,8 +1624,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module7(self):
         # Test lazy module works well with namedtuple/dict input
         m = LazyModuleWithNamedTupleInput()
@@ -1691,8 +1679,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         with self.assertRaises(AttributeError):
             exp_res = opt_m(x, y)
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module_speculation_log_divergence(self):
         class ModWithOneLazyLinear(torch.nn.Module):
             def __init__(self) -> None:
@@ -1836,7 +1822,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
 
 
 class NNModuleTestsDevice(torch._dynamo.test_case.TestCase):
-    @expectedFailureDynamic
     @skipIfHpu
     def test_lazy_module3(self, device):
         m = LazyMLP()

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -125,7 +125,7 @@ def initialize_lazy_module(
             the C++ backend rejects SymInts. This patches torch.empty to auto-convert
             SymInts to concrete ints during initialization.
             """
-            from torch.fx.experimental.symbolic_shapes import size_hint
+            from torch.fx.experimental.symbolic_shapes import optimization_hint
 
             original_empty = torch.empty
 
@@ -134,7 +134,7 @@ def initialize_lazy_module(
 
                 def _convert(val: Any) -> Any:
                     if isinstance(val, torch.SymInt):
-                        return size_hint(val)
+                        return optimization_hint(val)
                     elif isinstance(val, (tuple, list)):
                         return type(val)(_convert(v) for v in val)
                     return val

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -26,7 +26,7 @@ import inspect
 import itertools
 import re
 import types
-from collections.abc import Iterable, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager, nullcontext
 from typing import Any, TYPE_CHECKING
 
@@ -114,14 +114,54 @@ def initialize_lazy_module(
         proxy_args, proxy_kwargs = proxy_args_kwargs(args, kwargs)
         fake_args = [convert_to_fake(arg) for arg in proxy_args]
         fake_kwargs = {k: convert_to_fake(v) for k, v in proxy_kwargs.items()}
+
+        # Context manager to convert SymInt to concrete int during lazy module init
+        @contextmanager
+        def _materialize_symints_for_lazy_init() -> Generator[None, None, None]:
+            """
+            During lazy module initialization with dynamic=True, modules receive fake
+            tensors with SymInt dimensions. When they extract dimensions (e.g.,
+            input.shape[1]) and pass them to torch.empty() for parameter materialization,
+            the C++ backend rejects SymInts. This patches torch.empty to auto-convert
+            SymInts to concrete ints during initialization.
+            """
+            from torch.fx.experimental.symbolic_shapes import size_hint
+
+            original_empty = torch.empty
+
+            def _wrapped_empty(*args: Any, **kwargs: Any) -> torch.Tensor:
+                """Convert SymInt arguments to concrete ints before calling torch.empty."""
+
+                def _convert(val: Any) -> Any:
+                    if isinstance(val, torch.SymInt):
+                        return size_hint(val)
+                    elif isinstance(val, (tuple, list)):
+                        return type(val)(_convert(v) for v in val)
+                    return val
+
+                args = tuple(_convert(arg) for arg in args)
+                kwargs = {k: _convert(v) for k, v in kwargs.items()}
+                return original_empty(*args, **kwargs)
+
+            torch.empty = _wrapped_empty
+            try:
+                yield
+            finally:
+                torch.empty = original_empty
+
         try:
-            mod._infer_parameters(mod, fake_args, fake_kwargs)  # type: ignore[operator]
-        except AttributeError:
+            with _materialize_symints_for_lazy_init():
+                mod._infer_parameters(mod, fake_args, fake_kwargs)  # type: ignore[operator]
+        except AttributeError as e:
             # Re-raise with the original error message from the AttributeError
             raise_observed_exception(
                 AttributeError,
                 tx,
-                args=["AttributeError during lazy module initialization"],
+                args=[
+                    str(e)
+                    if str(e)
+                    else "AttributeError during lazy module initialization"
+                ],
             )
 
 

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1480,7 +1480,10 @@ class _LazyConvXdMixin(LazyModuleMixin):
                 f"to {self.__class__.__name__}, but "
                 f"got input of size: {input.shape}"
             )
-        return input.shape[1] if input.dim() == num_dims_batch else input.shape[0]
+        in_channels = (
+            input.shape[1] if input.dim() == num_dims_batch else input.shape[0]
+        )
+        return in_channels
 
     # Function to return the number of spatial dims expected for inputs to the module.
     # This is expected to be implemented by subclasses.

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1480,10 +1480,7 @@ class _LazyConvXdMixin(LazyModuleMixin):
                 f"to {self.__class__.__name__}, but "
                 f"got input of size: {input.shape}"
             )
-        in_channels = (
-            input.shape[1] if input.dim() == num_dims_batch else input.shape[0]
-        )
-        return in_channels
+        return input.shape[1] if input.dim() == num_dims_batch else input.shape[0]
 
     # Function to return the number of spatial dims expected for inputs to the module.
     # This is expected to be implemented by subclasses.


### PR DESCRIPTION
Fixes #173252 
The issue was that lazy modules tried to use SymInt dimensions directly for materialization which requires concrete integers. Now converts SymInt to concrete int using optimization_hint( ).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela