### PR TITLE
[pytorch] expose profiling post-processing timeouts in public API

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -167,6 +167,11 @@ class profile:
 
         acc_events (bool): Enable the accumulation of FunctionEvents across multiple profiling cycles
 
+        post_processing_timeout_s (float): Optional timeout in seconds for post-processing profiler
+            results. In this context, post-processing happens after the profiling itself has finished.
+            If specified, event parsing will stop after this duration and return partial results. Useful
+            for handling large traces that may take too long to process.
+
 
     .. warning::
         Enabling memory profiling or source attribution incurs additional profiler
@@ -220,6 +225,7 @@ class profile:
         experimental_config=None,
         acc_events=False,
         custom_trace_id_callback=None,
+        post_processing_timeout_s: Optional[float] = None,
     ):
         self.enabled: bool = enabled
         if not self.enabled:
@@ -257,6 +263,7 @@ class profile:
         self.profiling_end_time_ns = 0
         self._stats = _ProfilerStats()
         self.custom_trace_id_callback = custom_trace_id_callback
+        self.post_processing_timeout_s = post_processing_timeout_s
         self.trace_id = ""
         if not self.use_cpu:
             if not use_kineto:
@@ -334,6 +341,12 @@ class profile:
 
         if len(self.kineto_activities) == 0:
             raise AssertionError("No activities specified for the profiler")
+
+        if (
+            self.post_processing_timeout_s is not None
+            and self.post_processing_timeout_s < 0
+        ):
+            raise ValueError("post_processing_timeout_s must be non-negative")
 
     def default_trace_id(self):
         # Generate a UUID
@@ -442,7 +455,9 @@ class profile:
         t0 = perf_counter_ns()
         parsed_results = []
         if self.kineto_results:
-            parsed_results = self._parse_kineto_results(self.kineto_results)
+            parsed_results = self._parse_kineto_results(
+                self.kineto_results, timeout_s=self.post_processing_timeout_s
+            )
         t1 = perf_counter_ns()
         self._stats.parse_kineto_call_duration_us = int((t1 - t0) / 1000)
 
@@ -566,6 +581,8 @@ class profile:
         # result.events() has most of the events - PyTorch op-level and device-level events
 
         timeout_ns = int(timeout_s * 1e9) if timeout_s is not None else None
+        if timeout_ns is not None and timeout_ns < 0:
+            raise ValueError("timeout_s must be non-negative")
         start_time_ns = perf_counter_ns()
         timed_out = False
 

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -129,6 +129,10 @@ class _KinetoProfile:
             When this argument is included the observer start() and stop() will be called for the
             same time window as PyTorch profiler.
         acc_events (bool): Enable the accumulation of FunctionEvents across multiple profiling cycles
+        post_processing_timeout_s (float): Optional timeout in seconds for post-processing profiler
+            results. In this context, post-processing happens after the profiling itself has finished.
+            If specified, event parsing will stop after this duration and return partial results. Useful
+            for handling large traces that may take too long to process.
 
 
     .. note::
@@ -153,6 +157,7 @@ class _KinetoProfile:
         execution_trace_observer: _ITraceObserver | None = None,
         acc_events: bool = False,
         custom_trace_id_callback: Callable[[], str] | None = None,
+        post_processing_timeout_s: float | None = None,
     ) -> None:
         self.activities = set(activities) if activities else supported_activities()
         self.record_shapes = record_shapes
@@ -164,6 +169,7 @@ class _KinetoProfile:
         self.execution_trace_observer = execution_trace_observer
         self.acc_events = acc_events
         self.custom_trace_id_callback = custom_trace_id_callback
+        self.post_processing_timeout_s = post_processing_timeout_s
         self.profiler: prof.profile | None = None
         self.has_cudagraphs = False
         self.mem_tl: MemoryProfileTimeline | None = None
@@ -212,6 +218,7 @@ class _KinetoProfile:
                 experimental_config=self.experimental_config,
                 acc_events=self.acc_events,
                 custom_trace_id_callback=self.custom_trace_id_callback,
+                post_processing_timeout_s=self.post_processing_timeout_s,
             )
         if (self.profiler is not None) and (not self.acc_events):
             _warn_once(
@@ -623,6 +630,9 @@ class profile(_KinetoProfile):
             When this argument is included the observer start() and stop() will be called for the
             same time window as PyTorch profiler. See the examples section below for a code sample.
         acc_events (bool): Enable the accumulation of FunctionEvents across multiple profiling cycles
+        post_processing_timeout_s (float): Optional timeout in seconds for post-processing profiler
+            results. If specified, event parsing will stop after this duration and return partial
+            results. Useful for handling large traces that may take too long to process.
         use_cuda (bool):
             .. deprecated:: 1.8.1
                 use ``activities`` instead.
@@ -739,6 +749,7 @@ class profile(_KinetoProfile):
         # deprecated:
         use_cuda: bool | None = None,
         custom_trace_id_callback: Callable[[], str] | None = None,
+        post_processing_timeout_s: float | None = None,
     ) -> None:
         activities_set = set(activities) if activities else supported_activities()
         if use_cuda is not None:
@@ -767,6 +778,7 @@ class profile(_KinetoProfile):
             else ExecutionTraceObserver.build_execution_trace_obs_from_env(),
             acc_events=acc_events,
             custom_trace_id_callback=custom_trace_id_callback,
+            post_processing_timeout_s=post_processing_timeout_s,
         )
 
         if schedule:


### PR DESCRIPTION
Summary:
Adds `post_processing_timeout_s` to the public `torch.profiler.profile()` API. At the moment, this only controls the `timeout_s` parameter to `torch.autograd.profiler.profile._parse_kineto_results()`.

I am making this a parameter to the constructor, rather than just a parameter to `export_chrome_trace()` because `_parse_kineto_results()` is called in `_ensure_function_events()`, and `_ensure_function_events()` is called in every method inside `torch.autograd.profiler.profile` that returns any results; there's 10 of them. That means this timeout is really a global property of the object, not just a parameter to a single method. Even if we tried to just start with adding the parameter to `export_chrome_trace()`, it would do nothing if users called, say, `function_events()` first.

I'm open to a different name. My intent is use a name that describes what it currently does, but also allow it potentially work for any post-processing. That is, if there's another post-processing operation that we discover becomes a problem, this parameter would also cover that.

Test Plan: Added tests to `test/profiler/test_profile.py`.

Differential Revision: D91845044


