### PR TITLE
Ensure  that d_model is an even number when instanciating a PositionalEncoding

### DIFF
--- a/benchmarks/functional_autograd_benchmark/torchaudio_models.py
+++ b/benchmarks/functional_autograd_benchmark/torchaudio_models.py
@@ -389,7 +389,7 @@ class PositionalEncoding(nn.Module):
         \text{PosEncoder}(pos, 2i+1) = cos(pos/10000^(2i/d_model))
         \text{where pos is the word position and i is the embed idx)
     Args:
-        d_model: the embed dim (required).
+        d_model: the embed dim (required). This must be an even number.
         dropout: the dropout value (default=0.1).
         max_len: the max. length of the incoming sequence (default=5000).
     Examples:
@@ -398,6 +398,8 @@ class PositionalEncoding(nn.Module):
 
     def __init__(self, d_model, dropout=0.1, max_len=5000):
         super().__init__()
+
+        assert d_model % 2 == 0, 'The dimension of the embedding must be an even number.'
         self.dropout = nn.Dropout(p=dropout)
 
         pe = torch.zeros(max_len, d_model)


### PR DESCRIPTION
The proposed change adds an assertion to ensure that `d_model` is even. Without this, using a odd number fails with a less informative message such as:
```
RuntimeError: The expanded size of the tensor (2) must match the existing size (3) at non-singleton dimension 1.
```