### PR TITLE
[NATIVE] [CUDA] Use c10 for load of potential non-standard bools in reduction_template.cuh

### DIFF
--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -344,7 +344,7 @@ struct ReduceJitOp {
       const auto values_vec = memory::load_vector<input_vec_size>(data, idx);
       #pragma unroll
       for (uint32_t i = 0; i < input_vec_size; i++) {
-        value_list[i] = ops.reduce(value_list[i], values_vec.val[i], shift + idx * input_vec_size + i);
+        value_list[i] = reducer::reduce(value_list[i], values_vec.val[i], shift + idx * input_vec_size + i);
       }
       idx += stride;
     }

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -222,15 +222,13 @@ struct ReduceJitOp {
       value = thread_reduce<${output_vec_size}>(input_slice);
     }
 
-
     if (config.should_block_x_reduce()) {
       value = block_x_reduce<${output_vec_size}>(value, shared_memory);
     }
+
     if (config.should_block_y_reduce()) {
       value = block_y_reduce<${output_vec_size}>(value, shared_memory);
     }
-
-
     using out_ptr_vec_t = Array<out_scalar_t*, ${output_vec_size}>;
     using offset_vec_t = Array<uint32_t, ${output_vec_size}>;
     offset_vec_t base_offsets;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -222,12 +222,14 @@ struct ReduceJitOp {
       value = thread_reduce<${output_vec_size}>(input_slice);
     }
 
-    if (config.should_block_y_reduce()) {
-      value = block_y_reduce<${output_vec_size}>(value, shared_memory);
-    }
+
     if (config.should_block_x_reduce()) {
       value = block_x_reduce<${output_vec_size}>(value, shared_memory);
     }
+    if (config.should_block_y_reduce()) {
+      value = block_y_reduce<${output_vec_size}>(value, shared_memory);
+    }
+
 
     using out_ptr_vec_t = Array<out_scalar_t*, ${output_vec_size}>;
     using offset_vec_t = Array<uint32_t, ${output_vec_size}>;


### PR DESCRIPTION
This PR should allow (if I'm not mistaken) loading potential non-standard bools in reduction_template.cuh to accept boolean tensors with values other than 1 or 0. Important note: This was not tested, it just refers to #78957 (credits to @peterbell10 👍) as it implements the reduction_template.cuh in (nearly) the same way as @peterbell10 does in Reduce.cuh (but I'm not quite sure as this wasn't tested and it may include mistakes, and as well I'm not quite sure whether this might cause (in future (or even already)) any errors because back then @peterbell10 said that he only does this in some cases (except those using cub or
thrust) and maybe this one was explicitly not changed and I didn't really notice the reason for this (as searching for "cub" or "thrust" only shows up results in "//", but I may have missed something or it may be written in another way / there may be another reason why this was not changed, so please review, thanks)).

cc @PaulZhang12 