### PR TITLE
[BE][Auto-triager] Add additional context for triaging PT2 issues

### DIFF
--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -19,13 +19,13 @@ hooks:
 This skill helps triage GitHub issues by routing issues, applying labels, and leaving first-line responses.
 
 ## Contents
-
 - [MCP Tools Available](#mcp-tools-available)
 - [Labels You Must NEVER Add](#labels-you-must-never-add)
 - [Issue Triage Steps](#issue-triage-for-each-issue)
   - Step 0: Already Routed — SKIP
   - Step 1: Question vs Bug/Feature
   - Step 2: Transfer
+  - Step 2.5: PT2 Issues — Special Handling
   - Step 3: Redirect to Secondary Oncall
   - Step 4: Label the Issue
   - Step 5: High Priority — REQUIRES HUMAN REVIEW
@@ -34,6 +34,8 @@ This skill helps triage GitHub issues by routing issues, applying labels, and le
 - [V1 Constraints](#v1-constraints)
 
 **Labels reference:** See [labels.json](labels.json) for the full catalog of 305 labels suitable for triage. This file excludes CI triggers, test configs, release notes, and deprecated labels.
+
+**PT2 triage guide:** See [pt2-triage-rubric.md](pt2-triage-rubric.md) for detailed labeling guidance when triaging PT2/torch.compile issues.
 
 **Response templates:** See [templates.json](templates.json) for standard response messages.
 
@@ -91,9 +93,18 @@ That issue belongs to the sub-oncall team. They own their queue.
 
 If the issue belongs in another repo (vision/text/audio/RL/ExecuTorch/etc.), transfer the issue and **STOP**.
 
+### 2.5) PT2 Issues — Special Handling
+
+When triaging PT2 issues (torch.compile, dynamo, inductor), see [pt2-triage-rubric.md](pt2-triage-rubric.md) for detailed labeling decisions.
+
+**Key differences from general triage:**
+- For PT2 issues, you MAY apply `module:` labels (e.g., `module: dynamo`, `module: inductor`, `module: dynamic shapes`)
+- Use the rubric to determine the correct component labels
+- Only redirect to `oncall: cpu inductor` for MKLDNN-specific issues; otherwise keep in PT2 queue
+
 ### 3) Redirect to Secondary Oncall
 
-**CRITICAL:** When redirecting to an oncall queue, apply exactly one `oncall: ...` label and **STOP**. Do NOT:
+**CRITICAL:** When redirecting issues to an oncall queue (**critical** with the exception of PT2), apply exactly one `oncall: ...` label and **STOP**. Do NOT:
 - Add any `module:` labels
 - Mark it `triaged`
 - Do any further triage work
@@ -104,7 +115,6 @@ The sub-oncall team will handle their own triage. Your job is only to route it t
 
 | Label | When to use |
 |-------|-------------|
-| `oncall: pt2` | torch.compile, dynamo, inductor, aotdispatch, dynamic shapes |
 | `oncall: jit` | TorchScript issues |
 | `oncall: distributed` | Distributed training (DDP, FSDP, RPC, c10d) |
 | `oncall: export` | torch.export issues |

--- a/.claude/skills/triaging-issues/pt2-triage-rubric.md
+++ b/.claude/skills/triaging-issues/pt2-triage-rubric.md
@@ -22,13 +22,7 @@ This rubric guides labeling decisions for PT2 oncall triage.
 When component isn't clear from the issue body:
 
 1. **Check comments first** - often contains debugging info
-2. **If unclear, run repro with different backends:**
-   ```python
-   torch.compile(fn, backend="eager")      # baseline
-   torch.compile(fn, backend="aot_eager")  # AOT dispatch, no inductor
-   torch.compile(fn, backend="inductor")   # full compile
-   ```
-
+2. **Look for information with backends:**
 | Result | Label |
 |--------|-------|
 | Fails on `aot_eager`, not `eager` | `module: pt2-dispatcher` |

--- a/.claude/skills/triaging-issues/pt2-triage-rubric.md
+++ b/.claude/skills/triaging-issues/pt2-triage-rubric.md
@@ -1,0 +1,179 @@
+# PT2 Triage Rubric
+
+This rubric guides labeling decisions for PT2 oncall triage.
+
+## 1. Component Isolation - Be Precise, Don't Over-Tag
+
+### Dynamo vs Dynamic Shapes
+
+| Signal | Label |
+|--------|-------|
+| `dynamic=False` fixes it | `module: dynamic shapes` only |
+| Graph breaks, bytecode errors | `module: dynamo` |
+| Guard failures, SymInt issues | `module: dynamic shapes` |
+| Data-dependent operations (.item(), etc.) | `module: dynamic shapes` |
+
+**Don't just slap `module: dynamo` on every torch.compile issue.**
+
+---
+
+## 2. Backend Isolation for Correctness Issues
+
+When component isn't clear from the issue body:
+
+1. **Check comments first** - often contains debugging info
+2. **If unclear, run repro with different backends:**
+   ```python
+   torch.compile(fn, backend="eager")      # baseline
+   torch.compile(fn, backend="aot_eager")  # AOT dispatch, no inductor
+   torch.compile(fn, backend="inductor")   # full compile
+   ```
+
+| Result | Label |
+|--------|-------|
+| Fails on `aot_eager`, not `eager` | `module: pt2-dispatcher` |
+| Fails on `inductor`, not `aot_eager` | `module: inductor` |
+| Fails during tracing (before backend) | `module: dynamo` |
+
+---
+
+## 3. Don't Over-Tag pt2-dispatcher
+
+`module: pt2-dispatcher` is for bugs **IN** the dispatcher code, not just when it appears in a stack trace.
+
+**Common mistake:** Seeing `_aot_autograd/` in a stack trace and assuming it's a pt2-dispatcher bug. The dispatcher code is on the call path for almost everything - that doesn't mean the bug is there.
+
+**Only add pt2-dispatcher when:**
+- The bug is clearly in AOT autograd logic (e.g., incorrect tensor metadata handling)
+- The bug is in functionalization
+- The bug is in FakeTensor implementation
+- The bug is in custom operator registration/dispatch
+
+**Don't add pt2-dispatcher when:**
+- AOT autograd just happens to be on the stack trace
+- The actual bug is in functorch transforms (use `module: functorch` instead)
+- The actual bug is in inductor codegen (use `module: inductor` instead)
+- You're not sure where the bug actually is
+
+---
+
+## 4. Don't Redirect When PT2 Owns the Code
+
+**This is critical:** Don't redirect to another oncall just because their subsystem is *involved*. Only redirect when:
+1. The bug is clearly **IN** their code, AND
+2. PT2 code is not at fault
+
+**Examples - DO NOT redirect:**
+
+| Situation | Why NOT redirect |
+|-----------|------------------|
+| Export triggers a bug, but the bug is a leaked hook in AOT autograd | Bug is in PT2 code → PT2 owns it |
+| DTensor has a bad error message under compile | Bug is in PT2's error handling → PT2 owns UX |
+| Distributed training fails, but stack trace shows inductor issue | Bug is in inductor → PT2 owns it |
+
+**Examples - DO redirect:**
+
+| Situation | Why redirect |
+|-----------|--------------|
+| MKLDNN-specific codegen bug | `oncall: cpu inductor` owns MKLDNN |
+| Export-only issue with no compile involvement | `oncall: export` owns it |
+| Bug in DTensor's tensor subclass implementation | `oncall: distributed` owns DTensor internals |
+
+**The test:** Ask "where would the fix need to be made?" If the fix is in PT2 code, PT2 owns it.
+
+**Adding labels for visibility:** You CAN add domain labels (e.g., `module: dtensor`) so domain experts see the issue, but don't ADD the oncall redirect label unless you're actually handing it off.
+
+---
+
+## 5. Add Domain-Specific Labels for Visibility
+
+Even when not redirecting, add labels so domain experts see the issue:
+
+| Domain | Label |
+|--------|-------|
+| DTensor | `module: dtensor` |
+| FSDP | `module: fsdp` |
+| DDP | `module: ddp` |
+| Flex attention | `module: flex attention` |
+
+---
+
+## 6. Use Feature-Specific Labels
+
+Check for existing labels before inventing categories:
+
+| Feature | Label |
+|---------|-------|
+| Caching issues | `compile-cache` |
+| Determinism | `module: determinism` |
+| Compile/startup time | `module: compile-time` |
+| Numerical issues | `module: numerical-stability` |
+| UX/error messages | `module: compile ux` |
+
+---
+
+## 7. functorch + compile
+
+| Situation | Labels |
+|-----------|--------|
+| Compiling a functorch transform (vjp, grad, vmap) | `module: functorch`, `dynamo-functorch` |
+| Only add `pt2-dispatcher` if stack trace shows AOT autograd | Check stack trace first |
+
+---
+
+## 8. High Priority Criteria
+
+Mark `high priority` if ANY of these apply:
+
+| Criteria | Example |
+|----------|---------|
+| **Crash** (segfault, illegal memory access) | Device-side assert, SIGSEGV |
+| **Silently wrong results** | Output differs from eager with no error |
+| **Regression** | "This used to work in version X" |
+| **Flaky test** | Usually indicates regression |
+| **Important model regressed** (>10% perf) | Common model, significant slowdown |
+| **Important customer** | Huggingface, common usage patterns |
+
+Note: Adding `high priority` auto-adds `triage review` for discussion.
+
+---
+
+## 9. Fuzzer Issues
+
+For `topic: fuzzer` issues:
+
+1. Ensure rtol/atol are at default tolerances
+2. Don't compare indices of max/min (avoids tolerance issues)
+3. Use `torch._dynamo.utils.same` with `fp64_ref` for comparison
+4. If criteria met and bug appears easy/common → triage normally
+5. If complex and rare → add `low priority`
+
+---
+
+## 10. Quick Label Reference
+
+### Core Components
+- `module: dynamo` - Tracing, bytecode, graph breaks
+- `module: inductor` - Codegen, Triton kernels
+- `module: dynamic shapes` - Symbolic shapes, guards, data-dependent
+- `module: pt2-dispatcher` - AOT autograd, functionalization, FakeTensor
+- `module: cuda graphs` - CUDA graph capture/replay
+- `module: flex attention` - Flex attention API
+
+### Holistic Areas
+- `module: compile ux` - Error messages, APIs, programming model
+- `module: startup-compile-tracing time` - Compilation speed
+- `module: performance` - Runtime performance
+- `module: memory usage` - Memory issues
+
+### Status Labels
+- `triaged` - Done triaging
+- `triage review` - Discuss at meeting
+- `needs reproduction` - Blocked on repro
+- `needs research` - Needs investigation
+- `actionable` - Clear what to do
+
+### Redirects
+- `oncall: cpu inductor` - CPU/MKLDNN issues
+- `oncall: export` - Export-specific issues
+- `oncall: distributed` - Distributed training issues


### PR DESCRIPTION
See title; example issues tagged with this are: 

* Issue [69](https://github.com/pytorch/ciforge/issues/69): https://github.com/pytorch/ciforge/actions/runs/21531769852
* Issue [71](https://github.com/pytorch/ciforge/issues/71): https://github.com/pytorch/ciforge/actions/runs/21531769852
* Issue [81](https://github.com/pytorch/ciforge/issues/81): https://github.com/pytorch/ciforge/actions/runs/21532949917
* Issue [82](https://github.com/pytorch/ciforge/issues/82): https://github.com/pytorch/ciforge/actions/runs/21532949917

This rubric was adopted from @ezyang's rubric https://github.com/ezyang/pt2-triage/blob/main/.claude/skills/pt2-triage.md