### PR TITLE
[aoti] better error message for mixed device tensors

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -636,6 +636,21 @@ class AOTInductorModelBase {
       size_t data_size = this->constant_data_size(i);
       int32_t const_device_type = this->constant_device_type(i);
       bool device_type_matches = const_device_type == device_type_;
+
+      // Mixed-device constants are only supported when the secondary device is
+      // CPU. If a constant was compiled for a non-CPU device but we're loading
+      // on a different device, we cannot safely create the tensor.
+      AOTI_RUNTIME_CHECK(
+          device_type_matches ||
+              const_device_type == aoti_torch_device_type_cpu(),
+          "Mixed-device constants are only supported when the secondary "
+          "device is CPU. Constant '" +
+              name +
+              "' was compiled for a non-CPU device. "
+              "Hint: This can happen if you compiled on GPU but are loading "
+              "on CPU, which is not supported. In AOTI, you must compile and "
+              "load on the same device type.");
+
       uint8_t* internal_ptr = nullptr;
       if (data_size != 0) {
         if (device_type_matches) {


### PR DESCRIPTION
Fixes #172739 

Though the aot_export/aot_load API is deprecated, we should error out gracefully instead of segfault. 

Error message now:

```
W0130 17:59:03.071000 1959179 torch/_export/__init__.py:71] +============================+
W0130 17:59:03.071000 1959179 torch/_export/__init__.py:72] |     !!!   WARNING   !!!    |
W0130 17:59:03.071000 1959179 torch/_export/__init__.py:73] +============================+
W0130 17:59:03.071000 1959179 torch/_export/__init__.py:74] torch._export.aot_compile()/torch._export.aot_load() is being deprecated, please switch to directly calling torch._inductor.aoti_compile_and_package(torch.export.export())/torch._inductor.aoti_load_package() instead.
Error: Mixed-device constants are only supported when the secondary device is CPU. Constant 'linear_weight' was compiled for a non-CPU device.
Error loading on CPU: create_func_( &container_handle_, num_models, device_str.c_str(), cubin_dir.empty() ? nullptr : cubin_dir.c_str()) API call failed at /data/users/shangdiy/pytorch/torch/csrc/inductor/aoti_runner/model_container_runner.cpp, line 121
```