### PR TITLE
[RISCV] enable lintrunner on riscv64 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ filelock
 fsspec>=0.8.5
 hypothesis
 jinja2
-lintrunner ; platform_machine != "s390x" and platform_machine != "riscv64"
+lintrunner ; platform_machine != "s390x"
 networkx>=2.5.1
 optree>=0.13.0
 psutil


### PR DESCRIPTION
lintrunner now provides official riscv64 wheels from 0.13.0, so it can be safely enabled on riscv64