### PR TITLE
Fix indexing errors in tensordot documentation formula

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1276,8 +1276,8 @@ def tensordot(  # noqa: F811
     respectively, :func:`~torch.tensordot` computes
 
     .. math::
-        r_{i_0,...,i_{m-d}, i_d,...,i_n}
-          = \sum_{k_0,...,k_{d-1}} a_{i_0,...,i_{m-d},k_0,...,k_{d-1}} \times b_{k_0,...,k_{d-1}, i_d,...,i_n}.
+        r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}}
+          = \sum_{k_1,...,k_d} a_{i_1,...,i_{m-d},k_1,...,k_d} \times b_{k_1,...,k_d, j_1,...,j_{n-d}}.
 
     When called with :attr:`dims` of the list form, the given dimensions will be contracted
     in place of the last :math:`d` of :attr:`a` and the first :math:`d` of :math:`b`. The sizes


### PR DESCRIPTION
## Summary
Fixes the mathematical formula in `torch.tensordot` documentation which had indexing errors.

## Issue
Fixes #173879

## Changes
The original formula had two problems:
1. **Incorrect number of indices**: `a` has `m` dimensions but `m+1` indices in the formula; similarly for `b` and `r`
2. **Reused index names**: When `m=n`, indices like `i_d` would appear in both `a` and `b` subscripts

## Fix
- Uses 1-based indexing (common in mathematical notation to simplify expressions)
- Uses `i` for indices from `a`, `j` for indices from `b`, `k` for contracted indices
- Correctly shows `m-d` free indices for `a`, `n-d` free indices for `b`, and `d` contracted indices

### Before
```math
r_{i_0,...,i_{m-d}, i_d,...,i_n} = \sum_{k_0,...,k_{d-1}} a_{i_0,...,i_{m-d},k_0,...,k_{d-1}} \times b_{k_0,...,k_{d-1}, i_d,...,i_n}
```

### After
```math
r_{i_1,...,i_{m-d}, j_1,...,j_{n-d}} = \sum_{k_1,...,k_d} a_{i_1,...,i_{m-d},k_1,...,k_d} \times b_{k_1,...,k_d, j_1,...,j_{n-d}}
```

cc @svekars @sekyondaMeta @AlannaBurke