### PR TITLE
Update torch.sparse.mm and addmm documentation for gradient support

### DIFF
--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -54,7 +54,12 @@ When inputs are COO tensors, this function also supports backward for both input
 Supports both CSR and COO storage formats.
 
 .. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
+    Gradient support:
+
+    - COO @ Dense: backward supported, returns sparse COO gradient
+    - CSR @ Dense: backward supported, returns sparse CSR gradient
+    - Sparse @ Sparse (COO @ COO, CSR @ CSR): forward works but backward is not supported
+    - Mixed format operations (COO @ CSR, CSR @ COO): not supported
 
 Args:
     mat (Tensor): a dense matrix to be added
@@ -74,12 +79,16 @@ mm = _add_docstr(
     :math:`(n \times m)` tensor, :attr:`mat2` is a :math:`(m \times p)` tensor, out will be a
     :math:`(n \times p)` tensor.
     When :attr:`mat1` is a COO tensor it must have `sparse_dim = 2`.
-    When inputs are COO tensors, this function also supports backward for both inputs.
 
     Supports both CSR and COO storage formats.
 
 .. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
+    Gradient support:
+
+    - COO @ Dense: backward supported, returns sparse COO gradient
+    - CSR @ Dense: backward supported, returns sparse CSR gradient
+    - Sparse @ Sparse (COO @ COO, CSR @ CSR): forward works but backward is not supported
+    - Mixed format operations (COO @ CSR, CSR @ COO): not supported
 
     This function also additionally accepts an optional :attr:`reduce` argument that allows
     specification of an optional reduction operation, mathematically performs the following operation:


### PR DESCRIPTION
## Summary
Fixes incorrect documentation in `torch.sparse.mm` and `torch.sparse.addmm` regarding gradient support for CSR matrices.

## Issue
Fixes #172550

## Problem
The documentation incorrectly stated:
> "This function doesn't support computing derivatives with respect to CSR matrices."

However, CSR @ Dense operations **do** support backward passes and return sparse CSR gradients on both CPU and CUDA.

## Changes
Updated both `torch.sparse.mm` and `torch.sparse.addmm` documentation to accurately describe gradient support:

- **COO @ Dense**: backward supported, returns sparse COO gradient
- **CSR @ Dense**: backward supported, returns sparse CSR gradient  
- **Sparse @ Sparse** (COO @ COO, CSR @ CSR): forward works but backward is not supported
- **Mixed format operations** (COO @ CSR, CSR @ COO): not supported

## Test Verification
As demonstrated in the linked issue, these operations work correctly:
```python
# CSR @ Dense - works and returns sparse CSR gradient
A = torch.tensor([[1., 0, 2], [0, 3, 0]]).to_sparse_csr().requires_grad_(True)
B = torch.tensor([[0, 1.], [2, 0], [0, 0]], requires_grad=True)
y = torch.sparse.mm(A, B)
y.sum().backward()
print(f"A.grad layout: {A.grad.layout}")  # torch.sparse_csr ✓
```

cc @nikitaved @pearu @cpuhrsch @amjames @bhosmer @jcaip