### PR TITLE
Improve nn.Flatten docstring to clarify Sequential usage

### DIFF
--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -13,7 +13,9 @@ class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor.
 
-    For use with :class:`~nn.Sequential`, see :meth:`torch.flatten` for details.
+    This module is designed for use with :class:`~nn.Sequential`. Unlike the functional
+    :meth:`torch.flatten`, this class can be instantiated and added to a Sequential
+    container. Both perform the same flattening operation.
 
     Shape:
         - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,'


### PR DESCRIPTION
## Summary

Improves the `nn.Flatten` docstring to clarify its purpose with `nn.Sequential`.

## Issue

Fixes #171401

## Problem

The previous docstring said:
> "For use with Sequential, see torch.flatten for details"

However, the `torch.flatten` documentation doesn't contain any information about Sequential usage. This was confusing because users were directed to documentation that didn't have the expected information.

## Solution

Updated the docstring to clearly explain:
- `nn.Flatten` is designed for use with `nn.Sequential`
- Unlike `torch.flatten` (a function), `nn.Flatten` can be instantiated and added to a Sequential container
- Both perform the same flattening operation

### Before
```
For use with Sequential, see torch.flatten for details.
```

### After
```
This module is designed for use with nn.Sequential. Unlike the functional
torch.flatten, this class can be instantiated and added to a Sequential
container. Both perform the same flattening operation.
```

cc @svekars @sekyondaMeta @AlannaBurke