### PR TITLE
Add docstring for Node.next_functions property

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -70,6 +70,27 @@ class Node(abc.ABC):
     @property
     @abc.abstractmethod
     def next_functions(self) -> tuple[tuple[Optional["Node"], int], ...]:
+        r"""Return the next functions in the autograd graph.
+
+        Returns a tuple of (Node, int) pairs representing the edges to input nodes
+        in the autograd graph. Each tuple contains:
+        - The Node that produced the corresponding input to this Node's forward function
+          (or None if the input was not a tensor or didn't require grad)
+        - The output index of that Node which corresponds to this input
+
+        This property is used during backpropagation to traverse the computational graph
+        and propagate gradients to the appropriate inputs.
+
+        Example::
+
+            >>> import torch
+            >>> a = torch.tensor([1., 2., 3.], requires_grad=True)
+            >>> b = torch.tensor([4., 5., 6.], requires_grad=True)
+            >>> c = a + b
+            >>> # c.grad_fn is AddBackward0, with next_functions pointing to a and b's accumulators
+            >>> print(c.grad_fn.next_functions)
+            ((<AccumulateGrad object at ...>, 0), (<AccumulateGrad object at ...>, 0))
+        """
         raise NotImplementedError
 
     @abc.abstractmethod


### PR DESCRIPTION
## Summary

Adds documentation for the `Node.next_functions` property in the autograd graph.

## Issue

Fixes #171620

## Problem

The `next_functions` property documentation page only describes the structure of the object, not what it does or how to use it.

## Solution

Added a comprehensive docstring that:
- Explains that it returns a tuple of (Node, int) pairs representing edges in the autograd graph
- Describes what each tuple element represents:
  - The Node that produced the corresponding input
  - The output index of that Node
- Explains the purpose: used during backpropagation to traverse the graph
- Provides a practical usage example

## Example Added

```python
>>> import torch
>>> a = torch.tensor([1., 2., 3.], requires_grad=True)
>>> b = torch.tensor([4., 5., 6.], requires_grad=True)
>>> c = a + b
>>> # c.grad_fn is AddBackward0, with next_functions pointing to a and b's accumulators
>>> print(c.grad_fn.next_functions)
((<AccumulateGrad object at ...>, 0), (<AccumulateGrad object at ...>, 0))
```

cc @svekars @sekyondaMeta @AlannaBurke @ezyang @albanD