### PR TITLE
[DTensor] Fix IndexError in _get_flattened_mesh_by_layout for unflattened meshes

### DIFF
--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -183,6 +183,11 @@ def _get_flattened_mesh_by_layout(
     if mesh_dim_names is None:
         return None
 
+    # If mesh_dims references dimensions beyond root_mesh's dimensions,
+    # we can't map to flattened mesh (mesh was created from_group or differently)
+    if any(i >= len(mesh_dim_names) for i in mesh_dims):
+        return None
+
     # Convert mesh dim indices to dim names
     dim_names = tuple(mesh_dim_names[i] for i in mesh_dims)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174006

When a mesh is created by unflattening a 1D world mesh (e.g., torchtitan's
pattern of creating a 2D mesh from a 1D world mesh), the redistribute
optimization code would crash with IndexError.

The bug: `_get_flattened_mesh_by_layout` used `root_mesh.mesh_dim_names` to
convert `mesh_dims` indices to names, but `mesh_dims` are indices into the
current mesh, not the root. When the current mesh has more dimensions than
the root (e.g., 2D mesh unflattened from 1D root), accessing
`root_mesh.mesh_dim_names[1]` fails.

The fix: add a bounds check to return None (skip optimization) when mesh_dims
indices exceed the root mesh's dimensions. This safely disables the flattening
optimization for these mesh configurations rather than crashing.

Authored with Claude.