### PR TITLE
[DTensor] Propagate 'grad_dtype' attribute in to_local/from_local/redistribute

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3833,29 +3833,6 @@ class TestAutograd(TestCase):
         z2.sum().backward()
         self.assertEqual(l.grad.dtype, torch.float32)
 
-    @skipIfTorchDynamo("grad_dtype not supported in compile")
-    def test_grad_dtype_nonleaf(self):
-        # Test that grad_dtype can be read from non-leaf tensors
-        leaf = torch.tensor([1.0, 2.0], requires_grad=True)
-        leaf.grad_dtype = torch.float16
-        
-        # Create non-leaf tensor through operations
-        non_leaf = leaf * 2
-        self.assertFalse(non_leaf.is_leaf)
-        
-        # Reading grad_dtype from non-leaf tensor should work
-        grad_dtype_value = non_leaf.grad_dtype
-        self.assertIsNotNone(grad_dtype_value)
-        
-        # grad_dtype is propagated from the leaf tensor
-        # (the non-leaf tensor inherits the grad_dtype context)
-        
-        # But setting grad_dtype on non-leaf should still fail
-        with self.assertRaisesRegex(
-            RuntimeError, "grad_dtype can only be set on leaf tensors"
-        ):
-            non_leaf.grad_dtype = torch.float32
-
     def test_gc_in_destructor(self):
         """
         Previously, if a Function destructor triggered a garbage collection,

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3724,10 +3724,6 @@ class TestAutograd(TestCase):
         non_leaf = leaf * 2
         self.assertFalse(non_leaf.is_leaf)
         with self.assertRaisesRegex(
-            RuntimeError, "grad_dtype can only be accessed on leaf tensors"
-        ):
-            _ = non_leaf.grad_dtype
-        with self.assertRaisesRegex(
             RuntimeError, "grad_dtype can only be set on leaf tensors"
         ):
             non_leaf.grad_dtype = torch.float16

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -3070,8 +3070,6 @@ static PyObject* THPVariable_get_grad_dtype(THPVariable* self, void* unused) {
     return handle_torch_function_getter(self, "grad_dtype");
   }
   const auto& var = THPVariable_Unpack(self);
-  TORCH_CHECK(
-      !var.grad_fn(), "grad_dtype can only be accessed on leaf tensors.");
   if (!var.grad_dtype().has_value()) {
     Py_RETURN_NONE;
   } else {

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -107,7 +107,9 @@ class _ToTorchTensor(torch.autograd.Function):
         # We need to return a fresh Tensor object there as autograd metadata
         # will be inplaced into it. So we don't want to pollute the Tensor
         # object stored in the _local_tensor of this DTensor.
-        return local_tensor.view_as(local_tensor)
+        local_tensor = local_tensor.view_as(local_tensor)
+        local_tensor.grad_dtype = input.grad_dtype
+        return local_tensor
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
@@ -226,6 +228,7 @@ class _FromTorchTensor(torch.autograd.Function):
             # pyrefly: ignore [unexpected-keyword]
             requires_grad=input.requires_grad,
         )
+        dist_tensor.grad_dtype = input.grad_dtype
         return dist_tensor
 
     @staticmethod

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1676,13 +1676,17 @@ class Redistribute(torch.autograd.Function):
             target_spec = current_spec
 
         # pyrefly: ignore [bad-argument-type]
-        return dtensor.DTensor(
+        dist_tensor = dtensor.DTensor(
             # pyrefly: ignore [bad-argument-count]
             output,
             target_spec,
             # pyrefly: ignore [unexpected-keyword]
             requires_grad=input.requires_grad,
         )
+        # set grad_dtype to backward_dtype
+        if backward_dtype is not None:
+            dist_tensor.grad_dtype = backward_dtype
+        return dist_tensor
 
     @staticmethod
     def backward(ctx, grad_output: "dtensor.DTensor"):  # type: ignore[override]


### PR DESCRIPTION
This PR enables the preservation of gradient precision (preventing downcasting) during DTensor conversions by explicitly handling the grad_dtype attribute.(#173990)

**Key Changes:**

1.Removed grad_dtype validation for non-leaf nodes to support change 2
2.Propagated grad_dtype in DTensor operations: Updated to_local, from_local, and redistribute methods to pass and set the grad_dtype attribute correctly. 

**Example:**
Here is an example demonstrating this in an FSDP + EP scenario:
**AS IS:**
```text
W(dtensor) ---> (to_local) ---> W(tensor) -------> (gmm) --------> Y
dtype=bf16                      dtype=bf16                    dtype=bf16
grad_dtype=fp32

(leaf node)                     (non-leaf)                       
                                                                   
dW(dtensor) <--(to_local_bwd)-- dW(tensor) <------(gmmbwd) <------ dY
dtype=fp32                      dtype=bf16      with fp32 out   dtype=bf16
      ^                               ^                         
      |____[upcast to fp32]          |____[downcast to bf16] (align to W dtype)
```
**TO BE:**
Since grad_dtype is passed through to_local, backward gradients are no longer downcasted
```text
W(dtensor) ---> (to_local) ---> W(tensor) -------> (gmm) --------> Y
dtype=bf16                      dtype=bf16                    dtype=bf16
grad_dtype=fp32                 grad_dtype=fp32

(leaf node)                     (non-leaf)                       
                                                                   
dW(dtensor) <--(to_local_bwd)-- dW(tensor) <------(gmmbwd) <------ dY
dtype=fp32                      dtype=fp32      with fp32 out   dtype=bf16
                                      ^                         
                                      |____[no cast] (align to W grad_dtype)
```