### PR TITLE
[Inductor] Round scalar constants before compute type promotion

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -578,7 +578,7 @@ def promote_constants(inputs, override_return_dtype=None, type_promotion_kind=No
     def round_pyfloat_to_dtype(value, dtype):
         # To match eager semantics, Python float literals should be first rounded to
         # dtype before pointwise computation. Low-precision dtypes compute in higher
-        # precision via opmath. This ensures the scalar is the widened low-precision
+        # precision via op math. This ensures the scalar is the widened low-precision
         # value.
         if isinstance(value, float) and dtype in (torch.float16, torch.bfloat16):
             return torch.tensor(value, dtype=dtype).item()


### PR DESCRIPTION
Fixes: #173987

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos