### PR TITLE
Bind SymmetricMemory as torch class for use in op definition

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -1,11 +1,21 @@
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 
+#include <torch/custom_class.h>
+
 #include <atomic>
 
 namespace {
 
 using namespace c10d::symmetric_memory;
+
+// Register SymmetricMemory as a TorchBind custom class so that dispatcher
+// schemas can accept/return it via
+// __torch__.torch.classes.c10d.SymmetricMemory. Note: SymmetricMemory is
+// abstract; instances are produced by backend rendezvous and may be of a
+// derived type stored behind an intrusive_ptr.
+static auto symm_mem_torchbind_class =
+    torch::class_<SymmetricMemory>("c10d", "SymmetricMemory");
 
 static bool is_finalizing_ = false;
 
@@ -540,6 +550,28 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
       "tile_reduce(Tensor in_tile, Tensor(a!) out_tile, int root, str group_name, str reduce_op='sum') -> ()");
   m.def(
       "multi_root_tile_reduce(Tensor[] in_tiles, Tensor(a!) out_tile, int[] roots, str group_name, str reduce_op='sum') -> ()");
+
+  // Dispatcher-visible (TorchBind) SymmetricMemory API.
+  m.def(
+      "_rendezvous(Tensor tensor, str? group_name=None) -> __torch__.torch.classes.c10d.SymmetricMemory");
+  m.def("_barrier(__torch__.torch.classes.c10d.SymmetricMemory symm) -> ()");
+}
+
+c10::intrusive_ptr<SymmetricMemory> rendezvous_op(
+    const at::Tensor& tensor,
+    std::optional<std::string> group_name) {
+  return c10d::symmetric_memory::rendezvous(tensor, group_name);
+}
+
+void barrier_op(const c10::intrusive_ptr<SymmetricMemory>& symm) {
+  // Keep the dispatcher signature minimal for now; use the common default
+  // semantics (channel=0, timeout_ms=0).
+  symm->barrier(/*channel=*/0, /*timeout_ms=*/0);
+}
+
+TORCH_LIBRARY_IMPL(symm_mem, CompositeExplicitAutograd, m) {
+  m.impl("_rendezvous", rendezvous_op);
+  m.impl("_barrier", barrier_op);
 }
 
 TORCH_LIBRARY_IMPL(symm_mem, Meta, m) {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -552,6 +552,8 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
       "multi_root_tile_reduce(Tensor[] in_tiles, Tensor(a!) out_tile, int[] roots, str group_name, str reduce_op='sum') -> ()");
 
   // Dispatcher-visible (TorchBind) SymmetricMemory API.
+  // For now, `_rendezvous` and `_barrier` are for testing dispatcher support
+  // only. Please do not use them in production code.
   m.def(
       "_rendezvous(Tensor tensor, str? group_name=None) -> __torch__.torch.classes.c10d.SymmetricMemory");
   m.def("_barrier(__torch__.torch.classes.c10d.SymmetricMemory symm) -> ()");
@@ -570,6 +572,8 @@ void barrier_op(const c10::intrusive_ptr<SymmetricMemory>& symm) {
 }
 
 TORCH_LIBRARY_IMPL(symm_mem, CompositeExplicitAutograd, m) {
+  // For now, `_rendezvous` and `_barrier` are for testing dispatcher support
+  // only. Please do not use them in production code.
   m.impl("_rendezvous", rendezvous_op);
   m.impl("_barrier", barrier_op);
 }

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/core/ivalue.h>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 
 namespace c10d::symmetric_memory {
@@ -35,7 +36,7 @@ namespace c10d::symmetric_memory {
 // correctness of the barriers since signals issued from barrier on stream A
 // can be received by the barrier on stream B. By specifying different channels
 // for these two barriers, they can operate correctly in parallel.
-class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
+class TORCH_API SymmetricMemory : public torch::CustomClassHolder {
  public:
   ~SymmetricMemory() override = default;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #174034
* __->__ #174019

## Motivation
For some ops, it is necessary to provide the SymmetricMemory handle, for example, in one-sided operations:
`wait(handle, peer)`

(Detail: if a symm tensor is provided here instead of `handle`, then the `wait` op would have to perform implicit rendezvous internally. This can lead to hang because unlike collectives, one-sided operations do not have the guarantee from users that (i) the whole world would call into the op; and (ii) send/recv sides would call ops in the same order). 

## This PR

- Register `c10d::symmetric_memory::SymmetricMemory` as a TorchBind custom class (`__torch__.torch.classes.c10d.SymmetricMemory`) so it can be used in dispatcher schemas.
- Add dispatcher ops for testing return and accept of SymmMem handles:
`symm_mem::_rendezvous(Tensor, str?) -> __torch__.torch.classes.c10d.SymmetricMemory`
`symm_mem::_barrier(__torch__.torch.classes.c10d.SymmetricMemory) -> ()`
(Note has been added that these ops should *not* be used in production code, they are for use in CI making sure the binding does not break)
- Update distributed tests to exercise returning/accepting the TorchBind SymmetricMemory object through torch.ops.symm_mem.*.
 
