### PR TITLE
[ROCm]Enable previously skipped distributed UTs

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -22,9 +22,7 @@ from torch.distributed.elastic.utils.distributed import (
 from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_WINDOWS,
-    MI200_ARCH,
     run_tests,
-    skipIfRocmArch,
     TEST_WITH_TSAN,
     TestCase,
 )
@@ -175,7 +173,6 @@ class DistributedUtilTest(TestCase):
                 is_server=True, server_addr=server_addr, server_port=store1.port
             )
 
-    @skipIfRocmArch(MI200_ARCH)
     def test_port_already_in_use_on_worker(self):
         sock = get_socket_with_port()
         with closing(sock):

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -17,7 +17,7 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor._sharding_prop import ShardingPropagator
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import MI200_ARCH, run_tests, skipIfRocmArch
+from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorConverter,
@@ -609,7 +609,6 @@ class DistTensorOpsTest(DTensorTestBase):
             self.assertEqual(output_dt.placements, [Shard(gather_dim)])
             self.assertEqual(output_dt.full_tensor(), global_output)
 
-    @skipIfRocmArch(MI200_ARCH)
     @with_comms
     def test_index(self):
         meshes = [


### PR DESCRIPTION
Investigating distributed UTs skipped specifically based on target arch

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang