### PR TITLE
[xpu][test] Skip XPU fp8 for known oneDNN accuracy issue

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -652,7 +652,7 @@ class TestFP8Matmul(TestCase):
             self.assertEqual(out_dtype, out_fp8.dtype)
         self.assertEqual(out_fp32, out_fp8.to(torch.float))
 
-    # Skip on XPU duet to known oneDNN accuracy issue (#169772)
+    # Skip on XPU due to known oneDNN accuracy issue (#169772)
     @skipXPU
     def test_float8_basics(self, device) -> None:
         if not _device_supports_scaled_mm_fp8(device):

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -652,7 +652,7 @@ class TestFP8Matmul(TestCase):
             self.assertEqual(out_dtype, out_fp8.dtype)
         self.assertEqual(out_fp32, out_fp8.to(torch.float))
 
-    # Skip XPU as known bug in oneDNN (See #169772)
+    # Skip on XPU duet to known oneDNN accuracy issue (#169772)
     @skipXPU
     def test_float8_basics(self, device) -> None:
         if not _device_supports_scaled_mm_fp8(device):

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -652,6 +652,8 @@ class TestFP8Matmul(TestCase):
             self.assertEqual(out_dtype, out_fp8.dtype)
         self.assertEqual(out_fp32, out_fp8.to(torch.float))
 
+    # Skip XPU as known bug in oneDNN (See #169772)
+    @skipXPU
     def test_float8_basics(self, device) -> None:
         if not _device_supports_scaled_mm_fp8(device):
             raise unittest.SkipTest(f8_msg)


### PR DESCRIPTION
Skip tests in https://github.com/pytorch/pytorch/issues/169772
The fix relies on oneDNN upgrade, and we won't upgrade oneDNN in v2.11, so we will temporarily skip this test for now.

The oneDNN accuracy issue only affects the single unittest, and we didn't witness the error in model running, so we skip it as a temporary solution.

cc @gujinghui @EikanWang @fengyuan14 @guangyey