### PR TITLE
Fix _foreach_norm to support symbolic tensors with dynamic shapes

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -494,8 +494,8 @@ std::vector<Tensor> foreach_tensor_norm_slow(
     // If the tensor is empty and norm == infinity, we cannot compute the norm
     // because the operation does not have an identity
     if (p == std::numeric_limits<double>::infinity()) {
-      TORCH_CHECK(
-          t.numel() > 0,
+      TORCH_SYM_CHECK(
+          t.sym_numel().sym_gt(0),
           "_foreach_norm cannot compute the infinity norm on an empty tensor because the operation does not have an identity");
     }
     result.emplace_back(at::linalg_vector_norm(t, ord, {}, false, dtype));

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -591,8 +591,8 @@ std::vector<Tensor> foreach_tensor_norm_cuda(
   bool has_int_or_complex = false;
   if (p == std::numeric_limits<double>::infinity()) {
     for (const auto& t : tensors) {
-      TORCH_CHECK(
-          t.numel() > 0,
+      TORCH_SYM_CHECK(
+          t.sym_numel().sym_gt(0),
           "_foreach_norm cannot compute the infinity norm on an empty tensor because the operation does not have an identity");
       const auto scalar_type = t.scalar_type();
       if (at::isIntegralType(scalar_type, /*includeBool*/ true) ||


### PR DESCRIPTION
Summary:
D91979475 added a check for infinity norm on empty tensors using `t.numel()`, but this fails during tracing with dynamic shapes because `numel()` cannot be called on tensors with symbolic sizes/strides.

This change uses `sym_numel()` and `TORCH_SYM_CHECK` which properly handle both symbolic and non-symbolic tensors, fixing the breaking test while maintaining the same validation behavior for concrete tensors.

Differential Revision: D92010344


