### PR TITLE
[Inductor][B200] Enable exhaustive autotuning for B200 scaled_mm

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -979,6 +979,9 @@ def tuned_scaled_mm(
         if (
             use_triton_blackwell_tma_template(mat_a, mat_b, output_layout=layout)
             and not bias
+            and use_triton_scaling_template(
+                scale_option_a, scale_option_b, epilogue_scaling_types
+            )
         ):
             templates_to_use.append(blackwell_ws_persistent_device_tma_mm_template)
             kwarg_overrides[blackwell_ws_persistent_device_tma_mm_template.uid] = (

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2580,8 +2580,9 @@ class CUDAScaledBlackwellTMATemplateConfigHeuristic(
 
     def __init__(self) -> None:
         super().__init__()
-        # TODO: Tune scaled_persistent_mm_configs for Blackwell
-        self.mm_configs = self.blackwell_persistent_addmm_configs
+        # TODO: Tune self.blackwell_scaled_persistent_mm_configs
+        self.mm_configs = self.blackwell_scaled_persistent_mm_configs
+        self.exhaustive_configs = self._generate_exhaustive_configs()
 
 
 @register_template_heuristic(


### PR DESCRIPTION
Summary: Enable exhaustive autotuning for B200 `scaled_mm`. Previously, exhaustive autotuning was blocked by an IMA, which is now resolved using `_generate_exhaustive_configs`.

Test Plan:
```
buck2 test mode/opt fbcode//caffe2/test/inductor:max_autotune_blackwell
```

Differential Revision: D92009975




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo