### PR TITLE
[inductor] Improve constexpr handling for user-defined Triton kernels

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2665,6 +2665,51 @@ def forward(self, arg0_1, arg1_1):
         ).run(code[0])
 
     @requires_gpu
+    @unittest.skipIf(
+        not triton_version_uses_attrs_dict(),
+        "Test is only valid for new triton versions where attrs is represented by a raw dict",
+    )
+    def test_user_defined_kernel_constexpr_skipped_in_call(self):
+        """
+        Test that user-defined kernel args marked as constexpr in the signature
+        (but without tl.constexpr annotation) are correctly skipped in the call.
+        """
+
+        @triton.jit
+        def triton_(in_ptr, out_ptr, numel, add_amount, BLOCK_SIZE: tl.constexpr):
+            offsets = tl.arange(0, BLOCK_SIZE)
+            x = tl.load(in_ptr + offsets, mask=(offsets < numel))
+            output = x * x
+            if add_amount is not None:
+                output = output + add_amount
+            tl.store(out_ptr + offsets, output, mask=(offsets < numel))
+
+        def fn(x):
+            y = torch.empty_like(x)
+            BLOCK_SIZE = 256
+            grid = (1,)
+            # numel=1 and add_amount=None get marked as "constexpr" in signature
+            triton_[grid](x, y, x.numel(), None, BLOCK_SIZE)
+            return y
+
+        x = torch.full((1,), 2.5, device=GPU_TYPE)
+        expected = fn(x)
+
+        fn_c = torch.compile(fn)
+        res, code = run_and_get_code(fn_c, x)
+        self.assertEqual(expected, res)
+
+        # Verify the user_defined_kernel flag is set in inductor_meta
+        FileCheck().check("inductor_meta=").check("'user_defined_kernel': True").run(
+            code[0]
+        )
+
+        # The kernel call should only have 5 args: in_ptr, out_ptr, grid_0, grid_1, grid_2
+        # NOT 7 args including numel and add_amount
+        # Pattern: .run(arg0_1, buf0, 1, 1, 1, stream=stream0)
+        FileCheck().check(".run(").check_not(", -1,").check("stream=").run(code[0])
+
+    @requires_gpu
     @inductor_config.patch({"triton.autotune_at_compile_time": True})
     @parametrize("quotes", ["single", "double"])
     def test_kernel_with_docstring(self, quotes):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2675,6 +2675,7 @@ class PythonWrapperCodegen(CodeGen):
             compile_wrapper.writeline(f"async_compile.triton({original_name!r}, '''")
 
         inductor_meta["kernel_name"] = name
+        inductor_meta["user_defined_kernel"] = True
         triton_info_kernel_cls = self._get_triton_info_kernel_cls()
         inductor_meta.update(triton_info_kernel_cls.inductor_meta_common())
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7130,10 +7130,11 @@ class UserDefinedTritonKernel(ExternKernel):
         arg_types: list[Any] = []
         raw_keys_filtered: list[Any] = []
         raw_args_filtered: list[Any] = []
+        signature = triton_meta.get("signature", {})
         for name, arg in itertools.chain(
             named_args.items(), zip(itertools.repeat(""), extra_launch_args)
         ):
-            if name in constexpr_names and triton_version_uses_attrs_dict():
+            if triton_version_uses_attrs_dict() and signature.get(name) == "constexpr":
                 # see #160000 - we don't pass in constexpr args to speed up runtime.
                 continue
             raw_keys_filtered.append(name)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1600,9 +1600,21 @@ class CompileResult(Generic[_T]):
         """
         compile_meta = self.compile_meta
         cfg = self.config
-        known_constants = OrderedSet(
-            arg for i, arg in enumerate(arg_names) if i in constexprs
-        )
+
+        # For user-defined kernels, the signature is the authoritative source for
+        # all constexprs (both tl.constexpr annotated and runtime constants like N=1).
+        # For inductor-generated kernels, use annotation-based constexprs since
+        # size parameters like xnumel may be marked as "constexpr" in the signature
+        # but are handled differently.
+        if self.inductor_meta.get("user_defined_kernel"):
+            signature = compile_meta.get("signature", {})
+            known_constants = OrderedSet(
+                name for name, sig_type in signature.items() if sig_type == "constexpr"
+            )
+        else:
+            known_constants = OrderedSet(
+                arg for i, arg in enumerate(arg_names) if i in constexprs
+            )
 
         """
         https://github.com/pytorch/pytorch/issues/115344


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #173804
* __->__ #174031
* #173102
* #173101

Add proper constexpr handling for user-defined Triton kernels that pass
constant values without tl.constexpr annotations.

When a user passes a constant value like `n_elements=1`, it's marked as
"constexpr" in the signature and added to constants. The launcher and
call generation must agree on whether to skip such args. This is to prepare
for the cpp-wrapper lazy kernel compilation.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo