### PR TITLE
[docs] Fix incorrect gradient support documentation for torch.sparse.mm and sparse.addmm

### DIFF
--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -47,14 +47,20 @@ addmm = _add_docstr(
 sparse.addmm(mat, mat1, mat2, *, beta=1., alpha=1.) -> Tensor
 
 This function does exact same thing as :func:`torch.addmm` in the forward,
-except that it supports backward for sparse COO matrix :attr:`mat1`.
+except that it supports backward for sparse matrix :attr:`mat1`.
 When :attr:`mat1` is a COO tensor it must have `sparse_dim = 2`.
-When inputs are COO tensors, this function also supports backward for both inputs.
 
 Supports both CSR and COO storage formats.
 
 .. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
+    **Gradient support:**
+
+    - **COO @ Dense**: Backward is supported for both inputs. The gradient for the
+      sparse input is returned as a sparse COO tensor.
+    - **CSR @ Dense**: Backward is supported for both inputs. The gradient for the
+      sparse input is returned as a sparse CSR tensor.
+    - **Sparse @ Sparse** (COO @ COO, CSR @ CSR): Forward works, but backward is
+      not supported.
 
 Args:
     mat (Tensor): a dense matrix to be added
@@ -74,12 +80,19 @@ mm = _add_docstr(
     :math:`(n \times m)` tensor, :attr:`mat2` is a :math:`(m \times p)` tensor, out will be a
     :math:`(n \times p)` tensor.
     When :attr:`mat1` is a COO tensor it must have `sparse_dim = 2`.
-    When inputs are COO tensors, this function also supports backward for both inputs.
 
     Supports both CSR and COO storage formats.
 
 .. note::
-    This function doesn't support computing derivatives with respect to CSR matrices.
+    **Gradient support:**
+
+    - **COO @ Dense**: Backward is supported for both inputs. The gradient for the
+      sparse input is returned as a sparse COO tensor.
+    - **CSR @ Dense**: Backward is supported for both inputs. The gradient for the
+      sparse input is returned as a sparse CSR tensor.
+    - **Sparse @ Sparse** (COO @ COO, CSR @ CSR): Forward works, but backward is
+      not supported.
+    - **Mixed formats** (COO @ CSR, CSR @ COO): Not supported.
 
     This function also additionally accepts an optional :attr:`reduce` argument that allows
     specification of an optional reduction operation, mathematically performs the following operation:

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -47,7 +47,7 @@ addmm = _add_docstr(
 sparse.addmm(mat, mat1, mat2, *, beta=1., alpha=1.) -> Tensor
 
 This function does exact same thing as :func:`torch.addmm` in the forward,
-except that it supports backward for sparse matrix :attr:`mat1`.
+except that it supports backward for sparse COO and CSR matrix :attr:`mat1`.
 When :attr:`mat1` is a COO tensor it must have `sparse_dim = 2`.
 
 Supports both CSR and COO storage formats.
@@ -59,6 +59,7 @@ Supports both CSR and COO storage formats.
       sparse input is returned as a sparse COO tensor.
     - **CSR @ Dense**: Backward is supported for both inputs. The gradient for the
       sparse input is returned as a sparse CSR tensor.
+    - **CSC/BSR/BSC @ Dense**: Not supported.
     - **Sparse @ Sparse** (COO @ COO, CSR @ CSR): Forward works, but backward is
       not supported.
 
@@ -90,6 +91,7 @@ mm = _add_docstr(
       sparse input is returned as a sparse COO tensor.
     - **CSR @ Dense**: Backward is supported for both inputs. The gradient for the
       sparse input is returned as a sparse CSR tensor.
+    - **CSC/BSR/BSC @ Dense**: Not supported.
     - **Sparse @ Sparse** (COO @ COO, CSR @ CSR): Forward works, but backward is
       not supported.
     - **Mixed formats** (COO @ CSR, CSR @ COO): Not supported.


### PR DESCRIPTION
## Summary

Fixes incorrect documentation for `torch.sparse.mm` and `sparse.addmm` that stated CSR gradients are not supported, when they actually are.

## Changes

The documentation previously stated:
> "This function doesn't support computing derivatives with respect to CSR matrices."

This is **incorrect**. CSR @ Dense operations do support backward pass and return sparse CSR gradients on both CPU and CUDA.

Updated the `.. note::` sections to accurately describe gradient support:

| Operation | Forward | Backward | Gradient Type |
|-----------|---------|----------|---------------|
| COO @ Dense | ✅ | ✅ | sparse COO |
| CSR @ Dense | ✅ | ✅ | sparse CSR |
| COO @ COO | ✅ | ❌ | - |
| CSR @ CSR | ✅ | ❌ | - |
| COO @ CSR | ❌ | - | - |
| CSR @ COO | ❌ | - | - |

## Reproduction

```python
import torch

# CSR @ Dense - works and returns sparse CSR gradient
A = torch.tensor([[1., 0, 2], [0, 3, 0]]).to_sparse_csr().requires_grad_(True)
B = torch.tensor([[0, 1.], [2, 0], [0, 0]], requires_grad=True)
y = torch.sparse.mm(A, B)
y.sum().backward()
print(f"A.grad layout: {A.grad.layout}")  # torch.sparse_csr
```

Fixes #172550

cc @nikitaved @pearu @cpuhrsch @amjames @bhosmer @jcaip @svekars @sekyondaMeta @AlannaBurke