### PR TITLE
[2/2][XPU] Implement XPUGraph remaining features: pool()/debug_dump() etc

### DIFF
--- a/aten/src/ATen/xpu/XPUGeneratorImpl.cpp
+++ b/aten/src/ATen/xpu/XPUGeneratorImpl.cpp
@@ -245,6 +245,20 @@ void XPUGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   this->set_philox_offset_per_thread(philox_offset);
 }
 
+void XPUGeneratorImpl::graphsafe_set_state(
+    const c10::intrusive_ptr<GeneratorImpl>& gen) {
+  c10::intrusive_ptr<XPUGeneratorImpl> xpu_gen =
+      dynamic_intrusive_pointer_cast<XPUGeneratorImpl>(gen);
+  TORCH_CHECK(xpu_gen, "Expected a XPU Generator");
+  state_ = xpu_gen->state_;
+}
+
+c10::intrusive_ptr<c10::GeneratorImpl> XPUGeneratorImpl::graphsafe_get_state()
+    const {
+  auto gen = make_intrusive<XPUGeneratorImpl>(device().index(), state_);
+  return gen;
+}
+
 void XPUGeneratorImpl::set_philox_offset_per_thread(uint64_t offset) {
   TORCH_CHECK(offset % 4 == 0, "offset must be a multiple of 4");
   if (C10_LIKELY(

--- a/aten/src/ATen/xpu/XPUGeneratorImpl.h
+++ b/aten/src/ATen/xpu/XPUGeneratorImpl.h
@@ -55,6 +55,9 @@ struct TORCH_XPU_API XPUGeneratorImpl : public GeneratorImpl {
   uint64_t seed() override;
   void set_state(const c10::TensorImpl& new_state) override;
   c10::intrusive_ptr<c10::TensorImpl> get_state() const override;
+  void graphsafe_set_state(
+      const c10::intrusive_ptr<GeneratorImpl>& state) override;
+  c10::intrusive_ptr<c10::GeneratorImpl> graphsafe_get_state() const override;
 
   void set_philox_offset_per_thread(uint64_t offset);
   uint64_t philox_offset_per_thread() const;

--- a/aten/src/ATen/xpu/XPUGraph.cpp
+++ b/aten/src/ATen/xpu/XPUGraph.cpp
@@ -185,27 +185,35 @@ void XPUGraph::enable_debug_mode() {
 }
 
 void XPUGraph::debug_dump(const std::string& debug_path) {
-  TORCH_CHECK(debug_path.size() >= 4 && debug_path.substr(debug_path.size() - 4) == ".dot",
-              "debug_path must end with .dot extension, got: ", debug_path);
+  TORCH_CHECK(
+      debug_path.size() >= 4 &&
+          debug_path.substr(debug_path.size() - 4) == ".dot",
+      "debug_path must end with .dot extension, got: ",
+      debug_path);
 
   if (_xpu_graphs_debug || keep_graph_) {
     TORCH_WARN("DEBUG: calling debug_dump()");
     if (has_graph_) {
-        TORCH_WARN("DEBUG: calling print_graph(verbose=1) to ", debug_path);
-        graph_->print_graph(debug_path, /* verbose = */ 1);
+      TORCH_WARN("DEBUG: calling print_graph(verbose=1) to ", debug_path);
+      graph_->print_graph(debug_path, /* verbose = */ 1);
       if (!keep_graph_) {
         graph_.reset();
         has_graph_ = false;
       }
     }
   } else {
-    TORCH_WARN("XPU Graphs debug not enabled, set with [graph].enable_debug_mode()");
+    TORCH_WARN(
+        "XPU Graphs debug not enabled, set with [graph].enable_debug_mode()");
   }
 }
 
 xpuGraph_t* XPUGraph::raw_xpu_graph() {
-  TORCH_CHECK(keep_graph_, "You cannot access the raw xpuGraph_t instance unless XPUGraph was initialized with keep_graph=true");
-  TORCH_CHECK(has_graph_, "You cannot access the raw xpuGraph_t instance until capture_end() has been called");
+  TORCH_CHECK(
+      keep_graph_,
+      "You cannot access the raw xpuGraph_t instance unless XPUGraph was initialized with keep_graph=true");
+  TORCH_CHECK(
+      has_graph_,
+      "You cannot access the raw xpuGraph_t instance until capture_end() has been called");
   return graph_.get();
 }
 
@@ -216,10 +224,12 @@ xpuGraphExec_t* XPUGraph::raw_xpu_graph_exec() {
   return graph_exec_.get();
 }
 
-// Returns an id another graph's capture_begin can use to share the same memory pool as this graph.
+// Returns an id another graph's capture_begin can use to share the same memory
+// pool as this graph.
 MempoolId_t XPUGraph::pool() {
-TORCH_CHECK(capture_ended_,
-              "Called XPUGraph::pool() without a preceding successful capture.");
+  TORCH_CHECK(
+      capture_ended_,
+      "Called XPUGraph::pool() without a preceding successful capture.");
   return mempool_id_;
 }
 

--- a/aten/src/ATen/xpu/XPUGraph.cpp
+++ b/aten/src/ATen/xpu/XPUGraph.cpp
@@ -180,6 +180,50 @@ void XPUGraph::reset() {
   }
 }
 
+void XPUGraph::enable_debug_mode() {
+  _xpu_graphs_debug = true;
+}
+
+void XPUGraph::debug_dump(const std::string& debug_path) {
+  TORCH_CHECK(debug_path.size() >= 4 && debug_path.substr(debug_path.size() - 4) == ".dot",
+              "debug_path must end with .dot extension, got: ", debug_path);
+
+  if (_xpu_graphs_debug || keep_graph_) {
+    TORCH_WARN("DEBUG: calling debug_dump()");
+    if (has_graph_) {
+        TORCH_WARN("DEBUG: calling print_graph(verbose=1) to ", debug_path);
+        graph_->print_graph(debug_path, /* verbose = */ 1);
+      if (!keep_graph_) {
+        graph_.reset();
+        has_graph_ = false;
+      }
+    }
+  } else {
+    TORCH_WARN("XPU Graphs debug not enabled, set with [graph].enable_debug_mode()");
+  }
+}
+
+// Is it necessary to have keep_graph_ = true to access the raw xpuGraph_t instance?
+xpuGraph_t* XPUGraph::raw_xpu_graph() {
+  TORCH_CHECK(keep_graph_, "You cannot access the raw xpuGraph_t instance unless XPUGraph was initialized with keep_graph=true");
+  TORCH_CHECK(has_graph_, "You cannot access the raw xpuGraph_t instance until capture_end() has been called");
+  return graph_.get();
+}
+
+xpuGraphExec_t* XPUGraph::raw_xpu_graph_exec() {
+  TORCH_CHECK(
+      has_graph_exec_,
+      "You cannot access the raw xpuGraphExec_t instance until instantiate() has been called");
+  return graph_exec_.get();
+}
+
+// Returns an id another graph's capture_begin can use to share the same memory pool as this graph.
+MempoolId_t XPUGraph::pool() {
+TORCH_CHECK(capture_ended_,
+              "Called XPUGraph::pool() without a preceding successful capture.");
+  return mempool_id_;
+}
+
 XPUGraph::~XPUGraph() {
   for (auto& [generator_state, wholegraph_increments] :
        captured_generator_states_) {

--- a/aten/src/ATen/xpu/XPUGraph.cpp
+++ b/aten/src/ATen/xpu/XPUGraph.cpp
@@ -203,7 +203,6 @@ void XPUGraph::debug_dump(const std::string& debug_path) {
   }
 }
 
-// Is it necessary to have keep_graph_ = true to access the raw xpuGraph_t instance?
 xpuGraph_t* XPUGraph::raw_xpu_graph() {
   TORCH_CHECK(keep_graph_, "You cannot access the raw xpuGraph_t instance unless XPUGraph was initialized with keep_graph=true");
   TORCH_CHECK(has_graph_, "You cannot access the raw xpuGraph_t instance until capture_end() has been called");

--- a/aten/src/ATen/xpu/XPUGraph.h
+++ b/aten/src/ATen/xpu/XPUGraph.h
@@ -33,6 +33,11 @@ struct TORCH_XPU_API XPUGraph {
   void instantiate();
   void replay();
   void reset();
+  MempoolId_t pool();
+  void enable_debug_mode();
+  void debug_dump(const std::string& debug_path);
+  xpuGraph_t* raw_xpu_graph();
+  xpuGraphExec_t* raw_xpu_graph_exec();  
 
  protected:
   std::unique_ptr<xpuGraph_t> graph_;

--- a/aten/src/ATen/xpu/XPUGraph.h
+++ b/aten/src/ATen/xpu/XPUGraph.h
@@ -37,7 +37,7 @@ struct TORCH_XPU_API XPUGraph {
   void enable_debug_mode();
   void debug_dump(const std::string& debug_path);
   xpuGraph_t* raw_xpu_graph();
-  xpuGraphExec_t* raw_xpu_graph_exec();  
+  xpuGraphExec_t* raw_xpu_graph_exec();
 
  protected:
   std::unique_ptr<xpuGraph_t> graph_;

--- a/torch/csrc/xpu/Graph.cpp
+++ b/torch/csrc/xpu/Graph.cpp
@@ -38,9 +38,45 @@ void THXPGraph_init(PyObject* module) {
           "instantiate",
           torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::instantiate))
       .def(
+          "register_generator_state",
+          [](::at::xpu::XPUGraph& self, py::handle raw_generator) {
+            auto generator = THPGenerator_Unwrap(raw_generator.ptr());
+            // We've unwrapped Python object to C++ object,
+            // so we could release GIL before calling into C++
+            py::gil_scoped_release release;
+            return self.register_generator_state(generator);
+          },
+          py::arg("generator"))
+      .def(
           "replay",
           torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::replay))
       .def(
           "reset",
-          torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::reset));
+          torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::reset))
+      .def(
+          "pool",
+          torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::pool))
+      .def(
+          "enable_debug_mode",
+          torch::wrap_pybind_function_no_gil(
+              &at::xpu::XPUGraph::enable_debug_mode))
+      .def(
+          "debug_dump",
+          torch::wrap_pybind_function_no_gil(
+              &at::xpu::XPUGraph::debug_dump),
+          py::arg("debug_path"))
+      .def(
+          "raw_xpu_graph",
+          [](at::xpu::XPUGraph& self) {
+            at::xpu::xpuGraph_t* graph = self.raw_xpu_graph();
+            return reinterpret_cast<uintptr_t>(graph);
+          },
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "raw_xpu_graph_exec",
+          [](at::xpu::XPUGraph& self) {
+            at::xpu::xpuGraphExec_t* graph_exec = self.raw_xpu_graph_exec();
+            return reinterpret_cast<uintptr_t>(graph_exec);
+          },
+          py::call_guard<py::gil_scoped_release>());
 }

--- a/torch/csrc/xpu/Graph.cpp
+++ b/torch/csrc/xpu/Graph.cpp
@@ -53,17 +53,14 @@ void THXPGraph_init(PyObject* module) {
       .def(
           "reset",
           torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::reset))
-      .def(
-          "pool",
-          torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::pool))
+      .def("pool", torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::pool))
       .def(
           "enable_debug_mode",
           torch::wrap_pybind_function_no_gil(
               &at::xpu::XPUGraph::enable_debug_mode))
       .def(
           "debug_dump",
-          torch::wrap_pybind_function_no_gil(
-              &at::xpu::XPUGraph::debug_dump),
+          torch::wrap_pybind_function_no_gil(&at::xpu::XPUGraph::debug_dump),
           py::arg("debug_path"))
       .def(
           "raw_xpu_graph",


### PR DESCRIPTION
XPUGraph PR submission plan, following this [RFC](https://github.com/pytorch/pytorch/issues/162143).

- [x] 1, enhance XPUGenerator to cover XPUGeneratorState and philoxState
- [x] 2, the implementation of MemPool in XPU device allocator
- [x] 3, the implementations of capture_begin/capture_end/instantiate for XPUGraph
- [ ] -> 4, the implementations of replay/debug_dump/reset for XPUGraph
- [ ] 5, XPUGraph python APIs: is_current_stream_capturing/graph_pool_handle/graph
- [ ] 6, XPUGraph python APIs: make_graphed_callables