### PR TITLE
Add CPU device check for batch_sizes tensor in RNN ops

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -2594,6 +2594,10 @@ std::pair<Tensor, hidden_type> _cudnn_impl(
       bidirectional);
 
   TORCH_CHECK(_batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+  TORCH_CHECK(
+      _batch_sizes.device().is_cpu(),
+      "batch_sizes tensor must be on CPU, but got ",
+      _batch_sizes.device());
   IntArrayRef batch_sizes{
       _batch_sizes.data_ptr<int64_t>(),
       static_cast<size_t>(_batch_sizes.size(0))};

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -905,6 +905,10 @@ std::pair<Tensor, hidden_type> _miopen_impl(
     int64_t hidden_size = hx.size(2);
 
     TORCH_CHECK(_batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+    TORCH_CHECK(
+        _batch_sizes.device().is_cpu(),
+        "batch_sizes tensor must be on CPU, but got ",
+        _batch_sizes.device());
     IntArrayRef batch_sizes { _batch_sizes.data_ptr<int64_t>(), static_cast<size_t>(_batch_sizes.size(0)) };
 
     Tensor dropout_state = at::empty({0}, input.options());


### PR DESCRIPTION
## Summary
Fixes the segmentation fault that occurs when calling `torch.ops.aten.gru` (and other RNN ops) with `batch_sizes` tensor on CUDA instead of CPU.

## Changes
- Added `TORCH_CHECK` validation in `aten/src/ATen/native/cudnn/RNN.cpp` to verify `batch_sizes` is on CPU
- Added same validation in `aten/src/ATen/native/miopen/RNN_miopen.cpp` for AMD/ROCm

## Root Cause
When using packed sequences with RNN operations, the `batch_sizes` tensor is converted to an `IntArrayRef` by directly accessing its data pointer via `data_ptr<int64_t>()`. If the tensor is on CUDA, this causes a segmentation fault because we're trying to access GPU memory from CPU code.

## Reproduction
```python
import torch

def model_func(data, batch_sizes, hx, params):
    out = torch.ops.aten.gru(data, batch_sizes=batch_sizes, hx=hx, params=params,
                              has_biases=True, num_layers=1, dropout=0, train=False, bidirectional=False)
    return out

input_config = {
    'data': torch.randn([4, 3, 4], dtype=torch.float32, device='cuda'),
    'batch_sizes': torch.tensor([3, 2, 2, 1], dtype=torch.int64, device='cuda'),  # Bug: should be on CPU
    'hx': torch.randn([1, 3, 2], dtype=torch.float32, device='cuda'),
    'params': [torch.randn([6, 4], dtype=torch.float32, device='cuda'),
               torch.randn([6, 2], dtype=torch.float32, device='cuda'),
               torch.randn([6], dtype=torch.float32, device='cuda'),
               torch.randn([6], dtype=torch.float32, device='cuda')]
}

model_func(**input_config)  # Before: Segmentation fault; After: RuntimeError with helpful message
```

## Expected Behavior After Fix
```
RuntimeError: batch_sizes tensor must be on CPU, but got cuda:0
```

Fixes #173623

cc @mikaylagawarecki @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @malfet