### PR TITLE
[ROCm] make CompilerBisector tests more deterministic

### DIFF
--- a/test/dynamo/test_compiler_bisector.py
+++ b/test/dynamo/test_compiler_bisector.py
@@ -121,7 +121,7 @@ class TestCompilerBisector(TestCase):
 
             return torch.allclose(out, out_c)
 
-        with config.patch(pre_grad_custom_pass=pass_fn, pattern_matcher=True):
+        with config.patch(pre_grad_custom_pass=pass_fn):
             out = CompilerBisector.do_bisect(test_fn)
         self.assertEqual(out.backend, "inductor")
         self.assertEqual(out.subsystem, "pre_grad_passes")

--- a/test/dynamo/test_compiler_bisector.py
+++ b/test/dynamo/test_compiler_bisector.py
@@ -121,11 +121,11 @@ class TestCompilerBisector(TestCase):
 
             return torch.allclose(out, out_c)
 
-        with config.patch(pre_grad_custom_pass=pass_fn):
+        with config.patch(pre_grad_custom_pass=pass_fn, pattern_matcher=True):
             out = CompilerBisector.do_bisect(test_fn)
         self.assertEqual(out.backend, "inductor")
         self.assertEqual(out.subsystem, "pre_grad_passes")
-        self.assertEqual(out.bisect_number, 0)
+        self.assertEqual(out.bisect_number, 3)
         self.assertTrue("pre_grad_custom_pass" in out.debug_info)
 
     def test_joint_graph(self):
@@ -166,6 +166,8 @@ class TestCompilerBisector(TestCase):
 
         def test_fn():
             torch._dynamo.reset()
+            # fixed seed to make the test deterministic
+            torch.manual_seed(1234)
 
             with preserve_rng_state():
                 out = foo()


### PR DESCRIPTION
Fixes #164462
Fixes #139590


### Summary
1. `test_pre_grad`

 The test was non-deterministic because it didn't explicitly set `config.pattern_matcher`. The `bisect_number` (which indicates the position of the failing pass in the pre-grad passes sequence) varies depending on this config. Explicitly set `pattern_matcher=True` in the test config patch to ensure deterministic behavior:
      
 When the pattern matcher is True.
      The following passes run before `pre_grad_custom_pass`:
      `group_batch_fusion_passes` (index 0)
      `efficient_conv_bn_eval_pass` (index 1)
      `apply_gumbel_max_trick_pass` (index 2)
      `pre_grad_custom_pass` (index 3)
      
      `Result: bisect_number = 3`
      
 When the pattern matcher is False.
      The three passes above are skipped, so only:
       `pre_grad_custom_pass` (index 0)
      
      `Result: `bisect_number = 0`
      
  The test would pass or fail depending on whether previous tests or the environment had modified the `pattern_matcher` config.

2. `test_rng`

The test was flaky and occasionally failed with:
```
AssertionError: None mismatch: None is not inductor_fallback_random
```

The root cause was that `CompilerBisector.do_bisect()` calls `test_fn()` multiple times (10-20+ iterations) as it tests different backends and subsystems. Each call started with a different global RNG state depending on operations from previous iterations, leading to non-deterministic test behavior.

Added `torch.manual_seed(1234)` at the start of `test_fn()` to ensure every bisector iteration starts with the same RNG state:

This ensures consistent, deterministic behavior across all bisector iterations, allowing the bisector to reliably identify the `inductor_fallback_random` subsystem.

### Testing

- Verified the fix maintains correct test behavior.
- The test now consistently passes with deterministic results on MI308.




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @azahed98