### PR TITLE
Avoid wrong transform when auto-detecting cuda arch in cmake for SM121

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -138,7 +138,7 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
     string(REGEX MATCHALL "[0-9]+\\.[0-9]+" compute_capabilities "${compute_capabilities}")
 
     if(run_result EQUAL 0)
-      string(REPLACE "2.1" "2.1(2.0)" compute_capabilities "${compute_capabilities}")
+      list(TRANSFORM compute_capabilities REPLACE "2.1" "2.1(2.0)" REGEX "^2\.1$" OUTPUT_VARIABLE compute_capabilities)
       set(CUDA_GPU_DETECT_OUTPUT ${compute_capabilities}
         CACHE INTERNAL "Returned GPU architectures from detect_gpus tool" FORCE)
     endif()


### PR DESCRIPTION
current implementation of `CUDA_DETECT_INSTALLED_GPUS` will transform all cuda arch code `12.1` to `12.1(2.0)`, which will eventually feed a wrong argument `-gencode;arch=compute_20,code=sm_121` to nvcc.