### PR TITLE
Use `untyped_storage` to get storage size

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3629,7 +3629,7 @@ class AlgorithmSelectorCache(PersistentCache):
         needed_out_size = torch._prims_common.compute_required_storage_length(
             out.size(), out.stride(), out_offset
         )
-        current_out_size = out_base.storage().size()
+        current_out_size = out_base.untyped_storage().size()
 
         if needed_out_size > current_out_size:
             # Create a new base tensor with sufficient storage


### PR DESCRIPTION
following the warning message of
```
[2026-02-02 06:10:50] test/inductor/test_nv_universal_gemm.py::TestNVUniversalGemm::test_bmm_non_standard_batch_stride_bfloat16 /opt/pytorch/pytorch/torch/_inductor/select_algorithm.py:3632: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.
untyped_storage() instead of tensor.storage()
  current_out_size = out_base.storage().size()
  ```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo