### PR TITLE
[Inductor] Fix argmax/argmin returning incorrect indices for boolean tensors on CUDA

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10708,6 +10708,29 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         t1[:, 100] = float("nan")
         self.common(fn, (t1,))
 
+    def test_max_min_bool(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/174069
+        # max/min on boolean tensors returned incorrect indices in Triton
+        def fn(x):
+            return (
+                x.max(0),
+                x.min(0),
+                x.max(1),
+                x.min(1),
+            )
+
+        # Unrolled reduction
+        t1 = torch.randint(2, size=(6, 6), dtype=torch.bool)
+        self.common(fn, (t1,))
+
+        # Persistent reduction
+        t1 = torch.randint(2, size=(32, 32), dtype=torch.bool)
+        self.common(fn, (t1,))
+
+        # Non-persistent reduction
+        t1 = torch.randint(2, size=(1028, 1028), dtype=torch.bool)
+        self.common(fn, (t1,))
+
     def test_conv_backward(self):
         def fn(rank4_inps, rank3_inps, rank5_inps):
             out1 = aten.convolution_backward(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10708,6 +10708,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         t1[:, 100] = float("nan")
         self.common(fn, (t1,))
 
+    @requires_cuda
     def test_max_min_bool(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/174069
         # max/min on boolean tensors returned incorrect indices in Triton

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -61,6 +61,8 @@ test_failures = {
     # PDL tests are CUDA SM90+ only, skip on CPU
     "test_pdl_mutation_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_pdl_template_and_delay_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
+    # Bool argmax/argmin fix is Triton-only (see #174069), skip on CPU
+    "test_max_min_bool_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     # calling div on only symint args
     "test_AllenaiLongformerBase_repro_dynamic_shapes": TestFailure(
         ("cpu", "cuda", "xpu", "mps")

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6281,6 +6281,10 @@ def _make_reduction_inner(
 
 def make_reduction(reduction_type: ReductionType, override_return_dtype=None):
     def inner(x, axis=None, keepdims=False, *, dtype=None):
+        # For argmax/argmin on boolean tensors, cast to int32 first to ensure
+        # correct comparison in Triton. See https://github.com/pytorch/pytorch/issues/174069
+        if reduction_type in ("argmax", "argmin") and x.get_dtype() == torch.bool:
+            x = to_dtype(x, torch.int32)
         kwargs = _make_reduction_inner(
             x,
             axis=axis,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6283,7 +6283,12 @@ def make_reduction(reduction_type: ReductionType, override_return_dtype=None):
     def inner(x, axis=None, keepdims=False, *, dtype=None):
         # For argmax/argmin on boolean tensors, cast to int32 first to ensure
         # correct comparison in Triton. See https://github.com/pytorch/pytorch/issues/174069
-        if reduction_type in ("argmax", "argmin") and x.get_dtype() == torch.bool:
+        # Only apply on Triton backend; MPS handles bool comparisons natively.
+        if (
+            reduction_type in ("argmax", "argmin")
+            and x.get_dtype() == torch.bool
+            and is_triton(x)
+        ):
             x = to_dtype(x, torch.int32)
         kwargs = _make_reduction_inner(
             x,


### PR DESCRIPTION
## Summary

When using `torch.compile` with the Inductor backend on CUDA, `max(dim)[1]` (argmax) and `min(dim)[1]` (argmin) returned incorrect indices for boolean tensors. This was because Triton's comparison operators don't work correctly on boolean types.

The fix casts boolean tensors to int32 before performing argmax/argmin reductions in the lowering pass.

## Test Plan

Tested locally on CUDA:

```python
import torch
import torch._dynamo

def fn(x):
    return x.max(1, keepdim=True)[1]

mask = torch.zeros(4, 8, 32, device='cuda', dtype=torch.bool)
mask[:, 4:, :] = True

# Before fix: Inductor returned 1, should be 4
# After fix: Inductor correctly returns 4
result_eager = fn(mask)
result_compiled = torch.compile(fn, backend='inductor')(mask)
assert torch.equal(result_eager, result_compiled)
```

Fixes https://github.com/pytorch/pytorch/issues/174069

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @ezyang @jansel @Chillee @bdhirsh
