### PR TITLE
[standalone_compile] Improve error message when there are no aot_autograd artifacts

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1943,6 +1943,35 @@ class TestStandaloneCompile(TestCase):
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_is_saveable(self) -> None:
+        mod = torch.nn.Linear(1, 3)
+        x = torch.randn(4, 1)
+
+        @torch._dynamo.allow_in_graph
+        def uncacheable(x):
+            return x.sin()
+
+        def f(x):
+            with torch.no_grad():
+                result = mod(x)
+                return uncacheable(result)
+
+        with fresh_cache():
+            gm, args, kwargs = self.capture(f)(x)
+            assert not kwargs
+
+            compiled_artifact = torch._inductor.standalone_compile(gm, args)
+
+            self.assertFalse(compiled_artifact.is_saveable())
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                path = os.path.join(temp_dir, "new_dir")
+                with self.assertRaisesRegex(RuntimeError, "not serializable"):
+                    compiled_artifact.save(path=path, format="unpacked")
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": True})
     @parametrize("dynamic", (False, True))
     @parametrize("is_aot", (False, True))
     def test_call_in_backend(self, dynamic: bool, is_aot: bool) -> None:

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -125,7 +125,7 @@ class CacheCompiledArtifact(CompiledArtifact):
         if self._artifacts is None:
             return False
         _, cache_info = self._artifacts
-        if len(cache_info.aot_autograd_artifacts) == 0:
+        if len(cache_info.aot_autograd_artifacts) != 1:
             return False
         return True
 
@@ -146,6 +146,8 @@ class CacheCompiledArtifact(CompiledArtifact):
                     f"ensuring that your model only uses constructs that are serializable. "
                     f"{cache_info}"
                 )
+            # training support not implemented
+            assert len(cache_info.aot_autograd_artifacts) == 1, cache_info
             key = cache_info.aot_autograd_artifacts[0]
 
             if format == "binary":

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -121,6 +121,14 @@ class CacheCompiledArtifact(CompiledArtifact):
     def __call__(self, *args: Any) -> Any:
         return self._compiled_fn(*args)
 
+    def is_saveable(self):
+        if self._artifacts is None:
+            return False
+        _, cache_info = self._artifacts
+        if len(cache_info.aot_autograd_artifacts) == 0:
+            return False
+        return True
+
     def save(
         self, *, path: str, format: Literal["binary", "unpacked"] = "binary"
     ) -> None:
@@ -130,7 +138,14 @@ class CacheCompiledArtifact(CompiledArtifact):
                     "CompiledArtifact.save failed to save since there's no artifact to save"
                 )
             artifact_bytes, cache_info = self._artifacts
-            assert len(cache_info.aot_autograd_artifacts) == 1, cache_info
+            if len(cache_info.aot_autograd_artifacts) == 0:
+                raise RuntimeError(
+                    f"CompiledArtifact.save failed to save due to no aot_autograd artifacts. "
+                    f"This likely means there was something that was not serializable in the "
+                    f"graph passed to standalone_compile. This can generally be fixed by "
+                    f"ensuring that your model only uses constructs that are serializable. "
+                    f"{cache_info}"
+                )
             key = cache_info.aot_autograd_artifacts[0]
 
             if format == "binary":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174086

Also add an `is_saveable` API so one doesn't need to try-catch the save
path. I want vLLM to do something specific when we the artifact is not
saveable (e.g. log a warning to disk).

Test Plan:
- new tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo