### PR TITLE
tensordot | align XPU checks with other backends

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -343,12 +343,12 @@ Tensor& tensordot_out(
   auto output_device = result.device();
   auto input1_device = input1.device();
   auto input2_device = input2.device();
-  if(result.defined()) {
+  if (result.defined()) {
     TORCH_CHECK(
-      !(result.requires_grad() && at::GradMode::is_enabled() && result.sizes() != result_tmp.sizes()),
-      "tensordot(): the 'out' tensor was specified and requires gradients, and its shape does not match the expected result. "
-      "Either remove the 'out' argument, ensure it does not require gradients, or make sure its shape matches the expected output."
-    );
+        !(result.requires_grad() && at::GradMode::is_enabled() &&
+          result.sizes() != result_tmp.sizes()),
+        "tensordot(): the 'out' tensor was specified and requires gradients, and its shape does not match the expected result. "
+        "Either remove the 'out' argument, ensure it does not require gradients, or make sure its shape matches the expected output.");
   }
   // check if the input & output tensors are on the same device.
   TORCH_CHECK(

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -343,6 +343,13 @@ Tensor& tensordot_out(
   auto output_device = result.device();
   auto input1_device = input1.device();
   auto input2_device = input2.device();
+  if(result.defined()) {
+    TORCH_CHECK(
+      !(result.requires_grad() && at::GradMode::is_enabled() && result.sizes() != result_tmp.sizes()),
+      "tensordot(): the 'out' tensor was specified and requires gradients, and its shape does not match the expected result. "
+      "Either remove the 'out' argument, ensure it does not require gradients, or make sure its shape matches the expected output."
+    );
+  }
   // check if the input & output tensors are on the same device.
   TORCH_CHECK(
       (output_device == input1_device) && (input1_device == input2_device),


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2818

XPU didn't have rigorous checks for `out` tensor in tensordot operator. For other backends such behavior would early exit, but XPU didn't have this check. Goal of this PR is to align XPU checks to other backends.

Minimal repro
```Python
import torch
import pytest


@pytest.mark.parametrize("device", ["cpu", "xpu"])
def test_shape_error(device):
    a = torch.empty((2,3), device=device)
    b = torch.empty((3,4), device=device)
    c = torch.empty((5,5), device=device, requires_grad=True)

    expected_error = "the 'out' tensor was specified and requires gradients"
    with pytest.raises(RuntimeError, match=expected_error):
        torch.tensordot(a, b, dims=1, out=c)
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01