### PR TITLE
Add skip_torch_function_mode_dispatch for keeping mode active in backward

### DIFF
--- a/aten/src/ATen/PythonTorchFunctionTLS.cpp
+++ b/aten/src/ATen/PythonTorchFunctionTLS.cpp
@@ -40,6 +40,14 @@ const PythonTorchFunctionTLS& PythonTorchFunctionTLS::get_state() {
   return pythonTorchFunctionState;
 }
 
+void PythonTorchFunctionTLS::set_skip_one_hop(bool skip) {
+  pythonTorchFunctionState.skip_one_hop_ = skip;
+}
+
+bool PythonTorchFunctionTLS::get_skip_one_hop() {
+  return pythonTorchFunctionState.skip_one_hop_;
+}
+
 bool torch_function_mode_enabled() {
   // Manually flatten because gcc is refusing to inline here.  Note
   // that we are still calling __tls_get_addr twice here with GCC,

--- a/aten/src/ATen/PythonTorchFunctionTLS.h
+++ b/aten/src/ATen/PythonTorchFunctionTLS.h
@@ -19,6 +19,13 @@ struct TORCH_API PythonTorchFunctionTLS {
   static const PythonTorchFunctionTLS& get_state();
   static void set_state(const PythonTorchFunctionTLS& state);
 
+  // "Skip one hop" mechanism for backward() etc.
+  // When set, the next torch function mode dispatch will skip stashing the mode
+  // and call the original function directly, but keep the mode enabled for
+  // subsequent operations.
+  static void set_skip_one_hop(bool skip);
+  static bool get_skip_one_hop();
+
  private:
   // The mode TLS is split into
   //   - disabled_state, which says which part of torch function are disabled
@@ -27,6 +34,7 @@ struct TORCH_API PythonTorchFunctionTLS {
   TorchFunctionDisabledState disabled_state_ =
       TorchFunctionDisabledState::ENABLED;
   std::vector<std::shared_ptr<c10::SafePyObject>> stack_;
+  bool skip_one_hop_ = false;
   friend TORCH_API bool torch_function_mode_enabled();
 };
 

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -2069,5 +2069,8 @@ class TestTorchFunctionMode(TestCase):
 
 
 
+
+
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1913,9 +1913,9 @@ class TestTorchFunctionMode(TestCase):
         finally:
             torch.set_default_device(None)
 
-    def test_skip_torch_function_mode_dispatch_basic(self):
-        """Test that skip_torch_function_mode_dispatch prevents infinite recursion."""
-        from torch.overrides import skip_torch_function_mode_dispatch
+    def test_skip_one_torch_function_hop_basic(self):
+        """Test that skip_one_torch_function_hop prevents infinite recursion."""
+        from torch.overrides import skip_one_torch_function_hop
 
         class TrackingMode(TorchFunctionMode):
             def __init__(self):
@@ -1927,7 +1927,7 @@ class TestTorchFunctionMode(TestCase):
                 self.calls.append(name)
 
                 if func in (torch.autograd.backward, torch.Tensor.backward, torch.autograd.grad):
-                    with skip_torch_function_mode_dispatch(self):
+                    with skip_one_torch_function_hop(self):
                         return func(*args, **kwargs)
 
                 return func(*args, **kwargs)
@@ -1942,9 +1942,9 @@ class TestTorchFunctionMode(TestCase):
         # Should not cause infinite recursion and should see backward
         self.assertIn("backward", mode.calls)
 
-    def test_skip_torch_function_mode_dispatch_sees_backward_ops(self):
-        """Test that skip_torch_function_mode_dispatch keeps mode active for ops inside backward."""
-        from torch.overrides import skip_torch_function_mode_dispatch
+    def test_skip_one_torch_function_hop_sees_backward_ops(self):
+        """Test that skip_one_torch_function_hop keeps mode active for ops inside backward."""
+        from torch.overrides import skip_one_torch_function_hop
 
         class MyMul(torch.autograd.Function):
             @staticmethod
@@ -1967,7 +1967,7 @@ class TestTorchFunctionMode(TestCase):
                 self.calls.append(name)
 
                 if func in (torch.autograd.backward, torch.Tensor.backward):
-                    with skip_torch_function_mode_dispatch(self):
+                    with skip_one_torch_function_hop(self):
                         return func(*args, **kwargs)
 
                 return func(*args, **kwargs)
@@ -2004,9 +2004,9 @@ class TestTorchFunctionMode(TestCase):
         mul_count_after_backward = mode2.calls[mode2.calls.index('backward'):].count('mul')
         self.assertGreater(mul_count_after_backward, 0)
 
-    def test_skip_torch_function_mode_dispatch_backward_hook(self):
-        """Test that skip_torch_function_mode_dispatch allows mode to see ops in backward hooks."""
-        from torch.overrides import skip_torch_function_mode_dispatch
+    def test_skip_one_torch_function_hop_backward_hook(self):
+        """Test that skip_one_torch_function_hop allows mode to see ops in backward hooks."""
+        from torch.overrides import skip_one_torch_function_hop
 
         class TrackingModeWithSkip(TorchFunctionMode):
             def __init__(self):
@@ -2018,7 +2018,7 @@ class TestTorchFunctionMode(TestCase):
                 self.calls.append(name)
 
                 if func in (torch.autograd.backward, torch.Tensor.backward):
-                    with skip_torch_function_mode_dispatch(self):
+                    with skip_one_torch_function_hop(self):
                         return func(*args, **kwargs)
 
                 return func(*args, **kwargs)

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1324,6 +1324,26 @@ static PyObject* is_torch_function_mode_enabled(
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* get_torch_function_skip_one_hop(
+    PyObject* _unused,
+    PyObject* _unused2) {
+  HANDLE_TH_ERRORS
+  if (at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* set_torch_function_skip_one_hop(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(PyBool_Check(arg), "expected a bool");
+  at::impl::PythonTorchFunctionTLS::set_skip_one_hop(arg == Py_True);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* push_on_torch_function_stack(
     PyObject* _unused,
     PyObject* arg) {
@@ -1637,6 +1657,14 @@ static PyMethodDef methods[] = {
     {"_is_torch_function_mode_enabled",
      is_torch_function_mode_enabled,
      METH_NOARGS,
+     nullptr},
+    {"_get_torch_function_skip_one_hop",
+     get_torch_function_skip_one_hop,
+     METH_NOARGS,
+     nullptr},
+    {"_set_torch_function_skip_one_hop",
+     set_torch_function_skip_one_hop,
+     METH_O,
      nullptr},
     {"_push_on_torch_function_stack",
      push_on_torch_function_stack,

--- a/torch/csrc/utils/disable_torch_function.cpp
+++ b/torch/csrc/utils/disable_torch_function.cpp
@@ -350,13 +350,6 @@ inline static bool array_has_torch_function(
 }
 
 PyObject* THPModule_has_torch_function(PyObject* /*unused*/, PyObject* arg) {
-  // Check skip_one_hop first: if set, skip ALL dispatch (mode and subclass)
-  // for this call but keep mode enabled for subsequent operations.
-  if (at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
-    at::impl::PythonTorchFunctionTLS::set_skip_one_hop(false);
-    Py_RETURN_FALSE;
-  }
-
   bool result = false;
   if (PyTuple_CheckExact(arg) || PyList_CheckExact(arg)) {
     // Fast path:
@@ -383,13 +376,6 @@ PyObject* THPModule_has_torch_function(PyObject* /*unused*/, PyObject* arg) {
 PyObject* THPModule_has_torch_function_unary(
     PyObject* /*unused*/,
     PyObject* obj) {
-  // Check skip_one_hop first: if set, skip ALL dispatch (mode and subclass)
-  // for this call but keep mode enabled for subsequent operations.
-  if (at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
-    at::impl::PythonTorchFunctionTLS::set_skip_one_hop(false);
-    Py_RETURN_FALSE;
-  }
-
   // Special case `THPModule_has_torch_function` for the single arg case.
   if (torch::check_has_torch_function(obj)) {
     Py_RETURN_TRUE;
@@ -401,13 +387,6 @@ PyObject* THPModule_has_torch_function_variadic(
     PyObject* /*unused*/,
     PyObject* const* args,
     Py_ssize_t nargs) {
-  // Check skip_one_hop first: if set, skip ALL dispatch (mode and subclass)
-  // for this call but keep mode enabled for subsequent operations.
-  if (at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
-    at::impl::PythonTorchFunctionTLS::set_skip_one_hop(false);
-    Py_RETURN_FALSE;
-  }
-
   if (array_has_torch_function(args, nargs)) {
     Py_RETURN_TRUE;
   }

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -609,16 +609,6 @@ auto handle_torch_function_no_python_arg_parser(
   // subclasses override sizes/strides metadata calls with __torch_dispatch__,
   // which would mean a mode would be **required** to access their metadata.
 
-  // Check skip_one_hop flag: if set, skip ALL dispatch (mode and subclass)
-  // for this call but keep mode enabled for subsequent operations.
-  if (is_torch_function && at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
-    at::impl::PythonTorchFunctionTLS::set_skip_one_hop(false);
-    // Return nullptr to signal to the caller that it should invoke the
-    // original function directly. The mode remains on the stack so
-    // subsequent operations will still trigger mode dispatch.
-    return nullptr;
-  }
-
   if (is_mode_active()) {
     // Step 1: Try to dispatch on any user TorchDispatchModes (including infra
     // modes, which will always be at the bottom of the mode stack).

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -609,16 +609,26 @@ auto handle_torch_function_no_python_arg_parser(
   // subclasses override sizes/strides metadata calls with __torch_dispatch__,
   // which would mean a mode would be **required** to access their metadata.
 
+  bool skipped_mode_dispatch = false;
   if (is_mode_active()) {
-    // Step 1: Try to dispatch on any user TorchDispatchModes (including infra
-    // modes, which will always be at the bottom of the mode stack).
-    std::tie(ret, mode_obj) = dispatch_on_mode(
-        args,
-        kwargs,
-        py_types,
-        torch_api_function,
-        is_torch_function,
-        torch_function_name_str);
+    // Check skip_one_hop flag: if set, skip this mode dispatch but keep mode
+    // enabled for subsequent operations (e.g., inside backward()).
+    if (is_torch_function && at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
+      at::impl::PythonTorchFunctionTLS::set_skip_one_hop(false);
+      skipped_mode_dispatch = true;
+      // Skip mode dispatch, fall through to subclass dispatch or return
+      // nullptr so the underlying function is called with mode still enabled.
+    } else {
+      // Step 1: Try to dispatch on any user TorchDispatchModes (including infra
+      // modes, which will always be at the bottom of the mode stack).
+      std::tie(ret, mode_obj) = dispatch_on_mode(
+          args,
+          kwargs,
+          py_types,
+          torch_api_function,
+          is_torch_function,
+          torch_function_name_str);
+    }
   }
 
   // Step 2: Try to dispatch based on any user subclasses,
@@ -644,6 +654,13 @@ auto handle_torch_function_no_python_arg_parser(
   }
 
   if (ret.ptr() == nullptr) {
+    if (skipped_mode_dispatch) {
+      // We intentionally skipped mode dispatch due to skip_one_hop.
+      // Return nullptr to signal to the caller that it should invoke the
+      // original function directly. The mode remains on the stack so
+      // subsequent operations will still trigger mode dispatch.
+      return nullptr;
+    }
     // We didn't successfully dispatch anything, this should be impossible
     TORCH_INTERNAL_ASSERT(
         0,
@@ -654,6 +671,11 @@ auto handle_torch_function_no_python_arg_parser(
         ", is_mode_active = ",
         is_mode_active());
   } else if (ret.ptr() == Py_NotImplemented) {
+    if (skipped_mode_dispatch) {
+      // We intentionally skipped mode dispatch and subclasses all returned
+      // NotImplemented. Return nullptr to invoke original function.
+      return nullptr;
+    }
     // all __torch_function__ implementations in overloaded_args
     // returned NotImplemented, so we raise a TypeError.
     std::stringstream ss;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -388,6 +388,11 @@ inline PythonArgs PythonArgParser::parse(PyObject* self, ParsedArgs<0>& dst) {
 }
 
 inline bool PythonArgs::has_torch_function() {
+  // Check skip_one_hop: if set, skip torch function dispatch for this call.
+  // The flag stays true for all calls in the skip block.
+  if (at::impl::PythonTorchFunctionTLS::get_skip_one_hop()) {
+    return false;
+  }
   return !overloaded_args.empty() || at::impl::torch_function_mode_enabled();
 }
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1735,18 +1735,12 @@ def handle_torch_function(
 
     # Check for __torch_function__ mode.
     if _is_torch_function_mode_enabled():
-        # Check skip_one_hop: if set, skip mode dispatch for this call but keep
-        # mode enabled for subsequent operations.
-        if torch._C._get_torch_function_skip_one_hop():
-            torch._C._set_torch_function_skip_one_hop(False)
-            # Skip mode dispatch, fall through to subclass dispatch
-        else:
-            # if we're here, the mode must be set to a TorchFunctionStackMode
-            # this unsets it and calls directly into TorchFunctionStackMode's torch function
-            with _pop_mode_temporarily() as mode:
-                result = mode.__torch_function__(public_api, types, args, kwargs)
-            if result is not NotImplemented:
-                return result
+        # if we're here, the mode must be set to a TorchFunctionStackMode
+        # this unsets it and calls directly into TorchFunctionStackMode's torch function
+        with _pop_mode_temporarily() as mode:
+            result = mode.__torch_function__(public_api, types, args, kwargs)
+        if result is not NotImplemented:
+            return result
 
     # Call overrides
     for overloaded_arg in overloaded_args:

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1728,6 +1728,12 @@ def handle_torch_function(
     ...         return handle_torch_function(func, (a,), a)
     ...     return a + 0
     """
+    # Check skip_one_hop: if set, skip torch function dispatch and call the
+    # original function directly. This is used by skip_torch_function_mode_dispatch.
+    if torch._C._get_torch_function_skip_one_hop():
+        torch._C._set_torch_function_skip_one_hop(False)
+        return public_api(*args, **kwargs)
+
     # Check for __torch_function__ methods.
     overloaded_args = _get_overloaded_args(relevant_args)
     # overloaded_args already have unique types.

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1729,7 +1729,7 @@ def handle_torch_function(
     ...     return a + 0
     """
     # Check skip_one_hop: if set, skip torch function dispatch and call the
-    # original function directly. This is used by skip_torch_function_mode_dispatch.
+    # original function directly. This is used by skip_one_torch_function_hop.
     if torch._C._get_torch_function_skip_one_hop():
         torch._C._set_torch_function_skip_one_hop(False)
         return public_api(*args, **kwargs)
@@ -2124,9 +2124,9 @@ def _enable_torch_function():
 
 
 @contextlib.contextmanager
-def skip_torch_function_mode_dispatch(mode):
+def skip_one_torch_function_hop(mode):
     """
-    Context manager to skip the next torch function mode dispatch while keeping
+    Context manager to skip the next torch function dispatch while keeping
     the mode active for subsequent operations.
 
     When used inside a TorchFunctionMode's __torch_function__ method, this pushes
@@ -2144,7 +2144,7 @@ def skip_torch_function_mode_dispatch(mode):
                 if func in (torch.autograd.backward, torch.Tensor.backward):
                     # Skip mode dispatch for backward, but keep mode active
                     # for gradient computations inside backward
-                    with skip_torch_function_mode_dispatch(self):
+                    with skip_one_torch_function_hop(self):
                         return func(*args, **(kwargs or {}))
                 # ... handle other functions
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174221
* __->__ #174098

This adds a mechanism to skip torch function mode dispatch for a single
call while keeping the mode active for subsequent operations. This is
useful for functions like backward() where you want to skip the mode
dispatch for the function itself, but still have the mode active for
operations inside the function (e.g., in backward hooks or custom
autograd functions).

The implementation adds:
- A skip_one_hop TLS flag in PythonTorchFunctionTLS
- C++ handling in check_has_torch_function and handle_torch_function_no_python_arg_parser
- Python handling in handle_torch_function
- A skip_torch_function_mode_dispatch(mode) context manager in torch.overrides

Usage:
    class MyMode(TorchFunctionMode):
        def __torch_function__(self, func, types, args, kwargs=None):
            if func in (torch.autograd.backward, torch.Tensor.backward):
                with skip_torch_function_mode_dispatch(self):
                    return func(*args, **(kwargs or {}))
            return func(*args, **(kwargs or {}))

This PR was authored with Claude.