### PR TITLE
Fix torch.compile + torch.func compatibility for autograd.Function

### DIFF
--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -814,8 +814,7 @@ class AutogradFunctionApply(HigherOrderOperator):
 
         class ApplyTemplate(torch.autograd.Function):
             @staticmethod
-            # pyrefly: ignore [bad-override]
-            def forward(ctx: Any, *args: Any) -> Any:
+            def forward(*args: Any, **kwargs: Any) -> Any:
                 nonlocal saved_values
 
                 # The Interpreter here is required to propagate metadata
@@ -834,6 +833,10 @@ class AutogradFunctionApply(HigherOrderOperator):
                         for proxy in _get_proxies(t):
                             proxy.node.meta["saved_tensor_with_no_vc_check"] = True
 
+                return output
+
+            @staticmethod
+            def setup_context(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
                 # If users call ctx.mark_non_differentiable() in the original fwd function.
                 if len(non_differentiable_idx) > 0:
                     non_differentiable_output = []
@@ -841,8 +844,6 @@ class AutogradFunctionApply(HigherOrderOperator):
                         if i in non_differentiable_idx:
                             non_differentiable_output.append(x)
                     ctx.mark_non_differentiable(*non_differentiable_output)
-
-                return output
 
             @staticmethod
             def backward(ctx: Any, *grad: Any) -> Any:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174099

Fixes #174067

When torch.compile traces an autograd.Function, it wraps it in ApplyTemplate.
Previously, ApplyTemplate used the old-style autograd.Function API (forward
takes ctx as first argument), which is incompatible with torch.func transforms
like grad, vmap, jacrev.

This updates ApplyTemplate to use the new-style API:
- forward(*args) without ctx parameter
- setup_context(ctx, inputs, output) to handle mark_non_differentiable

The fix enables torch.func transforms to work with compiled autograd.Function
subclasses, regardless of whether the original function uses old or new style.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo