### PR TITLE
[AArch64][CI]Add m8g as an option for nightly Inductor benchmark instances for AArch64

### DIFF
--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -37,11 +37,25 @@ on:
         description: |
           Fetch's GitHub Issue from pytorch/test-infra
           Example: https://github.com/pytorch/test-infra/issues/5132
+      runner_config:
+        required: false
+        type: string
+        default: ""
+        description: Runner configuration used by the caller to derive runner-type.
 
     outputs:
       label-type:
         description: Type of runners to use
         value: ${{ jobs.runner-determinator.outputs.label-type }}
+      runner-config:
+        description: Normalized runner configuration derived from the caller input
+        value: ${{ jobs.runner-determinator.outputs.runner-config }}
+      runner-type:
+        description: Runner suffix to use for workflow-specific runner selection
+        value: ${{ jobs.runner-determinator.outputs.runner-type }}
+      runner-label:
+        description: Fully qualified runner label derived from runner_config
+        value: ${{ jobs.runner-determinator.outputs.runner-label }}
       use-arc:
         description: Whether to use ARC runners
         value: ${{ jobs.runner-determinator.outputs.use-arc }}
@@ -53,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       label-type: ${{ steps.set-condition.outputs.label-type }}
+      runner-config: ${{ steps.set-runner-info.outputs.runner-config }}
+      runner-type: ${{ steps.set-runner-info.outputs.runner-type }}
+      runner-label: ${{ steps.set-runner-info.outputs.runner-label }}
       use-arc: ${{ steps.set-condition.outputs.use-arc }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,3 +104,30 @@ jobs:
             --eligible-experiments "$CHECK_EXPERIMENTS" \
             --opt-out-experiments "$OPT_OUT_EXPERIMENTS" \
             --pr-number "${PR_NUMBER}"
+
+      - name: Determine runner configuration
+        id: set-runner-info
+        run: |
+          case "${{ inputs.runner_config }}" in
+            "")
+              runner_config="m8g"
+              runner_type="metal-24xl"
+              ;;
+            "m8g")
+              runner_config="m8g"
+              runner_type="metal-24xl"
+              ;;
+            "m7g")
+              runner_config="m7g"
+              runner_type="metal"
+              ;;
+            *)
+              echo "Unsupported runner_config: ${{ inputs.runner_config }}"
+              exit 1
+              ;;
+          esac
+
+          runner_label="linux.arm64.${runner_config}.${runner_type}"
+          echo "runner-config=${runner_config}" >> "$GITHUB_OUTPUT"
+          echo "runner-type=${runner_type}" >> "$GITHUB_OUTPUT"
+          echo "runner-label=${runner_label}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -7,6 +7,14 @@ on:
   # NB: GitHub has an upper limit of 10 inputs here
   workflow_dispatch:
     inputs:
+      runner_config:
+        description: "AArch64 runner instance type"
+        required: true
+        type: choice
+        default: m8g
+        options:
+          - m8g
+          - m7g
       training:
         # CPU for training is not typical, but leave the option open here
         description: Run training (off by default)?
@@ -64,6 +72,7 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
       opt_out_experiments: lf
+      runner_config: ${{ github.event.inputs.runner_config || 'm8g' }}
 
   linux-jammy-aarch64-py3_10-inductor-build:
     name: linux-jammy-aarch64-py3.10-inductor
@@ -71,50 +80,50 @@ jobs:
     needs: get-label-type
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: linux.arm64.m7g.4xlarge
+      runner: linux.arm64.${{ needs.get-label-type.outputs.runner-config }}.4xlarge
       build-environment: linux-jammy-aarch64-py3.10
       docker-image-name: ci-image:pytorch-linux-jammy-aarch64-py3.10-gcc13-inductor-benchmarks
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 1, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 2, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 3, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 4, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 5, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 6, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 7, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 8, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 9, num_shards: 9, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  1, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  2, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  3, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  4, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  5, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  6, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  7, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  8, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard:  9, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard: 10, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard: 11, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard: 12, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard: 13, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard: 14, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_timm_perf_cpu_aarch64", shard: 15, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  1, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  2, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  3, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  4, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  5, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  6, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  7, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  8, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  9, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 10, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 11, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 12, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 13, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 14, num_shards: 15, runner: "linux.arm64.m7g.metal" },
-          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 15, num_shards: 15, runner: "linux.arm64.m7g.metal" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 1, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 2, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 3, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 4, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 5, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 6, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 7, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 8, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_huggingface_perf_cpu_aarch64", shard: 9, num_shards: 9, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  1, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  2, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  3, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  4, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  5, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  6, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  7, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  8, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard:  9, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard: 10, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard: 11, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard: 12, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard: 13, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard: 14, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_timm_perf_cpu_aarch64", shard: 15, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  1, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  2, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  3, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  4, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  5, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  6, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  7, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  8, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard:  9, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 10, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 11, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 12, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 13, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 14, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
+          { config: "inductor_torchbench_perf_cpu_aarch64", shard: 15, num_shards: 15, runner: "${{ needs.get-label-type.outputs.runner-label }}" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio torchao"


### PR DESCRIPTION
## Summary
Depends on machines configuration here: https://github.com/pytorch/test-infra/pull/7771 

Add `m8g` instance as an option for nightly inductor benchmarking for AArch64. With this PR, it is possible to toggle either `m7g` or `m8g` to be used as the runner instances.

cc: @aditew01 @robert-hardwick 