### PR TITLE
Adding a thread safe RNG utility function (updated)

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1084,22 +1084,7 @@ def _test_worker_info_init_fn(worker_id):
         raise AssertionError("worker_info should have correct dataset copy")
     if hasattr(dataset, "value"):
         raise AssertionError("worker_info should have correct dataset copy")
-    # test that WorkerInfo attributes are read-only
-    try:
-        worker_info.id = 3999
-    except RuntimeError as e:
-        if str(e) != "Cannot assign attributes to WorkerInfo objects":
-            raise AssertionError(
-                "Expected RuntimeError for WorkerInfo attribute assignment"
-            ) from None
-    try:
-        worker_info.a = 3
-    except RuntimeError as e:
-        if str(e) != "Cannot assign attributes to WorkerInfo objects":
-            raise AssertionError(
-                "Expected RuntimeError for WorkerInfo attribute assignment"
-            ) from None
-    for k in ["id", "num_workers", "seed", "dataset"]:
+    for k in ["id", "num_workers", "seed", "dataset", "rng"]:
         if f"{k}=" not in repr(worker_info):
             raise AssertionError(f"Expected {k} in worker_info repr")
     dataset.value = [worker_id, os.getpid()]

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -132,6 +132,7 @@ __all__ = [
     "sym_min",
     "sym_not",
     "sym_sum",
+    "thread_safe_generator",
     "typename",
     "unravel_index",
     "use_deterministic_algorithms",
@@ -2144,7 +2145,14 @@ _tensor_classes: set[type["torch.Tensor"]] = set()
 from torch import amp as amp, random as random, serialization as serialization
 from torch._tensor_str import set_printoptions
 from torch.amp import autocast, GradScaler
-from torch.random import get_rng_state, initial_seed, manual_seed, seed, set_rng_state
+from torch.random import (
+    get_rng_state,
+    initial_seed,
+    manual_seed,
+    seed,
+    set_rng_state,
+    thread_safe_generator,
+)
 from torch.serialization import load, save
 
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -132,6 +132,7 @@ def get_ignored_functions() -> set[Callable]:
         torch.manual_seed,
         torch.initial_seed,
         torch.seed,
+        torch.thread_safe_generator,
         torch.save,
         torch.load,
         torch.set_printoptions,


### PR DESCRIPTION
[Identical version of [PR](https://github.com/pytorch/pytorch/pull/172659) but with alterations to keep BC with torchdata statefuldataloader]

This includes part of the changes in https://github.com/pytorch/pytorch/pull/161044/

When using PyTorch's DataLoader with thread-based workers, all worker threads share the same global random number generator (RNG) state. This creates a race condition: multiple threads may call random functions like torch.randint() or torch.rand() simultaneously, leading to non-reproducible results.

`torch.thread_safe_generator()` solves this by returning a thread-local generator when called from within a DataLoader thread worker.

This PR:
* we only include the utility public function to return the RNG. The RNG will be populated with the thread dataloader PR linked above. Right now this PR doesn't open any new functionality, the function will return `None` as RNG state isn't populated for thread workers (there are no thread workers right now - will land with PR#161044).
* landing this function separately to enable integration with Torchvision random transforms.
* Also, refactored `WorkerInfo` in `worker.py` to be a frozen dataclass.