### PR TITLE
[MAGMA][CUDA] triangular_solve: deprecate MAGMA and dispatch to cuBLAS unconditionally

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4752,7 +4752,7 @@ class TestLinalg(TestCase):
     @slowTest
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
     @onlyCUDA
-    @skipCUDAIfNoMagma  # Magma needed for the PLU decomposition
+    @unittest.skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "MAGMA required for ROCm")
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
@@ -4812,7 +4812,7 @@ class TestLinalg(TestCase):
             A_triangular.diagonal(dim1=-2, dim2=-1).fill_(1.)
         return b, A_triangular
 
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "MAGMA required for ROCm")
     @skipCPUIfNoLapack
     @skipIfTorchDynamo("flaky, needs investigation")
     @dtypes(*floating_and_complex_types())
@@ -4832,7 +4832,7 @@ class TestLinalg(TestCase):
                 self.assertEqual(b, np.matmul(A.cpu(), x.cpu()))
 
     @skipCPUIfNoLapack
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "MAGMA required for ROCm")
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
@@ -4881,7 +4881,7 @@ class TestLinalg(TestCase):
                                                upper, unitriangular, transpose)
 
     @slowTest
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "MAGMA required for ROCm")
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
@@ -4911,7 +4911,7 @@ class TestLinalg(TestCase):
 
             self.assertEqual(torch.matmul(A, x), b)
 
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "MAGMA required for ROCm")
     @skipCPUIfNoLapack
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
     @skipIfTorchDynamo("flaky, needs investigation")
@@ -4957,7 +4957,7 @@ class TestLinalg(TestCase):
         X = torch.linalg.solve_triangular(A, B, upper=False)
         self.assertEqual(A @ X, B)
 
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "MAGMA required for ROCm")
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
     def test_triangular_solve_out_errors_and_warnings(self, device, dtype):


### PR DESCRIPTION
Another step towards deprecating MAGMA, covers both `torch.linalg.solve_triangular` and `torch.triangular_solve`. Both cuBLAS and hipBLAS implement `trsm` functions which can handle cases previously handled by MAGMA, so I just removed all relevant MAGMA paths and test skip decorators. Performance improves with cuBLAS except for very small cases, and absolute performance losses for those cases is small.

Benchmarking script:
```python
import torch
import torch.utils.benchmark as benchmark

from itertools import product

results = []

batches = [(), (16,), (64,)]
sizes = [16, 128, 512,  2048]

for b, n in product(batches, sizes):
    shape = b + (n, n)
    print(f"Testing shape={shape}")
    label = "torch.linalg.solve_triangular"
    sub_label = f"{shape}"
    X = torch.rand(*shape, device="cuda")
    P, L, U = torch.linalg.lu(X)
    PX = P.mT @ X
    stmt = "torch.linalg.solve_triangular(L, PX, upper=False, unitriangular=True)"
    for backend in ("magma", "cusolver"):
        torch.backends.cuda.preferred_linalg_library(backend)
        # warm-up
        for _ in range(5):
            exec(stmt)

        results.append(benchmark.Timer(
            stmt=stmt,
            globals={'L': L, 'PX': PX},
            label=label,
            sub_label=sub_label,
            description=backend,
        ).blocked_autorange(min_run_time=1))

compare = benchmark.Compare(results)
compare.print()
```

Results on RTX Pro 6000:
```
[------- torch.linalg.solve_triangular -------]
                        |   magma   |  cusolver | cusolver speedup
1 threads: ------------------------------------
      (16, 16)          |      6.7  |     10.6  | 0.6
      (128, 128)        |    149.8  |     10.3  | 14.5
      (512, 512)        |    490.7  |     61.4  | 8.0
      (2048, 2048)      |   2996.5  |    558.0  | 5.4
      (16, 16, 16)      |      6.7  |     10.8  | 0.6
      (16, 128, 128)    |    196.0  |     53.3  | 3.7
      (16, 512, 512)    |   7878.0  |    329.5  | 23.9
      (16, 2048, 2048)  |  20976.0  |   6380.4  | 3.3
      (64, 16, 16)      |      6.8  |     10.8  | 0.6
      (64, 128, 128)    |    209.1  |     67.6  | 3.1
      (64, 512, 512)    |   8955.2  |    790.1  | 11.3
      (64, 2048, 2048)  |  59483.7  |  25025.1  | 2.4

Times are in microseconds (us).
```

cc @nikitaved @eqy 