### PR TITLE
[inductor] Add persistent profiler session to ProfilingBenchmarker

### DIFF
--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import queue
 import threading
 import time
 from collections.abc import Callable
@@ -453,6 +454,123 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
             )
 
 
+class DynamicSchedule:
+    """A profiler schedule that can be toggled between NONE and RECORD states.
+
+    This allows a single profiler session to be reused across multiple
+    benchmark calls by dynamically controlling when recording happens.
+    """
+
+    def __init__(self) -> None:
+        self._phase = torch.profiler.ProfilerAction.NONE
+        self._steps_in_record = 0
+
+    def start_recording(self) -> None:
+        """Transition to RECORD state on next step() call."""
+        self._phase = torch.profiler.ProfilerAction.RECORD
+        self._steps_in_record = 1
+
+    def __call__(self, step: int) -> torch.profiler.ProfilerAction:
+        """Return the action for the current step."""
+        if self._phase == torch.profiler.ProfilerAction.RECORD:
+            self._steps_in_record -= 1
+            if self._steps_in_record <= 0:
+                self._phase = torch.profiler.ProfilerAction.NONE
+                return torch.profiler.ProfilerAction.RECORD_AND_SAVE
+            return torch.profiler.ProfilerAction.RECORD
+        return torch.profiler.ProfilerAction.NONE
+
+
+class ProfilerSession:
+    """Manages a long-running profiler session with automatic cleanup.
+
+    This session can be reused across multiple benchmark calls, avoiding the
+    overhead and CUPTI issues from creating/destroying profiler contexts.
+    The profiler is lazily started on first record() call and automatically
+    cleaned up after a fixed duration to prevent CUPTI memory buildup.
+    """
+
+    _PROFILER_MAX_LIFETIME_SECONDS: float = 30.0
+
+    def __init__(self, device_type: str) -> None:
+        from torch.autograd.profiler_util import FunctionEvent
+
+        self._device_type = device_type
+        self._schedule = DynamicSchedule()
+        self._events_queue: queue.Queue[list[FunctionEvent]] = queue.Queue()
+        self._profiler: torch.profiler.profile | None = None
+        self._lock = threading.Lock()
+        self._generation = 0
+
+    def _on_trace_ready(self, prof: torch.profiler.profile) -> None:
+        """Callback invoked on RECORD_AND_SAVE - captures events."""
+        events = list(prof.events())
+        self._events_queue.put(events)
+
+    def _start_profiler(self) -> None:
+        """Start the profiler and schedule delayed cleanup."""
+        self._generation += 1
+        current_generation = self._generation
+
+        self._profiler = torch.profiler.profile(
+            activities=[
+                getattr(torch.profiler.ProfilerActivity, self._device_type.upper()),
+            ],
+            schedule=self._schedule,
+            on_trace_ready=self._on_trace_ready,
+        )
+        self._profiler.__enter__()
+        self._profiler.step()  # Initial step in NONE state
+
+        # Schedule cleanup after max lifetime
+        cleanup_thread = threading.Thread(
+            target=self._delayed_cleanup,
+            args=(current_generation,),
+            daemon=True,
+        )
+        cleanup_thread.start()
+
+    def _delayed_cleanup(self, generation: int) -> None:
+        """Background thread that stops profiler after max lifetime."""
+        time.sleep(self._PROFILER_MAX_LIFETIME_SECONDS)
+        self._stop_profiler(generation)
+
+    def _stop_profiler(self, generation: int | None = None) -> None:
+        """Stop the profiler if running and generation matches."""
+        with self._lock:
+            if self._profiler is not None:
+                # Only stop if generation matches (or no generation specified)
+                if generation is None or generation == self._generation:
+                    self._profiler.__exit__(None, None, None)
+                    self._profiler = None
+
+    def record(self, work_fn: Callable[[], None]) -> list["FunctionEvent"]:
+        """Execute work_fn while recording, return captured events."""
+        from torch.autograd.profiler_util import FunctionEvent
+
+        with self._lock:
+            # Lazily start profiler if not running
+            if self._profiler is None:
+                self._start_profiler()
+
+            profiler = self._profiler
+            assert profiler is not None
+
+            try:
+                self._schedule.start_recording()
+                profiler.step()  # Transition to RECORD
+                work_fn()  # Do the actual benchmarking work
+                profiler.step()  # Transition to RECORD_AND_SAVE -> NONE
+                events: list[FunctionEvent] = self._events_queue.get(timeout=30.0)
+                return events
+            except Exception:
+                # Increment generation to invalidate any pending cleanup threads
+                self._generation += 1
+                profiler.__exit__(None, None, None)
+                self._profiler = None
+                raise
+
+
 class ProfilingBenchmarker(Benchmarker):
     """
     Benchmarker using torch.profiler to capture device-side events.
@@ -461,6 +579,20 @@ class ProfilingBenchmarker(Benchmarker):
     profiler timings entirely exclude host-side overhead that other
     methods may include in adverse situations.
     """
+
+    def __init__(self: Self) -> None:
+        if getattr(self, "_initialized", False):
+            return
+        super().__init__()
+        self._sessions: dict[str, ProfilerSession] = {}
+        self._sessions_lock: threading.Lock = threading.Lock()
+
+    def _get_session(self: Self, device_type: str) -> ProfilerSession:
+        """Get or create a profiler session for the given device type."""
+        with self._sessions_lock:
+            if device_type not in self._sessions:
+                self._sessions[device_type] = ProfilerSession(device_type)
+            return self._sessions[device_type]
 
     @may_distort_benchmarking_result
     @time_and_count
@@ -528,31 +660,20 @@ class ProfilingBenchmarker(Benchmarker):
             _callable()
 
         device_interface.synchronize()
-        with torch.profiler.profile(
-            activities=[
-                getattr(torch.profiler.ProfilerActivity, device_type.upper()),
-            ]
-        ) as profiler:
-            # Benchmark
+
+        def work_fn() -> None:
             for _ in range(n_repeat):
-                # Clear the L2 cache before each run
                 cache.zero_()
-                # Record time of `_callable`
                 _callable()
-            # Record clocks
             device_interface.synchronize()
 
-        logger.debug("raw events")
-        logger.debug(
-            profiler.key_averages().table(
-                sort_by="self_device_time_total", row_limit=-1
-            )
-        )
+        session = self._get_session(device_type)
+        events = session.record(work_fn)
 
         filtered_events = EventList(
             [
                 event
-                for event in profiler.events()
+                for event in events
                 if event.device_type == DeviceType.CUDA
                 and event.name != "Context Sync"
             ]


### PR DESCRIPTION
Summary:
Fixes non-deterministic silent program crashes when using
ProfilingBenchmarker for many back-to-back profiling sessions,
such as during Diode data collection for GEMM sampling.

The root cause was CUPTI state accumulation from constantly
creating and destroying profiler contexts. This manifested as
"start timestamp is in the past" errors or silent crashes.

The fix introduces a persistent profiler session that:
- Reuses a single profiler context across multiple benchmark calls
- Automatically cleans up after 30 seconds to prevent CUPTI state
  issues from long-running sessions
- Lazily restarts the profiler on next benchmark call
- Maintains per-device-type sessions to support multiple backends

Key additions:
- `DynamicSchedule`: Toggles profiler between NONE and RECORD states
- `ProfilerSession`: Manages lazy profiler lifecycle with auto-cleanup
- `ProfilingBenchmarker._sessions`: Device-type to session mapping

The 30-second cleanup interval was chosen based on throughput testing
(see D92037209) which showed this value balances restart overhead
amortization with memory buildup prevention.

Authored with Claude.

Test Plan: buck test fbcode//mode/opt caffe2/test/inductor:benchmarking

Differential Revision: D92033495




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo