### PR TITLE
[ROCm][CI] Add linux.rocm.mi210.docker-cache to docker-cache

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -63,6 +63,7 @@ self-hosted-runner:
     - linux.rocm.gpu.mi250.4
     - linux.rocm.gpu.2
     - linux.rocm.gpu.4
+    - linux.rocm.mi210.docker-cache
     - linux.rocm.mi250.docker-cache
     # gfx942 runners
     - linux.rocm.gpu.gfx942.1

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux.rocm.mi250.docker-cache]
+        runner: [linux.rocm.mi250.docker-cache, linux.rocm.mi210.docker-cache]
         docker-image: [
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -55,17 +55,15 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.mi210.2.test" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.mi210.2.test" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -55,15 +55,17 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1.test" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4.test" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.mi210.2.test" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.mi210.2.test" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
This PR is for the purpose of introducing mi210 kubernetes runners to the CI to increase our capacity.

We have tested the docker caching as part of https://github.com/pytorch/pytorch/pull/165997 here:
https://github.com/pytorch/pytorch/actions/runs/21953766292/job/63804648511?pr=165997

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang