### PR TITLE
[caffe2] Skip subprocess test in fbcode for D91862702

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7767,6 +7767,7 @@ class AOTInductorTestsTemplate:
         with config.patch("triton.autotune_with_sample_inputs", True):
             AOTIRunnerUtil.run(Model(), example_inputs)
 
+    @unittest.skipIf(IS_FBCODE, "Subprocess spawning doesn't work in fbcode Buck environment")
     def test_aoti_load_package_in_fresh_subprocess(self):
         """
         Test that loading an AOTI package in a fresh subprocess works correctly.


### PR DESCRIPTION
Summary:
The new test `test_aoti_load_package_in_fresh_subprocess` spawns a subprocess
using `sys.executable`, but in Meta's Buck environment the subprocess doesn't
have access to torch because dependencies are managed through Buck's link tree.

Skipping this test in fbcode using the existing `IS_FBCODE` pattern that's
used for similar tests in this file.

Test Plan: arc lint

Reviewed By: yushangdi

Differential Revision: D92025735




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo