### PR TITLE
Fix test_qrnncell unit-test failure

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -3672,7 +3672,7 @@ class TestDynamicQuantizedOps(TestCase):
         return Xq, Hq, Cq
 
     def _get_rnn_weights_and_bias(self, input_size, hidden_size, num_directions, per_channel_quant, rnn_type):
-        hidden_mult_map = {'LSTM': 4, 'LSTMCell': 4, 'GRU': 3, 'GRUCell': 3, 'RNNTanh': 2, 'RNNReLU': 2}
+        hidden_mult_map = {'LSTM': 4, 'LSTMCell': 4, 'GRU': 3, 'GRUCell': 3, 'RNNTanh': 1, 'RNNReLU': 1}
         hidden_mult = hidden_mult_map[rnn_type]
         weights1 = torch.randn(hidden_mult * hidden_size, input_size)
         weights2 = torch.randn(hidden_mult * hidden_size, hidden_size)


### PR DESCRIPTION
This PR fixes a failure in the ```test/test_quantization.py::TestDynamicQuantizedOps::test_qrnncell``` unit test. The test was failing following the changes in #168348, where a check was added.

### Solution
Modify the weight multipliers for RNNTanh and RNNReLU from 2 to 1. 
### Testing
Before:
```
FAILED [1.3088s] test/test_quantization.py::TestDynamicQuantizedOps::test_qrnncell - RuntimeError: weight_ih first dim must be 1 * hidden_size = 4, but got 8
```
After:
Test passes successfully.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki