### PR TITLE
[DTensor] Fix non-contiguous local tensor after Shard->Replicate redistribute

### DIFF
--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -380,6 +380,8 @@ class Shard(torch._C._distributed.Shard):
             full_chunk_size = (logical_dim_size + num_chunks - 1) // num_chunks
             unpad_size = full_chunk_size * num_chunks - logical_dim_size  # type: ignore[possibly-undefined]
             local_tensor = unpad_tensor(local_tensor, self.dim, unpad_size)
+            if not local_tensor.is_contiguous():
+                local_tensor = local_tensor.contiguous()
 
         return local_tensor
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174134

When redistributing from `Shard(dim)` to `Replicate()` with uneven shard
sizes (dimension size not divisible by world_size), the local tensor
becomes non-contiguous. This happens because `_maybe_unpad_tensor` uses
`tensor.narrow()` which returns a view with incorrect strides.

For example, redistributing a tensor of shape [4, 31, 10] from Shard(1)
to Replicate results in stride (320, 10, 1) instead of the expected
contiguous stride (310, 10, 1).

The fix adds a contiguity check after unpadding, matching the existing
pattern in `_maybe_pad_tensor` which already ensures contiguity.

Fixes #173041

Claude