### PR TITLE
[MPS] Fix complex to real power scalar

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -41,7 +41,7 @@ static void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp
   if (!exp_scalar.isComplex() && exp_scalar.to<float>() == .5) {
     return lib.exec_unary_kernel(iter, "sqrt");
   }
-  if (exp_scalar.isComplex()) {
+  if (exp_scalar.isComplex() || c10::isComplexType(iter.common_dtype())) {
     return lib.exec_unary_kernel(iter, "pow_scalar", exp_scalar, ScalarType::ComplexFloat);
   }
   lib.exec_unary_kernel(iter, "pow_scalar", exp_scalar, ScalarType::Float);

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16339,10 +16339,6 @@ op_db: list[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_rms_norm,
-           skips=(
-               # Exception: Failed to create function state object for: pow_scalar_dense_float2_float2_float
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
-           ),
            error_inputs_func=error_inputs_rms_norm,),
     OpInfo('nn.functional.local_response_norm',
            dtypes=floating_types_and(torch.int64, torch.float16, torch.bfloat16),
@@ -19086,15 +19082,6 @@ op_db: list[OpInfo] = [
                    supports_fwgrad_bwgrad=True,
                    promotes_int_to_float=True,
                    skips=(
-                       # RuntimeError: Failed to create function state object for: pow_scalar_dense_float2_float2_float
-                       DecorateInfo(
-                           unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                           device_type='mps', dtypes=(torch.complex64,)
-                       ),
-                       DecorateInfo(
-                           unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                           device_type='mps', dtypes=(torch.complex64,)
-                       ),
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                     dtypes=(torch.cfloat, torch.cdouble)),
                        # AssertionError: Tensor-likes are not close!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #174158
* __->__ #174147

Before this change `torch.rand(10, device='mps', dtype=torch.cfloat).pow(.51)` would fail with `Failed to create function state object for: pow_scalar_dense_float2_float2_float`

Tested by removing respective skips in common_method_invocation