### PR TITLE
[Helion + torch.compile] Add template codegen/emission override hooks for external template buffers

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2154,6 +2154,22 @@ class Kernel(CodeGen, Generic[CSEVariableType]):
             if disallow_stores:
                 assert not sb, "unexpected store inside swap_buffers"
 
+    def emit_kernel_override(
+        self,
+        wrapper,
+        src_code: str,
+        kernel_name: str,
+        node_schedule,
+        kernel_path: str,
+        get_kernel_metadata,
+    ) -> bool:
+        """Override kernel emission. Return True if overridden, False to use default.
+
+        External template handlers (e.g. Helion) can override this method
+        to implement custom kernel emission to the wrapper.
+        """
+        return False
+
     def load(self, name: str, index: sympy.Expr) -> CSEVariable:
         raise NotImplementedError
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -463,6 +463,24 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         self.rsplit_size = 0
         self.saved_partial_accumulate: list[PartialAccumulate] = []
 
+    def codegen_template_override(
+        self,
+        scheduling,
+        template_node,
+        epilogue_nodes,
+        prologue_nodes,
+        buf_name_to_prologue_group,
+        prologue_preserves_zero_mask_fn,
+        render,
+        only_gen_src_code: bool,
+    ) -> str | None:
+        """Override template codegen. Return None to use default flow.
+
+        External template handlers (e.g. Helion) can override this method
+        to implement custom code generation.
+        """
+        return None
+
     def _get_store_output_subgraph_name(self, i: int) -> str:
         return f"<STORE_OUTPUT_{i}>"
 
@@ -2034,6 +2052,20 @@ class SIMDScheduling(BaseScheduling):
 
         # all prologue groups should have finalized with use in template
         assert len(prologue_group) == 0
+
+        # External template handlers (e.g. Helion) can override codegen
+        result = kernel.codegen_template_override(
+            self,
+            template_node,
+            epilogue_nodes,
+            prologue_nodes,
+            buf_name_to_prologue_group,
+            prologue_preserves_zero_mask,
+            render,
+            only_gen_src_code,
+        )
+        if result is not None:
+            return result
 
         with kernel:
             if not only_gen_src_code:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5955,6 +5955,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
 
 class TritonScheduling(SIMDScheduling):
+    """Scheduling backend for Triton kernel code generation."""
+
     kernel_type: type[Any] = TritonKernel
     backend_features = OrderedSet(
         [
@@ -6021,6 +6023,48 @@ class TritonScheduling(SIMDScheduling):
             )
             wrapper.write_provenance_debug_handle(kernel_name, debug_handle)
 
+    def _emit_kernel_to_wrapper(
+        self,
+        wrapper,
+        kernel,
+        src_code,
+        kernel_name,
+        subs_name,
+        node_schedule,
+        kernel_path,
+        get_kernel_metadata,
+    ):
+        """Emit kernel to wrapper, with support for external template handlers."""
+        # External template handlers (e.g. Helion) can override kernel emission
+        if kernel.emit_kernel_override(
+            wrapper,
+            src_code,
+            kernel_name,
+            node_schedule,
+            kernel_path,
+            get_kernel_metadata,
+        ):
+            return  # External handler handled it
+
+        compile_wrapper = IndentedBuffer()
+
+        if async_compile.use_process_pool():
+            # The process pool is warm, we can shell out to workers right away. This
+            # allows us to save the result in async_compile.CompiledTritonKernels,
+            # so that the second time we call async_compile.triton, we do no work.
+            async_compile.triton(subs_name, src_code)
+
+        compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")
+
+        compile_wrapper.splice(src_code, strip=True)
+        current_device = V.graph.get_current_device_or_throw()
+        compile_wrapper.writeline(f"''', device_str='{current_device.type}')")
+
+        metadata_comment = f"# kernel path: {kernel_path}"
+        origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
+        metadata_comment += "\n" + origins + "\n" + detailed_origins
+        wrapper.define_kernel(kernel_name, compile_wrapper.getvalue(), metadata_comment)
+
     def define_kernel(self, src_code, node_schedule, kernel):
         wrapper = V.graph.wrapper_code
         if src_code in wrapper.src_to_kernel:
@@ -6055,25 +6099,16 @@ class TritonScheduling(SIMDScheduling):
             src_code = src_code.replace("#pragma CMT", "#")
 
             _basename, _, kernel_path = get_path(code_hash(src_code.strip()), "py")
-            compile_wrapper = IndentedBuffer()
 
-            if async_compile.use_process_pool():
-                # The process pool is warm, we can shell out to workers right away. This
-                # allows us to save the result in async_compile.CompiledTritonKernels,
-                # so that the second time we call async_compile.triton, we do no work.
-                async_compile.triton(subs_name, src_code)
-
-            compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")
-
-            compile_wrapper.splice(src_code, strip=True)
-            current_device = V.graph.get_current_device_or_throw()
-            compile_wrapper.writeline(f"''', device_str='{current_device.type}')")
-
-            metadata_comment = f"# kernel path: {kernel_path}"
-            origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
-            metadata_comment += "\n" + origins + "\n" + detailed_origins
-            wrapper.define_kernel(
-                kernel_name, compile_wrapper.getvalue(), metadata_comment
+            self._emit_kernel_to_wrapper(
+                wrapper,
+                kernel,
+                src_code,
+                kernel_name,
+                subs_name,
+                node_schedule,
+                kernel_path,
+                get_kernel_metadata,
             )
 
             # log kernel metadata for offline analysis.


### PR DESCRIPTION
Design doc: https://github.com/pytorch/helion/issues/1346.

Add two extension points for external template buffers (e.g. Helion kernel):
- `codegen_template_override()` in SIMDKernel - allows custom template code generation
- `emit_kernel_override()` in Kernel - allows custom kernel emission to wrapper

These hooks enable external template buffers to integrate with Inductor's template fusion without modifying core Inductor code.

After this PR, we will add Helion dynamo variable and HOP handling in https://github.com/pytorch/helion/pull/1351.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo