### PR TITLE
soft_pending_unbacked_not_found_error flag to bypass PendingUnbackedSymbolNotFound errors

### DIFF
--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -108,5 +108,13 @@ enrich_profiler_metadata: bool = Config(  # type: ignore[var-annotated]
     env_name_default="TORCH_ENRICH_RPOFILER_STACK_TRACE",
 )
 
+# When True, log a warning instead of raising PendingUnbackedSymbolNotFound exception
+# when pending unbacked symbols are not found in returned outputs.
+# The worst that can happen is an error somewhere else in the stack where we expect
+# to locate an unbacked binding. Or a runtime assertion not being lowered in the output
+# code.
+# [@compile_ignored: debug]
+soft_pending_unbacked_not_found_error = False
+
 
 install_config_module(sys.modules[__name__])

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -113,7 +113,6 @@ enrich_profiler_metadata: bool = Config(  # type: ignore[var-annotated]
 # The worst that can happen is an error somewhere else in the stack where we expect
 # to locate an unbacked binding. Or a runtime assertion not being lowered in the output
 # code.
-# [@compile_ignored: debug]
 soft_pending_unbacked_not_found_error = False
 
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1412,12 +1412,16 @@ def compute_unbacked_bindings(
             if isinstance(example_value, torch.Tensor)
             else ""
         )
-        raise PendingUnbackedSymbolNotFound(
+        msg = (
             f"Pending unbacked symbols {pending} not in returned outputs {example_value} {extra}.\n"
             "Did you accidentally call new_dynamic_size() or item() more times "
             "than you needed to in your fake implementation?\n"
             "For more help, see https://docs.google.com/document/d/1RWrH-3wLEpzR9kCS6gGBNen_-Fs-8PVbWWFE5AcgeWE/edit"
         )
+        if torch.fx.experimental._config.soft_pending_unbacked_not_found_error:
+            log.warning(msg)
+        else:
+            raise PendingUnbackedSymbolNotFound(msg)
 
     # Why do we have to do some rebinding here?  If the original FX node
     # wasn't a binding site because you had a memo hit, but post


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174150

Most of the recent PendingUnbackedSymbolNotFound errors occur in cases where we genuinely do not care about the allocated unbacked SymInts (as opposed to real bugs where we fail to track a value or miss an access path, etc.).

With this flag enabled, we skip raising an error when we cannot find a binding site for an unbacked symbol. The consequence is that a different error might be raised later, a runtime assertion might be missing, or nothing may happen at all.

In principle, verifying that all runtime assertions have been lowered would be a sufficient condition to remove this raise entirely. However, we are not there yet, and performing such a check is neither ready nor trivial at the moment.