### PR TITLE
use optimizations_hints in defake

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4177,24 +4177,10 @@ class numpy_operator_wrapper(Generic[_P, R]):
 def defake(x: Any) -> Any:
     if not isinstance(x, FakeTensor):
         return x
-    size: torch._prims_common.ShapeType
-    stride: torch._prims_common.StrideType
-    if x._has_symbolic_sizes_strides:
-        size = []
-        for s in x.size():
-            if isinstance(s, torch.SymInt):
-                size.append(s.node.shape_env.size_hint(s.node.expr))
-            else:
-                size.append(s)
-        stride = []
-        for s in x.stride():
-            if isinstance(s, torch.SymInt):
-                stride.append(s.node.shape_env.size_hint(s.node.expr))
-            else:
-                stride.append(s)
-    else:
-        size = x.size()
-        stride = x.stride()
+    from torch._inductor.virtualized import V
+
+    size = V.graph.sizevars.optimization_hints(x.size())
+    stride = V.graph.sizevars.optimization_hints(x.stride())
     y = torch.empty_strided(
         size,
         stride,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174155
* #174154
* __->__ #174153

The output of defake (real tensors) is used for Triton kernel autotuning during C++ wrapper code generation.
hence optimization hint is appropriate. 

test plan:
run existing tests. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo