### PR TITLE
[WIP][inductor] Add decompose_functional_to_out pass for CUDAGraph compatibility

### DIFF
--- a/test/inductor/test_decompose_functional_to_out.py
+++ b/test/inductor/test_decompose_functional_to_out.py
@@ -1,0 +1,120 @@
+# Owner(s): ["module: inductor"]
+"""
+Minimal tests for decompose_functional_to_out pass.
+"""
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch._library.functional_to_out import (
+    clear_registry,
+    register_functional_to_out,
+    get_out_variant,
+)
+
+
+class TestDecomposeFunctionalToOut(TestCase):
+    """Tests for the decompose pass."""
+
+    def setUp(self):
+        clear_registry()
+        self._setup_test_ops()
+
+    def tearDown(self):
+        clear_registry()
+
+    def _setup_test_ops(self):
+        """Create test custom ops."""
+
+        @torch.library.custom_op("test_pass::add_one", mutates_args=())
+        def add_one(x: torch.Tensor) -> torch.Tensor:
+            return x + 1
+
+        @add_one.register_fake
+        def _(x):
+            return torch.empty_like(x)
+
+        @torch.library.custom_op("test_pass::add_one_out", mutates_args=("out",))
+        def add_one_out(out: torch.Tensor, x: torch.Tensor) -> None:
+            out.copy_(x + 1)
+
+        @add_one_out.register_fake
+        def _(out, x):
+            pass
+
+        self.functional_op = torch.ops.test_pass.add_one.default
+        self.out_op = torch.ops.test_pass.add_one_out.default
+
+    def test_decompose_single_output(self):
+        """Test decomposition of a single-output functional op."""
+        register_functional_to_out(
+            functional_op=self.functional_op,
+            out_op=self.out_op,
+            out_arg_positions=(0,),
+        )
+
+        def fn(x):
+            return torch.ops.test_pass.add_one(x)
+
+        x = torch.randn(4, 4)
+
+        with torch._inductor.config.patch(decompose_functional_to_out=True):
+            compiled = torch.compile(fn, backend="inductor")
+            result = compiled(x)
+
+        expected = x + 1
+        torch.testing.assert_close(result, expected)
+
+    def test_no_decompose_when_disabled(self):
+        """Test that decomposition is skipped when config is disabled."""
+        register_functional_to_out(
+            functional_op=self.functional_op,
+            out_op=self.out_op,
+            out_arg_positions=(0,),
+        )
+
+        def fn(x):
+            return torch.ops.test_pass.add_one(x)
+
+        x = torch.randn(4, 4)
+
+        # Default is disabled
+        compiled = torch.compile(fn, backend="inductor")
+        result = compiled(x)
+
+        expected = x + 1
+        torch.testing.assert_close(result, expected)
+
+    def test_no_decompose_unregistered_op(self):
+        """Test that unregistered ops are not decomposed."""
+
+        def fn(x):
+            return torch.ops.test_pass.add_one(x)
+
+        x = torch.randn(4, 4)
+
+        with torch._inductor.config.patch(decompose_functional_to_out=True):
+            compiled = torch.compile(fn, backend="inductor")
+            result = compiled(x)
+
+        expected = x + 1
+        torch.testing.assert_close(result, expected)
+
+
+class TestConfigOption(TestCase):
+    """Test config option exists and works."""
+
+    def test_config_option_exists(self):
+        """Test that config option exists."""
+        from torch._inductor import config
+
+        self.assertTrue(hasattr(config, "decompose_functional_to_out"))
+
+    def test_config_default_is_false(self):
+        """Test that config defaults to False (opt-in)."""
+        from torch._inductor import config
+
+        self.assertFalse(config.decompose_functional_to_out)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -643,6 +643,11 @@ use_pre_grad_passes: bool = True
 use_joint_graph_passes: bool = True
 use_post_grad_passes: bool = True
 
+# Decompose functional custom ops to out variants for CUDAGraph compatibility.
+# When enabled, functional ops with registered out variants will be converted
+# to their out variants during compilation (pre-allocated buffers).
+decompose_functional_to_out: bool = False
+
 
 cutedsl_enable_autotuning: bool = (
     os.environ.get("CUTEDSL_ENABLE_AUTOTUNING", "0") == "1"

--- a/torch/_inductor/fx_passes/decompose_functional_to_out.py
+++ b/torch/_inductor/fx_passes/decompose_functional_to_out.py
@@ -1,0 +1,234 @@
+"""
+Inductor pass to decompose functional custom ops to their out variants.
+
+This pass runs during Inductor's post-grad optimization phase. It:
+1. Identifies functional custom ops with registered out variants
+2. Inserts buffer allocation nodes before the op
+3. Replaces the functional op call with the out variant call
+
+This enables:
+- CUDAGraph compatibility (requires fixed buffer addresses)
+- Future memory optimization through buffer reuse (Phase 2)
+
+The pass is controlled by `torch._inductor.config.decompose_functional_to_out`.
+"""
+
+import logging
+import operator
+from typing import Any, Optional
+
+import torch
+import torch.fx as fx
+from torch._library.functional_to_out import (
+    FunctionalToOutMapping,
+    get_out_variant,
+    has_any_registered_mappings,
+    TensorSpec,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+def decompose_functional_to_out(graph: fx.Graph) -> bool:
+    """
+    Decompose functional custom ops to their out variants.
+
+    Args:
+        graph: The FX graph to transform
+
+    Returns:
+        True if any transformations were made
+    """
+    if not has_any_registered_mappings():
+        return False
+
+    modified = False
+    nodes_to_transform = []
+
+    for node in graph.nodes:
+        if node.op != "call_function":
+            continue
+        if get_out_variant(node.target) is not None:
+            nodes_to_transform.append(node)
+
+    for node in nodes_to_transform:
+        mapping = get_out_variant(node.target)
+        if mapping is None:
+            continue
+
+        success = _decompose_node(graph, node, mapping)
+        modified |= success
+        if success:
+            log.debug("Decomposed %s -> %s", node.target, mapping.out_op)
+
+    if modified:
+        graph.lint()
+        graph.eliminate_dead_code()
+
+    return modified
+
+
+def _decompose_node(
+    graph: fx.Graph,
+    node: fx.Node,
+    mapping: FunctionalToOutMapping,
+) -> bool:
+    """Transform a single functional op node to its out variant."""
+    output_specs = _get_output_specs_from_node(node, mapping)
+    if output_specs is None:
+        log.warning("Could not infer output specs for %s", node.target)
+        return False
+
+    with graph.inserting_before(node):
+        output_buffers = []
+        for i, spec in enumerate(output_specs):
+            alloc_node = _create_allocation_node(graph, spec, node, i)
+            output_buffers.append(alloc_node)
+
+        out_args = tuple(output_buffers) + tuple(node.args)
+        out_kwargs = dict(node.kwargs)
+
+        out_op = mapping.out_op
+        if hasattr(out_op, "default"):
+            out_op = out_op.default
+
+        out_call = graph.call_function(out_op, args=out_args, kwargs=out_kwargs)
+        out_call.meta["val"] = None
+        out_call.meta["decomposed_from"] = node.target
+
+    _replace_output_uses(graph, node, output_buffers)
+    graph.erase_node(node)
+
+    return True
+
+
+def _get_output_specs_from_node(
+    node: fx.Node,
+    mapping: FunctionalToOutMapping,
+) -> Optional[list[TensorSpec]]:
+    """Extract output tensor specifications from the node's metadata."""
+    val = node.meta.get("val")
+    if val is None:
+        fake_args = tuple(_get_fake_val(a) for a in node.args)
+        fake_kwargs = {k: _get_fake_val(v) for k, v in node.kwargs.items()}
+
+        if any(isinstance(a, fx.Node) for a in fake_args):
+            return None
+        if any(isinstance(v, fx.Node) for v in fake_kwargs.values()):
+            return None
+
+        return mapping.get_output_specs(fake_args, fake_kwargs)
+
+    if isinstance(val, torch.Tensor):
+        vals = (val,)
+    elif isinstance(val, (tuple, list)):
+        vals = val
+    else:
+        return None
+
+    specs = []
+    for v in vals:
+        if isinstance(v, torch.Tensor):
+            specs.append(
+                TensorSpec(
+                    shape=tuple(v.shape),
+                    dtype=v.dtype,
+                    device=v.device,
+                    requires_grad=v.requires_grad,
+                )
+            )
+
+    return specs if specs else None
+
+
+def _get_fake_val(node_or_val: Any) -> Any:
+    """Get the fake tensor value from a node or return the value as-is."""
+    if isinstance(node_or_val, fx.Node):
+        return node_or_val.meta.get("val", node_or_val)
+    return node_or_val
+
+
+def _create_allocation_node(
+    graph: fx.Graph,
+    spec: TensorSpec,
+    source_node: fx.Node,
+    output_idx: int,
+) -> fx.Node:
+    """Create a tensor allocation node in the graph."""
+    alloc_node = graph.call_function(
+        torch.empty,
+        args=(spec.shape,),
+        kwargs={"dtype": spec.dtype, "device": spec.device},
+    )
+
+    from torch._guards import detect_fake_mode
+
+    fake_mode = detect_fake_mode([source_node.meta.get("val")])
+
+    if fake_mode is not None:
+        with fake_mode:
+            fake_tensor = torch.empty(
+                spec.shape,
+                dtype=spec.dtype,
+                device=spec.device,
+                requires_grad=spec.requires_grad,
+            )
+    else:
+        fake_tensor = torch.empty(
+            spec.shape,
+            dtype=spec.dtype,
+            device="meta",
+            requires_grad=spec.requires_grad,
+        )
+
+    alloc_node.meta["val"] = fake_tensor
+    alloc_node.meta["allocation_for"] = (source_node.target, output_idx)
+
+    return alloc_node
+
+
+def _replace_output_uses(
+    graph: fx.Graph,
+    original_node: fx.Node,
+    output_buffers: list[fx.Node],
+) -> None:
+    """Replace uses of the original functional op's outputs with the new buffers."""
+    if len(output_buffers) == 1:
+        original_node.replace_all_uses_with(output_buffers[0])
+        return
+
+    users_to_replace = []
+    for user in list(original_node.users.keys()):
+        if user.op == "call_function" and user.target is operator.getitem:
+            idx = user.args[1]
+            if isinstance(idx, int) and 0 <= idx < len(output_buffers):
+                users_to_replace.append((user, output_buffers[idx]))
+
+    for getitem_node, replacement in users_to_replace:
+        getitem_node.replace_all_uses_with(replacement)
+        graph.erase_node(getitem_node)
+
+
+def run_decompose_pass(gm: fx.GraphModule) -> fx.GraphModule:
+    """
+    Run the decompose pass on a GraphModule.
+
+    Args:
+        gm: The GraphModule to transform
+
+    Returns:
+        The transformed GraphModule
+    """
+    from torch._inductor import config
+
+    if not getattr(config, "decompose_functional_to_out", False):
+        return gm
+
+    modified = decompose_functional_to_out(gm.graph)
+
+    if modified:
+        gm.recompile()
+        log.info("Decomposed functional ops to out variants")
+
+    return gm

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -136,6 +136,14 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     fake_tensor_updater = FakeTensorUpdater(gm.graph)
 
+    # Decompose functional custom ops to out variants for CUDAGraph compatibility
+    if config.decompose_functional_to_out:
+        from .decompose_functional_to_out import decompose_functional_to_out
+
+        GraphTransformObserver(gm, "decompose_functional_to_out").apply_graph_pass(
+            decompose_functional_to_out
+        )
+
     if post_grad_custom_pre_pass := config.post_grad_custom_pre_pass:
         GraphTransformObserver(gm, "post_grad_custom_pre_pass").apply_graph_pass(
             post_grad_custom_pre_pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174160
* #174145

Summary:
This PR adds the core pass that decomposes functional custom ops to their
out variants during Inductor compilation. This enables CUDAGraph compatibility
for custom operators that have registered functional-to-out mappings.

Changes:
- Add decompose_functional_to_out() pass in fx_passes
- Integrate pass into post_grad optimization phase
- Add config option config.decompose_functional_to_out (default: False)
- Minimal tests verifying pass behavior

Test Plan:
python test/inductor/test_decompose_functional_to_out.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo