### PR TITLE
Add support for architecture '120a' from .ptx to .fatbin

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3938,6 +3938,8 @@ def _nvcc_arch_as_compile_option() -> str:
         return "100f"
     if arch == "100":
         return "100a"
+    if arch == "120":
+        return "120a"
     return arch
 
 


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/174161

We are seeing a mismatch between what .ptx is targeting at (sm_120a) vs what nvcc is expecting:

```
nvcc -fatbin /tmp/torchinductor_larryliu/cn2b7b3axqd67apcipd7hhra5w6yptgpisf47u3ksrwycqjr4tiq/clps3nzvdel6iy7tuyubpl5bio42qofv3tnaw3kh6srfe7qy2w7u.ptx -o /tmp/torchinductor_larryliu/cn2b7b3axqd67apcipd7hhra5w6yptgpisf47u3ksrwycqjr4tiq/clps3nzvdel6iy7tuyubpl5bio42qofv3tnaw3kh6srfe7qy2w7u.fatbin -gencode arch=compute_120,code=compute_120 -gencode arch=compute_120,code=sm_120  failed with:
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo