### PR TITLE
[test] Add error_inputs for nn.Linear module

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -287,6 +287,31 @@ def module_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, tra
     return module_inputs
 
 
+def module_error_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, training, **kwargs):
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    return [
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(10, 8),
+                forward_input=FunctionInput(make_input((4, 5))),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"mat1 and mat2 shapes cannot be multiplied"
+        ),
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(-1, 8),
+                forward_input=FunctionInput(),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"Trying to create tensor with negative dimension"
+        ),
+    ]
+
+
 def module_inputs_torch_nn_Bilinear(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -4142,6 +4167,7 @@ module_db: list[ModuleInfo] = [
                )),
     ModuleInfo(torch.nn.Linear,
                module_inputs_func=module_inputs_torch_nn_Linear,
+               module_error_inputs_func=module_error_inputs_torch_nn_Linear,
                skips=(
                    # No channels_last support for Linear currently.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),)


### PR DESCRIPTION
## Summary

Add `module_error_inputs_torch_nn_Linear` function to test error messages for invalid inputs to `nn.Linear` module.

## Motivation

Currently, `torch.nn.Linear` does not have `module_error_inputs_func` defined in `common_modules.py`. This PR adds error input tests to enable regression testing for error messages and follow the pattern already established for other modules (BatchNorm, GroupNorm, RNN cells, etc.).

## Test Cases Added

1. **Wrong input features**: Tests error when last dimension doesn't match `in_features`
   - Input: `Linear(10, 8)` with tensor of shape `(4, 5)`
   - Expected: `RuntimeError: mat1 and mat2 shapes cannot be multiplied`

2. **Negative in_features**: Tests error when constructor has negative dimension
   - Input: `Linear(-1, 8)`
   - Expected: `RuntimeError: Trying to create tensor with negative dimension`

## Duplicate Check

Searched `test/test_nn.py` for existing Linear error tests:
- **`test_linear_raise_on_scalar_input`** (line 7050) — already tests scalar/0-dim input error. **Removed from this PR** to avoid duplication.
- **`test_linear_broadcasting`** — tests valid broadcasting, not an error case.
- No existing tests found for shape mismatch or negative dimension errors.

## Test Environment

- Tested on H200 GPU with CUDA 12.8
- Verified error messages match on both CPU and CUDA

Fixes #174177

cc @mruberry @albanD @jbschlosser