### PR TITLE
[test] Add error_inputs for nn.Embedding module

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -2844,6 +2844,58 @@ def module_inputs_torch_nn_Embedding(module_info, device, dtype, requires_grad, 
     ]
 
 
+def module_error_inputs_torch_nn_Embedding(module_info, device, dtype, requires_grad, training, **kwargs):
+    """
+    Error inputs for Embedding that test error messages for invalid inputs.
+    """
+    samples = []
+
+    # Out of range indices: index exceeds num_embeddings
+    # Only test on CPU - CUDA triggers kernel assertion instead of Python exception
+    device_str = str(device)
+    if 'cuda' not in device_str and 'mps' not in device_str:
+        samples.append(
+            ErrorModuleInput(
+                ModuleInput(
+                    constructor_input=FunctionInput(num_embeddings=10, embedding_dim=3),
+                    forward_input=FunctionInput(torch.tensor([0, 5, 15], device=device, dtype=torch.long)),
+                ),
+                error_on=ModuleErrorEnum.FORWARD_ERROR,
+                error_type=IndexError,
+                error_regex=r"index out of range in self"
+            )
+        )
+
+    # Float indices: wrong dtype for indices (works on all devices)
+    samples.append(
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(num_embeddings=10, embedding_dim=3),
+                forward_input=FunctionInput(torch.tensor([1.5, 2.5], device=device, dtype=torch.float32)),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"Expected tensor for argument.*indices.*to have.*scalar type.*Long.*Int"
+        )
+    )
+
+    # Negative num_embeddings (construction error, device-independent)
+    samples.append(
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(num_embeddings=-1, embedding_dim=3),
+                forward_input=FunctionInput(),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"Trying to create tensor with negative dimension"
+        )
+    )
+
+    return samples
+
+
+
 def module_inputs_torch_nn_MultiheadAttention(module_info, device, dtype, requires_grad, training, **kwargs):
     # Currently all samples below are for validating the no-batch-dim support.
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
@@ -4389,6 +4441,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.Embedding,
                module_inputs_func=module_inputs_torch_nn_Embedding,
+               module_error_inputs_func=module_error_inputs_torch_nn_Embedding,
                gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
                decorators=[
                    DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-4, rtol=1e-4)}),


### PR DESCRIPTION
## Summary

Add `module_error_inputs_torch_nn_Embedding` function to test error messages for invalid inputs to `nn.Embedding` module.

## Motivation

Currently, `torch.nn.Embedding` does not have `module_error_inputs_func` defined in `common_modules.py`. This PR adds error input tests to enable regression testing for error messages and follow the pattern already established for other modules (BatchNorm, GroupNorm, RNN cells, etc.).

## Test Cases Added

1. **Out of range indices**: Tests IndexError when index exceeds `num_embeddings`
   - Input: `Embedding(10, 3)` with indices `[0, 5, 15]` (15 is out of range)
   - Expected: `IndexError: index out of range in self`
   - **Note**: Only tested on CPU - CUDA triggers kernel assertion instead of Python exception

2. **Float indices**: Tests RuntimeError when float tensor used instead of Long/Int
   - Input: `Embedding(10, 3)` with float tensor `[1.5, 2.5]`
   - Expected: `RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int`

3. **Negative num_embeddings**: Tests RuntimeError when constructor has negative dimension
   - Input: `Embedding(-1, 3)`
   - Expected: `RuntimeError: Trying to create tensor with negative dimension`

## Test Environment

- Tested on H200 GPU with CUDA 12.8
- Verified error messages match on CPU
- CUDA tests pass for dtype and construction errors

Fixes #174179

cc @mruberry @albanD @jbschlosser