### PR TITLE
[test] Add error_inputs for nn.MaxPool2d module

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -2285,6 +2285,47 @@ def module_inputs_torch_nn_MaxPool2d(module_info, device, dtype, requires_grad, 
             desc='return_indices'),
     ]
 
+
+def module_error_inputs_torch_nn_MaxPool2d(module_info, device, dtype, requires_grad, training, **kwargs):
+    """
+    Error inputs for MaxPool2d that test error messages for invalid inputs.
+    """
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    return [
+        # Wrong input dimensions: 2D input instead of 3D/4D
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(2),
+                forward_input=FunctionInput(make_input((3, 4))),  # 2D input
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"non-empty 3D or 4D \(batch mode\) tensor expected for input"
+        ),
+        # Wrong input dimensions: 5D input
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(2),
+                forward_input=FunctionInput(make_input((1, 2, 3, 4, 5))),  # 5D input
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"non-empty 3D or 4D \(batch mode\) tensor expected for input"
+        ),
+        # Invalid padding: padding > kernel_size / 2
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(3, padding=5),  # kernel=3, pad=5 > 3/2
+                forward_input=FunctionInput(make_input((1, 1, 10, 10))),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=r"pad should be at most half of effective kernel size"
+        ),
+    ]
+
+
 def module_inputs_torch_nn_MaxPool3d(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -4103,6 +4144,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.MaxPool2d,
                module_inputs_func=module_inputs_torch_nn_MaxPool2d,
+               module_error_inputs_func=module_error_inputs_torch_nn_MaxPool2d,
                ),
     ModuleInfo(torch.nn.MaxPool3d,
                module_inputs_func=module_inputs_torch_nn_MaxPool3d,


### PR DESCRIPTION
## Summary

Add `module_error_inputs_torch_nn_MaxPool2d` function to test error messages for invalid inputs to `nn.MaxPool2d` module.

## Motivation

Currently, `torch.nn.MaxPool2d` does not have `module_error_inputs_func` defined in `common_modules.py`. This PR adds error input tests to enable regression testing for error messages and follow the pattern already established for other modules (BatchNorm, GroupNorm, Pad modules, etc.).

## Test Cases Added

1. **Wrong input dimensions (2D)**: Tests RuntimeError when 2D input is given instead of 3D/4D
   - Input: MaxPool2d with 2D tensor input
   - Expected: `RuntimeError: non-empty 3D or 4D (batch mode) tensor expected for input`

2. **Wrong input dimensions (5D)**: Tests RuntimeError when 5D input is given instead of 3D/4D
   - Input: MaxPool2d with 5D tensor input
   - Expected: `RuntimeError: non-empty 3D or 4D (batch mode) tensor expected for input`

3. **Invalid padding**: Tests RuntimeError when padding exceeds half of effective kernel size
   - Input: MaxPool2d(3, padding=5) - padding=5 > kernel_size/2=1.5
   - Expected: `RuntimeError: pad should be at most half of effective kernel size`

## Test Environment

- Tested on H200 GPU with CUDA 12.8
- Verified error messages match on both CPU and CUDA
- All tests pass

Fixes #174185

cc @mruberry @albanD @jbschlosser