### PR TITLE
[docs] Add documentation for torch.pi and torch.e constants

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -320,9 +320,23 @@ Constants
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ======================================= ===========================================
+``e``                                       The mathematical constant *e*, the base of natural logarithms. Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
 ``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
+``pi``                                      The mathematical constant π (pi). Alias for :attr:`math.pi`.
 ======================================= ===========================================
+
+Example::
+
+    >>> import torch
+    >>> torch.e
+    2.718281828459045
+    >>> torch.pi
+    3.141592653589793
+    >>> torch.inf
+    inf
+    >>> torch.nan
+    nan
 
 Pointwise Ops
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Adds documentation for the mathematical constants `torch.pi` and `torch.e` in the Constants section of the torch module documentation.

These constants are exported from the `math` module for Python Array API and NumPy consistency but were previously undocumented.

**Changes:**
- Added `torch.e` documentation: "The mathematical constant *e*, the base of natural logarithms. Alias for math.e."
- Added `torch.pi` documentation: "The mathematical constant π (pi). Alias for math.pi."
- Added example showing usage of all constants (`torch.e`, `torch.pi`, `torch.inf`, `torch.nan`)

```python
>>> import torch
>>> torch.e
2.718281828459045
>>> torch.pi
3.141592653589793
```

## Test Plan

This is a documentation-only change. The constants are already functional in PyTorch:

```python
>>> import torch
>>> torch.pi
3.141592653589793
>>> torch.e
2.718281828459045
```

Fixes #167535

cc @svekars @sekyondaMeta @AlannaBurke