### PR TITLE
[aten] Add batch_sizes device check to RNN packed sequence operators

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1196,6 +1196,17 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
 // PUBLIC FUNCTIONS
 ////////////////////////////////////////////////////////////////////////////////
 
+// Helper function to validate batch_sizes tensor for packed RNN sequences.
+// batch_sizes must be 1D and on CPU since it's accessed via data_ptr<int64_t>()
+// in PackedLayer and ReversedPackedLayer which assumes CPU memory.
+inline void check_rnn_batch_sizes(const Tensor& batch_sizes) {
+  TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+  TORCH_CHECK(
+      batch_sizes.is_cpu(),
+      "batch_sizes tensor should be on CPU, but got ",
+      batch_sizes.device());
+}
+
 #define ONE_HIDDEN_RNN(NAME, CELL)                                          \
   DEFINE_DISPATCH(NAME##_cudnn_stub);                                       \
   DEFINE_DISPATCH(NAME##_miopen_stub);                                      \
@@ -1278,11 +1289,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
       double dropout_p,                                                     \
       bool train,                                                           \
       bool bidirectional) {                                                 \
-    TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D"); \
-    TORCH_CHECK(                                                            \
-        batch_sizes.device().is_cpu(),                                      \
-        "batch_sizes tensor should be on CPU, but got ",                           \
-        batch_sizes.device());                                              \
+    check_rnn_batch_sizes(batch_sizes);                                     \
     if (use_cudnn(data)) {                                                  \
       Tensor output, hy;                                                    \
       NAME##_packed_cudnn_stub(                                             \
@@ -1373,11 +1380,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
       double dropout_p,                                                     \
       bool train,                                                           \
       bool bidirectional) {                                                 \
-    TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D"); \
-    TORCH_CHECK(                                                            \
-        batch_sizes.device().is_cpu(),                                      \
-        "batch_sizes tensor should be on CPU, but got ",                           \
-        batch_sizes.device());                                              \
+    check_rnn_batch_sizes(batch_sizes);                                     \
     std::vector<QRNNCellParamsWrapper> params;                              \
     for (c10::intrusive_ptr<CellParamsBase> x : _params) {                  \
       params.emplace_back(std::move(x));                                    \
@@ -1517,11 +1520,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
       TensorList _params, bool has_biases,
       int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
-  TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
-  TORCH_CHECK(
-      batch_sizes.device().is_cpu(),
-      "batch_sizes tensor should be on CPU, but got ",
-      batch_sizes.device());
+  check_rnn_batch_sizes(batch_sizes);
   if (use_cudnn(data)) {
     Tensor output, hy, cy;
     lstm_packed_cudnn_stub(data.device().type(), output, hy, cy, data, batch_sizes, hx,
@@ -1797,11 +1796,7 @@ static std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data(
   }
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
   TORCH_CHECK(hx[0].size(2) == hx[1].size(2), "quantized LSTM with projections is not supported");
-  TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
-  TORCH_CHECK(
-      batch_sizes.device().is_cpu(),
-      "batch_sizes tensor should be on CPU, but got ",
-      batch_sizes.device());
+  check_rnn_batch_sizes(batch_sizes);
 
   PackedSequence input { data, batch_sizes };
   auto results = _lstm_impl<PackedLayer, PackedBidirectionalLayer>(

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1281,7 +1281,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
     TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D"); \
     TORCH_CHECK(                                                            \
         batch_sizes.device().is_cpu(),                                      \
-        "batch_sizes should be on CPU, but got ",                           \
+        "batch_sizes tensor should be on CPU, but got ",                           \
         batch_sizes.device());                                              \
     if (use_cudnn(data)) {                                                  \
       Tensor output, hy;                                                    \
@@ -1376,7 +1376,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
     TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D"); \
     TORCH_CHECK(                                                            \
         batch_sizes.device().is_cpu(),                                      \
-        "batch_sizes should be on CPU, but got ",                           \
+        "batch_sizes tensor should be on CPU, but got ",                           \
         batch_sizes.device());                                              \
     std::vector<QRNNCellParamsWrapper> params;                              \
     for (c10::intrusive_ptr<CellParamsBase> x : _params) {                  \
@@ -1520,7 +1520,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
   TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
   TORCH_CHECK(
       batch_sizes.device().is_cpu(),
-      "batch_sizes should be on CPU, but got ",
+      "batch_sizes tensor should be on CPU, but got ",
       batch_sizes.device());
   if (use_cudnn(data)) {
     Tensor output, hy, cy;
@@ -1800,7 +1800,7 @@ static std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data(
   TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
   TORCH_CHECK(
       batch_sizes.device().is_cpu(),
-      "batch_sizes should be on CPU, but got ",
+      "batch_sizes tensor should be on CPU, but got ",
       batch_sizes.device());
 
   PackedSequence input { data, batch_sizes };

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1278,6 +1278,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
       double dropout_p,                                                     \
       bool train,                                                           \
       bool bidirectional) {                                                 \
+    TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D"); \
+    TORCH_CHECK(                                                            \
+        batch_sizes.device().is_cpu(),                                      \
+        "batch_sizes should be on CPU, but got ",                           \
+        batch_sizes.device());                                              \
     if (use_cudnn(data)) {                                                  \
       Tensor output, hy;                                                    \
       NAME##_packed_cudnn_stub(                                             \
@@ -1368,6 +1373,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
       double dropout_p,                                                     \
       bool train,                                                           \
       bool bidirectional) {                                                 \
+    TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D"); \
+    TORCH_CHECK(                                                            \
+        batch_sizes.device().is_cpu(),                                      \
+        "batch_sizes should be on CPU, but got ",                           \
+        batch_sizes.device());                                              \
     std::vector<QRNNCellParamsWrapper> params;                              \
     for (c10::intrusive_ptr<CellParamsBase> x : _params) {                  \
       params.emplace_back(std::move(x));                                    \
@@ -1507,6 +1517,11 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
       TensorList _params, bool has_biases,
       int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
+  TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+  TORCH_CHECK(
+      batch_sizes.device().is_cpu(),
+      "batch_sizes should be on CPU, but got ",
+      batch_sizes.device());
   if (use_cudnn(data)) {
     Tensor output, hy, cy;
     lstm_packed_cudnn_stub(data.device().type(), output, hy, cy, data, batch_sizes, hx,
@@ -1782,6 +1797,11 @@ static std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data(
   }
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
   TORCH_CHECK(hx[0].size(2) == hx[1].size(2), "quantized LSTM with projections is not supported");
+  TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+  TORCH_CHECK(
+      batch_sizes.device().is_cpu(),
+      "batch_sizes should be on CPU, but got ",
+      batch_sizes.device());
 
   PackedSequence input { data, batch_sizes };
   auto results = _lstm_impl<PackedLayer, PackedBidirectionalLayer>(


### PR DESCRIPTION
## Summary

Fixes https://github.com/pytorch/pytorch/issues/171284
Fixes https://github.com/pytorch/pytorch/issues/173944

This PR addresses a segmentation fault that occurs when using RNN packed sequence operators (GRU, LSTM, RNN tanh, RNN relu) with `batch_sizes` tensor on CUDA instead of CPU.

**Root cause:** The `batch_sizes` tensor is accessed via `data_ptr<int64_t>()` in `PackedLayer` and `ReversedPackedLayer` classes, which assumes CPU memory. When `batch_sizes` is on GPU, dereferencing this pointer from CPU code causes a SEGFAULT.

**Affected operators:**
- `aten::lstm.data`
- `aten::gru.data`
- `aten::rnn_tanh.data`
- `aten::rnn_relu.data`
- `aten::quantized_lstm.data`
- `aten::quantized_gru.data`

### Changes

1. **C++ Native Path** (`aten/src/ATen/native/RNN.cpp`):
   - Move `batch_sizes` validation to occur before CUDA dispatch in the `ONE_HIDDEN_RNN` macro
   - Add `TORCH_CHECK` to validate `batch_sizes` is 1D and on CPU

2. **Python Decomposition Path** (`torch/_decomp/decompositions.py`):
   - Add `_check_batch_sizes()` helper function with `torch._check` validation
   - Call validation in all 4 packed RNN decomposition functions: `gru_impl_data`, `lstm_data_impl`, `rnn_tanh_data`, `rnn_relu_data`

3. **Tests** (`test/test_decomp.py`):
   - Add `test_rnn_packed_batch_sizes_device_validation` for CUDA device validation
   - Add `test_rnn_packed_batch_sizes_dim_validation` for dimension validation
   - Cover all RNN variants (GRU, LSTM, RNN tanh, RNN relu)

### Before

```python
batch_sizes = torch.tensor([6, 5, 4, 3], device="cuda")
torch.ops.aten.gru.data(data, batch_sizes, hx, params, ...)
# Result: SIGSEGV (segmentation fault)
```

### After

```python
batch_sizes = torch.tensor([6, 5, 4, 3], device="cuda")
torch.ops.aten.gru.data(data, batch_sizes, hx, params, ...)
# Result: RuntimeError: batch_sizes tensor should be on CPU, but got cuda:0
```

## Test Plan

- [x] Added unit tests in `test/test_decomp.py` covering all RNN variants
- [x] Verified fix with manual testing on CUDA GPU (PyTorch 2.11.0a0+git6d1f6cd)
- [x] Tests without patch: 0/4 passed (confirms bug exists)
- [x] Tests with patch: 4/4 passed (confirms fix works)

cc @albanD @malfet @mruberry @jbschlosser