### PR TITLE
[XPU] Handle empty tensor for addmv

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -52,15 +52,15 @@ Tensor& addmm_out(
       " != ",
       mat2.dtype())
 
+  std::vector<int64_t> result_shape = {mat1.size(0), mat2.size(1)};
+  result.resize_(result_shape);
+
   // complex case
   if (self.is_complex()) {
     at::native::addmm_complex_out_xpu(self, mat1, mat2, beta, alpha, result);
 
     return result;
   }
-
-  std::vector<int64_t> result_shape = {mat1.size(0), mat2.size(1)};
-  result.resize_(result_shape);
 
   IntArrayRef result_sizes = result.sizes();
   if ((result_sizes[0] == 0) || (result_sizes[1] == 0)) {

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -344,9 +344,7 @@ class TestBasicGEMM(TestCase):
         out = torch.empty((2, 3), dtype=dtype, device=device)
         self.assertEqual(
             torch.full((2, 3), beta * value, dtype=dtype, device=device),
-            torch.addmm(
-                input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta
-            ),
+            torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta),
         )
         self.assertEqual(
             torch.full((2, 3), beta * value, dtype=dtype, device=device),

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -332,11 +332,11 @@ class TestBasicGEMM(TestCase):
             beta = 3
         self.assertEqual(
             torch.full((2,), beta * value, dtype=dtype, device=device),
-            torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta)
+            torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta),
         )
         self.assertEqual(
             torch.full((2,), beta * value, dtype=dtype, device=device),
-            torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out)
+            torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out),
         )
 
         input = torch.full((2, 3), value, dtype=dtype, device=device)
@@ -344,10 +344,15 @@ class TestBasicGEMM(TestCase):
         out = torch.empty((2, 3), dtype=dtype, device=device)
         self.assertEqual(
             torch.full((2, 3), beta * value, dtype=dtype, device=device),
-            torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
+            torch.addmm(
+                input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta
+            ),
+        )
         self.assertEqual(
             torch.full((2, 3), beta * value, dtype=dtype, device=device),
-            torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out)
+            torch.addmm(
+                input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out
+            ),
         )
 
     @dtypes(

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -317,6 +317,32 @@ class TestBasicGEMM(TestCase):
         for m, v in itertools.product(ms, vs):
             self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
 
+    @dtypes(torch.complex64, torch.complex128, torch.float64)
+    def test_blas_alpha_beta_empty(self, device, dtype):
+        value = 11
+        input = torch.full((2,), value, dtype=dtype, device=device)
+        mat = torch.ones((2, 0), dtype=dtype, device=device)
+        vec = torch.ones((0,), dtype=dtype, device=device)
+        out = torch.empty((2,), dtype=dtype, device=device)
+        if dtype.is_complex:
+            alpha = 6 + 7j
+            beta = 3 + 4j
+        else:
+            alpha = 6
+            beta = 3
+        self.assertEqual(torch.full((2,), beta * value, dtype=dtype, device=device),
+                         torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta))
+        self.assertEqual(torch.full((2,), beta * value, dtype=dtype, device=device),
+                         torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out))
+
+        input = torch.full((2, 3), value, dtype=dtype, device=device)
+        mat2 = torch.ones((0, 3), dtype=dtype, device=device)
+        out = torch.empty((2, 3), dtype=dtype, device=device)
+        self.assertEqual(torch.full((2, 3), beta * value, dtype=dtype, device=device),
+                         torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
+        self.assertEqual(torch.full((2, 3), beta * value, dtype=dtype, device=device),
+                         torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out))
+
     @dtypes(
         torch.half,
         torch.float32,

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -330,18 +330,25 @@ class TestBasicGEMM(TestCase):
         else:
             alpha = 6
             beta = 3
-        self.assertEqual(torch.full((2,), beta * value, dtype=dtype, device=device),
-                         torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta))
-        self.assertEqual(torch.full((2,), beta * value, dtype=dtype, device=device),
-                         torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out))
+        self.assertEqual(
+            torch.full((2,), beta * value, dtype=dtype, device=device),
+            torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta)
+        )
+        self.assertEqual(
+            torch.full((2,), beta * value, dtype=dtype, device=device),
+            torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out)
+        )
 
         input = torch.full((2, 3), value, dtype=dtype, device=device)
         mat2 = torch.ones((0, 3), dtype=dtype, device=device)
         out = torch.empty((2, 3), dtype=dtype, device=device)
-        self.assertEqual(torch.full((2, 3), beta * value, dtype=dtype, device=device),
-                         torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
-        self.assertEqual(torch.full((2, 3), beta * value, dtype=dtype, device=device),
-                         torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out))
+        self.assertEqual(
+            torch.full((2, 3), beta * value, dtype=dtype, device=device),
+            torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
+        self.assertEqual(
+            torch.full((2, 3), beta * value, dtype=dtype, device=device),
+            torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out)
+        )
 
     @dtypes(
         torch.half,


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/2815

Add proper handling for in xpu::addmv_out for `mat.numel() = 0` tensors.

Make output full zeros if Beta is zero and multiplicate self by beta otherwise.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01