### PR TITLE
Adjust test_linalg_lstsq_input_check to be compatible with other devices

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -564,7 +564,7 @@ class TestLinalg(TestCase):
         a = torch.rand(2, 2, 2, 2, dtype=dtype, device=device)
         b = torch.rand(2, 2, 2, dtype=dtype, device=device)
 
-        if device != 'cpu':
+        if device == 'cuda':
             with self.assertRaisesRegex(RuntimeError, '`driver` other than `gels` is not supported on CUDA'):
                 torch.linalg.lstsq(a, b, driver='fictitious_driver')
         # if on cpu


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/2817 

Make test_linalg_lstsq_input_checks more universal as the CUDA specific check should be under ```if device == 'cuda'``` and not under  ```if device != 'cpu'``` as it makes more sense and resolves xpu specific issues with this UT.