### PR TITLE
[ROCm][CUDA] Fix unused-result warning in UniqueCub.cu

### DIFF
--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -85,7 +85,7 @@ std::tuple<Tensor, Tensor, Tensor> compute_unique(
         dim3(std::min(static_cast<int64_t>(cuda::getApplyBlock().x), num_inp));
     dim3 grid;
     c10::DeviceIndex curDevice = -1;
-    c10::cuda::GetDevice(&curDevice);
+    C10_CUDA_CHECK(c10::cuda::GetDevice(&curDevice));
     cuda::getApplyGrid(num_inp, grid, curDevice);
     adjacent_difference_kernel<<<grid, block, 0, stream>>>(
         num_inp, data, inv_loc_ptr);


### PR DESCRIPTION
Wraps the `c10::cuda::GetDevice` call in `C10_CUDA_CHECK` to properly handle its return value. This resolves a `[-Wunused-result]` compiler warning caused by the function's `[[nodiscard]]` attribute.

This change resolve 30+ compilation warnings:
```c++
  /src/pytorch/aten/src/ATen/native/hip/UniqueCub.hip:90:5: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
     90 |     c10::hip::GetDevice(&curDevice);
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang