### PR TITLE
clean up FA3 linux build script

### DIFF
--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -2,27 +2,22 @@
 
 set -ex -o pipefail
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-PYTORCH_ROOT="${PYTORCH_ROOT:-$(cd "$SOURCE_DIR/../.." && pwd)}"
+PYTORCH_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 source "${PYTORCH_ROOT}/.ci/pytorch/common_utils.sh"
 FLASH_ATTENTION_DIR="${PYTORCH_ROOT}/third_party/flash-attention"
 FLASH_ATTENTION_HOPPER_DIR="${FLASH_ATTENTION_DIR}/hopper"
 
-if [[ -z "$FA_FINAL_PACKAGE_DIR" ]]; then
-    fatal "FA_FINAL_PACKAGE_DIR must be set"
-fi
-
-if [[ -z "$WHEEL_PLAT" ]]; then
-    fatal "WHEEL_PLAT must be set"
-fi
-
-if [[ ! -d "$FLASH_ATTENTION_HOPPER_DIR" ]]; then
-    fatal "flash attn directory not found $FLASH_ATTENTION_HOPPER_DIR"
-fi
+[[ -z "$FA_FINAL_PACKAGE_DIR" ]] && fatal "FA_FINAL_PACKAGE_DIR must be set"
+[[ -z "$MANYLINUX_PLAT" ]] && fatal "MANYLINUX_PLAT must be set"
+[[ -z "$CUDA_VERSION" ]] && fatal "CUDA_VERSION must be set"
+[[ -z "$CUDA_SHORT" ]] && fatal "CUDA_SHORT must be set"
+[[ ! -d "$FLASH_ATTENTION_HOPPER_DIR" ]] && fatal "flash attn directory not found $FLASH_ATTENTION_HOPPER_DIR"
 
 PYTHON="${PYTHON_EXECUTABLE:-python}"
 
+# for ARM builds we need GLIBC 2.29+ so we use upstream linux image
+# need to install dependencies
 if [[ "$(uname -m)" == "aarch64" ]]; then
     if command -v dnf &> /dev/null; then
         dnf install -y \
@@ -32,22 +27,14 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
             xz \
             bzip2 \
             gcc-toolset-13-gcc \
-            gcc-toolset-13-gcc-c++ \
-            || true
-        if [[ -d "/opt/rh/gcc-toolset-13" ]]; then
-            export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
-            export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH:-}
-        fi
+            gcc-toolset-13-gcc-c++
+        export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+        export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH:-}
     fi
 
     source "${PYTORCH_ROOT}/.ci/docker/common/install_cuda.sh"
-    if [[ "${CUDA_VERSION:-12.6}" == "13.0" ]]; then
-        echo "installing CUDA 13.0.0 for ARM"
-        install_cuda 13.0.2 cuda_13.0.2_580.95.05_linux
-    else
-        echo "installing CUDA 12.6.3 for ARM"
-        install_cuda 12.6.3 cuda_12.6.3_560.35.05_linux
-    fi
+    [[ -z "$CUDA_INSTALLER_NAME" ]] && fatal "CUDA_INSTALLER_NAME must be set for aarch64 builds"
+    install_cuda "$CUDA_VERSION" "$CUDA_INSTALLER_NAME"
 
     export CUDA_HOME=/usr/local/cuda
     export PATH=/usr/local/cuda/bin:$PATH
@@ -60,7 +47,6 @@ echo "installing dependencies"
 "$PYTHON" -m pip install einops packaging ninja numpy wheel setuptools
 
 export PATH="$(dirname "$PYTHON"):$PATH"
-echo "ninja location: $(which ninja)"
 
 export FLASH_ATTENTION_FORCE_BUILD="${FLASH_ATTENTION_FORCE_BUILD:-TRUE}"
 
@@ -95,29 +81,21 @@ pushd "$FLASH_ATTENTION_HOPPER_DIR"
 git config --global --add safe.directory '*'
 git submodule update --init ../csrc/cutlass
 
-if [[ "${CUDA_VERSION:-12.6}" == 13.* ]]; then
+if [[ "${CUDA_VERSION}" == 13.* ]]; then
     CCCL_INCLUDE="/usr/local/cuda/include/cccl"
     if [[ -d "${CCCL_INCLUDE}" ]]; then
         echo "Adding CCCL include path: ${CCCL_INCLUDE}"
         export CPLUS_INCLUDE_PATH="${CCCL_INCLUDE}${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"
         export C_INCLUDE_PATH="${CCCL_INCLUDE}${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
     else
-        echo "WARNING: CCCL include directory not found at ${CCCL_INCLUDE}"
+        fatal "CCCL include directory not found at ${CCCL_INCLUDE}"
     fi
 fi
 
-sed -i 's/bare_metal_version != Version("12.8")/bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8")/' \
-    "$FLASH_ATTENTION_HOPPER_DIR/setup.py"
-
-BUILD_DATE=$(date +%Y%m%d)
-if [[ "${WHEEL_PLAT}" == "aarch64" ]]; then
-    ARCH_TAG="arm"
-    MANYLINUX_PLAT="manylinux_2_34_aarch64"
-else
-    ARCH_TAG="x86"
-    MANYLINUX_PLAT="manylinux_2_28_x86_64"
+if [[ "${FA_TEST_BUILD}" == "true" ]]; then
+    BUILD_DATE=$(date +%Y%m%d)
+    export FLASH_ATTN_LOCAL_VERSION="${BUILD_DATE}.cu${CUDA_SHORT}"
 fi
-export FLASH_ATTN_LOCAL_VERSION="${BUILD_DATE}.cu${CUDA_SHORT}.${ARCH_TAG}"
 
 "$PYTHON" setup.py bdist_wheel \
     -d "$FA_FINAL_PACKAGE_DIR" \

--- a/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
+++ b/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
@@ -59,7 +59,7 @@ jobs:
           - cuda_version: "12.6.3"
             arch: "aarch64"
             cuda_short: "126"
-            torch_cuda_arch_list: "8.0;8.6;9.0"
+            torch_cuda_arch_list: "9.0"
             docker_image: "quay.io/pypa/manylinux_2_34_aarch64"
             runner: "linux.arm64.r7g.12xlarge.memory"
             max_jobs: "4"
@@ -116,7 +116,7 @@ jobs:
           )
           PYTHON_EXECUTABLE=/opt/python/cp310-cp310/bin/python
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" -m pip install \
-            torch==2.9.0 --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+            torch==2.10.0 --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
           docker exec -t \
             -e CUDA_VERSION="${CUDA_VERSION}" \
             -e CUDA_SHORT="${CUDA_SHORT}" \

--- a/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
+++ b/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
@@ -2,6 +2,12 @@ name: Build Flash Attention 3 wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      test:
+        description: 'Build test wheels with date suffix in version'
+        required: false
+        default: true
+        type: boolean
   pull_request:
     paths:
       - .github/workflows/_binary-build-flash-attention-wheel-linux.yml
@@ -34,19 +40,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cuda_version: "12.6"
+          - cuda_version: "12.6.3"
             arch: "x86_64"
             cuda_short: "126"
             torch_cuda_arch_list: "8.0;8.6;9.0"
             docker_image: "pytorch/manylinux2_28-builder:cuda12.6"
             runner: "linux.12xlarge.memory"
-          - cuda_version: "13.0"
+            manylinux_plat: "manylinux_2_28_x86_64"
+          - cuda_version: "13.0.2"
             arch: "x86_64"
             cuda_short: "130"
             torch_cuda_arch_list: "8.0;8.6;9.0;10.0"
             docker_image: "pytorch/manylinux2_28-builder:cuda13.0"
             runner: "linux.12xlarge.memory"
-          - cuda_version: "12.6"
+            manylinux_plat: "manylinux_2_28_x86_64"
+          - cuda_version: "12.6.3"
             arch: "aarch64"
             cuda_short: "126"
             torch_cuda_arch_list: "8.0;8.6;9.0"
@@ -54,7 +62,9 @@ jobs:
             runner: "linux.arm64.r7g.12xlarge.memory"
             max_jobs: "4"
             nvcc_threads: "2"
-          - cuda_version: "13.0"
+            manylinux_plat: "manylinux_2_34_aarch64"
+            cuda_installer_name: "cuda_12.6.3_560.35.05_linux"
+          - cuda_version: "13.0.2"
             arch: "aarch64"
             cuda_short: "130"
             torch_cuda_arch_list: "9.0;10.0"
@@ -62,6 +72,8 @@ jobs:
             runner: "linux.arm64.r7g.12xlarge.memory"
             max_jobs: "4"
             nvcc_threads: "2"
+            manylinux_plat: "manylinux_2_34_aarch64"
+            cuda_installer_name: "cuda_13.0.2_580.95.05_linux"
     timeout-minutes: 1440
     env:
       DOCKER_IMAGE: ${{ matrix.docker_image }}
@@ -108,11 +120,12 @@ jobs:
             -e CUDA_SHORT="${CUDA_SHORT}" \
             -e TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
             -e FA_FINAL_PACKAGE_DIR="/artifacts" \
-            -e WHEEL_PLAT="${{ matrix.arch }}" \
-            -e PYTORCH_ROOT="/pytorch" \
+            -e MANYLINUX_PLAT="${{ matrix.manylinux_plat }}" \
             -e PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
             -e MAX_JOBS="${{ matrix.max_jobs }}" \
             -e NVCC_THREADS="${{ matrix.nvcc_threads }}" \
+            -e CUDA_INSTALLER_NAME="${{ matrix.cuda_installer_name }}" \
+            -e FA_TEST_BUILD="${{ inputs.test }}" \
             "${container_name}" bash -c \
             "bash /pytorch/.ci/flash-attention/build.sh"
           docker exec -t "${container_name}" chown -R 1000:1000 /artifacts
@@ -130,18 +143,22 @@ jobs:
     name: "Upload FA3 ${{ matrix.cuda_short }} ${{ matrix.arch }}"
     needs: build-wheel
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - cuda_short: "126"
+          - cuda_version: "12.6.3"
+            cuda_short: "126"
             arch: "x86_64"
-          - cuda_short: "130"
+          - cuda_version: "13.0.2"
+            cuda_short: "130"
             arch: "x86_64"
-          - cuda_short: "126"
+          - cuda_version: "12.6.3"
+            cuda_short: "126"
             arch: "aarch64"
-          - cuda_short: "130"
+          - cuda_version: "13.0.2"
+            cuda_short: "130"
             arch: "aarch64"
     permissions:
       id-token: write

--- a/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
+++ b/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
@@ -8,6 +8,8 @@ on:
         required: false
         default: true
         type: boolean
+  schedule:
+    - cron: '0 0 1,15 * *'  # periodic builds (no uploads) every 2 weeks to test the script
   pull_request:
     paths:
       - .github/workflows/_binary-build-flash-attention-wheel-linux.yml

--- a/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
+++ b/.github/workflows/_binary-build-flash-attention-wheel-linux.yml
@@ -112,9 +112,9 @@ jobs:
             -w /pytorch \
             "${DOCKER_IMAGE}"
           )
-          PYTHON_EXECUTABLE=/opt/python/cp312-cp312/bin/python
+          PYTHON_EXECUTABLE=/opt/python/cp310-cp310/bin/python
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" -m pip install \
-            torch --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+            torch==2.9.0 --extra-index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
           docker exec -t \
             -e CUDA_VERSION="${CUDA_VERSION}" \
             -e CUDA_SHORT="${CUDA_SHORT}" \


### PR DESCRIPTION
As title. Changes include: 
- Adding a test boolean as a workflow param - if this is provided the name of the wheel will include the build date, else it will just be `flash-attn-3`.
- Adding periodic runs every 2 weeks. This should just build the wheels but not upload them (just a test to prevent the script from going stale). Uploads happen on manual trigger still. 
- Pinning Python version to 3.10 and PyTorch version to 2.10. Even though we are building with torch 2.10, users should be able to run with torch >= 2.9 since it's ABI stable.