### PR TITLE
[ROCm] Unskip Python 3.12 tests for ROCm and move trunk mi355 jobs to py3.12

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -267,16 +267,16 @@ jobs:
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
     secrets: inherit
 
-  linux-jammy-rocm-py3_12-build:
-    name: linux-jammy-rocm-py3.12
+  linux-noble-rocm-py3_12-build:
+    name: linux-noble-rocm-py3.12
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.12
-      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      build-environment: linux-noble-rocm-py3.12
+      docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |
         { include: [
@@ -292,20 +292,20 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-rocm-py3_12-test:
+  linux-noble-rocm-py3_12-test:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3.12
+    name: linux-noble-rocm-py3.12
     uses: ./.github/workflows/_rocm-test.yml
     needs:
-      - linux-jammy-rocm-py3_12-build
+      - linux-noble-rocm-py3_12-build
       - target-determination
       - job-filter
     with:
-      build-environment: ${{ needs.linux-jammy-rocm-py3_12-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-rocm-py3_12-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-rocm-py3_12-build.outputs.test-matrix }}
+      build-environment: ${{ needs.linux-noble-rocm-py3_12-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-noble-rocm-py3_12-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-noble-rocm-py3_12-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -267,15 +267,15 @@ jobs:
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
     secrets: inherit
 
-  linux-jammy-rocm-py3_10-build:
-    name: linux-jammy-rocm-py3.10
+  linux-jammy-rocm-py3_12-build:
+    name: linux-jammy-rocm-py3.12
     uses: ./.github/workflows/_linux-build.yml
     needs:
       - get-label-type
       - job-filter
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-rocm-py3.10
+      build-environment: linux-jammy-rocm-py3.12
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |
@@ -292,20 +292,20 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-rocm-py3_10-test:
+  linux-jammy-rocm-py3_12-test:
     permissions:
       id-token: write
       contents: read
-    name: linux-jammy-rocm-py3.10
+    name: linux-jammy-rocm-py3.12
     uses: ./.github/workflows/_rocm-test.yml
     needs:
-      - linux-jammy-rocm-py3_10-build
+      - linux-jammy-rocm-py3_12-build
       - target-determination
       - job-filter
     with:
-      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
+      build-environment: ${{ needs.linux-jammy-rocm-py3_12-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_12-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-rocm-py3_12-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1772,8 +1772,6 @@ def get_selected_tests(options) -> list[str]:
         options.exclude.extend(["distributions/test_constraints"])
 
     # these tests failing in Python 3.12 temporarily disabling
-    # Skip for non-ROCm platforms; ROCm MI300/MI355 now run on Python 3.12
-    if sys.version_info >= (3, 12) and not TEST_WITH_ROCM:
         options.exclude.extend(
             [
                 "functorch/test_dims",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1772,7 +1772,8 @@ def get_selected_tests(options) -> list[str]:
         options.exclude.extend(["distributions/test_constraints"])
 
     # these tests failing in Python 3.12 temporarily disabling
-    if sys.version_info >= (3, 12):
+    # Skip for non-ROCm platforms; ROCm MI300/MI355 now run on Python 3.12
+    if sys.version_info >= (3, 12) and not TEST_WITH_ROCM:
         options.exclude.extend(
             [
                 "functorch/test_dims",

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -5319,18 +5319,18 @@ class TestFunctionalTracing(JitTestCase):
             "max_pool2d",
             "max_pool3d",
         ]
-        
+
         functional_list = cls._get_functional()
         for func_name, fn in functional_list:
             test_name = "test_nn_functional_" + func_name
             functional_test = cls.generate_test_func(func_name, fn)
-            
+
             # Apply skip decorator for specific tests on Python 3.12 + ROCm
             if func_name in SKIP_ON_PY312_ROCM and sys.version_info >= (3, 12) and TEST_WITH_ROCM:
                 functional_test = unittest.skip(
                     f"Skipping {func_name} on Python 3.12 + ROCm due to proxy iteration errors"
                 )(functional_test)
-            
+
             setattr(cls, test_name, functional_test)
 
     @classmethod

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -73,7 +73,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.jit_utils import JitTestCase
 
@@ -5308,29 +5307,10 @@ class TestFunctionalTracing(JitTestCase):
 
     @classmethod
     def generate_tests(cls):
-        # Skip these tests on Python 3.12 + ROCm due to proxy iteration errors
-        SKIP_ON_PY312_ROCM = [
-            "adaptive_max_pool1d",
-            "adaptive_max_pool2d",
-            "adaptive_max_pool3d",
-            "fractional_max_pool2d",
-            "fractional_max_pool3d",
-            "max_pool1d",
-            "max_pool2d",
-            "max_pool3d",
-        ]
-
         functional_list = cls._get_functional()
         for func_name, fn in functional_list:
             test_name = "test_nn_functional_" + func_name
             functional_test = cls.generate_test_func(func_name, fn)
-
-            # Apply skip decorator for specific tests on Python 3.12 + ROCm
-            if func_name in SKIP_ON_PY312_ROCM and sys.version_info >= (3, 12) and TEST_WITH_ROCM:
-                functional_test = unittest.skip(
-                    f"Skipping {func_name} on Python 3.12 + ROCm due to proxy iteration errors"
-                )(functional_test)
-
             setattr(cls, test_name, functional_test)
 
     @classmethod

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -73,6 +73,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.jit_utils import JitTestCase
 
@@ -5307,10 +5308,29 @@ class TestFunctionalTracing(JitTestCase):
 
     @classmethod
     def generate_tests(cls):
+        # Skip these tests on Python 3.12 + ROCm due to proxy iteration errors
+        SKIP_ON_PY312_ROCM = [
+            "adaptive_max_pool1d",
+            "adaptive_max_pool2d",
+            "adaptive_max_pool3d",
+            "fractional_max_pool2d",
+            "fractional_max_pool3d",
+            "max_pool1d",
+            "max_pool2d",
+            "max_pool3d",
+        ]
+        
         functional_list = cls._get_functional()
         for func_name, fn in functional_list:
             test_name = "test_nn_functional_" + func_name
             functional_test = cls.generate_test_func(func_name, fn)
+            
+            # Apply skip decorator for specific tests on Python 3.12 + ROCm
+            if func_name in SKIP_ON_PY312_ROCM and sys.version_info >= (3, 12) and TEST_WITH_ROCM:
+                functional_test = unittest.skip(
+                    f"Skipping {func_name} on Python 3.12 + ROCm due to proxy iteration errors"
+                )(functional_test)
+            
             setattr(cls, test_name, functional_test)
 
     @classmethod


### PR DESCRIPTION
ROCm MI300 and MI355 CI runners now use Python 3.12. This PR unskips the following tests on ROCm to verify if they now pass:

- functorch/test_dims
- functorch/test_rearrange
- functorch/test_parsing
- functorch/test_memory_efficient_fusion
- torch_np/numpy_tests/core/test_multiarray
- test_fx

These tests were previously disabled globally for Python 3.12, but this change enables them specifically on ROCm platforms to test if they work now on the newer hardware.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang