### PR TITLE
S390x nightly tests fixes

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -242,9 +242,10 @@ echo "The next three invocations are expected to fail with invalid command error
 if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
   # rocm builds fail when WERROR=1
   # XLA test build fails when WERROR=1
+  # s390x builds currently fail when WERROR=1
   # set only when building other architectures
   # or building non-XLA tests.
-  if [[ "$BUILD_ENVIRONMENT" != *rocm*  && "$BUILD_ENVIRONMENT" != *xla* && "$BUILD_ENVIRONMENT" != *riscv64* ]]; then
+  if [[ "$BUILD_ENVIRONMENT" != *rocm*  && "$BUILD_ENVIRONMENT" != *xla* && "$BUILD_ENVIRONMENT" != *riscv64*  && "$BUILD_ENVIRONMENT" != *s390x* ]]; then
     # TODO: Remove me and may be just focus on numpy-2.x testing
     if [[ "$ANACONDA_PYTHON_VERSION" =~ ^3\.1[0-2]$ ]]; then
       # Install numpy-2.0.2 for builds which are backward compatible with 1.X

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -153,7 +153,7 @@ function detect_cuda_arch() {
 function install_torchaudio() {
   local commit
   commit=$(get_pinned_commit audio)
-  pip_build_and_install "git+https://github.com/pytorch/audio.git@${commit}" dist/audio
+  retry pip_build_and_install "git+https://github.com/pytorch/audio.git@${commit}" dist/audio
 }
 
 function install_torchtext() {
@@ -161,8 +161,8 @@ function install_torchtext() {
   local text_commit
   data_commit=$(get_pinned_commit data)
   text_commit=$(get_pinned_commit text)
-  pip_build_and_install "git+https://github.com/pytorch/data.git@${data_commit}" dist/data
-  pip_build_and_install "git+https://github.com/pytorch/text.git@${text_commit}" dist/text
+  retry pip_build_and_install "git+https://github.com/pytorch/data.git@${data_commit}" dist/data
+  retry pip_build_and_install "git+https://github.com/pytorch/text.git@${text_commit}" dist/text
 }
 
 function install_torchvision() {
@@ -181,7 +181,7 @@ function install_torchvision() {
     export FORCE_CUDA=1
     export WITH_CUDA=1
   fi
-  pip_build_and_install "git+https://github.com/pytorch/vision.git@${commit}" dist/vision
+  retry pip_build_and_install "git+https://github.com/pytorch/vision.git@${commit}" dist/vision
 
   if [ -n "${LD_PRELOAD}" ]; then
     LD_PRELOAD=${orig_preload}

--- a/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile
+++ b/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile
@@ -95,6 +95,9 @@ RUN chmod +x /usr/bin/actions-runner /usr/bin/entrypoint
 COPY --from=podman /tmp/podman /tmp/podman
 RUN apt-get update && apt -y install /tmp/podman/*.deb && /bin/rm -rfv /tmp/podman
 
+# fix container detection for pytorch/setup-linux workflow action
+RUN touch /.incontainer
+
 # amd64 Github Actions Runner.
 RUN useradd -m actions-runner
 USER actions-runner

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -9,12 +9,7 @@ import unittest
 from pathlib import Path
 
 import torch
-from torch.testing._internal.common_utils import (
-    run_tests,
-    set_cwd,
-    TestCase,
-    xfailIfS390X,
-)
+from torch.testing._internal.common_utils import IS_S390X, run_tests, set_cwd, TestCase
 
 
 try:
@@ -96,8 +91,7 @@ def get_all_examples():
 
 
 class TestTypeHints(TestCase):
-    # when this test fails on s390x, it also leads to OOM on test reruns
-    @xfailIfS390X
+    @unittest.skipIf(IS_S390X, "flaky on s390x")
     @unittest.skipIf(not HAVE_MYPY, "need mypy")
     def test_doc_examples(self):
         """


### PR DESCRIPTION
Skip test_type_hints.py::TestTypeHints::test_doc_examples while it's flaky on s390x.

Add retries while installing pytorch vision, audio, data and text.

Silence deprecated warnings. It could be fixed, but clang-15 doesn't compile resulting code with proposed fixes.

Silence false warning on s390x with gcc-14.