### PR TITLE
Support opaque value types in partitioner and inductor fallback

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -22,6 +22,7 @@ from contextlib import nullcontext
 from typing import Any, Optional, TYPE_CHECKING, Union
 
 from torch._library.fake_class_registry import FakeScriptObject
+from torch._library.opaque_object import is_opaque_value
 
 
 if TYPE_CHECKING:
@@ -560,6 +561,7 @@ def collect_fw_donated_buffer_idxs(
         t = saved_tensors[i]
         if (
             t is not None
+            and isinstance(t, FakeTensor)
             and not is_sparse_any(t)
             and StorageWeakRef(t.untyped_storage()) not in storage_refs
         ):
@@ -1737,7 +1739,9 @@ def _aot_stage2a_partition(
                         }
                         if dynamic_dims:
                             fw_metadata.dynamic_saved_tensors_idxs[idx] = dynamic_dims
-                    elif isinstance(node.meta["val"], FakeScriptObject):
+                    elif isinstance(node.meta["val"], FakeScriptObject) or is_opaque_value(
+                        node.meta["val"]
+                    ):
                         opaque_outs_saved_for_bw.append(node)
 
             num_symints_saved_for_bw = len(symint_outs_saved_for_bw)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -23,7 +23,7 @@ from torch import device, Tensor
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import defake, dynamo_timed
 from torch._library.fake_class_registry import FakeScriptObject
-from torch._library.opaque_object import is_opaque_type
+from torch._library.opaque_object import is_opaque_type, is_opaque_value
 from torch._library.utils import get_layout_constraint_tag
 from torch._logging import LazyString, trace_structured
 from torch._prims_common import (
@@ -1179,6 +1179,12 @@ class GraphLowering(torch.fx.Interpreter):
             return expr
         elif isinstance(example, FakeScriptObject):
             obj = TorchBindObject(name=target, value=example)
+            self.graph_inputs[target] = obj
+            self.graph_input_names.append(target)
+            return obj
+        elif is_opaque_value(example):
+            # Handle opaque value types (like FakeScriptObject but for value types)
+            obj = TorchBindObject(name=target, value=example)  # type: ignore[arg-type]
             self.graph_inputs[target] = obj
             self.graph_input_names.append(target)
             return obj

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -105,6 +105,7 @@ class DeviceContext(TorchFunctionMode):
                 )
         if self.prev_mode is not None:
             _push_mode(self.prev_mode)
+            self.prev_mode = None
 
         for mode in reversed(cur_stack):
             _push_mode(mode)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This extends the existing FakeScriptObject (opaque reference type) support to also
handle opaque value types registered via `register_opaque_type(..., typ="value")`.
These value types are created inside compiled regions and need to flow through
the partitioner and inductor for selective activation checkpointing (SAC) to work.

Changes include handling opaque values in AOT autograd graph compilation, assigning
zero weight in min-cut partitioner so they partition correctly, and proper handling
in inductor's GraphLowering and FallbackKernel for inputs/outputs.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo