### PR TITLE
[dynamo] Add per-graph inductor config override for debugging/bisecting

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -51,6 +51,17 @@ verify_correctness = False
 # [@compile_ignored: debug]
 debug_backend_override: str = os.environ.get("TORCH_COMPILE_OVERRIDE_BACKENDS", "")
 
+# Override inductor config for specific graphs (for debugging/bisecting).
+# Format: "filter1:config1;filter2:config2;..." where filter uses same syntax as
+# debug_backend_override, and config is "key=value" or "key=value,key2=value2".
+# Examples:
+#   "0-5:triton.cudagraph_skip_dynamic_graphs=False"  - Disable skip for graphs 0-5
+#   ">10:triton.cudagraphs=False"                     - Disable cudagraphs for graphs > 10
+# [@compile_ignored: debug]
+debug_inductor_config_override: str = os.environ.get(
+    "TORCH_COMPILE_OVERRIDE_INDUCTOR_CONFIGS", ""
+)
+
 # Validate that fake_fn and real_fn in @leaf_function decorators produce outputs
 # with matching shapes and dtypes in eager mode. Helps catch mismatches early.
 # Disabled by default to avoid runtime overhead.

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -104,7 +104,10 @@ from .exc import (
 )
 from .graph_bytecode_inputs import has_user_objects, index_to_bytecode_constructor
 from .graph_deduplication import apply_graph_deduplication
-from .graph_id_filter import get_backend_override_for_compile_id
+from .graph_id_filter import (
+    get_backend_override_for_compile_id,
+    get_inductor_config_override_for_compile_id,
+)
 from .graph_region_tracker import GraphRegionTracker
 from .guards import GuardBuilder, install_guard
 from .mutation_guard import is_dynamic_nn_module
@@ -186,6 +189,24 @@ RootGuardManager = guards.RootGuardManager
 # as static in case user overrides fn ptr
 og_module_named_buffers_fn_ptr = torch.nn.Module.named_buffers
 og_module_named_parameters_fn_ptr = torch.nn.Module.named_parameters
+
+
+def _wrap_with_inductor_config(
+    compiler_fn: Any, config_patches: dict[str, Any]
+) -> Callable[..., Any]:
+    """
+    Wrap a compiler function to apply inductor config patches during compilation.
+    """
+    from torch._inductor import config as inductor_config
+
+    def wrapped(gm: Any, example_inputs: Any) -> Any:
+        with inductor_config.patch(config_patches):
+            return compiler_fn(gm, example_inputs)
+
+    # Preserve function metadata for logging
+    wrapped.__name__ = getattr(compiler_fn, "__name__", "<wrapped>")
+    wrapped.__wrapped__ = compiler_fn  # type: ignore[attr-defined]
+    return wrapped
 
 
 @dataclass(frozen=True)
@@ -2537,6 +2558,15 @@ class OutputGraph(OutputGraphCommon):
             )
             or self.compiler_fn
         )
+
+        # Check for per-graph inductor config override (for debugging/bisecting)
+        inductor_config_override = get_inductor_config_override_for_compile_id(
+            self.dynamo_compile_id, config.debug_inductor_config_override
+        )
+        if inductor_config_override:
+            compiler_fn = _wrap_with_inductor_config(
+                compiler_fn, inductor_config_override
+            )
 
         name = (
             compiler_fn.__name__


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174229
* __->__ #174228

This extends the per-graph backend override feature to support overriding
inductor config options for specific graphs. This is useful for debugging
and bisecting issues where certain graphs need different inductor settings.

Usage: Set TORCH_COMPILE_OVERRIDE_INDUCTOR_CONFIGS environment variable with
the format "filter:config1=val1,config2=val2;filter2:config3=val3".

Examples:
  "0-5:triton.cudagraph_skip_dynamic_graphs=False" - Disable skip for graphs 0-5
  ">10:triton.cudagraphs=False" - Disable cudagraphs for graphs > 10
  "0:triton.cudagraphs=False,triton.cudagraph_trees=False" - Multiple options

This commit intentionally has some code duplication between GraphBackendRouter
and GraphConfigRouter to keep the feature change focused. A follow-up commit
will refactor to eliminate the duplication.

Co-authored-by: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @mlazos

Differential Revision: [D92186362](https://our.internmc.facebook.com/intern/diff/D92186362)