### PR TITLE
[MPS] Add `_unique` aten op

### DIFF
--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -7,6 +7,8 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_unique.h>
+#include <ATen/ops/_unique_native.h>
 #include <ATen/ops/_unique2.h>
 #include <ATen/ops/_unique2_native.h>
 #include <ATen/ops/arange.h>
@@ -314,6 +316,13 @@ std::tuple<Tensor, Tensor, Tensor> _unique2_mps(const Tensor& self,
                                                 const bool return_inverse,
                                                 const bool return_counts) {
   return _unique_impl_mps(self, return_inverse, return_counts, false, std::nullopt);
+}
+
+std::tuple<Tensor, Tensor> _unique_mps(const Tensor& self,
+                                       const bool sorted,
+                                       const bool return_inverse) {
+  auto [output, inverse_indices, _] = _unique_impl_mps(self, return_inverse, false, false, std::nullopt);
+  return std::make_tuple(std::move(output), std::move(inverse_indices));
 }
 
 static Tensor lexsort_rows_perm_mps(const Tensor& mat_2d) {

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -8,9 +8,9 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_unique.h>
-#include <ATen/ops/_unique_native.h>
 #include <ATen/ops/_unique2.h>
 #include <ATen/ops/_unique2_native.h>
+#include <ATen/ops/_unique_native.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/argsort.h>
 #include <ATen/ops/cat.h>
@@ -318,9 +318,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique2_mps(const Tensor& self,
   return _unique_impl_mps(self, return_inverse, return_counts, false, std::nullopt);
 }
 
-std::tuple<Tensor, Tensor> _unique_mps(const Tensor& self,
-                                       const bool sorted,
-                                       const bool return_inverse) {
+std::tuple<Tensor, Tensor> _unique_mps(const Tensor& self, const bool sorted, const bool return_inverse) {
   auto [output, inverse_indices, _] = _unique_impl_mps(self, return_inverse, false, false, std::nullopt);
   return std::make_tuple(std::move(output), std::move(inverse_indices));
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6569,6 +6569,7 @@
   dispatch:
     CPU: _unique_cpu
     CUDA: _unique_cuda
+    MPS: _unique_mps
   autogen: _unique.out
 
 - func: unique_dim(Tensor self, int dim, bool sorted=True, bool return_inverse=False, bool return_counts=False) -> (Tensor, Tensor, Tensor)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19661,14 +19661,6 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake_crossref_backward_no_amp'),
                # RuntimeError: Mismatch on aten._unique.default: Shapes torch.Size([2]) and torch.Size([1]) are not equal!
                DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake_crossref_backward_amp'),
-               # Error: The operator 'aten::_unique' is not currently implemented for the MPS device
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
-               DecorateInfo(
-                   unittest.expectedFailure,
-                   'TestCommon',
-                   'test_noncontiguous_samples',
-                   device_type='mps',
-                   dtypes=(torch.float32,)),
                # RuntimeError: index_fill_(): Complex types are yet not supported
                # NotImplementedError: "_local_scalar_dense_mps" not implemented for 'ComplexHalf'
                DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64, torch.complex32)),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -927,7 +927,6 @@ if torch.backends.mps.is_available():
             "cdist": None,
             "masked.scatter": [torch.float16, torch.float32],
             "grid_sampler_3d": None,
-            "index_fill": [torch.float16, torch.float32],  # missing `aten::_unique`.
             "igamma": None,  # currently not supported for any device
             "igammac": None,  # currently not supported for any device
             "linalg.solve": [torch.float16, torch.float32],  # missing `aten::lu_solve`.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #174238

Which is used during backward pass of `index_fill`
Claude-caude to just call `_unique_impl_mps` and ignore `counts`

Tested by unskipping xfails in common_mps

TODO: Remove opinfo decorators prefixed with `The operator 'aten::_unique' is not currently implemented for the MPS device`, but I want to see failures in CI first