### PR TITLE
[MPS] Fix conv backward to preserve input memory format

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -76,6 +76,14 @@ static bool is_packed_channels_last_2d(const Tensor& t) {
       t.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == at::MemoryFormat::ChannelsLast;
 }
 
+// `a` supplies the rank, so it has to be an activation
+static at::MemoryFormat conv_backward_memory_format(const Tensor& a, const Tensor& b) {
+  if (!mps_conv_use_channels_last(a, b)) {
+    return at::MemoryFormat::Contiguous;
+  }
+  return a.dim() == 5 ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
+}
+
 // DHWIO costs one in-graph weight transpose per call; only worth it when
 // Cin/groups is large enough and the kernel is not factorized.
 static bool conv3d_dhwio_is_beneficial(IntArrayRef weight_size) {
@@ -813,7 +821,8 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                              IntArrayRef stride,
                                              IntArrayRef dilation,
                                              int64_t groups,
-                                             bool bias_defined) {
+                                             bool bias_defined,
+                                             at::MemoryFormat output_memory_format) {
   using namespace at::native::mps;
   using namespace mps;
   bool is3DConv = grad_output_t.dim() == 5;
@@ -839,9 +848,15 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
       conv3d_dhwio_is_beneficial(weight_t.sizes());
   const bool use_nhwc = !is3DConv && is_macos_15_plus && is_packed_channels_last_2d(grad_output_t);
   const auto desc_layout = use_dhwio ? kChannelsLast3d : use_nhwc ? kChannelsLast : kContiguous;
-  // Allocate grad_input in the user-requested layout. The fast path writes
-  // directly; the NCDHW fallback writes via a contig scratch + copy below.
-  const bool is_channels_last = mps_conv_use_channels_last(grad_output_t, weight_t);
+  // Allocate grad_input in the caller-supplied layout so it matches input.
+  const bool is_channels_last = output_memory_format == kChannelsLast || output_memory_format == kChannelsLast3d;
+  // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
+  // The depthwise op is NCHW-only, hence the desc_layout condition.
+  const bool isDepthwiseConv = groups > 1 && weight_t.dim() >= 4 && weight_t.size(1) == 1 &&
+      grad_output_t.ndimension() >= 4 && desc_layout == kContiguous;
+  // The graph computes in desc_layout, which is chosen from grad_output; transpose
+  // back in-graph when the caller asked for a different layout.
+  const bool transpose_grad_input = (use_nhwc || use_dhwio) && !is_channels_last;
   auto grad_input_t =
       at::empty(input_size,
                 grad_output_t.options(),
@@ -888,10 +903,6 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
       auto weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
       MPSGraphTensor* gradInputTensor;
-      MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
-      // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
-      bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && grad_output_t.ndimension() >= 4 &&
-                              weightOutputShape.count >= 4 && !is_channels_last);
 
       if (is3DConv) {
         MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
@@ -951,6 +962,11 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                                                                    name:nil];
       }
 
+      if (transpose_grad_input) {
+        MPSShape* to_nchw = is3DConv ? @[ @0, @4, @1, @2, @3 ] : @[ @0, @3, @1, @2 ];
+        gradInputTensor = [mpsGraph transposeTensor:gradInputTensor permutation:to_nchw name:nil];
+      }
+
       newCachedGraph->gradOutputTensor_ = gradOutputTensor;
       newCachedGraph->weightTensor_ = weightTensor;
       newCachedGraph->gradInputTensor_ = gradInputTensor;
@@ -962,8 +978,9 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
     // MPSGraph conv miscomputes for non-dense (offset/gapped) weight views; gather instead of using the strided API.
     auto weightsPlaceholder =
         Placeholder(cachedGraph->weightTensor_, weight_t, nil, true, MPSDataTypeInvalid, /*useMPSStridedAPI=*/false);
-    auto outputPlaceholder = grad_input_c
-        ? Placeholder(cachedGraph->gradInputTensor_, *grad_input_c)
+    const auto& grad_input_out = grad_input_c ? *grad_input_c : grad_input_t;
+    auto outputPlaceholder = grad_input_c || transpose_grad_input
+        ? Placeholder(cachedGraph->gradInputTensor_, grad_input_out)
         : make_conv_placeholder(cachedGraph->gradInputTensor_, grad_input_t, desc_layout);
 
     auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, weightsPlaceholder);
@@ -982,7 +999,8 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                                IntArrayRef stride,
                                                IntArrayRef dilation,
                                                int64_t groups,
-                                               bool bias_defined) {
+                                               bool bias_defined,
+                                               at::MemoryFormat output_memory_format) {
   using namespace at::native::mps;
   using namespace mps;
   const bool is3DConv = input_t.dim() == 5;
@@ -1001,9 +1019,9 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   const bool use_hwio = !is3DConv && is_macos_15_plus &&
       (is_packed_channels_last_2d(input_t) || is_packed_channels_last_2d(grad_output_t));
   const auto desc_layout = use_dhwio ? kChannelsLast3d : use_hwio ? kChannelsLast : kContiguous;
-  // grad_weight allocation: 2D follows the standard CL convention; 3D always
+  // grad_weight allocation: 2D follows the caller-supplied layout; 3D always
   // stays contiguous OIDHW (the graph already transposes DHWIO -> OIDHW).
-  const bool allocate_grad_weight_cl = mps_conv_use_channels_last(input_t, grad_output_t) && !is3DConv;
+  const bool allocate_grad_weight_cl = output_memory_format == kChannelsLast && !is3DConv;
 
   // For uniformity with everything else, although it seems grad_weight
   // would be unambiguous too.
@@ -1168,13 +1186,15 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> mps_convolution_backward(const at
       grad_weight = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     }
   } else {
+    // Decide the layout once from input and weight; both gradients must share it.
+    const auto memory_format = conv_backward_memory_format(input, weight);
     if (output_mask[0]) {
       grad_input = mps_convolution_backward_input(
-          input.sizes(), grad_output, weight, padding, stride, dilation, groups, output_mask[2]);
+          input.sizes(), grad_output, weight, padding, stride, dilation, groups, output_mask[2], memory_format);
     }
     if (output_mask[1]) {
       grad_weight = mps_convolution_backward_weights(
-          weight.sizes(), grad_output, input, padding, stride, dilation, groups, output_mask[2]);
+          weight.sizes(), grad_output, input, padding, stride, dilation, groups, output_mask[2], memory_format);
     }
   }
 
@@ -1190,7 +1210,9 @@ static Tensor mps_convolution_transpose_forward(const Tensor& grad_output,
                                                 int64_t groups) {
   auto input_size =
       conv_input_size(grad_output.sizes(), weight.sizes(), padding, output_padding, stride, dilation, groups);
-  return mps_convolution_backward_input(input_size, grad_output, weight, padding, stride, dilation, groups, false);
+  const auto output_memory_format = conv_backward_memory_format(grad_output, weight);
+  return mps_convolution_backward_input(
+      input_size, grad_output, weight, padding, stride, dilation, groups, false, output_memory_format);
 }
 
 Tensor _mps_convolution_transpose(const Tensor& input_t,
@@ -1226,8 +1248,9 @@ static Tensor mps_convolution_transpose_backward_weight(IntArrayRef weight_size,
                                                         IntArrayRef stride,
                                                         IntArrayRef dilation,
                                                         int64_t groups) {
+  const auto output_memory_format = conv_backward_memory_format(input_t, grad_output_t);
   return mps_convolution_backward_weights(
-      weight_size, input_t, grad_output_t, padding, stride, dilation, groups, false);
+      weight_size, input_t, grad_output_t, padding, stride, dilation, groups, false, output_memory_format);
 }
 
 std::tuple<Tensor, Tensor> mps_convolution_transpose_backward(const Tensor& input,

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -763,7 +763,8 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                              IntArrayRef stride,
                                              IntArrayRef dilation,
                                              int64_t groups,
-                                             bool bias_defined) {
+                                             bool bias_defined,
+                                             at::MemoryFormat output_memory_format) {
   using namespace at::native::mps;
   using namespace mps;
   bool is3DConv = grad_output_t.dim() == 5;
@@ -788,9 +789,8 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
   const bool use_dhwio = is3DConv && is_macos_15_plus && is_packed_channels_last_3d(grad_output_t) &&
       conv3d_dhwio_is_beneficial(weight_t.sizes());
   const auto desc_layout = use_dhwio ? kChannelsLast3d : kContiguous;
-  // Allocate grad_input in the user-requested layout. The fast path writes
-  // directly; the NCDHW fallback writes via a contig scratch + copy below.
-  const bool is_channels_last = mps_conv_use_channels_last(grad_output_t, weight_t);
+  // Allocate grad_input in the caller-supplied layout so it matches input.
+  const bool is_channels_last = output_memory_format == kChannelsLast || output_memory_format == kChannelsLast3d;
   auto grad_input_t =
       at::empty(input_size,
                 grad_output_t.options(),
@@ -926,7 +926,8 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                                IntArrayRef stride,
                                                IntArrayRef dilation,
                                                int64_t groups,
-                                               bool bias_defined) {
+                                               bool bias_defined,
+                                               at::MemoryFormat output_memory_format) {
   using namespace at::native::mps;
   using namespace mps;
   const bool is3DConv = input_t.dim() == 5;
@@ -943,9 +944,9 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   const bool use_dhwio = is3DConv && is_macos_15_plus && !half_precision_wg && is_packed_channels_last_3d(input_t) &&
       is_packed_channels_last_3d(grad_output_t) && conv3d_dhwio_is_beneficial(weight_size);
   const auto desc_layout = use_dhwio ? kChannelsLast3d : kContiguous;
-  // grad_weight allocation: 2D follows the standard CL convention; 3D always
+  // grad_weight allocation: 2D follows the caller-supplied layout; 3D always
   // stays contiguous OIDHW (the graph already transposes DHWIO -> OIDHW).
-  const bool allocate_grad_weight_cl = mps_conv_use_channels_last(input_t, grad_output_t) && !is3DConv;
+  const bool allocate_grad_weight_cl = output_memory_format == kChannelsLast && !is3DConv;
 
   // For uniformity with everything else, although it seems grad_weight
   // would be unambiguous too.
@@ -1067,9 +1068,12 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
       newCachedGraph->gradWeightTensor_ = gradWeightTensor;
     });
 
+    // For 2D CL grad_weight the kernel emits in the input's layout, so feed CL
+    // input to match the CL-allocated output.
+    const auto input_for_2d = allocate_grad_weight_cl ? input_t.contiguous(kChannelsLast) : input_t;
     const auto grad_out_for_graph =
         grad_weight_c ? grad_output_t.contiguous() : materialize_for_conv(grad_output_t, desc_layout);
-    const auto input_for_graph = grad_weight_c ? input_t.contiguous() : materialize_for_conv(input_t, desc_layout);
+    const auto input_for_graph = grad_weight_c ? input_t.contiguous() : materialize_for_conv(input_for_2d, desc_layout);
     auto gradOutputPlaceholder = make_conv_placeholder(cachedGraph->gradOutputTensor_, grad_out_for_graph, desc_layout);
     auto inputPlaceholder = make_conv_placeholder(cachedGraph->inputTensor_, input_for_graph, desc_layout);
     auto outputPlaceholder =
@@ -1102,13 +1106,18 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> mps_convolution_backward(const at
       grad_weight = at::zeros_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     }
   } else {
+    // Decide the layout once from input and weight; both gradients must share it.
+    const bool use_cl = mps_conv_use_channels_last(input, weight);
+    const auto memory_format = use_cl
+        ? (input.dim() == 5 ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast)
+        : at::MemoryFormat::Contiguous;
     if (output_mask[0]) {
       grad_input = mps_convolution_backward_input(
-          input.sizes(), grad_output, weight, padding, stride, dilation, groups, output_mask[2]);
+          input.sizes(), grad_output, weight, padding, stride, dilation, groups, output_mask[2], memory_format);
     }
     if (output_mask[1]) {
       grad_weight = mps_convolution_backward_weights(
-          weight.sizes(), grad_output, input, padding, stride, dilation, groups, output_mask[2]);
+          weight.sizes(), grad_output, input, padding, stride, dilation, groups, output_mask[2], memory_format);
     }
   }
 
@@ -1124,7 +1133,12 @@ static Tensor mps_convolution_transpose_forward(const Tensor& grad_output,
                                                 int64_t groups) {
   auto input_size =
       conv_input_size(grad_output.sizes(), weight.sizes(), padding, output_padding, stride, dilation, groups);
-  return mps_convolution_backward_input(input_size, grad_output, weight, padding, stride, dilation, groups, false);
+  const bool use_cl = mps_conv_use_channels_last(grad_output, weight);
+  const auto output_memory_format = use_cl
+      ? (grad_output.dim() == 5 ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast)
+      : at::MemoryFormat::Contiguous;
+  return mps_convolution_backward_input(
+      input_size, grad_output, weight, padding, stride, dilation, groups, false, output_memory_format);
 }
 
 Tensor _mps_convolution_transpose(const Tensor& input_t,
@@ -1160,8 +1174,12 @@ static Tensor mps_convolution_transpose_backward_weight(IntArrayRef weight_size,
                                                         IntArrayRef stride,
                                                         IntArrayRef dilation,
                                                         int64_t groups) {
+  const bool use_cl = mps_conv_use_channels_last(input_t, grad_output_t);
+  const auto output_memory_format = use_cl
+      ? (input_t.dim() == 5 ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast)
+      : at::MemoryFormat::Contiguous;
   return mps_convolution_backward_weights(
-      weight_size, input_t, grad_output_t, padding, stride, dilation, groups, false);
+      weight_size, input_t, grad_output_t, padding, stride, dilation, groups, false, output_memory_format);
 }
 
 std::tuple<Tensor, Tensor> mps_convolution_transpose_backward(const Tensor& input,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6458,6 +6458,61 @@ for dtype in (torch.int32, torch.int64):
         )
 
     @skip_if_cpu
+    @config.patch(
+        {
+            "max_autotune": True,
+            "max_autotune_conv_bwd_weight_backends": "TRITON",
+            "max_autotune_conv_bwd_input_backends": "TRITON",
+        }
+    )
+    @parametrize("nhwc_weight", (False, True))
+    @parametrize("nhwc_input", (False, True))
+    @with_tf32_off
+    @skipIfRocmVersionAtLeast(
+        [7, 14]
+    )  # ROCm 7.14+ Triton conv2d backward accuracy issue in this UT family
+    def test_conv2d_backward_input_layout(self, nhwc_weight: bool, nhwc_input: bool):
+        in_channels, out_channels, groups = 3, 4, 1
+        stride, dilation, padding, kernel = 1, 1, 1, 3
+
+        if torch._inductor.compile_fx.fx_compile_mode == FxCompileMode.SUBPROCESS:
+            self.skipTest("Expected failure under subprocess compile mode")
+
+        def fn(grad_output, inp, weight):
+            return torch.ops.aten.convolution_backward.default(
+                grad_output,
+                inp,
+                weight,
+                [out_channels],
+                [stride, stride],
+                [padding, padding],
+                [dilation, dilation],
+                False,
+                [0, 0],
+                groups,
+                [True, True, True],
+            )
+
+        input_h = input_w = 16
+        output_h = (input_h + 2 * padding - dilation * (kernel - 1) - 1) // stride + 1
+        output_w = (input_w + 2 * padding - dilation * (kernel - 1) - 1) // stride + 1
+
+        weight = torch.randn([out_channels, in_channels // groups, kernel, kernel])
+        if nhwc_weight:
+            weight = weight.to(memory_format=torch.channels_last)
+        inp = torch.randn([2, in_channels, input_h, input_w])
+        if nhwc_input:
+            inp = inp.to(memory_format=torch.channels_last)
+
+        self.common(
+            fn,
+            (torch.randn([2, out_channels, output_h, output_w]), inp, weight),
+            atol=3e-4,
+            rtol=0.001,
+            check_lowp=False,
+        )
+
+    @skip_if_cpu
     @skipIfRocm  # Triton conv backward kernels stay enabled on ROCm
     @config.patch(
         {

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6338,6 +6338,7 @@ for dtype in (torch.int32, torch.int64):
         ),
     )
     @parametrize("nhwc", (False, True))
+    @parametrize("nhwc_input", (False, True))
     @with_tf32_off
     @skipIfRocmVersionAtLeast(
         [7, 14]
@@ -6350,6 +6351,7 @@ for dtype in (torch.int32, torch.int64):
         padding: int,
         kernel: int,
         nhwc: bool,
+        nhwc_input: bool,
     ):
         in_channels = channels_groups[0]
         out_channels = channels_groups[1]
@@ -6402,11 +6404,14 @@ for dtype in (torch.int32, torch.int64):
         )
         if nhwc:
             weight = weight.to(memory_format=torch.channels_last)
+        inp = torch.randn([2, in_channels, input_h, input_w], dtype=dtype)
+        if nhwc_input:
+            inp = inp.to(memory_format=torch.channels_last)
         self.common(
             fn,
             (
                 torch.randn([2, out_channels, output_h, output_w], dtype=dtype),
-                torch.randn([2, in_channels, input_h, input_w], dtype=dtype),
+                inp,
                 weight,
             ),
             atol=atol,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11715,6 +11715,53 @@ class TestNNMPS(NNTestCase):
         bn_mps.load_state_dict(bn.state_dict())
         self.assertEqual(bn(mps_slice.cpu()), bn_mps(mps_slice).cpu())
 
+    def test_conv2d_backward_channels_last_input(self):
+        grad_out = torch.randn(2, 64, 8, 8, device='mps')
+        x = torch.randn(2, 32, 8, 8, device='mps').to(memory_format=torch.channels_last)
+        w = torch.randn(64, 32, 3, 3, device='mps')
+        result = torch.ops.aten.convolution_backward.default(
+            grad_out, x, w, [0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, False]
+        )
+        self.assertTrue(result[0].is_contiguous(memory_format=torch.channels_last))
+
+    def test_conv2d_backward_contiguous_input_stays_contiguous(self):
+        grad_out = torch.randn(2, 64, 8, 8, device='mps')
+        x = torch.randn(2, 32, 8, 8, device='mps')
+        w = torch.randn(64, 32, 3, 3, device='mps')
+        result = torch.ops.aten.convolution_backward.default(
+            grad_out, x, w, [0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, False]
+        )
+        self.assertTrue(result[0].is_contiguous())
+
+    def test_conv2d_backward_both_channels_last(self):
+        grad_out = torch.randn(2, 64, 8, 8, device='mps').to(memory_format=torch.channels_last)
+        x = torch.randn(2, 32, 8, 8, device='mps').to(memory_format=torch.channels_last)
+        w = torch.randn(64, 32, 3, 3, device='mps')
+        result = torch.ops.aten.convolution_backward.default(
+            grad_out, x, w, [0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, False]
+        )
+        self.assertTrue(result[0].is_contiguous(memory_format=torch.channels_last))
+
+    def test_conv2d_backward_grad_weight_channels_last_weight(self):
+        grad_out = torch.randn(2, 64, 8, 8)
+        x = torch.randn(2, 32, 8, 8)
+        w = torch.randn(64, 32, 3, 3).to(memory_format=torch.channels_last)
+        args = ([0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [False, True, False])
+        cpu = torch.ops.aten.convolution_backward.default(grad_out, x, w, *args)
+        mps = torch.ops.aten.convolution_backward.default(
+            grad_out.to('mps'), x.to('mps'), w.to('mps'), *args
+        )
+        self.assertEqual(mps[1].cpu(), cpu[1])
+
+    def test_conv3d_backward_channels_last_3d_input(self):
+        x = torch.randn(2, 16, 8, 8, 8, device='mps').to(
+            memory_format=torch.channels_last_3d
+        ).detach().requires_grad_(True)
+        conv = nn.Conv3d(16, 32, 3, padding=1, device='mps')
+        y = conv(x)
+        y.backward(torch.randn_like(y))
+        self.assertTrue(x.grad.is_contiguous(memory_format=torch.channels_last_3d))
+
     # Regression test for https://github.com/pytorch/pytorch/issues/141471
     def test_conv3d_channels_last_3d(self):
         m_cpu = nn.Conv3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(4, 2, 0), device="cpu")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11767,6 +11767,73 @@ class TestNNMPS(NNTestCase):
         bn_mps.load_state_dict(bn.state_dict())
         self.assertEqual(bn(mps_slice.cpu()), bn_mps(mps_slice).cpu())
 
+    @parametrize("channels_last_weight", (False, True))
+    @parametrize("channels_last_grad_out", (False, True))
+    @parametrize("channels_last_input", (False, True))
+    @parametrize("groups", (1, 32))
+    def test_conv2d_backward_input_memory_format(
+        self, channels_last_input, channels_last_grad_out, channels_last_weight, groups
+    ):
+        def make(shape, channels_last):
+            t = torch.randn(shape)
+            return t.to(memory_format=torch.channels_last) if channels_last else t
+
+        grad_out = make((2, 64, 8, 8), channels_last_grad_out)
+        x = make((2, 32, 8, 8), channels_last_input)
+        w = make((64, 32 // groups, 3, 3), channels_last_weight)
+
+        args = ([0], [1, 1], [1, 1], [1, 1], False, [0, 0], groups, [True, True, False])
+        expected = torch.ops.aten.convolution_backward.default(grad_out, x, w, *args)
+        actual = torch.ops.aten.convolution_backward.default(
+            grad_out.to('mps'), x.to('mps'), w.to('mps'), *args
+        )
+
+        # The layout comes from input and weight, never from grad_output.
+        for mps_out, cpu_out in zip(actual[:2], expected[:2]):
+            for fmt in (torch.contiguous_format, torch.channels_last):
+                self.assertEqual(
+                    mps_out.is_contiguous(memory_format=fmt), cpu_out.is_contiguous(memory_format=fmt)
+                )
+        self.assertEqual(expected[0], actual[0].cpu(), rtol=1e-4, atol=1e-4)
+        self.assertEqual(expected[1], actual[1].cpu(), rtol=1e-4, atol=1e-4)
+
+    def test_conv2d_backward_grad_weight_channels_last_weight(self):
+        grad_out = torch.randn(2, 64, 8, 8)
+        x = torch.randn(2, 32, 8, 8)
+        w = torch.randn(64, 32, 3, 3).to(memory_format=torch.channels_last)
+        args = ([0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [False, True, False])
+        cpu = torch.ops.aten.convolution_backward.default(grad_out, x, w, *args)
+        mps = torch.ops.aten.convolution_backward.default(
+            grad_out.to('mps'), x.to('mps'), w.to('mps'), *args
+        )
+        self.assertEqual(mps[1].cpu(), cpu[1])
+
+    def test_conv3d_backward_channels_last_3d_input(self):
+        x = torch.randn(2, 16, 8, 8, 8, device='mps').to(
+            memory_format=torch.channels_last_3d
+        ).detach().requires_grad_(True)
+        conv = nn.Conv3d(16, 32, 3, padding=1, device='mps')
+        y = conv(x)
+        y.backward(torch.randn_like(y))
+        self.assertTrue(x.grad.is_contiguous(memory_format=torch.channels_last_3d))
+
+    def test_conv3d_backward_channels_last_3d_grad_output_only(self):
+        x_cpu = torch.randn(2, 16, 8, 8, 8)
+        conv_cpu = nn.Conv3d(16, 32, 3, padding=1)
+        conv_mps = nn.Conv3d(16, 32, 3, padding=1, device='mps')
+        conv_mps.load_state_dict(conv_cpu.state_dict())
+
+        x = x_cpu.clone().requires_grad_(True)
+        x_mps = x_cpu.clone().to('mps').requires_grad_(True)
+        grad_out = torch.randn(2, 32, 8, 8, 8)
+
+        conv_cpu(x).backward(grad_out)
+        conv_mps(x_mps).backward(grad_out.to('mps').contiguous(memory_format=torch.channels_last_3d))
+
+        self.assertTrue(x_mps.grad.is_contiguous())
+        self.assertEqual(x.grad, x_mps.grad)
+        self.assertEqual(conv_cpu.weight.grad, conv_mps.weight.grad, rtol=1e-4, atol=1e-4)
+
     # Regression test for https://github.com/pytorch/pytorch/issues/141471
     def test_conv3d_channels_last_3d(self):
         m_cpu = nn.Conv3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(4, 2, 0), device="cpu")
@@ -14436,6 +14503,33 @@ class TestConvolutionMPS(TestCaseMPS):
 
             # non-square kernels and unequal stride and with padding
             helper(nn.ConvTranspose2d(16, 33, (3, 5), stride=(2, 1), padding=(4, 2)).requires_grad_(), mem_format_input)
+
+    @parametrize("channels_last_grad_out", (False, True))
+    @parametrize("channels_last_input", (False, True))
+    def test_conv_transpose2d_backward_memory_format(self, channels_last_input, channels_last_grad_out):
+        torch.manual_seed(0)
+        m_cpu = nn.ConvTranspose2d(8, 4, 3, stride=1, padding=1)
+        x_cpu = torch.randn(2, 8, 8, 8)
+        if channels_last_input:
+            x_cpu = x_cpu.to(memory_format=torch.channels_last)
+        x_cpu = x_cpu.requires_grad_(True)
+
+        m_mps = copy.deepcopy(m_cpu).to("mps")
+        x_mps = x_cpu.detach().clone().to("mps").requires_grad_(True)
+
+        y_cpu = m_cpu(x_cpu)
+        y_mps = m_mps(x_mps)
+
+        grad_out = torch.randn_like(y_cpu)
+        if channels_last_grad_out:
+            grad_out = grad_out.to(memory_format=torch.channels_last)
+        y_cpu.backward(grad_out)
+        y_mps.backward(grad_out.to("mps"))
+
+        for mps_grad, cpu_grad in ((x_mps.grad, x_cpu.grad), (m_mps.weight.grad, m_cpu.weight.grad)):
+            self.assertEqual(cpu_grad, mps_grad.cpu(), atol=1e-4, rtol=1e-4)
+            for fmt in (torch.contiguous_format, torch.channels_last):
+                self.assertEqual(mps_grad.is_contiguous(memory_format=fmt), cpu_grad.is_contiguous(memory_format=fmt))
 
     def test_conv_transpose_2d_specified_output(self):
         input_cpu = torch.randn(1, 16, 12, 12)
@@ -17439,6 +17533,7 @@ instantiate_parametrized_tests(MatmulTest)
 instantiate_parametrized_tests(TestBinaryIteratorConformance)
 instantiate_parametrized_tests(TestLogical)
 instantiate_parametrized_tests(TestMPS)
+instantiate_parametrized_tests(TestNNMPS)
 instantiate_parametrized_tests(TestSDPA)
 instantiate_parametrized_tests(TestSmoothL1Loss)
 instantiate_parametrized_tests(TestMetalLibrary)


### PR DESCRIPTION
## Summary

Fixes `convolution_backward` on MPS to preserve the original input tensor's memory format, rather than deriving it from `grad_output`.

When `convolution_backward` is called with a `channels_last` input but contiguous `grad_output`, the `grad_input` should preserve the input's memory format (`channels_last`), not adopt `grad_output`'s format (contiguous).

## Problem

Previously, `mps_convolution_backward_input` determined the output memory format based on `grad_output` and `weight` tensors:

```cpp
bool is_channels_last = mps_conv_use_channels_last(grad_output_t, weight_t) && !is3DConv;
```

This caused `grad_input` to be contiguous when `grad_output` was contiguous, even if the original input was `channels_last`.

This breaks `torch.compile` with inductor backend, which asserts that `grad_input` has the same strides as the original input:

```
AssertionError: expected size 768==768, stride 64==1 at dim=1
Error in op: torch.ops.aten.convolution_backward.default
```

## Reproduction

```python
import torch

# grad_output: contiguous strides
grad_out = torch.randn(8, 3072, 8, 8, device='mps', dtype=torch.float16)

# input: channels_last strides
x = torch.randn(8, 768, 8, 8, device='mps', dtype=torch.float16)
x = x.to(memory_format=torch.channels_last)

# weight: contiguous
w = torch.randn(3072, 768, 3, 3, device='mps', dtype=torch.float16)

result = torch.ops.aten.convolution_backward.default(
    grad_out, x, w, [0], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, False]
)

print(result[0].stride())  
# Before: (49152, 64, 8, 1) - WRONG (contiguous)
# After:  (49152, 1, 6144, 768) - CORRECT (channels_last)
```

## Solution

Pass the original input's memory format to `mps_convolution_backward_input` and use it to determine the output format:

```cpp
grad_input = mps_convolution_backward_input(
    input.sizes(), grad_output, weight, padding, stride, dilation, groups, output_mask[2],
    input.suggest_memory_format());  // NEW: pass input's memory format
```

## Test

Added `test/test_mps_conv_channels_last.py` with tests for:
- channels_last input with contiguous grad_output (the bug case)
- contiguous input stays contiguous (no regression)
- both channels_last (existing behavior preserved)

Fixes #174269

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @kulinseth @malfet