### PR TITLE
[cuDNN][SDPA] Don't route to cuDNN SDPA when dropout probability is not a multiple of 1/16

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -483,6 +483,18 @@ bool check_all_tensors_on_device(sdp_params const& params, bool debug) {
   return true;
 }
 
+bool check_cudnn_dropout(sdp_params const& params, bool debug) {
+  if (params.dropout * 16.0 != std::floor(params.dropout * 16.0)) {
+    if (debug) {
+      TORCH_WARN("cuDNN dropout probability resolution is limited to 1/16."
+		 "Use a dropout probability that is a multiple of 1/16 to "
+		 "select the cuDNN backend");
+    }
+    return false;
+  }
+  return true;
+}
+
 bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
   const auto s_q = params.query.sym_size(2);
   const auto s_k = params.key.sym_size(2);
@@ -758,7 +770,8 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
           check_cudnn_deterministic,
           check_dtypes_low_precision,
           check_attn_mask_shape,
-          check_cudnn_hardware_support
+          check_cudnn_hardware_support,
+	  check_cudnn_dropout
           );
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -487,8 +487,8 @@ bool check_cudnn_dropout(sdp_params const& params, bool debug) {
   if (params.dropout * 16.0 != std::floor(params.dropout * 16.0)) {
     if (debug) {
       TORCH_WARN("cuDNN dropout probability resolution is limited to 1/16."
-		 "Use a dropout probability that is a multiple of 1/16 to "
-		 "select the cuDNN backend");
+                 "Use a dropout probability that is a multiple of 1/16 to "
+                 "select the cuDNN backend");
     }
     return false;
   }
@@ -771,7 +771,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
           check_dtypes_low_precision,
           check_attn_mask_shape,
           check_cudnn_hardware_support,
-	  check_cudnn_dropout
+          check_cudnn_dropout
           );
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2972,6 +2972,14 @@ class TestSDPACudaOnly(NNTestCase):
             out = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=0.5)
             out.backward(grad)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_low_dropout(self):
+        q = torch.randn(2, 8, 128, 128, dtype=torch.half, device='cuda')
+        dropout_p = 0.00000000001
+        out1 = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=dropout_p)
+        out2 = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=0.)
+        self.assertEqual(out1, out2)
+
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_broken_166211(self):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2978,7 +2978,8 @@ class TestSDPACudaOnly(NNTestCase):
         dropout_p = 0.00000000001
         out1 = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=dropout_p)
         out2 = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=0.)
-        self.assertEqual(out1, out2)
+        with self.assertRaisesRegex(AssertionError, "AssertionError not raised"):
+            self.assertNotEqual(out1, out2)
 
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")


### PR DESCRIPTION
certain cuDNN SDPA kernels only have a dropout probability resolution of 1/16, and this implicit rounding is a gotcha for users/tests