### PR TITLE
[caffe2] Fix signal handler deleting siginfo_t in resulting Coredump

### DIFF
--- a/c10/util/signal_handler.h
+++ b/c10/util/signal_handler.h
@@ -66,8 +66,8 @@ class C10_API FatalSignalHandler {
  private:
   void installFatalSignalHandlers();
   void uninstallFatalSignalHandlers();
-  static void fatalSignalHandlerStatic(int signum);
-  void fatalSignalHandler(int signum);
+  static void fatalSignalHandlerStatic(int signum, siginfo_t* info, void* ctx);
+  void fatalSignalHandler(int signum, siginfo_t* info);
   virtual void fatalSignalHandlerPostProcess();
   struct sigaction* getPreviousSigaction(int signum);
   const char* getSignalName(int signum);


### PR DESCRIPTION
Summary:
This patch fixes the loss of signal info in Coredumps produced by caffe2 apps when they crash.

The culprit is the signal handler's call to `raise` after unregistering itself. Raise under the hood actually calls `tgkill` which replaces whatever the data into the `siginfo_t` with the uid and pid of the calling process. This means when the signal and re-raised and the process coredumps, the reason for the coredump is something like `SEGV sent by=your pid, your user` without the address info or the SI_CODE from the original signal. We fix this by calling raise signal directly with the original signal. 

This is a port of yfeldblum's change in [Folly Signal Handler](https://github.com/facebook/folly/commit/79d7f8e9b154880be10b907fc7d030dc63abe1ae) to caffe2.

Test Plan:
In the diff above this one creates a small app that loads the caffe2 app and then SEGV's. Then inspecting the core locally 

```
(lldb) thread siginfo
thread #1: tid = 1711969, 0x000000000024f76a, name = 'signal_handler_', stop reason = SIGSEGV: address not mapped to object (fault address=0x1000)

(__lldb_siginfo_t) __lldb_siginfo = {
  si_signo = 11
  si_errno = 0
  si_code = 1
  __pad0 = 0
  _sifields = {
    _kill = (si_pid = 4096, si_uid = 0)
    _timer = {
      si_tid = 4096
      si_overrun = 0
      si_sigval = (sival_int = 0, sival_ptr = 0x0000000000000000)
    }
    _rt = {
      si_pid = 4096
      si_uid = 0
      si_sigval = (sival_int = 0, sival_ptr = 0x0000000000000000)
    }
    _sigchld = (si_pid = 4096, si_uid = 0, si_status = 0, si_utime = 0, si_stime = 0)
    _sigfault = {
      si_addr = 0x0000000000001000
      si_addr_lsb = 0
      _bounds = {
        _addr_bnd = (_lower = 0x0000000000000000, _upper = 0x0000000000000000)
        _pkey = 0
      }
    }
    _sigpoll = (si_band = 4096, si_fd = 0)
    _sigsys = (_call_addr = 0x0000000000001000, _syscall = 0, _arch = 0)
  }
}
```

And we see the siginfo contains the address which triggered the original SEGV.

Differential Revision: D92093984


