### PR TITLE
[BE] Replace `if: elfif:` with Py-3.10 `match:`

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1259,16 +1259,17 @@ def set_sync_debug_mode(debug_mode: int | str) -> None:
     """
     _lazy_init()
     if isinstance(debug_mode, str):
-        if debug_mode == "default":
-            debug_mode = 0
-        elif debug_mode == "warn":
-            debug_mode = 1
-        elif debug_mode == "error":
-            debug_mode = 2
-        else:
-            raise RuntimeError(
-                "invalid value of debug_mode, expected one of `default`, `warn`, `error`"
-            )
+        match debug_mode:
+            case "default":
+                debug_mode = 0
+            case "warn":
+                debug_mode = 1
+            case "error":
+                debug_mode = 2
+            case _:
+                raise RuntimeError(
+                    "invalid value of debug_mode, expected one of `default`, `warn`, `error`"
+                )
 
     torch._C._cuda_set_sync_debug_mode(debug_mode)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #174250

Pure syntactic changes