### PR TITLE
 [pyi] Fix set_() type stub to include Tensor overloads

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1771,7 +1771,7 @@ def gen_pyi(
                     "set_",
                     [
                         "self",
-                        "source: Storage | TypedStorage | UntypedStorage",
+                        "source: Storage | TypedStorage | UntypedStorage | Tensor",
                         "storage_offset: IntLikeType",
                         "size: _symsize",
                         "stride: _symsize",
@@ -1780,7 +1780,12 @@ def gen_pyi(
                 ),
                 defs(
                     "set_",
-                    ["self", "source: Storage | TypedStorage | UntypedStorage"],
+                    ["self", "source: Storage | TypedStorage | UntypedStorage | Tensor"],
+                    "Tensor",
+                ),
+                defs(
+                    "set_",
+                    ["self"],
                     "Tensor",
                 ),
             ],

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1780,7 +1780,10 @@ def gen_pyi(
                 ),
                 defs(
                     "set_",
-                    ["self", "source: Storage | TypedStorage | UntypedStorage | Tensor"],
+                    [
+                        "self",
+                        "source: Storage | TypedStorage | UntypedStorage | Tensor",
+                    ],
                     "Tensor",
                 ),
                 defs(


### PR DESCRIPTION
The `set_()` method type stub in `gen_pyi.py` was missing the Tensor overloads that are defined in `native_functions.yaml`:
- `set_.source_Tensor(self, Tensor source)`
- `set_.source_Tensor_storage_offset(self, Tensor source, offset, size, stride)`
- `set_(self)` (no arguments)

This caused type checkers to incorrectly flag `tensor.set_(other_tensor)` as an invalid argument type, expecting only Storage types.

Add `Tensor` to the source union type and add the no-argument overload to match the actual C++ API.

Refer to native_functions.yaml https://github.com/pytorch/pytorch/blob/1b7a8336e95c04a3ed46699e1be5d5d71f5042ac/aten/src/ATen/native/native_functions.yaml#L8214-L8261



Before the patch, there are no Tensor overloads of source parameter in (`torch/_C/__init__.pyi`)
```python
    @overload
    def set_(
        self,
        source: Storage | TypedStorage | UntypedStorage,
        storage_offset: IntLikeType,
        size: _symsize,
        stride: _symsize,
    ) -> Tensor:
        r"""
        set_(source=None, storage_offset=0, size=None, stride=None) -> Tensor

        Sets the underlying storage, size, and strides. If :attr:`source` is a tensor,
        :attr:`self` tensor will share the same storage and have the same size and
        strides as :attr:`source`. Changes to elements in one tensor will be reflected
        in the other.

        If :attr:`source` is a :class:`~torch.Storage`, the method sets the underlying
        storage, offset, size, and stride.

        Args:
            source (Tensor or Storage): the tensor or storage to use
            storage_offset (int, optional): the offset in the storage
            size (torch.Size, optional): the desired size. Defaults to the size of the source.
            stride (tuple, optional): the desired stride. Defaults to C-contiguous strides.
        """

    @overload
    def set_(self, source: Storage | TypedStorage | UntypedStorage) -> Tensor:
        r"""
        set_(source=None, storage_offset=0, size=None, stride=None) -> Tensor

        Sets the underlying storage, size, and strides. If :attr:`source` is a tensor,
        :attr:`self` tensor will share the same storage and have the same size and
        strides as :attr:`source`. Changes to elements in one tensor will be reflected
        in the other.

        If :attr:`source` is a :class:`~torch.Storage`, the method sets the underlying
        storage, offset, size, and stride.

        Args:
            source (Tensor or Storage): the tensor or storage to use
            storage_offset (int, optional): the offset in the storage
            size (torch.Size, optional): the desired size. Defaults to the size of the source.
            stride (tuple, optional): the desired stride. Defaults to C-contiguous strides.
        """
```

After this patch is applied, there are Tensor overloads of source parameter. (`torch/_C/__init__.pyi`)
```python
    @overload
    def set_(
        self,
        source: Storage | TypedStorage | UntypedStorage | Tensor,
        storage_offset: IntLikeType,
        size: _symsize,
        stride: _symsize,
    ) -> Tensor:
        r"""
        set_(source=None, storage_offset=0, size=None, stride=None) -> Tensor

        Sets the underlying storage, size, and strides. If :attr:`source` is a tensor,
        :attr:`self` tensor will share the same storage and have the same size and
        strides as :attr:`source`. Changes to elements in one tensor will be reflected
        in the other.

        If :attr:`source` is a :class:`~torch.Storage`, the method sets the underlying
        storage, offset, size, and stride.

        Args:
            source (Tensor or Storage): the tensor or storage to use
            storage_offset (int, optional): the offset in the storage
            size (torch.Size, optional): the desired size. Defaults to the size of the source.
            stride (tuple, optional): the desired stride. Defaults to C-contiguous strides.
        """

    @overload
    def set_(
        self,
        source: Storage | TypedStorage | UntypedStorage | Tensor,
    ) -> Tensor:
        r"""
        set_(source=None, storage_offset=0, size=None, stride=None) -> Tensor

        Sets the underlying storage, size, and strides. If :attr:`source` is a tensor,
        :attr:`self` tensor will share the same storage and have the same size and
        strides as :attr:`source`. Changes to elements in one tensor will be reflected
        in the other.

        If :attr:`source` is a :class:`~torch.Storage`, the method sets the underlying
        storage, offset, size, and stride.

        Args:
            source (Tensor or Storage): the tensor or storage to use
            storage_offset (int, optional): the offset in the storage
            size (torch.Size, optional): the desired size. Defaults to the size of the source.
            stride (tuple, optional): the desired stride. Defaults to C-contiguous strides.
        """

    @overload
    def set_(self) -> Tensor:
        r"""
        set_(source=None, storage_offset=0, size=None, stride=None) -> Tensor

        Sets the underlying storage, size, and strides. If :attr:`source` is a tensor,
        :attr:`self` tensor will share the same storage and have the same size and
        strides as :attr:`source`. Changes to elements in one tensor will be reflected
        in the other.

        If :attr:`source` is a :class:`~torch.Storage`, the method sets the underlying
        storage, offset, size, and stride.

        Args:
            source (Tensor or Storage): the tensor or storage to use
            storage_offset (int, optional): the offset in the storage
            size (torch.Size, optional): the desired size. Defaults to the size of the source.
            stride (tuple, optional): the desired stride. Defaults to C-contiguous strides.
        """
```