### PR TITLE
Adjust to use __riscv_v to detect for RISC-V Vector Extension

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -354,7 +354,7 @@ struct ConvParams {
   }
 
   bool use_cpu_depthwise3x3_winograd(const at::Tensor& input, const at::Tensor& weight, const std::optional<at::Tensor>& bias) const {
-#if defined(__ARM_NEON__) || (defined(__riscv_v_intrinsic) && __riscv_v_intrinsic>=12000)
+#if defined(__ARM_NEON__) || (defined(__riscv_v) && __riscv_v_intrinsic>=12000)
     // Currently only 3x3 depthwise convolutions on tensors of float are supported.
     return (input.ndimension() == 4) &&
            (at::symint::size<T>(input, 1) == groups) &&

--- a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+++ b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
@@ -13,7 +13,7 @@
 
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
-#elif defined(__riscv_v_intrinsic) && __riscv_v_intrinsic>=12000
+#elif defined(__riscv_v) && __riscv_v_intrinsic>=12000
 #include <riscv_vector.h>
 #endif
 
@@ -246,7 +246,7 @@ void convolution_depthwise3x3_winograd_impl(
   }
 }
 
-#elif defined(__riscv_v_intrinsic) && __riscv_v_intrinsic>=12000
+#elif defined(__riscv_v) && __riscv_v_intrinsic>=12000
 
 inline void winograd_f2k3_input_transform_inplace__rvv(
     vfloat32m1x4_t* input_tile_val) {


### PR DESCRIPTION
Newer compilers are now defining '__riscv_v_intrinsic' to mean that "the compiler does support the RVV intrinsics" instead of indicating "currently compiling for RVV enabled".

For reference:
https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/376

This means that current parts that are using only '__riscv_v_intrinsic' to guard RVV-specific code is failing to build, at least Clang 20 and probably above (Clang 19 and GCC 14 appears to have old behavior)

This patch adjusts to test for the '__riscv_v' symbol first, which should be the proper macro here.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01