### PR TITLE
[bug-fix] Fix FakeTensorMode to properly handle nn.Parameter subclasses

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3375,11 +3375,14 @@ def _check_for_subclass(flat_args: Sequence[object]) -> bool:
 
 
 def _check_for_subclass_arg(x: object) -> bool:
+    # Use issubclass(type(x), Parameter) rather than isinstance(x, Parameter)
+    # because isinstance uses C++ checks that return True for wrapper subclasses
+    # (e.g. Parameter(TwoTensor(...))), which still need subclass dispatch.
     return (
         not isinstance(x, FakeTensor)
         and isinstance(x, Tensor)
         and type(x) is not Tensor
-        and not isinstance(x, torch.nn.Parameter)
+        and not issubclass(type(x), torch.nn.Parameter)
     )
 
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3379,7 +3379,7 @@ def _check_for_subclass_arg(x: object) -> bool:
         not isinstance(x, FakeTensor)
         and isinstance(x, Tensor)
         and type(x) is not Tensor
-        and type(x) is not torch.nn.Parameter
+        and not isinstance(x, torch.nn.Parameter)
     )
 
 


### PR DESCRIPTION
Issue #174274 

## Summary

Fix `_check_for_subclass_arg` to properly handle `nn.Parameter` subclasses in `FakeTensorMode`. 

Parameter subclasses (like vLLM's ModelWeightParameter) should NOT be flagged as unrecognized tensor subclasses. They should be treated the same as nn.Parameter itself.

## Test Plan

Added `test_check_for_subclass_arg_parameter_subclass` in `test/test_fake_tensor.py`

