### PR TITLE
[CI][Windows] Add NVIDIA RTX workflow

### DIFF
--- a/.github/workflows/_win-rtx-build.yml
+++ b/.github/workflows/_win-rtx-build.yml
@@ -1,0 +1,242 @@
+name: windows-rtx-build
+
+on:
+  workflow_call:
+    inputs:
+      build-environment:
+        required: true
+        type: string
+        description: Top-level label for what's being built/tested.
+      cuda-version:
+        required: true
+        type: string
+        description: What CUDA version to build with, "cpu" for none.
+      use-xpu:
+        required: false
+        type: boolean
+        default: false
+        description: If set, build with XPU support.
+      xpu-version:
+        required: false
+        type: string
+        description: The version of XPU support package.
+      vc-year:
+        required: false
+        type: string
+        default: "2022"
+        description: The Visual Studio year to use for building.
+      build-with-debug:
+        required: false
+        type: boolean
+        default: false
+        description: If set, build in debug mode.
+      sync-tag:
+        required: false
+        type: string
+        default: ""
+        description: |
+          If this is set, our linter will use this to make sure that every other
+          job with the same `sync-tag` is identical.
+      test-matrix:
+        required: false
+        type: string
+        description: |
+          An option JSON description of what test configs to run later on. This
+          is moved here from the Linux test workflow so that we can apply filter
+          logic using test-config labels earlier and skip unnecessary builds
+      runner:
+        required: false
+        type: string
+        default: "windows.4xlarge.nonephemeral"
+        description: |
+          Label of the runner this job should run on.
+      cuda-arch-list:
+        required: false
+        type: string
+        default: "8.6"
+        description: |
+          CUDA architectures to build for (e.g., "8.9" for 40xx, "9.0" for 50xx)
+      build-test:
+        required: false
+        type: boolean
+        default: true
+        description: |
+          If set, build C++ test binaries (torchbind_test.dll, etc.) for comprehensive testing.
+          Increases build time and wheel size. Use for development/testing builds only.
+
+    outputs:
+      test-matrix:
+        value: ${{ jobs.build.outputs.test-matrix }}
+        description: An optional JSON description of what test configs to run later on.
+      build-secure-hash:
+        value: ${{ jobs.build.outputs.build-secure-hash }}
+      build-artifact-name:
+        value: ${{ jobs.build.outputs.build-artifact-name }}
+
+env:
+  GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  build:
+    # Don't run on forked repos.
+    if: github.repository_owner == 'pytorch'
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 240
+    outputs:
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      build-secure-hash: ${{ steps.compute_hash.outputs.hash_val }}
+      build-artifact-name: ${{ steps.compute_hash.outputs.filename }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Duplicated in win-test because this MUST go before a checkout
+      - name: Enable git long paths and symlinks on Windows and disable fsmonitor daemon
+        shell: bash
+        run: |
+          git config --global core.longpaths true
+          git config --global core.symlinks true
+
+          # https://git-scm.com/docs/git-fsmonitor--daemon.  The daemon could lock
+          # the directory on Windows and prevent GHA from checking out as reported
+          # in https://github.com/actions/checkout/issues/1018
+          git config --global core.fsmonitor false
+
+          # Prevent Git locking issues on ephemeral runners
+          git config --global gc.auto 0
+
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          no-sudo: true
+
+      - name: Parse ref
+        id: parse-ref
+        shell: bash
+        run: python3 .github/scripts/parse_ref.py
+
+      - name: Get workflow job id
+        id: get-job-id
+        uses: ./.github/actions/get-workflow-job-id
+        if: always()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Apply the filter logic to the build step too if the test-config label is already there
+      - name: Select all requested test configurations (if the test matrix is available)
+        id: filter
+        uses: ./.github/actions/filter-test-configs
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-matrix: ${{ inputs.test-matrix }}
+          job-name: ${{ steps.get-job-id.outputs.job-name }}
+
+      - name: Download pytest cache
+        uses: ./.github/actions/pytest-cache-download
+        continue-on-error: true
+        with:
+          cache_dir: .pytest_cache
+          job_identifier: ${{ github.workflow }}_${{ inputs.build-environment }}
+
+      - name: Build
+        if: steps.filter.outputs.is-test-matrix-empty == 'False' || inputs.test-matrix == ''
+        # if: false
+        id: build
+        shell: bash
+        env:
+          PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/${{ inputs.build-environment }}/build-results/
+          BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+          BUILD_WHEEL: 1
+          BUILD_TEST: ${{ inputs.build-test && '1' || '0' }}
+          MAX_JOBS: 8
+          CUDA_VERSION: ${{ inputs.cuda-version }}
+          PYTHON_VERSION: "3.12"
+          SCCACHE_BUCKET: "ossci-compiler-cache"
+          SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
+          SCCACHE_REGION: us-east-1
+          VC_PRODUCT: "BuildTools"
+          VC_VERSION: ""
+          VC_YEAR: "${{ inputs.vc-year }}"
+          ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+          AWS_DEFAULT_REGION: us-east-1
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          DEBUG: ${{ inputs.build-with-debug && '1' || '0' }}
+          TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
+          USE_CUDA: ${{ inputs.cuda-version != 'cpu' && '1' || '0' }}
+          USE_XPU: ${{ inputs.use-xpu == true && '1' || '0' }}
+          XPU_VERSION: "${{ inputs.xpu-version }}"
+          OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
+        run: |
+          .ci/pytorch/win-build.sh
+
+      - name: Compute and Secure Hash
+        id: compute_hash
+        shell: bash
+        env:
+          PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/${{ inputs.build-environment }}/build-results/
+        run: |
+          cd "$PYTORCH_FINAL_PACKAGE_DIR"
+
+          # Find the .whl file.
+          # Note: Bash uses forward slashes even on Windows, which is safer here.
+          FILENAME=$(ls *.whl | head -n 1)
+
+          # 1. Calculate SHA256 using Git Bash's built-in sha256sum
+          HASH_VALUE=$(sha256sum "$FILENAME" | awk '{print $1}')
+          echo "Raw Hash Value: $HASH_VALUE" | cat -v
+
+          # 2. Set as output for the next job
+          echo "hash_val=$HASH_VALUE" >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+          echo "Hash calculated and secured."
+
+      # Collect Windows torch libs and CUDA libs for cross-compilation
+      - name: Collect Windows CUDA libs for cross-compilation
+        if: steps.build.outcome != 'skipped' && inputs.cuda-version != 'cpu'
+        shell: bash
+        run: |
+          set -ex
+
+          # Create directory structure if does not exist
+          mkdir -p /c/${{ github.run_id }}/build-results
+
+          # Copy CUDA libs
+          CUDA_PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.cuda-version }}"
+
+          if [ -f "${CUDA_PATH}/lib/x64/cuda.lib" ]; then
+            cp "${CUDA_PATH}/lib/x64/cuda.lib" /c/${{ github.run_id }}/build-results/
+          fi
+
+          if [ -f "${CUDA_PATH}/lib/x64/cudart.lib" ]; then
+            cp "${CUDA_PATH}/lib/x64/cudart.lib" /c/${{ github.run_id }}/build-results/
+          fi
+
+          # List collected files
+          echo "Collected CUDA libs:"
+          ls -lah /c/${{ github.run_id }}/build-results/*.lib
+
+      # Upload to github so that people can click and download artifacts
+      - name: Upload artifacts to s3
+        if: steps.build.outcome != 'skipped'
+        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+        with:
+          retention-days: 14
+          if-no-files-found: error
+          name: ${{ inputs.build-environment }}
+          path: C:\${{ github.run_id }}\build-results
+
+      - name: Upload sccache stats
+        if: steps.build.outcome != 'skipped'
+        uses: ./.github/actions/upload-sccache-stats
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Teardown Windows
+        uses: ./.github/actions/teardown-win
+        if: always()
+        timeout-minutes: 120
+        with:
+          extra-delete-dir: /c/${{ github.run_id }}/build-results/

--- a/.github/workflows/_win-rtx-test.yml
+++ b/.github/workflows/_win-rtx-test.yml
@@ -1,0 +1,306 @@
+name: win-test
+
+on:
+  workflow_call:
+    inputs:
+      build-environment:
+        required: true
+        type: string
+        description: Top-level label for what's being built/tested.
+      build-secure-hash:
+        required: true
+        type: string
+        description: Secure hash generated during build process.
+      build-artifact-name:
+        required: true
+        type: string
+        description: filename of the build wheel.
+      cuda-version:
+        required: true
+        type: string
+        description: What CUDA version to build with, "cpu" for none.
+      test-matrix:
+        required: true
+        type: string
+        description: JSON description of what test configs to run.
+      sync-tag:
+        required: false
+        type: string
+        default: ""
+        description: |
+          If this is set, our linter will use this to make sure that every other
+          job with the same `sync-tag` is identical.
+      timeout-minutes:
+        required: false
+        type: number
+        default: 240
+        description: |
+          Set the maximum (in minutes) how long the workflow should take to finish
+      disable-monitor:
+        description: |
+          [Experimental] Disable utilization monitoring for tests.
+          Currently, by default we disable the monitor job and only look for specific tests,
+          since we are investigating the behaviour of the monitor script with different tests.
+        required: false
+        type: boolean
+        default: true
+      monitor-log-interval:
+        description: |
+          Set the interval for the monitor script to log utilization.
+        required: false
+        type: number
+        default: 5
+      monitor-data-collect-interval:
+        description: |
+          Set the interval for the monitor script to collect data.
+        required: false
+        type: number
+        default: 1
+env:
+  GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  test:
+    # Don't run on forked repos or empty test matrix
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]'
+    strategy:
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
+      fail-fast: false
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Duplicated in win-build because this MUST go before a checkout
+      - name: Enable git long paths and symlinks on Windows and disable fsmonitor daemon
+        shell: bash
+        run: |
+          git config --global core.longpaths true
+          git config --global core.symlinks true
+
+          # https://git-scm.com/docs/git-fsmonitor--daemon.  The daemon could lock
+          # the directory on Windows and prevent GHA from checking out as reported
+          # in https://github.com/actions/checkout/issues/1018
+          git config --global core.fsmonitor false
+
+          # Prevent Git locking issues on ephemeral runners
+          git config --global gc.auto 0
+
+      # [see note: pytorch repo ref]
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          no-sudo: true
+
+      - name: Get workflow job id
+        id: get-job-id
+        uses: ./.github/actions/get-workflow-job-id
+        if: always()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start monitoring script
+        id: monitor-script
+        env:
+          JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
+          JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_RUN_ID: ${{github.run_id}}
+          MONITOR_LOG_INTERVAL: ${{ inputs.monitor-log-interval }}
+          MONITOR_DATA_COLLECT_INTERVAL: ${{ inputs.monitor-data-collect-interval }}
+        shell: bash
+        if: ${{ !inputs.disable-monitor }}
+        continue-on-error: true
+        run: |
+          # Windows conda doesn't have python3 binary, only python, but it's python3
+          ${CONDA_RUN} python -m pip install psutil==5.9.8 dataclasses_json==0.6.7 nvidia-ml-py==11.525.84
+          ${CONDA_RUN} python -m tools.stats.monitor --log-interval "$MONITOR_LOG_INTERVAL" --data-collect-interval "$MONITOR_DATA_COLLECT_INTERVAL" > usage_log.txt 2>&1 &
+          echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download PyTorch Build Artifacts
+        uses: seemethere/download-artifact-s3@1da556a7aa0a088e3153970611f6c432d58e80e6 # v4.2.0
+        with:
+          name: ${{ inputs.build-environment }}
+          path: C:\${{ github.run_id }}\${{ inputs.build-environment }}\build-results
+
+      - name: Download PyTorch Build Artifacts
+        shell: bash
+        run: |
+          build_artifacts="${{ github.run_id }}__${{ inputs.build-environment }}.zip"
+          curl -O "http://10.104.227.223/download/$build_artifacts"
+          unzip "$build_artifacts" -d /c/
+
+          curl -O "http://10.104.227.223/download/test-times.zip"
+          unzip test-times.zip -d /c/
+
+          buildPath="/c/${{ github.run_id }}/${{ inputs.build-environment }}/build-results"
+          echo "Checking build path: $buildPath"
+          if [ -d "$buildPath" ]; then
+            echo "Build path found, listing contents:"
+            ls -laR "$buildPath"
+            mkdir -p $buildPath/.additional_ci_files
+            mv /c/times/* $buildPath/.additional_ci_files/
+          else
+            echo "Build path not found: $buildPath"
+          fi
+
+      - name: Validate Build Artifacts Integrity
+        env:
+          # Pull the trusted hash from GitHub context
+          FILENAME: ${{ inputs.build-artifact-name }}
+          PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/${{ inputs.build-environment }}/build-results/
+        shell: bash
+        run: |
+          cd "$PYTORCH_FINAL_PACKAGE_DIR"
+          # 1. Calculate hash of downloaded file
+          TRUSTED_HASH=${{ inputs.build-secure-hash }}
+          DOWNLOADED_HASH=$(sha256sum "$FILENAME" | awk '{print $1}')
+          echo "Downloaded: $DOWNLOADED_HASH" | cat -v
+          echo "Trusted: $TRUSTED_HASH" | cat -v
+
+          # 2. Compare safely (No printing to logs)
+          if [ "$DOWNLOADED_HASH" == "$TRUSTED_HASH" ]; then
+            echo "SECURITY CHECK PASSED: Artifact integrity verified."
+          else
+            echo "SECURITY ALERT: Hash Mismatch!"
+            echo "The file downloaded from S3 does not match the build."
+            exit 1
+          fi
+
+      - name: Scan the Build Artifact
+        env:
+          # Pull the trusted hash from GitHub context
+          FILENAME: ${{ inputs.build-artifact-name }}
+          PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/${{ inputs.build-environment }}/build-results/
+        shell: bash
+        run: |
+           /c/scan-file.sh $PYTORCH_FINAL_PACKAGE_DIR/$FILENAME
+
+      - name: Check build-results folder
+        shell: powershell
+        run: |
+          tree /F C:\$Env:GITHUB_RUN_ID\build-results
+
+      - name: Download TD artifacts
+        continue-on-error: true
+        uses: ./.github/actions/download-td-artifacts
+
+      - name: Check for keep-going label and re-enabled test issues
+        # This uses the filter-test-configs action because it conveniently
+        # checks for labels and re-enabled test issues.  It does not actually do
+        # any filtering.  All filtering is done in the build step.
+        id: keep-going
+        uses: ./.github/actions/filter-test-configs
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-matrix: ${{ inputs.test-matrix }}
+          job-name: ${{ steps.get-job-id.outputs.job-name }}
+
+      - name: Set Test step time
+        id: test-timeout
+        shell: bash
+        env:
+          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+        run: |
+          echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
+
+      - name: Test
+        id: test
+        shell: bash
+        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
+        env:
+          USE_CUDA: ${{ inputs.cuda-version != 'cpu' && '1' || '0' }}
+          INSTALL_WINDOWS_SDK: 1
+          PYTHON_VERSION: 3.12
+          CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
+          VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
+          TEST_SHOWLOCALS: ${{ steps.keep-going.outputs.ci-test-showlocals }}
+          NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
+          VC_PRODUCT: "BuildTools"
+          VC_VERSION: ""
+          VS_VERSION: "16.8.6"
+          VC_YEAR: "2022"
+          AWS_DEFAULT_REGION: us-east-1
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
+          JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
+          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CUDA_VERSION: ${{ inputs.cuda-version }}
+          PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/${{ inputs.build-environment }}/build-results/
+          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+          ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+          SHARD_NUMBER: ${{ matrix.shard }}
+          NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+          TEST_CONFIG: ${{ matrix.config }}
+          REENABLED_ISSUES: ${{ github.event.pull_request.reenabled-issues }}
+          TORCH_CUDA_ARCH_LIST: "8.6"
+          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
+          PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
+        run: |
+          pushd "${PYTORCH_FINAL_PACKAGE_DIR}"
+          # shellcheck disable=SC2046,SC2102
+          python3 -m pip install $(echo *.whl)[opt-einsum,optree] optree==0.13.0
+          popd
+
+          .ci/pytorch/win-test.sh
+
+      - name: Upload pytest cache if tests failed
+        uses: ./.github/actions/pytest-cache-upload
+        continue-on-error: true
+        if: failure() && steps.test.conclusion && steps.test.conclusion == 'failure'
+        with:
+          cache_dir: .pytest_cache
+          shard: ${{ matrix.shard }}
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          test_config: ${{ matrix.config }}
+          job_identifier: ${{ github.workflow }}_${{ inputs.build-environment }}
+
+      - name: Print remaining test logs
+        shell: bash
+        if: always() && steps.test.conclusion
+        run: |
+          cat test/**/*_toprint.log || true
+
+      - name: Stop monitoring script
+        if: ${{ always() && steps.monitor-script.outputs.monitor-script-pid }}
+        shell: bash
+        continue-on-error: true
+        env:
+          MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        run: |
+          kill "$MONITOR_SCRIPT_PID"
+
+      - name: Upload test artifacts
+        uses: ./.github/actions/upload-test-artifacts
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
+        with:
+          file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
+
+      - name: Upload utilization stats
+        if: ${{ always() && steps.test.conclusion && steps.test.conclusion != 'skipped' && !inputs.disable-monitor }}
+        continue-on-error: true
+        uses: ./.github/actions/upload-utilization-stats
+        with:
+          job_id: ${{ steps.get-job-id.outputs.job-id }}
+          job_name: ${{ steps.get-job-id.outputs.job-name }}
+          workflow_name: ${{ github.workflow }}
+          workflow_run_id: ${{github.run_id}}
+          workflow_attempt: ${{github.run_attempt}}
+
+      - name: Parse ref
+        id: parse-ref
+        shell: bash
+        run: python3 .github/scripts/parse_ref.py
+
+      - name: Teardown Windows
+        uses: ./.github/actions/teardown-win
+        if: always()
+        timeout-minutes: 120

--- a/.github/workflows/_win-rtx-test.yml
+++ b/.github/workflows/_win-rtx-test.yml
@@ -1,4 +1,4 @@
-name: win-test
+name: windows-rtx-test
 
 on:
   workflow_call:

--- a/.github/workflows/win-rtx.yml
+++ b/.github/workflows/win-rtx.yml
@@ -2,7 +2,7 @@ name: Windows RTX Nightly
 
 on:
   schedule:
-    # Run every day at 1:15 AM UTC
+    # Run every day at 00:30 AM UTC
     - cron: '30 0 * * *'
 
 concurrency:

--- a/.github/workflows/win-rtx.yml
+++ b/.github/workflows/win-rtx.yml
@@ -1,0 +1,106 @@
+name: Windows RTX Nightly
+
+on:
+  schedule:
+    # Run every day at 1:15 AM UTC
+    - cron: '30 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+
+  llm-td:
+    if: github.repository_owner == 'pytorch'
+    name: before-test
+    uses: ./.github/workflows/llm_td_retrieval.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  target-determination:
+    name: before-test
+    uses: ./.github/workflows/target_determination.yml
+    needs: llm-td
+    permissions:
+      id-token: write
+      contents: read
+
+  # Windows CUDA Build & Test - sm_89 (RTX 40xx)
+  win_vs2022_cuda12_8_py3_build_sm89:
+    name: win-vs2022-cuda12.8-py3-sm89
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2022-cuda12.8-py3-sm89
+      cuda-version: "12.8"
+      runner: "rtx-40x0-build"
+      cuda-arch-list: "8.9"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "rtx-40x0-test" },
+        ]}
+    secrets: inherit
+
+  win_vs2022_cuda12_8_py3_test_sm89:
+    name: win-vs2022-cuda12.8-py3-sm89
+    needs:
+      - win_vs2022_cuda12_8_py3_build_sm89
+    uses: ./.github/workflows/_win-test.yml
+    with:
+      build-environment: win-vs2022-cuda12.8-py3-sm89
+      build-secure-hash: ${{ needs.win_vs2022_cuda12_8_py3_build_sm89.outputs.build-secure-hash }}
+      build-artifact-name: ${{ needs.win_vs2022_cuda12_8_py3_build_sm89.outputs.build-artifact-name }}
+      cuda-version: 12.8
+      test-matrix: |
+        { include: [
+          { config: "default",          shard: 1, num_shards: 5, runner: "rtx-40x0-test" },
+          { config: "default",          shard: 2, num_shards: 5, runner: "rtx-40x0-test" },
+          { config: "default",          shard: 3, num_shards: 5, runner: "rtx-40x0-test" },
+          { config: "default",          shard: 4, num_shards: 5, runner: "rtx-40x0-test" },
+          { config: "default",          shard: 5, num_shards: 5, runner: "rtx-40x0-test" }
+        ]}
+      disable-monitor: true
+      timeout-minutes: 360
+    secrets: inherit
+
+  # Windows CUDA Build & Test - sm_120 (Blackwell - RTX 5070)
+  win_vs2022_cuda12_8_py3_build_sm120:
+    name: win-vs2022-cuda12.8-py3-sm120
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2022-cuda12.8-py3-sm120
+      cuda-version: "12.8"
+      runner: "rtx-50x0-build"
+      cuda-arch-list: "12.0"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "rtx-50x0-test" },
+        ]}
+    secrets: inherit
+
+  win_vs2022_cuda12_8_py3_test_sm120:
+    name: win-vs2022-cuda12.8-py3-sm120
+    needs:
+      - win_vs2022_cuda12_8_py3_build_sm120
+    uses: ./.github/workflows/_win-test.yml
+    with:
+      build-environment: win-vs2022-cuda12.8-py3-sm120
+      build-secure-hash: ${{ needs.win_vs2022_cuda12_8_py3_build_sm120.outputs.build-secure-hash }}
+      build-artifact-name : ${{ needs.win_vs2022_cuda12_8_py3_build_sm120.outputs.build-artifact-name }}
+      cuda-version: 12.8
+      test-matrix: |
+        { include: [
+          { config: "default",          shard: 1, num_shards: 5, runner: "rtx-50x0-test" },
+          { config: "default",          shard: 2, num_shards: 5, runner: "rtx-50x0-test" },
+          { config: "default",          shard: 3, num_shards: 5, runner: "rtx-50x0-test" },
+          { config: "default",          shard: 4, num_shards: 5, runner: "rtx-50x0-test" },
+          { config: "default",          shard: 5, num_shards: 5, runner: "rtx-50x0-test" },
+        ]}
+      disable-monitor: true
+      timeout-minutes: 360
+    secrets: inherit


### PR DESCRIPTION
Summary: 
This PR adds a new experimental GitHub Actions workflow (.github/workflows/win-rtx.yml) to enable CI testing on Windows NVIDIA RTX GPUs. This workflow targets self-hosted runners to validate PyTorch functionality on consumer-grade RTX hardware.

Motivation: To improve test coverage for Windows users running PyTorch on RTX series cards. Currently, specific RTX related regressions can be missed because upstream CI validates primarily on Data Center GPUs.

Implementation Details

    Trigger: Set to Nightly only. This ensures it does not run automatically on every PR and consumes zero upstream CI resources/capacity.

    Runners: configured to target self-hosted Windows runners provided by Nvidia with RTX GPUs.

    Scope: This is purely an infrastructure addition; no core PyTorch source code is modified.


Issue Reference: https://github.com/pytorch/pytorch/issues/170753

Release Notes: This is a CI infrastructure change and not user-facing.