### PR TITLE
expose triton_meta to TritonTemplate user-facing maybe_append_choice API

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1878,7 +1878,7 @@ class TestMaxAutotune(TestCase):
         # Make sure all args of generate_and_load_args are passed to make_key_args (Except generate_with_caching)
         # update this function each time new arg added to generate_and_load and make sure arg is added to make_key
         self.assertEqual(generate_and_load_args - 1, make_key_args)
-        self.assertEqual(generate_and_load_args, 19)
+        self.assertEqual(generate_and_load_args, 20)
 
     @fresh_cache()
     @config.patch(
@@ -1969,7 +1969,8 @@ class TestMaxAutotune(TestCase):
                         'num_consumer_groups':0,'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
                         'transpose_discontiguous_tensor_descriptors_override':None,
                         'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32',
-                        'BLOCK_M':16,'BLOCK_N':32,'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},'hint_override':None}"""
+                        'BLOCK_M':16,'BLOCK_N':32,'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},
+                        'hint_override':None,'triton_meta':None}"""
 
                 expected = expected.replace("cuda", GPU_TYPE)
                 self.assertExpectedInline(
@@ -2010,7 +2011,7 @@ class TestMaxAutotune(TestCase):
                     'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
                     'transpose_discontiguous_tensor_descriptors_override':None,
                     'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32','BLOCK_M':16,'BLOCK_N':32,
-                    'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},'hint_override':None}"""
+                    'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},'hint_override':None,'triton_meta':None}"""
                 expected = expected.replace("cuda", GPU_TYPE)
                 self.assertExpectedInline(
                     remove_white_space(cache_key),

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -416,6 +416,7 @@ class TritonTemplateKernel(TritonKernel):
         workspace_arg: Optional[WorkspaceArg] = None,
         prologue_loads_all_inputs=False,
         hint_override: Optional[int] = None,
+        triton_meta: Optional[dict[str, object]] = None,
     ) -> None:
         if tma_store:
             pass
@@ -485,7 +486,7 @@ class TritonTemplateKernel(TritonKernel):
         # pyrefly: ignore [invalid-type-var]
         self.epilogue_fn = epilogue_fn
         self.render_hooks = {}  # type: ignore[var-annotated]
-        self.triton_meta: Optional[dict[str, object]] = None
+        self.triton_meta: Optional[dict[str, object]] = triton_meta
         # For Templated Attention this can be a list of ir.Subgraph
         self.subgraphs: Optional[list[ir.ComputedBuffer]] = subgraphs
 
@@ -683,7 +684,10 @@ class TritonTemplateKernel(TritonKernel):
             if v := self.meta.get(k, None):
                 triton_meta[k] = v
 
-        self.triton_meta = triton_meta
+        if self.triton_meta is None:
+            self.triton_meta = triton_meta
+        else:
+            self.triton_meta.update(triton_meta)
 
         inductor_meta = {
             "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
@@ -702,7 +706,7 @@ class TritonTemplateKernel(TritonKernel):
         template_args = f"""
             num_stages={self.num_stages},
             num_warps={self.num_warps},
-            triton_meta={triton_meta!r},
+            triton_meta={self.triton_meta!r},
             inductor_meta={inductor_meta!r},
         """
 
@@ -1623,6 +1627,7 @@ class GeneratedCodeCache:
         num_buffers_warp_spec: int,
         kwargs: dict[str, Any],
         hint_override: Optional[int] = None,
+        triton_meta: Optional[dict[str, Any]] = None,
     ) -> Optional[str]:
         def layout_key(layout: ir.Layout) -> str:
             assert not isinstance(layout, ir.FlexibleLayout)
@@ -1676,6 +1681,7 @@ class GeneratedCodeCache:
                 "transpose_discontiguous_tensor_descriptors_override": transpose_discontiguous_tensor_descriptors_override,
                 "kwargs": kwargs,
                 "hint_override": hint_override,
+                "triton_meta": triton_meta,
             }
         )
 
@@ -1790,6 +1796,7 @@ class TritonTemplate(KernelTemplate):
         hint_override: Optional[int] = None,
         tma_store: bool = False,
         transpose_discontiguous_tensor_descriptors_override: Optional[bool] = None,
+        triton_meta: Optional[dict[str, Any]] = None,
     ) -> Optional[GenerateAndLoadResult]:
         """Generate the python code and load it into the current process"""
         caching_enabled = (
@@ -1816,6 +1823,8 @@ class TritonTemplate(KernelTemplate):
                 num_consumer_groups,
                 num_buffers_warp_spec,
                 kwargs,
+                hint_override,
+                triton_meta,
             )
 
         assert self.template, "requires jinja2"
@@ -1871,6 +1880,7 @@ class TritonTemplate(KernelTemplate):
                 hint_override=hint_override,
                 tma_store=tma_store,
                 transpose_discontiguous_tensor_descriptors_override=transpose_discontiguous_tensor_descriptors_override,
+                triton_meta=triton_meta,
                 **kernel_options,
             )
 
@@ -1992,6 +2002,7 @@ class TritonTemplate(KernelTemplate):
         hint_override: Optional[int] = None,
         tma_store: bool = False,
         transpose_discontiguous_tensor_descriptors_override: Optional[bool] = None,
+        triton_meta: Optional[dict[str, Any]] = None,
         **kwargs,
     ):
         """This function generates a TritonTemplateCaller
@@ -2039,6 +2050,7 @@ class TritonTemplate(KernelTemplate):
             hint_override=hint_override,
             tma_store=tma_store,
             transpose_discontiguous_tensor_descriptors_override=transpose_discontiguous_tensor_descriptors_override,
+            triton_meta=triton_meta,
         )
 
         # May happen as result of dev by 0.
@@ -2114,6 +2126,7 @@ class TritonTemplate(KernelTemplate):
                 hint_override=hint_override,
                 tma_store=tma_store,
                 transpose_discontiguous_tensor_descriptors_override=transpose_discontiguous_tensor_descriptors_override,
+                triton_meta=triton_meta,
                 **options,
             )
             render = functools.partial(


### PR DESCRIPTION
Summary:
Use case: Third party backends would like to set `triton_meta` for lowering via TritonTemplate. If there are Triton-related configurations in triton_meta that are associated with the TritonTemplate, it can be propagated to the codegen and accessed down the line. Eg. Triton compiler optimization flags associated with using a TritonTemplate generated kernel.

Implementation: `TritonTemplateKernel` class has an attribute `self.triton_meta` used in codegen in `jit_lines` function, we **expose `triton_meta` all the way to user-facing `TritonTemplate.generate` API** so user can perform 
```
my_template.maybe_append_choice(..., triton_meta=custom_dictionary)
```

Notable changes include:

- In `TritonTemplateKernel.__init__`, expose `triton_meta` to function signature and set `self.triton_meta = triton_meta`.
- in `TritonTemplateKernel.jit_lines`, update `self.triton_meta` if it's not None 
- update `GeneratedCodeCache.make_key` to take in `triton_meta` as well -- different `triton_meta` here can affect generated triton kernel.

Test Plan: test_select_algorithms

Differential Revision: D92236086




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos