### PR TITLE
Fix GIL deadlock in PyTorch context recorder

### DIFF
--- a/torch/csrc/profiler/combined_traceback.cpp
+++ b/torch/csrc/profiler/combined_traceback.cpp
@@ -13,8 +13,11 @@ std::shared_ptr<CapturedTraceback> CapturedTraceback::gather(
   if (python) {
     auto p = python_support_.load();
     while (p && r->frames_.empty()) {
-      r->frames_ = p->gather();
-      r->python_ = p;
+      // Check if it's safe to gather Python frames from current thread
+      if (p->canGather()) {
+        r->frames_ = p->gather();
+        r->python_ = p;
+      }
       p = p->next_;
     }
   }

--- a/torch/csrc/profiler/combined_traceback.h
+++ b/torch/csrc/profiler/combined_traceback.h
@@ -36,6 +36,9 @@ struct TORCH_API CapturedTraceback : public c10::GatheredContext {
   using visitproc = int (*)(void* self, void* arg);
 
   struct Python {
+    // Check if it's safe to gather Python frames from the current thread.
+    // Returns false for pure C++ threads that cannot acquire the GIL.
+    virtual bool canGather() = 0;
     virtual std::vector<PyFrame> gather() = 0;
     virtual void release(std::vector<PyFrame>& frames) = 0;
     virtual void appendSymbolized(


### PR DESCRIPTION
Summary:
Fix Python frame collection deadlock in MTIA memory tracer by adding smart GIL detection in gather_with_cpp().                                                                  
                                                                                                                                                                                  
The memory tracer callback was previously using gather_without_py which skipped Python frames entirely. Switching to gather_with_cpp enables Python frame collection by         

How we handle the GIL now:                                                                                                                                   
1. Already holding GIL → Use it directly (no re-acquire, no deadlock)                                                                                                           
2. Pure C++ callback thread (no Python state) → Skip Python frames safely                                                                                                       
3. Registered Python thread without GIL → Acquire, gather, release

Test Plan:
# GenAI Inference Test
```
./vllm/fb/scripts/mtia/run_mtia_multihost.sh   --bsr   --model /data/model_ckpts/DeepSeek-R1-0528-shrunk-1dense-1moe-256experts   --dp-size 2   --enable-ep   --hosts 92,94   --print-tokens   --max-model-len 1024   --moe mtia_v3   --enable-oom-catcher
```
Snapshot: https://mtia-insight-visualizer.edge.x2p.facebook.net/?tool=memento&manifold_bucket=mtia_traces&manifold_path=tree%2Fgpu_snapshot%2Fdevgpu094.dkl6.facebook.com%2Fvllm_mtia_worker%3A%201.Feb_03_10_16_23.629736.snapshot.pickle

{F1985169480} 

P2164705644


# MAI Test

https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-mai_mtia_4T_200_1024_null_hive_shampoo_graph_v3-551f5164bd

Snapshot: https://mtia-insight-visualizer.edge.x2p.facebook.net/?tool=memento&manifold_bucket=aps_traces&manifold_path=tree%2Fgpu_snapshot%2Faps-mai_mtia_4T_200_1024_null_hive_shampoo_graph_v3-551f5164bd%2F0%2Frank-0.Feb_04_07_25_53.4509.snapshot.pickle

 {F1985207437}

Differential Revision: D92111206


