### PR TITLE
fix([DTensor]): honor single-dim RuntimeSchemaInfo in C++/Python dispatch 

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -820,6 +820,8 @@ class DistTensorOpsTest(DTensorTestBase):
         the C++ dispatch path should include dtype in the cache key. This ensures
         calls with different dtypes don't return the same cached result.
         """
+        from unittest.mock import patch
+
         from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
         from torch.distributed.tensor._ops.single_dim_strategy import (
             _ShardingPlaceholder,
@@ -829,10 +831,6 @@ class DistTensorOpsTest(DTensorTestBase):
 
         call_count = [0]
 
-        @register_single_dim_strategy(
-            torch.ops.aten._to_copy.default,
-            schema_info=RuntimeSchemaInfo(static_kwargkey=["dtype"]),
-        )
         def to_copy_single_dim_strategy(op, args_schema, kwargs_schema):
             call_count[0] += 1
             self_meta = args_schema[0]
@@ -850,20 +848,27 @@ class DistTensorOpsTest(DTensorTestBase):
         local_tensor = torch.randn(2, 8, dtype=torch.float32)
         sharded_dtensor = DTensor.from_local(local_tensor, mesh, shard_spec)
 
-        strategy_cache = DTensor._op_dispatcher.sharding_propagator
-        strategy_cache.op_strategy_funcs.pop(torch.ops.aten._to_copy.default, None)
-        strategy_cache.op_to_schema_info.pop(torch.ops.aten._to_copy.default, None)
-        strategy_cache.op_to_schema_info_for_single_dim_strategy.pop(
-            torch.ops.aten._to_copy.default,
-            None,
-        )
+        propagator = DTensor._op_dispatcher.sharding_propagator
+        op = torch.ops.aten._to_copy.default
+        schema_info = RuntimeSchemaInfo(static_kwargkey=["dtype"])
 
-        call_count[0] = 0
-        sharded_dtensor.to(torch.int32)
-        sharded_dtensor.to(torch.float64)
+        with (
+            patch.dict(
+                propagator.op_single_dim_strategy_funcs,
+                {op: to_copy_single_dim_strategy},
+            ),
+            patch.dict(
+                propagator.op_to_schema_info_for_single_dim_strategy, {op: schema_info}
+            ),
+            patch.dict(propagator.op_strategy_funcs, clear=True),
+            patch.dict(propagator.op_to_schema_info, clear=True),
+        ):
+            call_count[0] = 0
+            sharded_dtensor.to(torch.int32)
+            sharded_dtensor.to(torch.float64)
 
-        # With dtype in cache key, strategy should be called twice (different dtypes)
-        self.assertEqual(call_count[0], 2)
+            # With dtype in cache key, strategy should be called twice (different dtypes)
+            self.assertEqual(call_count[0], 2)
 
     @with_comms
     def test_slice(self):

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -825,7 +825,6 @@ class DistTensorOpsTest(DTensorTestBase):
         from torch.distributed.tensor._op_schema import RuntimeSchemaInfo
         from torch.distributed.tensor._ops.single_dim_strategy import (
             _ShardingPlaceholder,
-            register_single_dim_strategy,
         )
         from torch.distributed.tensor.debug import _clear_sharding_prop_cache
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1918,9 +1918,9 @@ static PyObject* DTensor_compute_global_tensor_info_impl(
       const auto placement_type_name =
           py::str(py::handle(PyType_GetName(Py_TYPE(placement.ptr()))));
 #else
-      const auto placement_type_name = py::str(
-          py::handle((PyObject*)Py_TYPE(placement.ptr()))
-              .attr(dtensor_interned_strings.__name__));
+      const auto placement_type_name =
+          py::str(py::handle((PyObject*)Py_TYPE(placement.ptr()))
+                      .attr(dtensor_interned_strings.__name__));
 #endif
       return PyErr_Format(
           PyExc_RuntimeError,

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -536,6 +536,12 @@ class OpDispatcher:
         runtime_schema_info = self.sharding_propagator.op_to_schema_info.get(
             op_call, None
         )
+        if runtime_schema_info is None:
+            runtime_schema_info = (
+                self.sharding_propagator.op_to_schema_info_for_single_dim_strategy.get(
+                    op_call, None
+                )
+            )
 
         # Auto-detect needs_pytree if any arg is a list/tuple containing tensors
         def _contains_tensor(arg: object) -> bool:


### PR DESCRIPTION
### Summary
- Add a fallback so runtime schema info lookup checks single‑dim strategy metadata when standard schema info is missing, keeping DTensor dispatch consistent between C++ and Python paths.
- Update Python dispatch to mirror the C++ fallback behavior.
- Add a regression test that ensures dtype is part of the cache key for single‑dim strategies (_to_copy).

### Related issue:
Closes #174301 