### PR TITLE
test: removes remaining torch.set_default_device(cuda)

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4114,7 +4114,6 @@ class TestAutograd(TestCase):
         def fn(x):
             return x.sin().cos()
 
-        torch.set_default_device("cuda")
         a = torch.tensor(1.0, requires_grad=True)
         out = torch.utils.checkpoint.checkpoint(
             fn, a, context_fn=context_fn, use_reentrant=False


### PR DESCRIPTION
This causes later tests, such as `test_numpy_requires_grad`, to default to creating CUDA tensors when they expect CPU tensors, leading to unexpected behavior and test failures.