### PR TITLE
[CUDA] Fix cuBLAS/cuBLASLt library version mismatch

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -330,7 +330,7 @@ def _preload_cuda_deps(err: OSError | None = None) -> None:
         # libcublas from loading a mismatched system-wide libcublasLt via its RUNPATH.
         # Without this, if a different CUDA Toolkit version exists in the system PATH,
         # libcublas may load the wrong libcublasLt, causing symbol errors or runtime failures.
-        ("cublas" "libcublasLt.so.*[0-9]"),
+        ("cublas", "libcublasLt.so.*[0-9]"),
         ("cublas", "libcublas.so.*[0-9]"),
         ("cudnn", "libcudnn.so.*[0-9]"),
         ("cuda_nvrtc", "libnvrtc.so.*[0-9]"),

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -326,6 +326,7 @@ def _preload_cuda_lib(lib_folder: str, lib_name: str, required: bool = True) -> 
 
 def _preload_cuda_deps(err: OSError | None = None) -> None:
     cuda_libs: list[tuple[str, str]] = [
+        ("cublaslt", "libcublasLt.so.*[0-9]"),
         ("cublas", "libcublas.so.*[0-9]"),
         ("cudnn", "libcudnn.so.*[0-9]"),
         ("cuda_nvrtc", "libnvrtc.so.*[0-9]"),

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -326,6 +326,8 @@ def _preload_cuda_lib(lib_folder: str, lib_name: str, required: bool = True) -> 
 
 def _preload_cuda_deps(err: OSError | None = None) -> None:
     cuda_libs: list[tuple[str, str]] = [
+        # NOTE: Order matters! Libraries must be loaded before their dependents.
+        # libcublasLt must be loaded before libcublas (cublas depends on cublasLt)
         ("cublaslt", "libcublasLt.so.*[0-9]"),
         ("cublas", "libcublas.so.*[0-9]"),
         ("cudnn", "libcudnn.so.*[0-9]"),

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -326,9 +326,11 @@ def _preload_cuda_lib(lib_folder: str, lib_name: str, required: bool = True) -> 
 
 def _preload_cuda_deps(err: OSError | None = None) -> None:
     cuda_libs: list[tuple[str, str]] = [
-        # NOTE: Order matters! Libraries must be loaded before their dependents.
-        # libcublasLt must be loaded before libcublas (cublas depends on cublasLt)
-        ("cublaslt", "libcublasLt.so.*[0-9]"),
+        # NOTE: Order matters! We must preload libcublasLt BEFORE libcublas to prevent
+        # libcublas from loading a mismatched system-wide libcublasLt via its RUNPATH.
+        # Without this, if a different CUDA Toolkit version exists in the system PATH,
+        # libcublas may load the wrong libcublasLt, causing symbol errors or runtime failures.
+        ("cublas" "libcublasLt.so.*[0-9]"),
         ("cublas", "libcublas.so.*[0-9]"),
         ("cudnn", "libcudnn.so.*[0-9]"),
         ("cuda_nvrtc", "libnvrtc.so.*[0-9]"),


### PR DESCRIPTION
We recently discovered an issue in cublas where libcublas.so uses its RUNPATH pointing to [$ORIGIN] to link against libcublasLt.so. This would cause the system libcublasLt.so to be used as a dependency for the pip-installed libcublas.so. If the system installed lib version mismatches, we would see this issue: https://github.com/pytorch/pytorch/issues/91067
```
OSError: /home/ubuntu/.local/lib/python3.8/site-packages/torch/lib/../../nvidia/cublas/lib/libcublas.so.11: undefined symbol: cublasLtHSHMatmulAlgoInit, version libcublasLt.so.11
```
or 
```
RuntimeError: CUDA error: CUBLAS_STATUS_INVALID_VALUE when calling `cublasSgemm( handle, opa, opb, m, n, k, &alpha, a, lda, b, ldb, &beta, c, ldc)`
```

Solution is explicitly preload libcublasLt.so before it load libcublas.so, so that the pip-installed libcublasLt.so is used instead of the system lib. Adding the fix here suggested by @ptrblck in https://github.com/pytorch/pytorch/issues/170676#issuecomment-3807779114

cc @ptrblck @eqy 

