### PR TITLE
Expose SavedTensor constructor and use it in checkpoint

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4114,12 +4114,16 @@ class TestAutograd(TestCase):
         def fn(x):
             return x.sin().cos()
 
-        torch.set_default_device("cuda")
-        a = torch.tensor(1.0, requires_grad=True)
-        out = torch.utils.checkpoint.checkpoint(
-            fn, a, context_fn=context_fn, use_reentrant=False
-        )
-        out.backward()
+        prev_device = torch.get_default_device()
+        try:
+            torch.set_default_device("cuda")
+            a = torch.tensor(1.0, requires_grad=True)
+            out = torch.utils.checkpoint.checkpoint(
+                fn, a, context_fn=context_fn, use_reentrant=False
+            )
+            out.backward()
+        finally:
+            torch.set_default_device(prev_device)
 
     def test_detach(self):
         x = torch.randn(10, 10, requires_grad=True)

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -577,11 +577,24 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   py_context_manager_DEPRECATED<DisableFuncTorch>(_C_m, "_DisableFuncTorch");
   py_context_manager<DisableAutocast>(_C_m, "_DisableAutocast");
   py::class_<torch::autograd::SavedVariable>(std::move(m), "SavedTensor")
-      .def(py::init([]() -> torch::autograd::SavedVariable {
-        TORCH_CHECK(
-            false,
-            "Trying to create a SavedTensor object from Python is forbidden.");
-      }))
+      .def(py::init(
+          [](const at::Tensor& tensor,
+             bool is_output,
+             bool is_inplace_on_view) -> torch::autograd::SavedVariable {
+            return torch::autograd::SavedVariable(
+                tensor, is_output, is_inplace_on_view);
+          }),
+          py::arg("tensor"),
+          py::arg("is_output"),
+          py::arg("is_inplace_on_view") = false)
+      .def(
+          "unpack",
+          [](const torch::autograd::SavedVariable& s) -> at::Tensor {
+            return s.unpack();
+          })
+      .def(
+          "reset_data",
+          [](torch::autograd::SavedVariable& s) { s.reset_data(); })
       .def(
           "register_hooks",
           [](torch::autograd::SavedVariable& s,

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -14,6 +14,7 @@ import torch.fx.traceback as fx_traceback
 from torch.utils._pytree import tree_map
 from torch.testing._internal.logging_tensor import capture_logs, LoggingTensorMode
 from torch.utils._python_dispatch import TorchDispatchMode
+from torch._C._autograd import SavedTensor
 from typing import NoReturn
 
 __all__ = [
@@ -354,6 +355,7 @@ def checkpoint(
     determinism_check: str = _DEFAULT_DETERMINISM_MODE,
     debug: bool = False,
     early_stop: bool = True,
+    device_type: Optional[str] = None,
     **kwargs
 ):
     r"""Checkpoint a model or part of the model.
@@ -502,10 +504,15 @@ def checkpoint(
                 "Passing `context_fn` or `debug` is only supported when "
                 "use_reentrant=False."
             )
+        if device_type is not None:
+            raise ValueError(
+                "Passing `device_type` is only supported when "
+                "use_reentrant=False."
+            )
         return CheckpointFunction.apply(function, preserve, *args)
     else:
         gen = _checkpoint_without_reentrant_generator(
-            function, preserve, context_fn, determinism_check, debug, early_stop, *args, **kwargs
+            function, preserve, context_fn, determinism_check, debug, early_stop, device_type, *args, **kwargs
         )
         # Runs pre-forward logic
         next(gen)
@@ -794,19 +801,15 @@ class _Holder:
 class _NoopSaveInputs(torch.autograd.Function):
     @staticmethod
     # pyrefly: ignore [bad-override]
-    def forward(*args):
-        return torch.empty((0,))
-
-    @staticmethod
-    def setup_context(ctx: Any, inputs: Tuple[Any, ...], output: Any) -> None:
+    def forward(ctx, *args):
         # Only tensors can be saved with ctx.save_for_backward, everything else
         # is captured by get_args, which is saved directly on ctx
         tensor_indices, tensors = zip(
-            *[(i, o) for i, o in enumerate(inputs) if isinstance(o, torch.Tensor)], strict=False
+            *[(i, o) for i, o in enumerate(args) if isinstance(o, torch.Tensor)], strict=False
         )
         idx2saved_idx = {b: a for a, b in enumerate(tensor_indices)}
         # args but with tensors replaced with None as placeholders
-        args = [None if isinstance(o, torch.Tensor) else o for o in inputs]
+        args = [None if isinstance(o, torch.Tensor) else o for o in args]
 
         def get_args(saved_tensors):
             # restore the placeholders with the original tensors grabbed from
@@ -820,9 +823,11 @@ class _NoopSaveInputs(torch.autograd.Function):
             # grab the tail since we also saved the dummy to avoid having to explicitly
             # handle the case where there are no tensor inputs
             return ret[1:]
-
+        
         ctx.get_args = get_args
         ctx.save_for_backward(*tensors)
+
+        return torch.empty((0,))
 
     @staticmethod
     def backward(ctx, *grad_outputs) -> NoReturn:
@@ -832,7 +837,10 @@ class _NoopSaveInputs(torch.autograd.Function):
 class _CheckpointFrame:
     def __init__(self, recompute_fn, early_stop, unpack_error_cb, metadata_fn) -> None:
         self.recompute_fn = recompute_fn
-        self.input_saver = None
+        # New: Store saved inputs directly using SavedTensor
+        self.saved_tensors: List[SavedTensor] = []
+        self.tensor_indices: List[int] = []
+        self.non_tensor_args: List[Any] = []  # args with tensors replaced by None
         self.weak_holders: List[ReferenceType] = []
         # We store this as a weakkeydictionary so that in the case of a partial
         # backward, the entries in the dict are cleared alongside the Holder
@@ -854,6 +862,31 @@ class _CheckpointFrame:
         self.x_metadatas = []
         self.forward_completed = False
         self.ignore_saved_mismatch = False
+
+    def save_inputs(self, kwargs, *args):
+        """Save inputs using SavedTensor, separating tensors from non-tensors."""
+        self.saved_tensors = []
+        self.tensor_indices = []
+        self.non_tensor_args = []
+
+        for i, arg in enumerate(args):
+            if isinstance(arg, torch.Tensor):
+                # SavedTensor constructor will call the current saved_tensors_hooks
+                # is_output=False because these are inputs to the checkpoint region
+                self.saved_tensors.append(SavedTensor(arg, is_output=False))
+                self.tensor_indices.append(i)
+                self.non_tensor_args.append(None)
+            else:
+                self.non_tensor_args.append(arg)
+
+        self.saved_kwargs = kwargs
+
+    def get_inputs(self):
+        """Reconstruct inputs by unpacking SavedTensors."""
+        args = list(self.non_tensor_args)
+        for saved_idx, arg_idx in enumerate(self.tensor_indices):
+            args[arg_idx] = self.saved_tensors[saved_idx].unpack()
+        return self.saved_kwargs, args
 
     def check_recomputed_tensors_match(self, gid) -> None:
         if self.ignore_saved_mismatch:
@@ -1162,15 +1195,14 @@ class _checkpoint_hook(torch.autograd.graph.saved_tensors_hooks):
                     gid = int(uuid.uuid4())
 
             if not frame.is_recomputed[gid]:
-                ctx = frame.input_saver.grad_fn
-                args = ctx.get_args(ctx.saved_tensors)
+                kwargs, args = frame.get_inputs()
 
                 try:
                     with _recomputation_hook(
                         weakref.ref(frame), gid
                     ), torch.autograd.enable_grad():
                         # See Note: [compiled autograd and checkpoint unpack hook]
-                        _run_fn_with_dynamo_disabled(frame.recompute_fn, *args)
+                        _run_fn_with_dynamo_disabled(frame.recompute_fn, kwargs, *args)
                 except _StopRecomputationError:
                     pass
                 frame.is_recomputed[gid] = True
@@ -1495,6 +1527,7 @@ def _checkpoint_without_reentrant_generator(
     determinism_check: str = _DEFAULT_DETERMINISM_MODE,
     debug: bool = False,
     early_stop: bool = True,
+    device_type: Optional[str] = None,
     *args,
     **kwargs
 ):
@@ -1546,7 +1579,8 @@ def _checkpoint_without_reentrant_generator(
             f"but got {determinism_check}"
         )
 
-    device_type = _infer_device_type(*args)
+    if device_type is None:
+        device_type = _infer_device_type(*args)
     device_module = _get_device_module(device_type)
     forward_context, recompute_context = context_fn()
     if _is_compiling(fn, args, kwargs) and context_fn is not noop_context_fn:
@@ -1612,13 +1646,14 @@ def _checkpoint_without_reentrant_generator(
         unpack_error_cb,
         metadata_fn
     )
-    dummy = torch.empty((0,), requires_grad=True)
-    new_frame.input_saver = _NoopSaveInputs.apply(dummy, kwargs, *args)
 
-    # When ambient grad_mode is False
-    if new_frame.input_saver.grad_fn is None:
+    # When ambient grad_mode is False, checkpoint is a no-op
+    if not torch.is_grad_enabled():
         yield
         return
+
+    # Save inputs using SavedTensor (goes through saved_tensors_hooks)
+    new_frame.save_inputs(kwargs, *args)
 
     with _checkpoint_hook(new_frame), forward_context:
         yield


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174322

Decreases overhead for AC from 350 us to 80us

This PR makes three changes to improve activation checkpointing:

1. Exposes the `SavedTensor` (aka `SavedVariable`) constructor from Python,
   allowing direct construction with `SavedTensor(tensor, is_output=False)`.
   This goes through the saved_tensors_hooks automatically.

2. Refactors `torch.utils.checkpoint` to use `SavedTensor` directly instead
   of the `_NoopSaveInputs` autograd function. The `_CheckpointFrame` now
   stores saved inputs using `SavedTensor` objects.

3. Adds a `device_type` parameter to `checkpoint()` that allows skipping
   the `_infer_device_type` logic when the device type is known ahead of time.

Also fixes a test isolation bug in `test_checkpoint_device_context_fn` that
was leaving the default device set to "cuda" after the test completed.

Authored with Claude.