### PR TITLE
[effectful ops] get tokens working with AC

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6819,15 +6819,6 @@ def forward(self, primals_1, tangents_1):
 
             force_save_effectful_ops(gm)
 
-            for node in effect_token_nodes:
-                is_output = any(u.op == "output" for u in node.users)
-                if not is_output:
-                    self.assertEqual(
-                        node.meta.get("recompute"),
-                        CheckpointPolicy.MUST_RECOMPUTE,
-                        f"Intermediate effect token {node.name} should be MUST_RECOMPUTE",
-                    )
-
             for node in tensor_result_nodes:
                 self.assertEqual(
                     node.meta.get("recompute"),

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -53,6 +53,7 @@ from torch._decomp import decomposition_table
 from torch._dynamo.testing import normalize_gm
 from torch._dynamo.utils import counters
 from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
+from torch._functorch._aot_autograd.utils import is_with_effects_token
 from torch._functorch.aot_autograd import (
     _aot_export_function,
     aot_export_joint_simple,
@@ -5776,6 +5777,33 @@ def forward(self, primals, tangents):
         )
 
 
+class GraphCaptureBackend:
+    """A backend that captures the graph before passing to inductor.
+
+    Usage:
+        capture = GraphCaptureBackend()
+
+        @torch.compile(backend=capture)
+        def fn(x):
+            return x * 2
+
+        fn(torch.randn(4, 4))
+        gm = capture.gm  # The captured graph module
+    """
+
+    def __init__(self):
+        self.gm = None
+
+    def __call__(self, graph_module, example_inputs):
+        from torch._inductor.compile_fx import compile_fx, compile_fx_inner
+
+        def log_and_compile(graph_module, example_inputs, **kwargs):
+            self.gm = graph_module
+            return compile_fx_inner(graph_module, example_inputs, **kwargs)
+
+        return compile_fx(graph_module, example_inputs, inner_compile=log_and_compile)
+
+
 class TestPartitioning(AOTTestCase):
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
     def test_recompute_partitioning(self):
@@ -6523,24 +6551,9 @@ def forward(self, primals_1, tangents_1):
         handle = _register_effectful_op(effectful_op, EffectType.ORDERED)
 
         try:
-            gm = None
+            capture = GraphCaptureBackend()
 
-            def graph_capture_backend(graph_module, example_inputs):
-                """Custom backend that captures the graph before passing to inductor."""
-                nonlocal gm
-
-                from torch._inductor.compile_fx import compile_fx, compile_fx_inner
-
-                def log_and_compile(graph_module, example_inputs, **kwargs):
-                    nonlocal gm
-                    gm = graph_module
-                    return compile_fx_inner(graph_module, example_inputs, **kwargs)
-
-                return compile_fx(
-                    graph_module, example_inputs, inner_compile=log_and_compile
-                )
-
-            @torch.compile(backend=graph_capture_backend)
+            @torch.compile(backend=capture)
             def fn(x, weight):
                 a = torch.ops.test.effectful_op(x)
                 return a.sum() * weight
@@ -6549,6 +6562,7 @@ def forward(self, primals_1, tangents_1):
             weight = torch.randn(4, 4)
             fn(x, weight)
 
+            gm = capture.gm
             force_save_effectful_ops(gm)
 
             with_effects_nodes = [
@@ -6565,7 +6579,7 @@ def forward(self, primals_1, tangents_1):
                 for n in gm.graph.nodes
                 if n.op == "call_function"
                 and n.target == operator.getitem
-                and n.args[0] == with_effects_nodes[0]
+                and not is_with_effects_token(n)
             ]
 
             def is_must_save(node):
@@ -6574,8 +6588,8 @@ def forward(self, primals_1, tangents_1):
             must_save_count = sum(1 for n in getitem_nodes if is_must_save(n))
             self.assertEqual(
                 must_save_count,
-                2,
-                f"2 items should be MUST_SAVE, got {must_save_count}",
+                1,
+                f"1 items should be MUST_SAVE, got {must_save_count}",
             )
             self.assertEqual(
                 len(getitem_nodes),
@@ -6609,24 +6623,9 @@ def forward(self, primals_1, tangents_1):
         handle = _register_effectful_op(effectful_tuple_op, EffectType.ORDERED)
 
         try:
-            gm = None
+            capture = GraphCaptureBackend()
 
-            def graph_capture_backend(graph_module, example_inputs):
-                """Custom backend that captures the graph before passing to inductor."""
-                nonlocal gm
-
-                from torch._inductor.compile_fx import compile_fx, compile_fx_inner
-
-                def log_and_compile(graph_module, example_inputs, **kwargs):
-                    nonlocal gm
-                    gm = graph_module
-                    return compile_fx_inner(graph_module, example_inputs, **kwargs)
-
-                return compile_fx(
-                    graph_module, example_inputs, inner_compile=log_and_compile
-                )
-
-            @torch.compile(backend=graph_capture_backend)
+            @torch.compile(backend=capture)
             def fn(x):
                 a, b = torch.ops.test.effectful_tuple_op(x)
                 return a.sum() + b.sum()
@@ -6634,6 +6633,7 @@ def forward(self, primals_1, tangents_1):
             x = torch.randn(4, 4)
             fn(x)
 
+            gm = capture.gm
             with_effects_node = None
             for node in gm.graph.nodes:
                 if node.op == "call_function" and node.target == with_effects:
@@ -6646,7 +6646,7 @@ def forward(self, primals_1, tangents_1):
                 for n in gm.graph.nodes
                 if n.op == "call_function"
                 and n.target == operator.getitem
-                and n.args[0] == with_effects_node
+                and not is_with_effects_token(n)
             ]
 
             force_save_effectful_ops(gm)
@@ -6665,14 +6665,175 @@ def forward(self, primals_1, tangents_1):
 
             self.assertEqual(
                 tensor_getitem_count,
-                3,
-                f"expected 3 getitems, got {tensor_getitem_count}",
+                2,
+                f"expected 2 getitems, got {tensor_getitem_count}",
             )
             self.assertEqual(
                 must_save_count,
                 tensor_getitem_count,
                 f"all {tensor_getitem_count} tensor getitems should be MUST_SAVE, got {must_save_count}",
             )
+        finally:
+            handle.destroy()
+
+    def test_effect_token_rewiring_in_backward(self):
+        """Test that forward with_effects can be recomputed in backward via effect token re-wiring.
+
+        When a forward with_effects is inside an activation checkpointed region (marked
+        PREFER_RECOMPUTE), the partitioner should be able to include it in the backward
+        graph by re-wiring its effect token input to use the backward token chain.
+        """
+        from torch._functorch._aot_autograd.utils import is_with_effects
+        from torch._functorch.partitioners import _extract_graph_with_inputs_outputs
+        from torch._higher_order_ops.effects import _register_effectful_op, with_effects
+        from torch._library.effects import EffectType
+
+        @torch.library.custom_op("test::effectful_op_rewire", mutates_args=())
+        def effectful_op_rewire(x: torch.Tensor) -> torch.Tensor:
+            return x * 2
+
+        @effectful_op_rewire.register_fake
+        def _(x: torch.Tensor) -> torch.Tensor:
+            return torch.empty_like(x)
+
+        handle = _register_effectful_op(effectful_op_rewire, EffectType.ORDERED)
+
+        try:
+            import torch.fx as fx
+
+            graph = fx.Graph()
+
+            x = graph.placeholder("x")
+            x.meta["val"] = torch.randn(4, 4)
+
+            fwd_token = graph.placeholder("fwd_token")
+            fwd_token.meta["val"] = None  # Effect tokens are None at runtime
+
+            bwd_token = graph.placeholder("tangents_token")
+            bwd_token.meta["val"] = None
+
+            tangent = graph.placeholder("tangents_1")
+            tangent.meta["val"] = torch.randn(4, 4)
+
+            with_effects_node = graph.call_function(
+                with_effects,
+                args=(fwd_token, torch.ops.test.effectful_op_rewire, x),
+            )
+            with_effects_node.meta["val"] = (None, torch.randn(4, 4))
+
+            result = graph.call_function(operator.getitem, args=(with_effects_node, 1))
+            result.meta["val"] = torch.randn(4, 4)
+
+            graph.output((result,))
+
+            inputs = [bwd_token, tangent, x]
+            outputs = [result]
+
+            new_graph = _extract_graph_with_inputs_outputs(
+                graph,
+                inputs,
+                outputs,
+                outputs_descs=[],
+                subgraph="backward",
+            )
+
+            has_with_effects = False
+            for node in new_graph.nodes:
+                if node.op == "call_function" and is_with_effects(node):
+                    has_with_effects = True
+                    token_arg = node.args[0]
+                    self.assertEqual(
+                        token_arg.name,
+                        "tangents_token",
+                        f"Expected token to be re-wired to tangents_token, got {token_arg.name}",
+                    )
+                    break
+
+            self.assertTrue(
+                has_with_effects,
+                "Expected with_effects node to be included in backward graph via token re-wiring",
+            )
+        finally:
+            handle.destroy()
+
+    def test_mark_getitem_outputs_effect_tokens(self):
+        """Test that intermediate effect tokens are marked MUST_RECOMPUTE, not MUST_SAVE.
+
+        When force_save_effectful_ops marks outputs of with_effects nodes:
+        - Tensor outputs (getitem[1], etc.) should be marked MUST_SAVE
+        - Intermediate effect tokens (getitem[0] not used as output) should be MUST_RECOMPUTE
+          so they don't end up in saved_values (they'll be re-wired in backward instead)
+        - Effect tokens that ARE graph outputs should not be marked MUST_RECOMPUTE
+        """
+        from torch._functorch._aot_autograd.utils import (
+            is_with_effects,
+            is_with_effects_token,
+        )
+        from torch._functorch.partitioners import (
+            CheckpointPolicy,
+            force_save_effectful_ops,
+        )
+        from torch._higher_order_ops.effects import _register_effectful_op
+        from torch._library.effects import EffectType
+
+        @torch.library.custom_op("test::effectful_op_token_test", mutates_args=())
+        def effectful_op_token_test(x: torch.Tensor) -> torch.Tensor:
+            return x * 2
+
+        @effectful_op_token_test.register_fake
+        def _(x: torch.Tensor) -> torch.Tensor:
+            return torch.empty_like(x)
+
+        handle = _register_effectful_op(effectful_op_token_test, EffectType.ORDERED)
+
+        try:
+            capture = GraphCaptureBackend()
+
+            @torch.compile(backend=capture)
+            def fn(x):
+                return torch.ops.test.effectful_op_token_test(x).sum()
+
+            x = torch.randn(4, 4)
+            fn(x)
+
+            gm = capture.gm
+            effect_token_nodes = []
+            tensor_result_nodes = []
+            for node in gm.graph.nodes:
+                if node.op == "call_function" and node.target == operator.getitem:
+                    if is_with_effects_token(node):
+                        effect_token_nodes.append(node)
+                    elif isinstance(node.meta.get("val"), torch.Tensor):
+                        parent = node.args[0]
+                        if isinstance(parent, torch.fx.Node) and is_with_effects(
+                            parent
+                        ):
+                            tensor_result_nodes.append(node)
+
+            self.assertTrue(
+                len(effect_token_nodes) > 0, "Should have effect token nodes"
+            )
+            self.assertTrue(
+                len(tensor_result_nodes) > 0, "Should have tensor result nodes"
+            )
+
+            force_save_effectful_ops(gm)
+
+            for node in effect_token_nodes:
+                is_output = any(u.op == "output" for u in node.users)
+                if not is_output:
+                    self.assertEqual(
+                        node.meta.get("recompute"),
+                        CheckpointPolicy.MUST_RECOMPUTE,
+                        f"Intermediate effect token {node.name} should be MUST_RECOMPUTE",
+                    )
+
+            for node in tensor_result_nodes:
+                self.assertEqual(
+                    node.meta.get("recompute"),
+                    CheckpointPolicy.MUST_SAVE,
+                    f"Tensor result {node.name} should be MUST_SAVE",
+                )
         finally:
             handle.destroy()
 

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -284,6 +284,15 @@ def is_with_effects(node: torch.fx.Node) -> bool:
     return False
 
 
+def is_with_effects_token(node: torch.fx.Node) -> bool:
+    """Check if a node is an effect token (getitem[0] from a with_effects node)."""
+    if node.target is not operator.getitem:
+        return False
+    parent = node.args[0] if node.args else None
+    idx = node.args[1] if len(node.args) > 1 else None
+    return isinstance(parent, torch.fx.Node) and idx == 0 and is_with_effects(parent)  # type: ignore[possibly-undefined]
+
+
 def unlift_tokens(
     fw_module: torch.fx.GraphModule,
     fw_metadata: "ViewAndMutationMeta",

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -26,7 +26,7 @@ from torch._dynamo.utils import counters, is_node_meta_valid
 from torch._functorch._activation_checkpointing.ac_logging_utils import (
     create_structured_trace_for_min_cut_info,
 )
-from torch._functorch._aot_autograd.utils import is_with_effects
+from torch._functorch._aot_autograd.utils import is_with_effects, is_with_effects_token
 from torch._inductor import config as inductor_config
 from torch._inductor.custom_graph_pass import (
     CustomKnapsackSolver,
@@ -222,6 +222,12 @@ def _extract_graph_with_inputs_outputs(
     new_graph = fx.Graph()
     env = {}
 
+    # track the current effect token for re-wiring forward with_effects in backward.
+    # when we copy a forward with_effects into backward, we substitute its effect
+    # token input with the current backward token, then update current_effect_token
+    # to be the output token of the copied node.
+    current_effect_token: fx.Node | None = None
+
     # Add new placeholder nodes in the order specified by the inputs
     for node in inputs:
         new_node = new_graph.placeholder(node.name)
@@ -229,6 +235,9 @@ def _extract_graph_with_inputs_outputs(
         new_node.meta = node.meta
         # pyrefly: ignore [unsupported-operation]
         env[node] = new_node
+        # init current_effect_token from tangents_token placeholder
+        if subgraph == "backward" and node.name == "tangents_token":
+            current_effect_token = new_node
 
     for node in joint_graph.nodes:
         if not ignore_must_be_in_fw_bw:
@@ -257,16 +266,54 @@ def _extract_graph_with_inputs_outputs(
             env[node] = InvalidNode  # type: ignore[assignment]
         elif node.op == "call_function":
             all_args = pytree.arg_tree_leaves(*node.args, **node.kwargs)
-            all_args = [
+
+            # if with_effects, skip the token when checking validity - it can be re-wired to the backward token chain
+            skip_effect_token = (
+                is_with_effects(node)
+                and subgraph == "backward"
+                and current_effect_token is not None
+            )
+
+            effect_token_arg = node.args[0] if skip_effect_token else None
+            all_args_invalid = [
                 isinstance(env[x], InvalidNodeBase)
                 for x in all_args
-                if isinstance(x, fx.Node)
+                if isinstance(x, fx.Node) and x is not effect_token_arg
             ]
-            if any(all_args):
+            if any(all_args_invalid):
                 env[node] = InvalidNode  # type: ignore[assignment]
                 continue
-            # pyrefly: ignore [unsupported-operation, bad-argument-type]
-            env[node] = new_graph.node_copy(node, lambda x: env[x])
+
+            if skip_effect_token and isinstance(
+                env.get(effect_token_arg), InvalidNodeBase
+            ):
+                # substitute the invalid forward token with current backward token
+                def make_arg_mapper(effect_tok):
+                    def arg_mapper(x):
+                        if x is effect_token_arg:
+                            return effect_tok
+                        return env[x]
+
+                    return arg_mapper
+
+                new_node = new_graph.node_copy(
+                    node, make_arg_mapper(current_effect_token)
+                )
+                # pyrefly: ignore [unsupported-operation]
+                env[node] = new_node
+                new_node.meta["_rewired_with_effects"] = True
+                continue
+
+            copied_node = new_graph.node_copy(node, lambda x: env[x])
+            env[node] = copied_node
+
+            # update current_effect_token if we copy a getitem[0] from a rewired with_effects
+            # pyrefly: ignore [missing-attribute]
+            if is_with_effects_token(node) and env[node.args[0]].meta.get(
+                "_rewired_with_effects"
+            ):
+                current_effect_token = copied_node
+
         elif node.op == "get_attr":
             # pyrefly: ignore [unsupported-operation, bad-argument-type]
             env[node] = new_graph.node_copy(node, lambda x: env[x])
@@ -1781,6 +1828,13 @@ def force_save_effectful_ops(joint_module: fx.GraphModule) -> None:
     def mark_getitem_outputs(node: fx.Node) -> None:
         for user in node.users:
             if user.target is operator.getitem:
+                if is_with_effects_token(user):
+                    if not any(u.op == "output" for u in user.users):
+                        # intermediate tokens will be re-wired into
+                        # the backward effect token chain, and we don't
+                        # want them to show up in tensors_saved_with_vc_check
+                        user.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+                    continue
                 mark_getitem_outputs(user)
                 if not isinstance(user.meta.get("val"), (tuple, list)):
                     user.meta["recompute"] = CheckpointPolicy.MUST_SAVE
@@ -1790,6 +1844,7 @@ def force_save_effectful_ops(joint_module: fx.GraphModule) -> None:
             is_with_effects(node)
             and not must_recompute(node)
             and not _has_tag_is_backward(node)
+            and not _has_tag_must_be_in_backward(node)
         ):
             mark_getitem_outputs(node)
 


### PR DESCRIPTION
when we need to recompute an effectful op (it's marked as PREFER_RECOMPUTE via. an AC annotation) we need to enforce that the recomputation order is maintained relative to the backward effectful ops.

i ended up running into this because we don't filter intermediate tokens out of the saved_values (i assumed they would never be saved in the first place!), and since at runtime they are None, we'd end up hitting this assertion:  https://github.com/pytorch/pytorch/blob/67bf5b5fd02be47988f5eda3614592874047b144/torch/_functorch/_aot_autograd/runtime_wrappers.py#L2523

to make this work, we could:                                                                                               
  1. mark the input token to the effectful op marked for recomputation as MUST_SAVE (but this would break the chain)     
  2. walk the chain from the effectful op marked for recomputation, marking all of its ancestors as MUST_RECOMPUTE (not just the ones in the region) - this is obviously bad
  3. if we run into an effectful op marked for recomputation, substitute the original token with current backward token (i.e., the output of the last-computed effectful op in the backward, or the tangent_token if no effectful ops have been computed yet), and update the 'current' token to the output of the recomputed op.

to better illustrate the problem w/ ```#1``` you might get:  
```
fwd:                                                                                                                                
  token_0 (placeholder)                                                                                                                           
    → with_effects_1 → token_1                                                                                                        
      → with_effects_2 (PREFER_RECOMPUTE) → token_2                                                                                      
        → with_effects_3 → token_3                                                                                                    
        
bwd:                                                                                                                                          
  tangents_token (placeholder)                                                                                                                    
    → with_effects_bwd → token_bwd                                                                                                    
```
if you were to mark token_1 as MUST_SAVE, the bwd would end up with two independent chains that could interleave arbitrarily:
```
tangents_token → with_effects_bwd → token_bwd

saved_token_1 → recomputed_with_effects_2 → token_2
```
this will only get more convoluted the more effectful ops you have inside AC regions. i'd also argue this goes against the principals of with_effects (and defeats its purpose).

with ```#3``` (the basis of this PR) we would get a single chain with deterministic ordering:
```
tangents_token → with_effects_bwd → token_bwd → recomputed_with_effects_2 → token_2
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174323

