### PR TITLE
Fix test isolation bug in test_checkpoint_device_context_fn

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4114,12 +4114,16 @@ class TestAutograd(TestCase):
         def fn(x):
             return x.sin().cos()
 
-        torch.set_default_device("cuda")
-        a = torch.tensor(1.0, requires_grad=True)
-        out = torch.utils.checkpoint.checkpoint(
-            fn, a, context_fn=context_fn, use_reentrant=False
-        )
-        out.backward()
+        prev_device = torch.get_default_device()
+        try:
+            torch.set_default_device("cuda")
+            a = torch.tensor(1.0, requires_grad=True)
+            out = torch.utils.checkpoint.checkpoint(
+                fn, a, context_fn=context_fn, use_reentrant=False
+            )
+            out.backward()
+        finally:
+            torch.set_default_device(prev_device)
 
     def test_detach(self):
         x = torch.randn(10, 10, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4114,16 +4114,12 @@ class TestAutograd(TestCase):
         def fn(x):
             return x.sin().cos()
 
-        prev_device = torch.get_default_device()
-        try:
-            torch.set_default_device("cuda")
+        with apply_device("cuda"):
             a = torch.tensor(1.0, requires_grad=True)
             out = torch.utils.checkpoint.checkpoint(
                 fn, a, context_fn=context_fn, use_reentrant=False
             )
             out.backward()
-        finally:
-            torch.set_default_device(prev_device)
 
     def test_detach(self):
         x = torch.randn(10, 10, requires_grad=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174328
* #174327
* #174333
* __->__ #174325

The test was setting torch.set_default_device("cuda") but not resetting
it after the test completed, causing subsequent tests to fail when they
expected tensors to be created on CPU by default.

Authored with Claude.