### PR TITLE
Expose SavedTensor constructor from Python

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -577,11 +577,24 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   py_context_manager_DEPRECATED<DisableFuncTorch>(_C_m, "_DisableFuncTorch");
   py_context_manager<DisableAutocast>(_C_m, "_DisableAutocast");
   py::class_<torch::autograd::SavedVariable>(std::move(m), "SavedTensor")
-      .def(py::init([]() -> torch::autograd::SavedVariable {
-        TORCH_CHECK(
-            false,
-            "Trying to create a SavedTensor object from Python is forbidden.");
-      }))
+      .def(py::init(
+          [](const at::Tensor& tensor,
+             bool is_output,
+             bool is_inplace_on_view) -> torch::autograd::SavedVariable {
+            return torch::autograd::SavedVariable(
+                tensor, is_output, is_inplace_on_view);
+          }),
+          py::arg("tensor"),
+          py::arg("is_output"),
+          py::arg("is_inplace_on_view") = false)
+      .def(
+          "unpack",
+          [](const torch::autograd::SavedVariable& s) -> at::Tensor {
+            return s.unpack();
+          })
+      .def(
+          "reset_data",
+          [](torch::autograd::SavedVariable& s) { s.reset_data(); })
       .def(
           "register_hooks",
           [](torch::autograd::SavedVariable& s,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174328
* #174327
* __->__ #174326
* #174325

Allows constructing SavedTensor (the Python binding for SavedVariable)
from Python with: SavedTensor(tensor, is_output, is_inplace_on_view=False)

The constructor goes through the saved_tensors_hooks automatically, so
tensors saved this way will be packed/unpacked by any active hooks.

Also adds unpack() and reset_data() methods to allow retrieving and
releasing the saved tensor data.

Authored with Claude.