### PR TITLE
[dynamo] Trace functorch jvp_increment_nesting

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -60,6 +60,8 @@ from .variables import (
     BuiltinVariable,
     FunctionalCallVariable,
     FunctorchHigherOrderVariable,
+    JvpDecrementNestingVariable,
+    JvpIncrementNestingVariable,
     LocalGeneratorFunctionVariable,
     LocalGeneratorObjectVariable,
     NestedUserFunctionVariable,
@@ -153,6 +155,8 @@ If you are removing an existing torch level API:
 manual_torch_name_rule_map: dict[
     str,
     Union[
+        type[JvpDecrementNestingVariable],
+        type[JvpIncrementNestingVariable],
         type[TorchInGraphFunctionVariable],
         type[SkipFunctionVariable],
         type[UserFunctionVariable],
@@ -341,6 +345,8 @@ manual_torch_name_rule_map: dict[
     "torch._C._functorch.is_batchedtensor": TorchInGraphFunctionVariable,
     "torch._C._functorch.peek_interpreter_stack": TorchInGraphFunctionVariable,
     "torch._C._functorch.unwrap_if_dead": TorchInGraphFunctionVariable,
+    "torch._C._functorch._jvp_increment_nesting": JvpIncrementNestingVariable,
+    "torch._C._functorch._jvp_decrement_nesting": JvpDecrementNestingVariable,
     "torch._functorch.predispatch._vmap_increment_nesting": TorchInGraphFunctionVariable,
     "torch._functorch.predispatch._vmap_decrement_nesting": TorchInGraphFunctionVariable,
     # everything else

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -34,7 +34,6 @@ from .ctx_manager import (
     GradInplaceRequiresGradCtxManagerVariable,
     GradModeVariable,
     InferenceModeVariable,
-    JvpIncrementNestingCtxManagerVariable,
     SDPAKernelVariable,
     SetFwdGradEnabledContextManager,
     TemporarilyPopInterpreterStackCtxManagerVariable,
@@ -145,7 +144,12 @@ from .tensor import (
     UnspecializedPythonVariable,
     UntypedStorageVariable,
 )
-from .torch import TorchCtxManagerClassVariable, TorchInGraphFunctionVariable
+from .torch import (
+    JvpDecrementNestingVariable,
+    JvpIncrementNestingVariable,
+    TorchCtxManagerClassVariable,
+    TorchInGraphFunctionVariable,
+)
 from .user_defined import (
     FrozenDataClassVariable,
     MutableMappingVariable,
@@ -186,6 +190,8 @@ __all__ = [
     "GradModeVariable",
     "IteratorVariable",
     "ItertoolsVariable",
+    "JvpDecrementNestingVariable",
+    "JvpIncrementNestingVariable",
     "LambdaVariable",
     "LazyConstantVariable",
     "LazyVariableTracker",

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -326,51 +326,6 @@ class TemporarilyPopInterpreterStackCtxManagerVariable(ContextWrappingVariable):
         return variables.ConstantVariable.create(None)
 
 
-class JvpIncrementNestingCtxManagerVariable(ContextWrappingVariable):
-    """represents torch.func.jvp increment/decrement nesting"""
-
-    # A guard is needed as the grad level is baked into the torch FX graph
-    # This is fine if jvp is only called from within the function
-    # being compiled. But the FX graph may be invalid in the case of a jvp
-    # call from eager that calls the compiled function, as the jvp levels
-    # may be different.
-    _guards_singleton = Guard(GlobalStateSource(), GuardBuilder.FUNCTORCH_STACK_MATCH)  # type: ignore[arg-type]
-
-    @staticmethod
-    def create(
-        tx: "InstructionTranslator", **kwargs: Any
-    ) -> "JvpIncrementNestingCtxManagerVariable":
-        var = JvpIncrementNestingCtxManagerVariable(
-            target_values=None,
-            initial_values=None,
-            **kwargs,
-        )
-        return var
-
-    def enter(self, tx: "InstructionTranslator") -> VariableTracker:
-        install_guard(self._guards_singleton)
-        jvp_level = torch._functorch.eager_transforms.enter_jvp_nesting()
-        self.set_cleanup_hook(
-            tx, lambda: torch._functorch.eager_transforms.exit_jvp_nesting()
-        )
-        self.proxy = tx.output.create_node(
-            "call_function",
-            torch._C._functorch._jvp_increment_nesting,
-            (),
-            {},
-        )
-        return variables.ConstantVariable.create(jvp_level)
-
-    def exit(
-        self, tx: "InstructionTranslator", *args: VariableTracker
-    ) -> VariableTracker:
-        self.cleanup()
-        tx.output.create_node(
-            "call_function", torch._C._functorch._jvp_decrement_nesting, (), {}
-        )
-        return variables.ConstantVariable.create(None)
-
-
 class SetFwdGradEnabledContextManager(ContextWrappingVariable):
     """represents torch.autograd.forward_ad._set_fwd_grad_enabled() to enable/disable fwd grad"""
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -129,7 +129,6 @@ supported_ctx_manager_classes = dict.fromkeys(
         torch._C.DisableTorchFunction,
         torch._functorch.vmap.vmap_increment_nesting,
         torch._functorch.eager_transforms.grad_increment_nesting,
-        torch._functorch.eager_transforms.jvp_increment_nesting,
         torch._functorch.eager_transforms.enable_inplace_requires_grad,
         torch.amp.autocast_mode.autocast,
         torch.autograd.grad_mode.enable_grad,
@@ -471,7 +470,6 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             GradInplaceRequiresGradCtxManagerVariable,
             GradModeVariable,
             InferenceModeVariable,
-            JvpIncrementNestingCtxManagerVariable,
             SDPAKernelVariable,
             SetFwdGradEnabledContextManager,
             StreamVariable,
@@ -556,9 +554,6 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
                 tx,
                 args,
             )
-        elif self.value is torch._functorch.eager_transforms.jvp_increment_nesting:
-            assert len(args) == 0
-            return JvpIncrementNestingCtxManagerVariable.create(tx)
         elif self.value is torch.autograd.forward_ad._set_fwd_grad_enabled:
             assert len(args) == 1
             return SetFwdGradEnabledContextManager.create(
@@ -3143,3 +3138,49 @@ class FuncTorchInterpreterVariable(BaseTorchVariable):
                 tx, None
             )
         return super().call_method(tx, name, args, kwargs)
+
+
+class JvpIncrementNestingVariable(BaseTorchVariable):
+    """
+    Represents torch._C._functorch._jvp_increment_nesting. Typically called
+    inside jvp_increment_nesting context manager.
+    """
+
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        assert not args and not kwargs
+        tx.output.create_node(
+            "call_function",
+            torch._C._functorch._jvp_increment_nesting,
+            (),
+            {},
+        )
+        level = torch._C._functorch._jvp_increment_nesting()
+        return variables.ConstantVariable.create(level)
+
+
+class JvpDecrementNestingVariable(BaseTorchVariable):
+    """
+    Represents torch._C._functorch._jvp_decrement_nesting. Typically called
+    inside jvp_increment_nesting context manager.
+    """
+
+    def call_function(
+        self,
+        tx: "InstructionTranslator",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        assert not args and not kwargs
+        tx.output.create_node(
+            "call_function",
+            torch._C._functorch._jvp_decrement_nesting,
+            (),
+            {},
+        )
+        torch._C._functorch._jvp_decrement_nesting()
+        return variables.ConstantVariable.create(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174242
* __->__ #174329

Earlier we had special handling of jvp_increment_nesting but this caused
problems becase it would hide the global mutation of JVP_NESTING
constant varible. Dynamo now supports tracing context managers, so this
PR just deletes the special support, lets Dynamo trace it and supports
_jvp_increment_nesting and _jvp_decrement_nesting functions (which were earlier handled in the special ctx manager handling). Now, Dynamo sees the JVP_NESTING global mutation and unblocks the next PR in the stack.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo