### PR TITLE
Expose SavedTensor constructor from Python for internal use

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8266,9 +8266,7 @@ for shape in [(1,), ()]:
 
         a = torch.randn(5, requires_grad=True)
         with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
-            saved = torch.autograd.SavedTensor(
-                a, is_output=False, _INTERNAL_USE_ONLY=True
-            )
+            saved = torch._C._autograd._make_saved_tensor(a, is_output=False)
             self.assertEqual(pack_count[0], 1)
             self.assertEqual(unpack_count[0], 0)
 
@@ -8289,9 +8287,9 @@ for shape in [(1,), ()]:
         a = torch.randn(5, requires_grad=True)
         with self.assertRaisesRegex(
             RuntimeError,
-            "SavedTensor constructor is exposed for internal use only and is subject to change",
+            "Trying to create a SavedTensor object from Python is forbidden",
         ):
-            torch.autograd.SavedTensor(a, is_output=False)
+            torch.autograd.SavedTensor()
 
     def test_custom_function_saved_tensors(self):
         def getFn(save=True):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8267,7 +8267,7 @@ for shape in [(1,), ()]:
         a = torch.randn(5, requires_grad=True)
         with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
             saved = torch.autograd.SavedTensor(
-                a, is_output=False, _UNSAFE_INTERNAL_USE=True
+                a, is_output=False, _INTERNAL_USE_ONLY=True
             )
             self.assertEqual(pack_count[0], 1)
             self.assertEqual(unpack_count[0], 0)
@@ -8281,7 +8281,7 @@ for shape in [(1,), ()]:
         a = torch.randn(5, requires_grad=True)
         with self.assertRaisesRegex(
             RuntimeError,
-            "Constructing SavedTensor from Python is internal API and subject to change",
+            "SavedTensor constructor is exposed for internal use only and is subject to change",
         ):
             torch.autograd.SavedTensor(a, is_output=False)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8267,7 +8267,7 @@ for shape in [(1,), ()]:
         a = torch.randn(5, requires_grad=True)
         with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
             saved = torch.autograd.SavedTensor(
-                a, is_output=False, _unsafe_internal_use_do_not_use=True
+                a, is_output=False, _UNSAFE_INTERNAL_USE=True
             )
             self.assertEqual(pack_count[0], 1)
             self.assertEqual(unpack_count[0], 0)
@@ -8281,7 +8281,7 @@ for shape in [(1,), ()]:
         a = torch.randn(5, requires_grad=True)
         with self.assertRaisesRegex(
             RuntimeError,
-            "Trying to create a SavedTensor object from Python is forbidden",
+            "Constructing SavedTensor from Python is internal API and subject to change",
         ):
             torch.autograd.SavedTensor(a, is_output=False)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8275,7 +8275,15 @@ for shape in [(1,), ()]:
             unpacked = saved.unpack()
             self.assertEqual(pack_count[0], 1)
             self.assertEqual(unpack_count[0], 1)
-            self.assertEqual(unpacked, a)
+
+            unpacked2 = saved.unpack()
+            self.assertEqual(pack_count[0], 1)
+            self.assertEqual(unpack_count[0], 2)
+
+        # Check tensor equality outside the hooks context to avoid
+        # triggering additional pack hooks from assertEqual internals
+        self.assertEqual(unpacked, a)
+        self.assertEqual(unpacked2, a)
 
     def test_saved_tensor_constructor_forbidden_without_flag(self):
         a = torch.randn(5, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8266,7 +8266,9 @@ for shape in [(1,), ()]:
 
         a = torch.randn(5, requires_grad=True)
         with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
-            saved = torch.autograd.SavedTensor(a, is_output=False)
+            saved = torch.autograd.SavedTensor(
+                a, is_output=False, _unsafe_internal_use_do_not_use=True
+            )
             self.assertEqual(pack_count[0], 1)
             self.assertEqual(unpack_count[0], 0)
 
@@ -8274,6 +8276,14 @@ for shape in [(1,), ()]:
             self.assertEqual(pack_count[0], 1)
             self.assertEqual(unpack_count[0], 1)
             self.assertEqual(unpacked, a)
+
+    def test_saved_tensor_constructor_forbidden_without_flag(self):
+        a = torch.randn(5, requires_grad=True)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Trying to create a SavedTensor object from Python is forbidden",
+        ):
+            torch.autograd.SavedTensor(a, is_output=False)
 
     def test_custom_function_saved_tensors(self):
         def getFn(save=True):

--- a/torch/_C/_autograd.pyi
+++ b/torch/_C/_autograd.pyi
@@ -89,15 +89,13 @@ class _ProfilerResult:
     def trace_start_ns(self) -> int: ...
 
 class SavedTensor:
-    def __init__(
-        self,
-        tensor: torch.Tensor,
-        *,
-        is_output: bool,
-        is_inplace_on_view: bool = False,
-        _INTERNAL_USE_ONLY: bool = False,
-    ) -> None: ...
     def unpack(self) -> torch.Tensor: ...
+
+def _make_saved_tensor(
+    tensor: torch.Tensor,
+    is_output: bool,
+    is_inplace_on_view: bool = False,
+) -> SavedTensor: ...
 
 def _enable_profiler(
     config: ProfilerConfig,

--- a/torch/_C/_autograd.pyi
+++ b/torch/_C/_autograd.pyi
@@ -96,7 +96,6 @@ def _make_saved_tensor(
     is_output: bool,
     is_inplace_on_view: bool = False,
 ) -> SavedTensor: ...
-
 def _enable_profiler(
     config: ProfilerConfig,
     activities: set[ProfilerActivity],

--- a/torch/_C/_autograd.pyi
+++ b/torch/_C/_autograd.pyi
@@ -88,7 +88,16 @@ class _ProfilerResult:
     def experimental_event_tree(self) -> list[_ProfilerEvent]: ...
     def trace_start_ns(self) -> int: ...
 
-class SavedTensor: ...
+class SavedTensor:
+    def __init__(
+        self,
+        tensor: torch.Tensor,
+        *,
+        is_output: bool,
+        is_inplace_on_view: bool = False,
+        _INTERNAL_USE_ONLY: bool = False,
+    ) -> None: ...
+    def unpack(self) -> torch.Tensor: ...
 
 def _enable_profiler(
     config: ProfilerConfig,

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -631,7 +631,8 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       [](const at::Tensor& tensor,
          bool is_output,
          bool is_inplace_on_view) -> torch::autograd::SavedVariable {
-        return torch::autograd::SavedVariable(tensor, is_output, is_inplace_on_view);
+        return torch::autograd::SavedVariable(
+            tensor, is_output, is_inplace_on_view);
       },
       py::arg("tensor"),
       py::arg("is_output"),

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -577,23 +577,11 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   py_context_manager_DEPRECATED<DisableFuncTorch>(_C_m, "_DisableFuncTorch");
   py_context_manager<DisableAutocast>(_C_m, "_DisableAutocast");
   py::class_<torch::autograd::SavedVariable>(std::move(m), "SavedTensor")
-      .def(
-          py::init(
-              [](const at::Tensor& tensor,
-                 bool is_output,
-                 bool is_inplace_on_view,
-                 bool _INTERNAL_USE_ONLY) -> torch::autograd::SavedVariable {
-                TORCH_CHECK(
-                    _INTERNAL_USE_ONLY,
-                    "SavedTensor constructor is exposed for internal use only and is subject to change.");
-                return torch::autograd::SavedVariable(
-                    tensor, is_output, is_inplace_on_view);
-              }),
-          py::arg("tensor"),
-          py::kw_only(),
-          py::arg("is_output"),
-          py::arg("is_inplace_on_view") = false,
-          py::arg("_INTERNAL_USE_ONLY") = false)
+      .def(py::init([]() -> torch::autograd::SavedVariable {
+        TORCH_CHECK(
+            false,
+            "Trying to create a SavedTensor object from Python is forbidden.");
+      }))
       .def(
           "unpack",
           [](const torch::autograd::SavedVariable& s) -> at::Tensor {
@@ -637,6 +625,17 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
             auto* unpack_ptr = unpack_safe.ptr(getPyInterpreter());
             return py::reinterpret_borrow<py::function>(unpack_ptr);
           });
+
+  m.def(
+      "_make_saved_tensor",
+      [](const at::Tensor& tensor,
+         bool is_output,
+         bool is_inplace_on_view) -> torch::autograd::SavedVariable {
+        return torch::autograd::SavedVariable(tensor, is_output, is_inplace_on_view);
+      },
+      py::arg("tensor"),
+      py::arg("is_output"),
+      py::arg("is_inplace_on_view") = false);
 
   torch::autograd::profiler::python_tracer::init();
   Py_RETURN_TRUE;

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -577,17 +577,18 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   py_context_manager_DEPRECATED<DisableFuncTorch>(_C_m, "_DisableFuncTorch");
   py_context_manager<DisableAutocast>(_C_m, "_DisableAutocast");
   py::class_<torch::autograd::SavedVariable>(std::move(m), "SavedTensor")
-      .def(py::init(
-          [](const at::Tensor& tensor,
-             bool is_output,
-             bool is_inplace_on_view,
-             bool _INTERNAL_USE_ONLY) -> torch::autograd::SavedVariable {
-            TORCH_CHECK(
-                _INTERNAL_USE_ONLY,
-                "SavedTensor constructor is exposed for internal use only and is subject to change.");
-            return torch::autograd::SavedVariable(
-                tensor, is_output, is_inplace_on_view);
-          }),
+      .def(
+          py::init(
+              [](const at::Tensor& tensor,
+                 bool is_output,
+                 bool is_inplace_on_view,
+                 bool _INTERNAL_USE_ONLY) -> torch::autograd::SavedVariable {
+                TORCH_CHECK(
+                    _INTERNAL_USE_ONLY,
+                    "SavedTensor constructor is exposed for internal use only and is subject to change.");
+                return torch::autograd::SavedVariable(
+                    tensor, is_output, is_inplace_on_view);
+              }),
           py::arg("tensor"),
           py::kw_only(),
           py::arg("is_output"),

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -581,10 +581,10 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           [](const at::Tensor& tensor,
              bool is_output,
              bool is_inplace_on_view,
-             bool _UNSAFE_INTERNAL_USE) -> torch::autograd::SavedVariable {
+             bool _INTERNAL_USE_ONLY) -> torch::autograd::SavedVariable {
             TORCH_CHECK(
-                _UNSAFE_INTERNAL_USE,
-                "Constructing SavedTensor from Python is internal API and subject to change.");
+                _INTERNAL_USE_ONLY,
+                "SavedTensor constructor is exposed for internal use only and is subject to change.");
             return torch::autograd::SavedVariable(
                 tensor, is_output, is_inplace_on_view);
           }),
@@ -592,7 +592,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           py::kw_only(),
           py::arg("is_output"),
           py::arg("is_inplace_on_view") = false,
-          py::arg("_UNSAFE_INTERNAL_USE") = false)
+          py::arg("_INTERNAL_USE_ONLY") = false)
       .def(
           "unpack",
           [](const torch::autograd::SavedVariable& s) -> at::Tensor {

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -591,6 +591,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           py::arg("tensor"),
           py::arg("is_output"),
           py::arg("is_inplace_on_view") = false,
+          py::kw_only(),
           py::arg("_unsafe_internal_use_do_not_use") = false)
       .def(
           "unpack",

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -577,11 +577,21 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   py_context_manager_DEPRECATED<DisableFuncTorch>(_C_m, "_DisableFuncTorch");
   py_context_manager<DisableAutocast>(_C_m, "_DisableAutocast");
   py::class_<torch::autograd::SavedVariable>(std::move(m), "SavedTensor")
-      .def(py::init([]() -> torch::autograd::SavedVariable {
-        TORCH_CHECK(
-            false,
-            "Trying to create a SavedTensor object from Python is forbidden.");
-      }))
+      .def(py::init(
+          [](const at::Tensor& tensor,
+             bool is_output,
+             bool is_inplace_on_view) -> torch::autograd::SavedVariable {
+            return torch::autograd::SavedVariable(
+                tensor, is_output, is_inplace_on_view);
+          }),
+          py::arg("tensor"),
+          py::arg("is_output"),
+          py::arg("is_inplace_on_view") = false)
+      .def(
+          "unpack",
+          [](const torch::autograd::SavedVariable& s) -> at::Tensor {
+            return s.unpack();
+          })
       .def(
           "register_hooks",
           [](torch::autograd::SavedVariable& s,

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -581,18 +581,18 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           [](const at::Tensor& tensor,
              bool is_output,
              bool is_inplace_on_view,
-             bool _unsafe_internal_use_do_not_use) -> torch::autograd::SavedVariable {
+             bool _UNSAFE_INTERNAL_USE) -> torch::autograd::SavedVariable {
             TORCH_CHECK(
-                _unsafe_internal_use_do_not_use,
-                "Trying to create a SavedTensor object from Python is forbidden.");
+                _UNSAFE_INTERNAL_USE,
+                "Constructing SavedTensor from Python is internal API and subject to change.");
             return torch::autograd::SavedVariable(
                 tensor, is_output, is_inplace_on_view);
           }),
           py::arg("tensor"),
+          py::kw_only(),
           py::arg("is_output"),
           py::arg("is_inplace_on_view") = false,
-          py::kw_only(),
-          py::arg("_unsafe_internal_use_do_not_use") = false)
+          py::arg("_UNSAFE_INTERNAL_USE") = false)
       .def(
           "unpack",
           [](const torch::autograd::SavedVariable& s) -> at::Tensor {

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -580,13 +580,18 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def(py::init(
           [](const at::Tensor& tensor,
              bool is_output,
-             bool is_inplace_on_view) -> torch::autograd::SavedVariable {
+             bool is_inplace_on_view,
+             bool _unsafe_internal_use_do_not_use) -> torch::autograd::SavedVariable {
+            TORCH_CHECK(
+                _unsafe_internal_use_do_not_use,
+                "Trying to create a SavedTensor object from Python is forbidden.");
             return torch::autograd::SavedVariable(
                 tensor, is_output, is_inplace_on_view);
           }),
           py::arg("tensor"),
           py::arg("is_output"),
-          py::arg("is_inplace_on_view") = false)
+          py::arg("is_inplace_on_view") = false,
+          py::arg("_unsafe_internal_use_do_not_use") = false)
       .def(
           "unpack",
           [](const torch::autograd::SavedVariable& s) -> at::Tensor {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175348
* #175338
* #174328
* #174327
* __->__ #174333

Allows constructing SavedTensor (the Python binding for SavedVariable)
directly from Python by passing in a tensor and a boolean indicating
whether it's an inplace output.

This is useful when implementing a checkpoint-like API, where you want
to manually manage saved tensors.

Authored with Claude.