### PR TITLE
[ROCm] ADDMM behavior now takes into account preferred BLAS backend.

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -118,24 +118,40 @@ cuda::blas::GEMMAndBiasActivationEpilogue activation_to_gemm_and_blas_arg(Activa
  * Additionally, for ROCM we test whether the architecture supports the Lt.
  */
 static bool isGloballyDisabledAddmmCudaLt(const at::Device& device) {
-  // When hipBLASLt is not supported on the architecture, return true
+  /* On ROCM, we have the following order of precedence:
+  - When hipBLASLt is NOT supported on the architecture, return true.
+  - If and only if the environment is set, then return the value that it set to.
+  - If the environment variable is NOT set, treturn a value based on the preferred BLAS backend.
+  */
+  static const auto is_addmm_cuda_lt_disabled = c10::utils::get_env("DISABLE_ADDMM_CUDA_LT");
   #ifdef USE_ROCM
   const auto& archs = at::detail::getCUDAHooks().getHipblasltSupportedArchs();
   const auto is_hipblas_lt_arch_supported = at::detail::getCUDAHooks().isGPUArch(archs, device.index());
   if (!is_hipblas_lt_arch_supported) {
     return true;
   }
-  #endif
 
-  // Check whether it is disabled in the env
-  static const auto is_addmm_cuda_lt_disabled = c10::utils::get_env("DISABLE_ADDMM_CUDA_LT");
+  // If environment variable is explicitly set, respect it
+  if (!is_addmm_cuda_lt_disabled.empty()) {
+    return is_addmm_cuda_lt_disabled == "1";
+  }
+
+  // The available BLAS backends on ROCm are: rocBLAS, hipBLASLt, and CK.
+  const auto preferred_backend = at::globalContext().blasPreferredBackend();
+  if (preferred_backend == at::BlasBackend::Cublaslt) {
+    return false;
+  } else {
+    return true;
+  }
+
+  #else
   if (is_addmm_cuda_lt_disabled == "1") {
     return true;
   }
 
   return false;
+  #endif
 }
-
 /*
  * Check whether for the given input we want to enable the Lt interface
  */

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -132,7 +132,7 @@ static bool isGloballyDisabledAddmmCudaLt(const at::Device& device) {
   }
 
   // If environment variable is explicitly set, respect it
-  if (!is_addmm_cuda_lt_disabled.empty()) {
+  if (is_addmm_cuda_lt_disabled.has_value()) {
     return is_addmm_cuda_lt_disabled == "1";
   }
 


### PR DESCRIPTION
This PR improves out of the box performance on AMD Navi architectures.

On AMD Navi architectures, hipBLASLt is supported, but there is better performance in the unfused GEMM code path. We take into account the preferred BLAS backend when the DISABLE_ADDMM_CUDA_LT environment variable is not set.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang