### PR TITLE
fix race condition in ~orStream()

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -68,7 +68,6 @@ struct orStream {
   }
 };
 
-
 orError_t openreg::addTaskToStream(
     orStream_t stream,
     std::function<void()> task) {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/stream.cpp
@@ -35,7 +35,7 @@ struct orStream {
   std::mutex mtx;
   std::condition_variable cv;
   std::thread worker;
-  std::atomic<bool> stop_flag{false};
+  bool stop_flag = false;
   int device_index = -1;
 
   orStream() {
@@ -45,9 +45,9 @@ struct orStream {
         {
           std::unique_lock<std::mutex> lock(this->mtx);
           this->cv.wait(lock, [this] {
-            return this->stop_flag.load() || !this->tasks.empty();
+            return this->stop_flag || !this->tasks.empty();
           });
-          if (this->stop_flag.load() && this->tasks.empty()) {
+          if (this->stop_flag && this->tasks.empty()) {
             return;
           }
           task = std::move(this->tasks.front());
@@ -59,11 +59,15 @@ struct orStream {
   }
 
   ~orStream() {
-    stop_flag.store(true);
+    {
+      std::lock_guard<std::mutex> lock(this->mtx);
+      stop_flag = true;
+    }
     cv.notify_one();
     worker.join();
   }
 };
+
 
 orError_t openreg::addTaskToStream(
     orStream_t stream,


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/174359

When I repeatedly execute openreg runtime unit tests, the thread occasionally gets stuck and cannot exit.

I changed the atomic stop_flag variable to a bool type, and used a mutex lock when assigning the value of the variable. This solved the problem.