### PR TITLE
[inductor] fix sdpa pattern matcher issue when scale is not default 

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -363,10 +363,31 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             )
             return attn_weight @ value
 
+        def sfdp_pattern_5_v3(query, key, value):
+            # https://github.com/pytorch/pytorch/issues/174049.
+            attn_mask = torch.ones(
+                query.size(-2), key.size(-2), dtype=torch.bool, device=query.device
+            ).tril(diagonal=0)
+            attn_mask = attn_mask.masked_fill(
+                torch.logical_not(attn_mask), -float("inf")
+            )
+            attn_weight = torch.softmax(
+                (query @ key.transpose(-2, -1) / math.sqrt(query.size(-1)) + 0.1)
+                + attn_mask,
+                dim=-1,
+            )
+            return attn_weight @ value
+
         self._check_common(sfdp_pattern_5_v1, contains=False)
         self._check_common(checkpoint_wrapper(sfdp_pattern_5_v1), contains=False)
         self._check_common(sfdp_pattern_5_v2, contains=False)
         self._check_common(checkpoint_wrapper(sfdp_pattern_5_v2), contains=False)
+        self._check_common(sfdp_pattern_5_v3, contains=False, has_fuse_pattern=False)
+        self._check_common(
+            checkpoint_wrapper(sfdp_pattern_5_v3),
+            contains=False,
+            has_fuse_pattern=False,
+        )
 
     def _test_sdpa_rewriter_6(self):
         def sfdp_pattern_6(query, key, value, training):
@@ -383,9 +404,33 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             attn_weight = torch.nn.functional.dropout(attn_weight, 0.5, training)
             return attn_weight @ value
 
+        def sfdp_pattern_6_v2(query, key, value, training):
+            attn_mask = torch.ones(
+                query.size(-2), key.size(-2), dtype=torch.bool, device=query.device
+            ).tril(diagonal=0)
+            attn_mask = attn_mask.masked_fill(
+                torch.logical_not(attn_mask), -float("inf")
+            )
+            attn_weight = torch.softmax(
+                (query @ key.transpose(-2, -1) / math.sqrt(query.size(-1)) + 0.1)
+                + attn_mask,
+                dim=-1,
+            )
+            attn_weight = torch.nn.functional.dropout(attn_weight, 0.5, training)
+            return attn_weight @ value
+
         self._check_common(sfdp_pattern_6, contains=False, has_dropout=True)
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_6), contains=False, has_dropout=True
+        )
+        self._check_common(
+            sfdp_pattern_6_v2, contains=False, has_dropout=True, has_fuse_pattern=False
+        )
+        self._check_common(
+            checkpoint_wrapper(sfdp_pattern_6_v2),
+            contains=False,
+            has_dropout=True,
+            has_fuse_pattern=False,
         )
 
     def _test_sdpa_rewriter_7(self):
@@ -394,6 +439,18 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             k = key.permute(0, 2, 1, 3)
             v = value.permute(0, 2, 1, 3)
             div = q @ k.transpose(-2, -1) / math.sqrt(q.size(-1))
+            div = div.to(torch.float32)
+            attn_weight = torch.softmax(div, dim=-1)
+            # Set to False
+            attn_weight = torch.dropout(attn_weight, 0.00000000001, training)
+            attn_weight = attn_weight.to(torch.float16)
+            return attn_weight @ v
+
+        def sfdp_pattern_7_v2(query, key, value, training):
+            q = query.permute(0, 2, 1, 3)
+            k = key.permute(0, 2, 1, 3)
+            v = value.permute(0, 2, 1, 3)
+            div = q @ k.transpose(-2, -1) / (math.sqrt(q.size(-1)) + 0.1)
             div = div.to(torch.float32)
             attn_weight = torch.softmax(div, dim=-1)
             # Set to False
@@ -414,6 +471,15 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             override_check_equal=True,
             atol=2e-3,
         )
+        self._check_common(
+            sfdp_pattern_7_v2,
+            args,
+            contains=False,
+            has_dropout=True,
+            has_fuse_pattern=False,
+            override_check_equal=True,
+            atol=2e-3,
+        )
 
         args = (
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
@@ -425,6 +491,15 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args,
             contains=SM80OrLater,
             has_dropout=True,
+            override_check_equal=True,
+            atol=2e-3,
+        )
+        self._check_common(
+            checkpoint_wrapper(sfdp_pattern_7_v2),
+            args,
+            contains=False,
+            has_dropout=True,
+            has_fuse_pattern=False,
             override_check_equal=True,
             atol=2e-3,
         )
@@ -440,12 +515,25 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             attn_weight = attn_weight.to(torch.float16)
             return attn_weight @ v
 
+        def sfdp_pattern_8_v2(query, key, value):
+            q = query.permute(0, 2, 1, 3)
+            k = key.permute(0, 2, 1, 3)
+            v = value.permute(0, 2, 1, 3)
+            div = q @ k.transpose(-2, -1) / (math.sqrt(q.size(-1)) + 0.1)
+            div = div.to(torch.float32)
+            attn_weight = torch.softmax(div, dim=-1)
+            attn_weight = attn_weight.to(torch.float16)
+            return attn_weight @ v
+
         args = (
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
         )
         self._check_common(sfdp_pattern_8, args, atol=2e-3)
+        self._check_common(
+            sfdp_pattern_8_v2, args, atol=2e-3, contains=False, has_fuse_pattern=False
+        )
 
         args = (
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
@@ -453,6 +541,13 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
         )
         self._check_common(checkpoint_wrapper(sfdp_pattern_8), args, atol=2e-3)
+        self._check_common(
+            checkpoint_wrapper(sfdp_pattern_8_v2),
+            args,
+            atol=2e-3,
+            contains=False,
+            has_fuse_pattern=False,
+        )
 
     def _test_sdpa_rewriter_9(self):
         def sfdp_pattern_9(query, key, value, training):
@@ -460,6 +555,19 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             k = key.permute(0, 2, 1, 3)
             v = value.permute(0, 2, 1, 3)
             q = q / math.sqrt(q.size(-1))
+            div = q @ k.transpose(-2, -1)
+            div = div.to(torch.float32)
+            attn_weight = torch.softmax(div, dim=-1)
+            # very low dropout to make test pass
+            attn_weight = torch.dropout(attn_weight, 0.00000000001, training)
+            attn_weight = attn_weight.to(torch.float16)
+            return attn_weight @ v
+
+        def sfdp_pattern_9_v2(query, key, value, training):
+            q = query.permute(0, 2, 1, 3)
+            k = key.permute(0, 2, 1, 3)
+            v = value.permute(0, 2, 1, 3)
+            q = q / (math.sqrt(q.size(-1)) + 0.1)
             div = q @ k.transpose(-2, -1)
             div = div.to(torch.float32)
             attn_weight = torch.softmax(div, dim=-1)
@@ -481,6 +589,15 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             override_check_equal=True,
             atol=2e-3,
         )
+        self._check_common(
+            sfdp_pattern_9_v2,
+            args,
+            contains=False,
+            has_dropout=True,
+            has_fuse_pattern=False,
+            override_check_equal=True,
+            atol=2e-3,
+        )
         args = (
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
@@ -491,6 +608,15 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args,
             contains=SM80OrLater,
             has_dropout=True,
+            override_check_equal=True,
+            atol=2e-3,
+        )
+        self._check_common(
+            checkpoint_wrapper(sfdp_pattern_9_v2),
+            args,
+            contains=False,
+            has_dropout=True,
+            has_fuse_pattern=False,
             override_check_equal=True,
             atol=2e-3,
         )
@@ -507,12 +633,30 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             attn_weight = attn_weight.to(torch.float16)
             return attn_weight @ v
 
+        def sfdp_pattern_10_v2(query, key, value):
+            q = query.permute(0, 2, 1, 3)
+            k = key.permute(0, 2, 1, 3)
+            v = value.permute(0, 2, 1, 3)
+            q = q / (math.sqrt(q.size(-1)) + 0.1)
+            div = q @ k.transpose(-2, -1)
+            div = div.to(torch.float32)
+            attn_weight = torch.softmax(div, dim=-1)
+            attn_weight = attn_weight.to(torch.float16)
+            return attn_weight @ v
+
         args = (
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
         )
         self._check_common(sfdp_pattern_10, args, atol=2e-3)
+        self._check_common(
+            sfdp_pattern_10_v2,
+            args,
+            atol=2e-3,
+            contains=False,
+            has_fuse_pattern=False,
+        )
 
         args = (
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
@@ -520,6 +664,13 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
         )
         self._check_common(checkpoint_wrapper(sfdp_pattern_10), args, atol=2e-3)
+        self._check_common(
+            checkpoint_wrapper(sfdp_pattern_10_v2),
+            args,
+            atol=2e-3,
+            contains=False,
+            has_fuse_pattern=False,
+        )
 
     def _test_pattern_fails_with_tensor_factor(self):
         # https://github.com/pytorch/pytorch/issues/99124
@@ -888,6 +1039,37 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                 value.permute([0, 2, 1, 3]),
             )
 
+        def dot_prod_attention_v2(
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+            causal_mask: torch.Tensor,
+        ) -> torch.Tensor:
+            query = query.permute([0, 2, 1, 3])
+            key = key.permute([0, 2, 1, 3])
+            value = value.permute([0, 2, 1, 3])
+            attn_weights = torch.matmul(query, key.permute(0, 1, 3, 2))
+            inv_scale = torch.full(
+                (),
+                math.sqrt(value.size(-1)) + 0.1,
+                dtype=query.dtype,
+                device=query.device,
+            )
+            attn_weights = attn_weights.div(inv_scale)
+            causal_mask_value = torch.full(
+                (), torch.finfo(query.dtype).min, dtype=query.dtype, device=query.device
+            )
+            attn_weights = torch.where(causal_mask, attn_weights, causal_mask_value)
+            return (
+                (
+                    torch.nn.functional.dropout(
+                        attn_weights.softmax(dim=-1), 0.0
+                    ).matmul(value)
+                ),
+                key.permute([0, 2, 1, 3]),
+                value.permute([0, 2, 1, 3]),
+            )
+
         tensor_shape = (4, 2, 16, 32)
         causal_mask = torch.ones(2, 2, dtype=torch.bool, device=self.device).tril(
             diagonal=0
@@ -906,6 +1088,16 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             check_train=False,
         )
 
+        self._check_common(
+            dot_prod_attention_v2,
+            args1=args,
+            atol=2e-3,
+            contains=False,
+            has_dropout=False,
+            has_fuse_pattern=False,
+            check_train=False,
+        )
+
         # also check batch_size=1 because the graph is slightly different
         tensor_shape = (1, 2, 16, 32)
         args = [
@@ -919,6 +1111,15 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args1=args,
             contains=False,
             has_dropout=False,
+            check_train=False,
+        )
+        self._check_common(
+            dot_prod_attention_v2,
+            args1=args,
+            contains=False,
+            atol=2e-3,
+            has_dropout=False,
+            has_fuse_pattern=False,
             check_train=False,
         )
 
@@ -935,6 +1136,35 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             inv_scale = torch.full(
                 (),
                 math.sqrt(value.size(-1)),
+                dtype=attn_weights.dtype,
+                device=attn_weights.device,
+            )
+            attn_weights = attn_weights.div(inv_scale)
+            causal_mask_value = torch.full(
+                (), torch.finfo(query.dtype).min, dtype=query.dtype, device=query.device
+            )
+            attn_weights = torch.where(causal_mask, attn_weights, causal_mask_value)
+            attn_weights = attn_weights + attn_mask
+            attn_weights = attn_weights.softmax(dim=-1).type(value.dtype)
+            return torch.nn.functional.dropout(
+                attn_weights,
+                p=0.4,
+                training=training,
+                inplace=False,
+            ).matmul(value)
+
+        def dot_prod_attention_v2(
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+            causal_mask: torch.Tensor,
+            attn_mask: torch.Tensor,
+            training,
+        ) -> torch.Tensor:
+            attn_weights = torch.matmul(query, key.permute(0, 1, 3, 2))
+            inv_scale = torch.full(
+                (),
+                math.sqrt(value.size(-1)) + 0.1,
                 dtype=attn_weights.dtype,
                 device=attn_weights.device,
             )
@@ -969,6 +1199,14 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args1=args,
             contains=False,
             has_dropout=True,
+            check_train=False,
+        )
+        self._check_common(
+            dot_prod_attention_v2,
+            args1=args,
+            contains=False,
+            has_dropout=True,
+            has_fuse_pattern=False,
             check_train=False,
         )
 

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -372,7 +372,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                 torch.logical_not(attn_mask), -float("inf")
             )
             attn_weight = torch.softmax(
-                (query @ key.transpose(-2, -1) / math.sqrt(query.size(-1)) + 0.1)
+                (query @ key.transpose(-2, -1) / (math.sqrt(query.size(-1)) + 0.1))
                 + attn_mask,
                 dim=-1,
             )
@@ -412,7 +412,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                 torch.logical_not(attn_mask), -float("inf")
             )
             attn_weight = torch.softmax(
-                (query @ key.transpose(-2, -1) / math.sqrt(query.size(-1)) + 0.1)
+                (query @ key.transpose(-2, -1) / (math.sqrt(query.size(-1)) + 0.1))
                 + attn_mask,
                 dim=-1,
             )

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -382,11 +382,10 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         self._check_common(checkpoint_wrapper(sfdp_pattern_5_v1), contains=False)
         self._check_common(sfdp_pattern_5_v2, contains=False)
         self._check_common(checkpoint_wrapper(sfdp_pattern_5_v2), contains=False)
-        self._check_common(sfdp_pattern_5_v3, contains=False, has_fuse_pattern=False)
+        self._check_common(sfdp_pattern_5_v3, contains=False)
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_5_v3),
             contains=False,
-            has_fuse_pattern=False,
         )
 
     def _test_sdpa_rewriter_6(self):
@@ -423,14 +422,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_6), contains=False, has_dropout=True
         )
-        self._check_common(
-            sfdp_pattern_6_v2, contains=False, has_dropout=True, has_fuse_pattern=False
-        )
+        self._check_common(sfdp_pattern_6_v2, contains=False, has_dropout=True)
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_6_v2),
             contains=False,
             has_dropout=True,
-            has_fuse_pattern=False,
         )
 
     def _test_sdpa_rewriter_7(self):
@@ -476,7 +472,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args,
             contains=False,
             has_dropout=True,
-            has_fuse_pattern=False,
             override_check_equal=True,
             atol=2e-3,
         )
@@ -497,9 +492,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_7_v2),
             args,
-            contains=False,
+            contains=SM80OrLater,
             has_dropout=True,
-            has_fuse_pattern=False,
             override_check_equal=True,
             atol=2e-3,
         )
@@ -531,9 +525,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
         )
         self._check_common(sfdp_pattern_8, args, atol=2e-3)
-        self._check_common(
-            sfdp_pattern_8_v2, args, atol=2e-3, contains=False, has_fuse_pattern=False
-        )
+        self._check_common(sfdp_pattern_8_v2, args, atol=2e-3, contains=False)
 
         args = (
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
@@ -546,7 +538,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args,
             atol=2e-3,
             contains=False,
-            has_fuse_pattern=False,
         )
 
     def _test_sdpa_rewriter_9(self):
@@ -592,9 +583,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         self._check_common(
             sfdp_pattern_9_v2,
             args,
-            contains=False,
+            contains=SM80OrLater,
             has_dropout=True,
-            has_fuse_pattern=False,
             override_check_equal=True,
             atol=2e-3,
         )
@@ -614,9 +604,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_9_v2),
             args,
-            contains=False,
+            contains=SM80OrLater,
             has_dropout=True,
-            has_fuse_pattern=False,
             override_check_equal=True,
             atol=2e-3,
         )
@@ -655,7 +644,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args,
             atol=2e-3,
             contains=False,
-            has_fuse_pattern=False,
         )
 
         args = (
@@ -669,7 +657,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args,
             atol=2e-3,
             contains=False,
-            has_fuse_pattern=False,
         )
 
     def _test_pattern_fails_with_tensor_factor(self):
@@ -1094,7 +1081,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             atol=2e-3,
             contains=False,
             has_dropout=False,
-            has_fuse_pattern=False,
             check_train=False,
         )
 
@@ -1119,7 +1105,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             contains=False,
             atol=2e-3,
             has_dropout=False,
-            has_fuse_pattern=False,
             check_train=False,
         )
 
@@ -1206,7 +1191,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             args1=args,
             contains=False,
             has_dropout=True,
-            has_fuse_pattern=False,
             check_train=False,
         )
 

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -467,6 +467,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             override_check_equal=True,
             atol=2e-3,
         )
+        args = (
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+        )
         self._check_common(
             sfdp_pattern_7_v2,
             args,
@@ -488,6 +493,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             has_dropout=True,
             override_check_equal=True,
             atol=2e-3,
+        )
+        args = (
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
         )
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_7_v2),
@@ -525,6 +535,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
         )
         self._check_common(sfdp_pattern_8, args, atol=2e-3)
+        args = (
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+        )
         self._check_common(sfdp_pattern_8_v2, args, atol=2e-3, contains=False)
 
         args = (
@@ -533,6 +548,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
         )
         self._check_common(checkpoint_wrapper(sfdp_pattern_8), args, atol=2e-3)
+        args = (
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+        )
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_8_v2),
             args,
@@ -580,6 +600,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             override_check_equal=True,
             atol=2e-3,
         )
+        args = (
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+        )
         self._check_common(
             sfdp_pattern_9_v2,
             args,
@@ -600,6 +625,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             has_dropout=True,
             override_check_equal=True,
             atol=2e-3,
+        )
+        args = (
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
         )
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_9_v2),
@@ -639,6 +669,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
         )
         self._check_common(sfdp_pattern_10, args, atol=2e-3)
+        args = (
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=self.device, dtype=torch.half),
+        )
         self._check_common(
             sfdp_pattern_10_v2,
             args,
@@ -652,6 +687,11 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
         )
         self._check_common(checkpoint_wrapper(sfdp_pattern_10), args, atol=2e-3)
+        args = (
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+            torch.randn((2, 8, 4, 16), device=GPU_TYPE, dtype=torch.half),
+        )
         self._check_common(
             checkpoint_wrapper(sfdp_pattern_10_v2),
             args,

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -2,9 +2,7 @@
 import functools
 import inspect
 import logging
-import math
 import warnings
-from typing import Optional
 
 import torch
 
@@ -109,15 +107,15 @@ def _sfdp_replacement_4(query, key, value, scale_factor, dropout_p):
     )
 
 
-def _sfdp_pattern_5(query, key, value, attn_mask):
+def _sfdp_pattern_5(query, key, value, attn_mask, inv_scale):
     attn_weight = torch.softmax(
-        (query @ key.transpose(-2, -1) / math.sqrt(query.size(-1))) + attn_mask, dim=-1
+        (query @ key.transpose(-2, -1) / (inv_scale)) + attn_mask, dim=-1
     )
     # attn_weight = torch.dropout(attn_weight, dropout_p)
     return attn_weight @ value
 
 
-def _sfdp_replacement_5(query, key, value, attn_mask):
+def _sfdp_replacement_5(query, key, value, attn_mask, inv_scale):
     counters["inductor"]["fuse_attention"] += 1
     return _scaled_dot_product_attention(
         query,
@@ -125,19 +123,20 @@ def _sfdp_replacement_5(query, key, value, attn_mask):
         value,
         attn_mask=attn_mask.to(dtype=query.dtype),
         dropout_p=0.0,
+        scale=1.0 / inv_scale,
         is_causal=False,
     )
 
 
-def _sfdp_pattern_6(query, key, value, attn_mask, dropout_p):
+def _sfdp_pattern_6(query, key, value, attn_mask, inv_scale, dropout_p):
     attn_weight = torch.softmax(
-        (query @ key.transpose(-2, -1) / math.sqrt(query.size(-1))) + attn_mask, dim=-1
+        (query @ key.transpose(-2, -1) / inv_scale) + attn_mask, dim=-1
     )
     attn_weight = torch.dropout(attn_weight, dropout_p, True)
     return attn_weight @ value
 
 
-def _sfdp_replacement_6(query, key, value, attn_mask, dropout_p):
+def _sfdp_replacement_6(query, key, value, attn_mask, inv_scale, dropout_p):
     counters["inductor"]["fuse_attention"] += 1
     return _scaled_dot_product_attention(
         query,
@@ -145,18 +144,19 @@ def _sfdp_replacement_6(query, key, value, attn_mask, dropout_p):
         value,
         attn_mask=attn_mask.to(dtype=query.dtype),
         dropout_p=dropout_p,
+        scale=1.0 / inv_scale,
         is_causal=False,
     )
 
 
-def _sfdp_pattern_7(query, key, value, dropout_p):
+def _sfdp_pattern_7(query, key, value, inv_scale, dropout_p):
     # in real workloads inputs to matmul are permuted
     # causing matmul to expand to a series of expand and clone calls
     # we want the same to happen during pattern tracing
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
     v = value.permute(0, 2, 1, 3)
-    div = q @ k.transpose(-2, -1) / math.sqrt(q.size(-1))
+    div = q @ k.transpose(-2, -1) / inv_scale
     div = div.to(torch.float32)
     attn_weight = torch.softmax(div, dim=-1)
     attn_weight = torch.dropout(attn_weight, dropout_p, True)
@@ -164,7 +164,7 @@ def _sfdp_pattern_7(query, key, value, dropout_p):
     return attn_weight @ v
 
 
-def _sfdp_replacement_7(query, key, value, dropout_p):
+def _sfdp_replacement_7(query, key, value, inv_scale, dropout_p):
     # sdpa prefers inputs in permuted format
     # it makes a copy to put them in this format
     # if they aren't already
@@ -180,23 +180,24 @@ def _sfdp_replacement_7(query, key, value, dropout_p):
         v,
         attn_mask=None,  # attn_mask,
         dropout_p=dropout_p,
+        scale=1.0 / inv_scale,
         is_causal=False,
     )
 
 
-def _sfdp_pattern_8(query, key, value):
+def _sfdp_pattern_8(query, key, value, inv_scale):
     # no dropout version of pattern 7
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
     v = value.permute(0, 2, 1, 3)
-    div = q @ k.transpose(-2, -1) / math.sqrt(q.size(-1))
+    div = q @ k.transpose(-2, -1) / inv_scale
     div = div.to(torch.float32)
     attn_weight = torch.softmax(div, dim=-1)
     attn_weight = attn_weight.to(torch.float16)
     return attn_weight @ v
 
 
-def _sfdp_replacement_8(query, key, value):
+def _sfdp_replacement_8(query, key, value, inv_scale):
     counters["inductor"]["fuse_attention"] += 1
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
@@ -207,15 +208,16 @@ def _sfdp_replacement_8(query, key, value):
         v,
         attn_mask=None,  # attn_mask,
         dropout_p=0.0,
+        scale=1.0 / inv_scale,
         is_causal=False,
     )
 
 
-def _sfdp_pattern_9(query, key, value, dropout_p):
+def _sfdp_pattern_9(query, key, value, inv_scale, dropout_p):
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
     v = value.permute(0, 2, 1, 3)
-    q = q / math.sqrt(q.size(-1))
+    q = q / inv_scale
     div = q @ k.transpose(-2, -1)
     div = div.to(torch.float32)
     attn_weight = torch.softmax(div, dim=-1)
@@ -224,7 +226,7 @@ def _sfdp_pattern_9(query, key, value, dropout_p):
     return attn_weight @ v
 
 
-def _sfdp_replacement_9(query, key, value, dropout_p):
+def _sfdp_replacement_9(query, key, value, inv_scale, dropout_p):
     counters["inductor"]["fuse_attention"] += 1
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
@@ -235,16 +237,17 @@ def _sfdp_replacement_9(query, key, value, dropout_p):
         v,
         attn_mask=None,  # attn_mask,
         dropout_p=dropout_p,
+        scale=1.0 / inv_scale,
         is_causal=False,
     )
 
 
-def _sfdp_pattern_10(query, key, value):
+def _sfdp_pattern_10(query, key, value, inv_scale):
     # no dropout version of 9
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
     v = value.permute(0, 2, 1, 3)
-    q = q / math.sqrt(q.size(-1))
+    q = q / inv_scale
     div = q @ k.transpose(-2, -1)
     div = div.to(torch.float32)
     attn_weight = torch.softmax(div, dim=-1)
@@ -252,7 +255,7 @@ def _sfdp_pattern_10(query, key, value):
     return attn_weight @ v
 
 
-def _sfdp_replacement_10(query, key, value):
+def _sfdp_replacement_10(query, key, value, inv_scale):
     counters["inductor"]["fuse_attention"] += 1
     q = query.permute(0, 2, 1, 3)
     k = key.permute(0, 2, 1, 3)
@@ -263,6 +266,7 @@ def _sfdp_replacement_10(query, key, value):
         v,
         attn_mask=None,  # attn_mask,
         dropout_p=0.0,
+        scale=1.0 / inv_scale,
         is_causal=False,
     )
 
@@ -461,7 +465,7 @@ def _sfdp_replacement_17(query, key, value, attn_mask, inv_scale, dropout_p):
     )
 
 
-def _sfdp_pattern_18(query, key, value, causal_mask, dropout_p):
+def _sfdp_pattern_18(query, key, value, causal_mask, inv_scale, dropout_p):
     # for hf_GPT2 with dropout (introduces clone node) for inference
     # it also returns permuted key & value
     query = query.permute([0, 2, 1, 3])
@@ -470,7 +474,7 @@ def _sfdp_pattern_18(query, key, value, causal_mask, dropout_p):
     attn_weights = torch.matmul(query, key.permute(0, 1, 3, 2))
     inv_scale = torch.full(
         [],
-        value.size(-1) ** 0.5,
+        inv_scale,
         dtype=attn_weights.dtype,
         device=attn_weights.device,
     )
@@ -490,7 +494,7 @@ def _sfdp_pattern_18(query, key, value, causal_mask, dropout_p):
     )
 
 
-def _sfdp_replacement_18(query, key, value, causal_mask, dropout_p):
+def _sfdp_replacement_18(query, key, value, causal_mask, inv_scale, dropout_p):
     counters["inductor"]["fuse_attention"] += 1
     permuted_key = key.transpose(1, 2)
     permuted_value = value.transpose(1, 2)
@@ -502,19 +506,19 @@ def _sfdp_replacement_18(query, key, value, causal_mask, dropout_p):
             attn_mask=causal_mask,
             dropout_p=dropout_p,
             is_causal=False,
-            scale=1.0 / math.sqrt(value.size(-1)),
+            scale=1.0 / inv_scale,
         ),
         permuted_key,
         permuted_value,
     )
 
 
-def _sfdp_pattern_19(query, key, value, causal_mask, attn_mask, dropout_p):
+def _sfdp_pattern_19(query, key, value, causal_mask, attn_mask, inv_scale, dropout_p):
     # for token-classification+gpt2 / text-generation+gpt2
     attn_weights = torch.matmul(query, key.permute(0, 1, 3, 2))
     inv_scale = torch.full(
         [],
-        value.size(-1) ** 0.5,
+        inv_scale,
         dtype=attn_weights.dtype,
         device=attn_weights.device,
     )
@@ -528,7 +532,9 @@ def _sfdp_pattern_19(query, key, value, causal_mask, attn_mask, dropout_p):
     return torch.nn.functional.dropout(attn_weights, dropout_p).matmul(value)
 
 
-def _sfdp_replacement_19(query, key, value, causal_mask, attn_mask, dropout_p):
+def _sfdp_replacement_19(
+    query, key, value, causal_mask, attn_mask, inv_scale, dropout_p
+):
     counters["inductor"]["fuse_attention"] += 1
     fill_value = torch.full((), -float("inf"), dtype=query.dtype, device=query.device)
     attn_mask = torch.where(causal_mask, attn_mask, fill_value)
@@ -539,18 +545,18 @@ def _sfdp_replacement_19(query, key, value, causal_mask, attn_mask, dropout_p):
         attn_mask=attn_mask,
         dropout_p=dropout_p,
         is_causal=False,
-        scale=1.0 / math.sqrt(value.size(-1)),
+        scale=1.0 / inv_scale,
     )
 
 
-def _sfdp_pattern_20(query, key, value, attn_mask, dropout_p):
+def _sfdp_pattern_20(query, key, value, attn_mask, inv_scale, dropout_p):
     # for DistilBert with dropout transformers==4.44.2
     q = query.permute([0, 2, 1, 3])
     k = key.permute([0, 2, 1, 3])
     v = value.permute([0, 2, 1, 3])
     bs = q.size(0)
     k_len = k.size(-2)
-    q = q.div(math.sqrt(q.size(-1)))
+    q = q.div(inv_scale)
     scores = q @ k.transpose(-2, -1)
     fill_value = torch.full((), -float("inf"), dtype=query.dtype, device=query.device)
     attn_mask = (attn_mask == 0).view((bs, 1, 1, k_len)).expand_as(scores)
@@ -562,7 +568,7 @@ def _sfdp_pattern_20(query, key, value, attn_mask, dropout_p):
     )
 
 
-def _sfdp_replacement_20(query, key, value, attn_mask, dropout_p):
+def _sfdp_replacement_20(query, key, value, attn_mask, inv_scale, dropout_p):
     counters["inductor"]["fuse_attention"] += 1
     bs = query.size(0)
     n_head = query.size(2)
@@ -579,7 +585,7 @@ def _sfdp_replacement_20(query, key, value, attn_mask, dropout_p):
         attn_mask=attn_mask.to(dtype=torch.bool),
         dropout_p=dropout_p,
         is_causal=False,
-        scale=1.0 / math.sqrt(query.size(-1)),
+        scale=1.0 / inv_scale,
     )
 
 
@@ -874,9 +880,7 @@ def _sfdp_params_check(match):
     return True
 
 
-def _sfdp_extra_check(
-    scale_factor_op=None, disable_cuda=False, check_scale_value=False
-):
+def _sfdp_extra_check(scale_factor_op=None, disable_cuda=False):
     def fn(match):
         if (
             disable_cuda
@@ -890,39 +894,6 @@ def _sfdp_extra_check(
             scale_factor = scale_factor_node.args[1]
             # make sure the scale_factor a float/int. SymInt?
             if not isinstance(scale_factor, (float, int)):
-                return False
-        if check_scale_value:
-            has_scale = any("scale" in k for k in match.kwargs)
-            assert not has_scale, (
-                match.kwargs,
-                "do not check scale value when it's in kwargs",
-            )
-            div_nodes = filter_nodes(match.nodes, aten.div.Tensor)
-            inv_scale_factor: Optional[float] = None
-            for div_node in div_nodes:
-                node = div_node
-                div_args = getattr(div_node, "args", None)
-                if (
-                    isinstance(div_args, (tuple, list))
-                    and len(div_args) > 1
-                    and hasattr(div_args[1], "target")
-                    and hasattr(div_args[1].target, "name")
-                    and div_args[1].target.name() == "aten::full"
-                ):
-                    node = div_args[1]
-                node_args = getattr(node, "args", None)
-                if (
-                    isinstance(node_args, (tuple, list))
-                    and len(node_args) > 1
-                    and isinstance(node.args[1], (float, int))
-                ):
-                    if inv_scale_factor is None:
-                        inv_scale_factor = node.args[1]
-                    else:
-                        assert inv_scale_factor == node.args[1]
-            query_node = match.kwargs["query"]
-            expected_inv_scale = math.sqrt(query_node.meta["val"].size(-1))
-            if expected_inv_scale != inv_scale_factor:
                 return False
         return _sfdp_params_check(match)
 
@@ -981,6 +952,8 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
     # workaround https://github.com/pytorch/pytorch/issues/97894
     # 0.113377 is a "magic" value that lets us recover the lost input arg relationship
     d = {"dropout_p": 0.113377}
+    s = {"inv_scale": 0.66666}
+    sd = {"inv_scale": 0.66666, "dropout_p": 0.113377}
 
     # we could also generate all these patterns in 3d.. TODO
     g_3d_inp = functools.partial(
@@ -1046,43 +1019,43 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                 _sfdp_pattern_5,
                 _sfdp_replacement_5,
                 [g(), g(), g(), b()],
-                {},
-                _sfdp_extra_check(check_scale_value=True),
+                s,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_6,
                 _sfdp_replacement_6,
                 [g(), g(), g(), b()],
-                d,
-                _sfdp_extra_check(check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_7,
                 _sfdp_replacement_7,
                 [g(), g(), g()],
-                d,
-                _sfdp_extra_check(check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_8,
                 _sfdp_replacement_8,
                 [g(), g(), g()],
-                {},
-                _sfdp_extra_check(check_scale_value=True),
+                s,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_9,
                 _sfdp_replacement_9,
                 [g(), g(), g()],
-                d,
-                _sfdp_extra_check(check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_10,
                 _sfdp_replacement_10,
                 [g(), g(), g()],
-                {},
-                _sfdp_extra_check(check_scale_value=True),
+                s,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_11,
@@ -1149,29 +1122,29 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                 _sfdp_pattern_18,
                 _sfdp_replacement_18,
                 [g(), g(), g(), m_bool()],
-                d,
-                _sfdp_extra_check(check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_18,
                 _sfdp_replacement_18,
                 [g_bs1(), g_bs1(), g_bs1(), m_bs1_bool()],
-                d,
-                _sfdp_extra_check(check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_19,
                 _sfdp_replacement_19,
                 [g(), g(), g(), b_bool(), b_float()],
-                d,
-                _sfdp_extra_check(check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_20,
                 _sfdp_replacement_20,
                 [g(), g(), g(), m_2d()],
-                d,
-                _sfdp_extra_check(aten.div.Tensor, check_scale_value=True),
+                sd,
+                _sfdp_params_check,
             ),
             (
                 _sfdp_pattern_21,
@@ -1323,15 +1296,17 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                     "skip_duplicates": True,
                 },
             )
-
+            inference_workaround = {}
             if workaround:
-                assert len(workaround) == 1 and "dropout_p" in workaround
-                # functools.partial insufficient because we look at signature downstream
-                pattern = partialize_and_update_signature(pattern, dropout_p=0.0)
-                replacement = partialize_and_update_signature(
-                    replacement, dropout_p=0.0
-                )
-                workaround = {}
+                assert len(workaround) <= 2
+                if "inv_scale" in workaround:
+                    inference_workaround["inv_scale"] = workaround["inv_scale"]
+                if "dropout_p" in workaround:
+                    # functools.partial insufficient because we look at signature downstream
+                    pattern = partialize_and_update_signature(pattern, dropout_p=0.0)
+                    replacement = partialize_and_update_signature(
+                        replacement, dropout_p=0.0
+                    )
 
             inference_name = name + "_inference"
             yield (
@@ -1343,7 +1318,7 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                     "trace_fn": fwd_only,
                     "pass_dicts": patterns,
                     "extra_check": extra_check,
-                    "scalar_workaround": workaround,
+                    "scalar_workaround": inference_workaround,
                     # with dropout turned into clone, we end up with a number of
                     # semantically identical graphs
                     "skip_duplicates": True,

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import math
 import warnings
+from typing import Optional
 
 import torch
 
@@ -873,7 +874,9 @@ def _sfdp_params_check(match):
     return True
 
 
-def _sfdp_extra_check(scale_factor_op=None, disable_cuda=False):
+def _sfdp_extra_check(
+    scale_factor_op=None, disable_cuda=False, check_scale_value=False
+):
     def fn(match):
         if (
             disable_cuda
@@ -887,6 +890,39 @@ def _sfdp_extra_check(scale_factor_op=None, disable_cuda=False):
             scale_factor = scale_factor_node.args[1]
             # make sure the scale_factor a float/int. SymInt?
             if not isinstance(scale_factor, (float, int)):
+                return False
+        if check_scale_value:
+            has_scale = any("scale" in k for k in match.kwargs)
+            assert not has_scale, (
+                match.kwargs,
+                "do not check scale value when it's in kwargs",
+            )
+            div_nodes = filter_nodes(match.nodes, aten.div.Tensor)
+            inv_scale_factor: Optional[float] = None
+            for div_node in div_nodes:
+                node = div_node
+                div_args = getattr(div_node, "args", None)
+                if (
+                    isinstance(div_args, (tuple, list))
+                    and len(div_args) > 1
+                    and hasattr(div_args[1], "target")
+                    and hasattr(div_args[1].target, "name")
+                    and div_args[1].target.name() == "aten::full"
+                ):
+                    node = div_args[1]
+                node_args = getattr(node, "args", None)
+                if (
+                    isinstance(node_args, (tuple, list))
+                    and len(node_args) > 1
+                    and isinstance(node.args[1], (float, int))
+                ):
+                    if inv_scale_factor is None:
+                        inv_scale_factor = node.args[1]
+                    else:
+                        assert inv_scale_factor == node.args[1]
+            query_node = match.kwargs["query"]
+            expected_inv_scale = math.sqrt(query_node.meta["val"].size(-1))
+            if expected_inv_scale != inv_scale_factor:
                 return False
         return _sfdp_params_check(match)
 
@@ -1011,42 +1047,42 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                 _sfdp_replacement_5,
                 [g(), g(), g(), b()],
                 {},
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_6,
                 _sfdp_replacement_6,
                 [g(), g(), g(), b()],
                 d,
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_7,
                 _sfdp_replacement_7,
                 [g(), g(), g()],
                 d,
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_8,
                 _sfdp_replacement_8,
                 [g(), g(), g()],
                 {},
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_9,
                 _sfdp_replacement_9,
                 [g(), g(), g()],
                 d,
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_10,
                 _sfdp_replacement_10,
                 [g(), g(), g()],
                 {},
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_11,
@@ -1114,28 +1150,28 @@ def _get_sfdp_patterns(input_device: torch.device | None = None):
                 _sfdp_replacement_18,
                 [g(), g(), g(), m_bool()],
                 d,
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_18,
                 _sfdp_replacement_18,
                 [g_bs1(), g_bs1(), g_bs1(), m_bs1_bool()],
                 d,
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_19,
                 _sfdp_replacement_19,
                 [g(), g(), g(), b_bool(), b_float()],
                 d,
-                _sfdp_params_check,
+                _sfdp_extra_check(check_scale_value=True),
             ),
             (
                 _sfdp_pattern_20,
                 _sfdp_replacement_20,
                 [g(), g(), g(), m_2d()],
                 d,
-                _sfdp_extra_check(aten.div.Tensor),
+                _sfdp_extra_check(aten.div.Tensor, check_scale_value=True),
             ),
             (
                 _sfdp_pattern_21,

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py
@@ -32,7 +32,7 @@ from torch._inductor.pattern_matcher import (
    _TargetExprVarArgs,
 )
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored(), _users=2)
@@ -71,7 +71,7 @@ view_default_8 = CallFunction(aten.view.default, fma_default, Ignored(), _users=
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
 view_default_9 = CallFunction(aten.view.default, bmm_default_3, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, KeywordArg('inv_scale'))
 permute_default_6 = CallFunction(aten.permute.default, div_Tensor_2, Ignored())
 permute_default_7 = CallFunction(aten.permute.default, view_default, Ignored())
 bmm_default_4 = CallFunction(aten.bmm.default, permute_default_7, view_default_8)
@@ -85,12 +85,13 @@ permute_default_11 = CallFunction(aten.permute.default, view_default_11, Ignored
 _sfdp_pattern_10_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
-  permute_default_11
+  permute_default_11,
+  None
 ])
 
 
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored())
@@ -118,7 +119,7 @@ _sfdp_pattern_10_inference = CallFunction(aten.view.default, bmm_default_1, Igno
 
 
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored(), _users=2)
@@ -158,7 +159,7 @@ view_default_8 = CallFunction(aten.view.default, convert_element_type_default_3,
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
 view_default_9 = CallFunction(aten.view.default, bmm_default_3, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, KeywordArg('inv_scale'))
 permute_default_6 = CallFunction(aten.permute.default, div_Tensor_2, Ignored())
 permute_default_7 = CallFunction(aten.permute.default, view_default, Ignored())
 bmm_default_4 = CallFunction(aten.bmm.default, permute_default_7, view_default_8)
@@ -172,12 +173,13 @@ permute_default_11 = CallFunction(aten.permute.default, view_default_11, Ignored
 _sfdp_pattern_10_half_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
-  permute_default_11
+  permute_default_11,
+  None
 ])
 
 
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored())

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py
@@ -44,7 +44,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1, _users=2)
@@ -98,6 +98,7 @@ _sfdp_pattern_18_training = MultiOutputPattern([view_default_5,
   permute_default_9,
   permute_default_11,
   None,
+  None,
   None
 ])
 
@@ -113,7 +114,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1, _users=2)
@@ -147,7 +148,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default_2, Ignored(
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1, _users=2)
@@ -200,6 +201,7 @@ _sfdp_pattern_18_bs1_training = MultiOutputPattern([view_default_5,
   permute_default_9,
   permute_default_11,
   None,
+  None,
   None
 ])
 
@@ -213,7 +215,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default_2, Ignored(
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1, _users=2)
@@ -248,7 +250,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)
@@ -307,6 +309,7 @@ _sfdp_pattern_18_half_training = MultiOutputPattern([view_default_5,
   permute_default_9,
   permute_default_11,
   None,
+  None,
   None
 ])
 
@@ -322,7 +325,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)
@@ -358,7 +361,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default_2, Ignored(
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)
@@ -416,6 +419,7 @@ _sfdp_pattern_18_half_bs1_training = MultiOutputPattern([view_default_5,
   permute_default_9,
   permute_default_11,
   None,
+  None,
   None
 ])
 
@@ -429,7 +433,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default_2, Ignored(
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
@@ -40,7 +40,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)
@@ -89,6 +89,7 @@ _sfdp_pattern_19_training = MultiOutputPattern([view_default_5,
   view_default_11,
   None,
   None,
+  None,
   None
 ])
 
@@ -100,7 +101,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)
@@ -127,7 +128,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False, _users=2)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)
@@ -179,6 +180,7 @@ _sfdp_pattern_19_half_training = MultiOutputPattern([view_default_5,
   view_default_11,
   None,
   None,
+  None,
   None
 ])
 
@@ -190,7 +192,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
+full_default = CallFunction(aten.full.default, [], KeywordArg('inv_scale'), dtype=Ignored(), device=Ignored(), pin_memory=False)
 div_Tensor = CallFunction(aten.div.Tensor, view_default_2, full_default)
 full_default_1 = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 where_self = CallFunction(aten.where.self, KeywordArg('causal_mask'), div_Tensor, full_default_1)

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_20.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_20.py
@@ -38,7 +38,7 @@ view_default = CallFunction(aten.view.default, eq_Scalar, Ignored())
 expand_default = CallFunction(aten.expand.default, view_default, Ignored(), _users=2)
 full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default_1 = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default_1, memory_format=torch.contiguous_format)
 view_default_1 = CallFunction(aten.view.default, clone_default, Ignored(), _users=2)
@@ -82,7 +82,7 @@ view_default_9 = CallFunction(aten.view.default, where_self_1, Ignored(), _users
 permute_default_5 = CallFunction(aten.permute.default, view_default_2, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_9, permute_default_5)
 view_default_10 = CallFunction(aten.view.default, bmm_default_3, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_10, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_10, KeywordArg('inv_scale'))
 permute_default_6 = CallFunction(aten.permute.default, div_Tensor_2, Ignored())
 permute_default_7 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_4 = CallFunction(aten.bmm.default, permute_default_7, view_default_9)
@@ -98,6 +98,7 @@ _sfdp_pattern_20_training = MultiOutputPattern([view_default_6,
   permute_default_9,
   permute_default_11,
   None,
+  None,
   None
 ])
 
@@ -107,7 +108,7 @@ view_default = CallFunction(aten.view.default, eq_Scalar, Ignored())
 expand_default = CallFunction(aten.expand.default, view_default, Ignored())
 full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default_1 = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default_1, memory_format=torch.contiguous_format)
 view_default_1 = CallFunction(aten.view.default, clone_default, Ignored())
@@ -141,7 +142,7 @@ view_default = CallFunction(aten.view.default, eq_Scalar, Ignored())
 expand_default = CallFunction(aten.expand.default, view_default, Ignored(), _users=2)
 full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default_1 = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default_1, memory_format=torch.contiguous_format)
 view_default_1 = CallFunction(aten.view.default, clone_default, Ignored(), _users=2)
@@ -190,7 +191,7 @@ view_default_9 = CallFunction(aten.view.default, where_self_1, Ignored(), _users
 permute_default_5 = CallFunction(aten.permute.default, view_default_2, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_9, permute_default_5)
 view_default_10 = CallFunction(aten.view.default, bmm_default_3, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_10, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_10, KeywordArg('inv_scale'))
 permute_default_6 = CallFunction(aten.permute.default, div_Tensor_2, Ignored())
 permute_default_7 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_4 = CallFunction(aten.bmm.default, permute_default_7, view_default_9)
@@ -206,6 +207,7 @@ _sfdp_pattern_20_half_training = MultiOutputPattern([view_default_6,
   permute_default_9,
   permute_default_11,
   None,
+  None,
   None
 ])
 
@@ -215,7 +217,7 @@ view_default = CallFunction(aten.view.default, eq_Scalar, Ignored())
 expand_default = CallFunction(aten.expand.default, view_default, Ignored())
 full_default = CallFunction(aten.full.default, [], Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default_1 = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default_1, memory_format=torch.contiguous_format)
 view_default_1 = CallFunction(aten.view.default, clone_default, Ignored())

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py
@@ -38,7 +38,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'), _users=2)
 amax_default = CallFunction(aten.amax.default, add_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, add_Tensor, amax_default)
@@ -59,7 +59,7 @@ view_default_7 = CallFunction(aten.view.default, bmm_default_2, Ignored())
 mul_Tensor = CallFunction(aten.mul.Tensor, view_default_7, div_Tensor_1, _users=2)
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor)
-div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_2 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_2)
@@ -75,6 +75,7 @@ _sfdp_pattern_5_training = MultiOutputPattern([view_default_5,
   view_default_9,
   permute_default_4,
   view_default_11,
+  None,
   None
 ])
 
@@ -86,7 +87,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'), _users=2)
 amax_default = CallFunction(aten.amax.default, add_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, add_Tensor, amax_default)
@@ -108,7 +109,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, add_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)
@@ -134,7 +135,7 @@ mul_Tensor = CallFunction(aten.mul.Tensor, convert_element_type_default_3, conve
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor)
 convert_element_type_default_4 = CallFunction(prims.convert_element_type.default, fma_default, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_4, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_4, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_2 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_2)
@@ -150,6 +151,7 @@ _sfdp_pattern_5_half_training = MultiOutputPattern([view_default_5,
   view_default_9,
   permute_default_4,
   view_default_11,
+  None,
   None
 ])
 
@@ -161,7 +163,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, add_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py
@@ -40,7 +40,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'), _users=2)
 amax_default = CallFunction(aten.amax.default, add_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, add_Tensor, amax_default)
@@ -66,7 +66,7 @@ mul_Tensor_3 = CallFunction(aten.mul.Tensor, view_default_7, mul_Tensor_2)
 mul_Tensor_4 = CallFunction(aten.mul.Tensor, mul_Tensor_3, div_Tensor_1, _users=2)
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor_4, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor_4)
-div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_2 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_2)
@@ -83,6 +83,7 @@ _sfdp_pattern_6_training = MultiOutputPattern([view_default_5,
   permute_default_4,
   view_default_11,
   None,
+  None,
   None
 ])
 
@@ -94,7 +95,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'), _users=2)
 amax_default = CallFunction(aten.amax.default, add_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, add_Tensor, amax_default)
@@ -118,7 +119,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, add_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)
@@ -149,7 +150,7 @@ mul_Tensor_4 = CallFunction(aten.mul.Tensor, convert_element_type_default_4, con
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor_4, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor_4)
 convert_element_type_default_5 = CallFunction(prims.convert_element_type.default, fma_default, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_5, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_5, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_2 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_2)
@@ -166,6 +167,7 @@ _sfdp_pattern_6_half_training = MultiOutputPattern([view_default_5,
   permute_default_4,
   view_default_11,
   None,
+  None,
   None
 ])
 
@@ -177,7 +179,7 @@ expand_default_1 = CallFunction(aten.expand.default, permute_default, Ignored())
 view_default_1 = CallFunction(aten.view.default, expand_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, add_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py
@@ -44,7 +44,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored(), _users=2)
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'), _users=2)
 amax_default = CallFunction(aten.amax.default, div_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, div_Tensor, amax_default)
 exp_default = CallFunction(aten.exp.default, sub_Tensor, _users=2)
@@ -74,7 +74,7 @@ mul_Tensor_3 = CallFunction(aten.mul.Tensor, convert_element_type_default_2, mul
 mul_Tensor_4 = CallFunction(aten.mul.Tensor, mul_Tensor_3, div_Tensor_1, _users=2)
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor_4, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor_4)
-div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
@@ -93,6 +93,7 @@ _sfdp_pattern_7_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
   permute_default_11,
+  None,
   None
 ])
 
@@ -108,7 +109,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored(), _users=2)
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'), _users=2)
 amax_default = CallFunction(aten.amax.default, div_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, div_Tensor, amax_default)
 exp_default = CallFunction(aten.exp.default, sub_Tensor, _users=2)
@@ -138,7 +139,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, div_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, convert_element_type_default, amax_default)
@@ -169,7 +170,7 @@ mul_Tensor_4 = CallFunction(aten.mul.Tensor, mul_Tensor_3, div_Tensor_1, _users=
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor_4, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor_4)
 convert_element_type_default_4 = CallFunction(prims.convert_element_type.default, fma_default, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_4, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_4, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
@@ -188,6 +189,7 @@ _sfdp_pattern_7_half_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
   permute_default_11,
+  None,
   None
 ])
 
@@ -203,7 +205,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, div_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, convert_element_type_default, amax_default)

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py
@@ -42,7 +42,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored(), _users=2)
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'), _users=2)
 amax_default = CallFunction(aten.amax.default, div_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, div_Tensor, amax_default)
 exp_default = CallFunction(aten.exp.default, sub_Tensor, _users=2)
@@ -67,7 +67,7 @@ convert_element_type_default_2 = CallFunction(prims.convert_element_type.default
 mul_Tensor = CallFunction(aten.mul.Tensor, convert_element_type_default_2, div_Tensor_1, _users=2)
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor)
-div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, fma_default, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
@@ -85,7 +85,8 @@ permute_default_11 = CallFunction(aten.permute.default, view_default_11, Ignored
 _sfdp_pattern_8_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
-  permute_default_11
+  permute_default_11,
+  None
 ])
 
 
@@ -100,7 +101,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored(), _users=2)
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'), _users=2)
 amax_default = CallFunction(aten.amax.default, div_Tensor, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, div_Tensor, amax_default)
 exp_default = CallFunction(aten.exp.default, sub_Tensor, _users=2)
@@ -128,7 +129,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored(), _users=2)
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, div_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, convert_element_type_default, amax_default)
@@ -154,7 +155,7 @@ mul_Tensor = CallFunction(aten.mul.Tensor, convert_element_type_default_2, div_T
 sum_dim_IntList_1 = CallFunction(aten.sum.dim_IntList, mul_Tensor, Ignored(), True)
 fma_default = CallFunction(prims.fma.default, neg_default, sum_dim_IntList_1, mul_Tensor)
 convert_element_type_default_3 = CallFunction(prims.convert_element_type.default, fma_default, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_3, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, convert_element_type_default_3, KeywordArg('inv_scale'))
 view_default_8 = CallFunction(aten.view.default, div_Tensor_2, Ignored(), _users=2)
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
@@ -172,7 +173,8 @@ permute_default_11 = CallFunction(aten.permute.default, view_default_11, Ignored
 _sfdp_pattern_8_half_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
-  permute_default_11
+  permute_default_11,
+  None
 ])
 
 
@@ -187,7 +189,7 @@ clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_form
 view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
 bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
 view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, view_default_2, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
 convert_element_type_default = CallFunction(prims.convert_element_type.default, div_Tensor, Ignored(), _users=2)
 amax_default = CallFunction(aten.amax.default, convert_element_type_default, Ignored(), True)
 sub_Tensor = CallFunction(aten.sub.Tensor, convert_element_type_default, amax_default)

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py
@@ -34,7 +34,7 @@ from torch._inductor.pattern_matcher import (
 rand_default = CallFunction(aten.rand.default, Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 gt_Scalar = CallFunction(aten.gt.Scalar, rand_default, KeywordArg('dropout_p'), _users=2)
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored(), _users=2)
@@ -78,7 +78,7 @@ view_default_8 = CallFunction(aten.view.default, fma_default, Ignored(), _users=
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
 view_default_9 = CallFunction(aten.view.default, bmm_default_3, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, KeywordArg('inv_scale'))
 permute_default_6 = CallFunction(aten.permute.default, div_Tensor_2, Ignored())
 permute_default_7 = CallFunction(aten.permute.default, view_default, Ignored())
 bmm_default_4 = CallFunction(aten.bmm.default, permute_default_7, view_default_8)
@@ -93,12 +93,13 @@ _sfdp_pattern_9_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
   permute_default_11,
+  None,
   None
 ])
 
 
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored())
@@ -128,7 +129,7 @@ _sfdp_pattern_9_inference = CallFunction(aten.view.default, bmm_default_1, Ignor
 rand_default = CallFunction(aten.rand.default, Ignored(), dtype=Ignored(), device=Ignored(), pin_memory=False)
 gt_Scalar = CallFunction(aten.gt.Scalar, rand_default, KeywordArg('dropout_p'), _users=2)
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored(), _users=2)
@@ -173,7 +174,7 @@ view_default_8 = CallFunction(aten.view.default, convert_element_type_default_4,
 permute_default_5 = CallFunction(aten.permute.default, view_default_1, Ignored())
 bmm_default_3 = CallFunction(aten.bmm.default, view_default_8, permute_default_5)
 view_default_9 = CallFunction(aten.view.default, bmm_default_3, Ignored())
-div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, Ignored())
+div_Tensor_2 = CallFunction(aten.div.Tensor, view_default_9, KeywordArg('inv_scale'))
 permute_default_6 = CallFunction(aten.permute.default, div_Tensor_2, Ignored())
 permute_default_7 = CallFunction(aten.permute.default, view_default, Ignored())
 bmm_default_4 = CallFunction(aten.bmm.default, permute_default_7, view_default_8)
@@ -188,12 +189,13 @@ _sfdp_pattern_9_half_training = MultiOutputPattern([view_default_5,
   permute_default_6,
   permute_default_9,
   permute_default_11,
+  None,
   None
 ])
 
 
 permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
-div_Tensor = CallFunction(aten.div.Tensor, permute_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, permute_default, KeywordArg('inv_scale'))
 expand_default = CallFunction(aten.expand.default, div_Tensor, Ignored())
 clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
 view_default = CallFunction(aten.view.default, clone_default, Ignored())


### PR DESCRIPTION
Fix #174049 
Fix #151098
scale in sdpa is passed as a scalar into pattern matcher. Some sdpa pattern replacement graph use the default value (sqrt(head_dim)), but eager code may not be default. In this case, there will be accuracy issue for torch compile. I add a check for scalar values. We may add support for non-default scale in future if we meet such cases in real workload (maybe follow the way in dropout)

We may revert #172951 before this pr because it tries to solve the same issue by disabling pattern matcher.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo