### PR TITLE
[ATen][NATIVE][CUDA] Allow all 10.x compute capabilities for using vec8 kernel

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -166,7 +166,7 @@ template <int vec_size, typename func_t, typename array_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
 __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
   if constexpr (vec_size == 8) {
-#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000 || __CUDA_ARCH__ == 1030
+#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1000
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();
     int remaining = N - io_block_work_size<io_size>() * blockIdx.x;
@@ -191,7 +191,7 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
       elementwise_kernel_helper(
       f, memory::policies::vectorized<vec_size, array_t, elems_per_thread<io_size>()>(data));
     }
-#endif // __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000
+#endif // __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1000
   } else {
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();
@@ -308,8 +308,7 @@ static inline void launch_vectorized_kernel(
   // that causes some numerical mismatches with uint8 on sm80 and sm90.
   // TODO: Revisit this after CUDA 12.8 update.
   cudaDeviceProp* p = at::cuda::getDeviceProperties(stream.device().index());
-  const int computeCapability = p->major * 10 + p->minor;
-  if (computeCapability != 90 && computeCapability != 100 && computeCapability != 103) {
+  if (p->major != 9 && p->major != 10) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }
   if constexpr (sizeof(cpp_type) < 2) {

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -306,7 +306,7 @@ static inline void launch_vectorized_kernel(
   const uint16_t max_vec_size = memory::can_vectorize_up_to<func_t>(data);
   uint16_t vec_size = 16 / static_cast<uint16_t>(sizeof(cpp_type));
   vec_size = std::min<uint16_t>(vec_size, max_vec_size);
-  // due to exessive binary size the `vectorized_elementwise_kernel` of
+  // due to excessive binary size the `vectorized_elementwise_kernel` of
   // the size 8 is compiled for sm_90 and sm_10x only.
   // TODO: Lift this limitation when CUDA 12.x support is fully dropped
   cudaDeviceProp* p = at::cuda::getDeviceProperties(stream.device().index());

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -166,7 +166,7 @@ template <int vec_size, typename func_t, typename array_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
 __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
   if constexpr (vec_size == 8) {
-#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1000
+#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();
     int remaining = N - io_block_work_size<io_size>() * blockIdx.x;
@@ -191,7 +191,7 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
       elementwise_kernel_helper(
       f, memory::policies::vectorized<vec_size, array_t, elems_per_thread<io_size>()>(data));
     }
-#endif // __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1000
+#endif // __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10
   } else {
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -161,12 +161,12 @@ constexpr auto calc_io_size(){
 #ifndef USE_ROCM
 // To save on binary size of libtorch_cuda.so, we split the vectorized_elementwise_kernel
 // into two: one for vec_size=8 and one for vec_size=[2, 4], since vec8 is going to be
-// used on sm_90 and sm_100 exclusively.
+// used on sm_90 and sm_10x exclusively.
 template <int vec_size, typename func_t, typename array_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
 __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
   if constexpr (vec_size == 8) {
-#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10
+#if __CUDA_ARCH__ / 100 == 9 || __CUDA_ARCH__ / 100 == 10
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();
     int remaining = N - io_block_work_size<io_size>() * blockIdx.x;
@@ -191,7 +191,9 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
       elementwise_kernel_helper(
       f, memory::policies::vectorized<vec_size, array_t, elems_per_thread<io_size>()>(data));
     }
-#endif // __CUDA_ARCH__ == 900 || __CUDA_ARCH__ / 100 == 10
+#else
+    CUDA_KERNEL_ASSERT(false && "Fatal! vectorized_elementwise_kernel<8,...> supports only sm_90 and sm_10x. Please report an issue on GitHub.");
+#endif // __CUDA_ARCH__ / 100 == 9 || __CUDA_ARCH__ / 100 == 10
   } else {
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();
@@ -304,13 +306,16 @@ static inline void launch_vectorized_kernel(
   const uint16_t max_vec_size = memory::can_vectorize_up_to<func_t>(data);
   uint16_t vec_size = 16 / static_cast<uint16_t>(sizeof(cpp_type));
   vec_size = std::min<uint16_t>(vec_size, max_vec_size);
-  // Here we purposely omit vec8 for 1-byte data because of a bug in NVCC
-  // that causes some numerical mismatches with uint8 on sm80 and sm90.
-  // TODO: Revisit this after CUDA 12.8 update.
+  // due to exessive binary size the `vectorized_elementwise_kernel` of
+  // the size 8 is compiled for sm_90 and sm_10x only.
+  // TODO: Lift this limitation when CUDA 12.x support is fully dropped
   cudaDeviceProp* p = at::cuda::getDeviceProperties(stream.device().index());
   if (p->major != 9 && p->major != 10) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }
+  // Here we purposely omit vec8 for 1-byte data because of a bug in NVCC
+  // that causes some numerical mismatches with uint8 on sm80 and sm90.
+  // TODO: Revisit this after CUDA 12.8 update.
   if constexpr (sizeof(cpp_type) < 2) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -166,7 +166,7 @@ template <int vec_size, typename func_t, typename array_t>
 C10_LAUNCH_BOUNDS_1(num_threads())
 __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
   if constexpr (vec_size == 8) {
-#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000
+#if __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000 || __CUDA_ARCH__ == 1030
     using traits = function_traits<func_t>;
     constexpr auto io_size = calc_io_size<func_t>();
     int remaining = N - io_block_work_size<io_size>() * blockIdx.x;
@@ -309,7 +309,7 @@ static inline void launch_vectorized_kernel(
   // TODO: Revisit this after CUDA 12.8 update.
   cudaDeviceProp* p = at::cuda::getDeviceProperties(stream.device().index());
   const int computeCapability = p->major * 10 + p->minor;
-  if (computeCapability != 90 && computeCapability != 100) {
+  if (computeCapability != 90 && computeCapability != 100 && computeCapability != 103) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }
   if constexpr (sizeof(cpp_type) < 2) {


### PR DESCRIPTION
This will allow `sm_103` devices call vec8 kernels.
Verification script:
```Python
import torch
from torch.profiler import profile, ProfilerActivity

device = torch.device("cuda")

for dtype in (torch.bfloat16, torch.float16,):
    x = torch.randn(1024, device=device, dtype=dtype)
    with profile(activities=[ProfilerActivity.CUDA], record_shapes=True) as prof:
        y = torch.relu(x)
    stats = prof.key_averages()
    for entry in stats:
        if "at::native::vectorized_elementwise_kernel" in entry.key:
            print(entry.key)
```

Before:
```
void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#9}::operator()() const::{lambda(c10::BFloat16)#1}, std::array<char*, 2ul> >(int, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#9}::operator()() const::{lambda(c10::BFloat16)#1}, std::array<char*, 2ul>)
void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#8}::operator()() const::{lambda(c10::Half)#1}, std::array<char*, 2ul> >(int, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#8}::operator()() const::{lambda(c10::Half)#1}, std::array<char*, 2ul>)
```

After:
```
void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#9}::operator()() const::{lambda(c10::BFloat16)#1}, std::array<char*, 2ul> >(int, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#9}::operator()() const::{lambda(c10::BFloat16)#1}, std::array<char*, 2ul>)
void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#8}::operator()() const::{lambda(c10::Half)#1}, std::array<char*, 2ul> >(int, at::native::(anonymous namespace)::launch_clamp_scalar(at::TensorIteratorBase&, c10::Scalar, c10::Scalar, at::native::detail::ClampLimits)::{lambda()#1}::operator()() const::{lambda()#8}::operator()() const::{lambda(c10::Half)#1}, std::array<char*, 2ul>)
```

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @manuelcandales @angelayi