### PR TITLE
[PowerPC][onednn] Disable FP8 qconv support on PowerPC

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -463,7 +463,7 @@ at::Tensor _qconv_prepack_onednn(
 #define FP8E4M3_MAX 448.0
 
 #define CACHE_ONEDNN_CONTEXT_FLAG "ONEDNN_CACHE_CONTEXT_UNSAFE"
-#if IDEEP_PREREQ(3, 9, 0, 0)
+#if IDEEP_PREREQ(3, 9, 0, 0) && !defined(__powerpc__)
 #define ONEDNN_FP8_QCONV_SUPPORTED
 #endif
 


### PR DESCRIPTION
OneDNN FP8 support is enabled when IDEEP >= 3.9.0.

However, the FP8 path currently depends on x86-specific cpuinfo interfaces such as cpuinfo_has_x86_amx_fp16(). These APIs are not available on PowerPC platforms, which results in build failures when compiling the FP8 path.

Build failure observed:
`error: ‘cpuinfo_has_x86_amx_fp16’ was not declared in this scope
  543 |   if (is_fp8 && !cpuinfo_has_x86_amx_fp16()) {`


To fix this, ONEDNN_FP8_QCONV_SUPPORTED is disabled on PowerPC by checking the architecture using `__powerpc__`. This ensures that the FP8 qconv code path is only enabled on supported architectures.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01