### PR TITLE
[ROCm] assert HIP events in profiler stack trace

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -1424,7 +1424,7 @@ def _canonicalize_profiler_events(events):
 
         events_with_traces.append(
             {
-                "event_name": event_name[:20],
+                "event_name": event_name[:30],
                 "node_name": node_name,
                 "stack_trace": stack_trace,
                 "start_time": event.get("ts", 0),


### PR DESCRIPTION
Fixes #168751
Fixes #168750

#### Summary
The `test_profiler_stack_trace_augmentation` test expected CUDA-specific event names and failed on ROCm with HIP events. Profiler event names were being truncated to 20 characters causing:
- `hipExtModuleLaunchKernel` → `hipExtModuleLaunchKe`
- `hipGetDevicePropertiesR0600` → `hipGetDeviceProperti`

#### Fix:
- Increased event name character limit for longer HIP names.
- Filter out `hipGetDeviceProperties` events on ROCm.

#### Testing
Test now passes on MI308 with ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang