### PR TITLE
[DTensor] Add layer_norm decomposition handler to avoid forced redistribution

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -16,6 +16,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._nonlinear_redux import (
     argminmax_handler,
+    layer_norm_handler,
     minmax_dim_handler,
 )
 from torch.distributed.tensor._op_schema import (
@@ -163,6 +164,7 @@ class OpDispatcher:
             aten.argmax.default: argminmax_handler,
             aten.max.dim: minmax_dim_handler,
             aten.min.dim: minmax_dim_handler,
+            aten.native_layer_norm.default: layer_norm_handler,
         }
 
     # ********************************************************************************************


### PR DESCRIPTION
When input is sharded on normalized dimensions, decompose layer_norm into local sum reductions followed by a single all-reduce instead of forcing full tensor redistribution. Reduces communication from O(tensor_size) to O(outer_dims_size).

So, basically added custom handler for `native_layer_norm` that decomposes the operation when input is sharded on normalized dimensions. Instead of forcing redistribution to Replicate (all-gather), we:

1. Compute local `sum(x)` and `sum(x²)` → Partial placement
2. Stack and all-reduce in a single collective
3. Compute mean/variance from global sums
4. Normalize locally (input stays sharded)

FIXES #174276 