### PR TITLE
Allow fmt headers in downstream libs with TORCH_STABLE_ONLY

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1121,6 +1121,10 @@ class build_ext(setuptools.command.build_ext.build_ext):
             "torch/csrc/stable/",
             "torch/csrc/inductor/aoti_torch/c/",
             "torch/csrc/inductor/aoti_torch/generated/",
+            # Also skip headers from fmt library. Projects like TorchCodec rely
+            # on it. It's safe because pytorch only relies on
+            # fmt::fmt-header-only.
+            "fmt/",
         ]
 
         # Marker to detect if a header is already wrapped

--- a/setup.py
+++ b/setup.py
@@ -1125,6 +1125,8 @@ class build_ext(setuptools.command.build_ext.build_ext):
             # on it. It's safe because pytorch only relies on
             # fmt::fmt-header-only.
             "fmt/",
+            # Same for pybind, and it's header-only by definition.
+            "pybind11/",
         ]
 
         # Marker to detect if a header is already wrapped


### PR DESCRIPTION
Torch ships the headers of the `fmt` and `pybind` library, which some downstream libs like TorchCodec [rely on](https://github.com/meta-pytorch/torchcodec/blob/65ed0d5adf76c4e935afc29af5829de3a71e9bea/src/torchcodec/_core/CMakeLists.txt#L54-L59). Since torch only uses the "header-only" parts of `fmt`, it is safe to not error when a lib includes these headers in stable ABI mode. `pybind` is also safe since it's header-only by definition.

This PR removes the compilation errors when dowstream libraries try to include such headers.

The current workaround in TorchCodec is to use something like this:

```C
#ifdef TORCH_TARGET_VERSION
#pragma push_macro("TORCH_TARGET_VERSION")
#undef TORCH_TARGET_VERSION
#endif

#include <fmt/format.h>

// Restore TORCH_TARGET_VERSION
#pragma pop_macro("TORCH_TARGET_VERSION")
```

Test for this PR: build a wheel and validate that `fmt` and `pybind` headers are skipped:

```
python -m build --no-isolation --wheel 2&>1 | grep "Skipping header:" | grep -e fmt -e pybind

...
Skipping header: pybind11/eigen/matrix.h
Skipping header: pybind11/eigen/tensor.h
Skipping header: pybind11/stl/filesystem.h
Skipping header: fmt/args.h
Skipping header: fmt/base.h
Skipping header: fmt/chrono.h
Skipping header: fmt/color.h
...
```