### PR TITLE
Prefer cublas when TORCH_BLAS_PREFER_CUBLASLT is false

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -502,10 +502,10 @@ class TORCH_API Context {
       (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == true ||
        c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == true) // alias
       ? at::BlasBackend::Cublaslt
-      : (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == false ||
+      : ((c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == false ||
          c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == false) // alias
-      ? at::BlasBackend::Cublas
-      : at::BlasBackend::Default;
+          ? at::BlasBackend::Cublas
+          : at::BlasBackend::Default);
   at::ROCmFABackend rocm_fa_preferred_backend =
       c10::utils::check_env("TORCH_ROCM_FA_PREFER_CK") == true
       ? at::ROCmFABackend::Ck

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -502,8 +502,8 @@ class TORCH_API Context {
       (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == true ||
        c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == true) // alias
       ? at::BlasBackend::Cublaslt
-      : (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLAS") == true ||
-         c10::utils::check_env("TORCH_BLAS_PREFER_ROCBLAS") == true) // alias
+      : (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == false ||
+         c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == false) // alias
       ? at::BlasBackend::Cublas
       : at::BlasBackend::Default;
   at::ROCmFABackend rocm_fa_preferred_backend =

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -503,9 +503,10 @@ class TORCH_API Context {
        c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == true) // alias
       ? at::BlasBackend::Cublaslt
       : ((c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == false ||
-         c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == false) // alias
-          ? at::BlasBackend::Cublas
-          : at::BlasBackend::Default);
+          c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") ==
+              false) // alias
+             ? at::BlasBackend::Cublas
+             : at::BlasBackend::Default);
   at::ROCmFABackend rocm_fa_preferred_backend =
       c10::utils::check_env("TORCH_ROCM_FA_PREFER_CK") == true
       ? at::ROCmFABackend::Ck

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -502,6 +502,9 @@ class TORCH_API Context {
       (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == true ||
        c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == true) // alias
       ? at::BlasBackend::Cublaslt
+      : (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLAS") == true ||
+         c10::utils::check_env("TORCH_BLAS_PREFER_ROCBLAS") == true) // alias
+      ? at::BlasBackend::Cublas
       : at::BlasBackend::Default;
   at::ROCmFABackend rocm_fa_preferred_backend =
       c10::utils::check_env("TORCH_ROCM_FA_PREFER_CK") == true

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -692,6 +692,8 @@ print(t.is_pinned())
         custom_envs_cublaslt = [
             {"TORCH_BLAS_PREFER_CUBLASLT": "1"},
             {"TORCH_BLAS_PREFER_HIPBLASLT": "1"},
+            {"TORCH_BLAS_PREFER_CUBLAS": "1"},
+            {"TORCH_BLAS_PREFER_ROCBLAS": "1"},
         ]
         test_script = "import torch;print(torch.backends.cuda.preferred_blas_library())"
         for env_config in custom_envs_cublaslt:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -707,6 +707,13 @@ print(t.is_pinned())
             )
             self.assertEqual(expected, r)
 
+        # explicitly check default when no env vars are set
+        if not any(
+            os.environ.get(v)
+            for v in ("TORCH_BLAS_PREFER_CUBLASLT", "TORCH_BLAS_PREFER_HIPBLASLT")
+        ):
+            _check_default()
+
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @serialTest()
     @blas_library_context("cublas")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -689,12 +689,12 @@ print(t.is_pinned())
         with self.assertRaisesRegex(RuntimeError, "Unknown input value type."):
             torch.backends.cuda.preferred_blas_library(1.0)
         # check env var override
-        custom_envs = [
+        custom_envs_cublaslt = [
             {"TORCH_BLAS_PREFER_CUBLASLT": "1"},
             {"TORCH_BLAS_PREFER_HIPBLASLT": "1"},
         ]
         test_script = "import torch;print(torch.backends.cuda.preferred_blas_library())"
-        for env_config in custom_envs:
+        for env_config in custom_envs_cublaslt:
             env = os.environ.copy()
             for key, value in env_config.items():
                 env[key] = value
@@ -704,6 +704,21 @@ print(t.is_pinned())
                 .strip()
             )
             self.assertEqual("_BlasBackend.Cublaslt", r)
+        # check CUBLAS/ROCBLAS env var aliases
+        custom_envs_cublas = [
+            {"TORCH_BLAS_PREFER_CUBLAS": "1"},
+            {"TORCH_BLAS_PREFER_ROCBLAS": "1"},
+        ]
+        for env_config in custom_envs_cublas:
+            env = os.environ.copy()
+            for key, value in env_config.items():
+                env[key] = value
+            r = (
+                subprocess.check_output([sys.executable, "-c", test_script], env=env)
+                .decode("ascii")
+                .strip()
+            )
+            self.assertEqual("_BlasBackend.Cublas", r)
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @serialTest()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -689,14 +689,14 @@ print(t.is_pinned())
         with self.assertRaisesRegex(RuntimeError, "Unknown input value type."):
             torch.backends.cuda.preferred_blas_library(1.0)
         # check env var override
-        custom_envs_cublaslt = [
-            {"TORCH_BLAS_PREFER_CUBLASLT": "1"},
-            {"TORCH_BLAS_PREFER_HIPBLASLT": "1"},
-            {"TORCH_BLAS_PREFER_CUBLAS": "1"},
-            {"TORCH_BLAS_PREFER_ROCBLAS": "1"},
+        custom_envs = [
+            ({"TORCH_BLAS_PREFER_CUBLASLT": "1"}, "_BlasBackend.Cublaslt"),
+            ({"TORCH_BLAS_PREFER_HIPBLASLT": "1"}, "_BlasBackend.Cublaslt"),
+            ({"TORCH_BLAS_PREFER_CUBLASLT": "0"}, "_BlasBackend.Cublas"),
+            ({"TORCH_BLAS_PREFER_HIPBLASLT": "0"}, "_BlasBackend.Cublas"),
         ]
         test_script = "import torch;print(torch.backends.cuda.preferred_blas_library())"
-        for env_config in custom_envs_cublaslt:
+        for env_config, expected in custom_envs:
             env = os.environ.copy()
             for key, value in env_config.items():
                 env[key] = value
@@ -705,22 +705,7 @@ print(t.is_pinned())
                 .decode("ascii")
                 .strip()
             )
-            self.assertEqual("_BlasBackend.Cublaslt", r)
-        # check CUBLAS/ROCBLAS env var aliases
-        custom_envs_cublas = [
-            {"TORCH_BLAS_PREFER_CUBLAS": "1"},
-            {"TORCH_BLAS_PREFER_ROCBLAS": "1"},
-        ]
-        for env_config in custom_envs_cublas:
-            env = os.environ.copy()
-            for key, value in env_config.items():
-                env[key] = value
-            r = (
-                subprocess.check_output([sys.executable, "-c", test_script], env=env)
-                .decode("ascii")
-                .strip()
-            )
-            self.assertEqual("_BlasBackend.Cublas", r)
+            self.assertEqual(expected, r)
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @serialTest()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -712,6 +712,7 @@ print(t.is_pinned())
             os.environ.get(v)
             for v in ("TORCH_BLAS_PREFER_CUBLASLT", "TORCH_BLAS_PREFER_HIPBLASLT")
         ):
+            torch.backends.cuda.preferred_blas_library("default")
             _check_default()
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -303,9 +303,10 @@ def preferred_blas_library(
     * If `"ck"` is set then CK will be used wherever possible.
     * If `"default"` (the default) is set then heuristics will be used to pick between the other options.
     * When no input is given, this function returns the currently preferred library.
-    * User may use the environment variable TORCH_BLAS_PREFER_CUBLASLT=1 to set the preferred library to cuBLASLt
-      globally.
-      This flag only sets the initial value of the preferred library and the preferred library
+    * User may use environment variables to set the preferred library globally:
+      - TORCH_BLAS_PREFER_CUBLASLT=1 or TORCH_BLAS_PREFER_HIPBLASLT=1 for cuBLASLt
+      - TORCH_BLAS_PREFER_CUBLAS=1 or TORCH_BLAS_PREFER_ROCBLAS=1 for cuBLAS
+      These flags only set the initial value of the preferred library and the preferred library
       may still be overridden by this function call later in your script.
 
     Note: When a library is preferred other libraries may still be used if the preferred library

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -303,10 +303,9 @@ def preferred_blas_library(
     * If `"ck"` is set then CK will be used wherever possible.
     * If `"default"` (the default) is set then heuristics will be used to pick between the other options.
     * When no input is given, this function returns the currently preferred library.
-    * User may use environment variables to set the preferred library globally:
-      - TORCH_BLAS_PREFER_CUBLASLT=1 or TORCH_BLAS_PREFER_HIPBLASLT=1 for cuBLASLt
-      - TORCH_BLAS_PREFER_CUBLAS=1 or TORCH_BLAS_PREFER_ROCBLAS=1 for cuBLAS
-      These flags only set the initial value of the preferred library and the preferred library
+    * User may use the environment variable TORCH_BLAS_PREFER_CUBLASLT=1 to set the preferred library to cuBLASLt
+      globally.
+      This flag only sets the initial value of the preferred library and the preferred library
       may still be overridden by this function call later in your script.
 
     Note: When a library is preferred other libraries may still be used if the preferred library


### PR DESCRIPTION
### Summary

Set blas_preferred_backend = at::BlasBackend::Cublas when TORCH_BLAS_PREFER_CUBLASLT / TORCH_BLAS_PREFER_HIPBLASLT is explicitly set to false.

For ROCm, if a gfx arch is in the list returned by getHipblasltPreferredArchs() hipBLASLt will be set as blas_preferred_backend by default regardless of TORCH_BLAS_PREFER_HIPBLASLT setting. This PR enables users to explicitly select cublas/rocblas and makes this env. variable behave like a binary toggle.


### Changes

- Modified checks for TORCH_BLAS_PREFER_CUBLASLT/TORCH_BLAS_PREFER_HIPBLASLT env. variables
- Updated test_preferred_blas_library_settings