### PR TITLE
[MPS] Fix masked_scatter to preserve scalar tensor shape

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -981,6 +981,8 @@ Tensor& masked_scatter__mps(Tensor& self, const Tensor& mask, const Tensor& sour
   TORCH_CHECK(mask.scalar_type() == ScalarType::Byte || mask.scalar_type() == ScalarType::Bool,
               "masked_scatter: expected BoolTensor or ByteTensor for mask");
 
+  bool was_scalar = self.dim() == 0;
+
   auto mask_temp =
       (mask.dim() == 0) ? c10::MaybeOwned<Tensor>::owned(mask.unsqueeze(0)) : c10::MaybeOwned<Tensor>::borrowed(mask);
   auto self_temp =
@@ -1014,8 +1016,12 @@ Tensor& masked_scatter__mps(Tensor& self, const Tensor& mask, const Tensor& sour
     final_indices.push_back(index);
   }
 
-  return at::index_put_out(
+  at::index_put_out(
       self, *std::get<1>(mask_self_expanded), final_indices, source.flatten().narrow(0, 0, indices[0].numel()));
+  if (was_scalar) {
+    self.squeeze_();
+  }
+  return self;
 }
 
 static void index_fill_mps_kernel(TensorIterator& iter,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1672,6 +1672,18 @@ class TestMPS(TestCaseMPS):
         helper([10, 5, 10, 3])
         helper([10, 5, 10, 3, 20])
 
+        # Test scalar tensor (0-dimensional) - should preserve shape
+        x_mps = torch.tensor(0, device="mps")
+        x_cpu = x_mps.detach().clone().cpu()
+        mask_mps = torch.tensor(True, device="mps")
+        mask_cpu = mask_mps.detach().clone().cpu()
+        source_mps = torch.tensor([42], device="mps")
+        source_cpu = source_mps.detach().clone().cpu()
+        result_mps = x_mps.masked_scatter(mask_mps, source_mps)
+        result_cpu = x_cpu.masked_scatter(mask_cpu, source_cpu)
+        self.assertEqual(result_mps.shape, result_cpu.shape)
+        self.assertEqual(result_mps, result_cpu)
+
     def test_masked_scatter_raises(self):
         x_mps = torch.tensor([0, 0, 0], device="mps")
         mask_mps = torch.tensor([1, 1, 1], dtype=torch.bool, device="mps")


### PR DESCRIPTION
## Summary
- Fix MPS `masked_scatter` to preserve scalar tensor shape `[]` instead of incorrectly returning `[1]`
- The function now records whether `self` was originally 0-dimensional and squeezes the result back after processing

## Test plan
- Added scalar tensor test case to `test_masked_scatter` in `test/test_mps.py`
- Verified fix with reproducer script

Related error: https://github.com/pytorch/rl/issues/3137#issuecomment-3854034059