### PR TITLE
Add remove_duplicate parameter to Module.modules() function

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -505,6 +505,9 @@ class TestNN(NNTestCase):
         n = Net()
         s = nn.Sequential(n, n, n, n)
         self.assertEqual(list(s.modules()), [s, n, l])
+        # test the option to not remove duplicate module instances
+        self.assertEqual(list(s.modules(remove_duplicate=False)), [
+            s, n, l, l, n, l, l, n, l, l, n, l, l])
 
     def test_named_modules(self):
         class Net(nn.Module):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2803,14 +2803,18 @@ class Module:
                 memo.add(module)
                 yield name, module
 
-    def modules(self) -> Iterator["Module"]:
+    def modules(self, remove_duplicate: bool = True) -> Iterator["Module"]:
         r"""Return an iterator over all modules in the network.
+
+        Args:
+            remove_duplicate: whether to remove the duplicated module instances in the result
+                or not.
 
         Yields:
             Module: a module in the network
 
         Note:
-            Duplicate modules are returned only once. In the following
+            Duplicate modules are returned only once by default. In the following
             example, ``l`` will be returned only once.
 
         Example::
@@ -2827,7 +2831,7 @@ class Module:
             1 -> Linear(in_features=2, out_features=2, bias=True)
 
         """
-        for _, module in self.named_modules():
+        for _, module in self.named_modules(remove_duplicate=remove_duplicate):
             yield module
 
     def named_modules(


### PR DESCRIPTION
#166690 introduced a regression in the `test/test_quantization.py::TestQuantizeFx::test_copy_node_has_shared_actpp_instance` unit test. The test is failing with the following message:
```
FAILED [0.0337s] test/test_quantization.py::TestQuantizeFx::test_copy_node_has_shared_actpp_instance - TypeError: Module.modules() got an unexpected keyword argument 'remove_duplicate'
```

The change of
```
for name, module in m.named_modules(remove_duplicate=False):
```
to
```
for module in m.modules(remove_duplicate=False):
```
introduces a failure because the `modules()` function does not have the `remove_duplicates` parameter.
Considering that `modules()` is a wrapper around and calls `named_modules()`, this PR addresses the failure by adding the `remove_duplicate` parameter to `modules()` the same way as implemented in `named_modules()`. The default behavior still remains the same (removing duplicates by default).