### PR TITLE
Possible buffer overflow on loading data from memory into a CPU vector register

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
@@ -250,7 +250,10 @@ class Vectorized16 {
   static Vectorized<T> loadu(const void* ptr, int16_t count = size()) {
     if (count == size())
       return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
-
+    assert(count <= size() && "Vectorized16::loadu cannot load more than 16 elements!");
+    if (count > size()) {
+      count = size();
+    }
     __at_align__ int16_t tmp_values[size()];
 #ifndef __msvc_cl__
 #pragma unroll


### PR DESCRIPTION
[CPU] Possible buffer overflow on loading data from memory into a CPU vector register
    
Problem in class template Vectorized16, methd template "_load unaligned_":
    
      static Vectorized<T> loadu(const void* ptr, int16_t count = size())
    
variable "_tmp_values_" has a fixed size of 32 bytes _(16 elements * 2 bytes)_.
    
      __at_align__ int16_t tmp_values[size()]
    
where size() is _static constexpr_ and it always returns 16.
    
But what if "count" argument of _loadu()_ would be larger than 16?
    
In _loadu()_, there is a check "_if (count == size())_", that only handles the exact case of 16.
If someone intentionally or accidentally would call _loadu(ptr, 17)_, the first if condition
would be skipped, and the code would proceed to _memcpy_ with a size of 34 bytes
and overflowing the 32-byte buffer (_tmp_values_).
    
This change fixes:
  1. Adds a check for count size.
  2. Adds an assertion before the memory operations to prevent "tmp_values" overflow.

Passing more than 16 elements is either:
-  a programmer error (a bug in the logic calling the function)
-  intentional action to cause the buffer overflow

Using assertion will have no performance impact on release code, as assertion
will be completely removed by the compiler. While in debug mode, the code will crash
with a helpful error message.


### Environment
Collecting environment information...                                                                                                                          
PyTorch version: 2.11.0a0+gitc57d1d2       
Is debug build: False                      
CUDA used to build PyTorch: None          
ROCM used to build PyTorch: N/A           
                                                                      
OS: CentOS Stream 10 (Coughlan) (x86_64)                              
GCC version: (GCC) 14.3.1 20251022 (Red Hat 14.3.1-4)
Clang version: 21.1.6 (CentOS 21.1.6-1.el10)   
CMake version: version 4.2.1                                          
Libc version: glibc-2.39                                                                                                                     
                                                                      
Python version: 3.12.12 (main, Jan 16 2026, 00:00:00) [GCC 14.3.1 20251022 (Red Hat 14.3.1-4)] (64-bit runtime)                                                                                                                                                                                                               
Python platform: Linux-6.18.6-200.fc43.x86_64-x86_64-with-glibc2.39                                                                                                                                                                                                                                                           
Is CUDA available: False                                                                                                                                                                                                                                                                                                      
CUDA runtime version: No CUDA                                                                                                                
CUDA_MODULE_LOADING set to: N/A                               
GPU models and configuration: No CUDA                         
Nvidia driver version: No CUDA                                                                                                                                                                                      
cuDNN version: No CUDA                                      
Is XPU available: False                    
HIP runtime version: N/A                     
MIOpen runtime version: N/A                          
Is XNNPACK available: True                           
Caching allocator config: N/A                        
                                                                      
CPU:                                                 
Architecture:                            x86_64                                                                                                                                                                                                                                           
CPU op-mode(s):                          32-bit, 64-bit                                                                                                                                                                                                                                   
Address sizes:                           48 bits physical, 48 bits virtual                                                                                                                                                                                                                
Byte Order:                              Little Endian                                                                                                                                                                                                                                                                                                                                                                                  
CPU(s):                                  16                                                                                                                                                                                                                                                                                                                                                                                             
On-line CPU(s) list:                     0-15                                                                                                                                                                       
Vendor ID:                               AuthenticAMD         
Model name:                              AMD Ryzen 7 5700G with Radeon Graphics                                                                                                                                                                               
CPU family:                              25                                                                                                                    
Model:                                   80                                                                                                                    
Thread(s) per core:                      2           
Core(s) per socket:                      8           
Socket(s):                               1           
Stepping:                                0           
Frequency boost:                         enabled                      
CPU(s) scaling MHz:                      61%                                   
CPU max MHz:                             4673.8232                             
CPU min MHz:                             422.3340                              
BogoMIPS:                                7585.72                               
Flags:                                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfc
tr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca
 fsrm debug_swap                                                               
L1d cache:                               256 KiB (8 instances)                 
L1i cache:                               256 KiB (8 instances)                 
L2 cache:                                4 MiB (8 instances)                   
L3 cache:                                16 MiB (1 instance)                                                                                                                                                        
NUMA node(s):                            1                                                                                                                                                                          
NUMA node0 CPU(s):                       0-15                                  
Vulnerability Gather data sampling:      Not affected                          
Vulnerability Ghostwrite:                Not affected                          
Vulnerability Indirect target selection: Not affected                                                     
Vulnerability Itlb multihit:             Not affected                                                                          
Vulnerability L1tf:                      Not affected                                                     
Vulnerability Mds:                       Not affected                                                     
Vulnerability Meltdown:                  Not affected                                                     
Vulnerability Mmio stale data:           Not affected                                                     
Vulnerability Old microcode:             Not affected                                                     
Vulnerability Reg file data sampling:    Not affected                                                     
Vulnerability Retbleed:                  Not affected                                                     
Vulnerability Spec rstack overflow:      Vulnerable                                                       
Vulnerability Spec store bypass:         Vulnerable                                                       
Vulnerability Spectre v1:                Vulnerable: __user pointer sanitization and usercopy barriers only; no swapgs barriers                                                                                                                               
Vulnerability Spectre v2:                Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected                                                                                                                            
Vulnerability Srbds:                     Not affected                                                     
Vulnerability Tsa:                       Vulnerable                                                       
Vulnerability Tsx async abort:           Not affected                                                     
Vulnerability Vmscape:                   Vulnerable                                                       

Versions of relevant libraries:                                                                                                
[pip3] intel-cmplr-lib-ur==2025.3.2                                                                                            
[pip3] intel-openmp==2025.3.2                                                                                                  
[pip3] mkl-include==2025.3.1                                                                                                   
[pip3] mkl-static==2025.3.1                                                                                                    
[pip3] numpy==2.4.2                                                                                                            
[pip3] onemkl-license==2025.3.1                                                                                                
[pip3] optree==0.18.0                                                                                                          
[pip3] tbb==2022.3.1                                                                                                           
[pip3] tbb-devel==2022.3.1                                                                                                     
[pip3] tcmlib==1.4.1                                                                                                           
[pip3] torch==2.11.0a0+gitc57d1d2                                                                                              
[pip3] umf==1.0.3                                                                                                              
[conda] Could not collect    




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01