### PR TITLE
Allow dispatch of LayerNormBackwardKernel on all devices.

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorBackward.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBackward.cpp
@@ -269,7 +269,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_nested(
   }
   if (M > 0) {
     LayerNormBackwardKernel(
-        input_buffer.is_cuda() ? kCUDA : kCPU,
+        input_buffer.device().type(),
         grad_buffer,
         input_buffer,
         mean,


### PR DESCRIPTION
Current implementation only allows for dispatching kCUDA and kCPU devices.

This change allows for dispatching to other devices also.