### PR TITLE
[ROCm] disable test_max_autotune on gfx1100 and skip CPU failure

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -34,8 +34,10 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_FBCODE,
     IS_MACOS,
+    MI200_ARCH,
     parametrize,
     skipIfRocm,
+    skipIfRocmArch,
     slowTest,
     TEST_MKL,
     xfailIfS390X,
@@ -5834,6 +5836,7 @@ class CPUReproTests(TestCase):
 
         torch.compile(fn)(torch.randn(2, 2))
 
+    @skipIfRocmArch(MI200_ARCH)
     @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
     @requires_vectorization
     @config.patch(freezing=True)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_utils import (
     get_report_path,
     IS_CI,
     IS_MACOS,
+    isRocmArchAnyOf,
     retry_shell,
     set_cwd,
     shell,
@@ -196,6 +197,11 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
 ]
+
+# Add architecture-specific blocklist entries
+if TEST_WITH_ROCM and isRocmArchAnyOf(("gfx1100",)):
+    # Some autotune tests on gfx1100 are hanging, disable for now
+    ROCM_BLOCKLIST.append("inductor/test_max_autotune")
 
 S390X_BLOCKLIST = [
     # these tests fail due to various reasons


### PR DESCRIPTION
Re-enabling max_autotune on ROCm caused some timeouts on gfx1100, disabling while investigating.

Skipping a CPU failure on trunk that shows up in gfx942 runners, to investigate further.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben