### PR TITLE
Reset dummy_allocator indicator variables

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5780,6 +5780,11 @@ class TestMemPool(TestCase):
         torch.cuda.empty_cache()
         self.assertEqual(called_dummy_free.value, 321)
 
+        # reset dummy allocator indicator variables because they are global
+        called_dummy_free.value = 0
+        called_dummy_alloc.value = 0
+
+    @serialTest()
     def test_mempool_with_allocator(self):
         pool = torch.cuda.MemPool()
 
@@ -5851,6 +5856,11 @@ class TestMemPool(TestCase):
         # out tensor
         self.assertEqual(called_dummy_free.value, 321)
 
+        # reset dummy allocator indicator variables because they are global
+        called_dummy_free.value = 0
+        called_dummy_alloc.value = 0
+
+    @serialTest()
     def test_tensor_delete_after_allocator_delete(self):
         allocator, dummy_allocator = self.get_dummy_allocator(check_vars=True)
         pool = torch.cuda.MemPool(allocator.allocator())
@@ -5881,6 +5891,10 @@ class TestMemPool(TestCase):
         torch.cuda.empty_cache()
 
         self.assertEqual(called_dummy_free.value, 321)
+
+        # reset dummy allocator indicator variables because they are global
+        called_dummy_free.value = 0
+        called_dummy_alloc.value = 0
 
     @serialTest()
     def test_mempool_limited_memory_with_allocator(self):


### PR DESCRIPTION
Fixes #174392. The indicator variables used to check if the custom allocator was working as expected exist outside of the scope of the individual tests and thus don't get reset to 0, which can cause test failures if two tests with  
```python
allocator, dummy_allocator = self.get_dummy_allocator(check_vars=True)
```
are run back-to-back. Running a test in the middle that calls 
```python
allocator, _ = self.get_dummy_allocator(check_vars=False)
```
recompiles the allocator code, indirectly resetting the variables. This simply resets the variables to 0 at the end of the tests that check them, and adds a couple `@serialTest()` decorators to ensure that tests don't try to access/modify these variables in parallel.

cc @eqy 