### PR TITLE
Remove MemPool allocator property

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5783,14 +5783,9 @@ class TestMemPool(TestCase):
     def test_mempool_with_allocator(self):
         pool = torch.cuda.MemPool()
 
-        # MemPool doesn't have an allocator by default
-        self.assertEqual(pool.allocator, None)
         allocator, dummy_allocator = self.get_dummy_allocator(check_vars=True)
 
         pool = torch.cuda.MemPool(allocator.allocator())
-
-        # pool should point to the same allocator as the one passed into it
-        self.assertEqual(allocator.allocator(), pool.allocator)
 
         # pool's use count should be 1 at this point as MemPool object
         # holds a reference

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1264,11 +1264,6 @@ class MemPool(_MemPool):
         r"""Returns the ID of this pool as a tuple of two ints."""
         return super().id
 
-    @property
-    def allocator(self) -> _cuda_CUDAAllocator | None:
-        r"""Returns the allocator this MemPool routes allocations to."""
-        return super().allocator
-
     def use_count(self) -> int:  # pylint: disable=useless-parent-delegation
         r"""Returns the reference count of this pool."""
         return super().use_count()


### PR DESCRIPTION
Noticed `test_mempool_with_allocator` was failing, and that #172657 removed the allocator property on the C++ side. This is just some final cleanup to remove it on the Python side + tests.

The failure:
```
======================================================================
ERROR: test_mempool_with_allocator (__main__.TestMemPool.test_mempool_with_allocator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/pytorch/torch/testing/_internal/common_utils.py", line 3364, in wrapper
    method(*args, **kwargs)
  File "/workspace/pytorch/test/test_cuda.py", line 5792, in test_mempool_with_allocator
    self.assertEqual(pool.allocator, None)
                     ^^^^^^^^^^^^^^
  File "/workspace/pytorch/torch/cuda/memory.py", line 1270, in allocator
    return super().allocator
           ^^^^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute 'allocator'

To execute this test, run the following from the base repo dir:
    python test/test_cuda.py TestMemPool.test_mempool_with_allocator

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

----------------------------------------------------------------------
Ran 1 test in 0.002s

FAILED (errors=1)
```

cc @galv @eqy 