### PR TITLE
[bugfix][dynamo] Fix named children in `wrap_values` for NNModuleVarible

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -682,9 +682,9 @@ class NNModuleVariable(VariableTracker):
         def wrap_values(
             items: Iterable[tuple[Any, Any]],
         ) -> "variables.ListIteratorVariable":
-            result = []
+            named_children: list[VariableTracker] = []
             for name, submod in items:
-                result.append(
+                named_children.append(
                     tx.output.register_attr_or_module(
                         submod,
                         key,


### PR DESCRIPTION
### Summary
See title - we renamed a variable in a refactor that was not caught by any testing, resulting in a bug in 2.10 release.

This PR fixes the error by:
* correcting the misnamed variable
* Adding a unit test to ensure we have coverage for this code path

Fixes https://github.com/pytorch/pytorch/issues/173924 

### Unit Test
```bash
pytest test/dynamo/test_repros.py::ReproTests::test_nnmodule_variable_children_wrap_value
```

#### On Main:
```bash
...
  File "/home/lucaskabela/pytorch/torch/_dynamo/symbolic_convert.py", line 4070, in _call
    self.call_function(fn, args, kwargs)
  File "/home/lucaskabela/pytorch/torch/_dynamo/symbolic_convert.py", line 1360, in call_function
    self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucaskabela/pytorch/torch/_dynamo/variables/functions.py", line 1444, in call_function
    return self.obj.call_method(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucaskabela/pytorch/torch/_dynamo/variables/nn_module.py", line 773, in call_method
    return wrap_values(module.named_children())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucaskabela/pytorch/torch/_dynamo/variables/nn_module.py", line 696, in wrap_values
    named_children, mutation_type=ValueMutationNew()
    ^^^^^^^^^^^^^^
torch._dynamo.exc.InternalTorchDynamoError: NameError: cannot access free variable 'named_children' where it is not associated with a value in enclosing scope

from user code:
   File "/home/lucaskabela/pytorch/test/dynamo/test_repro.py", line 29, in forward
    for child in self.container.children():
```

#### This PR
```bash
Running 1 items in this shard

test/dynamo/test_repros.py .                                       [100%]

=========================== 1 passed in 1.98s ============================
```

Co-authored-by: Damian @DamJanusz 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo