### PR TITLE
[CD] Disable `MI_NO_OPT_ARCH` on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,11 @@ option(USE_MIMALLOC "Use mimalloc" OFF)
 option(USE_MIMALLOC_ON_MKL "Use mimalloc on MKL" OFF)
 if(WIN32 OR (CPU_AARCH64 AND NOT APPLE))
   set(USE_MIMALLOC ON)
+  # Disable OPT flags for mimalloc on aarch64 as it breaks ARMv8.0
+  # See https://github.com/pytorch/pytorch/issues/174344
+  if(CPU_AARCH64)
+    set(MI_NO_OPT_ARCH ON)
+  endif()
 
   # Not enable USE_MIMALLOC_ON_MKL due to it caused issue:
   # https://github.com/pytorch/pytorch/issues/138994


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #174401

As it makes binaries incompatible with ARMv8.0

Test plan:
 - Allocate `a1.4xlarge` and try importing torch from 2.10 and artifacts from https://github.com/pytorch/pytorch/actions/runs/21724911010?pr=174401
```shell
$ python3.10 -mvenv ~/py3.10-torch2.10
$ python3.10 -mvenv ~/py3.10-torch2.11
$ source ~/py3.10-torch2.10/bin/activate
(py3.10-torch2.10) $ pip install torch
...
(py3.10-torch2.10) $ python3 -c "import torch;print(torch.__version__)"
Illegal instruction (core dumped)
(py3.10-torch2.10) $ source ~/py3.10-torch2.11/bin/activate
pip install ./torch-2.11.0.dev20260205+cpu-cp310-cp310-manylinux_2_28_aarch64.whl
(py3.10-torch2.11) $ python3 -c "import torch;print(torch.__version__)"
/home/ubuntu/py3.10-torch2.11/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py:307: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
2.11.0.dev20260205+cpu

```

Plus benchmarks run by @murste01 https://github.com/pytorch/pytorch/pull/174401#issuecomment-3859100551

Fixes https://github.com/pytorch/pytorch/issues/174344