### PR TITLE
[wip][_inductor] Specify out_dtype when decomposing addmm in post_grad pass

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1323,10 +1323,13 @@ def forward(self, primals_1):
         self.assertEqual(cnt.frame_count, 1)
 
         code = run_and_get_triton_code(compiled_model, inp)
+        mm_name = "extern_kernels.mm_dtype" \
+            if device_type in (torch.float16, torch.bfloat16) \
+            else "extern_kernels.mm"
         FileCheck().check(
             "buf0 = torch.ops._c10d_functional.all_gather_into_tensor.default(primal"
         ).check("torch.ops._c10d_functional.wait_tensor.default(buf0").check(
-            "extern_kernels.mm(buf0,"
+            f"{mm_name}(buf0,"
         ).run(code)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1518,12 +1518,18 @@ def should_prefer_unfused_addmm(match):
 )
 def unfuse_bias_add_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
     def repl(inp, x1, x2, alpha, beta):
-        mm_result = x1 @ x2
+        in_dtype = inp.dtype
+        # deal with numeric loss in fp16/bf16 when decomposing addmm to mm+add
+        if in_dtype in (torch.float16, torch.bfloat16):
+            mm_result = aten.mm(x1, x2, out_dtype=torch.float32)
+        else:
+            mm_result = aten.mm(x1, x2)
         if alpha != 1:
             mm_result = alpha * mm_result
         if beta != 1:
             inp = beta * inp
-        return inp + mm_result
+        out = inp + mm_result
+        return out.to(dtype=in_dtype)
 
     # pyrefly: ignore [bad-argument-type]
     match.replace_by_example(repl, [inp, mat1, mat2, alpha, beta])


### PR DESCRIPTION
Summary:
Decomposing addmm to mm and add will cause numeric issues: https://fb.workplace.com/groups/1144215345733672/posts/3402368019918382

This is because the output of `mm` is the same as the input dtype, while `addmm` accumulation is done with `float32`

Therefore, `addmm` is numerically equvalient with `(mm(out_dtype=float32)+add).to(inp.dtype)`, not `mm+add`.

This is reported by Tritonbench user: https://github.com/meta-pytorch/tritonbench/issues/607

Test Plan:
Before fix:

tlparse:
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmplSoLcG/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

```
$ buck2 run mode/opt //pytorch/tritonbench:run_lite -- --op mlp --use_bias --metrics accuracy

  x_val    compile_mlp-accuracy
-------  ----------------------
      0                       0
      1                       0
      2                       0
      3                       0
      4                       0
      5                       0
      6                       0
      7                       0
      8                       0
      9                       0
average                       0
```


After fix:

tlparse:
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpjMKOz7/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000


```
$ buck2 run mode/opt //pytorch/tritonbench:run_lite -- --op mlp --use_bias --metrics accuracy

  x_val    compile_mlp-accuracy
-------  ----------------------
      0                       1
      1                       1
      2                       1
      3                       1
      4                       1
      5                       1
      6                       1
      7                       1
      8                       1
      9                       1
average                       1
```

Differential Revision: D92417852




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo