### PR TITLE
Nested Comprehension Graph Breaks

### DIFF
--- a/test/dynamo/test_comprehensions.py
+++ b/test/dynamo/test_comprehensions.py
@@ -772,6 +772,181 @@ class ComprehensionTests(torch._inductor.test_case.TestCase):
         for i in range(6):
             self.assertEqual(count_op(backend.graphs[i], operator.add), 1)
 
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_function_calls_with_comprehension_graph_break_nested_graph_breaks_true(
+        self,
+    ):
+        """Test nested function calls where inner function has comprehension with graph break."""
+
+        def h(x):
+            x = x + 3
+            [torch._dynamo.graph_break() or i for i in range(3)]
+            x = x + 4
+            return x
+
+        def g(x):
+            x = x + 2
+            x = h(x)
+            x = x + 5
+            return x
+
+        def f(x):
+            x = x + 1
+            x = g(x)
+            x = x + 6
+            return x
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(f, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), f(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 3)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 3)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_function_comprehension_with_walrus(self):
+        """Nested function with comprehension containing walrus operator."""
+
+        def inner(x):
+            x = x + 1
+            result = [(y := i * 2) for i in [torch._dynamo.graph_break() or 1, 2, 3]]
+            x = x + 2
+            return x + sum(result)
+
+        def outer(x):
+            x = x + 3
+            x = inner(x)
+            x = x + 4
+            return x
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_function_comprehension_with_captured_var(self):
+        """Nested function with comprehension capturing outer variable passed as parameter."""
+
+        def inner(x, multiplier):
+            x = x + 1
+            result = [multiplier * i for i in [torch._dynamo.graph_break() or 1, 2, 3]]
+            x = x + 2
+            return x
+
+        def outer(x):
+            multiplier = 5
+            x = x + 3
+            x = inner(x, multiplier)
+            x = x + 4
+            return x
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_triple_nested_function_comprehension(self):
+        """Triple nested function calls (f->g->h->deepest) with comprehension in deepest."""
+
+        def deepest(x):
+            x = x + 4
+            [torch._dynamo.graph_break() or i for i in range(3)]
+            x = x + 5
+            return x
+
+        def h(x):
+            x = x + 3
+            x = deepest(x)
+            x = x + 6
+            return x
+
+        def g(x):
+            x = x + 2
+            x = h(x)
+            x = x + 7
+            return x
+
+        def f(x):
+            x = x + 1
+            x = g(x)
+            x = x + 8
+            return x
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(f, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), f(x))
+        self.assertEqual(len(backend.graphs), 2)
+        # Before comprehension: x+1, x+2, x+3, x+4 = 4 adds
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 4)
+        # After comprehension: x+5, x+6, x+7, x+8 = 4 adds
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 4)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_multiple_nested_comprehensions_in_different_functions(self):
+        """Two sequential nested function calls each with comprehensions."""
+
+        def inner1(x):
+            x = x + 1
+            [torch._dynamo.graph_break() or i for i in range(2)]
+            x = x + 2
+            return x
+
+        def inner2(x):
+            x = x + 3
+            [torch._dynamo.graph_break() or i for i in range(2)]
+            x = x + 4
+            return x
+
+        def outer(x):
+            x = inner1(x)
+            x = inner2(x)
+            return x
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        # Graph 1: x+1, Graph 2: x+2, x+3, Graph 3: x+4
+        self.assertEqual(len(backend.graphs), 3)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_function_comprehension_with_outer_list_mutation(self):
+        """Nested function with comprehension mutating outer list."""
+
+        def inner(x, results):
+            x = x + 1
+            [results.append(torch._dynamo.graph_break() or i) for i in range(3)]
+            x = x + 2
+            return x
+
+        def outer(x):
+            results = []
+            x = x + 3
+            x = inner(x, results)
+            x = x + 4
+            return x, results
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        compiled_result = compiled(x)
+        eager_result = outer(x)
+        self.assertEqual(compiled_result[0], eager_result[0])
+        self.assertEqual(compiled_result[1], eager_result[1])
+        self.assertEqual(len(backend.graphs), 2)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_comprehensions.py
+++ b/test/dynamo/test_comprehensions.py
@@ -954,13 +954,13 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_list_comprehension_graph_break."""
 
         def inner(x):
-            y = x + 1
+            y = x + 2
             result = [torch._dynamo.graph_break() or i for i in range(3)]
-            z = x + 2
+            z = x + 3
             return y, result, z
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -979,13 +979,13 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_dict_comprehension_graph_break."""
 
         def inner(x):
-            y = x + 1
+            y = x + 2
             result = {i: torch._dynamo.graph_break() or i**2 for i in range(3)}
-            z = x + 2
+            z = x + 3
             return y, result, z
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1011,11 +1011,11 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         def inner(x):
             y = x * 2
             lst = [graph_break_fn(i) for i in range(5)]
-            z = x + sum(lst)
+            z = x + 3
             return z, y
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1035,15 +1035,15 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_multiple_comprehensions_one_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             list1 = [i for i in range(2)]  # noqa: C416
             list2 = [torch._dynamo.graph_break() or i for i in range(2)]
-            b = x + 2
+            b = x + 3
             list3 = [i * 2 for i in range(2)]
             return a, list1, list2, b, list3
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1062,16 +1062,16 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_nested_comprehension_inner_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 [torch._dynamo.graph_break() or i * j for j in range(2)]
                 for i in range(2)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1090,17 +1090,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_multi_iterator_comprehension_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 (torch._dynamo.graph_break() or i, j)
                 for i in range(2)
                 for j in range(2)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1119,13 +1119,13 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_discarded_comprehension_graph_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             [torch._dynamo.graph_break() or i for i in range(3)]
-            b = x + 2
+            b = x + 3
             return a, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1144,13 +1144,13 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_comprehension_in_expression_graph_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             total = sum([torch._dynamo.graph_break() or i for i in range(3)])
-            b = x + 2
+            b = x + 3
             return a, total, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1169,11 +1169,11 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_comprehension_return_directly."""
 
         def inner(x):
-            a = x + 1  # noqa: F841
+            a = x + 2  # noqa: F841
             return [torch._dynamo.graph_break() or i for i in range(3)]
 
         def outer(x):
-            x = x + 2
+            x = x + 1
             result = inner(x)
             x = x + 3
             return result
@@ -1191,13 +1191,13 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_walrus_operator_in_comprehension."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [(y := (torch._dynamo.graph_break() or i * 2)) for i in range(3)]
-            b = x + 2
+            b = x + 3
             return a, result, y, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1216,15 +1216,15 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_walrus_operator_in_if_in_comprehension."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 (torch._dynamo.graph_break() or y) for i in range(5) if (y := i * 2) > 2
             ]
-            b = x + 2
+            b = x + 3
             return a, result, y, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1243,17 +1243,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_walrus_operator_in_comprehension_with_tensor."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 (torch._dynamo.graph_break() or y + x.numel())
                 for i in range(5)
                 if (y := i * 2) > 2
             ]
-            b = x + 2
+            b = x + 3
             return a, result, y, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1272,16 +1272,16 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_multiple_walrus_operators_in_comprehension."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 ((y := (torch._dynamo.graph_break() or i * 2)), (z := i * 3))
                 for i in range(3)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, y, z, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1300,7 +1300,7 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_nested_comprehension_with_walrus_operators."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 (
                     outer_val := i * 10,
@@ -1311,11 +1311,11 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
                 )
                 for i in range(3)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, outer_val, inner_val, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1335,16 +1335,16 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             outer_val = 100
-            a = x + 1
+            a = x + 2
             result = [
                 [outer_val + j for j in range(2) if torch._dynamo.graph_break() or True]
                 for i in range(2)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1363,7 +1363,7 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_triple_nested_comprehension_with_walrus."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 [
                     [
@@ -1375,11 +1375,11 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
                 ]
                 for i in range(2)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, w, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1399,7 +1399,7 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             multiplier = 10
-            a = x + 1
+            a = x + 2
             result = {
                 i: {
                     j: (inner_val := j * multiplier)
@@ -1408,11 +1408,11 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
                 }
                 for i in range(3)
             }
-            b = x + 2
+            b = x + 3
             return a, result, inner_val, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1432,15 +1432,15 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             outer_val = 10
-            a = x + 1
+            a = x + 2
             result = [
                 i + outer_val for i in range(3) if torch._dynamo.graph_break() or True
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1460,17 +1460,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             outer_list = []
-            a = x + 1
+            a = x + 2
             result = [
                 outer_list.append(i) or i * 2
                 for i in range(3)
                 if torch._dynamo.graph_break() or True
             ]
-            b = x + 2
+            b = x + 3
             return a, result, outer_list, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1490,17 +1490,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             outer_dict = {}
-            a = x + 1
+            a = x + 2
             result = [
                 outer_dict.update({i: i * 10}) or i * 2
                 for i in range(3)
                 if torch._dynamo.graph_break() or True
             ]
-            b = x + 2
+            b = x + 3
             return a, result, outer_dict, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1520,17 +1520,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             outer_list = [100]
-            a = x + 1
+            a = x + 2
             result = [
                 outer_list.extend([i, i * 10]) or i
                 for i in range(3)
                 if torch._dynamo.graph_break() or True
             ]
-            b = x + 2
+            b = x + 3
             return a, result, outer_list, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1551,17 +1551,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         def inner(x):
             outer_list = [10, 20, 30, 40, 50]
             popped_values = []
-            a = x + 1
+            a = x + 2
             result = [
                 popped_values.append(outer_list.pop()) or i
                 for i in range(3)
                 if torch._dynamo.graph_break() or True
             ]
-            b = x + 2
+            b = x + 3
             return a, result, outer_list, popped_values, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1582,17 +1582,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         _GLOBAL_VALUE_FOR_COMPREHENSION_TEST = 100
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 i + _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
                 for i in range(3)
                 if torch._dynamo.graph_break() or True
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1614,17 +1614,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
             closure_val = 50
 
             def inner(x):
-                a = x + 1
+                a = x + 2
                 result = [
                     i + closure_val
                     for i in range(3)
                     if torch._dynamo.graph_break() or True
                 ]
-                b = x + 2
+                b = x + 3
                 return a, result, b
 
             def outer(x):
-                x = x + 3
+                x = x + 1
                 result = inner(x)
                 x = x + 4
                 return result
@@ -1649,17 +1649,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
             closure_list = []
 
             def inner(x):
-                a = x + 1
+                a = x + 2
                 result = [
                     closure_list.append(i) or i * 2
                     for i in range(3)
                     if torch._dynamo.graph_break() or True
                 ]
-                b = x + 2
+                b = x + 3
                 return a, result, closure_list.copy(), b
 
             def outer(x):
-                x = x + 3
+                x = x + 1
                 result = inner(x)
                 x = x + 4
                 return result
@@ -1683,17 +1683,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_nested_multi_for_comprehension_graph_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 [(torch._dynamo.graph_break() or i + j + k) for k in range(2)]
                 for i in range(2)
                 for j in range(2)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1712,15 +1712,15 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_multiple_comprehension_graph_breaks."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             list1 = [torch._dynamo.graph_break() or i for i in range(2)]
-            b = x + 2
+            b = x + 3
             list2 = [torch._dynamo.graph_break() or i * 2 for i in range(2)]
-            c = x + 3
+            c = x + 4
             return a, list1, b, list2, c
 
         def outer(x):
-            x = x + 4
+            x = x + 1
             result = inner(x)
             x = x + 5
             return result
@@ -1744,17 +1744,17 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
 
         def inner(x):
             global _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
-            a = x + 1
+            a = x + 2
             _GLOBAL_VALUE_FOR_COMPREHENSION_TEST += 1
             result = [
                 torch._dynamo.graph_break() or _GLOBAL_VALUE_FOR_COMPREHENSION_TEST + i
                 for i in range(3)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result
@@ -1782,16 +1782,16 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
             closure_val = [0]
 
             def inner(x):
-                a = x + 1
+                a = x + 2
                 closure_val[0] += 1
                 result = [
                     torch._dynamo.graph_break() or closure_val[0] + i for i in range(3)
                 ]
-                b = x + 2
+                b = x + 3
                 return a, result, closure_val[0], b
 
             def outer(x):
-                x = x + 3
+                x = x + 1
                 result = inner(x)
                 x = x + 4
                 return result
@@ -1815,15 +1815,15 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_list_and_dict_comprehension_graph_breaks."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             list1 = [torch._dynamo.graph_break() or i for i in range(2)]
-            b = x + 2
+            b = x + 3
             dict1 = {i: torch._dynamo.graph_break() or i * 10 for i in range(2)}
-            c = x + 3
+            c = x + 4
             return a, list1, b, dict1, c
 
         def outer(x):
-            x = x + 4
+            x = x + 1
             result = inner(x)
             x = x + 5
             return result
@@ -1843,16 +1843,16 @@ class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
         """Nested version of test_nested_dict_in_list_comprehension_graph_break."""
 
         def inner(x):
-            a = x + 1
+            a = x + 2
             result = [
                 {j: torch._dynamo.graph_break() or i * j for j in range(2)}
                 for i in range(2)
             ]
-            b = x + 2
+            b = x + 3
             return a, result, b
 
         def outer(x):
-            x = x + 3
+            x = x + 1
             result = inner(x)
             x = x + 4
             return result

--- a/test/dynamo/test_comprehensions.py
+++ b/test/dynamo/test_comprehensions.py
@@ -741,6 +741,8 @@ class ComprehensionTests(torch._inductor.test_case.TestCase):
         self.assertEqual(count_op(backend.graphs[0], operator.add), 1)
         self.assertEqual(count_op(backend.graphs[1], operator.add), 1)
 
+@skipIfNotPy312
+class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
     @torch._dynamo.config.patch(nested_graph_breaks=False)
     def test_nested_function_calls_with_comprehension_graph_break(self):
         """Test nested function calls where inner function has comprehension with graph break."""
@@ -946,6 +948,923 @@ class ComprehensionTests(torch._inductor.test_case.TestCase):
         self.assertEqual(compiled_result[0], eager_result[0])
         self.assertEqual(compiled_result[1], eager_result[1])
         self.assertEqual(len(backend.graphs), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_list_comprehension_graph_break(self):
+        """Nested version of test_list_comprehension_graph_break."""
+
+        def inner(x):
+            y = x + 1
+            result = [torch._dynamo.graph_break() or i for i in range(3)]
+            z = x + 2
+            return y, result, z
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_dict_comprehension_graph_break(self):
+        """Nested version of test_dict_comprehension_graph_break."""
+
+        def inner(x):
+            y = x + 1
+            result = {i: torch._dynamo.graph_break() or i**2 for i in range(3)}
+            z = x + 2
+            return y, result, z
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_list_comprehension_with_graph_break_function(self):
+        """Nested version of test_list_comprehension_with_graph_break_function."""
+
+        def graph_break_fn(i):
+            if i == 3:
+                torch._dynamo.graph_break()
+            return i
+
+        def inner(x):
+            y = x * 2
+            lst = [graph_break_fn(i) for i in range(5)]
+            z = x + sum(lst)
+            return z, y
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 1)
+        self.assertEqual(count_op(backend.graphs[0], operator.mul), 1)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_multiple_comprehensions_one_break(self):
+        """Nested version of test_multiple_comprehensions_one_break."""
+
+        def inner(x):
+            a = x + 1
+            list1 = [i for i in range(2)]  # noqa: C416
+            list2 = [torch._dynamo.graph_break() or i for i in range(2)]
+            b = x + 2
+            list3 = [i * 2 for i in range(2)]
+            return a, list1, list2, b, list3
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_nested_comprehension_inner_break(self):
+        """Nested version of test_nested_comprehension_inner_break."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                [torch._dynamo.graph_break() or i * j for j in range(2)]
+                for i in range(2)
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_multi_iterator_comprehension_break(self):
+        """Nested version of test_multi_iterator_comprehension_break."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                (torch._dynamo.graph_break() or i, j)
+                for i in range(2)
+                for j in range(2)
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_discarded_comprehension_graph_break(self):
+        """Nested version of test_discarded_comprehension_graph_break."""
+
+        def inner(x):
+            a = x + 1
+            [torch._dynamo.graph_break() or i for i in range(3)]
+            b = x + 2
+            return a, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_in_expression_graph_break(self):
+        """Nested version of test_comprehension_in_expression_graph_break."""
+
+        def inner(x):
+            a = x + 1
+            total = sum([torch._dynamo.graph_break() or i for i in range(3)])
+            b = x + 2
+            return a, total, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_return_directly(self):
+        """Nested version of test_comprehension_return_directly."""
+
+        def inner(x):
+            a = x + 1  # noqa: F841
+            return [torch._dynamo.graph_break() or i for i in range(3)]
+
+        def outer(x):
+            x = x + 2
+            result = inner(x)
+            x = x + 3
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertGreaterEqual(len(backend.graphs), 1)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_walrus_operator_in_comprehension(self):
+        """Nested version of test_walrus_operator_in_comprehension."""
+
+        def inner(x):
+            a = x + 1
+            result = [(y := (torch._dynamo.graph_break() or i * 2)) for i in range(3)]
+            b = x + 2
+            return a, result, y, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_walrus_operator_in_if_in_comprehension(self):
+        """Nested version of test_walrus_operator_in_if_in_comprehension."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                (torch._dynamo.graph_break() or y) for i in range(5) if (y := i * 2) > 2
+            ]
+            b = x + 2
+            return a, result, y, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_walrus_operator_in_comprehension_with_tensor(self):
+        """Nested version of test_walrus_operator_in_comprehension_with_tensor."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                (torch._dynamo.graph_break() or y + x.numel())
+                for i in range(5)
+                if (y := i * 2) > 2
+            ]
+            b = x + 2
+            return a, result, y, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_multiple_walrus_operators_in_comprehension(self):
+        """Nested version of test_multiple_walrus_operators_in_comprehension."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                ((y := (torch._dynamo.graph_break() or i * 2)), (z := i * 3))
+                for i in range(3)
+            ]
+            b = x + 2
+            return a, result, y, z, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_nested_comprehension_with_walrus_operators(self):
+        """Nested version of test_nested_comprehension_with_walrus_operators."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                (
+                    outer_val := i * 10,
+                    [
+                        (inner_val := (torch._dynamo.graph_break() or j * 2))
+                        for j in range(2)
+                    ],
+                )
+                for i in range(3)
+            ]
+            b = x + 2
+            return a, result, outer_val, inner_val, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_nested_comprehension_with_captured_outer_variable(self):
+        """Nested version of test_nested_comprehension_with_captured_outer_variable."""
+
+        def inner(x):
+            outer_val = 100
+            a = x + 1
+            result = [
+                [outer_val + j for j in range(2) if torch._dynamo.graph_break() or True]
+                for i in range(2)
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_triple_nested_comprehension_with_walrus(self):
+        """Nested version of test_triple_nested_comprehension_with_walrus."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                [
+                    [
+                        (w := i + j + k)
+                        for k in range(2)
+                        if torch._dynamo.graph_break() or True
+                    ]
+                    for j in range(2)
+                ]
+                for i in range(2)
+            ]
+            b = x + 2
+            return a, result, w, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_nested_dict_comprehension_with_walrus_and_captured(self):
+        """Nested version of test_nested_dict_comprehension_with_walrus_and_captured."""
+
+        def inner(x):
+            multiplier = 10
+            a = x + 1
+            result = {
+                i: {
+                    j: (inner_val := j * multiplier)
+                    for j in range(2)
+                    if torch._dynamo.graph_break() or True
+                }
+                for i in range(3)
+            }
+            b = x + 2
+            return a, result, inner_val, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_outer_variable_read(self):
+        """Nested version of test_comprehension_with_outer_variable_read."""
+
+        def inner(x):
+            outer_val = 10
+            a = x + 1
+            result = [
+                i + outer_val for i in range(3) if torch._dynamo.graph_break() or True
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_outer_list_mutation(self):
+        """Nested version of test_comprehension_with_outer_list_mutation."""
+
+        def inner(x):
+            outer_list = []
+            a = x + 1
+            result = [
+                outer_list.append(i) or i * 2
+                for i in range(3)
+                if torch._dynamo.graph_break() or True
+            ]
+            b = x + 2
+            return a, result, outer_list, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_outer_dict_mutation(self):
+        """Nested version of test_comprehension_with_outer_dict_mutation."""
+
+        def inner(x):
+            outer_dict = {}
+            a = x + 1
+            result = [
+                outer_dict.update({i: i * 10}) or i * 2
+                for i in range(3)
+                if torch._dynamo.graph_break() or True
+            ]
+            b = x + 2
+            return a, result, outer_dict, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_outer_list_extend(self):
+        """Nested version of test_comprehension_with_outer_list_extend."""
+
+        def inner(x):
+            outer_list = [100]
+            a = x + 1
+            result = [
+                outer_list.extend([i, i * 10]) or i
+                for i in range(3)
+                if torch._dynamo.graph_break() or True
+            ]
+            b = x + 2
+            return a, result, outer_list, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_outer_list_pop(self):
+        """Nested version of test_comprehension_with_outer_list_pop."""
+
+        def inner(x):
+            outer_list = [10, 20, 30, 40, 50]
+            popped_values = []
+            a = x + 1
+            result = [
+                popped_values.append(outer_list.pop()) or i
+                for i in range(3)
+                if torch._dynamo.graph_break() or True
+            ]
+            b = x + 2
+            return a, result, outer_list, popped_values, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_global_variable(self):
+        """Nested version of test_comprehension_with_global_variable."""
+        global _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
+        _GLOBAL_VALUE_FOR_COMPREHENSION_TEST = 100
+
+        def inner(x):
+            a = x + 1
+            result = [
+                i + _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
+                for i in range(3)
+                if torch._dynamo.graph_break() or True
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_closure_variable(self):
+        """Nested version of test_comprehension_with_closure_variable."""
+
+        def make_outer():
+            closure_val = 50
+
+            def inner(x):
+                a = x + 1
+                result = [
+                    i + closure_val
+                    for i in range(3)
+                    if torch._dynamo.graph_break() or True
+                ]
+                b = x + 2
+                return a, result, b
+
+            def outer(x):
+                x = x + 3
+                result = inner(x)
+                x = x + 4
+                return result
+
+            return outer
+
+        outer = make_outer()
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_with_closure_list_mutation(self):
+        """Nested version of test_comprehension_with_closure_list_mutation."""
+
+        def make_outer():
+            closure_list = []
+
+            def inner(x):
+                a = x + 1
+                result = [
+                    closure_list.append(i) or i * 2
+                    for i in range(3)
+                    if torch._dynamo.graph_break() or True
+                ]
+                b = x + 2
+                return a, result, closure_list.copy(), b
+
+            def outer(x):
+                x = x + 3
+                result = inner(x)
+                x = x + 4
+                return result
+
+            return outer
+
+        outer = make_outer()
+        outer_ref = make_outer()
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer_ref(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_nested_multi_for_comprehension_graph_break(self):
+        """Nested version of test_nested_multi_for_comprehension_graph_break."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                [(torch._dynamo.graph_break() or i + j + k) for k in range(2)]
+                for i in range(2)
+                for j in range(2)
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_multiple_comprehension_graph_breaks(self):
+        """Nested version of test_multiple_comprehension_graph_breaks."""
+
+        def inner(x):
+            a = x + 1
+            list1 = [torch._dynamo.graph_break() or i for i in range(2)]
+            b = x + 2
+            list2 = [torch._dynamo.graph_break() or i * 2 for i in range(2)]
+            c = x + 3
+            return a, list1, b, list2, c
+
+        def outer(x):
+            x = x + 4
+            result = inner(x)
+            x = x + 5
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 3)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[2], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_modifying_global_variable(self):
+        """Nested version of test_comprehension_modifying_global_variable."""
+        global _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
+        _GLOBAL_VALUE_FOR_COMPREHENSION_TEST = 100
+        original_value = _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
+
+        def inner(x):
+            global _GLOBAL_VALUE_FOR_COMPREHENSION_TEST
+            a = x + 1
+            _GLOBAL_VALUE_FOR_COMPREHENSION_TEST += 1
+            result = [
+                torch._dynamo.graph_break() or _GLOBAL_VALUE_FOR_COMPREHENSION_TEST + i
+                for i in range(3)
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        _GLOBAL_VALUE_FOR_COMPREHENSION_TEST = original_value
+        compiled_result = compiled(x)
+        _GLOBAL_VALUE_FOR_COMPREHENSION_TEST = original_value
+        expected_result = outer(x)
+        _GLOBAL_VALUE_FOR_COMPREHENSION_TEST = original_value
+
+        self.assertEqual(compiled_result, expected_result)
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_comprehension_modifying_closure_variable(self):
+        """Nested version of test_comprehension_modifying_closure_variable."""
+
+        def make_outer():
+            closure_val = [0]
+
+            def inner(x):
+                a = x + 1
+                closure_val[0] += 1
+                result = [
+                    torch._dynamo.graph_break() or closure_val[0] + i for i in range(3)
+                ]
+                b = x + 2
+                return a, result, closure_val[0], b
+
+            def outer(x):
+                x = x + 3
+                result = inner(x)
+                x = x + 4
+                return result
+
+            return outer
+
+        outer = make_outer()
+        outer_ref = make_outer()
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer_ref(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_list_and_dict_comprehension_graph_breaks(self):
+        """Nested version of test_list_and_dict_comprehension_graph_breaks."""
+
+        def inner(x):
+            a = x + 1
+            list1 = [torch._dynamo.graph_break() or i for i in range(2)]
+            b = x + 2
+            dict1 = {i: torch._dynamo.graph_break() or i * 10 for i in range(2)}
+            c = x + 3
+            return a, list1, b, dict1, c
+
+        def outer(x):
+            x = x + 4
+            result = inner(x)
+            x = x + 5
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 3)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[2], operator.add), 2)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_nested_nested_dict_in_list_comprehension_graph_break(self):
+        """Nested version of test_nested_dict_in_list_comprehension_graph_break."""
+
+        def inner(x):
+            a = x + 1
+            result = [
+                {j: torch._dynamo.graph_break() or i * j for j in range(2)}
+                for i in range(2)
+            ]
+            b = x + 2
+            return a, result, b
+
+        def outer(x):
+            x = x + 3
+            result = inner(x)
+            x = x + 4
+            return result
+
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+        compiled = torch.compile(outer, backend=backend)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled(x), outer(x))
+        self.assertEqual(len(backend.graphs), 2)
+        self.assertEqual(count_op(backend.graphs[0], operator.add), 2)
+        self.assertEqual(count_op(backend.graphs[1], operator.add), 2)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_comprehensions.py
+++ b/test/dynamo/test_comprehensions.py
@@ -14,7 +14,7 @@ import operator
 
 import torch
 import torch._dynamo.testing
-import torch._inductor.test_case
+import torch._dynamo.test_case
 from torch._dynamo.testing import skipIfNotPy312
 
 
@@ -24,7 +24,7 @@ def count_op(graph, op):
 
 
 @skipIfNotPy312
-class ComprehensionTests(torch._inductor.test_case.TestCase):
+class ComprehensionTests(torch._dynamo.test_case.TestCase):
     def test_list_comprehension_graph_break(self):
         """Test that list comprehension with graph break creates 2 graphs."""
 
@@ -774,7 +774,7 @@ class ComprehensionTests(torch._inductor.test_case.TestCase):
 
 
 @skipIfNotPy312
-class NestedGraphBreakTests(torch._inductor.test_case.TestCase):
+class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(nested_graph_breaks=True)
     def test_nested_function_calls_with_comprehension_graph_break_nested_graph_breaks_true(
         self,

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -382,6 +382,7 @@ class TestTensorCreation(TestCase):
             ):
                 torch.block_diag(torch.ones(2, 2).cpu(), torch.ones(2, 2, device=device))
 
+    @xfailIfTorchDynamo
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     def test_block_diag_scipy(self, device):
         import scipy.linalg

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_utils import (
     IS_S390X,
     IS_ARM64,
     parametrize,
+    TEST_WITH_TORCHDYNAMO,
     xfailIfTorchDynamo,
 )
 from torch.testing._internal.common_device_type import (
@@ -382,7 +383,6 @@ class TestTensorCreation(TestCase):
             ):
                 torch.block_diag(torch.ones(2, 2).cpu(), torch.ones(2, 2, device=device))
 
-    @xfailIfTorchDynamo
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     def test_block_diag_scipy(self, device):
         import scipy.linalg

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -383,6 +383,7 @@ class TestTensorCreation(TestCase):
             ):
                 torch.block_diag(torch.ones(2, 2).cpu(), torch.ones(2, 2, device=device))
 
+    @skipCPUIf(TEST_WITH_TORCHDYNAMO, "test doesn't currently work with dynamo on CPU")
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     def test_block_diag_scipy(self, device):
         import scipy.linalg

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -531,6 +531,22 @@ class PyCodegen:
                 create_instruction("UNPACK_SEQUENCE", arg=n),
             ]
 
+    def pop_null(self) -> list[Instruction]:
+        # POP_TOP doesn't work for null, so we pop nulls by pushing in a
+        # nop function, calling it (which consumes the null), and popping the result.
+        assert sys.version_info >= (3, 11)
+        return [
+            self.create_load_const_unchecked(lambda: None),
+            # 3.13 swapped NULL and callable
+            *(
+                (create_instruction("SWAP", arg=2),)
+                if sys.version_info >= (3, 13)
+                else ()
+            ),
+            *create_call_function(0, False),
+            create_instruction("POP_TOP"),
+        ]
+
     def pop_top(self) -> None:
         self.append_output(create_instruction("POP_TOP"))
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -73,6 +73,7 @@ from .bytecode_analysis import (
 )
 from .bytecode_transformation import (
     cleaned_instructions,
+    clear_instruction_args,
     create_binary_slice,
     create_call_function,
     create_call_function_ex,
@@ -136,6 +137,7 @@ from .utils import (
     get_instruction_source_311,
     get_metrics_context,
     graph_break_dup_warning_checker,
+    is_safe_constant,
     istype,
     LazyString,
     proxy_args_kwargs,
@@ -4215,6 +4217,10 @@ class InstructionTranslatorBase(
             self.pop()
         else:
             self.popn(2)
+        # Decrement comprehension depth when exiting a comprehension's for loop.
+        # This ensures sequential comprehensions each set up their own speculation.
+        if self._comprehension_depth > 0:
+            self._comprehension_depth -= 1
 
     def LOAD_FAST_CHECK(self, inst: Instruction) -> None:
         if istype(self.symbolic_locals.get(inst.argval, None), NullVariable):
@@ -4552,6 +4558,12 @@ class InstructionTranslatorBase(
                     if var_name not in defined_inside and var_name not in captured_vars:
                         captured_vars.append(var_name)
 
+            # Detect LOAD_DEREF referencing closure variables
+            elif inst.opname == "LOAD_DEREF":
+                var_name = inst.argval
+                if var_name not in captured_vars:
+                    captured_vars.append(var_name)
+
         # Extract pre_store_ops: all opcodes from END_FOR+1 until first STORE_FAST
         pre_store_ops: list[str] = []
         scan_ip = end_for_ip + 1
@@ -4722,13 +4734,88 @@ class InstructionTranslatorBase(
 
         # --- Step 3: Add the comprehension bytecode ---
 
-        # Ensure iterator variables are in co_varnames for the generated code.
-        # The comprehension bytecode uses STORE_FAST for iterator cleanup.
-        for var_name in analysis.iterator_vars:
+        # Ensure all variables used by comprehension bytecode are in co_varnames.
+        # - iterator_vars: variables from LOAD_FAST_AND_CLEAR pattern
+        # - walrus_vars: variables created by walrus operator (:=)
+        # - captured_vars: outer scope variables accessed via LOAD_FAST
+        # - result_var: variable the comprehension result is assigned to
+        vars_for_co_varnames = (
+            analysis.iterator_vars
+            + analysis.walrus_vars
+            + analysis.captured_vars
+            + ([analysis.result_var] if analysis.result_var else [])
+        )
+
+        for var_name in vars_for_co_varnames:
             if var_name not in self.output.code_options["co_varnames"]:
                 self.output.code_options["co_varnames"] += (var_name,)
 
-        copied_insts = self._copy_comprehension_bytecode(start_ip, analysis.end_ip)
+        # Identify closure vars that need LOAD_DEREF -> LOAD_FAST conversion.
+        # These are captured_vars that are in cell_and_freevars (closure variables).
+        deref_to_fast_vars = {
+            var_name
+            for var_name in analysis.captured_vars
+            if var_name in self.cell_and_freevars()
+        }
+
+        # Load closure variables into local slots before the comprehension bytecode.
+        # LOAD_DEREF instructions will be converted to LOAD_FAST, so we need
+        # the values in local slots.
+        if deref_to_fast_vars:
+            cg = PyCodegen(self)
+            for var_name in deref_to_fast_vars:
+                if self.parent is None:
+                    # Top-level function: use LOAD_DEREF
+                    cg.extend_output(
+                        [
+                            create_instruction("LOAD_DEREF", argval=var_name),
+                            create_instruction("STORE_FAST", argval=var_name),
+                        ]
+                    )
+                else:
+                    # Inlined function: the closure variable is not in the outer
+                    # function's freevars. Get the actual closure cell contents
+                    # from the function's closure and install it as a global.
+                    assert hasattr(self, "funcvar"), (
+                        "Expected InliningInstructionTranslator to have funcvar"
+                    )
+                    fn = self.funcvar.fn
+                    closure = fn.__closure__ or ()
+                    freevars = fn.__code__.co_freevars
+                    if var_name in freevars:
+                        idx = freevars.index(var_name)
+                        actual_value = closure[idx].cell_contents
+                        if is_safe_constant(actual_value):
+                            cg.extend_output(
+                                [
+                                    cg.create_load_const(actual_value),
+                                    create_instruction("STORE_FAST", argval=var_name),
+                                ]
+                            )
+                        else:
+                            # Mutable object: install as a global
+                            global_name = self.output.install_global_by_id(
+                                f"__closure_{var_name}", actual_value
+                            )
+                            cg.extend_output(
+                                [
+                                    cg.create_load_global(global_name, add=True),
+                                    create_instruction("STORE_FAST", argval=var_name),
+                                ]
+                            )
+                    else:
+                        # Fall back to symbolic reconstruction
+                        cell = self.symbolic_locals[var_name]
+                        cell_contents = self.output.side_effects.load_cell(cell)
+                        cg(cell_contents, allow_cache=False)
+                        cg.extend_output(
+                            [create_instruction("STORE_FAST", argval=var_name)]
+                        )
+            self.output.add_output_instructions(cg.get_instructions())
+
+        copied_insts = self._copy_comprehension_bytecode(
+            start_ip, analysis.end_ip, deref_to_fast_vars
+        )
         self.output.add_output_instructions(copied_insts)
 
         if analysis.result_on_stack:
@@ -4782,9 +4869,13 @@ class InstructionTranslatorBase(
         self.instruction_pointer = None
 
     def _copy_comprehension_bytecode(
-        self, start_ip: int, end_ip: int
+        self, start_ip: int, end_ip: int, deref_to_fast_vars: set[str] | None = None
     ) -> list[Instruction]:
-        """Copy comprehension bytecode instructions, updating jump targets."""
+        """Copy comprehension bytecode instructions, updating jump targets.
+
+        Args:
+            deref_to_fast_vars: Variable names to convert from LOAD_DEREF to LOAD_FAST
+        """
         inst_map: dict[Instruction, Instruction] = {}
         copied_insts: list[Instruction] = []
 
@@ -4795,9 +4886,24 @@ class InstructionTranslatorBase(
             inst_map[original_inst] = copied_inst
             copied_insts.append(copied_inst)
 
+        # Clear instruction args so fix_vars can recalculate them for the new context.
+        # This is needed because the copied bytecode has arg values that reference
+        # indices in the original function's co_varnames/co_consts, which may differ
+        # from the generated code's.
+        clear_instruction_args(copied_insts)
+
         for copied_inst in copied_insts:
             if copied_inst.target is not None and copied_inst.target in inst_map:
                 copied_inst.target = inst_map[copied_inst.target]
+
+            # Convert LOAD_DEREF to LOAD_FAST for closure vars loaded to local slots
+            if (
+                deref_to_fast_vars
+                and copied_inst.opname == "LOAD_DEREF"
+                and copied_inst.argval in deref_to_fast_vars
+            ):
+                copied_inst.opname = "LOAD_FAST"
+                copied_inst.opcode = dis.opmap["LOAD_FAST"]
 
         return copied_insts
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4635,11 +4635,7 @@ class InstructionTranslatorBase(
         """
         assert sys.version_info >= (3, 12)
 
-        from .bytecode_transformation import create_instruction
-        from .codegen import PyCodegen
-        from .source import LocalSource
-        from .variables.misc import UnknownVariable
-        from .variables.tensor import SymNodeVariable, TensorVariable
+        from .variables.tensor import TensorVariable
 
         analysis = self._analyze_comprehension()
 
@@ -4947,8 +4943,6 @@ class InstructionTranslatorBase(
         calls it via codegen_call_resume, then chains into the resume
         function for the post-comprehension code.
         """
-        from .variables.misc import UnknownVariable
-
         assert config.nested_graph_breaks
         meta = all_stack_locals_metadata[0]
         cg = PyCodegen(self.output.root_tx)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5113,9 +5113,7 @@ class InstructionTranslatorBase(
         self.instruction_pointer = None
 
     def _copy_comprehension_bytecode(
-        self,
-        start_ip: int,
-        end_ip: int,
+        self, start_ip: int, end_ip: int
     ) -> list[Instruction]:
         """Copy comprehension bytecode instructions, updating jump targets."""
         inst_map: dict[Instruction, Instruction] = {}

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5068,10 +5068,10 @@ class InstructionTranslatorBase(
                         create_instruction("LIST_APPEND", arg=1),
                     ]
                 )
-            cg.extend_output([create_instruction("POP_TOP")])  # pop fv0
-            # Extract the plain result from the tuple.
             cg.extend_output(
                 [
+                    create_instruction("POP_TOP"),  # pop fv0
+                    # Extract the plain result from the tuple.
                     cg.create_load_const(0),
                     cg.create_binary_subscr(),
                 ]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5078,9 +5078,7 @@ class InstructionTranslatorBase(
                         ]
                     )
                 else:
-                    cg.extend_output(
-                        [create_instruction("LIST_APPEND", arg=1)]
-                    )
+                    cg.extend_output([create_instruction("LIST_APPEND", arg=1)])
                 # Stack: ..., comp_tuple, fv0
             cg.extend_output(
                 [

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5094,14 +5094,17 @@ class InstructionTranslatorBase(
         if analysis.result_on_stack:
             self.push(UnknownVariable())
         elif analysis.result_var:
+            cg.extend_output(
+                [
+                    *create_copy(fv_depth),
+                    cg.create_load_const(0),
+                    cg.create_binary_subscr(),
+                    # Stack: ..., result, fv0
+                ]
+            )
             if analysis.result_var in existing_vars:
-                # Stack: ..., result
                 cg.extend_output(
                     [
-                        *create_copy(fv_depth),
-                        cg.create_load_const(0),
-                        cg.create_binary_subscr(),
-                        # Stack: ..., result, fv0
                         cg.create_load_const(existing_vars[analysis.result_var]),
                         create_instruction("STORE_SUBSCR"),
                         # fv0[idx] = result
@@ -5110,9 +5113,6 @@ class InstructionTranslatorBase(
             else:
                 cg.extend_output(
                     [
-                        *create_copy(fv_depth),
-                        cg.create_load_const(0),
-                        cg.create_binary_subscr(),
                         *create_swap(2),
                         create_instruction("LIST_APPEND", arg=1),
                         create_instruction("POP_TOP"),

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3479,7 +3479,7 @@ class InstructionTranslatorBase(
                 return True
             self.current_speculation = speculation
         end_for_ip = self._find_comprehension_end_for_ip()
-        assert end_for_ip is not None
+        assert end_for_ip >= 0
         self._comprehension_end_for_ips.add(end_for_ip)
         self._comprehension_depth += 1
         return False
@@ -4485,7 +4485,7 @@ class InstructionTranslatorBase(
 
         return prefix == pattern
 
-    def _find_comprehension_end_for_ip(self) -> int | None:
+    def _find_comprehension_end_for_ip(self) -> int:
         """Find the instruction pointer of the outermost END_FOR for current comprehension."""
         assert sys.version_info >= (3, 12)
         assert self.instruction_pointer is not None
@@ -4499,7 +4499,7 @@ class InstructionTranslatorBase(
                 nesting_depth -= 1
                 if nesting_depth == 0:
                     return search_ip
-        return None
+        return -1
 
     def _analyze_comprehension(self) -> ComprehensionAnalysis:
         """Analyze comprehension bytecode to determine result handling pattern."""
@@ -4528,7 +4528,7 @@ class InstructionTranslatorBase(
         defined_inside.update(iterator_vars)
 
         end_for_ip = self._find_comprehension_end_for_ip()
-        if end_for_ip is None:
+        if end_for_ip == -1:
             unimplemented(
                 gb_type="Comprehension analysis failed: No END_FOR",
                 context="",

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -3433,6 +3433,14 @@ class InstructionTranslatorBase(
         items = self.popn(inst.argval)
         self.push(SliceVariable(items, tx=self))  # type: ignore[arg-type]
 
+    def _can_speculate_comprehension_nested(self) -> bool:
+        """Check if comprehension speculation is allowed in nested context.
+
+        For the base class (non-inlined), this always returns False since
+        self.parent is None. Subclasses override to check nested conditions.
+        """
+        return False
+
     def _maybe_setup_comprehension_speculation(self, inst: Instruction) -> bool:
         """
         Handle comprehension start for Python 3.12+ BUILD_LIST/BUILD_MAP with argval 0.
@@ -3451,8 +3459,16 @@ class InstructionTranslatorBase(
             and not self.is_tracing_resume_prologue
             and not self.active_generic_context_managers
             and self.output.current_tracer.parent is None
-            and self.parent is None
         )
+
+        # For inlined functions, allow speculation if nested_graph_breaks is enabled
+        # and all parent frames can compile partial graphs.
+        # We don't use should_compile_partial_graph() directly because it includes
+        # an exception table entry check that isn't appropriate for comprehension
+        # speculation (the comprehension bytecode has its own exception handling
+        # that we'll copy to run in eager mode).
+        if can_speculate and self.parent is not None:
+            can_speculate = self._can_speculate_comprehension_nested()
         # Only set up speculation at depth 0 (outermost comprehension)
         if can_speculate and self._comprehension_depth == 0:
             speculation = self.speculate()
@@ -4666,7 +4682,9 @@ class InstructionTranslatorBase(
             )
             # Tensors/symnodes must already be in their correct slot
             if isinstance(var, (TensorVariable, SymNodeVariable)):
-                if not in_correct_slot:
+                # In nested context, tensor may be from parent frame argument
+                # compile_subgraph handles passing it through frame_list correctly
+                if self.parent is None and not in_correct_slot:
                     unimplemented(
                         gb_type="Comprehension with captured tensor not in local slot",
                         context="",
@@ -4703,6 +4721,12 @@ class InstructionTranslatorBase(
             self.output.add_output_instructions(cg.get_instructions())
 
         # --- Step 3: Add the comprehension bytecode ---
+
+        # Ensure iterator variables are in co_varnames for the generated code.
+        # The comprehension bytecode uses STORE_FAST for iterator cleanup.
+        for var_name in analysis.iterator_vars:
+            if var_name not in self.output.code_options["co_varnames"]:
+                self.output.code_options["co_varnames"] += (var_name,)
 
         copied_insts = self._copy_comprehension_bytecode(start_ip, analysis.end_ip)
         self.output.add_output_instructions(copied_insts)
@@ -5785,6 +5809,23 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     def run_ctx_mgr(self) -> Any:
         return TracingContext.current_frame(self.parent.frame_summary())
+
+    def _can_speculate_comprehension_nested(self) -> bool:
+        """Check if comprehension speculation is allowed in this inlined context.
+
+        Checks that nested_graph_breaks is enabled, the function allows nested
+        graph breaks, and parent frames can compile partial graphs. Unlike
+        should_compile_partial_graph(), this skips the exception table entry
+        check for the current frame since comprehension bytecode has its own
+        exception handling that will be copied for eager execution.
+        """
+        if not config.nested_graph_breaks:
+            return False
+        if not self.funcvar.should_allow_nested_graph_breaks():
+            return False
+        if not self.parent.should_compile_partial_graph():
+            return False
+        return True
 
     def should_compile_partial_graph(self) -> bool:
         if config.nested_graph_breaks:

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1271,6 +1271,8 @@ class SizeVariable(TupleVariable):
         return torch.Size
 
     def as_proxy(self) -> Any:
+        from torch._subclasses.fake_tensor import FakeTensor
+
         if self.proxy is not None:
             return self.proxy
 
@@ -1306,15 +1308,20 @@ class SizeVariable(TupleVariable):
             return torch.Size(proxies)
 
         proxy = tracer.create_proxy("call_function", torch.Size, (proxies,), {})
-        set_example_value(
-            proxy.node,
-            torch.Size(
-                [
-                    p.node.meta["example_value"] if not isinstance(p, int) else p
-                    for p in proxies
-                ]
-            ),
-        )
+
+        proxy_values = []
+        for p in proxies:
+            if isinstance(p, int):
+                proxy_values.append(p)
+            else:
+                example_value = p.node.meta["example_value"]
+                if isinstance(
+                    example_value, FakeTensor
+                ) and example_value.size() == torch.Size([]):
+                    continue
+                proxy_values.append(example_value)
+
+        set_example_value(proxy.node, torch.Size(proxy_values))
         return proxy
 
     def reconstruct(self, codegen: "PyCodegen") -> None:


### PR DESCRIPTION
**Context**
This PR extends PyTorch Dynamo's comprehension graph break handling to work in nested/inlined function contexts with nested_graph_breaks=True. Previously, comprehensions with graph breaks only worked at the top-level frame; now they can work when the comprehension is inside a function that has been inlined during tracing.

References
- #173558

**Solution**
At a high level, when encountering a nested comprehension graph break, we encapsulate the comprehension in a synthetic function and execute this comprehension in a new frame. We then create a resume function after to continue tracing after the comprehension graph break code.

**Test Plan**
- New tests in test/dynamo/test_comprehensions.py under a new NestedGraphBreakTests class covering: simple nested calls, multiple nesting levels, closures, walrus operators, dict comprehensions, captured tensors, nonlocal mutations, and varied varname scenarios.
- `python -m pytest test/dynamo/test_comprehensions.py`

**Walkthrough**
Consider this example:

```
import torch

torch._dynamo.config.nested_graph_breaks=True

def h(x):
    x = x + 3
    result = [torch._dynamo.graph_break() or i for i in range(3)]
    x = x + 4
    return x

def g(x):
    x = x + 2
    x = h(x)
    x = x + 5
    return x

def f(x):
    x = x + 1
    x = g(x)
    x = x + 6
    return x

torch.compile(f)(x)
```

Dynamo inlines g into f, then inlines h into that. When it hits BUILD_LIST 0 (the list comprehension start), speculation begins. The FOR_ITER triggers a graph break because range(3) produces an untraced iterator. Here's what happens:

1. Graph 1 compiled: x + 1, x + 2, x + 3(the ops before the comprehension across all three inlined frames).
2. compile_subgraph emits bytecode that leaves the runtime stack in the nested graph break layout: cells, [frame_values], *(frame N stack). frame_values[0] contains frame N's live locals (including x).
3. Pop stack_pops items: The comprehension's iterator and saved variables (from LOAD_FAST_AND_CLEAR) are on top of the runtime stack
4. Extend frame_values[0]: The non-null stack items are appended to frame_values[0]. This is because codegen_call_resume unpacks frame_values[0] as positional args to the synthetic function — so the iterator and saved vars need to be in that list alongside the locals.
5. Build synthetic function: _build_comprehension_fn creates a new code object. The epilogue packs the result (and any walrus vars) and returns it. The function is skip_code'd so Dynamo won't try to trace it.
6. Call the function: [cells[0]] and [frame_values[0]] are extracted and passed to codegen_call_resume, which calls the synthetic function. It runs the comprehension eagerly (with the graph break inside it executing normally since Dynamo skips it). The result lands on the runtime stack.
7. Clean up frame_values[0]: The stack items appended in step 2 are removed from frame_values[0] via del frame_values[0][-n:], restoring it to just the locals.
8. Store result and pass to resume: The comprehension result is stored to result. Any new variables (result, walrus vars) are added to frame_values[0] so the resume function can access them.
9. Chain to resume: create_call_resume_at builds the resume function starting at END_FOR + 1 (i.e., x = x + 4). This resume function is called with the full frame stack, resuming execution of the inlined frames.
10. Graph 2 compiled: The resume function re-enters Dynamo, which traces x + 4 , x + 5, x + 6 as graph 2. Final result: 2 graphs, 3 add ops each.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo