### PR TITLE
Enable passing in compiler variables for TORCH_LIBRARY namespace

### DIFF
--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -310,20 +310,18 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
   _STABLE_TORCH_LIBRARY_IMPL(ns, k, m, C10_UID)
 
 #define _STABLE_TORCH_LIBRARY_IMPL(ns, k, m, uid)                             \
-  static void C10_CONCATENATE(                                             \
+  static void C10_CONCATENATE(                                                \
       STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_,                           \
       uid)(torch::stable::detail::StableLibrary&);                            \
-  static const torch::stable::detail::StableTorchLibraryInit                  \
-      C10_CONCATENATE(                                                     \
-          STABLE_TORCH_LIBRARY_IMPL_static_init_##ns##_##k##_, uid)(          \
-          torch::stable::detail::StableLibrary::Kind::IMPL,                   \
-          &C10_CONCATENATE(                                                \
-              STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid),             \
-          C10_STRINGIZE(ns),                                               \
-          C10_STRINGIZE(k),                                                \
-          __FILE__,                                                           \
-          __LINE__);                                                          \
-  void C10_CONCATENATE(STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid)( \
+  static const torch::stable::detail::StableTorchLibraryInit C10_CONCATENATE( \
+      STABLE_TORCH_LIBRARY_IMPL_static_init_##ns##_##k##_, uid)(              \
+      torch::stable::detail::StableLibrary::Kind::IMPL,                       \
+      &C10_CONCATENATE(STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid),    \
+      C10_STRINGIZE(ns),                                                      \
+      C10_STRINGIZE(k),                                                       \
+      __FILE__,                                                               \
+      __LINE__);                                                              \
+  void C10_CONCATENATE(STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid)(    \
       torch::stable::detail::StableLibrary & m)
 
 #define STABLE_TORCH_LIBRARY(ns, m)                          \
@@ -333,7 +331,7 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
       STABLE_TORCH_LIBRARY_static_init_##ns(                 \
           torch::stable::detail::StableLibrary::Kind::DEF,   \
           &STABLE_TORCH_LIBRARY_init_##ns,                   \
-          C10_STRINGIZE(ns),                              \
+          C10_STRINGIZE(ns),                                 \
           nullptr,                                           \
           __FILE__,                                          \
           __LINE__);                                         \
@@ -342,19 +340,17 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 #define STABLE_TORCH_LIBRARY_FRAGMENT(ns, m) \
   _STABLE_TORCH_LIBRARY_FRAGMENT(ns, m, C10_UID)
 
-#define _STABLE_TORCH_LIBRARY_FRAGMENT(ns, m, uid)                          \
-  static void C10_CONCATENATE(                                           \
-      STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_,                           \
-      uid)(torch::stable::detail::StableLibrary&);                          \
-  static const torch::stable::detail::StableTorchLibraryInit                \
-      C10_CONCATENATE(                                                   \
-          STABLE_TORCH_LIBRARY_FRAGMENT_static_init_##ns##_, uid)(          \
-          torch::stable::detail::StableLibrary::Kind::FRAGMENT,             \
-          &C10_CONCATENATE(                                              \
-              STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid),             \
-          C10_STRINGIZE(ns),                                             \
-          nullptr,                                                          \
-          __FILE__,                                                         \
-          __LINE__);                                                        \
-  void C10_CONCATENATE(STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid)( \
+#define _STABLE_TORCH_LIBRARY_FRAGMENT(ns, m, uid)                            \
+  static void C10_CONCATENATE(                                                \
+      STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_,                             \
+      uid)(torch::stable::detail::StableLibrary&);                            \
+  static const torch::stable::detail::StableTorchLibraryInit C10_CONCATENATE( \
+      STABLE_TORCH_LIBRARY_FRAGMENT_static_init_##ns##_, uid)(                \
+      torch::stable::detail::StableLibrary::Kind::FRAGMENT,                   \
+      &C10_CONCATENATE(STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid),      \
+      C10_STRINGIZE(ns),                                                      \
+      nullptr,                                                                \
+      __FILE__,                                                               \
+      __LINE__);                                                              \
+  void C10_CONCATENATE(STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid)(      \
       torch::stable::detail::StableLibrary & m)

--- a/torch/csrc/stable/library.h
+++ b/torch/csrc/stable/library.h
@@ -306,35 +306,24 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
       std::remove_pointer_t<std::remove_reference_t<decltype(func)>>, \
       (func)>::boxed_fn
 
-// macros copied from c10/macros/Macros.h
-#ifdef __COUNTER__
-#define STABLE_UID __COUNTER__
-#else
-#define STABLE_UID __LINE__
-#endif
-
-#define STABLE_CONCATENATE_IMPL(s1, s2) s1##s2
-#define STABLE_CONCATENATE(s1, s2) STABLE_CONCATENATE_IMPL(s1, s2)
-// end of macros copied from c10/macros/Macros.h
-
 #define STABLE_TORCH_LIBRARY_IMPL(ns, k, m) \
-  _STABLE_TORCH_LIBRARY_IMPL(ns, k, m, STABLE_UID)
+  _STABLE_TORCH_LIBRARY_IMPL(ns, k, m, C10_UID)
 
 #define _STABLE_TORCH_LIBRARY_IMPL(ns, k, m, uid)                             \
-  static void STABLE_CONCATENATE(                                             \
+  static void C10_CONCATENATE(                                             \
       STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_,                           \
       uid)(torch::stable::detail::StableLibrary&);                            \
   static const torch::stable::detail::StableTorchLibraryInit                  \
-      STABLE_CONCATENATE(                                                     \
+      C10_CONCATENATE(                                                     \
           STABLE_TORCH_LIBRARY_IMPL_static_init_##ns##_##k##_, uid)(          \
           torch::stable::detail::StableLibrary::Kind::IMPL,                   \
-          &STABLE_CONCATENATE(                                                \
+          &C10_CONCATENATE(                                                \
               STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid),             \
-          #ns,                                                                \
-          #k,                                                                 \
+          C10_STRINGIZE(ns),                                               \
+          C10_STRINGIZE(k),                                                \
           __FILE__,                                                           \
           __LINE__);                                                          \
-  void STABLE_CONCATENATE(STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid)( \
+  void C10_CONCATENATE(STABLE_TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid)( \
       torch::stable::detail::StableLibrary & m)
 
 #define STABLE_TORCH_LIBRARY(ns, m)                          \
@@ -344,28 +333,28 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
       STABLE_TORCH_LIBRARY_static_init_##ns(                 \
           torch::stable::detail::StableLibrary::Kind::DEF,   \
           &STABLE_TORCH_LIBRARY_init_##ns,                   \
-          #ns,                                               \
+          C10_STRINGIZE(ns),                              \
           nullptr,                                           \
           __FILE__,                                          \
           __LINE__);                                         \
   void STABLE_TORCH_LIBRARY_init_##ns(torch::stable::detail::StableLibrary& m)
 
 #define STABLE_TORCH_LIBRARY_FRAGMENT(ns, m) \
-  _STABLE_TORCH_LIBRARY_FRAGMENT(ns, m, STABLE_UID)
+  _STABLE_TORCH_LIBRARY_FRAGMENT(ns, m, C10_UID)
 
 #define _STABLE_TORCH_LIBRARY_FRAGMENT(ns, m, uid)                          \
-  static void STABLE_CONCATENATE(                                           \
+  static void C10_CONCATENATE(                                           \
       STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_,                           \
       uid)(torch::stable::detail::StableLibrary&);                          \
   static const torch::stable::detail::StableTorchLibraryInit                \
-      STABLE_CONCATENATE(                                                   \
+      C10_CONCATENATE(                                                   \
           STABLE_TORCH_LIBRARY_FRAGMENT_static_init_##ns##_, uid)(          \
           torch::stable::detail::StableLibrary::Kind::FRAGMENT,             \
-          &STABLE_CONCATENATE(                                              \
+          &C10_CONCATENATE(                                              \
               STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid),             \
-          #ns,                                                              \
+          C10_STRINGIZE(ns),                                             \
           nullptr,                                                          \
           __FILE__,                                                         \
           __LINE__);                                                        \
-  void STABLE_CONCATENATE(STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid)( \
+  void C10_CONCATENATE(STABLE_TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid)( \
       torch::stable::detail::StableLibrary & m)

--- a/torch/library.h
+++ b/torch/library.h
@@ -984,7 +984,7 @@ class TorchLibraryInit final {
   static const torch::detail::TorchLibraryInit TORCH_LIBRARY_static_init_##ns( \
       torch::Library::DEF,                                                     \
       &TORCH_LIBRARY_init_##ns,                                                \
-      #ns,                                                                     \
+      C10_STRINGIZE(ns),                                                                     \
       std::nullopt,                                                            \
       __FILE__,                                                                \
       __LINE__);                                                               \
@@ -1014,7 +1014,7 @@ class TorchLibraryInit final {
       TORCH_LIBRARY_FRAGMENT_static_init_##ns##_, uid)(           \
       torch::Library::FRAGMENT,                                   \
       &C10_CONCATENATE(TORCH_LIBRARY_FRAGMENT_init_##ns##_, uid), \
-      #ns,                                                        \
+      C10_STRINGIZE(ns),                                                        \
       std::nullopt,                                               \
       __FILE__,                                                   \
       __LINE__);                                                  \
@@ -1076,7 +1076,7 @@ class TorchLibraryInit final {
       TORCH_LIBRARY_IMPL_static_init_##ns##_##k##_, uid)(                 \
       torch::Library::IMPL,                                               \
       &C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid),       \
-      #ns,                                                                \
+      C10_STRINGIZE(ns),                                                                \
       std::make_optional(c10::DispatchKey::k),                            \
       __FILE__,                                                           \
       __LINE__);                                                          \


### PR DESCRIPTION
We use C10_STRINGIZE to first expand/evaluate the ns (namespace) and k (dispatch key) arguments instead of passing them along as literal strings. e.g., if ns is MY_LIBRARY_NAME which is set through -DMY_LIBRARY_NAME=mylib, we want to register to mylib, and not literally "MY_LIBRARY_NAME". This is the same strategy used in PYBIND: https://github.com/pybind/pybind11/blob/8f68ecd32c8e18d3b064dbf0ea5fc31a6cb37e9a/include/pybind11/detail/common.h#L452

Note that I remove the STABLE_* versions of macros that are now headeronly as of 6 months ago. I don't believe this has any implications on BC or stability as headeronly macros are expanded during compile time and are not "APIs". 

Test plan:
The PR stacked on top of this one relies on this functionality to allow for code deduplication.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #173669
* #174425
* __->__ #174424

