### PR TITLE
[RFC] Add run_dtensor_rng_op HOP to make DTensor RNG traceable

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -114,7 +114,7 @@ dtensor_dispatch_view,instruction_count,66300,0.1
 
 
 
-dtensor_dispatch_random,instruction_count,557400,0.1
+dtensor_dispatch_random,instruction_count,592800,0.1
 
 
 

--- a/test/test_hop_infra.py
+++ b/test/test_hop_infra.py
@@ -63,6 +63,7 @@ class TestHOPInfra(TestCase):
         FIXME_ALLOWLIST = {
             "autograd_function_apply",
             "run_with_rng_state",
+            "run_dtensor_rng_op",
             "graphsafe_run_with_rng_state",
             "map_impl",
             "_export_tracepoint",

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3114,6 +3114,7 @@ make_fallback(aten._thnn_fused_lstm_cell, require_dense)
 make_fallback(torch._prims.rng_prims.run_and_save_rng_state)
 make_fallback(torch._prims.rng_prims.run_with_rng_state)
 make_fallback(torch._prims.rng_prims.graphsafe_run_with_rng_state)
+make_fallback(torch._prims.rng_prims.run_dtensor_rng_op)
 
 
 # Implemented / Half implemented

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -7,10 +7,12 @@ from typing import cast
 
 import torch
 import torch.distributed as dist
+import torch.distributed.config as dist_config
 import torch.distributed.tensor._api as dtensor
 import torch.distributed.tensor._random as random
 from torch._library.utils import fill_defaults
 from torch._logging import LazyString
+from torch._prims.rng_prims import run_dtensor_rng_op
 from torch.distributed._functional_collectives import _are_we_tracing
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
@@ -302,9 +304,20 @@ class OpDispatcher:
             local_tensor_args = cast(tuple[object, ...], local_tensor_args)
             if op_call in self._random_ops:
                 if not random._rng_tracker and is_rng_supported_mesh(mesh):
-                    # Default to `OffsetBasedRNGTracker` if the parallelism API
-                    # did not already construct one
-                    random._rng_tracker = random.OffsetBasedRNGTracker(mesh)
+                    # Default to `OffsetBasedRNGTracker` if the parallelism API did not already construct one
+                    # Skip RNG state sync during tracing to avoid lazily initializing real RNG state under fake mode.
+                    run_state_sync = not _are_we_tracing()
+                    if not run_state_sync:
+                        logger.info(
+                            "DTensor RNG tracker is being lazily initialized during tracing. "
+                            "RNG states may not be synchronized across ranks, which can lead "
+                            "to silent incorrectness. Please call `torch.manual_seed()` with "
+                            "the same seed on all ranks before compiling DTensor random ops.",
+                            stacklevel=2,
+                        )
+                    random._rng_tracker = random.OffsetBasedRNGTracker(
+                        mesh, run_state_sync
+                    )
 
                 first_arg, first_local_arg = (
                     cast(dtensor.DTensor, args[0]),
@@ -320,17 +333,48 @@ class OpDispatcher:
                     or isinstance(maybe_user_generator, torch.Generator)
                 ):
                     raise AssertionError
-                # maybe_user_generator = None
-                rng_context = (
-                    random._rng_tracker._distribute_region(
-                        first_arg._spec, generator=maybe_user_generator
-                    )
-                    if random._rng_tracker and not first_local_arg.is_meta
-                    else contextlib.nullcontext()
-                )
-                # For DTensor random operator, run it within a RNGTracker context to
-                # ensure the random number generator is properly distributed.
-                with rng_context:
+
+                if (
+                    random._rng_tracker
+                    and not first_local_arg.is_meta
+                    and random._rng_tracker.distribute_region_enabled
+                ):
+                    if (
+                        maybe_user_generator is not None
+                        or first_local_arg.device.type != "cuda"
+                        or (
+                            not _are_we_tracing()
+                            and type(first_local_arg) is not torch.Tensor
+                        )
+                    ):
+                        with random._rng_tracker._distribute_region(
+                            first_arg._spec, generator=maybe_user_generator
+                        ):
+                            local_results = op_call(
+                                *local_tensor_args, **op_info.local_kwargs
+                            )
+                    else:
+                        # CUDA device without user generator, use HOP for traceability
+                        if dist_config.compile_on_one_rank:
+                            raise NotImplementedError(
+                                "run_dtensor_rng_op is not yet compatible with compile_on_one_rank"
+                            )
+                        if not isinstance(
+                            random._rng_tracker, random.OffsetBasedRNGTracker
+                        ):
+                            raise AssertionError
+                        start_offset_incr, end_offset_incr = (
+                            random._rng_tracker._compute_rng_offsets(first_arg._spec)
+                        )
+                        local_results = run_dtensor_rng_op(
+                            start_offset_incr,
+                            end_offset_incr,
+                            op_call,
+                            *local_tensor_args,
+                            **op_info.local_kwargs,
+                        )
+                else:
+                    # No rng_tracker, meta tensor, or distribute_region disabled
                     local_results = op_call(*local_tensor_args, **op_info.local_kwargs)
             else:
                 # normal case, run local sharded op computation

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -77,6 +77,7 @@ FIXME_hop_that_doesnt_have_opinfo_test_allowlist = [
     "autograd_function_apply",
     "run_and_save_rng_state",
     "run_with_rng_state",
+    "run_dtensor_rng_op",
     "graphsafe_run_with_rng_state",
     "out_dtype",
     "trace_wrapped",


### PR DESCRIPTION
Summary:

Fixes: https://github.com/pytorch/pytorch/issues/147757, https://github.com/pytorch/pytorch/issues/156649

This PR introduces a new higher-order operator (`run_dtensor_rng_op`) that makes DTensor random operations traceable by `torch.compile`. 

Previously, DTensor random ops (dropout, uniform_, normal_, etc.) rely on per-rank RNG state manipulation to produce correct distributed results. This was done via the `_distribute_region` context manager, which is not torch.compile friendly

The new HOP takes pre-computed integer offsets (derived from the DTensorSpec at trace time) and the op + args, then handles the RNG state forking internally. Since the offsets are plain integers, they can be burned into the compiled graph as constants with no references to DTensorSpec or DeviceMesh objects at runtime.

With this HOP, one can call `torch.compile()` on a random op with DTensor inputs.

e.g.

```
@torch.compile(backend="aot_eager")
def fn(x):
    return torch.nn.functional.dropout(x, p=0.5, training=True)
```

```
graph after dynamo:
class GraphModule(torch.nn.Module):
    def forward(self, L_x_: "DTensor(f32[8, 8], S(0))"):
        l_x_ = L_x_
        dropout: "DTensor(f32[8, 8], S(0))" = torch.nn.functional.dropout(l_x_, p = 0.5);  l_x_ = None
        return (dropout,)

graph after aot autograd:
class <lambda>(torch.nn.Module):
    def forward(self, arg0_1: "f32[4, 8]"):
        run_dtensor_rng_op = torch.ops.higher_order.run_dtensor_rng_op(0, 64, torch.ops.aten.native_dropout.default, arg0_1, 0.5, True);  arg0_1 = None
        getitem: "f32[4, 8]" = run_dtensor_rng_op[0];  run_dtensor_rng_op = None
        return (getitem,)
```

TODOs:
1. This should compose with the ThreadBasedOffsetTracker (to be added soon). We need to consolidate which change lands first (cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @mori360).
2. Currently, the generated graph is rank-dependent. The HOP takes start_offset_incr, which is embedded into the graph during tracing and differs across ranks when the tensor is sharded. As a result, it won’t work out-of-the-box when compiling on a single rank. To make it work, we probably need to make start_offset_incr symbolic (cc @aorenste).

Test Plan: 

Added `DistTensorRandomOpCompileTest` 
