### PR TITLE
[ROCm] Upgrade GCC version to version 13

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -193,7 +193,7 @@ case "$tag" in
     else
       ANACONDA_PYTHON_VERSION=3.12
     fi
-    GCC_VERSION=11
+    GCC_VERSION=13
     VISION=yes
     ROCM_VERSION=7.1
     NINJA_VERSION=1.9.0
@@ -208,7 +208,7 @@ case "$tag" in
     ;;
   pytorch-linux-noble-rocm-nightly-py3)
     ANACONDA_PYTHON_VERSION=3.12
-    GCC_VERSION=11
+    GCC_VERSION=13
     VISION=yes
     ROCM_VERSION=nightly
     NINJA_VERSION=1.9.0

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -89,7 +89,7 @@ case ${image} in
         fi
         TARGET=rocm_final
         MANY_LINUX_VERSION="2_28"
-        DEVTOOLSET_VERSION="11"
+        DEVTOOLSET_VERSION="13"
         GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
         PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"


### PR DESCRIPTION
The current PyTorch code is being compiled with GCC-11 which doesn't support bf16.
GCC-13 adds support for bf16 and Float16 types, which are required for hipSPARSELt.
Upgrading GCC version to 13 for rocm is required for the enablement of hipSPARSELt. 



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang