### PR TITLE
[inductor] Add decompose_functional_to_out pass

### DIFF
--- a/test/inductor/test_decompose_functional_to_out.py
+++ b/test/inductor/test_decompose_functional_to_out.py
@@ -1,110 +1,295 @@
 # Owner(s): ["module: inductor"]
 """
-Tests for decompose_functional_to_out pass with schema-based detection.
+Tests for decompose_functional_to_out pass.
+
+This test verifies that the pass correctly transforms functional ops
+to their out variants by:
+1. Detecting out variants via schema matching
+2. Allocating output buffers with torch.empty
+3. Replacing functional calls with out variant calls
 """
 
 import torch
+from torch import Tensor
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestDecomposeFunctionalToOut(TestCase):
-    """Tests for the decompose pass with auto-detection."""
+    """Core tests for the decompose_functional_to_out pass."""
 
-    def setUp(self):
-        self._setup_test_ops()
+    @classmethod
+    def setUpClass(cls):
+        cls._setup_test_ops()
 
-    def _setup_test_ops(self):
-        """Create test custom ops with .out convention."""
+    @classmethod
+    def _setup_test_ops(cls):
+        """Register test ops with functional and out variants."""
+        cls.lib = torch.library.Library("test_decompose", "FRAGMENT")
 
-        # Functional op
-        @torch.library.custom_op("test_decompose::add_one", mutates_args=())
-        def add_one(x: torch.Tensor) -> torch.Tensor:
+        # === Single output op ===
+        cls.lib.define("add_one(Tensor x) -> Tensor")
+
+        @torch.library.impl("test_decompose::add_one", "CompositeExplicitAutograd")
+        def add_one_impl(x: Tensor) -> Tensor:
             return x + 1
 
-        @add_one.register_fake
-        def _(x):
+        @torch.library.impl("test_decompose::add_one", "Meta")
+        def add_one_meta(x: Tensor) -> Tensor:
             return torch.empty_like(x)
 
-        # Out variant with .out overload
-        @torch.library.custom_op("test_decompose::add_one.out", mutates_args=("out",))
-        def add_one_out(out: torch.Tensor, x: torch.Tensor) -> None:
+        cls.lib.define("add_one.out(Tensor x, *, Tensor(a!) out) -> Tensor(a!)")
+
+        @torch.library.impl("test_decompose::add_one.out", "CompositeExplicitAutograd")
+        def add_one_out_impl(x: Tensor, *, out: Tensor) -> Tensor:
             out.copy_(x + 1)
+            return out
 
-        @add_one_out.register_fake
-        def _(out, x):
-            pass
+        @torch.library.impl("test_decompose::add_one.out", "Meta")
+        def add_one_out_meta(x: Tensor, *, out: Tensor) -> Tensor:
+            return out
 
-        self.functional_op = torch.ops.test_decompose.add_one.default
-        self.out_op = torch.ops.test_decompose.add_one.out
+        # === Multiple outputs op ===
+        cls.lib.define("split_scale(Tensor x, float scale) -> (Tensor, Tensor)")
 
-    def test_find_out_variant(self):
-        """Test that schema-based detection finds the out variant."""
-        from torch._library._out_variant import check_out_variant, to_out_variant
+        @torch.library.impl("test_decompose::split_scale", "CompositeExplicitAutograd")
+        def split_scale_impl(x: Tensor, scale: float) -> tuple[Tensor, Tensor]:
+            return x * scale, x / scale
 
-        out_op = to_out_variant(self.functional_op)
+        @torch.library.impl("test_decompose::split_scale", "Meta")
+        def split_scale_meta(x: Tensor, scale: float) -> tuple[Tensor, Tensor]:
+            return torch.empty_like(x), torch.empty_like(x)
+
+        cls.lib.define(
+            "split_scale.out(Tensor x, float scale, *, "
+            "Tensor(a!) out_scaled, Tensor(b!) out_divided) -> (Tensor(a!), Tensor(b!))"
+        )
+
+        @torch.library.impl(
+            "test_decompose::split_scale.out", "CompositeExplicitAutograd"
+        )
+        def split_scale_out_impl(
+            x: Tensor, scale: float, *, out_scaled: Tensor, out_divided: Tensor
+        ) -> tuple[Tensor, Tensor]:
+            out_scaled.copy_(x * scale)
+            out_divided.copy_(x / scale)
+            return out_scaled, out_divided
+
+        @torch.library.impl("test_decompose::split_scale.out", "Meta")
+        def split_scale_out_meta(
+            x: Tensor, scale: float, *, out_scaled: Tensor, out_divided: Tensor
+        ) -> tuple[Tensor, Tensor]:
+            return out_scaled, out_divided
+
+    def test_single_output_graph_transformation(self):
+        """
+        Test that a single-output functional op is transformed to out variant.
+
+        Verifies:
+        - Before: graph contains add_one.default (functional)
+        - After: graph contains torch.empty + add_one.out
+        - Result is correct
+        """
+        from torch._inductor.fx_passes.decompose_functional_to_out import (
+            decompose_functional_to_out,
+        )
+        from torch.export import export
+
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.test_decompose.add_one(x)
+
+        x = torch.randn(4, 4)
+        exported = export(TestModule(), (x,))
+        graph = exported.graph_module.graph
+
+        # Verify functional op exists before transformation
+        has_functional = any(
+            n.target == torch.ops.test_decompose.add_one.default
+            for n in graph.nodes
+            if n.op == "call_function"
+        )
+        self.assertTrue(has_functional, "Functional op should exist before transform")
+
+        # Apply decompose pass
+        modified = decompose_functional_to_out(graph)
+        self.assertTrue(modified, "Pass should modify the graph")
+
+        # Verify out variant exists after transformation
+        has_out = any(
+            n.target == torch.ops.test_decompose.add_one.out
+            for n in graph.nodes
+            if n.op == "call_function"
+        )
+        has_empty = any(
+            n.target == torch.empty for n in graph.nodes if n.op == "call_function"
+        )
+        self.assertTrue(has_out, "Out variant should exist after transform")
+        self.assertTrue(has_empty, "torch.empty allocation should exist")
+
+        # Verify functional op is removed
+        has_functional_after = any(
+            n.target == torch.ops.test_decompose.add_one.default
+            for n in graph.nodes
+            if n.op == "call_function"
+        )
+        self.assertFalse(has_functional_after, "Functional op should be removed")
+
+        # Verify correctness
+        exported.graph_module.recompile()
+        result = exported.graph_module(x)
+        if isinstance(result, tuple):
+            result = result[0]
+        torch.testing.assert_close(result, x + 1)
+
+    def test_multiple_outputs_graph_transformation(self):
+        """
+        Test that a multi-output functional op is transformed correctly.
+
+        Verifies:
+        - Out variant has multiple out args (out_scaled, out_divided)
+        - Both outputs are correctly allocated and returned
+        """
+        from torch._inductor.fx_passes.decompose_functional_to_out import (
+            decompose_functional_to_out,
+        )
+        from torch._library._out_variant import get_out_arg_names, to_out_variant
+        from torch.export import export
+
+        # Verify out variant detection
+        functional_op = torch.ops.test_decompose.split_scale.default
+        out_op = to_out_variant(functional_op)
         self.assertIsNotNone(out_op)
-        self.assertEqual(out_op, self.out_op)
+        self.assertEqual(out_op, torch.ops.test_decompose.split_scale.out)
+        self.assertEqual(get_out_arg_names(out_op), ["out_scaled", "out_divided"])
 
-        self.assertTrue(check_out_variant(self.functional_op, self.out_op))
+        # Test graph transformation
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.test_decompose.split_scale(x, 2.0)
 
-    def test_decompose_with_config_enabled(self):
-        """Test decomposition when config is enabled."""
+        x = torch.randn(4, 4)
+        exported = export(TestModule(), (x,))
+        graph = exported.graph_module.graph
+
+        modified = decompose_functional_to_out(graph)
+        self.assertTrue(modified)
+
+        # Verify out variant in graph
+        has_out = any(
+            n.target == torch.ops.test_decompose.split_scale.out
+            for n in graph.nodes
+            if n.op == "call_function"
+        )
+        self.assertTrue(has_out)
+
+        # Verify correctness
+        exported.graph_module.recompile()
+        result = exported.graph_module(x)
+        if isinstance(result, tuple) and len(result) == 2:
+            scaled, divided = result
+        else:
+            scaled, divided = result[0], result[1]
+        torch.testing.assert_close(scaled, x * 2.0)
+        torch.testing.assert_close(divided, x / 2.0)
+
+
+class TestNativeQuantizeOp(TestCase):
+    """
+    Tests with real native PyTorch quantization op.
+
+    fake_quantize_per_tensor_affine_cachemask is a native op with:
+    - Multiple outputs: (Tensor output, Tensor mask)
+    - Auto-generated .out variant
+    """
+
+    def test_fake_quantize_graph_transformation(self):
+        """
+        Test decompose pass transforms fake_quantize_per_tensor_affine_cachemask.
+
+        Verifies:
+        - Before: graph contains functional op
+        - After: graph contains out variant + torch.empty allocations
+        """
+        from torch._inductor.fx_passes.decompose_functional_to_out import (
+            decompose_functional_to_out,
+        )
+        from torch.export import export
+
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.fake_quantize_per_tensor_affine_cachemask(
+                    x, 0.1, 0, -128, 127
+                )
+
+        x = torch.randn(4, 4)
+        exported = export(TestModule(), (x,))
+        graph = exported.graph_module.graph
+
+        # Check before transformation
+        has_functional = any(
+            n.target == torch.ops.aten.fake_quantize_per_tensor_affine_cachemask.default
+            for n in graph.nodes
+            if n.op == "call_function"
+        )
+        self.assertTrue(has_functional, "Functional op should exist before transform")
+
+        # Apply pass
+        modified = decompose_functional_to_out(graph)
+
+        if modified:
+            # Verify out variant in graph
+            has_out = any(
+                n.target == torch.ops.aten.fake_quantize_per_tensor_affine_cachemask.out
+                for n in graph.nodes
+                if n.op == "call_function"
+            )
+            self.assertTrue(has_out, "Out variant should exist after transform")
+
+            # Verify torch.empty allocations
+            has_empty = any(
+                n.target == torch.empty for n in graph.nodes if n.op == "call_function"
+            )
+            self.assertTrue(has_empty, "torch.empty allocation should exist")
+
+    def test_fake_quantize_end_to_end(self):
+        """
+        End-to-end test with torch.compile for fake_quantize_per_tensor_affine_cachemask.
+
+        Verifies:
+        1. The decompose pass works in the full compilation pipeline
+        2. The compiled result matches eager execution
+        3. Output shapes and types are correct
+        """
 
         def fn(x):
-            return torch.ops.test_decompose.add_one(x)
+            return torch.ops.aten.fake_quantize_per_tensor_affine_cachemask(
+                x, 0.1, 0, -128, 127
+            )
 
         x = torch.randn(4, 4)
 
+        # Eager execution for reference
+        expected_output, expected_mask = fn(x)
+
+        # Compiled execution with decompose pass enabled
         with torch._inductor.config.patch(decompose_functional_to_out=True):
-            compiled = torch.compile(fn, backend="inductor")
-            result = compiled(x)
+            compiled_fn = torch.compile(fn, backend="inductor")
+            result = compiled_fn(x)
 
-        expected = x + 1
-        torch.testing.assert_close(result, expected)
+        # Handle result (may be tuple or individual tensors)
+        if isinstance(result, tuple):
+            output, mask = result
+        else:
+            output, mask = result[0], result[1]
 
-    def test_no_decompose_when_disabled(self):
-        """Test that decomposition is skipped when config is disabled."""
+        # Verify correctness
+        torch.testing.assert_close(output, expected_output)
+        torch.testing.assert_close(mask, expected_mask)
 
-        def fn(x):
-            return torch.ops.test_decompose.add_one(x)
-
-        x = torch.randn(4, 4)
-
-        # Default is disabled
-        compiled = torch.compile(fn, backend="inductor")
-        result = compiled(x)
-
-        expected = x + 1
-        torch.testing.assert_close(result, expected)
-
-
-class TestOutVariantDetection(TestCase):
-    """Tests for out variant detection utilities."""
-
-    def test_no_out_variant_returns_none(self):
-        """Test that None is returned when no out variant exists."""
-        from torch._library._out_variant import to_out_variant
-
-        # Create an op without an out variant
-        @torch.library.custom_op("test_no_out::my_op", mutates_args=())
-        def my_op(x: torch.Tensor) -> torch.Tensor:
-            return x * 2
-
-        @my_op.register_fake
-        def _(x):
-            return torch.empty_like(x)
-
-        result = to_out_variant(torch.ops.test_no_out.my_op.default)
-        self.assertIsNone(result)
-
-    def test_native_op_out_variant(self):
-        """Test detection works for native ops too."""
-        from torch._library._out_variant import to_out_variant
-
-        # aten::add has an out variant
-        out_op = to_out_variant(torch.ops.aten.add.Tensor)
-        self.assertIsNotNone(out_op)
-        self.assertEqual(out_op, torch.ops.aten.add.out)
+        # Verify shapes and types
+        self.assertEqual(output.shape, x.shape)
+        self.assertEqual(mask.shape, x.shape)
+        self.assertEqual(mask.dtype, torch.bool)
 
 
 if __name__ == "__main__":

--- a/torch/_library/_out_variant.py
+++ b/torch/_library/_out_variant.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+
+import torch
+from torchgen.model import FunctionSchema, SchemaKind
+
+log = logging.getLogger(__name__)
+
+
+def get_out_arg_count(out_op: torch._ops.OpOverload) -> int:
+    """Get the number of out arguments for an out variant op.
+
+    Out arguments are mutable tensor arguments that appear at the end of
+    the argument list in the out variant's schema.
+    """
+    native_schema = _pybind_schema_to_native_schema(out_op._schema)
+    if native_schema is None:
+        return 0
+
+    if native_schema.kind() != SchemaKind.out:
+        return 0
+
+    return len(native_schema.arguments.out)
+
+
+def get_out_arg_names(out_op: torch._ops.OpOverload) -> list[str]:
+    """Get the names of out arguments for an out variant op.
+
+    Out arguments are keyword-only mutable tensor arguments in the schema.
+    Returns an empty list if the op is not an out variant.
+    """
+    native_schema = _pybind_schema_to_native_schema(out_op._schema)
+    if native_schema is None:
+        return []
+
+    if native_schema.kind() != SchemaKind.out:
+        return []
+
+    return [arg.name for arg in native_schema.arguments.out]
+
+
+def to_out_variant(op: torch._ops.OpOverload) -> torch._ops.OpOverload | None:
+    """
+    Given a functional operator overload, return its corresponding out variant.
+
+    Uses signature matching to find the correct out variant among all overloads.
+    """
+    native_schema = _pybind_schema_to_native_schema(op._schema)
+    if native_schema is None:
+        return None
+
+    # Only convert functional ops
+    if native_schema.kind() != SchemaKind.functional:
+        return None
+
+    # Get the normalized signature for matching
+    signature = dataclasses.replace(native_schema.signature(), returns=())
+
+    # Get the op packet to access all overloads
+    namespace = op.namespace
+    op_name = op._schema.name.split("::")[1]
+    torch_packet = getattr(getattr(torch.ops, namespace), op_name)
+
+    # Search through all overloads for matching out variant
+    overload_names = torch._C._jit_get_operation(op._schema.name)[1]
+    for overload_name in overload_names:
+        candidate = getattr(torch_packet, overload_name)
+        candidate_native_schema = _pybind_schema_to_native_schema(candidate._schema)
+        if candidate_native_schema is None:
+            continue
+
+        if candidate_native_schema.kind() != SchemaKind.out:
+            continue
+
+        candidate_signature = dataclasses.replace(
+            candidate_native_schema.signature(), returns=()
+        )
+        if candidate_signature == signature:
+            return candidate
+
+    return None
+
+
+def _pybind_schema_to_native_schema(
+    schema: torch._C.FunctionSchema,
+) -> FunctionSchema | None:
+    """Convert a pybind FunctionSchema to a torchgen FunctionSchema."""
+    try:
+        return FunctionSchema.parse(str(schema))
+    except Exception:
+        log.debug("Failed to parse schema: %s", schema)
+        return None
+
+
+def check_out_variant(functional_op, expected_out_op):
+    """
+    Verify that to_out_variant returns the expected out variant for a functional op.
+
+    Returns True if successful, raises AssertionError with detailed message otherwise.
+    """
+    out_op = to_out_variant(functional_op)
+    if out_op is None:
+        raise AssertionError(
+            f"to_out_variant({functional_op}) returned None. "
+            f"Expected to find out variant {expected_out_op}. "
+            f"Check that the out variant overload name follows the correct naming convention "
+            f"(e.g., 'op.out' for default overload or 'op.overload_out' for named overloads)."
+        )
+    if out_op != expected_out_op:
+        raise AssertionError(
+            f"to_out_variant({functional_op}) returned {out_op}, "
+            f"but expected {expected_out_op}. "
+            f"The out variant name does not match the functional op."
+        )
+    return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174465

This diff adds an inductor pass that automatically transforms functional ops to their out variants during compilation.

**Motivation:**
- Normalize ops to out variants for consistent memory planning
- Enable pre-allocated output buffers for memory reuse

**Implementation:**

1. **Out variant detection** (\`torch/_library/_out_variant.py\`):
   - Finds matching out variant by comparing non-mutable argument signatures
   - Uses pybind API (\`arg.alias_info.is_write\`) to support vLLM-style custom ops

2. **Transformation pass** (\`torch/_inductor/fx_passes/decompose_functional_to_out.py\`):
   - Allocates output buffers and replaces functional calls with out variant calls
   - Handles single and multiple output ops
   - TODO: reinplace reused buffers (next PR)

3. **Tests** (\`test/inductor/test_decompose_functional_to_out.py\`):
   - Graph transformation and end-to-end \`torch.compile\` tests

Controlled by \`config.decompose_functional_to_out\` (default: False)

Test Plan:
```python -m pytest test/inductor/test_decompose_functional_to_out.py -v```

All 4 tests pass

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos