### PR TITLE
test_linalg: Increase torch.float tolerance in test_tensorinv for rocm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3771,8 +3771,7 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float: 1.35e-3 if TEST_WITH_ROCM else 1e-3,
-                        torch.cfloat: 1e-3})
+    @precisionOverride({torch.float: 1.35e-3, torch.cfloat: 1e-3})
     def test_tensorinv(self, device, dtype):
 
         def run_test(a_shape, ind):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3771,7 +3771,8 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float: 1e-3, torch.cfloat: 1e-3})
+    @precisionOverride({torch.float: 1.35e-3 if TEST_WITH_ROCM else 1e-3,
+                        torch.cfloat: 1e-3})
     def test_tensorinv(self, device, dtype):
 
         def run_test(a_shape, ind):


### PR DESCRIPTION
This fails locally on ROCm with Radeon Pro V710 and ROCm 7.2, and failed on recent CI runs: https://www.torch-ci.com/tests/testInfo?name=test_tensorinv_cuda_float32&suite=TestLinalgCUDA&file=test_linalg.py

```
AssertionError: Tensor-likes are not close!

 Mismatched elements: 1 / 144 (0.7%)
 Greatest absolute difference: 0.00130462646484375 at index (1, 3, 6) (up to 0.001 allowed)
 Greatest relative difference: 1.5133813576539978e-05 at index (1, 3, 6) (up to 1.3e-06 allowed)
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang