### PR TITLE
[bug] Fix string-conversion issue in caffe2/torch/csrc/Storage.cpp +4

### DIFF
--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -247,6 +247,7 @@ static PyObject* THPStorage_pynew(
       }
     } catch (const std::exception&) {
       TORCH_CHECK(
+          false,
           THPStorageStr "(): tried to construct a storage from a sequence (",
           THPUtils_typename(sequence),
           "), ",
@@ -296,6 +297,7 @@ static PyObject* THPStorage_get(THPStorage* self, PyObject* index) {
     slicelength = PySlice_AdjustIndices(len, &start, &stop, step);
     if (step != 1) {
       TORCH_CHECK(
+          false,
           "Trying to slice with a step of ",
           step,
           ", but only a step of "
@@ -345,6 +347,7 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
   THPStorage_assertNotNull(self);
   if (!THPByteUtils_checkReal(value)) {
     TORCH_CHECK(
+        false,
         "can only set storage content with a int types, but got ",
         THPUtils_typename(value),
         " instead");
@@ -366,6 +369,7 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
     PySlice_AdjustIndices(len, &start, &stop, step);
     if (step != 1) {
       TORCH_CHECK(
+          false,
           "Trying to slice with a step of ",
           step,
           ", but only a step of "
@@ -379,7 +383,7 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
     return 0;
   }
   TORCH_CHECK(
-      "can't index a " THPStorageStr " with ", THPUtils_typename(index));
+      false, "can't index a " THPStorageStr " with ", THPUtils_typename(index));
   return -1;
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -616,6 +616,7 @@ std::unordered_map<std::string, std::string> AOTIModelPackageLoader::
     }
 
     TORCH_CHECK(
+        false,
         "Failed to find a generated cpp file or so file for model '",
         model_name,
         "' in the zip archive.\n\nAvailable models in the archive:\n",


### PR DESCRIPTION
Summary:
This could is triggering `-Wstring-conversion`, which presents as:
```
warning: implicit conversion turns string literal into bool: A to B
```
This is often a bug and what was intended. The most frequent cause is the code was:
```
void foo(bool) { ... }
void foo(std::string) { ... }
foo("this gets interpreted as a bool");
```

It is also possible the issue is innocuous as part of an assert:
```
assert(!"this string is true, so the assertion is false");
EXPECT_FALSE("this string is true, so the expect fails");
```
in these cases the use is to "cute", so we modify the code to make it more obvious.
```
assert(false && "the compiler recognizes and doesn't complain about this pattern");
FAIL() << "much more obvious";
```

Test Plan: Sandcastle

Differential Revision: D92528310


