### PR TITLE
[ROCM] use rocm-sdk to auto-detect ROCm path when ROCM_PATH is not set

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1639,22 +1639,7 @@ if(USE_KINETO)
 
   if(NOT LIBKINETO_NOROCTRACER)
     if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
-      if(ROCM_SDK_EXECUTABLE)
-        execute_process(
-          COMMAND ${ROCM_SDK_EXECUTABLE} path --root
-          OUTPUT_VARIABLE _ROCM_SDK_ROOT
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          RESULT_VARIABLE _ROCM_SDK_RESULT
-          ERROR_QUIET
-        )
-        if(_ROCM_SDK_RESULT EQUAL 0 AND EXISTS "${_ROCM_SDK_ROOT}")
-          set(ENV{ROCM_SOURCE_DIR} "${_ROCM_SDK_ROOT}")
-        else()
-          set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
-        endif()
-      else()
-        set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
-      endif()
+      set(ENV{ROCM_SOURCE_DIR} "${ROCM_PATH}")
     endif()
   endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1639,7 +1639,22 @@ if(USE_KINETO)
 
   if(NOT LIBKINETO_NOROCTRACER)
     if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
-      set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
+      if(ROCM_SDK_EXECUTABLE)
+        execute_process(
+          COMMAND ${ROCM_SDK_EXECUTABLE} path --root
+          OUTPUT_VARIABLE _ROCM_SDK_ROOT
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          RESULT_VARIABLE _ROCM_SDK_RESULT
+          ERROR_QUIET
+        )
+        if(_ROCM_SDK_RESULT EQUAL 0 AND EXISTS "${_ROCM_SDK_ROOT}")
+          set(ENV{ROCM_SOURCE_DIR} "${_ROCM_SDK_ROOT}")
+        else()
+          set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
+        endif()
+      else()
+        set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
+      endif()
     endif()
   endif()
 

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -2,7 +2,8 @@ set(PYTORCH_FOUND_HIP FALSE)
 
 # If ROCM_PATH is set, assume intention is to compile with
 # ROCm support and error out if the ROCM_PATH does not exist.
-# Else ROCM_PATH does not exist, assume a default of /opt/rocm
+# Else ROCM_PATH does not exist, try to get it from rocm-sdk,
+# or assume a default of /opt/rocm
 # In the latter case, if /opt/rocm does not exist emit status
 # message and return.
 if(DEFINED ENV{ROCM_PATH})
@@ -13,11 +14,31 @@ if(DEFINED ENV{ROCM_PATH})
       "Set a valid ROCM_PATH or unset ROCM_PATH environment variable to fix.")
   endif()
 else()
-  if(UNIX)
-    set(ROCM_PATH /opt/rocm)
-  else() # Win32
-    set(ROCM_PATH C:/opt/rocm)
+  # Try to get ROCM_PATH from rocm-sdk if available
+  find_program(ROCM_SDK_EXECUTABLE rocm-sdk)
+  if(ROCM_SDK_EXECUTABLE)
+    execute_process(
+      COMMAND ${ROCM_SDK_EXECUTABLE} path --root
+      OUTPUT_VARIABLE ROCM_SDK_PATH
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE ROCM_SDK_RESULT
+      ERROR_QUIET
+    )
+    if(ROCM_SDK_RESULT EQUAL 0 AND EXISTS "${ROCM_SDK_PATH}")
+      set(ROCM_PATH "${ROCM_SDK_PATH}")
+      message(STATUS "Found ROCm installation via rocm-sdk at: ${ROCM_PATH}")
+    endif()
   endif()
+
+  # Fall back to default paths if rocm-sdk did not work
+  if(NOT DEFINED ROCM_PATH OR NOT EXISTS ${ROCM_PATH})
+    if(UNIX)
+      set(ROCM_PATH /opt/rocm)
+    else() # Win32
+      set(ROCM_PATH C:/opt/rocm)
+    endif()
+  endif()
+
   if(NOT EXISTS ${ROCM_PATH})
     message(STATUS
         "ROCM_PATH environment variable is not set and ${ROCM_PATH} does not exist.\n"

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -47,6 +47,11 @@ else()
   endif()
 endif()
 
+# Set ROCM_SOURCE_DIR for Kineto/roctracer if not already set
+if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
+  set(ENV{ROCM_SOURCE_DIR} "${ROCM_PATH}")
+endif()
+
 # MAGMA_HOME
 if(NOT DEFINED ENV{MAGMA_HOME})
   set(MAGMA_HOME ${ROCM_PATH}/magma)

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -47,11 +47,6 @@ else()
   endif()
 endif()
 
-# Set ROCM_SOURCE_DIR for Kineto/roctracer if not already set
-if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
-  set(ENV{ROCM_SOURCE_DIR} "${ROCM_PATH}")
-endif()
-
 # MAGMA_HOME
 if(NOT DEFINED ENV{MAGMA_HOME})
   set(MAGMA_HOME ${ROCM_PATH}/magma)


### PR DESCRIPTION
Set ROCM_PATH using rocm-sdk path --root if ROCM_PATH is not set. This should enable PyTorch builds in environments where theRock is installed but ROCM_PATH env var is not already set.

Without this fix:
```
-- ROCM_PATH environment variable is not set and /opt/rocm does not exist.
Building without ROCm support.
...
disabling ROCM because NOT USE_ROCM is set
-- MIOpen not found. Compiling without MIOpen support
...
--   USE_ROCM              : OFF
```

With this fix:
```
-- Found ROCm installation via rocm-sdk at: /opt/venv/lib/python3.12/site-packages/_rocm_sdk_devel
Building PyTorch for GPU arch: gfx908
-- Found HIP: /opt/venv/lib/python3.12/site-packages/_rocm_sdk_devel (found suitable version "7.2.53150-7b886380f9", minimum required is "1.0")
...
ROCM_VERSION_DEV: 7.12.0
ROCM_VERSION_DEV_INT:   71200
TORCH_HIP_VERSION: 702
...
--   USE_ROCM              : ON
--     ROCM_VERSION                  : 7.12.0
--     USE_FLASH_ATTENTION           : ON
--     USE_MEM_EFF_ATTENTION         : ON
```
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang