### PR TITLE
[KJT + nativert] Runtime changes for handling KJTs in nativert

### DIFF
--- a/torch/csrc/export/pt2_archive_constants.h
+++ b/torch/csrc/export/pt2_archive_constants.h
@@ -47,6 +47,8 @@ namespace torch::_export::archive_spec {
   DO(SAMPLE_INPUTS_DIR, "data/sample_inputs/")                                 \
   DO(SAMPLE_INPUTS_FILENAME_FORMAT,                                            \
      "data/sample_inputs/{}.pt") /* {model_name} */                            \
+  DO(TS_SAMPLE_INPUTS_FILENAME_FORMAT,                                         \
+     "extra/{}.forward.sample_input.pt") /* {model_name} */                    \
   /* ExecuTorch artifacts, including PTE files */                              \
   DO(EXECUTORCH_DIR, "data/executorch/")                                       \
   /* extra folder */                                                           \

--- a/torch/nativert/detail/ITree.cpp
+++ b/torch/nativert/detail/ITree.cpp
@@ -326,6 +326,15 @@ class PytreeNodeRegistry {
     registry_.emplace(typeName, nodeDef);
   }
 
+  void registerOrReplaceNode(std::string_view typeName, NodeDef nodeDef) {
+    auto it = registry_.find(std::string{typeName});
+    if (it != registry_.end()) {
+      it->second = nodeDef;
+    } else {
+      registry_.emplace(typeName, nodeDef);
+    }
+  }
+
  private:
   std::unordered_map<std::string, NodeDef> registry_;
 };
@@ -378,6 +387,12 @@ ITreeSpec makeITreeSpec(
 void registerPytreeNode(std::string_view typeName, NodeDef nodeDef) {
   getPytreeNodeRegistry().withLock([&](auto& registry) {
     registry.registerNode(typeName, std::move(nodeDef));
+  });
+}
+
+void registerOrReplacePytreeNode(std::string_view typeName, NodeDef nodeDef) {
+  getPytreeNodeRegistry().withLock([&](auto& registry) {
+    registry.registerOrReplaceNode(typeName, std::move(nodeDef));
   });
 }
 

--- a/torch/nativert/detail/ITree.h
+++ b/torch/nativert/detail/ITree.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string_view>
 #include <unordered_map>
@@ -21,7 +22,7 @@ class ITreeSpec;
 using ITreeFlattenFn =
     void (*)(const c10::IValue&, const ITreeSpec&, std::vector<c10::IValue>&);
 using ITreeUnflattenFn =
-    c10::IValue (*)(std::vector<c10::IValue>, const nlohmann::json&);
+    std::function<c10::IValue(std::vector<c10::IValue>, const nlohmann::json&)>;
 
 using ContextLoadFn = nlohmann::json (*)(std::string_view);
 
@@ -121,6 +122,12 @@ class ITreeSpec {
 };
 
 void registerPytreeNode(std::string_view typeName, NodeDef nodeDef);
+
+// Register a pytree node, replacing any existing registration with the same
+// name. This is useful for customizing unflatten behavior for types like
+// KeyedJaggedTensor where the default implementation returns a tuple but the
+// caller wants to reconstruct the actual custom class object.
+void registerOrReplacePytreeNode(std::string_view typeName, NodeDef nodeDef);
 
 // Serialized json tree spec should be dumped from treespec_dumps() in
 // torch.utils._pytree directly .


### PR DESCRIPTION
Summary:
For PT2 models published with TGIF, we use the torchscripted sample inputs in the extra directory for container warmup in order to allow for deserilaization of KJT types in the inputs. Luckily, we already package these scripted sample inputs even when publishing for PT2, so it's just a matter of changing the file path we load from.

We also use a dummy KJT module added at publish time (previous diff) to gain access to a KJT type ptr, which allows us to serialize KJTs in the ouptut

Test Plan:
```
buck2 test fbcode//sigmoid/inference/test_cpu:model_runner_test -- ModelRunnerTest.LoadChainedModulesWithScriptedDummyKJT --run-disabled
```

Also ran local sigrid predictor e2e:


```
GFLAGS_CONFIG_PATH=sigrid/predictor/predictor_x_gflags_tgif_lsr_template BUILD=1 MODEL_ID=2140458821 SNAPSHOT_ID=27 LOCAL_MODEL_DIR=/data/users/georgiaphillips/models/${MODEL_ID}/${SNAPSHOT_ID} sh ~/fbsource/fbcode/scripts/dsy842974287/load_model.sh 2>&1 |tee pt2_logs.txt

BUILD=1 sh hpc/inference/scripts/gif/vdd/1_card/launch_gpu_replayer.sh

```

Differential Revision: D91510526


