### PR TITLE
[MPS] Add MacOS Tahoe testing shard

### DIFF
--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -24,12 +24,11 @@ jobs:
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.12.7
-      # The runner macos-m2-14 is not a typo, it's a custom runner that is different
-      # than our AWS macos-m1-14 runners
       test-matrix: |
         { include: [
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
           { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-15" },
+          { config: "test_mps", shard: 1, num_shards: 1, runner: "macos-m2-26" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #174484

That runs on `macos-m2-26` runners. So far there are only 6 of them, but this workflow only runs on PRs with `ciflow/mps` tags