### PR TITLE
test: fix data race in MockWaitCounterBackend

### DIFF
--- a/c10/test/util/WaitCounter_test.cpp
+++ b/c10/test/util/WaitCounter_test.cpp
@@ -22,30 +22,18 @@ class MockWaitCounterBackend
 
   intptr_t start(std::chrono::steady_clock::time_point now) noexcept override {
     startCount_.fetch_add(1);
-    lastStartTime_ = now;
     return reinterpret_cast<intptr_t>(this);
   }
 
   void stop(std::chrono::steady_clock::time_point now, intptr_t ctx) noexcept
       override {
     stopCount_.fetch_add(1);
-    lastStopTime_ = now;
     EXPECT_EQ(ctx, reinterpret_cast<intptr_t>(this));
-  }
-
-  std::chrono::steady_clock::time_point lastStartTime() const {
-    return lastStartTime_;
-  }
-
-  std::chrono::steady_clock::time_point lastStopTime() const {
-    return lastStopTime_;
   }
 
  private:
   std::atomic<int>& startCount_;
   std::atomic<int>& stopCount_;
-  std::chrono::steady_clock::time_point lastStartTime_;
-  std::chrono::steady_clock::time_point lastStopTime_;
 };
 
 class MockWaitCounterBackendFactory


### PR DESCRIPTION
A sanitizer tool found this issue:

The `start()` and `stop()` methods modify `lastStartTime_` and `lastStopTime_` without synchronization, causing a race condition when multiple threads access the same `MockWaitCounterBackend` instance via a shared `WaitCounterImpl`. These time-related members and their accessor methods appear to be unused in any tests.

cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh @bobrenjc93 @mruberry