### PR TITLE
[BE] Remove duplicate typing-extension from requirements

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,5 +7,5 @@ packaging
 pyyaml
 requests
 six  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions>=4.10.0
+typing-extensions>=4.15.0
 pip  # not technically needed, but this makes setup.py invocation work

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,4 @@ optree>=0.13.0
 psutil
 spin
 sympy>=1.13.3
-typing-extensions>=4.15.0
 wheel


### PR DESCRIPTION
Noticed while trying to run `pip install -r requirements.txt`:
```
ERROR: Double requirement given: typing-extensions>=4.15.0 (from -r requirements.txt (line 19)) (already in typing-extensions>=4.10.0 (from -r requirements-build.txt (line 10)), name='typing-extensions')
```

So remove it from requirements and updates requirements-build to 4.15