### PR TITLE
[XPU] Fix numerical instability in logcumsumexp with complex inputs

### DIFF
--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -327,7 +327,7 @@ C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T>& x) {
 template <typename T>
 C10_HOST_DEVICE inline c10::complex<T> log1p(const c10::complex<T>& z) {
 #if defined(__APPLE__) || defined(__MACOSX) || defined(__CUDACC__) || \
-    defined(__HIPCC__)
+    defined(__HIPCC__) || defined(__SYCL_DEVICE_ONLY__)
   // For Mac, the new implementation yielded a high relative error. Falling back
   // to the old version for now.
   // See https://github.com/numpy/numpy/pull/22611#issuecomment-1667945354

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -560,8 +560,6 @@ class TestReductions(TestCase):
 
     @skipIfNoSciPy
     @dtypes(torch.complex64, torch.complex128)
-    @dtypesIfXPU(torch.complex128)
-    # Skip the torch.complex64 for XPU, see https://github.com/intel/torch-xpu-ops/issues/2279 for details
     @skipIfMPS
     def test_logcumsumexp_complex(self, device, dtype):
         # logcumsumexp is a more precise way to compute than ``log(cumsum(exp(a)))``


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2816

Route XPU complex `log1p` through the same implementation used by other devices, as currently it falls into default (cpu) path. This prevents NaNs that showed up for complex64 e.g. in `logcumsumexp` described in linked issue