### PR TITLE
test: allocate 4 bytes in materialize_test_copy_on_write

### DIFF
--- a/c10/test/core/impl/cow_test.cpp
+++ b/c10/test/core/impl/cow_test.cpp
@@ -230,7 +230,7 @@ bool buffers_are_equal(const void* a, const void* b, size_t nbytes) {
 
 TEST(materialize_test, copy_on_write) {
   StorageImpl original_storage(
-      {}, /*size_bytes=*/6, GetCPUAllocator(), /*resizable=*/false);
+      {}, /*size_bytes=*/4, GetCPUAllocator(), /*resizable=*/false);
   std::memcpy(original_storage.mutable_data(), "abcd", 4);
   void const* original_data = original_storage.data();
 


### PR DESCRIPTION
The `materialize_test_copy_on_write` test allocated a 6-byte buffer but only initialized 4 bytes via `std::memcpy`. The `buffers_are_equal` function then read uninitialized memory when comparing the full 6 bytes, as reported by `nbytes()`, leading to a memory sanitizer error.

This change corrects the allocated size to 4 bytes, aligning it with the initialized data size and resolving the sanitizer error.