### PR TITLE
Update libtorch_agnostic_targetting workflow to be comprehensive for BC

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1362,7 +1362,7 @@ test_libtorch_agnostic_targetting() {
         "$VENV_UV" pip install --python "$VENV_PY" expecttest numpy unittest-xml-reporting
     }
 
-    CURRENT_VERSION=$(python -c "import torch; print(torch.__version__.split('+')[0].split('a')[0].split('b')[0].split('rc')[0])")
+    CURRENT_VERSION=$(python -I -c "import torch; print(torch.__version__.split('+')[0].split('a')[0].split('b')[0].split('rc')[0])")
     local CURRENT_major CURRENT_minor
     parse_version "$CURRENT_VERSION" "CURRENT"
     echo "Current: ${CURRENT_major}.${CURRENT_minor}, CUDA: $([[ "$BUILD_ENVIRONMENT" =~ cuda ]] && echo yes || echo no)"

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1354,7 +1354,7 @@ test_libtorch_agnostic_targetting() {
         "$VENV_UV" pip install --python "$VENV_PY" expecttest numpy unittest-xml-reporting
     }
 
-    CURRENT_VERSION=$(python -c "import torch; print(torch.__version__.split('+')[0].split('a')[0].split('b')[0].split('rc')[0])")
+    CURRENT_VERSION=$(python -I -c "import torch; print(torch.__version__.split('+')[0].split('a')[0].split('b')[0].split('rc')[0])")
     local CURRENT_major CURRENT_minor
     parse_version "$CURRENT_VERSION" "CURRENT"
     echo "Current: ${CURRENT_major}.${CURRENT_minor}, CUDA: $([[ "$BUILD_ENVIRONMENT" =~ cuda ]] && echo yes || echo no)"


### PR DESCRIPTION
```
                        Runtime Version
                        2.9     2.10    curr
                       ┌───────┬───────┬───────┐
Build 2.9,  Tgt 2.9    │   *   │       │       │
                       ├───────┼───────┼───────┤
Build 2.10, Tgt 2.9    │   *   │   *   │       │
Build 2.10, Tgt 2.10   │   -   │   *   │       │
                       ├───────┼───────┼───────┤
Build curr, Tgt 2.9    │   ✓   │   #   │   ✓   │
Build curr, Tgt 2.10   │   -   │   #   │   ✓   │
Build curr, Tgt curr   │   -   │   -   │   ✓   │
                       └───────┴───────┴───────┘

Legend:
  #  = NEW: Covered by this PR (backward compat workflow)
  ✓  = Already tested by normal CI for test_libtorch_agnostic.py or libtorch_agnostic_targetting (before this PR)
  *  = Historically tested (when older PyTorch was current)
  -  = Invalid (runtime < target version)
     = Valid but not tested

````


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174505

