### PR TITLE
[MTIA] Add device_module.get_device_name API (#169787)

### DIFF
--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -17,6 +17,13 @@ namespace at {
 class Context;
 }
 
+struct mtiaDeviceProp {
+  char name[256];
+  uint64_t total_memory;
+  uint32_t max_grid_height;
+  uint32_t max_grid_width;
+};
+
 namespace at {
 constexpr const char* MTIA_HELP =
     "The MTIA backend requires MTIA extension for PyTorch;"
@@ -114,7 +121,7 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
     return nullptr;
   }
 
-  virtual PyObject* getDeviceProperties(DeviceIndex device) const {
+  virtual mtiaDeviceProp* getDeviceProperties(DeviceIndex device) const {
     FAIL_MTIAHOOKS_FUNC(__func__);
     return nullptr;
   }

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 import torch
 from torch import Tensor
 from torch._environment import is_fbcode
-from torch._utils import _LazySeedTracker
+from torch._utils import _dummy_type, _LazySeedTracker
 from torch.types import Device
 
 from ._utils import _get_device_index
@@ -33,6 +33,11 @@ _tls = threading.local()
 _initialization_lock = threading.Lock()
 _lazy_seed_tracker = _LazySeedTracker()
 
+# Define dummy _MtiaDeviceProperties type if PyTorch was compiled without CUDA
+if hasattr(torch._C, "_MtiaDeviceProperties"):
+    _MtiaDeviceProperties = torch._C._MtiaDeviceProperties
+else:
+    _MtiaDeviceProperties = _dummy_type("_MtiaDeviceProperties")  # type: ignore[assignment, misc]
 
 if hasattr(torch._C, "_mtia_exchangeDevice"):
     _exchange_device = torch._C._mtia_exchangeDevice
@@ -276,13 +281,18 @@ def set_device(device: Device) -> None:
         torch._C._accelerator_hooks_set_current_device(device)
 
 
-def get_device_properties(device: Device = None) -> dict[str, Any]:
-    r"""Return a dictionary of MTIA device properties
+# pyrefly: ignore [not-a-type]
+def get_device_properties(device: Device = None) -> _MtiaDeviceProperties:
+    r"""Get the properties of a device.
 
     Args:
-        device (torch.device or int, optional) selected device. Returns
-            statistics for the current device, given by current_device(),
-            if device is None (default).
+        device (torch.device or int or str, optional): device for which to return the
+            properties of the device.  It uses the current device, given by
+            :func:`~torch.mtia.current_device`, if :attr:`device` is ``None``
+            (default).
+
+    Returns:
+        _MtiaDeviceProperties: the properties of the device
     """
     return torch._C._mtia_getDeviceProperties(_get_device_index(device, optional=True))
 

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -281,6 +281,21 @@ def set_device(device: Device) -> None:
         torch._C._accelerator_hooks_set_current_device(device)
 
 
+def get_device_name(device: "Device" = None) -> str:
+    r"""Get the name of a device.
+
+    Args:
+        device (torch.device or int or str, optional): device for which to return the
+            name. This function is a no-op if this argument is a negative
+            integer. It uses the current device, given by :func:`~torch.mtia.current_device`,
+            if :attr:`device` is ``None`` (default).
+
+    Returns:
+        str: the name of the device
+    """
+    return get_device_properties(device).name
+
+
 # pyrefly: ignore [not-a-type]
 def get_device_properties(device: Device = None) -> _MtiaDeviceProperties:
     r"""Get the properties of a device.
@@ -561,6 +576,7 @@ __all__ = [
     "memory_allocated",
     "reset_peak_memory_stats",
     "get_device_capability",
+    "get_device_name",
     "get_device_properties",
     "record_memory_history",
     "snapshot",


### PR DESCRIPTION
Summary:

Makes MTIA more device agnostic by adding the get_device_name API, similar to CUDA

Test Plan: CI

Reviewed By: egienvalue

Differential Revision: D88586817


