### PR TITLE
[BE] Add clang-[format|tidy] and actionlint binaries for aarch64

### DIFF
--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -199,8 +199,9 @@ if __name__ == "__main__":
         config = json.load(f)
     config = config[args.linter]
 
-    # Allow processor specific binaries for platform (namely Intel and M1 binaries for MacOS)
-    host_platform = HOST_PLATFORM if HOST_PLATFORM in config else HOST_PLATFORM_ARCH
+    # Allow processor specific binaries for platform (e.g. Intel/M1 for macOS, x86_64/aarch64 for Linux)
+    # Try arch-specific first, then fall back to generic platform
+    host_platform = HOST_PLATFORM_ARCH if HOST_PLATFORM_ARCH in config else HOST_PLATFORM
     # If the host platform is not in platform_to_hash, it is unsupported.
     if host_platform not in config:
         logging.error("Unsupported platform: %s/%s", HOST_PLATFORM, HOST_PLATFORM_ARCH)

--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 # String representing the host platform (e.g. Linux, Darwin).
 HOST_PLATFORM = platform.system()
-HOST_PLATFORM_ARCH = platform.system() + "-" + platform.processor()
+HOST_PLATFORM_ARCH = platform.system() + "-" + platform.machine()
 
 # PyTorch directory root
 try:

--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -201,7 +201,9 @@ if __name__ == "__main__":
 
     # Allow processor specific binaries for platform (e.g. Intel/M1 for macOS, x86_64/aarch64 for Linux)
     # Try arch-specific first, then fall back to generic platform
-    host_platform = HOST_PLATFORM_ARCH if HOST_PLATFORM_ARCH in config else HOST_PLATFORM
+    host_platform = (
+        HOST_PLATFORM_ARCH if HOST_PLATFORM_ARCH in config else HOST_PLATFORM
+    )
     # If the host platform is not in platform_to_hash, it is unsupported.
     if host_platform not in config:
         logging.error("Unsupported platform: %s/%s", HOST_PLATFORM, HOST_PLATFORM_ARCH)

--- a/tools/linter/adapters/s3_init_config.json
+++ b/tools/linter/adapters/s3_init_config.json
@@ -18,6 +18,10 @@
         "Linux": {
             "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/19.1.4/clang-format",
             "hash": "bfa9ef6eccb372f79ffcb6196af966fd84519ea9567f5ae7b6ad30208cd82109"
+        },
+        "Linux-aarch64": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux-aarch64/19.1.4/clang-format",
+            "hash": "9cfa17f68100f4cbb3ba6180df9db6d0a32b3a8b45e122aa20e2dda1feaf9902"
         }
     },
     "clang-tidy": {
@@ -32,6 +36,10 @@
         "Linux": {
             "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/19.1.4/clang-tidy",
             "hash": "5637bd0fca665d2797926fedf53ca5ad4655bb9dbed1e1c8654c8e032ce1e7a8"
+        },
+        "Linux-aarch64": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux-aarch64/19.1.4/clang-tidy",
+            "hash": "cd6708ca9731002abd8ecc1b616716d8a21cf682a3cb931dd3265c3f3f600d30"
         }
     },
     "actionlint": {
@@ -46,6 +54,10 @@
         "Linux": {
             "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.7.7/Linux_x86_64/actionlint",
             "hash": "9f7dedb4e23f89f2922073d1a6720405b7b520d4f5832ebb96f0d55a2958886c"
+        },
+        "Linux-aarch64": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.7.7/Linux_arm64/actionlint",
+            "hash": "446687e63fac45472b0a66bae28975c28678af062670af119c11a7087baf35cc"
         }
     },
     "bazel": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #174510

- `clang-[tidy|format]` are built by https://github.com/pytorch/test-infra/blob/main/.github/workflows/clang-tidy-linux.yml
- `actionlint` binary are uploaded from artifacts published at https://github.com/rhysd/actionlint/releases/tag/v1.7.7

Test plan: Run `actionlint init` and execute binaries on linux-aarch64 system

Fixes https://github.com/pytorch/pytorch/issues/161057