### PR TITLE
Add device check to solve_triangular inputs

### DIFF
--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -140,6 +140,9 @@ inline void checkInputsSolver(const Tensor& A,
                                      const char* const f_name) {
   squareCheckInputs(A, f_name, "A");
   checkIsMatrix(B, f_name, "B");
+  TORCH_CHECK(A.device() == B.device(),
+              f_name, ": Expected A and B to be on the same device, but found A on ",
+              A.device(), " and B on ", B.device(), " instead.");
   TORCH_CHECK(left ? A.size(-2) == B.size(-2) : A.size(-1) == B.size(-1),
               f_name, ": Incompatible shapes of A and B for the equation ",
               left ? "AX = B" : "XA = B",

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4788,18 +4788,12 @@ class TestLinalg(TestCase):
 
                 self.assertEqual(*torch.broadcast_tensors(B, B_other))
 
+    @onlyCUDA
     @dtypes(*floating_and_complex_types())
     def test_linalg_solve_triangular_errors(self, device, dtype):
-        # device mismatch (gh-142048)
-        if device != 'cpu' or torch.cuda.is_available():
-            A = torch.randn(3, 3, dtype=dtype, device=device).triu()
-            if device == 'cpu' and torch.cuda.is_available():
-                wrong_device = 'cuda'
-            elif device != 'cpu':
-                wrong_device = 'cpu'
-            else:
-                return
-            B = torch.randn(3, 2, dtype=dtype, device=wrong_device)
+        for (device1, device2) in [(device, "cpu"), ("cpu", device)]:
+            A = torch.randn(3, 3, dtype=dtype, device=device1).triu()
+            B = torch.randn(3, 2, dtype=dtype, device=device2)
             with self.assertRaisesRegex(RuntimeError, 'same device'):
                 torch.linalg.solve_triangular(A, B, upper=True)
 


### PR DESCRIPTION
## Issue

Fixes #142048

## Summary

`checkInputsSolver` validates shapes but not devices, so cross-device inputs to `solve_triangular` (and `solve`, `lu_solve`) segfault. Add a device check.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. Current behavior is a segfault.

cc @malfet