### PR TITLE
[TTD] Split inductor/dynamo/export keyword synonyms in filepath heuristic

### DIFF
--- a/tools/testing/target_determination/heuristics/filepath.py
+++ b/tools/testing/target_determination/heuristics/filepath.py
@@ -31,7 +31,9 @@ keyword_synonyms: dict[str, list[str]] = {
     "ops": ["opinfo"],
     "hop": ["higher_order_op"],
     "aot": ["flex_attention", "autograd"],
-    "inductor": ["dynamo", "export"],  # not actually synonyms but they interact a lot
+    "inductor": ["torchinductor"],
+    "dynamo": [],
+    "export": [],
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

The filepath heuristic previously treated "inductor", "dynamo", and "export"
as synonyms, causing any change to torch/_inductor/ to also match all dynamo
and export tests, and vice versa. These three subsystems account for ~33% of
all commits (4,600/year), so this conflation causes massive over-selection.

Split them into independent keywords so each subsystem's changes only match
its own tests. Add "torchinductor" as a synonym for "inductor" to preserve
the mapping to test_torchinductor.py.