### PR TITLE
[TTD] Filter CI/docs path keywords from filepath heuristic

### DIFF
--- a/tools/testing/target_determination/heuristics/filepath.py
+++ b/tools/testing/target_determination/heuristics/filepath.py
@@ -56,6 +56,14 @@ def is_valid_keyword(keyword: str) -> bool:
         "ns",
         "tools",
         "internal",
+        "github",
+        ".github",
+        "ci",
+        ".ci",
+        "workflows",
+        "docker",
+        "docs",
+        "scripts",
     ]
     return keyword == "nn" or (keyword not in not_keyword and len(keyword) > 2)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #174529
* #174528
* #174526
* __->__ #174525
* #174524

CI and documentation path components like "github", ".github", "ci",
".ci", "workflows", "docker", "docs", "scripts" are extracted as keywords
by the filepath heuristic but never meaningfully match any test names.
For CI-only PRs (~10% of commits, 1,347/year), all heuristics return
score 0, leading to essentially random test selection from the 25%
threshold.

Adding these to the not_keyword list prevents them from polluting the
keyword frequency dict and producing spurious matches.