### PR TITLE
[mtia] Skip cxx_resource_manager in non-prod environments to fix init crash

### DIFF
--- a/torch/_environment.py
+++ b/torch/_environment.py
@@ -3,3 +3,7 @@ from typing import Literal
 
 def is_fbcode() -> Literal[False]:
     return False
+
+
+def is_prod() -> Literal[False]:
+    return False

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import torch
 from torch import Tensor
-from torch._environment import is_fbcode
+from torch._environment import is_fbcode, is_prod
 from torch._utils import _LazySeedTracker
 from torch.types import Device
 
@@ -111,7 +111,7 @@ def _lazy_init() -> None:
 
         # Install the C++ resource manager to enable Buck resource lookup from Python.
         # This must be called before _mtia_init() which may access Buck resources.
-        if is_fbcode():
+        if is_fbcode() and is_prod():
             try:
                 from libfb.py.cxx_resources import cxx_resource_manager
 


### PR DESCRIPTION
Summary:
Skip cxx_resource_manager.install() in non-production environments to prevent PythonResourceManager crashes during MTIA initialization.

D92078050 added cxx_resource_manager.install() before torch._C._mtia_init() to enable Buck resource lookup from Python. However, this causes fatal crashes in environments where fbcode is not fully available (e.g., MTIA engenv).

D92275169 attempted to fix this by catching ModuleNotFoundError, but the module exists - the crash happens inside torch._C._mtia_init() when it tries to USE the resource manager, not during install().


Solution is to skip the resource manager installation in some certain scenarios to indicate a non-production environment.

Test Plan:
With this change:
https://www.internalfb.com/manifold/explorer/hccl/tree/multi_evb_logs/20260206/bartoszb_044714

Without:
https://www.internalfb.com/manifold/explorer/hccl/tree/multi_evb_logs/20260206/bartoszb_040910_failed

Reviewed By: danielhou0515

Differential Revision: D92512962


