### PR TITLE
[TTD] Make ROCm build respect job-filter on PRs

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -415,8 +415,7 @@ jobs:
     secrets: inherit
 
   linux-jammy-rocm-py3_10-build:
-    if: github.event_name == 'pull_request' || (needs.job-filter.outputs.jobs != '' && contains(needs.job-filter.outputs.jobs, ' linux-jammy-rocm-py3.10 '))
-    # don't run build twice on main
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-rocm-py3.10 ') }}
     name: linux-jammy-rocm-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #174529
* #174528
* #174526
* #174525
* #174524

The ROCm build had a pre-existing `github.event_name == 'pull_request'`
condition that bypassed the job filter, causing it to always run on
every PR regardless of changed files. Switch to the standard job-filter
pattern so ROCm only runs when C++/CUDA/ROCm/build files are changed.

The original condition existed to avoid running the build twice on main
(push events). The standard pattern handles this correctly: on push
events, job-filter returns empty (run all), and on PRs, determine_jobs
controls which jobs run.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang