### PR TITLE
[PT2 AOT] Propagate is_export flag to prepare_aot_module_simplified

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -934,6 +934,7 @@ def prepare_aot_module_simplified(
     disable_functionalization: bool = False,
     _record_nn_module_stack: bool = False,
     _disable_torch_fn_metadata_mode: bool = False,
+    is_export: bool = False,
 ) -> tuple[
     Any,
     list[torch.nn.Parameter | Tensor],
@@ -1040,7 +1041,7 @@ def prepare_aot_module_simplified(
         # pyrefly: ignore[bad-argument-type]
         aot_autograd_arg_pos_to_source=aot_autograd_arg_pos_to_source,
         static_input_indices=static_input_indices,
-        is_export=False,
+        is_export=is_export,
         no_tangents=False,
         cache_info=None,
         ignore_shape_env=ignore_shape_env,
@@ -1332,6 +1333,7 @@ def aot_export_joint_with_descriptors(
         disable_functionalization=disable_functionalization,
         _record_nn_module_stack=_record_nn_module_stack,
         _disable_torch_fn_metadata_mode=_disable_torch_fn_metadata_mode,
+        is_export=True,
     )
 
     # TODO: Maybe this should be in create_aot_state?  Not sure, that would


### PR DESCRIPTION
Summary:
prepare_aot_module_simplified was always creating AOTConfig with
is_export=False, even when called from aot_export_joint_with_descriptors
(which is an export path). This caused the AOTSyntheticBaseWrapper to skip
export-mode checks for aliased+mutated inputs, producing a confusing error:

  "expected compiled_fn to be GraphModule, got <class 'function'>"

instead of the proper diagnostic:

  "Encountered aliased inputs that are mutated in the graph you are trying
  to export. This functionality is currently not supported."

Fix:
- Add is_export parameter to prepare_aot_module_simplified
- Pass is_export=True from aot_export_joint_with_descriptors
- AOTConfig now correctly reflects export mode, so
  AOTSyntheticBaseWrapper raises the proper error with synthetic_base_info
  and fw_metadata for debugging

Test Plan:
Verified that export with aliased+mutated inputs now raises the correct
RuntimeError with actionable information instead of the opaque type error.

Differential Revision: D92625582


