### PR TITLE
Fix/fp8 nan asserts 149002

### DIFF
--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -259,9 +259,13 @@ class MultiKernel:
                     continue
                 seen.add(arg)
                 if isinstance(precompile_arg, TensorArg):
-                    line = f"assert not {arg}.isnan().any().item()"
+                    # FP8 dtypes do not support isnan/isinf directly; upcast to float first
+                    from .wrapper import _nan_check_expr
+
+                    fp8_check = _nan_check_expr(arg)
+                    line = f"assert not ({fp8_check}).isnan().any().item()"
                     wrapper.writeline(line)
-                    line = f"assert not {arg}.isinf().any().item()"
+                    line = f"assert not ({fp8_check}).isinf().any().item()"
                     wrapper.writeline(line)
 
     @property


### PR DESCRIPTION
## Summary

Fixes #149002

When `config.nan_asserts = True`, the inductor generates code like
`assert not tensor.isnan().any().item()` which crashes on FP8 tensors
(`float8_e4m3fn`, `float8_e4m3fnuz`, `float8_e5m2`, `float8_e5m2fnuz`,
`float8_e8m0fnu`) because `isnan()`/`isinf()` are not implemented for
FP8 dtypes.

### Changes

- Added a shared `_nan_check_expr()` helper in `wrapper.py` that generates
  a ternary expression to upcast FP8 tensors to `float32` before calling
  `isnan()`/`isinf()`
- Applied this fix to all 4 codegen locations that emit nan/inf assertions:
  - `wrapper.py` — `codegen_input_nan_asserts()`
  - `wrapper.py` — `generate_return()`
  - `triton.py` — `codegen_nan_check()`
  - `multi_kernel.py` — `codegen_nan_check()`
- Added tests in `NanCheckerTest`:
  - `test_nan_checker_fp8_pass` — verifies FP8 tensors work with nan_asserts enabled
  - `test_nan_checker_fp8_fail` — verifies NaN is correctly detected in FP8 tensors

### Design Notes

- Uses a ternary expression (`x.float() if x.dtype in (...) else x`) to avoid
  upcasting non-FP8 tensors, keeping the cost zero for the common case
- `multi_kernel.py` uses a lazy import (`from .wrapper import _nan_check_expr`)
  to avoid circular imports since `wrapper.py` imports from `multi_kernel.py`
  at module level
- All 5 FP8 dtypes are covered, including `float8_e8m0fnu`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo