### PR TITLE
Migrate CUDA kernels using RestrictPtrTraits

### DIFF
--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -58,4 +58,10 @@ using PackedTensorAccessor32 = GenericPackedTensorAccessor<T, N, PtrTraits, int3
 
 template <typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits>
 using PackedTensorAccessor64 = GenericPackedTensorAccessor<T, N, PtrTraits, int64_t>;
+
+using torch::headeronly::PackedTensorAccessorMetadata;
+using torch::headeronly::make_packed_accessor_metadata;
+using torch::headeronly::packed_accessor_offset;
+using torch::headeronly::packed_accessor_get;
+
 } // namespace at

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -72,7 +72,6 @@ list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_integer_divider_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_optional_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_packedtensoraccessor_test.cu
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_restrict_benchmark.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_restrict_migration_benchmark.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_reportMemoryUsage_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_allocatorTraceTracker_test.cpp

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -72,6 +72,8 @@ list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_integer_divider_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_optional_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_packedtensoraccessor_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_restrict_benchmark.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_restrict_migration_benchmark.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_reportMemoryUsage_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_allocatorTraceTracker_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_stream_test.cpp

--- a/aten/src/ATen/test/cuda_packedtensoraccessor_test.cu
+++ b/aten/src/ATen/test/cuda_packedtensoraccessor_test.cu
@@ -45,3 +45,108 @@ TEST(PackedtensoraccessorTest, PackedtensoraccessorTestCUDA) {
 
   ASSERT_TRUE(res.allclose(expected));
 }
+
+// Test the new metadata-based approach for RestrictPtrTraits workaround
+__global__ void test_metadata_accessor_kernel(
+    float* __restrict__ res_data,
+    const float* __restrict__ t1_data,
+    const float* __restrict__ t2_data,
+    PackedTensorAccessorMetadata<1, int64_t> res_meta,
+    PackedTensorAccessorMetadata<2, int64_t> t1_meta,
+    PackedTensorAccessorMetadata<1, int64_t> t2_meta) {
+  for (int64_t i = 0; i < res_meta.size(0); i++) {
+    float val = 0.0f;
+    for (int64_t j = 0; j < t1_meta.size(1); j++) {
+      val += packed_accessor_get(t1_data, t1_meta, i, j) *
+             packed_accessor_get(t2_data, t2_meta, j);
+    }
+    packed_accessor_get(res_data, res_meta, i) = val;
+  }
+}
+
+// Test using packed_accessor_offset directly
+__global__ void test_offset_accessor_kernel(
+    float* __restrict__ res_data,
+    const float* __restrict__ t1_data,
+    const float* __restrict__ t2_data,
+    PackedTensorAccessorMetadata<1, int64_t> res_meta,
+    PackedTensorAccessorMetadata<2, int64_t> t1_meta,
+    PackedTensorAccessorMetadata<1, int64_t> t2_meta) {
+  for (int64_t i = 0; i < res_meta.size(0); i++) {
+    float val = 0.0f;
+    for (int64_t j = 0; j < t1_meta.size(1); j++) {
+      int64_t t1_offset = packed_accessor_offset(t1_meta, i, j);
+      int64_t t2_offset = packed_accessor_offset(t2_meta, j);
+      val += t1_data[t1_offset] * t2_data[t2_offset];
+    }
+    int64_t res_offset = packed_accessor_offset(res_meta, i);
+    res_data[res_offset] = val;
+  }
+}
+
+TEST(PackedtensoraccessorTest, MetadataAccessorTestCUDA) {
+  if (!at::cuda::is_available()) return;
+  manual_seed(456);
+
+  Tensor t1 = rand({4, 4}, CUDA(kFloat));
+  Tensor t2 = rand({4}, CUDA(kFloat));
+  Tensor res = empty({4}, CUDA(kFloat));
+
+  // Create accessors to extract metadata
+  auto t1a = t1.packed_accessor64<float, 2, RestrictPtrTraits>();
+  auto t2a = t2.packed_accessor64<float, 1, RestrictPtrTraits>();
+  auto resa = res.packed_accessor64<float, 1, RestrictPtrTraits>();
+
+  // Extract metadata using the new API
+  auto t1_meta = make_packed_accessor_metadata(t1a);
+  auto t2_meta = make_packed_accessor_metadata(t2a);
+  auto res_meta = make_packed_accessor_metadata(resa);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  // Test with packed_accessor_get
+  test_metadata_accessor_kernel<<<1, 1, 0, stream>>>(
+      res.data_ptr<float>(),
+      t1.data_ptr<float>(),
+      t2.data_ptr<float>(),
+      res_meta, t1_meta, t2_meta);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  ASSERT_TRUE(cudaSuccess == cudaDeviceSynchronize());
+
+  auto expected = mv(t1, t2);
+  ASSERT_TRUE(res.allclose(expected));
+
+  // Reset and test with packed_accessor_offset
+  res.zero_();
+  test_offset_accessor_kernel<<<1, 1, 0, stream>>>(
+      res.data_ptr<float>(),
+      t1.data_ptr<float>(),
+      t2.data_ptr<float>(),
+      res_meta, t1_meta, t2_meta);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  ASSERT_TRUE(cudaSuccess == cudaDeviceSynchronize());
+
+  ASSERT_TRUE(res.allclose(expected));
+}
+
+// Test metadata extraction preserves correct values
+TEST(PackedtensoraccessorTest, MetadataValuesTestCUDA) {
+  if (!at::cuda::is_available()) return;
+
+  // Create a strided tensor to test non-trivial strides
+  Tensor t = rand({8, 6, 4}, CUDA(kFloat));
+  Tensor t_strided = t.transpose(0, 1);  // Now shape [6, 8, 4] with non-contiguous strides
+
+  auto acc = t_strided.packed_accessor64<float, 3, RestrictPtrTraits>();
+  auto meta = make_packed_accessor_metadata(acc);
+
+  // Verify sizes match
+  ASSERT_EQ(meta.size(0), acc.size(0));
+  ASSERT_EQ(meta.size(1), acc.size(1));
+  ASSERT_EQ(meta.size(2), acc.size(2));
+
+  // Verify strides match
+  ASSERT_EQ(meta.stride(0), acc.stride(0));
+  ASSERT_EQ(meta.stride(1), acc.stride(1));
+  ASSERT_EQ(meta.stride(2), acc.stride(2));
+}

--- a/aten/src/ATen/test/cuda_restrict_migration_benchmark.cu
+++ b/aten/src/ATen/test/cuda_restrict_migration_benchmark.cu
@@ -1,0 +1,375 @@
+/**
+ * Performance benchmark for RestrictPtrTraits migration
+ * See: https://github.com/pytorch/pytorch/issues/76632
+ *
+ * This benchmark compares:
+ * - OLD: PackedTensorAccessor with RestrictPtrTraits (broken - __restrict__ ignored)
+ * - NEW: Separate __restrict__ pointers with PackedTensorAccessorMetadata (working)
+ *
+ * Using a kernel pattern similar to embedding_bag_nbits_rowwise_offsets_kernel
+ */
+
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/core/TensorAccessor.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include <iostream>
+
+using namespace at;
+
+// ============================================================================
+// OLD kernel: Uses PackedTensorAccessor with RestrictPtrTraits
+// The __restrict__ on member pointer is IGNORED by nvcc
+// ============================================================================
+template <typename index_t>
+__global__ void embedding_bag_kernel_old(
+    const PackedTensorAccessor64<uint8_t, 2, RestrictPtrTraits> weight,
+    const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> indices,
+    const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> offsets,
+    const PackedTensorAccessor32<float, 1, RestrictPtrTraits> per_sample_weights,
+    PackedTensorAccessor32<float, 2, RestrictPtrTraits> output,
+    const bool include_last_offset) {
+
+  const int32_t B = output.size(0);
+  const int32_t D = output.size(1);
+  const int32_t D_bytes = weight.size(1);
+
+  const int32_t b = blockIdx.x;
+  if (b >= B) return;
+
+  const bool use_per_sample = per_sample_weights.size(0) > 0;
+
+  int64_t indices_start = offsets[b];
+  int64_t indices_end;
+  if (include_last_offset) {
+    indices_end = offsets[b + 1];
+  } else {
+    indices_end = (b + 1) < offsets.size(0) ? offsets[b + 1] : indices.size(0);
+  }
+
+  int32_t L = indices_end - indices_start;
+
+  if (L == 0) {
+    for (int32_t d = threadIdx.x; d < D; d += blockDim.x) {
+      output[b][d] = 0.0f;
+    }
+    return;
+  }
+
+  // Each thread handles some dimensions
+  for (int32_t d = threadIdx.x; d < D; d += blockDim.x) {
+    float accumulator = 0.0f;
+
+    for (int32_t l = indices_start; l < indices_end; ++l) {
+      int64_t idx = indices[static_cast<int32_t>(l)];
+      float sample_weight = use_per_sample ? per_sample_weights[static_cast<int32_t>(l)] : 1.0f;
+
+      // Simulate dequantization: read scale/bias from end of row, data from start
+      const uint8_t* row_ptr = &weight[idx][0];
+      float scale = *reinterpret_cast<const float*>(&row_ptr[D_bytes - 8]);
+      float bias = *reinterpret_cast<const float*>(&row_ptr[D_bytes - 4]);
+
+      // Dequantize: val = weight_byte * scale + bias
+      float val = static_cast<float>(weight[idx][d]) * scale + bias;
+      accumulator += val * sample_weight;
+    }
+
+    output[b][d] = accumulator;
+  }
+}
+
+// ============================================================================
+// NEW kernel: Uses separate __restrict__ pointers with metadata
+// The __restrict__ on kernel arguments IS recognized by nvcc
+// ============================================================================
+template <typename index_t>
+__global__ void embedding_bag_kernel_new(
+    const uint8_t* __restrict__ weight_data,
+    const PackedTensorAccessorMetadata<2, int64_t> weight_meta,
+    const index_t* __restrict__ indices_data,
+    const PackedTensorAccessorMetadata<1, int32_t> indices_meta,
+    const index_t* __restrict__ offsets_data,
+    const PackedTensorAccessorMetadata<1, int32_t> offsets_meta,
+    const float* __restrict__ per_sample_weights_data,
+    const PackedTensorAccessorMetadata<1, int32_t> per_sample_weights_meta,
+    float* __restrict__ output_data,
+    const PackedTensorAccessorMetadata<2, int32_t> output_meta,
+    const bool include_last_offset) {
+
+  const int32_t B = output_meta.size(0);
+  const int32_t D = output_meta.size(1);
+  const int64_t D_bytes = weight_meta.size(1);
+
+  const int32_t b = blockIdx.x;
+  if (b >= B) return;
+
+  const bool use_per_sample = per_sample_weights_meta.size(0) > 0;
+
+  int64_t indices_start = offsets_data[packed_accessor_offset(offsets_meta, b)];
+  int64_t indices_end;
+  if (include_last_offset) {
+    indices_end = offsets_data[packed_accessor_offset(offsets_meta, b + 1)];
+  } else {
+    indices_end = (b + 1) < offsets_meta.size(0)
+        ? offsets_data[packed_accessor_offset(offsets_meta, b + 1)]
+        : indices_meta.size(0);
+  }
+
+  int32_t L = indices_end - indices_start;
+
+  if (L == 0) {
+    for (int32_t d = threadIdx.x; d < D; d += blockDim.x) {
+      output_data[packed_accessor_offset(output_meta, b, d)] = 0.0f;
+    }
+    return;
+  }
+
+  // Each thread handles some dimensions
+  for (int32_t d = threadIdx.x; d < D; d += blockDim.x) {
+    float accumulator = 0.0f;
+
+    for (int32_t l = indices_start; l < indices_end; ++l) {
+      int64_t idx = indices_data[packed_accessor_offset(indices_meta, static_cast<int32_t>(l))];
+      float sample_weight = use_per_sample
+          ? per_sample_weights_data[packed_accessor_offset(per_sample_weights_meta, static_cast<int32_t>(l))]
+          : 1.0f;
+
+      // Simulate dequantization: read scale/bias from end of row, data from start
+      int64_t row_offset = packed_accessor_offset(weight_meta, idx, static_cast<int64_t>(0));
+      const uint8_t* row_ptr = &weight_data[row_offset];
+      float scale = *reinterpret_cast<const float*>(&row_ptr[D_bytes - 8]);
+      float bias = *reinterpret_cast<const float*>(&row_ptr[D_bytes - 4]);
+
+      // Dequantize: val = weight_byte * scale + bias
+      float val = static_cast<float>(weight_data[packed_accessor_offset(weight_meta, idx, static_cast<int64_t>(d))]) * scale + bias;
+      accumulator += val * sample_weight;
+    }
+
+    output_data[packed_accessor_offset(output_meta, b, d)] = accumulator;
+  }
+}
+
+// Benchmark helper using CUDA events
+float benchmark_kernel(
+    std::function<void(cudaStream_t)> kernel_launch,
+    cudaStream_t stream,
+    int warmup_iters = 20,
+    int bench_iters = 100) {
+
+  for (int i = 0; i < warmup_iters; ++i) {
+    kernel_launch(stream);
+  }
+  cudaStreamSynchronize(stream);
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  cudaEventRecord(start, stream);
+  for (int i = 0; i < bench_iters; ++i) {
+    kernel_launch(stream);
+  }
+  cudaEventRecord(stop, stream);
+  cudaEventSynchronize(stop);
+
+  float milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+
+  return milliseconds / bench_iters;
+}
+
+TEST(RestrictMigrationBenchmark, EmbeddingBagKernel) {
+  if (!at::cuda::is_available()) return;
+
+  // Realistic embedding bag dimensions
+  const int64_t num_embeddings = 100000;  // vocabulary size
+  const int64_t embedding_dim = 128;       // D (output dimension)
+  const int64_t D_bytes = embedding_dim + 8;  // +8 for scale/bias (fp32)
+  const int64_t batch_size = 512;         // B
+  const int64_t avg_bag_size = 20;        // average indices per bag
+
+  std::cout << "\n=== Embedding Bag Kernel Benchmark ===" << std::endl;
+  std::cout << "num_embeddings=" << num_embeddings
+            << ", embedding_dim=" << embedding_dim
+            << ", batch_size=" << batch_size
+            << ", avg_bag_size=" << avg_bag_size << std::endl;
+
+  // Create quantized weight tensor [num_embeddings, D_bytes]
+  auto weight = at::randint(0, 256, {num_embeddings, D_bytes}, at::CUDA(at::kByte));
+
+  // Initialize scale and bias in the last 8 bytes of each row
+  auto weight_cpu = weight.cpu();
+  auto weight_accessor = weight_cpu.accessor<uint8_t, 2>();
+  for (int64_t i = 0; i < num_embeddings; ++i) {
+    float scale = 0.1f;
+    float bias = 0.0f;
+    std::memcpy(&weight_accessor[i][D_bytes - 8], &scale, sizeof(float));
+    std::memcpy(&weight_accessor[i][D_bytes - 4], &bias, sizeof(float));
+  }
+  weight = weight_cpu.cuda();
+
+  // Create indices - random indices for each bag
+  const int64_t total_indices = batch_size * avg_bag_size;
+  auto indices = at::randint(0, num_embeddings, {total_indices}, at::CUDA(at::kInt));
+
+  // Create offsets - evenly spaced bags
+  std::vector<int32_t> offsets_vec(batch_size + 1);
+  for (int64_t i = 0; i <= batch_size; ++i) {
+    offsets_vec[i] = static_cast<int32_t>(i * avg_bag_size);
+  }
+  auto offsets = at::from_blob(offsets_vec.data(), {batch_size + 1}, at::kInt).clone().cuda();
+
+  // Create per-sample weights
+  auto per_sample_weights = at::rand({total_indices}, at::CUDA(at::kFloat));
+
+  // Create output tensors
+  auto output_old = at::empty({batch_size, embedding_dim}, at::CUDA(at::kFloat));
+  auto output_new = at::empty({batch_size, embedding_dim}, at::CUDA(at::kFloat));
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  const int block_size = 128;
+
+  // Create accessors for OLD kernel
+  auto weight_acc = weight.packed_accessor64<uint8_t, 2, RestrictPtrTraits>();
+  auto indices_acc = indices.packed_accessor32<int32_t, 1, RestrictPtrTraits>();
+  auto offsets_acc = offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>();
+  auto per_sample_weights_acc = per_sample_weights.packed_accessor32<float, 1, RestrictPtrTraits>();
+  auto output_old_acc = output_old.packed_accessor32<float, 2, RestrictPtrTraits>();
+
+  // Create metadata for NEW kernel
+  auto weight_meta = make_packed_accessor_metadata(weight_acc);
+  auto indices_meta = make_packed_accessor_metadata(indices_acc);
+  auto offsets_meta = make_packed_accessor_metadata(offsets_acc);
+  auto per_sample_weights_meta = make_packed_accessor_metadata(per_sample_weights_acc);
+  auto output_new_meta = make_packed_accessor_metadata(
+      output_new.packed_accessor32<float, 2, RestrictPtrTraits>());
+
+  // Benchmark OLD kernel (RestrictPtrTraits - broken)
+  float time_old = benchmark_kernel([&](cudaStream_t s) {
+    embedding_bag_kernel_old<int32_t><<<batch_size, block_size, 0, s>>>(
+        weight_acc, indices_acc, offsets_acc, per_sample_weights_acc,
+        output_old_acc, true);
+  }, stream);
+
+  // Benchmark NEW kernel (metadata + __restrict__ - working)
+  float time_new = benchmark_kernel([&](cudaStream_t s) {
+    embedding_bag_kernel_new<int32_t><<<batch_size, block_size, 0, s>>>(
+        weight.data_ptr<uint8_t>(), weight_meta,
+        indices.data_ptr<int32_t>(), indices_meta,
+        offsets.data_ptr<int32_t>(), offsets_meta,
+        per_sample_weights.data_ptr<float>(), per_sample_weights_meta,
+        output_new.data_ptr<float>(), output_new_meta,
+        true);
+  }, stream);
+
+  // Verify correctness
+  ASSERT_TRUE(output_old.allclose(output_new, 1e-3, 1e-3))
+      << "Output mismatch between old and new kernels";
+
+  // Print results
+  std::cout << "\nResults:" << std::endl;
+  std::cout << "  OLD (RestrictPtrTraits in accessor): " << time_old << " ms" << std::endl;
+  std::cout << "  NEW (metadata + __restrict__ ptr):   " << time_new << " ms" << std::endl;
+
+  float speedup = time_old / time_new;
+  std::cout << "\nSpeedup: " << speedup << "x" << std::endl;
+
+  if (speedup > 1.05) {
+    std::cout << "*** NEW approach is faster - __restrict__ optimization is working! ***" << std::endl;
+  } else if (speedup < 0.95) {
+    std::cout << "(NEW approach is slower - unexpected)" << std::endl;
+  } else {
+    std::cout << "(Similar performance - __restrict__ may not help this memory access pattern)" << std::endl;
+  }
+}
+
+// Additional test with varying bag sizes to stress the memory access pattern
+TEST(RestrictMigrationBenchmark, EmbeddingBagVaryingBagSize) {
+  if (!at::cuda::is_available()) return;
+
+  const int64_t num_embeddings = 50000;
+  const int64_t embedding_dim = 256;
+  const int64_t D_bytes = embedding_dim + 8;
+  const int64_t batch_size = 256;
+
+  std::cout << "\n=== Embedding Bag with Varying Bag Sizes ===" << std::endl;
+
+  // Create weight tensor
+  auto weight = at::randint(0, 256, {num_embeddings, D_bytes}, at::CUDA(at::kByte));
+
+  // Initialize scale and bias in the last 8 bytes of each row
+  auto weight_cpu = weight.cpu();
+  auto weight_accessor = weight_cpu.accessor<uint8_t, 2>();
+  for (int64_t i = 0; i < num_embeddings; ++i) {
+    float scale = 0.1f;
+    float bias = 0.0f;
+    std::memcpy(&weight_accessor[i][D_bytes - 8], &scale, sizeof(float));
+    std::memcpy(&weight_accessor[i][D_bytes - 4], &bias, sizeof(float));
+  }
+  weight = weight_cpu.cuda();
+
+  // Create varying bag sizes (some small, some large)
+  std::vector<int32_t> offsets_vec;
+  offsets_vec.push_back(0);
+  int32_t current_offset = 0;
+  for (int64_t i = 0; i < batch_size; ++i) {
+    // Varying bag size: 5 to 50 indices per bag
+    int32_t bag_size = 5 + (i % 46);
+    current_offset += bag_size;
+    offsets_vec.push_back(current_offset);
+  }
+  const int64_t total_indices = current_offset;
+
+  auto indices = at::randint(0, num_embeddings, {total_indices}, at::CUDA(at::kInt));
+  auto offsets = at::from_blob(offsets_vec.data(), {static_cast<int64_t>(offsets_vec.size())}, at::kInt).clone().cuda();
+  auto per_sample_weights = at::rand({total_indices}, at::CUDA(at::kFloat));
+
+  auto output_old = at::empty({batch_size, embedding_dim}, at::CUDA(at::kFloat));
+  auto output_new = at::empty({batch_size, embedding_dim}, at::CUDA(at::kFloat));
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const int block_size = 256;
+
+  // Create accessors and metadata
+  auto weight_acc = weight.packed_accessor64<uint8_t, 2, RestrictPtrTraits>();
+  auto indices_acc = indices.packed_accessor32<int32_t, 1, RestrictPtrTraits>();
+  auto offsets_acc = offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>();
+  auto per_sample_weights_acc = per_sample_weights.packed_accessor32<float, 1, RestrictPtrTraits>();
+  auto output_old_acc = output_old.packed_accessor32<float, 2, RestrictPtrTraits>();
+
+  auto weight_meta = make_packed_accessor_metadata(weight_acc);
+  auto indices_meta = make_packed_accessor_metadata(indices_acc);
+  auto offsets_meta = make_packed_accessor_metadata(offsets_acc);
+  auto per_sample_weights_meta = make_packed_accessor_metadata(per_sample_weights_acc);
+  auto output_new_meta = make_packed_accessor_metadata(
+      output_new.packed_accessor32<float, 2, RestrictPtrTraits>());
+
+  float time_old = benchmark_kernel([&](cudaStream_t s) {
+    embedding_bag_kernel_old<int32_t><<<batch_size, block_size, 0, s>>>(
+        weight_acc, indices_acc, offsets_acc, per_sample_weights_acc,
+        output_old_acc, true);
+  }, stream);
+
+  float time_new = benchmark_kernel([&](cudaStream_t s) {
+    embedding_bag_kernel_new<int32_t><<<batch_size, block_size, 0, s>>>(
+        weight.data_ptr<uint8_t>(), weight_meta,
+        indices.data_ptr<int32_t>(), indices_meta,
+        offsets.data_ptr<int32_t>(), offsets_meta,
+        per_sample_weights.data_ptr<float>(), per_sample_weights_meta,
+        output_new.data_ptr<float>(), output_new_meta,
+        true);
+  }, stream);
+
+  ASSERT_TRUE(output_old.allclose(output_new, 1e-3, 1e-3))
+      << "Output mismatch between old and new kernels";
+
+  std::cout << "  OLD: " << time_old << " ms" << std::endl;
+  std::cout << "  NEW: " << time_new << " ms" << std::endl;
+  std::cout << "  Speedup: " << (time_old / time_new) << "x" << std::endl;
+}

--- a/torch/headeronly/core/TensorAccessor.h
+++ b/torch/headeronly/core/TensorAccessor.h
@@ -399,7 +399,7 @@ struct HeaderOnlyIndexBoundsCheck {
 // RestrictPtrTraits Workaround
 // ============================================================================
 // NVIDIA's nvcc does not recognize __restrict__ on member pointers in structs
-// passed to kernels. This means RestrictPtrTraits has no effect when 
+// passed to kernels. This means RestrictPtrTraits has no effect when
 // using PackedTensorAccessor.
 //
 // The workaround is to decouple the pointer from the accessor metadata:


### PR DESCRIPTION
This is potentially one of many PRs to address issue [76632](https://github.com/pytorch/pytorch/issues/76632). Essentially, this PR changes the ways parameters are passed to CUDA kernels so that the restrict keyword on variables are respected and do not silently fail/not applied.  This is some implementation issue of NVCC that has no plans to be supported at the moment. Initial benchmarks show a considerable improvement.

```
root@1f7332d59882:/workspace/pytorch# ./build/bin/cuda_restrict_migration_benchmark 
Running main() from /workspace/pytorch/third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from RestrictMigrationBenchmark
[ RUN      ] RestrictMigrationBenchmark.EmbeddingBagKernel

=== Embedding Bag Kernel Benchmark ===
num_embeddings=100000, embedding_dim=128, batch_size=512, avg_bag_size=20

Results:
  OLD (RestrictPtrTraits in accessor): 0.00820608 ms
  NEW (metadata + __restrict__ ptr):   0.00679552 ms

Speedup: 1.20757x
*** NEW approach is faster - __restrict__ optimization is working! ***
[       OK ] RestrictMigrationBenchmark.EmbeddingBagKernel (445 ms)
[ RUN      ] RestrictMigrationBenchmark.EmbeddingBagVaryingBagSize

=== Embedding Bag with Varying Bag Sizes ===
  OLD: 0.0123197 ms
  NEW: 0.0123018 ms
  Speedup: 1.00146x
[       OK ] RestrictMigrationBenchmark.EmbeddingBagVaryingBagSize (4 ms)
[----------] 2 tests from RestrictMigrationBenchmark (449 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (449 ms total)
[  PASSED  ] 2 tests.
```

The point of this PR is to add the structures to allow migration of the RestrictPtrTraits struct. For now, we only migrate one of the kernels just to have an example. We can make more PRs to migrate the rest if approved.

Please let me know if you have any suggestions to this PR. I'm not too familiar with PyTorch source code, but from the speedup I'm seeing on one kernel leads me to believe this can be a very beneficial PR, especially if these kernels are executed very often.