### PR TITLE
[attention] Add scaled_dot_product_attention_with_weights utility

### DIFF
--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -24,6 +24,7 @@ __all__: list[str] = [
     "list_flash_attention_impls",
     "current_flash_attention_impl",
     "restore_flash_attention_impl",
+    "scaled_dot_product_attention_with_weights",
 ]
 
 
@@ -195,3 +196,5 @@ restore_flash_attention_impl.__module__ = __name__
 
 # Import built-in implementations to trigger self-registration
 from . import _fa3, _fa4  # noqa: F401  # noqa: F401
+
+from ._utils import scaled_dot_product_attention_with_weights


### PR DESCRIPTION
Summary:
Add a utility function that computes scaled dot product attention
using the efficient SDPA kernel for output computation, but it  also
returning attention weights. We're delegating to the original one here.

This is used in the next diff in the stack for torchmultimodal where we want to migrate it to common api.

Test Plan:
Check output weights match.

```
buck2 test fbcode//caffe2/test:transformers -- TestSDPAWithWeight
```

Differential Revision: D92574120


