### PR TITLE
[DCP] Enable _OverlappingCpuLoader for multi-threaded checkpoint saves

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -566,6 +566,7 @@ instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 _CUDA_THREAD_COUNTS = {1, 2, 4}
 
+
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestMultiThreadedCudaSave(TestCase):
     @parametrize("thread_count", _CUDA_THREAD_COUNTS)

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -2,6 +2,7 @@
 
 import sys
 import tempfile
+import unittest
 from typing import Any, IO
 
 import torch
@@ -561,6 +562,49 @@ instantiate_parametrized_tests(TestDistributedStateDictSaveLoadRot13)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadZStandard)
 instantiate_parametrized_tests(TestDistributedReshardOnLoad)
+
+
+_CUDA_THREAD_COUNTS = {1, 2, 4}
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestMultiThreadedCudaSave(TestCase):
+    @parametrize("thread_count", _CUDA_THREAD_COUNTS)
+    def test_save_load_cuda_tensors(self, thread_count: int) -> None:
+        with tempfile.TemporaryDirectory() as path:
+            state_dict_to_save = {
+                f"weight_{i}": torch.randn(64, 64, device="cuda") for i in range(8)
+            }
+
+            fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+            save_state_dict(
+                state_dict=state_dict_to_save,
+                storage_writer=fs_writer,
+                no_dist=True,
+            )
+
+            state_dict_to_load = {
+                k: torch.zeros_like(v, device="cpu")
+                for k, v in state_dict_to_save.items()
+            }
+
+            fs_reader = FileSystemReader(path=path)
+            load_state_dict(
+                state_dict=state_dict_to_load,
+                storage_reader=fs_reader,
+                no_dist=True,
+            )
+
+            for key in state_dict_to_save:
+                self.assertTrue(
+                    torch.equal(
+                        state_dict_to_save[key].cpu(),
+                        state_dict_to_load[key],
+                    ),
+                    f"Tensor {key} mismatch with thread_count={thread_count}",
+                )
+
+
+instantiate_parametrized_tests(TestMultiThreadedCudaSave)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -380,32 +380,35 @@ def _write_files_from_queue(
     transforms: _StorageWriterTransforms,
     inflight_threshhold: int,
     use_fsync: bool,
-    thread_count: int,
     serialization_format: SerializationFormat,
 ) -> None:
+    custom_backend_name = torch._C._get_privateuse1_backend_name()
+    custom_device_mod = getattr(torch, custom_backend_name, None)
+
+    # Create a dedicated device stream per thread so that
+    # _OverlappingCpuLoader.stream.synchronize() in _drain() only waits
+    # on this thread's in-flight copies, avoiding cross-thread stalls on
+    # the shared default stream.
+    device_mod = None
+    dedicated_stream = None
+    if (
+        torch.cuda.is_available()
+        or (custom_device_mod and custom_device_mod.is_available())
+    ) and inflight_threshhold > 0:
+        device_mod = torch.cuda if torch.cuda.is_available() else custom_device_mod
+        dedicated_stream = device_mod.Stream()
+
     try:
         while True:
             file_name, storage_key, write_items = file_queue.get_nowait()
             loader: _TensorLoader
 
-            custom_backend_name = torch._C._get_privateuse1_backend_name()
-            custom_device_mod = getattr(torch, custom_backend_name, None)
-
-            # TODO: Using the OverlappingCpuLoader with multiple threads creates significant
-            # performance degradation, observed as being related to cuda stream syncs. We
-            # should try to fix this and use _OverlappingCpuLoader for all threaded cases
-            if (
-                thread_count == 1
-                and (
-                    torch.cuda.is_available()
-                    or (custom_device_mod and custom_device_mod.is_available())
-                )
-                and inflight_threshhold > 0
-            ):
-                loader = _OverlappingCpuLoader(
-                    planner.resolve_data,
-                    inflight_threshhold=inflight_threshhold,
-                )
+            if dedicated_stream is not None:
+                with device_mod.stream(dedicated_stream):
+                    loader = _OverlappingCpuLoader(
+                        planner.resolve_data,
+                        inflight_threshhold=inflight_threshhold,
+                    )
             else:
                 loader = _SerialCpuLoader(
                     planner.resolve_data,
@@ -724,7 +727,6 @@ class _FileSystemWriter(StorageWriter):
                     self.transforms,
                     self.per_thread_copy_ahead,
                     self.sync_files,
-                    self.thread_count,
                     self.serialization_format,
                 ),
             )
@@ -739,7 +741,6 @@ class _FileSystemWriter(StorageWriter):
             transforms=self.transforms,
             inflight_threshhold=self.per_thread_copy_ahead,
             use_fsync=self.sync_files,
-            thread_count=self.thread_count,
             serialization_format=self.serialization_format,
         )
 

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -398,7 +398,7 @@ def _write_files_from_queue(
             file_name, storage_key, write_items = file_queue.get_nowait()
             loader: _TensorLoader
 
-            if dedicated_stream is not None:
+            if device_mod is not None and dedicated_stream is not None:
                 with device_mod.stream(dedicated_stream):
                     loader = _OverlappingCpuLoader(
                         planner.resolve_data,


### PR DESCRIPTION
Fixes the TODO added in #118114

## Summary

I came across this while profiling distributed checkpoint saves as part of checkpointing perf related work. The `_OverlappingCpuLoader` in `filesystem.py` pipelines GPU-to-CPU tensor transfers using a CUDA stream, but it was only enabled for `thread_count == 1`. For any higher thread count, `_write_files_from_queue` fell back to `_SerialCpuLoader`, which does blocking `.cpu()` copies one tensor at a time. I noticed the TODO in the code from #118114 explaining that the overlapping loader caused significant performance degradation with multiple threads, observed as being related to CUDA stream synchronization.

The issue (IIUC) seems to be that all writer threads were sharing the default CUDA stream. When `_OverlappingCpuLoader._drain()` calls `stream.synchronize()` in one thread, it blocks until every in-flight copy on that shared stream completes, including copies issued by other threads. This effectively serializes all the threads and can make multi-threaded saves slower than single-threaded.

This PR gives each writer thread its own dedicated CUDA stream via a context manager before constructing the loader. Since the constructor captures `current_stream()`, each thread's loader gets its own isolated stream, and `synchronize()` in one thread only waits on that thread's copies.

This also removes the `thread_count` parameter from `_write_files_from_queue`, which was added in #118114 solely for the `thread_count == 1` guard and had no other use in the function.

I benchmarked on a single H200 GPU, saving a 4.70 GB checkpoint to a RAMdisk to isolate the GPU-to-CPU transfer pipeline from disk throughput. Comparing the stock behavior (where `thread_count > 1` falls back to `_SerialCpuLoader` due to the guard) against the patched code (where all thread counts use `_OverlappingCpuLoader` with a dedicated stream), I saw modest but consistent improvements that grew with thread count: around 19% faster at `thread_count=4` (1.015s to 0.825s) and around 43% faster at `thread_count=8` (0.780s to 0.446s). At `thread_count=1`, the difference was small (about 7%), which is expected since there is no cross-thread stream contention in the single-threaded case.

Important note: the improvement scales with storage throughput. On systems where disk I/O is the bottleneck, the change is net neutral since the save is already disk-bound.

