### PR TITLE
[lint] Enable Ruff PYI056 by replacing __all__.append/extend usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ ignore = [
     "PYI024",
     "PYI036",
     "PYI041",
-    "PYI056",
     "SIM102", "SIM103", "SIM112", # flake8-simplify code styles
     "SIM105", # these ignores are from flake8-simplify. please fix or ignore with commented reason
     "SIM108", # SIM108 ignored because we prefer if-else-block instead of ternary expression

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1008,7 +1008,7 @@ del __fn, __name, __sym_name, _get_sym_math_fn
 
 # Adding temporary shortcut
 sym_sqrt = globals()["_sym_sqrt"]
-__all__.append("sym_sqrt")
+__all__[len(__all__) :] = ["sym_sqrt"]
 
 
 def sym_ite(b, t, f):
@@ -1064,7 +1064,7 @@ from torch import _C as _C
 __name, __obj = "", None
 for __name in dir(_C):
     if __name[0] != "_" and not __name.endswith("Base"):
-        __all__.append(__name)
+        __all__[len(__all__) :] = [__name]
         __obj = getattr(_C, __name)
         if callable(__obj) or inspect.isclass(__obj):
             if __obj.__module__ != __name__:  # "torch"
@@ -1902,7 +1902,7 @@ from math import e, inf, nan, pi
 
 newaxis: None = None
 
-__all__.extend(["e", "pi", "nan", "inf", "newaxis"])
+__all__[len(__all__) :] = ["e", "pi", "nan", "inf", "newaxis"]
 
 ################################################################################
 # Define Storage and Tensor classes
@@ -2194,7 +2194,7 @@ for __name in dir(_C._VariableFunctions):
         __name = "_" + __name
     globals()[__name] = __obj
     if not __name.startswith("_"):
-        __all__.append(__name)
+        __all__[len(__all__) :] = [__name]
 
 del __name, __obj
 
@@ -2205,9 +2205,9 @@ del __name, __obj
 import torch
 
 
-__all__.extend(
+__all__[len(__all__) :] = [
     name for name in dir(torch) if isinstance(getattr(torch, name), torch.dtype)
-)
+]
 
 ################################################################################
 # Import TorchDynamo's lazy APIs to avoid circular dependencies

--- a/torch/_dynamo/polyfills/_collections.py
+++ b/torch/_dynamo/polyfills/_collections.py
@@ -27,7 +27,7 @@ try:
         for elem in iterable:
             mapping[elem] = mapping_get(elem, 0) + 1
 
-    __all__.append("_count_elements")
+    __all__[len(__all__) :] = ["_count_elements"]
 
 except ImportError:
     pass

--- a/torch/_numpy/_funcs.py
+++ b/torch/_numpy/_funcs.py
@@ -43,7 +43,7 @@ for name, func in itertools.chain(
     decorated.__qualname__ = name
     decorated.__name__ = name
     vars()[name] = decorated
-    __all__.append(name)
+    __all__[len(__all__) :] = [name]
 
 
 """

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -171,4 +171,4 @@ __all__ = [
     "register_kl",
     "transform_to",
 ]
-__all__.extend(transforms.__all__)
+__all__[len(__all__) :] = transforms.__all__

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -736,7 +736,7 @@ for name in math_op_names:
     setattr(SymNode, sym_name, _get_sym_node_fn(name))
     METHOD_TO_OPERATOR[sym_name] = getattr(torch, priv_sym_name)
     unary_magic_methods.add(sym_name)
-    __all__.append(sym_name)
+    __all__[len(__all__) :] = [sym_name]
 
 
 # Unary methods that are not magic methods

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -51,7 +51,7 @@ def _apply_docstring_templates(func: Callable[_P, _T]) -> Callable[_P, _T]:
         func.__doc__ = doc_string
 
     # Expose function as public symbol
-    __all__.append(func.__name__)
+    __all__[len(__all__) :] = [func.__name__]
 
     return func
 

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -309,7 +309,7 @@ def _export(name: str):
 
     def wrapper(func):
         globals()[name] = func
-        __all__.append(name)
+        __all__[len(__all__) :] = [name]
         return func
 
     return wrapper

--- a/torch/return_types.py
+++ b/torch/return_types.py
@@ -39,7 +39,7 @@ for name in dir(return_types):
     globals()[name] = _attr
 
     if not name.startswith("_"):
-        __all__.append(name)
+        __all__[len(__all__) :] = [name]
         all_return_types.append(_attr)
 
     # Today everything in torch.return_types is a structseq, aka a "namedtuple"-like


### PR DESCRIPTION
## Summary
- remove `PYI056` from the Ruff ignore list in `pyproject.toml`
- replace `__all__.append(...)` / `__all__.extend(...)` with slice-based list updates in affected modules
- keep behavior unchanged while making `__all__` updates compatible with flake8-pyi's `PYI056`

Resolves #110950

## Validation
- `python3 -m ruff check --config pyproject.toml pyproject.toml torch/__init__.py torch/_dynamo/polyfills/_collections.py torch/_numpy/_funcs.py torch/distributions/__init__.py torch/fx/experimental/sym_node.py torch/masked/_ops.py torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py torch/return_types.py`
- `python3 -m ruff check --config pyproject.toml --select PYI056 --exclude caffe2,functorch/docs,torch/_inductor/fx_passes/serialized_patterns,torch/_inductor/autoheuristic/artifacts,test/dynamo/cpython,test/test_torchfuzz_repros.py,scripts,third_party,fb .`
- `python3 -m compileall torch/__init__.py torch/_dynamo/polyfills/_collections.py torch/_numpy/_funcs.py torch/distributions/__init__.py torch/fx/experimental/sym_node.py torch/masked/_ops.py torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py torch/return_types.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @Lucaskabela