### PR TITLE
[dynamo] Improve int[] custom-op error by de-immutablizing FX args

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10381,6 +10381,44 @@ def ___make_guard_fn():
             f(torch.randn(9, requires_grad=True), torch.tensor([3, 6]))
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_custom_op_int_list_error_uses_list_not_immutable_list(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::split_with_sizes_and_clone_for_int_list_error",
+                "(Tensor input, int[] sizes) -> Tensor[]",
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "mylib::split_with_sizes_and_clone_for_int_list_error",
+                "cpu",
+                lib=lib,
+            )
+            @torch.library.register_fake(
+                "mylib::split_with_sizes_and_clone_for_int_list_error", lib=lib
+            )
+            def split_with_sizes_and_clone(input, sizes):
+                return [
+                    t.clone()
+                    for t in torch.ops.aten.split_with_sizes.default(input, sizes)
+                ]
+
+            @torch.compile(backend="eager", fullgraph=True)
+            def f(sz, x):
+                s0, s1 = sz.tolist()
+                split_with_sizes_and_clone_op = (
+                    torch.ops.mylib.split_with_sizes_and_clone_for_int_list_error.default
+                )
+                _, r1 = split_with_sizes_and_clone_op(x, [s0, s1])
+                return torch.ops.aten.sort.default(r1)
+
+            with self.assertRaises(torch._dynamo.exc.TorchRuntimeError) as cm:
+                f(torch.tensor([420, 7312 - 420]), torch.randn(7312))
+            self.assertIn("Expected a value of type 'List[int]'", str(cm.exception))
+            self.assertIn("instead found type 'list'", str(cm.exception))
+            self.assertNotIn("immutable_list", str(cm.exception))
+
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_dim_order(self):
         @torch.compile(dynamic=False, fullgraph=True, backend="eager")
         def f(x):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3781,6 +3781,31 @@ def set_current_node(node: torch.fx.Node) -> Generator[None, None, None]:
         _current_node.value = old
 
 
+def _normalize_fx_immutable_collections(arg: Any) -> Any:
+    immutable_collections = fx.immutable_collections
+    if type(arg) is immutable_collections.immutable_list:
+        return [_normalize_fx_immutable_collections(x) for x in arg]
+    if type(arg) is immutable_collections.immutable_dict:
+        return {k: _normalize_fx_immutable_collections(v) for k, v in arg.items()}
+    if isinstance(arg, tuple):
+        elems = tuple(_normalize_fx_immutable_collections(x) for x in arg)
+        if hasattr(arg, "_fields"):
+            # namedtuple: preserve the tuple subclass
+            return type(arg)(*elems)
+        return elems
+    if isinstance(arg, list):
+        return [_normalize_fx_immutable_collections(x) for x in arg]
+    if isinstance(arg, dict):
+        return {k: _normalize_fx_immutable_collections(v) for k, v in arg.items()}
+    if isinstance(arg, slice):
+        return slice(
+            _normalize_fx_immutable_collections(arg.start),
+            _normalize_fx_immutable_collections(arg.stop),
+            _normalize_fx_immutable_collections(arg.step),
+        )
+    return arg
+
+
 def run_node(
     tracer: Any, node: torch.fx.Node, args: Any, kwargs: Any, nnmodule: Any
 ) -> Any:
@@ -3801,6 +3826,8 @@ def run_node(
     op = node.op
 
     with set_current_node(node):
+        args = _normalize_fx_immutable_collections(args)
+        kwargs = _normalize_fx_immutable_collections(kwargs)
 
         def make_error_message(e: Any) -> str:
             return (


### PR DESCRIPTION
## Summary
- normalize `torch.fx.immutable_collections.immutable_list` / `immutable_dict` to plain Python `list` / `dict` before Dynamo's fake-tensor `run_node` invocation
- preserve nested structures (including slices and namedtuples) while recursively de-immutablizing containers
- add a regression test showing the custom-op schema error now reports `list` instead of `immutable_list`

Resolves #122129

## Why
`torch.compile` may route FX node arguments through `immutable_list`; when a custom op schema expects `int[]`, the error currently blames `immutable_list`, which obscures the actual schema mismatch (e.g., using `int[]` with symbolic values). Converting these FX wrapper containers to standard Python containers makes the error significantly clearer.

## Validation
- `python3 -m compileall torch/_dynamo/utils.py test/dynamo/test_misc.py`
- `python3 -m ruff check --config pyproject.toml --select F821,F823,F841,PLE0604 torch/_dynamo/utils.py test/dynamo/test_misc.py`
- locally reproduced issue behavior in a standalone script with equivalent logic to confirm error text changes from `immutable_list` to `list`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo