### PR TITLE
docs(distributions): add LaTeX formula to Laplace docstring

### DIFF
--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -14,7 +14,8 @@ __all__ = ["Laplace"]
 class Laplace(Distribution):
     r"""
     Creates a Laplace distribution parameterized by :attr:`loc` and :attr:`scale`.
-
+    .. math::
+        f(x|\mu, b) = \frac{1}{2b} \exp\left(-\frac{|x-\mu|}{b}\right)
     Example::
 
         >>> # xdoctest: +IGNORE_WANT("non-deterministic")


### PR DESCRIPTION
Added the Probability Density Function (PDF) formula in LaTeX to the Laplace distribution docstring. This improves mathematical clarity and aligns the documentation with other distributions in the module.