### PR TITLE
Fix #174546: Remove deprecated device arg from Tensor.pin_memory() call

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -54,7 +54,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device) -> None
 
 def pin_memory(data, device=None):
     if isinstance(data, torch.Tensor):
-        return data.pin_memory(device)
+        return data.pin_memory()
 
     if hasattr(data, "pin_memory"):
         return data.pin_memory()


### PR DESCRIPTION
## Description
Fixes #174546

This PR removes the deprecated `device` argument from the `Tensor.pin_memory()` call in the DataLoader's pin-memory utility.

## Problem
In PyTorch 2.8+, `Tensor.pin_memory()` deprecated the `device` argument and now automatically uses the current accelerator device. However, the DataLoader pin-memory helper at `torch/utils/data/_utils/pin_memory.py:57` was still passing this argument, causing deprecation warnings:

## Solution
Removed the `device` argument from the `data.pin_memory(device)` call on line 57.

The tensor now correctly uses the current accelerator device implicitly, as intended by the deprecation.

## Changes
- **File:** `torch/utils/data/_utils/pin_memory.py`
- **Line 57:** Changed `data.pin_memory(device)` to `data.pin_memory()`
- The function signature still accepts the `device` parameter for backward compatibility with external callers

## Testing
Tested with:
```python
from torch.utils.data import DataLoader, TensorDataset
import torch

x = torch.arange(10)
ds = TensorDataset(x)
loader = DataLoader(ds, batch_size=2, pin_memory=True, pin_memory_device="cuda")
next(iter(loader))
```

Confirmed that the deprecation warning no longer appears.

## Related Issues
- Closes #174546
- Related to device-agnostic pin-memory transition (#126376)
- Addresses downstream issues in tch-rs (#941) and others

cc @albertvillanova @andrewkho @ssnl