### PR TITLE
[CI] Enable TIMM pretrained model caching on shared HF cache

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -133,6 +133,8 @@
 
 "ci-refresh-hf-cache":
 - .github/ci_commit_pins/vllm.txt
+- .ci/docker/ci_commit_pins/huggingface-requirements.txt
+- .ci/docker/ci_commit_pins/timm.txt
 
 "ciflow/inductor-pallas":
 - torch/_inductor/codegen/pallas.py

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -389,6 +389,14 @@ jobs:
             export HF_DATASETS_OFFLINE=0
           fi
 
+          # If TIMM pretrained model weights haven't been cached yet, enable
+          # online mode so they can be downloaded and cached for future runs.
+          # TIMM uses huggingface_hub which stores models under hub/models--timm--*.
+          if [[ "${TEST_CONFIG}" == *timm* ]] && ! ls "${HF_CACHE}"/hub/models--timm--* &>/dev/null; then
+            export TRANSFORMERS_OFFLINE=0
+            export HF_DATASETS_OFFLINE=0
+          fi
+
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG, SHM_OPTS, JENKINS_USER and DOCKER_SHELL_CMD since that doesn't play nice

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -61,6 +61,7 @@ on:
     paths:
       - .github/workflows/inductor-perf-test-nightly-h100.yml
       - .ci/docker/ci_commit_pins/huggingface-requirements.txt
+      - .ci/docker/ci_commit_pins/timm.txt
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174581

Newer TIMM versions download pretrained weights from HF Hub via
huggingface_hub, which respects TRANSFORMERS_OFFLINE (mapped to
HF_HUB_OFFLINE internally). Since CI defaults to offline mode,
TIMM benchmarks fail when the models aren't in /mnt/hf_cache.

Fix this by:
- Auto-labeling PRs that change timm.txt (or huggingface-requirements.txt)
  with ci-refresh-hf-cache so the cache is refreshed with online mode.
- Triggering inductor-perf-test-nightly-h100 on timm.txt changes so TIMM
  benchmarks actually run during the cache refresh PR.
- Adding a runtime check in _linux-test.yml that enables online mode for
  TIMM shards when no cached TIMM models exist yet, allowing the first
  nightly run to populate the shared FSx cache.

Authored with Claude.