### PR TITLE
[c10] Move P2P access logic from ATen to c10

### DIFF
--- a/aten/src/ATen/cuda/PeerToPeerAccess.cpp
+++ b/aten/src/ATen/cuda/PeerToPeerAccess.cpp
@@ -1,182 +1,20 @@
 #include <ATen/cuda/PeerToPeerAccess.h>
 
-#include <ATen/cuda/CUDAContext.h>
-
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAGuard.h>
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-#include <c10/cuda/driver_api.h>
-#endif
-#include <c10/util/Exception.h>
-#include <c10/util/irange.h>
-
-#include <vector>
+#include <ATen/Context.h>
+#include <c10/cuda/PeerToPeerAccess.h>
 
 namespace at::cuda {
 
-static std::vector<int8_t> p2pAccessEnabled_;
-static std::vector<int8_t> fabricAccessEnabled_;
-static int64_t num_devices_ = -1;
-
-namespace detail {
-
-void init_p2p_access_cache(int64_t num_devices) {
-  // p2pAccessEnabled records if p2p copies are allowed between pairs of
-  // devices. Values include "1" (copy allowed), "0" (copy not allowed), and
-  // "-1" (unknown).
-  // Currently the max number of gpus in P2P group is 8, so if there are more
-  // we enable P2P in groups of 8
-  p2pAccessEnabled_.clear();
-  p2pAccessEnabled_.resize(num_devices * num_devices, -1);
-  num_devices_ = num_devices;
-
-  for (const auto i : c10::irange(num_devices)) {
-    p2pAccessEnabled_[i * num_devices + i] = 1;
-  }
-  fabricAccessEnabled_.clear();
-  fabricAccessEnabled_.resize(num_devices, -1);
-}
-
-} // namespace detail
-
 bool get_p2p_access(c10::DeviceIndex dev, c10::DeviceIndex dev_to_access) {
+  // Ensure CUDA is lazily initialized before forwarding to c10
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
-
-  TORCH_CHECK(dev >= 0 && dev < num_devices_, static_cast<int>(dev), " is not a device");
-  TORCH_CHECK(
-      dev_to_access >= 0 && dev_to_access < num_devices_,
-      static_cast<int>(dev_to_access),
-      " is not a device");
-  TORCH_INTERNAL_ASSERT(num_devices_ >= 0, "p2p access cache not initialized");
-
-  auto& cache = p2pAccessEnabled_[dev * num_devices_ + dev_to_access];
-
-  if (cache != -1) {
-    return cache;
-  }
-
-  int result = 0;
-  C10_CUDA_CHECK(cudaDeviceCanAccessPeer(&result, dev, dev_to_access));
-  cache = result ? 1 : 0;
-  if (cache) {
-    CUDACachingAllocator::enablePeerAccess(dev, dev_to_access);
-  }
-
-  return cache;
+  return c10::cuda::get_p2p_access(dev, dev_to_access);
 }
-
-namespace {
-#if !defined USE_ROCM && defined CUDA_VERSION && CUDA_VERSION >= 12040 && defined PYTORCH_C10_DRIVER_API_SUPPORTED
-
-nvmlDevice_t get_nvml_device(c10::DeviceIndex dev) {
-  static bool nvml_init [[maybe_unused]] = []() {
-    TORCH_INTERNAL_ASSERT(NVML_SUCCESS == DriverAPI::get()->nvmlInit_v2_());
-    return true;
-  }();
-
-  auto prop = at::cuda::getDeviceProperties(dev);
-  char pci_id // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-      [NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-  snprintf(
-      pci_id,
-      sizeof(pci_id),
-      NVML_DEVICE_PCI_BUS_ID_FMT,
-      prop->pciDomainID,
-      prop->pciBusID,
-      prop->pciDeviceID);
-
-  nvmlDevice_t nvml_device = nullptr;
-  TORCH_INTERNAL_ASSERT(
-      NVML_SUCCESS ==
-      DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_(
-          pci_id, &nvml_device));
-  return nvml_device;
-}
-
-bool isFabricSupported() {
-  // 1. try allocating memory
-  CUmemGenericAllocationHandle handle = 0;
-  CUmemAllocationProp prop = {};
-  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
-  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-
-  size_t granularity{};
-  const auto driver_api = c10::cuda::DriverAPI::get();
-  C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
-      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED));
-
-  auto status = driver_api->cuMemCreate_(&handle, granularity, &prop, 0);
-  if (status != CUDA_SUCCESS) {
-    LOG(INFO)
-        << "status " << status
-        << " Could not allocate memory with FABRIC handle, falling back to fd handle exchange\n";
-    return false;
-  }
-  // 2. check export
-  CUmemFabricHandle sharedHandle;
-  status = driver_api->cuMemExportToShareableHandle_(
-      &sharedHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
-  if (status != CUDA_SUCCESS) {
-    LOG(INFO)
-        << "status " << status
-        << " Could not export FABRIC handle, falling back to fd handle exchange\n";
-    driver_api->cuMemRelease_(handle);
-    return false;
-  }
-  // 3. check import
-  CUmemGenericAllocationHandle import_handle = 0;
-  status = driver_api->cuMemImportFromShareableHandle_(
-      &import_handle, &sharedHandle, CU_MEM_HANDLE_TYPE_FABRIC);
-  if (status != CUDA_SUCCESS) {
-    LOG(INFO)
-        << "status " << status
-        << " Could not import FABRIC handle, falling back to fd handle exchange\n";
-    driver_api->cuMemRelease_(handle);
-    return false;
-  }
-  driver_api->cuMemRelease_(import_handle);
-  driver_api->cuMemRelease_(handle);
-  LOG(INFO) << "using fabric to exchange memory handles\n";
-  return true;
-}
-#endif
-} // namespace
 
 bool get_fabric_access(c10::DeviceIndex dev) {
-#if !defined USE_ROCM && defined CUDA_VERSION && CUDA_VERSION >= 12040 && defined PYTORCH_C10_DRIVER_API_SUPPORTED
+  // Ensure CUDA is lazily initialized before forwarding to c10
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
-
-  TORCH_CHECK(dev >= 0 && dev < num_devices_, static_cast<int>(dev), " is not a device");
-  auto& cache = fabricAccessEnabled_[dev];
-  if (cache != -1) {
-    return cache;
-  }
-  auto nvml_device = get_nvml_device(dev);
-  if (nvml_device != nullptr) {
-    nvmlGpuFabricInfoV_t fabricInfo;
-    fabricInfo.state = NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
-    fabricInfo.version = nvmlGpuFabricInfo_v2;
-    if (DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_ == nullptr) {
-      return false;
-    }
-    TORCH_CHECK(
-        NVML_SUCCESS ==
-        DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_(
-            nvml_device, &fabricInfo));
-    auto state = fabricInfo.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
-    if (state) {
-      // now perform the full cycle of allocating - exporting - importing memory
-      state = isFabricSupported();
-    }
-    cache = state ? 1 : 0;
-    return cache;
-  } else {
-    return false;
-  }
-#else
-  return false;
-#endif
+  return c10::cuda::get_fabric_access(dev);
 }
 
 } // namespace at::cuda

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -34,6 +34,7 @@ set(C10_CUDA_SRCS
     CUDAMallocAsyncAllocator.cpp
     CUDAMiscFunctions.cpp
     CUDAStream.cpp
+    PeerToPeerAccess.cpp
     impl/CUDAGuardImpl.cpp
     impl/CUDATest.cpp
     driver_api.cpp
@@ -50,6 +51,7 @@ set(C10_CUDA_HEADERS
     CUDAMathCompat.h
     CUDAMiscFunctions.h
     CUDAStream.h
+    PeerToPeerAccess.h
     impl/CUDAGuardImpl.h
     impl/CUDATest.h
 )

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -1,0 +1,206 @@
+#include <c10/cuda/PeerToPeerAccess.h>
+
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+#include <c10/cuda/driver_api.h>
+#endif
+#include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
+#include <c10/util/irange.h>
+
+#include <vector>
+
+namespace c10::cuda {
+
+static std::vector<int8_t> p2pAccessEnabled_;
+static std::vector<int8_t> fabricAccessEnabled_;
+static int64_t num_devices_ = -1;
+
+namespace detail {
+
+void init_p2p_access_cache(int64_t num_devices) {
+  // p2pAccessEnabled records if p2p copies are allowed between pairs of
+  // devices. Values include "1" (copy allowed), "0" (copy not allowed), and
+  // "-1" (unknown).
+  // Currently the max number of gpus in P2P group is 8, so if there are more
+  // we enable P2P in groups of 8
+  p2pAccessEnabled_.clear();
+  p2pAccessEnabled_.resize(num_devices * num_devices, -1);
+  num_devices_ = num_devices;
+
+  for (const auto i : c10::irange(num_devices)) {
+    p2pAccessEnabled_[i * num_devices + i] = 1;
+  }
+  fabricAccessEnabled_.clear();
+  fabricAccessEnabled_.resize(num_devices, -1);
+}
+
+} // namespace detail
+
+bool get_p2p_access(c10::DeviceIndex dev, c10::DeviceIndex dev_to_access) {
+  TORCH_CHECK(
+      num_devices_ >= 0,
+      "p2p access cache not initialized. "
+      "Ensure c10::cuda::detail::init_p2p_access_cache() is called first.");
+  TORCH_CHECK(
+      dev >= 0 && dev < num_devices_,
+      static_cast<int>(dev),
+      " is not a valid device");
+  TORCH_CHECK(
+      dev_to_access >= 0 && dev_to_access < num_devices_,
+      static_cast<int>(dev_to_access),
+      " is not a valid device");
+
+  auto& cache = p2pAccessEnabled_[dev * num_devices_ + dev_to_access];
+
+  if (cache != -1) {
+    return cache;
+  }
+
+  int result = 0;
+  C10_CUDA_CHECK(cudaDeviceCanAccessPeer(&result, dev, dev_to_access));
+  cache = result ? 1 : 0;
+  if (cache) {
+    CUDACachingAllocator::enablePeerAccess(dev, dev_to_access);
+  }
+
+  return cache;
+}
+
+namespace {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12040 && \
+    defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+
+nvmlDevice_t get_nvml_device(c10::DeviceIndex dev) {
+  static bool nvml_init [[maybe_unused]] = []() {
+    TORCH_INTERNAL_ASSERT(NVML_SUCCESS == DriverAPI::get()->nvmlInit_v2_());
+    return true;
+  }();
+
+  // Direct CUDA call instead of at::cuda::getDeviceProperties()
+  cudaDeviceProp prop{};
+  C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
+
+  char
+      pci_id // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+          [NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
+  snprintf(
+      pci_id,
+      sizeof(pci_id),
+      NVML_DEVICE_PCI_BUS_ID_FMT,
+      prop.pciDomainID,
+      prop.pciBusID,
+      prop.pciDeviceID);
+
+  nvmlDevice_t nvml_device = nullptr;
+  TORCH_INTERNAL_ASSERT(
+      NVML_SUCCESS ==
+      DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_(
+          pci_id, &nvml_device));
+  return nvml_device;
+}
+
+bool isFabricSupported() {
+  // 1. try allocating memory with FABRIC handle type
+  CUmemGenericAllocationHandle handle = 0;
+  CUmemAllocationProp prop = {};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+
+  size_t granularity{};
+  const auto driver_api = DriverAPI::get();
+  C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
+      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED));
+
+  auto status = driver_api->cuMemCreate_(&handle, granularity, &prop, 0);
+  if (status != CUDA_SUCCESS) {
+    LOG(INFO)
+        << "status " << status
+        << " Could not allocate memory with FABRIC handle, falling back to fd handle exchange\n";
+    return false;
+  }
+
+  // 2. check export
+  CUmemFabricHandle sharedHandle;
+  status = driver_api->cuMemExportToShareableHandle_(
+      &sharedHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+  if (status != CUDA_SUCCESS) {
+    LOG(INFO)
+        << "status " << status
+        << " Could not export FABRIC handle, falling back to fd handle exchange\n";
+    driver_api->cuMemRelease_(handle);
+    return false;
+  }
+
+  // 3. check import
+  CUmemGenericAllocationHandle import_handle = 0;
+  status = driver_api->cuMemImportFromShareableHandle_(
+      &import_handle, &sharedHandle, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (status != CUDA_SUCCESS) {
+    LOG(INFO)
+        << "status " << status
+        << " Could not import FABRIC handle, falling back to fd handle exchange\n";
+    driver_api->cuMemRelease_(handle);
+    return false;
+  }
+
+  driver_api->cuMemRelease_(import_handle);
+  driver_api->cuMemRelease_(handle);
+  LOG(INFO) << "using fabric to exchange memory handles\n";
+  return true;
+}
+
+#endif
+} // namespace
+
+bool get_fabric_access(c10::DeviceIndex dev) {
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12040 && \
+    defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+  TORCH_CHECK(
+      num_devices_ >= 0,
+      "p2p access cache not initialized. "
+      "Ensure c10::cuda::detail::init_p2p_access_cache() is called first.");
+  TORCH_CHECK(
+      dev >= 0 && dev < num_devices_,
+      static_cast<int>(dev),
+      " is not a valid device");
+
+  auto& cache = fabricAccessEnabled_[dev];
+  if (cache != -1) {
+    return cache;
+  }
+
+  auto nvml_device = get_nvml_device(dev);
+  if (nvml_device != nullptr) {
+    nvmlGpuFabricInfoV_t fabricInfo;
+    fabricInfo.state = NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
+    fabricInfo.version = nvmlGpuFabricInfo_v2;
+    if (DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_ == nullptr) {
+      cache = 0;
+      return false;
+    }
+    TORCH_CHECK(
+        NVML_SUCCESS ==
+        DriverAPI::get()->nvmlDeviceGetGpuFabricInfoV_(
+            nvml_device, &fabricInfo));
+    auto state = fabricInfo.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
+    if (state) {
+      // now perform the full cycle of allocating - exporting - importing memory
+      state = isFabricSupported();
+    }
+    cache = state ? 1 : 0;
+    return cache;
+  } else {
+    cache = 0;
+    return false;
+  }
+#else
+  (void)dev; // Suppress unused parameter warning
+  return false;
+#endif
+}
+
+} // namespace c10::cuda

--- a/c10/cuda/PeerToPeerAccess.h
+++ b/c10/cuda/PeerToPeerAccess.h
@@ -1,37 +1,35 @@
 #pragma once
 
 #include <c10/core/Device.h>
-#include <c10/cuda/PeerToPeerAccess.h>
+#include <c10/cuda/CUDAMacros.h>
 #include <c10/macros/Macros.h>
 
 #include <cstdint>
 
-namespace at::cuda {
+namespace c10::cuda {
 
 namespace detail {
 
 /// Initialize the peer-to-peer and fabric access caches.
-/// Forwards to c10::cuda::detail::init_p2p_access_cache.
+/// Must be called before any calls to get_p2p_access or get_fabric_access.
 /// @param num_devices The number of CUDA devices in the system.
-inline void init_p2p_access_cache(int64_t num_devices) {
-  c10::cuda::detail::init_p2p_access_cache(num_devices);
-}
+C10_CUDA_API void init_p2p_access_cache(int64_t num_devices);
 
 } // namespace detail
 
 /// Query if peer-to-peer access is available between two devices.
-/// This wrapper ensures CUDA lazy initialization before forwarding to c10.
 /// @param source_dev The source device index.
 /// @param dest_dev The destination device index.
 /// @return true if P2P access is available, false otherwise.
-TORCH_CUDA_CPP_API bool get_p2p_access(
+C10_CUDA_API bool get_p2p_access(
     c10::DeviceIndex source_dev,
     c10::DeviceIndex dest_dev);
 
-/// Query if GPU fabric (high-speed interconnect) is available for a device.
-/// This wrapper ensures CUDA lazy initialization before forwarding to c10.
+/// Query if GPU fabric (high-speed interconnect like NVLink/NVSwitch) is
+/// available for a device. This checks both hardware support and the ability
+/// to allocate/export/import memory with fabric handles.
 /// @param device The device index to check.
 /// @return true if fabric access is available, false otherwise.
-TORCH_CUDA_CPP_API bool get_fabric_access(c10::DeviceIndex device);
+C10_CUDA_API bool get_fabric_access(c10::DeviceIndex device);
 
-} // namespace at::cuda
+} // namespace c10::cuda

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3413,6 +3413,7 @@ C10_MAPPINGS = collections.OrderedDict([
     ("c10/cuda/CUDAMathCompat.h", "c10/hip/HIPMathCompat.h"),
     ("c10/cuda/CUDAMiscFunctions.h", "c10/hip/HIPMiscFunctions.h"),
     ("c10/cuda/CUDAStream.h", "c10/hip/HIPStream.h"),
+    ("c10/cuda/PeerToPeerAccess.h", "c10/hip/PeerToPeerAccess.h"),    
     ("c10/cuda/CUDAEvent.h", "c10/hip/HIPEvent.h"),
     ("c10/cuda/impl/CUDAGuardImpl.h", "c10/hip/impl/HIPGuardImpl.h"),
     ("c10/cuda/impl/CUDATest.h", "c10/hip/impl/HIPTest.h"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174582

Refactor PeerToPeerAccess by moving the core implementation from
aten/src/ATen/cuda to c10/cuda. This makes P2P and fabric access
queries available at the c10 layer without requiring ATen dependencies.
The ATen layer now provides thin wrappers that ensure CUDA lazy
initialization before forwarding to c10. This separation allows
lower-level CUDA code to query P2P capabilities without pulling in
ATen context machinery.

Original diff by @minsii #173571

Bifferential Revision: [D92675476](https://our.internmc.facebook.com/intern/diff/D92675476/)