### PR TITLE
Fix #174546: Remove deprecated device arg from Tensor.pin_memory() call

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -54,7 +54,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device) -> None
 
 def pin_memory(data, device=None):
     if isinstance(data, torch.Tensor):
-        return data.pin_memory(device)
+        return data.pin_memory()
 
     if hasattr(data, "pin_memory"):
         return data.pin_memory()


### PR DESCRIPTION
## Description
Fixes #174546

This PR removes the deprecated `device` argument from the `Tensor.pin_memory()` call in the DataLoader's pin-memory utility.

## Problem
In PyTorch 2.8+, `Tensor.pin_memory()` deprecated the `device` argument and now automatically uses the current accelerator device. However, the DataLoader pin-memory helper at `torch/utils/data/_utils/pin_memory.py:57` was still passing this argument, causing deprecation warnings.

## Solution
Removed the `device` argument from the `data.pin_memory(device)` call on line 57.

## Changes
- **File:** `torch/utils/data/_utils/pin_memory.py`
- **Line 57:** Changed `data.pin_memory(device)` to `data.pin_memory()`

## Testing
Tested with the reproduction code from the issue - deprecation warning no longer appears.

Fixes #174546

cc @albertvillanova @andrewkho @ssnl