### PR TITLE
[ROCm] Check for re-initialization of the process group

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -839,16 +839,18 @@ class CompileTest(TestCase):
         torch.accelerator.set_device_index(0)
         self.device = torch.accelerator.current_accelerator()
 
-        store = FakeStore()
-        dist.init_process_group(
-            backend="fake",
-            world_size=self.world_size,
-            rank=self.rank,
-            store=store,
-        )
+        if not dist.is_initialized():
+            store = FakeStore()
+            dist.init_process_group(
+                backend="fake",
+                world_size=self.world_size,
+                rank=self.rank,
+                store=store,
+            )
 
     def tearDown(self):
-        dist.destroy_process_group()
+        if dist.is_initialized():
+            dist.destroy_process_group()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
@@ -1075,7 +1077,7 @@ class CompileTest(TestCase):
             FileCheck()
             .check(
                 "buf0 = torch.ops._c10d_functional.all_gather_into_tensor_coalesced"
-                ".default([arg3_1, arg2_1, arg1_1, arg0_1]"
+                ".default([arg0_1, arg1_1, arg2_1, arg3_1]"
             )
             .check("buf1 = buf0[0]")
             .check("buf2 = buf0[1]")


### PR DESCRIPTION
Fixes #146806
Fixes #147707
Fixes #147795
Fixes #147816
Fixes #147852
Fixes #148014

### Summary
Fixes flaky test failures in `CompileTest` by adding a check to prevent double initialization of the process group. This matches the defensive pattern already used in `CompileTestCPU` and prevents `ValueError: trying to initialize the default process group twice!` errors.
1. test_inductor_inplace_op_on_view
2. test_wait_tensor
3. test_inductor_broadcast
4. test_inductor_all_to_all_single
5. test_inductor_all_gather_into_tensor_single
```
Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/test/distributed/test_c10d_functional_native.py", line 706, in setUp
    dist.init_process_group(
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/distributed/c10d_logger.py", line 95, in wrapper
    func_return = func(*args, **kwargs)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py", line 1638, in init_process_group
    raise ValueError("trying to initialize the default process group twice!")
ValueError: trying to initialize the default process group twice!
```
6. test_inductor_all_gather_into_tensor_coalesced
The compiler generates arguments in the natural order `[arg0_1, arg1_1, arg2_1, arg3_1]` , but the test was expecting them in reverse order. Updated the FileCheck pattern to expect the correct argument order that matches the compiler's output.


## Testing
Ran a stress test for above fixes, tests passed consistently on MI300.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang