### PR TITLE
Add C++ API support for set_printoptions with sci_mode parameter

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -43,6 +43,16 @@ std::string toString(const Scalar& s) {
 } // namespace c10
 
 namespace at {
+namespace internal {
+struct PrintOptions {
+  bool sci_mode = true;
+};
+
+PrintOptions& get_print_options() {
+  static PrintOptions options;
+  return options;
+}
+} // namespace internal
 
 std::ostream& operator<<(std::ostream& out, const DeprecatedTypeProperties& t) {
   return out << t.toString();
@@ -116,7 +126,8 @@ static PrintFormat __printFormat(const Tensor& self) {
   if (intMode) {
     if (expMax > 9) {
       sz = 11;
-      return PrintFormat(scale, sz, FormatType::Scientific);
+      auto& opts = internal::get_print_options();
+      return PrintFormat(scale, sz, opts.sci_mode ? FormatType::Scientific : FormatType::Fixed);
     } else {
       sz = static_cast<int>(expMax) + 1;
       return PrintFormat(scale, sz, FormatType::Default);
@@ -127,7 +138,8 @@ static PrintFormat __printFormat(const Tensor& self) {
       if (std::fabs(expMax) > 99 || std::fabs(expMin) > 99) {
         sz = sz + 1;
       }
-      return PrintFormat(scale, sz, FormatType::Scientific);
+    auto& opts = internal::get_print_options();
+    return PrintFormat(scale, sz, opts.sci_mode ? FormatType::Scientific : FormatType::Fixed);
     } else {
       if (expMax > 5 || expMax < 0) {
         sz = 7;
@@ -378,6 +390,11 @@ std::ostream& print(
 
   fmt::print(stream, " ]");
   return stream;
+}
+
+void set_printoptions(bool sci_mode) {
+  auto& opts = internal::get_print_options();
+  opts.sci_mode = sci_mode;
 }
 
 } // namespace at

--- a/aten/src/ATen/core/Formatting.h
+++ b/aten/src/ATen/core/Formatting.h
@@ -22,4 +22,5 @@ inline std::ostream& operator<<(std::ostream & out, const Tensor & t) {
   return print(out,t,80);
 }
 TORCH_API void print(const Tensor & t, int64_t linesize=80);
+TORCH_API void set_printoptions(bool sci_mode = true);
 }

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -722,6 +722,7 @@ if(NOT NO_API AND NOT BUILD_LITE_INTERPRETER)
     ${TORCH_SRC_DIR}/csrc/api/src/optim/schedulers/reduce_on_plateau_scheduler.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/serialize/input-archive.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/serialize/output-archive.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/print.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/xpu.cpp
   )
 endif()

--- a/test/cpp/api/printing.cpp
+++ b/test/cpp/api/printing.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <sstream>
+#include <iostream>
+
+TEST(PrintOptionsTest, ToggleScientificNotation) {
+    auto t = torch::tensor({0.00001, 100000.0});
+    
+    // Test with scientific notation enabled
+    torch::set_printoptions(true);
+    std::ostringstream oss1;
+    oss1 << t;
+    auto out1 = oss1.str();
+    std::cout << "With sci_mode=true: '" << out1 << "'" << std::endl;
+    EXPECT_TRUE(out1.find("e-") != std::string::npos || out1.find("e+") != std::string::npos);
+    
+    // Test with scientific notation disabled
+    torch::set_printoptions(false);
+    std::ostringstream oss2;
+    oss2 << t;
+    auto out2 = oss2.str();
+    std::cout << "With sci_mode=false: '" << out2 << "'" << std::endl;
+    EXPECT_TRUE(out2.find("e-") == std::string::npos && out2.find("e+") == std::string::npos);
+}

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -21,3 +21,4 @@
 #include <torch/utils.h>
 #include <torch/version.h>
 #include <torch/xpu.h>
+#include <torch/print.h>

--- a/torch/csrc/api/include/torch/print.h
+++ b/torch/csrc/api/include/torch/print.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <c10/macros/Export.h>
+
+namespace torch {
+/// Set print options for tensor printing
+/// 
+/// Controls how tensors are displayed when printed to streams.
+/// 
+/// \param sci_mode Whether to use scientific notation for floating point numbers
+TORCH_API void set_printoptions(bool sci_mode = true);
+
+} // namespace torch

--- a/torch/csrc/api/src/print.cpp
+++ b/torch/csrc/api/src/print.cpp
@@ -1,0 +1,10 @@
+#include <torch/print.h>
+#include <ATen/core/Formatting.h>
+
+namespace torch {
+
+void set_printoptions(bool sci_mode) {
+  at::set_printoptions(sci_mode);
+}
+
+} // namespace torch


### PR DESCRIPTION
- Implement set_printoptions in ATen core with sci_mode control
- Add torch::set_printoptions wrapper for C++ API
- Update __printFormat to respect sci_mode setting
- Add test demonstrating functionality
- Fixes #40613: Suppress scientific notation in libtorch
- Fixes #43490: Implement set_printoptions method in libtorch
