### PR TITLE
Add pickle support for __slots__ in Module class

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -80,34 +80,6 @@ if TEST_NUMPY:
 # update test/run_test.py to list it, otherwise it will NOT be run in
 # CI.
 
-
-# Helper classes for testing __slots__ pickling (must be at module level for pickle)
-class _ModuleWithSlots(nn.Module):
-    __slots__ = ['slot_attr', 'another_slot']
-
-    def __init__(self):
-        super().__init__()
-        self.slot_attr = "slot_value"
-        self.another_slot = 42
-        self.regular_attr = "regular_value"
-
-
-class _ParentModuleWithSlots(nn.Module):
-    __slots__ = ['parent_slot']
-
-    def __init__(self):
-        super().__init__()
-        self.parent_slot = "parent_value"
-
-
-class _ChildModuleWithSlots(_ParentModuleWithSlots):
-    __slots__ = ['child_slot']
-
-    def __init__(self):
-        super().__init__()
-        self.child_slot = "child_value"
-
-
 class TestNN(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -7642,6 +7614,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_pickle_module_with_slots(self):
         # Test that pickling works for subclasses that define __slots__
+        class _ModuleWithSlots(nn.Module):
+            __slots__ = ['slot_attr', 'another_slot']
+
+            def __init__(self):
+                super().__init__()
+                self.slot_attr = "slot_value"
+                self.another_slot = 42
+                self.regular_attr = "regular_value"
+
         m = _ModuleWithSlots()
         m_loaded = pickle.loads(pickle.dumps(m))
 
@@ -7652,6 +7633,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     def test_pickle_module_with_slots_inheritance(self):
         # Verify pickling preserves __slots__ attributes from both parent
         # and child classes.
+        class _ParentModuleWithSlots(nn.Module):
+            __slots__ = ['parent_slot']
+
+            def __init__(self):
+                super().__init__()
+                self.parent_slot = "parent_value"
+
+
+        class _ChildModuleWithSlots(_ParentModuleWithSlots):
+            __slots__ = ['child_slot']
+
+            def __init__(self):
+                super().__init__()
+                self.child_slot = "child_value"
+        
         m = _ChildModuleWithSlots()
         m_loaded = pickle.loads(pickle.dumps(m))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -80,6 +80,34 @@ if TEST_NUMPY:
 # update test/run_test.py to list it, otherwise it will NOT be run in
 # CI.
 
+
+# Helper classes for testing __slots__ pickling (must be at module level for pickle)
+class _ModuleWithSlots(nn.Module):
+    __slots__ = ['slot_attr', 'another_slot']
+
+    def __init__(self):
+        super().__init__()
+        self.slot_attr = "slot_value"
+        self.another_slot = 42
+        self.regular_attr = "regular_value"
+
+
+class _ParentModuleWithSlots(nn.Module):
+    __slots__ = ['parent_slot']
+
+    def __init__(self):
+        super().__init__()
+        self.parent_slot = "parent_value"
+
+
+class _ChildModuleWithSlots(_ParentModuleWithSlots):
+    __slots__ = ['child_slot']
+
+    def __init__(self):
+        super().__init__()
+        self.child_slot = "child_value"
+
+
 class TestNN(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -7597,6 +7625,38 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with warnings.catch_warnings(record=True) as w:
             pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))
         self.assertEqual(len(w), 0)
+
+    def test_pickle_module_without_slots(self):
+        # Test that pickling works for base nn.Module (no 
+        # __slots__ defined)
+        # https://github.com/pytorch/pytorch/issues/66813
+        m = nn.Linear(10, 10)
+        m.custom_attr = "test_value"
+        m_loaded = pickle.loads(pickle.dumps(m))
+        self.assertEqual(m_loaded.custom_attr, "test_value")
+        self.assertEqual(m_loaded.in_features, 10)
+        self.assertEqual(m_loaded.out_features, 10)
+        # Verify the module still works
+        x = torch.randn(2, 10)
+        self.assertEqual(m(x).shape, m_loaded(x).shape)
+
+    def test_pickle_module_with_slots(self):
+        # Test that pickling works for subclasses that define __slots__
+        m = _ModuleWithSlots()
+        m_loaded = pickle.loads(pickle.dumps(m))
+
+        self.assertEqual(m_loaded.slot_attr, "slot_value")
+        self.assertEqual(m_loaded.another_slot, 42)
+        self.assertEqual(m_loaded.regular_attr, "regular_value")
+
+    def test_pickle_module_with_slots_inheritance(self):
+        # Verify pickling preserves __slots__ attributes from both parent
+        # and child classes.
+        m = _ChildModuleWithSlots()
+        m_loaded = pickle.loads(pickle.dumps(m))
+
+        self.assertEqual(m_loaded.parent_slot, "parent_value")
+        self.assertEqual(m_loaded.child_slot, "child_value")
 
     def test_rnn_cell_gate_weights_size(self):
         def test_rnn_cell(cell_fn, gate_count):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7599,7 +7599,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(len(w), 0)
 
     def test_pickle_module_without_slots(self):
-        # Test that pickling works for base nn.Module (no 
+        # Test that pickling works for base nn.Module (no
         # __slots__ defined)
         # https://github.com/pytorch/pytorch/issues/66813
         m = nn.Linear(10, 10)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1925,7 +1925,7 @@ class Module:
             slots.extend(getattr(cls, "__slots__", []))
         for slot in slots:
             if slot != "__dict__" and slot != "__weakref__" and hasattr(self, slot):
-                state[slot] = getattr(self, slot)
+                state[slot] = object.__getattribute__(self, slot)
 
         return state
 
@@ -1934,12 +1934,8 @@ class Module:
         for cls in type(self).__mro__:
             slots.update(getattr(cls, "__slots__", []))
         for slot in slots:
-            if slot in state and slot != "__dict__" and slot != "__weakref__":
-                try:
-                    setattr(self, slot, state.pop(slot))
-                except AttributeError:
-                    # Slot might be read-only or have other restrictions
-                    pass
+            if slot in state:
+                object.__setattr__(self, slot, state.pop(slot))
 
         self.__dict__.update(state)
 


### PR DESCRIPTION
This PR addresses issue [66813](https://github.com/pytorch/pytorch/issues/66813) This PR adds supports for slots in the __getstate__ and __setstate__ function for nn.Module class. 

Test cases have been added to support this feature, and the code snippet that was failing in the issue is now passing. Specifcally:

```
>>> import torch.nn
>>> import pickle
>>> 
>>> class A(torch.nn.Module):
...     __slots__ = ['x']
... 
>>> a = A()
>>> a.x = True
>>> a2 = pickle.loads(pickle.dumps(a))
>>> print(a2.x)
True
```