### PR TITLE
[xpu] Add proper float64 handling for addmv, addmm and baddbmm.

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -374,8 +374,8 @@ Tensor& addmv_out(
 
   Tensor vec_v = vec.view({vec.size(0), 1});
 
-  bool is_float64 = mat.scalar_type() == at::kDouble ||
-                    vec.scalar_type() == at::kDouble;
+  bool is_float64 =
+      mat.scalar_type() == at::kDouble || vec.scalar_type() == at::kDouble;
   bool is_inplace = self.is_same(out);
   if (is_float64 && is_inplace) {
     Tensor self_v_copy = self_v.clone();

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -85,7 +85,8 @@ Tensor& addmm_out(
       " but got:",
       self.sizes());
 
-  // Different float64 handling.
+  // Bypass OneDNN optimization path for float64 due to lack of full double
+  // precision support.
   if (mat1.scalar_type() == at::kDouble) {
     bool is_inplace = self.is_same(result);
     bool is_beta_ne_zero = beta.to<double>() != 0.0;
@@ -246,7 +247,8 @@ Tensor& baddbmm_out(
     return result;
   }
 
-  // Different float64 handling.
+  // Bypass OneDNN optimization path for float64 due to lack of full double
+  // precision support.
   if (batch1.scalar_type() == at::kDouble ||
       batch2.scalar_type() == at::kDouble) {
     bool is_inplace = input.is_same(result);

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1154,30 +1154,30 @@ if(USE_XPU)
   # ATen XPU implementation
   set(TORCH_XPU_OPS_DIR ${TORCH_ROOT}/third_party/torch-xpu-ops)
   set(TORCH_XPU_OPS_REPO_URL https://github.com/intel/torch-xpu-ops.git)
-  # file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
-  # string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
-  # if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
-  #   execute_process(
-  #     COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
-  #     RESULT_VARIABLE _exitcode)
-  #   if(NOT _exitcode EQUAL 0)
-  #     message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
-  #   endif()
-  # endif()
-  # execute_process(
-  #   COMMAND git fetch --quiet
-  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-  #   RESULT_VARIABLE _exitcode)
-  # if(NOT _exitcode EQUAL 0)
-  #   message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
-  # endif()
-  # execute_process(
-  #   COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
-  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-  #   RESULT_VARIABLE _exitcode)
-  # if(NOT _exitcode EQUAL 0)
-  #   message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
-  # endif()
+  file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
+  string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
+  if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
+    execute_process(
+      COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
+      RESULT_VARIABLE _exitcode)
+    if(NOT _exitcode EQUAL 0)
+      message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
+    endif()
+  endif()
+  execute_process(
+    COMMAND git fetch --quiet
+    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+    RESULT_VARIABLE _exitcode)
+  if(NOT _exitcode EQUAL 0)
+    message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+  endif()
+  execute_process(
+    COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
+    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+    RESULT_VARIABLE _exitcode)
+  if(NOT _exitcode EQUAL 0)
+    message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
+  endif()
 
   set(TORCH_XPU_OPS_INCLUDE_DIRS
       ${TORCH_SRC_DIR}/csrc/api

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1154,30 +1154,30 @@ if(USE_XPU)
   # ATen XPU implementation
   set(TORCH_XPU_OPS_DIR ${TORCH_ROOT}/third_party/torch-xpu-ops)
   set(TORCH_XPU_OPS_REPO_URL https://github.com/intel/torch-xpu-ops.git)
-  file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
-  string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
-  if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
-    execute_process(
-      COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
-      RESULT_VARIABLE _exitcode)
-    if(NOT _exitcode EQUAL 0)
-      message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
-    endif()
-  endif()
-  execute_process(
-    COMMAND git fetch --quiet
-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-    RESULT_VARIABLE _exitcode)
-  if(NOT _exitcode EQUAL 0)
-    message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
-  endif()
-  execute_process(
-    COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-    RESULT_VARIABLE _exitcode)
-  if(NOT _exitcode EQUAL 0)
-    message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
-  endif()
+  # file(READ "${TORCH_ROOT}/third_party/xpu.txt" TORCH_XPU_OPS_COMMIT)
+  # string(REGEX REPLACE "\n$" "" TORCH_XPU_OPS_COMMIT "${TORCH_XPU_OPS_COMMIT}")
+  # if(NOT EXISTS "${TORCH_XPU_OPS_DIR}/.git")
+  #   execute_process(
+  #     COMMAND git clone --quiet ${TORCH_XPU_OPS_REPO_URL} ${TORCH_XPU_OPS_DIR}
+  #     RESULT_VARIABLE _exitcode)
+  #   if(NOT _exitcode EQUAL 0)
+  #     message(FATAL_ERROR "Fail to clone ${TORCH_XPU_OPS_REPO_URL}")
+  #   endif()
+  # endif()
+  # execute_process(
+  #   COMMAND git fetch --quiet
+  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+  #   RESULT_VARIABLE _exitcode)
+  # if(NOT _exitcode EQUAL 0)
+  #   message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+  # endif()
+  # execute_process(
+  #   COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
+  #   WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+  #   RESULT_VARIABLE _exitcode)
+  # if(NOT _exitcode EQUAL 0)
+  #   message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
+  # endif()
 
   set(TORCH_XPU_OPS_INCLUDE_DIRS
       ${TORCH_SRC_DIR}/csrc/api

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -297,7 +297,6 @@ inductor_expected_failures_single_sample["xpu"] = {
     },  # align with cuda.
     ("linalg.pinv", "singular"): {f64},
     # could not create a primitive
-    "addmv": {f64},
     "fft.fft": {f16},
     "fft.fft2": {f16},
     "fft.fftn": {f16},

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -238,13 +238,13 @@ class TestBasicGEMM(TestCase):
                     activation=activation,
                 )
 
-    @precisionOverride({torch.float: 1e-4, torch.double: 1e-6, torch.half: 1e-1})
+    @precisionOverride({torch.float: 1e-4, torch.half: 1e-1})
     @dtypes(torch.float32, torch.half, torch.double, torch.complex64)
     @tf32_on_and_off(0.05)
     def test_addmm(self, device, dtype):
         self._test_addmm_impl(torch.addmm, None, device, dtype)
 
-    @precisionOverride({torch.float: 1e-4, torch.double: 1e-6, torch.half: 1e-1})
+    @precisionOverride({torch.float: 1e-4, torch.half: 1e-1})
     @dtypes(torch.float, torch.half, torch.double)
     def test_addmm_badmm_scalar_tnesor_input(self, device, dtype):
         input = torch.tensor(1).to(device=device, dtype=dtype)
@@ -638,7 +638,7 @@ class TestBasicGEMM(TestCase):
         for b1, b2, ref, out_tensor in generate_tensor():
             self._test_addbmm_baddbmm("addbmm", b1, b2, ref, out_tensor)
 
-    @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.5, torch.float64: 1e-6})
+    @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.5})
     @dtypes(torch.float64, torch.float32, torch.bfloat16, torch.half, torch.complex64)
     @tf32_on_and_off(0.01)
     def test_baddbmm(self, device, dtype):
@@ -908,7 +908,6 @@ class TestBasicGEMM(TestCase):
                 y = torch.baddbmm(input, mat1, mat2, beta=0.0, out=out)
                 self.assertEqual(y_ref, y)
 
-    @precisionOverride({torch.double: 1e-6})
     @dtypes(torch.float, torch.double)
     @tf32_on_and_off(0.005)
     def test_addmm_sizes(self, device, dtype):
@@ -933,7 +932,6 @@ class TestBasicGEMM(TestCase):
 
     @precisionOverride(
         {
-            torch.double: 1e-6,
             torch.float: 1e-4,
             torch.bfloat16: 5e-2,
             torch.half: 5e-2,
@@ -948,7 +946,6 @@ class TestBasicGEMM(TestCase):
 
     @precisionOverride(
         {
-            torch.double: 1e-6,
             torch.float: 1e-4,
             torch.bfloat16: 5e-2,
             torch.half: 5e-2,
@@ -997,7 +994,6 @@ class TestBasicGEMM(TestCase):
 
     @precisionOverride(
         {
-            torch.double: 1e-8,
             torch.float: 1e-4,
             torch.bfloat16: 0.6,
             torch.half: 1e-1,

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -175,6 +175,12 @@ class TestBasicGEMM(TestCase):
         self.assertEqual(res1, res2)
         self.assertEqual(res1, res3)
 
+        # Test inplace versions if they exist.
+        if hasattr(t, f.__name__ + "_"):
+            out_tensor = torch.broadcast_to(t, res1.shape).clone()
+            getattr(out_tensor, f.__name__ + "_")(m, v, alpha=alpha, beta=beta)
+            self.assertEqual(res1, out_tensor)
+
     def _test_addmm_impl(self, func, activation, device, dtype):
         M = torch.randn(10, 25, device="cpu", dtype=torch.float32).to(dtype).to(device)
         m1 = torch.randn(10, 50, device="cpu", dtype=torch.float32).to(dtype).to(device)


### PR DESCRIPTION
Fixes intel/torch-xpu-ops#2269
Fixes intel/torch-xpu-ops#2356
Fixes intel/torch-xpu-ops#2687

The root cause of all the failed test cases from mentioned issues is that float64 type is not properly handled by operators `addmm_out` and `baddbmm_out`.
In their implementations, they both use `onednn::matmul` call with added post operations (`attr.append_post_eltwise` and `attr.append_post_sum`). The problem is that according to my best knowledge, those post operations doesn't support float64. Just basic matrix multiplication of `onednn::matmul` has support for float64. So adding any post operations without possibility to handle float64 results in numerical precision issues.

This PR changes approach to split one `onednn::matmul` call into separate add, multiply by scalar and matrix multiplication operations. They all support float64 thus the results are correct.
This change enforced a little different handling of inplace usage case. For inplace case, the `self (input)` and `result` tensors are the same objects. In the original approach, `onednn::matmul` performed all the operations, so there were no any problems as we passed the `self` and `result` tensors to `matmul` and we got the correct result. When we use `onednn::matmul` just for matrix multiplication and perform scalar multiplication and add operations separately, we cannot use the `self` tensor as it is the same as `result` tensor after `matmul` operation and the `result` contains now the matrix multiplication result. That is why the additional copy for inplace version is needed.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo