### PR TITLE
[Dont review][wip][dynamo] Cache tx

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -912,6 +912,8 @@ class TracingContext:
         self.previously_cleaned_instructions: dict[Any, Any] = dict()
         # Combined cache for inlined code data (instructions, indexof, code_options)
         self.inlined_code_cache: dict[Any, InlinedCodeCache] = dict()
+        # Cache for reusing InliningInstructionTranslator objects across invocations
+        self.inlined_translator_cache: dict[Any, Any] = dict()
         self.fake_mode: FakeTensorMode | None = fake_mode
         self.frame_summary_stack: list[traceback.FrameSummary] = []
         # This is morally part of frame_summary_stack, but it is kept separate
@@ -964,6 +966,7 @@ class TracingContext:
         self.previously_inlined_functions.clear()
         self.previously_cleaned_instructions.clear()
         self.inlined_code_cache.clear()
+        self.inlined_translator_cache.clear()
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174603
* #174598

We create InlineInstructionTranslator object for every inlined frame. However, for frames that are very small but called frequently, creating these translator objects can be more expensive than tracing them. So, we cache the translator objects and then re-init them if we see the same function getting inlined again.

This reduces compile time from 9.3 seconds to 9.0 seconds for an internal model.


UPDATE - Dropping this because 0.3 seconds was just a noise. There is not much difference between reinit and `__init__`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo