### PR TITLE
Support FlexAttention blockmask taking arbitrary callable

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1189,6 +1189,142 @@ def forward(self, args_0):
         with self.assertRaises(TypeError):
             _restore_state_dict(lambda x: x, gm)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_aot_export_blockmask_with_new_closure(self):
+        import contextlib
+
+        from torch._export.utils import _compiling_state_context
+        from torch._functorch.aot_autograd import (
+            aot_compile_joint_with_descriptors,
+            aot_export_joint_with_descriptors,
+        )
+        from torch._guards import tracing as torch_tracing, TracingContext
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            res = 4
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        args = (torch.randn(2, 128, device="cuda"),)
+        gm = dynamo_graph_capture_for_export(Model())(*args)
+
+        fake_mode = gm.meta["fake_mode"]
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(torch_tracing(TracingContext(fake_mode)))
+            stack.enter_context(_compiling_state_context())
+            stack.enter_context(fake_mode)
+
+            joint_with_descriptors = aot_export_joint_with_descriptors(
+                stack,
+                gm,
+                args=args,
+                kwargs={},
+                keep_inference_input_mutations=True,
+            )
+            self.assertExpectedInline(
+                str(joint_with_descriptors.graph_module.code).strip(),
+                """\
+def forward(self, arg0_1):
+    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
+    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
+    add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
+    view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
+    ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
+    expand = torch.ops.aten.expand.default(ge, [1, 64, 64]);  ge = None
+    expand_1 = torch.ops.aten.expand.default(expand, [1, 1, 64, 64]);  expand = None
+    constant_pad_nd = torch.ops.aten.constant_pad_nd.default(expand_1, [0, 64, 0, 64], 0.0);  expand_1 = None
+    view_1 = torch.ops.aten.view.default(constant_pad_nd, [1, 1, 1, 128, 1, 128]);  constant_pad_nd = None
+    permute = torch.ops.aten.permute.default(view_1, [0, 1, 2, 4, 3, 5]);  view_1 = None
+    sum_1 = torch.ops.aten.sum.dim_IntList(permute, [-2, -1]);  permute = None
+    eq = torch.ops.aten.eq.Scalar(sum_1, 16384)
+    gt = torch.ops.aten.gt.Scalar(sum_1, 0)
+    lt = torch.ops.aten.lt.Scalar(sum_1, 16384);  sum_1 = None
+    bitwise_and = torch.ops.aten.bitwise_and.Tensor(gt, lt);  gt = lt = None
+    _to_copy = torch.ops.aten._to_copy.default(bitwise_and, dtype = torch.int8);  bitwise_and = None
+    _to_copy_1 = torch.ops.aten._to_copy.default(eq, dtype = torch.int8);  eq = None
+    _to_copy_2 = torch.ops.aten._to_copy.default(_to_copy, dtype = torch.int32);  _to_copy = None
+    sum_2 = torch.ops.aten.sum.dim_IntList(_to_copy_2, [-1])
+    sort = torch.ops.aten.sort.stable(_to_copy_2, stable = True, descending = True);  _to_copy_2 = None
+    getitem_1 = sort[1];  sort = None
+    _to_copy_3 = torch.ops.aten._to_copy.default(sum_2, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_2 = None
+    _to_copy_4 = torch.ops.aten._to_copy.default(getitem_1, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_1 = None
+    _to_copy_5 = torch.ops.aten._to_copy.default(_to_copy_1, dtype = torch.int32);  _to_copy_1 = None
+    sum_3 = torch.ops.aten.sum.dim_IntList(_to_copy_5, [-1])
+    sort_1 = torch.ops.aten.sort.stable(_to_copy_5, stable = True, descending = True);  _to_copy_5 = None
+    getitem_3 = sort_1[1];  sort_1 = None
+    _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
+    _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
+    new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
+    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
+    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_1 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
+    lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_1);  arange_5 = unsqueeze_1 = None
+    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
+    where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
+    new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
+    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
+    unsqueeze_3 = torch.ops.aten.unsqueeze.default(unsqueeze_2, -1);  unsqueeze_2 = None
+    view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
+    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
+    unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
+    unsqueeze_6 = torch.ops.aten.unsqueeze.default(unsqueeze_5, -1);  unsqueeze_5 = None
+    index_put = torch.ops.aten.index_put.default(new_zeros, [unsqueeze_6, unsqueeze_3, unsqueeze, where], view_2);  new_zeros = unsqueeze_6 = unsqueeze_3 = unsqueeze = where = view_2 = None
+    slice_3 = torch.ops.aten.slice.Tensor(index_put, 3, 0, 1);  index_put = None
+    transpose_1 = torch.ops.aten.transpose.int(slice_3, -2, -1);  slice_3 = None
+    sum_4 = torch.ops.aten.sum.dim_IntList(transpose_1, [-1])
+    sort_2 = torch.ops.aten.sort.stable(transpose_1, stable = True, descending = True);  transpose_1 = None
+    getitem_5 = sort_2[1];  sort_2 = None
+    _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
+    _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
+    new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
+    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_7 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
+    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_8 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
+    lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_8);  arange_9 = unsqueeze_8 = None
+    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
+    where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
+    new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
+    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
+    unsqueeze_10 = torch.ops.aten.unsqueeze.default(unsqueeze_9, -1);  unsqueeze_9 = None
+    view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
+    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
+    unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
+    unsqueeze_13 = torch.ops.aten.unsqueeze.default(unsqueeze_12, -1);  unsqueeze_12 = None
+    index_put_1 = torch.ops.aten.index_put.default(new_zeros_1, [unsqueeze_13, unsqueeze_10, unsqueeze_7, where_1], view_3);  new_zeros_1 = unsqueeze_13 = unsqueeze_10 = unsqueeze_7 = where_1 = view_3 = None
+    slice_6 = torch.ops.aten.slice.Tensor(index_put_1, 3, 0, 1);  index_put_1 = None
+    transpose_3 = torch.ops.aten.transpose.int(slice_6, -2, -1);  slice_6 = None
+    sum_5 = torch.ops.aten.sum.dim_IntList(transpose_3, [-1])
+    sort_3 = torch.ops.aten.sort.stable(transpose_3, stable = True, descending = True);  transpose_3 = None
+    getitem_7 = sort_3[1];  sort_3 = None
+    _to_copy_10 = torch.ops.aten._to_copy.default(sum_5, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_5 = None
+    _to_copy_11 = torch.ops.aten._to_copy.default(getitem_7, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_7 = None
+    return (arg0_1, _to_copy_3, _to_copy_4, _to_copy_6, _to_copy_7, _to_copy_8, _to_copy_9, _to_copy_10, _to_copy_11)""",
+            )
+
+            compiled_fn = aot_compile_joint_with_descriptors(joint_with_descriptors)
+            # Shouldn't crash
+            self.assertIsNotNone(compiled_fn)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1165,6 +1165,25 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return self.value
             # TODO else try reconstructing the object by, e.g., leveraging side
             # effects and `as_python_constant`.
+
+        # Special case for _MaskModWrapper during legacy export: reconstruct from
+        # tracked attributes since Dynamo creates objects via __new__ without
+        # calling __init__. This path is not really important but we shouldn't
+        # break existing cases
+        from torch.nn.attention.flex_attention import _MaskModWrapper
+
+        if isinstance(self.value, _MaskModWrapper):
+            from torch._dynamo.symbolic_convert import InstructionTranslator
+
+            tx = InstructionTranslator.current_tx()
+            if tx is not None and tx.export:
+                fn_vt = tx.output.side_effects.load_attr(self, "fn", deleted_ok=True)
+                if fn_vt is not None:
+                    # Let as_python_constant() raise the proper exception
+                    # (e.g., ClosureConversionError for non-constant closures)
+                    fn = fn_vt.as_python_constant()
+                    return _MaskModWrapper(fn)
+
         return super().as_python_constant()
 
     def guard_as_python_constant(self) -> object:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1166,10 +1166,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             # TODO else try reconstructing the object by, e.g., leveraging side
             # effects and `as_python_constant`.
 
-        # Special case for _MaskModWrapper during legacy export: reconstruct from
-        # tracked attributes since Dynamo creates objects via __new__ without
-        # calling __init__. This path is not really important but we shouldn't
-        # break existing cases
+        # Special case for _MaskModWrapper during legacy export: Dynamo creates
+        # objects via __new__ without calling __init__, so self.value.fn is unset.
+        # Reconstruct from the tracked side-effect attribute instead.
         from torch.nn.attention.flex_attention import _MaskModWrapper
 
         if isinstance(self.value, _MaskModWrapper):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174610

There is an interesting use case I need to call out here: 

FlexAttention BlockMask's pytree registration contains arbitrary user defined mask_mod function. This gets problematic when we are exporting via dynamo_graph_capture_for_export because we re-run the model code multiple times where the output bytecode contains a logic to reconstruct user defined mask_mod. This doesn't work with aot_export's pytree thunkify logic as it would receive an spec that has different id for the mask_mod (because we reconstructed multiple times). This was not a problem for torch.compile because we always just re-run the inner graph module without inp/out processing. I think this is a result of our independent API's working correctly but the integration point between them is little awkward. (torch IR API + aot_autograd) 


The way we fix it is we wrap the user defined function with _MaskMod wrapper that does value based checking instead of identity so that two different reconstructions of mask_mod still returns True. I had to special case _MaskMod for the old export path since torch.export.export is still on the _dynamo_graph_capture_for_export. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo