### PR TITLE
[DTensor] Optimize redistribute comms using flattened meshes

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1476,6 +1476,43 @@ class outer_fn(torch.nn.Module):
             f"Expected 1 compilation, got {compile_counter.frame_count}",
         )
 
+    def test_compile_redistribute_flattened_mesh(self):
+        """
+        Test that redistribute works with pre-flattened meshes during compile.
+
+        When redistributing from [Shard, Shard, Replicate] to [Replicate, Replicate, Replicate]
+        on a 3D mesh, DTensor can optimize by using a single all-gather on the flattened
+        mesh instead of 2 sequential all-gathers. This requires the flattened mesh to be
+        pre-created before compile to avoid tracing issues.
+        """
+        dist.destroy_process_group()
+        dist.init_process_group("fake", store=FakeStore(), rank=0, world_size=8)
+
+        mesh = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("fsdp", "cp", "tp")
+        )
+        # Pre-create flattened mesh for fsdp+cp before compile
+        mesh["fsdp", "cp"]._flatten()
+
+        def redistribute_fn(x):
+            return x.redistribute(placements=[Replicate(), Replicate(), Replicate()])
+
+        input_dt = DTensor.from_local(
+            torch.randn(4, 8, device=self.device_type, requires_grad=True),
+            device_mesh=mesh,
+            placements=[Shard(0), Shard(0), Replicate()],
+            run_check=False,
+        )
+
+        compiled_fn = torch.compile(
+            redistribute_fn, fullgraph=True, backend="aot_eager"
+        )
+        result = compiled_fn(input_dt)
+        self.assertEqual(result.placements, (Replicate(), Replicate(), Replicate()))
+
+        # Test backward pass
+        result.sum().backward()
+
 
 @instantiate_parametrized_tests
 class TestDTensorCompileE2E(DTensorTestBase):

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -3,10 +3,13 @@
 
 import contextlib
 import itertools
+import logging
 import random
 import unittest
+from unittest.mock import patch
 
 import torch
+import torch.distributed as dist
 from torch.distributed._local_tensor import (
     maybe_disable_local_tensor_mode,
     maybe_run_for_local_tensor,
@@ -30,7 +33,11 @@ from torch.distributed.tensor._dtensor_spec import (
     TensorMeta,
 )
 from torch.distributed.tensor._redistribute import (
+    _FlattenedTransformInfo,
     _gen_transform_infos,
+    _optimize_transform_infos,
+    _TransformInfo,
+    disable_redistribute_transform_optimization,
     redistribute_local_tensor,
     use_min_cost_redistribution_plan,
 )
@@ -41,6 +48,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -1480,6 +1488,154 @@ class DistributeWithDeviceOrderTest(DTensorTestBase):
         )
         self.assertEqual(x_ordered_dt.to_local(), x_strided_dt.to_local())
 
+    @with_comms
+    def test_ordered_all_gather_with_flattening(self):
+        """Test that flattened all_gather produces correct results with non-ascending shard order.
+
+        This test verifies that when we have a tensor sharded with non-ascending order
+        and redistribute to fully replicated, the flattened all_gather optimization
+        correctly avoids flattening (which would produce wrong results).
+        """
+        torch.manual_seed(42)
+
+        # Create a 3D mesh with all flattened submeshes
+        mesh = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("A", "B", "C")
+        )
+        mesh["A", "B"]._flatten("A_B")
+        mesh["A", "C"]._flatten("A_C")
+        mesh["B", "C"]._flatten("B_C")
+        mesh["A", "B", "C"]._flatten("A_B_C")
+
+        input_data = torch.randn((8, 8, 8), device=self.device_type)
+
+        comm_mode = CommDebugMode()
+
+        # Test case 1: ascending order (baseline - can use flattened all_gather)
+        # With ascending shard order, flattening should occur, resulting in fewer all_gathers
+        ascending_src = _distribute_tensor(
+            input_data.clone(),
+            mesh,
+            [Shard(0), Shard(0), Shard(0)],
+            shard_order=(ShardOrderEntry(tensor_dim=0, mesh_dims=(0, 1, 2)),),
+        )
+        with comm_mode:
+            ascending_result = redistribute(
+                ascending_src,
+                mesh,
+                [Replicate(), Replicate(), Replicate()],
+                shard_order=(),
+            )
+        ascending_all_gather_count = comm_mode.get_comm_counts()[
+            funcol.all_gather_into_tensor
+        ]
+        # With flattening: all 3 mesh dims are flattened into 1 all_gather
+        # (A_B_C flattened mesh enables single operation)
+        self.assertEqual(
+            ascending_all_gather_count,
+            1,
+            f"ascending order: expected 1 all_gather (with full flattening), got {ascending_all_gather_count}",
+        )
+
+        # Test case 2: non-ascending order (1, 0, 2) - should NOT use flattened all_gather
+        # Individual all_gathers should be used for correctness
+        non_ascending_src = _distribute_tensor(
+            input_data.clone(),
+            mesh,
+            [Shard(0), Shard(0), Shard(0)],
+            shard_order=(ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0, 2)),),
+        )
+        with comm_mode:
+            non_ascending_result = redistribute(
+                non_ascending_src,
+                mesh,
+                [Replicate(), Replicate(), Replicate()],
+                shard_order=(),
+            )
+        non_ascending_all_gather_count = comm_mode.get_comm_counts()[
+            funcol.all_gather_into_tensor
+        ]
+        # Without flattening: 3 individual all_gathers (one per mesh dim)
+        self.assertEqual(
+            non_ascending_all_gather_count,
+            3,
+            f"non-ascending order: expected 3 all_gathers (no flattening), got {non_ascending_all_gather_count}",
+        )
+
+        # Both should produce the same fully replicated tensor
+        self.assertEqual(ascending_result.to_local(), non_ascending_result.to_local())
+
+        # Verify the results are correct by comparing with the original input
+        self.assertEqual(ascending_result.to_local(), input_data)
+        self.assertEqual(non_ascending_result.to_local(), input_data)
+
+    @with_comms
+    def test_debug_mode_shows_optimized_trace(self):
+        """Test that DebugMode captures the optimized (flattened) redistribution trace.
+
+        This verifies that debug_mode.record_redistribute_calls receives the
+        optimized transform_infos, not the unoptimized ones.
+        """
+        torch.manual_seed(42)
+
+        # Create a 2D mesh with flattened submesh
+        mesh = init_device_mesh(self.device_type, (4, 2), mesh_dim_names=("A", "B"))
+        mesh["A", "B"]._flatten("A_B")
+
+        input_data = torch.randn((8, 8), device=self.device_type)
+
+        # Create a tensor sharded on both mesh dims with ascending order
+        sharded_src = _distribute_tensor(
+            input_data.clone(),
+            mesh,
+            [Shard(0), Shard(0)],
+            shard_order=(ShardOrderEntry(tensor_dim=0, mesh_dims=(0, 1)),),
+        )
+
+        # Capture the debug trace during redistribution to fully replicated
+        with DebugMode(record_torchfunction=False) as debug_mode:
+            result = redistribute(
+                sharded_src,
+                mesh,
+                [Replicate(), Replicate()],
+                shard_order=(),
+            )
+
+        trace_str = self._extract_redistribute_trace_from_debug_mode(
+            debug_mode.debug_string()
+        )
+
+        import torch.distributed as dist
+
+        if dist.get_rank() == 0:
+            print(f"\nDebug trace: {trace_str}")
+
+        # The trace should show the OPTIMIZED redistribution:
+        # S(0)[0]S(0)[1]-->RR (single flattened all_gather, note double arrow)
+        # Not: S(0)[0]S(0)[1]->S(0)R->RR (two separate all_gathers)
+
+        # Verify '-->' is used for the flattened transform
+        self.assertIn(
+            "-->",
+            trace_str,
+            "Debug trace should use '-->' to indicate flattened/optimized transform",
+        )
+
+        # The optimized trace should NOT contain an intermediate S(0)R state
+        self.assertNotIn(
+            "S(0)R",
+            trace_str,
+            "Debug trace should show optimized (flattened) redistribution, "
+            "not unoptimized individual all_gathers",
+        )
+
+        # Verify the expected optimized trace format: S(0)[0]S(0)[1]-->RR
+        self.assertIn("S(0)[0]S(0)[1]", trace_str)
+        self.assertIn("RR", trace_str)
+
+        # Verify correctness
+        self.assertEqual(result.to_local(), input_data)
+
 
 class DistributeWithStridedShardTest(DTensorTestBase):
     @property
@@ -1565,17 +1721,17 @@ class DistributeWithStridedShardTest(DTensorTestBase):
             if idx == 0:
                 self.assertExpectedInline(
                     trace_str,
-                    """S(0)[0]S(0)[1]_S(0, 3)->S(0)[0]S(0)[1]R->S(0)[0]RR->RRR->RS(0)[1]R->RS(0)[1]S(0)[2]""",  # noqa: B950
+                    """S(0)[0]S(0)[1]_S(0, 3)[2]->S(0)[0]S(0)[1]R->S(0)RR->RRR->RS(0)R->RS(0)[0]S(0)[1]""",  # noqa: B950
                 )
             elif idx == 1:
                 self.assertExpectedInline(
                     trace_str,
-                    """S(0)[1]S(0)[0]S(0)[2]->S(0)[1]S(0)[0]R->RS(0)R->RS(0)_S(0, 3)""",
+                    """S(0)[1]S(0)[0]S(0)[2]->S(0)[1]S(0)[0]R->RS(0)R->RS(0)[0]_S(0, 3)[1]""",
                 )
             elif idx == 2:
                 self.assertExpectedInline(
                     trace_str,
-                    """S(0)[1]_S(0, 3)S(0)[2]->S(0)[1]_S(0, 3)R->S(0)[1]RR->RRR->_S(0, 3)RR->_S(0, 3)S(0)[0]R""",
+                    """S(0)[0]_S(0, 3)[1]S(0)[2]->S(0)[0]_S(0, 3)[1]R->S(0)RR->RRR->_S(0, 3)RR->_S(0, 3)[0]S(0)[1]R""",
                 )
             elif idx == 3:
                 self.assertExpectedInline(
@@ -1592,6 +1748,1095 @@ class DistributeWithStridedShardTest(DTensorTestBase):
             self.assertEqual(sharded_dt.to_local(), expected_dt.to_local())
 
 
+class TransformInfoTest(TestCase):
+    """Tests for _TransformInfo._comm_type_key method."""
+
+    def test_comm_type_key(self):
+        """Test _comm_type_key returns correct keys for different placement transforms."""
+        # Comm ops: return comm type string
+        test_cases = [
+            ((Partial("sum"), Replicate()), "all_reduce"),
+            ((Partial("max"), Replicate()), "all_reduce"),
+            ((Partial("sum"), Shard(0)), "reduce_scatter"),
+            ((Shard(0), Replicate()), "all_gather"),
+            ((Shard(0), Shard(1)), "all_to_all"),
+        ]
+        for placements, expected_key in test_cases:
+            info = _TransformInfo(0, placements, [8, 8])
+            self.assertEqual(info._comm_type_key(), expected_key)
+
+        # Local ops: return None
+        local_cases = [
+            (Replicate(), Shard(0)),  # local split
+            (Replicate(), Partial("sum")),  # local partition
+            # Note: (Replicate(), Replicate()) is a no-op and _TransformInfo
+            # rejects no-ops in __post_init__, so we don't test it here
+        ]
+        for placements in local_cases:
+            info = _TransformInfo(0, placements, [8, 8])
+            self.assertIsNone(info._comm_type_key())
+
+
+class OptimizeFlattenedReductionsTest(TestCase):
+    """Tests for _optimize_transform_infos helper.
+
+    Uses fake process group since these tests don't perform actual communications.
+    """
+
+    def setUp(self):
+        super().setUp()
+        store = dist.HashStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=8, store=store)
+
+    def tearDown(self):
+        super().tearDown()
+        dist.destroy_process_group()
+
+    def test_no_flattened_mesh_returns_original(self):
+        """When no flattened mesh exists, original transforms are returned with a warning."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=2,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        # Use a fresh warning cache to avoid global side effects
+        with patch(
+            "torch.distributed.tensor._redistribute._warned_flatten_issues",
+            new=set(),
+        ):
+            with self.assertLogs(
+                "torch.distributed.tensor._redistribute", level=logging.WARNING
+            ) as log_context:
+                src_placements = (Partial("sum"), Replicate(), Partial("sum"))
+                dst_placements = (Replicate(), Replicate(), Replicate())
+                result = _optimize_transform_infos(
+                    transform_infos, mesh, src_placements, dst_placements
+                )
+
+            self.assertEqual(len(result), 2)
+            self.assertTrue(all(isinstance(r, _TransformInfo) for r in result))
+
+            # Verify warning message content
+            self.assertEqual(len(log_context.output), 1)
+            warning_msg = log_context.output[0]
+            self.assertIn("While redistributing from", warning_msg)
+            self.assertIn("Partial(sum)", warning_msg)  # src placement
+            self.assertIn("Replicate()", warning_msg)  # dst placement
+            self.assertIn("2 sequential", warning_msg)  # number of ops
+            self.assertIn("all_reduce", warning_msg)  # comm type
+            self.assertIn('"A"', warning_msg)  # mesh dim name
+            self.assertIn('"C"', warning_msg)  # mesh dim name
+            self.assertIn("suboptimal", warning_msg)
+
+            # Verify warning is only issued once for same mesh dims
+            with self.assertNoLogs(
+                "torch.distributed.tensor._redistribute", level=logging.WARNING
+            ):
+                _optimize_transform_infos(
+                    transform_infos, mesh, src_placements, dst_placements
+                )
+
+    def test_consecutive_reductions_flattened(self):
+        """Consecutive same-type reductions on consecutive mesh dims are flattened."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "B"]._flatten("A_B")
+
+        # Dims 0 and 1 are consecutive
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Partial("sum"), Replicate()),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+        self.assertEqual(result[0].original_mesh_dims, (0, 1))
+
+    def test_non_consecutive_dims_not_merged(self):
+        """Reductions on dims 0 and 2 with different op on dim 1 are NOT merged.
+
+        Only consecutive same-type operations are merged to preserve correctness.
+        Reordering operations can produce wrong results.
+        """
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "C"]._flatten("A_C")
+
+        # Shard on dim 1 is being transformed to Replicate
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Shard(0), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=2,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Shard(0), Partial("sum")),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        # Non-consecutive allreduces should NOT be merged (would change order)
+        self.assertEqual(len(result), 3)
+        self.assertTrue(all(isinstance(r, _TransformInfo) for r in result))
+
+    def test_all_dims_flattened(self):
+        """All dims with same reduce_op are flattened when full mesh exists."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "B", "C"]._flatten("A_B_C")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=2,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Partial("sum"), Partial("sum")),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+        self.assertEqual(result[0].original_mesh_dims, (0, 1, 2))
+
+    def test_single_reduction_not_flattened(self):
+        """A single reduction is not flattened even if mesh exists."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "C"]._flatten("A_C")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Replicate(), Replicate()),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _TransformInfo)
+
+    def test_redistribute_with_submesh_flattened(self):
+        """Test that redistribute works correctly with a flattened submesh.
+
+        This exercises _get_flattened_mesh_by_layout through the public
+        DTensor.redistribute() API, ensuring mesh_dims are correctly
+        interpreted relative to the submesh, not the root mesh.
+        """
+        root_mesh = init_device_mesh(
+            "cpu", (2, 2, 1, 2), mesh_dim_names=("dp", "fsdp", "cp", "ep")
+        )
+
+        submesh = root_mesh["cp", "ep"]
+        submesh._flatten("cp_ep")
+
+        local_tensor = torch.randn(8)
+        dtensor = DTensor.from_local(
+            local_tensor, submesh, [Partial("sum"), Partial("sum")]
+        )
+
+        result = dtensor.redistribute(submesh, [Replicate(), Replicate()])
+
+        self.assertEqual(result.placements, (Replicate(), Replicate()))
+
+    def test_reduce_scatter_with_intervening_shard_flattened(self):
+        """Reduce-scatter SHOULD be flattened when intervening shard still allows even division.
+
+        Scenario:
+        - Tensor shape: (8,)
+        - Mesh: (2, 4, 1) with dims A, B, C
+        - src_placements: (Partial, S(0), Partial)
+        - dst_placements: (S(0), S(0), S(0))
+
+        Transforms: dims 0 and 2 are Partial->S(0), dim 1 is S(0)->S(0) (no-op)
+
+        The intervening shard on dim 1 (size 4) means logical_shape = 8/4 = 2.
+        Flattened mesh for dims 0 and 2 has size 2*1 = 2.
+        2 % 2 == 0, so flattening SHOULD be allowed.
+
+        This catches a bug where effective_shard_mesh_size incorrectly includes
+        the intervening shard (dim 1), computing 2*4*1=8 instead of 2, and
+        incorrectly rejecting flattening because 2 % 8 != 0.
+
+        The intervening shard is already accounted for in logical_shape, so it
+        should NOT be double-counted in effective_shard_mesh_size.
+        """
+        mesh = init_device_mesh("cpu", (2, 4, 1), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "C"]._flatten("A_C")
+
+        # Transforms only for dims where src != dst (dim 1 is S(0)->S(0), no transform)
+        # logical_shape = [2] because tensor is already sharded on dim 1 (8/4=2)
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[2],
+            ),
+            _TransformInfo(
+                mesh_dim=2,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[2],
+            ),
+        ]
+
+        src_placements = (Partial("sum"), Shard(0), Partial("sum"))
+        dst_placements = (Shard(0), Shard(0), Shard(0))
+
+        result = _optimize_transform_infos(
+            transform_infos, mesh, src_placements, dst_placements
+        )
+
+        # effective_shard_mesh_size should only count dims being transformed (0 and 2),
+        # giving 2*1=2. Since 2 % 2 == 0, flattening should succeed.
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+
+    def test_reduce_scatter_with_prior_shard_flattened(self):
+        """Reduce-scatter should be flattened when prior shard is already in logical_shape.
+
+        Scenario:
+        - Tensor shape: (24,)
+        - Mesh: (2, 2, 2) with dims A, B, C
+        - src_placements: (Shard(0), Partial, Partial)
+        - dst_placements: (Shard(0), Shard(0), Shard(0))
+
+        Transforms: dims 1 and 2 are Partial->S(0), dim 0 is S(0)->S(0) (no-op)
+
+        The outermost transform is on mesh_dim=1, with logical_shape=[12]
+        (already reduced from global 24 by dim 0's shard).
+
+        effective_shard_mesh_size should only include dims >= 1, so = 2*2 = 4.
+        12 % 4 == 0, so flattening should be ALLOWED.
+        """
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["B", "C"]._flatten("B_C")
+
+        # Transforms only for dims where src != dst (dim 0 is S(0)->S(0), no transform)
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[12],  # after dim 0's shard (24/2=12)
+            ),
+            _TransformInfo(
+                mesh_dim=2,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[12],  # same, since dim 1 is Partial
+            ),
+        ]
+
+        src_placements = (Shard(0), Partial("sum"), Partial("sum"))
+        dst_placements = (Shard(0), Shard(0), Shard(0))
+
+        result = _optimize_transform_infos(
+            transform_infos, mesh, src_placements, dst_placements
+        )
+
+        # Should be flattened: 12 % 4 == 0
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+        self.assertEqual(result[0].original_mesh_dims, (1, 2))
+
+    def test_uneven_tensor_shape_returns_original_with_warning(self):
+        """When tensor dim is not evenly divisible by flattened mesh, originals returned with warning.
+
+        Scenario:
+        - Tensor shape: (10,) on dim 0
+        - Mesh: (2, 3) with dims A, B - flattened size = 6
+        - src_placements: (Partial, Partial)
+        - dst_placements: (Shard(0), Shard(0))
+
+        This is a reduce_scatter where tensor_dim_size (10) % effective_shard_mesh_size (6) != 0.
+        Flattening would produce incorrect results, so it should be rejected with a warning.
+        """
+        mesh = init_device_mesh("cpu", (2, 3), mesh_dim_names=("A", "B"))
+        mesh["A", "B"]._flatten("A_B")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[10],  # Not evenly divisible by 6
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[10],
+            ),
+        ]
+
+        src_placements = (Partial("sum"), Partial("sum"))
+        dst_placements = (Shard(0), Shard(0))
+
+        # Use a fresh warning cache to avoid global side effects
+        with patch(
+            "torch.distributed.tensor._redistribute._warned_flatten_issues",
+            new=set(),
+        ):
+            with self.assertLogs(
+                "torch.distributed.tensor._redistribute", level=logging.WARNING
+            ) as log_context:
+                result = _optimize_transform_infos(
+                    transform_infos, mesh, src_placements, dst_placements
+                )
+
+            # Should NOT be flattened: 10 % 6 != 0
+            self.assertEqual(len(result), 2)
+            self.assertTrue(all(isinstance(r, _TransformInfo) for r in result))
+
+            # Verify warning message content - specific to uneven tensor shape
+            self.assertEqual(len(log_context.output), 1)
+            warning_msg = log_context.output[0]
+            self.assertIn("While redistributing from", warning_msg)
+            self.assertIn("reduce_scatter", warning_msg)
+            self.assertIn("not evenly divisible", warning_msg)
+
+    def test_empty_input(self):
+        """Empty input returns empty output."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+
+        result = _optimize_transform_infos(
+            [],
+            mesh,
+            (Replicate(), Replicate(), Replicate()),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        self.assertEqual(result, [])
+
+    def test_all_gathers_grouped(self):
+        """Multiple all-gather operations are grouped and flattened."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "B"]._flatten("A_B")
+
+        # we simulate all-gather applied to a DTensor with S0S0 placement in default
+        # left-to-right order.
+        # This means we all-gather in reverse (right-to-left) order.
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Shard(0), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Shard(0), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Shard(0), Shard(0), Replicate()),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+        self.assertEqual(result[0].original_mesh_dims, (0, 1))
+
+    def test_mixed_collective_types_not_grouped(self):
+        """Different collective types (allreduce vs all-gather) are not grouped."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "B"]._flatten("A_B")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),  # allreduce
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Shard(0), Replicate()),  # all-gather
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Shard(0), Replicate()),
+            (Replicate(), Replicate(), Replicate()),
+        )
+
+        # Should remain as 2 separate transforms since collective types differ
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(r, _TransformInfo) for r in result))
+
+    def test_mixed_sum_avg_partial_types_merged_allreduce(self):
+        """Mixed Partial types (sum vs avg) SHOULD be grouped for allreduce.
+
+        When redistributing (Partial("sum"), Partial("avg")) -> (Replicate, Replicate),
+        the all-reduce operations can be merged since both use sum reduction internally
+        (avg applies scaling after the sum).
+        """
+        mesh = init_device_mesh("cpu", (2, 2), mesh_dim_names=("A", "B"))
+        mesh["A", "B"]._flatten("A_B")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("avg"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Partial("avg")),
+            (Replicate(), Replicate()),
+        )
+
+        # Should be merged into 1 flattened transform since sum/avg can be combined
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+
+    def test_mixed_sum_avg_partial_types_merged_reduce_scatter(self):
+        """Mixed Partial types (sum vs avg) SHOULD be grouped for reduce_scatter.
+
+        When redistributing (Partial("sum"), Partial("avg")) -> (Shard(0), Shard(0)),
+        the reduce-scatter operations can be merged since both use sum reduction internally
+        (avg applies scaling after the sum).
+        """
+        mesh = init_device_mesh("cpu", (2, 2), mesh_dim_names=("A", "B"))
+        mesh["A", "B"]._flatten("A_B")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("avg"), Shard(0)),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        result = _optimize_transform_infos(
+            transform_infos,
+            mesh,
+            (Partial("sum"), Partial("avg")),
+            (Shard(0), Shard(0)),
+        )
+
+        # Should be merged into 1 flattened transform since sum/avg can be combined
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+
+    def test_reduce_scatter_ordering_uses_transform_order(self):
+        """Flattened mesh order must match transform_infos order for reduce_scatter.
+
+        When transform_infos are in order (1, 0) - i.e., mesh_dim=1 first, then
+        mesh_dim=0 - the flattened mesh must use the same ordering. Otherwise,
+        elements end up on wrong ranks.
+
+        With mesh (2, 4):
+        - Transforms in order (0, 1): Row-major distribution
+        - Transforms in order (1, 0): Column-major distribution
+
+        Currently, the code SORTS mesh dims, so (1, 0) transforms get flattened
+        using (0, 1) mesh - which is INCORRECT. This test exposes the bug.
+        """
+        mesh = init_device_mesh("cpu", (2, 4), mesh_dim_names=("A", "B"))
+        mesh["A", "B"]._flatten("A_B")  # Only (0, 1) order available
+
+        # Transform infos in REVERSED order: mesh_dim=1 first, then mesh_dim=0
+        transform_infos_reversed = [
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[16],
+            ),
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Shard(0)),
+                logical_shape=[4],  # After first reduce_scatter: 16/4=4
+            ),
+        ]
+
+        # Use a fresh warning cache to avoid global side effects
+        with patch(
+            "torch.distributed.tensor._redistribute._warned_flatten_issues",
+            new=set(),
+        ):
+            with self.assertLogs(
+                "torch.distributed.tensor._redistribute", level=logging.WARNING
+            ) as log_context:
+                result = _optimize_transform_infos(
+                    transform_infos_reversed,
+                    mesh,
+                    (Partial("sum"), Partial("sum")),
+                    (Shard(0), Shard(0)),
+                )
+
+            # we do not flatten due to non-ascending order
+            self.assertEqual(len(result), 2)
+
+            # Verify warning message content
+            self.assertEqual(len(log_context.output), 1)
+            warning_msg = log_context.output[0]
+            self.assertIn("non-ascending order", warning_msg)
+            self.assertIn("reduce_scatter", warning_msg)
+
+    def test_disable_optimization_context_manager(self):
+        """The disable_redistribute_transform_optimization context manager prevents merging."""
+        mesh = init_device_mesh("cpu", (2, 2, 2), mesh_dim_names=("A", "B", "C"))
+        mesh["A", "B"]._flatten("A_B")
+
+        transform_infos = [
+            _TransformInfo(
+                mesh_dim=0,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+            _TransformInfo(
+                mesh_dim=1,
+                src_dst_placements=(Partial("sum"), Replicate()),
+                logical_shape=[8, 8],
+            ),
+        ]
+
+        src_placements = (Partial("sum"), Partial("sum"), Replicate())
+        dst_placements = (Replicate(), Replicate(), Replicate())
+
+        # Without the kill switch, transforms should be merged into one flattened op.
+        result = _optimize_transform_infos(
+            transform_infos, mesh, src_placements, dst_placements
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+
+        # With the kill switch, the original transforms should be returned as-is.
+        with disable_redistribute_transform_optimization():
+            result = _optimize_transform_infos(
+                transform_infos, mesh, src_placements, dst_placements
+            )
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(r, _TransformInfo) for r in result))
+        self.assertIs(result[0], transform_infos[0])
+        self.assertIs(result[1], transform_infos[1])
+
+        # After exiting the context manager, optimization should be restored.
+        result = _optimize_transform_infos(
+            transform_infos, mesh, src_placements, dst_placements
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], _FlattenedTransformInfo)
+
+
+class MultiDimRedistributeOptimizationTest(DTensorTestBase):
+    """Integration tests for multi-dimensional redistribute correctness and optimization.
+
+    These tests verify numerical correctness of various redistribute patterns
+    on multi-dimensional meshes, including the flattened mesh optimization.
+    """
+
+    @property
+    def world_size(self):
+        return 8
+
+    @with_comms
+    def test_multi_dim_redistribute(self):
+        """Test various redistribute patterns for correctness and comm count optimization.
+
+        Each test case is: (mesh_shape, flattened_dims, src_placements, dst_placements, expected_comm_counts)
+        - mesh_shape: tuple of mesh dimensions
+        - flattened_dims: list of tuples of dims to flatten, e.g., [("A", "B")] or None
+        - src_placements: source placements
+        - dst_placements: target placements
+        - expected_comm_counts: dict of {collective_op: count} for verification
+        """
+        # Pre-create meshes to avoid repeated init_device_mesh overhead
+        mesh_2d = init_device_mesh(self.device_type, (4, 2), mesh_dim_names=("A", "B"))
+        mesh_2d["A", "B"]._flatten("A_B")
+
+        mesh_3d = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("A", "B", "C")
+        )
+        mesh_3d["A", "B"]._flatten("A_B")
+        mesh_3d["A", "C"]._flatten("A_C")
+        mesh_3d["A", "B", "C"]._flatten("A_B_C")
+
+        # Define test cases: (mesh, src_placements, dst_placements, expected_comm_counts, desc)
+        test_cases = [
+            # ===== 2D mesh cases =====
+            (
+                mesh_2d,
+                (Partial("sum"), Partial("sum")),
+                (Replicate(), Replicate()),
+                {funcol.all_reduce: 1},
+                "2 allreduces merged to 1",
+            ),
+            (
+                mesh_2d,
+                (Partial("sum"), Partial("sum")),
+                (Shard(0), Shard(0)),
+                {funcol.reduce_scatter_tensor: 1},
+                "nested reduce_scatter",
+            ),
+            (
+                mesh_2d,
+                (Partial("sum"), Partial("sum")),
+                (Shard(0), Shard(1)),
+                {funcol.reduce_scatter_tensor: 2},
+                "reduce_scatter to different dims",
+            ),
+            (
+                mesh_2d,
+                (Shard(0), Shard(0)),
+                (Replicate(), Replicate()),
+                {funcol.all_gather_into_tensor: 1},
+                "2 allgathers nested",
+            ),
+            (
+                mesh_2d,
+                (Shard(0), Shard(1)),
+                (Replicate(), Replicate()),
+                {funcol.all_gather_into_tensor: 2},
+                "2 separate allgathers",
+            ),
+            # ===== 3D mesh cases =====
+            (
+                mesh_3d,
+                (Partial("sum"), Partial("sum"), Shard(0)),
+                (Shard(0), Shard(0), Shard(0)),
+                {
+                    funcol.reduce_scatter_tensor: 1,
+                    funcol.all_reduce: 1,
+                    funcol.all_gather_into_tensor: 1,
+                },
+                "Partial,Partial,Shard -> Shard,Shard,Shard",
+            ),
+            (
+                mesh_3d,
+                (Partial("sum"), Partial("sum"), Partial("sum")),
+                (Replicate(), Replicate(), Replicate()),
+                {funcol.all_reduce: 1},
+                "3 allreduces merged to 1",
+            ),
+            (
+                mesh_3d,
+                (Partial("sum"), Shard(0), Partial("sum")),
+                (Replicate(), Replicate(), Replicate()),
+                {funcol.all_reduce: 2, funcol.all_gather_into_tensor: 1},
+                "non-consecutive allreduces with shard in between",
+            ),
+            (
+                mesh_3d,
+                (Partial("sum"), Replicate(), Partial("sum")),
+                (Replicate(), Replicate(), Replicate()),
+                {funcol.all_reduce: 1},
+                "non-consecutive allreduces with replica in between",
+            ),
+            (
+                mesh_3d,
+                (Partial("sum"), Partial("sum"), Replicate()),
+                (Shard(0), Shard(1), Replicate()),
+                {funcol.reduce_scatter_tensor: 2},
+                "reduce_scatter with Replicate unchanged",
+            ),
+            (
+                mesh_3d,
+                (Partial("sum"), Partial("sum"), Partial("sum")),
+                (Shard(0), Shard(0), Shard(1)),
+                {funcol.reduce_scatter_tensor: 2},
+                "3 partials: 2 merged reduce_scatter + 1 separate",
+            ),
+        ]
+
+        for mesh, src_placements, dst_placements, expected_counts, desc in test_cases:
+            with self.subTest(desc=desc):
+                # Create global tensor - size must be divisible by mesh for sharding
+                global_shape = tuple(16 for _ in range(max(3, mesh.ndim)))
+                global_tensor = torch.randn(global_shape, device=self.device_type)
+
+                # Create source DTensor
+                # For Partial dims, use Replicate then reinterpret as Partial
+                src_for_distribute = [
+                    Replicate() if p.is_partial() else p for p in src_placements
+                ]
+                base_dt = distribute_tensor(
+                    global_tensor, mesh, list(src_for_distribute)
+                )
+                local = base_dt.to_local()
+                dt = DTensor.from_local(local, mesh, src_placements, run_check=False)
+
+                # Redistribute with comm tracking
+                comm_mode = CommDebugMode()
+                with comm_mode:
+                    result = dt.redistribute(mesh, list(dst_placements))
+
+                # Check comm counts
+                for op, expected_count in expected_counts.items():
+                    actual_count = comm_mode.get_comm_counts().get(op, 0)
+                    self.assertEqual(
+                        actual_count,
+                        expected_count,
+                        f"{desc}: expected {expected_count} {op}, got {actual_count}",
+                    )
+
+                # Verify placements
+                self.assertEqual(tuple(result.placements), tuple(dst_placements))
+
+                # Verify numerical correctness via full_tensor
+                # The full tensor should equal global_tensor * (product of partial mesh dim sizes)
+                num_partial_sums = 1
+                for i, p in enumerate(src_placements):
+                    if p.is_partial():
+                        num_partial_sums *= mesh.size(i)
+
+                result_full = result.full_tensor()
+                expected_full = global_tensor * num_partial_sums
+                self.assertEqual(result_full, expected_full)
+
+    @with_comms
+    def test_mixed_sum_avg_partial_numerics(self):
+        """Test numerical correctness for mixed Partial("sum") and Partial("avg").
+
+        This test verifies that when merging mixed sum/avg partials:
+        1. The merged collective uses 1 comm op (not separate ops per partial)
+        2. The scaling is correct: only avg dims contribute to the divisor
+
+        Example: (Partial("avg"), Partial("avg"), Partial("sum")) on mesh (2, 2, 2)
+        - All 8 ranks have the same local tensor value V
+        - After all-reduce sum: V * 8 (sum across all 8 ranks)
+        - Avg scaling: divide by 4 (product of avg mesh dims: 2 * 2)
+        - Final result: V * 8 / 4 = V * 2
+
+        The scaling should be 4 (only avg dims), NOT 8 (total mesh size).
+        """
+        mesh = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("A", "B", "C")
+        )
+        mesh["A", "B", "C"]._flatten("A_B_C")
+
+        # Global tensor
+        global_tensor = torch.arange(16, dtype=torch.float32, device=self.device_type)
+
+        # src: (Partial("avg"), Partial("avg"), Partial("sum"))
+        # dst: (Replicate, Replicate, Replicate) for allreduce
+        src_placements_allreduce = (Partial("avg"), Partial("avg"), Partial("sum"))
+        dst_placements_allreduce = (Replicate(), Replicate(), Replicate())
+
+        # Create source DTensor - replicate first then reinterpret as Partial
+        base_dt = distribute_tensor(
+            global_tensor, mesh, [Replicate(), Replicate(), Replicate()]
+        )
+        local = base_dt.to_local()
+
+        # Test allreduce case
+        dt_allreduce = DTensor.from_local(
+            local.clone(), mesh, list(src_placements_allreduce), run_check=False
+        )
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result_allreduce = dt_allreduce.redistribute(
+                mesh, list(dst_placements_allreduce)
+            )
+
+        # Should be 1 merged allreduce
+        self.assertEqual(
+            comm_mode.get_comm_counts().get(funcol.all_reduce, 0),
+            1,
+            "mixed sum/avg allreduce should merge to 1 collective",
+        )
+
+        # Numerical correctness:
+        # All 8 ranks contribute value V via sum -> V * 8
+        # Then scale by product of avg dims only: 2 * 2 = 4
+        # Final = V * 8 / 4 = V * 2
+        total_mesh_size = mesh.size(0) * mesh.size(1) * mesh.size(2)  # 8
+        avg_scale_factor = mesh.size(0) * mesh.size(1)  # 4 (avg dims only)
+        expected_allreduce = global_tensor * total_mesh_size / avg_scale_factor
+        self.assertEqual(make_full_tensor(result_allreduce), expected_allreduce)
+
+        # Test reduce_scatter case
+        # src: (Partial("avg"), Partial("avg"), Partial("sum"))
+        # dst: (Shard(0), Shard(0), Shard(0))
+        dst_placements_reduce_scatter = (Shard(0), Shard(0), Shard(0))
+
+        dt_reduce_scatter = DTensor.from_local(
+            local.clone(), mesh, list(src_placements_allreduce), run_check=False
+        )
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result_reduce_scatter = dt_reduce_scatter.redistribute(
+                mesh, list(dst_placements_reduce_scatter)
+            )
+
+        # Should be 1 merged reduce_scatter
+        self.assertEqual(
+            comm_mode.get_comm_counts().get(funcol.reduce_scatter_tensor, 0),
+            1,
+            "mixed sum/avg reduce_scatter should merge to 1 collective",
+        )
+
+        # Numerical correctness: same scaling logic
+        expected_reduce_scatter = global_tensor * total_mesh_size / avg_scale_factor
+        self.assertEqual(
+            make_full_tensor(result_reduce_scatter), expected_reduce_scatter
+        )
+
+
+class FlattenedReductionIntegrationTest(DTensorTestBase):
+    """Integration tests for flattened reduction optimization.
+
+    These tests verify that redistribute actually performs fewer communications
+    when flattened meshes are available.
+    """
+
+    @property
+    def world_size(self):
+        return 8
+
+    @with_comms
+    def test_merging_reductions(self):
+        """Tests various combinations in the same test function to avoid setup time"""
+        mesh = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("A", "B", "C")
+        )
+
+        # Test: All three consecutive dims with same reduce op CAN be merged
+        mesh["A", "B", "C"]._flatten("A_B_C")
+
+        local_tensor = torch.ones(8, 8, device=self.device_type)
+        dt = DTensor.from_local(
+            local_tensor,
+            mesh,
+            (Partial("sum"), Partial("sum"), Partial("sum")),
+            run_check=False,
+        )
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result = dt.redistribute(mesh, (Replicate(), Replicate(), Replicate()))
+
+        # With full flattened mesh, should have 1 allreduce instead of 3
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+
+        # Verify correctness: result should be 8x (reduced across all 8 ranks)
+        expected = local_tensor * 8
+        self.assertEqual(result.to_local(), expected)
+
+        # Test: Two consecutive dims (A,B) with same reduce op CAN be merged
+        mesh["A", "B"]._flatten("A_B")
+
+        local_tensor = torch.ones(8, 8, device=self.device_type)
+        dt = DTensor.from_local(
+            local_tensor,
+            mesh,
+            (Partial("sum"), Partial("sum"), Replicate()),
+            run_check=False,
+        )
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result = dt.redistribute(mesh, (Replicate(), Replicate(), Replicate()))
+
+        # Dims 0 and 1 are consecutive, should merge to 1 allreduce
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+
+        # Verify correctness: sum across A (2) and B (2) = 4x
+        expected = local_tensor * 4
+        self.assertEqual(result.to_local(), expected)
+
+        # Test: Non-consecutive dims (A,C) with Replicate on B - CAN merge now
+        mesh["A", "C"]._flatten("A_C")
+
+        local_tensor = torch.ones(8, 8, device=self.device_type)
+        dt = DTensor.from_local(
+            local_tensor,
+            mesh,
+            (Partial("sum"), Replicate(), Partial("sum")),
+            run_check=False,
+        )
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result = dt.redistribute(mesh, (Replicate(), Replicate(), Replicate()))
+
+        # Replicate on dim B (not Partial) - CAN merge dims 0 and 2
+        self.assertEqual(comm_mode.get_total_counts(), 1)
+
+        # Verify correctness: sum across A (2) and C (2) = 4x
+        expected = local_tensor * 4
+        self.assertEqual(result.to_local(), expected)
+
+        # Test: Non-consecutive dims (A,C) with Shard on B - CAN merge
+        local_tensor = torch.ones(8, 8, device=self.device_type)
+        dt = DTensor.from_local(
+            local_tensor,
+            mesh,
+            (Partial("sum"), Shard(0), Partial("sum")),
+            run_check=False,
+        )
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result = dt.redistribute(mesh, (Replicate(), Replicate(), Replicate()))
+
+        # Shard on dim B breaks the consecutive allreduce sequence
+        # So we have 3 ops: allreduce on A, allgather on B, allreduce on C
+        # (non-consecutive allreduces are not merged to preserve correctness)
+        self.assertEqual(comm_mode.get_total_counts(), 3)
+
+        # Verify correctness: sum across A (2) and C (2) = 4x, gather on B
+        expected = torch.ones(8 * 2, 8, device=self.device_type) * 4
+        self.assertEqual(result.to_local(), expected)
+
+
+class UnevenFlattenedReduceScatterTest(DTensorTestBase):
+    """Test for correctness of flattened reduce_scatter with uneven tensor dimensions.
+
+    When redistributing Partial,Partial → Shard(dim),Shard(dim) on a 2D mesh,
+    uneven tensor dimensions can cause incorrect results if the flattened
+    optimization doesn't properly handle padding/unpadding.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 6  # 2 x 3 mesh
+
+    @with_comms
+    def test_partial_partial_to_shard_shard_uneven(self):
+        """Test that Partial,Partial -> Shard(0),Shard(0) produces correct results with uneven dims.
+
+        With mesh [2, 3] and tensor dim 0 size = 4:
+        - Two-step approach: elements end up on ranks [0,1,_,3,4,_] (2 and 5 empty)
+        - Flattened approach: elements end up on ranks [0,1,2,3,_,_] (4 and 5 empty)
+
+        The flattened optimization should NOT be applied when it would change
+        which elements go to which ranks.
+        """
+        mesh = init_device_mesh(self.device_type, (2, 3), mesh_dim_names=("A", "B"))
+        # Create flattened mesh for the optimization
+        mesh["A", "B"]._flatten("A_B")
+
+        # Tensor size 4 on dim 0, mesh total size 6
+        # This creates an uneven sharding scenario
+        tensor_size = 4
+        local_tensor = torch.arange(
+            tensor_size, dtype=torch.float32, device=self.device_type
+        ).unsqueeze(1)  # Shape: [4, 1]
+
+        # Create a Partial,Partial DTensor (each rank has the same values)
+        dt = DTensor.from_local(
+            local_tensor.clone(),
+            mesh,
+            (Partial("sum"), Partial("sum")),
+            run_check=False,
+        )
+
+        # Redistribute to Shard(0),Shard(0)
+        result = dt.redistribute(mesh, (Shard(0), Shard(0)))
+
+        # Compute what the two-step approach should produce
+        # Step 1: reduce_scatter on mesh dim 0 (size 2)
+        #   Tensor size 4, 2 chunks -> [2, 2], no padding
+        #   Row 0 (ranks 0,1,2): elements [0,1]
+        #   Row 1 (ranks 3,4,5): elements [2,3]
+        # Step 2: reduce_scatter on mesh dim 1 (size 3)
+        #   Row 0: size 2, 3 chunks -> [1,1,0], padded to [1,1,1]
+        #     Rank 0: element 0, Rank 1: element 1, Rank 2: empty
+        #   Row 1: size 2, 3 chunks -> [1,1,0], padded to [1,1,1]
+        #     Rank 3: element 2, Rank 4: element 3, Rank 5: empty
+
+        # Expected local tensor sizes per rank (two-step):
+        # Ranks 0,1,3,4: size 1
+        # Ranks 2,5: size 0 (empty)
+        expected_sizes = {0: 1, 1: 1, 2: 0, 3: 1, 4: 1, 5: 0}
+
+        # Expected values per rank (after reduction = 6x original since 6 ranks)
+        # Two-step: rank 0 -> 0*6, rank 1 -> 1*6, rank 3 -> 2*6, rank 4 -> 3*6
+        expected_values = {0: 0.0, 1: 1.0, 3: 2.0, 4: 3.0}
+
+        rank = dist.get_rank()
+        local_result = result.to_local()
+
+        # Check size
+        expected_size = expected_sizes[rank]
+        self.assertEqual(
+            local_result.size(0),
+            expected_size,
+            f"Rank {rank}: expected size {expected_size}, got {local_result.size(0)}",
+        )
+
+        # Check value for non-empty ranks
+        if expected_size > 0:
+            expected_val = expected_values[rank] * 6  # 6 ranks contributing
+            self.assertEqual(
+                local_result[0, 0].item(),
+                expected_val,
+                f"Rank {rank}: expected value {expected_val}, got {local_result[0, 0].item()}",
+            )
+
+
 RedistributeTestWithLocalTensor = create_local_tensor_test_class(
     RedistributeTest,
 )
@@ -1599,6 +2844,10 @@ RedistributeTestWithLocalTensor = create_local_tensor_test_class(
 MultiDimRedistributeTestWithLocalTensor = create_local_tensor_test_class(
     MultiDimRedistributeTest,
     skipped_tests=["test_multi_dim_mesh"],
+)
+
+MultiDimRedistributeOptimizationTestWithLocalTensor = create_local_tensor_test_class(
+    MultiDimRedistributeOptimizationTest,
 )
 
 DistributeWithDeviceOrderTestWithLocalTensor = create_local_tensor_test_class(

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -531,7 +531,7 @@ class DTensorSpec:
         # native dtensor-style sharding representation: map from mesh
         # dim to tensor dim
         for mesh_dim, placement in enumerate(placements):
-            if isinstance(placement, Shard):
+            if isinstance(placement, (Shard, _StridedShard)):
                 if shard_order is not None:
                     for entry in shard_order:
                         tensor_dim = entry.tensor_dim

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -4,11 +4,12 @@ import contextlib
 import dataclasses
 import itertools
 import logging
+import math
 import weakref
 from collections import defaultdict
 from collections.abc import Sequence
 from functools import cache
-from typing import cast, NamedTuple
+from typing import cast
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -40,6 +41,12 @@ logger = logging.getLogger(__name__)
 # When False, prefers the greedy algorithm for faster planning. Uses the graph-based algorithm
 # only when necessary to support strided-shard redistribution
 _FORCE_MIN_COST_REDISTRIBUTION_PLAN: bool | None = None
+
+# Global kill switch to disable the transform optimization pass in
+# _optimize_transform_infos.  When True, the optimization that merges
+# consecutive same-type collectives into flattened operations is skipped,
+# and the unmodified transform_infos list is returned as-is.
+_DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION: bool = False
 
 
 @contextlib.contextmanager
@@ -103,7 +110,37 @@ def use_min_cost_redistribution_plan(enabled: bool = True):
         _FORCE_MIN_COST_REDISTRIBUTION_PLAN = old_value
 
 
-class _TransformInfo(NamedTuple):
+@contextlib.contextmanager
+def disable_redistribute_transform_optimization(disabled: bool = True):
+    """
+    Context manager to disable the transform optimization pass that merges
+    consecutive same-type collectives into single flattened operations.
+
+    When the optimization is disabled, ``_optimize_transform_infos`` becomes a
+    no-op and returns the original list of ``_TransformInfo`` objects unchanged.
+    This is useful for debugging or isolating issues related to the flattened
+    collective merging logic.
+
+    The flag can also be set directly::
+
+        torch.distributed.tensor._redistribute._DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION = True
+
+    Args:
+        disabled (bool): If True (default), disables the optimization.
+                         If False, explicitly enables it (the normal default).
+    """
+    global _DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION
+
+    old_value = _DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION
+    _DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION = disabled
+    try:
+        yield
+    finally:
+        _DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION = old_value
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _TransformInfo:
     mesh_dim: int
     src_dst_placements: tuple[Placement, Placement]
     # logical_shape on this mesh dimension
@@ -114,6 +151,393 @@ class _TransformInfo(NamedTuple):
         assert self.src_dst_placements[0] != self.src_dst_placements[1], (
             "TransformInfo should only be created if it is an op with some effect, not a no-op"
         )
+
+    def _comm_type_key(self) -> str | None:
+        """
+        Return a key for grouping transforms by communication type.
+
+        Returns None for local ops (no communication needed), or a string
+        that identifies the collective type for potential grouping/merging.
+        """
+        src, dst = self.src_dst_placements
+        if src.is_partial() and dst.is_replicate():
+            return "all_reduce"
+        elif src.is_partial() and dst.is_shard():
+            return "reduce_scatter"
+        elif src.is_shard() and dst.is_replicate():
+            return "all_gather"
+        elif src.is_shard() and dst.is_shard():
+            return "all_to_all"
+        else:
+            # Local ops (Replicate->Shard, Replicate->Partial, noop, etc.)
+            return None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _FlattenedTransformInfo(_TransformInfo):
+    """
+    Represents a flattened transform that combines multiple mesh dimensions
+    into a single collective operation using a flattened DeviceMesh.
+
+    Note: inherits the fields from _TransformInfo. Gets an __init__ with parent fields, followed by child fields,
+    and runs parent validation (post_init)
+    """
+
+    # The flattened DeviceMesh to use for the collective operation
+    mesh: DeviceMesh
+    # The mesh dimensions from the original mesh that are being flattened (for debugging)
+    original_mesh_dims: tuple[int, ...]
+    # Scale factor for merged sum/avg partials (product of avg mesh dim sizes)
+    # When merging sum/avg partials, we use sum for the collective and divide by this afterward
+    avg_scale: int | None = None
+
+    def __post_init__(self) -> None:
+        _TransformInfo.__post_init__(self)
+        if self.avg_scale is not None:
+            assert self.avg_scale > 1, (
+                f"avg_scale must be > 1 if set, got {self.avg_scale}"
+            )
+
+
+def _get_flattened_mesh_by_layout(
+    mesh: DeviceMesh, mesh_dims: tuple[int, ...]
+) -> DeviceMesh | None:
+    """
+    Query for an explicitly created flattened mesh using layout comparison.
+
+    Args:
+        mesh: The DeviceMesh to query
+        mesh_dims: Tuple of mesh dimension indices to look for
+
+    Returns:
+        The flattened DeviceMesh if it was explicitly created, None otherwise.
+    """
+    root_mesh = mesh._get_root_mesh()
+    mesh_dim_names = mesh.mesh_dim_names
+
+    if mesh_dim_names is None:
+        return None
+
+    # Convert mesh dim indices to dim names
+    dim_names = tuple(mesh_dim_names[i] for i in mesh_dims)
+
+    # Compute expected layout WITHOUT creating a submesh (avoids tracing issues)
+    # _get_slice_mesh_layout does pure layout math, no tensor operations
+    sliced_layout = mesh._get_slice_mesh_layout(dim_names)
+    expected_layout = sliced_layout.coalesce()
+    if len(expected_layout) > 1:
+        expected_layout = expected_layout.nest()
+
+    # Search existing flattened meshes by comparing layouts
+    for flattened_mesh in root_mesh._flatten_mapping.values():
+        if flattened_mesh._layout == expected_layout:
+            return flattened_mesh
+
+    return None
+
+
+# Track (mesh_hash, mesh_dims, reason) we've already warned about to avoid repeated warnings
+_warned_flatten_issues: set[tuple[int, tuple[int, ...], str]] = set()
+
+
+def _warn_flatten_optimization_not_possible(
+    device_mesh: DeviceMesh,
+    mesh_dims: tuple[int, ...],
+    src_placements: tuple[Placement, ...],
+    dst_placements: tuple[Placement, ...],
+    num_ops: int,
+    comm_type: str,
+    reason: str,
+) -> None:
+    """
+    Warn once per (mesh, dims, reason) about inability to flatten operations.
+
+    Args:
+        device_mesh: The device mesh being used
+        mesh_dims: Tuple of mesh dimensions that could not be flattened
+        src_placements: Source placements for the redistribution
+        dst_placements: Target placements for the redistribution
+        num_ops: Number of sequential operations that will be performed
+        comm_type: Type of collective operation (e.g., "reduce_scatter")
+        reason: Either "no_flattened_mesh" or "uneven_tensor_shape"
+    """
+    cache_key = (hash(device_mesh), mesh_dims, reason)
+    if cache_key in _warned_flatten_issues:
+        return
+    _warned_flatten_issues.add(cache_key)
+
+    mesh_dim_names = device_mesh.mesh_dim_names
+    if mesh_dim_names is not None:
+        dim_names = [mesh_dim_names[d] for d in mesh_dims]
+        dims_str = ", ".join(f'"{name}"' for name in dim_names)
+    else:
+        dims_str = f"dims {', '.join(str(d) for d in mesh_dims)} of {device_mesh}"
+
+    common_warning = (
+        "While redistributing from %s to %s, %d sequential %s "
+        "operations will be performed. This is suboptimal: "
+        "multiple collective operations have higher latency "
+        "(separate kernel launches and synchronization points) "
+        "and may give inconsistent results between ranks due to different reduction orders. %s"
+    )
+
+    if reason == "no_flattened_mesh":
+        reason_msg = f"To optimize, flatten mesh dimensions [{dims_str}] so DTensor can use a single operation instead."
+    elif reason == "uneven_tensor_shape":
+        reason_msg = (
+            " Unfortunately, because the tensor dimension is not evenly divisible by the product of "
+            "the mesh dim sizes that would need to be flattened for the optimization to work, it can not be optimized.",
+        )
+    elif reason == "non_ascending_mesh_dims":
+        reason_msg = (
+            f"it is not possible to merge non-ascending order {comm_type} operations."
+        )
+    else:
+        raise AssertionError(f"Unexpected reason: {reason}")
+
+    logger.warning(
+        common_warning, src_placements, dst_placements, num_ops, comm_type, reason_msg
+    )
+
+
+def _optimize_transform_infos(
+    transform_infos: list[_TransformInfo],
+    device_mesh: DeviceMesh,
+    src_placements: tuple[Placement, ...],
+    dst_placements: tuple[Placement, ...],
+) -> list[_TransformInfo | _FlattenedTransformInfo]:
+    """
+    Optimize transform infos by merging consecutive same-type collectives into
+    a single flattened operation when a matching flattened DeviceMesh exists.
+
+    Merging requirements:
+    - Operations must be consecutive in the transform list (no reordering).
+      Notably, redistributing from P, P, P -> R, S, R is not optimized here and cannot be optimized due to
+      optimization needing to fuse non-contiguous reductions, leaving this pattern vulnerable to numerics issues and
+      suboptimal perf
+    - Operations must have the same comm type (e.g., all allgather or all reduce_scatter)
+    - Operations must have identical src_dst_placements (e.g., can't merge
+      Partial->Shard(0) with Partial->Shard(1))
+    - A flattened mesh covering the relevant dimensions must exist
+    - For reduce_scatter, tensor dim must be evenly divisible by flattened mesh size
+
+    For nested sharding, the merged operation uses the logical_shape from the
+    outermost mesh dimension (smallest mesh_dim index) which represents the
+    global tensor shape needed for correct padding/unpadding.
+
+    TODO:
+    - all_to_all operations are excluded from merging, but it may be possible to merge them in some cases.
+
+    """
+    if len(transform_infos) < 2:
+        return transform_infos
+
+    if _DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION:
+        return transform_infos
+
+    # Comm types that are safe to merge (all_to_all excluded for now)
+    MERGEABLE_COMM_TYPES = frozenset({"all_gather", "all_reduce", "reduce_scatter"})
+
+    def is_mergeable(key: str | None) -> bool:
+        """Check if a comm type key represents a mergeable operation."""
+        return key in MERGEABLE_COMM_TYPES
+
+    def are_placements_mergeable(
+        p1: tuple[Placement, Placement], p2: tuple[Placement, Placement]
+    ) -> bool:
+        """
+        Check if two src_dst_placements can be merged.
+
+        Allows merging of Partial("sum") and Partial("avg") since they can be
+        combined: perform sum reduction, then scale by avg mesh dims afterward.
+        """
+        if p1 == p2:
+            return True
+
+        src1, dst1 = p1
+        src2, dst2 = p2
+
+        # Destinations must match exactly
+        if dst1 != dst2:
+            return False
+
+        # Both sources must be partial
+        if not (src1.is_partial() and src2.is_partial()):
+            return False
+
+        # Only sum and avg can be merged (both use sum reduction, avg just scales)
+        partial1 = cast(Partial, src1)
+        partial2 = cast(Partial, src2)
+        mergeable_reduce_ops = {"sum", "avg"}
+        return (
+            partial1.reduce_op in mergeable_reduce_ops
+            and partial2.reduce_op in mergeable_reduce_ops
+        )
+
+    def try_create_flattened(
+        infos: list[_TransformInfo],
+    ) -> tuple[_FlattenedTransformInfo | None, str | None]:
+        """
+        Try to create a flattened transform from 2+ same-type transforms.
+
+        Returns (result, failure_reason) where:
+        - result is the FlattenedTransformInfo if successful, None otherwise
+        - failure_reason is None if successful, or one of:
+          - "too_few_transforms": Less than 2 transforms provided
+          - "no_flattened_mesh": No flattened mesh exists for the required dimensions
+          - "uneven_tensor_shape": For reduce_scatter, tensor dim not evenly divisible
+        """
+        if len(infos) < 2:
+            return None, "too_few_transforms"
+
+        # All transforms must have mergeable src_dst_placements
+        # (e.g., can't merge Partial->Shard(0) with Partial->Shard(1))
+        first_placements = infos[0].src_dst_placements
+        comm_type = infos[0]._comm_type_key()
+        assert all(
+            are_placements_mergeable(info.src_dst_placements, first_placements)
+            for info in infos
+        )
+        mesh_dims = tuple(info.mesh_dim for info in infos)
+        sorted_mesh_dims = tuple(sorted(mesh_dims))
+
+        # For reduce_scatter and all_gather, order matters for correctness.
+        # Flattened meshes only exist for ascending dim order.
+        if comm_type == "reduce_scatter":
+            # For reduce_scatter: the transform order determines the operation sequence.
+            # If transforms are in order (1, 0) but flattened mesh is (0, 1), we can't flatten.
+            if mesh_dims != sorted_mesh_dims:
+                return None, "non_ascending_mesh_dims"
+        elif comm_type == "all_gather":
+            # For all_gather: transforms come from planner in innermost-to-outermost order
+            # (descending mesh dims for ascending shard order). If transforms are not in
+            # descending order, the shard order isn't ascending and we can't flatten.
+            if mesh_dims != sorted_mesh_dims[::-1]:
+                return None, "non_ascending_mesh_dims"
+        # Use sorted dims for mesh lookup (required by DeviceMesh API)
+        flattened_mesh = _get_flattened_mesh_by_layout(device_mesh, sorted_mesh_dims)
+        if flattened_mesh is None:
+            return None, "no_flattened_mesh"
+
+        # For nested sharding, each transform has a different logical_shape.
+        # We need the outermost transform's logical_shape, which represents the
+        # tensor shape before any of the transforms in this group are applied.
+        # The outermost transform has the largest logical_shape on the affected
+        # tensor dimension (least divided by prior shards).
+        src, dst = first_placements
+        if comm_type == "all_gather":
+            # S->R (all_gather): affected dim is the source shard dim
+            affected_dim = cast(Shard, src).dim
+            outermost_info = max(infos, key=lambda x: x.logical_shape[affected_dim])
+        elif comm_type == "reduce_scatter":
+            affected_dim = cast(Shard, dst).dim
+            outermost_info = max(infos, key=lambda x: x.logical_shape[affected_dim])
+            tensor_dim_size = outermost_info.logical_shape[affected_dim]
+            effective_shard_mesh_size = math.prod(
+                device_mesh.size(info.mesh_dim) for info in infos
+            )
+            # For reduce_scatter (Partial -> Shard), we cannot flatten if the tensor
+            # dimension is not evenly divisible by the flattened mesh size.
+            # The effective size is the product of mesh sizes for dims being transformed
+            # (not all dims with matching placement - intervening shards are already
+            # accounted for in logical_shape).
+            if tensor_dim_size % effective_shard_mesh_size != 0:
+                return None, "uneven_tensor_shape"
+        elif comm_type == "all_reduce":
+            # no shape change, any info works
+            outermost_info = infos[0]
+        else:
+            raise NotImplementedError(
+                f"Unsupported comm type for try_create_flattened: {comm_type}"
+            )
+
+        # For mixed sum/avg partials: use sum for the collective, compute avg scale
+        avg_scale = None
+        merged_src = src
+        if src.is_partial():
+            scale = math.prod(
+                device_mesh.size(info.mesh_dim)
+                for info in infos
+                if cast(Partial, info.src_dst_placements[0]).reduce_op == "avg"
+            )
+            if scale > 1:
+                avg_scale = scale
+                merged_src = Partial("sum")
+
+        merged_placements = (merged_src, dst)
+
+        return (
+            _FlattenedTransformInfo(
+                mesh_dim=0,
+                src_dst_placements=merged_placements,
+                logical_shape=outermost_info.logical_shape,
+                mesh=flattened_mesh,
+                original_mesh_dims=sorted_mesh_dims,
+                avg_scale=avg_scale,
+            ),
+            None,
+        )
+
+    # Merge consecutive same-type operations (without reordering)
+    result: list[_TransformInfo | _FlattenedTransformInfo] = []
+    i = 0
+
+    while i < len(transform_infos):
+        info = transform_infos[i]
+        current_key = info._comm_type_key()
+
+        # Only try to merge if this is a mergeable comm type
+        if not is_mergeable(current_key):
+            result.append(info)
+            i += 1
+            continue
+
+        # Collect consecutive transforms with mergeable src_dst_placements
+        # (not just same comm type - e.g., Partial->Shard(0) vs Partial->Shard(1) can't merge)
+        # Note: sum/avg partials can be merged since they use the same reduction
+        current_placements = info.src_dst_placements
+        group: list[_TransformInfo] = [info]
+        j = i + 1
+        while (
+            j < len(transform_infos)
+            and is_mergeable(transform_infos[j]._comm_type_key())
+            and are_placements_mergeable(
+                transform_infos[j].src_dst_placements, current_placements
+            )
+        ):
+            group.append(transform_infos[j])
+            j += 1
+
+        # Try to flatten the group
+        flattened, failure_reason = try_create_flattened(group)
+        if flattened is not None:
+            result.append(flattened)
+        else:
+            # Can't flatten - add individually and warn once if applicable
+            result.extend(group)
+            # Warn for reasons that indicate a real optimization opportunity was missed
+            if failure_reason in (
+                "no_flattened_mesh",
+                "uneven_tensor_shape",
+                "non_ascending_mesh_dims",
+            ):
+                mesh_dims = tuple(sorted(g.mesh_dim for g in group))
+                _warn_flatten_optimization_not_possible(
+                    device_mesh,
+                    mesh_dims,
+                    src_placements,
+                    dst_placements,
+                    len(group),
+                    current_key,  # type: ignore[arg-type]
+                    failure_reason,
+                )
+
+        i = j
+    logger.debug(
+        "_optimize_transform_infos original: %s, optimized: %s", transform_infos, result
+    )
+
+    return result
 
 
 # Global cache for DTensorRedistributePlanner instances
@@ -272,26 +696,74 @@ class DTensorRedistributePlanner:
         state_list = [
             cur_state,
         ]
+        # Track whether each transition is flattened (for visualization)
+        is_flattened_list: list[bool] = []
+
         for transform_info in transform_infos:
             src_dim_placement, dst_dim_placement = transform_info.src_dst_placements
-            if src_dim_placement.is_shard():
+
+            # Handle flattened transforms specially - they affect multiple mesh dims
+            if isinstance(transform_info, _FlattenedTransformInfo):
+                mesh_dims_to_update = transform_info.original_mesh_dims
+                is_flattened = True
+            else:
+                mesh_dims_to_update = (transform_info.mesh_dim,)
+                is_flattened = False
+
+            # Check for both Shard and _StridedShard (which has is_shard() = False)
+            if src_dim_placement.is_shard() or isinstance(
+                src_dim_placement, _StridedShard
+            ):
                 src_dim = src_dim_placement.dim  # type: ignore[attr-defined]
                 assert (
                     src_dim in shard_order_dict and len(shard_order_dict[src_dim]) > 0
                 )
-                shard_order_dict[src_dim].pop()
-            if dst_dim_placement.is_shard():
+                # Remove mesh dims in reverse order and verify they match expected dims
+                # (shard_order_dict stores in innermost-to-outermost order)
+                removed_dims = []
+                for _ in mesh_dims_to_update:
+                    removed_dim = shard_order_dict[src_dim].pop()
+                    removed_dims.append(removed_dim)
+                # Verify the removed dims match what we expect (in reverse order)
+                removed_dims.reverse()
+                assert tuple(removed_dims) == mesh_dims_to_update, (
+                    f"Flattened transform mesh dims mismatch: "
+                    f"expected {mesh_dims_to_update}, but shard_order had {tuple(removed_dims)}"
+                )
+
+            # Check for both Shard and _StridedShard for destination
+            if dst_dim_placement.is_shard() or isinstance(
+                dst_dim_placement, _StridedShard
+            ):
                 dst_dim = dst_dim_placement.dim  # type: ignore[attr-defined]
                 if dst_dim not in shard_order_dict:
                     shard_order_dict[dst_dim] = []
-                shard_order_dict[dst_dim].append(transform_info.mesh_dim)
-            cur_placement[transform_info.mesh_dim] = dst_dim_placement
+                # Add mesh dims in order and verify they don't already exist
+                for mesh_dim in mesh_dims_to_update:
+                    assert mesh_dim not in shard_order_dict[dst_dim], (
+                        f"Mesh dim {mesh_dim} already in shard_order for tensor dim {dst_dim}: "
+                        f"existing={shard_order_dict[dst_dim]}, adding={mesh_dims_to_update}"
+                    )
+                    shard_order_dict[dst_dim].append(mesh_dim)
+
+            # Update placements for all affected mesh dims
+            for mesh_dim in mesh_dims_to_update:
+                cur_placement[mesh_dim] = dst_dim_placement
+
             new_state = DTensorRedistributePlanner.DistState(
                 tuple(cur_placement),
                 DTensorRedistributePlanner._dict_to_ShardOrder(shard_order_dict),
             )
             state_list.append(new_state)
-        return "->".join([str(s) for s in state_list])
+            is_flattened_list.append(is_flattened)
+
+        # Build the trace string using '-->' for flattened transforms, '->' for regular
+        trace_parts = [str(state_list[0])]
+        for i, is_flattened in enumerate(is_flattened_list):
+            separator = "-->" if is_flattened else "->"
+            trace_parts.append(separator)
+            trace_parts.append(str(state_list[i + 1]))
+        return "".join(trace_parts)
 
     def __init__(
         self,
@@ -1013,7 +1485,33 @@ def redistribute_local_tensor(
             current_spec, target_spec, use_graph_based_transform
         )
 
+    # Optimize by grouping same-type collectives into flattened operations
+    optimized_transform_infos = _optimize_transform_infos(
+        transform_infos,
+        device_mesh,
+        current_spec.placements,
+        target_spec.placements,
+    )
+
     debug_mode = get_active_debug_mode()
+
+    # For stringify_transform_infos, we need to use the same shard_order that was
+    # used to generate the transforms. When _StridedShard is present, the planner
+    # derives shard_order from placements rather than using the spec's shard_order.
+    # This mirrors the logic in generate_graph_based_transform_infos._try_normalize_spec.
+    stringify_shard_order = current_spec.shard_order
+    if any(isinstance(p, _StridedShard) for p in current_spec.placements):
+        _, derived_shard_order = DTensorSpec._normalize_placements_into_shard_order(
+            current_spec.placements, current_spec.mesh
+        )
+        if derived_shard_order is not None:
+            stringify_shard_order = derived_shard_order
+        else:
+            # Fallback: compute default shard_order (treat _StridedShard as normal shard)
+            stringify_shard_order = DTensorSpec.compute_default_shard_order(
+                current_spec.placements, treat_strided_shard_as_shard=True
+            )
+
     redistribute_context = (
         debug_mode.record_redistribute_calls(  # type: ignore[union-attr]
             local_tensor,
@@ -1021,9 +1519,9 @@ def redistribute_local_tensor(
             target_spec.placements,
             DTensorRedistributePlanner.stringify_transform_infos(
                 device_mesh,
-                transform_infos,
+                optimized_transform_infos,
                 current_spec.placements,
-                current_spec.shard_order,
+                stringify_shard_order,
             ),
             is_explicit=is_explicit,
         )
@@ -1032,10 +1530,15 @@ def redistribute_local_tensor(
     )
 
     with redistribute_context:
-        for transform_info in transform_infos:
+        for transform_info in optimized_transform_infos:
+            # Determine which mesh to use: flattened transforms have their own mesh
+            if isinstance(transform_info, _FlattenedTransformInfo):
+                mesh_to_use = transform_info.mesh
+            else:
+                mesh_to_use = device_mesh
             i = transform_info.mesh_dim
             current, target = transform_info.src_dst_placements
-            num_chunks = device_mesh.size(mesh_dim=i)
+            num_chunks = mesh_to_use.size(mesh_dim=i)
 
             if current == target:
                 # short cut, just use the original local tensor
@@ -1053,12 +1556,18 @@ def redistribute_local_tensor(
                 if current.is_partial():
                     partial_spec = cast(Partial, current)
                     new_local_tensor = partial_spec._reduce_value(
-                        local_tensor, device_mesh, i
+                        local_tensor, mesh_to_use, i
                     )
+                    # For merged sum/avg partials, apply avg scaling
+                    if (
+                        isinstance(transform_info, _FlattenedTransformInfo)
+                        and transform_info.avg_scale is not None
+                    ):
+                        new_local_tensor = new_local_tensor / transform_info.avg_scale
                 elif current.is_shard():
                     current_placement = cast(Shard, current)
                     new_local_tensor = current_placement._to_replicate_tensor(
-                        local_tensor, device_mesh, i, transform_info.logical_shape
+                        local_tensor, mesh_to_use, i, transform_info.logical_shape
                     )
                 elif isinstance(current, _StridedShard):
                     new_local_tensor = current._to_replicate_tensor(
@@ -1075,19 +1584,25 @@ def redistribute_local_tensor(
                 if current.is_partial():
                     partial_spec = cast(Partial, current)
                     new_local_tensor = partial_spec._reduce_shard_value(
-                        local_tensor, device_mesh, i, target_placement
+                        local_tensor, mesh_to_use, i, target_placement
                     )
+                    # For merged sum/avg partials, apply avg scaling
+                    if (
+                        isinstance(transform_info, _FlattenedTransformInfo)
+                        and transform_info.avg_scale is not None
+                    ):
+                        new_local_tensor = new_local_tensor / transform_info.avg_scale
                 elif current.is_replicate():
                     # split the tensor and return the corresponding cloned local shard
                     new_local_tensor = target_placement._replicate_to_shard(
-                        local_tensor, device_mesh, i, device_mesh._sym_get_coordinate(i)
+                        local_tensor, mesh_to_use, i, mesh_to_use._sym_get_coordinate(i)
                     )
                 elif current.is_shard():
                     shard_spec = cast(Shard, current)
                     if shard_spec.dim != target_placement.dim:
                         new_local_tensor = shard_spec._to_new_shard_dim(
                             local_tensor,
-                            device_mesh,
+                            mesh_to_use,
                             i,
                             transform_info.logical_shape,
                             target_placement.dim,
@@ -1104,7 +1619,7 @@ def redistribute_local_tensor(
                 if current.is_replicate():
                     partial_spec = cast(Partial, target)
                     new_local_tensor = partial_spec._partition_value(
-                        local_tensor, device_mesh, i
+                        local_tensor, mesh_to_use, i
                     )
                 elif current.is_shard() or isinstance(current, _StridedShard):
                     raise RuntimeError(


### PR DESCRIPTION
Reland of #172610: same code as previous land except:
- includes #173873 (credit @bdhirsh)
- includes #173790 (credit @IvanKobzarev)
- includes https://github.com/pytorch/pytorch/pull/173436
- adds disable contextmanager + test

Ensures that when possible (when such a flattened mesh exists), DTensor will find and use it to avoid more costly sequential comms, and particularly for reduce comms, also avoids the risk of different reduction orders causing divergent results. (See [this doc](https://docs.google.com/document/d/1hJsnodQmHfs1QosNgR39HZNiOOzfnZ6bnALqonDpcDs/edit?userstoinvite=rrathaur@redhat.com&sharingaction=manageaccess&role=reader&tab=t.0) for more info.

Example: For a (2,2,2) mesh with dims (A,B,C) and placements
when redistributing from (Psum, Replicate, Psum) -> (Replicate,
Replicate, Replicate) - the original behavior would be 2 separate
all_reduces.  After this PR, if the user flattens dims A,C, this becomes
one larger all_reduce.

Compared with earlier attempt #172119, this PR
- includes optimization for comms other than all_reduce
- explicitly bans mixed partial types (Psum, Pmax) is not a valid placement, so we don't have to worry about optimizing around it
- therefore uses a simpler implementation involving grouping adjacent transforminfos and then merging like kinds
- Warns once per mesh shape for missing flattened meshes
- Won't optimize reduce_scatters when they shard an uneven sized tensor dim

Details/Limitations
- all_to_all is never merged (left for possible future work, but not obvious how to do it in general)
- reduce_scatter is only merged when the outermost partial shape is evenly divisible by the flattened mesh - otherwise, warns
- reduce_scatter and all_gather are only merged when the shards are in left-to-right (ascending) order, since DeviceMesh only supports flattening in ascending order and the mesh ordering impacts correctness.
- groups of like-kind collectives are NOT combined if they are not adjacent in the transform_info list
- flattened device-meshes are not automatically created due to preference of explicit creation and ensuring torch.compile works, but warnings prompt the user to create them when it would help allow an optimization
- DOES support merging mixed Partial (sum, avg) reductions, using the product of the avg dim sizes to scale after performing a sum reduction on the merged mesh.  Refuses to merge any other combinations of mixed partials.

Fixes #171916

Note: initial attempt used stable sort with a __lt__
method in TransformInfo comparing comm type key, but this was not correct because sorting a
local (no-comm) operation like chunking before or after a comm operation
on the same mesh time affects results.

Differential Revision: D92540256


