### PR TITLE
Pin setuptools<82 in Dockerfiles and CI scripts

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -122,7 +122,7 @@ ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 # Install setuptools and wheel for python 3.12/3.13
 RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
-    /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
+    /opt/python/${cpython_version}/bin/python -m pip install "setuptools<82" wheel; \
     done;
 ADD ./common/patch_libstdc.sh patch_libstdc.sh
 RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -128,7 +128,7 @@ RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
 # for some reason old version is getting pulled in otherwise.
 # packaging package is required for onnxruntime wheel build.
 RUN pip3 install flatbuffers && \
-  pip3 install cython 'pkgconfig>=1.5.5' 'setuptools>=77' 'numpy<2.3.0' && \
+  pip3 install cython 'pkgconfig>=1.5.5' 'setuptools>=77,<82' 'numpy<2.3.0' && \
   pip3 install --no-build-isolation h5py==3.11.0 && \
   pip3 install packaging && \
   git clone https://github.com/microsoft/onnxruntime && \

--- a/.ci/docker/ubuntu-cross-riscv/Dockerfile
+++ b/.ci/docker/ubuntu-cross-riscv/Dockerfile
@@ -145,7 +145,7 @@ ENV PATH="/usr/local/bin:${PATH}"
 # Set up cross Python environment
 SHELL ["/bin/bash", "-c"]
 RUN source /opt/riscv-cross-env/bin/activate \
-    && pip install setuptools pyyaml typing_extensions wheel
+    && pip install "setuptools<82" pyyaml typing_extensions wheel
 
 # Set default environment variables for PyTorch build
 ENV Python_ROOT_DIR=${SYSROOT}

--- a/.ci/flash-attention/build.sh
+++ b/.ci/flash-attention/build.sh
@@ -46,7 +46,7 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
 fi
 
 echo "installing dependencies"
-"$PYTHON" -m pip install einops packaging ninja numpy wheel setuptools
+"$PYTHON" -m pip install einops packaging ninja numpy wheel "setuptools<82"
 
 export PATH="$(dirname "$PYTHON"):$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir /opt/ccache && ccache --set-config=cache_dir=/opt/ccache
 FROM dev-base as python-deps
 COPY requirements.txt requirements-build.txt .
 # Install Python packages to system Python
-RUN pip3 install --upgrade --ignore-installed pip setuptools wheel && \
+RUN pip3 install --upgrade --ignore-installed pip "setuptools<82" wheel && \
     pip3 install cmake pyyaml numpy ipython -r requirements.txt
 
 FROM dev-base as submodule-update


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #174633
* #174631

Pin setuptools<82 in Dockerfiles and CI build scripts to prevent
pulling setuptools 82.0.0+ which removed pkg_resources.