### PR TITLE
[BE] Update pandas version for python-3.12 to 2.2.3

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -141,8 +141,8 @@ numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
 numpy==2.1.2; python_version >= "3.13" and python_version < "3.14"
 numpy==2.3.4; python_version >= "3.14"
 
-pandas==2.0.3; python_version < "3.13"
-pandas==2.2.3; python_version >= "3.13" and python_version < "3.14"
+pandas==2.0.3; python_version < "3.12"
+pandas==2.2.3; python_version >= "3.12" and python_version < "3.14"
 pandas==2.3.3; python_version >= "3.14"
 
 #onnxruntime


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #174634
* #174632

Otherwise, it'll be build from source, which will cause failures, after latest setuptools-82 release, which now causes builds to fail with
```
Collecting pandas==2.0.3 (from -r .ci/docker/requirements-ci.txt (line 144))
  Using cached pandas-2.0.3.tar.gz (5.3 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "/Users/ec2-user/runner/_work/_temp/venv-3.12-1770652963/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/Users/ec2-user/runner/_work/_temp/venv-3.12-1770652963/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/ec2-user/runner/_work/_temp/venv-3.12-1770652963/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/5w/plbd92450xjbrkml0x0q8zsh0000gn/T/pip-build-env-eohasqdp/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/5w/plbd92450xjbrkml0x0q8zsh0000gn/T/pip-build-env-eohasqdp/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/5w/plbd92450xjbrkml0x0q8zsh0000gn/T/pip-build-env-eohasqdp/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 520, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/private/var/folders/5w/plbd92450xjbrkml0x0q8zsh0000gn/T/pip-build-env-eohasqdp/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 19, in <module>
      ModuleNotFoundError: No module named 'pkg_resources'
      [end of output]
```