### PR TITLE
[Inductor][CPP] Fix masked vectorization for Inductor CPP backend

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5163,8 +5163,8 @@ class CPUReproTests(TestCase):
                 .view(-1, window_size * window_size)
             )
             attn_mask = masked_window.unsqueeze(1) - masked_window.unsqueeze(2)
-            res = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(
-                attn_mask == 0, float(0.0)
+            res = attn_mask.masked_fill(attn_mask != 0, -100.0).masked_fill(
+                attn_mask == 0, 0.0
             )
             return res
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1736,7 +1736,8 @@ class CppVecOverrides(CppOverrides):
                 V.kernel.compute,
                 code,
             )
-            result.is_vec = True
+            assert isinstance(csevar, CppCSEVariable)
+            csevar.is_vec = True
         elif result.is_vec:
             csevar = V.kernel.cse.generate(
                 V.kernel.compute, f"{mask} ? {body_code_vec} : {other_code_vec}"


### PR DESCRIPTION
Fixes #173626.

Fixes `is_vec` flag for masked vectorization.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo