### PR TITLE
skip xpu cow histogramdd

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21427,6 +21427,8 @@ op_db: list[OpInfo] = [
                # JIT tests don't work with Tensor keyword arguments
                # https://github.com/pytorch/pytorch/issues/58507
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
+               # Not implemented on XPU
+               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_cow_input', device_type='xpu'),
            )),
     OpInfo('histc',
            dtypes=floating_types_and(torch.bfloat16, torch.float16),


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/2248
https://github.com/intel/torch-xpu-ops/issues/2918

aten::_histogramdd_bin_edges is not implemented on XPU.
The test fails before any COW checks and is not COW-related.

This PR skip test_cow_input_histogramdd on XPU.