### PR TITLE
[be] Diff 1/6: Convert arch_deps to select() in faiss, facer, caffe, sigrid

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,13 +1,14 @@
 def get_blas_gomp_arch_deps():
-    return [
-        ("x86_64", [
+    return select({
+        "ovr_config//cpu:x86_64": [
             "fbsource//third-party/mkl:{}".format(native.read_config("fbcode", "mkl_lp64", "mkl_lp64_omp")),
-        ]),
-        ("aarch64", [
+        ],
+        "ovr_config//cpu:arm64": [
             "third-party//Arm-Performance-Libraries:armpl_lp64_mp",
             "third-party//openmp:omp",
-        ]),
-    ]
+        ],
+        "DEFAULT": [],
+    })
 
 default_compiler_flags = [
     "-Wall",


### PR DESCRIPTION
Summary:
Migrate arch_deps and exported_arch_deps attributes to select() statements
using ovr_config//cpu:x86_64 and ovr_config//cpu:arm64 constraints.

Test Plan: Files modified, no functional change expected. Build verification pending.

Reviewed By: get9, dtolnay

Differential Revision: D92397123


