### PR TITLE
[BE] Run only MPS tests in MPS shard

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17279,5 +17279,5 @@ def _run_and_get_stripped_kernels(
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if RUN_CPU or RUN_GPU:
+    if RUN_CPU or RUN_GPU or HAS_MPS:
         run_tests(needs="filelock")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1691,7 +1691,7 @@ def get_selected_tests(options) -> list[str]:
         options.exclude.extend(CPP_TESTS)
 
     if options.mps:
-        os.environ["PYTORCH_TEST_OPS_ONLY_MPS"] = "1"
+        os.environ["PYTORCH_TESTING_DEVICE_ONLY_FOR"] = "mps"
         selected_tests = [
             "test_ops",
             "test_mps",
@@ -1708,7 +1708,7 @@ def get_selected_tests(options) -> list[str]:
             "inductor/test_torchinductor_dynamic_shapes",
         ]
     else:
-        # Exclude all mps tests otherwise
+        # Exclude mps-only tests otherwise
         options.exclude.extend(["test_mps", "test_metal"])
 
     if options.xpu:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -80,16 +80,6 @@ from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_map
 
 
-# If env var PYTORCH_TEST_OPS_ONLY_MPS is set, add 'mps' to the PYTORCH_TESTING_DEVICE_ONLY_FOR env var
-# so that only MPS tests (and any others in PYTORCH_TESTING_DEVICE_ONLY_FOR) are run.
-if os.getenv("PYTORCH_TEST_OPS_ONLY_MPS"):
-    key = "PYTORCH_TESTING_DEVICE_ONLY_FOR"
-    value = os.environ.get(key)
-    devices = value.split(",") if value else []
-    if "mps" not in devices:
-        devices.append("mps")
-        os.environ[key] = ",".join(devices)
-
 if torch.get_default_dtype() != torch.float32:
     raise AssertionError(
         f"default dtype should be float32, got {torch.get_default_dtype()}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #174343
* #174678
* #174677
* __->__ #174676

By defining `PYTORCH_TESTING_DEVICE_ONLY_FOR` in run_test.py

Requires small adjustement to test_torchinductor.py as "mps" is still a not considered GPU from inductor tests PoV

Reduces test time from 62 to 54 min
Test plan: Manually check which slides are running

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo