### PR TITLE
[BE] Allow running only subset of MPS ops benchmarks

### DIFF
--- a/test/bench_mps_ops.py
+++ b/test/bench_mps_ops.py
@@ -165,9 +165,7 @@ def main() -> None:
         ):
             x = torch.testing.make_tensor((B, N, N), device="mps", dtype=dtype)
             y = torch.randint(0, B, (3,))
-            rc.append(
-                bench_binary_op(torch.Tensor.__getitem__, x, y, f"{B}x{N}x{N}")
-            )
+            rc.append(bench_binary_op(torch.Tensor.__getitem__, x, y, f"{B}x{N}x{N}"))
         Compare(rc).print()
 
     def bench_unary_ops():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #174343
* #174678
* __->__ #174677

For example invoking `python test/bench_mps_ops.py index` will benchmark only indexing ops

Claude coded