### PR TITLE
Use version check for XPU fallback registration in inductor

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -273,12 +273,18 @@ with patch.object(torch._C, '_xpu_getDeviceCount', counting_getDeviceCount):
     import torch._inductor.lowering
 
 print(call_count)
+print(torch.xpu.is_initialized())
 """
-        # XPU have extra lines, so get the last line, refer https://github.com/intel/torch-xpu-ops/issues/2261
-        rc = check_output(test_script).splitlines()[-1]
+        rc = check_output(test_script).splitlines()
         self.assertEqual(
-            rc, "0",
-            "Importing torch._inductor.lowering should not query XPU device count"
+            rc[0],
+            "0",
+            "Importing torch._inductor.lowering should not query XPU device count",
+        )
+        self.assertEqual(
+            rc[1],
+            "False",
+            "Importing torch._inductor.lowering should not initialize XPU",
         )
 
     def test_streams(self):

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -244,6 +244,43 @@ if __name__ == "__main__":
         rc = check_output(test_script).splitlines()[-1]
         self.assertEqual(rc, str(torch.xpu.device_count()))
 
+    @unittest.skipIf(
+        IS_WINDOWS, "Only for lazy initialization on Linux, not applicable on Windows."
+    )
+    def test_no_xpu_device_query_on_inductor_import(self):
+        """Validate that importing torch._inductor.lowering does not trigger XPU device queries"""
+
+        def check_output(script: str) -> str:
+            return (
+                subprocess.check_output([sys.executable, "-c", script])
+                .decode("ascii")
+                .strip()
+            )
+
+        test_script = """\
+import torch
+from unittest.mock import patch
+
+call_count = 0
+original_getDeviceCount = torch._C._xpu_getDeviceCount
+
+def counting_getDeviceCount():
+    global call_count
+    call_count += 1
+    return original_getDeviceCount()
+
+with patch.object(torch._C, '_xpu_getDeviceCount', counting_getDeviceCount):
+    import torch._inductor.lowering
+
+print(call_count)
+"""
+        # XPU have extra lines, so get the last line, refer https://github.com/intel/torch-xpu-ops/issues/2261
+        rc = check_output(test_script).splitlines()[-1]
+        self.assertEqual(
+            rc, "0",
+            "Importing torch._inductor.lowering should not query XPU device count"
+        )
+
     def test_streams(self):
         s0 = torch.xpu.Stream()
         torch.xpu.set_stream(s0)

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -60,7 +60,7 @@ bmm_template = TritonTemplate(
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)
 aten_bmm_dtype = ExternKernelChoice(
     torch.bmm,
-    "at::_bmm_out_dtype_xpu" if torch.xpu.is_available() else "at::_bmm_out_dtype_cuda",
+    "at::_bmm_out_dtype_xpu" if torch.xpu._is_compiled() else "at::_bmm_out_dtype_cuda",
     name="bmm_dtype",
     op_overload=aten.bmm.dtype_out,
 )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2987,7 +2987,7 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward, require_contiguous)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
-if torch.xpu.is_available():
+if torch.version.xpu is not None:
     make_fallback(
         aten.embedding_dense_backward, warn=False
     )  # (XPU-only and faster than decomp)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2987,7 +2987,7 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward, require_contiguous)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
-if torch.version.xpu is not None:
+if torch.xpu._is_compiled():
     make_fallback(
         aten.embedding_dense_backward, warn=False
     )  # (XPU-only and faster than decomp)


### PR DESCRIPTION
Use version check for XPU fallback registration in inductor

Replace torch.xpu.is_available() with torch.xpu._is_compiled() in:
    * Inductor fallback registration for embedding_dense_backward
    * Inductor bmm dtype kernel selection
to avoid unnecessary device queries during PyTorch initialization.

Fixes #174672

Testing:
Existing XPU fallback tests cover this path
No behavioral change - same fallback registered

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo