### PR TITLE
[MAGMA][CUDA] cholesky_inverse: deprecate MAGMA and dispatch to cuSolver unconditionally

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -887,81 +887,63 @@ REGISTER_CUDA_DISPATCH(cholesky_stub, &cholesky_kernel)
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ cholesky_inverse ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/*
-Computes the inverse of a symmetric (Hermitian) positive-definite matrix n-by-n matrix 'input' using the Cholesky solver
-This is an in-place routine, content of 'input' is overwritten.
-'infos' is an int Tensor containing error codes for each matrix in the batched input.
-MAGMA requires 'infos' to reside in CPU memory.
-For more information see MAGMA's documentation for POTRS routine.
-*/
-template <typename scalar_t>
-static void apply_cholesky_inverse(Tensor& input, Tensor& infos, bool upper) {
-#if !AT_MAGMA_ENABLED()
-  TORCH_CHECK(false, "cholesky_inverse: MAGMA library not found in compilation. Please rebuild with MAGMA.");
-#else
-  // magmaCholeskyInverse (magma_dpotri_gpu) is slow because internally
-  // it transfers data several times between GPU and CPU and calls lapack routine on CPU
-  // using magmaCholeskySolveBatched is a lot faster
-  // note that magmaCholeskySolve is also slow
-
-  // 'input' is modified in-place we need to clone it and replace with a diagonal matrix
-  // for apply_cholesky_solve
-  auto input_working_copy = cloneBatchedColumnMajor(input);
-
-  // 'input' tensor has to be a batch of diagonal matrix
-  input.fill_(0);
-  input.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1).fill_(1);
-
-  Tensor result_u, input_u;
-  if (input.dim() == 2) {
-    // unsqueezing here so that the batched version is used
-    result_u = input.unsqueeze(0);
-    input_u = input_working_copy.unsqueeze(0);
-  } else {
-    result_u = input;
-    input_u = input_working_copy;
+namespace {
+  // At the time of writing, the unconditional dispatch
+  // to the native cholesky_inverse method in cuSOLVER is slow
+  // with batched inputs.
+  template <bool use_dedicated_kernel_unconditionally = false>
+  inline Tensor& _cholesky_inverse_helper_cuda_cusolver_algo_selector(
+    Tensor& result,
+    Tensor& infos,
+    bool upper) {
+    if constexpr (use_dedicated_kernel_unconditionally) {
+      return cholesky_inverse_kernel_impl_cusolver(result, infos, upper);
+    } else {
+      // TODO: cusolverDn<T>potrsBatched only supports nrhs == 1 and does not have good performance.
+      // TODO: Non-batched potrs is too slow in the batched setting compared to two triangular solves.
+      // Non-batched input -> non-batched potrs.
+      // Batched input -> two triangular solves.
+      if (batchCount(result) == 1) {
+        return cholesky_inverse_kernel_impl_cusolver(result, infos, upper);
+      } else {
+        at::Tensor input_working_copy = cloneBatchedColumnMajor(result);
+        result.fill_(0);
+        result.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1).fill_(1);
+        const auto L = upper
+          ? c10::MaybeOwned<Tensor>::owned(input_working_copy.mH())
+          : c10::MaybeOwned<Tensor>::borrowed(input_working_copy);
+        // NOTE: we tolerate redispatch with at::triangular_solve_triangular
+        // because it handles memory layout optimization and conj/neg flags.
+        // IMPORTANT NOTE: `self` and `A` are not processed for kernel calls yet!
+        // Step 1: Solve for Y: L Y = B or U^H Y = B.
+        auto X = at::linalg_solve_triangular(*L, result, /*upper=*/false);
+        // Step 2: Solve for X: L^H X = Y or U X = Y.
+        at::linalg_solve_triangular_out(result, L->mH(), X, /*upper=*/true);
+        return result;
+      }
+    }
   }
-
-  // magma's potrs_batched doesn't take matrix-wise array of ints as an 'info' argument
-  // it returns a single 'magma_int_t'
-  // if info = 0 the operation is successful, if info = -i, the i-th parameter had an illegal value.
-  int64_t info_tmp = 0;
-  apply_cholesky_solve<scalar_t>(result_u, input_u, upper, info_tmp);
-  infos.fill_(info_tmp);
-#endif
-}
-
-// This is a type dispatching helper function for 'apply_cholesky_inverse'
-Tensor& cholesky_inverse_kernel_impl_magma(Tensor &result, Tensor& infos, bool upper) {
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(result.scalar_type(), "cholesky_inverse_out_cuda", [&]{
-    apply_cholesky_inverse<scalar_t>(result, infos, upper);
-  });
-  return result;
-}
+  
+  inline Tensor& _cholesky_inverse_helper_cuda_cusolver_dispatcher(
+      Tensor& result,
+      Tensor& infos,
+      bool upper) {
+    // For now, unconditional dispatch to the dedicated cholesky inverse
+    // kernel in cuSOLVER is slow for batched inputs.
+    // TODO: switch once resolved.
+    return _cholesky_inverse_helper_cuda_cusolver_algo_selector<
+      /*use_dedicated_kernel_unconditionally=*/false
+    >(result, infos, upper);
+  }
+  
+} // namespace (anonymous)
 
 Tensor& cholesky_inverse_kernel_impl(Tensor &result, Tensor& infos, bool upper) {
   // This function calculates the inverse matrix in-place
   // result should be in column major order and contain matrices to invert
   // the content of result is overwritten by 'apply_cholesky_inverse'
-#if defined(USE_LINALG_SOLVER)
-  auto preferred_backend = at::globalContext().linalgPreferredBackend();
-  switch (preferred_backend) {
-    case at::LinalgBackend::Cusolver:
-      return cholesky_inverse_kernel_impl_cusolver(result, infos, upper);
-    case at::LinalgBackend::Magma:
-      return cholesky_inverse_kernel_impl_magma(result, infos, upper);
-    default:
-      if (batchCount(result) == 1 ||
-          !use_magma_) {
-        return cholesky_inverse_kernel_impl_cusolver(result, infos, upper);
-      } else {
-        return cholesky_inverse_kernel_impl_magma(result, infos, upper);
-      }
-  }
-#else
-  return cholesky_inverse_kernel_impl_magma(result, infos, upper);
-#endif
-
+  _warn_once_magma_deprecation("linalg.cholesky_inverse");
+  return _cholesky_inverse_helper_cuda_cusolver_dispatcher(result, infos, upper);
 }
 
 REGISTER_CUDA_DISPATCH(cholesky_inverse_stub, &cholesky_inverse_kernel_impl)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -923,7 +923,7 @@ namespace {
       }
     }
   }
-  
+
   inline Tensor& _cholesky_inverse_helper_cuda_cusolver_dispatcher(
       Tensor& result,
       Tensor& infos,
@@ -935,7 +935,7 @@ namespace {
       /*use_dedicated_kernel_unconditionally=*/false
     >(result, infos, upper);
   }
-  
+
 } // namespace (anonymous)
 
 Tensor& cholesky_inverse_kernel_impl(Tensor &result, Tensor& infos, bool upper) {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -813,19 +813,19 @@ namespace {
 // to the native cholesky_solve method in cuSOLVER is slow
 // with batched inputs.
 template <bool use_dedicated_kernel_unconditionally = false>
-inline Tensor _cholesky_solve_helper_cuda_cusolver_algo_selector(
-  const Tensor& self,
+inline void _cholesky_solve_helper_cuda_cusolver_algo_selector(
+  Tensor& self,
   const Tensor& A,
   bool upper) {
   if constexpr (use_dedicated_kernel_unconditionally) {
-    return _cholesky_solve_helper_cuda_cusolver(self, A, upper);
+    _cholesky_solve_helper_cuda_cusolver(self, A, upper);
   } else {
     // TODO: cusolverDn<T>potrsBatched only supports nrhs == 1 and does not have good performance.
     // TODO: Non-batched potrs is too slow in the batched setting compared to two triangular solves.
     // Non-batched input -> non-batched potrs.
     // Batched input -> two triangular solves.
     if (batchCount(self) == 1) {
-      return _cholesky_solve_helper_cuda_cusolver(self, A, upper);
+      _cholesky_solve_helper_cuda_cusolver(self, A, upper);
     } else {
       const auto L = upper
         ? c10::MaybeOwned<Tensor>::owned(A.mH())
@@ -834,22 +834,21 @@ inline Tensor _cholesky_solve_helper_cuda_cusolver_algo_selector(
       // because it handles memory layout optimization and conj/neg flags.
       // IMPORTANT NOTE: `self` and `A` are not processed for kernel calls yet!
       // Step 1: Solve for Y: L Y = B or U^H Y = B.
-      auto X = at::linalg_solve_triangular(*L, self, /*upper=*/false);
+      at::linalg_solve_triangular_out(self, *L, self, /*upper=*/false);
       // Step 2: Solve for X: L^H X = Y or U X = Y.
-      at::linalg_solve_triangular_out(const_cast<Tensor&>(X), L->mH(), X, /*upper=*/true);
-      return X;
+      at::linalg_solve_triangular_out(self, L->mH(), self, /*upper=*/true);
     }
   }
 }
 
-inline Tensor _cholesky_solve_helper_cuda_cusolver_dispatcher(
-    const Tensor& self,
+inline void _cholesky_solve_helper_cuda_cusolver_dispatcher(
+    Tensor& self,
     const Tensor& A,
     bool upper) {
   // For now, unconditional dispatch to the dedicated cholesky solve
   // kernel in cuSOLVER is slow for batched inputs.
   // TODO: switch once resolved.
-  return _cholesky_solve_helper_cuda_cusolver_algo_selector<
+  _cholesky_solve_helper_cuda_cusolver_algo_selector<
     /*use_dedicated_kernel_unconditionally=*/false
   >(self, A, upper);
 }
@@ -860,13 +859,18 @@ Tensor _cholesky_solve_helper_cuda(const Tensor& self, const Tensor& A, bool upp
 #if defined(USE_LINALG_SOLVER)
   auto preferred_backend = at::globalContext().linalgPreferredBackend();
   switch (preferred_backend) {
-    case at::LinalgBackend::Cusolver:
-      return _cholesky_solve_helper_cuda_cusolver_dispatcher(self, A, upper);
+    case at::LinalgBackend::Cusolver: {
+      at::Tensor self_working_copy = cloneBatchedColumnMajor(self);
+      _cholesky_solve_helper_cuda_cusolver_dispatcher(self_working_copy, A, upper);
+      return self_working_copy;
+    }
     case at::LinalgBackend::Magma:
       return _cholesky_solve_helper_cuda_magma(self, A, upper);
     default:
       if (!use_magma_) {
-        return _cholesky_solve_helper_cuda_cusolver_dispatcher(self, A, upper);
+        at::Tensor self_working_copy = cloneBatchedColumnMajor(self);
+        _cholesky_solve_helper_cuda_cusolver_dispatcher(self_working_copy, A, upper);
+        return self_working_copy;
       } else {
         return _cholesky_solve_helper_cuda_magma(self, A, upper);
       }
@@ -887,63 +891,16 @@ REGISTER_CUDA_DISPATCH(cholesky_stub, &cholesky_kernel)
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ cholesky_inverse ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-namespace {
-  // At the time of writing, the unconditional dispatch
-  // to the native cholesky_inverse method in cuSOLVER is slow
-  // with batched inputs.
-  template <bool use_dedicated_kernel_unconditionally = false>
-  inline Tensor& _cholesky_inverse_helper_cuda_cusolver_algo_selector(
-    Tensor& result,
-    Tensor& infos,
-    bool upper) {
-    if constexpr (use_dedicated_kernel_unconditionally) {
-      return cholesky_inverse_kernel_impl_cusolver(result, infos, upper);
-    } else {
-      // TODO: cusolverDn<T>potrsBatched only supports nrhs == 1 and does not have good performance.
-      // TODO: Non-batched potrs is too slow in the batched setting compared to two triangular solves.
-      // Non-batched input -> non-batched potrs.
-      // Batched input -> two triangular solves.
-      if (batchCount(result) == 1) {
-        return cholesky_inverse_kernel_impl_cusolver(result, infos, upper);
-      } else {
-        at::Tensor input_working_copy = cloneBatchedColumnMajor(result);
-        result.fill_(0);
-        result.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1).fill_(1);
-        const auto L = upper
-          ? c10::MaybeOwned<Tensor>::owned(input_working_copy.mH())
-          : c10::MaybeOwned<Tensor>::borrowed(input_working_copy);
-        // NOTE: we tolerate redispatch with at::triangular_solve_triangular
-        // because it handles memory layout optimization and conj/neg flags.
-        // IMPORTANT NOTE: `self` and `A` are not processed for kernel calls yet!
-        // Step 1: Solve for Y: L Y = B or U^H Y = B.
-        auto X = at::linalg_solve_triangular(*L, result, /*upper=*/false);
-        // Step 2: Solve for X: L^H X = Y or U X = Y.
-        at::linalg_solve_triangular_out(result, L->mH(), X, /*upper=*/true);
-        return result;
-      }
-    }
-  }
-
-  inline Tensor& _cholesky_inverse_helper_cuda_cusolver_dispatcher(
-      Tensor& result,
-      Tensor& infos,
-      bool upper) {
-    // For now, unconditional dispatch to the dedicated cholesky inverse
-    // kernel in cuSOLVER is slow for batched inputs.
-    // TODO: switch once resolved.
-    return _cholesky_inverse_helper_cuda_cusolver_algo_selector<
-      /*use_dedicated_kernel_unconditionally=*/false
-    >(result, infos, upper);
-  }
-
-} // namespace (anonymous)
-
-Tensor& cholesky_inverse_kernel_impl(Tensor &result, Tensor& infos, bool upper) {
+Tensor& cholesky_inverse_kernel_impl(Tensor &result, [[maybe_unused]] Tensor& infos, bool upper) {
   // This function calculates the inverse matrix in-place
   // result should be in column major order and contain matrices to invert
-  // the content of result is overwritten by 'apply_cholesky_inverse'
+  // the content of result is overwritten
   _warn_once_magma_deprecation("linalg.cholesky_inverse");
-  return _cholesky_inverse_helper_cuda_cusolver_dispatcher(result, infos, upper);
+  at::Tensor A = cloneBatchedColumnMajor(result);
+  result.fill_(0);
+  result.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1).fill_(1);
+  _cholesky_solve_helper_cuda_cusolver_dispatcher(result, A, upper);
+  return result;
 }
 
 REGISTER_CUDA_DISPATCH(cholesky_inverse_stub, &cholesky_inverse_kernel_impl)

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -899,52 +899,28 @@ static void apply_cholesky_cusolver_potrsBatched(Tensor& self_working_copy, cons
   );
 }
 
-Tensor _cholesky_solve_helper_cuda_cusolver(const Tensor& self, const Tensor& A, bool upper) {
+void _cholesky_solve_helper_cuda_cusolver(Tensor& self, const Tensor& A, bool upper) {
   const int64_t batch_size = batchCount(self);
   at::Tensor infos = at::zeros({1}, self.options().dtype(at::kInt));
-  at::Tensor self_working_copy = cloneBatchedColumnMajor(self);
   at::Tensor A_column_major_copy = cloneBatchedColumnMajor(A);
 
-  const int64_t nrhs = self_working_copy.size(-1);
+  const int64_t nrhs = self.size(-1);
 
   // cusolverDn<t>potrsBatched only supports nrhs == 1
   if (batch_size > 1 && nrhs == 1) {
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self.scalar_type(), "cholesky_cuda_potrs_batched", [&] {
-      apply_cholesky_cusolver_potrsBatched<scalar_t>(self_working_copy, A_column_major_copy, upper, infos);
+      apply_cholesky_cusolver_potrsBatched<scalar_t>(self, A_column_major_copy, upper, infos);
     });
   } else {
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self.scalar_type(), "cholesky_cuda_potrs", [&] {
-      apply_cholesky_cusolver_potrs<scalar_t>(self_working_copy, A_column_major_copy, upper, infos);
+      apply_cholesky_cusolver_potrs<scalar_t>(self, A_column_major_copy, upper, infos);
     });
   }
 
   // info from potrs and potrsBatched only report if the i-th parameter is wrong, not about the matrix singularity, etc.
   // So we don't need to check it all the time.
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(infos.item().toInt() == 0);
-
-  return self_working_copy;
 }
-
-
-void _cholesky_inverse_cusolver_potrs_based(Tensor& result, Tensor& infos, bool upper) {
-  at::Tensor input_working_copy = cloneBatchedColumnMajor(result);
-  at::Tensor infos_gpu = at::zeros({1}, result.options().dtype(at::kInt));
-  result.fill_(0);
-  result.diagonal(/*offset=*/0, /*dim1=*/-2, /*dim2=*/-1).fill_(1);
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(result.scalar_type(), "cholesky_cuda_potri", [&] {
-    apply_cholesky_cusolver_potrs<scalar_t>(result, input_working_copy, upper, infos_gpu);
-  });
-
-  // Debug only: info of cusolver potrs only check if the i-th parameter is wrong
-  // Function argument `infos` is a CPU tensor, the following copy will cause a device-host sync.
-  // infos.copy_(infos_gpu);
-}
-
-Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, bool upper) {
-  _cholesky_inverse_cusolver_potrs_based(result, infos, upper);
-  return result;
-}
-
 
 /*
   The geqrf function computes the QR decomposition of a m x n matrix A.

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
@@ -59,8 +59,7 @@ void svd_cusolver(const Tensor& A,
 
 // entrance of calculations of `cholesky` using cusolver potrf and potrfBatched
 void cholesky_helper_cusolver(const Tensor& input, bool upper, const Tensor& info);
-Tensor _cholesky_solve_helper_cuda_cusolver(const Tensor& self, const Tensor& A, bool upper);
-Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor& result, Tensor& infos, bool upper);
+void _cholesky_solve_helper_cuda_cusolver(Tensor& self, const Tensor& A, bool upper);
 
 void geqrf_cusolver(const Tensor& input, const Tensor& tau);
 void ormqr_cusolver(const Tensor& input, const Tensor& tau, const Tensor& other, bool left, bool transpose);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9539,7 +9539,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             run_test(matsize, batchdims, mat_chars=['sym', 'sym_pd', 'sym_psd'])
             run_test(matsize, batchdims, mat_chars=['sing', 'non_sing'])
 
-    @skipCUDAIfNoMagmaAndNoCusolver
+    @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
     def test_cholesky_inverse(self, device, dtype):
@@ -9587,7 +9587,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         expected = torch.inverse(A)
         self.assertEqual(expected, out)
 
-    @skipCUDAIfNoMagma
+    @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
     def test_cholesky_inverse_errors_and_warnings(self, device, dtype):


### PR DESCRIPTION
Both cuSolver and hipSolver implement potrs, so this removes the MAGMA path entirely and adds a deprecation warning, and updates the tests to skip only if missing cuSolver. Thanks @nikitaved for implementing relevant performance improvements in #175898- this PR takes advantage of the triangular solve path as well and benchmarking results are much better than before.

Benchmarking script:
```python
import torch
import torch.utils.benchmark as benchmark

from itertools import product

results = []

batches = [(), (16,), (64,)]
sizes = [16, 128, 512,  2048]

for b, n in product(batches, sizes):
    shape = b + (n, n)
    print(f"Testing shape={shape}")
    label = "torch.cholesky_inverse"
    sub_label = f"{shape}"
    X = torch.rand(*shape, device="cuda")
    X = X @ X.mT + torch.eye(n, device="cuda")
    L = torch.linalg.cholesky(X)
    stmt = "torch.cholesky_inverse(L)"
    for backend in ("magma", "cusolver"):
        torch.backends.cuda.preferred_linalg_library(backend)
        # warm-up
        for _ in range(5):
            exec(stmt)

        results.append(benchmark.Timer(
            stmt=stmt,
            globals={'L': L},
            label=label,
            sub_label=sub_label,
            description=backend,
        ).blocked_autorange(min_run_time=1))

compare = benchmark.Compare(results)
compare.print()
```

Benchmarking results on RTX Pro 6000:
```
[----------- torch.cholesky_inverse ----------]
                        |   magma   |  cusolver | speedup
1 threads: ------------------------------------ |
      (16, 16)          |     37.2  |     31.4  | 1.2
      (128, 128)        |    463.7  |     66.9  | 6.9
      (512, 512)        |   1632.4  |    283.8  | 5.8
      (2048, 2048)      |   7354.0  |   1779.6  | 4.1
      (16, 16, 16)      |     39.1  |     57.8  | 0.7
      (16, 128, 128)    |    597.9  |    159.7  | 3.7
      (16, 512, 512)    |   2947.6  |    852.0  | 3.5
      (16, 2048, 2048)  |  21657.2  |  12394.5  | 1.7
      (64, 16, 16)      |     39.9  |     58.1  | 0.7
      (64, 128, 128)    |    629.5  |    179.2  | 3.5
      (64, 512, 512)    |   4267.9  |   2095.4  | 2.0
      (64, 2048, 2048)  |  63178.9  |  44213.6  | 1.4

Times are in microseconds (us).
```

cc @nikitaved @eqy 