### PR TITLE
[c10d] Document higher-precision reduction

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -248,7 +248,8 @@ accuracy of reduction operations without changing the collective call.
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 
-# Allocate tensors using symmetric memory
+# Allocate tensors using NCCL symmetric memory
+symm_mem.set_backend("NCCL")
 inp = symm_mem.empty(1024, 1024, device=device, dtype=torch.bfloat16)
 symm_mem.rendezvous(inp, group_name)
 

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -152,6 +152,8 @@ You can tune NCCL communicators even further using `torch.distributed.ProcessGro
 and `torch.distributed.ProcessGroupNCCL.Options`. Learn more about them using `help`
 (e.g. `help(torch.distributed.ProcessGroupNCCL.NCCLConfig)`) in the interpreter.
 
+(copy-engine-collectives)=
+
 ### Copy Engine Collectives
 
 :::{note}
@@ -222,6 +224,8 @@ environment variable `NCCL_CTA_POLICY` be set to 2
 - As of NCCL 2.28, CE collectives cannot run with the default stream, so you
 would need to use the `async_op=True` flag to activate the internal stream of
 `ProcessGroupNCCL` or create a side stream yourself
+
+(higher-precision-reduction-with-symmetric-memory)=
 
 ### Higher-Precision Reduction with Symmetric Memory
 

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -152,121 +152,6 @@ You can tune NCCL communicators even further using `torch.distributed.ProcessGro
 and `torch.distributed.ProcessGroupNCCL.Options`. Learn more about them using `help`
 (e.g. `help(torch.distributed.ProcessGroupNCCL.NCCLConfig)`) in the interpreter.
 
-(copy-engine-collectives)=
-
-### Copy Engine Collectives
-
-:::{note}
-Copy Engine Collectives require NCCL 2.28 or later, and GPUs with peer-to-peer (P2P) access.
-:::
-
-Copy Engine (CE) Collectives are an optimization for NCCL collective operations that offload
-data movement to the GPU's copy engines (DMA engines) instead of using CUDA streaming
-multiprocessors (SMs). This frees up SMs for compute work, enabling better overlap of
-communication and computation during distributed training.
-
-To use CE collectives, you need to:
-
-1. Configure the NCCL process group with the zero-CTA policy
-2. Set up symmetric memory with the NCCL backend
-3. Allocate tensors using symmetric memory
-4. Register the tensors with symmetric memory via rendezvous
-
-Once set up, standard collective functions like {func}`all_gather_into_tensor` and
-{func}`all_to_all_single` will automatically use the copy engines when operating
-on symmetric memory tensors.
-
-**Example**
-
-```
-import torch
-import torch.distributed as dist
-import torch.distributed._symmetric_memory as symm_mem
-
-# Initialize process group with zero-CTA policy for CE collectives
-opts = dist.ProcessGroupNCCL.Options()
-opts.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
-device = torch.device("cuda", rank)
-dist.init_process_group(backend="nccl", pg_options=opts, device_id=device)
-
-# Set up symmetric memory with NCCL backend
-symm_mem.set_backend("NCCL")
-group_name = dist.group.WORLD.group_name
-
-# Allocate tensors using symmetric memory
-numel = 1024 * 1024
-inp = symm_mem.empty(numel, device=device)
-out = symm_mem.empty(numel * world_size, device=device)
-
-# Register tensors for symmetric memory operations
-symm_mem.rendezvous(inp, group=group_name)
-symm_mem.rendezvous(out, group=group_name)
-
-# Perform collective operation using copy engines
-# This now runs on DMA engines instead of SMs
-work = dist.all_gather_into_tensor(out, inp, async_op=True)
-work.wait()
-```
-
-**Benefits**
-
-- **SM offloading**: Communication runs on copy engines, leaving SMs free for computation
-- **Better overlap**: Enables more efficient computation/communication overlap
-- **Transparent API**: Uses the same collective API, just with symmetric memory tensors
-
-**Requirements and Limitations**
-
-- NCCL version 2.28 or later
-- GPUs must have peer-to-peer (P2P) access enabled
-- Tensors must be allocated using {func}`torch.distributed._symmetric_memory` and rendezvoused
-- The NCCL process group must be configured with `NCCL_CTA_POLICY_ZERO` or the
-environment variable `NCCL_CTA_POLICY` be set to 2
-- As of NCCL 2.28, CE collectives cannot run with the default stream, so you
-would need to use the `async_op=True` flag to activate the internal stream of
-`ProcessGroupNCCL` or create a side stream yourself
-
-(higher-precision-reduction-with-symmetric-memory)=
-
-### Higher-Precision Reduction with Symmetric Memory
-
-When tensors are allocated with symmetric memory, NCCL's symmetric kernel
-implementation enables internal reduction with higher precision. For example, with
-BF16 inputs, NCCL will automatically accumulate in FP32 internally before producing
-BF16 outputs (BF16 in → FP32 accumulate → BF16 out). This improves numerical
-accuracy of reduction operations without changing the collective call.
-
-**Scope**
-
-- **Applicable operations**: ``reduce_scatter`` and ``all_reduce`` only
-- **Domain**: Within the NVLink domain as of torch 2.9 (NCCL 2.27);
-  NVLink + network for ``reduce_scatter`` as of torch 2.11 (NCCL 2.29)
-- **Precision**: BF16/FP16 in → FP32 internal accumulation → BF16/FP16 out
-
-**Example**
-
-```python
-import torch.distributed as dist
-import torch.distributed._symmetric_memory as symm_mem
-
-# Allocate tensors using NCCL symmetric memory
-symm_mem.set_backend("NCCL")
-inp = symm_mem.empty(1024, 1024, device=device, dtype=torch.bfloat16)
-symm_mem.rendezvous(inp, group_name)
-
-# reduce_scatter and all_reduce on symmetric memory tensors
-# automatically benefit from FP32 internal accumulation
-dist.all_reduce(inp)
-```
-
-:::{note}
-This higher-precision accumulation is enabled transparently by NCCL when
-using symmetric memory tensors. No additional configuration is required
-beyond the symmetric tensor creation and rendezvous described above. This
-currently applies to ``reduce_scatter`` and ``all_reduce`` within the
-supported domains only; other collectives (e.g., ``all_gather``) and
-inter-node communication are not affected.
-:::
-
 (distributed-basics)=
 
 ## Basics
@@ -777,6 +662,29 @@ with torch.profiler():
 ```
 
 Please refer to the [profiler documentation](https://pytorch.org/docs/main/profiler.html) for a full overview of profiler features.
+
+## Optimization with Symmetric Memory
+
+### Copy Engine Collectives
+
+When NCCL collective operations are performed on symmetric memory tensors with
+the zero-CTA policy, data movement is offloaded to the GPU's copy engines (DMA
+engines) instead of using CUDA streaming multiprocessors (SMs). This frees up
+SMs for compute work, enabling better overlap of communication and computation.
+
+For setup instructions, requirements, and examples, see
+[Copy Engine Collectives](copy-engine-collectives) in the Symmetric Memory documentation.
+
+### Higher-Precision Reduction
+
+When NCCL collectives such as ``reduce_scatter`` and ``all_reduce`` operate on
+symmetric memory tensors, NCCL's symmetric kernel implementation automatically
+performs internal reduction with higher precision (e.g., BF16/FP16 in → FP32
+accumulate → BF16/FP16 out). This improves numerical accuracy without any code
+changes to the collective call.
+
+For details on scope, supported domains, and version requirements, see
+[Higher-Precision Reduction](higher-precision-reduction) in the Symmetric Memory documentation.
 
 ## Multi-GPU collective functions
 

--- a/docs/source/symmetric_memory.md
+++ b/docs/source/symmetric_memory.md
@@ -263,26 +263,120 @@ result tensor will be created from symmetric memory too.
 As of torch 2.11, the `CUDA` and `NVSHMEM` backends support MemPool. MemPool
 support of the `NCCL` backend is in progress.
 
+(copy-engine-collectives)=
+
 ## Copy Engine Collectives
 
-When NCCL collective operations are performed on symmetric memory tensors with
-the zero-CTA policy, data movement is offloaded to the GPU's copy engines (DMA
-engines) instead of using CUDA streaming multiprocessors (SMs). This frees up
-SMs for compute work, enabling better overlap of communication and computation.
+:::{note}
+Copy Engine Collectives require NCCL 2.28 or later, and GPUs with peer-to-peer (P2P) access.
+:::
 
-For setup instructions, requirements, and examples, see
-[Copy Engine Collectives](copy-engine-collectives).
+Copy Engine (CE) Collectives are an optimization for NCCL collective operations that offload
+data movement to the GPU's copy engines (DMA engines) instead of using CUDA streaming
+multiprocessors (SMs). This frees up SMs for compute work, enabling better overlap of
+communication and computation during distributed training.
+
+To use CE collectives, you need to:
+
+1. Configure the NCCL process group with the zero-CTA policy
+2. Set up symmetric memory with the NCCL backend
+3. Allocate tensors using symmetric memory
+4. Register the tensors with symmetric memory via rendezvous
+
+Once set up, standard collective functions like {func}`all_gather_into_tensor` and
+{func}`all_to_all_single` will automatically use the copy engines when operating
+on symmetric memory tensors.
+
+**Example**
+
+```
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+# Initialize process group with zero-CTA policy for CE collectives
+opts = dist.ProcessGroupNCCL.Options()
+opts.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
+device = torch.device("cuda", rank)
+dist.init_process_group(backend="nccl", pg_options=opts, device_id=device)
+
+# Set up symmetric memory with NCCL backend
+symm_mem.set_backend("NCCL")
+group_name = dist.group.WORLD.group_name
+
+# Allocate tensors using symmetric memory
+numel = 1024 * 1024
+inp = symm_mem.empty(numel, device=device)
+out = symm_mem.empty(numel * world_size, device=device)
+
+# Register tensors for symmetric memory operations
+symm_mem.rendezvous(inp, group=group_name)
+symm_mem.rendezvous(out, group=group_name)
+
+# Perform collective operation using copy engines
+# This now runs on DMA engines instead of SMs
+work = dist.all_gather_into_tensor(out, inp, async_op=True)
+work.wait()
+```
+
+**Benefits**
+
+- **SM offloading**: Communication runs on copy engines, leaving SMs free for computation
+- **Better overlap**: Enables more efficient computation/communication overlap
+- **Transparent API**: Uses the same collective API, just with symmetric memory tensors
+
+**Requirements and Limitations**
+
+- NCCL version 2.28 or later
+- GPUs must have peer-to-peer (P2P) access enabled
+- Tensors must be allocated using {func}`torch.distributed._symmetric_memory` and rendezvoused
+- The NCCL process group must be configured with `NCCL_CTA_POLICY_ZERO` or the
+environment variable `NCCL_CTA_POLICY` be set to 2
+- As of NCCL 2.28, CE collectives cannot run with the default stream, so you
+would need to use the `async_op=True` flag to activate the internal stream of
+`ProcessGroupNCCL` or create a side stream yourself
+
+(higher-precision-reduction)=
 
 ## Higher-Precision Reduction
 
-When NCCL collectives such as ``reduce_scatter`` and ``all_reduce`` operate on
-symmetric memory tensors, NCCL's symmetric kernel implementation automatically
-performs internal reduction with higher precision (e.g., BF16/FP16 in → FP32
-accumulate → BF16/FP16 out). This improves numerical accuracy without any code
-changes.
+When tensors are allocated with symmetric memory, NCCL's symmetric kernel
+implementation enables internal reduction with higher precision. For example, with
+BF16 inputs, NCCL will automatically accumulate in FP32 internally before producing
+BF16 outputs (BF16 in → FP32 accumulate → BF16 out). This improves numerical
+accuracy of reduction operations without changing the collective call.
 
-For details on scope, supported domains, and version requirements, see
-[Higher-Precision Reduction with Symmetric Memory](higher-precision-reduction-with-symmetric-memory).
+**Scope**
+
+- **Applicable operations**: ``reduce_scatter`` and ``all_reduce`` only
+- **Domain**: Within the NVLink domain as of torch 2.9 (NCCL 2.27);
+  NVLink + network for ``reduce_scatter`` as of torch 2.11 (NCCL 2.29)
+- **Precision**: BF16/FP16 in → FP32 internal accumulation → BF16/FP16 out
+
+**Example**
+
+```python
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+# Allocate tensors using NCCL symmetric memory
+symm_mem.set_backend("NCCL")
+inp = symm_mem.empty(1024, 1024, device=device, dtype=torch.bfloat16)
+symm_mem.rendezvous(inp, group_name)
+
+# reduce_scatter and all_reduce on symmetric memory tensors
+# automatically benefit from FP32 internal accumulation
+dist.all_reduce(inp)
+```
+
+:::{note}
+This higher-precision accumulation is enabled transparently by NCCL when
+using symmetric memory tensors. No additional configuration is required
+beyond the symmetric tensor creation and rendezvous described above. This
+currently applies to ``reduce_scatter`` and ``all_reduce`` within the
+supported domains only; other collectives (e.g., ``all_gather``) and
+inter-node communication are not affected.
+:::
 
 ## API Reference
 

--- a/docs/source/symmetric_memory.md
+++ b/docs/source/symmetric_memory.md
@@ -263,6 +263,27 @@ result tensor will be created from symmetric memory too.
 As of torch 2.11, the `CUDA` and `NVSHMEM` backends support MemPool. MemPool
 support of the `NCCL` backend is in progress.
 
+## Copy Engine Collectives
+
+When NCCL collective operations are performed on symmetric memory tensors with
+the zero-CTA policy, data movement is offloaded to the GPU's copy engines (DMA
+engines) instead of using CUDA streaming multiprocessors (SMs). This frees up
+SMs for compute work, enabling better overlap of communication and computation.
+
+For setup instructions, requirements, and examples, see
+[Copy Engine Collectives](distributed.md#copy-engine-collectives).
+
+## Higher-Precision Reduction
+
+When NCCL collectives such as ``reduce_scatter`` and ``all_reduce`` operate on
+symmetric memory tensors, NCCL's symmetric kernel implementation automatically
+performs internal reduction with higher precision (e.g., BF16/FP16 in → FP32
+accumulate → BF16/FP16 out). This improves numerical accuracy without any code
+changes.
+
+For details on scope, supported domains, and version requirements, see
+[Higher-Precision Reduction with Symmetric Memory](distributed.md#higher-precision-reduction-with-symmetric-memory).
+
 ## API Reference
 
 ```{eval-rst}

--- a/docs/source/symmetric_memory.md
+++ b/docs/source/symmetric_memory.md
@@ -271,7 +271,7 @@ engines) instead of using CUDA streaming multiprocessors (SMs). This frees up
 SMs for compute work, enabling better overlap of communication and computation.
 
 For setup instructions, requirements, and examples, see
-[Copy Engine Collectives](distributed.md#copy-engine-collectives).
+[Copy Engine Collectives](copy-engine-collectives).
 
 ## Higher-Precision Reduction
 
@@ -282,7 +282,7 @@ accumulate → BF16/FP16 out). This improves numerical accuracy without any code
 changes.
 
 For details on scope, supported domains, and version requirements, see
-[Higher-Precision Reduction with Symmetric Memory](distributed.md#higher-precision-reduction-with-symmetric-memory).
+[Higher-Precision Reduction with Symmetric Memory](higher-precision-reduction-with-symmetric-memory).
 
 ## API Reference
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #175014
* #175013
* __->__ #174690

NCCL's symmetric memory kernels now support accumulation in higher precision for reduce_scatter and all_reduce.
e.g. BF16 in → FP32 accumulate → BF16 out. 
Requires symmetric tensor allocation from `torch.distributed._symmetric_memory`; no change needed to the collective call itself, i.e. still `dist.all_reduce` and `dist.reduce_scatter`.

Edit:
Doc section is put under symmetric_memory.md, then we add cross reference in distributed.md to boost awareness.