### PR TITLE
Fix torch.sparse.spdiags crash with zero-dimension shapes (#174052)

### DIFF
--- a/aten/src/ATen/native/sparse/SparseFactories.cpp
+++ b/aten/src/ATen/native/sparse/SparseFactories.cpp
@@ -12,6 +12,7 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/sparse_coo_tensor.h>
 #include <ATen/ops/where.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at::native {
@@ -50,6 +51,12 @@ Tensor spdiags(
   TORCH_CHECK(
       offsets_1d.numel() == std::get<0>(at::_unique(offsets_1d)).numel(),
       "Offset tensor contains duplicate values");
+
+  // Handle zero-dimension shapes early - return empty sparse tensor
+  // This matches scipy.sparse.spdiags behavior
+  if (shape[0] == 0 || shape[1] == 0) {
+    return at::zeros(shape, diagonals_2d.options().layout(layout.value_or(Layout::Sparse)));
+  }
 
   auto nnz_per_diag = at::where(
       offsets_1d.le(0),

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4172,6 +4172,12 @@ class TestSparse(TestSparseBase):
             # some normal cases
             yield (make_diags((1, 5)), make_offsets([0]), (5, 5))
             yield (make_diags((3, 3)), make_offsets([-1, 0, 1]), (4, 4))
+            # zero-dimension shapes (regression test for issue #171505)
+            yield (make_diags((1, 3)), make_offsets([0]), (0, 4))
+            yield (make_diags((1, 3)), make_offsets([0]), (4, 0))
+            yield (make_diags((1, 3)), make_offsets([0]), (0, 0))
+            yield (make_diags((1, 3)), make_offsets([0]), (0, 4), torch.sparse_csr)
+            yield (make_diags((1, 3)), make_offsets([0]), (0, 4), torch.sparse_csc)
             # non-contiguous diags
             yield (make_diags((5, 4), noncontiguous=True), make_offsets([-1, 1, 0, 2, -2]), (5, 5))
             # non-contiguous offsets


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Summary
Fixes the crash (`free(): invalid size`) that occurs when calling `torch.sparse.spdiags` with a shape containing zero dimensions (e.g., `shape=(0, 4)`).

## Changes
- Added early return in `aten/src/ATen/native/sparse/SparseFactories.cpp` to handle zero-dimension shapes
- Returns an empty sparse tensor matching the requested shape and layout

## Root Cause
When the target shape has a zero dimension, the `nnz_per_diag` calculation produces invalid/negative values because the formula doesn't account for zero-sized dimensions. This leads to memory corruption downstream.

## Reproduction
```python
import torch

diagonals = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
offsets = torch.tensor([-1, 0, 1])
shape = (0, 4)

result = torch.sparse.spdiags(diagonals, offsets, shape)
# Before: free(): invalid size / Aborted (core dumped)
# After: Returns empty sparse tensor with shape (0, 4)
```

## Expected Behavior (matching SciPy)
```python
import scipy.sparse
scipy.sparse.spdiags([[1,2,3],[4,5,6],[7,8,9]], [-1,0,1], 0, 4)
# Returns: matrix([], shape=(0, 4), dtype=int64)
```

Fixes #171505
Approved by: https://github.com/pearu, https://github.com/malfet