### PR TITLE
[nativert]additional input/output types for nativert graph serialization

### DIFF
--- a/test/cpp/nativert/test_graph_signature.cpp
+++ b/test/cpp/nativert/test_graph_signature.cpp
@@ -51,6 +51,49 @@ class GraphSignatureTest : public ::testing::Test {
   }
 };
 
+// Helper function to create a tensor argument
+torch::_export::TensorArgument makeTensorArg(const std::string& name) {
+  torch::_export::TensorArgument arg;
+  arg.set_name(name);
+  return arg;
+}
+
+// Helper function to create a SymInt argument with a name
+torch::_export::SymIntArgument makeSymIntArg(const std::string& name) {
+  torch::_export::SymIntArgument arg;
+  arg.set_as_name(name);
+  return arg;
+}
+
+// Helper function to create a SymInt argument with a constant int
+torch::_export::SymIntArgument makeSymIntArgConst(int64_t value) {
+  torch::_export::SymIntArgument arg;
+  arg.set_as_int(value);
+  return arg;
+}
+
+// Helper function to create a SymBool argument with a name
+torch::_export::SymBoolArgument makeSymBoolArg(const std::string& name) {
+  torch::_export::SymBoolArgument arg;
+  arg.set_as_name(name);
+  return arg;
+}
+
+// Helper function to create an OptionalTensorArgument with a tensor
+torch::_export::OptionalTensorArgument makeOptionalTensorArg(
+    const std::string& name) {
+  torch::_export::OptionalTensorArgument arg;
+  arg.set_as_tensor(makeTensorArg(name));
+  return arg;
+}
+
+// Helper function to create an OptionalTensorArgument with None
+torch::_export::OptionalTensorArgument makeOptionalTensorArgNone() {
+  torch::_export::OptionalTensorArgument arg;
+  arg.set_as_none({});
+  return arg;
+}
+
 // Test the constructor with a simple GraphSignature
 TEST_F(GraphSignatureTest, ConstructorTest) {
   std::vector<std::string_view> expected_params = {"param"};
@@ -72,6 +115,470 @@ TEST_F(GraphSignatureTest, ReplaceAllUsesTest) {
   graph_sig.replaceAllUses("output", "new_output");
   std::vector<std::optional<std::string>> expected_outputs = {"new_output"};
   EXPECT_EQ(graph_sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_TENSORS user input handling - each tensor in the list should become
+// a separate entry in userInputs
+TEST(GraphSignatureInputTypesTest, UserInputAsTensors) {
+  // Create list of tensor arguments
+  std::vector<torch::_export::TensorArgument> tensor_list;
+  tensor_list.push_back(makeTensorArg("tensor_0"));
+  tensor_list.push_back(makeTensorArg("tensor_1"));
+  tensor_list.push_back(makeTensorArg("tensor_2"));
+
+  torch::_export::Argument input_arg;
+  input_arg.set_as_tensors(tensor_list);
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  // All tensors in the list should be expanded to individual user inputs
+  std::vector<std::string> expected_inputs = {
+      "tensor_0", "tensor_1", "tensor_2"};
+  EXPECT_EQ(sig.userInputs(), expected_inputs);
+}
+
+// Test AS_OPTIONAL_TENSOR user input handling
+TEST(GraphSignatureInputTypesTest, UserInputAsOptionalTensor) {
+  // Create an optional tensor that has a value
+  torch::_export::Argument input_arg;
+  input_arg.set_as_optional_tensor(makeOptionalTensorArg("opt_tensor"));
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::string> expected_inputs = {"opt_tensor"};
+  EXPECT_EQ(sig.userInputs(), expected_inputs);
+}
+
+// Test AS_OPTIONAL_TENSOR with None value - should be skipped
+TEST(GraphSignatureInputTypesTest, UserInputAsOptionalTensorNone) {
+  torch::_export::Argument input_arg;
+  input_arg.set_as_optional_tensor(makeOptionalTensorArgNone());
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  // None optional tensor should be skipped
+  EXPECT_TRUE(sig.userInputs().empty());
+}
+
+// Test AS_OPTIONAL_TENSORS user input handling - mixed tensors and None values
+TEST(GraphSignatureInputTypesTest, UserInputAsOptionalTensors) {
+  std::vector<torch::_export::OptionalTensorArgument> opt_tensors;
+  opt_tensors.push_back(makeOptionalTensorArg("opt_tensor_0"));
+  opt_tensors.push_back(
+      makeOptionalTensorArgNone()); // None - should be skipped
+  opt_tensors.push_back(makeOptionalTensorArg("opt_tensor_2"));
+
+  torch::_export::Argument input_arg;
+  input_arg.set_as_optional_tensors(opt_tensors);
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  // Only non-None tensors should be in user inputs
+  std::vector<std::string> expected_inputs = {"opt_tensor_0", "opt_tensor_2"};
+  EXPECT_EQ(sig.userInputs(), expected_inputs);
+}
+
+// Test AS_SYM_INT user input handling
+TEST(GraphSignatureInputTypesTest, UserInputAsSymInt) {
+  torch::_export::Argument input_arg;
+  input_arg.set_as_sym_int(makeSymIntArg("sym_int_0"));
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::string> expected_inputs = {"sym_int_0"};
+  EXPECT_EQ(sig.userInputs(), expected_inputs);
+}
+
+// Test AS_SYM_INT with constant value - should be skipped
+TEST(GraphSignatureInputTypesTest, UserInputAsSymIntConstant) {
+  torch::_export::Argument input_arg;
+  input_arg.set_as_sym_int(makeSymIntArgConst(42));
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  // Constant symints should be skipped
+  EXPECT_TRUE(sig.userInputs().empty());
+}
+
+// Test AS_SYM_INTS user input handling - mixed names and constants
+TEST(GraphSignatureInputTypesTest, UserInputAsSymInts) {
+  std::vector<torch::_export::SymIntArgument> sym_ints;
+  sym_ints.push_back(makeSymIntArg("s0"));
+  sym_ints.push_back(makeSymIntArgConst(8)); // Constant - should be skipped
+  sym_ints.push_back(makeSymIntArg("s1"));
+
+  torch::_export::Argument input_arg;
+  input_arg.set_as_sym_ints(sym_ints);
+  torch::_export::UserInputSpec user_input_spec;
+  user_input_spec.set_arg(input_arg);
+  torch::_export::InputSpec input_spec;
+  input_spec.set_user_input(user_input_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  // Only named symints should be in user inputs
+  std::vector<std::string> expected_inputs = {"s0", "s1"};
+  EXPECT_EQ(sig.userInputs(), expected_inputs);
+}
+
+// Test AS_TENSORS user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsTensors) {
+  std::vector<torch::_export::TensorArgument> tensor_list;
+  tensor_list.push_back(makeTensorArg("out_tensor_0"));
+  tensor_list.push_back(makeTensorArg("out_tensor_1"));
+
+  torch::_export::Argument output_arg;
+  output_arg.set_as_tensors(tensor_list);
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::optional<std::string>> expected_outputs = {
+      "out_tensor_0", "out_tensor_1"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_OPTIONAL_TENSOR user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsOptionalTensor) {
+  torch::_export::Argument output_arg;
+  output_arg.set_as_optional_tensor(makeOptionalTensorArg("opt_out_tensor"));
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::optional<std::string>> expected_outputs = {"opt_out_tensor"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_OPTIONAL_TENSOR user output with None - should have nullopt name
+TEST(GraphSignatureOutputTypesTest, UserOutputAsOptionalTensorNone) {
+  torch::_export::Argument output_arg;
+  output_arg.set_as_optional_tensor(makeOptionalTensorArgNone());
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  // None optional tensor should result in nullopt
+  EXPECT_EQ(sig.userOutputs().size(), 1);
+  EXPECT_FALSE(sig.userOutputs()[0].has_value());
+}
+
+// Test AS_OPTIONAL_TENSORS user output handling - mixed tensors and None
+TEST(GraphSignatureOutputTypesTest, UserOutputAsOptionalTensors) {
+  std::vector<torch::_export::OptionalTensorArgument> opt_tensors;
+  opt_tensors.push_back(makeOptionalTensorArg("opt_out_0"));
+  opt_tensors.push_back(makeOptionalTensorArgNone());
+  opt_tensors.push_back(makeOptionalTensorArg("opt_out_2"));
+
+  torch::_export::Argument output_arg;
+  output_arg.set_as_optional_tensors(opt_tensors);
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  EXPECT_EQ(sig.userOutputs().size(), 3);
+  EXPECT_EQ(sig.userOutputs()[0], "opt_out_0");
+  EXPECT_FALSE(sig.userOutputs()[1].has_value()); // None becomes nullopt
+  EXPECT_EQ(sig.userOutputs()[2], "opt_out_2");
+}
+
+// Test AS_SYM_INT user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsSymInt) {
+  torch::_export::Argument output_arg;
+  output_arg.set_as_sym_int(makeSymIntArg("sym_out_0"));
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::optional<std::string>> expected_outputs = {"sym_out_0"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_SYM_INTS user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsSymInts) {
+  std::vector<torch::_export::SymIntArgument> sym_ints;
+  sym_ints.push_back(makeSymIntArg("sym_out_0"));
+  sym_ints.push_back(makeSymIntArgConst(10)); // Constant - should be skipped
+  sym_ints.push_back(makeSymIntArg("sym_out_1"));
+
+  torch::_export::Argument output_arg;
+  output_arg.set_as_sym_ints(sym_ints);
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  // Only named symints should appear
+  std::vector<std::optional<std::string>> expected_outputs = {
+      "sym_out_0", "sym_out_1"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_SYM_BOOL user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsSymBool) {
+  torch::_export::Argument output_arg;
+  output_arg.set_as_sym_bool(makeSymBoolArg("sym_bool_out"));
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::optional<std::string>> expected_outputs = {"sym_bool_out"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_SYM_BOOLS user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsSymBools) {
+  std::vector<torch::_export::SymBoolArgument> sym_bools;
+  sym_bools.push_back(makeSymBoolArg("sym_bool_0"));
+  sym_bools.push_back(makeSymBoolArg("sym_bool_1"));
+
+  torch::_export::Argument output_arg;
+  output_arg.set_as_sym_bools(sym_bools);
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::optional<std::string>> expected_outputs = {
+      "sym_bool_0", "sym_bool_1"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
+}
+
+// Test AS_SYM_FLOAT user output handling - should result in nullopt (unnamed)
+TEST(GraphSignatureOutputTypesTest, UserOutputAsSymFloat) {
+  torch::_export::SymFloatArgument sym_float;
+  sym_float.set_as_name("sym_float_out");
+  torch::_export::Argument output_arg;
+  output_arg.set_as_sym_float(sym_float);
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  // SymFloat outputs currently result in nullopt (unnamed)
+  EXPECT_EQ(sig.userOutputs().size(), 1);
+  EXPECT_FALSE(sig.userOutputs()[0].has_value());
+}
+
+// Test AS_SYM_FLOATS user output handling
+TEST(GraphSignatureOutputTypesTest, UserOutputAsSymFloats) {
+  torch::_export::SymFloatArgument sym_float_0;
+  sym_float_0.set_as_name("sym_float_0");
+  torch::_export::SymFloatArgument sym_float_1;
+  sym_float_1.set_as_name("sym_float_1");
+  std::vector<torch::_export::SymFloatArgument> sym_floats = {
+      sym_float_0, sym_float_1};
+
+  torch::_export::Argument output_arg;
+  output_arg.set_as_sym_floats(sym_floats);
+  torch::_export::UserOutputSpec user_output_spec;
+  user_output_spec.set_arg(output_arg);
+  torch::_export::OutputSpec output_spec;
+  output_spec.set_user_output(user_output_spec);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec});
+
+  GraphSignature sig(storage);
+
+  // SymFloats outputs are treated as unnamed (nullopt)
+  EXPECT_EQ(sig.userOutputs().size(), 2);
+  for (const auto& output : sig.userOutputs()) {
+    EXPECT_FALSE(output.has_value());
+  }
+}
+
+// Test mixed input types in the same GraphSignature
+TEST(GraphSignatureMixedTypesTest, MixedInputTypes) {
+  // First input: single tensor
+  torch::_export::Argument input_arg_0;
+  input_arg_0.set_as_tensor(makeTensorArg("single_tensor"));
+  torch::_export::UserInputSpec user_input_spec_0;
+  user_input_spec_0.set_arg(input_arg_0);
+  torch::_export::InputSpec input_spec_0;
+  input_spec_0.set_user_input(user_input_spec_0);
+
+  // Second input: list of tensors
+  std::vector<torch::_export::TensorArgument> tensor_list;
+  tensor_list.push_back(makeTensorArg("list_tensor_0"));
+  tensor_list.push_back(makeTensorArg("list_tensor_1"));
+  torch::_export::Argument input_arg_1;
+  input_arg_1.set_as_tensors(tensor_list);
+  torch::_export::UserInputSpec user_input_spec_1;
+  user_input_spec_1.set_arg(input_arg_1);
+  torch::_export::InputSpec input_spec_1;
+  input_spec_1.set_user_input(user_input_spec_1);
+
+  // Third input: symint
+  torch::_export::Argument input_arg_2;
+  input_arg_2.set_as_sym_int(makeSymIntArg("batch_size"));
+  torch::_export::UserInputSpec user_input_spec_2;
+  user_input_spec_2.set_arg(input_arg_2);
+  torch::_export::InputSpec input_spec_2;
+  input_spec_2.set_user_input(user_input_spec_2);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({input_spec_0, input_spec_1, input_spec_2});
+  storage.set_output_specs({});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::string> expected_inputs = {
+      "single_tensor", "list_tensor_0", "list_tensor_1", "batch_size"};
+  EXPECT_EQ(sig.userInputs(), expected_inputs);
+}
+
+// Test mixed output types in the same GraphSignature
+TEST(GraphSignatureMixedTypesTest, MixedOutputTypes) {
+  // First output: single tensor
+  torch::_export::Argument output_arg_0;
+  output_arg_0.set_as_tensor(makeTensorArg("single_out"));
+  torch::_export::UserOutputSpec user_output_spec_0;
+  user_output_spec_0.set_arg(output_arg_0);
+  torch::_export::OutputSpec output_spec_0;
+  output_spec_0.set_user_output(user_output_spec_0);
+
+  // Second output: list of tensors
+  std::vector<torch::_export::TensorArgument> tensor_list;
+  tensor_list.push_back(makeTensorArg("list_out_0"));
+  tensor_list.push_back(makeTensorArg("list_out_1"));
+  torch::_export::Argument output_arg_1;
+  output_arg_1.set_as_tensors(tensor_list);
+  torch::_export::UserOutputSpec user_output_spec_1;
+  user_output_spec_1.set_arg(output_arg_1);
+  torch::_export::OutputSpec output_spec_1;
+  output_spec_1.set_user_output(user_output_spec_1);
+
+  // Third output: symint
+  torch::_export::Argument output_arg_2;
+  output_arg_2.set_as_sym_int(makeSymIntArg("out_size"));
+  torch::_export::UserOutputSpec user_output_spec_2;
+  user_output_spec_2.set_arg(output_arg_2);
+  torch::_export::OutputSpec output_spec_2;
+  output_spec_2.set_user_output(user_output_spec_2);
+
+  torch::_export::GraphSignature storage;
+  storage.set_input_specs({});
+  storage.set_output_specs({output_spec_0, output_spec_1, output_spec_2});
+
+  GraphSignature sig(storage);
+
+  std::vector<std::optional<std::string>> expected_outputs = {
+      "single_out", "list_out_0", "list_out_1", "out_size"};
+  EXPECT_EQ(sig.userOutputs(), expected_outputs);
 }
 
 } // namespace torch::nativert

--- a/test/cpp/nativert/test_serialization.cpp
+++ b/test/cpp/nativert/test_serialization.cpp
@@ -2,6 +2,50 @@
 #include <torch/nativert/graph/Serialization.h>
 
 namespace torch::nativert {
+
+// Helper to create tensor argument
+torch::_export::TensorArgument makeTensorArg(const std::string& name) {
+  torch::_export::TensorArgument arg;
+  arg.set_name(name);
+  return arg;
+}
+
+// Helper to create SymInt argument with name
+torch::_export::SymIntArgument makeSymIntArg(const std::string& name) {
+  torch::_export::SymIntArgument arg;
+  arg.set_as_name(name);
+  return arg;
+}
+
+// Helper to create SymInt argument with constant int
+torch::_export::SymIntArgument makeSymIntArgConst(int64_t value) {
+  torch::_export::SymIntArgument arg;
+  arg.set_as_int(value);
+  return arg;
+}
+
+// Helper to create SymBool argument
+torch::_export::SymBoolArgument makeSymBoolArg(const std::string& name) {
+  torch::_export::SymBoolArgument arg;
+  arg.set_as_name(name);
+  return arg;
+}
+
+// Helper to create OptionalTensorArgument with tensor
+torch::_export::OptionalTensorArgument makeOptionalTensorArg(
+    const std::string& name) {
+  torch::_export::OptionalTensorArgument arg;
+  arg.set_as_tensor(makeTensorArg(name));
+  return arg;
+}
+
+// Helper to create OptionalTensorArgument with None
+torch::_export::OptionalTensorArgument makeOptionalTensorArgNone() {
+  torch::_export::OptionalTensorArgument arg;
+  arg.set_as_none({});
+  return arg;
+}
+
 TEST(SerializationTest, CheckIsSymbolic) {
   torch::_export::TensorArgument tensor_arg;
   torch::_export::Argument as_tensor_arg;
@@ -31,6 +75,132 @@ TEST(SerializationTest, CheckIsSymbolic) {
   EXPECT_FALSE(isSymbolic(as_string_arg));
 }
 
+// Test isSymbolic for AS_OPTIONAL_TENSOR
+TEST(SerializationTest, CheckIsSymbolicOptionalTensor) {
+  torch::_export::Argument arg;
+  arg.set_as_optional_tensor(makeOptionalTensorArg("opt_tensor"));
+  EXPECT_TRUE(isSymbolic(arg));
+
+  // Also test with None optional tensor
+  torch::_export::Argument arg_none;
+  arg_none.set_as_optional_tensor(makeOptionalTensorArgNone());
+  EXPECT_TRUE(isSymbolic(arg_none));
+}
+
+// Test isSymbolic for AS_OPTIONAL_TENSORS
+TEST(SerializationTest, CheckIsSymbolicOptionalTensors) {
+  std::vector<torch::_export::OptionalTensorArgument> opt_tensors;
+  opt_tensors.push_back(makeOptionalTensorArg("opt_0"));
+  opt_tensors.push_back(makeOptionalTensorArgNone());
+
+  torch::_export::Argument arg;
+  arg.set_as_optional_tensors(opt_tensors);
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test isSymbolic for AS_SYM_INTS
+TEST(SerializationTest, CheckIsSymbolicSymInts) {
+  std::vector<torch::_export::SymIntArgument> sym_ints;
+  sym_ints.push_back(makeSymIntArg("s0"));
+  sym_ints.push_back(makeSymIntArgConst(8));
+
+  torch::_export::Argument arg;
+  arg.set_as_sym_ints(sym_ints);
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test isSymbolic for AS_SYM_BOOL
+TEST(SerializationTest, CheckIsSymbolicSymBool) {
+  torch::_export::Argument arg;
+  arg.set_as_sym_bool(makeSymBoolArg("sym_bool"));
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test isSymbolic for AS_SYM_BOOLS
+TEST(SerializationTest, CheckIsSymbolicSymBools) {
+  std::vector<torch::_export::SymBoolArgument> sym_bools;
+  sym_bools.push_back(makeSymBoolArg("b0"));
+  sym_bools.push_back(makeSymBoolArg("b1"));
+
+  torch::_export::Argument arg;
+  arg.set_as_sym_bools(sym_bools);
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test isSymbolic for AS_SYM_FLOAT
+TEST(SerializationTest, CheckIsSymbolicSymFloat) {
+  torch::_export::SymFloatArgument sym_float;
+  sym_float.set_as_name("sym_float");
+
+  torch::_export::Argument arg;
+  arg.set_as_sym_float(sym_float);
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test isSymbolic for AS_SYM_FLOATS
+TEST(SerializationTest, CheckIsSymbolicSymFloats) {
+  torch::_export::SymFloatArgument sym_float_0;
+  sym_float_0.set_as_name("sym_float_0");
+  torch::_export::SymFloatArgument sym_float_1;
+  sym_float_1.set_as_name("sym_float_1");
+  std::vector<torch::_export::SymFloatArgument> sym_floats = {
+      sym_float_0, sym_float_1};
+
+  torch::_export::Argument arg;
+  arg.set_as_sym_floats(sym_floats);
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test isSymbolic for AS_CUSTOM_OBJ
+TEST(SerializationTest, CheckIsSymbolicCustomObj) {
+  torch::_export::CustomObjArgument custom_obj;
+  custom_obj.set_name("my_custom_obj");
+  custom_obj.set_class_fqn("my.custom.Class");
+
+  torch::_export::Argument arg;
+  arg.set_as_custom_obj(custom_obj);
+  EXPECT_TRUE(isSymbolic(arg));
+}
+
+// Test that non-symbolic types return false
+TEST(SerializationTest, CheckIsSymbolicNonSymbolicTypes) {
+  // AS_FLOAT
+  torch::_export::Argument as_float;
+  torch::_export::F64 f64_val;
+  f64_val.set(3.14);
+  as_float.set_as_float(f64_val);
+  EXPECT_FALSE(isSymbolic(as_float));
+
+  // AS_INTS
+  torch::_export::Argument as_ints;
+  as_ints.set_as_ints({1, 2, 3});
+  EXPECT_FALSE(isSymbolic(as_ints));
+
+  // AS_FLOATS
+  torch::_export::Argument as_floats;
+  torch::_export::F64 f64_1, f64_2, f64_3;
+  f64_1.set(1.0);
+  f64_2.set(2.0);
+  f64_3.set(3.0);
+  as_floats.set_as_floats({f64_1, f64_2, f64_3});
+  EXPECT_FALSE(isSymbolic(as_floats));
+
+  // AS_BOOLS
+  torch::_export::Argument as_bools;
+  as_bools.set_as_bools({true, false, true});
+  EXPECT_FALSE(isSymbolic(as_bools));
+
+  // AS_NONE
+  torch::_export::Argument as_none;
+  as_none.set_as_none({});
+  EXPECT_FALSE(isSymbolic(as_none));
+
+  // AS_STRINGS
+  torch::_export::Argument as_strings;
+  as_strings.set_as_strings({"a", "b", "c"});
+  EXPECT_FALSE(isSymbolic(as_strings));
+}
+
 TEST(SerializationTest, ConstantToValue) {
   torch::_export::Argument as_int_arg;
   as_int_arg.set_as_int(static_cast<int64_t>(42));
@@ -46,6 +216,116 @@ TEST(SerializationTest, ConstantToValue) {
   as_string_arg.set_as_string("test_string");
   value = constantToValue(as_string_arg, false);
   EXPECT_EQ(value, Constant("test_string"));
+}
+
+// Test constantToValue for AS_FLOAT
+TEST(SerializationTest, ConstantToValueFloat) {
+  torch::_export::Argument arg;
+  torch::_export::F64 f64_val;
+  f64_val.set(3.14159);
+  arg.set_as_float(f64_val);
+  auto value = constantToValue(arg, false);
+  EXPECT_EQ(value, Constant(3.14159));
+}
+
+// Test constantToValue for AS_INTS
+TEST(SerializationTest, ConstantToValueInts) {
+  torch::_export::Argument arg;
+  arg.set_as_ints({1, 2, 3, 4, 5});
+  auto value = constantToValue(arg, false);
+  std::vector<int64_t> expected = {1, 2, 3, 4, 5};
+  EXPECT_EQ(value, Constant(expected));
+}
+
+// Test constantToValue for AS_FLOATS
+TEST(SerializationTest, ConstantToValueFloats) {
+  torch::_export::Argument arg;
+  torch::_export::F64 f64_1, f64_2, f64_3;
+  f64_1.set(1.0);
+  f64_2.set(2.5);
+  f64_3.set(3.14);
+  arg.set_as_floats({f64_1, f64_2, f64_3});
+  auto value = constantToValue(arg, false);
+  std::vector<double> expected = {1.0, 2.5, 3.14};
+  EXPECT_EQ(value, Constant(expected));
+}
+
+// Test constantToValue for AS_BOOLS
+TEST(SerializationTest, ConstantToValueBools) {
+  torch::_export::Argument arg;
+  arg.set_as_bools({true, false, true});
+  auto value = constantToValue(arg, false);
+  std::vector<bool> expected = {true, false, true};
+  EXPECT_EQ(value, Constant(expected));
+}
+
+// Test constantToValue for AS_NONE
+TEST(SerializationTest, ConstantToValueNone) {
+  torch::_export::Argument arg;
+  arg.set_as_none({});
+  auto value = constantToValue(arg, false);
+  EXPECT_EQ(value, Constant(None()));
+}
+
+// Test constantToValue for AS_STRINGS
+TEST(SerializationTest, ConstantToValueStrings) {
+  torch::_export::Argument arg;
+  arg.set_as_strings({"hello", "world"});
+  auto value = constantToValue(arg, false);
+  std::vector<std::string> expected = {"hello", "world"};
+  EXPECT_EQ(value, Constant(expected));
+}
+
+// Test that symbolic types throw when passed to constantToValue
+TEST(SerializationTest, ConstantToValueThrowsOnSymbolicTypes) {
+  // AS_TENSOR should throw
+  torch::_export::Argument as_tensor;
+  as_tensor.set_as_tensor(makeTensorArg("tensor"));
+  EXPECT_THROW(constantToValue(as_tensor, false), std::exception);
+
+  // AS_TENSORS should throw
+  torch::_export::Argument as_tensors;
+  as_tensors.set_as_tensors({makeTensorArg("t1"), makeTensorArg("t2")});
+  EXPECT_THROW(constantToValue(as_tensors, false), std::exception);
+
+  // AS_OPTIONAL_TENSORS should throw
+  torch::_export::Argument as_opt_tensors;
+  as_opt_tensors.set_as_optional_tensors(
+      {makeOptionalTensorArg("opt_t1"), makeOptionalTensorArgNone()});
+  EXPECT_THROW(constantToValue(as_opt_tensors, false), std::exception);
+
+  // AS_SYM_INT should throw
+  torch::_export::Argument as_sym_int;
+  as_sym_int.set_as_sym_int(makeSymIntArg("s0"));
+  EXPECT_THROW(constantToValue(as_sym_int, false), std::exception);
+
+  // AS_SYM_INTS should throw
+  torch::_export::Argument as_sym_ints;
+  as_sym_ints.set_as_sym_ints({makeSymIntArg("s0"), makeSymIntArg("s1")});
+  EXPECT_THROW(constantToValue(as_sym_ints, false), std::exception);
+
+  // AS_SYM_BOOL should throw
+  torch::_export::Argument as_sym_bool;
+  as_sym_bool.set_as_sym_bool(makeSymBoolArg("b0"));
+  EXPECT_THROW(constantToValue(as_sym_bool, false), std::exception);
+
+  // AS_SYM_BOOLS should throw
+  torch::_export::Argument as_sym_bools;
+  as_sym_bools.set_as_sym_bools({makeSymBoolArg("b0"), makeSymBoolArg("b1")});
+  EXPECT_THROW(constantToValue(as_sym_bools, false), std::exception);
+
+  // AS_CUSTOM_OBJ should throw
+  torch::_export::CustomObjArgument custom_obj;
+  custom_obj.set_name("obj");
+  custom_obj.set_class_fqn("MyClass");
+  torch::_export::Argument as_custom_obj;
+  as_custom_obj.set_as_custom_obj(custom_obj);
+  EXPECT_THROW(constantToValue(as_custom_obj, false), std::exception);
+
+  // AS_OPTIONAL_TENSOR should throw
+  torch::_export::Argument as_opt_tensor;
+  as_opt_tensor.set_as_optional_tensor(makeOptionalTensorArg("opt"));
+  EXPECT_THROW(constantToValue(as_opt_tensor, false), std::exception);
 }
 
 } // namespace torch::nativert

--- a/torch/nativert/graph/GraphSignature.cpp
+++ b/torch/nativert/graph/GraphSignature.cpp
@@ -17,6 +17,7 @@ bool isSymbolicOutput(torch::_export::Argument::Tag t) {
   switch (t) {
     case torch::_export::Argument::Tag::AS_TENSOR:
     case torch::_export::Argument::Tag::AS_TENSORS:
+    case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR:
     case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS:
     case torch::_export::Argument::Tag::AS_SYM_BOOL:
     case torch::_export::Argument::Tag::AS_SYM_BOOLS:
@@ -196,6 +197,75 @@ GraphSignature::GraphSignature(const torch::_export::GraphSignature& storage) {
             userInputArg.tag() ==
             torch::_export::Argument::Tag::AS_CUSTOM_OBJ) {
           userInputs_.emplace_back(userInputArg.get_as_custom_obj().get_name());
+        } else if (
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_TENSORS) {
+          // Handle list of tensors
+          for (const auto& tensor : userInputArg.get_as_tensors()) {
+            userInputs_.emplace_back(tensor.get_name());
+          }
+        } else if (
+            userInputArg.tag() ==
+            torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS) {
+          // Handle list of optional tensors
+          for (const auto& optTensor : userInputArg.get_as_optional_tensors()) {
+            if (optTensor.tag() ==
+                torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+              userInputs_.emplace_back(optTensor.get_as_tensor().get_name());
+            }
+            // Skip None tensors
+          }
+        } else if (
+            userInputArg.tag() ==
+            torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR) {
+          // Handle single optional tensor
+          const auto& optTensor = userInputArg.get_as_optional_tensor();
+          if (optTensor.tag() ==
+              torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+            userInputs_.emplace_back(optTensor.get_as_tensor().get_name());
+          }
+          // Skip if None
+        } else if (
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_SYM_INT) {
+          // Handle symbolic int input
+          const auto& symInt = userInputArg.get_as_sym_int();
+          if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+            userInputs_.emplace_back(symInt.get_as_name());
+          }
+          // Skip AS_INT (constant) symints
+        } else if (
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_SYM_INTS) {
+          // Handle list of symbolic ints
+          for (const auto& symInt : userInputArg.get_as_sym_ints()) {
+            if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+              userInputs_.emplace_back(symInt.get_as_name());
+            }
+            // Skip AS_INT (constant) symints
+          }
+        } else if (
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_NONE ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_INT ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_INTS ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_FLOAT ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_FLOATS ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_BOOL ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_BOOLS ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_STRING ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_STRINGS ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_SYM_BOOL ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_SYM_BOOLS ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_SYM_FLOAT ||
+            userInputArg.tag() ==
+                torch::_export::Argument::Tag::AS_SYM_FLOATS ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_INT_LISTS ||
+            userInputArg.tag() ==
+                torch::_export::Argument::Tag::AS_SCALAR_TYPE ||
+            userInputArg.tag() ==
+                torch::_export::Argument::Tag::AS_MEMORY_FORMAT ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_LAYOUT ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_DEVICE ||
+            userInputArg.tag() == torch::_export::Argument::Tag::AS_COMPLEX) {
+          // Non-tensor inputs are constant values, skip them for now
+          // These don't map to named graph inputs in the same way tensors do
         } else {
           // TODO: handle other types
           TORCH_CHECK(false, "Non tensor inputs not implemented yet.");
@@ -256,21 +326,96 @@ GraphSignature::GraphSignature(const torch::_export::GraphSignature& storage) {
       case torch::_export::OutputSpec::Tag::LOSS_OUTPUT:
         lossOutput_ = outputSpec.get_loss_output().get_arg().get_name();
         break;
-      case torch::_export::OutputSpec::Tag::USER_OUTPUT:
-        if (isSymbolicOutput(outputSpec.get_user_output().get_arg().tag())) {
-          switch (outputSpec.get_user_output().get_arg().tag()) {
+      case torch::_export::OutputSpec::Tag::USER_OUTPUT: {
+        const auto& userOutputArg = outputSpec.get_user_output().get_arg();
+        if (isSymbolicOutput(userOutputArg.tag())) {
+          switch (userOutputArg.tag()) {
             case torch::_export::Argument::Tag::AS_TENSOR: {
-              userOutputs_.emplace_back(outputSpec.get_user_output()
-                                            .get_arg()
-                                            .get_as_tensor()
-                                            .get_name());
+              userOutputs_.emplace_back(
+                  userOutputArg.get_as_tensor().get_name());
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_TENSORS: {
+              // Handle list of tensors - each tensor is a separate output
+              for (const auto& tensor : userOutputArg.get_as_tensors()) {
+                userOutputs_.emplace_back(tensor.get_name());
+              }
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS: {
+              // Handle list of optional tensors
+              for (const auto& optTensor :
+                   userOutputArg.get_as_optional_tensors()) {
+                if (optTensor.tag() ==
+                    torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+                  userOutputs_.emplace_back(
+                      optTensor.get_as_tensor().get_name());
+                } else {
+                  // None tensor - no name
+                  userOutputs_.emplace_back(std::nullopt);
+                }
+              }
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR: {
+              // Handle single optional tensor
+              const auto& optTensor = userOutputArg.get_as_optional_tensor();
+              if (optTensor.tag() ==
+                  torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+                userOutputs_.emplace_back(optTensor.get_as_tensor().get_name());
+              } else {
+                // None tensor - no name
+                userOutputs_.emplace_back(std::nullopt);
+              }
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_CUSTOM_OBJ: {
+              userOutputs_.emplace_back(
+                  userOutputArg.get_as_custom_obj().get_name());
               break;
             }
             case torch::_export::Argument::Tag::AS_SYM_INT: {
-              userOutputs_.emplace_back(outputSpec.get_user_output()
-                                            .get_arg()
-                                            .get_as_sym_int()
-                                            .get_as_name());
+              userOutputs_.emplace_back(
+                  userOutputArg.get_as_sym_int().get_as_name());
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_SYM_INTS: {
+              for (const auto& symInt : userOutputArg.get_as_sym_ints()) {
+                if (symInt.tag() ==
+                    torch::_export::SymIntArgument::Tag::AS_NAME) {
+                  userOutputs_.emplace_back(symInt.get_as_name());
+                }
+                // Skip AS_INT (constant) symints
+              }
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+              userOutputs_.emplace_back(
+                  userOutputArg.get_as_sym_bool().get_as_name());
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_SYM_BOOLS: {
+              for (const auto& symBool : userOutputArg.get_as_sym_bools()) {
+                if (symBool.tag() ==
+                    torch::_export::SymBoolArgument::Tag::AS_NAME) {
+                  userOutputs_.emplace_back(symBool.get_as_name());
+                }
+                // Skip AS_BOOL (constant) symbools
+              }
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+              // SymFloat doesn't have get_as_name in all versions
+              // For now, treat as unnamed symbolic output
+              userOutputs_.emplace_back(std::nullopt);
+              break;
+            }
+            case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+              // SymFloats - treat each as unnamed for now
+              for (size_t i = 0; i < userOutputArg.get_as_sym_floats().size();
+                   ++i) {
+                userOutputs_.emplace_back(std::nullopt);
+              }
               break;
             }
             default: {
@@ -283,6 +428,7 @@ GraphSignature::GraphSignature(const torch::_export::GraphSignature& storage) {
           userOutputs_.emplace_back(std::nullopt);
         }
         break;
+      }
       case torch::_export::OutputSpec::Tag::BUFFER_MUTATION:
         buffersToMutate_.emplace(
             outputSpec.get_buffer_mutation().get_arg().get_name(),

--- a/torch/nativert/graph/Serialization.cpp
+++ b/torch/nativert/graph/Serialization.cpp
@@ -200,6 +200,86 @@ std::unique_ptr<Graph> jsonToSubgraph(
           graph->addInput(name, Type::Kind::Tensor);
           break;
         }
+        case torch::_export::Argument::Tag::AS_TENSORS: {
+          // Handle list of tensors - each tensor becomes a separate input
+          for (const auto& tensor : input.get_as_tensors()) {
+            graph->addInput(tensor.get_name(), Type::Kind::Tensor);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR: {
+          // Handle single optional tensor
+          const auto& optTensor = input.get_as_optional_tensor();
+          if (optTensor.tag() ==
+              torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+            graph->addInput(
+                optTensor.get_as_tensor().get_name(), Type::Kind::Tensor);
+          }
+          // Skip if None
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS: {
+          // Handle list of optional tensors
+          for (const auto& optTensor : input.get_as_optional_tensors()) {
+            if (optTensor.tag() ==
+                torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+              graph->addInput(
+                  optTensor.get_as_tensor().get_name(), Type::Kind::Tensor);
+            }
+            // Skip None tensors
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INT: {
+          const auto& symInt = input.get_as_sym_int();
+          if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+            graph->addInput(symInt.get_as_name(), Type::Kind::SymInt);
+          }
+          // Skip constant symints
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INTS: {
+          for (const auto& symInt : input.get_as_sym_ints()) {
+            if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+              graph->addInput(symInt.get_as_name(), Type::Kind::SymInt);
+            }
+            // Skip constant symints
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+          const auto& symBool = input.get_as_sym_bool();
+          if (symBool.tag() == torch::_export::SymBoolArgument::Tag::AS_NAME) {
+            graph->addInput(symBool.get_as_name(), Type::Kind::SymBool);
+          }
+          // Skip constant symbools
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOLS: {
+          for (const auto& symBool : input.get_as_sym_bools()) {
+            if (symBool.tag() ==
+                torch::_export::SymBoolArgument::Tag::AS_NAME) {
+              graph->addInput(symBool.get_as_name(), Type::Kind::SymBool);
+            }
+            // Skip constant symbools
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+          // SymFloat inputs - add as SymFloat type
+          graph->addInput(
+              fmt::format("sym_float_{}", graph->numValues()),
+              Type::Kind::SymFloat);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+          for (size_t i = 0; i < input.get_as_sym_floats().size(); ++i) {
+            graph->addInput(
+                fmt::format("sym_float_{}_{}", graph->numValues(), i),
+                Type::Kind::SymFloat);
+          }
+          break;
+        }
         case torch::_export::Argument::Tag::AS_CUSTOM_OBJ: {
           const auto& asCustomObj = input.get_as_custom_obj();
           const std::string& name = asCustomObj.get_name();
@@ -339,12 +419,91 @@ std::unique_ptr<Graph> jsonToSubgraph(
           graph->addOutput(outputValue);
           break;
         }
+        case torch::_export::Argument::Tag::AS_TENSORS: {
+          // Handle list of tensors - each tensor becomes a separate output
+          for (const auto& tensor : output.get_as_tensors()) {
+            Value* outputValue = graph->getValue(tensor.get_name());
+            graph->addOutput(outputValue);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR: {
+          // Handle single optional tensor
+          const auto& optTensor = output.get_as_optional_tensor();
+          if (optTensor.tag() ==
+              torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+            Value* outputValue =
+                graph->getValue(optTensor.get_as_tensor().get_name());
+            graph->addOutput(outputValue);
+          }
+          // Skip None tensors
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS: {
+          // Handle list of optional tensors
+          for (const auto& optTensor : output.get_as_optional_tensors()) {
+            if (optTensor.tag() ==
+                torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+              Value* outputValue =
+                  graph->getValue(optTensor.get_as_tensor().get_name());
+              graph->addOutput(outputValue);
+            }
+            // Skip None tensors
+          }
+          break;
+        }
         case torch::_export::Argument::Tag::AS_SYM_INT: {
           const auto& asSymInt = output.get_as_sym_int();
           TORCH_CHECK(
               asSymInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME);
           const auto& name = asSymInt.get_as_name();
           Value* outputValue = graph->getValue(name);
+          graph->addOutput(outputValue);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INTS: {
+          for (const auto& symInt : output.get_as_sym_ints()) {
+            if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+              Value* outputValue = graph->getValue(symInt.get_as_name());
+              graph->addOutput(outputValue);
+            }
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+          const auto& symBool = output.get_as_sym_bool();
+          if (symBool.tag() == torch::_export::SymBoolArgument::Tag::AS_NAME) {
+            Value* outputValue = graph->getValue(symBool.get_as_name());
+            graph->addOutput(outputValue);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOLS: {
+          for (const auto& symBool : output.get_as_sym_bools()) {
+            if (symBool.tag() ==
+                torch::_export::SymBoolArgument::Tag::AS_NAME) {
+              Value* outputValue = graph->getValue(symBool.get_as_name());
+              graph->addOutput(outputValue);
+            }
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+          const auto& symFloat = output.get_as_sym_float();
+          Value* outputValue = graph->getValue(symFloat.get_as_name());
+          graph->addOutput(outputValue);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+          for (const auto& symFloat : output.get_as_sym_floats()) {
+            Value* outputValue = graph->getValue(symFloat.get_as_name());
+            graph->addOutput(outputValue);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_CUSTOM_OBJ: {
+          const auto& asCustomObj = output.get_as_custom_obj();
+          Value* outputValue = graph->getValue(asCustomObj.get_name());
           graph->addOutput(outputValue);
           break;
         }


### PR DESCRIPTION
Summary:
We've extended the C++ code to handle additional input/output types for the sigmoid runtime:

  1. GraphSignature.cpp (nativert):
    - Added handling for AS_TENSORS, AS_OPTIONAL_TENSOR, AS_OPTIONAL_TENSORS, AS_SYM_INT/INTS,
  AS_SYM_BOOL/BOOLS, AS_SYM_FLOAT/FLOATS
    - These expand lists of tensors into individual entries in userInputs_
  2. Serialization.cpp (nativert):
    - Added similar handling

Test Plan:
```
buck2 build mode/opt-split-dwarf --show-output //minimal_viable_ai/fire:light

../buck-out/v2/gen/fbcode/5127ce5d381465ea/minimal_viable_ai/fire/__light__/light.par -d ~/fbsource/fbcode/minimal_viable_ai/  -d ~/fbsource/fbcode/minimal_viable_ai/models/ig_ranking/preproc/roo/ -d ~/fbsource/fbcode/torcharrow/accel/ -d ~/fbsource/fbcode/dper_lib/slimper_lib/  -d ~/fbsource/fbcode/sigmoid/  minimal_viable_ai/models/ig_ranking/preproc/roo/benchmark/roo_train_pt2_export_benchmark.py --test-sigmoid-interpreter
```

```
buck2 test //caffe2/test/cpp/nativert:graph_signature_test 

buck2 test //caffe2/test/cpp/nativert:serialization_test
```

Differential Revision: D91826601


