### PR TITLE
[inductor] Preserve zero strides for meta tensors during type conversion

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -991,7 +991,6 @@ inductor_skip_exact_stride = {
     "ormqr",
     "rot90",
     "sum",
-    "tensordot",
 }
 
 # On XPU, Inductor may apply additional layout optimizations that can change

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -54,6 +54,13 @@ def _maybe_convert_to_dtype(a: None, dtype: torch.dtype) -> None:
 def _maybe_convert_to_dtype(a, dtype):
     if isinstance(a, TensorLike):
         if a.dtype != dtype:
+            # Use prims.convert_element_type for meta tensors to preserve
+            # zero strides from broadcast tensors. The .to() method goes
+            # through C++ _to_copy which doesn't preserve zero strides.
+            if a.is_meta:
+                import torch._prims as prims
+
+                return prims.convert_element_type(a, dtype)
             return a.to(dtype)
         return a
     if isinstance(a, Number):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174709

Fix stride mismatch in tensordot opinfo tests by preserving zero strides
(from broadcast tensors created via expand()) during dtype conversion for
meta tensors. The C++ _to_copy path doesn't preserve zero strides, so we
use prims.convert_element_type for meta tensors instead.

Co-authored-by: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo