### PR TITLE
Correctly pass is_inference in the cudagraphs torch.compile backend.

### DIFF
--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -175,7 +175,7 @@ def cudagraphs(dynamo_model: torch.fx.GraphModule, dynamo_inputs: Sequence[Any])
             range(fixed),
             device_index=boxed_device_index.value,
             is_backward=False,
-            is_inference=False,  # Q: should forward is_inference here?
+            is_inference=is_inference,
             stack_traces=get_stack_traces(aot_model),
             placeholders=get_placeholder_info(aot_model.graph),
             mutated_input_idxs=find_input_mutations(aot_model.graph),


### PR DESCRIPTION
Previously, running in inference mode would require the user to call torch.compiler.mark_step_begin() after each call of the torch.compile function, which is not the intended behavior and did not match the behavior of cudagraph trees in the inductor backend.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo