### PR TITLE
Add missing device check in torch.linalg.solve_triangular

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3835,6 +3835,7 @@ Tensor& linalg_solve_triangular_out(
     bool unitriangular,
     Tensor& out) {
   checkInputsSolver(A, B, left, "linalg.solve_triangular");
+  checkSameDevice("linalg.solve_triangular", B, A, "B");
   auto [B_, A_] = _linalg_broadcast_batch_dims(B, A, /*don't check errors*/nullptr);
 
   // We'll write F-contig / F-transpose for FORTRAN contiguous / FORTRAN transpose etc

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4800,6 +4800,14 @@ class TestLinalg(TestCase):
 
                 self.assertEqual(*torch.broadcast_tensors(B, B_other))
 
+    @onlyCUDA
+    @dtypes(torch.float32)
+    def test_linalg_solve_triangular_device_mismatch(self, device, dtype):
+        A = torch.eye(3, dtype=dtype, device=device)
+        B = torch.randn(3, 1, dtype=dtype, device='cpu')
+        with self.assertRaisesRegex(RuntimeError, "same device"):
+            torch.linalg.solve_triangular(A, B, upper=True)
+
     def triangular_solve_test_helper(self, A_dims, b_dims, upper, unitriangular,
                                      device, dtype):
         triangle_function = torch.triu if upper else torch.tril


### PR DESCRIPTION
Fixes #142048

`torch.linalg.solve_triangular` crashes with SIGSEGV when input tensors `A` and `B` are on different devices. This adds a checkSameDevice call to validate that both tensors are on the same device before proceeding, consistent with other linalg functions.

Also adds a regression test for device mismatch.