### PR TITLE
[CD][CUDA13][PTXAS] Remove ptxas bundle from PyTorch cu13 Binary

### DIFF
--- a/.ci/manywheel/build_cuda.sh
+++ b/.ci/manywheel/build_cuda.sh
@@ -117,7 +117,6 @@ case ${CUDA_VERSION} in
     13.0|13.2)
         TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};$([[ "$ARCH" == "aarch64" ]] && echo "11.0;" || echo "")12.0+PTX"
         export TORCH_NVCC_FLAGS="-compress-mode=size"
-        export BUILD_BUNDLE_PTXAS=1
         ;;
     *) echo "unknown cuda version $CUDA_VERSION"; exit 1 ;;
 esac

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -42,7 +42,7 @@ def _reload_python_module(
 def _set_triton_ptxas_path() -> None:
     if os.environ.get("TRITON_PTXAS_PATH") is not None:
         return
-    ptxas = Path(__file__).absolute().parents[2] / "bin" / "ptxas"
+    ptxas = Path(__file__).absolute().parents[1] / "bin" / "ptxas"
     if not ptxas.exists():
         return
     if ptxas.is_file() and os.access(ptxas, os.X_OK):


### PR DESCRIPTION
The ptxas bundling was introduced in https://github.com/pytorch/pytorch/pull/163988 to workaround issues users may face due to https://github.com/pytorch/pytorch/issues/163801 

Fortunately, on the triton upstream side, https://github.com/triton-lang/triton/commit/884fdae82344b2de8206b6e622e2adf75d68f1ed finally landed, which is means https://github.com/pytorch/pytorch/issues/163801  is permanently fixed. 

In addition, pytorch's triton commit pin has been updated via https://github.com/pytorch/pytorch/pull/178821 

We can now roll back https://github.com/pytorch/pytorch/issues/163801 . 

In between, we unified the arm sbsa build with x86, so revert won't work. Manually reverting the export.

Test plan: download and check the binary size to confirm 1) ptxas is gone from both x86 and sbsa (even though I only added to sbsa cu13 initially) 2) unit test that ran on  https://github.com/pytorch/pytorch/pull/163988 should still pass. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy @ptrblck @tinglvv @malfet @atalman 