### PR TITLE
[memoryviz] Adding a checkbox to toggle on/off show trace on click

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1803,7 +1803,7 @@ const interactionCheckbox = interactionLabel.append('input')
   .attr('type', 'checkbox')
   .attr('id', 'interaction-mode-toggle')
   .attr('style', 'cursor: pointer; margin-right: 5px;');
-interactionLabel.append('span').text('Click to show trace (applies on file load)');
+interactionLabel.append('span').text('Require click to show trace (applies on file load)');
 
 interactionCheckbox.on('change', function() {
   const mode = this.checked ? 'click' : 'hover';


### PR DESCRIPTION
This is as per feature request from @stas00, this come handy when the trace spans over many pages.

Default behavior remains unchanged. 

<img width="636" height="126" alt="Screenshot 2026-02-10 at 1 19 16 PM" src="https://github.com/user-attachments/assets/4ea6a520-1a11-4006-bfe3-a4d6dff34223" />

Mostly used claude for this.
