### PR TITLE
Generate SASS instead of PTX from NVRTC

### DIFF
--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -79,8 +79,8 @@ def _get_hiprtc_library() -> ctypes.CDLL:
     lib.nvrtcCreateProgram = lib.hiprtcCreateProgram  # type: ignore[attr-defined]
     lib.nvrtcDestroyProgram = lib.hiprtcDestroyProgram  # type: ignore[attr-defined]
     lib.nvrtcCompileProgram = lib.hiprtcCompileProgram  # type: ignore[attr-defined]
-    lib.nvrtcGetPTXSize = lib.hiprtcGetCodeSize  # type: ignore[attr-defined]
-    lib.nvrtcGetPTX = lib.hiprtcGetCode  # type: ignore[attr-defined]
+    lib.nvrtcGetCUBINSize = lib.hiprtcGetCodeSize  # type: ignore[attr-defined]
+    lib.nvrtcGetCUBIN = lib.hiprtcGetCode  # type: ignore[attr-defined]
     lib.nvrtcGetProgramLogSize = lib.hiprtcGetProgramLogSize  # type: ignore[attr-defined]
     lib.nvrtcGetProgramLog = lib.hiprtcGetProgramLog  # type: ignore[attr-defined]
     lib.nvrtcAddNameExpression = lib.hiprtcAddNameExpression  # type: ignore[attr-defined]
@@ -263,11 +263,11 @@ def _nvrtc_compile(
         libnvrtc.nvrtcGetProgramLog(prog, log)
         raise RuntimeError(f"Kernel compilation failed:\n{log.value.decode()}")
 
-    # Get PTX
-    ptx_size = ctypes.c_size_t()
-    check_nvrtc(libnvrtc.nvrtcGetPTXSize(prog, ctypes.byref(ptx_size)))
-    ptx = ctypes.create_string_buffer(ptx_size.value)
-    check_nvrtc(libnvrtc.nvrtcGetPTX(prog, ptx))
+    # Get binary
+    binary_size = ctypes.c_size_t()
+    check_nvrtc(libnvrtc.nvrtcGetCUBINSize(prog, ctypes.byref(binary_size)))
+    binary = ctypes.create_string_buffer(binary_size.value)
+    check_nvrtc(libnvrtc.nvrtcGetCUBIN(prog, binary))
 
     # Get mangled name
     c_mangled_name = ctypes.c_char_p()
@@ -281,11 +281,9 @@ def _nvrtc_compile(
 
     libnvrtc.nvrtcDestroyProgram(ctypes.byref(prog))
 
-    # For HIP, hipRTC generates raw CO binaries instead of PTX,
-    # and for some reason, ".value" causes the string to be truncated,
+    # For some reason, ".value" causes the string to be truncated,
     # likely due to the presence of '\0' in the string. So we use .raw instead.
-    ptx_bytes = ptx.raw if torch.version.hip else ptx.value
-    return ptx_bytes, mangled_name
+    return binary.raw, mangled_name
 
 
 class _CudaModule:


### PR DESCRIPTION
Generating PTX from NVRTC and then loading it using driver API causes compatibility issues when the driver is from an older cuda toolkit as compared to NVRTC.

NVRTC is a dependency for PyTorch and comes from the CTK that is used to build PyTorch. This version is often newer compared to the CUDA toolkit installed on the user machine. When the CUDA driver on the user machine tries to compile the PTX generated by the later NVRTC, it fails because that PTX version is higher than what the driver supports.

We work around this issue by directly generating SASS for the user's device architecture. There is no need to generate PTX as we are not concerned about portability/backwards compatibility here. The output of JIT compilation is only meant to be used on the current device.