### PR TITLE
[export] Fix non-strict export handling of subclass attr access in __torch_function__

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15625,6 +15625,8 @@ graph():
             "torch.testing._internal.two_tensor.TwoTensor", 2, exactly=True
         ).run(gm_torch_ir.code)
 
+    @testing.expectedFailureSerDerNonStrict  # local subclass can't be pickled
+    @testing.expectedFailureSerDer  # local subclass can't be pickled
     def test_nonstrict_subclass_attr_access_in_torch_function(self):
         class DummyTensor(torch.Tensor):
             @staticmethod

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15641,7 +15641,11 @@ graph():
 
             @classmethod
             def __tensor_unflatten__(
-                cls, tensor_data_dict, extra_metadata, outer_size=None, outer_stride=None
+                cls,
+                tensor_data_dict,
+                extra_metadata,
+                outer_size=None,
+                outer_stride=None,
             ):
                 return DummyTensor(tensor_data_dict["inner"])
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1807,6 +1807,18 @@ def _export_to_aten_ir_make_fx(
                     non_strict_root, assigned_buffers
                 )
 
+            def _find_tracer():
+                """Find the active tracer from torch function mode stack or proxy mode."""
+                if torch._C._is_torch_function_mode_enabled():
+                    for mode in torch.overrides._get_current_function_mode_stack():
+                        if isinstance(mode, PreDispatchTorchFunctionMode):
+                            return mode.tracer
+                # When called from within a subclass's __torch_function__,
+                # PreDispatchTorchFunctionMode has been temporarily popped from
+                # the mode stack. Fall back to ProxyTorchDispatchMode.
+                proxy_mode = get_proxy_mode()
+                return proxy_mode.tracer if proxy_mode is not None else None
+
             def custom_getattribute(self, attr, *, original_getattr, attrs_to_proxy):
                 """
                 The idea here is that we override subclass getattr methods to proxy
@@ -1815,45 +1827,19 @@ def _export_to_aten_ir_make_fx(
                 system.
                 """
                 out = original_getattr(self, attr)
-                if attr in attrs_to_proxy:
-                    if isinstance(out, torch.Tensor):
-                        tracer = None
-                        if torch._C._is_torch_function_mode_enabled():
-                            # When we get here there is no guarantee that we will hit the
-                            # PreDispatchTorchFunctionMode, so we manually peak into the torch
-                            # function mode list and tweak the PreDispatchTorchFunctionMode.
-                            # This has side effect of proxying stuff like
-                            # proxy.node.meta["val"] = extract_val(val) because at that time, torch function
-                            # mode is still active. It seems bad to turn it off inside proxy_tensor.py, so
-                            # I guess we will just rely on DCE for now to remove extra stuff like detach
-                            torch_function_mode_stack = (
-                                torch.overrides._get_current_function_mode_stack()
-                            )
-                            for mode in torch_function_mode_stack:
-                                if isinstance(mode, PreDispatchTorchFunctionMode):
-                                    tracer = mode.tracer
-                                    break
-
-                        # When this is called from within a subclass's __torch_function__,
-                        # PreDispatchTorchFunctionMode has been temporarily popped from the
-                        # torch function mode stack. Fall back to get_proxy_mode() which
-                        # accesses ProxyTorchDispatchMode via the dispatch mode registry.
-                        if tracer is None:
-                            proxy_mode = get_proxy_mode()
-                            if proxy_mode is not None:
-                                tracer = proxy_mode.tracer
-
-                        if tracer is not None:
-                            proxy = get_proxy_slot(self, tracer).proxy
-                            inner_proxy = tracer.create_proxy(
-                                "call_function",
-                                torch.ops.export.access_subclass_inner_tensor.default,
-                                (proxy, attr),
-                                {},
-                            )
-                            track_tensor_tree(
-                                out, inner_proxy, constant=None, tracer=tracer
-                            )
+                if attr in attrs_to_proxy and isinstance(out, torch.Tensor):
+                    tracer = _find_tracer()
+                    if tracer is not None:
+                        proxy = get_proxy_slot(self, tracer).proxy
+                        inner_proxy = tracer.create_proxy(
+                            "call_function",
+                            torch.ops.export.access_subclass_inner_tensor.default,
+                            (proxy, attr),
+                            {},
+                        )
+                        track_tensor_tree(
+                            out, inner_proxy, constant=None, tracer=tracer
+                        )
                 return out
 
             @contextmanager


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174725

Two bugs prevented non-strict export from tracing through subclass inner
tensor attribute access when done inside `__torch_function__`:

1. `attrs_to_proxy` was computed as `set(dir(instance)) - set(dir(torch.Tensor))`,
   which excluded inner tensor attributes that shadow existing `torch.Tensor`
   methods (e.g. `inner` shadows `torch.Tensor.inner`). Fix: also include
   attributes from `__tensor_flatten__()`, the canonical source for inner
   tensor attribute names.

2. `custom_getattribute` looked for `PreDispatchTorchFunctionMode` in the
   torch function mode stack to find the tracer. But during `__torch_function__`
   dispatch, that mode is temporarily popped from the stack. Fix: fall back to
   `get_proxy_mode()` which accesses `ProxyTorchDispatchMode` via the dispatch
   mode pre-dispatch registry, which remains accessible during dispatch.


fixes: https://github.com/pytorch/pytorch/issues/167007 

Authored with Claude.