### PR TITLE
[Pallas] Fix argmax/argmin with keepdim on 3D+ tensors

### DIFF
--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2488,11 +2488,10 @@ class PallasKernel(SIMDKernel):
                 reduction_expr = f"jnp.bitwise_xor.reduce({value})"
         elif reduction_type in ("argmax", "argmin"):
             # For argmax/argmin, the result is indices into the reduction dimension.
-            # Unlike sum/max/min, we can't just reshape because the indices depend
-            # on which axis we reduce over. We need to determine the correct axis.
+            # Use the same pallas_partial_reduce helper as other reductions
+            # to correctly handle 3D+ tensors with multiple pointwise dimensions.
+            # See https://github.com/pytorch/pytorch/issues/174719
             reduction_op = reduction_ops[reduction_type]
-            # Check if this is a true partial reduction (pointwise numel > 1)
-            # When pointwise_numel == 1, it's effectively a full reduction to scalar
             is_partial_reduction = (
                 has_pointwise
                 and pointwise_numel
@@ -2500,42 +2499,7 @@ class PallasKernel(SIMDKernel):
                 and reduction_numel
             )
             if is_partial_reduction and n_reduction_dims > 0:
-                # Partial reduction: determine the reduction axis from load index
-                # The reduction variable's coefficient in the index expression tells us its stride
-                # Higher stride = outer axis (lower axis number in row-major order)
-                reduction_axis = -1  # Default to last axis
-                if self.load_index_exprs:
-                    # Get the first load index expression
-                    load_index = next(iter(self.load_index_exprs.values()))
-                    # Find the reduction variable (starts with 'r')
-                    reduction_vars = [
-                        var
-                        for var, entry in self.range_tree_nodes.items()
-                        if entry.is_reduction
-                    ]
-                    if reduction_vars:
-                        r_var = reduction_vars[0]
-                        # Get the coefficient (stride) of the reduction variable
-                        r_coeff = load_index.coeff(r_var)
-                        r_stride = self._safe_int(r_coeff) if r_coeff != 0 else 1
-                        if r_stride is None:
-                            r_stride = 1
-                        # Get pointwise variable
-                        pw_vars = [
-                            var
-                            for var, entry in self.range_tree_nodes.items()
-                            if not entry.is_reduction
-                        ]
-                        if pw_vars:
-                            pw_var = pw_vars[0]
-                            pw_coeff = load_index.coeff(pw_var)
-                            pw_stride = self._safe_int(pw_coeff) if pw_coeff != 0 else 1
-                            if pw_stride is None:
-                                pw_stride = 1
-                            # Higher stride = earlier (outer) axis
-                            # For 2D: axis 0 has stride = dim1_size, axis 1 has stride = 1
-                            reduction_axis = 0 if r_stride > pw_stride else -1
-                reduction_expr = f"{reduction_op}({value}, axis={reduction_axis})"
+                reduction_expr = f"pallas_partial_reduce({reduction_op}, {value}, {pointwise_numel}, {reduction_numel})"
             else:
                 # Full reduction to scalar
                 reduction_expr = f"{reduction_op}({value})"

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -247,7 +247,13 @@ def torch_dtype_to_jax(dtype: torch.dtype) -> str:
     return f"jnp.{dtype_name}"
 
 
-def pallas_partial_reduce(reduce_fn: Any, v: Any, pw_numel: int, red_numel: int) -> Any:
+def pallas_partial_reduce(
+    reduce_fn: Any,
+    v: Any,
+    pw_numel: int,
+    red_numel: int,
+    reduction_axis: int | None = None,
+) -> Any:
     """
     Helper for partial reductions in Pallas kernels.
 
@@ -259,6 +265,7 @@ def pallas_partial_reduce(reduce_fn: Any, v: Any, pw_numel: int, red_numel: int)
         v: The input array to reduce
         pw_numel: The number of pointwise elements
         red_numel: The number of reduction elements
+        reduction_axis: Optional explicit axis for reduction disambiguation
 
     Returns:
         Reduced array with keepdims-style shape
@@ -266,19 +273,43 @@ def pallas_partial_reduce(reduce_fn: Any, v: Any, pw_numel: int, red_numel: int)
     import jax.numpy as jnp  # pyrefly: ignore [import-error, missing-import]
 
     shape = tuple(v.shape)
+    red_axes: list[int] | None
+    if reduction_axis is not None:
+        axis = reduction_axis
+        if axis < 0:
+            axis += len(shape)
+        if axis < 0 or axis >= len(shape):
+            raise ValueError(
+                f"Invalid reduction_axis={reduction_axis} for shape={shape}"
+            )
+        red_axes = [axis]
+    else:
+        red_axes = None
+
     # Find contiguous axes whose product = red_numel (search from right)
-    red_axes = None
-    for i in range(len(shape) - 1, -1, -1):
-        prod = 1
-        for j in range(i, -1, -1):
-            prod *= shape[j]
-            if prod == red_numel:
-                red_axes = list(range(j, i + 1))
-                break
-        if red_axes is not None:
-            break
+    # when no explicit axis is provided or when the explicit axis would
+    # produce an output shape incompatible with pw_numel.
     if red_axes is None:
-        red_axes = [len(shape) - 1]
+        should_search_red_axes = True
+    else:
+        out_shape = tuple(1 if i in red_axes else s for i, s in enumerate(shape))
+        should_search_red_axes = math.prod(out_shape) != pw_numel
+    if should_search_red_axes:
+        red_axes = None
+        for i in range(len(shape) - 1, -1, -1):
+            prod = 1
+            for j in range(i, -1, -1):
+                prod *= shape[j]
+                if prod == red_numel:
+                    red_axes = list(range(j, i + 1))
+                    break
+            if red_axes is not None:
+                break
+        if red_axes is None:
+            red_axes = [len(shape) - 1]
+    if red_axes is None:
+        raise RuntimeError("Failed to infer reduction axes for pallas_partial_reduce")
+
     # Build output shape with 1s for reduced dimensions (keepdims style)
     out_shape = tuple(1 if i in red_axes else s for i, s in enumerate(shape))
     # Move pointwise axes to front, reduction axes to back


### PR DESCRIPTION
## Summary

Fix Pallas backend codegen crash when lowering `argmax`/`argmin` with `keepdim=True` on non-outermost dimensions of 3D+ tensors.

## Problem

The Pallas codegen produced an incorrect reshape in the generated kernel:
```
TypeError: cannot reshape array of shape (8, 64) into shape (4, 1, 64)
```

The argmax/argmin partial reduction code used custom axis-detection logic that only handled 2D cases (one pointwise var, one reduction var). For 3D+ tensors with multiple pointwise dimensions, it selected the wrong reduction axis.

## Fix

Replace the custom axis-detection logic with the existing `pallas_partial_reduce` helper that already correctly handles 3D+ tensors for other reductions (sum, max, min). This helper reorders axes, reshapes to `(pw_numel, red_numel)`, and reduces on `axis=-1`.

Fixes #174719

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo