### PR TITLE
[DTensor] Fix embedding_dense_backward cache key missing num_weights

### DIFF
--- a/torch/distributed/tensor/_ops/_embedding_ops.py
+++ b/torch/distributed/tensor/_ops/_embedding_ops.py
@@ -8,6 +8,7 @@ from torch.distributed.tensor._op_schema import (
     OpSchema,
     OpStrategy,
     PlacementList,
+    RuntimeSchemaInfo,
     StrategyType,
 )
 from torch.distributed.tensor._ops.utils import (
@@ -74,7 +75,10 @@ def embedding_strategy(op_schema: OpSchema) -> StrategyType:
     return expand_to_full_mesh_op_strategy(mesh, op_schema, single_mesh_dim_strategies)
 
 
-@register_op_strategy(aten.embedding_dense_backward.default)
+@register_op_strategy(
+    aten.embedding_dense_backward.default,
+    schema_info=RuntimeSchemaInfo(static_argnum=2),
+)
 def embedding_dense_backward_strategy(op_schema: OpSchema) -> StrategyType:
     """
     This strategy handles embedding op. We have two possible embedding shardings:


### PR DESCRIPTION
Summary:
The `embedding_dense_backward` op strategy was registered without `RuntimeSchemaInfo(static_argnum=2)`, causing `num_weights` to be excluded from the DTensor op strategy cache key. When multiple embeddings with different vocab sizes (e.g., 32 and 64) ran backward in the same computation graph, the cached strategy from the first call was reused for subsequent calls with different `num_weights`, producing gradients with incorrect shapes.                                                                                                
                                                            
The fix adds `schema_info=RuntimeSchemaInfo(static_argnum=2)` so that `num_weights` is part of the cache key, ensuring each embedding gets the correct backward strategy.

claude-assited

Test Plan: Added `test_embedding_backward_different_num_embeddings` which creates two column-wise sharded embeddings with different vocab sizes (16 and 32), runs forward + backward, and verifies each embedding's weight gradient has the correct shape. Without the fix, the smaller embedding gets a gradient shaped like the larger one, triggering `RuntimeError: Function EmbeddingBackward0 returned an invalid gradient`.

Differential Revision: D92768501


