### PR TITLE
[inductor] Fix missed symbol propagation in cudagraphs partition

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6089,7 +6089,7 @@ class Scheduler:
         candidate_symbols: OrderedSet[sympy.Symbol] = OrderedSet().union(
             *(get_scheduler_node_symbol_uses(node) for node in partition)
         )
-        candidate_symbols.union(
+        candidate_symbols.update(
             *(get_input_node_symbols(node) for _, node in input_nodes.items())
         )
 


### PR DESCRIPTION
Summary: Change a mistaken OrderedSet.union() to OrderedSet.update(). This caused cudagraph cache miskeying when a partition takes dynamically-shaped inputs from non-cudagraphable ops.

Differential Revision: D92879629




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo