### PR TITLE
[Kineto] Fix tempfile read error in _memory_profiler

### DIFF
--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -1210,7 +1210,7 @@ class MemoryProfileTimeline:
         axes.set_title(title)
 
         # Embed the memory timeline image into the HTML file
-        with NamedTemporaryFile("wb", suffix=".png") as tmpfile:
+        with NamedTemporaryFile("w+b", suffix=".png") as tmpfile:
             fig.savefig(tmpfile, format="png")
 
             tmpfile.seek(0, 0)


### PR DESCRIPTION
Summary:
A codemod messed up the file settings for the TemporaryFile, this needs read access as well. This addresses an error in the kineto mlp benchmark test.
{F1985398088}

Test Plan: buck2 run @//mode/dev //kineto/libkineto/fb/integration_tests:mlp_training no longer fails

Differential Revision: D92863219


