### PR TITLE
c10d: convert NanCheck to an op + tests

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -504,6 +504,7 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/Functional.cpp",
     "torch/csrc/distributed/c10d/GlooDeviceFactory.cpp",
     "torch/csrc/distributed/c10d/GroupRegistry.cpp",
+    "torch/csrc/distributed/c10d/NanCheck.cpp",
     "torch/csrc/distributed/c10d/Ops.cpp",
     "torch/csrc/distributed/c10d/ParamCommsUtils.cpp",
     "torch/csrc/distributed/c10d/PrefixStore.cpp",

--- a/test/distributed/test_nan_check.py
+++ b/test/distributed/test_nan_check.py
@@ -1,0 +1,123 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+import unittest
+
+import torch
+import torch.distributed as dist
+
+
+if not dist.is_available():
+    print("distributed package not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+HAS_ACCELERATOR = torch.accelerator.is_available()
+ACCELERATOR = (
+    torch.accelerator.current_accelerator() if HAS_ACCELERATOR else torch.device("cpu")
+)
+
+
+class TestNanCheck(TestCase):
+    def _check_for_nan(self, tensor):
+        torch.ops.c10d.check_for_nan(tensor)
+
+    def test_no_nan_float32(self):
+        self._check_for_nan(torch.randn(100))
+
+    def test_no_nan_float64(self):
+        self._check_for_nan(torch.randn(100, dtype=torch.float64))
+
+    def test_no_nan_float16(self):
+        self._check_for_nan(torch.randn(100, dtype=torch.float16))
+
+    def test_no_nan_bfloat16(self):
+        self._check_for_nan(torch.randn(100, dtype=torch.bfloat16))
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_no_nan_float32_accelerator(self):
+        self._check_for_nan(torch.randn(100, device=ACCELERATOR))
+        torch.accelerator.synchronize()
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_no_nan_float64_accelerator(self):
+        self._check_for_nan(torch.randn(100, dtype=torch.float64, device=ACCELERATOR))
+        torch.accelerator.synchronize()
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_no_nan_float16_accelerator(self):
+        self._check_for_nan(torch.randn(100, dtype=torch.float16, device=ACCELERATOR))
+        torch.accelerator.synchronize()
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_no_nan_bfloat16_accelerator(self):
+        self._check_for_nan(torch.randn(100, dtype=torch.bfloat16, device=ACCELERATOR))
+        torch.accelerator.synchronize()
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_skips_integer_tensors_accelerator(self):
+        self._check_for_nan(
+            torch.tensor([1, 2, 3], dtype=torch.int32, device=ACCELERATOR)
+        )
+        torch.accelerator.synchronize()
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_empty_tensor_accelerator(self):
+        self._check_for_nan(torch.tensor([], dtype=torch.float32, device=ACCELERATOR))
+        torch.accelerator.synchronize()
+
+    @unittest.skipUnless(HAS_ACCELERATOR, "no accelerator available")
+    def test_large_tensor_no_nan_accelerator(self):
+        self._check_for_nan(torch.randn(100000, device=ACCELERATOR))
+        torch.accelerator.synchronize()
+
+    def test_nan_float32(self):
+        tensor = torch.tensor([1.0, 2.0, float("nan"), 4.0])
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(tensor)
+
+    def test_nan_float64(self):
+        tensor = torch.tensor([1.0, float("nan")], dtype=torch.float64)
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(tensor)
+
+    def test_nan_float16(self):
+        tensor = torch.tensor([1.0, float("nan")], dtype=torch.float16)
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(tensor)
+
+    def test_nan_bfloat16(self):
+        tensor = torch.tensor([1.0, float("nan")], dtype=torch.bfloat16)
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(tensor)
+
+    def test_nan_at_end(self):
+        tensor = torch.ones(1000)
+        tensor[-1] = float("nan")
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(tensor)
+
+    def test_skips_integer_tensors(self):
+        self._check_for_nan(torch.tensor([1, 2, 3], dtype=torch.int32))
+
+    def test_empty_tensor(self):
+        self._check_for_nan(torch.tensor([], dtype=torch.float32))
+
+    def test_all_nan(self):
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(torch.full((10,), float("nan")))
+
+    def test_large_tensor_no_nan(self):
+        self._check_for_nan(torch.randn(100000))
+
+    def test_large_tensor_with_nan(self):
+        tensor = torch.randn(100000)
+        tensor[99999] = float("nan")
+        with self.assertRaisesRegex(RuntimeError, "NaN"):
+            self._check_for_nan(tensor)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/distributed/c10d/NanCheck.cpp
+++ b/torch/csrc/distributed/c10d/NanCheck.cpp
@@ -1,0 +1,55 @@
+#include <ATen/Dispatch.h>
+#include <ATen/NumericUtils.h>
+#include <ATen/Parallel.h>
+#include <torch/csrc/distributed/c10d/NanCheck.hpp>
+#include <torch/library.h>
+
+namespace c10d {
+
+namespace {
+
+void check_for_nan_cpu(const at::Tensor& tensor) {
+  if (!tensor.is_floating_point()) {
+    return;
+  }
+  if (tensor.numel() == 0) {
+    return;
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND4(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      at::ScalarType::Float8_e4m3fn,
+      at::ScalarType::Float8_e5m2,
+      tensor.scalar_type(),
+      "check_for_nan_cpu",
+      [&] {
+        auto* data = tensor.data_ptr<scalar_t>();
+        auto numel = tensor.numel();
+        std::atomic<bool> found{false};
+        at::parallel_for(0, numel, 1024, [&](int64_t begin, int64_t end) {
+          for (int64_t i = begin; i < end; i++) {
+            if (at::_isnan(data[i])) {
+              found.store(true, std::memory_order_relaxed);
+              return;
+            }
+          }
+        });
+        TORCH_CHECK(!found.load(), "NaN found in input tensor.");
+      });
+}
+
+TORCH_LIBRARY_IMPL(c10d, CPU, m) {
+  m.impl("check_for_nan", check_for_nan_cpu);
+}
+
+} // namespace
+
+void checkForNan(const at::Tensor& tensor) {
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("c10d::check_for_nan", "")
+                       .typed<void(const at::Tensor&)>();
+  op.call(tensor);
+}
+
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/NanCheck.hpp
+++ b/torch/csrc/distributed/c10d/NanCheck.hpp
@@ -1,16 +1,12 @@
 #pragma once
 
-#ifdef USE_C10D_NCCL
-
 #include <ATen/ATen.h>
-#include <c10/cuda/CUDAStream.h>
+#include <torch/csrc/Export.h>
 
 namespace c10d {
 
-// Check for NaNs in a tensor on a given stream. If any are found, throw a
-// device-side error.
-void checkForNan(const at::Tensor& tensor, at::cuda::CUDAStream& stream);
+// Check for NaNs in a tensor. If any are found, throw an error.
+// Dispatches to device-specific implementations via the c10d::check_for_nan op.
+TORCH_API void checkForNan(const at::Tensor& tensor);
 
 } // namespace c10d
-
-#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -59,6 +59,7 @@ TORCH_LIBRARY(c10d, m) {
       "recv_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int src, int tag) -> __torch__.torch.classes.c10d.Work");
   m.def(
       "recv_any_source_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int tag) -> __torch__.torch.classes.c10d.Work");
+  m.def("check_for_nan(Tensor tensor) -> ()");
 }
 } // namespace
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3742,8 +3742,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   }
 
   if (nanCheck) {
+    at::cuda::CUDAStreamGuard guard(ncclStream);
     for (const auto& input : inputs) {
-      checkForNan(input, ncclStream);
+      checkForNan(input);
     }
   }
 
@@ -4220,7 +4221,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   // Only check for NaN for send ops, for recv ops `tensor` can be a random
   // placeholder
   if (enableNanCheck_ && opType == OpType::SEND) {
-    checkForNan(tensor, ncclStream);
+    at::cuda::CUDAStreamGuard guard(ncclStream);
+    checkForNan(tensor);
   }
 
   if (!coalescing_state_) {


### PR DESCRIPTION
This converts NanCheck into an op so it can be used from outside of ProcessGroupNCCL. This can be used from torchcomms.

Misc changes:
* add CPU implementation
* use CUDA_KERNEL_ASSERT macro so it logs a more helpful message when nancheck fires

Test plan:

CI

```
$ python -c "import torch; torch.ops.c10d.check_for_nan(torch.tensor(float('nan'), device='cuda')); torch.cuda.synchronize()"                 (pytorch-3.12) 
/home/tristanr/pytorch/torch/csrc/distributed/c10d/NanCheck.cu:217: checkForNaN: block: [0,0,0], thread: [0,0,0] Assertion `!isnan(tailPtr[threadIdx.x])` failed.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/tristanr/pytorch/torch/cuda/__init__.py", line 1165, in synchronize
    return torch._C._cuda_synchronize()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: device-side assert triggered
Search for `cudaErrorAssert' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```