### PR TITLE
Fix test_replicate_with_fsdp.py

### DIFF
--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -2,6 +2,7 @@
 
 import copy
 import functools
+import sys
 from copy import deepcopy
 
 import torch
@@ -21,6 +22,7 @@ from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     run_subtests,
     skip_if_lt_x_gpu,
+    TEST_SKIPS,
 )
 from torch.testing._internal.common_fsdp import check_sharded_parity, MLPStack
 from torch.testing._internal.common_utils import run_tests
@@ -56,6 +58,8 @@ class ReplicateTest(MultiProcContinuousTest):
     def _init_pg(cls, rank, world_size, rdvz_file):
         if torch.accelerator.is_available():
             torch.accelerator.set_device_index(rank)
+        if torch.accelerator.device_count() < world_size:
+            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
         super()._init_pg(rank, world_size, rdvz_file)
 
     def init_replicate_tp_mesh(self) -> DeviceMesh:


### PR DESCRIPTION
Summary:
Added a GPU availability check in _init_pg that exits with the appropriate skip code when there aren't enough GPUs.

Fix T254596208

Test Plan: Sandcastle

Differential Revision: D92888486


