### PR TITLE
[ONNX] Use OpSignature from onnx_ir

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -341,12 +341,12 @@ sympy==1.13.3
 #test that import:
 
 onnx==1.20.0
-#Description: Required by onnx tests, and mypy and test_public_bindings.py when checking torch.onnx._internal
+#Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:
 
 onnxscript==0.6.2
-#Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
+#Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -350,9 +350,9 @@ onnxscript==0.6.0
 #Pinned versions:
 #test that import:
 
-onnx-ir==0.1.15
+onnx-ir==0.1.16
 #Description: In-memory IR for ONNX, dependency of onnxscript. Pinned to avoid breaking changes in newer versions.
-#Pinned versions: 0.1.12
+#Pinned versions:
 #test that import:
 
 parameterized==0.8.1

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -345,7 +345,7 @@ onnx==1.20.0
 #Pinned versions:
 #test that import:
 
-onnxscript==0.6.0
+onnxscript==0.6.2
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -16,11 +16,10 @@ import logging
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, TYPE_CHECKING, Union
 
-import onnxscript
-from onnxscript import evaluator, ir
-from onnxscript.ir import convenience as ir_convenience
+from onnxscript import evaluator
 
 import torch
+from torch.onnx._internal._lazy_import import onnx_ir as ir, onnxscript
 from torch.onnx._internal.exporter import _errors, _schemas, _tensors
 
 
@@ -41,7 +40,7 @@ AllowedArgType = Union[
 
 # Logic for adapting inputs from general Python or PyTorch inputs to ONNX ir.Value
 def _construct_named_inputs_and_attrs(
-    signature: _schemas.OpSignature,
+    signature: ir.schemas.OpSignature,
     args: Sequence[AllowedArgType],
     kwargs: Mapping[str, AllowedArgType],
 ) -> tuple[dict[str, AllowedArgType], dict[str, ValidAttributeType]]:
@@ -71,7 +70,7 @@ def _construct_named_inputs_and_attrs(
     named_attrs: dict[str, Any] = {}
     reversed_args_stack = list(reversed(args))
     for param in signature.params:
-        if isinstance(param, _schemas.Parameter):
+        if isinstance(param, ir.schemas.Parameter):
             # Handle inputs
             if reversed_args_stack:
                 # First exhaust the positional arguments
@@ -98,7 +97,7 @@ def _construct_named_inputs_and_attrs(
         else:
             # Handle attributes
             attribute: ValidAttributeType | ir.Attr
-            if not isinstance(param, _schemas.AttributeParameter):
+            if not isinstance(param, ir.schemas.AttributeParameter):
                 raise AssertionError(f"Expected AttributeParameter, got {type(param)}")
             if reversed_args_stack:
                 # First exhaust the positional arguments
@@ -140,8 +139,8 @@ def _construct_named_inputs_and_attrs(
 
 
 def _resolve_parameter_dtypes(
-    signature: _schemas.OpSignature, named_inputs: Mapping[str, AllowedArgType]
-) -> Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol]:
+    signature: ir.schemas.OpSignature, named_inputs: Mapping[str, AllowedArgType]
+) -> Mapping[ir.schemas.TypeConstraintParam, ir.TypeProtocol]:
     """Determine which parameter takes which type.
 
     Handle non-tensor input corner cases and type promotion.
@@ -165,7 +164,7 @@ def _resolve_parameter_dtypes(
     type_binding = {}
     for name, arg in named_inputs.items():
         param = signature.params_map[name]
-        if not isinstance(param, _schemas.Parameter):
+        if not isinstance(param, ir.schemas.Parameter):
             raise AssertionError(f"Expected Parameter, got {type(param)}")
         if isinstance(arg, (int, float, bool, str, Sequence, torch.Tensor)):
             # Skip the Python constants because we do not know what dtype they should take yet
@@ -183,9 +182,9 @@ def _resolve_parameter_dtypes(
 
 
 def _determine_input_dtype(
-    param: _schemas.Parameter,
+    param: ir.schemas.Parameter,
     arg: AllowedArgType,
-    type_binding: Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol],
+    type_binding: Mapping[ir.schemas.TypeConstraintParam, ir.TypeProtocol],
 ) -> ir.DataType:
     """Determine the dtype of the input that is a mix of Python constants and ir.Value."""
     if param.type_constraint in type_binding:
@@ -288,9 +287,9 @@ def _get_or_create_constant(
 
 
 def _process_python_constants(
-    signature: _schemas.OpSignature,
+    signature: ir.schemas.OpSignature,
     named_inputs: dict[str, AllowedArgType],
-    type_binding: Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol],
+    type_binding: Mapping[ir.schemas.TypeConstraintParam, ir.TypeProtocol],
     constant_farm: dict[
         tuple[
             bool | int | float | str | tuple[int, ...] | tuple[float, ...],
@@ -324,7 +323,7 @@ def _process_python_constants(
     #       - Otherwise, set named_inputs[param.name] = Constant(value)
     for name, arg in named_inputs.items():
         param = signature.params_map[name]
-        if not isinstance(param, _schemas.Parameter):
+        if not isinstance(param, ir.schemas.Parameter):
             raise AssertionError(f"Expected Parameter, got {type(param)}")
 
         if isinstance(arg, ir.Value):
@@ -369,9 +368,9 @@ def _reshape_to_1d_tensor(opset: onnxscript.values.Opset, arg: ir.Value) -> ir.V
 
 
 def _process_python_sequences(
-    signature: _schemas.OpSignature,
+    signature: ir.schemas.OpSignature,
     named_inputs: dict[str, AllowedArgType],
-    type_binding: Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol],
+    type_binding: Mapping[ir.schemas.TypeConstraintParam, ir.TypeProtocol],
     constant_farm: dict[
         tuple[
             bool
@@ -396,7 +395,7 @@ def _process_python_sequences(
     """
     for name, arg in named_inputs.items():
         param = signature.params_map[name]
-        if not isinstance(param, _schemas.Parameter):
+        if not isinstance(param, ir.schemas.Parameter):
             raise AssertionError(f"Expected Parameter, got {type(param)}")
 
         if not isinstance(arg, (tuple, list)):
@@ -470,7 +469,7 @@ def _process_python_sequences(
 
 
 def _determine_output_number(
-    signature: _schemas.OpSignature, named_attrs: Mapping[str, ValidAttributeType]
+    signature: ir.schemas.OpSignature, named_attrs: Mapping[str, ValidAttributeType]
 ) -> int:
     """Determine the number of outputs for the node with heuristics."""
     if signature.domain == "":
@@ -490,7 +489,7 @@ def _determine_output_number(
 
 
 def _construct_node(
-    signature: _schemas.OpSignature,
+    signature: ir.schemas.OpSignature,
     named_inputs: Mapping[str, ir.Value | None],
     named_attrs: Mapping[str, ValidAttributeType],
     opset: onnxscript.values.Opset,
@@ -527,7 +526,7 @@ def _construct_node(
     # Construct and filter out None attributes
     attributes = [
         attr
-        for attr in ir_convenience.convert_attributes(named_attrs)
+        for attr in ir.convenience.convert_attributes(named_attrs)
         if attr.value is not None
     ]
     outputs = [_tensors.SymbolicTensor(opset) for _ in range(num_outputs)]
@@ -537,7 +536,7 @@ def _construct_node(
         inputs=inputs,
         attributes=attributes,
         outputs=outputs,
-        version=signature.opset_version,
+        version=signature.since_version,
     )
 
 
@@ -556,7 +555,7 @@ class OpRecorder(evaluator.Evaluator):
 
     def _call_op(
         self,
-        op_signature: _schemas.OpSignature,
+        op_signature: ir.schemas.OpSignature,
         named_inputs: dict[str, AllowedArgType],
         named_attrs: dict[str, ValidAttributeType],
         num_outputs: int,
@@ -612,7 +611,7 @@ class OpRecorder(evaluator.Evaluator):
         kwargs: Mapping[str, AllowedArgType],
     ) -> _tensors.SymbolicTensor | Sequence[_tensors.SymbolicTensor]:
         try:
-            op_signature = _schemas.OpSignature.from_opschema(schema)
+            op_signature = ir.schemas.OpSignature.from_op_schema(schema)
             named_inputs, named_attrs = _construct_named_inputs_and_attrs(
                 op_signature, args, kwargs
             )
@@ -661,11 +660,11 @@ class OpRecorder(evaluator.Evaluator):
             if hasattr(function, "_pt_onnx_signature"):
                 op_signature = function._pt_onnx_signature  # type: ignore[attr-defined]
             else:
-                op_signature = _schemas.OpSignature.from_function(
+                op_signature = _schemas.op_signature_from_function(
                     function,
                     function.function_ir.domain,
                     function.name,
-                    opset_version=function.opset.version,
+                    since_version=function.opset.version,
                 )
                 function._pt_onnx_signature = op_signature  # type: ignore[attr-defined]
 

--- a/torch/onnx/_internal/exporter/_registration.py
+++ b/torch/onnx/_internal/exporter/_registration.py
@@ -23,7 +23,7 @@ from typing import Literal, TypeAlias, Union
 
 import torch
 import torch._ops
-from torch.onnx._internal._lazy_import import onnxscript, onnxscript_apis
+from torch.onnx._internal._lazy_import import onnx_ir as ir, onnxscript, onnxscript_apis
 from torch.onnx._internal.exporter import _constants, _schemas
 from torch.onnx._internal.exporter._torchlib import _torchlib_registry
 
@@ -51,7 +51,7 @@ class OnnxDecompMeta:
 
     onnx_function: Callable
     fx_target: TorchOp
-    signature: _schemas.OpSignature | None
+    signature: ir.schemas.OpSignature | None
     is_custom: bool = False
     is_complex: bool = False
     opset_introduced: int = 18
@@ -62,17 +62,17 @@ class OnnxDecompMeta:
         if self.signature is None and not self.skip_signature_inference:
             try:
                 if isinstance(self.onnx_function, onnxscript.OnnxFunction):
-                    signature = _schemas.OpSignature.from_function(  # type: ignore[attr-defined]
+                    signature = _schemas.op_signature_from_function(
                         self.onnx_function,
                         # pyrefly: ignore [missing-attribute]
                         self.onnx_function.function_ir.domain,
                         # pyrefly: ignore [missing-attribute]
                         self.onnx_function.name,
                         # pyrefly: ignore [missing-attribute]
-                        opset_version=self.onnx_function.opset.version,
+                        since_version=self.onnx_function.opset.version,
                     )
                 else:
-                    signature = _schemas.OpSignature.from_function(
+                    signature = _schemas.op_signature_from_function(
                         self.onnx_function, "__traced", self.onnx_function.__name__
                     )
             except Exception as e:

--- a/torch/onnx/_internal/exporter/_schemas.py
+++ b/torch/onnx/_internal/exporter/_schemas.py
@@ -220,6 +220,9 @@ def op_signature_from_function(
                 f"T_{param.name}"
             )
             type_constraints[param.name] = type_constraint
+            kwargs: dict[str, Any] = {}
+            if param.default is not inspect.Parameter.empty:
+                kwargs["default"] = param.default
             params.append(
                 ir.schemas.Parameter(
                     name=param.name,
@@ -227,9 +230,7 @@ def op_signature_from_function(
                     required=param.default is inspect.Parameter.empty,
                     # TODO: Handle variadic
                     variadic=False,
-                    default=param.default
-                    if param.default is not inspect.Parameter.empty
-                    else ir.schemas._EMPTY_DEFAULT,
+                    **kwargs,
                 )
             )
         else:
@@ -270,6 +271,9 @@ def op_signature_from_function(
                     )
                     type_constraints[type_constraint_name] = type_constraint
                 # 4. Create Parameter
+                kwargs: dict[str, Any] = {}
+                if param.default is not inspect.Parameter.empty:
+                    kwargs["default"] = param.default
                 params.append(
                     ir.schemas.Parameter(
                         name=param.name,
@@ -277,9 +281,7 @@ def op_signature_from_function(
                         required=param.default is inspect.Parameter.empty,
                         # TODO: Handle variadic
                         variadic=False,
-                        default=param.default
-                        if param.default is not inspect.Parameter.empty
-                        else ir.schemas._EMPTY_DEFAULT,
+                        **kwargs,
                     )
                 )
 
@@ -318,7 +320,6 @@ def op_signature_from_function(
                     type_constraint=type_constraint,
                     required=True,
                     variadic=False,
-                    default=ir.schemas._EMPTY_DEFAULT,
                 )
             )
 

--- a/torch/onnx/_internal/exporter/_schemas.py
+++ b/torch/onnx/_internal/exporter/_schemas.py
@@ -1,28 +1,21 @@
 # mypy: allow-untyped-defs
+"""Helpers for constructing ONNX operator signatures from Python functions."""
+
 from __future__ import annotations
 
 import collections.abc
-import dataclasses
 import inspect
 import logging
 import types
 import typing
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any, Optional, TypeVar, Union
 
-from torch.onnx._internal._lazy_import import onnx, onnx_ir as ir, onnxscript
+from torch.onnx._internal._lazy_import import onnx_ir as ir, onnxscript
 
 
 logger = logging.getLogger(__name__)
 
-
-# A special value to indicate that the default value is not specified
-class _Empty:
-    def __repr__(self) -> str:
-        return "_EMPTY_DEFAULT"
-
-
-_EMPTY_DEFAULT = _Empty()
 
 # Map from python type to corresponding ONNX AttributeProto type
 _PY_TYPE_TO_ATTR_TYPE = {
@@ -65,131 +58,6 @@ _ALL_VALUE_TYPES = (
 # - TypeVars with above bounds
 # - Above types with annotation attached
 TypeAnnotationValue = Any
-
-
-@dataclasses.dataclass(frozen=True)
-class TypeConstraintParam:
-    """Type constraint for a parameter.
-
-    Attributes:
-        name: Name of the parameter. E.g. "TFloat"
-        allowed_types: Allowed types for the parameter.
-    """
-
-    name: str
-    allowed_types: set[ir.TypeProtocol]
-    description: str = ""
-
-    def __hash__(self) -> int:
-        return hash((self.name, tuple(self.allowed_types)))
-
-    def __str__(self) -> str:
-        allowed_types_str = " | ".join(str(t) for t in self.allowed_types)
-        return f"{self.name}={allowed_types_str}"
-
-    @classmethod
-    def any_tensor(cls, name: str, description: str = "") -> TypeConstraintParam:
-        return cls(name, {ir.TensorType(dtype) for dtype in ir.DataType}, description)
-
-    @classmethod
-    def any_value(cls, name: str, description: str = "") -> TypeConstraintParam:
-        return cls(name, _ALL_VALUE_TYPES, description)  # type: ignore[arg-type]
-
-
-@dataclasses.dataclass(frozen=True)
-class Parameter:
-    """A formal parameter of an operator."""
-
-    name: str
-    type_constraint: TypeConstraintParam
-    required: bool
-    variadic: bool
-    default: Any = _EMPTY_DEFAULT
-    # TODO: Add other properties too
-
-    def __str__(self) -> str:
-        type_str = self.type_constraint.name
-        if self.has_default():
-            return f"{self.name}: {type_str} = {self.default}"
-        return f"{self.name}: {type_str}"
-
-    def has_default(self) -> bool:
-        return self.default is not _EMPTY_DEFAULT
-
-
-@dataclasses.dataclass(frozen=True)
-class AttributeParameter:
-    """A parameter in the function signature that represents an ONNX attribute."""
-
-    name: str
-    type: ir.AttributeType
-    required: bool
-    default: ir.Attr | None = None
-
-    def __str__(self) -> str:
-        type_str = self.type.name
-        if self.has_default():
-            return f"{self.name}: {type_str} = {self.default}"
-        return f"{self.name}: {type_str}"
-
-    def has_default(self) -> bool:
-        return self.default is not None
-
-
-def _get_type_from_str(
-    type_str: str,
-) -> ir.TensorType | ir.SequenceType | ir.OptionalType:
-    """Converter a type_str from ONNX Opschema to ir.TypeProtocol.
-
-    A type str has the form of "tensor(float)" or composite type like "seq(tensor(float))".
-    """
-
-    # TODO: Upstream this to IR
-
-    # Split the type_str a sequence types and dtypes
-    # 1. Remove the ending ")"
-    striped = type_str.rstrip(")")
-    # 2. Split the type_str by "("
-    type_parts = striped.split("(")
-
-    # Convert the dtype to ir.DataType
-    dtype = ir.DataType[type_parts[-1].upper()]
-
-    # Create a place holder type first
-    type_: ir.TypeProtocol = ir.TensorType(ir.DataType.UNDEFINED)
-
-    # Construct the type
-    for type_part in reversed(type_parts[:-1]):
-        if type_part == "tensor":
-            type_ = ir.TensorType(dtype)
-        elif type_part == "seq":
-            type_ = ir.SequenceType(type_)
-        elif type_part == "optional":
-            type_ = ir.OptionalType(type_)
-        else:
-            raise ValueError(f"Unknown type part: '{type_part}' in type '{type_str}'")
-    return type_  # type: ignore[return-value]
-
-
-def _convert_formal_parameter(
-    param: onnx.defs.OpSchema.FormalParameter,
-    type_constraints: Mapping[str, TypeConstraintParam],
-) -> Parameter:
-    """Convert a formal parameter from ONNX Opschema to Parameter."""
-    if param.type_str in type_constraints:
-        type_constraint = type_constraints[param.type_str]
-    else:
-        # param.type_str can be a plain type like 'int64'.
-        type_constraint = TypeConstraintParam(
-            name=param.name,
-            allowed_types={_get_type_from_str(param.type_str)},
-        )
-    return Parameter(
-        name=param.name,
-        type_constraint=type_constraint,
-        required=param.option != onnx.defs.OpSchema.FormalParameterOption.Optional,
-        variadic=param.option == onnx.defs.OpSchema.FormalParameterOption.Variadic,
-    )
 
 
 def _is_optional(type_: type) -> bool:
@@ -322,144 +190,88 @@ def _get_allowed_types_from_type_annotation(
     return _ALL_VALUE_TYPES  # type: ignore[return-value]
 
 
-@dataclasses.dataclass
-class OpSignature:
-    """Schema for an operator.
+def op_signature_from_function(
+    func,
+    domain: str,
+    name: str | None = None,
+    overload: str = "",
+    *,
+    since_version: int = 1,
+) -> ir.schemas.OpSignature:
+    """Produce an OpSignature from a function using type annotation."""
 
-    Attributes:
-        domain: Domain of the operator. E.g. "".
-        name: Name of the operator. E.g. "Add".
-        overload: Overload name of the operator.
-        params: Input parameters. When the op is an ONNX function definition,
-          the order is according to the function signature. This mean we can
-          interleave ONNX inputs and ONNX attributes in the list.
-        outputs: Output parameters.
-    """
+    py_signature = inspect.signature(func)
+    # Not using inspect.get_annotations because typing.get_type_hints seems to handle more cases
+    # https://github.com/python/cpython/issues/102405
+    type_hints = typing.get_type_hints(func)
 
-    domain: str
-    name: str
-    overload: str
-    params: Sequence[Parameter | AttributeParameter]
-    outputs: Sequence[Parameter]
-    params_map: Mapping[str, Parameter | AttributeParameter] = dataclasses.field(
-        init=False, repr=False
-    )
-    opset_version: int | None = None
+    params: list[ir.schemas.Parameter | ir.schemas.AttributeParameter] = []
+    # Create a mapping from type to a unique name
+    type_constraints: dict[str, ir.schemas.TypeConstraintParam] = {}
 
-    def __post_init__(self):
-        self.params_map = {param.name: param for param in self.params}
-
-    def get(self, name: str) -> Parameter | AttributeParameter:
-        return self.params_map[name]
-
-    def __contains__(self, name: str) -> bool:
-        return name in self.params_map
-
-    def __iter__(self) -> Iterator[Parameter | AttributeParameter]:
-        return iter(self.params)
-
-    def __str__(self) -> str:
-        domain = self.domain or "''"
-        # TODO: Double check the separator for overload
-        overload = f"::{self.overload}" if self.overload else ""
-        params = ", ".join(str(param) for param in self.params)
-        outputs = ", ".join(str(param.type_constraint.name) for param in self.outputs)
-        type_constraints = {}
-        for param in self.params:
-            if isinstance(param, Parameter):
-                type_constraints[param.type_constraint.name] = param.type_constraint
-        for param in self.outputs:
-            type_constraints[param.type_constraint.name] = param.type_constraint
-        type_constraints_str = ", ".join(
-            str(type_constraint) for type_constraint in type_constraints.values()
-        )
-        return f"{domain}::{self.name}{overload}({params}) -> ({outputs}) where {type_constraints_str}"
-
-    @classmethod
-    def from_opschema(cls, opschema: onnx.defs.OpSchema) -> OpSignature:
-        """Produce an OpSignature from an ONNX Opschema."""
-        type_constraints = {
-            constraint.type_param_str: TypeConstraintParam(
-                name=constraint.type_param_str,
-                allowed_types={
-                    _get_type_from_str(type_str)
-                    for type_str in constraint.allowed_type_strs
-                },
-                description=constraint.description,
+    for param in py_signature.parameters.values():
+        if param.name not in type_hints:
+            logger.debug(
+                "Missing annotation for parameter '%s' from %s. Treating as an Input.",
+                param.name,
+                py_signature,
             )
-            for constraint in opschema.type_constraints
-        }
-
-        params = [
-            _convert_formal_parameter(param, type_constraints)
-            for param in opschema.inputs
-        ]
-
-        for param in opschema.attributes.values():
-            default_attr = (
-                ir.serde.deserialize_attribute(param.default_value)
-                if param.default_value is not None
-                else None
+            type_constraint = ir.schemas.TypeConstraintParam.any_value(
+                f"T_{param.name}"
             )
-            if default_attr is not None:
-                # Set the name of the default attribute because it may have a different name from the parameter
-                default_attr.name = param.name
+            type_constraints[param.name] = type_constraint
             params.append(
-                # pyrefly: ignore [bad-argument-type]
-                AttributeParameter(
+                ir.schemas.Parameter(
                     name=param.name,
-                    type=ir.AttributeType(param.type),  # type: ignore[arg-type]
-                    required=param.required,
-                    default=default_attr,  # type: ignore[arg-type]
+                    type_constraint=type_constraint,
+                    required=param.default is inspect.Parameter.empty,
+                    # TODO: Handle variadic
+                    variadic=False,
+                    default=param.default
+                    if param.default is not inspect.Parameter.empty
+                    else ir.schemas._EMPTY_DEFAULT,
                 )
             )
-
-        outputs = [
-            _convert_formal_parameter(param, type_constraints)
-            for param in opschema.outputs
-        ]
-
-        return cls(
-            domain=opschema.domain,
-            name=opschema.name,
-            overload="",
-            params=params,
-            outputs=outputs,
-            opset_version=opschema.since_version,
-        )
-
-    @classmethod
-    def from_function(
-        cls,
-        func,
-        domain: str,
-        name: str | None = None,
-        overload: str = "",
-        *,
-        opset_version: int = 1,
-    ) -> OpSignature:
-        """Produce an OpSignature from a function using type annotation."""
-
-        py_signature = inspect.signature(func)
-        # Not using inspect.get_annotations because typing.get_type_hints seems to handle more cases
-        # https://github.com/python/cpython/issues/102405
-        type_hints = typing.get_type_hints(func)
-
-        params: list[Parameter | AttributeParameter] = []
-        # Create a mapping from type to a unique name
-        type_constraints: dict[str, TypeConstraintParam] = {}
-
-        for param in py_signature.parameters.values():
-            if param.name not in type_hints:
-                logger.debug(
-                    "Missing annotation for parameter '%s' from %s. Treating as an Input.",
-                    param.name,
-                    py_signature,
-                )
-                type_constraint = TypeConstraintParam.any_value(f"T_{param.name}")
-                type_constraints[param.name] = type_constraint
+        else:
+            type_ = type_hints[param.name]
+            if (attr_type := _get_attr_type(type_)) != ir.AttributeType.UNDEFINED:
+                # Construct the default attribute
+                if param.default is not inspect.Parameter.empty:
+                    # TODO: Use ir_convenience instead to handle int as float
+                    default = ir.Attr(param.name, attr_type, param.default)
+                else:
+                    default = None
                 params.append(
-                    Parameter(
+                    ir.schemas.AttributeParameter(
+                        name=param.name,
+                        type=attr_type,
+                        required=param.default is inspect.Parameter.empty,
+                        default=default,
+                    )
+                )
+            else:
+                # Obtain the type constraint from the type annotation
+
+                # 1. Get a type constraint name from the type annotation
+                # If the type annotation is a TypeVar or Optional[TypeVar], get its name
+                # Otherwise, name it T_{param.name}
+                type_constraint_name = _get_type_constraint_name(type_)
+                if type_constraint_name is None:
+                    type_constraint_name = f"T_{param.name}"
+
+                # 2. If the type constraint param is already initialized, use it
+                if type_constraint_name in type_constraints:
+                    type_constraint = type_constraints[type_constraint_name]
+                else:
+                    # 3. Otherwise, create a new TypeConstraintParam
+                    type_constraint = ir.schemas.TypeConstraintParam(
+                        name=type_constraint_name,
+                        allowed_types=_get_allowed_types_from_type_annotation(type_),
+                    )
+                    type_constraints[type_constraint_name] = type_constraint
+                # 4. Create Parameter
+                params.append(
+                    ir.schemas.Parameter(
                         name=param.name,
                         type_constraint=type_constraint,
                         required=param.default is inspect.Parameter.empty,
@@ -467,106 +279,54 @@ class OpSignature:
                         variadic=False,
                         default=param.default
                         if param.default is not inspect.Parameter.empty
-                        else _EMPTY_DEFAULT,
+                        else ir.schemas._EMPTY_DEFAULT,
                     )
                 )
-            else:
-                type_ = type_hints[param.name]
-                if (attr_type := _get_attr_type(type_)) != ir.AttributeType.UNDEFINED:
-                    # Construct the default attribute
-                    if param.default is not inspect.Parameter.empty:
-                        # TODO: Use ir_convenience instead to handle int as float
-                        default = ir.Attr(param.name, attr_type, param.default)
-                    else:
-                        default = None
-                    params.append(
-                        AttributeParameter(
-                            name=param.name,
-                            type=attr_type,
-                            required=param.default is inspect.Parameter.empty,
-                            default=default,
-                        )
-                    )
-                else:
-                    # Obtain the type constraint from the type annotation
 
-                    # 1. Get a type constraint name from the type annotation
-                    # If the type annotation is a TypeVar or Optional[TypeVar], get its name
-                    # Otherwise, name it T_{param.name}
-                    type_constraint_name = _get_type_constraint_name(type_)
-                    if type_constraint_name is None:
-                        type_constraint_name = f"T_{param.name}"
+    return_type = type_hints.get("return")
 
-                    # 2. If the type constraint param is already initialized, use it
-                    if type_constraint_name in type_constraints:
-                        type_constraint = type_constraints[type_constraint_name]
-                    else:
-                        # 3. Otherwise, create a new TypeConstraintParam
-                        type_constraint = TypeConstraintParam(
-                            name=type_constraint_name,
-                            allowed_types=_get_allowed_types_from_type_annotation(
-                                type_
-                            ),
-                        )
-                        type_constraints[type_constraint_name] = type_constraint
-                    # 4. Create Parameter
-                    params.append(
-                        Parameter(
-                            name=param.name,
-                            type_constraint=type_constraint,
-                            required=param.default is inspect.Parameter.empty,
-                            # TODO: Handle variadic
-                            variadic=False,
-                            default=param.default
-                            if param.default is not inspect.Parameter.empty
-                            else _EMPTY_DEFAULT,
-                        )
-                    )
-
-        return_type = type_hints.get("return")
-
-        outputs = []
-        if return_type is None:
-            # No returns
-            pass
+    outputs = []
+    if return_type is None:
+        # No returns
+        pass
+    else:
+        if typing.get_origin(return_type) is tuple:
+            # Multiple returns
+            return_types = typing.get_args(return_type)
         else:
-            if typing.get_origin(return_type) is tuple:
-                # Multiple returns
-                return_types = typing.get_args(return_type)
+            return_types = [return_type]  # type: ignore[assignment]
+
+        for i, return_type_i in enumerate(return_types):
+            if (
+                return_param_name := _get_type_constraint_name(return_type_i)
+            ) in type_constraints:
+                # pyrefly: ignore [bad-index, index-error]
+                type_constraint = type_constraints[return_param_name]
             else:
-                return_types = [return_type]  # type: ignore[assignment]
-
-            for i, return_type_i in enumerate(return_types):
-                if (
-                    return_param_name := _get_type_constraint_name(return_type_i)
-                ) in type_constraints:
-                    # pyrefly: ignore [bad-index, index-error]
-                    type_constraint = type_constraints[return_param_name]
-                else:
-                    return_param_name = f"TReturn{i}"
-                    type_constraint = TypeConstraintParam(
-                        name=return_param_name,
-                        allowed_types=_get_allowed_types_from_type_annotation(
-                            return_type_i
-                        ),
-                    )
-                    type_constraints[return_param_name] = type_constraint
-                outputs.append(
-                    Parameter(
-                        # pyrefly: ignore [bad-argument-type]
-                        name=return_param_name,
-                        type_constraint=type_constraint,
-                        required=True,
-                        variadic=False,
-                        default=_EMPTY_DEFAULT,
-                    )
+                return_param_name = f"TReturn{i}"
+                type_constraint = ir.schemas.TypeConstraintParam(
+                    name=return_param_name,
+                    allowed_types=_get_allowed_types_from_type_annotation(
+                        return_type_i
+                    ),
                 )
+                type_constraints[return_param_name] = type_constraint
+            outputs.append(
+                ir.schemas.Parameter(
+                    # pyrefly: ignore [bad-argument-type]
+                    name=return_param_name,
+                    type_constraint=type_constraint,
+                    required=True,
+                    variadic=False,
+                    default=ir.schemas._EMPTY_DEFAULT,
+                )
+            )
 
-        return cls(
-            domain=domain,
-            name=name or func.__name__,
-            overload=overload,
-            params=params,
-            outputs=outputs,
-            opset_version=opset_version,
-        )
+    return ir.schemas.OpSignature(
+        domain=domain,
+        name=name or func.__name__,
+        overload=overload,
+        params=params,
+        outputs=outputs,
+        since_version=since_version,
+    )


### PR DESCRIPTION
This pull request refactors how ONNX operator signatures and related schema types are handled in the exporter codebase. The main change is to consistently use types from the new `onnx_ir` module (`ir.schemas`) instead of the legacy `_schemas` module.

**Dependency updates**
* Updated the pinned version of `onnx-ir` in `.ci/docker/requirements-ci.txt` from `0.1.15` to `0.1.16` to ensure compatibility with the new IR features.

cc @titaiwangms