### PR TITLE
Fix scatter_reduce in-place op handling in Inductor memref converter and FXIR codegen

### DIFF
--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -917,6 +917,8 @@ class FxConverter:
         kwargs = {}
         if reduce := ir_node.kwargs.get("reduce"):
             kwargs["reduce"] = reduce
+        if "include_self" in ir_node.kwargs:
+            kwargs["include_self"] = ir_node.kwargs["include_self"]
 
         self._generate_fallback_call(ir_node, args, kwargs)
 


### PR DESCRIPTION
Summary:
Two bugs caused scatter_reduce to produce incorrect output on MTIA:

1. **Inductor memref converter**: `_convert_generic()` always allocates a new activation buffer for every op's output. For in-place ops like `aten.scatter_reduce_.two`, the new buffer receives the result but is never read — the graph continues referencing the original (unmodified) input buffer. Fix: detect in-place ops via PyTorch schema (mutable `self` argument) and reuse the mutated input's buffer as `out_memref`.

2. **FXIR wrapper codegen**: `_generate_scatter_fallback()` only forwards the `reduce` kwarg from ScatterFallback IR nodes, silently dropping `include_self`. This causes `include_self=False` to become `True` (the default) in the
   generated FX graph. Fix: forward `include_self` from ir_node.kwargs.

Affects 224 test: https://fburl.com/scuba/mtia_triton_inductor_torchbench_opinfo_e2e/fywasmk5

Test Plan:
- Verified the originally failing e2e test now passes:
  `OPINFO_TEST_CASE="scatter_reduce+amax; 6; 0; tensor, f64x10x5; int, -1; tensor, i64x5x5; tensor, f64x5x5; str, amax; dict, include_self=bool, False" buck run mode/{opt,mtia,inplace} mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e_user_defined`
- All 5 existing `test_fba_inductor_memref` unit tests pass (no regressions)

Differential Revision: D92911145



@diff-train-skip-merge

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo