### PR TITLE
[Inductor] Add BLOCK_K=64 and 128 for conv

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -631,13 +631,27 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         ]
 
         self.conv_configs: list[BaseConfig] = [
+            # BLOCK_K=16 configs
             ConvConfig(64, 256, 16, 2, 4),
             ConvConfig(256, 64, 16, 2, 4),
             ConvConfig(1024, 16, 16, 1, 8),
+            # BLOCK_K=32 configs
             ConvConfig(128, 128, 32, 2, 8),
             ConvConfig(64, 64, 32, 2, 4),
             ConvConfig(64, 256, 32, 2, 8),
             ConvConfig(256, 64, 32, 2, 8),
+            # BLOCK_K=64 configs
+            ConvConfig(128, 128, 64, 3, 8),
+            ConvConfig(64, 128, 64, 4, 4),
+            ConvConfig(128, 64, 64, 4, 4),
+            ConvConfig(256, 128, 64, 2, 8),
+            ConvConfig(128, 256, 64, 2, 8),
+            # BLOCK_K=128 configs - optimal when IN_C=128 (single iteration over channels)
+            ConvConfig(128, 128, 128, 2, 8),
+            ConvConfig(128, 128, 128, 3, 8),
+            ConvConfig(64, 128, 128, 4, 4),
+            ConvConfig(256, 128, 128, 2, 8),
+            ConvConfig(128, 256, 128, 2, 8),
         ]
 
         self.flex_attn_fwd_autotune_configs: list[FlexConfig] = [


### PR DESCRIPTION
Summary: Add more autotuning configs to support larger channel sizes and heights

Test Plan:
Benchmark script: D92905270

For input size — x=(3072, 128, 202), w=(384, 128, 3):

**Before**
x=(3072,128,1,202)  w=(384,128,1,3)  stride=(1,1)  padding=(0,0)
  Variant                    Time (ms)   Relative   Max Diff
  ------------------------- ---------- ---------- ----------
  triton_conv2d_CF              0.9294      44.8%   0.062500
  triton_conv2d_CL              0.7131      58.3%   0.062500
  cudnn_conv2d_CF               1.1085      37.5%   0.000000
  cudnn_conv2d_CL               0.4161     100.0%   0.000000

**After**
x=(3072,128,1,202)  w=(384,128,1,3)  stride=(1,1)  padding=(0,0)
  Variant                    Time (ms)   Relative   Max Diff
  ------------------------- ---------- ---------- ----------
  triton_conv2d_CF              0.7173      56.8%   0.062500
  triton_conv2d_CL              0.5492      74.2%   0.062500
  cudnn_conv2d_CF               1.1098      36.7%   0.000000
  cudnn_conv2d_CL               0.4077     100.0%   0.000000

Differential Revision: D92904397




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo