### PR TITLE
[export] Add test and improve comments for subclass attr access fix

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15625,6 +15625,8 @@ graph():
             "torch.testing._internal.two_tensor.TwoTensor", 2, exactly=True
         ).run(gm_torch_ir.code)
 
+    @testing.expectedFailureSerDerNonStrict  # local subclass can't be pickled
+    @testing.expectedFailureSerDer  # local subclass can't be pickled
     def test_nonstrict_subclass_attr_access_in_torch_function(self):
         class DummyTensor(torch.Tensor):
             @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174754
* #174725

Add a regression test for non-strict export of subclasses that access
inner tensor attrs from within __torch_function__. Also refactor the
tracer lookup into _find_tracer() with a detailed comment explaining
the dispatch chain that necessitates the ProxyTorchDispatchMode
fallback, and mark serdes variants as expected failures since locally
defined subclasses can't be pickled.

Co-authored-by: Claude <noreply@anthropic.com>