### PR TITLE
[DTensor] enable single dim strategy for mm and bmm

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -2,6 +2,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import itertools
+import math
 import unittest
 from typing import cast, Optional
 
@@ -16,14 +17,9 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
-from torch.distributed.tensor._ops._matrix_ops import (
-    gen_single_dim_einsum_strategies,
-    mm_single_dim_strategy,
-)
-from torch.distributed.tensor._ops.single_dim_strategy import (
-    register_single_dim_strategy,
-)
+from torch.distributed.tensor._ops._matrix_ops import gen_single_dim_einsum_strategies
 from torch.distributed.tensor.debug import CommDebugMode
+from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
 from torch.testing._internal.common_device_type import E4M3_MAX_POS, e4m3_type
 from torch.testing._internal.common_utils import (
@@ -274,6 +270,71 @@ class DistMatrixOpsTest(DTensorTestBase):
                     )
 
     @with_comms
+    def test_mm_with_strided_input(self):
+        # Case 1: 1D mesh with StridedShard
+        # Tests mm where input has _StridedShard(dim=0, split_factor=2) placement.
+        # Input shape: (batch_size * seq_len, contract_dim), weight is Replicate.
+        # Output should preserve the same StridedShard placement.
+        mesh = self.build_device_mesh()
+        batch_size, seq_len, contract_dim, out_dim = 2, self.world_size, 3, 7
+        global_inps_viewed = (
+            torch.arange(batch_size * seq_len * contract_dim)
+            .float()
+            .view(batch_size * seq_len, contract_dim)
+        )
+        inps_viewed = distribute_tensor(
+            global_inps_viewed,
+            mesh,
+            (_StridedShard(dim=0, split_factor=2),),
+            src_data_rank=None,
+        )
+        global_weight = (
+            torch.arange(contract_dim * out_dim).float().view(contract_dim, out_dim)
+        )
+        weight = distribute_tensor(global_weight, mesh, (Replicate(),))
+        out = torch.mm(inps_viewed, weight)
+        expected_placements = (_StridedShard(dim=0, split_factor=2),)
+        self.assertEqual(out.placements, expected_placements)
+
+        # Case 2: 2D mesh (2x2) with nested StridedShard on both mesh dimensions
+        # Tests mm where input has StridedShard on both mesh dims with different split_factors.
+        # This simulates a more complex sharding pattern (e.g., from a reshaped 4D tensor).
+        # Output should preserve both StridedShard placements.
+        mesh = init_device_mesh(self.device_type, (2, 2))
+        tensor_dims = (4, mesh.size(0) * mesh.size(1), 6, 8)
+        global_inps_viewed = (
+            torch.arange(math.prod(tensor_dims))
+            .float()
+            .view(math.prod(tensor_dims[:3]), 8)
+        )
+        inps_viewed = distribute_tensor(
+            global_inps_viewed,
+            mesh,
+            (
+                _StridedShard(dim=0, split_factor=4),
+                _StridedShard(
+                    dim=0,
+                    split_factor=tensor_dims[0] * (tensor_dims[1] // mesh.size(0)),
+                ),
+            ),
+            src_data_rank=None,
+        )
+        global_weight = (
+            torch.arange(tensor_dims[-1] * tensor_dims[-1])
+            .float()
+            .view(tensor_dims[-1], tensor_dims[-1])
+        )
+        weight = distribute_tensor(global_weight, mesh, (Replicate(), Replicate()))
+        out = torch.mm(inps_viewed, weight)
+        expected_placements = (
+            _StridedShard(dim=0, split_factor=4),
+            _StridedShard(
+                dim=0, split_factor=tensor_dims[0] * (tensor_dims[1] // mesh.size(0))
+            ),
+        )
+        self.assertEqual(out.placements, expected_placements)
+
+    @with_comms
     def test_mm(self):
         device_mesh = self.build_device_mesh()
         shard0_spec = Shard(0)
@@ -302,32 +363,6 @@ class DistMatrixOpsTest(DTensorTestBase):
         shard_specs_comb = list(itertools.product(placement_specs, placement_specs))
         for spec in shard_specs_comb:
             test_placement_comb([spec[0]], [spec[1]])
-
-    @with_comms
-    def test_mm_single_dim_strategy(self):
-        register_single_dim_strategy(torch.ops.aten.mm.default)(mm_single_dim_strategy)
-        # unshardable input where some rank have empty _local_tensor
-        # eg sharding tensor (world_size - 1) over world_size
-        device_mesh = self.build_device_mesh()
-        global_inps_viewed = (
-            torch.arange((self.world_size - 1) * self.world_size)
-            .float()
-            .view(self.world_size - 1, self.world_size)
-        )
-        inps_viewed = distribute_tensor(
-            global_inps_viewed,
-            device_mesh,
-            (Shard(dim=0),),
-        )
-        global_weight = (
-            torch.arange(self.world_size * self.world_size)
-            .float()
-            .view(self.world_size, self.world_size)
-        )
-        weight = distribute_tensor(global_weight, device_mesh, (Replicate(),))
-        out = torch.mm(inps_viewed, weight)
-        expected_placements = (Replicate(),)
-        self.assertEqual(out.placements, expected_placements)
 
     @with_comms
     @skip_unless_torch_gpu

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -414,9 +414,7 @@ def gen_single_dim_einsum_strategies(
     return strategies_over_one_mesh_dim
 
 
-# TODO enable in a separate PR along with more extensive validation.
-# currently just used in test_single_dim_strategy.py to help validate the single-dim expansion infra
-# @register_single_dim_strategy(aten.mm.default)
+@register_single_dim_strategy(aten.mm.default, allow_unbacked_sharding=True)
 def mm_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
 ) -> list[list[Placement | _ShardingPlaceholder]]:
@@ -429,7 +427,7 @@ def addmm_strategy(op_schema: OpSchema) -> OpStrategy:
     return _addmm_like_strategy("mk,kn->mn", mesh, op_schema)
 
 
-@register_single_dim_strategy(aten.addmm.default)
+@register_single_dim_strategy(aten.addmm.default, allow_unbacked_sharding=True)
 def addmm_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
 ) -> list[list[Placement | _ShardingPlaceholder]]:
@@ -444,13 +442,20 @@ def bmm_strategy(op_schema: OpSchema) -> OpStrategy:
     return _mm_like_strategy("bmk,bkn->bmn", mesh, op_schema)
 
 
+@register_single_dim_strategy(aten.bmm.default, allow_unbacked_sharding=True)
+def bmm_single_dim_strategy(
+    op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    return gen_single_dim_einsum_strategies("bmk,bkn->bmn")
+
+
 @register_op_strategy(aten.baddbmm.default)
 def baddbmm_strategy(op_schema: OpSchema) -> OpStrategy:
     mesh = op_schema.get_mesh_from_args()
     return _addmm_like_strategy("bmk,bkn->bmn", mesh, op_schema)
 
 
-@register_single_dim_strategy(aten.baddbmm.default)
+@register_single_dim_strategy(aten.baddbmm.default, allow_unbacked_sharding=True)
 def baddbmm_single_dim_strategy(
     op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
 ) -> list[list[Placement | _ShardingPlaceholder]]:

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -361,6 +361,7 @@ def expand_to_full_mesh_op_strategy(
         [list[DTensorSpec], DTensorSpec | tuple[DTensorSpec | None, ...]], bool
     ]
     | None = None,
+    allow_unbacked_sharding: bool = False,
 ) -> OpStrategy:
     """
     Convenience function to allow writing a sharding strategy considering only a single mesh dimension,
@@ -483,7 +484,9 @@ def expand_to_full_mesh_op_strategy(
 
         # check all inputs are shardable
         if not all(
-            is_tensor_shardable(inp.shape, s)
+            is_tensor_shardable(
+                inp.shape, s, allow_unbacked_sharding=allow_unbacked_sharding
+            )
             for inp, s in zip(input_args_strategy, input_specs)
         ):
             continue


### PR DESCRIPTION
how allow_unbacked_sharding gets passed 

<img width="721" height="830" alt="Screenshot 2026-02-10 at 21 37 38" src="https://github.com/user-attachments/assets/14ef047b-e869-47f5-a93c-dbcb0c52283b" />

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174756

