### PR TITLE
Check availability of accelerator in test_schedule

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -55,7 +55,11 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "artifacts")
 
-device = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+device = (
+    acc.type
+    if (acc := torch.accelerator.current_accelerator(check_available=True))
+    else "cpu"
+)
 logger = logging.getLogger(__name__)
 torch.manual_seed(0)
 


### PR DESCRIPTION
The device check contains a fallback if no accelerator is available but doesn't check if one is available and only checks if support is available.

This causes tests to fail with e.g.
> RuntimeError: Found no NVIDIA driver on your system.

Add the `check_avail=True` argument.