### PR TITLE
[Dynamo] Graph Break on __class__ assignment

### DIFF
--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2622,6 +2622,16 @@
       ]
     }
   ],
+  "GB4271": [
+    {
+      "Gb_type": "__class__ assignment on user-defined object",
+      "Context": "object={self}, value={value}",
+      "Explanation": "Dynamo does not support reassigning __class__ on user-defined objects.",
+      "Hints": [
+        "Move the __class__ assignment outside of the torch.compile region."
+      ]
+    }
+  ],
   "GB0221": [
     {
       "Gb_type": "non-generator contextlib.contextmanager",

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1323,6 +1323,16 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             "an AttributeMutation mutation_type"
         )
 
+        if name_str == "__class__":
+            unimplemented(
+                gb_type="__class__ assignment on user-defined object",
+                context=f"object={self}, value={value}",
+                explanation="Dynamo does not support reassigning __class__ on user-defined objects.",
+                hints=[
+                    "Move the __class__ assignment outside of the torch.compile region.",
+                ],
+            )
+
         if directly_update_dict:
             self.attrs_directly_modifed_on_dict.add(name_str)
         else:


### PR DESCRIPTION
Fixes: #174050

### Summary:

- Adds a graph break when user code reassigns `__class__` on a user defined object in torch.compile
- Previously Dynamo would store the `__class__` mutation as a regular attribute side effect but never update its internal `value_type` causing `is_instance()` to silently return incorrect result.

### Test Plan:
Added new unit test: `python test/dynamo/test_misc.py MiscTests.test_class_reassignment_graph_break`

Before (on main) `is_instance() `silently returns False in compiled output
```
Eager: (tensor([2.]), True, False)
Compile: (tensor([2.]), False, False)
```
After (this PR) compiled output matches eager because of graph break
```
Eager: (tensor([2.]), True, False)
Compile: (tensor([2.]), True, False)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo