### PR TITLE
Fix hpu backend mapping issue - alternate

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -349,8 +349,12 @@ class Backend(str):  # noqa: SLOT000
 
         if devices is not None:
             for device in devices:
-                if device not in Backend.default_device_backend_map:
+                current = Backend.default_device_backend_map.get(device)
+                # Allow remapping from fake backend to actual backend (e.g., HPU from fake to HCCL)
+                # but prevent fake backend from claiming devices
+                if current is None or (current == "fake" and name.lower() != "fake"):
                     Backend.default_device_backend_map[device] = name.lower()
+
         Backend.backend_type_map[name.lower()] = ProcessGroup.BackendType.CUSTOM
 
         # Update device capability matrix in Backend class


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/159945 .

## Motivation:
This PR provides an alternate approach to fix the issue mentioned above. We had initially propsed a solution in https://github.com/pytorch/pytorch/pull/160063 , which is not yet merged. If this PR gets merged, the previous one will be deleted. 

## Changes:
This pull request makes a targeted improvement to the backend registration logic in `torch/distributed/distributed_c10d.py`. The change allows remapping devices from a "fake" backend to a real backend, while preventing the "fake" backend from claiming devices already mapped.

Backend registration logic improvement:

* Updated `register_backend` to permit devices mapped to the "fake" backend to be remapped to a real backend, while preventing the "fake" backend from claiming devices already assigned to another backend. (`torch/distributed/distributed_c10d.py`)

@H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta, @EikanWang , @kwen2501, @ankurneog @albanD @jerome-habana : please review. 