### PR TITLE
[ROCm] remove the exact count for benchmark check

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -84,10 +84,11 @@ class TestKernelBenchmark(TestCase):
             raise e
 
         # make sure we have the bandwidth information in the output
+        # -kc flag benchmarks all autotuning configs,
+        # so we check for at least GB_count occurrences rather than exactly.
         FileCheck().check_count(
             "GB/s",
             GB_count,
-            exactly=1,
         ).run(bench_out)
 
     def verify_remove_inductor_deps(self, compiled_module):


### PR DESCRIPTION
Fixes #165875

### Summary
The `test_pw_kernel_benchmark` test was flaky, failing intermittently with:
```
Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/test/inductor/test_kernel_benchmark.py", line 145, in test_pw_kernel_benchmark
    self.verify_compiled_kernels()
  File "/var/lib/jenkins/pytorch/test/inductor/test_kernel_benchmark.py", line 78, in verify_compiled_kernels
    ).run(bench_out)
RuntimeError: Expected to not find "GB/s" but found it
None                 UNK c4fmwupa7r
  0.007ms    	0.000 GB 	    0.01GB/s   23 regs    0 spills         0 shared mem @ XBLOCK: 8, num_warps: 1, num_ctas: 1, num_stages: 1, maxnreg: None
  0.007ms    	0.000 GB 	    0.01GB/s   23 regs    0 spills         0 shared mem @ XBLOCK: 8, waves_per_eu: 2, num_warps: 1, num_ctas: 1, num_stages: 1, maxnreg: None
                                ~~~~ <--- HERE
  0.007ms    	0.000 GB 	    0.01GB/s   23 regs    0 spills         0 shared mem @ XBLOCK: 8, waves_per_eu: 1, num_warps: 8, num_ctas: 1, num_stages: 2, maxnreg: None
From CHECK-NOT: GB/s


To execute this test, run the following from the base repo dir:
    PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_kernel_benchmark.py TestKernelBenchmark.test_pw_kernel_benchmark

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

The test required exactly one "GB/s" occurrence. However, when using the `-kc` flag (which benchmarks all autotuning configurations), multiple configs are benchmarked and each prints "GB/s", causing the test to fail when more than one config is tested.

### Fix:
Changed the assertion to check for **at least** `GB_count` occurrences instead of exactly, by removing the `exactly=1`. This aligns with the intended behavior of the `-kc` flag and makes the test robust to variable numbers of autotuning configs.

### Testing
All of the below test passed on MI300.
- `test_pw_kernel_benchmark` - passes consistently
- `test_matmul_triton_kernel_benchmark` - still passes
- `test_mm_triton_kernel_benchmark` - still passes

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben