### PR TITLE
Normalize object names in TreeProfiler test

### DIFF
--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -247,6 +247,11 @@ class TestProfilerTree(TestCase):
         # simply coerce them into a platform independent form. If you made a
         # change in the codebase which changes the trace produced, simply use
         # EXPECTTEST_ACCEPT=1 to update the tests to reflect the new structure.
+        def normalize(tree):
+            return re.sub(r"of pybind11\w+ object at", "of PyCapsule object at", tree)
+
+        actual = normalize(actual)
+        expected = normalize(expected)
 
         # expecttest will not show the diff view if `len(actual) < len(expected)`
         if not expecttest.ACCEPT:


### PR DESCRIPTION
Based on a failure in
`python profiler/test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree_with_stack_and_modules`


Depending on versions of Python, pybind11, ... the object might be slightly different:

```diff
- <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+ <built-in method _get_tracing_state of pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1 object at 0xXXXXXXXXXXXX>
```

Simply replace the name of the pybind11 objects by "PyCapsule" to unify and still keep object names of other instances.