### PR TITLE
[LocalTensor] Guard data_ptr() access on wrapper subclass

### DIFF
--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -229,6 +229,21 @@ class TestLocalTensorWorld2(LocalTensorWorldTest):
         result = node1.le(node2)
         self.assertTrue(bool(result))
 
+    def test_data_ptr_raises(self):
+        """data_ptr() on a LocalTensor should raise instead of returning 0."""
+        local_tensors = {
+            0: torch.randn(4),
+            1: torch.randn(4),
+        }
+        lt = LocalTensor(local_tensors)
+        with self.assertRaises(RuntimeError):
+            lt.data_ptr()
+
+        # Native ops still work (dispatched per-rank via __torch_dispatch__)
+        with LocalTensorMode(lt._ranks):
+            result = lt + lt
+            self.assertIsInstance(result, LocalTensor)
+
     def test_sym_and_sym_or(self):
         node1 = LocalIntNode({0: 3, 1: 4})
         node2 = LocalIntNode({0: 10, 1: 10})

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -960,6 +960,10 @@ class LocalTensor(torch.Tensor):
             requires_grad=requires_grad,
             _extra_dispatch_keys=extra_dispatch_keys,
         )
+        # The wrapper has no real storage (data_ptr()=0). Prevent callers
+        # (e.g. Triton kernels) from silently reading the null pointer —
+        # turn it into a clear RuntimeError instead of a CUDA IMA.
+        torch._C._set_throw_on_mutable_data_ptr(r)
 
         local_tensors = {
             r: v if not isinstance(v, AsyncCollectiveTensor) else v.wait()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #174774
* __->__ #174772

LocalTensor's wrapper subclass has no real storage (data_ptr()=0).
Callers like Triton kernels that bypass __torch_dispatch__ and read
data_ptr() directly would silently access a null pointer, causing
a CUDA IMA that poisons the entire CUDA context.

Set the throw_on_mutable_data_ptr StorageImpl flag (already used by
FakeTensor and FunctionalTensor) so that data_ptr() raises a clear
RuntimeError instead.

Authored with Claude.