### PR TITLE
Reserve vector capacity in AdvancedIndex constructor

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -661,6 +661,7 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list) {
   this->dims_after = dims_after;
   this->src = restride_src(src, dims_before, dims_indexed, replacement_shape);
 
+  indices.reserve(dims_indexed);
   for (auto& index : indices_list) {
     if (index.defined()) {
       indices.push_back(reshape_indexer(index, dims_before, dims_after));


### PR DESCRIPTION
Add `indices.reserve(dims_indexed)` before the loop that populates `indices` via `push_back` to avoid potential reallocations.

Replicates PR #173691 / D91595115.

Closes: #173691.