### PR TITLE
[memoryviz] Fix y-axis unit mismatch

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -115,13 +115,16 @@ function EventSelector(outer, events, stack_info, memory_view) {
   return es;
 }
 
-function formatSize(num) {
+function formatSize(num, showBytes = true) {
   const orig = num;
   // https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
   const units = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi'];
   for (const unit of units) {
     if (Math.abs(num) < 1024.0) {
-      return `${num.toFixed(1)}${unit}B (${orig} bytes)`;
+      if (showBytes) {
+        return `${num.toFixed(1)}${unit}B (${orig} bytes)`;
+      }
+      return `${num.toFixed(1)}${unit}B`;
     }
     num /= 1024.0;
   }
@@ -1177,7 +1180,8 @@ function MemoryPlot(
   const plot_height = height;
 
   const yscale = scaleLinear().domain([0, max_size]).range([plot_height, 0]);
-  const yaxis = axisLeft(yscale).tickFormat(d3.format('.3s'));
+  // Use formatSize with showBytes=false for clean axis labels
+  const yaxis = axisLeft(yscale).tickFormat(d => formatSize(d, false));
   const xscale = scaleLinear().domain([0, max_timestep]).range([0, plot_width]);
   const plot_coordinate_space = svg
     .append('g')


### PR DESCRIPTION
Builds on top of https://github.com/pytorch/pytorch/pull/174717

This fixes the mismatch in the logged data and the y-axis of the memory viz - the right unit was binary (GiB) not decimal (GB).  Thanks @stas00 for this feedback.

<img width="1700" height="768" alt="Screenshot 2026-02-11 at 11 19 57 AM" src="https://github.com/user-attachments/assets/9fe7cfeb-152e-44ba-8129-f3e7f5c5c64b" />
