### PR TITLE
torch.distributed.debug: add support for periodic dumping

### DIFF
--- a/torch/distributed/debug/_debug_handlers.py
+++ b/torch/distributed/debug/_debug_handlers.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tabulate import tabulate
+
+from torch.distributed.debug._frontend import (
+    DebugHandler,
+    fetch_all,
+    format_json,
+    NavLink,
+    Response,
+    Route,
+)
+from torch.distributed.debug._store import tcpstore_client
+from torch.distributed.flight_recorder.components.builder import build_db
+from torch.distributed.flight_recorder.components.config_manager import JobConfig
+from torch.distributed.flight_recorder.components.types import (
+    Collective,
+    Database,
+    Group,
+    Membership,
+    NCCLCall,
+)
+
+
+if TYPE_CHECKING:
+    from torch.distributed.debug._frontend import FrontendServer, HTTPRequestHandler
+
+
+# ---------------------------------------------------------------------------
+# Handler-specific templates
+# ---------------------------------------------------------------------------
+
+INDEX_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+  <h1>{% block title %}Index{% endblock %}</h1>
+{% endblock %}
+{% block content %}
+Hi
+{% endblock %}
+    """
+
+PYSPY_DUMP_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+    <h1>{% block title %}py-spy Stack Traces{% endblock %}</h1>
+{% endblock %}
+{% block content %}
+    <form action="" method="get">
+        <input type="checkbox" id="native" name="native" value="1"/>
+        <label for="native">Native</label>
+        <input type="checkbox" id="subprocesses" name="subprocesses" value="1"/>
+        <label for="subprocesses">Subprocesses</label>
+        <input type="submit" value="Submit">
+    </form>
+
+    {% for i, (addr, resp) in enumerate(zip(addrs, resps)) %}
+        <h2>Rank {{ i }}: {{ addr }}</h2>
+        {% if resp.status_code != 200 %}
+            <p>Failed to fetch: status={{ resp.status_code }}</p>
+            <pre>{{ resp.text }}</pre>
+        {% else %}
+            <pre>{{ resp.text }}</pre>
+        {% endif %}
+    {% endfor %}
+{% endblock %}
+    """
+
+FR_TRACE_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+    <h1>{% block title %}{{ title }}{% endblock %}</h1>
+{% endblock %}
+{% block content %}
+    <h2>Groups</h2>
+    {{ groups | safe }}
+    <h2>Memberships</h2>
+    {{ memberships | safe }}
+    <h2>Collectives</h2>
+    {{ collectives | safe }}
+    <h2>NCCL Calls</h2>
+    {{ ncclcalls | safe }}
+{% endblock %}
+    """
+
+PROFILE_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+    <h1>{% block title %}torch.profiler{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+    <form action="" method="get">
+        <label for="duration">Duration (seconds):</label>
+        <input type="number" id="duration" name="duration" value="{{ duration }}" min="1" max="60">
+        <input type="submit" value="Submit">
+    </form>
+
+    <script>
+    function stringToArrayBuffer(str) {
+        const encoder = new TextEncoder();
+        return encoder.encode(str).buffer;
+    }
+    async function openPerfetto(data) {
+        const ui = window.open('https://ui.perfetto.dev/#!/');
+        if (!ui) { alert('Popup blocked. Allow popups for this page and click again.'); return; }
+
+        // Perfetto readiness handshake: PING until we receive PONG
+        await new Promise((resolve, reject) => {
+        const onMsg = (e) => {
+            if (e.source === ui && e.data === 'PONG') {
+            window.removeEventListener('message', onMsg);
+            clearInterval(pinger);
+            resolve();
+            }
+        };
+        window.addEventListener('message', onMsg);
+        const pinger = setInterval(() => { try { ui.postMessage('PING', '*'); } catch (_e) {} }, 250);
+        setTimeout(() => { clearInterval(pinger); window.removeEventListener('message', onMsg); reject(); }, 20000);
+        }).catch(() => { alert('Perfetto UI did not respond. Try again.'); return; });
+
+        ui.postMessage({
+        perfetto: {
+            buffer: stringToArrayBuffer(JSON.stringify(data)),
+            title: "torch profiler",
+            fileName: "trace.json",
+        }
+        }, '*');
+    }
+    </script>
+
+    {% for i, (addr, resp) in enumerate(zip(addrs, resps)) %}
+        <h2>Rank {{ i }}: {{ addr }}</h2>
+        {% if resp.status_code != 200 %}
+            <p>Failed to fetch: status={{ resp.status_code }}</p>
+            <pre>{{ resp.text }}</pre>
+        {% else %}
+            <script>
+            function run{{ i }}() {
+                var data = {{ resp.text | safe }};
+                openPerfetto(data);
+            }
+            </script>
+
+            <button onclick="run{{ i }}()">View {{ i }}</button>
+        {% endif %}
+    {% endfor %}
+{% endblock %}
+    """
+
+TCPSTORE_TEMPLATE = """
+{% extends "base.html" %}
+{% block header %}
+    <h1>{% block title %}TCPStore Keys{% endblock %}</h1>
+{% endblock %}
+{% block content %}
+    <pre>
+    {% for k, v in zip(keys, values) -%}
+{{ k }}: {{ v | truncate(100) }}
+    {% endfor %}
+    </pre>
+{% endblock %}
+    """
+
+
+# ---------------------------------------------------------------------------
+# Handler classes
+# ---------------------------------------------------------------------------
+
+
+class IndexHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [Route("/", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/", "Home")]
+
+    def templates(self) -> dict[str, str]:
+        return {"index.html": INDEX_TEMPLATE}
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        return req.frontend.render_template("index.html")
+
+
+class StacksHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [Route("/stacks", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/stacks", "Python Stack Traces")]
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("dump_traceback")
+        return req.frontend.render_template(
+            "raw_resp.html", title="Stacks", addrs=addrs, resps=resps
+        )
+
+    def dump(self) -> str | None:
+        addrs, resps = fetch_all("dump_traceback")
+        parts: list[str] = []
+        for i, (addr, resp) in enumerate(zip(addrs, resps)):
+            parts.append(f"=== Rank {i}: {addr} ===")
+            parts.append(
+                resp.text if resp.status_code == 200 else f"Error: {resp.status_code}"
+            )
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "stacks"
+
+
+class PySpyHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [Route("/pyspy_dump", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/pyspy_dump", "py-spy Stacks")]
+
+    def templates(self) -> dict[str, str]:
+        return {"pyspy_dump.html": PYSPY_DUMP_TEMPLATE}
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("pyspy_dump", req.get_raw_query())
+        return req.frontend.render_template(
+            "pyspy_dump.html",
+            addrs=addrs,
+            resps=resps,
+        )
+
+    def dump(self) -> str | None:
+        addrs, resps = fetch_all("pyspy_dump")
+        parts: list[str] = []
+        for i, (addr, resp) in enumerate(zip(addrs, resps)):
+            parts.append(f"=== Rank {i}: {addr} ===")
+            parts.append(
+                resp.text if resp.status_code == 200 else f"Error: {resp.status_code}"
+            )
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "pyspy_dump"
+
+
+class FlightRecorderHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [
+            Route("/fr_trace", self._handle_fr_trace),
+            Route("/fr_trace_json", self._handle_fr_trace_json),
+            Route("/fr_trace_nccl", self._handle_fr_trace_nccl),
+            Route("/fr_trace_nccl_json", self._handle_fr_trace_nccl_json),
+        ]
+
+    def nav_links(self) -> list[NavLink]:
+        return [
+            NavLink("/fr_trace", "FlightRecorder CPU"),
+            NavLink("/fr_trace_json", "(JSON)"),
+            NavLink("/fr_trace_nccl", "FlightRecorder NCCL"),
+            NavLink("/fr_trace_nccl_json", "(JSON)"),
+        ]
+
+    def templates(self) -> dict[str, str]:
+        return {"fr_trace.html": FR_TRACE_TEMPLATE}
+
+    @staticmethod
+    def _build_db(addrs: list[str], resps: list[Response]) -> Database:
+        config = JobConfig()
+        args = config.parse_args(args=[])
+        args.allow_incomplete_ranks = True
+        args.verbose = True
+
+        details = {}
+        for rank, resp in enumerate(resps):
+            resp.raise_for_status()
+            dump = {
+                "rank": rank,
+                "host_name": addrs[rank],
+                **resp.json(),
+            }
+            if "entries" not in dump:
+                dump["entries"] = []
+            details[f"rank{rank}.json"] = dump
+
+        version = next(iter(details.values()))["version"]
+        return build_db(details, args, version)
+
+    def _render_tables(
+        self, server: FrontendServer, addrs: list[str], resps: list[Response]
+    ) -> bytes:
+        db = self._build_db(addrs, resps)
+        return server.render_template(
+            "fr_trace.html",
+            title="FlightRecorder",
+            groups=tabulate(db.groups, headers=Group._fields, tablefmt="html"),
+            memberships=tabulate(
+                db.memberships, headers=Membership._fields, tablefmt="html"
+            ),
+            collectives=tabulate(
+                db.collectives, headers=Collective._fields, tablefmt="html"
+            ),
+            ncclcalls=tabulate(db.ncclcalls, headers=NCCLCall._fields, tablefmt="html"),
+        )
+
+    def _handle_fr_trace(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("fr_trace_json")
+        return self._render_tables(req.frontend, addrs, list(resps))
+
+    def _handle_fr_trace_json(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("fr_trace_json")
+        return req.frontend.render_template(
+            "json_resp.html",
+            title="FlightRecorder",
+            addrs=addrs,
+            resps=resps,
+        )
+
+    def _handle_fr_trace_nccl(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("dump_nccl_trace_json", "onlyactive=true")
+        return self._render_tables(req.frontend, addrs, list(resps))
+
+    def _handle_fr_trace_nccl_json(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("dump_nccl_trace_json", "onlyactive=true")
+        return req.frontend.render_template(
+            "json_resp.html",
+            title="FlightRecorder NCCL",
+            addrs=addrs,
+            resps=resps,
+        )
+
+    def dump(self) -> str | None:
+        parts = []
+
+        addrs, resps = fetch_all("fr_trace_json")
+        db = self._build_db(addrs, list(resps))
+        parts.extend(
+            [
+                "=== FR Trace ===",
+                "--- Groups ---",
+                tabulate(db.groups, headers=Group._fields, tablefmt="plain"),
+                "--- Memberships ---",
+                tabulate(db.memberships, headers=Membership._fields, tablefmt="plain"),
+                "--- Collectives ---",
+                tabulate(db.collectives, headers=Collective._fields, tablefmt="plain"),
+                "--- NCCL Calls ---",
+                tabulate(db.ncclcalls, headers=NCCLCall._fields, tablefmt="plain"),
+            ]
+        )
+
+        try:
+            nccl_addrs, nccl_resps = fetch_all(
+                "dump_nccl_trace_json", "onlyactive=true"
+            )
+            nccl_db = self._build_db(nccl_addrs, list(nccl_resps))
+            parts.extend(
+                [
+                    "",
+                    "=== FR Trace NCCL ===",
+                    "--- Groups ---",
+                    tabulate(nccl_db.groups, headers=Group._fields, tablefmt="plain"),
+                    "--- Memberships ---",
+                    tabulate(
+                        nccl_db.memberships,
+                        headers=Membership._fields,
+                        tablefmt="plain",
+                    ),
+                    "--- Collectives ---",
+                    tabulate(
+                        nccl_db.collectives,
+                        headers=Collective._fields,
+                        tablefmt="plain",
+                    ),
+                    "--- NCCL Calls ---",
+                    tabulate(
+                        nccl_db.ncclcalls,
+                        headers=NCCLCall._fields,
+                        tablefmt="plain",
+                    ),
+                ]
+            )
+        except Exception:
+            parts.append("\n=== FR Trace NCCL ===\nFailed to fetch NCCL trace")
+
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "fr_trace"
+
+
+class ProfilerHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [Route("/profile", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/profile", "torch profiler")]
+
+    def templates(self) -> dict[str, str]:
+        return {"profile.html": PROFILE_TEMPLATE}
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        duration = req.get_query_arg("duration", default=1.0, type=float)
+        addrs, resps = fetch_all("torch_profile", f"duration={duration}")
+        return req.frontend.render_template("profile.html", addrs=addrs, resps=resps)
+
+
+class WaitCountersHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [Route("/wait_counters", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/wait_counters", "Wait Counters")]
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        addrs, resps = fetch_all("wait_counter_values")
+        return req.frontend.render_template(
+            "json_resp.html", title="Wait Counters", addrs=addrs, resps=resps
+        )
+
+    def dump(self) -> str | None:
+        addrs, resps = fetch_all("wait_counter_values")
+        parts: list[str] = []
+        for i, (addr, resp) in enumerate(zip(addrs, resps)):
+            parts.append(f"=== Rank {i}: {addr} ===")
+            if resp.status_code == 200:
+                parts.append(format_json(resp.text))
+            else:
+                parts.append(f"Error: {resp.status_code}")
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "wait_counters"
+
+
+class TCPStoreHandler(DebugHandler):
+    def routes(self) -> list[Route]:
+        return [Route("/tcpstore", self._handle)]
+
+    def nav_links(self) -> list[NavLink]:
+        return [NavLink("/tcpstore", "TCPStore")]
+
+    def templates(self) -> dict[str, str]:
+        return {"tcpstore.html": TCPSTORE_TEMPLATE}
+
+    def _handle(self, req: HTTPRequestHandler) -> bytes:
+        store = tcpstore_client(prefix="")
+        keys = store.list_keys()
+        keys.sort()
+        values = [repr(v) for v in store.multi_get(keys)]
+        return req.frontend.render_template("tcpstore.html", keys=keys, values=values)
+
+    def dump(self) -> str | None:
+        store = tcpstore_client(prefix="")
+        keys = store.list_keys()
+        keys.sort()
+        values = [repr(v) for v in store.multi_get(keys)]
+        parts = [f"{k}: {v}" for k, v in zip(keys, values)]
+        return "\n".join(parts)
+
+    def dump_filename(self) -> str:
+        return "tcpstore"
+
+
+def default_handlers() -> list[DebugHandler]:
+    return [
+        IndexHandler(),
+        StacksHandler(),
+        PySpyHandler(),
+        FlightRecorderHandler(),
+        ProfilerHandler(),
+        WaitCountersHandler(),
+        TCPStoreHandler(),
+    ]

--- a/torch/distributed/debug/_frontend.py
+++ b/torch/distributed/debug/_frontend.py
@@ -1,29 +1,28 @@
 import asyncio
 import json
 import logging
+import os
 import socket
 import threading
-from collections.abc import Iterable
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 from jinja2 import DictLoader, Environment
-from tabulate import tabulate
 
 from torch.distributed.debug._store import get_world_size, tcpstore_client
-from torch.distributed.flight_recorder.components.builder import build_db
-from torch.distributed.flight_recorder.components.config_manager import JobConfig
-from torch.distributed.flight_recorder.components.types import (
-    Collective,
-    Group,
-    Membership,
-    NCCLCall,
-)
 
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Base types
+# ---------------------------------------------------------------------------
 
 
 @dataclass(slots=True)
@@ -37,6 +36,40 @@ class Response:
 
     def json(self):
         return json.loads(self.text)
+
+
+@dataclass(slots=True)
+class NavLink:
+    path: str
+    label: str
+
+
+@dataclass(slots=True)
+class Route:
+    path: str
+    handler: Callable[["HTTPRequestHandler"], bytes]
+
+
+class DebugHandler(ABC):
+    @abstractmethod
+    def routes(self) -> list[Route]: ...
+
+    @abstractmethod
+    def nav_links(self) -> list[NavLink]: ...
+
+    def templates(self) -> dict[str, str]:
+        return {}
+
+    def dump(self) -> str | None:
+        return None
+
+    def dump_filename(self) -> str:
+        return type(self).__name__.lower()
+
+
+# ---------------------------------------------------------------------------
+# Network helpers
+# ---------------------------------------------------------------------------
 
 
 def fetch_thread_pool(urls: list[str]) -> Iterable[Response]:
@@ -91,8 +124,12 @@ def format_json(blob: str):
     return json.dumps(parsed, indent=2)
 
 
-templates = {
-    "base.html": """
+# ---------------------------------------------------------------------------
+# Template constants
+# ---------------------------------------------------------------------------
+
+
+BASE_TEMPLATE = """
 <!doctype html>
 <head>
     <title>{% block title %}{% endblock %} - PyTorch Distributed</title>
@@ -147,33 +184,16 @@ templates = {
 <nav>
     <h1>Torch Distributed Debug Server</h1>
 
-    <a href="/">Home</a> <!--@lint-ignore-->
-    <a href="/stacks">Python Stack Traces</a> <!--@lint-ignore-->
-    <a href="/pyspy_dump">py-spy Stacks</a> <!--@lint-ignore-->
-    <a href="/fr_trace">FlightRecorder CPU</a> <!--@lint-ignore-->
-    <a href="/fr_trace_json">(JSON)</a> <!--@lint-ignore-->
-    <a href="/fr_trace_nccl">FlightRecorder NCCL</a> <!--@lint-ignore-->
-    <a href="/fr_trace_nccl_json">(JSON)</a> <!--@lint-ignore-->
-    <a href="/profile">torch profiler</a> <!--@lint-ignore-->
-    <a href="/wait_counters">Wait Counters</a> <!--@lint-ignore-->
-    <a href="/tcpstore">TCPStore</a> <!--@lint-ignore-->
+    {{ nav_links | safe }}
 </nav>
 
 <section class="content">
   {% block header %}{% endblock %}
   {% block content %}{% endblock %}
 </section>
-    """,
-    "index.html": """
-{% extends "base.html" %}
-{% block header %}
-  <h1>{% block title %}Index{% endblock %}</h1>
-{% endblock %}
-{% block content %}
-Hi
-{% endblock %}
-    """,
-    "raw_resp.html": """
+    """
+
+RAW_RESP_TEMPLATE = """
 {% extends "base.html" %}
 {% block header %}
     <h1>{% block title %}{{title}}{% endblock %}</h1>
@@ -189,8 +209,9 @@ Hi
         {% endif %}
     {% endfor %}
 {% endblock %}
-    """,
-    "json_resp.html": """
+    """
+
+JSON_RESP_TEMPLATE = """
 {% extends "base.html" %}
 {% block header %}
     <h1>{% block title %}{{ title }}{% endblock %}</h1>
@@ -206,126 +227,65 @@ Hi
         {% endif %}
     {% endfor %}
 {% endblock %}
-    """,
-    "profile.html": """
-{% extends "base.html" %}
-{% block header %}
-    <h1>{% block title %}torch.profiler{% endblock %}</h1>
-{% endblock %}
+    """
 
-{% block content %}
-    <form action="" method="get">
-        <label for="duration">Duration (seconds):</label>
-        <input type="number" id="duration" name="duration" value="{{ duration }}" min="1" max="60">
-        <input type="submit" value="Submit">
-    </form>
 
-    <script>
-    function stringToArrayBuffer(str) {
-        const encoder = new TextEncoder();
-        return encoder.encode(str).buffer;
-    }
-    async function openPerfetto(data) {
-        const ui = window.open('https://ui.perfetto.dev/#!/');
-        if (!ui) { alert('Popup blocked. Allow popups for this page and click again.'); return; }
+# ---------------------------------------------------------------------------
+# PeriodicDumper
+# ---------------------------------------------------------------------------
 
-        // Perfetto readiness handshake: PING until we receive PONG
-        await new Promise((resolve, reject) => {
-        const onMsg = (e) => {
-            if (e.source === ui && e.data === 'PONG') {
-            window.removeEventListener('message', onMsg);
-            clearInterval(pinger);
-            resolve();
-            }
-        };
-        window.addEventListener('message', onMsg);
-        const pinger = setInterval(() => { try { ui.postMessage('PING', '*'); } catch (_e) {} }, 250);
-        setTimeout(() => { clearInterval(pinger); window.removeEventListener('message', onMsg); reject(); }, 20000);
-        }).catch(() => { alert('Perfetto UI did not respond. Try again.'); return; });
 
-        ui.postMessage({
-        perfetto: {
-            buffer: stringToArrayBuffer(JSON.stringify(data)),
-            title: "torch profiler",
-            fileName: "trace.json",
-        }
-        }, '*');
-    }
-    </script>
+class PeriodicDumper:
+    def __init__(
+        self,
+        handlers: list[DebugHandler],
+        output_dir: str,
+        interval_seconds: float = 60.0,
+    ) -> None:
+        self._handlers = handlers
+        self._output_dir = output_dir
+        self._interval_seconds = interval_seconds
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
 
-    {% for i, (addr, resp) in enumerate(zip(addrs, resps)) %}
-        <h2>Rank {{ i }}: {{ addr }}</h2>
-        {% if resp.status_code != 200 %}
-            <p>Failed to fetch: status={{ resp.status_code }}</p>
-            <pre>{{ resp.text }}</pre>
-        {% else %}
-            <script>
-            function run{{ i }}() {
-                var data = {{ resp.text | safe }};
-                openPerfetto(data);
-            }
-            </script>
+    def start(self) -> None:
+        os.makedirs(self._output_dir, exist_ok=True)
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="distributed.debug.PeriodicDumper",
+        )
+        self._thread.start()
 
-            <button onclick="run{{ i }}()">View {{ i }}</button>
-        {% endif %}
-    {% endfor %}
-{% endblock %}
-    """,
-    "tcpstore.html": """
-{% extends "base.html" %}
-{% block header %}
-    <h1>{% block title %}TCPStore Keys{% endblock %}</h1>
-{% endblock %}
-{% block content %}
-    <pre>
-    {% for k, v in zip(keys, values) -%}
-{{ k }}: {{ v | truncate(100) }}
-    {% endfor %}
-    </pre>
-{% endblock %}
-    """,
-    "fr_trace.html": """
-{% extends "base.html" %}
-{% block header %}
-    <h1>{% block title %}{{ title }}{% endblock %}</h1>
-{% endblock %}
-{% block content %}
-    <h2>Groups</h2>
-    {{ groups | safe }}
-    <h2>Memberships</h2>
-    {{ memberships | safe }}
-    <h2>Collectives</h2>
-    {{ collectives | safe }}
-    <h2>NCCL Calls</h2>
-    {{ ncclcalls | safe }}
-{% endblock %}
-    """,
-    "pyspy_dump.html": """
-{% extends "base.html" %}
-{% block header %}
-    <h1>{% block title %}py-spy Stack Traces{% endblock %}</h1>
-{% endblock %}
-{% block content %}
-    <form action="" method="get">
-        <input type="checkbox" id="native" name="native" value="1"/>
-        <label for="native">Native</label>
-        <input type="checkbox" id="subprocesses" name="subprocesses" value="1"/>
-        <label for="subprocesses">Subprocesses</label>
-        <input type="submit" value="Submit">
-    </form>
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
 
-    {% for i, (addr, resp) in enumerate(zip(addrs, resps)) %}
-        <h2>Rank {{ i }}: {{ addr }}</h2>
-        {% if resp.status_code != 200 %}
-            <p>Failed to fetch: status={{ resp.status_code }}</p>
-            <pre>{{ resp.text }}</pre>
-        {% else %}
-            <pre>{{ resp.text }}</pre>
-        {% endif %}
-    {% endfor %}
-{% endblock %}
-    """,
-}
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            for handler in self._handlers:
+                try:
+                    content = handler.dump()
+                except Exception:
+                    logger.exception("Failed to dump %s", handler.dump_filename())
+                    continue
+                if content is None:
+                    continue
+                timestamp = time.strftime("%Y%m%d_%H%M%S")
+                filename = f"{handler.dump_filename()}_{timestamp}.txt"
+                path = os.path.join(self._output_dir, filename)
+                try:
+                    with open(path, "w") as f:
+                        f.write(content)
+                except Exception:
+                    logger.exception("Failed to write dump to %s", path)
+            self._stop_event.wait(self._interval_seconds)
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
 
 
 class _IPv6HTTPServer(ThreadingHTTPServer):
@@ -365,29 +325,48 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 
 
 class FrontendServer:
-    def __init__(self, port: int):
-        # Setup templates
-        loader = DictLoader(templates)
+    def __init__(
+        self,
+        port: int,
+        handlers: list[DebugHandler] | None = None,
+    ):
+        if handlers is None:
+            from torch.distributed.debug._debug_handlers import default_handlers
+
+            handlers = default_handlers()
+
+        # Build nav HTML from handlers
+        nav_html = "\n".join(
+            f'    <a href="{link.path}">{link.label}</a> <!--@lint-ignore-->'
+            for handler in handlers
+            for link in handler.nav_links()
+        )
+
+        # Merge all handler templates + shared templates
+        all_templates: dict[str, str] = {
+            "base.html": BASE_TEMPLATE,
+            "raw_resp.html": RAW_RESP_TEMPLATE,
+            "json_resp.html": JSON_RESP_TEMPLATE,
+        }
+        for handler in handlers:
+            all_templates.update(handler.templates())
+
+        loader = DictLoader(all_templates)
         self._jinja_env = Environment(loader=loader, enable_async=True)
         self._jinja_env.globals.update(
             zip=zip,
             format_json=format_json,
             enumerate=enumerate,
+            nav_links=nav_html,
         )
 
-        # Create routes
-        self._routes = {
-            "/": self._handle_index,
-            "/stacks": self._handle_stacks,
-            "/pyspy_dump": self._handle_pyspy_dump,
-            "/fr_trace": self._handle_fr_trace,
-            "/fr_trace_json": self._handle_fr_trace_json,
-            "/fr_trace_nccl": self._handle_fr_trace_nccl,
-            "/fr_trace_nccl_json": self._handle_fr_trace_nccl_json,
-            "/profile": self._handle_profiler,
-            "/wait_counters": self._handle_wait_counters,
-            "/tcpstore": self._handle_tcpstore,
-        }
+        # Build route table from handlers
+        self._routes: dict[str, Callable[[HTTPRequestHandler], bytes]] = {}
+        for handler in handlers:
+            for route in handler.routes():
+                self._routes[route.path] = route.handler
+
+        self._handlers = handlers
 
         # Create HTTP server
         RequestHandlerClass = type(
@@ -439,116 +418,42 @@ class FrontendServer:
         req.end_headers()
         req.wfile.write(resp)
 
-    def _render_template(self, template: str, **kwargs: object) -> bytes:
+    def render_template(self, template: str, **kwargs: object) -> bytes:
         return self._jinja_env.get_template(template).render(**kwargs).encode()
 
-    def _handle_index(self, req: HTTPRequestHandler) -> bytes:
-        return self._render_template("index.html")
 
-    def _handle_stacks(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("dump_traceback")
-        return self._render_template(
-            "raw_resp.html", title="Stacks", addrs=addrs, resps=resps
-        )
-
-    def _handle_pyspy_dump(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("pyspy_dump", req.get_raw_query())
-        return self._render_template(
-            "pyspy_dump.html",
-            addrs=addrs,
-            resps=resps,
-        )
-
-    def _render_fr_trace(self, addrs: list[str], resps: list[Response]) -> bytes:
-        config = JobConfig()
-
-        args = config.parse_args(args=[])
-        args.allow_incomplete_ranks = True
-        args.verbose = True
-
-        details = {}
-        for rank, resp in enumerate(resps):
-            resp.raise_for_status()
-            dump = {
-                "rank": rank,
-                "host_name": addrs[rank],
-                **resp.json(),
-            }
-            if "entries" not in dump:
-                dump["entries"] = []
-            details[f"rank{rank}.json"] = dump
-
-        version = next(iter(details.values()))["version"]
-
-        db = build_db(details, args, version)
-
-        return self._render_template(
-            "fr_trace.html",
-            title="FlightRecorder",
-            groups=tabulate(db.groups, headers=Group._fields, tablefmt="html"),
-            memberships=tabulate(
-                db.memberships, headers=Membership._fields, tablefmt="html"
-            ),
-            collectives=tabulate(
-                db.collectives, headers=Collective._fields, tablefmt="html"
-            ),
-            ncclcalls=tabulate(db.ncclcalls, headers=NCCLCall._fields, tablefmt="html"),
-        )
-
-    def _handle_fr_trace(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("fr_trace_json")
-
-        return self._render_fr_trace(addrs, list(resps))
-
-    def _handle_fr_trace_json(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("fr_trace_json")
-
-        return self._render_template(
-            "json_resp.html",
-            title="FlightRecorder",
-            addrs=addrs,
-            resps=resps,
-        )
-
-    def _handle_fr_trace_nccl(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("dump_nccl_trace_json", "onlyactive=true")
-
-        return self._render_fr_trace(addrs, list(resps))
-
-    def _handle_fr_trace_nccl_json(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("dump_nccl_trace_json", "onlyactive=true")
-
-        return self._render_template(
-            "json_resp.html",
-            title="FlightRecorder NCCL",
-            addrs=addrs,
-            resps=resps,
-        )
-
-    def _handle_profiler(self, req: HTTPRequestHandler) -> bytes:
-        duration = req.get_query_arg("duration", default=1.0, type=float)
-
-        addrs, resps = fetch_all("torch_profile", f"duration={duration}")
-
-        return self._render_template("profile.html", addrs=addrs, resps=resps)
-
-    def _handle_wait_counters(self, req: HTTPRequestHandler) -> bytes:
-        addrs, resps = fetch_all("wait_counter_values")
-        return self._render_template(
-            "json_resp.html", title="Wait Counters", addrs=addrs, resps=resps
-        )
-
-    def _handle_tcpstore(self, req: HTTPRequestHandler) -> bytes:
-        store = tcpstore_client(prefix="")
-        keys = store.list_keys()
-        keys.sort()
-        values = [repr(v) for v in store.multi_get(keys)]
-        return self._render_template("tcpstore.html", keys=keys, values=values)
-
-
-def main(port: int) -> None:
+def main(
+    port: int,
+    dump_dir: str | None,
+    dump_interval: float,
+    handlers: list[DebugHandler],
+    enabled_dumps: set[str],
+) -> None:
     logger.setLevel(logging.INFO)
 
-    server = FrontendServer(port=port)
+    server = FrontendServer(port=port, handlers=handlers)
     logger.info("Frontend server started on port %d", server._server.server_port)
-    server.join()
+
+    dumper: PeriodicDumper | None = None
+    if dump_dir is not None:
+        dumper = PeriodicDumper(
+            [
+                handler
+                for handler in handlers
+                if handler.dump_filename() in enabled_dumps
+            ],
+            dump_dir,
+            dump_interval,
+        )
+        dumper.start()
+        logger.info(
+            "Periodic dumper started, writing to %s every %.0fs",
+            dump_dir,
+            dump_interval,
+        )
+
+    try:
+        server.join()
+    finally:
+        if dumper is not None:
+            dumper.stop()


### PR DESCRIPTION
This adds support for periodic collection and dumping of the handlers.

Dumping can be enabled by passing `dump_dir` to `start_debug_server`.

```
start_debug_server(port=40001, dump_dir="/tmp/debug_dump", dump_interval=5.0)
```

Changes:

* move handlers out of _frontend.py and into their own DebugHandler implementation classes
* added PeriodicDumper which will call `dump` periodically and write it into a new file

Test plan:

Run on a small model w/ dumps enabled

```
tristanr@devvm5553 ~/pytorch (d4l3k/debug_handlers)> cat /tmp/debug_dump/stacks_20260211_124536.txt
=== Rank 0: http://devvm5553.cco0.facebook.com:42151/handler/dump_traceback? ===
Current thread 0x00007fdfa2784640 (most recent call first):
  <no Python frame>

Thread 0x00007fdd4cdde640 (most recent call first):
  <no Python frame>

Thread 0x00007fdd4f7fe640 (most recent call first):
  <no Python frame>

Thread 0x00007fdd4ffff640 (most recent call first):
  <no Python frame>

Thread 0x00007fdd65efc640 (most recent call first):
  <no Python frame>

Thread 0x00007fe081a22740 (most recent call first):
  File "/home/tristanr/scripts/debug_test.py", line 61 in <module>

=== Rank 1: http://devvm5553.cco0.facebook.com:64509/handler/dump_traceback? ===
Current thread 0x00007fea55f9b640 (most recent call first):
  <no Python frame>
```

```
tristanr@devvm5553 ~/pytorch (d4l3k/debug_handlers)> cat /tmp/debug_dump/fr_trace_20260211_124306.txt 
=== FR Trace ===
--- Groups ---
id    desc    size
--- Memberships ---
group_id    global_rank
--- Collectives ---
id    group_id    pass_check    collective_seq_id    p2p_seq_id    record_id    pg_desc    collective_name    input_sizes    output_sizes    expected_ranks    collective_state    collective_frames    input_numel    output_numel    missing_ranks    mismatch_collectives    type_of_mismatch
--- NCCL Calls ---
id    collective_id    group_id    global_rank    traceback_id    collective_type    sizes

=== FR Trace NCCL ===
--- Groups ---
                  id  desc          size
07327027465595056883  default_pg       4
--- Memberships ---
            group_id    global_rank
07327027465595056883              0
07327027465595056883              1
07327027465595056883              2
07327027465595056883              3
--- Collectives ---
  id    group_id  pass_check      collective_seq_id    p2p_seq_id    record_id  pg_desc       collective_name          input_sizes    output_sizes    expected_ranks    collective_state    collective_frames    input_numel    output_numel    missing_ranks    mismatch_collectives    type_of_mismatch
   0           0  True                          307             0          306  0:default_pg  nccl:all_reduce_barrier  [[1]]          [[1]]           {0, 1, 2, 3}      started             []                                                  {0}
--- NCCL Calls ---
  id  collective_id      group_id    global_rank    traceback_id  collective_type          sizes
   0                            0              1               0  nccl:all_reduce_barrier  [[1]]
   1                            0              2               0  nccl:all_reduce_barrier  [[1]]
   2                            0              3               0  nccl:all_reduce_barrier  [[1]]⏎                                   
```

<img width="2714" height="1323" alt="20260211_15h50m35s_grim" src="https://github.com/user-attachments/assets/d3d6db32-a9da-4cb3-8255-13173fb6cf7d" />
