### PR TITLE
[ROCm][CI] install patched libdrm for updated amdgpu.ids file

### DIFF
--- a/.ci/docker/common/install_rocm_drm.sh
+++ b/.ci/docker/common/install_rocm_drm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Script used only in CD pipeline
 
+PREFIX="$1"
+
 ###########################
 ### prereqs
 ###########################
@@ -33,12 +35,12 @@ pushd drm
 ###########################
 patch -p1 <<'EOF'
 diff --git a/amdgpu/amdgpu_asic_id.c b/amdgpu/amdgpu_asic_id.c
-index a5007ffc..13fa07fc 100644
+index cd8ee596..3e453ecd 100644
 --- a/amdgpu/amdgpu_asic_id.c
 +++ b/amdgpu/amdgpu_asic_id.c
-@@ -22,6 +22,13 @@
-  *
-  */
+@@ -27,6 +27,13 @@
+ #define _GNU_SOURCE
+ #endif
 
 +#define _XOPEN_SOURCE 700
 +#define _LARGEFILE64_SOURCE
@@ -50,7 +52,7 @@ index a5007ffc..13fa07fc 100644
  #include <ctype.h>
  #include <stdio.h>
  #include <stdlib.h>
-@@ -34,6 +41,19 @@
+@@ -39,6 +46,19 @@
  #include "amdgpu_drm.h"
  #include "amdgpu_internal.h"
 
@@ -70,12 +72,12 @@ index a5007ffc..13fa07fc 100644
  static int parse_one_line(struct amdgpu_device *dev, const char *line)
  {
  	char *buf, *saveptr;
-@@ -113,10 +133,46 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
- 	int line_num = 1;
- 	int r = 0;
+@@ -290,9 +310,46 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
+ 	if (!amdgpu_asic_id_table_path)
+ 		amdgpu_asic_id_table_path = strdup(AMDGPU_ASIC_ID_TABLE);
 
 +	// attempt to find typical location for amdgpu.ids file
- 	fp = fopen(AMDGPU_ASIC_ID_TABLE, "r");
+ 	fp = fopen(amdgpu_asic_id_table_path, "r");
 +
 +	// if it doesn't exist, search
 +	if (!fp) {
@@ -108,41 +110,48 @@ index a5007ffc..13fa07fc 100644
 +
 +	}
 +	else {
-+		amdgpuids_path_msg = AMDGPU_ASIC_ID_TABLE;
++		amdgpuids_path_msg = amdgpu_asic_id_table_path;
 +	}
 +
 +	// both hard-coded location and search have failed
  	if (!fp) {
--		fprintf(stderr, "%s: %s\n", AMDGPU_ASIC_ID_TABLE,
--			strerror(errno));
-+		//fprintf(stderr, "amdgpu.ids: No such file or directory\n");
- 		return;
+-		fprintf(stderr, "%s: %s\n", amdgpu_asic_id_table_path,
++		fprintf(stderr, "%s: %s\n", amdgpuids_path_msg,
+ 			strerror(errno));
+ 		goto get_cpu;
  	}
-
-@@ -132,7 +188,7 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
+@@ -309,7 +366,7 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
  			continue;
  		}
 
--		drmMsg("%s version: %s\n", AMDGPU_ASIC_ID_TABLE, line);
+-		drmMsg("%s version: %s\n", amdgpu_asic_id_table_path, line);
 +		drmMsg("%s version: %s\n", amdgpuids_path_msg, line);
  		break;
  	}
 
-@@ -150,7 +206,7 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
+@@ -327,7 +384,7 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
 
  	if (r == -EINVAL) {
  		fprintf(stderr, "Invalid format: %s: line %d: %s\n",
--			AMDGPU_ASIC_ID_TABLE, line_num, line);
+-			amdgpu_asic_id_table_path, line_num, line);
 +			amdgpuids_path_msg, line_num, line);
  	} else if (r && r != -EAGAIN) {
  		fprintf(stderr, "%s: Cannot parse ASIC IDs: %s\n",
  			__func__, strerror(-r));
+@@ -338,6 +395,7 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
+
+ get_cpu:
+ 	free(amdgpu_asic_id_table_path);
++	if (amdgpuids_path) free(amdgpuids_path);
+ 	if (dev->info.ids_flags & AMDGPU_IDS_FLAGS_FUSION &&
+ 	    dev->marketing_name == NULL) {
+ 		amdgpu_parse_proc_cpuinfo(dev);
 EOF
 
 ###########################
 ### build
 ###########################
-meson builddir --prefix=/opt/amdgpu
+meson builddir --prefix=${PREFIX}
 pushd builddir
 ninja install
 

--- a/.ci/docker/libtorch/Dockerfile
+++ b/.ci/docker/libtorch/Dockerfile
@@ -101,7 +101,7 @@ RUN apt-get update -y && \
     apt-get install python3 python-is-python3 -y && \
     apt-get clean
 
-RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
+RUN bash ./install_rocm_drm.sh /opt/amdgpu && rm install_rocm_drm.sh
 RUN bash ./install_rocm_magma.sh ${ROCM_VERSION} && rm install_rocm_magma.sh
 
 FROM ${BASE_TARGET} as final

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -154,7 +154,7 @@ RUN python3 -m pip install --upgrade pip && \
     python3 -mpip install cmake==3.28.4
 # replace the libdrm in /opt/amdgpu with custom amdgpu.ids lookup path
 ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
-RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
+RUN bash ./install_rocm_drm.sh /opt/amdgpu && rm install_rocm_drm.sh
 # ROCm 6.4 rocm-smi depends on system drm.h header
 RUN yum install -y libdrm-devel
 ENV MKLROOT /opt/intel

--- a/.ci/docker/ubuntu-rocm/Dockerfile
+++ b/.ci/docker/ubuntu-rocm/Dockerfile
@@ -65,6 +65,8 @@ RUN if [ "${ROCM_VERSION}" != "nightly" ]; then bash ./install_rocm_magma.sh ${R
 RUN rm install_rocm_magma.sh
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN if [ "${ROCM_VERSION}" != "nightly" ]; then bash ./install_miopen.sh ${ROCM_VERSION}; fi && rm install_miopen.sh
+ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
+RUN if [ "${ROCM_VERSION}" != "nightly" ]; then bash ./install_rocm_drm.sh /usr ; fi && rm install_rocm_drm.sh
 
 # ROCm environment variables are set in /etc/rocm_env.sh by install_rocm.sh
 # and sourced via /etc/bash.bashrc for interactive shells.


### PR DESCRIPTION
The system libdrm is too old and doesn't contain the latest device names. The libdrm patch is also updated.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang