### PR TITLE
Remove Claude Code conclusions from mergeability checks to prevent blocking merges

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1063,6 +1063,11 @@ class GitHubPR:
         # this workflow doesn't provide mergability info
         self.conclusions.pop("Apply lint suggestions", None)
 
+        # Same issue for Claude Code: triggered by comment events, uses a
+        # protected environment (bedrock), resulting in ACTION_REQUIRED
+        # check suite conclusions that block merges
+        self.conclusions.pop("Claude Code", None)
+
         return self.conclusions
 
     def get_authors(self) -> dict[str, str]:


### PR DESCRIPTION
Works similarly to "apply lint".

Should solve [issues like this](https://github.com/pytorch/pytorch/pull/171710) when merge is blocked by this workflow.