### PR TITLE
[inductor] Decompose mm to pointwise mul when K==1

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -325,6 +325,16 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
             lambda: "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs",
         )
 
+    # When K == 1, the matmul is an outer product: (M, 1) @ (1, N) = (M, N).
+    # Instead of a full GEMM, broadcast both tensors to (M, N) and do
+    # pointwise multiplication, which is more efficient for this memory-bound case.
+    k = mat1.get_size()[1]
+    if k == 1:
+        result = lowerings[aten.mul](mat1, mat2)
+        if out_dtype is not None and out_dtype != mat1.get_dtype():
+            result = lowerings[prims.convert_element_type.default](result, out_dtype)
+        return result
+
     # Lower matmul-related operations (e.g., torch.matmul / torch.bmm / torch.addmm)
     # into native matmul IR using `ops.dot`. When we see a matmul pattern
     # (C[y, x] = A[y, r] * B[r, x]), the core idea is to emulate a broadcasted


### PR DESCRIPTION
Summary:
When K == 1, matrix multiplication (M, 1) @ (1, N) is an outer product.
Instead of launching a full GEMM kernel, we decompose it into a broadcasted
pointwise multiply, which is more efficient for this memory-bound case.

This is analogous to D56667030 which decomposed BMM for M==1 or N==1 cases.

TritonBench results on B200 (denoised, clocks locked at 1000 MHz, 750W):

| Shape (M, N, K) | aten_matmul (ms) | pt2_triton (ms) | Speedup | Accuracy |
|---|---|---|---|---|
| **Small shapes** |||||
| (100, 100, 1) | 0.0092 | 0.0077 | **1.20x** | 1.0 |
| (150, 150, 1) | 0.0092 | 0.0092 | 1.00x | 1.0 |
| (200, 200, 1) | 0.0092 | 0.0091 | 1.01x | 1.0 |
| **Production models shapes** |||||
| (4608, 1, 1) | 0.0092 | 0.0090 | 1.02x | 1.0 |
| (4608, 20, 1) | 0.0092 | 0.0091 | 1.01x | 1.0 |
| (4608, 32, 1) | 0.0092 | 0.0091 | 1.01x | 1.0 |
| (4608, 128, 1) | 0.0092 | 0.0092 | 1.00x | 1.0 |
| (4608, 256, 1) | 0.0112 | 0.0092 | **1.23x** | 1.0 |
| (4608, 512, 1) | 0.0133 | 0.0112 | **1.19x** | 1.0 |
| (4608, 1024, 1) | 0.0195 | 0.0133 | **1.46x** | 1.0 |
| **Square / large shapes** |||||
| (256, 256, 1) | 0.0092 | 0.0091 | 1.01x | 1.0 |
| (512, 512, 1) | 0.0092 | 0.0092 | 1.00x | 1.0 |
| (1024, 1024, 1) | 0.0112 | 0.0092 | **1.22x** | 1.0 |
| (1024, 4096, 1) | 0.0174 | 0.0113 | **1.54x** | 1.0 |
| (2048, 2048, 1) | 0.0174 | 0.0113 | **1.54x** | 1.0 |
| (4096, 1024, 1) | 0.0174 | 0.0114 | **1.52x** | 1.0 |
| (4096, 4096, 1) | 0.0420 | 0.0236 | **1.78x** | 1.0 |
| (8192, 8192, 1) | 0.1382 | 0.0687 | **2.01x** | 1.0 |
| (16384, 16384, 1) | 0.4906 | 0.2529 | **1.94x** | 1.0 |

No regressions at any shape. 1.2x-2.0x speedups for M*N >= ~250K elements.
Perfect accuracy (bit-identical to cuBLAS baseline) across all shapes.

Test Plan:
Benchmarked with tritonbench on B200 GPU under denoise.sh (locked clocks,
NUMA pinning). Example command:

```
CUDA_VISIBLE_DEVICES=0 bash fbcode/ads_mkl/benchmarks/denoise.sh \
  buck2 run \
    @//mode/opt \
    -m ovr_config//triton:beta \
    -c fbcode.nvcc_arch=b200a \
    -c fbcode.platform010_cuda_version=12.8 \
    -c fbcode.enable_gpu_sections=true \
    //pytorch/tritonbench:run -- \
    --op gemm --m 4096 --k 1 --n 4096 \
    --only aten_matmul,pt2_triton_matmul \
    --metrics latency,speedup,accuracy --csv
```

Ran tlparse to verify the lowering produces a pointwise Triton kernel
instead of a GEMM:

```
TORCH_TRACE=~/tmp/trace_logs_k1 buck2 run \
    @//mode/opt \
    -m ovr_config//triton:beta \
    -c fbcode.nvcc_arch=b200a \
    -c fbcode.platform010_cuda_version=12.8 \
    -c fbcode.enable_gpu_sections=true \
    //pytorch/tritonbench:run -- \
    --op gemm --m 4096 --k 1 --n 1024 \
    --only aten_matmul,pt2_triton_matmul \
    --metrics latency,speedup,accuracy --csv

buck2 run //caffe2/fb/tlparse:tlparse -- ~/tmp/trace_logs_k1 --overwrite-manifold
```

The generated Triton kernel confirms the lowering — a `triton_poi` (pointwise)
kernel instead of a GEMM template:

```python
# Topologically Sorted Source Nodes: [matmul], Original ATen: [aten.mm]
triton_poi_fused_mm_0 = async_compile.triton('triton_poi_fused_mm_0', '''
triton_heuristics.pointwise(size_hints={'x': 4194304}, ...)
triton.jit
def triton_poi_fused_mm_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK):
    x1 = xindex // 1024        # row index (M dim)
    x0 = (xindex % 1024)       # col index (N dim)
    tmp0 = tl.load(in_ptr0 + (x1), ...)  # mat1 broadcast along N
    tmp1 = tl.load(in_ptr1 + (x0), ...)  # mat2 broadcast along M
    tmp2 = tmp0 * tmp1                    # pointwise multiply
    tl.store(out_ptr0 + (x2), tmp2, None)
''')
```

Differential Revision: D93017048




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo