### PR TITLE
Fix bug when converting annotation from tuple to dict in NestedUserFunctionVariable

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1724,9 +1724,9 @@ class NestedUserFunctionVariable(BaseUserFunctionVariable):
         if self.annotations:
             annotations = self.annotations.as_python_constant()
             if isinstance(annotations, tuple):
-                from itertools import pairwise
-
-                annotations = dict(pairwise(annotations))
+                annotations = dict(
+                    zip(annotations[::2], annotations[1::2], strict=True)
+                )
 
             # TypeError: __annotations__ must be set to a dict object
             assert isinstance(annotations, dict)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #174714
* #174570
* __->__ #174821
* #174450
* #174569
* #174568
* #174449

`itertools.pairwise(ABCD)` returns AB BC CD and not AB CD. This could also be replaced by `itertools.batched` but it only exists on Python 3.12+

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo