### PR TITLE
[AMP] [BUGFIX] Fixes RMSNorm mixed precision

### DIFF
--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -872,6 +872,7 @@ copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
   _(softplus)                         \
   _(layer_norm)                       \
   _(native_layer_norm)                \
+  _(rms_norm)                         \
   _(group_norm)                       \
   _(frobenius_norm, dim)              \
   _(nuclear_norm)                     \

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -146,6 +146,7 @@ class AutocastTestLists:
             ("softmax", pointwise0_fp16 + (0,)),
             ("log_softmax", pointwise0_fp16 + (0,)),
             ("layer_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
+            ("rms_norm", pointwise0_fp16 + ((pointwise0_fp16[0].numel(),),)),
             ("group_norm", mat0_fp16 + (1,)),
             ("norm", pointwise0_fp16),
             ("norm", pointwise0_fp16, {"dim": 0}),


### PR DESCRIPTION
Fixes #167308

Running the repro script from the issue
Before:
```
Testing MinimalRMS with apply_linear=False, layernorm=RMSNorm
<FusedRmsNormBackward0 object at 0xea647dfdb130>

Testing MinimalRMS with apply_linear=True, layernorm=RMSNorm
/opt/pytorch/pytorch/torch/nn/functional.py:2954: UserWarning: Mismatch dtype between input and weight: input dtype = c10::BFloat16, weight dtype = float, Cannot dispatch to fused implementation. (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/layer_norm.cpp:344.)
  return torch.rms_norm(input, normalized_shape, weight, eps)
<ToCopyBackward0 object at 0xea647db65a50>

Testing MinimalRMS with apply_linear=False, layernorm=LayerNorm
<NativeLayerNormBackward0 object at 0xea647dfdb130>

Testing MinimalRMS with apply_linear=True, layernorm=LayerNorm
<NativeLayerNormBackward0 object at 0xea647db65a50>
```
After
```
Testing MinimalRMS with apply_linear=False, layernorm=RMSNorm
<FusedRmsNormBackward0 object at 0xe08d32d630a0>

Testing MinimalRMS with apply_linear=True, layernorm=RMSNorm
<FusedRmsNormBackward0 object at 0xe08d3458b7f0>

Testing MinimalRMS with apply_linear=False, layernorm=LayerNorm
<NativeLayerNormBackward0 object at 0xe08d32d630a0>

Testing MinimalRMS with apply_linear=True, layernorm=LayerNorm
<NativeLayerNormBackward0 object at 0xe08d3458b7f0>
```

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5