### PR TITLE
[caffe2][elastic] Fix Mock spec usage for Python 3.12 compatibility

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -21,7 +21,7 @@ from unittest import TestCase
 from unittest.mock import call, MagicMock, Mock, patch, PropertyMock
 
 import torch.distributed as dist
-from torch.distributed import HashStore, Store
+from torch.distributed import HashStore, PrefixStore, Store
 from torch.distributed.elastic.rendezvous import (
     RendezvousClosedError,
     RendezvousError,
@@ -1829,7 +1829,7 @@ class IntegrationTest(TestCase):
             def set(self, key, value):
                 pass
 
-        prefix_store = CustomPrefixStore(spec=dist.PrefixStore)
+        prefix_store = CustomPrefixStore(spec=PrefixStore)
         prefix_store_class_mock.return_value = prefix_store
         tcp_store = Mock(spec=dist.TCPStore)
         original_addr = "original_addr"


### PR DESCRIPTION
Summary: Python 3.12 added `InvalidSpecError` which prevents using a Mock object as a `spec` argument. In `test_share_tcp_store_from_backend`, `patch.object(dist, "PrefixStore")` replaces `dist.PrefixStore` with a MagicMock, and then the test uses `dist.PrefixStore` as `spec=` which fails. Fix by importing `PrefixStore` directly so the local binding refers to the real class even after patching.

Test Plan: buck test fbcode//mode/opt fbcode//caffe2/test/distributed/elastic/rendezvous:dynamic_rendezvous_test -- --exact 'fbcode//caffe2/test/distributed/elastic/rendezvous:dynamic_rendezvous_test - test_share_tcp_store_from_backend (dynamic_rendezvous_test.IntegrationTest)'

Differential Revision: D93005363


