### PR TITLE
[FSDP2] Fix backward when loss depends on non-output tensor

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -684,6 +684,44 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             self.assertEqual(ref_loss, loss)
 
 
+class TestFullyShard1DTrainingBackward(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(2, torch.get_device_module(device_type).device_count())
+
+    @skip_if_lt_x_gpu(2)
+    def test_backward_reshard_with_non_output_loss(self):
+        """
+        Tests that backward works when reshard_after_forward=True and the loss
+        depends on a cached intermediate tensor rather than the module output.
+
+        Regression: https://github.com/pytorch/pytorch/issues/173709
+        """
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = nn.Linear(64, 64)
+                self.linear2 = nn.Linear(64, 64)
+
+            def forward(self, x):
+                intermediate = self.linear1(x)
+                self.cached_intermediate = intermediate
+                return self.linear2(intermediate)
+
+        torch.manual_seed(42)
+        model = Model().to(device_type)
+        fully_shard(model, reshard_after_forward=True)
+        x = torch.randn(4, 64, device=device_type.type, requires_grad=True)
+        _output = model(x)
+        loss = model.cached_intermediate.sum()
+        # Should not raise "storage of size 0" error
+        loss.backward()
+        for param in model.parameters():
+            if param.requires_grad:
+                self.assertIsNotNone(param.grad)
+
+
 class TestFullyShard1DTrainingCompose(FSDPTest):
     @property
     def world_size(self) -> int:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
+import contextlib
 import functools
 import logging
 from collections.abc import Callable, Sequence
@@ -89,6 +90,7 @@ class FSDPState(_State):
         # ``False`` when user set reshard_after_forward
         # through ``fully_shard`` or ``set_reshard_after_forward``
         self._auto_reshard_after_forward: bool | None = True
+        self._saved_tensors_hook_ctx: contextlib.AbstractContextManager | None = None
 
     def _get_state_for_module(self, module: nn.Module) -> "FSDPState | None":
         """Get the state for a module. Subclasses can override to use different state getters."""
@@ -266,6 +268,11 @@ class FSDPState(_State):
                 )
         if self._fsdp_param_group:
             args, kwargs = self._fsdp_param_group.pre_forward(module, args, kwargs)
+        if (
+            self._fsdp_param_group
+            and self._fsdp_param_group._reshard_after_forward
+        ):
+            self._setup_saved_tensors_hooks()
         for fsdp_state in self._states_to_forward_prefetch:
             if (target_param_group := fsdp_state._fsdp_param_group) is not None:
                 FSDPParamGroup._prefetch_unshard(target_param_group, "forward")
@@ -277,6 +284,7 @@ class FSDPState(_State):
         # post-backward hook is responsible for the reshard
         if self._training_state == TrainingState.PRE_BACKWARD:
             return output
+        self._teardown_saved_tensors_hooks()
         if self._fsdp_param_group:
             output = self._fsdp_param_group.post_forward(module, input, output)
         output = self._register_pre_backward_hook(output)
@@ -298,6 +306,29 @@ class FSDPState(_State):
                     output,
                 )
         return output
+
+    def _setup_saved_tensors_hooks(self) -> None:
+        # Use saved_tensors_hooks so that when any tensor saved during forward
+        # is accessed during backward, we trigger _pre_backward to unshard
+        # parameters. This handles cases where the loss depends on a tensor
+        # that is not the module output (e.g. a cached intermediate), since
+        # _register_pre_backward_hook only hooks on the module output.
+        fsdp_state = self
+
+        def unpack_hook(tensor: torch.Tensor) -> torch.Tensor:
+            if fsdp_state._training_state != TrainingState.PRE_BACKWARD:
+                fsdp_state._pre_backward(torch.empty(0))
+            return tensor
+
+        self._saved_tensors_hook_ctx = torch.autograd.graph.saved_tensors_hooks(
+            lambda t: t, unpack_hook
+        )
+        self._saved_tensors_hook_ctx.__enter__()
+
+    def _teardown_saved_tensors_hooks(self) -> None:
+        if self._saved_tensors_hook_ctx is not None:
+            self._saved_tensors_hook_ctx.__exit__(None, None, None)
+            self._saved_tensors_hook_ctx = None
 
     def _pre_backward(self, grad: torch.Tensor) -> torch.Tensor:
         self._training_state = TrainingState.PRE_BACKWARD


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/173709

## Summary
- When `reshard_after_forward=True`, `_register_pre_backward_hook` only hooks on module output tensors. If the loss depends on a cached intermediate instead of the output, hooks never fire and parameters stay resharded (0-size storage) during backward.
- Use `saved_tensors_hooks` during the module forward so that when any saved tensor is accessed during backward, parameters are unsharded first. `_pre_backward` is idempotent so the existing output-based hooks still work without conflict.

## Test plan
- Added `TestFullyShard1DTrainingBackward.test_backward_reshard_with_non_output_loss`
- Verified fix on PyTorch 2.9.0 container with `torchrun --nproc_per_node=2`