### PR TITLE
[DTensor] single dim bucketize rule supporting sharded buckets

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1093,22 +1093,6 @@ class DistArgMaxArgMinTest(DTensorTestBase):
                 local_result = op(local_tensor, dim=1)
                 self.assertEqual(full_dresult, local_result)
 
-    @with_comms
-    def test_argmax_argmin_sharded_reduction_dim(self):
-        """Unlike max/min which use reduction_linear=True and produce
-        Partial("max")/Partial("min") outputs, argmax/argmin return indices
-        that can't be combined across shards with an element-wise max/min.
-        The strategy sets reduction_linear=False, which forces the input to
-        be redistributed to Replicate on the sharded reduction dim before
-        the op runs. No Partial placement appears in the output."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
-        tensor = torch.tensor(self.sample, device=self.device_type, dtype=torch.float)
-        dtensor = distribute_tensor(tensor, mesh, [Shard(0)])
-
-        for op in self._ops:
-            self.assertEqual(op(dtensor, dim=0).full_tensor(), op(tensor, dim=0))
-            self.assertEqual(op(dtensor).full_tensor(), op(tensor))
-
     def build_device_mesh(self):
         return init_device_mesh(self.device_type, (2, 2))
 

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -289,6 +289,7 @@ def bucketize_single_dim_strategy(
        result as bucketizing the reduced input values.
     """
     input_meta, _boundaries_meta = args_schema
+    assert isinstance(input_meta, TensorMeta)
     strategies: list[list[Placement | _ShardingPlaceholder]] = []
     for dim in range(len(input_meta.shape)):
         strategies.append(

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -21,7 +21,10 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops._common_rules import pointwise_rule
-from torch.distributed.tensor._ops.single_dim_strategy import _ShardingPlaceholder
+from torch.distributed.tensor._ops.single_dim_strategy import (
+    _ShardingPlaceholder,
+    register_single_dim_strategy,
+)
 from torch.distributed.tensor._ops.utils import (
     expand_to_full_mesh_op_strategy,
     generate_redistribute_costs,
@@ -269,49 +272,26 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
     return new_factory_strategy
 
 
-@register_op_strategy(aten.bucketize.Tensor)
-def gen_bucketize_strategy(op_schema: OpSchema) -> StrategyType:
-    """
-    Propagate input sharding to output, but expect replicated for boundaries input.
-    For Partial inputs, convert to Replicate since bucketize returns indices
-    which cannot be meaningfully combined with sum/avg reductions.
-    """
-    mesh = op_schema.get_mesh_from_args()
-    input_strategy, boundaries_strategy = op_schema.args_schema
-    bucketize_strategy = OpStrategy([])
-    if not isinstance(input_strategy, OpStrategy):
-        raise AssertionError(f"Expected OpStrategy, got {type(input_strategy)}")
-    if not isinstance(boundaries_strategy, OpStrategy):
-        raise AssertionError(f"Expected OpStrategy, got {type(boundaries_strategy)}")
-    for arg_strategy in input_strategy.strategies:
-        # Convert Partial placements to Replicate - bucketize returns indices
-        # which cannot be combined with sum/avg reductions
-        placements = tuple(
-            Replicate() if isinstance(p, Partial) else p
-            for p in arg_strategy.output_spec.placements
-        )
-        arg_spec = DTensorSpec(
-            mesh,
-            placements,
-            arg_strategy.output_spec.tensor_meta,
-        )
-        replica_spec = DTensorSpec(
-            mesh,
-            tuple([Replicate()] * mesh.ndim),
-            boundaries_strategy.strategies[0].output_spec.tensor_meta,
-        )
-        bucketize_strategy.strategies.append(
-            OpSpec(
-                output_specs=arg_spec,
-                input_specs=(arg_spec, replica_spec),
-                redistribute_cost=[
-                    generate_redistribute_costs(input_strategy, arg_spec),
-                    generate_redistribute_costs(boundaries_strategy, replica_spec),
-                ],
-            )
-        )
+@register_single_dim_strategy(aten.bucketize.Tensor)
+def bucketize_single_dim_strategy(
+    op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    """Bucketize returns indices into a sorted boundary tensor.
 
-    return bucketize_strategy
+    Two families of strategies:
+    1. Shard the input (and output) on any dim, keep boundaries replicated.
+    2. Shard boundaries on dim 0, replicate input, output is Partial("sum").
+       Each rank counts how many of its local boundary values each input
+       element exceeds; summing across ranks gives the correct global index.
+    """
+    input_meta, _boundaries_meta = args_schema
+    strategies: list[list[Placement | _ShardingPlaceholder]] = []
+    for dim in range(len(input_meta.shape)):
+        strategies.append(
+            [_ShardingPlaceholder(dim), _ShardingPlaceholder(dim), Replicate()]
+        )
+    strategies.append([Partial("sum"), Replicate(), _ShardingPlaceholder(0)])
+    return strategies
 
 
 @register_op_strategy(aten.select.int, schema_info=RuntimeSchemaInfo(1))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174830
* #173937

Addresses feedback from
https://github.com/pytorch/pytorch/pull/173937#pullrequestreview-3775644846
and adds support for the strategy where the buckets themselves are
sharded and the output is partial(sum).

Sharding validator agrees with these rules (it found the missing ones). It still has some false missing rules that claude says are invalid, so i'm working on improving the validator to denoise if possible.