### PR TITLE
[DTensor] Fix StridedShard usage conflict with shard order

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -1731,7 +1731,7 @@ class DistributeWithStridedShardTest(DTensorTestBase):
             elif idx == 2:
                 self.assertExpectedInline(
                     trace_str,
-                    """S(0)[0]_S(0, 3)[1]S(0)[2]->S(0)[0]_S(0, 3)[1]R->S(0)RR->RRR->_S(0, 3)RR->_S(0, 3)[0]S(0)[1]R""",
+                    """S(0)[1]_S(0, 3)[0]S(0)[2]->S(0)[1]_S(0, 3)[0]R->R_S(0, 3)R->RRR->_S(0, 3)RR->_S(0, 3)[0]S(0)[1]R""",
                 )
             elif idx == 3:
                 self.assertExpectedInline(

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -1035,12 +1035,11 @@ class Test_StridedShard_Propagation(LocalDTensorTestBase):
 
             with CommDebugMode() as comm_mode:
                 # `A @ B2` will trigger redistribution on both inputs as below:
-                # A: S(1)[0]S(1)[1]
-                # B2: _S(0, 4)S(0)[0]->RS(0)->RR->S(0)R->S(0)[0]S(0)[1]
-                # The final output res2's placements will be PP.
+                # A: S(1)[0]S(1)[1]->S(1)R->RR
+                # B2: S(0)[1]S(0)[0]->RS(0)->RR
                 res2 = A @ B2
             self.assertEqual(
-                comm_mode.get_comm_counts()[c10d_functional.all_gather_into_tensor], 2
+                comm_mode.get_comm_counts()[c10d_functional.all_gather_into_tensor], 4
             )
             assert isinstance(res1, DTensor)
             assert isinstance(res2, DTensor)

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -88,29 +88,52 @@ class DTensorSpec:
     #     )
     shard_order: ShardOrder = None  # type: ignore[assignment]
 
+    # When True, _StridedShard placements encode the shard order, and the
+    # shard_order field must be left as None (it will be derived on demand).
+    # Set explicitly to False to treat _StridedShard as a regular Shard,
+    # e.g., in view propagation.
+    use_strided_shard_as_shard_order: bool | None = None
+
     def __post_init__(self) -> None:
         if not isinstance(self.placements, tuple):
             self.placements = tuple(self.placements)
-        if self.shard_order is None:
-            _, self.shard_order = self._normalize_placements_into_shard_order(
-                self.placements, self.mesh
-            )
+        if self.use_strided_shard_as_shard_order is None:
+            if any(isinstance(p, _StridedShard) for p in self.placements):
+                self.use_strided_shard_as_shard_order = True
+            else:
+                self.use_strided_shard_as_shard_order = False
+        if self.use_strided_shard_as_shard_order:
+            if self.shard_order is not None:
+                raise ValueError(
+                    "DTensorSpec doesn't allow specify shard_order when "
+                    "use_strided_shard_as_shard_order is True. This may result "
+                    "in conflicting shard order."
+                )
+        else:
+            if self.shard_order is None:
+                self.shard_order = self.compute_default_shard_order(self.placements)
+
         self._hash: int | None = None
 
     @staticmethod
     def _normalize_placements_into_shard_order(
-        placements: tuple[Placement, ...], mesh: DeviceMesh
-    ) -> tuple[tuple[Placement, ...], ShardOrder | None]:
-        # If the returned shard_order is None, it means the StridedShard/Shard
-        # combinations can't be interpreted as shard order.
-        # If no _StridedShard in placements, we create default order.
-        if not any(isinstance(p, _StridedShard) for p in placements):
-            return placements, DTensorSpec.compute_default_shard_order(placements)
-        # _StridedShard in placements, try check if it can be decoded as shard order
-        shard_order = DTensorSpec._maybe_convert_StridedShard_to_shard_order(
-            placements, mesh
-        )
-        if shard_order is not None:
+        placements: tuple[Placement, ...],
+        mesh: DeviceMesh,
+        use_strided_shard_as_shard_order: bool = True,
+    ) -> tuple[tuple[Placement, ...], ShardOrder]:
+        # If use_strided_shard_as_shard_order, it means the StridedShard/Shard
+        # combinations should be interpreted as shard order.
+        if use_strided_shard_as_shard_order:
+            # _StridedShard in placements, try check if it can be decoded as shard order
+            shard_order = DTensorSpec._maybe_convert_StridedShard_to_shard_order(
+                placements, mesh
+            )
+            if shard_order is None:
+                raise ValueError(
+                    "use_strided_shard_as_shard_order is True, but placements: "
+                    f"{placements} is unable to be interpreted into a corresponding "
+                    "shard_order"
+                )
             normalized_placements = tuple(
                 [
                     p if not isinstance(p, _StridedShard) else Shard(p.dim)
@@ -118,13 +141,12 @@ class DTensorSpec:
                 ]
             )
             return normalized_placements, shard_order
-        # unable to decode placements to shard order(e.g., the _StridedShard is
-        # also used by `view` op shard propagation).
-        return placements, None
+        else:
+            return placements, DTensorSpec.compute_default_shard_order(placements)
 
     @staticmethod
     def compute_default_shard_order(
-        placements: tuple[Placement, ...], treat_strided_shard_as_shard: bool = False
+        placements: tuple[Placement, ...],
     ) -> ShardOrder:
         """
         Compute the default shard order from placements.
@@ -135,26 +157,11 @@ class DTensorSpec:
         Args:
             placements: Tuple of Placement objects representing how a tensor is
                 distributed across mesh dimensions.
-            treat_strided_shard_as_shard: If False (default), the presence of any
-                _StridedShard in placements causes the function to return an empty
-                ShardOrder tuple. This is because _StridedShard already encodes a
-                non-default (right-to-left) sharding order via its split_factor,
-                making it incompatible with the left-to-right shard order semantics.
-                If True, _StridedShard is treated as a regular Shard for the purpose
-                of computing shard order. This is useful when the caller only needs
-                to know which tensor dimensions are sharded on which mesh dimensions,
-                without caring about the actual execution order (e.g., for computing
-                local shard sizes and offsets).
         """
         # follow default left-to-right device order if shard_order is not specified
         tensor_dim_to_mesh_dims: defaultdict[int, list[int]] = defaultdict(list)
         mesh_ndim = len(placements)
         for mesh_dim in range(mesh_ndim):
-            # shard_order doesn't work with _StridedShard
-            if not treat_strided_shard_as_shard and isinstance(
-                placements[mesh_dim], _StridedShard
-            ):
-                return ()
             if isinstance(placements[mesh_dim], Shard | _StridedShard):
                 placement = placements[mesh_dim]
                 shard_dim = placement.dim  # pyrefly: ignore [missing-attribute]

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -986,6 +986,9 @@ def patched_distribute_tensor(
     tensor_dt = distribute_tensor(
         input_tensor, device_mesh, placements, src_data_rank=src_data_rank
     )
+    # Do not consider _StridedShard to express shard order
+    tensor_dt._spec.use_strided_shard_as_shard_order = False
+    tensor_dt._spec.__post_init__()
     # fix the shard order
     return redistribute(
         tensor_dt, device_mesh, placements, shard_order, use_graph_based_transform


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174832
* __->__ #174831

Add explicit `use_strided_shard_as_shard_order` flag to DTensorSpec to
control whether _StridedShard placements should be interpreted as encoding
shard order. Previously this was inferred ad-hoc at each usage site by
checking for _StridedShard presence in placements. The flag is auto-detected
in __post_init__ and can be explicitly set to False (e.g. in view
propagation) to treat _StridedShard as a regular Shard.

Also extracts `_update_shard_order_and_placements` as a shared helper for
updating placements and shard order after each transform step, used by both
`stringify_transform_infos` and the upcoming `fill_transform_infos_unsharded_shape`.