### PR TITLE
[ROCm] Optimize RadixSelect synchronization overhead

### DIFF
--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -436,6 +436,73 @@ __device__ __forceinline__ void countRadixLoop(
   }
 }
 
+// Aggregates radix matches across all warps and distributes results back to all threads.
+// Uses double-buffering via buffer_index (0 or 1) to alternate between two smem segments,
+// preventing race conditions between concurrent iterations. Since countRadixUsingMaskDataSmem
+// performs __syncthreads() internally, at most two loop iterations can be in flight
+// simultaneously, so two buffers are sufficient. buffer_index is toggled after each
+// countRadixUsingMaskDataSmem invocation.
+template <
+    typename CountType,
+    int RadixSize,
+    int RadixBits>
+__device__ __forceinline__ void countRadixAggregateCounts(
+    CountType counts[RadixSize], // counts[i] will be the number of matching
+                                 // elements ((val & desiredMask) == desired)
+                                 // that have the digits [radixDigitPos,
+                                 // radixDigitPos+RADIX_BITS-1] set to i.
+    CountType* smem, // shared memory for inter-warp reduction of counts.
+    int buffer_index){ // buffer index for smem.
+
+  constexpr uint MAX_WARPS = 1024/32; // maximum number of warps in a block
+  const int buffer_offset = buffer_index * MAX_WARPS * RadixSize; // offset of the buffer in smem.
+  const uint WARP_BITS = __builtin_ctz(warpSize);
+  
+  const uint num_warps = blockDim.x >> WARP_BITS;  // Actual number of warps in this block
+  const uint warp_id = threadIdx.x >> WARP_BITS; // = threadIdx.x / warpSize
+  const int lane_id = at::cuda::getLaneId(); // = threadIdx.x % warpSize
+    
+  // Stage 1: Each warp's lane 0 stores its counts in smem.
+  // Layout after Stage 1: [warp0: all radix bins], [warp1: all radix bins], ...
+  // this layout starts from index buffer_offset.
+  if (lane_id == 0) {
+#pragma unroll
+    for (uint32_t i = 0; i < RadixSize; ++i) {
+      smem[
+            buffer_offset
+          + warp_id * RadixSize 
+          + i
+          ] = counts[i];
+    }
+  }
+    
+  __syncthreads(); // wait for all warps to finish storing their counts to smem.
+    
+  // Stage 2: Warp0 performs reduction for all bins.
+  // Layout after Stage 2: [final radix0 sum], [final radix1 sum], ..., [final radix(RadixSize-1) sum]
+  // this layout starts from index buffer_offset.
+  if (warp_id == 0 && lane_id < RadixSize) {
+    CountType sum = 0;
+#pragma unroll
+    for (int w = 0; w < num_warps; ++w) {
+      sum += smem[
+                    buffer_offset
+                  + w * RadixSize 
+                  + lane_id
+                  ];
+    }
+    smem[buffer_offset + lane_id] = sum;
+  }
+    
+  __syncthreads(); // Wait for warp 0 to finish reduction.
+  
+  // Stage 3: Each thread reads the final counts from smem.
+#pragma unroll
+  for (uint32_t i = 0; i < RadixSize; ++i) {
+    counts[i] = smem[buffer_offset + i];
+  }
+}
+
 // This function counts the distribution of all input values in a
 // slice we are selecting by radix digit at `radixDigitPos`, but only
 // those that pass the filter `((v & desiredMask) == desired)`.
@@ -457,6 +524,7 @@ __device__ void countRadixUsingMaskDataSmem(
                            // digits [radixDigitPos, radixDigitPos+RADIX_BITS-1]
                            // set to i in the warp.
     CountType* smem, // shared memory for inter-warp reduction of counts.
+    int buffer_index, // buffer index for smem.
     bitwise_t
         desired, // combined with desiredMask to filter relevant elements. An
                  // element is relevant if ((val & desiredMask) == desired).
@@ -478,14 +546,6 @@ __device__ void countRadixUsingMaskDataSmem(
   for (int i = 0; i < RadixSize; ++i) {
     counts[i] = 0; // initialize counts to 0.
   }
-
-  // initialize smem to 0. This is for reduction of counts across all warps.
-  if (threadIdx.x < RadixSize) {
-    smem[threadIdx.x] = 0;
-  }
-
-  __syncthreads(); // wait for all threads in the block to finish initializing
-                   // smem.
 
   // count the distribution of the bits in the radix digit at `radixDigitPos` to
   // `radixDigitPos`+RADIX_BITS-1 for values that match the desired pattern
@@ -512,27 +572,11 @@ __device__ void countRadixUsingMaskDataSmem(
         });
   }
 
-  // accumulate the counts across all warps.
-  // sum for each warp is added to smem by thread 0 in the warp.
-  if (at::cuda::getLaneId() == 0) {
-#pragma unroll
-    for (uint32_t i = 0; i < RadixSize; ++i) {
-      gpuAtomicAddNoReturn(
-          &smem[i],
-          counts[i]); // thread0 in warp atomically adds the counts to smem.
-    }
-  }
-
-  __syncthreads(); // wait for all warps to finish adding their counts to smem.
-
-// each thread reads the final counts from smem.
-#pragma unroll
-  for (uint32_t i = 0; i < RadixSize; ++i) {
-    counts[i] = smem[i];
-  }
-
-  __syncthreads(); // wait for all threads in the block to finish reading the
-                   // counts.
+  // aggregate counts across all warps and distribute results back to all threads.
+  countRadixAggregateCounts<CountType, RadixSize, RadixBits>(
+    counts,
+    smem,
+    buffer_index);
 }
 
 // This is the main loop of the findPattern function that finds the unique value
@@ -862,6 +906,14 @@ __device__ void radixSelect(
   // successive digits
   int kToFind = k;
 
+  // buffer index for smem. We use two segments of smem for inter-warp communication of counts.
+  // Given the counting operation in countRadixUsingMaskDataSmem performs __syncthreads() internally,
+  // we need to alternate between the at most two segments of smem to avoid race conditions.
+  // No more than two iterations of the loop will be "in flight" at any given time because
+  // of the __syncthreads() in countRadixUsingMaskDataSmem.
+  // buffer_index is either 0 or 1. It is toggled after each countRadixUsingMaskDataSmem invocation.
+  int buffer_index = 0;
+
   // We start at the most significant digit in our radix, scanning
   // through to the least significant digit
   for (int digitPos = sizeof(scalar_t) * 8 - RADIX_BITS; digitPos >= 0;
@@ -895,6 +947,7 @@ __device__ void radixSelect(
         RADIX_BITS>(
         counts,
         smem,
+        buffer_index,
         desired,
         desiredMask,
         digitPos,
@@ -903,6 +956,9 @@ __device__ void radixSelect(
         data,
         dataSmem,
         dataSmemSize);
+
+    buffer_index ^= 1; // toggle buffer index.
+
 #else
     countRadixUsingMask<
         scalar_t,

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -454,7 +454,10 @@ __device__ __forceinline__ void countRadixAggregateCounts(
     CountType* smem, // shared memory for inter-warp reduction of counts.
     int buffer_index){ // buffer index for smem.
 
-  constexpr uint MAX_WARPS = 1024/32; // maximum number of warps in a block
+  // Maximum number of warps per workgroup. HIP workgroups have at most 1024 threads.
+  // Warp size is at least 32 (can be 64 on some architectures), so we use 32 for safety.
+  // This sizes shared memory buffers to accommodate all possible warps: 1024/32 = 32.
+  constexpr uint MAX_WARPS = 1024/32;
   const int buffer_offset = buffer_index * MAX_WARPS * RadixSize; // offset of the buffer in smem.
   const uint WARP_BITS = __builtin_ctz(warpSize);
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -257,7 +257,7 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 
   // Indices are limited to integer fp precision, so counts can fit in
   // int32, regardless of IndexType
-  __shared__ int smem[64];
+  __shared__ int smem[256];
   __shared__ int writeIndexStart; // index to track where to write results. This is shared by all threads in the block. Increases atomically.
 
   IndexType slice = getLinearBlockId<IndexType>();

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -257,6 +257,10 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
 
   // Indices are limited to integer fp precision, so counts can fit in
   // int32, regardless of IndexType
+
+  // Maximum shared memory size for radix select (used in countRadixAggregateCounts): NUM_BUFFERS * MAX_WARPS * RADIX_SIZE.
+  // HIP workgroups have at most 1024 threads. Warp size is at least 32 (can be 64 on some
+  // architectures), so we use 32 for safety: 2 buffers * (1024/32) warps * 4 radix bins = 256.
   __shared__ int smem[256];
   __shared__ int writeIndexStart; // index to track where to write results. This is shared by all threads in the block. Increases atomically.
 


### PR DESCRIPTION
**Summary:**
This PR optimizes the `radixSelect` kernel on ROCm by reducing synchronization overhead when aggregating radix counts across warps. The previous implementation used 3 block-level `__syncthreads()` calls plus atomic operations on 4 radix buckets (contended by all warps). The new implementation uses 2 `__syncthreads()` calls with no atomic contention, reducing synchronization overhead and improving performance.

**Background:**
The `radixSelect` algorithm finds the k-th element by iteratively uncovering its bit pattern through multiple passes over the data. Each pass determines 2 bits of the top-k value's bitmap (up to 16 passes for float32). Each iteration involves:
1. Counting input elements that match the already uncovered pattern
2. Grouping them by radix bucket (4 buckets per iteration)
3. Aggregating counts across all warps
4. Broadcasting the aggregated counts back to all threads

**Previous Implementation:**
The original sequence for each iteration was:
```cpp
initialize smem[RadixSize] to 0
__syncthreads()                    // Sync 1
count within warp
if (lane_id == 0) {
    atomicAdd(&smem[i], counts[i]) // Atomic contention on 4 buckets
}
__syncthreads()                    // Sync 2
read back total counts from smem
__syncthreads()                    // Sync 3
```

This involved **3 synchronizations** and **atomic contention** on 4 buckets from all warps.

**Changes:**

* **Warp-level reduction without atomics:**
  - Each warp's lane 0 writes its counts to a dedicated location in shared memory
  - Warp 0's lanes perform parallel reduction: each lane reduces one radix bin across all warps
  - This eliminates atomic contention while maintaining correctness

* **Double-buffering for concurrent iterations:**
  - Observation: Due to block-level synchronization, at most two consecutive iterations can be in-flight simultaneously
  - When threads are in "section 2" (post-sync) of iteration `i`, other threads can only reach "section 1" (pre-sync) of iteration `i+1` and wait there
  - We use `buffer_index` (0 or 1) to alternate between two shared memory segments, allowing safe concurrent execution
  - This enables removing the first and last `__syncthreads()` calls, reducing from 3 to 2 synchronizations per iteration (2 = 3 - 2 + 1, where the +1 is required for the new warp-level aggregation step that replaces atomics)

**Performance:**
Measured on AMD MI350 (gfx950) using single-block TopK operator, where RadixSelect accounts for ~80% of total latency for typical workloads.

- **Smaller datatypes (bfloat16, float16):** 4-5% improvement on smaller inputs, ~1% on larger inputs
- **float32:** Similar improvements, slightly less pronounced
- **Average improvement:** ~2% (weighted by larger input latencies)

**Testing:**
- Verified correctness across multiple data types (float32, float16, bfloat16) and input shapes
- Tested with various K values to ensure correct behavior across all iteration counts
- Performance benchmarks included below
<img width="2307" height="1537" alt="topk_latency_comparison" src="https://github.com/user-attachments/assets/1d0b8428-055a-4fa9-b3b0-31427021adf9" />


**Testing code:**
 - benchmark code: [code](https://github.com/user-attachments/files/24484540/benchmark.py)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang