### PR TITLE
[nativert] Add nested tensor deserialization support

### DIFF
--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -194,6 +194,9 @@ std::ostream& operator<<(std::ostream& out, const Type& ty) {
             case Type::Kind::TensorList:
               out << "TensorList";
               break;
+            case Type::Kind::NestedTensorList:
+              out << "NestedTensorList";
+              break;
             case Type::Kind::OptionalTensorList:
               out << "OptionalTensorList";
               break;
@@ -417,6 +420,10 @@ Node* Graph::createListPack(std::vector<Value*> inputs, const Type& inputType) {
     node->addOutput(name, Type::Kind::TensorList);
   } else if (inputType == Type::Kind::SymInt) {
     node->addOutput(name, Type::Kind::SymIntList);
+  } else if (inputType == Type::Kind::TensorList) {
+    // For nested tensor lists (List[List[Tensor]]), the inner lists are
+    // TensorList type. We output a NestedTensorList type.
+    node->addOutput(name, Type::Kind::NestedTensorList);
   }
 
   return node;

--- a/torch/nativert/graph/Graph.h
+++ b/torch/nativert/graph/Graph.h
@@ -28,6 +28,7 @@ class Type {
     None,
     Tensor,
     TensorList,
+    NestedTensorList,
     OptionalTensorList,
     SymInt,
     SymIntList,

--- a/torch/nativert/graph/GraphSignature.cpp
+++ b/torch/nativert/graph/GraphSignature.cpp
@@ -17,6 +17,7 @@ bool isSymbolicOutput(torch::_export::Argument::Tag t) {
   switch (t) {
     case torch::_export::Argument::Tag::AS_TENSOR:
     case torch::_export::Argument::Tag::AS_TENSORS:
+    case torch::_export::Argument::Tag::AS_NESTED_TENSORS:
     case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR:
     case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS:
     case torch::_export::Argument::Tag::AS_SYM_BOOL:

--- a/torch/nativert/kernels/PrimKernelRegistry.cpp
+++ b/torch/nativert/kernels/PrimKernelRegistry.cpp
@@ -21,6 +21,10 @@ class OpKernel_prim_listpack : public OpKernel {
       case Type::Kind::TensorList:
         type_ = c10::TensorType::get();
         break;
+      case Type::Kind::NestedTensorList:
+        // For List[List[Tensor]], each element is a List[Tensor]
+        type_ = c10::ListType::create(c10::TensorType::get());
+        break;
       case Type::Kind::SymIntList:
         type_ = c10::IntType::get();
         break;


### PR DESCRIPTION
Summary:
This diff adds support for deserializing and processing nested tensor lists (List[List[Tensor]]) in the nativert graph serialization layer and sigmoid backend. Previously, nativert could not properly handle nested tensor structures, causing inputs to be None.
Key Changes:
Added new NestedTensorList type kind to Graph type system (fbcode & xplat)
Implemented deserialization logic for AS_NESTED_TENSORS argument type in both nativert and sigmoid serialization layers
Creates inner ListPack nodes for each inner list, then packs them together with outer ListPack
Updated PrimKernelRegistry to handle NestedTensorList type mapping to c10::ListType::create(c10::TensorType::get())
Added validation checks in datafm_merge_and_dedup_by_reference operator to detect and report when nativert fails to deserialize nested inputs
Fixed variable declarations (removed incorrect const qualifiers) and improved code clarity in operator implementations
Enhanced benchmark comparison logic with direct KJT field comparisons and better debugging output
This enables models using operators with nested tensor list inputs (like datafm_merge_and_dedup_by_reference) to be properly exported and run via PT2/sigmoid interpreters.

Test Plan:
buck2 build mode/opt-split-dwarf --show-output //minimal_viable_ai/fire:light
../buck-out/v2/gen/fbcode/5127ce5d381465ea/minimal_viable_ai/fire/__light__/light.par -d ~/fbsource/fbcode/minimal_viable_ai/  -d ~/fbsource/fbcode/minimal_viable_ai/models/ig_ranking/preproc/roo/ -d ~/fbsource/fbcode/torcharrow/accel/ -d ~/fbsource/fbcode/dper_lib/slimper_lib/  -d ~/fbsource/fbcode/sigmoid/  minimal_viable_ai/models/ig_ranking/preproc/roo/benchmark/roo_train_pt2_export_benchmark.py --test-sigmoid-interpreter

Reviewed By: jijunyan

Differential Revision: D92067219


