### PR TITLE
[DTensor] set device index only for existing devices

### DIFF
--- a/test/distributed/test_collective_utils.py
+++ b/test/distributed/test_collective_utils.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skip_if_lt_x_gpu,
     TestCase,
 )
 from torch.testing._internal.distributed.fake_pg import FakeStore
@@ -132,6 +133,7 @@ class TestCollectiveUtils(MultiProcessTestCase):
             all_gather(data_or_fn=func)
 
     @parametrize("device", ["cpu", "cuda"])
+    @skip_if_lt_x_gpu(4)
     def test_check_rng_sync(
         self,
         device,

--- a/test/distributed/test_collective_utils.py
+++ b/test/distributed/test_collective_utils.py
@@ -13,12 +13,14 @@ from torch.distributed.collective_utils import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.testing import FileCheck
-from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    skip_if_lt_x_gpu,
     TestCase,
 )
 from torch.testing._internal.distributed.fake_pg import FakeStore

--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -616,7 +616,7 @@ class TestCollectivesWithDistributedBackend(DistributedTestBase):
                 return batch * 5
 
         compiled_func = torch.compile(func)
-        compiled_func(torch.ones((100,), device=device), self.process_group, self.rank)
+        compiled_func(torch.ones((100,), device=device), self.pg, self.rank)
         dist.barrier()
 
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -738,7 +738,10 @@ def cleanup_temp_dir() -> None:
 
 
 # Most tests operate with this worldsize
-DEFAULT_WORLD_SIZE = 4
+if TEST_WITH_ROCM:
+    DEFAULT_WORLD_SIZE = min(4, max(2, torch.cuda.device_count()))
+else:
+    DEFAULT_WORLD_SIZE = 4
 
 # [How does MultiProcessTestCase work?]
 # Each MultiProcessTestCase instance uses 1 + `world_size()` processes, by

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -70,7 +70,7 @@ from torch.utils._triton import has_triton
 
 
 if TEST_WITH_ROCM:
-    DEVICE_COUNT = min(4, max(2, DEVICE_COUNT))
+    DEVICE_COUNT = min(4, max(2, torch.cuda.device_count()))
 else:
     DEVICE_COUNT = 4
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -63,12 +63,16 @@ from torch.testing._internal.common_utils import (
     set_rng_seed,
     TEST_CUDA,
     TEST_HPU,
+    TEST_WITH_ROCM,
     TEST_XPU,
 )
 from torch.utils._triton import has_triton
 
 
-DEVICE_COUNT = 4  # default
+if TEST_WITH_ROCM:
+    DEVICE_COUNT = min(4, max(2, DEVICE_COUNT))
+else:
+    DEVICE_COUNT = 4
 
 if TEST_CUDA:
     DEVICE_TYPE = "cuda"

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -14,10 +14,7 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 
-if TEST_WITH_ROCM:
-    TEST_GPU_NUM = min(4, max(2, torch.cuda.device_count()))
-else:
-    TEST_GPU_NUM = 4
+TEST_GPU_NUM = 4
 
 
 class ShardedTensorTestBase(MultiProcessTestCase):

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -11,7 +11,6 @@ from torch.testing._internal.common_distributed import (
     TEST_SKIPS,
     tp_transports,
 )
-from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 
 TEST_GPU_NUM = 4

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -11,9 +11,13 @@ from torch.testing._internal.common_distributed import (
     TEST_SKIPS,
     tp_transports,
 )
+from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 
-TEST_GPU_NUM = 4
+if TEST_WITH_ROCM:
+    TEST_GPU_NUM = min(4, max(2, torch.cuda.device_count()))
+else:
+    TEST_GPU_NUM = 4
 
 
 class ShardedTensorTestBase(MultiProcessTestCase):

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -644,10 +644,16 @@ class DTensorContinuousTestBase(MultiProcContinuousTest):
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
+        
         # Set device before initializing process group to ensure
-        # each rank is bound to the correct GPU
+        # each rank is bound to the correct GPU. However, if world_size > device_count,
+        # we skip the test.
         if torch.accelerator.is_available():
-            torch.accelerator.set_device_index(rank)
+            if world_size > torch.accelerator.device_count():
+                sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+            else:
+                torch.accelerator.set_device_index(rank)
+ 
         # Call parent's _init_pg to do the actual process group initialization
         super()._init_pg(rank, world_size, rdvz_file)
 

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -79,7 +79,7 @@ else:
     PG_BACKEND = "gloo"
 
 if TEST_WITH_ROCM:
-    NUM_DEVICES = min(4, max(2, DEVICE_COUNT))
+    NUM_DEVICES = min(4, max(2, torch.cuda.device_count()))
 else:
     NUM_DEVICES = 4
 


### PR DESCRIPTION
In DTensorContinuousTestBase, a new `_init_pg` was added which calls `set_device_index(rank)`. However, we need to ensure that we have enough GPUs in the system before calling `set_device_index(rank)`