### PR TITLE
[DTensor] Fix RowwiseParallel embedding crash with torch.compile + dynamic shapes

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -1755,6 +1755,35 @@ class TestDTensorCompileE2E(DTensorTestBase):
         self.assertEqual(output.full_tensor(), ref_out)
 
     @with_comms
+    def test_compile_rowwise_embedding_mark_dynamic(self):
+        mesh = self.build_device_mesh()
+
+        vocab_size = 256
+        embed_dim = 64
+        seq_len = 128
+
+        embedding = nn.Embedding(vocab_size, embed_dim, device=self.device_type)
+        tokens = torch.randint(0, vocab_size, (1, seq_len), device=self.device_type)
+
+        parallelize_module(
+            embedding,
+            mesh,
+            RowwiseParallel(
+                input_layouts=Replicate(),
+                output_layouts=Shard(1),
+            ),
+        )
+
+        eager_out = embedding(tokens)
+
+        torch._dynamo.mark_dynamic(tokens, 1)
+        compiled_embedding = torch.compile(
+            embedding, backend="aot_eager", fullgraph=True
+        )
+        compiled_out = compiled_embedding(tokens)
+        self.assertEqual(compiled_out, eager_out)
+
+    @with_comms
     def test_split_with_symint_split_size(self):
         """
         Test that split works with symbolic integer split_size when using

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -72,11 +72,13 @@ def _rebuild_tensor_from_dtensor_meta(arg) -> object:
     This is used to propagate tensor metadata, must be under fake mode
     """
     assert arg.tensor_meta is not None, "DTensorSpec does not contain tensor_meta."
+    # zero-fill so that integer tensors used as indices (e.g. for embedding)
+    # contain valid values when AOT autograd records this op in the graph
     return torch.empty_strided(
         arg.tensor_meta.shape,
         arg.tensor_meta.stride,
         dtype=arg.tensor_meta.dtype,
-    )
+    ).zero_()
 
 
 def _pretty_print_spec(spec: object) -> str:

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -1290,9 +1290,9 @@ class _MaskPartial(Partial):
         mask = (tensor < local_offset_on_dim) | (
             tensor >= local_offset_on_dim + local_shard_size
         )
-        # mask the input tensor
-        masked_tensor = tensor.clone() - local_offset_on_dim
-        masked_tensor[mask] = 0
+        # mask the input tensor, using torch.where to avoid in-place index_put_
+        # which doesn't functionalize correctly under torch.compile + dynamic shapes
+        masked_tensor = torch.where(mask, 0, tensor - local_offset_on_dim)
         return mask, masked_tensor
 
     def _partition_value(


### PR DESCRIPTION
Fixes #174732

## Summary
RowwiseParallel embedding crashes with `torch.compile + mark_dynamic` due to two issues:

1. `_MaskPartial._mask_tensor()` uses `clone() + subtract + in-place index_put_` to mask out-of-shard indices. This pattern does not functionalize correctly under AOT autograd with dynamic shapes. Replaced with `torch.where`.

2. `_rebuild_tensor_from_dtensor_meta()` creates `torch.empty_strided` tensors (uninitialized) for shape propagation. When AOT autograd traces these into the FX graph, the uninitialized int32 values are used as embedding indices at runtime, causing `IndexError: index out of range`. Fixed by zero-filling the tensors.