### PR TITLE
[FSDP2] Fix to differing gradient computation graphs in different ranks

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_dtensor.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_dtensor.py
@@ -340,7 +340,7 @@ class TestFullyShardDTensor(FSDPTest):
                 self.assertIsInstance(param.placements[1], Replicate)
 
     @skip_if_lt_x_gpu(4)
-    def test_reduce_scatter_unused_dtensor_param(self):
+    def test_reduce_scatter_globally_unused_dtensor_param(self):
         class TwoExpertParams(nn.Module):
             def __init__(self, ep_mesh) -> None:
                 super().__init__()
@@ -356,6 +356,7 @@ class TestFullyShardDTensor(FSDPTest):
                 )
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
+                # all ranks only use the "used" tensor. "Unused" is globally untouched.
                 return self.used.to_local().float().sum() + (x.float().sum() * 0)
 
         mesh = init_device_mesh(
@@ -372,11 +373,65 @@ class TestFullyShardDTensor(FSDPTest):
         torch.get_device_module(device_type).synchronize()
 
         unused_grad = model.unused.grad
-        self.assertIsNotNone(unused_grad)
-        self.assertIsInstance(unused_grad, DTensor)
-        self.assertEqual(
-            unused_grad.to_local(), torch.zeros_like(unused_grad.to_local())
+        used_grad = model.used.grad
+        self.assertIsNone(unused_grad)
+        self.assertIsNotNone(used_grad)
+        self.assertIsInstance(used_grad, DTensor)
+        self.assertNotEqual(used_grad, torch.zeros_like(used_grad))
+
+    @skip_if_lt_x_gpu(4)
+    def test_reduce_scatter_diff_exp_dtensor_param(self):
+        """
+        Test MoE scenario where parameters are locally unused but used on other ranks.
+        Also for the edge case where there is not enough rows for the experts to be
+            sharded along the dp dimension.
+        """
+
+        class TwoExpertParams(nn.Module):
+            def __init__(self, mesh) -> None:
+                super().__init__()
+                experts = torch.randn(2, 4, device=device_type)
+                self.register_parameter(
+                    "experts",
+                    nn.Parameter(distribute_tensor(experts, mesh["ep"], [Shard(0)])),
+                )
+                self.dp_mesh = mesh["dp"]
+                self.ep_mesh = mesh["ep"]
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                local_expert = self.experts.to_local()
+                dp_rank = self.dp_mesh.get_local_rank()
+                ep_rank = self.ep_mesh.get_local_rank()
+                if dp_rank == ep_rank:
+                    return local_expert.sum() + (x.sum() * 0)
+                else:
+                    return x.sum() * 0
+
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size // 2, 2), mesh_dim_names=("dp", "ep")
         )
+        model = TwoExpertParams(mesh)
+        fully_shard(model, mesh=mesh["dp"], reshard_after_forward=True)
+        model.set_reduce_scatter_unused_params(True)
+
+        loss = model(torch.ones(1, device=device_type, requires_grad=True))
+        loss.backward()
+        torch.get_device_module(device_type).synchronize()
+
+        dp_rank = mesh["dp"].get_local_rank()
+        if dp_rank == 0:
+            # DP rank 0 holds a non-empty (1, 4) shard. Reduce-scatter
+            # delivers real gradient values here regardless of whether
+            # this rank used the expert, because the contributing rank's
+            # gradient spans both shard rows.
+            self.assertIsNotNone(model.experts.grad)
+            self.assertIsInstance(model.experts.grad, DTensor)
+            self.assertTrue(model.experts.grad.to_local().any())
+        else:
+            # DP rank 1 holds an empty (0, 4) shard because the (1, 4)
+            # local tensor cannot be split into 2 rows. No gradient
+            # data can be received, so grad is None.
+            self.assertIsNone(model.experts.grad)
 
     @skip_if_lt_x_gpu(2)
     def test_validation_non_replicate_dp_placement(self):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2748,6 +2748,7 @@ class TestFSDPMissingParamGrad(FSDPTest):
         model = SomeUnusedParamModel(use_sometimes=random.choice([True, False])).to(
             device
         )
+        cloned_param_list = [p.clone() for p in model.parameters()]
         fully_shard(model)
 
         x = torch.randn(2, 8, device=device)
@@ -2755,16 +2756,9 @@ class TestFSDPMissingParamGrad(FSDPTest):
         loss = model(x).sum()
         loss.backward()
 
-        for name, param in model.named_parameters():
-            if param.requires_grad:
-                self.assertIsNotNone(
-                    param.grad, f"{name} has no grad on rank {self.rank}"
-                )
-            else:
-                self.assertIsNone(
-                    param.grad,
-                    f"frozen {name} should not have grad on rank {self.rank}",
-                )
+        for param, param_clone in zip(model.parameters(), cloned_param_list, strict=True):
+            param_full = param.full_tensor()
+            assert torch.equal(param_full, param_clone), "FSDP should not modify the original parameters"
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2745,9 +2745,7 @@ class TestFSDPMissingParamGrad(FSDPTest):
         if device_type.type == "cuda":
             torch.cuda.set_device(self.rank)
         device = torch.device(device_type.type, self.rank)
-        model = SomeUnusedParamModel(use_sometimes=self.rank == 0).to(
-            device
-        )
+        model = SomeUnusedParamModel(use_sometimes=self.rank == 0).to(device)
         cloned_param_list = [p.clone() for p in model.parameters()]
         fully_shard(model)
 
@@ -2759,7 +2757,7 @@ class TestFSDPMissingParamGrad(FSDPTest):
         sync_done = threading.Event()
         sync_thread = threading.Thread(
             target=lambda: (torch.cuda.synchronize(device), sync_done.set()),
-            daemon=True
+            daemon=True,
         )
         sync_thread.start()
         local_ok = sync_done.wait(timeout=10)
@@ -2768,15 +2766,19 @@ class TestFSDPMissingParamGrad(FSDPTest):
         result = torch.tensor([int(local_ok)])
         dist.all_reduce(result, op=dist.ReduceOp.MIN, group=gloo_pg)
         dist.destroy_process_group(gloo_pg)
-        
+
         if result.item() == 0:
             self.fail(
-                "Backward reduce-scatter deadlocked due to mismatched gradient " \
+                "Backward reduce-scatter deadlocked due to mismatched gradient "
                 "tensor sizes across ranks."
             )
 
-        for param, param_clone in zip(model.parameters(), cloned_param_list, strict=True):
-            assert torch.equal(param.full_tensor(), param_clone), "FSDP should not modify the original parameters"
+        for param, param_clone in zip(
+            model.parameters(), cloned_param_list, strict=True
+        ):
+            assert torch.equal(param.full_tensor(), param_clone), (
+                "FSDP should not modify the original parameters"
+            )
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2719,14 +2719,22 @@ class SomeUnusedParamModel(nn.Module):
         self.sometimes_used = nn.Linear(8, 8, bias=False)
         self.frozen_layer = nn.Linear(8, 8, bias=False)
         self.frozen_layer.weight.requires_grad = False
-        self.use_sometimes = use_sometimes
+        self._use_sometimes = use_sometimes
 
     def forward(self, x):
         out = self.always_used(x)
-        if self.use_sometimes:
+        if self._use_sometimes:
             out += self.sometimes_used(x)
         out += self.frozen_layer(x)
         return out
+
+    @property
+    def use_sometimes(self) -> bool:
+        return self._use_sometimes
+
+    @use_sometimes.setter
+    def use_sometimes(self, value: bool):
+        self._use_sometimes = value
 
 
 class TestFSDPMissingParamGrad(FSDPTest):
@@ -2780,6 +2788,57 @@ class TestFSDPMissingParamGrad(FSDPTest):
                 "FSDP should not modify the original parameters"
             )
 
+class TestZeroGradMomentum(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_unused_param_optimizer_state_unchanged(self):
+        torch.cuda.set_device(self.rank)
+        device = torch.device("cuda", self.rank)
+
+        model = SomeUnusedParamModel(use_sometimes=True).to(device)
+        fully_shard(model)
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+        x = torch.randn(2, 8, device=device)
+
+        # Step 1: use both params to initialize optimizer state
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+        # Snapshot optimizer state for sometimes_used after it was legitimately used
+        sometimes_param = model.sometimes_used.weight
+        state_after_use = {
+            "exp_avg": optimizer.state[sometimes_param]["exp_avg"].clone(),
+            "exp_avg_sq": optimizer.state[sometimes_param]["exp_avg_sq"].clone(),
+            "step": optimizer.state[sometimes_param]["step"].clone(),
+        }
+
+        # Step 2: do NOT use sometimes_used
+        model.use_sometimes = False
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+        # Optimizer state for sometimes_used should NOT have changed
+        # If the bug exists (fsdp_param appended instead of None),
+        # a zero grad flows through reduce-scatter and Adam updates state
+        state_after_skip = optimizer.state[sometimes_param]
+        self.assertEqual(
+            state_after_use["exp_avg"],
+            state_after_skip["exp_avg"],
+            msg="exp_avg changed for unused param — zero grad corrupted momentum",
+        )
+        self.assertEqual(
+            state_after_use["exp_avg_sq"],
+            state_after_skip["exp_avg_sq"],
+            msg="exp_avg_sq changed for unused param — zero grad corrupted adaptive LR",
+        )
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -5,7 +5,7 @@ import copy
 import functools
 import gc
 import itertools
-import random
+import threading
 import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -2741,11 +2741,11 @@ class TestFSDPMissingParamGrad(FSDPTest):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    def test_unused_param_has_grad(self):
+    def test_unused_param_grad_no_deadlock(self):
         if device_type.type == "cuda":
             torch.cuda.set_device(self.rank)
         device = torch.device(device_type.type, self.rank)
-        model = SomeUnusedParamModel(use_sometimes=random.choice([True, False])).to(
+        model = SomeUnusedParamModel(use_sometimes=self.rank == 0).to(
             device
         )
         cloned_param_list = [p.clone() for p in model.parameters()]
@@ -2756,9 +2756,27 @@ class TestFSDPMissingParamGrad(FSDPTest):
         loss = model(x).sum()
         loss.backward()
 
+        sync_done = threading.Event()
+        sync_thread = threading.Thread(
+            target=lambda: (torch.cuda.synchronize(device), sync_done.set()),
+            daemon=True
+        )
+        sync_thread.start()
+        local_ok = sync_done.wait(timeout=10)
+
+        gloo_pg = dist.new_group(backend="gloo")
+        result = torch.tensor([int(local_ok)])
+        dist.all_reduce(result, op=dist.ReduceOp.MIN, group=gloo_pg)
+        dist.destroy_process_group(gloo_pg)
+        
+        if result.item() == 0:
+            self.fail(
+                "Backward reduce-scatter deadlocked due to mismatched gradient " \
+                "tensor sizes across ranks."
+            )
+
         for param, param_clone in zip(model.parameters(), cloned_param_list, strict=True):
-            param_full = param.full_tensor()
-            assert torch.equal(param_full, param_clone), "FSDP should not modify the original parameters"
+            assert torch.equal(param.full_tensor(), param_clone), "FSDP should not modify the original parameters"
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2756,6 +2756,7 @@ class TestFSDPDivergentRanks(FSDPTest):
         model = SomeUnusedParamModel(use_sometimes=self.rank == 0).to(device)
         cloned_param_list = [p.clone() for p in model.parameters()]
         fully_shard(model)
+        model.set_reduce_scatter_unused_params(True)
 
         x = torch.randn(2, 8, device=device)
 
@@ -2800,6 +2801,7 @@ class TestFSDPDivergentRanks(FSDPTest):
 
         model = SomeUnusedParamModel(use_sometimes=True).to(device)
         fully_shard(model)
+        model.set_reduce_scatter_unused_params(True)
         optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
 
         x = torch.randn(2, 8, device=device)
@@ -2851,6 +2853,7 @@ class TestFSDPDivergentRanks(FSDPTest):
         # Rank 0 uses sometimes_used, rank 1 does not
         model = SomeUnusedParamModel(use_sometimes=self.rank == 0).to(device)
         fully_shard(model)
+        model.set_reduce_scatter_unused_params(True)
 
         x = torch.randn(2, 8, device=device)
         loss = model(x).sum()

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2737,7 +2737,7 @@ class SomeUnusedParamModel(nn.Module):
         self._use_sometimes = value
 
 
-class TestFSDPMissingParamGrad(FSDPTest):
+class TestFSDPDivergentRanks(FSDPTest):
     """
     This test makes sure that even when a layer is sometimes used during the forward of the backward computation
     in FSDP, the fsdp_params will gather all the params with the requires_grad=True flag so the reduce-scatter
@@ -2784,18 +2784,17 @@ class TestFSDPMissingParamGrad(FSDPTest):
         for param, param_clone in zip(
             model.parameters(), cloned_param_list, strict=True
         ):
-            assert torch.equal(param.full_tensor(), param_clone), (
-                "FSDP should not modify the original parameters"
+            self.assertEqual(
+                param.full_tensor(),
+                param_clone,
+                "FSDP backward should not corrupt values.",
             )
-
-
-class TestZeroGradMomentum(FSDPTest):
-    @property
-    def world_size(self) -> int:
-        return 2
 
     @skip_if_lt_x_gpu(2)
     def test_unused_param_optimizer_state_unchanged(self):
+        """
+        Test for divergent rank behavior where a parameter group is unused on both ranks.
+        """
         torch.cuda.set_device(self.rank)
         device = torch.device("cuda", self.rank)
 
@@ -2839,6 +2838,45 @@ class TestZeroGradMomentum(FSDPTest):
             state_after_use["exp_avg_sq"],
             state_after_skip["exp_avg_sq"],
             msg="exp_avg_sq changed for unused param — zero grad corrupted adaptive LR",
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_rank_divergent_shard_consistency(self):
+        """
+        Test for divergent rank behavior where a parameter group is unused on one rank and used on the other.
+        """
+        torch.cuda.set_device(self.rank)
+        device = torch.device("cuda", self.rank)
+
+        # Rank 0 uses sometimes_used, rank 1 does not
+        model = SomeUnusedParamModel(use_sometimes=self.rank == 0).to(device)
+        fully_shard(model)
+
+        x = torch.randn(2, 8, device=device)
+        loss = model(x).sum()
+        loss.backward()
+
+        # check if gradient was written back to sometimes_used on each rank
+        grad = model.sometimes_used.weight.grad
+        has_grad = grad is not None
+
+        # Gather has_grad from all ranks
+        has_grad_tensor = torch.tensor([int(has_grad)], device=device)
+        gathered = [
+            torch.zeros(1, device=device, dtype=torch.int64)
+            for _ in range(self.world_size)
+        ]
+        dist.all_gather(gathered, has_grad_tensor)
+        rank0_has_grad = gathered[0].item()
+        rank1_has_grad = gathered[1].item()
+
+        # Both ranks should have gradient for sometimes_used since rank 0 used it.
+        # If rank 1 has no gradient, then the optimizer will not update anything for rank 1's shard
+        # leading to inconsistencies in the shards amongst ranks.
+        self.assertTrue(
+            rank0_has_grad and rank1_has_grad,
+            f"Gradient not set on all ranks (rank0={bool(rank0_has_grad)}, rank1={bool(rank1_has_grad)}) "
+            "This indicates that the shard after reduce-scatter is inconsistent.",
         )
 
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import gc
 import itertools
+import random
 import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -2709,6 +2710,61 @@ class TestFullyShardCudaGraph(FSDPTest):
                 for graph_grad, ref_grad in zip(static_output_grads, ref_grads):
                     self.assertTrue(torch.equal(graph_grad, ref_grad))
                 model.zero_grad(set_to_none=True)
+
+
+class SomeUnusedParamModel(nn.Module):
+    def __init__(self, use_sometimes: bool):
+        super().__init__()
+        self.always_used = nn.Linear(8, 8, bias=False)
+        self.sometimes_used = nn.Linear(8, 8, bias=False)
+        self.frozen_layer = nn.Linear(8, 8, bias=False)
+        self.frozen_layer.weight.requires_grad = False
+        self.use_sometimes = use_sometimes
+
+    def forward(self, x):
+        out = self.always_used(x)
+        if self.use_sometimes:
+            out += self.sometimes_used(x)
+        out += self.frozen_layer(x)
+        return out
+
+
+class TestFSDPMissingParamGrad(FSDPTest):
+    """
+    This test makes sure that even when a layer is sometimes used during the forward of the backward computation
+    in FSDP, the fsdp_params will gather all the params with the requires_grad=True flag so the reduce-scatter
+    will receive the same input size for all ranks.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_unused_param_has_grad(self):
+        if device_type.type == "cuda":
+            torch.cuda.set_device(self.rank)
+        device = torch.device(device_type.type, self.rank)
+        model = SomeUnusedParamModel(use_sometimes=random.choice([True, False])).to(
+            device
+        )
+        fully_shard(model)
+
+        x = torch.randn(2, 8, device=device)
+
+        loss = model(x).sum()
+        loss.backward()
+
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                self.assertIsNotNone(
+                    param.grad, f"{name} has no grad on rank {self.rank}"
+                )
+            else:
+                self.assertIsNone(
+                    param.grad,
+                    f"frozen {name} should not have grad on rank {self.rank}",
+                )
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2788,6 +2788,7 @@ class TestFSDPMissingParamGrad(FSDPTest):
                 "FSDP should not modify the original parameters"
             )
 
+
 class TestZeroGradMomentum(FSDPTest):
     @property
     def world_size(self) -> int:
@@ -2839,6 +2840,7 @@ class TestZeroGradMomentum(FSDPTest):
             state_after_skip["exp_avg_sq"],
             msg="exp_avg_sq changed for unused param — zero grad corrupted adaptive LR",
         )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -520,7 +520,7 @@ def foreach_all_gather_copy_out(
 
 @torch.no_grad()
 def foreach_reduce(
-    fsdp_params: list[FSDPParam | None],
+    fsdp_params: list[FSDPParam],
     unsharded_grads: list[torch.Tensor],
     reduce_scatter_group: dist.ProcessGroup,
     reduce_scatter_stream: torch.Stream,
@@ -580,7 +580,7 @@ def foreach_reduce(
         for i, (fsdp_param, unsharded_grad) in enumerate(
             zip(fsdp_params, unsharded_grads)
         ):
-            if fsdp_param is None or (shard_dim := fsdp_param.fsdp_placement.dim) == 0:
+            if (shard_dim := fsdp_param.fsdp_placement.dim) == 0:
                 continue
             if unsharded_grad.size(shard_dim) % world_size != 0:
                 raise AssertionError(
@@ -699,9 +699,6 @@ def foreach_reduce(
         for padded_unsharded_size, fsdp_param in zip(
             padded_unsharded_sizes, fsdp_params
         ):
-            if fsdp_param is None:
-                flat_grad_offset += padded_unsharded_size.numel() // world_size
-                continue
             # Assume even sharding for Shard(i), i > 0; otherwise would require
             # copy-out for contiguous strides
             new_sharded_grad = torch.as_strided(

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -520,7 +520,7 @@ def foreach_all_gather_copy_out(
 
 @torch.no_grad()
 def foreach_reduce(
-    fsdp_params: list[FSDPParam],
+    fsdp_params: list[FSDPParam | None],
     unsharded_grads: list[torch.Tensor],
     reduce_scatter_group: dist.ProcessGroup,
     reduce_scatter_stream: torch.Stream,

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -580,7 +580,7 @@ def foreach_reduce(
         for i, (fsdp_param, unsharded_grad) in enumerate(
             zip(fsdp_params, unsharded_grads)
         ):
-            if (shard_dim := fsdp_param.fsdp_placement.dim) == 0:
+            if fsdp_param is None or (shard_dim := fsdp_param.fsdp_placement.dim) == 0:
                 continue
             if unsharded_grad.size(shard_dim) % world_size != 0:
                 raise AssertionError(
@@ -699,6 +699,9 @@ def foreach_reduce(
         for padded_unsharded_size, fsdp_param in zip(
             padded_unsharded_sizes, fsdp_params
         ):
+            if fsdp_param is None:
+                flat_grad_offset += padded_unsharded_size.numel() // world_size
+                continue
             # Assume even sharding for Shard(i), i > 0; otherwise would require
             # copy-out for contiguous strides
             new_sharded_grad = torch.as_strided(

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -188,6 +188,7 @@ class FSDPParam:
     orig_dtype: torch.dtype
     param_dtype: torch.dtype | None
     reduce_dtype: torch.dtype | None
+    _zero_buf: torch.Tensor
     _orig_size: torch.Size  # ND
     sharded_size: torch.Size  # ND
     contiguous_sharded_stride: tuple[int, ...]
@@ -813,6 +814,10 @@ class FSDPParam:
             param_dtype = None
         self.param_dtype = param_dtype
         self.reduce_dtype = reduce_dtype
+        grad_dtype = self.param_dtype or self.orig_dtype
+        self._zero_buf = torch.zeros(
+            1, dtype=grad_dtype, device=self.sharded_param.device
+        )
         # None indicates that the mixed precision is not enabled
 
     def _init_extensions(self) -> None:
@@ -1146,7 +1151,7 @@ class FSDPParam:
 
     @property
     def unsharded_zero_grad_data(self) -> torch.Tensor:
-        return self._get_grad_inner_tensor(torch.zeros_like(self.unsharded_param))
+        return self._get_grad_inner_tensor(self._zero_buf.expand(self._orig_size))
 
     def _get_grad_inner_tensor(self, grad: torch.Tensor) -> torch.Tensor:
         if self.is_spmd_types:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -1151,7 +1151,12 @@ class FSDPParam:
 
     @property
     def unsharded_zero_grad_data(self) -> torch.Tensor:
-        return self._get_grad_inner_tensor(self._zero_buf.expand(self._orig_size))
+        if self.is_dtensor:
+            # for spmd and advance tensor parallelism
+            return self._get_grad_inner_tensor(torch.zeros_like(self.unsharded_param))
+        else:
+            # for regular fsdp
+            return self._get_grad_inner_tensor(self._zero_buf.expand(self._orig_size))
 
     def _get_grad_inner_tensor(self, grad: torch.Tensor) -> torch.Tensor:
         if self.is_spmd_types:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -660,7 +660,8 @@ class FSDPParamGroup:
                         unsharded_grads.append(fsdp_param.unsharded_grad_data)
                         fsdp_param.unsharded_param.grad = None
                     elif (
-                        fsdp_param.sharded_param.requires_grad
+                        self.reduce_scatter_unused_params
+                        and fsdp_param.sharded_param.requires_grad
                         and self._zero_buf is not None
                     ):
                         # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -645,7 +645,9 @@ class FSDPParamGroup:
                     # previous backward did not reduce-scatter
                     if fsdp_param.unsharded_accumulated_grad is not None:
                         fsdp_params_with_grad.append(fsdp_param)
-                        unsharded_grads.append(fsdp_param.unsharded_accumulated_grad_data)
+                        unsharded_grads.append(
+                            fsdp_param.unsharded_accumulated_grad_data
+                        )
                         fsdp_param.unsharded_accumulated_grad = None
                     elif fsdp_param.unsharded_param.grad is not None:
                         fsdp_params_with_grad.append(fsdp_param)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -634,7 +634,30 @@ class FSDPParamGroup:
                 # access the unsharded parameters when their data is present
                 fsdp_params_with_grad: list[FSDPParam] = []
                 unsharded_grads: list[torch.Tensor] = []
+            
+                # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
+                # This leads to different sets of missing parameters in different ranks,
+                # and thus leading `unsharded_grads` to be different across ranks.
+                # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
+                # reduce-scatter has the same input sizes across ranks.
 
+                # compute total numel of missing grads
+                total_missing_numel = 0
+                grad_dtype = None
+                for fp in self.fsdp_params:
+                    if grad_dtype is None and fp.sharded_param.requires_grad:
+                        grad_dtype = fp.param_dtype or fp.orig_dtype
+                    if (hasattr(fp, "_unsharded_param")
+                    and fp.sharded_param.requires_grad
+                    and fp.unsharded_param.grad is None
+                    and fp.unsharded_accumulated_grad is None
+                    ):
+                        total_missing_numel += fp.unsharded_param.data.numel()
+                
+                if total_missing_numel > 0:
+                    zero_buf = torch.zeros(total_missing_numel, dtype=grad_dtype, device=self.device)
+                    zero_offset = 0
+            
                 for fsdp_param in self.fsdp_params:
                     if not hasattr(fsdp_param, "_unsharded_param"):
                         continue
@@ -650,10 +673,10 @@ class FSDPParamGroup:
                         fsdp_params_with_grad.append(fsdp_param)
                         unsharded_grads.append(fsdp_param.unsharded_grad_data)
                         fsdp_param.unsharded_param.grad = None
-                    elif (
-                        self.reduce_scatter_unused_params
-                        and fsdp_param.unsharded_param.requires_grad
-                    ):
+                    elif fsdp_param.sharded_param.requires_grad:
+                        numel = fsdp_param.unsharded_param.data.numel()
+                        zero_grad = zero_buf[zero_offset:zero_offset + numel]
+                        zero_offset += numel
                         fsdp_params_with_grad.append(fsdp_param)
                         unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
                 if self.reshard_after_backward:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -802,17 +802,29 @@ class FSDPParamGroup:
         self.comm_ctx._last_post_reduce_events = dict()
         self._post_reduce_event = None
         self._all_reduce_state = None
+        globally_used: torch.Tensor | None = None
+        if self._locally_unused_params:
+            globally_used = torch.ones(
+                len(self.fsdp_params), dtype=torch.uint8, device=self.device
+            )
+            for i in self._locally_unused_params:
+                globally_used[i] = 0
+            dist.all_reduce(
+                globally_used,
+                op=dist.ReduceOp.MAX,
+                group=self._reduce_scatter_process_group,
+            )
+            # do bulk transfer once (typically < 100 bytes)
+            globally_used = globally_used.cpu()
         for i, fsdp_param in enumerate(self.fsdp_params):
-            # For unused parameters, we set their gradients to None to avoid optimizer issues
-            # (e.g. with momentum or adaptive methods) else keep the zero gradients for legitimate parameters
-            # to ensure consistent sharded parameters across ranks.
-            if (
-                i in self._locally_unused_params
-                and fsdp_param.sharded_param.grad is not None
-                and hasattr(fsdp_param.sharded_param.grad, "_local_tensor")
-                and not fsdp_param.sharded_param.grad._local_tensor.any()  # This .any is a host to device sync. Defer to async?
+            if fsdp_param.sharded_param.grad is not None and hasattr(
+                fsdp_param.sharded_param.grad, "_local_tensor"
             ):
-                fsdp_param.sharded_param.grad = None
+                local_grad = fsdp_param.sharded_param.grad._local_tensor
+                if local_grad.numel() == 0 or (
+                    globally_used is not None and not globally_used[i]
+                ):
+                    fsdp_param.sharded_param.grad = None
 
             if fsdp_param.grad_offload_event is not None:
                 fsdp_param.grad_offload_event.synchronize()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -269,6 +269,8 @@ class FSDPParamGroup:
         # block while this layer's AR is still in flight. See
         # AllReduceState docstring and regression test PR #180900.
         self._all_reduce_state: AllReduceState | None = None
+        # Create a zero buffer for missing parameters
+        self._zero_buf: torch.Tensor | None = None
 
     # Initialization #
     def _init_mp_dtypes(self) -> None:
@@ -279,6 +281,10 @@ class FSDPParamGroup:
         ]
         if trainable_params:
             params_for_dtype = trainable_params
+            grad_type = (
+                trainable_params[0].param_dtype or trainable_params[0].orig_dtype
+            )
+            self._zero_buf = torch.zeros(1, dtype=grad_type, device=self.device)
         else:
             params_for_dtype = [
                 p for p in self.fsdp_params if p.orig_dtype.is_floating_point
@@ -634,35 +640,7 @@ class FSDPParamGroup:
                 # access the unsharded parameters when their data is present
                 fsdp_params_with_grad: list[FSDPParam] = []
                 unsharded_grads: list[torch.Tensor] = []
-            
-                # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
-                # This leads to different sets of missing parameters in different ranks,
-                # and thus leading `unsharded_grads` to be different across ranks.
-                # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
-                # reduce-scatter has the same input sizes across ranks.
 
-                # compute total numel of missing grads
-                total_missing_numel = 0
-                grad_dtype: torch.dtype | None = None
-                for fp in self.fsdp_params:
-                    if grad_dtype is None and fp.sharded_param.requires_grad:
-                        grad_dtype = fp.param_dtype or fp.orig_dtype
-                    if (
-                        not self.is_sharded
-                        and hasattr(fp, "_unsharded_param")
-                        and fp.sharded_param.requires_grad
-                        and fp.unsharded_param.grad is None
-                        and fp.unsharded_accumulated_grad is None
-                    ):
-                        total_missing_numel += fp.unsharded_param.data.numel()
-                
-                zero_buf: torch.Tensor | None = None
-                if total_missing_numel > 0:
-                    zero_buf = torch.zeros(
-                        total_missing_numel, dtype=grad_dtype, device=self.device
-                    )
-                    zero_offset = 0
-            
                 for fsdp_param in self.fsdp_params:
                     if not hasattr(fsdp_param, "_unsharded_param"):
                         continue
@@ -681,11 +659,14 @@ class FSDPParamGroup:
                     elif (
                         fsdp_param.sharded_param.requires_grad
                         and not self.is_sharded
-                        and zero_buf is not None
+                        and self._zero_buf is not None
                     ):
-                        numel = fsdp_param.unsharded_param.data.numel()
-                        zero_grad = zero_buf[zero_offset : zero_offset + numel]
-                        zero_offset += numel
+                        # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
+                        # This leads to different sets of missing parameters in different ranks,
+                        # and thus leading `unsharded_grads` to be different across ranks.
+                        # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
+                        # reduce-scatter has the same input sizes across ranks.
+                        zero_grad = self._zero_buf.expand(fsdp_param._orig_size)
                         fsdp_params_with_grad.append(fsdp_param)
                         unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
                 if self.reshard_after_backward:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -643,19 +643,24 @@ class FSDPParamGroup:
 
                 # compute total numel of missing grads
                 total_missing_numel = 0
-                grad_dtype = None
+                grad_dtype: torch.dtype | None = None
                 for fp in self.fsdp_params:
                     if grad_dtype is None and fp.sharded_param.requires_grad:
                         grad_dtype = fp.param_dtype or fp.orig_dtype
-                    if (hasattr(fp, "_unsharded_param")
-                    and fp.sharded_param.requires_grad
-                    and fp.unsharded_param.grad is None
-                    and fp.unsharded_accumulated_grad is None
+                    if (
+                        not self.is_sharded
+                        and hasattr(fp, "_unsharded_param")
+                        and fp.sharded_param.requires_grad
+                        and fp.unsharded_param.grad is None
+                        and fp.unsharded_accumulated_grad is None
                     ):
                         total_missing_numel += fp.unsharded_param.data.numel()
                 
+                zero_buf: torch.Tensor | None = None
                 if total_missing_numel > 0:
-                    zero_buf = torch.zeros(total_missing_numel, dtype=grad_dtype, device=self.device)
+                    zero_buf = torch.zeros(
+                        total_missing_numel, dtype=grad_dtype, device=self.device
+                    )
                     zero_offset = 0
             
                 for fsdp_param in self.fsdp_params:
@@ -673,9 +678,13 @@ class FSDPParamGroup:
                         fsdp_params_with_grad.append(fsdp_param)
                         unsharded_grads.append(fsdp_param.unsharded_grad_data)
                         fsdp_param.unsharded_param.grad = None
-                    elif fsdp_param.sharded_param.requires_grad:
+                    elif (
+                        fsdp_param.sharded_param.requires_grad
+                        and not self.is_sharded
+                        and zero_buf is not None
+                    ):
                         numel = fsdp_param.unsharded_param.data.numel()
-                        zero_grad = zero_buf[zero_offset:zero_offset + numel]
+                        zero_grad = zero_buf[zero_offset : zero_offset + numel]
                         zero_offset += numel
                         fsdp_params_with_grad.append(fsdp_param)
                         unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -271,6 +271,8 @@ class FSDPParamGroup:
         self._all_reduce_state: AllReduceState | None = None
         # Create a zero buffer for missing parameters
         self._zero_buf: torch.Tensor | None = None
+        # keep track of locally unused parameters indices for optimizer momentum and adaptive lrs
+        self._locally_unused_params: set[int] = set()
 
     # Initialization #
     def _init_mp_dtypes(self) -> None:
@@ -640,8 +642,9 @@ class FSDPParamGroup:
                 # access the unsharded parameters when their data is present
                 fsdp_params_with_grad: list[FSDPParam | None] = []
                 unsharded_grads: list[torch.Tensor] = []
+                self._locally_unused_params.clear()
 
-                for fsdp_param in self.fsdp_params:
+                for i, fsdp_param in enumerate(self.fsdp_params):
                     if not hasattr(fsdp_param, "_unsharded_param"):
                         continue
                     # May have an accumulated gradient of the reduce dtype if the
@@ -658,7 +661,6 @@ class FSDPParamGroup:
                         fsdp_param.unsharded_param.grad = None
                     elif (
                         fsdp_param.sharded_param.requires_grad
-                        and not self.is_sharded
                         and self._zero_buf is not None
                     ):
                         # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
@@ -669,6 +671,10 @@ class FSDPParamGroup:
                         zero_grad = self._zero_buf.expand(fsdp_param._orig_size)
                         fsdp_params_with_grad.append(fsdp_param)
                         unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
+                        self._locally_unused_params.add(
+                            i
+                        )  # keep track of the index of unused params.
+
                 if self.reshard_after_backward:
                     self.reshard()
             # Recycle prior modules' reduce-scatter input buffers, keeping at most
@@ -805,10 +811,22 @@ class FSDPParamGroup:
         self.comm_ctx._last_post_reduce_events = dict()
         self._post_reduce_event = None
         self._all_reduce_state = None
-        for fsdp_param in self.fsdp_params:
+        for i, fsdp_param in enumerate(self.fsdp_params):
+            # For unused parameters, we set their gradients to None to avoid optimizer issues
+            # (e.g. with momentum or adaptive methods) else keep the zero gradients for legitimate parameters
+            # to ensure consistent sharded parameters across ranks.
+            if (
+                i in self._locally_unused_params
+                and fsdp_param.sharded_param.grad is not None
+                and hasattr(fsdp_param.sharded_param.grad, "_local_tensor")
+                and not fsdp_param.sharded_param.grad._local_tensor.any()
+            ):
+                fsdp_param.sharded_param.grad = None
+
             if fsdp_param.grad_offload_event is not None:
                 fsdp_param.grad_offload_event.synchronize()
                 fsdp_param.grad_offload_event = None
+        self._locally_unused_params.clear()
         if self._all_gather_result is not None:
             # If there was a mistargeted unshard without a corresponding wait,
             # then we wait here and clear the unshard

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -638,33 +638,33 @@ class FSDPParamGroup:
                 unsharded_grads: list[torch.Tensor] = []
                 self._locally_unused_params.clear()
 
-            for i, fsdp_param in enumerate(self.fsdp_params):
-                if not hasattr(fsdp_param, "_unsharded_param"):
-                    continue
-                # May have an accumulated gradient of the reduce dtype if the
-                # previous backward did not reduce-scatter
-                if fsdp_param.unsharded_accumulated_grad is not None:
-                    fsdp_params_with_grad.append(fsdp_param)
-                    unsharded_grads.append(fsdp_param.unsharded_accumulated_grad_data)
-                    fsdp_param.unsharded_accumulated_grad = None
-                elif fsdp_param.unsharded_param.grad is not None:
-                    fsdp_params_with_grad.append(fsdp_param)
-                    unsharded_grads.append(fsdp_param.unsharded_grad_data)
-                    fsdp_param.unsharded_param.grad = None
-                elif (
-                    self.reduce_scatter_unused_params
-                    and fsdp_param.unsharded_param.requires_grad
-                ):
-                    # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
-                    # This leads to different sets of missing parameters in different ranks,
-                    # and thus leading `unsharded_grads` to be different across ranks.
-                    # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
-                    # reduce-scatter has the same input sizes across ranks.
-                    fsdp_params_with_grad.append(fsdp_param)
-                    unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
-                    self._locally_unused_params.add(
-                        i
-                    )  # keep track of the index of unused params.
+                for i, fsdp_param in enumerate(self.fsdp_params):
+                    if not hasattr(fsdp_param, "_unsharded_param"):
+                        continue
+                    # May have an accumulated gradient of the reduce dtype if the
+                    # previous backward did not reduce-scatter
+                    if fsdp_param.unsharded_accumulated_grad is not None:
+                        fsdp_params_with_grad.append(fsdp_param)
+                        unsharded_grads.append(fsdp_param.unsharded_accumulated_grad_data)
+                        fsdp_param.unsharded_accumulated_grad = None
+                    elif fsdp_param.unsharded_param.grad is not None:
+                        fsdp_params_with_grad.append(fsdp_param)
+                        unsharded_grads.append(fsdp_param.unsharded_grad_data)
+                        fsdp_param.unsharded_param.grad = None
+                    elif (
+                        self.reduce_scatter_unused_params
+                        and fsdp_param.unsharded_param.requires_grad
+                    ):
+                        # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
+                        # This leads to different sets of missing parameters in different ranks,
+                        # and thus leading `unsharded_grads` to be different across ranks.
+                        # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
+                        # reduce-scatter has the same input sizes across ranks.
+                        fsdp_params_with_grad.append(fsdp_param)
+                        unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
+                        self._locally_unused_params.add(
+                            i
+                        )  # keep track of the index of unused params.
 
                 if self.reshard_after_backward:
                     self.reshard()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -269,8 +269,6 @@ class FSDPParamGroup:
         # block while this layer's AR is still in flight. See
         # AllReduceState docstring and regression test PR #180900.
         self._all_reduce_state: AllReduceState | None = None
-        # Create a zero buffer for missing parameters
-        self._zero_buf: torch.Tensor | None = None
         # keep track of locally unused parameters indices for optimizer momentum and adaptive lrs
         self._locally_unused_params: set[int] = set()
 
@@ -283,10 +281,6 @@ class FSDPParamGroup:
         ]
         if trainable_params:
             params_for_dtype = trainable_params
-            grad_type = (
-                trainable_params[0].param_dtype or trainable_params[0].orig_dtype
-            )
-            self._zero_buf = torch.zeros(1, dtype=grad_type, device=self.device)
         else:
             params_for_dtype = [
                 p for p in self.fsdp_params if p.orig_dtype.is_floating_point
@@ -640,41 +634,37 @@ class FSDPParamGroup:
                     return
                 # Save the autograd-computed gradients before resharding to only
                 # access the unsharded parameters when their data is present
-                fsdp_params_with_grad: list[FSDPParam | None] = []
+                fsdp_params_with_grad: list[FSDPParam] = []
                 unsharded_grads: list[torch.Tensor] = []
                 self._locally_unused_params.clear()
 
-                for i, fsdp_param in enumerate(self.fsdp_params):
-                    if not hasattr(fsdp_param, "_unsharded_param"):
-                        continue
-                    # May have an accumulated gradient of the reduce dtype if the
-                    # previous backward did not reduce-scatter
-                    if fsdp_param.unsharded_accumulated_grad is not None:
-                        fsdp_params_with_grad.append(fsdp_param)
-                        unsharded_grads.append(
-                            fsdp_param.unsharded_accumulated_grad_data
-                        )
-                        fsdp_param.unsharded_accumulated_grad = None
-                    elif fsdp_param.unsharded_param.grad is not None:
-                        fsdp_params_with_grad.append(fsdp_param)
-                        unsharded_grads.append(fsdp_param.unsharded_grad_data)
-                        fsdp_param.unsharded_param.grad = None
-                    elif (
-                        self.reduce_scatter_unused_params
-                        and fsdp_param.sharded_param.requires_grad
-                        and self._zero_buf is not None
-                    ):
-                        # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
-                        # This leads to different sets of missing parameters in different ranks,
-                        # and thus leading `unsharded_grads` to be different across ranks.
-                        # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
-                        # reduce-scatter has the same input sizes across ranks.
-                        zero_grad = self._zero_buf.expand(fsdp_param._orig_size)
-                        fsdp_params_with_grad.append(fsdp_param)
-                        unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
-                        self._locally_unused_params.add(
-                            i
-                        )  # keep track of the index of unused params.
+            for i, fsdp_param in enumerate(self.fsdp_params):
+                if not hasattr(fsdp_param, "_unsharded_param"):
+                    continue
+                # May have an accumulated gradient of the reduce dtype if the
+                # previous backward did not reduce-scatter
+                if fsdp_param.unsharded_accumulated_grad is not None:
+                    fsdp_params_with_grad.append(fsdp_param)
+                    unsharded_grads.append(fsdp_param.unsharded_accumulated_grad_data)
+                    fsdp_param.unsharded_accumulated_grad = None
+                elif fsdp_param.unsharded_param.grad is not None:
+                    fsdp_params_with_grad.append(fsdp_param)
+                    unsharded_grads.append(fsdp_param.unsharded_grad_data)
+                    fsdp_param.unsharded_param.grad = None
+                elif (
+                    self.reduce_scatter_unused_params
+                    and fsdp_param.unsharded_param.requires_grad
+                ):
+                    # Models like the Qwen3 with mixture of experts will trigger different experts in different ranks.
+                    # This leads to different sets of missing parameters in different ranks,
+                    # and thus leading `unsharded_grads` to be different across ranks.
+                    # Need a way to account for the "missing" grads that are not in `unsharded_grads` to ensure
+                    # reduce-scatter has the same input sizes across ranks.
+                    fsdp_params_with_grad.append(fsdp_param)
+                    unsharded_grads.append(fsdp_param.unsharded_zero_grad_data)
+                    self._locally_unused_params.add(
+                        i
+                    )  # keep track of the index of unused params.
 
                 if self.reshard_after_backward:
                     self.reshard()
@@ -820,7 +810,7 @@ class FSDPParamGroup:
                 i in self._locally_unused_params
                 and fsdp_param.sharded_param.grad is not None
                 and hasattr(fsdp_param.sharded_param.grad, "_local_tensor")
-                and not fsdp_param.sharded_param.grad._local_tensor.any()
+                and not fsdp_param.sharded_param.grad._local_tensor.any()  # This .any is a host to device sync. Defer to async?
             ):
                 fsdp_param.sharded_param.grad = None
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -638,7 +638,7 @@ class FSDPParamGroup:
                     return
                 # Save the autograd-computed gradients before resharding to only
                 # access the unsharded parameters when their data is present
-                fsdp_params_with_grad: list[FSDPParam] = []
+                fsdp_params_with_grad: list[FSDPParam | None] = []
                 unsharded_grads: list[torch.Tensor] = []
 
                 for fsdp_param in self.fsdp_params:


### PR DESCRIPTION
Fixes #171355

## Problem
Models such as Qwen3 with MoE takes different forward paths in different ranks resulting in differing gradient computation graphs for each rank. This causes different input sizes to go into the NCCL reduce-scatter collective. The collective completes but sends incorrect weights/gradients to parameters.  This is especially egregious in activation checkpointing with prefetch.

## Solution
Initialize a zero buffer with the size of all the missing parameters that require grads. Put a view of the zero tensor with appropriate sizes to the correct index of the variable `unsharded_grads` so that the NCCL reduce-scatter collective will see the same **input size** for all ranks.


cc @soulitzer