### PR TITLE
[XPU] Fix accuracy issue in addmm for bf16/f16 dtypes

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -114,37 +114,28 @@ Tensor& addmm_out(
   float beta_ = beta.to<float>();
   float alpha_ = alpha.to<float>();
 
-  // For reduced-precision types (bf16/f16) with non-trivial alpha/beta, the
-  // oneDNN post-ops path introduces extra rounding at each post-op stage.
-  // which accumulates precision loss compared to CPU/CUDA that handle
-  // alpha/beta n f32 within the GEMM.
   bool is_reduced_float =
       mat1.scalar_type() == kBFloat16 || mat1.scalar_type() == kHalf;
-  bool needs_nontrivial_alphabeta =
-      !(beta_ == 0.f || (alpha_ == 1.f && beta_ == 1.f));
-  if (is_reduced_float && needs_nontrivial_alphabeta) {
-    // f32 mm + alpha/beta, single cast to output dtype.
-    auto result_f32 = at::empty(result_shape, result.options().dtype(kFloat));
-    onednn::matmul(result_f32, mat1, mat2, Tensor(), true, onednn::Attr());
-    // Apply alpha/beta in f32
-    auto self_expanded = self.expand(result_shape);
-    result_f32.mul_(alpha_).add_(self_expanded, beta_);
-    result.copy_(result_f32);
-    return result;
-  }
 
   Tensor bias = Tensor();
   onednn::Attr attr;
-  float alpha_ratio = beta_ == 0.f ? alpha_ : alpha_ / beta_;
   if (beta_ == 0.f) {
-    attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
-  } else if (alpha_ratio == 1.f && beta_ == 1.f && !result.is_same(self)) {
+    attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
+  } else if (alpha_ == 1.f && beta_ == 1.f && !result.is_same(self)) {
     // if result and self are the same tensor, we use post op sum.
     bias = self;
   } else {
     Tensor binary = self.dim() < 1 ? self.unsqueeze(0) : self;
     binary = binary.dim() == 1 ? binary.unsqueeze(0) : binary;
     bool inplace = binary.is_same(result);
+    if (!inplace && is_reduced_float) {
+      // For reduced-precision types, the 3-step post-op chain
+      // (eltwise -> binary_add -> eltwise) rounds intermediates to
+      // bf16/f16, losing precision. Use post_sum which fuses the
+      // addition in oneDNN's f32 accumulator, matching CPU behavior.
+      result.copy_(self.expand(result.sizes()));
+      inplace = true;
+    }
     if (inplace) {
       attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
@@ -161,6 +152,7 @@ Tensor& addmm_out(
       // Thus we need the following transformation
       // alpha * matmul(mat1, mat2) + beta * binary
       // beta * (alpha/beta * matmul(src, wei) + binary)
+      float alpha_ratio = alpha_ / beta_;
       attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
       attr.append_post_binary<true>(attr.kind_with_binary_add, binary);
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
@@ -283,8 +275,11 @@ Tensor& baddbmm_out(
   // general case
   onednn::Attr attr;
   float beta_ = beta.to<float>();
-  float alpha_ = beta_ == 0.f ? alpha.to<float>() : alpha.to<float>() / beta_;
-  Tensor binary;
+  float alpha_ = alpha.to<float>();
+
+  bool is_reduced_float =
+      batch1.scalar_type() == kBFloat16 || batch1.scalar_type() == kHalf;
+
   if (beta_ == 0.f) {
     attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
   } else {
@@ -293,9 +288,16 @@ Tensor& baddbmm_out(
     // If input is a 1d tensor need be broadcasted, we need unsqueeze twice.
     binary = binary.dim() < 3 ? binary.unsqueeze_(0) : binary;
     bool inplace = binary.is_same(result);
+    if (!inplace && is_reduced_float) {
+      // For reduced-precision types, the 3-step post-op chain
+      // (eltwise -> binary_add -> eltwise) rounds intermediates to
+      // bf16/f16, losing precision. Use post_sum which fuses the
+      // addition in oneDNN's f32 accumulator, matching CPU behavior.
+      result.copy_(input.expand(result.sizes()));
+      inplace = true;
+    }
     if (inplace) {
-      attr.append_post_eltwise(
-          1.f, alpha.to<float>(), 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
     } else {
       if (at::native::onednn::is_broadcast(binary)) {
@@ -304,12 +306,13 @@ Tensor& baddbmm_out(
       binary = at::native::onednn::is_onednn_matmul_strides(binary)
           ? binary
           : binary.contiguous();
-      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
+      float alpha_ratio = alpha_ / beta_;
+      attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
       attr.append_post_binary<true>(attr.kind_with_binary_add, binary);
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
     }
   }
-  onednn::matmul(result, batch1, batch2, at::Tensor(), true, attr);
+  onednn::matmul(result, batch1, batch2, Tensor(), true, attr);
   return result;
 }
 
@@ -332,8 +335,8 @@ Tensor& bmm_out(const Tensor& self, const Tensor& batch2, Tensor& result) {
     return result;
   }
 
-  onednn::matmul(result, self, batch2, at::Tensor(), true, onednn::Attr());
-  return result;
+  onednn::matmul(result, self, batch2, Tensor(), true, onednn::Attr());
+    return result;
 }
 
 Tensor& addmv_out(

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -154,7 +154,7 @@ Tensor& addmm_out(
     binary = binary.dim() == 1 ? binary.unsqueeze(0) : binary;
     bool inplace = binary.is_same(result);
     if (inplace) {
-      attr.append_post_eltwise(.f, alpha_, 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
     } else {
       if (at::native::onednn::is_broadcast(binary)) {

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -146,7 +146,7 @@ Tensor& addmm_out(
     binary = binary.dim() == 1 ? binary.unsqueeze(0) : binary;
     bool inplace = binary.is_same(result);
     if (inplace) {
-      attr.append_post_eltwise(.f, alpha_, 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
     } else {
       if (at::native::onednn::is_broadcast(binary)) {

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -111,13 +111,34 @@ Tensor& addmm_out(
   }
 
   // general case
+  float beta_ = beta.to<float>();
+  float alpha_ = alpha.to<float>();
+
+  // For reduced-precision types (bf16/f16) with non-trivial alpha/beta, the
+  // oneDNN post-ops path introduces extra rounding at each post-op stage.
+  // which accumulates precision loss compared to CPU/CUDA that handle
+  // alpha/beta n f32 within the GEMM.
+  bool is_reduced_float =
+      mat1.scalar_type() == kBFloat16 || mat1.scalar_type() == kHalf;
+  bool needs_nontrivial_alphabeta =
+      !(beta_ == 0.f || (alpha_ == 1.f && beta_ == 1.f));
+  if (is_reduced_float && needs_nontrivial_alphabeta) {
+    // f32 mm + alpha/beta, single cast to output dtype.
+    auto result_f32 = at::empty(result_shape, result.options().dtype(kFloat));
+    onednn::matmul(result_f32, mat1, mat2, Tensor(), true, onednn::Attr());
+    // Apply alpha/beta in f32
+    auto self_expanded = self.expand(result_shape);
+    result_f32.mul_(alpha_).add_(self_expanded, beta_);
+    result.copy_(result_f32);
+    return result;
+  }
+
   Tensor bias = Tensor();
   onednn::Attr attr;
-  float beta_ = beta.to<float>();
-  float alpha_ = beta_ == 0.f ? alpha.to<float>() : alpha.to<float>() / beta_;
+  float alpha_ratio = beta_ == 0.f ? alpha_ : alpha_ / beta_;
   if (beta_ == 0.f) {
-    attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
-  } else if (alpha_ == 1.f && beta_ == 1.f && !result.is_same(self)) {
+    attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
+  } else if (alpha_ratio == 1.f && beta_ == 1.f && !result.is_same(self)) {
     // if result and self are the same tensor, we use post op sum.
     bias = self;
   } else {
@@ -125,8 +146,7 @@ Tensor& addmm_out(
     binary = binary.dim() == 1 ? binary.unsqueeze(0) : binary;
     bool inplace = binary.is_same(result);
     if (inplace) {
-      attr.append_post_eltwise(
-          1.f, alpha.to<float>(), 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
     } else {
       if (at::native::onednn::is_broadcast(binary)) {
@@ -137,12 +157,11 @@ Tensor& addmm_out(
       binary = at::native::onednn::is_onednn_matmul_strides(binary)
           ? binary
           : binary.contiguous();
-      // Tensor binary = self.expand_as(result);
       // For post-binary-add, onednn needs binary scale=1.f
       // Thus we need the following transformation
       // alpha * matmul(mat1, mat2) + beta * binary
       // beta * (alpha/beta * matmul(src, wei) + binary)
-      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
       attr.append_post_binary<true>(attr.kind_with_binary_add, binary);
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
     }

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -309,10 +309,11 @@ Tensor& baddbmm_out(
     binary = binary.dim() < 3 ? binary.unsqueeze_(0) : binary;
     bool inplace = binary.is_same(result);
     if (!inplace && is_reduced_float) {
-      // For reduced-precision types, the 3-step post-op chain
-      // (eltwise -> binary_add -> eltwise) rounds intermediates to
-      // bf16/f16, losing precision. Use post_sum which fuses the
-      // addition in oneDNN's f32 accumulator, matching CPU behavior.
+      // Reduced-precision dtypes lose accuracy in the non-inplace path below,
+      // whose 3-step post-op chain (eltwise -> binary_add -> eltwise) rounds
+      // intermediates to bf16/f16. Copy self into result and take the inplace
+      // path instead, which uses post_sum and accumulates in oneDNN's f32
+      // accumulator, matching CPU/CUDA behavior.
       result.copy_(input.expand(result.sizes()));
       inplace = true;
     }

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -289,10 +289,11 @@ Tensor& baddbmm_out(
     binary = binary.dim() < 3 ? binary.unsqueeze_(0) : binary;
     bool inplace = binary.is_same(result);
     if (!inplace && is_reduced_float) {
-      // For reduced-precision types, the 3-step post-op chain
-      // (eltwise -> binary_add -> eltwise) rounds intermediates to
-      // bf16/f16, losing precision. Use post_sum which fuses the
-      // addition in oneDNN's f32 accumulator, matching CPU behavior.
+      // Reduced-precision dtypes lose accuracy in the non-inplace path below,
+      // whose 3-step post-op chain (eltwise -> binary_add -> eltwise) rounds
+      // intermediates to bf16/f16. Copy self into result and take the inplace
+      // path instead, which uses post_sum and accumulates in oneDNN's f32
+      // accumulator, matching CPU/CUDA behavior.
       result.copy_(input.expand(result.sizes()));
       inplace = true;
     }

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -356,7 +356,7 @@ Tensor& bmm_out(const Tensor& self, const Tensor& batch2, Tensor& result) {
   }
 
   onednn::matmul(result, self, batch2, Tensor(), true, onednn::Attr());
-    return result;
+  return result;
 }
 
 Tensor& addmv_out(

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -119,13 +119,34 @@ Tensor& addmm_out(
   }
 
   // general case
+  float beta_ = beta.to<float>();
+  float alpha_ = alpha.to<float>();
+
+  // For reduced-precision types (bf16/f16) with non-trivial alpha/beta, the
+  // oneDNN post-ops path introduces extra rounding at each post-op stage.
+  // which accumulates precision loss compared to CPU/CUDA that handle
+  // alpha/beta n f32 within the GEMM.
+  bool is_reduced_float =
+      mat1.scalar_type() == kBFloat16 || mat1.scalar_type() == kHalf;
+  bool needs_nontrivial_alphabeta =
+      !(beta_ == 0.f || (alpha_ == 1.f && beta_ == 1.f));
+  if (is_reduced_float && needs_nontrivial_alphabeta) {
+    // f32 mm + alpha/beta, single cast to output dtype.
+    auto result_f32 = at::empty(result_shape, result.options().dtype(kFloat));
+    onednn::matmul(result_f32, mat1, mat2, Tensor(), true, onednn::Attr());
+    // Apply alpha/beta in f32
+    auto self_expanded = self.expand(result_shape);
+    result_f32.mul_(alpha_).add_(self_expanded, beta_);
+    result.copy_(result_f32);
+    return result;
+  }
+
   Tensor bias = Tensor();
   onednn::Attr attr;
-  float beta_ = beta.to<float>();
-  float alpha_ = beta_ == 0.f ? alpha.to<float>() : alpha.to<float>() / beta_;
+  float alpha_ratio = beta_ == 0.f ? alpha_ : alpha_ / beta_;
   if (beta_ == 0.f) {
-    attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
-  } else if (alpha_ == 1.f && beta_ == 1.f && !result.is_same(self)) {
+    attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
+  } else if (alpha_ratio == 1.f && beta_ == 1.f && !result.is_same(self)) {
     // if result and self are the same tensor, we use post op sum.
     bias = self;
   } else {
@@ -133,8 +154,7 @@ Tensor& addmm_out(
     binary = binary.dim() == 1 ? binary.unsqueeze(0) : binary;
     bool inplace = binary.is_same(result);
     if (inplace) {
-      attr.append_post_eltwise(
-          1.f, alpha.to<float>(), 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
     } else {
       if (at::native::onednn::is_broadcast(binary)) {
@@ -145,12 +165,11 @@ Tensor& addmm_out(
       binary = at::native::onednn::is_onednn_matmul_strides(binary)
           ? binary
           : binary.contiguous();
-      // Tensor binary = self.expand_as(result);
       // For post-binary-add, onednn needs binary scale=1.f
       // Thus we need the following transformation
       // alpha * matmul(mat1, mat2) + beta * binary
       // beta * (alpha/beta * matmul(src, wei) + binary)
-      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
       attr.append_post_binary<true>(attr.kind_with_binary_add, binary);
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
     }

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -336,7 +336,7 @@ Tensor& bmm_out(const Tensor& self, const Tensor& batch2, Tensor& result) {
   }
 
   onednn::matmul(result, self, batch2, Tensor(), true, onednn::Attr());
-    return result;
+  return result;
 }
 
 Tensor& addmv_out(

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -122,37 +122,28 @@ Tensor& addmm_out(
   float beta_ = beta.to<float>();
   float alpha_ = alpha.to<float>();
 
-  // For reduced-precision types (bf16/f16) with non-trivial alpha/beta, the
-  // oneDNN post-ops path introduces extra rounding at each post-op stage.
-  // which accumulates precision loss compared to CPU/CUDA that handle
-  // alpha/beta n f32 within the GEMM.
   bool is_reduced_float =
       mat1.scalar_type() == kBFloat16 || mat1.scalar_type() == kHalf;
-  bool needs_nontrivial_alphabeta =
-      !(beta_ == 0.f || (alpha_ == 1.f && beta_ == 1.f));
-  if (is_reduced_float && needs_nontrivial_alphabeta) {
-    // f32 mm + alpha/beta, single cast to output dtype.
-    auto result_f32 = at::empty(result_shape, result.options().dtype(kFloat));
-    onednn::matmul(result_f32, mat1, mat2, Tensor(), true, onednn::Attr());
-    // Apply alpha/beta in f32
-    auto self_expanded = self.expand(result_shape);
-    result_f32.mul_(alpha_).add_(self_expanded, beta_);
-    result.copy_(result_f32);
-    return result;
-  }
 
   Tensor bias = Tensor();
   onednn::Attr attr;
-  float alpha_ratio = beta_ == 0.f ? alpha_ : alpha_ / beta_;
   if (beta_ == 0.f) {
-    attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
-  } else if (alpha_ratio == 1.f && beta_ == 1.f && !result.is_same(self)) {
+    attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
+  } else if (alpha_ == 1.f && beta_ == 1.f && !result.is_same(self)) {
     // if result and self are the same tensor, we use post op sum.
     bias = self;
   } else {
     Tensor binary = self.dim() < 1 ? self.unsqueeze(0) : self;
     binary = binary.dim() == 1 ? binary.unsqueeze(0) : binary;
     bool inplace = binary.is_same(result);
+    if (!inplace && is_reduced_float) {
+      // For reduced-precision types, the 3-step post-op chain
+      // (eltwise -> binary_add -> eltwise) rounds intermediates to
+      // bf16/f16, losing precision. Use post_sum which fuses the
+      // addition in oneDNN's f32 accumulator, matching CPU behavior.
+      result.copy_(self.expand(result.sizes()));
+      inplace = true;
+    }
     if (inplace) {
       attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
@@ -169,6 +160,7 @@ Tensor& addmm_out(
       // Thus we need the following transformation
       // alpha * matmul(mat1, mat2) + beta * binary
       // beta * (alpha/beta * matmul(src, wei) + binary)
+      float alpha_ratio = alpha_ / beta_;
       attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
       attr.append_post_binary<true>(attr.kind_with_binary_add, binary);
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
@@ -303,8 +295,11 @@ Tensor& baddbmm_out(
   // general case
   onednn::Attr attr;
   float beta_ = beta.to<float>();
-  float alpha_ = beta_ == 0.f ? alpha.to<float>() : alpha.to<float>() / beta_;
-  Tensor binary;
+  float alpha_ = alpha.to<float>();
+
+  bool is_reduced_float =
+      batch1.scalar_type() == kBFloat16 || batch1.scalar_type() == kHalf;
+
   if (beta_ == 0.f) {
     attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
   } else {
@@ -313,9 +308,16 @@ Tensor& baddbmm_out(
     // If input is a 1d tensor need be broadcasted, we need unsqueeze twice.
     binary = binary.dim() < 3 ? binary.unsqueeze_(0) : binary;
     bool inplace = binary.is_same(result);
+    if (!inplace && is_reduced_float) {
+      // For reduced-precision types, the 3-step post-op chain
+      // (eltwise -> binary_add -> eltwise) rounds intermediates to
+      // bf16/f16, losing precision. Use post_sum which fuses the
+      // addition in oneDNN's f32 accumulator, matching CPU behavior.
+      result.copy_(input.expand(result.sizes()));
+      inplace = true;
+    }
     if (inplace) {
-      attr.append_post_eltwise(
-          1.f, alpha.to<float>(), 0.f, attr.kind_with_linear);
+      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
       attr.append_post_sum(beta_);
     } else {
       if (at::native::onednn::is_broadcast(binary)) {
@@ -324,12 +326,13 @@ Tensor& baddbmm_out(
       binary = at::native::onednn::is_onednn_matmul_strides(binary)
           ? binary
           : binary.contiguous();
-      attr.append_post_eltwise(1.f, alpha_, 0.f, attr.kind_with_linear);
+      float alpha_ratio = alpha_ / beta_;
+      attr.append_post_eltwise(1.f, alpha_ratio, 0.f, attr.kind_with_linear);
       attr.append_post_binary<true>(attr.kind_with_binary_add, binary);
       attr.append_post_eltwise(1.f, beta_, 0.f, attr.kind_with_linear);
     }
   }
-  onednn::matmul(result, batch1, batch2, at::Tensor(), true, attr);
+  onednn::matmul(result, batch1, batch2, Tensor(), true, attr);
   return result;
 }
 
@@ -352,8 +355,8 @@ Tensor& bmm_out(const Tensor& self, const Tensor& batch2, Tensor& result) {
     return result;
   }
 
-  onednn::matmul(result, self, batch2, at::Tensor(), true, onednn::Attr());
-  return result;
+  onednn::matmul(result, self, batch2, Tensor(), true, onednn::Attr());
+    return result;
 }
 
 Tensor& addmv_out(

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -1708,9 +1708,7 @@ def forward(self, x_1, w_1):
 
         for alpha, beta in [(0.5, 2.0), (2.0, 0.5), (0.3, 0.7)]:
             result = torch.addmm(bias, mat1, mat2, alpha=alpha, beta=beta)
-            expected = alpha * (
-                mat1.float().cpu().numpy() @ mat2.float().cpu().numpy()
-            )
+            expected = alpha * (mat1.float().cpu().numpy() @ mat2.float().cpu().numpy())
             expected += beta * bias.float().cpu().numpy()
             expected = torch.from_numpy(expected).to(dtype)
             self.assertEqual(result, expected)
@@ -1737,10 +1735,9 @@ def forward(self, x_1, w_1):
             self.assertEqual(result, expected)
 
             out = torch.empty(B, M, N, device=device, dtype=dtype)
-            torch.baddbmm(
-                input_t, batch1, batch2, alpha=alpha, beta=beta, out=out
-            )
+            torch.baddbmm(input_t, batch1, batch2, alpha=alpha, beta=beta, out=out)
             self.assertEqual(out, expected)
+
 
 instantiate_device_type_tests(TestBasicGEMM, globals(), only_for="xpu", allow_xpu=True)
 

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -1698,6 +1698,49 @@ def forward(self, x_1, w_1):
             self.assertEqual(out.dtype, output_dtype)
             torch.testing.assert_close(out, baseline, atol=1e-3, rtol=1e-3)
 
+    @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.1})
+    @dtypes(torch.bfloat16, torch.half)
+    def test_addmm_reduced_float_non_inplace_precision(self, device, dtype):
+        M, K, N = 10, 25, 15
+        mat1 = torch.randn(M, K, device=device, dtype=torch.float32).to(dtype)
+        mat2 = torch.randn(K, N, device=device, dtype=torch.float32).to(dtype)
+        bias = torch.randn(M, N, device=device, dtype=torch.float32).to(dtype)
+
+        for alpha, beta in [(0.5, 2.0), (2.0, 0.5), (0.3, 0.7)]:
+            result = torch.addmm(bias, mat1, mat2, alpha=alpha, beta=beta)
+            expected = alpha * (
+                mat1.float().cpu().numpy() @ mat2.float().cpu().numpy()
+            )
+            expected += beta * bias.float().cpu().numpy()
+            expected = torch.from_numpy(expected).to(dtype)
+            self.assertEqual(result, expected)
+
+            out = torch.empty(M, N, device=device, dtype=dtype)
+            torch.addmm(bias, mat1, mat2, alpha=alpha, beta=beta, out=out)
+            self.assertEqual(out, expected)
+
+    @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.5})
+    @dtypes(torch.bfloat16, torch.half)
+    def test_baddbmm_reduced_float_non_inplace_precision(self, device, dtype):
+        B, M, K, N = 3, 10, 25, 15
+        batch1 = torch.randn(B, M, K, device=device, dtype=torch.float32).to(dtype)
+        batch2 = torch.randn(B, K, N, device=device, dtype=torch.float32).to(dtype)
+        input_t = torch.randn(B, M, N, device=device, dtype=torch.float32).to(dtype)
+
+        for alpha, beta in [(0.5, 2.0), (2.0, 0.5), (0.3, 0.7)]:
+            result = torch.baddbmm(input_t, batch1, batch2, alpha=alpha, beta=beta)
+            expected = alpha * (
+                batch1.float().cpu().numpy() @ batch2.float().cpu().numpy()
+            )
+            expected += beta * input_t.float().cpu().numpy()
+            expected = torch.from_numpy(expected).to(dtype)
+            self.assertEqual(result, expected)
+
+            out = torch.empty(B, M, N, device=device, dtype=dtype)
+            torch.baddbmm(
+                input_t, batch1, batch2, alpha=alpha, beta=beta, out=out
+            )
+            self.assertEqual(out, expected)
 
 instantiate_device_type_tests(TestBasicGEMM, globals(), only_for="xpu", allow_xpu=True)
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2837

Fixes precision loss in XPU addmm and baddbmm for bf16/f16 dtypes with non-trivial alpha/beta. The oneDNN 3-step post-op chain rounds intermediates to reduced precision at each stage. The fix pre-copies self into result and uses post_sum which accumulates in oneDNN's internal f32 accumulator, matching CPU/CUDA behavior. 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01