### PR TITLE
[MPS] Enable test for `nn.TransformerEncoderLayer`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13422,7 +13422,6 @@ if __name__ == '__main__':
         self.assertEqual(m_initialized.weight.device, m_uninitialized.weight.device)
         self.assertFalse(torch.allclose(m_initialized.weight, m_uninitialized.weight))
 
-    @skipIfMPS  # TODO(hvaara): Investigate as possible bug. macOS 13 passes, while 14 and 15 fails.
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.double, torch.float, torch.half)
     def test_transformerencoderlayer(self, device, dtype):


### PR DESCRIPTION
This test passes on macOS 26.2, so would be good to add to the suite (and I get to clean up a TODO 🙂). If it fails in ci for macOS 14 and/or 15 I'll add exceptions for the problematic versions.