### PR TITLE
Prevent incorrect fusion in index_put_ with duplicate indices

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8804,6 +8804,20 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             ],
         )
 
+    def test_index_put_duplicate_indices_inplace(self):
+        def fn(a, idx):
+            a = a.clone()
+            a[idx] += a[idx]
+            return a
+
+        self.common(
+            fn,
+            (
+                torch.tensor([[-0.8716, 0.1114]], dtype=torch.float64),
+                torch.tensor([0, 0], dtype=torch.int64),
+            ),
+        )
+
     def test_index_put_as_masked_fill(self):
         def fn(a, b, c, d):
             a = a.clone()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4173,6 +4173,9 @@ def index_put_impl_(self, indices, values, accumulate, check, may_realize=False)
             # the load of `values` might contain modified value from the store of `self`.
             # To address this, store values in a temporary buffer in such cases.
             values.realize()
+            if (values_name := ir.try_get_name(values)) is not None:
+                # Prevent fusion from inlining the RHS temp back into the scatter.
+                V.graph.no_fuse_buffer_names.add(values_name)
 
     # Dispatch to masked fill for single boolean index with single value
     if (


### PR DESCRIPTION
Fixes #174074 

x[[0,0]] means to get the element/s at index 0 and then duplicate them to form list. In example we do x[[0,0]] += x[[0,0]] which should give the tensor with 2x of data given at index 0. The reason for no duplication see is because += is inplace operation. Same response is seen in eager mode.

In compile mode with backend=inductor, there is an issue. Due to fusion the output kernel obtained is to get output_ptr modify and store in the same output_ptr. Whereas the behaviour should have been to get data from input_ptr and store in output_ptr. The reason for this happening is due to fusion of 2 kernels. One is RHS kernel reads original data , compute and store in seperate buffer. The next kernel is to write back to destination. With this change we will skip fusion for such cases. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo