### PR TITLE
[xpu][fix] Remove inappropriate usage of `torch.xpu.is_availabe()`

### DIFF
--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -280,7 +280,9 @@ def addmm_replace(
     )
 
 
-def is_mm_compute_bound(dtype: torch.dtype, device_type: str, M: int, K: int, N: int) -> bool:
+def is_mm_compute_bound(
+    dtype: torch.dtype, device_type: str, M: int, K: int, N: int
+) -> bool:
     denominator = M * K + N * K + M * N
     if denominator == 0:
         return False
@@ -443,7 +445,9 @@ def is_padded_faster(key: str, ori_time: float, pad_time: float) -> bool:
     return padded_is_faster
 
 
-def should_pad_mm_bf16(device_type: str, dtype: torch.dtype, M: int, N: int, K: int) -> bool:
+def should_pad_mm_bf16(
+    device_type: str, dtype: torch.dtype, M: int, N: int, K: int
+) -> bool:
     # always force pad for mm with bf16 when the following are satisfied to avoid perf regression
     large_k_threshold_to_pad = torch._inductor.config.post_grad_fusion_options[
         "pad_aten_mm_pass"

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -60,7 +60,7 @@ bmm_template = TritonTemplate(
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)
 aten_bmm_dtype = ExternKernelChoice(
     torch.bmm,
-    "at::_bmm_out_dtype_xpu" if torch.xpu.is_available() else "at::_bmm_out_dtype_cuda",
+    "at::_bmm_out_dtype_xpu" if torch.xpu._is_compiled() else "at::_bmm_out_dtype_cuda",
     name="bmm_dtype",
     op_overload=aten.bmm.dtype_out,
 )

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -389,7 +389,7 @@ def _tuned_grouped_mm_common(
             "A_IS_K_MAJOR": a_is_k_major,
             "B_IS_K_MAJOR": b_is_k_major,
             "USE_FAST_ACCUM": use_fast_accum,
-            "NUM_SMS": get_num_sms(),
+            "NUM_SMS": get_num_sms(mat_a.get_device().type),
             "USE_TMA_LOAD": use_tma_load,
             "USE_EXPERIMENTAL_MAKE_TENSOR_DESCRIPTOR": triton_has_experimental_make_tensor_descriptor,
         }

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2981,7 +2981,7 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward, require_contiguous)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
-if torch.version.xpu:
+if torch.xpu._is_compiled():
     make_fallback(
         aten.embedding_dense_backward, warn=False
     )  # (XPU-only and faster than decomp)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2981,7 +2981,7 @@ make_fallback(aten.exponential.default, warn=False)  # (fails accuracy on test_t
 make_fallback(aten._pdist_forward, require_contiguous)  # Has decomp. Needs benchmarks
 make_fallback(aten.soft_margin_loss_backward, warn=False)  # py_impl?
 make_fallback(aten._fused_rms_norm, warn=False)  # (MPS-only and faster than decomp)
-if torch.xpu.is_available():
+if torch.version.xpu:
     make_fallback(
         aten.embedding_dense_backward, warn=False
     )  # (XPU-only and faster than decomp)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2815,6 +2815,7 @@ def pointwise(
     Construct @triton.heuristics() based on size_hints.
     """
     inductor_meta = {} if inductor_meta is None else inductor_meta
+    device_type = triton_meta.device.type
 
     configs = _handle_combo_kernel_per_subkernel_blocks(
         size_hints,
@@ -2897,7 +2898,7 @@ def pointwise(
                             )
                         ]
                     )
-            if torch.xpu.is_available():
+            if device_type == "xpu":
                 configs.extend(
                     [  # intel-xpu-backend-for-triton #5133
                         triton_config_with_settings(size_hints, 32),
@@ -2946,7 +2947,7 @@ def pointwise(
                         ),  # +30% for some kernels
                     ]
                 )
-            if torch.xpu.is_available():
+            if device_type == "xpu":
                 configs.extend(
                     [
                         # intel-xpu-backend-for-triton #5198
@@ -2957,7 +2958,7 @@ def pointwise(
                 )
     if len(size_hints) == 3:
         if not (
-            inductor_meta.get("max_autotune_pointwise") or torch.xpu.is_available()
+            inductor_meta.get("max_autotune_pointwise") or device_type == "xpu"
         ):
             configs = [triton_config_with_settings(size_hints, 16, 16, 16)]
         else:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2815,7 +2815,7 @@ def pointwise(
     Construct @triton.heuristics() based on size_hints.
     """
     inductor_meta = {} if inductor_meta is None else inductor_meta
-    device_type = triton_meta.device.type
+    device_type = triton_meta["device"].type
 
     configs = _handle_combo_kernel_per_subkernel_blocks(
         size_hints,
@@ -2912,7 +2912,7 @@ def pointwise(
             or (
                 torch.version.hip is None
                 and tile_hint == TileHint.SQUARE
-                and torch.version.xpu is None
+                and device_type != "xpu"
             )
         ) and not (
             inductor_meta.get("max_autotune")

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2957,9 +2957,7 @@ def pointwise(
                     ]
                 )
     if len(size_hints) == 3:
-        if not (
-            inductor_meta.get("max_autotune_pointwise") or device_type == "xpu"
-        ):
+        if not (inductor_meta.get("max_autotune_pointwise") or device_type == "xpu"):
             configs = [triton_config_with_settings(size_hints, 16, 16, 16)]
         else:
             configs = [

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2069,7 +2069,7 @@ class TMATemplateConfigMixin(TMAWorkspaceMixin, MMTemplateConfigMixin):
         tma_opts = {
             "A_ROW_MAJOR": not mat1.layout.is_transposed(),
             "B_ROW_MAJOR": not mat2.layout.is_transposed(),
-            "NUM_SMS": get_num_sms(),
+            "NUM_SMS": get_num_sms(mat1.layout.device.type),
             "TMA_SIZE": TMA_DESCRIPTOR_SIZE,
             "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
             "tma_store": config.triton.enable_template_tma_store,
@@ -2115,9 +2115,11 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
                 and not constraints_violated
             )
             flatten = template_kwargs.get("FLATTEN", True) and not constraints_violated
+
+            (mat1,) = kernel_inputs.mat1mat2()
             yield {
                 **template_kwargs,
-                "NUM_SMS": get_num_sms(),
+                "NUM_SMS": get_num_sms(mat1.layout.device.type),
                 "WARP_SPECIALIZE": ws,
                 "FLATTEN": flatten,
             }
@@ -2339,7 +2341,8 @@ class ScaledTMAConfigMixin(TMAWorkspaceMixin, BaseScaledMMConfigMixin):
         ):
             # Add TMA-specific options for device TMA scaled MM
             template_kwargs["TMA_SIZE"] = TMA_DESCRIPTOR_SIZE
-            template_kwargs["NUM_SMS"] = get_num_sms()
+            mat1, _ = kernel_inputs.mat1mat2()
+            template_kwargs["NUM_SMS"] = get_num_sms(mat1.layout.device.type)
             template_kwargs["TMA_EXPERIMENTAL_API"] = not has_triton_stable_tma_api()
 
             yield template_kwargs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174883

This PR removes two categories of inappropriate usage of `torch.xpu.is_available()` in Inductor:

1. In scenarios where the `device_type` of the current workflow is already known, checking `device_type == "xpu"` is both cheaper and more precise than calling `torch.xpu.is_available()`.

2. In Python module initialization, calling torch.xpu.is_available() unnecessarily initializes the XPU runtime and invokes APIs such as `torch.xpu.device_count()` in CPU-only workflows. Replace with `torch.version.xpu` can avoid these overhead.

Fixes #174672


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo