### PR TITLE
[caffe2][cudnn] Fix incorrect TORCH_CHECK usage in MHA.cpp

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -1567,7 +1567,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
     variant_pack[OFFSET] = dropoutoffset.mutable_data_ptr();
   }
   if (attn_bias.has_value()) {
-    TORCH_CHECK("bias not supported with nestedtensor");
+    TORCH_CHECK(false, "bias not supported with nestedtensor");
   }
   auto workspace_size = mha_graph.get_workspace_size();
   auto workspace_ptr =


### PR DESCRIPTION
Summary:
`TORCH_CHECK("bias not supported with nestedtensor")` passes a string literal as the condition argument. Since a non-null `const char*` implicitly converts to `true`, this check never fires

The fix changes it to `TORCH_CHECK(false, "bias not supported with nestedtensor")` so the first argument is the boolean condition and the second is the error message, matching the intended semantics.

This also unblocks re-enabling `-Wstring-conversion`

Test Plan: `buck2 build mode/opt fbcode//caffe2:_ATen-cu` — BUILD SUCCEEDED (the target that was failing in the conveyor)

Differential Revision: D93102535


