### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from a few files

### DIFF
--- a/c10/cuda/test/impl/CUDAAssertionsTest_from_2_processes.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_from_2_processes.cu
@@ -86,7 +86,7 @@ void cuda_device_assertions_from_2_processes() {
         1);
     try {
       c10::cuda::device_synchronize();
-    } catch (const c10::Error& err) {
+    } catch (const c10::Error&) {
       ASSERT_TRUE(false); // This kernel should not have failed, but did.
     }
   }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D92975527


