### PR TITLE
[CUDA][Random] Remove unnecessary `__syncthreads` in `distribution_elementwise_grid_stride_kernel`

### DIFF
--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -83,7 +83,6 @@ __global__ void distribution_elementwise_grid_stride_kernel(int64_t numel,
         transform_func(li, static_cast<accscalar_t>((&rand.x)[ii]));
       }
     }
-    __syncthreads();
   }
 }
 


### PR DESCRIPTION
While looking at another issue Claude told me this `__syncthreads` is unnecessary and I don't see why not

(kernel is grid-stride, doesn't touch same global memory multiple times, all callsites don't even have shared memory allocated etc)

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @pbelevich