### PR TITLE
Raise runtime error if remainder by zero on compile similar like eager

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7573,6 +7573,27 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         self.common(fn, (torch.randn(64), torch.randn(64)))
 
+    def test_remainder_zero_divisor(self):
+        # Device side error from GPUs can be async and different from CPU
+        if self.device != "cpu":
+            self.skipTest(
+                "CPU-only: rely on CPU runtime error path for remainder by zero"
+            )
+
+        def fn(a, b):
+            return torch.remainder(a, b)
+
+        a = torch.tensor(0, dtype=torch.int64, device=self.device)
+        b = torch.tensor(0, dtype=torch.int64, device=self.device)
+
+        compiled = torch.compile(fn)
+        msg = "remainder by zero"
+        if config.cpp_wrapper:
+            msg = "aoti_torch_.* API call failed at .*"
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            compiled(a, b)
+
     def test_zeros(self):
         def fn(a):
             return (

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -57,6 +57,7 @@ from torch.utils._sympy.functions import (
 
 from .._dynamo.utils import import_submodule
 from . import config, inductor_prims, ir, test_operators  # NOQA: F401
+from .codegen.common import _check_nonzero_integer_divisor
 from .decomposition import decompositions, get_decompositions
 from .ir import (
     BaseView,
@@ -6833,6 +6834,7 @@ def fmod(a, b):
     if is_integral:
 
         def fn(a, b):
+            _check_nonzero_integer_divisor(b, op_name="fmod")
             return ops.mod(a, b)
 
     else:


### PR DESCRIPTION
Fixes #174174 

When I run torch.compile on remainder operation with 0 , it gives me tensor(0) which is different from eager mode. The remainder operator in inductor should have device assertion to raise runtime error when such cases happen.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo