### PR TITLE
[Not ready for review][Pallas TPU] Bump up the version of TorchTpu used in Torch CI.

### DIFF
--- a/.ci/docker/common/install_torch_tpu.sh
+++ b/.ci/docker/common/install_torch_tpu.sh
@@ -107,8 +107,6 @@ pull_torch_tpu() {
     echo "Done."
 }
 
-sleep 28800 # Debug sleep to connect to runner to streamline
-
 # 3. Configuration
 TORCH_TPU_REPO="${TORCH_TPU_REPO:-https://github.com/google-ml-infra/torch_tpu.git}"
 TORCH_TPU_BRANCH="${TORCH_TPU_BRANCH:-main}"
@@ -182,7 +180,6 @@ echo "Building TorchTPU Wheel..."
 export TORCH_SOURCE=$(python -c "import torch; import os; print(os.path.dirname(os.path.dirname(torch.__file__)))")
 
 as_jenkins env TORCH_SOURCE="${TORCH_SOURCE}" bazel build //ci/wheel:torch_tpu_wheel --config=local --define WHEEL_VERSION=0.1.0 --define TORCH_SOURCE=local
-
 # 11. Install
 pip_install bazel-bin/ci/wheel/*.whl
 

--- a/.ci/docker/common/install_torch_tpu.sh
+++ b/.ci/docker/common/install_torch_tpu.sh
@@ -107,7 +107,7 @@ pull_torch_tpu() {
     echo "Done."
 }
 
-# sleep 28800 # Debug sleep to connect to runner to streamline debugging, do not submit
+sleep 28800 # Debug sleep to connect to runner to streamline debugging, do not submit
 
 # 3. Configuration
 TORCH_TPU_REPO="${TORCH_TPU_REPO:-https://github.com/google-ml-infra/torch_tpu.git}"

--- a/.ci/docker/common/install_torch_tpu.sh
+++ b/.ci/docker/common/install_torch_tpu.sh
@@ -193,5 +193,5 @@ TORCH_LIB_PATH=$(python -c "import torch; import os; print(os.path.join(os.path.
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${TORCH_LIB_PATH}"
 echo "Updated LD_LIBRARY_PATH to include: ${TORCH_LIB_PATH}"
 
-# Verify installation
+# Verify torch installation
 python -c "import torch; from torch_tpu import api; print(f'Success! Device: {api.tpu_device()}')"

--- a/.ci/docker/common/install_torch_tpu.sh
+++ b/.ci/docker/common/install_torch_tpu.sh
@@ -193,5 +193,5 @@ TORCH_LIB_PATH=$(python -c "import torch; import os; print(os.path.join(os.path.
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${TORCH_LIB_PATH}"
 echo "Updated LD_LIBRARY_PATH to include: ${TORCH_LIB_PATH}"
 
-# Verify torch installation
+# Verify installation
 python -c "import torch; from torch_tpu import api; print(f'Success! Device: {api.tpu_device()}')"

--- a/.ci/docker/common/install_torch_tpu.sh
+++ b/.ci/docker/common/install_torch_tpu.sh
@@ -107,7 +107,7 @@ pull_torch_tpu() {
     echo "Done."
 }
 
-sleep 28800 # Debug sleep to connect to runner to streamline debugging, do not submit
+sleep 28800 # Debug sleep to connect to runner to streamline
 
 # 3. Configuration
 TORCH_TPU_REPO="${TORCH_TPU_REPO:-https://github.com/google-ml-infra/torch_tpu.git}"

--- a/.github/ci_commit_pins/torch_tpu.txt
+++ b/.github/ci_commit_pins/torch_tpu.txt
@@ -1,1 +1,1 @@
-efec24ca8adca3d742e7fa3e0483922de20b4ae9
+8a6bb766863ae8553b9aa31a509f9bdad3fed0ae


### PR DESCRIPTION
This is to update the pin of TorchTPU in an attempt to fix flaky results being observed. 

Additionally remove a commented out sleep command that doesn't need to be part of the checked in code. 

#### How it was tested

Sleep command was added to the torch install script to halt execution in the TPU and runner was connected to over an ssh-like setup.

Build stage was ran 10+ times with cache cleans between with no failures.  Build was ran by using the same docker command used in the CI job.  The exact command was pulled from logs in CI prior to the CI halting. 

I suspect if there is additional flakiness it may be coming from the environment not being fully hermetic  