### PR TITLE
[ROCm] RadixSelect: Remove loop padding and make prefetching conditional

### DIFF
--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -1478,16 +1478,16 @@ void launch_gather_topk_kernel(
 
 #if defined(USE_ROCM) && HAS_WARP_MERGE_SORT()
 #define RUN_MB(INDEX_T, DIM)                                              \
-  if (should_use_warp_topk(sliceSize, k)) {                               \
+  if (false && should_use_warp_topk(sliceSize, k)) {                               \
     RUN_K(INDEX_T, DIM, warptopk::launch);                                \
-  } else if (should_use_multiblock(numInputSlices, sliceSize)) {          \
+  } else if (false && should_use_multiblock(numInputSlices, sliceSize)) {          \
     RUN_K(INDEX_T, DIM, mbtopk::launch);                                  \
   } else {                                                                \
     RUN_K(INDEX_T, DIM, sbtopk::launch);                                  \
   }
 #else
 #define RUN_MB(INDEX_T, DIM)                                              \
-  if (should_use_multiblock(numInputSlices, sliceSize)) {                 \
+  if (false && should_use_multiblock(numInputSlices, sliceSize)) {                 \
     RUN_K(INDEX_T, DIM, mbtopk::launch);                                  \
   } else {                                                                \
     RUN_K(INDEX_T, DIM, sbtopk::launch);                                  \

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -1478,16 +1478,16 @@ void launch_gather_topk_kernel(
 
 #if defined(USE_ROCM) && HAS_WARP_MERGE_SORT()
 #define RUN_MB(INDEX_T, DIM)                                              \
-  if (false && should_use_warp_topk(sliceSize, k)) {                               \
+  if (should_use_warp_topk(sliceSize, k)) {                               \
     RUN_K(INDEX_T, DIM, warptopk::launch);                                \
-  } else if (false && should_use_multiblock(numInputSlices, sliceSize)) {          \
+  } else if (should_use_multiblock(numInputSlices, sliceSize)) {          \
     RUN_K(INDEX_T, DIM, mbtopk::launch);                                  \
   } else {                                                                \
     RUN_K(INDEX_T, DIM, sbtopk::launch);                                  \
   }
 #else
 #define RUN_MB(INDEX_T, DIM)                                              \
-  if (false && should_use_multiblock(numInputSlices, sliceSize)) {                 \
+  if (should_use_multiblock(numInputSlices, sliceSize)) {                 \
     RUN_K(INDEX_T, DIM, mbtopk::launch);                                  \
   } else {                                                                \
     RUN_K(INDEX_T, DIM, sbtopk::launch);                                  \


### PR DESCRIPTION
**Summary:**
This PR optimizes the `radixSelect` kernel on ROCm by removing unnecessary loop padding and making prefetching conditional. The previous implementation padded loop bounds to ensure all threads participate in warp-level operations, which added overhead. This does not seem necessary as other parts in PyTorch have not been doing it (see [example](https://github.com/pytorch/pytorch/blob/c8062c4fe279e840407ebf9e2457573498bee464/aten/src/ATen/native/cuda/TensorTopK.cu#L120)). Additionally, prefetching was always enabled even when accessing shared memory, where it provides no benefit and hurts performance by adding long dependency chains within the loop. This PR makes prefetching a compile-time conditional feature and removes the padding overhead.

**Previous Implementation:**
- Loop bounds were padded: `i < round_up(loopBound, warpSize)`
- Work was guarded: `if (i < loopBound) { ... }`
- Prefetching in `countRadixLoop` was always enabled, even for shared memory access

**Changes:**

* **Removed loop padding:**
  - Changed loop bounds from `round_up(loopBound, warpSize)` to `loopBound`
  - Removed `if (i < loopBound)` guards since padding is no longer needed

* **Conditional prefetching:**
  - Added `bool prefetch` template parameter to `countRadixLoop` function
  - Prefetching is enabled (`prefetch = true`) only for global memory access
  - Prefetching is disabled (`prefetch = false`) for shared memory access, where it hurts performance
  - Uses `if constexpr` for compile-time optimization, ensuring zero runtime overhead

**Performance:**
Measured on AMD MI350 (gfx950) using single-block TopK operator.
- **Overall average improvement:** ~2.4% across all tested configurations
- **By data type:**
  - float16: ~3.5% average improvement (best gains)
  - bfloat16: ~2.0% average improvement
  - float32: ~1.6% average improvement
- **By input size:**
  - Small inputs (10K and 100K elements): ~4.6% improvement
  - Medium inputs (1M elements): ~2.4% improvement
  - Large inputs (10M and 100M elements): ~0.2% improvement
- The optimization provides the greatest benefit on smaller inputs and half-precision types, where the overhead of padding and unnecessary prefetching has a larger relative impact. Although some regressions occur (primarily on float32 inputs), the overall impact remains positive across all data types, with float32 still achieving a 1.6% average improvement.


<img width="2311" height="1537" alt="topk_latency_comparison" src="https://github.com/user-attachments/assets/7210a6f7-da51-4bb5-acc3-ce60257ff6e9" />


**Testing:**
- Verified correctness across multiple data types (float32, float16, bfloat16) and input shapes
- Tested with various K values and input sizes to ensure correct behavior
- Confirmed that warp-level operations (`WARP_BALLOT`) work correctly without padding

**Benchmark code:**
See [benchmark.py](https://github.com/user-attachments/files/24484540/benchmark.py) for the performance measurement script.



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang