### PR TITLE
[Inductor][CUDA][TEST] Allow registration of `_register_woq_lowerings` without `mkldnn`

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -729,6 +729,10 @@ def lazy_init(input_device: Optional[torch.device] = None):
         from .mkldnn_fusion import _mkldnn_fusion_init
 
         _mkldnn_fusion_init()
+    else:
+        from .quantization import _register_woq_lowerings
+
+        _register_woq_lowerings()
 
     # Put this patterns in post-grad pass rather than joint-graph
     # pass since otherwise there will be perf/peak-memory regression:


### PR DESCRIPTION
Platforms such as GB200 (ARM-based) may not have mkldnn but this pass appears to work without it, otherwise tests such as `python test/inductor/test_gpu_select_algorithm.py TestSelectAlgorithmGpuCUDA.test_int8_woq_mm_concat_gpu_batch_size_1_mid_dim_1_in_features_128_out_features_64_cuda_bfloat16` fail.

Authored with Claude code

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jianyuh @raghuramank100 @jamesr66a @vkuzo @Xia-Weiwen @leslie-fang-intel