### PR TITLE
Handle unbacked SymInts in cross-ShapeEnv FakeTensor wrapping

### DIFF
--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -215,6 +215,7 @@ class Argument(_Union):
     as_nested_tensors: Annotated[list[list[TensorArgument]], 270]
     as_int_lists: Annotated[list[list[int]], 280]
     as_string_to_argument: Annotated[dict[str, "Argument"], 290]
+    as_arguments: Annotated[list["Argument"], 300]
 
 
 class ArgumentKind(IntEnum):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174905

When a HOP like `while_loop` internally calls `torch.compile`, Dynamo
creates a fresh FakeTensorMode with its own ShapeEnv. Input FakeTensors
from the outer compilation are then wrapped into this new mode via
cross-ShapeEnv wrapping in `sym_sizes_strides_storage_offset`. This
wrapping calls `_maybe_specialize_sym_int_with_hint` which extracts
the concrete hint from each SymInt to create corresponding symbols in
the new ShapeEnv.

This fails for unbacked SymInts (from data-dependent operations like
boolean indexing or nonzero) because they have no hint — raising
`GuardOnDataDependentSymNode`.

Fix: detect unbacked SymInts during cross-ShapeEnv wrapping and create
fresh unbacked SymInts in the target ShapeEnv, propagating the range
constraints and size-like marking from the original.

Fixes: https://github.com/pytorch/pytorch/issues/174876

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98