### PR TITLE
test: renamed custom operator in test_scheduling_with_multiple_mutates

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -1750,15 +1750,15 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
 
     @torch._inductor.config.patch(enable_auto_functionalized_v2=True)
     def test_scheduling_with_multiple_mutates(self):
-        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+        with torch.library._scoped_library("mylib_scheduling", "FRAGMENT") as lib:
             torch.library.define(
-                "mylib::foo",
+                "mylib_scheduling::foo",
                 "(Tensor! x, Tensor! y, Tensor z) -> ()",
                 tags=torch.Tag.pt2_compliant_tag,
                 lib=lib,
             )
 
-            @torch.library.impl("mylib::foo", "cpu", lib=lib)
+            @torch.library.impl("mylib_scheduling::foo", "cpu", lib=lib)
             @torch._dynamo.disable
             def foo(x, y, z):
                 pass
@@ -1766,9 +1766,9 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             def func(x, w):
                 a = torch.empty_like(x)  # buf0
                 b = torch.empty_like(x)  # buf1
-                torch.ops.mylib.foo(a, b, x)  # buf2, buf3, buf4
+                torch.ops.mylib_scheduling.foo(a, b, x)  # buf2, buf3, buf4
                 c = torch.mm(a, w)  # buf5
-                torch.ops.mylib.foo(c, b, x)  # buf6, buf7, buf8
+                torch.ops.mylib_scheduling.foo(c, b, x)  # buf6, buf7, buf8
                 return c
 
             input = torch.rand(2, 2)


### PR DESCRIPTION
The test was failing due to a naming collision with other tests in the same file that used the same `mylib::foo` name but with different signatures. Even with `_scoped_library`, some internal Inductor state (like schema normalization) was being leaked or improperly updated, leading to an `AssertionError`. Using a unique name resolves this.

This was the error I got when I ran the full suite:
```
"/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 1776, in test_scheduling_with_multiple_mutates
    [inductor_args, output, graph_inductor] = self.run_inductor(
                                              ^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 471, in run_inductor
    result = torch.compile(
             ^^^^^^^^^^^^^^
  File "/third_party/py/torch/_dynamo/eval_frame.py", line 1021, in compile_wrapper
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/_inductor/compile_fx.py", line 1046, in _compile_fx_inner
    raise InductorError(e, currentframe()).with_traceback(
  File "/third_party/py/torch/_inductor/compile_fx.py", line 1030, in _compile_fx_inner
    mb_compiled_graph = fx_codegen_and_compile(
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/_inductor/compile_fx.py", [line 1791, in fx_codegen_and_compile
    return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/_inductor/compile_fx.py", line 1478, in codegen_and_compile
    graph.run(*example_inputs)
  File "/third_party/py/torch/_inductor/graph.py", line 1021, in run
    return super().run(*args)
           ^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/fx/interpreter.py", line 200, in run
    self.env[node] = self.run_node(node)
                     ^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/_inductor/graph.py", line 1804, in run_node
    result = super().run_node(n)
             ^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/fx/interpreter.py", line 297, in run_node
    return getattr(self, n.op)(n.target, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/_inductor/graph.py", line 1413, in call_function
    raise LoweringException(
  File "/third_party/py/torch/_inductor/graph.py", line 1380, in call_function
    fake_args, fake_kwargs = normalize(fake_args, fake_kwargs)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/_inductor/graph.py", line 1377, in normalize
    assert result is not None
           ^^^^^^^^^^^^^^^^^^
torch._inductor.exc.InductorError: LoweringException: AssertionError: 
  target: mylib.foo.default
  args[0]: TensorBox(StorageBox(
    ComputedBuffer(name='buf0', layout=FixedLayout('cpu', torch.float32, size=[2, 2], stride=[2, 1]), data=Pointwise(
      'cpu',
      torch.float32,
      def inner_fn(index):
          i0, i1 = index
          tmp0 = ops.constant(0, torch.float32)
          return tmp0
      ,
      ranges=[0, 0],
      origin_node=empty,
      origins=OrderedSet([empty]),
      stack_traces = {,
        File "/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 1767, in func,
          a = torch.empty_like(x)  # buf0,
      ,
      }
    ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
  ))
  args[1]: TensorBox(StorageBox(
    ComputedBuffer(name='buf1', layout=FixedLayout('cpu', torch.float32, size=[2, 2], stride=[2, 1]), data=Pointwise(
      'cpu',
      torch.float32,
      def inner_fn(index):
          i0, i1 = index
          tmp0 = ops.constant(0, torch.float32)
          return tmp0
      ,
      ranges=[0, 0],
      origin_node=empty_1,
      origins=OrderedSet([empty_1]),
      stack_traces = {,
        File "/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 1768, in func,
          b = torch.empty_like(x)  # buf1,
      ,
      }
    ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
  ))
  args[2]: TensorBox(StorageBox(
    InputBuffer(name='arg0_1', layout=FixedLayout('cpu', torch.float32, size=[2, 2], stride=[2, 1]))
  ))AssertionError: 
  target: mylib.foo.default
  args[0]: TensorBox(StorageBox(
    ComputedBuffer(name='buf0', layout=FixedLayout('cpu', torch.float32, size=[2, 2], stride=[2, 1]), data=Pointwise(
      'cpu',
      torch.float32,
      def inner_fn(index):
          i0, i1 = index
          tmp0 = ops.constant(0, torch.float32)
          return tmp0
      ,
      ranges=[0, 0],
      origin_node=empty,
      origins=OrderedSet([empty]),
      stack_traces = {,
        File "/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 1767, in func,
          a = torch.empty_like(x)  # buf0,
      ,
      }
    ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
  ))
  args[1]: TensorBox(StorageBox(
    ComputedBuffer(name='buf1', layout=FixedLayout('cpu', torch.float32, size=[2, 2], stride=[2, 1]), data=Pointwise(
      'cpu',
      torch.float32,
      def inner_fn(index):
          i0, i1 = index
          tmp0 = ops.constant(0, torch.float32)
          return tmp0
      ,
      ranges=[0, 0],
      origin_node=empty_1,
      origins=OrderedSet([empty_1]),
      stack_traces = {,
        File "/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 1768, in func,
          b = torch.empty_like(x)  # buf1,
      ,
      }
    ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
  ))
  args[2]: TensorBox(StorageBox(
    InputBuffer(name='arg0_1', layout=FixedLayout('cpu', torch.float32, size=[2, 2], stride=[2, 1]))
  ))
Found from : 
   File "/third_party/py/torch/test/inductor/test_auto_functionalize.py", line 1769, in func
    torch.ops.mylib.foo(a, b, x)  # buf2, buf3, buf4


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo