### PR TITLE
Add Store::barrier API and TCPStore client BARRIER support to reduce sync round trips

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -261,6 +261,13 @@ class StoreTestBase:
         self.assertIn("foo", keys)
         self.assertIn("baz", keys)
 
+    def _test_barrier(self, store):
+        # Barrier with world_size=1 should return immediately
+        store.barrier("test_barrier_key", 1)
+
+    def test_barrier(self):
+        self._test_barrier(self._create_store())
+
     # This is the number of keys used in test_set_get. Adding this as a class
     # property instead of hardcoding in the test since some Store
     # implementations will have differing number of keys. In the base case,
@@ -641,6 +648,42 @@ class TCPStoreTest(TestCase, StoreTestBase):
         del os.environ[MASTER_PORT]
 
         self.assertEqual(second_server.port, store.port)
+
+    def test_barrier(self):
+        store = self._create_store()
+        # Single worker barrier should return immediately
+        store.barrier("test_barrier_key", 1)
+
+    def test_barrier_with_timeout(self):
+        store = self._create_store()
+        store.barrier("test_barrier_timeout_key", 1, timedelta(seconds=10))
+
+    def test_barrier_timeout_expires(self):
+        store = self._create_store()
+        with self.assertRaisesRegex(DistStoreError, "barrier timeout"):
+            store.barrier("test_barrier_fail", 2, timedelta(seconds=0.1))
+
+    def test_barrier_multi_worker(self):
+        server_store = self._create_store()
+        world_size = 4
+
+        def worker(rank):
+            if rank == 0:
+                worker_store = server_store
+            else:
+                worker_store = dist.TCPStore(
+                    host_name=server_store.host,
+                    port=server_store.port,
+                    is_master=False,
+                    wait_for_workers=False,
+                    use_libuv=self._use_libuv,
+                )
+            worker_store.barrier("multi_barrier", world_size, timedelta(seconds=10))
+
+        with ThreadPoolExecutor(max_workers=world_size) as pool:
+            futures = [pool.submit(worker, i) for i in range(world_size)]
+            for f in futures:
+                f.result()
 
 
 class LibUvTCPStoreTest(TCPStoreTest):

--- a/torch/csrc/distributed/c10d/Store.cpp
+++ b/torch/csrc/distributed/c10d/Store.cpp
@@ -66,4 +66,20 @@ bool Store::hasExtendedApi() const {
   return false;
 }
 
+void Store::barrier(
+    const std::string& key,
+    int64_t world_size,
+    const std::chrono::milliseconds& timeout) {
+  // Default implementation using add() + wait() pattern.
+  // Subclasses can override this with optimized implementations.
+  std::string numMembersKey = key + "/num_members";
+  std::string lastMemberKey = key + "/last_member";
+
+  int64_t idx = add(numMembersKey, 1);
+  if (idx == world_size) {
+    set(lastMemberKey, std::vector<uint8_t>{'1'});
+  }
+  wait({lastMemberKey}, timeout);
+}
+
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -119,6 +119,19 @@ class TORCH_API Store : public torch::CustomClassHolder {
         NotImplementedError, "listKeys support is not implemented.");
   }
 
+  // Barrier operation that blocks until world_size workers have reached it.
+  // This is an optimized operation that combines increment and wait into a
+  // single operation, reducing network round trips compared to using
+  // separate add() and wait() calls.
+  virtual void barrier(
+      const std::string& key,
+      int64_t world_size,
+      const std::chrono::milliseconds& timeout);
+
+  void barrier(const std::string& key, int64_t world_size) {
+    barrier(key, world_size, timeout_);
+  }
+
  protected:
   std::chrono::milliseconds timeout_;
 };

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -123,6 +123,11 @@ class TORCH_API TCPStore : public Store {
 
   std::vector<std::string> listKeys() override;
 
+  void barrier(
+      const std::string& key,
+      int64_t world_size,
+      const std::chrono::milliseconds& timeout) override;
+
   // Waits for all workers to join.
   void waitForWorkers();
 

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
@@ -37,6 +37,7 @@ enum class QueryType : uint8_t {
   QUEUE_POP,
   QUEUE_LEN,
   LIST_KEYS,
+  BARRIER,
 };
 
 enum class CheckResponseType : uint8_t { READY, NOT_READY };


### PR DESCRIPTION
Summary:
## LLM-generated Summary:
Add a barrier operation to the c10d Store interface with a default add+wait fallback, and implement TCPStore client-side support that issues a single BARRIER request with timeout/cancel handling. Define the BARRIER query type and backend hook to enable server-side optimization, reducing synchronization round trips versus the existing ADD+WAIT pattern.
---
Session: DEV63071792

Test Plan:
Added unit tests, CI

New feature

Differential Revision: D93159107


