### PR TITLE
Fix cutlass import error

### DIFF
--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -43,7 +43,7 @@ def move_cutlass_compiled_cache() -> None:
 
     try:
         import cutlass_cppgen  # type: ignore[import-not-found]
-    except ImportError as e:
+    except ImportError:
         return
 
     # Check if the CACHE_FILE attribute exists in cutlass_cppgen and if the file exists

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -38,7 +38,7 @@ XW_DTYPES: OrderedSet[torch.dtype] = OrderedSet(
 @atexit.register
 def move_cutlass_compiled_cache() -> None:
     """Move CUTLASS compiled cache file to the cache directory if it exists."""
-    if not try_import_cutlass.cache_info().currsize > 0:
+    if try_import_cutlass.cache_info().currsize == 0 or not try_import_cutlass():
         return
 
     import cutlass_cppgen  # type: ignore[import-not-found]

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -38,10 +38,13 @@ XW_DTYPES: OrderedSet[torch.dtype] = OrderedSet(
 @atexit.register
 def move_cutlass_compiled_cache() -> None:
     """Move CUTLASS compiled cache file to the cache directory if it exists."""
-    if try_import_cutlass.cache_info().currsize == 0 or not try_import_cutlass():
+    if try_import_cutlass.cache_info().currsize == 0:
         return
 
-    import cutlass_cppgen  # type: ignore[import-not-found]
+    try:
+        import cutlass_cppgen  # type: ignore[import-not-found]
+    except ImportError as e:
+        return
 
     # Check if the CACHE_FILE attribute exists in cutlass_cppgen and if the file exists
     if not hasattr(cutlass_cppgen, "CACHE_FILE") or not os.path.exists(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174938
* __->__ #174924

FIXES https://github.com/pytorch/pytorch/issues/110040

functools cache can cache False, and current logic incorrectly thinks cutlass is available

```python
(/home/xmfan/vibe/pytorch-3/.venv) [15:52:58] ~/vibe/pytorch-3 ((HEAD detached from 5308b2dbf20)) > gd
diff --git a/torch/_inductor/codegen/cutlass/utils.py b/torch/_inductor/codegen/cutlass/utils.py
index ba55d2ee663..6ad08392743 100644
--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -71,6 +71,7 @@ def _rename_cutlass_import(content: str, cutlass_modules: list[str]) -> str:
 
 @functools.cache
 def try_import_cutlass() -> bool:
+    return False
     """
     We want to support three ways of passing in CUTLASS:
     1. fbcode, handled by the internal build system.
(/home/xmfan/vibe/pytorch-3/.venv) [15:53:05] ~/vibe/pytorch-3 ((HEAD detached from 5308b2dbf20)) > python
Python 3.12.12 | packaged by Anaconda, Inc. | (main, Oct 21 2025, 20:16:04) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from torch._inductor.codegen.cutlass.utils import try_import_cutlass
WARNING:torch.utils.flop_counter:triton not found; flop counting will not work for triton kernels
>>> try_import_cutlass()
False
>>> try_import_cutlass.cache_info().currsize
1
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo