### PR TITLE
[DTensor] support Partial input for matmul in single-dim registration

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -586,30 +586,32 @@ class DistMatrixOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_mm_partial_inputs_non_single_dim(self):
-        # When inputs have only Partial placements (no Shard), the single-dim
-        # strategy should still consider Shard as a redistribution target.
-        # Partial -> Shard (reduce-scatter) is cheaper than Partial -> Replicate
-        # (all-reduce).
+    def test_mm_partial_inputs(self):
+        # mm with Partial inputs should produce Partial output via per-input
+        # linearity, for both the default and single-dim strategy paths.
         device_mesh = self.build_device_mesh()
-        dt1 = DTensor.from_local(torch.randn(16, 12, device=self.device_type), device_mesh, [Partial()], run_check=False)
-        dt2 = DTensor.from_local(torch.randn(12, 20, device=self.device_type), device_mesh, [Partial()], run_check=False)
-        dist_res = torch.mm(dt1, dt2)
-        self.assertEqual(dist_res.placements, (Partial(),))
 
-    @with_comms
-    @skip_unless_torch_gpu
-    def test_mm_partial_inputs_single_dim(self):
-        # When inputs have only Partial placements (no Shard), the single-dim
-        # strategy should still consider Shard as a redistribution target.
-        # Partial -> Shard (reduce-scatter) is cheaper than Partial -> Replicate
-        # (all-reduce).
+        def _run_mm():
+            dt1 = DTensor.from_local(
+                torch.randn(16, 12, device=self.device_type),
+                device_mesh,
+                [Partial()],
+                run_check=False,
+            )
+            dt2 = DTensor.from_local(
+                torch.randn(12, 20, device=self.device_type),
+                device_mesh,
+                [Partial()],
+                run_check=False,
+            )
+            dist_res = torch.mm(dt1, dt2)
+            self.assertEqual(dist_res.placements, (Partial(),))
+
+        # Default (non-single-dim) strategy path
+        _run_mm()
+        # Single-dim strategy path
         register_single_dim_strategy(torch.ops.aten.mm.default)(mm_single_dim_strategy)
-        device_mesh = self.build_device_mesh()
-        dt1 = DTensor.from_local(torch.randn(16, 12, device=self.device_type), device_mesh, [Partial()], run_check=False)
-        dt2 = DTensor.from_local(torch.randn(12, 20, device=self.device_type), device_mesh, [Partial()], run_check=False)
-        dist_res = torch.mm(dt1, dt2)
-        self.assertEqual(dist_res.placements, (Partial(),))
+        _run_mm()
 
     @with_comms
     @skip_unless_torch_gpu

--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -452,9 +452,10 @@ class TestExpandPlaceholder(TestCase):
         )
         assert isinstance(strategy, OpStrategy)
 
-        # For a 3D mesh with 4 single-dim strategies (3 explicit + 1 implicit replicate),
-        # we should have 4^3 = 64 strategies maximum
-        self.assertEqual(len(strategy.strategies), 64)
+        # For a 3D mesh with 8 single-dim strategies per mesh dim
+        # (3 sharding + 4 per-input linearity + 1 implicit replicate),
+        # we get 8^3 = 512 strategy combinations.
+        self.assertEqual(len(strategy.strategies), 512)
 
         all_replicate_found = False
         shard_0_found = False
@@ -533,9 +534,15 @@ class TestExpandPlaceholder(TestCase):
         )
 
         # Test Case 1: All-replicate inputs - no sharding expansion
-        # Expected: Only implicit all-replicate rule (no sharding builders available)
+        # Expected: The implicit all-replicate rule plus the per-input linearity
+        # strategies (which have no placeholders and pass through unchanged).
+        # Strategies with placeholders are dropped since there are no shard builders.
         expected_replicate = [
-            [Replicate(), Replicate(), Replicate()],  # Implicit all-replicate
+            [Replicate(), Replicate(), Replicate()],
+            [Partial("sum"), Partial("sum"), Replicate()],
+            [Partial("sum"), Replicate(), Partial("sum")],
+            [Partial("avg"), Partial("avg"), Replicate()],
+            [Partial("avg"), Replicate(), Partial("avg")],
         ]
         single_dim_strategies = _insert_single_dim_replication_strategy(
             single_dim_strategies, num_outputs=1, num_input_tensors=2
@@ -547,12 +554,17 @@ class TestExpandPlaceholder(TestCase):
         self.assertEqual(expanded_replicate, expected_replicate)
 
         # Test Case 2: (_Strided)Shard-only inputs - only (_Strided)Shard expansion
-        # Expected: 3 strategies with placeholders filled using (_Strided)Shard + implicit replicate
+        # Expected: 3 strategies with placeholders filled using (_Strided)Shard,
+        # plus the per-input linearity strategies (no placeholders), plus implicit replicate
         expected_shard = [
             [Replicate(), Replicate(), Replicate()],
             [Partial(), Shard(1), Shard(0)],
             [Shard(0), Shard(0), Replicate()],
             [Shard(1), Replicate(), Shard(1)],
+            [Partial("sum"), Partial("sum"), Replicate()],
+            [Partial("sum"), Replicate(), Partial("sum")],
+            [Partial("avg"), Partial("avg"), Replicate()],
+            [Partial("avg"), Replicate(), Partial("avg")],
         ]
 
         expanded_shard = _fill_single_dim_strategy_placeholders(
@@ -592,6 +604,11 @@ class TestExpandPlaceholder(TestCase):
                 Replicate(),
                 _StridedShard(dim=1, split_factor=4),
             ],
+            # Per-input linearity strategies (no placeholders, pass through unchanged)
+            [Partial("sum"), Partial("sum"), Replicate()],
+            [Partial("sum"), Replicate(), Partial("sum")],
+            [Partial("avg"), Partial("avg"), Replicate()],
+            [Partial("avg"), Replicate(), Partial("avg")],
         ]
         expanded_strided_shard = _fill_single_dim_strategy_placeholders(
             {
@@ -603,7 +620,8 @@ class TestExpandPlaceholder(TestCase):
         self.assertEqual(expanded_strided_shard, expected_strided_shard)
 
         # Test Case 3: Mixed Shard and _StridedShard inputs - both types of expansion
-        # Expected: 3 strategies * 2 shard types (Shard and _StridedShard) + implicit replicate
+        # Expected: 3 strategies * 2 shard types (Shard and _StridedShard),
+        # plus per-input linearity strategies, plus implicit replicate
         expected_mixed = [
             [Replicate(), Replicate(), Replicate()],
             [Partial(), Shard(1), Shard(0)],
@@ -624,6 +642,11 @@ class TestExpandPlaceholder(TestCase):
                 Replicate(),
                 _StridedShard(1, split_factor=2),
             ],
+            # Per-input linearity strategies (no placeholders, pass through unchanged)
+            [Partial("sum"), Partial("sum"), Replicate()],
+            [Partial("sum"), Replicate(), Partial("sum")],
+            [Partial("avg"), Partial("avg"), Replicate()],
+            [Partial("avg"), Replicate(), Partial("avg")],
         ]
 
         expanded_mixed = _fill_single_dim_strategy_placeholders(

--- a/torch/distributed/tensor/_ops/_einsum_strategy.py
+++ b/torch/distributed/tensor/_ops/_einsum_strategy.py
@@ -132,6 +132,12 @@ def gen_einsum_strategies(
         strategies_over_one_mesh_dim.append(placement_list)
 
     # split contracting dim
+    # NOTE: This is the only strategy that produces a Partial output, and it
+    # hardcodes Partial("sum"). No strategy accepts Partial as an input
+    # placement, so Partial inputs are always redistributed to Shard or
+    # Replicate. This means Partial("avg") inputs cannot be preserved through
+    # the op. Use gen_single_dim_einsum_strategies with per-input linearity
+    # for proper Partial support.
     for contracting_dim in edims.contracting_dims:
         # Contracting dim can shard on same device axis for both inputs. This
         # results in the output being Partial on that device axis. For example:

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -411,6 +411,14 @@ def gen_single_dim_einsum_strategies(
             linearity_placement_list.append(Partial())
         strategies_over_one_mesh_dim.append(_maybe_add_bias(linearity_placement_list))
 
+    # Per-input linearity: einsum is linear in each input individually.
+    # For each input, keep it Partial while replicating others → output Partial.
+    for i in range(len(input_dims)):
+        placement_list = [Partial()]
+        for j in range(len(input_dims)):
+            placement_list.append(Partial() if j == i else Replicate())
+        strategies_over_one_mesh_dim.append(_maybe_add_bias(placement_list))
+
     return strategies_over_one_mesh_dim
 
 

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -413,11 +413,14 @@ def gen_single_dim_einsum_strategies(
 
     # Per-input linearity: einsum is linear in each input individually.
     # For each input, keep it Partial while replicating others → output Partial.
-    for i in range(len(input_dims)):
-        placement_list = [Partial()]
-        for j in range(len(input_dims)):
-            placement_list.append(Partial() if j == i else Replicate())
-        strategies_over_one_mesh_dim.append(_maybe_add_bias(placement_list))
+    for reduce_op in Partial.LINEAR_REDUCE_OPS:
+        for i in range(len(input_dims)):
+            placement_list: list[Placement | _ShardingPlaceholder] = [
+                Partial(reduce_op)
+            ]
+            for j in range(len(input_dims)):
+                placement_list.append(Partial(reduce_op) if j == i else Replicate())
+            strategies_over_one_mesh_dim.append(_maybe_add_bias(placement_list))
 
     return strategies_over_one_mesh_dim
 

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -1133,6 +1133,10 @@ class Replicate(torch._C._distributed.Replicate):
 
 
 class Partial(torch._C._distributed.Partial):
+    # reduce_ops that distribute over addition, enabling per-input linearity
+    # for bilinear ops like mm: reduce_op(A_i @ B) = reduce_op(A_i) @ B
+    LINEAR_REDUCE_OPS: tuple[str, ...] = ("sum", "avg")
+
     """
     The ``Partial(reduce_op)`` placement describes the DTensor that is pending
     reduction on a specified ``DeviceMesh`` dimension, where each rank on the


### PR DESCRIPTION
 without the fix, the situation is like this: pytest -s test/distributed/tensor/test_matrix_ops.py -k mm_partial_inputs
```
  # input src placement: dt1 = Partial, dt2 = Partial
  # input tgt placement: dt1 = Partial, dt2 = Replicate or dt1 = Replicate, dt2 = Partial                                                                                                                                                                                           
  # output placement                                                                                                                                                                                                                        
  #     dist_res = Partial in non-single-dim code path
  #     dist_res = Replicate in single-dim code path
  dist_res = torch.mm(dt1, dt2)
```

adding 4 missing rules
```

  ┌──────────────────┬─────────────────────────────────────────────────────────────────┐
  │       Rule       │                          Why it works                           │                                           
  ├──────────────────┼─────────────────────────────────────────────────────────────────┤
  │ P(sum),R->P(sum) │ mm is linear in the first arg: Σ(A_r @ B) = (ΣA_r) @ B = A @ B  │
  ├──────────────────┼─────────────────────────────────────────────────────────────────┤
  │ R,P(sum)->P(sum) │ mm is linear in the second arg: Σ(A @ B_r) = A @ (ΣB_r) = A @ B │
  ├──────────────────┼─────────────────────────────────────────────────────────────────┤
  │ P(avg),R->P(avg) │ Same linearity, avg scaling cancels out                         │
  ├──────────────────┼─────────────────────────────────────────────────────────────────┤
  │ R,P(avg)->P(avg) │ Same linearity, avg scaling cancels out                         │
  └──────────────────┴─────────────────────────────────────────────────────────────────┘
```

this would unblock https://github.com/pytorch/pytorch/pull/172385

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174926