### PR TITLE
[DTensor] Support force mode in ExplicitRedistribution

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -222,7 +222,11 @@ class OpDispatcher:
         try:
             # We have basically inlined propagate() here, but WITHOUT the
             # output_sharding assignment
-            if try_cache and not _are_we_tracing():
+            if (
+                try_cache
+                and not _are_we_tracing()
+                and not ExplicitRedistributionContext.is_force_mode()
+            ):
                 result = self.sharding_propagator.propagate_op_sharding(op_info.schema)
             else:
                 result = self.sharding_propagator.propagate_op_sharding_non_cached(


### PR DESCRIPTION
Motivation: ExplicitRedistribution doesn't force a strategy decision if the strategy is possible. Instead DTensor still pick the min cost strategy and gives warning if redistribution is needed. However, User can have a global view on how the sharding should be and want to force the strategy picking.

This PR adds a `force` mode to ExplicitRedistribution to force a strategy choice instead of using the min cost strategy. It will error out if no such strategy exists.


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #174932
* __->__ #174931

Authored by Claude

