### PR TITLE
[DTensor] Cache for ExplicitRedistribution force mode

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -222,11 +222,7 @@ class OpDispatcher:
         try:
             # We have basically inlined propagate() here, but WITHOUT the
             # output_sharding assignment
-            if (
-                try_cache
-                and not _are_we_tracing()
-                and not ExplicitRedistributionContext.is_force_mode()
-            ):
+            if try_cache and not _are_we_tracing():
                 result = self.sharding_propagator.propagate_op_sharding(op_info.schema)
             else:
                 result = self.sharding_propagator.propagate_op_sharding_non_cached(


### PR DESCRIPTION
With `force` mode, sharding propagator can potentially choose a different strategy. We need to encoding the context var into the sharding key.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174932
* #174931

Authored by Claude