### PR TITLE
[distributed] Chunk large batch_isend_irecv to avoid NCCL hangs

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -5356,6 +5356,44 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
 
     @requires_nccl()
     @skip_if_lt_x_gpu(4)
+    @parametrize("chunk_size", [0, 2, 10])
+    def test_batch_send_recv_chunked(self, chunk_size):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl", store=store, rank=self.rank, world_size=self.world_size
+        )
+        device = torch.device(f"cuda:{self.rank}")
+        torch.cuda.set_device(device)
+
+        num_ops = 20
+        ops = []
+        recv_tensors = []
+        for i in range(num_ops):
+            peer = (self.rank + 1) % self.world_size
+            send_t = torch.full(
+                (10,), self.rank * 100 + i, device=device, dtype=torch.float32
+            )
+            ops.append(c10d.P2POp(dist.isend, send_t, peer))
+            recv_t = torch.zeros(10, device=device, dtype=torch.float32)
+            recv_peer = (self.rank - 1 + self.world_size) % self.world_size
+            ops.append(c10d.P2POp(dist.irecv, recv_t, recv_peer))
+            recv_tensors.append((recv_t, recv_peer, i))
+
+        with mock.patch.dict(
+            os.environ,
+            {"TORCH_NCCL_BATCH_P2P_CHUNK_SIZE": str(chunk_size)},
+        ):
+            for work in dist.batch_isend_irecv(ops):
+                work.wait()
+
+        for recv_t, recv_peer, i in recv_tensors:
+            expected = torch.full(
+                (10,), recv_peer * 100 + i, device=device, dtype=torch.float32
+            )
+            self.assertEqual(recv_t, expected)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
     @parametrize("group_rank", [True, False])
     def test_broadcast_subgroup(self, group_rank):
         world_size = 4

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -5394,6 +5394,55 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
 
     @requires_nccl()
     @skip_if_lt_x_gpu(4)
+    @parametrize("chunk_size", [0, 2, 10])
+    def test_batch_send_recv_chunked_multipeer(self, chunk_size):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl", store=store, rank=self.rank, world_size=self.world_size
+        )
+        device = torch.device(f"cuda:{self.rank}")
+        torch.cuda.set_device(device)
+
+        world_size = min(self.world_size, 4)
+        if self.rank >= world_size:
+            return
+
+        num_msgs_per_peer = 5
+        ops = []
+        recv_tensors = []
+        for peer in range(world_size):
+            if peer == self.rank:
+                continue
+            for i in range(num_msgs_per_peer):
+                send_t = torch.full(
+                    (10,),
+                    self.rank * 1000 + peer * 100 + i,
+                    device=device,
+                    dtype=torch.float32,
+                )
+                ops.append(c10d.P2POp(dist.isend, send_t, peer))
+                recv_t = torch.zeros(10, device=device, dtype=torch.float32)
+                ops.append(c10d.P2POp(dist.irecv, recv_t, peer))
+                recv_tensors.append((recv_t, peer, i))
+
+        with mock.patch.dict(
+            os.environ,
+            {"TORCH_NCCL_BATCH_P2P_CHUNK_SIZE": str(chunk_size)},
+        ):
+            for work in dist.batch_isend_irecv(ops):
+                work.wait()
+
+        for recv_t, peer, i in recv_tensors:
+            expected = torch.full(
+                (10,),
+                peer * 1000 + self.rank * 100 + i,
+                device=device,
+                dtype=torch.float32,
+            )
+            self.assertEqual(recv_t, expected)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
     @parametrize("group_rank", [True, False])
     def test_broadcast_subgroup(self, group_rank):
         world_size = 4

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3035,6 +3035,13 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
         this API call; otherwise, the behavior is undefined. If this API call is
         not the first collective call in the ``group``, batched P2P operations
         involving only a subset of ranks of the ``group`` are allowed.
+
+    .. note:: When using the NCCL backend with a large number of P2P operations,
+        operations are automatically split into smaller groups sorted by peer
+        rank to avoid NCCL internal hangs (default threshold: 256 ops).
+        Set ``TORCH_NCCL_BATCH_P2P_CHUNK_SIZE`` to override the threshold
+        or to ``0`` to disable chunking and revert to the legacy single-group
+        behaviour.
     """
     _check_p2p_op_list(p2p_op_list)
     group = p2p_op_list[0].group
@@ -3047,6 +3054,12 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
         return {key: op.group_peer}
 
     if type(group) is ProcessGroup and group._get_backend(device).supports_coalescing:
+        chunk_size = int(os.environ.get("TORCH_NCCL_BATCH_P2P_CHUNK_SIZE", 256))
+        if chunk_size > 0 and len(p2p_op_list) > chunk_size:
+            return _chunked_batch_p2p(
+                p2p_op_list, group, device, chunk_size, peer_kwarg
+            )
+
         # NCCL style coalescing
         with _coalescing_manager(group, device, async_ops=True) as cm:
             for p2p_op in p2p_op_list:
@@ -3071,6 +3084,41 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
             if work:
                 reqs.append(work)
         return reqs
+
+
+def _chunked_batch_p2p(
+    p2p_op_list: list[P2POp],
+    group: ProcessGroup,
+    device: torch.device,
+    chunk_size: int,
+    peer_kwarg: Callable[[P2POp], dict[str, int]],
+) -> list[Work]:
+    """Split P2P ops by peer rank and further chunk to avoid NCCL hangs.
+
+    Groups operations by peer rank (sorted), then splits each peer group into
+    chunks of at most ``chunk_size``. Each chunk is issued as a separate
+    coalescing group.  The per-peer grouping ensures that matching send/recv
+    pairs on communicating ranks are in corresponding chunks, avoiding deadlocks
+    from cross-peer circular dependencies on the CUDA stream.
+    """
+    ops_by_peer: dict[int, list[P2POp]] = {}
+    for op in p2p_op_list:
+        ops_by_peer.setdefault(op.peer, []).append(op)
+
+    all_works: list[Work] = []
+    for _peer, ops in sorted(ops_by_peer.items()):
+        for i in range(0, len(ops), chunk_size):
+            chunk = ops[i : i + chunk_size]
+            with _coalescing_manager(group, device, async_ops=True) as cm:
+                for p2p_op in chunk:
+                    p2p_op.op(
+                        p2p_op.tensor,
+                        group=p2p_op.group,
+                        tag=p2p_op.tag,
+                        **peer_kwarg(p2p_op),
+                    )
+            all_works.extend(cm.works)
+    return all_works
 
 
 def _is_fp8(tensor):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3090,18 +3090,40 @@ def _chunked_batch_p2p(
     device: torch.device,
     peer_kwarg: Callable[[P2POp], dict[str, int]],
 ) -> list[Work]:
-    """Split P2P ops into separate coalescing groups per peer rank.
+    """Split P2P ops into round-robin tournament rounds.
 
-    Groups operations by peer rank (sorted) and issues each group as a
-    separate coalescing call.  This prevents NCCL's internal plan splitting
-    from diverging across ranks when multiple peers are batched together.
+    Uses a round-robin tournament schedule so that in each round,
+    communicating rank pairs are matched on both sides.  This avoids
+    NCCL plan-splitting divergence while preventing hotspots and
+    deadlocks.
     """
     ops_by_peer: dict[int, list[P2POp]] = {}
     for op in p2p_op_list:
         ops_by_peer.setdefault(op.peer, []).append(op)
 
+    my_rank = group.rank()
+
+    # Build round-robin tournament schedule (circle method).
+    participants = sorted(set(ops_by_peer.keys()) | {my_rank})
+    n = len(participants)
+    if n % 2 == 1:
+        participants.append(-1)
+        n += 1
+
+    rank_to_idx = {r: i for i, r in enumerate(participants)}
+    my_idx = rank_to_idx[my_rank]
+
     all_works: list[Work] = []
-    for _peer, ops in sorted(ops_by_peer.items()):
+    for round_num in range(n - 1):
+        circle = [0] + [1 + (round_num + i) % (n - 1) for i in range(n - 1)]
+        my_pos = circle.index(my_idx)
+        partner_idx = circle[n - 1 - my_pos]
+        partner_rank = participants[partner_idx]
+
+        if partner_rank == -1 or partner_rank not in ops_by_peer:
+            continue
+
+        ops = ops_by_peer[partner_rank]
         with _coalescing_manager(group, device, async_ops=True) as cm:
             for p2p_op in ops:
                 p2p_op.op(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3037,11 +3037,11 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
         involving only a subset of ranks of the ``group`` are allowed.
 
     .. note:: When using the NCCL backend with a large number of P2P operations,
-        operations are automatically split into smaller groups sorted by peer
-        rank to avoid NCCL internal hangs (default threshold: 256 ops).
-        Set ``TORCH_NCCL_BATCH_P2P_CHUNK_SIZE`` to override the threshold
-        or to ``0`` to disable chunking and revert to the legacy single-group
-        behaviour.
+        operations are automatically grouped by peer rank into separate
+        coalescing groups to avoid NCCL internal hangs (default threshold:
+        256 ops).  Set ``TORCH_NCCL_BATCH_P2P_CHUNK_SIZE`` to override the
+        threshold or to ``0`` to disable grouping and revert to the legacy
+        single-group behaviour.
     """
     _check_p2p_op_list(p2p_op_list)
     group = p2p_op_list[0].group
@@ -3056,9 +3056,7 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
     if type(group) is ProcessGroup and group._get_backend(device).supports_coalescing:
         chunk_size = int(os.environ.get("TORCH_NCCL_BATCH_P2P_CHUNK_SIZE", 256))
         if chunk_size > 0 and len(p2p_op_list) > chunk_size:
-            return _chunked_batch_p2p(
-                p2p_op_list, group, device, chunk_size, peer_kwarg
-            )
+            return _chunked_batch_p2p(p2p_op_list, group, device, peer_kwarg)
 
         # NCCL style coalescing
         with _coalescing_manager(group, device, async_ops=True) as cm:
@@ -3090,16 +3088,13 @@ def _chunked_batch_p2p(
     p2p_op_list: list[P2POp],
     group: ProcessGroup,
     device: torch.device,
-    chunk_size: int,
     peer_kwarg: Callable[[P2POp], dict[str, int]],
 ) -> list[Work]:
-    """Split P2P ops by peer rank and further chunk to avoid NCCL hangs.
+    """Split P2P ops into separate coalescing groups per peer rank.
 
-    Groups operations by peer rank (sorted), then splits each peer group into
-    chunks of at most ``chunk_size``. Each chunk is issued as a separate
-    coalescing group.  The per-peer grouping ensures that matching send/recv
-    pairs on communicating ranks are in corresponding chunks, avoiding deadlocks
-    from cross-peer circular dependencies on the CUDA stream.
+    Groups operations by peer rank (sorted) and issues each group as a
+    separate coalescing call.  This prevents NCCL's internal plan splitting
+    from diverging across ranks when multiple peers are batched together.
     """
     ops_by_peer: dict[int, list[P2POp]] = {}
     for op in p2p_op_list:
@@ -3107,17 +3102,15 @@ def _chunked_batch_p2p(
 
     all_works: list[Work] = []
     for _peer, ops in sorted(ops_by_peer.items()):
-        for i in range(0, len(ops), chunk_size):
-            chunk = ops[i : i + chunk_size]
-            with _coalescing_manager(group, device, async_ops=True) as cm:
-                for p2p_op in chunk:
-                    p2p_op.op(
-                        p2p_op.tensor,
-                        group=p2p_op.group,
-                        tag=p2p_op.tag,
-                        **peer_kwarg(p2p_op),
-                    )
-            all_works.extend(cm.works)
+        with _coalescing_manager(group, device, async_ops=True) as cm:
+            for p2p_op in ops:
+                p2p_op.op(
+                    p2p_op.tensor,
+                    group=p2p_op.group,
+                    tag=p2p_op.tag,
+                    **peer_kwarg(p2p_op),
+                )
+        all_works.extend(cm.works)
     return all_works
 
 


### PR DESCRIPTION
NCCL can hang when a single `ncclGroupStart/End` pair contains a large number of P2P operations because its internal budget-based plan splitting can diverge across ranks, placing matching send/recv ops in different sequential kernel launches.

When the number of ops exceeds a threshold (default 256, configurable via `TORCH_NCCL_BATCH_P2P_CHUNK_SIZE`, 0 to disable), `batch_isend_irecv` now splits operations using a **round-robin tournament schedule** (circle method). In each round, ranks are paired symmetrically — if rank A talks to rank B, rank B also talks to rank A — so matching send/recv operations always land in the same step.

This approach addresses the review feedback on the original per-peer sorted grouping:
- **No hotspots**: Each round pairs different ranks, so no single peer is overwhelmed by all ranks simultaneously.
- **No deadlocks**: Symmetric pairing guarantees matching NCCL operations are in the same step (a naive per-rank rotation was shown to deadlock due to circular waits).
- **Better bandwidth utilization**: Multiple non-overlapping rank pairs communicate simultaneously within each round (e.g., rank 0↔1 and rank 2↔3), utilizing bandwidth across multiple links.
- **Odd GPU counts**: Handled via a dummy "bye" participant — one rank sits idle per round while the rest communicate.

Confirmed experimentally that the hang is multi-peer only — 2000 ops to a single peer completes fine. See discussion in #174288.

Tested on 8x H200 with `torchrun` across GPU counts 3, 4, 5, 7, 8 (both even and odd), with `chunk_size` values 0 (disabled), 2, and 10. All configurations pass with correct data and no hangs.

FIXES: #174288