### PR TITLE
[inductor] mix-order reduction avoid recompile

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -24,6 +24,7 @@ class TestBase(TestCase):
     def setUp(self):
         super().setUp()
         metrics.reset()
+        torch._dynamo.utils.clear_compilation_metrics()
 
     def check_numeric(self, f, args, tol=1e-3):
         ref = f(*args)
@@ -701,6 +702,28 @@ class MixOrderReductionTest(TestBase):
         ):
             self.assertTrue(MixOrderReduction.can_fuse(mock_node_1, mock_node_2))
 
+    @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
+    def test_no_recompile(self):
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x):
+            return x.sum(dim=1), x.sum(dim=0)
+        x0 = torch.randn(2048, 1024, device=GPU_TYPE)
+        torch._dynamo.mark_dynamic(x0, (0,))
+        opt_f = torch.compile(f)
+
+        ref = f(x0)
+        act = opt_f(x0)
+
+        torch.testing.assert_close(ref, act, atol=1e-3, rtol=1e-3)
+        self.assertEqual(metrics.codegen_mix_order_reduction, 1)
+
+        opt_f(torch.randn(4096, 1024, device=GPU_TYPE))
+        opt_f(torch.randn(512, 1024, device=GPU_TYPE))
+
+        compile_metrics = torch._dynamo.utils._compilation_metrics
+        self.assertEqual(len(compile_metrics), 1, "Don't recompile")
 
 @inductor_config.patch(
     "triton.mix_order_reduction", not inductor_config.triton.mix_order_reduction

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -709,6 +709,7 @@ class MixOrderReductionTest(TestBase):
 
         def f(x):
             return x.sum(dim=1), x.sum(dim=0)
+
         x0 = torch.randn(2048, 1024, device=GPU_TYPE)
         torch._dynamo.mark_dynamic(x0, (0,))
         opt_f = torch.compile(f)
@@ -724,6 +725,7 @@ class MixOrderReductionTest(TestBase):
 
         compile_metrics = torch._dynamo.utils._compilation_metrics
         self.assertEqual(len(compile_metrics), 1, "Don't recompile")
+
 
 @inductor_config.patch(
     "triton.mix_order_reduction", not inductor_config.triton.mix_order_reduction

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1641,9 +1641,6 @@ class SIMDScheduling(BaseScheduling):
     def _codegen_mix_order_reduction(self, node1, node2):
         numel, rnumel = scheduler.MixOrderReduction.get_numel_rnumel(node1)
 
-        if not V.graph.sizevars.evaluate_expr(sympy.Gt(numel, rnumel)):
-            return self._codegen_mix_order_reduction(node2, node1)
-
         def _pick_split_size():
             # the overridden has highest priority
             if config.triton.mix_order_reduction_split_size is not None:
@@ -1664,8 +1661,6 @@ class SIMDScheduling(BaseScheduling):
 
         # pyrefly: ignore [bad-assignment]
         metrics.codegen_mix_order_reduction += 1
-
-        assert V.graph.sizevars.evaluate_expr(sympy.Gt(numel, rnumel))
 
         # split epilogue out of node2
         node2_reductions, node2_epilogue = self._split_mix_order_reduction_epilogue(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -377,8 +377,7 @@ class MixOrderReduction:
     @classmethod
     def is_contiguous_node(cls, node: BaseSchedulerNode) -> bool:
         if not all(
-            cls.is_contiguous_load(dep.name, node)
-            for dep in node.read_writes.reads
+            cls.is_contiguous_load(dep.name, node) for dep in node.read_writes.reads
         ):
             return False
         return True

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -302,9 +302,15 @@ class MixOrderReduction:
         if len(common_reads) == 0:
             return False
 
-        g1 = cls.get_numel_rnumel(node1)
-        nrow = sympy.Max(g1[0], g1[1])
-        ncol = sympy.Min(g1[0], g1[1])
+        if cls.is_contiguous_node(node1):
+            contiguous_node, other_node = node1, node2
+        elif cls.is_contiguous_node(node2):
+            contiguous_node, other_node = node2, node1
+        else:
+            return False
+
+        g1 = cls.get_numel_rnumel(contiguous_node)
+        nrow, ncol = g1
 
         # in non strict mode, we will skip the non-critical checks
         if not config.triton.mix_order_reduction_non_strict_mode:
@@ -330,33 +336,6 @@ class MixOrderReduction:
             # Mix order reduction is less beneficial.
             if not V.graph.sizevars.guard_or_true(sympy.Ge(nrow, 4096)):
                 return False
-
-        # Determine which node is contiguous. If we can't determine this
-        # statically (e.g., due to unbacked symbols), skip the fusion.
-        eq_expr = sympy.Eq(g1[1], ncol)
-        if V.graph.sizevars.guard_or_false(eq_expr):
-            contiguous_node, other_node = (node1, node2)
-        elif V.graph.sizevars.guard_or_false(sympy.Not(eq_expr)):
-            contiguous_node, other_node = (node2, node1)
-        else:
-            # Can't statically determine which node is contiguous, skip fusion
-            return False
-
-        # We previously only check the contiguous_node has contiguous
-        # access to common_reads. But that turns out to be not enough.
-        # The contiguous node may access a buffer that's node use by
-        # other_ndoe. If that ascess is non-contiugous, generating
-        # mix-order reduction can be inefficient especially when we
-        # force XBLOCK to be 1
-        # if not all(
-        #     cls.is_contiguous_load(buf, contiguous_node) for buf in common_reads
-        # ):
-        #     return False
-        if not all(
-            cls.is_contiguous_load(dep.name, contiguous_node)
-            for dep in contiguous_node.read_writes.reads
-        ):
-            return False
 
         # Make sure a persistent reduction will be generated
         if any(
@@ -394,6 +373,15 @@ class MixOrderReduction:
         cls, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
         return cls.can_fuse(node1, node2)
+
+    @classmethod
+    def is_contiguous_node(cls, node: BaseSchedulerNode) -> bool:
+        if not all(
+            cls.is_contiguous_load(dep.name, node)
+            for dep in node.read_writes.reads
+        ):
+            return False
+        return True
 
     @classmethod
     def is_contiguous_load(cls, buf: str, parent_node: BaseSchedulerNode) -> bool:
@@ -2133,6 +2121,10 @@ class FusedSchedulerNode(BaseSchedulerNode):
 
 class FusedMixOrderReductions(FusedSchedulerNode):
     def __init__(self, node1: BaseSchedulerNode, node2: BaseSchedulerNode) -> None:
+        if not MixOrderReduction.is_contiguous_node(node1):
+            assert MixOrderReduction.is_contiguous_node(node2)
+            node1, node2 = node2, node1
+
         self.node1 = node1
         self.node2 = node2
         super().__init__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174947

MixOrderReduction previously pick the larger dimension as row-dimension and the smaller one as the column-dimension. It then checks that the node with shape [nrow, ncol] as the contiguous node. This may cause recompilation if user compiles with dynamic shape for nrow and `nrow<ncol` inputs can not share a compile with `nrow>ncol` inputs.

The PR do strides analysis to pick the contiguous node up front and then decide nrow/ncol based on the shape of the contiguous node. This avoids recompilation mentioned above.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

Differential Revision: [D93246281](https://our.internmc.facebook.com/intern/diff/D93246281)