### PR TITLE
[distributed] Add DeviceMesh.abort() method 

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -341,13 +341,8 @@ class DeviceMeshTest(DTensorTestBase):
     def test_abort_root_mesh(self):
         fake_store = FakeStore()
         init_process_group("fake", store=fake_store, rank=0, world_size=self.world_size)
-        device_type = (
-            torch.accelerator.current_accelerator().type
-            if torch.accelerator.is_available()
-            else "cpu"
-        )
         mesh = init_device_mesh(
-            device_type,
+            "cpu",
             (2, self.world_size // 2),
             mesh_dim_names=("dp", "tp"),
         )
@@ -357,13 +352,8 @@ class DeviceMeshTest(DTensorTestBase):
     def test_abort_submesh_raises(self):
         fake_store = FakeStore()
         init_process_group("fake", store=fake_store, rank=0, world_size=self.world_size)
-        device_type = (
-            torch.accelerator.current_accelerator().type
-            if torch.accelerator.is_available()
-            else "cpu"
-        )
         mesh = init_device_mesh(
-            device_type,
+            "cpu",
             (2, self.world_size // 2),
             mesh_dim_names=("dp", "tp"),
         )

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -338,6 +338,39 @@ class DeviceMeshTest(DTensorTestBase):
         backend = device_mesh.get_all_groups()[0]._get_backend(torch.device("cuda"))
         self.assertIsInstance(backend, torch._C._distributed_c10d.FakeProcessGroup)
 
+    def test_abort_root_mesh(self):
+        fake_store = FakeStore()
+        init_process_group("fake", store=fake_store, rank=0, world_size=self.world_size)
+        device_type = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
+        mesh = init_device_mesh(
+            device_type,
+            (2, self.world_size // 2),
+            mesh_dim_names=("dp", "tp"),
+        )
+        # abort() on root mesh should not raise
+        mesh.abort()
+
+    def test_abort_submesh_raises(self):
+        fake_store = FakeStore()
+        init_process_group("fake", store=fake_store, rank=0, world_size=self.world_size)
+        device_type = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
+        mesh = init_device_mesh(
+            device_type,
+            (2, self.world_size // 2),
+            mesh_dim_names=("dp", "tp"),
+        )
+        submesh = mesh["tp"]
+        with self.assertRaisesRegex(RuntimeError, "only supported on root DeviceMesh"):
+            submesh.abort()
+
     @with_comms
     def test_from_group_with_global_pg(self):
         # Simple test: check `from_group` from a mesh pg vs. directly

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -791,6 +791,56 @@ else:
             """
             return [self.get_group(i) for i in range(len(self._layout))]
 
+        def abort(self) -> None:
+            """
+            Abort all ProcessGroups owned by this DeviceMesh.
+
+            Only supported for root DeviceMeshes created via ``DeviceMesh(...)`` or
+            ``init_device_mesh(...)``. Raises ``RuntimeError`` if called on a submesh.
+
+            This wraps the abort calls with NCCL group semantics
+            (``ncclGroupStart``/``ncclGroupEnd``) to avoid the deadlock that occurs
+            when aborting multiple communicators sequentially.
+
+            .. note:: This API is experimental and currently only works with the NCCL
+                backend.
+            """
+            if self._root_mesh is not None:
+                raise RuntimeError(
+                    "abort() is only supported on root DeviceMesh. "
+                    "Call abort() on the root mesh instead."
+                )
+
+            all_groups = self.get_all_groups()
+            if not all_groups:
+                return
+
+            # Get the NCCL backend from the first PG to use ncclGroupStart/End
+            # semantics for concurrent abort. Without this, aborting multiple
+            # communicators sequentially can deadlock.
+            # See: https://github.com/pytorch/pytorch/issues/119797
+            from torch.distributed.distributed_c10d import (
+                is_nccl_available,
+                ProcessGroupNCCL,
+            )
+
+            backend = None
+            try:
+                backend = all_groups[0]._get_backend(torch.device("cuda"))
+            except RuntimeError:
+                pass
+
+            use_nccl_group = is_nccl_available() and isinstance(
+                backend, ProcessGroupNCCL
+            )
+
+            if use_nccl_group:
+                backend._group_start()
+            for pg in all_groups:
+                pg.abort()
+            if use_nccl_group:
+                backend._group_end()
+
         def _create_sub_mesh(
             self,
             layout: _MeshLayout,


### PR DESCRIPTION
Add an `abort()` method to DeviceMesh that safely aborts all ProcessGroups owned by the mesh using NCCL group semantics (`ncclGroupStart/ncclGroupEnd`) to prevent the deadlock that occurs when aborting multiple communicators sequentially. Only supported on root DeviceMeshes — calling `abort()` on a submesh raises `RuntimeError`.

FIXES: #173815 