### PR TITLE
Make server creation in distributed/elastic/test_control_plane more reliable

### DIFF
--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -167,7 +167,7 @@ class WorkerServerTest(TestCase):
 
         from torch._C._distributed_c10d import _WorkerServer
 
-        server = _WorkerServer("", 1234)
+        server = _WorkerServer("127.0.0.1", 1234)
         out = requests.get("http://localhost:1234/handler/")
         self.assertEqual(out.status_code, 200)
 

--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -195,7 +195,7 @@ class WorkerServerTest(TestCase):
 
         from torch._C._distributed_c10d import _WorkerServer
 
-        server = _WorkerServer("", 1234)
+        server = _WorkerServer("127.0.0.1", 1234)
         out = requests.get("http://localhost:1234/handler/")
         self.assertEqual(out.status_code, 200)
 


### PR DESCRIPTION
Using "" may cause a "connection refused" error in some environments. Using the localhost IP is more reliable.