### PR TITLE
Fix export crash on unsupported assert bytecode

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4574,6 +4574,8 @@ def forward(self, x, b, y):
 
         self.assertEqual(ref, res)
 
+
+class ExportTestsSubprocess(torch._dynamo.test_case.TestCase):
     def test_strict_export_under_pythonoptimize(self):
         env = dict(os.environ)
         env["PYTHONOPTIMIZE"] = "1"

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -9,6 +9,9 @@ import functools
 import inspect
 import io
 import operator
+import os
+import subprocess
+import sys
 import unittest
 from collections.abc import Sequence
 from enum import Enum
@@ -4570,6 +4573,30 @@ def forward(self, x, b, y):
             res = ep.module()(*inputs)
 
         self.assertEqual(ref, res)
+
+    def test_strict_export_under_pythonoptimize(self):
+        env = dict(os.environ)
+        env["PYTHONOPTIMIZE"] = "1"
+        code = """\
+import torch
+model = torch.nn.Linear(2, 3)
+example_input = torch.randn(1, 2)
+ep = torch.export.export(model, args=(example_input,), strict=True)
+out_export = ep.module()(example_input)
+out_orig = model(example_input)
+torch.testing.assert_close(out_export, out_orig)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"strict export under PYTHONOPTIMIZE=1 failed: stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
 
 
 class ExportTestsDevice(torch._dynamo.test_case.TestCase):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -512,7 +512,6 @@ def get_assert_bytecode_sequence(with_msg: bool) -> list[str]:
 
     # expect to find POP_JUMP_[FORWARD_]IF_TRUE
     begin_idx = next(i for i, inst in enumerate(insts) if inst.startswith("POP_JUMP"))
-
     end_idx = insts.index("RAISE_VARARGS")
 
     return insts[begin_idx + 1 : end_idx + 1]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -511,11 +511,7 @@ def get_assert_bytecode_sequence(with_msg: bool) -> list[str]:
     insts = [inst.opname for inst in dis.get_instructions(fn)]
 
     # expect to find POP_JUMP_[FORWARD_]IF_TRUE
-    begin_idx = next(
-        (i for i, inst in enumerate(insts) if inst.startswith("POP_JUMP")), None
-    )
-    if begin_idx is None or "RAISE_VARARGS" not in insts:
-        return ["<assert pattern unsupported>"]
+    begin_idx = next(i for i, inst in enumerate(insts) if inst.startswith("POP_JUMP"))
 
     end_idx = insts.index("RAISE_VARARGS")
 
@@ -777,6 +773,7 @@ def generic_jump(
         value: VariableTracker = self.pop()
         if (
             config.rewrite_assert_with_torch_assert
+            and sys.flags.optimize == 0
             and _detect_and_normalize_assert_statement(self, truth_fn, push)
         ):
             error_msg: VariableTracker = self.pop()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -511,7 +511,12 @@ def get_assert_bytecode_sequence(with_msg: bool) -> list[str]:
     insts = [inst.opname for inst in dis.get_instructions(fn)]
 
     # expect to find POP_JUMP_[FORWARD_]IF_TRUE
-    begin_idx = next(i for i, inst in enumerate(insts) if inst.startswith("POP_JUMP"))
+    begin_idx = next(
+        (i for i, inst in enumerate(insts) if inst.startswith("POP_JUMP")), None
+    )
+    if begin_idx is None or "RAISE_VARARGS" not in insts:
+        return ["<assert pattern unsupported>"]
+
     end_idx = insts.index("RAISE_VARARGS")
 
     return insts[begin_idx + 1 : end_idx + 1]


### PR DESCRIPTION
Fixes #174784 

**Problem**

During ```torch.export``` (strict mode), tracing hits ```get_assert_bytecode_sequence()```, which assumes assert bytecode always contains an instruction whose name starts with ```"POP_JUMP"```. It uses ```next(...)``` on that condition; when no such instruction exists (e.g. different Python version or bytecode layout), the generator is empty and ```next()``` raises ```StopIteration```, crashing export.

**Solution**

Use ```next(..., None)``` so a missing pattern returns ```None``` instead of raising. If ```begin_idx``` is ```None``` or ```"RAISE_VARARGS"``` is absent, return a sentinel list that will never match real bytecode, so ```_detect_and_normalize_assert_statement``` does not treat the sequence as an assert and export continues without crashing. A test was added that reproduces the previous crash and asserts export now succeeds.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo