### PR TITLE
Add hook to register extra cache-key data for AOTAutograd + Inductor code cache

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -765,6 +765,12 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 "cudagraphs": cudagraphs,
                 "boxed_forward_device_index": boxed_forward_device_index,
             }
+
+            # if there was provided extra_cache_key_data in aot_config, append it to the
+            # _CompileFxKwargs, so it will be pickled when calculating cache key
+            if aot_config.extra_cache_key_data is not None:
+                fx_config["extra_cache_key_data"] = aot_config.extra_cache_key_data
+
             try:
                 cache_key, debug_lines = autograd_cache_key(
                     gm, args, aot_config, fx_config

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -9,7 +9,7 @@ import collections
 import functools
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import Any, NewType, Optional, Protocol, TYPE_CHECKING, TypeVar, Union
+from typing import Any, NewType, Optional, Protocol, TYPE_CHECKING, TypeVar, Union, OrderedDict
 from typing_extensions import ParamSpec
 
 import torch
@@ -1101,6 +1101,7 @@ class AOTConfig:
     # This mode is used to track torch_fn metadata but can interfere with
     # certain tracing scenarios.
     _disable_torch_fn_metadata_mode: bool = False
+    extra_cache_key_data: Optional[OrderedDict[str, Any]] = None
 
     def __post_init__(self) -> None:
         if self.pre_dispatch:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1611,6 +1611,12 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         """
         try:
             FxGraphCache._check_can_cache(gm)
+
+            # if there was provided extra_cache_key_data in gm.meta, append it to the
+            # _CompileFxKwargs, so it will be pickled when calculating cache key
+            if "extra_cache_key_data" in gm.meta:
+                fx_kwargs["extra_cache_key_data"] = gm.meta["extra_cache_key_data"]
+
             key, debug_lines = compiled_fx_graph_hash(
                 gm, example_inputs, fx_kwargs, inputs_to_check
             )


### PR DESCRIPTION
Relates to RFC #174970

This change adds an opt-in mechanism to include additional, user-defined data in the compilation cache key used by AOTAutograd and TorchInductor. This enables correctness for scenarios where previously compiled artifacts should be invalidated based on additional context not currently captured by existing safeguards, e.g. external runtime configuration, some real inputs' characteristics, custom backend toggles, environment-controlled options, etc.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo