### PR TITLE
 [ROCm] Fix test_index_out_of_bounds_exception_cuda for Buck test environment

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1487,37 +1487,41 @@ except RuntimeError as e:
         self._spawn_test_multinomial_invalid_probs_cuda([1.0, -inf, 1.0])
         self._spawn_test_multinomial_invalid_probs_cuda([1.0, 1.0, nan])
 
+    @staticmethod
+    def _mute_init():
+        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stderr.fileno())
+
+    def _spawn_method(self, method, arg):
+        ctx = torch.multiprocessing.get_context("spawn")
+        with ctx.Pool(1, initializer=self._mute_init) as pool:
+            errors = pool.map(method, [arg])
+            for e in errors:
+                is_cuda_assert = "device-side assert triggered" in str(e)
+                is_hip_assert = "hipErrorLaunchFailure" in str(
+                    e
+                ) or "unspecified launch failure" in str(e)
+                is_hip_assert = is_hip_assert or "HSA_STATUS_ERROR_EXCEPTION" in str(e)
+                if not (is_cuda_assert or is_hip_assert):
+                    self.fail(e)
+                if e.error_code not in (710, 719):
+                    self.fail(e)
+
+    @staticmethod
+    def _test_index_bounds_cuda(idx):
+        x = torch.arange(10, device="cuda")
+        try:
+            y = x[torch.tensor([idx])]
+            return f"x[torch.tensor([{idx})]={y}"
+        except RuntimeError as err:
+            return err
+
     @slowTest
     def test_index_out_of_bounds_exception_cuda(self):
-        # Test that indexing out of bounds causes assert
-        stderr = TestCase.runWithPytorchAPIUsageStderr("""\
-#!/usr/bin/env python3
-
-import torch
-from torch.testing._internal.common_utils import (TestCase, run_tests, slowTest)
-
-class TestThatContainsCUDAAssertFailure(TestCase):
-
-    @slowTest
-    def test_index_bounds_cuda(self):
-        x = torch.arange(10, device="cuda")
-        y = x[torch.tensor([11])].cpu()
-
-if __name__ == '__main__':
-    run_tests()
-""")
-        # CUDA raises cudaErrorAssert (710) with "device-side assert triggered"
-        # ROCm with TORCH_USE_HIP_DSA raises a proper device-side assertion
-        # ROCm without TORCH_USE_HIP_DSA raises hipErrorLaunchFailure (719)
-        # which still catches the error but with less specific messaging
-        is_cuda_assert = "device-side assert triggered" in stderr
-        is_hip_assert = "hipErrorLaunchFailure" in stderr
-        is_hip_assert = is_hip_assert or "unspecified launch failure" in stderr
-        is_hip_assert = is_hip_assert or "HSA_STATUS_ERROR_EXCEPTION" in stderr
-        self.assertTrue(
-            is_cuda_assert or is_hip_assert,
-            f"Expected device assert error in stderr, got: {stderr}",
+        test_method = TestCuda._test_index_bounds_cuda
+        self.assertEqual(
+            test_method(1), "x[torch.tensor([1)]=tensor([1], device='cuda:0')"
         )
+        self._spawn_method(test_method, 11)
 
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")


### PR DESCRIPTION
 (#174388 follow-up)
 
 ## Summary

  This PR fixes `test_index_out_of_bounds_exception_cuda` which was broken by #174388 in Meta's internal Buck test environment.

  **Root Cause:** PR #174388 changed the test from using a multiprocessing pool approach to using `TestCase.runWithPytorchAPIUsageStderr()`. The subprocess spawned by `runWithPytorchAPIUsageStderr()` doesn't have access to the `torch` module in Buck's test environment, causing `ModuleNotFoundError: No module named 'torch'`.

  **Fix:** Revert to the original multiprocessing pool approach (`_spawn_method`, `_mute_init`, `_test_index_bounds_cuda`) which properly inherits the Python environment via `torch.multiprocessing.get_context("spawn")`.

  This fix **preserves** the ROCm `HSA_STATUS_ERROR_EXCEPTION` error handling that was added in #174388.

  ## Changes

  - Restore `_mute_init()`, `_spawn_method()`, and `_test_index_bounds_cuda()` helper methods
  - Keep the `HSA_STATUS_ERROR_EXCEPTION` check for ROCm compatibility
  - Affects: `test/test_cuda.py`

  ## Why `runWithPytorchAPIUsageStderr()` doesn't work here

  The `runWithPytorchAPIUsageStderr()` method writes a Python script to a temp file and executes it as a subprocess. In Buck's sandboxed test environment, this subprocess doesn't inherit the PyTorch dependencies, so `import torch` fails.

  The multiprocessing pool approach works because `torch.multiprocessing.get_context("spawn")` properly propagates the Python environment to child processes.

  ## Test Plan

  ```bash
  pytest test/test_cuda.py -k test_index_out_of_bounds_exception_cuda -v
  ```

  Verified passing in Meta's internal Buck test environment (and hopefully in OSS CI).

  Fixes the regression from #174388.

  cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang 
 




Differential Revision: D92655498