### PR TITLE
[Inductor] Add conv1d triton template

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -302,6 +302,7 @@ def fuse_reindexing(
 
 NHWC_STRIDE_ORDER = [3, 0, 2, 1]
 NHWDC_STRIDE_ORDER = [4, 0, 3, 2, 1]
+NWC_STRIDE_ORDER = [2, 0, 1]  # For Conv1d channels-last (N, W, C -> NWC)
 
 
 def get_fill_order(
@@ -6562,6 +6563,10 @@ class ExternKernel(InputsKernel):
     @classmethod
     def require_channels_last(cls, x: IRNode) -> IRNode:
         return cls.require_stride_order(x, NHWC_STRIDE_ORDER)
+
+    @classmethod
+    def require_channels_last_1d(cls, x: IRNode) -> IRNode:
+        return cls.require_stride_order(x, NWC_STRIDE_ORDER)
 
     @classmethod
     def require_channels_last_3d(cls, x: IRNode) -> IRNode:

--- a/torch/_inductor/kernel/templates/triton_conv1d.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_conv1d.py.jinja
@@ -1,0 +1,122 @@
+{{def_kernel("X", "W")}}
+    # Optimized Conv1D kernel using implicit GEMM approach
+    # M = Batch * OUT_L, N = OUT_C, K = IN_C (summed over kernel positions)
+    # Key optimizations: L2 swizzling, fused loop, base pointer precomputation
+
+    # Tensor dimensions
+    BATCH = {{size("X", 0)}}
+    IN_C = {{size("X", 1)}}
+    IN_L = {{size("X", 2)}}
+    OUT_C = {{size(None, 1)}}
+    OUT_L = {{size(None, 2)}}
+
+    # Strides (Input is NCL layout)
+    stride_xn = {{stride("X", 0)}}
+    stride_xc = {{stride("X", 1)}}
+    stride_xl = {{stride("X", 2)}}
+    stride_wc_out = {{stride("W", 0)}}
+    stride_wc_in = {{stride("W", 1)}}
+    stride_wk = {{stride("W", 2)}}
+
+{% if GROUPS == 1 %}
+    GROUP_IN_C = IN_C
+    GROUP_OUT_C = OUT_C
+{% else %}
+    GROUP_IN_C = IN_C // GROUPS
+    GROUP_OUT_C = OUT_C // GROUPS
+{% endif %}
+
+    # L2 cache swizzle for better cache utilization
+    pid = tl.program_id(0).to(INDEX_DTYPE)
+    num_pid_m = tl.cdiv(BATCH * OUT_L, BLOCK_M)
+    num_pid_n = tl.cdiv(GROUP_OUT_C, BLOCK_N)
+    num_pid_in_group = GROUP_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+
+    # M dimension: flatten batch and output length
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    idx_y_l = offs_m % OUT_L
+    idx_n = offs_m // OUT_L
+
+    # N dimension: output channels
+    idx_y_c = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+{% if GROUPS == 1 %}
+    group = 0
+{% else %}
+    group = tl.program_id(1).to(INDEX_DTYPE)
+{% endif %}
+
+    # Base pointers with precomputation
+    x_base = X + (group * stride_xc * GROUP_IN_C + idx_n * stride_xn)[:, None]
+    w_base = W + (group * stride_wc_out * GROUP_OUT_C + idx_y_c * stride_wc_out)[None, :]
+
+    # Initialize accumulator
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+{% if UNROLL %}
+    # Unrolled kernel loop for better ILP with small kernels
+{% for k_pos in range(KERNEL_L) %}
+    # Kernel position {{k_pos}}
+    idx_x_l_{{k_pos}} = {{k_pos}} - PADDING + idx_y_l * STRIDE
+    valid_l_{{k_pos}} = (idx_x_l_{{k_pos}} >= 0) & (idx_x_l_{{k_pos}} < IN_L)
+
+    for k in range(0, GROUP_IN_C, BLOCK_K):
+        idx_x_c = tl.arange(0, BLOCK_K) + k
+
+        # Load input tile [BLOCK_M, BLOCK_K]
+        x_ptrs = x_base + (idx_x_l_{{k_pos}} * stride_xl)[:, None] + (idx_x_c * stride_xc)[None, :]
+        mask_x = (idx_n < BATCH)[:, None] & valid_l_{{k_pos}}[:, None] & (idx_x_c < GROUP_IN_C)[None, :]
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
+
+        # Load weight tile [BLOCK_K, BLOCK_N]
+        w_ptrs = w_base + (idx_x_c * stride_wc_in)[:, None] + ({{k_pos}} * stride_wk)
+        mask_w = (idx_x_c[:, None] < GROUP_IN_C) & (idx_y_c[None, :] < GROUP_OUT_C)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
+
+        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32)
+{% endfor %}
+{% else %}
+    # Fused loop over kernel positions and channel blocks
+    BLOCK_K_COUNT = (GROUP_IN_C + BLOCK_K - 1) // BLOCK_K
+
+    for k_idx in range(KERNEL_L * BLOCK_K_COUNT):
+        k = (k_idx % BLOCK_K_COUNT) * BLOCK_K
+        k_pos = k_idx // BLOCK_K_COUNT
+
+        # Compute input position with padding and stride
+        idx_x_l = k_pos - PADDING + idx_y_l * STRIDE
+        idx_x_c = tl.arange(0, BLOCK_K) + k
+
+        # Load input tile [BLOCK_M, BLOCK_K]
+        x_ptrs = x_base + (idx_x_l * stride_xl)[:, None] + (idx_x_c * stride_xc)[None, :]
+        mask_x = (
+            (idx_n < BATCH)[:, None]
+            & (idx_x_l >= 0)[:, None]
+            & (idx_x_l < IN_L)[:, None]
+            & (idx_x_c < GROUP_IN_C)[None, :]
+        )
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
+
+        # Load weight tile [BLOCK_K, BLOCK_N]
+        w_ptrs = w_base + (idx_x_c * stride_wc_in)[:, None] + (k_pos * stride_wk)
+        mask_w = (idx_x_c[:, None] < GROUP_IN_C) & (idx_y_c[None, :] < GROUP_OUT_C)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
+
+        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32)
+{% endif %}
+
+    # Compute output mask
+    mask = (idx_n < BATCH)[:, None] & (idx_y_l < OUT_L)[:, None] & (idx_y_c < GROUP_OUT_C)[None, :]
+    idx_n = idx_n[:, None]
+    idx_c = idx_y_c[None, :] + group * GROUP_OUT_C
+    idx_l = idx_y_l[:, None]
+
+    # inductor generates a suffix
+    {{store_output(("idx_n", "idx_c", "idx_l"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}


### PR DESCRIPTION
Summary:
Add a conv1d triton template in Inductor.

Benchmarking results show
1. It is faster (0.47ms vs 0.55ms) than unsqueeze to 2d and utilize the existing conv2d template.
2. It is significantly faster than cudnn's conv1d with channels first and channels last

Test Plan:
Benchmark script in D92916707

```
Shape: Conv1d(3072, 128, 202) -> (384, 128, k=3, s=1, p=0)
       Conv2d(3072, 128, 1, 202) -> (384, 128, k=(1,3), s=(1,1), p=(0,0))

Input tensors:
  --- Conv1d ---
  x1d_CF : shape=[3072, 128, 202]  stride=[25856, 202, 1]
  x1d_CL : shape=[3072, 128, 202]  stride=[25856, 1, 128]
  w1d_CF : shape=[384, 128, 3]  stride=[384, 3, 1]
  w1d_CL : shape=[384, 128, 3]  stride=[384, 1, 128]
  --- Conv2d ---
  x2d_CF : shape=[3072, 128, 1, 202]  stride=[25856, 202, 202, 1]
  x2d_CL : shape=[3072, 128, 1, 202]  stride=[25856, 1, 25856, 128]
  w2d_CF : shape=[384, 128, 1, 3]  stride=[384, 3, 3, 1]
  w2d_CL : shape=[384, 128, 1, 3]  stride=[384, 1, 384, 128]

Results:
  Variant                    Time (ms)   Relative   Max Diff
  ------------------------- ---------- ---------- ----------
  triton_conv1d_CF              0.6324      64.5%   0.062500
  triton_conv1d_CL              0.4746      85.9%   0.062500
  triton_conv2d_CF              0.7171      56.8%   0.062500
  triton_conv2d_CL              0.5514      73.9%   0.062500
  cudnn_conv1d_CF               1.1107      36.7%   0.000000
  cudnn_conv1d_CL               1.2060      33.8%   0.000000
  cudnn_conv2d_CF               1.1099      36.7%   0.000000
  cudnn_conv2d_CL               0.4076     100.0%   0.000000
```

Differential Revision: D92536676


@diff-train-skip-merge

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo