### PR TITLE
Fix clang build on aarch64

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -628,11 +628,9 @@ class TORCH_API TensorBase {
     return mutable_data_ptr();
   }
 
-  template <typename T, std::enable_if_t<!std::is_const_v<T>, int> = 0>
+  // Implemented in aten/src/ATen/templates/TensorMethods.cpp
+  template <typename T>
   const T* const_data_ptr() const;
-
-  template <typename T, std::enable_if_t<std::is_const_v<T>, int> = 0>
-  const std::remove_const_t<T>* const_data_ptr() const;
 
   template <typename T>
   T* mutable_data_ptr() const;

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -52,13 +52,8 @@ private:
 #define CUDABLAS_GEMM_DTYPE_IS_FLOAT_TYPE_AND_C_DTYPE_IS_FLOAT \
     ((std::is_same<Dtype, at::Half>::value || std::is_same<Dtype, at::BFloat16>::value) && std::is_same<C_Dtype, float>::value)
 
-template <typename Dtype, typename C_Dtype = Dtype, typename std::enable_if<!CUDABLAS_GEMM_DTYPE_IS_FLOAT_TYPE_AND_C_DTYPE_IS_FLOAT, Dtype>::type* = nullptr>
-inline void gemm(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
-  static_assert(false&&sizeof(Dtype),"at::cuda::blas::gemm: not implemented");
-}
-
-template <typename Dtype, typename C_Dtype, typename std::enable_if<CUDABLAS_GEMM_DTYPE_IS_FLOAT_TYPE_AND_C_DTYPE_IS_FLOAT, Dtype>::type* = nullptr>
-void gemm(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype));
+template <typename Dtype, typename C_Dtype = Dtype>
+void gemm(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) = delete;
 
 template <>
 void gemm<double>(CUDABLAS_GEMM_ARGTYPES(double));

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -8,39 +8,39 @@ namespace at {
 namespace {
 
 // Verifies the requested type is the same as the Tensor's type.
-void check_type(const TensorBase& tensor, ScalarType type, std::string_view type_name) {
+void check_type(const TensorBase& tensor, ScalarType type) {
   TORCH_CHECK(
       tensor.scalar_type() == type
       || (isQIntType(tensor.scalar_type())
           && toUnderlying(tensor.scalar_type()) == type),
-      "expected scalar type ", type_name, " but found ", tensor.scalar_type());
+      "expected scalar type ", type, " but found ", tensor.scalar_type());
 }
 
 } // namespace
 
-#define DEFINE_CAST(T, name)                                         \
-   template <>                                                       \
-   TORCH_API const T* TensorBase::const_data_ptr() const {           \
-     check_type(*this, ScalarType::name, #name);                     \
-     return this->unsafeGetTensorImpl()->data_ptr_impl<T>();         \
-   }                                                                 \
-                                                                     \
-   template <>                                                       \
-   TORCH_API const T* TensorBase::const_data_ptr<const T>() const {  \
-     check_type(*this, ScalarType::name, #name);                     \
-     return this->unsafeGetTensorImpl()->data_ptr_impl<std::remove_const_t<T>>(); \
-   }                                                                 \
-                                                                     \
-   template <>                                                       \
-   TORCH_API T* TensorBase::mutable_data_ptr() const {               \
-     check_type(*this, ScalarType::name, #name);                     \
-     return this->unsafeGetTensorImpl()->mutable_data_ptr_impl<T>(); \
-   }                                                                 \
-                                                                     \
-   template <>                                                       \
-   TORCH_API T* TensorBase::data_ptr() const {                       \
-     return mutable_data_ptr<T>();                                   \
-   }                                                                 \
+template <typename T>
+const T* TensorBase::const_data_ptr() const {
+  using NonConstT = std::remove_const_t<T>;
+  check_type(*this, c10::CppTypeToScalarType<NonConstT>());
+  return this->unsafeGetTensorImpl()->data_ptr_impl<NonConstT>();
+}
+
+template <typename T>
+T* TensorBase::mutable_data_ptr() const {
+  check_type(*this, c10::CppTypeToScalarType<T>());
+  return this->unsafeGetTensorImpl()->mutable_data_ptr_impl<T>();
+}
+
+template <typename T>
+T* TensorBase::data_ptr() const {
+  return this->mutable_data_ptr<T>();
+}
+
+#define DEFINE_CAST(T, name)                                                \
+   template TORCH_API const T* TensorBase::const_data_ptr<T>() const;       \
+   template TORCH_API const T* TensorBase::const_data_ptr<const T>() const; \
+   template TORCH_API T* TensorBase::mutable_data_ptr() const;              \
+   template TORCH_API T* TensorBase::data_ptr() const;
 
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_CAST)
  AT_FORALL_QINT_TYPES(DEFINE_CAST)


### PR DESCRIPTION
We currently get a linker error when building with clang on aarch64. The linker error seems to happen because clang and nvcc mangle names differently. In particular, clang includes enable_if in the mangled name. The namespace for enable_if is encoded differently in the name generated by nvcc and the name generated by clang which causes the linking error.

This commit works around the issue by redefining the problematic symbols without using enable_if.

Fixes #174898