### PR TITLE
[AOTI]: Fix const folding in run_single_threaded

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -172,9 +172,9 @@ class AOTInductorModelContainer {
           /* use_inactive = */ false,
           /* validate_full_update = */ false);
       const_folded = ConstantState::FOLDED;
-    } else if (constant_folded_ != ConstantState::FOLDED) {
+    } else if (const_folded != ConstantState::FOLDED) {
       throw std::runtime_error(
-          "Unknown constant state: " + toStringConstantState(constant_folded_));
+          "Unknown constant state: " + toStringConstantState(const_folded));
     }
 
     model->run_single_threaded(


### PR DESCRIPTION
Summary: Found a small bug in AOTI single thread mode that we should use constant_folded instead of constant_folded_.

Test Plan: ci

Differential Revision: D93280447


