### PR TITLE
[mtia][inductor] Fix clamp dtype preservation and acosh numerical stability

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -23,7 +23,6 @@ from torch._decomp.decompositions import (
     _index_add,
     embedding_dense_backward as decomp_embedding_dense_backward,
     pw_cast_for_opmath,
-    pw_cast_for_opmath_non_tensor_args,
 )
 from torch._decomp.decompositions_for_rng import extra_random_decomps
 from torch._dynamo.utils import counters
@@ -188,7 +187,7 @@ def sym_constrain_range_for_size(
 
 
 @register_decomposition([aten.clamp])
-@pw_cast_for_opmath_non_tensor_args
+@pw_cast_for_opmath
 def clamp(
     x: torch.Tensor,
     min: Optional[torch.types.Number] = None,


### PR DESCRIPTION
Summary:
Fix two opinfo e2e test failures affecting 12 tests:

1. **clamp decomposition dtype bug (7 hardtanh tests + fused_clamp_max_bf16)**: The `pw_cast_for_opmath_non_tensor_args` decorator on Inductor's `aten.clamp` decomposition promoted integer tensor computation to float32 when scalar min/max args were floats. The `type_casts` decorator incorrectly computed `result_dtype` from ALL args (including non-tensor float scalars), causing the output dtype to be float32 instead of matching the input tensor's int32/int64 dtype. This broke `nn.functional.hardtanh` for integer inputs since the Triton kernel wrote float32 bit patterns into int32 output buffers. Fix: replace with `pw_cast_for_opmath` which only considers tensor args for type promotion — integer tensors stay at their original dtype (no scalar-driven promotion), while low-precision floats (bf16/fp16) still get promoted to float32 for computation and cast back, preserving correct behavior for both cases.

2. **acosh numerical instability (5 acosh tests)**: MTIA's `libdevice.acosh` implementation uses the formula `log(x + sqrt(x*x - 1))`, which suffers from catastrophic cancellation at `x=1` (where `x*x - 1` should be exactly 0 but can go slightly negative due to floating-point arithmetic, producing NaN from sqrt). Fix: add an MTIA-specific override using the mathematically equivalent but numerically stable formula `log(x + sqrt((x-1)*(x+1)))`, which avoids the cancellation since `(x-1)` is exactly 0 when `x=1`.

Remaining 16 tests (div, remainder, pow) fail due to MTIA Triton backend limitations:
- **div/remainder (10 tests)**: The mtia-translate pass optimizes `arith.divf` on f32 tensors into LUT-based reciprocal + mixed-precision SFU multiply, keeping the dividend in f16 despite the TTIR requesting f32 conversion. This loses precision for f16/bf16 division.
- **pow (6 tests)**: MTIA SFU saturates pow results to 65504 (f16 max) instead of producing inf. Masked comparison passes (finite values are correct).

Test Plan:
Ran all 28 originally failing opinfo e2e tests:
- 7 hardtanh tests (5258, 5260-5265): all PASS
- 5 acosh tests (787, 789, 791, 793, 794): all PASS
- 16 remaining tests (div, remainder, pow): confirmed as MTIA Triton backend issues

Commands:
```
OPINFO_START_INDEX=5258 OPINFO_END_INDEX=5266 OPINFO_LOWERING_MODE=AFG_INDUCTOR_COMPILE OPINFO_AUTO_DS=1 buck2 run fbcode//mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e
OPINFO_START_INDEX=787 OPINFO_END_INDEX=795 OPINFO_LOWERING_MODE=AFG_INDUCTOR_COMPILE OPINFO_AUTO_DS=1 buck2 run fbcode//mtia/compiler/graph_compiler/test_library/afg_opinfo_e2e_tests:test_afg_opinfo_e2e
```

Differential Revision: D93213788




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo