### PR TITLE
Fix segfault in scaled_dot_product_attention with zero-sized tensors

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6126,7 +6126,7 @@ def scaled_dot_product_attention(
         https://arxiv.org/pdf/2305.13245
     """
     # Handle zero-sized tensors to prevent segfault
-    if query.numel() == 0 or key.numel() == 0 or value.numel() == 0:
+    if query.sym_numel() == 0 or key.sym_numel() == 0 or value.sym_numel() == 0:
         # Output shape: (N, ..., Hq, L, Ev)
         # Take all dims from query except the last one, then append value's last dim
         output_shape = list(query.shape[:-1]) + [value.shape[-1]]


### PR DESCRIPTION
Fixes #174939

## Summary

Added validation to prevent segmentation fault when `scaled_dot_product_attention` receives zero-sized tensors. The function now returns a properly-shaped zero tensor instead of crashing.

## Changes

* Added zero-sized tensor validation at the start of `scaled_dot_product_attention`
* Returns `torch.zeros()` with correct output shape when any input tensor has `numel() == 0`
* Preserves dtype, device, and requires_grad properties from input
* Correctly handles tensors with any number of dimensions by using `query.shape[:-1] + [value.shape[-1]]`

## Test Case
```python
import torch
import torch.nn.functional as F

# Previously crashed with: Floating point exception (core dumped)
query = torch.zeros(0, 0, 2, 0, dtype=torch.bfloat16)
key = torch.zeros(0, 0, 13, 0, dtype=torch.bfloat16)
value = torch.zeros(0, 0, 0, 0, dtype=torch.bfloat16)

result = F.scaled_dot_product_attention(query, key, value)
print("Success! No crash occurred.")
print(f"Result shape: {result.shape}")
```

## Testing

Tested with the reproduction case from issue #174939. The function now handles zero-sized inputs gracefully without segfaulting.