### PR TITLE
[Inductor] Reduce threshold for autotuning on decompose-K template

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1777,7 +1777,7 @@ class triton:
     # specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables
     # it as an autotuning choice for all matmuls
     decompose_k_threshold = int(
-        os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32")
+        os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "8")
     )
 
     # Programmatic Dependent Launch improves launch latency on Nvidia Hopper+ devices


### PR DESCRIPTION
Summary:
Reduce `TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD` from 32 to 8, such that shapes for which `K > M * 8 * threshold_multiple` and `K > N * 8 * threshold_multiple` autotune only on the decompose-K template (rather than the Triton template) in max-autotune. Based on this study (https://docs.google.com/spreadsheets/d/1DuSB9hJgWSgy_kFzAspZGdP9RGswe1UQ3X1YfwsKYGw/edit?gid=0#gid=0), setting the threshold to 8 (instead of 32):
- never regresses performance meaningfully for any shapes choosing `triton_mm`
- meaningfully decreases runtime for shapes that switch from `triton_mm` to `decompose_k`

Test Plan:
`test_max_autotune`
`test_max_autotune_blackwell`

Differential Revision: D93288102




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo