### PR TITLE
Optimize SymInt copy constructor and assignment

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -54,13 +54,9 @@ class C10_API SymInt {
   // the negative value is -1; i.e., not user controlled)
   SymInt(Unchecked /*unused*/, int64_t d) : data_(d) {}
 
-  // TODO: these implementations are not optimal because they allocate a
-  // temporary and then use the move constructor/assignment
-  SymInt(const SymInt& s) : data_(0) {
+  SymInt(const SymInt& s) : data_(s.data_) {
     if (s.is_heap_allocated()) {
-      *this = SymInt(s.toSymNode());
-    } else {
-      data_ = s.data_;
+      c10::raw::intrusive_ptr::incref(s.toSymNodeImplUnowned());
     }
   }
   SymInt(SymInt&& s) noexcept : data_(s.data_) {
@@ -69,10 +65,10 @@ class C10_API SymInt {
 
   SymInt& operator=(const SymInt& s) {
     if (this != &s) {
+      release_();
+      data_ = s.data_;
       if (s.is_heap_allocated()) {
-        *this = SymInt(s.toSymNode());
-      } else {
-        data_ = s.data_;
+        c10::raw::intrusive_ptr::incref(s.toSymNodeImplUnowned());
       }
     }
     return *this;


### PR DESCRIPTION
## Summary
Fixes long-standing TODO in SymInt copy/move semantics that creates unnecessary temporaries.

## Problem
When copying a heap-allocated SymInt, the current implementation:
1. Calls `toSymNode()` which increments refcount
2. Creates a temporary SymInt from that SymNode
3. Move-assigns the temporary (decrements refcount)
4. Destroys temporary (decrements refcount again)

This results in redundant refcount thrashing and temporary allocation.

## Solution
Directly copy the packed `data_` field and manually increment the refcount using `c10::raw::intrusive_ptr::incref()`:
- No temporary allocation
- No redundant refcount cycles  
- Direct refcount manipulation via existing c10 API

## Impact
SymInt copying is extremely frequent in symbolic shape computations. This optimization reduces overhead in every shape-related operation during dynamic shape tracing and symbolic execution.

## Files Changed
- `c10/core/SymInt.h`: Updated copy constructor and copy assignment operator

## Test Plan
- Existing SymInt tests verify correctness (no behavior changes)
- Performance improved in symbolic shape-heavy workloads