### PR TITLE
docs: clarify distributed version homogeneity requirement

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -191,6 +191,10 @@ Initialization is not thread-safe. Process group creation should be performed fr
 inconsistent 'UUID' assignment across ranks, and to prevent races during initialization that can lead to hangs.
 :::
 
+:::{note}
+`torch.distributed` assumes that all processes participating in a distributed job run the same PyTorch version. Mixed-version clusters are outside the supported deployment model and may result in undefined behavior or runtime failures. When troubleshooting distributed initialization issues, verifying that all ranks report the same `torch.__version__` is a recommended first diagnostic step.
+:::
+
 ```{eval-rst}
 .. autofunction:: is_available
 ```


### PR DESCRIPTION
This PR clarifies that `torch.distributed` expects all processes in a distributed job to run the same PyTorch version.

This change makes the version homogeneity assumption explicit in the initialization section to aid troubleshooting and deployment clarity.

**Changes:**
- Add note to `docs/source/distributed.md` Initialization section documenting the version homogeneity expectation

**Testing:**
- Documentation-only change
- CI checks will verify docs build successfully