### PR TITLE
[Dist][CI] fix distributed timeout

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -669,24 +669,13 @@ class DistTensorOpsTest(DTensorTestBase):
                 torch.randn(16, 32, 16),
                 torch.randint(5, (4, 8, 16)),
             )
+            # Multi-index (3-tensor) calls: keep representative subset to avoid
+            # combinatorial explosion in DTensorConverter (each 3-tensor call
+            # generates 40-80 sharding combinations via itertools.product).
             self._test_op(
                 mesh,
                 lambda x, y, z: x[z, y],
                 torch.randn(16, 32, 16),
-                torch.randint(5, (12, 8, 12)),
-                torch.randint(2, (12, 8, 12)),
-            )
-            self._test_op(
-                mesh,
-                lambda x, y, z: x[z, :, y],
-                torch.randn(16, 32, 16),
-                torch.randint(5, (12, 8, 12)),
-                torch.randint(2, (12, 8, 12)),
-            )
-            self._test_op(
-                mesh,
-                lambda x, y, z: x[:, z, :, y],
-                torch.randn(16, 32, 16, 12),
                 torch.randint(5, (12, 8, 12)),
                 torch.randint(2, (12, 8, 12)),
             )
@@ -697,35 +686,6 @@ class DistTensorOpsTest(DTensorTestBase):
                 torch.randn(16, 32, 16, 12),
                 torch.randint(5, (12, 8, 12)),
                 torch.randint(2, (12, 1, 12)),
-            )
-            # implicit (left-padded) broadcast
-            self._test_op(
-                mesh,
-                lambda x, y, z: x[:, z, :, y],
-                torch.randn(16, 32, 16, 12),
-                torch.randint(5, (12, 8, 12)),
-                torch.randint(2, (8, 12)),
-            )
-            self._test_op(
-                mesh,
-                lambda x, y, z: x[z, y, :, :],
-                torch.randn(16, 32, 16, 12),
-                torch.randint(2, (8, 12)),
-                torch.randint(5, (12, 8, 12)),
-            )
-            self._test_op(
-                mesh,
-                lambda x, y, z: x[z, :, y, :],
-                torch.randn(16, 32, 16, 12),
-                torch.randint(2, (8, 12)),
-                torch.randint(5, (12, 8, 12)),
-            )
-            self._test_op(
-                mesh,
-                lambda x, y, z: x[z, :, :, y],
-                torch.randn(16, 32, 16, 12),
-                torch.randint(2, (8, 1)),
-                torch.randint(5, (12, 8, 12)),
             )
 
     @with_comms


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175030

It's timing out because it's moved out of slow test https://github.com/pytorch/pytorch/pull/171051

some device disabled test_index already, just not cuda device: https://github.com/pytorch/pytorch/pull/173181


from claude

  Root Cause

  The test_index method in test/distributed/tensor/test_tensor_ops.py:623 was causing the test suite to hang (taking
  >10 minutes for a single test, with the full suite never completing).

  Why: test_index made 15 calls to _test_op, which uses DTensorConverter to generate all possible sharding placement
  combinations via itertools.product. The 8 three-tensor calls (lines 672-729) each generated 40-80 combinations, for
  a total of ~504 combinations out of 564. Each combination requires multiple NCCL collective operations
  (distribute_tensor + full_tensor), making the test extremely slow. The test runs twice — once in DistTensorOpsTest
  and once in DistTensorOpsTestWithLocalTensor.

  Breakdown of combinations per call:
  - 2-tensor calls: 8-16 combinations each (76 total) — reasonable
  - 3-tensor calls: 40-80 combinations each (504 total) — combinatorial explosion from 4×4×4=64 or 5×4×4=80 products

  Fix

  Reduced the 3-tensor _test_op calls from 8 to 2 representative ones:
  1. x[z, y] — basic multi-index (64 combinations)
  2. x[:, z, :, y] with broadcast — covers 4D tensor + broadcast pattern (60 combinations)

  This reduces total combinations from 564 to ~200, bringing test_index from >10 minutes down to ~2 minutes, and the
  full suite from never-completing to ~11 minutes.