### PR TITLE
argmax cpu: fast path for dim=0 reductions with two rows

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2537,6 +2537,32 @@ class TestReductions(TestCase):
             torch.tensor([1, 0], device=device, dtype=torch.int64),
         )
 
+        # NaN handling: fast path must match generic reduction behavior
+        x_nan = torch.tensor(
+            [
+                [float("nan"), 1.0, float("nan"), 2.0],
+                [0.0, float("nan"), 3.0, float("nan")],
+            ],
+            device=device,
+        )
+        self.assertEqual(
+            x_nan.argmax(dim=0),
+            x_nan.t().argmax(dim=1),
+        )
+
+        # inf / -inf edge cases
+        x_inf = torch.tensor(
+            [
+                [float("-inf"), 1.0, float("inf"), -1.0],
+                [0.0, float("inf"), 2.0, float("-inf")],
+            ],
+            device=device,
+        )
+        self.assertEqual(
+            x_inf.argmax(dim=0),
+            x_inf.t().argmax(dim=1),
+        )
+
     @dtypes(torch.int, torch.long, torch.float, torch.double)
     @dtypesIfCUDA(torch.int, torch.long, torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.int, torch.long, torch.half, torch.float, torch.double)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2522,6 +2522,21 @@ class TestReductions(TestCase):
         self.assertEqual(x.argmax(dim=-2, keepdim=True), torch.zeros(1, n, dtype=torch.int64))
         self.assertEqual(x.argmin(dim=-2, keepdim=True), torch.zeros(1, n, dtype=torch.int64))
 
+    def test_argmax_dim0_two_rows(self, device):
+        x = torch.tensor([[1.0, 5.0, 3.0], [2.0, 4.0, 3.0]], device=device)
+        self.assertEqual(
+            x.argmax(dim=0),
+            torch.tensor([1, 0, 0], device=device, dtype=torch.int64),
+        )
+
+        # non-contiguous input should preserve tie-breaking semantics
+        y = x[:, ::2]
+        self.assertFalse(y.is_contiguous())
+        self.assertEqual(
+            y.argmax(dim=0),
+            torch.tensor([1, 0], device=device, dtype=torch.int64),
+        )
+
     @dtypes(torch.int, torch.long, torch.float, torch.double)
     @dtypesIfCUDA(torch.int, torch.long, torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.int, torch.long, torch.half, torch.float, torch.double)


### PR DESCRIPTION
## Summary
This PR adds a small CPU fast path in `argmax_kernel_impl` for a common shape pattern where reduction is over dim 0 and the reduced size is exactly 2 (e.g. `[2, ...] -> [...]`).

Instead of going through the generic `binary_kernel_reduce` path, it uses a narrowed iterator over non-reduced dims and directly compares the two candidate values per output element.

## Why
Issue: https://github.com/pytorch/pytorch/issues/140000

`argmax` eager CPU currently has notable overhead in some dim-reduction patterns. For the 2-row case, the reduction itself is trivial and dispatch/iterator overhead dominates. This path reduces that overhead while preserving semantics (tie-breaking, NaN handling) by reusing `ArgMaxOps`.

## Changes
- `aten/src/ATen/native/cpu/ReduceOpsKernel.cpp`
  - Add fast path in `argmax_kernel_impl` when:
    - single reduced dim
    - reduced dim is dim 0
    - one input
    - reduced size is 2
- `test/test_reductions.py`
  - Add `test_argmax_dim0_two_rows` covering:
    - contiguous case
    - non-contiguous sliced input
    - tie behavior

## Test
- `python3 -m py_compile test/test_reductions.py`

I can add a small benchmark snippet in this PR if maintainers want perf numbers checked in-tree.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01