### PR TITLE
[FSDP2] allow ModuleList/ModuleDict subclasses that implement forward()

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -46,6 +46,25 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 
+class _DictWithForward(nn.ModuleDict):
+    def __init__(self, in_features=8, out_features=8):
+        super().__init__({"lin": nn.Linear(in_features, out_features)})
+
+    def forward(self, x):
+        return self["lin"](x)
+
+
+class _ListWithForward(nn.ModuleList):
+    def __init__(self, in_features=8, out_features=8):
+        super().__init__([nn.Linear(in_features, out_features)])
+
+    def forward(self, x):
+        out = x
+        for m in self:
+            out = m(out)
+        return out
+
+
 device_type = torch.device(get_devtype())
 
 
@@ -153,6 +172,31 @@ class TestFullyShardDeviceDTensor(FSDPTestMultiThread):
         )
         with self.assertRaisesRegex(ValueError, regex):
             fully_shard(model, mesh=dp_mesh)
+
+
+class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
+    """Tests that fully_shard accepts ModuleDict/ModuleList subclasses that implement forward()."""
+
+    @property
+    def world_size(self) -> int:
+        return 1
+
+    @skip_if_lt_x_gpu(1)
+    def test_moduledict_subclass_with_forward(self):
+        model = _DictWithForward(8, 8)
+        mesh = init_device_mesh(device_type.type, (self.world_size,))
+        # Should not raise due to container type since forward() is implemented
+        fsdp_model = fully_shard(model, mesh=mesh)
+        x = torch.randn(2, 8, device=device_type)
+        _ = fsdp_model(x)
+
+    @skip_if_lt_x_gpu(1)
+    def test_modulelist_subclass_with_forward(self):
+        model = _ListWithForward(8, 8)
+        mesh = init_device_mesh(device_type.type, (self.world_size,))
+        fsdp_model = fully_shard(model, mesh=mesh)
+        x = torch.randn(2, 8, device=device_type)
+        _ = fsdp_model(x)
 
 
 class TestFullyShardMeshArg(FSDPTestMultiThread):

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -46,25 +46,6 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 
-class _DictWithForward(nn.ModuleDict):
-    def __init__(self, in_features=8, out_features=8):
-        super().__init__({"lin": nn.Linear(in_features, out_features)})
-
-    def forward(self, x):
-        return self["lin"](x)
-
-
-class _ListWithForward(nn.ModuleList):
-    def __init__(self, in_features=8, out_features=8):
-        super().__init__([nn.Linear(in_features, out_features)])
-
-    def forward(self, x):
-        out = x
-        for m in self:
-            out = m(out)
-        return out
-
-
 device_type = torch.device(get_devtype())
 
 
@@ -177,13 +158,30 @@ class TestFullyShardDeviceDTensor(FSDPTestMultiThread):
 class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
     """Tests that fully_shard accepts ModuleDict/ModuleList subclasses that implement forward()."""
 
+    class DictWithForward(nn.ModuleDict):
+        def __init__(self, in_features=8, out_features=8):
+            super().__init__({"lin": nn.Linear(in_features, out_features)})
+
+        def forward(self, x):
+            return self["lin"](x)
+
+    class ListWithForward(nn.ModuleList):
+        def __init__(self, in_features=8, out_features=8):
+            super().__init__([nn.Linear(in_features, out_features)])
+
+        def forward(self, x):
+            out = x
+            for m in self:
+                out = m(out)
+            return out
+
     @property
     def world_size(self) -> int:
         return 1
 
     @skip_if_lt_x_gpu(1)
     def test_moduledict_subclass_with_forward(self):
-        model = _DictWithForward(8, 8)
+        model = self.DictWithForward(8, 8)
         mesh = init_device_mesh(device_type.type, (self.world_size,))
         # Should not raise due to container type since forward() is implemented
         fsdp_model = fully_shard(model, mesh=mesh)
@@ -192,7 +190,7 @@ class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
 
     @skip_if_lt_x_gpu(1)
     def test_modulelist_subclass_with_forward(self):
-        model = _ListWithForward(8, 8)
+        model = self.ListWithForward(8, 8)
         mesh = init_device_mesh(device_type.type, (self.world_size,))
         fsdp_model = fully_shard(model, mesh=mesh)
         x = torch.randn(2, 8, device=device_type)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
@@ -36,7 +36,10 @@ def _validate_module(module: nn.Module, func_name: str) -> None:
 
     Raises ValueError if the module is a container that doesn't implement forward.
     """
-    if isinstance(module, (nn.ModuleList, nn.ModuleDict)):
+    if (
+        isinstance(module, (nn.ModuleList, nn.ModuleDict))
+        and module.__class__.forward is nn.Module.forward
+    ):
         raise ValueError(
             f"{func_name} does not support containers that do not implement forward: {module}"
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175033

duplciates to https://github.com/pytorch/pytorch/pull/168905
Fixes #167856.