### PR TITLE
Pin setuptools<82 in inductor benchmark docker build

### DIFF
--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -49,6 +49,10 @@ fi
 # Stable packages are ok here, just to satisfy TorchBench check
 pip_install torch torchvision torchaudio --index-url "${CUDA_INDEX_URL}"
 
+# Pin setuptools<82 to avoid breaking visdom install (setuptools 82 removed
+# pkg_resources which visdom's setup.py depends on)
+pip_install 'setuptools<82'
+
 install_torchbench
 install_huggingface
 install_timm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #175035
* #175034

setuptools 82 removed `pkg_resources`, which breaks `visdom`
(last updated 2022) during the torchbench docker image build. This
causes CycleGAN model setup to fail silently (due to
`--continue_on_fail`), leading to `eager_fail_to_run` accuracy
failures across all inductor torchbench CI jobs since Feb 10.

Authored with Claude.