### PR TITLE
[ROCm] Fix flaky test_graph_concurrent_replay

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2826,14 +2826,20 @@ exit(2)
             # But replay() (especially cudaGraphLaunch) can incur significant CPU overhead.
             # The following pattern helps align device-side execution of g0 and g1's kernels.
             torch.cuda.synchronize()
+            # Increase sleep cycles on ROCm to ensure proper kernel overlap alignment.
+            # HIP clock cycles map differently to wall-clock time compared to CUDA.
+            sleep_cycles = 10000000 if TEST_WITH_ROCM else 1000000
             with torch.cuda.stream(s0):
-                torch.cuda._sleep(1000000)
+                torch.cuda._sleep(sleep_cycles)
                 s1.wait_stream(s0)
                 g0.replay()
             with torch.cuda.stream(s1):
                 g1.replay()
             torch.cuda.current_stream().wait_stream(s0)
             torch.cuda.current_stream().wait_stream(s1)
+            if TEST_WITH_ROCM:
+                # Ensure all HIP operations complete before checking results
+                torch.cuda.synchronize()
 
             if (not TEST_CUDAMALLOCASYNC) and (share_mem != "Don't share"):
                 # If we used the native allocator and shared mempools,


### PR DESCRIPTION
## Summary

Fixes #104055


The test `test_graph_concurrent_replay` uses `torch.cuda._sleep(1000000)` to align device-side execution of two CUDA graphs for concurrent replay. On ROCm, HIP clock cycles map differently to wall-clock time, causing the synchronization alignment to fail and leading to intermittent assertion failures.

## Changes

- Increase sleep cycles to 10M on ROCm (vs 1M on CUDA) for proper kernel overlap alignment
- Add explicit `torch.cuda.synchronize()` on ROCm before assertion checks to ensure all HIP operations have completed

## Why this is safe

- Increasing the sleep duration only makes the test more reliable — it doesn't change what the test validates
- The extra synchronization on ROCm is strictly additive and ensures results are fully materialized before assertions
- Test logic and assertions remain identical; only timing calibration is adjusted for HIP

## Test Plan

```bash
PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda.py TestCuda.test_graph_concurrent_replay -v

# Stress test for flakiness:
for i in \$(seq 1 50); do
  python test/test_cuda.py TestCuda.test_graph_concurrent_replay 2>&1 | tail -1
done
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @pytorch/rocm