### PR TITLE
[ROCm] Fix flaky test_mem_get_info

### DIFF
--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -1014,9 +1014,10 @@ class TestCudaMultiGPU(TestCase):
             # increasing to 8MB to force acquiring a new block and overcome blocksize differences across platforms
             t = torch.randn(1024 * 1024 * 8, device=device)  # noqa: F841
 
-            if IS_JETSON:
+            if IS_JETSON or torch.version.hip:
                 # w/o syncing, mem_get_info will run before memory allocated has actually increased.
-                # This race condition causes consistent failure
+                # On ROCm, hipMemGetInfo() has the same race condition as Jetson
+                # due to asynchronous memory management in the HIP runtime.
                 torch.cuda.synchronize()
             after_free_bytes, after_available_bytes = torch.cuda.mem_get_info(device)
 


### PR DESCRIPTION
## Summary

Fixes #103495

The `test_mem_get_info` test has been flaky on ROCm since June 2023. The HIP runtime's `hipMemGetInfo()` has asynchronous memory reporting — without synchronization, the query runs before allocations are reflected in free memory counts (same issue as Jetson).

## Changes

Add `torch.version.hip` to the existing `IS_JETSON` synchronization path so that `torch.cuda.synchronize()` is called before querying memory info on ROCm.

## Why this is safe

- The synchronization pattern already exists for Jetson (same root cause)
- Adding sync on ROCm only makes the test more reliable
- No production code changes — test-only fix

## Test Plan

```bash
PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda_multigpu.py TestCudaMultiGPU.test_mem_get_info -v
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @pytorch/rocm