### PR TITLE
[ROCm] Fix test_compile_kernel_advanced TF32 precision mismatch

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7824,7 +7824,12 @@ class TestCompileKernel(TestCase):
         )
 
         # Verify results
+        # Custom kernel does FP32 math. Ensure reference also uses FP32
+        # to avoid TF32 precision mismatch on MI300X (see #169392).
+        old_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+        torch.backends.cuda.matmul.allow_tf32 = False
         expected = torch.matmul(A, B)
+        torch.backends.cuda.matmul.allow_tf32 = old_allow_tf32
         self.assertEqual(C, expected)
 
         # Test with different compute capability if specified

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7777,7 +7777,6 @@ class TestCompileKernel(TestCase):
         with self.assertRaises(RuntimeError):
             kernel.set_shared_memory_config(excessive_shared_mem)
 
-    @skipIfRocmArch(MI300_ARCH)
     @tf32_on_and_off(0.005)
     @unittest.skipIf(not TEST_CUDA, "No CUDA")
     def test_compile_kernel_advanced(self):


### PR DESCRIPTION
## Summary

Fixes #169392

The test compiles a custom CUDA/HIP matmul kernel that always uses **FP32 arithmetic**. The reference comparison uses `torch.matmul`, which may use TF32 when available (truncating mantissa to 10 bits).

On MI300X with hipBLASLt, TF32 produces noticeably different results from FP32, causing assertion failures.

## Changes

Temporarily disable TF32 for the reference `torch.matmul` call so both the custom kernel and reference use identical FP32 arithmetic.

## Why this is safe

- This is correct for **all platforms** (including NVIDIA): the test validates a custom FP32 kernel, not TF32 behavior
- The TF32 flag is properly saved and restored after the matmul call
- No changes to production code — test-only fix

## Test Plan

```bash
PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda.py TestCuda.test_compile_kernel_advanced -v
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @pytorch/rocm