### PR TITLE
[BE][MPS] Add `_3d` suffix `grid_sampler` kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/GridSampler.h
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.h
@@ -1,15 +1,6 @@
 #pragma once
 #include <c10/metal/common.h>
 
-#ifdef __METAL__
-enum class GridSamplerInterpolation { Bilinear, Nearest, Bicubic };
-enum class GridSamplerPadding { Zeros, Border, Reflection };
-#else
-#include <ATen/native/GridSamplerUtils.h>
-using at::native::GridSamplerInterpolation;
-using at::native::GridSamplerPadding;
-#endif
-
 template <unsigned N = 5, typename idx_type_t = int32_t>
 struct GridSamplerParams {
   int32_t sampler_dims;
@@ -19,7 +10,5 @@ struct GridSamplerParams {
   ::c10::metal::array<idx_type_t, N> input_strides;
   ::c10::metal::array<idx_type_t, N> grid_sizes;
   ::c10::metal::array<idx_type_t, N> grid_strides;
-  GridSamplerInterpolation interpolation_mode;
-  GridSamplerPadding padding_mode;
   bool align_corners;
 };

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -68,32 +68,6 @@ static int32_t mod(int32_t a, int32_t b) {
 // Sentinel index value to indicate zero padding
 constant int32_t IDX_ZERO = -1;
 
-// Apply padding to an index into the input
-static int32_t pad_input_index(
-    int32_t idx,
-    int32_t input_size,
-    GridSamplerPadding padding_mode,
-    bool align_corners) {
-  int32_t idx_padded = idx;
-
-  if (padding_mode == GridSamplerPadding::Zeros) {
-    idx_padded = (idx < 0) ? IDX_ZERO : idx_padded;
-    idx_padded = (idx >= input_size) ? IDX_ZERO : idx_padded;
-
-  } else if (padding_mode == GridSamplerPadding::Border) {
-    idx_padded = (idx < 0) ? 0 : idx_padded;
-    idx_padded = (idx >= input_size) ? input_size - 1 : idx_padded;
-
-  } else if (padding_mode == GridSamplerPadding::Reflection) {
-    auto scale_length = align_corners ? (input_size - 1) : input_size;
-    auto idx_mod = mod(idx, scale_length);
-    auto idx_mod_reverse = (input_size - 1) - idx_mod;
-    bool is_reverse = (abs(idx - idx_mod) / scale_length) % 2 == 1;
-    idx_padded = is_reverse ? idx_mod_reverse : idx_mod;
-  }
-  return idx_padded;
-}
-
 // Unnormalize grid coordinate from [-1, 1] to pixel space
 template <typename T>
 static T grid_sampler_unnormalize(T coord, int32_t size, bool align_corners) {
@@ -124,26 +98,57 @@ static T reflect_coordinates(T in, int32_t twice_low, int32_t twice_high) {
   return (flips % 2 == 0) ? (extra + min_val) : (span - extra + min_val);
 }
 
-// Compute source index with padding mode
-template <typename T>
-static T compute_source_index(
-    T coord,
-    int32_t size,
-    GridSamplerPadding padding_mode,
-    bool align_corners) {
-  coord = grid_sampler_unnormalize(coord, size, align_corners);
-  if (padding_mode == GridSamplerPadding::Border) {
-    coord = clip_coordinates(coord, size);
-  } else if (padding_mode == GridSamplerPadding::Reflection) {
+// Padding functors: each encapsulates the padding logic for integer indices
+// (pad) and float source coordinates (compute_source).
+struct PadZeros {
+  static constant constexpr bool checks_bounds = true;
+
+  static int32_t pad(int32_t idx, int32_t input_size, bool) {
+    return (idx < 0 || idx >= input_size) ? IDX_ZERO : idx;
+  }
+
+  template <typename T>
+  static T compute_source(T coord, int32_t size, bool align_corners) {
+    return grid_sampler_unnormalize(coord, size, align_corners);
+  }
+};
+
+struct PadBorder {
+  static constant constexpr bool checks_bounds = false;
+
+  static int32_t pad(int32_t idx, int32_t input_size, bool) {
+    return clamp(idx, 0, input_size - 1);
+  }
+
+  template <typename T>
+  static T compute_source(T coord, int32_t size, bool align_corners) {
+    coord = grid_sampler_unnormalize(coord, size, align_corners);
+    return clip_coordinates(coord, size);
+  }
+};
+
+struct PadReflection {
+  static constant constexpr bool checks_bounds = false;
+
+  static int32_t pad(int32_t idx, int32_t input_size, bool align_corners) {
+    auto scale_length = align_corners ? (input_size - 1) : input_size;
+    auto idx_mod = mod(idx, scale_length);
+    auto idx_mod_reverse = (input_size - 1) - idx_mod;
+    bool is_reverse = (abs(idx - idx_mod) / scale_length) % 2 == 1;
+    return is_reverse ? idx_mod_reverse : idx_mod;
+  }
+
+  template <typename T>
+  static T compute_source(T coord, int32_t size, bool align_corners) {
+    coord = grid_sampler_unnormalize(coord, size, align_corners);
     if (align_corners) {
       coord = reflect_coordinates(coord, 0, 2 * (size - 1));
     } else {
       coord = reflect_coordinates(coord, -1, 2 * size - 1);
     }
-    coord = clip_coordinates(coord, size);
+    return clip_coordinates(coord, size);
   }
-  return coord;
-}
+};
 
 // Cubic convolution helper 1: for |x| < 1
 template <typename T>
@@ -176,7 +181,7 @@ static T cubic_interp1d(T x0, T x1, T x2, T x3, T t) {
 }
 
 // 2D Bilinear interpolation
-template <typename T>
+template <typename Pad, typename T>
 static T interpolate_bilinear_2d(
     constant T* input,
     opmath_t<T> ix,
@@ -185,7 +190,6 @@ static T interpolate_bilinear_2d(
     int32_t inp_W,
     int32_t inp_sH,
     int32_t inp_sW,
-    GridSamplerPadding padding_mode,
     bool align_corners) {
   ix = grid_sampler_unnormalize(ix, inp_W, align_corners);
   iy = grid_sampler_unnormalize(iy, inp_H, align_corners);
@@ -208,14 +212,14 @@ static T interpolate_bilinear_2d(
   opmath_t<T> se = (ix - static_cast<opmath_t<T>>(ix_nw)) *
       (iy - static_cast<opmath_t<T>>(iy_nw));
 
-  int32_t iy_nw_p = pad_input_index(iy_nw, inp_H, padding_mode, align_corners);
-  int32_t ix_nw_p = pad_input_index(ix_nw, inp_W, padding_mode, align_corners);
-  int32_t iy_ne_p = pad_input_index(iy_ne, inp_H, padding_mode, align_corners);
-  int32_t ix_ne_p = pad_input_index(ix_ne, inp_W, padding_mode, align_corners);
-  int32_t iy_sw_p = pad_input_index(iy_sw, inp_H, padding_mode, align_corners);
-  int32_t ix_sw_p = pad_input_index(ix_sw, inp_W, padding_mode, align_corners);
-  int32_t iy_se_p = pad_input_index(iy_se, inp_H, padding_mode, align_corners);
-  int32_t ix_se_p = pad_input_index(ix_se, inp_W, padding_mode, align_corners);
+  int32_t iy_nw_p = Pad::pad(iy_nw, inp_H, align_corners);
+  int32_t ix_nw_p = Pad::pad(ix_nw, inp_W, align_corners);
+  int32_t iy_ne_p = Pad::pad(iy_ne, inp_H, align_corners);
+  int32_t ix_ne_p = Pad::pad(ix_ne, inp_W, align_corners);
+  int32_t iy_sw_p = Pad::pad(iy_sw, inp_H, align_corners);
+  int32_t ix_sw_p = Pad::pad(ix_sw, inp_W, align_corners);
+  int32_t iy_se_p = Pad::pad(iy_se, inp_H, align_corners);
+  int32_t ix_se_p = Pad::pad(ix_se, inp_W, align_corners);
 
   opmath_t<T> out_acc = static_cast<opmath_t<T>>(0);
   if (iy_nw_p != IDX_ZERO && ix_nw_p != IDX_ZERO) {
@@ -243,7 +247,7 @@ static T interpolate_bilinear_2d(
 }
 
 // 2D Nearest neighbor interpolation
-template <typename T>
+template <typename Pad, typename T>
 static T interpolate_nearest_2d(
     constant T* input,
     opmath_t<T> ix,
@@ -252,18 +256,14 @@ static T interpolate_nearest_2d(
     int32_t inp_W,
     int32_t inp_sH,
     int32_t inp_sW,
-    GridSamplerPadding padding_mode,
     bool align_corners) {
-  // For Border and Reflection modes, apply padding to float coordinates
-  // before rounding (matches CPU behavior)
-  ix = compute_source_index(ix, inp_W, padding_mode, align_corners);
-  iy = compute_source_index(iy, inp_H, padding_mode, align_corners);
+  ix = Pad::compute_source(ix, inp_W, align_corners);
+  iy = Pad::compute_source(iy, inp_H, align_corners);
 
   int32_t ix_nearest = static_cast<int32_t>(rint(ix));
   int32_t iy_nearest = static_cast<int32_t>(rint(iy));
 
-  // For Zeros padding, check bounds after rounding
-  if (padding_mode == GridSamplerPadding::Zeros) {
+  if (Pad::checks_bounds) {
     if (ix_nearest < 0 || ix_nearest >= inp_W || iy_nearest < 0 ||
         iy_nearest >= inp_H) {
       return static_cast<T>(0);
@@ -274,7 +274,7 @@ static T interpolate_nearest_2d(
 }
 
 // Helper to get bounded value for bicubic interpolation
-template <typename T>
+template <typename Pad, typename T>
 static opmath_t<T> get_bicubic_value(
     constant T* input,
     int32_t y,
@@ -283,10 +283,9 @@ static opmath_t<T> get_bicubic_value(
     int32_t inp_W,
     int32_t inp_sH,
     int32_t inp_sW,
-    GridSamplerPadding padding_mode,
     bool align_corners) {
-  int32_t y_p = pad_input_index(y, inp_H, padding_mode, align_corners);
-  int32_t x_p = pad_input_index(x, inp_W, padding_mode, align_corners);
+  int32_t y_p = Pad::pad(y, inp_H, align_corners);
+  int32_t x_p = Pad::pad(x, inp_W, align_corners);
   if (y_p == IDX_ZERO || x_p == IDX_ZERO) {
     return static_cast<opmath_t<T>>(0);
   }
@@ -294,7 +293,7 @@ static opmath_t<T> get_bicubic_value(
 }
 
 // 2D Bicubic interpolation
-template <typename T>
+template <typename Pad, typename T>
 static T interpolate_bicubic_2d(
     constant T* input,
     opmath_t<T> ix,
@@ -303,7 +302,6 @@ static T interpolate_bicubic_2d(
     int32_t inp_W,
     int32_t inp_sH,
     int32_t inp_sW,
-    GridSamplerPadding padding_mode,
     bool align_corners) {
   ix = grid_sampler_unnormalize(ix, inp_W, align_corners);
   iy = grid_sampler_unnormalize(iy, inp_H, align_corners);
@@ -319,7 +317,7 @@ static T interpolate_bicubic_2d(
 
   for (int32_t i = 0; i < 4; ++i) {
     coefficients[i] = cubic_interp1d(
-        get_bicubic_value<T>(
+        get_bicubic_value<Pad, T>(
             input,
             iy_nw_i - 1 + i,
             ix_nw_i - 1,
@@ -327,9 +325,8 @@ static T interpolate_bicubic_2d(
             inp_W,
             inp_sH,
             inp_sW,
-            padding_mode,
             align_corners),
-        get_bicubic_value<T>(
+        get_bicubic_value<Pad, T>(
             input,
             iy_nw_i - 1 + i,
             ix_nw_i + 0,
@@ -337,9 +334,8 @@ static T interpolate_bicubic_2d(
             inp_W,
             inp_sH,
             inp_sW,
-            padding_mode,
             align_corners),
-        get_bicubic_value<T>(
+        get_bicubic_value<Pad, T>(
             input,
             iy_nw_i - 1 + i,
             ix_nw_i + 1,
@@ -347,9 +343,8 @@ static T interpolate_bicubic_2d(
             inp_W,
             inp_sH,
             inp_sW,
-            padding_mode,
             align_corners),
-        get_bicubic_value<T>(
+        get_bicubic_value<Pad, T>(
             input,
             iy_nw_i - 1 + i,
             ix_nw_i + 2,
@@ -357,7 +352,6 @@ static T interpolate_bicubic_2d(
             inp_W,
             inp_sH,
             inp_sW,
-            padding_mode,
             align_corners),
         tx);
   }
@@ -366,8 +360,62 @@ static T interpolate_bicubic_2d(
       coefficients[0], coefficients[1], coefficients[2], coefficients[3], ty));
 }
 
+// Interpolation functors for the 2D kernel.
+// Each wraps the respective interpolation function with the padding already
+// baked in via the Pad template parameter.
+template <typename Pad>
+struct Bilinear2D {
+  template <typename T>
+  static T interpolate(
+      constant T* input,
+      opmath_t<T> ix,
+      opmath_t<T> iy,
+      int32_t inp_H,
+      int32_t inp_W,
+      int32_t inp_sH,
+      int32_t inp_sW,
+      bool align_corners) {
+    return interpolate_bilinear_2d<Pad, T>(
+        input, ix, iy, inp_H, inp_W, inp_sH, inp_sW, align_corners);
+  }
+};
+
+template <typename Pad>
+struct Nearest2D {
+  template <typename T>
+  static T interpolate(
+      constant T* input,
+      opmath_t<T> ix,
+      opmath_t<T> iy,
+      int32_t inp_H,
+      int32_t inp_W,
+      int32_t inp_sH,
+      int32_t inp_sW,
+      bool align_corners) {
+    return interpolate_nearest_2d<Pad, T>(
+        input, ix, iy, inp_H, inp_W, inp_sH, inp_sW, align_corners);
+  }
+};
+
+template <typename Pad>
+struct Bicubic2D {
+  template <typename T>
+  static T interpolate(
+      constant T* input,
+      opmath_t<T> ix,
+      opmath_t<T> iy,
+      int32_t inp_H,
+      int32_t inp_W,
+      int32_t inp_sH,
+      int32_t inp_sW,
+      bool align_corners) {
+    return interpolate_bicubic_2d<Pad, T>(
+        input, ix, iy, inp_H, inp_W, inp_sH, inp_sW, align_corners);
+  }
+};
+
 // 2D grid sampler kernel
-template <typename T>
+template <typename Interp, typename T>
 kernel void grid_sampler_2d(
     device T* output [[buffer(0)]],
     constant T* input [[buffer(1)]],
@@ -394,8 +442,6 @@ kernel void grid_sampler_2d(
   auto grid_sW = params.grid_strides[2];
   auto grid_sCoor = params.grid_strides[3];
 
-  auto interpolation_mode = params.interpolation_mode;
-  auto padding_mode = params.padding_mode;
   auto align_corners = params.align_corners;
 
   auto num_elements = N * out_H * out_W;
@@ -415,41 +461,8 @@ kernel void grid_sampler_2d(
   auto out_ptr_NCHW = output + n * out_sN + h * out_sH + w * out_sW;
 
   for (int32_t c = 0; c < C; ++c) {
-    T result;
-    if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-      result = interpolate_bilinear_2d<T>(
-          inp_ptr_N,
-          ix,
-          iy,
-          inp_H,
-          inp_W,
-          inp_sH,
-          inp_sW,
-          padding_mode,
-          align_corners);
-    } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-      result = interpolate_nearest_2d<T>(
-          inp_ptr_N,
-          ix,
-          iy,
-          inp_H,
-          inp_W,
-          inp_sH,
-          inp_sW,
-          padding_mode,
-          align_corners);
-    } else {
-      result = interpolate_bicubic_2d<T>(
-          inp_ptr_N,
-          ix,
-          iy,
-          inp_H,
-          inp_W,
-          inp_sH,
-          inp_sW,
-          padding_mode,
-          align_corners);
-    }
+    auto result = Interp::template interpolate<T>(
+        inp_ptr_N, ix, iy, inp_H, inp_W, inp_sH, inp_sW, align_corners);
     out_ptr_NCHW[c * out_sC] = result;
     inp_ptr_N += inp_sC;
   }
@@ -530,15 +543,9 @@ T interpolate_linear_3d(
       scale0_right * scale1_right * scale2_right * h);
 }
 
-// Calculates a single output element.
-// `input` shape:
-//    2 sampler dims: (Hin, Win)
-//    3 sampler dims: (Din, Hin, Win)
-// `coords` values:
-//    2 sampler dims: (Wcoord, Hcoord)
-//    3 sampler dims: (Wcoord, Hcoord, Dcoord)
-template <typename T>
-void grid_sampler_single_element(
+// 3D bilinear sampling for a single output element.
+template <typename Pad, typename T>
+void grid_sampler_3d_single_element(
     device T* output,
     constant T* input,
     constant T* coords,
@@ -546,88 +553,36 @@ void grid_sampler_single_element(
     constant int32_t* input_sizes,
     constant int32_t* input_strides,
     int32_t coord_stride,
-    GridSamplerInterpolation interpolation_mode,
-    GridSamplerPadding padding_mode,
     bool align_corners) {
   int32_t left_indices[3];
   int32_t right_indices[3];
   opmath_t<T> scales[3];
 
-  // For each dimension, find the pair of indices in the corresponding dimension
-  // of `input` which surround the grid coordinate in that dimension. We'll do
-  // this by mapping different coordinate spaces onto each other. There are
-  // basically three different coordinate spaces to keep in mind:
-  //
-  //  * aligned grid space
-  //    - `-1` refers to the leftmost input value.
-  //    - `1` refers to the rightmost input value.
-  //
-  //  * unaligned grid space
-  //    - `-1` refers to the midpoint between the leftmost input value and
-  //      a padding value to the left of that.
-  //    - `1` refers to the midpoint between the rightmost input value and
-  //      a padding value to the right of that.
-  //
-  //  * input index space
-  //    - `n` refers to the n-th value of the input.
-  //    - `0` refers to the leftmost input value.
-  //    - `N-1` refers to the rightmost input value.
-  //
-  // If `align_corners == False`, then the coordinates are is in unaligned grid
-  // space, and we will map it onto aligned grid space. If `align_corners ==
-  // True`, then coordinates are already in aligned grid space.
-  //
-  // Then we will map unaligned grid space onto input index space, making it
-  // relatively simple to find the two input indices that surround the
-  // coordinate.
   for (auto coord_dim = 0; coord_dim < dims; coord_dim++) {
     auto input_dim = dims - coord_dim - 1;
     auto input_size = input_sizes[input_dim];
     auto coord = static_cast<opmath_t<T>>(coords[coord_dim * coord_stride]);
 
     if (!align_corners) {
-      // Map unaligned grid space to aligned grid space
       auto corner_alignment_factor = static_cast<opmath_t<T>>(input_size) /
           static_cast<opmath_t<T>>(input_size - 1);
       coord = coord * corner_alignment_factor;
     }
 
-    // Map aligned grid space to input index space
     coord = (coord + 1) * (static_cast<opmath_t<T>>(input_size - 1) / 2);
 
-    // Get the input indices surrounding the coordinate, apply padding to them,
-    // and obtain the scaling factor between the two for interpolation.
     auto left_idx = static_cast<int32_t>(floor(coord));
     auto right_idx = static_cast<int32_t>(ceil(coord));
-    left_indices[input_dim] =
-        pad_input_index(left_idx, input_size, padding_mode, align_corners);
-    right_indices[input_dim] =
-        pad_input_index(right_idx, input_size, padding_mode, align_corners);
-
-    auto scale = coord - left_idx;
-
-    if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-      // Round to nearest even (banker's rounding) - matches CPU behavior
-      // For halfway cases (scale == 0.5), pick the even-indexed neighbor
-      if (scale == 0.5) {
-        // if left_idx is even -> round to 0, if odd round to 1
-        scale = (left_idx % 2 == 0) ? 0 : 1;
-      } else {
-        scale = (scale < 0.5) ? 0 : 1;
-      }
-    }
-    scales[input_dim] = scale;
+    left_indices[input_dim] = Pad::pad(left_idx, input_size, align_corners);
+    right_indices[input_dim] = Pad::pad(right_idx, input_size, align_corners);
+    scales[input_dim] = coord - left_idx;
   }
 
-  // Now that we have the bounding indices and scale factor for each dimension
-  // of the input, we can interpolate.
-  if (dims == 3) {
-    *output = interpolate_linear_3d(
-        input, input_strides, left_indices, right_indices, scales);
-  }
+  *output = interpolate_linear_3d(
+      input, input_strides, left_indices, right_indices, scales);
 }
 
-template <typename T>
+template <typename Pad, typename T>
 kernel void grid_sampler_3d(
     device T* output [[buffer(0)]],
     constant T* input [[buffer(1)]],
@@ -657,11 +612,7 @@ kernel void grid_sampler_3d(
   input_strides += 2;
   auto coord_stride = grid_strides[sampler_dims + 1];
 
-  auto interpolation_mode = params.interpolation_mode;
-  auto padding_mode = params.padding_mode;
-  auto align_corners = params.align_corners;
-
-  grid_sampler_single_element(
+  grid_sampler_3d_single_element<Pad>(
       output,
       input,
       coords,
@@ -669,26 +620,39 @@ kernel void grid_sampler_3d(
       input_sizes,
       input_strides,
       coord_stride,
-      interpolation_mode,
-      padding_mode,
-      align_corners);
+      params.align_corners);
 }
 
-#define REGISTER_GRID_SAMPLER_OPS(DTYPE)                    \
-  template [[host_name("grid_sampler_3d_" #DTYPE)]]          \
-  kernel void grid_sampler_3d<DTYPE>(                       \
-      device DTYPE * output [[buffer(0)]],                  \
-      constant DTYPE * input [[buffer(1)]],                 \
-      constant DTYPE * grid [[buffer(2)]],                  \
-      constant GridSamplerParams<5> & params [[buffer(3)]], \
-      uint tid [[thread_position_in_grid]]);                \
-  template [[host_name("grid_sampler_2d_" #DTYPE)]]         \
-  kernel void grid_sampler_2d<DTYPE>(                       \
-      device DTYPE * output [[buffer(0)]],                  \
-      constant DTYPE * input [[buffer(1)]],                 \
-      constant DTYPE * grid [[buffer(2)]],                  \
-      constant GridSamplerParams<5> & params [[buffer(3)]], \
+#define REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PAD, PNAME)      \
+  template [[host_name("grid_sampler_2d_" INAME "_" PNAME "_" #DTYPE)]] \
+  kernel void grid_sampler_2d<INTERP<PAD>, DTYPE>(                      \
+      device DTYPE * output [[buffer(0)]],                              \
+      constant DTYPE * input [[buffer(1)]],                             \
+      constant DTYPE * grid [[buffer(2)]],                              \
+      constant GridSamplerParams<5> & params [[buffer(3)]],             \
       uint tid [[thread_position_in_grid]]);
+
+#define REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, INTERP, INAME)         \
+  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadZeros, "zeros")   \
+  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadBorder, "border") \
+  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadReflection, "reflection")
+
+#define REGISTER_GRID_SAMPLER_3D(DTYPE, PAD, PNAME)           \
+  template [[host_name("grid_sampler_3d_" PNAME "_" #DTYPE)]] \
+  kernel void grid_sampler_3d<PAD, DTYPE>(                    \
+      device DTYPE * output [[buffer(0)]],                    \
+      constant DTYPE * input [[buffer(1)]],                   \
+      constant DTYPE * grid [[buffer(2)]],                    \
+      constant GridSamplerParams<5> & params [[buffer(3)]],   \
+      uint tid [[thread_position_in_grid]]);
+
+#define REGISTER_GRID_SAMPLER_OPS(DTYPE)                         \
+  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Bilinear2D, "bilinear") \
+  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Nearest2D, "nearest")   \
+  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Bicubic2D, "bicubic")   \
+  REGISTER_GRID_SAMPLER_3D(DTYPE, PadZeros, "zeros")             \
+  REGISTER_GRID_SAMPLER_3D(DTYPE, PadBorder, "border")           \
+  REGISTER_GRID_SAMPLER_3D(DTYPE, PadReflection, "reflection")
 
 REGISTER_GRID_SAMPLER_OPS(float);
 REGISTER_GRID_SAMPLER_OPS(half);

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -628,7 +628,7 @@ void grid_sampler_single_element(
 }
 
 template <typename T>
-kernel void grid_sampler(
+kernel void grid_sampler_3d(
     device T* output [[buffer(0)]],
     constant T* input [[buffer(1)]],
     constant T* grid [[buffer(2)]],
@@ -675,8 +675,8 @@ kernel void grid_sampler(
 }
 
 #define REGISTER_GRID_SAMPLER_OPS(DTYPE)                    \
-  template [[host_name("grid_sampler_" #DTYPE)]]            \
-  kernel void grid_sampler<DTYPE>(                          \
+  template [[host_name("grid_sampler_3d_" #DTYPE)]]          \
+  kernel void grid_sampler_3d<DTYPE>(                       \
       device DTYPE * output [[buffer(0)]],                  \
       constant DTYPE * input [[buffer(1)]],                 \
       constant DTYPE * grid [[buffer(2)]],                  \

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -24,6 +24,32 @@ static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 
 namespace mps {
 
+static const char* interp_to_string(GridSamplerInterpolation mode) {
+  switch (mode) {
+    case GridSamplerInterpolation::Bilinear:
+      return "bilinear";
+    case GridSamplerInterpolation::Nearest:
+      return "nearest";
+    case GridSamplerInterpolation::Bicubic:
+      return "bicubic";
+  }
+  TORCH_CHECK(false, "Unrecognised interpolation mode: ", mode);
+  return "";
+}
+
+static const char* padding_to_string(GridSamplerPadding mode) {
+  switch (mode) {
+    case GridSamplerPadding::Zeros:
+      return "zeros";
+    case GridSamplerPadding::Border:
+      return "border";
+    case GridSamplerPadding::Reflection:
+      return "reflection";
+  }
+  TORCH_CHECK(false, "Unrecognised Padding Mode: ", mode);
+  return "";
+}
+
 static void grid_sampler_2d_mps_impl(Tensor& output,
                                      const Tensor& input,
                                      const Tensor& grid,
@@ -46,30 +72,10 @@ static void grid_sampler_2d_mps_impl(Tensor& output,
   auto interpolation_mode = static_cast<GridSamplerInterpolation>(_interpolation_mode);
   auto padding_mode = static_cast<GridSamplerPadding>(_padding_mode);
 
-  switch (interpolation_mode) {
-    case GridSamplerInterpolation::Bilinear:
-    case GridSamplerInterpolation::Nearest:
-    case GridSamplerInterpolation::Bicubic:
-      break;
-    default:
-      TORCH_CHECK(false, "grid_sampler_2d: Unrecognised interpolation mode: ", _interpolation_mode);
-  }
-
-  switch (padding_mode) {
-    case GridSamplerPadding::Zeros:
-    case GridSamplerPadding::Border:
-    case GridSamplerPadding::Reflection:
-      break;
-    default:
-      TORCH_CHECK(false, "grid_sampler_2d: Unrecognised Padding Mode: ", _padding_mode);
-  }
-
   auto dims = input.dim();
 
   GridSamplerParams<5> params;
   params.sampler_dims = 2;
-  params.padding_mode = padding_mode;
-  params.interpolation_mode = interpolation_mode;
   params.align_corners = align_corners;
 
   for (const auto dim : c10::irange(dims)) {
@@ -91,7 +97,10 @@ static void grid_sampler_2d_mps_impl(Tensor& output,
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      auto pso = lib.getPipelineStateForFunc("grid_sampler_2d_" + scalarToMetalTypeString(input));
+      auto pso = lib.getPipelineStateForFunc(fmt::format("grid_sampler_2d_{}_{}_{}",
+                                                         interp_to_string(interpolation_mode),
+                                                         padding_to_string(padding_mode),
+                                                         scalarToMetalTypeString(input)));
 
       getMPSProfiler().beginProfileKernel(pso, "grid_sampler_2d", {input, grid});
       [computeEncoder setComputePipelineState:pso];
@@ -144,15 +153,6 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
       TORCH_CHECK(false, op_name, ": Unrecognised interpolation mode: ", _interpolation_mode);
   }
 
-  switch (padding_mode) {
-    case GridSamplerPadding::Zeros:
-    case GridSamplerPadding::Border:
-    case GridSamplerPadding::Reflection:
-      break;
-    default:
-      TORCH_CHECK(false, op_name, ": Unrecognised Padding Mode: ", _padding_mode);
-  }
-
   auto input_size = input.sizes();
   auto grid_size = grid.sizes();
   output.resize_({input_size[0], input_size[1], grid_size[1], grid_size[2], grid_size[3]}, MemoryFormat::Contiguous);
@@ -161,8 +161,6 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
 
   GridSamplerParams<5> params;
   params.sampler_dims = sampler_dims;
-  params.padding_mode = padding_mode;
-  params.interpolation_mode = interpolation_mode;
   params.align_corners = align_corners;
 
   for (const auto dim : c10::irange(dims)) {
@@ -180,7 +178,8 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      auto pso = lib.getPipelineStateForFunc("grid_sampler_3d_" + scalarToMetalTypeString(input));
+      auto pso = lib.getPipelineStateForFunc(std::string("grid_sampler_3d_") + padding_to_string(padding_mode) + "_" +
+                                             scalarToMetalTypeString(input));
 
       getMPSProfiler().beginProfileKernel(pso, op_name, {input, grid});
       [computeEncoder setComputePipelineState:pso];

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -46,7 +46,7 @@ static const char* padding_to_string(GridSamplerPadding mode) {
     case GridSamplerPadding::Reflection:
       return "reflection";
   }
-  TORCH_CHECK(false, "Unrecognised Padding Mode: ", mode);
+  TORCH_CHECK(false, "Unrecognised padding mode: ", mode);
   return "";
 }
 
@@ -74,7 +74,7 @@ static void grid_sampler_2d_mps_impl(Tensor& output,
 
   auto dims = input.dim();
 
-  GridSamplerParams<5> params;
+  GridSamplerParams<4> params;
   params.sampler_dims = 2;
   params.align_corners = align_corners;
 
@@ -178,8 +178,8 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      auto pso = lib.getPipelineStateForFunc(std::string("grid_sampler_3d_") + padding_to_string(padding_mode) + "_" +
-                                             scalarToMetalTypeString(input));
+      auto pso = lib.getPipelineStateForFunc(
+          fmt::format("grid_sampler_3d_{}_{}", padding_to_string(padding_mode), scalarToMetalTypeString(input)));
 
       getMPSProfiler().beginProfileKernel(pso, op_name, {input, grid});
       [computeEncoder setComputePipelineState:pso];

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -180,7 +180,7 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      auto pso = lib.getPipelineStateForFunc("grid_sampler_" + scalarToMetalTypeString(input));
+      auto pso = lib.getPipelineStateForFunc("grid_sampler_3d_" + scalarToMetalTypeString(input));
 
       getMPSProfiler().beginProfileKernel(pso, op_name, {input, grid});
       [computeEncoder setComputePipelineState:pso];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #175060

To match the pattern with `grid_sampler_2d` one

Also, refactor it to use template arguments rather than `if () else`  to dispatch to a different rounding/padding mode, which slightly improves pefromance
| Benchmark | Before | After | Change |
|-----------|-------:|------:|-------:|
| grid_sample-bilinear-64x64 (torch.float16) | 138.3 | 125.8 | -9.0% |
| grid_sample-bilinear-128x128 (torch.float16) | 225.2 | 216.7 | -3.8% |
| grid_sample-bilinear-256x256 (torch.float16) | 667.7 | 547.8 | -18.0% |
| grid_sample-bilinear-512x512 (torch.float16) | 2346.5 | 2170.6 | -7.5% |
| grid_sample-nearest-64x64 (torch.float16) | 118.6 | 113.3 | -4.5% |
| grid_sample-nearest-128x128 (torch.float16) | 149.9 | 147.2 | -1.8% |
| grid_sample-nearest-256x256 (torch.float16) | 301.1 | 307.1 | +2.0% |
| grid_sample-nearest-512x512 (torch.float16) | 1249.1 | 1257.1 | +0.6% |
| grid_sample-bicubic-64x64 (torch.float16) | 173.8 | 133.8 | -23.0% |
| grid_sample-bicubic-128x128 (torch.float16) | 365.7 | 327.7 | -10.4% |
| grid_sample-bicubic-256x256 (torch.float16) | 1111.6 | 1136.5 | +2.2% |
| grid_sample-bicubic-512x512 (torch.float16) | 5095.6 | 5178.0 | +1.6% |
| grid_sample-bilinear-64x64 (torch.float32) | 141.8 | 127.5 | -10.1% |
| grid_sample-bilinear-128x128 (torch.float32) | 236.1 | 231.7 | -1.9% |
| grid_sample-bilinear-256x256 (torch.float32) | 712.0 | 692.6 | -2.7% |
| grid_sample-bilinear-512x512 (torch.float32) | 5032.5 | 4981.4 | -1.0% |
| grid_sample-nearest-64x64 (torch.float32) | 120.6 | 115.5 | -4.2% |
| grid_sample-nearest-128x128 (torch.float32) | 165.6 | 162.4 | -1.9% |
| grid_sample-nearest-256x256 (torch.float32) | 338.1 | 348.4 | +3.0% |
| grid_sample-nearest-512x512 (torch.float32) | 2755.1 | 2723.1 | -1.2% |
| grid_sample-bicubic-64x64 (torch.float32) | 177.3 | 159.6 | -10.0% |
| grid_sample-bicubic-128x128 (torch.float32) | 398.9 | 421.9 | +5.8% |
| grid_sample-bicubic-256x256 (torch.float32) | 1266.5 | 1298.3 | +2.5% |
| grid_sample-bicubic-512x512 (torch.float32) | 10163.4 | 10018.9 | -1.4% |
| grid_sample-bilinear-64x64 (torch.bfloat16) | 140.8 | 124.1 | -11.9% |
| grid_sample-bilinear-128x128 (torch.bfloat16) | 223.3 | 207.9 | -6.9% |
| grid_sample-bilinear-256x256 (torch.bfloat16) | 658.3 | 550.3 | -16.4% |
| grid_sample-bilinear-512x512 (torch.bfloat16) | 2363.3 | 2117.2 | -10.4% |
| grid_sample-nearest-64x64 (torch.bfloat16) | 119.9 | 117.0 | -2.4% |
| grid_sample-nearest-128x128 (torch.bfloat16) | 146.7 | 151.7 | +3.4% |
| grid_sample-nearest-256x256 (torch.bfloat16) | 292.8 | 297.0 | +1.4% |
| grid_sample-nearest-512x512 (torch.bfloat16) | 999.1 | 994.1 | -0.5% |
| grid_sample-bicubic-64x64 (torch.bfloat16) | 196.5 | 149.1 | -24.1% |
| grid_sample-bicubic-128x128 (torch.bfloat16) | 366.7 | 339.4 | -7.4% |
| grid_sample-bicubic-256x256 (torch.bfloat16) | 1111.5 | 1142.0 | +2.7% |
| grid_sample-bicubic-512x512 (torch.bfloat16) | 5007.7 | 5095.7 | +1.8% |