### PR TITLE
Fix torch.trace backward for non-square matrices

### DIFF
--- a/aten/src/ATen/functorch/PyTorchOperatorHacks.cpp
+++ b/aten/src/ATen/functorch/PyTorchOperatorHacks.cpp
@@ -111,7 +111,9 @@ Tensor binary_cross_entropy_with_logits_hack(
 Tensor trace_backward_decomp(const Tensor& grad, IntArrayRef sizes) {
   TORCH_CHECK(sizes.size() == 2, "expected matrix input");
   auto grad_input = at::zeros(sizes[0] * sizes[1], grad.options());
-  auto indices = at::arange(0, grad_input.numel(), sizes[1] + 1, grad.options().dtype(at::kLong));
+  auto diag_size = std::min(sizes[0], sizes[1]);
+  auto step = sizes[1] + 1;
+  auto indices = at::arange(0, diag_size * step, step, grad.options().dtype(at::kLong));
   // Workaround using index_put instead of yet unsupported index_fill_
   grad_input = grad_input.index_put({indices}, grad);
   return grad_input.view(sizes);

--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -185,7 +185,10 @@ Tensor trace_backward_symint(const Tensor& grad, c10::SymIntArrayRef sizes) {
   TORCH_CHECK(sizes.size() == 2, "expected matrix input");
 
   auto grad_input = at::zeros_symint(sizes[0] * sizes[1], grad.options());
-  auto indices = at::arange(0, grad_input.numel(), sizes[1] + 1, grad.options().dtype(at::kLong));
+  // Only min(M, N) diagonal elements exist for an (M, N) matrix
+  auto diag_size = std::min(sizes[0], sizes[1]);
+  auto step = sizes[1] + 1;
+  auto indices = at::arange(0, diag_size * step, step, grad.options().dtype(at::kLong));
   // for composite compliance, use out-of-place variant of
   // `index_fill` if grad tensor is a Tensor Subclass.
   if (isTensorSubclassLike(grad)) {

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -8551,7 +8551,6 @@ symbolic_aot_autograd_failures = {
     xfail(
         "nn.functional.fractional_max_pool3d", ""
     ),  # rand() received an invalid combination of arguments - g...
-    xfail("trace", ""),  # Cannot call sizes() on tensor with symbolic sizes/strides
     decorate(
         "linalg.householder_product",
         decorator=unittest.skipIf(IS_MACOS and IS_X86, "flaky"),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15598,12 +15598,13 @@ class TestAutogradMultipleDispatch(TestCase):
     def test_trace_backward_nonsquare_171704(self):
         # https://github.com/pytorch/pytorch/issues/171704
         for shape in [(5, 2), (7, 3), (4, 1), (1, 5), (2, 5)]:
-            x = torch.randn(shape, dtype=torch.float64, requires_grad=True)
-            torch.trace(x).backward()
-            expected = torch.zeros(shape, dtype=torch.float64)
-            for i in range(min(shape)):
-                expected[i, i] = 1.0
-            self.assertEqual(x.grad, expected)
+            with self.subTest(shape=shape):
+                x = torch.randn(shape, dtype=torch.float64, requires_grad=True)
+                torch.trace(x).backward()
+                expected = torch.zeros(shape, dtype=torch.float64)
+                for i in range(min(shape)):
+                    expected[i, i] = 1.0
+                self.assertEqual(x.grad, expected)
 
 
 # Import test cases from below autograd/ here. These are found

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15595,6 +15595,16 @@ class TestAutogradMultipleDispatch(TestCase):
         )
         self.assertEqual(x.grad, 2 * torch.ones_like(x))
 
+    def test_trace_backward_nonsquare_171704(self):
+        # https://github.com/pytorch/pytorch/issues/171704
+        for shape in [(5, 2), (7, 3), (4, 1), (1, 5), (2, 5)]:
+            x = torch.randn(shape, dtype=torch.float64, requires_grad=True)
+            torch.trace(x).backward()
+            expected = torch.zeros(shape, dtype=torch.float64)
+            for i in range(min(shape)):
+                expected[i, i] = 1.0
+            self.assertEqual(x.grad, expected)
+
 
 # Import test cases from below autograd/ here. These are found
 # implicitly by the loader, so Flake8 thinks they are unused, hence

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2043,10 +2043,11 @@ def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
             yield SampleInput(t, dim)
 
 def sample_inputs_trace(self, device, dtype, requires_grad, **kwargs):
-    yield SampleInput(
-        make_tensor((S, S), dtype=dtype, device=device,
-                    low=None, high=None,
-                    requires_grad=requires_grad))
+    make_arg = partial(make_tensor, device=device, dtype=dtype,
+                       requires_grad=requires_grad, low=None, high=None)
+    # Square, tall (rows > cols), wide (rows < cols), single row/col (#171704)
+    for shape in ((S, S), (S + 2, S), (S, S + 2), (1, S), (S, 1)):
+        yield SampleInput(make_arg(shape))
 
 
 def error_inputs_trace(op, device):


### PR DESCRIPTION
`trace_backward_symint` computes diagonal indices via `arange(0, rows*cols, cols+1)`, which overshoots the diagonal for tall matrices (rows > cols) and writes gradient into off-diagonal positions.

Bound the arange stop to `min(M, N) * (cols + 1)`. Same fix applied to the functorch decomposition in `PyTorchOperatorHacks.cpp`. Added non-square sample inputs to `sample_inputs_trace` and a regression test in `test_autograd.py`.

Fixes https://github.com/pytorch/pytorch/issues/171704