### PR TITLE
[inductor] Respect use_compute_types in CuteDSLOpOverrides.to_dtype

### DIFF
--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -304,8 +304,8 @@ class CuteDSLOpOverrides(OpOverrides):
 
         Raises NotImplementedError for unsigned integer and unsupported dtypes.
         """
-        # Always convert up from bf16 and fp16 TODO on configuring
-        dtype = upcast_compute_type(dtype)
+        if use_compute_types:
+            dtype = upcast_compute_type(dtype)
 
         cute_type = CuteDSLOpOverrides.TORCH_TO_CUTE_DTYPE.get(dtype)
         if cute_type is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175070
* __->__ #175069

This should be unused in PyTorch (since we only use this for templates),
but is needed by Helion.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo