### PR TITLE
[ROCm] check if rocm_env.sh exists before sourcing

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
 set -ex -o pipefail
 
 # for ROCm environment variables
-if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
   # shellcheck disable=SC1091
   source /etc/rocm_env.sh
 fi


### PR DESCRIPTION
Ran into this trying to run tests on my local ROCm machine. The script assumes `/etc/rocm_env.sh` exists, but that file is only created by `install_rocm.sh` inside CI docker images - it's not there on a standard ROCm install.

Simple fix: check if the file exists first.

Fixes #170983

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang