### PR TITLE
[inductor] Improve 1D pointwise kernel heuristic on B200

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2865,16 +2865,20 @@ def pointwise(
 
     configs = None
     if len(size_hints) == 1:
+        # 1D kernels can use larger blocks since TRITON_MAX_BLOCK["X"] is 4096
+        bs_1d = max(256, min(numel // 128, 2048))
         if not inductor_meta.get("autotune_pointwise", True) and not (
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
         ):
-            configs = [triton_config_with_settings(size_hints, bs)]
+            configs = [triton_config_with_settings(size_hints, bs_1d)]
         else:
             configs = [
-                triton_config_with_settings(size_hints, bs, num_elements_per_warp=256),
                 triton_config_with_settings(
-                    size_hints, bs // 2, num_elements_per_warp=64
+                    size_hints, bs_1d, num_elements_per_warp=512
+                ),
+                triton_config_with_settings(
+                    size_hints, bs_1d // 2, num_elements_per_warp=64
                 ),
                 *hinted_configs,
             ]


### PR DESCRIPTION
Summary:
Raise the XBLOCK cap from 1024 to 2048 for 1D pointwise kernels only (introducing a separate `bs_1d` variable to avoid exceeding TRITON_MAX_BLOCK["Y"]=1024 in 2D/3D configs), and increase num_elements_per_warp from 256 to 512 for the primary autotune config. This targets warps=4 with larger blocks, which B200 autotune data shows is consistently optimal for large 1D pointwise ops.

The secondary config (bs_1d//2 with nepw=64) is kept unchanged from the original.

B200 microbenchmarks across 31 shapes show zero regressions for both MM and ADDMM workloads, with substantial speedups on medium-to-large shapes (up to 1.67x for MM, 1.13x for ADDMM). Combined with the K=1 decomposition diffs in this stack (D93372324, D93372325), this delivers significant end-to-end gains for pointwise-heavy workloads.

H100 validation (19 shapes): MM 1.026x geomean, ADDMM 1.022x geomean, 0 regressions.

Torchbench model benchmarks on B200 (17 models, inference bf16 + training AMP):
- Inference: geomean 1.001x, 0 wins, 0 losses across 15 comparable models
- Training: geomean 1.002x, 0 wins, 0 losses across 15 comparable models

Test Plan: Ran tritonbench gemm and addmm operators with 31 K=1 shapes on B200 and H100. Ran torchbench model suite (17 models, inference + training) on B200. Verified zero regressions across all benchmarks.

Differential Revision: D93372326




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo