### PR TITLE
[inductor] Decompose mm to pointwise mul when K==1

### DIFF
--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -169,6 +169,31 @@ class TestDecomp(NNTestCase):
         run_comp_nocomp(torch_bmm, t1, t2, rtol=rtol, atol=atol)
 
     @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @parametrize("dtype", [torch.float, torch.bfloat16])
+    def test_mm_k1(self, device, dtype):
+        fudge = 10
+        rtol = default_rtol[dtype] * fudge
+        atol = default_atol[dtype] * fudge
+
+        t1 = rand_math_tensor((64, 1), dtype=dtype, device=device)
+        t2 = rand_math_tensor((1, 64), dtype=dtype, device=device)
+
+        run_comp_nocomp(torch_mm, t1, t2, rtol=rtol, atol=atol)
+
+    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @parametrize("dtype", [torch.float, torch.bfloat16])
+    def test_addmm_k1(self, device, dtype):
+        fudge = 10
+        rtol = default_rtol[dtype] * fudge
+        atol = default_atol[dtype] * fudge
+
+        t1 = rand_math_tensor((64, 1), dtype=dtype, device=device)
+        t2 = rand_math_tensor((1, 64), dtype=dtype, device=device)
+        tadd = rand_math_tensor((64,), dtype=dtype, device=device)
+
+        run_comp_nocomp(torch_addmm, tadd, t1, t2, rtol=rtol, atol=atol)
+
+    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
     @parametrize("dtype", [torch.float, torch.bfloat16, torch.int])
     def test_some(self, device, dtype):
         # this Pytorch data type is not fully supported on cuda today

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -327,6 +327,16 @@ def bmm(
     return NotImplemented
 
 
+def _try_decompose_mm_k1(
+    mat1: torch.Tensor, mat2: torch.Tensor, counter_name: str
+) -> torch.Tensor | None:
+    if mat1.device.type not in ["cpu", "mps"]:
+        if statically_known_true(mat1.size(-1) == 1):
+            counters["inductor"][counter_name] += 1
+            return mat1 * mat2
+    return None
+
+
 @register_decomposition([aten.addmm])
 @pw_cast_for_opmath
 def addmm(
@@ -337,6 +347,10 @@ def addmm(
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
+    out = _try_decompose_mm_k1(mat1, mat2, "decompose_addmm")
+    if out is not None:
+        return alpha * out + beta * self
+
     if self.device.type == "cpu":
         if statically_known_true(mat1.size(0) == 1) and statically_known_true(
             mat2.size(-1) == 1
@@ -364,6 +378,10 @@ def mm(
     input2: torch.Tensor,
     out_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
+    out = _try_decompose_mm_k1(self, input2, "decompose_mm")
+    if out is not None:
+        return out
+
     # Our matrix vector multiplies only achieve peak bandwidth with coordinate descent tuning.
     # todo: Look into why and fix it (hopefully)
 


### PR DESCRIPTION
Summary:
When K == 1, matrix multiplication (M, 1) @ (1, N) is an outer product.
Instead of launching a full GEMM kernel, we decompose it into a broadcasted
pointwise multiply, which is more efficient for this memory-bound case.

This adds a `_try_decompose_mm_k1` helper function used by `tuned_mm`.

This is analogous to D56667030 which decomposed BMM for M==1 or N==1 cases.

**aten.mm** — TritonBench on B200, 19 K=1 shapes, median of 3 runs:

| Shape (M, N, K) | baseline compiled (us) | test compiled (us) | Speedup |
|---|---|---|---|
| (100, 100, 1) | 12.3 | 11.3 | 1.09x |
| (150, 150, 1) | 12.3 | 11.2 | 1.10x |
| (200, 200, 1) | 12.3 | 11.3 | 1.09x |
| (256, 256, 1) | 12.3 | 11.3 | 1.09x |
| (512, 512, 1) | 12.3 | 11.2 | 1.10x |
| (1024, 1024, 1) | 14.3 | 13.2 | 1.09x |
| (2048, 2048, 1) | 20.5 | 15.3 | **1.34x** |
| (4096, 4096, 1) | 35.8 | 26.8 | 1.33x |
| (8192, 8192, 1) | 96.3 | 68.6 | **1.40x** |
| (16384, 16384, 1) | 329.8 | 234.5 | **1.41x** |
| (4608, 1, 1) | 12.5 | 11.3 | 1.10x |
| (4608, 20, 1) | 13.2 | 11.3 | 1.17x |
| (4608, 32, 1) | 13.2 | 11.3 | 1.17x |
| (4608, 128, 1) | 13.2 | 11.4 | 1.17x |
| (4608, 256, 1) | 14.3 | 13.2 | 1.09x |
| (4608, 512, 1) | 17.4 | 13.3 | **1.31x** |
| (4608, 1024, 1) | 20.5 | 15.3 | **1.34x** |
| (1024, 4096, 1) | 20.5 | 15.3 | 1.34x |
| (4096, 1024, 1) | 20.5 | 15.3 | 1.34x |

Geomean speedup: **1.207x**, 0 regressions.

**aten.mm** — TritonBench on H100, 19 K=1 shapes, median of 3 runs:

| Shape (M, N, K) | baseline compiled (us) | test compiled (us) | Speedup |
|---|---|---|---|
| (100, 100, 1) | 9.76 | 8.64 | 1.13x |
| (150, 150, 1) | 9.82 | 8.70 | 1.13x |
| (200, 200, 1) | 9.95 | 8.80 | 1.13x |
| (256, 256, 1) | 9.76 | 8.70 | 1.12x |
| (512, 512, 1) | 9.92 | 8.80 | 1.13x |
| (1024, 1024, 1) | 11.39 | 9.44 | 1.21x |
| (2048, 2048, 1) | 16.19 | 12.83 | **1.26x** |
| (4096, 4096, 1) | 37.98 | 29.12 | **1.30x** |
| (8192, 8192, 1) | 120.48 | 89.12 | **1.35x** |
| (16384, 16384, 1) | 387.42 | 249.54 | **1.55x** |
| (4608, 1, 1) | 9.89 | 9.06 | 1.09x |
| (4608, 20, 1) | 10.02 | 8.86 | 1.13x |
| (4608, 32, 1) | 9.95 | 8.86 | 1.12x |
| (4608, 128, 1) | 10.94 | 8.99 | 1.22x |
| (4608, 256, 1) | 12.22 | 9.50 | **1.29x** |
| (4608, 512, 1) | 14.02 | 10.59 | **1.32x** |
| (4608, 1024, 1) | 17.06 | 13.18 | **1.29x** |
| (1024, 4096, 1) | 16.80 | 13.25 | **1.27x** |
| (4096, 1024, 1) | 16.22 | 12.51 | **1.30x** |

Geomean speedup: **1.224x**, 0 regressions.

Verified via tlparse that inductor generates a pointwise kernel (`triton_poi`)
instead of a GEMM template:

```python
# Topologically Sorted Source Nodes: [matmul], Original ATen: [aten.mm]
triton_heuristics.pointwise(size_hints={'x': 4194304}, ...)
triton.jit
def triton_poi_fused_mm_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK):
    x1 = xindex // 1024        # row index (M dim)
    x0 = (xindex % 1024)       # col index (N dim)
    tmp0 = tl.load(in_ptr0 + (x1), ...)  # mat1 broadcast along N
    tmp1 = tl.load(in_ptr1 + (x0), ...)  # mat2 broadcast along M
    tmp2 = tmp0 * tmp1                    # pointwise multiply
    tl.store(out_ptr0 + (x2), tmp2, None)
```

Test Plan:
Benchmarked with tritonbench gemm operator on B200 and H100 GPUs (NUMA pinned, locked clocks). Example command:

```
CUDA_VISIBLE_DEVICES=1 numactl -m 0 -c 0 buck2 run \
    @//mode/opt \
    -m ovr_config//triton:beta \
    -c fbcode.enable_gpu_sections=true \
    //pytorch/tritonbench:run -- \
    --op gemm --input /tmp/k1_shapes.csv \
    --only aten_matmul,pt2_triton_matmul \
    --metrics latency,speedup,accuracy --csv
```

Ran tlparse to verify the lowering produces a pointwise Triton kernel
instead of a GEMM.

Differential Revision: D93372324


@diff-train-skip-merge

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo