### PR TITLE
[ROCm] Add separate _HAS_AMDSMI flag for amdsmi availability check

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -52,6 +52,7 @@ _queued_calls: list[
 _is_in_bad_fork = getattr(torch._C, "_cuda_isInBadFork", lambda: False)
 
 _HAS_PYNVML = False
+_HAS_AMDSMI = False
 _PYNVML_ERR = None
 try:
     from torch import version as _version
@@ -106,6 +107,7 @@ try:
 
             with _amdsmi_cdll_hook():
                 import amdsmi  # type: ignore[import]
+            _HAS_AMDSMI = True
 
         _HAS_PYNVML = True
     except ModuleNotFoundError:
@@ -883,7 +885,7 @@ def _parse_visible_devices() -> list[int] | list[str]:
 
 
 def _raw_device_count_amdsmi() -> int:
-    if not _HAS_PYNVML:  # If amdsmi is not available
+    if not _HAS_AMDSMI:
         return -1
     try:
         amdsmi.amdsmi_init()
@@ -917,7 +919,7 @@ def _raw_device_count_nvml() -> int:
 def _raw_device_uuid_amdsmi() -> list[str] | None:
     from ctypes import byref, c_int, c_void_p, CDLL, create_string_buffer
 
-    if not _HAS_PYNVML:  # If amdsmi is not available
+    if not _HAS_AMDSMI:
         return None
     try:
         amdsmi.amdsmi_init()
@@ -1306,11 +1308,10 @@ def _get_pynvml_handler(device: Device = None):
 
 
 def _get_amdsmi_handler(device: Device = None):
-    if not _HAS_PYNVML:
+    if not _HAS_AMDSMI:
         raise ModuleNotFoundError(
             "amdsmi does not seem to be installed or it can't be imported."
-            # pyrefly: ignore [invalid-inheritance]
-        ) from _PYNVML_ERR
+        )
     try:
         amdsmi.amdsmi_init()
     except amdsmi.AmdSmiException as e:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -54,6 +54,7 @@ _is_in_bad_fork = getattr(torch._C, "_cuda_isInBadFork", lambda: False)
 _HAS_PYNVML = False
 _HAS_AMDSMI = False
 _PYNVML_ERR = None
+_AMDSMI_ERR = None
 try:
     from torch import version as _version
 
@@ -105,9 +106,13 @@ try:
                 def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
                     ctypes.CDLL = self.original_CDLL  # type: ignore[misc]
 
-            with _amdsmi_cdll_hook():
-                import amdsmi  # type: ignore[import]
-            _HAS_AMDSMI = True
+            try:
+                with _amdsmi_cdll_hook():
+                    import amdsmi  # type: ignore[import]
+                _HAS_AMDSMI = True
+            except ModuleNotFoundError as err:
+                _AMDSMI_ERR = err
+                raise
 
         _HAS_PYNVML = True
     except ModuleNotFoundError:
@@ -1311,7 +1316,7 @@ def _get_amdsmi_handler(device: Device = None):
     if not _HAS_AMDSMI:
         raise ModuleNotFoundError(
             "amdsmi does not seem to be installed or it can't be imported."
-        )
+        ) from _AMDSMI_ERR
     try:
         amdsmi.amdsmi_init()
     except amdsmi.AmdSmiException as e:


### PR DESCRIPTION
## Summary
Fixes #133259

When pynvml is installed (e.g., via DeepSpeed) but amdsmi is not available (ROCm without amdsmi package), calling `torch.cuda.device_count()` crashes with `NameError: name 'amdsmi' is not defined`.

The root cause is that `_HAS_PYNVML` is set True when either pynvml or amdsmi is successfully imported, but amdsmi-specific functions like `_raw_device_count_amdsmi()` check `_HAS_PYNVML` instead of verifying amdsmi is actually available.

This PR adds a separate `_HAS_AMDSMI` flag that is only set True when amdsmi is successfully imported, and updates the amdsmi functions to check this flag instead.

## Test plan
- Verified the logic handles the case where pynvml is installed but amdsmi is not
- The fix ensures `_raw_device_count_amdsmi()` returns -1 instead of crashing when amdsmi is unavailable

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang