### PR TITLE
Fix USE_RCOM typo to USE_ROCM in intra_node_comm.cpp

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
@@ -20,7 +20,7 @@ static int intraNodeCommIdx = 0;
  * Query the nvlink connection among devices.
  */
 static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
-#if !defined(USE_RCOM)
+#if !defined(USE_ROCM)
   auto connectivity = detect_dma_connectivity(c10::DeviceType::CUDA, "nvlink");
   NvlMesh nvlMesh = {};
   for (size_t srcRank = 0; srcRank < kMaxDevices; ++srcRank) {


### PR DESCRIPTION
## Summary
Fixes a typo in the preprocessor conditional that was preventing the ROCm-specific code path from ever being used.

The check `#if !defined(USE_RCOM)` should be `#if !defined(USE_ROCM)`. Since `USE_RCOM` is never defined anywhere in the codebase, the condition was always true, and the ROCm P2P accessibility code using `rsmi_is_P2P_accessible` was never executed on ROCm builds.

With this fix, ROCm builds will properly use the rocm_smi API to detect P2P connectivity instead of falling through to the NVLINK code path.

Related to #158725 (which mentions the same file needs proper rocm_smi checking)

## Test plan
- Verified `USE_RCOM` has no other occurrences in the codebase
- Verified `USE_ROCM` is the correct macro used throughout PyTorch for ROCm detection
- The fix is a simple one-character change that aligns the preprocessor logic with the include guard on line 5

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang