### PR TITLE
Revert "[fix] DISABLED test_index (__main__.DistTensorOpsTest) (#172373)"

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -19,12 +19,7 @@ from torch.distributed.tensor._dtensor_spec import TensorMeta
 from torch.distributed.tensor._sharding_prop import ShardingPropagator
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import (
-    MI200_ARCH,
-    run_tests,
-    serialTest,
-    skipIfRocmArch,
-)
+from torch.testing._internal.common_utils import MI200_ARCH, run_tests, skipIfRocmArch
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorConverter,
@@ -619,7 +614,6 @@ class DistTensorOpsTest(DTensorTestBase):
 
     @skipIfRocmArch(MI200_ARCH)
     @with_comms
-    @serialTest()
     def test_index(self):
         meshes = [
             self.build_device_mesh(),  # 1D mesh


### PR DESCRIPTION
This reverts commit 70726364e8565902d6f9ed9e47cd197caf544399.

Reverted https://github.com/pytorch/pytorch/pull/172373 on behalf of https://github.com/jeffdaily due to PR claims to fix ROCm DISABLED issue but it did not ([comment](https://github.com/pytorch/pytorch/pull/172373#issuecomment-3909564537))