### PR TITLE
Revert "[CI] Enable TIMM pretrained model caching on shared HF cache (#174596)"

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1937,12 +1937,6 @@ elif [[ "${TEST_CONFIG}" == *huggingface* ]]; then
   test_dynamo_benchmark huggingface "$id"
 elif [[ "${TEST_CONFIG}" == *timm* ]]; then
   install_torchvision
-  TIMM_PIN="$(< .ci/docker/ci_commit_pins/timm.txt)"
-  export HF_HOME="${HF_HOME}/timm_${TIMM_PIN}"
-  if [[ "${TRANSFORMERS_OFFLINE:-1}" == "0" ]]; then
-    python benchmarks/dynamo/timm_models.py --download-only \
-      && touch "${HF_HOME}/.timm_cache_complete"
-  fi
   id=$((SHARD_NUMBER-1))
   test_dynamo_benchmark timm_models "$id"
 elif [[ "${TEST_CONFIG}" == cachebench ]]; then

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -391,22 +391,6 @@ jobs:
             export HF_DATASETS_OFFLINE=0
           fi
 
-          # For TIMM jobs, create a pin-specific cache directory and make it
-          # world-writable so the jenkins user inside docker can write to it.
-          # Only enable online mode if the cache hasn't been fully populated.
-          if [[ "${TEST_CONFIG}" == *timm* ]]; then
-            TIMM_PIN="$(< .ci/docker/ci_commit_pins/timm.txt)"
-            TIMM_CACHE_DIR="${HF_CACHE}/timm_${TIMM_PIN}"
-            if [[ ! -d "${TIMM_CACHE_DIR}" ]]; then
-              mkdir -p "${TIMM_CACHE_DIR}"
-              chmod -R a+rwX "${TIMM_CACHE_DIR}"
-            fi
-            if [[ ! -f "${TIMM_CACHE_DIR}/.timm_cache_complete" ]]; then
-              export TRANSFORMERS_OFFLINE=0
-              export HF_DATASETS_OFFLINE=0
-            fi
-          fi
-
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG, SHM_OPTS, JENKINS_USER and DOCKER_SHELL_CMD since that doesn't play nice

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -475,7 +475,6 @@ def output_signpost(data, args, suite, error=None):
         "log_conv_args",
         "recompile_profiler",
         "find_batch_sizes",
-        "download_only",
         # Redundant
         "batch_size",
         "batch_size_file",
@@ -3683,13 +3682,8 @@ def parse_args(args=None):
         action="store_true",
         help="finds the largest batch size that could fit on GPUs",
     )
-    group.add_argument(
-        "--download-only",
-        action="store_true",
-        help="Download all models and exit without running benchmarks.",
-    )
 
-    mode_group = parser.add_mutually_exclusive_group(required=False)
+    mode_group = parser.add_mutually_exclusive_group(required=True)
     mode_group.add_argument(
         "--accuracy",
         action="store_true",
@@ -3703,7 +3697,7 @@ def parse_args(args=None):
         action="store_true",
         help="extracts the tolerance for each model with small batch size and eval mode",
     )
-    run_mode_group = parser.add_mutually_exclusive_group(required=False)
+    run_mode_group = parser.add_mutually_exclusive_group(required=True)
     run_mode_group.add_argument(
         "--training",
         action="store_true",
@@ -3712,13 +3706,7 @@ def parse_args(args=None):
     run_mode_group.add_argument(
         "--inference", action="store_true", help="Performs inference"
     )
-    args = parser.parse_args(args)
-    if not args.download_only:
-        if not any([args.accuracy, args.performance, args.tolerance]):
-            parser.error("one of --accuracy/--performance/--tolerance is required")
-        if not any([args.training, args.inference]):
-            parser.error("one of --training/--inference is required")
-    return args
+    return parser.parse_args(args)
 
 
 def process_caching_precompile():
@@ -4280,20 +4268,6 @@ def run(runner, args, original_dir=None):
             batch_size = runner.batch_size_finder(device, args.only)
             print(args.only, batch_size)
             write_outputs(output_filename, [], [args.only, batch_size])
-        return
-
-    if args.download_only:
-        model_names = list(runner.iter_model_names(args))
-        failed = []
-        for name in model_names:
-            try:
-                runner._download_model(name)
-                print(f"Downloaded: {name}")
-            except Exception as e:
-                print(f"Failed: {name}: {e}")
-                failed.append(name)
-        if failed:
-            sys.exit(1)
         return
 
     should_profile_details = args.profile_details


### PR DESCRIPTION
This reverts commit 781b5d1dc94544bcc3841ad7babcd1be783a5056.

Reverted https://github.com/pytorch/pytorch/pull/174596 on behalf of https://github.com/jeffdaily due to This broke ROCm dynamo benchmarks.  Lots of permission denied errors. ([comment](https://github.com/pytorch/pytorch/pull/174596#issuecomment-3909918521))

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo