### PR TITLE
[ROCm][Inductor] New Inductor benchmarker based on Torch Profiler

### DIFF
--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -9,7 +9,11 @@ from torch._inductor.config import (
     inductor_default_autotune_rep,
     inductor_default_autotune_warmup,
 )
-from torch._inductor.runtime.benchmarking import Benchmarker, TritonBenchmarker
+from torch._inductor.runtime.benchmarking import (
+    Benchmarker,
+    TorchProfilerBenchmarker,
+    TritonBenchmarker,
+)
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import (
     decorateIf,
@@ -220,6 +224,47 @@ class TestBenchmarker(TestCase):
         finally:
             _bench._BENCHMARK_DISPATCH.clear()
             _bench._BENCHMARK_DISPATCH.update(orig)
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @parametrize(
+        "hip_value, expected_buffer_size_bytes",
+        ((None, 1024), ("mock-hip", 256 * 1024 * 1024)),
+    )
+    def test_torch_profiler_benchmarker_reuses_inductor_helpers(
+        self, hip_value, expected_buffer_size_bytes, device=GPU_TYPE
+    ):
+        benchmarker = TorchProfilerBenchmarker()
+        benchmarker.__dict__["L2_cache_size"] = 1024
+        _, _callable = self.make_params(device, size=16)
+
+        captured_buffer_lengths = []
+        original_empty = torch.empty
+
+        def empty_spy(*args, **kwargs):
+            captured_buffer_lengths.append(args[0])
+            return original_empty(*args, **kwargs)
+
+        with patch.object(
+            benchmarker,
+            "get_event_pairs",
+            wraps=benchmarker.get_event_pairs,
+        ) as mock_get_event_pairs:
+            with patch.object(torch.version, "hip", hip_value):
+                with patch(
+                    "torch._inductor.runtime.benchmarking.torch.empty",
+                    side_effect=empty_spy,
+                ):
+                    timing = benchmarker.benchmark_gpu(
+                        _callable,
+                        rep=1,
+                        estimation_iters=1,
+                        memory_warmup_iters=0,
+                    )
+
+        self.assertGreater(timing, 0)
+        mock_get_event_pairs.assert_called_once_with(1)
+        self.assertGreater(len(captured_buffer_lengths), 0)
+        self.assertEqual(captured_buffer_lengths[0], expected_buffer_size_bytes // 4)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3951,6 +3951,51 @@ class TestMaxAutotuneSubproc(TestCase):
         with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
+    def test_max_autotune_profiler_benchmarker_smoke(self):
+        """
+        Smoke test that a simple max-autotune matmul runs with profiler
+        benchmarker selection enabled through config patching, and records
+        positive autotune benchmark timing.
+        """
+
+        def mm(a, b):
+            return a @ b
+
+        a = torch.randn(64, 32).to(GPU_TYPE)
+        b = torch.randn(32, 64).to(GPU_TYPE)
+
+        import torch._inductor.runtime.benchmarking as inductor_benchmarking
+
+        benchmark_timings_ms = []
+        original_benchmark_gpu = inductor_benchmarking.benchmarker.benchmark_gpu
+
+        def benchmark_gpu_with_capture(*args, **kwargs):
+            timing_ms = original_benchmark_gpu(*args, **kwargs)
+            benchmark_timings_ms.append(timing_ms)
+            return timing_ms
+
+        with config.patch(
+            {"max_autotune": True, "use_torch_profiler_benchmarker": True}
+        ):
+            with mock.patch.object(
+                inductor_benchmarking.benchmarker,
+                "benchmark_gpu",
+                side_effect=benchmark_gpu_with_capture,
+            ):
+                torch.compile(mm)(a, b)
+
+        finite_timings_ms = [t for t in benchmark_timings_ms if math.isfinite(t)]
+        self.assertGreater(
+            len(finite_timings_ms),
+            0,
+            f"Expected finite autotune benchmark timings, got {benchmark_timings_ms}",
+        )
+        self.assertGreater(
+            min(finite_timings_ms),
+            0.0,
+            f"Expected autotune benchmark timing > 0, got {finite_timings_ms}",
+        )
+
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     @parametrize("dynamic", (False, True))
     def test_max_autotune_addmm(self, search_space, dynamic=False):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -506,6 +506,14 @@ pipeline_max_autotune_gemm = (
     os.environ.get("TORCHINDUCTOR_PIPELINE_GEMM_AUTOTUNING") == "1"
 )
 
+# use torch profiler to benchmark kernels during autotuning
+# when enabled, this takes precedence over use_experimental_benchmarker
+use_torch_profiler_benchmarker: bool = Config(
+    default=False,
+    env_name_force="TORCHINDUCTOR_USE_TORCH_PROFILER_BENCHMARKER",
+    justknob="pytorch/inductor:use_torch_profiler_benchmarker",
+)
+
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"
 

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -19,6 +19,9 @@ logger = torch._logging.getArtifactLogger(__name__, "benchmarking")
 use_experimental_benchmarker = (
     inductor_config.use_experimental_benchmarker and torch.cuda.is_available()
 )
+use_torch_profiler_benchmarker = (
+    inductor_config.use_torch_profiler_benchmarker and torch.cuda.is_available()
+)
 
 
 MILLISECONDS_PER_SECOND = 1000
@@ -544,6 +547,155 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
             )
 
 
+class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
+    """Benchmarker that uses torch.profiler for GPU kernel benchmarking."""
+
+    @time_and_count
+    def benchmark_gpu(  # type: ignore[override]
+        self: Self,
+        _callable: Callable[[], Any],
+        warmup: int = 25,
+        rep: int = 100,
+        estimation_iters: int = 5,
+        memory_warmup_iters: int = 10,
+        max_benchmark_duration: int = 25,
+        return_mode: str = "mean",
+        grad_to_none: list[torch.Tensor] | None = None,
+        **kwargs: Any,
+    ) -> float:
+        """Benchmark a GPU callable using torch.profiler.
+
+        Arguments:
+        - _callable: The callable to benchmark.
+
+        Keyword Arguments:
+        - warmup: Ignored (kept for API compat). Warmup is handled by the
+        estimation phase which runs estimation_iters with cache flushing.
+        - rep: Optionally, the maximum number of iterations to run during benchmarking.
+        - estimation_iters: Optionally, the number of iterations used to estimate
+        the runtime of `_callable` for dynamic rep adjustment. These iterations
+        also serve as warmup for the callable.
+        - memory_warmup_iters: Optionally, the number of buffer.zero_() iterations
+        to run after estimation to bring the cache into a steady state before
+        the profiled benchmark phase.
+        - max_benchmark_duration: Optionally, the maximum duration of the profiled
+        benchmark phase, in milliseconds. The rep count is reduced if the
+        estimated total would exceed this budget.
+        - return_mode: Return mode for benchmark results. Options are "min", "mean" (default),
+        or "max".
+        - grad_to_none: Optionally, a list of tensors whose gradients should be cleared
+        before each benchmark iteration.
+        - **kwargs: Additional kwargs that may be passed to the fallback.
+
+        Returns:
+        - The runtime of `_callable` in milliseconds, computed according to return_mode.
+        """
+        # we don't want any outside errors propagating into benchmarking
+        torch.cuda.synchronize()
+
+        # warmup `_callable` (and catches any failures in the process)
+        _callable()
+        torch.cuda.synchronize()
+
+        # Keep Triton's 256 MB cache flush on ROCm. On other backends, reuse
+        # the shared L2-sized flush from InductorBenchmarker.
+        # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
+        if torch.version.hip:
+            buffer_size_bytes = 256 * 1024 * 1024
+        else:
+            buffer_size_bytes = self.L2_cache_size
+        buffer = torch.empty(buffer_size_bytes // 4, dtype=torch.int, device="cuda")
+        buffer.zero_()
+
+        # Estimation phase with separate event pairs — also serves as warmup.
+        # Using per-iteration event pairs lets us take the min, matching
+        # InductorBenchmarker's approach for a more robust estimate.
+        event_pairs = self.get_event_pairs(estimation_iters)
+        for start_event, end_event in event_pairs:
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            buffer.zero_()
+            start_event.record()
+            _callable()
+            end_event.record()
+        torch.cuda.synchronize()
+        estimated_ms = self.get_event_pairs_min_timing(event_pairs)
+        if estimated_ms > 0:
+            rep = max(min(rep, int(max_benchmark_duration / estimated_ms)), 1)
+
+        # Light memory warmup: flush the cache into a steady state before
+        # the profiled run.  No callable — estimation already warmed it.
+        for _ in range(memory_warmup_iters):
+            buffer.zero_()
+
+        # benchmark with profiler
+        # Use both CPU and CUDA activities, otherwise record_function
+        # will not record the region.
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            record_shapes=False,
+        ) as prof:
+            for _ in range(rep):
+                if grad_to_none is not None:
+                    for x in grad_to_none:
+                        x.grad = None
+                buffer.zero_()
+
+                with torch.profiler.record_function("_CALLABLE"):
+                    _callable()
+
+        torch.cuda.synchronize()
+
+        # Extract _CALLABLE GPU time directly from raw kineto events.
+        # This avoids prof.key_averages() which triggers expensive lazy
+        # processing: _parse_kineto_results (wrapping every raw event in
+        # a Python FunctionEvent), _build_tree, and grouping/aggregation.
+        from torch.autograd import DeviceType as _DeviceType
+
+        callable_gpu_time_us = 0.0
+        for kineto_event in prof.profiler.kineto_results.events():
+            if (
+                kineto_event.name() == "_CALLABLE"
+                and kineto_event.device_type() == _DeviceType.CUDA
+            ):
+                callable_gpu_time_us += (
+                    kineto_event.end_ns() - kineto_event.start_ns()
+                ) / 1000.0
+
+        if callable_gpu_time_us <= 0:
+            raise AssertionError(
+                "TorchProfilerBenchmarker: '_CALLABLE' CUDA event not found in "
+                "raw kineto results. This indicates record_function('_CALLABLE') did "
+                "not produce a GPU_USER_ANNOTATION profiler event."
+            )
+
+        # TODO: Revisit incorporating launch overhead effects.
+        total_time_us = callable_gpu_time_us
+        avg_time_ms = (total_time_us / rep) / 1000.0
+
+        # explicitly delete the buffer, sometimes helps memory
+        # footprint metrics in OSS Inductor performance benchmarks
+        del buffer
+
+        # Return based on the requested mode
+        # Note: For profiler-based benchmarking, we return the mean time per iteration
+        # min/max modes are kept for API compatibility but return the mean
+        if return_mode in ("min", "mean", "max"):
+            return avg_time_ms
+        else:
+            raise ValueError(
+                f"Unsupported return_mode: {return_mode}. Use 'min', 'mean', or 'max'."
+            )
+
+
 benchmarker = (
-    InductorBenchmarker() if use_experimental_benchmarker else TritonBenchmarker()
+    TorchProfilerBenchmarker()
+    if use_torch_profiler_benchmarker
+    else (
+        InductorBenchmarker() if use_experimental_benchmarker else TritonBenchmarker()
+    )
 )


### PR DESCRIPTION
A new benchmarker method for timing Inductor kernels during autotuning. We use Torch Profiler to collect the kernel execution times. This is particularly important for short-duration kernels that are not accurate timed with hipEvents.

Based on the Inductor benchmarker class, but using Torch profiler to obtain timings instead of hipEvents. We still use hipEvents to cap the total warmup sampling time, but the final time for the kernel is collected from the Torch Profiler.

The buffer size used for flushing the data cache is different between ROCm and NVIDIA. See comments in code.

Will also work on NVIDIA platform.

Ran the `inductor-perf-test-nightly-rocm-mi300` several times. There was more overhead with this Torch Profile benchmarker, but it was not significantly more. No test suite regressions.

Note that this feature is turned *off *by default, it must be activated using `TORCHINDUCTOR_USE_TORCH_PROFILER_BENCHMARKER=1`

Cursor was used to improve this PR.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos