### PR TITLE
patch .comms attribute for ThreadLocalWorld warnings

### DIFF
--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -560,6 +560,7 @@ class WorldData:
     tags_to_pg: dict[str, list[dist.ProcessGroup]]
     pg_to_tag: dict[dist.ProcessGroup, str]
     pg_coalesce_state: dict[dist.ProcessGroup, list[Union[_CollOp, P2POp]]]
+    comms: list
 
 
 class ThreadLocalWorld:
@@ -568,7 +569,7 @@ class ThreadLocalWorld:
     def _get_world(self) -> WorldData:
         if not hasattr(ThreadLocalWorld._world, "world"):
             ThreadLocalWorld._world.world = WorldData(
-                None, {}, {}, {}, {}, 0, {}, {}, {}
+                None, {}, {}, {}, {}, 0, {}, {}, {}, []
             )
         return ThreadLocalWorld._world.world
 
@@ -615,6 +616,10 @@ class ThreadLocalWorld:
     @property
     def pg_coalesce_state(self) -> dict[dist.ProcessGroup, list[Union[_CollOp, P2POp]]]:
         return self._get_world().pg_coalesce_state
+
+    @property
+    def comms(self):
+        return self._get_world().comms
 
 
 _old_pg_world = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #175099

patching for https://github.com/pytorch/pytorch/pull/174202. Running `python test/distributed/tensor/test_dtensor_ops.py -k TestMultiThreadedDTensorOps -v` is flooded with these errors:
```
test_dtensor_op_db___rdiv___cpu_float32 (__main__.TestMultiThreadedDTensorOpsCPU) ... Exception in thread Thread-19 (_run):
Traceback (most recent call last):
Exception in thread Thread-18 (_run):
Traceback (most recent call last):
Exception in thread Thread-20 (_run):
Traceback (most recent call last):
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 953, in run
    self.run()
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 953, in run
    self.run()
Exception in thread Thread-17 (_run):
Traceback (most recent call last):
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/data/users/pianpwk/pytorch/torch/testing/_internal/common_distributed.py", line 1428, in _run
    self._target(*self._args, **self._kwargs)
  File "/data/users/pianpwk/pytorch/torch/testing/_internal/common_distributed.py", line 1428, in _run
    self.run_test_with_threaded_pg(test_name, rank, world_size)
  File "/data/users/pianpwk/pytorch/torch/testing/_internal/common_distributed.py", line 1450, in run_test_with_threaded_pg
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self._target(*self._args, **self._kwargs)
  File "/data/users/pianpwk/pytorch/torch/testing/_internal/common_distributed.py", line 1428, in _run
    c10d.destroy_process_group()
  File "/data/users/pianpwk/pytorch/torch/distributed/distributed_c10d.py", line 2310, in destroy_process_group
    self.run_test_with_threaded_pg(test_name, rank, world_size)
  File "/data/users/pianpwk/pytorch/torch/testing/_internal/common_distributed.py", line 1450, in run_test_with_threaded_pg
    self.run_test_with_threaded_pg(test_name, rank, world_size)
  File "/data/users/pianpwk/pytorch/torch/testing/_internal/common_distributed.py", line 1450, in run_test_with_threaded_pg
    for comm in _world.comms:
    self.run()
  File "/home/pianpwk/.conda/envs/pytorch-3048/lib/python3.10/threading.py", line 953, in run
    c10d.destroy_process_group()
  File "/data/users/pianpwk/pytorch/torch/distributed/distributed_c10d.py", line 2310, in destroy_process_group
    c10d.destroy_process_group()
  File "/data/users/pianpwk/pytorch/torch/distributed/distributed_c10d.py", line 2310, in destroy_process_group
AttributeError: 'ThreadLocalWorld' object has no attribute 'comms'
```
