### PR TITLE
[torch/dynamo] Rename _PyOpcode_* symbols in cpython_defs.c

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -28,6 +28,12 @@ void init_THPCaches() {}
 
 #if IS_PYTHON_3_11_PLUS
 
+// Rename opcode table symbols to avoid multiple definition conflict
+// with the identical tables in libpython at link time.
+#define _PyOpcode_Caches _torch_PyOpcode_Caches
+#define _PyOpcode_Jump _torch_PyOpcode_Jump
+#define _PyOpcode_Deopt _torch_PyOpcode_Deopt
+
 #define Py_BUILD_CORE
 #define NEED_OPCODE_TABLES // To get _PyOpcode_Deopt, _PyOpcode_Caches
 
@@ -42,6 +48,9 @@ void init_THPCaches() {}
 
 #undef NEED_OPCODE_TABLES
 #undef Py_BUILD_CORE
+#undef _PyOpcode_Deopt
+#undef _PyOpcode_Jump
+#undef _PyOpcode_Caches
 
 // As a simple way to reduce the impact of ABI changes on the CPython side, this
 // check forces us to manually re-check that the function didn't change on the
@@ -497,8 +506,8 @@ const uint8_t* THP_PyOpcode_Caches = NULL;
 int THP_PyOpcode_Caches_size = 0;
 void init_THPCaches() {
 #if IS_PYTHON_3_11_PLUS
-  THP_PyOpcode_Caches = _PyOpcode_Caches;
-  THP_PyOpcode_Caches_size = sizeof(_PyOpcode_Caches) / sizeof(uint8_t);
+  THP_PyOpcode_Caches = _torch_PyOpcode_Caches;
+  THP_PyOpcode_Caches_size = sizeof(_torch_PyOpcode_Caches) / sizeof(uint8_t);
 #endif
 }
 


### PR DESCRIPTION
Context:
Dynamo includes CPython internal header which pulls in CPython symbols. This results in duplicate symbol error when linking libpython statically. 

`torch/csrc/dynamo/cpython_defs.c` emits definitions of `_PyOpcode_Caches`, `_PyOpcode_Jump`, and `_PyOpcode_Deopt` with external linkage (by including CPython's internal `pycore_opcode.h` / `pycore_opcode_metadata.h` with `NEED_OPCODE_TABLES` defined), conflicting with symbols in libpython.

Use preprocessor macros to rename these symbols to `_torch_PyOpcode_*` before the CPython header includes, so they no longer conflict with libpython's definitions.

The renamed symbols are only used internally within `cpython_defs.c` (via `init_THPCaches()`), so there is no impact on the public API (`THP_PyOpcode_Caches`).

Cinder follows a similar approach: 
https://github.com/facebookincubator/cinderx/blob/a8381ce4f4cfe021ff65717c366edcce56daad34/cinderx/Interpreter/3.12/cinder_opcode.h#L11-L14


Differential Revision: D93419625




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo