### PR TITLE
Add missing constants (e, pi) to docs

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -320,8 +320,11 @@ Constants
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ======================================= ===========================================
+``e``                                       Euler's number, the base of natural logarithms (~2.7183). Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
 ``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
+``newaxis``                                 An alias for ``None``, useful for indexing. Same as :data:`numpy.newaxis`.
+``pi``                                      The ratio of a circle's circumference to its diameter (~3.1416). Alias for :attr:`math.pi`.
 ======================================= ===========================================
 
 Pointwise Ops

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -323,7 +323,6 @@ Constants
 ``e``                                       Euler's number, the base of natural logarithms (~2.7183). Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
 ``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
-``newaxis``                                 An alias for ``None``, useful for indexing. Same as :data:`numpy.newaxis`.
 ``pi``                                      The ratio of a circle's circumference to its diameter (~3.1416). Alias for :attr:`math.pi`.
 ======================================= ===========================================
 


### PR DESCRIPTION
Add `torch.e` and `torch.pi` to the constants table.

Fixes #167535