### PR TITLE
[autograd] Lazy stream/event allocation in InputBuffer

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -10035,6 +10035,27 @@ for shape in [(1,), ()]:
         # Given gradients should not be modified inplace
         self.assertEqual(grad_out1, grad_out1_original)
 
+    def test_input_buffer_lazy_stream_tracking(self):
+        # Verify that lazy stream/event allocation in InputBuffer does not
+        # affect gradient correctness on CPU. Multiple uses of a tensor cause
+        # its grad_fn's InputBuffer to accumulate from multiple producers.
+        a = torch.randn(4, 4, requires_grad=True)
+        b = a * a
+        c = a + b
+        # b and a are each used twice, so their grad_fn InputBuffers accumulate
+        loss = (b + c).sum()
+        loss.backward()
+        expected = a.detach() * 2 + 1 + a.detach() * 2
+        self.assertEqual(a.grad, expected)
+
+        # Deep chain: many InputBuffers, all CPU-only
+        x = torch.randn(8, requires_grad=True)
+        out = x
+        for _ in range(100):
+            out = out * 1.0 + out * 0.0
+        out.sum().backward()
+        self.assertEqual(x.grad, torch.ones_like(x))
+
     def test_no_unnecessary_unwrapping(self):
         a = torch.randn(5, requires_grad=True)
         a_orig = a.detach().clone()

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1069,22 +1069,26 @@ void Engine::evaluate_function(
   auto opt_parent_stream = (*func).stream();
   c10::OptionalStreamGuard parent_stream_guard{opt_parent_stream};
 
-  // Ensure that the incoming gradients are ready
-  for (size_t pos = 0; pos < inputs.ready_events.size(); ++pos) {
-    if (!inputs.buffer[pos].defined()) {
-      continue;
-    }
-    const auto device = inputs.buffer[pos].device();
-    bool is_accelerator = at::accelerator::isAccelerator(device.type());
-    if (!is_accelerator) {
-      continue;
-    }
-    auto& opt_ready_stream = inputs.ready_streams[pos];
-    auto& opt_ready_event = inputs.ready_events[pos];
-    TORCH_INTERNAL_ASSERT(opt_ready_stream && opt_parent_stream);
-    if (*opt_parent_stream != *opt_ready_stream) {
-      TORCH_INTERNAL_ASSERT(opt_ready_event);
-      opt_parent_stream->wait(opt_ready_event.value());
+  // Ensure that the incoming gradients are ready.
+  // Stream tracking vectors are lazily allocated, so skip entirely for
+  // CPU-only InputBuffers where no accelerator tensors were accumulated.
+  if (inputs.has_stream_tracking()) {
+    for (size_t pos = 0; pos < inputs.buffer.size(); ++pos) {
+      if (!inputs.buffer[pos].defined()) {
+        continue;
+      }
+      const auto device = inputs.buffer[pos].device();
+      bool is_accelerator = at::accelerator::isAccelerator(device.type());
+      if (!is_accelerator) {
+        continue;
+      }
+      auto& opt_ready_stream = inputs.ready_streams[pos];
+      auto& opt_ready_event = inputs.ready_events[pos];
+      TORCH_INTERNAL_ASSERT(opt_ready_stream && opt_parent_stream);
+      if (*opt_parent_stream != *opt_ready_stream) {
+        TORCH_INTERNAL_ASSERT(opt_ready_event);
+        opt_parent_stream->wait(opt_ready_event.value());
+      }
     }
   }
 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1087,6 +1087,7 @@ void Engine::evaluate_function(
       TORCH_INTERNAL_ASSERT(opt_ready_stream && opt_parent_stream);
       if (*opt_parent_stream != *opt_ready_stream) {
         TORCH_INTERNAL_ASSERT(opt_ready_event);
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         opt_parent_stream->wait(opt_ready_event.value());
       }
     }

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -215,6 +215,8 @@ void InputBuffer::add(
     }
     return;
   }
+  ensure_stream_tracking();
+
   // Handle the case where var is on an accelerator but producer node has no
   // canonical stream, e.g. this can happen if forward is DtoH
   const std::optional<c10::Stream>& opt_producer_stream =
@@ -315,6 +317,15 @@ void InputBuffer::add(
       ready_events[pos] = std::move(event);
     }
     ready_streams[pos] = accum_stream;
+  }
+}
+
+void InputBuffer::ensure_stream_tracking() {
+  if (opt_accum_streams.empty()) {
+    const auto size = buffer.size();
+    opt_accum_streams.resize(size);
+    ready_events.resize(size);
+    ready_streams.resize(size);
   }
 }
 


### PR DESCRIPTION
## Summary

`InputBuffer` eagerly allocated three stream/event tracking vectors (`opt_accum_streams`, `ready_events`, `ready_streams`) per instance, even though they are only used when accelerator (CUDA/XPU) tensors flow through during backward. For CPU-only backward passes, this was unnecessary work: three heap allocations per autograd node that are never used.

This PR defers allocation of these vectors until the first accelerator tensor is actually added to the buffer, and skips the stream synchronization loop in `evaluate_function` entirely when no stream tracking is active. The benefit is largest in graphs with many small ops (where allocation is a larger share of overhead) and in reducing memory churn; for matmul-heavy CPU backward the impact is negligible.

## Review order

1. `torch/csrc/autograd/input_buffer.h` -- interface change: constructor now only allocates `buffer`; added `has_stream_tracking()` query and private `ensure_stream_tracking()`.
2. `torch/csrc/autograd/input_buffer.cpp` -- `ensure_stream_tracking()` implementation; called at the entry of the accelerator code path in `add()`.
3. `torch/csrc/autograd/engine.cpp` -- guarded the stream sync loop in `evaluate_function()` with `has_stream_tracking()`.
4. `test/test_autograd.py` -- new test `test_input_buffer_lazy_stream_tracking` verifying gradient correctness through multi-use tensor patterns and deep chains.

## Test plan

- Added `test_input_buffer_lazy_stream_tracking` covering CPU-only backward with multi-producer accumulation and deep (100-layer) chains.
- Existing `test_input_buffer_accum` continues to pass (sparse + dense gradient accumulation).
- Existing CUDA stream synchronization tests in `test_cuda_multigpu.py` continue to pass (multi-GPU InputBuffer accumulation).
- CI green across CPU and CUDA configurations.
