### PR TITLE
add seqused_k

### DIFF
--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -388,8 +388,6 @@ def _setup_context(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
     ) = inputs
     out, lse, rng_state = output
 
-    # do we want to add seqused_k to the backward? this is only supported in FA3
-    # is there a real use case for this or should it be inference only?
     if any(
         p is not None
         for p in (

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -60,6 +60,7 @@ def _varlen_attn(
     cache_seqlens: torch.Tensor | None = None,
     cache_batch_idx: torch.Tensor | None = None,
     page_table: torch.Tensor | None = None,
+    seqused_k: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Private custom op for variable-length attention.
@@ -71,11 +72,18 @@ def _varlen_attn(
     if (k_cache is None) != (v_cache is None):
         raise ValueError("k_cache and v_cache must both be provided or both be None")
 
+    if cache_seqlens is not None and seqused_k is not None:
+        raise ValueError("cache_seqlens and seqused_k cannot both be provided.")
+
     use_cudnn = query.is_cuda and _should_use_cudnn(query.device.index)
 
     if use_cudnn:
         if k_cache is not None:
             raise RuntimeError("cuDNN backend does not support KV cache.")
+        if seqused_k is not None:
+            # TODO: cuDNN supports per-sequence KV lengths via SEQ_LEN_KV + padding_mask,
+            # but _cudnn_attention_forward doesn't expose it yet.
+            raise RuntimeError("seqused_k is not yet supported with the cuDNN backend.")
         if window_size[0] != -1 or window_size[1] != -1:
             raise RuntimeError(
                 "cuDNN backend does not support window attention. Please use Flash Attention backend."
@@ -115,6 +123,7 @@ def _varlen_attn(
             scale=scale,
             window_size_left=window_size[0],
             window_size_right=window_size[1],
+            seqused_k=seqused_k,
             k_cache=k_cache,
             v_cache=v_cache,
             cache_seqlens=cache_seqlens,
@@ -157,6 +166,7 @@ def _varlen_attn_fake(
     cache_seqlens: torch.Tensor | None = None,
     cache_batch_idx: torch.Tensor | None = None,
     page_table: torch.Tensor | None = None,
+    seqused_k: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Fake implementation for meta tensor computation and tracing.
@@ -205,6 +215,7 @@ def varlen_attn(
     cache_seqlens: torch.Tensor | None = None,
     cache_batch_idx: torch.Tensor | None = None,
     page_table: torch.Tensor | None = None,
+    seqused_k: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     Compute variable-length attention using Flash Attention.
@@ -255,6 +266,12 @@ def varlen_attn(
             Shape ``(batch_size,)`` with dtype int32. If None, uses [0, 1, ..., batch_size-1].
         page_table (Tensor, optional): Page table for paged KV cache.
             Shape ``(batch_size, max_num_blocks_per_seq)`` with dtype int32.
+        seqused_k (Tensor, optional): Number of valid key/value tokens per batch element.
+            Shape ``(batch_size,)``. When provided, only the first
+            ``seqused_k[i]`` tokens of each sequence's keys/values are used during
+            attention. This is useful when key/value tensors (including any cached tokens)
+            are pre-populated and you want to limit how many are attended to, without
+            using the AppendKV cache path (``k_cache``/``v_cache``/``cache_seqlens``).
 
     Returns:
         output (Tensor): Output tensor from attention computation; shape :math:`(T_q, H, D)`.
@@ -321,6 +338,7 @@ def varlen_attn(
             cache_seqlens,
             cache_batch_idx,
             page_table,
+            seqused_k,
         )
         output = out
     else:
@@ -341,6 +359,7 @@ def varlen_attn(
             cache_seqlens,
             cache_batch_idx,
             page_table,
+            seqused_k,
         )
     if return_aux is not None and return_aux.lse:
         return output, lse
@@ -365,15 +384,28 @@ def _setup_context(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
         cache_seqlens,
         cache_batch_idx,
         page_table,
+        seqused_k,
     ) = inputs
     out, lse, rng_state = output
 
+    # do we want to add seqused_k to the backward? this is only supported in FA3
+    # is there a real use case for this or should it be inference only?
     if any(
         p is not None
-        for p in (_out, k_cache, v_cache, cache_seqlens, cache_batch_idx, page_table)
+        for p in (
+            _out,
+            k_cache,
+            v_cache,
+            cache_seqlens,
+            cache_batch_idx,
+            page_table,
+            seqused_k,
+        )
     ):
         raise RuntimeError(
-            "Inference-only parameters (out, k_cache, v_cache, cache_seqlens, cache_batch_idx, page_table) do not support autograd"
+            "Inference-only parameters \
+            (out, k_cache, v_cache, cache_seqlens, cache_batch_idx, page_table, seqused_k) \
+            do not support autograd"
         )
 
     ctx.save_for_backward(query, key, value, cu_seq_q, cu_seq_k, out, lse, rng_state)
@@ -511,8 +543,8 @@ def _backward(
         window_size,
     )
     # None for: cu_seq_q, cu_seq_k, max_q, max_k, out, is_causal, scale, window_size,
-    #           k_cache, v_cache, cache_seqlens, cache_batch_idx, page_table
-    return (dq, dk, dv, *((None,) * 13))
+    #           k_cache, v_cache, cache_seqlens, cache_batch_idx, page_table, seqused_k
+    return (dq, dk, dv, *((None,) * 14))
 
 
 _varlen_attn.register_autograd(_backward, setup_context=_setup_context)


### PR DESCRIPTION
In FA2, `seqused_k` limited valid K/V length and one of the use cases for this was KV caching. The caller writes cached + new tokens into the K/V buffer externally and then passes the buffer with `seqused_k` marking which tokens were valid. 

FA3 introduces AppendKV, a fused cache-append + attention path. Instead of the caller writing new tokens into the KV cache with a separate kernel and then running attention, the FA3 kernel does both using new parameters `k_cache`/`v_cache` (cache), `k_new`/`v_new` (new tokens), and `cache_seqlens` (where to append new tokens in the cache).

Adding `seqused_k` to `varlen_attn` provides the option of still managing your own cache. However, since paging is only supported in FA3, you still need FA3 to use `seqused_k` as paged KV caching. 

`seqused_k` is already a parameter in PyTorch's `_flash_attention_forward` (since it's an FA2 param) so no need to modify the C++ headers.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175114
* #175103
* #175102
* #175101

