### PR TITLE
[inductor] Single-output custom op ExternKernelOut lowering

### DIFF
--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -1,0 +1,98 @@
+# Owner(s): ["module: inductor"]
+"""
+Tests for inductor lowering of functional custom ops to out-variant via ExternKernelOut.
+
+Verifies that custom ops with both functional and .out overloads are lowered
+to ExternKernelOut (should_allocate=True) for buffer reuse, and that the config
+flag properly gates the behavior.
+"""
+import unittest
+
+import torch
+import torch._inductor.config as inductor_config
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+
+requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
+
+DEVICES = ("cpu", GPU_TYPE) if HAS_GPU else ("cpu",)
+
+
+@instantiate_parametrized_tests
+class TestCustomOpOutLowering(torch._inductor.test_case.TestCase):
+    """Tests for lowering functional custom ops to out-variant ExternKernelOut."""
+
+    def _register_add_one_ops(self, lib):
+        """Register a simple add_one op with functional + .out overloads."""
+        lib.define("add_one(Tensor x) -> Tensor")
+        lib.define(
+            "add_one.out(Tensor x, *, Tensor(a!) out) -> Tensor(a!)",
+            tags=(torch.Tag.out_variant,),
+        )
+
+        def _add_one_impl(x: torch.Tensor) -> torch.Tensor:
+            return x + 1
+
+        def _add_one_out_impl(x: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+            out.copy_(x + 1)
+            return out
+
+        lib.impl("add_one", _add_one_impl, "CompositeExplicitAutograd")
+        lib.impl("add_one.out", _add_one_out_impl, "CompositeExplicitAutograd")
+
+        @torch.library.register_fake("mylib::add_one", lib=lib)
+        def _add_one_fake(x):
+            return x.new_empty(x.shape)
+
+        return torch.ops.mylib.add_one, torch.ops.mylib.add_one.out
+
+    @inductor_config.patch(lower_custom_ops_to_out_variant=True)
+    @parametrize("device", DEVICES)
+    def test_add_one_lowered_to_out(self, device):
+        """Test that a simple functional op gets lowered to its out-variant."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            func_op, out_op = self._register_add_one_ops(lib)
+
+            def f(x):
+                return torch.ops.mylib.add_one(x)
+
+            x = torch.randn(4, 4, device=device)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True), x
+            )
+            self.assertEqual(compiled_out, eager_out)
+
+            self.assertIn(".out(", code)
+            self.assertNotIn(".default(", code)
+
+    @inductor_config.patch(lower_custom_ops_to_out_variant=False)
+    @parametrize("device", DEVICES)
+    def test_disabled_falls_back_to_fallback_kernel(self, device):
+        """Test that disabling the config causes the op to go through FallbackKernel."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            func_op, out_op = self._register_add_one_ops(lib)
+
+            def f(x):
+                return torch.ops.mylib.add_one(x)
+
+            x = torch.randn(4, 4, device=device)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True), x
+            )
+            self.assertEqual(compiled_out, eager_out)
+            self.assertNotIn(".out(", code)
+            self.assertIn(".default(", code)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/_inductor/custom_op_out_lowering.py
+++ b/torch/_inductor/custom_op_out_lowering.py
@@ -21,6 +21,7 @@ import torch
 from torch._ops import OpOverload
 
 from . import config, ir
+from .virtualized import V
 
 
 if TYPE_CHECKING:
@@ -105,11 +106,26 @@ def _lower_single_output(
     non_tensor_args: Sequence[Any],
     kwargs: dict[str, Any],
 ) -> Optional[ir.IRNode]:
-    """Lower a single-output functional op to ExternKernelOut.
+    """Lower a single-output functional op to ExternKernelOut."""
+    layout = ir.FixedLayout(
+        device=example_output.device,
+        dtype=example_output.dtype,
+        size=[*example_output.shape],
+        stride=[*example_output.stride()],
+    )
 
-    Implemented in a follow-up commit.
-    """
-    return None
+    node = CustomOpExternKernelOut(
+        layout=layout,
+        inputs=list(tensor_args),
+        constant_args=list(non_tensor_args),
+        out_op=out_op,
+        out_arg_names=out_arg_names,
+        op_overload=out_op,
+        kwargs=kwargs,
+    )
+
+    log.debug("Lowered %s -> %s (out args: %s)", kernel, out_op, out_arg_names)
+    return node
 
 
 def _lower_multi_output(
@@ -137,3 +153,71 @@ def _make_python_kernel_name(out_op: OpOverload) -> str:
     op_name = out_op._schema.name.split("::")[1]
     overload = out_op._overloadname
     return f"torch.ops.{ns}.{op_name}.{overload}"
+
+
+def _codegen_input_args(node: ir.ExternKernel) -> list[str]:
+    """Codegen positional + constant args as a list of strings."""
+    assert ir.is_node_sequence(node.inputs)
+    args = [x.codegen_reference() for x in node.inputs]  # type: ignore[union-attr]
+    for const in node.constant_args:
+        args.append(V.graph.wrapper_code.val_to_arg_str(const))
+    return args
+
+
+def _codegen_kwargs(node: ir.ExternKernel, skip_names: set[str]) -> list[str]:
+    """Codegen keyword args, skipping any names in ``skip_names``."""
+    result = []
+    for k, v in node.kwargs.items():
+        if k not in skip_names:
+            result.append(f"{k}={V.graph.wrapper_code.val_to_arg_str(v)}")
+    return result
+
+
+class CustomOpExternKernelOut(ir.ExternKernelOut):
+    """
+    ExternKernelOut for single-output custom ops with flexible out-arg naming.
+
+    Unlike the base ExternKernelOut which hardcodes ``out=`` in codegen,
+    this uses the actual out-arg name from the op's schema (e.g., "result",
+    "output").
+
+    Inherits ``should_allocate() = True`` from ExternKernelOut, enabling
+    Inductor's AllocateLine.plan() buffer reuse.
+    """
+
+    out_op: OpOverload
+    out_arg_names: list[str]
+
+    def __init__(
+        self,
+        layout: ir.Layout,
+        inputs: Sequence[ir.IRNode],
+        constant_args: Sequence[Any] = (),
+        out_op: Optional[OpOverload] = None,
+        out_arg_names: Optional[list[str]] = None,
+        op_overload: Optional[OpOverload] = None,
+        kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        assert out_op is not None, "out_op is required"
+        python_kernel_name = _make_python_kernel_name(out_op)
+        super().__init__(
+            layout=layout,
+            inputs=inputs,
+            constant_args=constant_args,
+            kwargs=kwargs,
+            python_kernel_name=python_kernel_name,
+            op_overload=op_overload,
+        )
+        self.out_op = out_op
+        self.out_arg_names = out_arg_names or ["out"]
+
+    def codegen(self, wrapper: Any) -> None:
+        self.codegen_comment(wrapper)
+        args = _codegen_input_args(self)
+        kwargs_list = _codegen_kwargs(self, skip_names=set(self.out_arg_names))
+        kernel_name = self.get_kernel_name()
+        out_ref = self.codegen_reference()
+
+        all_args = [*args, *kwargs_list]
+        all_args.append(f"{self.out_arg_names[0]}={out_ref}")
+        wrapper.writeline(f"{kernel_name}({', '.join(all_args)})")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175119
* #175118
* __->__ #175117
* #175116

Implement the single-output lowering path for functional custom ops:
- _lower_single_output(): creates FixedLayout + CustomOpExternKernelOut node
- CustomOpExternKernelOut: ExternKernelOut subclass with flexible out-arg naming
  (uses schema's actual out-arg name instead of hardcoded 'out=')
- _codegen_input_args / _codegen_kwargs: reusable codegen helpers

Minimal tests:
- test_add_one_lowered_to_out: verifies .out() call in generated code
- test_disabled_falls_back_to_fallback_kernel: verifies config gating

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo