### PR TITLE
[inductor] Multi-output custom op ExternKernelOut lowering

### DIFF
--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -71,6 +71,53 @@ class TestCustomOpOutLowering(torch._inductor.test_case.TestCase):
             self.assertIn(".out(", code)
             self.assertNotIn(".default(", code)
 
+    def _register_split_add_ops(self, lib):
+        """Register a split_add op returning two tensors with functional + .out overloads."""
+        lib.define("split_add(Tensor x, float a, float b) -> (Tensor, Tensor)")
+        lib.define(
+            "split_add.out(Tensor x, float a, float b, *, Tensor(a!) out0, Tensor(b!) out1) -> (Tensor(a!), Tensor(b!))",
+            tags=(torch.Tag.out_variant,),
+        )
+
+        def _split_add_impl(x, a, b):
+            return (x + a, x + b)
+
+        def _split_add_out_impl(x, a, b, *, out0, out1):
+            out0.copy_(x + a)
+            out1.copy_(x + b)
+            return (out0, out1)
+
+        lib.impl("split_add", _split_add_impl, "CompositeExplicitAutograd")
+        lib.impl("split_add.out", _split_add_out_impl, "CompositeExplicitAutograd")
+
+        @torch.library.register_fake("mylib::split_add", lib=lib)
+        def _split_add_fake(x, a, b):
+            return (x.new_empty(x.shape), x.new_empty(x.shape))
+
+        return torch.ops.mylib.split_add, torch.ops.mylib.split_add.out
+
+    @inductor_config.patch(lower_custom_ops_to_out_variant=True)
+    @parametrize("device", DEVICES)
+    def test_multi_output_lowered_to_out(self, device):
+        """Test a two-output functional op gets lowered to its .out variant."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            func_op, out_op = self._register_split_add_ops(lib)
+
+            def f(x):
+                a, b = torch.ops.mylib.split_add(x, 1.0, 2.0)
+                return a + b
+
+            x = torch.randn(4, 4, device=device)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True), x
+            )
+            self.assertEqual(compiled_out, eager_out)
+            self.assertIn(".out(", code)
+            self.assertIn("out0=", code)
+            self.assertIn("out1=", code)
+
     @inductor_config.patch(lower_custom_ops_to_out_variant=False)
     @parametrize("device", DEVICES)
     def test_disabled_falls_back_to_fallback_kernel(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175119
* __->__ #175118
* #175116


Extend the custom op out-variant lowering (D175116) to handle ops returning
tuples of tensors, e.g. scaled_fp4_quant(input, scale) -> (Tensor, Tensor).

- CustomOpMultiOutputNode (packed parent): emits the .out(out0=buf0,
  out1=buf1) call, referencing pre-allocated child buffers
- AllocatingMultiOutput (per-output child): should_allocate()=True so
  each output buffer participates in AllocateLine.plan() buffer reuse

The packed node pre-allocates child buffers before emitting the .out() call
(unlike FallbackKernel which uses post-hoc tuple indexing).

Validates all outputs are tensors on the same device before creating IR nodes
to prevent leaked registered nodes on bail-out.

## Test Plan

python -m pytest test/inductor/test_custom_op_out_lowering.py -xvs -k test_multi_output_lowered_to_out_device_cpu

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo