### PR TITLE
[inductor] CUDAGraph P2P pool handling + symm_mem CG tests

### DIFF
--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1258,6 +1258,10 @@ class CUDAGraphNode:
 
     def run_graph(self) -> None:
         assert self.graph is not None
+        log.debug(
+            "Executing cudagraph replay, cuda_graph_id=%d",
+            self.id.id,
+        )
         self.graph.replay()
 
     def all_outputs_are_dead(self) -> bool:
@@ -1857,7 +1861,17 @@ def check_memory_pool(
 ) -> None:
     """Validate cudagraph pool allocations against tracked live storages and surface leaks."""
     assert all(isinstance(elem, StorageWeakRefWrapper) for elem in live_storages_ptrs)  # noqa: C419
-    unique_storages = {stor.data_ptr() for stor in live_storages_ptrs if stor()}  # noqa: set_linter
+    unique_storages = set()  # noqa: set_linter
+    for stor in live_storages_ptrs:
+        storage_ptr = stor()
+        if storage_ptr is None:
+            continue
+        # Skip non-pool allocations (e.g., P2P symmetric memory buffers allocated
+        # via cuMemCreate/cuMemMap). These are not managed by the CUDA caching
+        # allocator and should not be validated against the cudagraph pool.
+        if not torch._C._has_Standard_Deleter(storage_ptr):
+            continue
+        unique_storages.add(stor.data_ptr())
 
     # check if there is a divergence first, then do the expensive snapshot call after
     # we know it will error
@@ -2364,6 +2378,12 @@ class CUDAGraphTreeManager:
     def execute_node(
         self, node: CUDAGraphNode, new_inputs: list[InputType]
     ) -> OutputType:
+        log.debug(
+            "[%s] Replaying cudagraph function=%s, cuda_graph_id=%d",
+            self.compile_id,
+            self.get_func_name(node.wrapped_function.id),
+            node.id.id,
+        )
         self.current_node = node
         self.path_state = ExecutionState.EXECUTION
         self.update_generation()
@@ -2698,8 +2718,9 @@ class CUDAGraphTreeManager:
             for wrapper in live_storages_wrappers:
                 storage_ptr = wrapper()
                 assert storage_ptr is not None
-                assert torch._C._has_Standard_Deleter(storage_ptr)
-                assert wrapper.data_ptr() not in ptrs_to_deallocate
+                # Skip non-pool allocations (e.g., P2P symmetric memory buffers)
+                if torch._C._has_Standard_Deleter(storage_ptr):
+                    assert wrapper.data_ptr() not in ptrs_to_deallocate
 
     def live_cudagraph_pool_storages_in_curr_execution(
         self,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3902,6 +3902,27 @@ def is_cudagraph_unsafe_op(node: Operation) -> bool:
     if fx_node is not None and is_cudagraph_unsafe_fx_node(fx_node):
         return True
 
+    # ExternKernelOut nodes created by lowering (e.g., out-variant
+    # lowering in comm_lowering.py) may not have an fx_node. Fall back to
+    # checking op_overload against FORBIDDEN_CUDAGRAPH_OPS directly.
+    if fx_node is None:
+        op_overload = getattr(node, "op_overload", None)
+        if op_overload is not None:
+            op_str = str(op_overload)
+            if op_str in FORBIDDEN_CUDAGRAPH_OPS:
+                log.debug(
+                    "is_cudagraph_unsafe_op: matched op_overload=%s (no fx_node)",
+                    op_str,
+                )
+                return True
+        pk_name = getattr(node, "python_kernel_name", None)
+        if pk_name is not None and pk_name in FORBIDDEN_CUDAGRAPH_OPS:
+            log.debug(
+                "is_cudagraph_unsafe_op: matched python_kernel_name=%s (no fx_node)",
+                pk_name,
+            )
+            return True
+
     return False
 
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -991,7 +991,7 @@ def _should_use_multimem_all_gather_matmul(
         and gather_dim == 0
         # The heuristic is empirical. We could refine it with a more
         # sophisticated perf model.
-        and local_M * group.size() <= 2048
+        and local_M * group.size() <= 8192
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175120
* #174954
* #174856

CUDAGraph integration for symmetric memory operations:
- check_memory_pool(): skip non-pool P2P allocations (cuMemCreate/cuMemMap)
  that are not managed by the CUDA caching allocator
- CUDAGraphTreeManager: relax Standard_Deleter assertion for P2P storages
- is_cudagraph_unsafe_op(): fallback to op_overload/python_kernel_name check
  for ExternKernelOut nodes without fx_node
- Debug logging for cudagraph replay
- Bump multimem_all_gather_matmul threshold to 8192

symm_mem ops are CG-safe (device-side only, auto-resetting signal pads) —
they are NOT added to FORBIDDEN_CUDAGRAPH_OPS.

Tests:
- test_cudagraph_partition_symm_mem: asserts symm_mem inside CG (<=1 partition)
- test_cudagraph_partition_symm_mem_correctness: numerical correctness
- test_cudagraph_symm_mem_codegen: verifies out-variant + P2P allocs in codegen

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo