### PR TITLE
Return cloned paths from `_clone_cutlass_paths`

### DIFF
--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -63,10 +63,12 @@ def _clone_cutlass_paths(build_root: str) -> list[str]:
 
 
 def _cutlass_include_paths() -> list[str]:
-    cutlass_path = _cutlass_path()
+    cutlass_root = _cutlass_path()
+    if cutlass_root is None:
+        return []
     return [
         # Use realpath to get canonical absolute paths, in order not to mess up cache keys
-        os.path.realpath(os.path.join(cutlass_path, path))
+        os.path.realpath(os.path.join(cutlass_root, path))
         for path in _cutlass_paths()
     ]
 

--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -35,7 +35,7 @@ def _cutlass_path() -> str | None:
 
         return parutil.get_dir_path("cutlass-4-headers")
     else:
-        from torch._inductor.codegen.cutlass_utils import try_import_cutlass
+        from torch._inductor.codegen.cutlass.utils import try_import_cutlass
 
         return config.cutlass.cutlass_dir if try_import_cutlass() else None
 

--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -48,12 +48,13 @@ def _cutlass_paths() -> list[str]:
 
 
 def _clone_cutlass_paths(build_root: str) -> list[str]:
-    paths = _cutlass_paths()
     cutlass_root = _cutlass_path()
+    paths = []
     for path in _cutlass_paths():
         old_path = os.path.join(cutlass_root, path)
         new_path = os.path.join(build_root, path)
         shutil.copytree(old_path, new_path, dirs_exist_ok=True)
+        paths.append(new_path)
     return paths
 
 

--- a/torch/_inductor/codegen/cuda/compile_utils.py
+++ b/torch/_inductor/codegen/cuda/compile_utils.py
@@ -29,13 +29,15 @@ def use_re_build() -> bool:
     return False
 
 
-def _cutlass_path() -> str:
+def _cutlass_path() -> str | None:
     if config.is_fbcode():
         from libfb.py import parutil
 
         return parutil.get_dir_path("cutlass-4-headers")
     else:
-        return config.cutlass.cutlass_dir
+        from torch._inductor.codegen.cutlass_utils import try_import_cutlass
+
+        return config.cutlass.cutlass_dir if try_import_cutlass() else None
 
 
 def _cutlass_paths() -> list[str]:
@@ -49,6 +51,8 @@ def _cutlass_paths() -> list[str]:
 
 def _clone_cutlass_paths(build_root: str) -> list[str]:
     cutlass_root = _cutlass_path()
+    if cutlass_root is None:
+        return []
     paths = []
     for path in _cutlass_paths():
         old_path = os.path.join(cutlass_root, path)


### PR DESCRIPTION
The folders are explicitely copied to the build dir and hence should be used from there

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo