### PR TITLE
Don't redefine `TORCH_USE_CUDA_DSA`

### DIFF
--- a/c10/cuda/CUDADeviceAssertionHost.h
+++ b/c10/cuda/CUDADeviceAssertionHost.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#if (defined(USE_CUDA) || defined(USE_ROCM)) && ! defined(TORCH_USE_CUDA_DSA)
+#if (defined(USE_CUDA) || defined(USE_ROCM)) && !defined(TORCH_USE_CUDA_DSA)
 #define TORCH_USE_CUDA_DSA
 #endif
 

--- a/c10/cuda/CUDADeviceAssertionHost.h
+++ b/c10/cuda/CUDADeviceAssertionHost.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#if defined(USE_CUDA) || defined(USE_ROCM)
+#if (defined(USE_CUDA) || defined(USE_ROCM)) && ! defined(TORCH_USE_CUDA_DSA)
 #define TORCH_USE_CUDA_DSA
 #endif
 


### PR DESCRIPTION
Check if the macro is defined before defining it to avoid compiler warnings