### PR TITLE
[ROCM][CI] Timeout 360 for ROCm nightly binaries

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -4,6 +4,7 @@
 {%- set download_artifact_action = "actions/download-artifact@v4.1.7" -%}
 
 {%- set timeout_minutes = 240 -%}
+{%- set timeout_minutes_rocm = 360 -%}
 {%- set timeout_minutes_windows_binary = 360 -%}
 
 {%- macro concurrency(build_environment) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -4,7 +4,6 @@
 {%- set download_artifact_action = "actions/download-artifact@v4.1.7" -%}
 
 {%- set timeout_minutes = 240 -%}
-{%- set timeout_minutes_rocm = 360 -%}
 {%- set timeout_minutes_windows_binary = 360 -%}
 
 {%- macro concurrency(build_environment) -%}

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -167,7 +167,7 @@ jobs:
         uses: ./.github/actions/teardown-xpu
     {%- else %}
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: !{{ common.timeout_minutes_rocm }}
+    timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}
     permissions:
       id-token: write

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -79,7 +79,7 @@ jobs:
       timeout-minutes: 420
       {%- elif config["gpu_arch_type"] == "rocm" %}
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420 
       {%- elif "conda" in build_environment and config["gpu_arch_type"] == "cuda" %}
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runs_on: linux.24xlarge.ephemeral

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -167,7 +167,7 @@ jobs:
         uses: ./.github/actions/teardown-xpu
     {%- else %}
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: !{{ common.timeout_minutes }}
+    timeout-minutes: !{{ common.timeout_minutes_rocm }}
     !{{ upload.binary_env(config) }}
     permissions:
       id-token: write

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -407,7 +407,7 @@ jobs:
       - manywheel-py3_10-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -523,7 +523,7 @@ jobs:
       - manywheel-py3_10-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1074,7 +1074,7 @@ jobs:
       - manywheel-py3_11-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1190,7 +1190,7 @@ jobs:
       - manywheel-py3_11-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1741,7 +1741,7 @@ jobs:
       - manywheel-py3_12-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1857,7 +1857,7 @@ jobs:
       - manywheel-py3_12-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -2408,7 +2408,7 @@ jobs:
       - manywheel-py3_13-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -2524,7 +2524,7 @@ jobs:
       - manywheel-py3_13-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3075,7 +3075,7 @@ jobs:
       - manywheel-py3_13t-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3191,7 +3191,7 @@ jobs:
       - manywheel-py3_13t-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3742,7 +3742,7 @@ jobs:
       - manywheel-py3_14-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3858,7 +3858,7 @@ jobs:
       - manywheel-py3_14-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -4409,7 +4409,7 @@ jobs:
       - manywheel-py3_14t-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -4525,7 +4525,7 @@ jobs:
       - manywheel-py3_14t-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 360
+    timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -407,7 +407,7 @@ jobs:
       - manywheel-py3_10-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -523,7 +523,7 @@ jobs:
       - manywheel-py3_10-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1074,7 +1074,7 @@ jobs:
       - manywheel-py3_11-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1190,7 +1190,7 @@ jobs:
       - manywheel-py3_11-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1741,7 +1741,7 @@ jobs:
       - manywheel-py3_12-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1857,7 +1857,7 @@ jobs:
       - manywheel-py3_12-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -2408,7 +2408,7 @@ jobs:
       - manywheel-py3_13-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -2524,7 +2524,7 @@ jobs:
       - manywheel-py3_13-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3075,7 +3075,7 @@ jobs:
       - manywheel-py3_13t-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3191,7 +3191,7 @@ jobs:
       - manywheel-py3_13t-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3742,7 +3742,7 @@ jobs:
       - manywheel-py3_14-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -3858,7 +3858,7 @@ jobs:
       - manywheel-py3_14-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -4409,7 +4409,7 @@ jobs:
       - manywheel-py3_14t-rocm7_1-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -4525,7 +4525,7 @@ jobs:
       - manywheel-py3_14t-rocm7_2-build
       - get-label-type
     runs-on: linux.rocm.gpu.mi250.1
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -395,7 +395,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.10"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_10-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -511,7 +511,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.10"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_10-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:
@@ -1062,7 +1062,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.11"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_11-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -1178,7 +1178,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.11"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_11-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:
@@ -1729,7 +1729,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.12"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_12-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -1845,7 +1845,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.12"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_12-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:
@@ -2396,7 +2396,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.13"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_13-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -2512,7 +2512,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.13"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_13-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:
@@ -3063,7 +3063,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.13t"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_13t-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -3179,7 +3179,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.13t"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_13t-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:
@@ -3730,7 +3730,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.14"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_14-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -3846,7 +3846,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.14"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_14-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:
@@ -4397,7 +4397,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.1
       DESIRED_PYTHON: "3.14t"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_14t-rocm7_1
       build_environment: linux-binary-manywheel
     secrets:
@@ -4513,7 +4513,7 @@ jobs:
       DOCKER_IMAGE_TAG_PREFIX: rocm7.2
       DESIRED_PYTHON: "3.14t"
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      timeout-minutes: 300
+      timeout-minutes: 420
       build_name: manywheel-py3_14t-rocm7_2
       build_environment: linux-binary-manywheel
     secrets:


### PR DESCRIPTION
This change is due to the set of timeouts we're seeing with the libtorch builds. See here: https://hud.pytorch.org/hud/pytorch/pytorch/281863dd88a8ec01ef733cd96b2d6bf576a7c37d/1?per_page=50&name_filter=rocm&mergeEphemeralLF=true

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang