### PR TITLE
Increase TransformerEncoderLayer gelu TF32 tolerance for ROCm

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2543,7 +2543,8 @@ def get_new_module_tests():
             check_gradgrad=False,
             desc='gelu_activation',
             with_tf32=True,
-            tf32_precision=0.08 if SM90OrLater else 0.05,
+            # ROCm TF32 has slightly different precision characteristics than CUDA
+            tf32_precision=0.15 if TEST_WITH_ROCM else (0.08 if SM90OrLater else 0.05),
             default_dtype=torch.double,
         ),
         dict(


### PR DESCRIPTION
Fixes #155217

## Summary
The `test_TransformerEncoderLayer_gelu_activation_cuda_tf32` test fails on ROCm because the TF32 tolerance is too tight for hipBLASLt's TF32 implementation. ROCm's TF32 matmul produces slightly larger rounding errors than CUDA's cuBLAS, which is expected since TF32 is a hardware-specific reduced-precision format and different implementations have different rounding characteristics.

The TransformerEncoderLayer with gelu activation involves multiple matmuls (self-attention QKV projections, output projection, feedforward layers), so TF32 rounding errors accumulate more than in a single Linear layer. The current tolerances (0.08 for SM90+, 0.05 otherwise) are sufficient for CUDA but not for ROCm. This sets the ROCm tolerance to 0.15 while preserving the existing CUDA tolerances.

## Test plan
Tested on MI300X (gfx942) with ROCm 7.0 — `test_TransformerEncoderLayer_gelu_activation_cuda_tf32` passes consistently with the 0.15 tolerance across multiple runs.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang