### PR TITLE
Thread nondet_tol through _test_batched_grad_forward_ad

### DIFF
--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1080,7 +1080,7 @@ Expected:
 """.strip()
 
 
-def _test_batched_grad_forward_ad(func, inputs) -> bool:
+def _test_batched_grad_forward_ad(func, inputs, nondet_tol=0.0) -> bool:
     fwAD = torch.autograd.forward_ad  # To avoid early import issues (do we need this?)
     if not isinstance(inputs, tuple):
         raise AssertionError("Expected inputs to be a tuple")
@@ -1130,7 +1130,7 @@ def _test_batched_grad_forward_ad(func, inputs) -> bool:
             ) from ex
 
         for input_idx, (res, exp) in enumerate(zip(result, expected)):
-            if torch.allclose(res, exp):
+            if torch.allclose(res, exp) or (nondet_tol > 0 and (res - exp).abs().max() <= nondet_tol):
                 continue
             raise GradcheckError(
                 _get_failed_batched_grad_test_msg(
@@ -2148,7 +2148,7 @@ def _gradcheck_helper(
     )
 
     if check_batched_forward_grad:
-        _test_batched_grad_forward_ad(func, tupled_inputs)
+        _test_batched_grad_forward_ad(func, tupled_inputs, nondet_tol)
 
     # Short circuit because remaining tests rely on backward AD to be implemented
     if not check_backward_ad:

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1130,7 +1130,9 @@ def _test_batched_grad_forward_ad(func, inputs, nondet_tol=0.0) -> bool:
             ) from ex
 
         for input_idx, (res, exp) in enumerate(zip(result, expected)):
-            if torch.allclose(res, exp) or (nondet_tol > 0 and (res - exp).abs().max() <= nondet_tol):
+            if torch.allclose(res, exp) or (
+                nondet_tol > 0 and (res - exp).abs().max() <= nondet_tol
+            ):
                 continue
             raise GradcheckError(
                 _get_failed_batched_grad_test_msg(


### PR DESCRIPTION
Fixes #164235
Fixes #164194

## Summary
`_test_batched_grad_forward_ad` does not accept or use the `nondet_tol` parameter from `gradcheck`. When an operator has nondeterministic results (e.g., `cholesky_solve` on ROCm), the batched forward-mode AD check fails because it compares vmap results against sequential results using only `torch.allclose` defaults, completely ignoring the `nondet_tol` tolerance the user or OpInfo has set.

Every other gradcheck subroutine that compares results (`_check_jacobians_equal`, `_check_no_differentiable_outputs_fast`, etc.) already respects `nondet_tol`, but it was missed for `_test_batched_grad_forward_ad`.

The fix:
1. Adds `nondet_tol=0.0` parameter to `_test_batched_grad_forward_ad`
2. Uses it in the comparison: passes if `allclose` succeeds (preserving current default behavior) or if the max absolute difference is within `nondet_tol`
3. Threads `nondet_tol` from `_gradcheck_helper` to the function call

When `nondet_tol=0.0` (the default), behavior is identical to before.

## Test plan
- Verified `_test_batched_grad_forward_ad` signature on current main lacks `nondet_tol` parameter
- Confirmed the fix preserves default behavior: when `nondet_tol=0.0`, the `allclose` check short-circuits identically to the original code
- Verified the comparison logic handles edge cases correctly (identical tensors, tiny differences, medium differences with/without tolerance, complex dtypes, boundary values)
- Confirmed both #164235 and #164194 tracebacks point to `_test_batched_grad_forward_ad` line 1113 as the failure site