### PR TITLE
[nativert] clear persistent values when releasing execution frame

### DIFF
--- a/torch/nativert/executor/ExecutionFrame.h
+++ b/torch/nativert/executor/ExecutionFrame.h
@@ -111,6 +111,18 @@ class ExecutionFrame {
     }
   }
 
+  // Clears all non-persistent, non-managed intermediate values.
+  // This is used when returning frames to the pool to prevent stale
+  // tensor data from persisting across frame reuses (e.g. during
+  // rebatching with varying batch sizes).
+  void clearNonPersistentValues() {
+    for (size_t i = 0; i < allValues_.size(); ++i) {
+      if (!persistent_[i] && !isManagedValue(static_cast<ValueId>(i))) {
+        allValues_[i] = c10::IValue();
+      }
+    }
+  }
+
   void destroyBorrowedIValues() {
     for (const auto& id : borrowedValueIds_) {
       c10::MaybeOwnedTraits<c10::IValue>::destroyBorrow(getIValue(id));


### PR DESCRIPTION
Summary:
Fix memory safety issue by clearing intermediate values when returning execution frames to the pool

When `tryFreeUnmanagedValuesAfterUse` is disabled, intermediate tensor values are not freed during execution. This causes stale tensor data to persist across frame reuses, leading to out-of-bounds accesses during rebatching with varying batch sizes.

This diff introduces `clearNonPersistentValues()` to explicitly clear non-persistent, non-managed intermediate values before returning frames to the pool. The cleanup is performed only when `tryFreeUnmanagedValuesAfterUse` is false, preventing stale data from causing correctness and safety issues.

Test Plan:
Run PT2 version of PYMK model locally in sigrid predictor with high enough QPS for rebatching to be enabled:

```
ENABLE_TGIF=true ENABLE_PT2_SIGMOID=true CUDA_VISIBLE_DEVICES=0 GFLAGS_CONFIG_PATH=sigrid/predictor/predictor_x_gflags_tgif_lsr_template BUILD=1 MODEL_ID=2136371769 SNAPSHOT_ID=0 LOCAL_MODEL_DIR=/data/users/georgiaphillips/models/${MODEL_ID}/${SNAPSHOT_ID} sh ~/fbsource/fbcode/scripts/dsy842974287/load_model.sh 2>&1 |tee pt2_logs.txt

BUILD=1 sh hpc/inference/scripts/gif/vdd/1_card/launch_gpu_replayer.sh

Differential Revision: D93437183


