### PR TITLE
Fix MultiThreadedTestCase for destroy_process_group

### DIFF
--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -5,7 +5,7 @@ import threading
 import weakref
 from dataclasses import dataclass
 from functools import partial, reduce
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -560,6 +560,7 @@ class WorldData:
     tags_to_pg: dict[str, list[dist.ProcessGroup]]
     pg_to_tag: dict[dist.ProcessGroup, str]
     pg_coalesce_state: dict[dist.ProcessGroup, list[Union[_CollOp, P2POp]]]
+    comms: list[Any]
 
 
 class ThreadLocalWorld:
@@ -568,7 +569,7 @@ class ThreadLocalWorld:
     def _get_world(self) -> WorldData:
         if not hasattr(ThreadLocalWorld._world, "world"):
             ThreadLocalWorld._world.world = WorldData(
-                None, {}, {}, {}, {}, 0, {}, {}, {}
+                None, {}, {}, {}, {}, 0, {}, {}, {}, []
             )
         return ThreadLocalWorld._world.world
 
@@ -615,6 +616,10 @@ class ThreadLocalWorld:
     @property
     def pg_coalesce_state(self) -> dict[dist.ProcessGroup, list[Union[_CollOp, P2POp]]]:
         return self._get_world().pg_coalesce_state
+
+    @property
+    def comms(self) -> list[Any]:
+        return self._get_world().comms
 
 
 _old_pg_world = None


### PR DESCRIPTION
Fixes #175065

Some tests fail with `AttributeError: 'ThreadLocalWorld' object has no attribute 'comms'` during `destroy_process_group()`

## Changes

`ThreadLocalWorld` is used by multi threaded pg (which is used by `MultiThreadedTestCase`) to allow each rank/thread to have its own independent view of the `_World` state. https://github.com/pytorch/pytorch/pull/174202 Updated `_World` to add a `comms` property, so we need to mirror this in the multithreaded pg.

## Follow ups
1. Not sure why this test wasn't captured in the trunk CI, everything was green in the offending PR.
2. We can make this more robust by deleting the `WorldData` class and directly referencing `_World()`. This is a more involved change where we also need to update some parts of distributed_c10d to turn the module-level globals (i.e. `_pg_map`, `_pg_names`, etc.) to become instance attributes on `_World`

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #175175

