### PR TITLE
[pytorch][mtia] Avoid the overhead of calling CUDA is_available API by explicitly returning MTIA current device

### DIFF
--- a/torch/mtia/_utils.py
+++ b/torch/mtia/_utils.py
@@ -35,4 +35,9 @@ def _get_device_index(
     if not torch.jit.is_scripting():
         if isinstance(device, torch.mtia.device):
             return device.idx
+
+    if device is None and optional:
+        # Avoid the overhead of calling CUDA is_available by explicitly returning MTIA current device
+        return torch._C._accelerator_hooks_get_current_device()
+
     return _torch_get_device_index(device, optional, allow_cpu)


### PR DESCRIPTION
Summary:
# Context

When running on MTIA, we are seeing a lot unnecessary dlopen calls caused by CUDA initialization. Although it's not very slow, we'd like to optimize it.

Call stack:
  torch/mtia/__init__.py(343): __enter__
  torch/mtia/__init__.py(180): current_stream
  torch/mtia/_utils.py(9): _get_device_index(device=None)
  torch/_utils.py(847): _get_device_index 
  torch/_utils.py(821): _get_current_device_index 
  torch/_utils.py(805): _get_device_attr
  torch/_utils.py(788): _get_available_device_type
  torch/cuda/__init__.py(161): is_available                     
  torch/cuda/__init__.py(1099): device_count

  torch/mtia/__init__.py(328): __init__
  torch/mtia/_utils.py(9): _get_device_index(device=None)
  ..(same as above)

Full context in T256026169.

# This PR

The `cuda.is_available` calls are triggered by `torch.mtia.stream`. This PR explicitly fetches mtia current device to avoid calling into torch util `_torch_get_device_index` which will call CUDA is_available.

Test Plan: CI

Differential Revision: D93510182


