### PR TITLE
[rocm] Fix build_amd.py failure when MSLK submodule is missing

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -225,8 +225,8 @@ mslk_dir = REPO_ROOT / "third_party/mslk/include/mslk/utils/"
 
 if not buck_build:
     mslk_original = mslk_dir / "tuning_cache.cuh"
-
-    extra_files.append(mslk_original.as_posix())
+    if mslk_original.exists():
+        extra_files.append(mslk_original.as_posix())
 
 # TODO Remove once the following submodules are updated to use hipify v2
 hipify_v1_to_v2_files = [
@@ -300,6 +300,10 @@ if not buck_build:
     # only update the file if it changes or doesn't exist
     do_write = True
     src_lines = None
+
+    if not mslk_move_src.exists():
+        _error = f"Error: Source file {mslk_move_src} does not exist"
+        sys.exit(_error)
     with open(mslk_move_src) as src:
         src_lines = src.readlines()
     if os.path.exists(mslk_move_dst):


### PR DESCRIPTION
The `build_amd.py` script previously attempted to access files in `third_party/mslk/` without verifying their existence. This caused immediate build failures (FileNotFoundError) in environments where optional submodules are stripped or not initialized, such as Fedora packaging builds.

This change adds `Path.exists()` checks to:
 1. The `extra_files` append logic for `tuning_cache.cuh`.
 2. The final file move/update logic for the hipified `tuning_cache_hip.cuh`.

Fixes #175160

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang