### PR TITLE
Update float8_basics supported layouts

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -673,8 +673,14 @@ class TestFP8Matmul(TestCase):
 
         if torch.cuda.is_available():
             for (x_cm, y_cm) in itertools.product([True, False], repeat=2):
-                # Blackwell (SM_10) supports all possible layout permutations, while Hopper only TN
-                layouts_supported = (x_cm, y_cm) == (True, False) or torch.cuda.get_device_properties(0).major == 10
+                # SM 10 and 11 support all permutations, SM 12 TT and TN, SM 9 only TN
+                major, minor = torch.cuda.get_device_capability(0)
+                if major in (10, 11):
+                    layouts_supported = True
+                elif major == 12 and (minor == 1 or _get_torch_cuda_version() >= (13, 1)):
+                    layouts_supported = x_cm == True
+                else:
+                    layouts_supported = (x_cm, y_cm) == (True, False)
                 with contextlib.nullcontext() if layouts_supported else self.assertRaises(RuntimeError):
                     self._test_tautological_mm(device, size=64, out_dtype=torch.bfloat16, x_cm=x_cm, y_cm=y_cm)
 

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -678,7 +678,7 @@ class TestFP8Matmul(TestCase):
                 if major in (10, 11):
                     layouts_supported = True
                 elif major == 12 and (minor == 1 or _get_torch_cuda_version() >= (13, 1)):
-                    layouts_supported = x_cm == True
+                    layouts_supported = x_cm
                 else:
                     layouts_supported = (x_cm, y_cm) == (True, False)
                 with contextlib.nullcontext() if layouts_supported else self.assertRaises(RuntimeError):


### PR DESCRIPTION
Spark and Thor (SM 12.1 and SM 11.0, respectively) support more layouts than are currently expected in `test_float8_basics`, leading to `AssertionError: RuntimeError not raised`. This PR updates the test to accurately reflect current support on those devices, and prepares for upcoming support improvements on SM 12.0.

Fixes #175182 

cc @eqy