### PR TITLE
Make traceback capture work with error already set

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5365,6 +5365,7 @@ if IS_S390X:
 # clear_saved_tensors_on_access is incompatible with compiled autograd
 skipped_tests.add("test_clear_saved_tensors_on_access")
 skipped_tests.add("test_clear_saved_tensors_on_access_double_access_error")
+skipped_tests.add("test_forward_traceback_preserves_exception_with_checkpoint")
 
 test_autograd = load_test_module("test_autograd")
 test_custom_ops = load_test_module("test_custom_ops")

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5934,36 +5934,57 @@ Done""",
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_forward_traceback_preserves_exception_with_checkpoint(self):
         # Regression test: gatherForwardTraceback() must not clear a pending
-        # Python exception.
+        # Python exception.  See combined_traceback.cpp for the fix.
         #
-        # Non-reentrant checkpoint raises _StopRecomputationError for early
-        # stopping during backward recomputation.  This exception propagates
-        # through C++ as python_error (default ctor, which does NOT persist
-        # the exception -- it stays pending in the thread state).
+        # Ingredients: (1) CUDA memory history recording with context="all"
+        # so allocator callbacks fire on free, (2) a custom library op whose
+        # forward goes through THPFunction_apply (via Generated in
+        # torch._library.autograd), (3) non-reentrant checkpoint.
         #
-        # With CUDA memory history recording enabled, every CUDA allocation
-        # triggers CapturedTraceback::gather() → gatherForwardTraceback().
-        # That function looks up ANOMALY_TRACE_KEY in the backward node's
-        # metadata dict.  When anomaly mode is off the dict is empty, so the
-        # key is not found.  On Python < 3.13 the compat shim for
-        # PyDict_GetItemRef checks PyErr_Occurred() to distinguish "not found"
-        # from "error" -- a pending _StopRecomputationError is misread as a
-        # lookup error and then cleared, causing:
-        #   SystemError: ... returned NULL without setting an exception
-        #
-        # The fix (PyErr_Fetch/PyErr_Restore in gatherForwardTraceback) saves
-        # and restores the exception state around all Python C-API calls.
+        # During backward recomputation, _StopRecomputationError is raised
+        # from the checkpoint pack_hook inside _save_variables.  The exception
+        # stays pending in Python thread state while C++ stack-unwinds (the
+        # default python_error ctor does not persist).  Destroying the output
+        # THPObjectPtr during unwinding frees the recomputed output tensor's
+        # CUDA storage, triggering the allocator callback ->
+        # CapturedTraceback::gather() -> gatherForwardTraceback().  On
+        # Python < 3.13, without the PyErr_Fetch/PyErr_Restore fix, the
+        # PyDict_GetItemRef compat shim clears the pending exception ->
+        # SystemError.
+        with torch.library._scoped_library("_test_autograd", "FRAGMENT"):
 
-        def fn(x):
-            return x.sigmoid()
+            @torch.library.custom_op(
+                "_test_autograd::sin_op", mutates_args=()
+            )
+            def sin_op(x: torch.Tensor) -> torch.Tensor:
+                return x.sin()
 
-        try:
-            torch.cuda.memory._record_memory_history("all", stacks="python")
-            x = torch.randn(4, device="cuda", requires_grad=True)
-            y = checkpoint(fn, x, use_reentrant=False)
-            y.sum().backward()
-        finally:
-            torch.cuda.memory._record_memory_history(None)
+            def setup_context(ctx, inputs, output):
+                (x,) = inputs
+                ctx.save_for_backward(x)
+
+            def backward(ctx, grad):
+                (x,) = ctx.saved_tensors
+                return grad * x.cos()
+
+            torch.library.register_autograd(
+                "_test_autograd::sin_op",
+                backward,
+                setup_context=setup_context,
+            )
+
+            def fn(x):
+                return torch.ops._test_autograd.sin_op(x)
+
+            try:
+                torch.cuda.memory._record_memory_history(
+                    "all", stacks="python"
+                )
+                x = torch.randn(4, device="cuda", requires_grad=True)
+                y = checkpoint(fn, x, use_reentrant=False)
+                y.sum().backward()
+            finally:
+                torch.cuda.memory._record_memory_history(None)
 
     def test_no_grad_copy(self):
         # create autograd function that saves grad pointer as class static

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5953,9 +5953,7 @@ Done""",
         # SystemError.
         with torch.library._scoped_library("_test_autograd", "FRAGMENT"):
 
-            @torch.library.custom_op(
-                "_test_autograd::sin_op", mutates_args=()
-            )
+            @torch.library.custom_op("_test_autograd::sin_op", mutates_args=())
             def sin_op(x: torch.Tensor) -> torch.Tensor:
                 return x.sin()
 
@@ -5977,9 +5975,7 @@ Done""",
                 return torch.ops._test_autograd.sin_op(x)
 
             try:
-                torch.cuda.memory._record_memory_history(
-                    "all", stacks="python"
-                )
+                torch.cuda.memory._record_memory_history("all", stacks="python")
                 x = torch.randn(4, device="cuda", requires_grad=True)
                 y = checkpoint(fn, x, use_reentrant=False)
                 y.sum().backward()

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -157,10 +157,23 @@ struct PythonTraceback : public CapturedTraceback::Python {
       return result;
     }
 
-    // Get the traceback from the metadata dict
+    // Get the traceback from the metadata dict.
+    // This runs from a CUDA allocator callback, so a Python exception may
+    // already be pending (e.g. the forward function just raised). The compat
+    // shim for PyDict_GetItemRef on Python < 3.13 uses PyErr_Occurred() to
+    // distinguish "not found" from "error", so a stale pending exception would
+    // be misread as a lookup failure and then cleared, destroying the real
+    // exception. Save/restore the exception state to avoid that.
     py::gil_scoped_acquire gil;
+
+    PyObject* exc_type = nullptr;
+    PyObject* exc_value = nullptr;
+    PyObject* exc_tb = nullptr;
+    PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
+
     PyObject* dict = metadata->dict();
     if (!dict || !PyDict_Check(dict)) {
+      PyErr_Restore(exc_type, exc_value, exc_tb);
       return result;
     }
 
@@ -170,11 +183,13 @@ struct PythonTraceback : public CapturedTraceback::Python {
             torch::autograd::PyAnomalyMetadata::ANOMALY_TRACE_KEY,
             &traceback) < 0) {
       PyErr_Clear();
+      PyErr_Restore(exc_type, exc_value, exc_tb);
       return result;
     }
 
     if (!traceback || !PyList_Check(traceback)) {
       Py_XDECREF(traceback);
+      PyErr_Restore(exc_type, exc_value, exc_tb);
       return result;
     }
 
@@ -192,6 +207,7 @@ struct PythonTraceback : public CapturedTraceback::Python {
     }
 
     Py_DECREF(traceback);
+    PyErr_Restore(exc_type, exc_value, exc_tb);
     return result;
   }
 };


### PR DESCRIPTION
I'm not yet satisfied with regression test, but checking if this helps.

This is the error from the added test without the fix:
```
$ python ../new_env/pytorch/test/test_autograd.py -k preserves_exc
E
======================================================================
ERROR: test_forward_traceback_preserves_exception_with_checkpoint (__main__.TestAutograd.test_forward_traceback_preserves_exception_with_checkpoint)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 3364, in wrapper
    method(*args, **kwargs)
  File "/home/albandes/local/pytorch/3.12_release_binary/../new_env/pytorch/test/test_autograd.py", line 5985, in test_forward_traceback_preserves_exception_with_checkpoint
    y.sum().backward()
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/_tensor.py", line 631, in backward
    torch.autograd.backward(
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/autograd/__init__.py", line 381, in backward
    _engine_run_backward(
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/autograd/graph.py", line 869, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/autograd/function.py", line 317, in apply
    return user_fn(self, *args)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/_library/autograd.py", line 78, in backward
    result = info._backward_fn(ctx, *grads)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary/../new_env/pytorch/test/test_autograd.py", line 5967, in backward
    (x,) = ctx.saved_tensors
           ^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/utils/checkpoint.py", line 1173, in unpack_hook
    _run_fn_with_dynamo_disabled(frame.recompute_fn, *args)
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/_compile.py", line 54, in inner
    return disable_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1263, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/utils/checkpoint.py", line 1139, in _run_fn_with_dynamo_disabled
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/utils/checkpoint.py", line 1607, in recompute_fn
    fn(*args, **kwargs)
  File "/home/albandes/local/pytorch/3.12_release_binary/../new_env/pytorch/test/test_autograd.py", line 5977, in fn
    return torch.ops._test_autograd.sin_op(x)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/_ops.py", line 1269, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/_library/autograd.py", line 110, in autograd_impl
    result = Generated.apply(*args, Metadata(keyset, keyword_only_args))  # type: ignore[attr-defined]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/albandes/local/pytorch/3.12_release_binary_env/lib/python3.12/site-packages/torch/autograd/function.py", line 596, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SystemError: <built-in method apply of FunctionMeta object at 0x37f73380> returned NULL without setting an exception

To execute this test, run the following from the base repo dir:
    python test/test_autograd.py TestAutograd.test_forward_traceback_preserves_exception_with_checkpoint

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

----------------------------------------------------------------------
Ran 1 test in 0.022s

FAILED (errors=1)
```