### PR TITLE
[Dynamo][Guard]Add best-effort cache walk for guard exclusion

### DIFF
--- a/test/dynamo/test_guard_exclusion.py
+++ b/test/dynamo/test_guard_exclusion.py
@@ -32,7 +32,6 @@ class GraphTracker:
 
 
 @skipIfTorchDynamo("uses custom backend incompatible with PYTORCH_TEST_WITH_DYNAMO")
-@torch._dynamo.config.patch(guard_exclusion_for_automatic_dynamic=True)
 class TestGuardExclusion(TestCase):
     def setUp(self):
         super().setUp()

--- a/torch/_C/_dynamo/guards.pyi
+++ b/torch/_C/_dynamo/guards.pyi
@@ -229,6 +229,12 @@ class GuardManager:
         verbose_code_parts: list[str],
         user_stack: Optional[traceback.StackSummary],
     ) -> None: ...
+    def add_exclusion_guard(
+        self,
+        user_lambda: Callable[..., Any],
+        verbose_code_parts: list[str],
+        user_stack: Optional[traceback.StackSummary],
+    ) -> None: ...
     def add_id_match_guard(
         self,
         id_val: int,

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -159,10 +159,9 @@ automatic_dynamic_shapes_mark_as: Literal["dynamic", "unbacked"] = "dynamic"
 # that rejects inputs matching the original static graph's sizes, so those
 # inputs fall through to the static graph. This prevents the dynamic graph
 # from shadowing the static graph in the cache (important for activation
-# checkpointing correctness). In distributed mode with compiler collectives,
-# this can cause guard divergence if ranks have different input shapes.
-# Set to False to disable if you hit hangs in distributed compilation.
-guard_exclusion_for_automatic_dynamic = False
+# checkpointing correctness). The exclusion is best-effort: if no static
+# fallback exists in the cache, the dynamic graph is used anyway.
+guard_exclusion_for_automatic_dynamic = True
 
 # log graph in/out metadata
 # This is only turned on for export today since we

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3067,18 +3067,12 @@ class GuardBuilder(GuardBuilderBase):
                         if v is not None and i < len(size) and size[i] is None
                     ]
 
-                    # Only add the exclusion if the current input doesn't
-                    # match all excluded dims. If it does, this graph was
-                    # compiled to handle that input and the exclusion would
-                    # reject the compilation's own input.
-                    if dims_and_values and not all(
-                        value.size(d) == v for d, v in dims_and_values
-                    ):
+                    if dims_and_values:
 
                         def check_exclusion(x, dvs=dims_and_values):
                             return not all(x.size(d) == v for d, v in dvs)
 
-                        guard_manager.add_lambda_guard(
+                        guard_manager.add_exclusion_guard(
                             check_exclusion,
                             get_verbose_code_parts(
                                 f"excluded_sizes({excluded_sizes})", guard

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -12,6 +12,7 @@ PyObject* torch_c_dynamo_guards_init();
 // not visible there.
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
+bool get_root_guard_manager_exclusion_flag(void* root);
 
 extern thread_local bool tls_is_in_mode_without_ignore_compile_internals;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175209
* #174993

When guard exclusion is enabled, a dynamic graph's exclusion guard always passes but sets a flag on the RootGuardManager. The cache walk uses this flag to implement preference: if a flagged entry matches, it's saved as a fallback and the walk continues. If a non-flagged entry (the static graph) matches later, it's preferred. If nothing else matches, the fallback is used.

This avoids two problems with hard rejection: unnecessary recompilation when the static graph is evicted, and distributed collective deadlocks when different ranks make different guard decisions. Flips
 guard_exclusion_for_automatic_dynamic to True.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo