### PR TITLE
[dynamo] Add polyfills for operator.concat and operator.iconcat

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3699,6 +3699,25 @@ class GraphModule(torch.nn.Module):
                 opt_fn = torch.compile(fn, fullgraph=True, backend="eager")
                 self.assertEqual(opt_fn(), fn())
 
+    def test_operator_concat(self):
+        for seq_type in (list, tuple):
+            with self.subTest(seq_type=seq_type):
+
+                def fn(a, b):
+                    return operator.concat(a, b)
+
+                opt_fn = torch.compile(fn, fullgraph=True)
+                a = seq_type([1, 2, 3])
+                b = seq_type([4, 5, 6])
+                self.assertEqual(opt_fn(a, b), fn(a, b))
+
+    def test_operator_iconcat(self):
+        def fn(a, b):
+            return operator.iconcat(a, b)
+
+        opt_fn = torch.compile(fn, fullgraph=True)
+        self.assertEqual(opt_fn([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6])
+
     def test_attrgetter(self):
         for attrs in (
             ("shape",),

--- a/torch/_dynamo/polyfills/operator.py
+++ b/torch/_dynamo/polyfills/operator.py
@@ -16,7 +16,20 @@ if TYPE_CHECKING:
 
 
 # Most unary and binary operators are handled by BuiltinVariable (e.g., `pos`, `add`)
-__all__ = ["attrgetter", "itemgetter", "methodcaller", "countOf"]
+__all__ = ["attrgetter", "concat", "iconcat", "itemgetter", "methodcaller", "countOf"]
+
+
+# Reference: https://docs.python.org/3/library/operator.html#operator.concat
+@substitute_in_graph(operator.concat, can_constant_fold_through=True)  # type: ignore[arg-type]
+def concat(a: Any, b: Any, /) -> Any:
+    return a + b
+
+
+# Reference: https://docs.python.org/3/library/operator.html#operator.iconcat
+@substitute_in_graph(operator.iconcat)  # type: ignore[arg-type]
+def iconcat(a: Any, b: Any, /) -> Any:
+    a += b
+    return a
 
 
 _T = TypeVar("_T")

--- a/torch/_dynamo/polyfills/operator.py
+++ b/torch/_dynamo/polyfills/operator.py
@@ -12,24 +12,11 @@ from ..decorators import substitute_in_graph
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
 
 
 # Most unary and binary operators are handled by BuiltinVariable (e.g., `pos`, `add`)
-__all__ = ["attrgetter", "concat", "iconcat", "itemgetter", "methodcaller", "countOf"]
-
-
-# Reference: https://docs.python.org/3/library/operator.html#operator.concat
-@substitute_in_graph(operator.concat, can_constant_fold_through=True)  # type: ignore[arg-type]
-def concat(a: Any, b: Any, /) -> Any:
-    return a + b
-
-
-# Reference: https://docs.python.org/3/library/operator.html#operator.iconcat
-@substitute_in_graph(operator.iconcat)  # type: ignore[arg-type]
-def iconcat(a: Any, b: Any, /) -> Any:
-    a += b
-    return a
+__all__ = ["attrgetter", "concat", "countOf", "iconcat", "itemgetter", "methodcaller"]
 
 
 _T = TypeVar("_T")
@@ -82,6 +69,25 @@ def attrgetter(*attrs: str) -> Callable[[Any], Any | tuple[Any, ...]]:
     return getter
 
 
+# Reference: https://docs.python.org/3/library/operator.html#operator.concat
+@substitute_in_graph(operator.concat, can_constant_fold_through=True)  # type: ignore[arg-type]
+def concat(a: Sequence[_T], b: Sequence[_T2], /) -> Sequence[_T | _T2]:
+    return a + b  # type: ignore[operator]
+
+
+# Reference: https://docs.python.org/3/library/operator.html#operator.countOf
+@substitute_in_graph(operator.countOf, can_constant_fold_through=True)  # type: ignore[arg-type,misc]
+def countOf(a: Iterable[_T], b: _T, /) -> int:
+    return sum(it is b or it == b for it in a)
+
+
+# Reference: https://docs.python.org/3/library/operator.html#operator.iconcat
+@substitute_in_graph(operator.iconcat)  # type: ignore[arg-type]
+def iconcat(a: Sequence[_T], b: Sequence[_T2], /) -> Sequence[_T | _T2]:
+    a += b  # type: ignore[operator]
+    return a  # type: ignore[return-value]
+
+
 @overload
 # pyrefly: ignore [inconsistent-overload]
 def itemgetter(item: _T, /) -> Callable[[Any], _U]: ...
@@ -124,9 +130,3 @@ def methodcaller(name: str, /, *args: Any, **kwargs: Any) -> Callable[[Any], Any
         return getattr(obj, name)(*args, **kwargs)
 
     return caller
-
-
-# Reference: https://docs.python.org/3/library/operator.html#operator.countOf
-@substitute_in_graph(operator.countOf, can_constant_fold_through=True)  # type: ignore[arg-type,misc]
-def countOf(a: Iterable[_T], b: _T, /) -> int:
-    return sum(it is b or it == b for it in a)


### PR DESCRIPTION
Fixes part of #116396.

`operator.concat` and `operator.iconcat` currently cause a graph break in Dynamo because they are C builtins with no traceable Python implementation. This PR adds `substitute_in_graph` polyfills for both, following the same pattern used for `operator.countOf`, `operator.attrgetter`, `operator.itemgetter`, and `operator.methodcaller`.

- `operator.concat(a, b)` — pure sequence concatenation, marked `can_constant_fold_through=True`
- `operator.iconcat(a, b)` — in-place sequence concatenation (mutates `a`), no constant folding

Tests added alongside the existing `test_attrgetter` / `test_itemgetter` tests in `test/dynamo/test_functions.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @XuehaiPan @jansel @zou3519
