### PR TITLE
Validate batch dimension in max_pool3d_backward_shape_check

### DIFF
--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -323,6 +323,12 @@ max_pool3d_backward_shape_check(
   check_dim_size(indices, ndim, ndim-3, otime);
   check_dim_size(indices, ndim, ndim-2, oheight);
   check_dim_size(indices, ndim, ndim-1, owidth);
+
+  if (ndim == 5) {
+    const int64_t batchSize = input.size(0);
+    check_dim_size(gradOutput, ndim, 0, batchSize);
+    check_dim_size(indices, ndim, 0, batchSize);
+  }
 }
 
 inline void

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1396,6 +1396,23 @@ torch.cuda.synchronize()
         helper(1, 79, 4, 4, 4, 3, stride=2)
         helper(0, 79, 4, 4, 4, 3, stride=2)
 
+    @onlyNativeDeviceTypes
+    def test_max_pool3d_with_indices_backward_batch_mismatch(self, device):
+        grad_output = torch.randn(1, 2, 1, 3, 2, device=device)
+        input = torch.randn(1, 2, 3, 6, 5, device=device)
+        indices = torch.zeros(0, 2, 1, 3, 2, dtype=torch.long, device=device)
+        with self.assertRaisesRegex(RuntimeError, "Expected a tensor of dimension"):
+            torch.ops.aten.max_pool3d_with_indices_backward(
+                grad_output,
+                input,
+                (3, 3, 3),
+                (2, 2, 2),
+                (0, 0, 0),
+                (1, 1, 1),
+                True,
+                indices,
+            )
+
     @onlyCPU
     @dtypes(torch.half, torch.bfloat16)
     def test_max_pool_bfloat16_half(self, device, dtype):


### PR DESCRIPTION
Fixes #142459

Adds batch dimension validation in `max_pool3d_backward_shape_check`, matching the existing check in `max_pool2d_backward_shape_check`.

This PR was authored with the assistance of Claude.