### PR TITLE
Add safe_downcast to check_max_pool1d to prevent overflow segfault

### DIFF
--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -40,6 +40,11 @@ inline void check_max_pool1d(
     stride = kernel_size;
   }
 
+  safe_downcast<int, int64_t>(kernel_size[0]);
+  safe_downcast<int, int64_t>(stride[0]);
+  safe_downcast<int, int64_t>(padding[0]);
+  safe_downcast<int, int64_t>(dilation[0]);
+
   TORCH_CHECK(
       kernel_size[0] > 0,
       "max_pool1d() kernel_size must be greater than zero, but got ",

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -688,6 +688,19 @@ class TestPoolingNNDeviceType(NNTestCase):
             )(samples)
 
     @onlyNativeDeviceTypes
+    def test_MaxPool1d_kernel_size_overflow(self, device):
+        input = torch.randn(1, 2, 3, device=device)
+        with self.assertRaisesRegex(RuntimeError, "integer out of range"):
+            torch.max_pool1d(
+                input,
+                kernel_size=[8608480567731124087],
+                stride=[],
+                padding=[1250999896764],
+                dilation=[1250999896764],
+                ceil_mode=True,
+            )
+
+    @onlyNativeDeviceTypes
     def test_MaxPool_zero_batch_dim(self, device):
         inp = torch.randn(0, 16, 50, device=device)
         mod = torch.nn.MaxPool1d(3, stride=2).to(device)


### PR DESCRIPTION
Fixes #142454

Adds `safe_downcast<int, int64_t>()` calls for kernel_size, stride, padding, and dilation in `check_max_pool1d`, matching the existing validation in `max_pool2d` and `max_pool3d`.

This PR was authored with the assistance of Claude.