### PR TITLE
Validate kernel_size matches weight dims in slow_conv_transpose3d

### DIFF
--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -100,6 +100,13 @@ inline void slow_conv_transpose3d_shape_check(
         " x kernel_height x kernel_width) tensor ",
         "expected for weight, but got: ",
         weight.sizes());
+    TORCH_CHECK(
+        weight.size(2) == kernel_depth && weight.size(3) == kernel_height &&
+            weight.size(4) == kernel_width,
+        "kernel_size must match weight dimensions, but got kernel_size=(",
+        kernel_depth, ", ", kernel_height, ", ", kernel_width,
+        ") and weight=(",
+        weight.size(2), ", ", weight.size(3), ", ", weight.size(4), ")");
     if (bias.defined()) {
       check_dim_size(bias, 1, 0, weight.size(1));
     }

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
@@ -102,6 +102,13 @@ static inline void slow_conv_transpose3d_shape_check(
         "x kernel_depth x kernel_height x kernel_width) tensor ",
         "expected for weight, but got: ",
         weight.sizes());
+    TORCH_CHECK(
+        weight.size(2) == kernel_depth && weight.size(3) == kernel_height &&
+            weight.size(4) == kernel_width,
+        "kernel_size must match weight dimensions, but got kernel_size=(",
+        kernel_depth, ", ", kernel_height, ", ", kernel_width,
+        ") and weight=(",
+        weight.size(2), ", ", weight.size(3), ", ", weight.size(4), ")");
     if (bias.defined()) {
       check_dim_size(bias, 1, 0, weight.size(1));
     }

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3537,6 +3537,22 @@ class TestConvolutionNNDeviceType(NNTestCase):
             exact_device=False,
         )
 
+    @onlyNativeDeviceTypes
+    def test_slow_conv_transpose3d_kernel_size_mismatch(self, device):
+        input = torch.randn(1, 2, 4, 5, 4, device=device)
+        weight = torch.randn(2, 3, 2, 3, 2, device=device)
+        with self.assertRaisesRegex(RuntimeError, "kernel_size must match weight"):
+            torch.ops.aten.slow_conv_transpose3d(
+                input,
+                weight,
+                [1, 1, 1],
+                None,
+                [1, 1, 1],
+                [0, 0, 0],
+                [0, 0, 0],
+                [1, 1, 1],
+            )
+
     @onlyCUDA
     def test_ConvTranspose3d_size_1_kernel(self, device):
         with set_default_dtype(torch.double):


### PR DESCRIPTION
Fixes #142457

The reported crash is caused by kernel_size not matching the weight tensor spatial dimensions when calling slow_conv_transpose3d directly. This causes a GEMM buffer overflow since columns is sized by kernel_size but the GEMM output dimensions use weight.size(2,3,4).

Adds a TORCH_CHECK in slow_conv_transpose3d_shape_check validating kernel_size against the weight spatial dims, in both CPU and CUDA paths.

This PR was authored with the assistance of Claude.