### PR TITLE
Use old name mangling when building with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1191,7 +1191,7 @@ if(NOT MSVC)
     append_cxx_flag_if_supported("-Wno-error=dangling-reference" CMAKE_CXX_FLAGS)
   endif()
   # needed for compat with newer versions of clang that use C++20 mangling rules
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
     append_cxx_flag_if_supported("-fclang-abi-compat=17" CMAKE_CXX_FLAGS)
   endif()
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1190,6 +1190,10 @@ if(NOT MSVC)
     append_cxx_flag_if_supported("-Wno-dangling-reference" CMAKE_CXX_FLAGS)
     append_cxx_flag_if_supported("-Wno-error=dangling-reference" CMAKE_CXX_FLAGS)
   endif()
+  # needed for compat with newer versions of clang that use C++20 mangling rules
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    append_cxx_flag_if_supported("-fclang-abi-compat=17" CMAKE_CXX_FLAGS)
+  endif()
 else()
   # Define export functions for AOTI.
   add_compile_definitions(EXPORT_AOTI_FUNCTIONS)

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -377,7 +377,7 @@ elseif(CUDA_DEVICE_DEBUG)
 endif()
 
 # needed for compat with newer versions of clang that use C++20 mangling rules
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
   list(APPEND CUDA_NVCC_FLAGS "-fclang-abi-compat=17")
 endif()
 

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -376,6 +376,11 @@ elseif(CUDA_DEVICE_DEBUG)
   list(APPEND CUDA_NVCC_FLAGS "-g" "-G")  # -G enables device code debugging symbols
 endif()
 
+# needed for compat with newer versions of clang that use C++20 mangling rules
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  list(APPEND CUDA_NVCC_FLAGS "-fclang-abi-compat=17")
+endif()
+
 # Set expt-relaxed-constexpr to suppress Eigen warnings
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
 

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -378,7 +378,7 @@ endif()
 
 # needed for compat with newer versions of clang that use C++20 mangling rules
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
-  list(APPEND CUDA_NVCC_FLAGS "-fclang-abi-compat=17")
+  list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fclang-abi-compat=17")
 endif()
 
 # Set expt-relaxed-constexpr to suppress Eigen warnings


### PR DESCRIPTION
Clang 18 changes name mangling rules for function templates. See [Clang 18.1.0 Release Notes][1] for details.

> The name mangling rules for function templates has been changed to take into account the possibility that functions could be overloaded on their template parameter lists or requires-clauses. This causes mangled names to change for function templates in the following cases:
> 
> - When a template parameter in a function template depends on a previous template parameter, such as template<typename T, T V> void f().
> - When the function has any constraints, whether from constrained template parameters or requires-clauses.
> - When the template parameter list includes a deduced type – either auto, decltype(auto), or a deduced class template specialization type.
> - When a template template parameter is given a template template argument that has a different template parameter list.
> 
> This fixes a number of issues where valid programs would be rejected due to mangling collisions, or would in some cases be silently miscompiled. Clang will use the old manglings if -fclang-abi-compat=17 or lower is specified.

In the case of PyTorch, the mangled names include std::enable_if in their mangled names. std::enable_if is mangled differently by the host compiler and nvcc because of internal namespacing.

This commit passes -fclang-abi-compat=17 to nvcc and clang so that they use the old mangling scheme preventing the name mismatch. https://github.com/pytorch/pytorch/pull/124862 does the same thing for HIP.

Fixes #174898

[1]: https://releases.llvm.org/18.1.0/tools/clang/docs/ReleaseNotes.html#c-specific-potentially-breaking-changes