### PR TITLE
[docs] Add warnings about autocast backward behavior mismatch

### DIFF
--- a/docs/source/amp.md
+++ b/docs/source/amp.md
@@ -43,6 +43,14 @@ datatype of `torch.bfloat16` only uses {class}`torch.autocast`.
 `torch.cuda.amp.GradScaler(args...)` and `torch.cpu.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler("cuda", args...)` or `torch.amp.GradScaler("cpu", args...)` instead.
 :::
 
+:::{warning}
+Autocast should wrap only the forward pass (and loss computation). Backward passes
+under autocast are not recommended. If using `torch.compile`, note that the default
+`backward_pass_autocast` setting is `"same_as_forward"`, which assumes backward runs
+under the same autocast context. Set `torch._functorch.config.backward_pass_autocast = "off"`
+if you run backward outside autocast. See {ref}`compiler_backward` for details.
+:::
+
 {class}`torch.autocast` and {class}`torch.cpu.amp.autocast` are new in version `1.10`.
 
 ```{contents}

--- a/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_backward.md
@@ -1,40 +1,40 @@
 (compiler_backward)=
 
-``torch.compile`` has different autograd semantics
-==================================================
+# `torch.compile` has different autograd semantics
 
-When you apply ``torch.compile`` to a function in your model's forward pass,
+When you apply `torch.compile` to a function in your model's forward pass,
 it will automatically generate a backward pass for the compiled function.
 During compilation, it will trace out a graph for the backward pass that
 is used whenever autograd is invoked. We refer to the component inside
-``torch.compile`` that is responsible for this as ``AOTDispatcher``
-(sometimes known as ``AOTAutograd``).
+`torch.compile` that is responsible for this as `AOTDispatcher`
+(sometimes known as `AOTAutograd`).
 
-As so, ``torch.compile`` bakes in details of the computation into the
+As so, `torch.compile` bakes in details of the computation into the
 traced-out backward graph during compilation of the function
 in the forward pass.
 However, in eager-mode PyTorch, the backward computation is dynamic:
 outside of the forward pass, you can wrap the call to
-``tensor.backward()`` or ``torch.autograd.grad(...)``
+`tensor.backward()` or `torch.autograd.grad(...)`
 in a context manager that may change its behavior.
 
-This page documents how ``torch.compile``'s autograd semantics differ from
+This page documents how `torch.compile`'s autograd semantics differ from
 eager-mode PyTorch and how to work around it.
 
-``Autocast`` behavior
----------------------
+## `Autocast` behavior
 
-``torch.compile`` bakes in an assumption on if the backward pass will be
+`torch.compile` bakes in an assumption on if the backward pass will be
 run under an ambient autocast context manager. By default,
-Use ``torch._functorch.config.backward_pass_autocast``
+Use `torch._functorch.config.backward_pass_autocast`
 to control that assumption; an incorrect assumption may lead to silent
 incorrectness.
 
 The options are either:
+
 - `"same_as_forward"` (default).
-  We assume that the backward of the ``torch.compile``'ed region
+  We assume that the backward of the `torch.compile`'ed region
   will be run under the same autocast context manager that the region was run
   under (if any). Use this if your code looks like the following:
+
   ```py
   with torch.amp.autocast(...):
       y = torch.compile(region)(x)
@@ -42,6 +42,14 @@ The options are either:
       # backward pass run under the same autocast context as the compiled region
       z.backward()
   ```
+
+  :::{warning}
+  The `torch.amp` documentation recommends wrapping only the forward pass
+  (and loss computation) under autocast, and running backward passes outside
+  autocast for numerical correctness. If you follow that recommendation,
+  use `"off"` instead of the default `"same_as_forward"`.
+  :::
+
 - `"off"`. We assume that the backward of the torch.compile'd region will
   not be run under any autocast context managers.
   Use this if your code looks like the following:
@@ -52,11 +60,12 @@ The options are either:
   # Backward pass runs under no autocast.
   z.backward()
   ```
-- There is a third option. If you set ``torch._functorch.config.backward_pass_autocast``
+- There is a third option. If you set `torch._functorch.config.backward_pass_autocast`
   to a list of kwargs, we will assume the backward pass runs under an autocast context
   constructed by those kwargs.
 
   For example, if your code looks like the following:
+
   ```py
   y = torch.compile(region)(x)
   ...
@@ -64,9 +73,11 @@ The options are either:
   with torch.amp.autocast(**kwargs):
       z.backward()
   ```
-  then set ``torch._functorch.config.backward_pass_autocast = kwargs``.
 
-Use ``patch`` to apply the option to a specific ``torch.compile`` call:
+  then set `torch._functorch.config.backward_pass_autocast = kwargs`.
+
+Use `patch` to apply the option to a specific `torch.compile` call:
+
 ```py
 with torch.amp.autocast(...):
     with torch._functorch.config.patch(backward_pass_autocast="same_as_forward")


### PR DESCRIPTION
Addresses #175166: The torch.compile docs assume backward runs under the same autocast context by default, but torch.amp docs recommend running backward outside autocast. Added cross-referenced warnings in both places to call out this discrepancy.