### PR TITLE
Fix incorrect mode formula in Kumaraswamy distribution

### DIFF
--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -81,12 +81,11 @@ class Kumaraswamy(TransformedDistribution):
 
     @property
     def mode(self) -> Tensor:
-        # Evaluate in log-space for numerical stability.
-        log_mode = (
-            self.concentration0.reciprocal() * (-self.concentration0).log1p()
-            - (-self.concentration0 * self.concentration1).log1p()
-        )
-        log_mode[(self.concentration0 < 1) | (self.concentration1 < 1)] = nan
+        # Mode = ((a - 1) / (a * b - 1)) ^ (1 / a), defined when a >= 1 and b >= 1.
+        a = self.concentration1
+        b = self.concentration0
+        log_mode = a.reciprocal() * ((a - 1).log() - (a * b - 1).log())
+        log_mode[(a < 1) | (b < 1) | ((a == 1) & (b == 1))] = nan
         return log_mode.exp()
 
     @property


### PR DESCRIPTION
## Summary
Fixes the `Kumaraswamy.mode` property which was computing a mathematically incorrect formula, returning NaN for all valid parameter values.

The previous implementation computed `(1-b)^(1/b) / (1-ab)`, but the correct mode of the Kumaraswamy distribution is `((a-1) / (ab-1))^(1/a)`, obtained by setting the derivative of the PDF `f(x) = a*b*x^(a-1)*(1-x^a)^(b-1)` to zero and solving for x.

Also fixes the NaN mask to include the `a=1, b=1` edge case (uniform distribution, no unique mode), which was previously missing.

## Test plan
- Verified the formula by deriving from the PDF (d/dx ln f = 0)
- Confirmed against published references (Wikipedia, John D. Cook)
- Tested all 9 cases from the issue reporter, including edge cases (a<1, b<1, a=b=1, a=1 b>1, a>1 b=1, extreme values)
- Verified the mode maximizes `log_prob` for random parameter values in [1, 2]
- Existing `test_mode` in `test_distributions.py` covers Kumaraswamy with parameters in [1, 2]

Fixes #173912

cc @fritzo @neerajprad @nikitaved