### PR TITLE
Fix torch.isclose broadcast failure with equal_nan=True

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -1,6 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
-#include <ATen/ExpandUtils.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/ScalarOps.h>
 #include <ATen/TensorIndexing.h>

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -387,16 +387,7 @@ Tensor isclose(
       if (self.sizes() == other.sizes()) {
         close.__ior__(self.isnan().__iand__(other.isnan()));
       } else {
-        auto self_nan = self.isnan();
-        auto other_nan = other.isnan();
-        auto expected = at::infer_size(self_nan.sizes(), other_nan.sizes());
-        if (other_nan.sizes().equals(expected)) {
-          close.__ior__(other_nan.__iand__(self_nan));
-        } else if (self_nan.sizes().equals(expected)) {
-          close.__ior__(self_nan.__iand__(other_nan));
-        } else {
-          close.__ior__(self_nan.bitwise_and(other_nan));
-        }
+        close.__ior__(self.isnan().bitwise_and(other.isnan()));
       }
     }
   }

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -282,6 +282,38 @@ class TestTesting(TestCase):
 
         self._isclose_helper(tests, device, dtype, equal_nan=True, rtol=0, atol=0)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float16, torch.float32)
+    def test_isclose_equal_nan_broadcast(self, device, dtype):
+        # Regression test: isclose with equal_nan=True should handle broadcasting
+        # See https://github.com/pytorch/pytorch/issues/174985
+        nan = torch.nan
+
+        # One-sided broadcast: different sizes
+        a = torch.tensor([nan], device=device, dtype=dtype)
+        b = torch.tensor([nan, nan], device=device, dtype=dtype)
+        result = torch.isclose(a, b, equal_nan=True)
+        self.assertEqual(result, torch.tensor([True, True], device=device))
+
+        # One-sided broadcast: scalar-like vs vector
+        a = torch.tensor([nan], device=device, dtype=dtype)
+        b = torch.tensor([nan, 1.0, nan], device=device, dtype=dtype)
+        result = torch.isclose(a, b, equal_nan=True)
+        self.assertEqual(result, torch.tensor([True, False, True], device=device))
+
+        # Mutual broadcast
+        a = torch.tensor([[nan], [1.0]], device=device, dtype=dtype)  # [2, 1]
+        b = torch.tensor([[nan, 1.0]], device=device, dtype=dtype)    # [1, 2]
+        result = torch.isclose(a, b, equal_nan=True)
+        expected = torch.tensor([[True, False], [False, True]], device=device)
+        self.assertEqual(result, expected)
+
+        # Same shape (fast path) still works
+        a = torch.tensor([nan, 1.0], device=device, dtype=dtype)
+        b = torch.tensor([nan, 1.0], device=device, dtype=dtype)
+        result = torch.isclose(a, b, equal_nan=True)
+        self.assertEqual(result, torch.tensor([True, True], device=device))
+
     # The following tests (test_cuda_assert_*) are added to ensure test suite terminates early
     # when CUDA assert was thrown. Because all subsequent test will fail if that happens.
     # These tests are slow because it spawn another process to run test suite.


### PR DESCRIPTION
Fixes #174985

The `equal_nan` handling in `isclose` has two branches: one for tensor subclasses (CompositeCompliance) and one for regular tensors. The subclass branch uses `bitwise_and` (out-of-place), but the regular tensor branch used `__iand__` (in-place AND)  to merge results of isnan checks.

But `self` and `other` have different, but broadcastable shapes in-place `__iand__` cannot be used, and results in

```
RuntimeError: output with shape [] doesn't match the broadcast shape [13, 2, 12]
```

The fix switches to `bitwise_and` (out-of-place) to match the subclass branch, which already handles this correctly.

**Repro:**
```python
import torch
scalar = torch.tensor(float('nan'), dtype=torch.float16)
tensor = torch.zeros(13, 2, 12, dtype=torch.float16)
result = torch.isclose(scalar, tensor, rtol=1e-5, atol=1e-8, equal_nan=True)
# RuntimeError: output with shape [] doesn't match the broadcast shape [13, 2, 12]
```