### PR TITLE
Fix MKL FFT crash on tensors with zero-size batch dimensions

### DIFF
--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -434,6 +434,12 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
   const int64_t signal_ndim = dim.size();
   const auto batch_dims = ndim - signal_ndim;
 
+  // Nothing to do for empty tensors
+  if (self.numel() == 0) {
+    out.resize_(out_sizes, MemoryFormat::Contiguous);
+    return out;
+  }
+
   // Permute dimensions so batch dimensions come first, and in stride order
   // This maximizes data locality when collapsing to a single batch dimension
   DimVector dim_permute(ndim);


### PR DESCRIPTION
Fixes #174984

When a tensor has a zero-size non-FFT dimension (e.g. shape `[0, 2, 16]`), the collapsed batch size in `_exec_fft` is 0. MKL's DFTI cannot handle zero-batch configurations and raises `Inconsistent configuration parameters`.

This adds an early return in `_exec_fft` when `batch_size` is 0, returning the pre-allocated output tensor which already has the correct shape and dtype from the caller. This matches numpy's behavior of returning an empty tensor with the expected output shape.

**Repro:**
```python
import torch

input_tensor = torch.zeros([0, 2, 16], dtype=torch.float32)
result = torch.fft.rfft(input_tensor)
# RuntimeError: MKL FFT error: Intel oneMKL DFTI ERROR: Inconsistent configuration parameters
```

**Expected:** Returns empty complex tensor with shape `[0, 2, 9]`, matching numpy:
```python
import numpy as np
np.fft.rfft(np.zeros([0, 2, 16])).shape  # (0, 2, 9)
```

The fix is in the MKL-specific `_exec_fft` function and handles all FFT operations that go through it (fft, ifft, rfft, irfft, hfft, ihfft, fft2, rfft2, etc.). The existing `TORCH_CHECK(n >= 1)` in the higher-level functions continues to correctly reject cases where the FFT dimension itself is 0. PocketFFT (used on ARM) is not affected as it already handles this case correctly.