### PR TITLE
Fix NLLLoss backward failure for non-contiguous 4D inputs

### DIFF
--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -714,6 +714,10 @@ Tensor nll_loss_nd_symint(
   if (input_.dim() == 1 || input_.dim() == 2) {
     ret = at::nll_loss_symint(input_, target_, weight, reduction, std::move(ignore_index));
   } else if (input_.dim() == 4) {
+#ifndef FBCODE_CAFFE2
+    input_ = input_.contiguous();
+    target_ = target_.contiguous();
+#endif
     ret = at::nll_loss2d_symint(input_, target_, weight, reduction, std::move(ignore_index));
   } else {
     // dim == 3 or dim > 4

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -37,7 +37,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     skipIfNoLapack, skipIfRocm, MI300_ARCH, skipIfRocmArch, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMPS, \
-    IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE256, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
+    IS_PPC, IS_FBCODE, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE256, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
     skipIfTorchDynamo, gcIfJetson, set_default_dtype
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
@@ -12972,6 +12972,36 @@ class TestNNDeviceType(NNTestCase):
             result_byte, grad_byte = compute_result_and_gradient(reduction, torch.uint8)
             self.assertEqual(result_long, result_byte)
             self.assertEqual(grad_long, grad_byte)
+
+    @unittest.skipIf(IS_FBCODE, "contiguous call skipped in fbcode, see #175084")
+    def test_nll_loss_noncontiguous_4d(self, device):
+        # Ref: https://github.com/pytorch/pytorch/issues/175084
+        # Non-contiguous 4D input used to crash backward with
+        # "grad_input must be contiguous"
+        for reduction in ["none", "mean", "sum"]:
+            # Create non-contiguous 4D input by moving the class dim
+            nc_input = torch.randn(2, 3, 5, 4, device=device).movedim(-1, 1)
+            nc_input.requires_grad_(True)
+            self.assertFalse(nc_input.is_contiguous())
+            target = torch.randint(0, 4, (2, 3, 5), device=device)
+
+            output = F.nll_loss(nc_input, target, reduction=reduction)
+            if reduction == "none":
+                output.sum().backward()
+            else:
+                output.backward()
+            self.assertEqual(nc_input.grad.shape, nc_input.shape)
+
+            # Compare against contiguous version for correctness
+            c_input = nc_input.detach().contiguous().requires_grad_(True)
+            output_c = F.nll_loss(c_input, target, reduction=reduction)
+            if reduction == "none":
+                output_c.sum().backward()
+            else:
+                output_c.backward()
+
+            self.assertEqual(output, output_c)
+            self.assertEqual(nc_input.grad, c_input.grad)
 
     @onlyCUDA
     @dtypes(torch.float16, torch.float32)


### PR DESCRIPTION
Fixes #175084

The `nll_loss2d` backward kernel requires contiguous `grad_input`, but the 4D case in `nll_loss_nd` dispatches directly to `nll_loss2d` without calling `.contiguous()` first. When the input is non-contiguous (e.g. from `movedim` or `permute`), `zeros_like` preserves those strides, causing the contiguity check in the backward to fail with `grad_input must be contiguous`.

The 3D and 5D+ cases already call `.contiguous()` before forwarding to `nll_loss2d`. This applies the same treatment for 4D inputs.

**Repro:**
```python
import torch

input = torch.rand(1, 2, 3, 4, requires_grad=True)
target = torch.randint(0, 1, (1, 2, 3))
transposed = torch.movedim(input, -1, 1)

output = torch.nn.NLLLoss()(transposed, target)
output.backward()  # RuntimeError: grad_input must be contiguous
```

Note that the same operation works for all other dimensionalities (2D, 3D, 5D+) because they either don't use `nll_loss2d` or go through the `else` branch that already calls `.contiguous()`.