### PR TITLE
Add dtype validation to CUDA binomial to match CPU path

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cpp
+++ b/aten/src/ATen/native/cuda/Distributions.cpp
@@ -28,6 +28,14 @@ Tensor _s_poisson_cuda(const Tensor& lambda, std::optional<Generator> gen_) {
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 Tensor _s_binomial_cuda(const Tensor& count, const Tensor& prob, std::optional<Generator> gen_) {
+  TORCH_CHECK_VALUE(
+      at::isFloatingType(count.scalar_type()),
+      "binomial only supports floating-point dtypes for count, got: ",
+      count.scalar_type());
+  TORCH_CHECK_VALUE(
+      at::isFloatingType(prob.scalar_type()),
+      "binomial only supports floating-point dtypes for prob, got: ",
+      prob.scalar_type());
   auto gen = get_generator_or_default<CUDAGeneratorImpl>(gen_, cuda::detail::getDefaultCUDAGenerator());
   Tensor ret = at::empty(count.sizes(), count.options());
   at::TensorIterator iter = at::TensorIteratorConfig()

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1821,26 +1821,30 @@ class TestDistributions(DistributionsTestCase):
 
     def test_torch_binomial_dtype_errors(self):
         dtypes = [torch.int, torch.long, torch.short]
+        devices = ["cpu"]
+        if TEST_CUDA:
+            devices.append("cuda")
 
-        for count_dtype in dtypes:
-            total_count = torch.tensor([10, 10], dtype=count_dtype)
-            total_prob = torch.tensor([0.5, 0.5], dtype=torch.float)
+        for device in devices:
+            for count_dtype in dtypes:
+                total_count = torch.tensor([10, 10], dtype=count_dtype, device=device)
+                total_prob = torch.tensor([0.5, 0.5], dtype=torch.float, device=device)
 
-            with self.assertRaisesRegex(
-                ValueError,
-                "binomial only supports floating-point dtypes for count.*",
-            ):
-                torch.binomial(total_count, total_prob)
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "binomial only supports floating-point dtypes for count.*",
+                ):
+                    torch.binomial(total_count, total_prob)
 
-        for prob_dtype in dtypes:
-            total_count = torch.tensor([10, 10], dtype=torch.float)
-            total_prob = torch.tensor([0.5, 0.5], dtype=prob_dtype)
+            for prob_dtype in dtypes:
+                total_count = torch.tensor([10, 10], dtype=torch.float, device=device)
+                total_prob = torch.tensor([0.5, 0.5], dtype=prob_dtype, device=device)
 
-            with self.assertRaisesRegex(
-                ValueError,
-                "binomial only supports floating-point dtypes for prob.*",
-            ):
-                torch.binomial(total_count, total_prob)
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "binomial only supports floating-point dtypes for prob.*",
+                ):
+                    torch.binomial(total_count, total_prob)
 
     @set_default_dtype(torch.double)
     def test_multinomial_1d(self):


### PR DESCRIPTION
## Summary

PR #157658 added `TORCH_CHECK_VALUE` dtype validation to the CPU binomial path (`_s_binomial_cpu`), giving a clear error message when non-floating-point tensors are passed. However, the CUDA path (`_s_binomial_cuda`) was not updated, so GPU users still get a confusing error from `TensorIterator` (e.g., "Found dtype Float but expected Long").

This adds the same validation to the CUDA path and extends the existing test to cover CUDA devices.

## Changes

- **`aten/src/ATen/native/cuda/Distributions.cpp`**: Add `TORCH_CHECK_VALUE` calls to `_s_binomial_cuda` matching the CPU implementation
- **`test/distributions/test_distributions.py`**: Extend `test_torch_binomial_dtype_errors` to iterate over both CPU and CUDA devices

## Test plan

- Existing `test_torch_binomial_dtype_errors` now covers both CPU and CUDA paths
- CPU path behavior is unchanged (same validation was already present)
- CUDA path now raises `ValueError` with a descriptive message instead of a confusing `TensorIterator` error

Fixes #133777