### PR TITLE
[BE][MPS] Use `fmt::format` to compute key

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -157,11 +157,17 @@ static void pool2d_template(const Tensor& input,
     padH = padW = 0;
   }
   @autoreleasepool {
-    std::string key = op_name + getTensorsStringKey({input, indices, grad_output}) + ":K[" +
-        getArrayRefString(kernel_size) + "]:S[" + getArrayRefString(stride) + "]:P[" + getArrayRefString(padding) +
-        "]:D[" + getArrayRefString(dilation) + "]" + (ceil_mode ? ":ceil" : "") +
-        (count_include_pad ? ":include_pad" : "") + (has_divisor ? ":divisor" : "") + ":" +
-        (suggested_memory_format == MemoryFormat::ChannelsLast ? "NHWC" : "NCHW");
+    const auto key = fmt::format("{}{}:K[{}]:S[{}]:P[{}]:D[{}]{}{}{}:{}",
+                                 op_name,
+                                 getTensorsStringKey({input, indices, grad_output}),
+                                 getArrayRefString(kernel_size),
+                                 getArrayRefString(stride),
+                                 getArrayRefString(padding),
+                                 getArrayRefString(dilation),
+                                 ceil_mode ? ":ceil" : "",
+                                 count_include_pad ? ":include_pad" : "",
+                                 has_divisor ? ":divisor" : "",
+                                 suggested_memory_format == MemoryFormat::ChannelsLast ? "NHWC" : "NCHW");
 
     MPSShape* inputShape = getMPSShape(input, memory_format);
     MPSShape* gradOutputShape = is_backward_pass ? getMPSShape(grad_output, memory_format) : nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175251
* #175235
* __->__ #175249

Rather than a very long string concatenation.
Get rid of a bit of a code duplication