### PR TITLE
[TorchDistributed] Add signal name to ChildFailedError exitcode output

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -247,3 +247,10 @@ class ApiTest(unittest.TestCase):
             # it SHOULD re-raise ChildFailedError for any upstream system
             # to handle it.
             self.assertFalse(os.path.isfile(self.test_error_file))
+
+    def test_child_failed_error_signal_name_in_message(self):
+        pf = self.failure_without_error_file(exitcode=-signal.SIGSEGV)
+        ex = ChildFailedError("trainer.par", {0: pf})
+        error_msg = str(ex)
+        self.assertIn("(SIGSEGV)", error_msg)
+        self.assertIn(f"exitcode  : {-signal.SIGSEGV}", error_msg)

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -185,7 +185,7 @@ _FAILURE_FORMAT_TEMPLATE = """[${idx}]:
   time      : ${time}
   host      : ${hostname}
   rank      : ${rank} (local_rank: ${local_rank})
-  exitcode  : ${exitcode} (pid: ${pid})
+  exitcode  : ${exitcode} (pid: ${pid}) ${signal_name}
   error_file: ${error_file}
   traceback : ${message}"""
 
@@ -294,6 +294,9 @@ class ChildFailedError(Exception):
                 .replace("\n", "\n  ")  # to properly indent the traceback
             )
 
+        signal_name = failure.signal_name()
+        signal_name_str = f" ({signal_name})" if signal_name != _NOT_AVAILABLE else ""
+
         fmt = Template(_FAILURE_FORMAT_TEMPLATE).substitute(
             idx=idx,
             time=failure.timestamp_isoformat(),
@@ -302,6 +305,7 @@ class ChildFailedError(Exception):
             local_rank=failure.local_rank,
             exitcode=failure.exitcode,
             pid=failure.pid,
+            signal_name=signal_name_str,
             error_file=failure.error_file,
             message=msg,
         )


### PR DESCRIPTION
Summary:
This change adds the signal name (e.g., SIGSEGV) to the error message output when a process fails with a negative exitcode (indicating it was killed by a signal).

Previously, the error message would show:
```
exitcode  : -11 (pid: 5277)
```

Now it will show:
```
exitcode  : -11 (pid: 5277) (SIGSEGV)
```

This makes it easier for users to understand the cause of process failures, especially for common signals like SIGSEGV (segmentation fault), SIGKILL, SIGABRT, etc.

The implementation:
1. Modified `_FAILURE_FORMAT_TEMPLATE` to include a `${signal_name}` placeholder
2. Updated `_format_failure()` method to compute the signal name using the existing `ProcessFailure.signal_name()` method and pass it to the template
3. The signal name is only displayed when it's available (i.e., when exitcode is negative and maps to a known signal)

Added a test case `test_child_failed_error_signal_name_in_message` to verify the signal name appears in the formatted error message.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=T235136724-9548e28a-5fdd-4f35-b2b9-36f7b9796d02)

Test Plan:
1. Verified Python syntax is correct for both modified files
2. Added unit test `test_child_failed_error_signal_name_in_message` that:
   - Creates a ProcessFailure with exitcode=-11 (SIGSEGV)
   - Creates a ChildFailedError with that failure
   - Verifies the error message contains "(SIGSEGV)" and the exitcode

The existing test `test_process_failure_signal` already validates that `ProcessFailure.signal_name()` returns "SIGSEGV" for exitcode=-11.


