### PR TITLE
fix varlen doc string

### DIFF
--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -169,8 +169,8 @@ def varlen_attn(
     scale: float | None = None,
     window_size: tuple[int, int] = (-1, -1),
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-    """
-    Compute variable-length attention using Flash Attention.
+    r"""Compute variable-length attention using Flash Attention.
+
     This function is similar to scaled_dot_product_attention but optimized for
     variable-length sequences using cumulative sequence position tensors.
 


### PR DESCRIPTION
as title, fixes #174961

**before:**
<img width="939" height="543" alt="Screenshot 2026-02-18 at 2 56 23 PM" src="https://github.com/user-attachments/assets/00862326-bdaa-4327-9eed-64910cc91cd1" />

**after:**
<img width="1070" height="576" alt="Screenshot 2026-02-18 at 2 56 02 PM" src="https://github.com/user-attachments/assets/bf073ebc-89fc-40be-9027-5556c73960f9" />
