### PR TITLE
ONNX: Support renamed input_names in dynamic_shapes for torch.onnx.export

### DIFF
--- a/test/onnx/exporter/test_dynamic_shapes.py
+++ b/test/onnx/exporter/test_dynamic_shapes.py
@@ -817,7 +817,14 @@ class TestDynamicShapes(common_utils.TestCase):
             {"a": torch.zeros(5), "b": torch.ones(5)},
             torch.ones(4),
         )
-        input_names = ["input_x", "input_y0", "input_y1", "input_a", "input_b", "input_c"]
+        input_names = [
+            "input_x",
+            "input_y0",
+            "input_y1",
+            "input_a",
+            "input_b",
+            "input_c",
+        ]
         dynamic_shapes = {
             "input_x": {0: "dim"},
             "input_y0": {0: "dim"},

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -130,7 +130,7 @@ def export_compat(
     # instead of the original parameter names (e.g., "x").
     if not isinstance(model, torch.export.ExportedProgram):
         dynamic_shapes = _dynamic_shapes.remap_dynamic_shapes_from_input_names(
-            model, dynamic_shapes, input_names
+            model, dynamic_shapes, input_names, args=args, kwargs=kwargs
         )
 
     dynamic_shapes_with_export_dim, need_axis_mapping = (

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -125,6 +125,14 @@ def export_compat(
                     "Refer to the documentation for 'torch.export.export' for more information on dynamic shapes."
                 ) from e
 
+    # Remap dynamic_shapes keys from input_names to original model parameter names.
+    # This allows users to use input_names (e.g., "bgr_image") as dynamic_shapes keys
+    # instead of the original parameter names (e.g., "x").
+    if not isinstance(model, torch.export.ExportedProgram):
+        dynamic_shapes = _dynamic_shapes.remap_dynamic_shapes_from_input_names(
+            model, dynamic_shapes, input_names
+        )
+
     dynamic_shapes_with_export_dim, need_axis_mapping = (
         _dynamic_shapes.convert_str_to_export_dim(dynamic_shapes)
     )

--- a/torch/onnx/_internal/exporter/_dynamic_shapes.py
+++ b/torch/onnx/_internal/exporter/_dynamic_shapes.py
@@ -432,13 +432,15 @@ def remap_dynamic_shapes_from_input_names(
 
     # Check for nested inputs only when we have actual args to inspect
     is_nested = False
+    num_flat_inputs = 0
+    tree_structure: _pytree.TreeSpec | None = None
     if inputs_for_tree:
         flat_inputs, tree_structure = _pytree.tree_flatten(inputs_for_tree)
         num_flat_inputs = len(flat_inputs)
         # Nested if flattening produces more leaves than parameters
         is_nested = num_flat_inputs > len(original_param_names)
 
-    if is_nested:
+    if is_nested and tree_structure is not None:
         # Nested case: the model has nested inputs (lists, dicts, etc.).
         # Unflatten the flat per-input-name shapes into the nested tree structure.
         # Only use the shapes for the actual input tensors (not extra output names).


### PR DESCRIPTION

#### Fixes  #166001

## Summary


When `torch.onnx.export(dynamo=True)` is used with both `input_names`
(to rename ONNX inputs) and `dynamic_shapes` (dict form keyed by those
renamed names), export fails validation because `torch.export.export`
expects `dynamic_shapes` keys to match the original `forward()` parameter
names (e.g., `"x"`), not the renamed ONNX input names (e.g., `"bgr_image"`).

This PR remaps `dynamic_shapes` keys from `input_names` back to the
original model parameter names before calling `torch.export.export`.

---

## Root Cause

`dynamic_shapes` was previously passed directly to `torch.export.export`
without accounting for `input_names`. Since ONNX renaming occurs later via
`_ir_passes.rename_inputs`, validation would fail early when dict keys did
not match the original `forward()` signature.

---

## Fix

Adds `remap_dynamic_shapes_from_input_names` in
`torch/onnx/_internal/exporter/_dynamic_shapes.py` and invokes it from
`export_compat()` before calling `torch.export.export`.


---

## Example
Previously Failing, Now Works

```python
torch.onnx.export(
    model,
    (input_tensor,),
    "model.onnx",
    input_names=["bgr_image"],
    dynamic_shapes={"bgr_image": {0: "batch"}},
    dynamo=True,
)