### PR TITLE
[Inductor] Add depthwise conv1d triton template

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -526,6 +526,53 @@ class TestSelectAlgorithm(TestCase):
         if not torch.version.hip:  # autotuning is not guaranteed to run on ROCm
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
+    @patches
+    def test_convolution_depthwise_conv1d(self):
+        @torch.compile
+        def foo(x, w, b):
+            return aten.convolution(
+                x,
+                w,
+                b,
+                stride=(1,),
+                padding=(4,),
+                dilation=(1,),
+                transposed=False,
+                output_padding=(0,),
+                groups=128,
+            )
+
+        foo(
+            torch.randn(2, 128, 202, device=GPU_TYPE),
+            torch.randn(128, 1, 9, device=GPU_TYPE),
+            torch.randn(128, device=GPU_TYPE),
+        )
+        if not torch.version.hip:
+            self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+
+    @patches
+    def test_convolution_depthwise_conv1d_no_bias(self):
+        @torch.compile
+        def foo(x, w):
+            return aten.convolution(
+                x,
+                w,
+                None,
+                stride=(2,),
+                padding=(1,),
+                dilation=(1,),
+                transposed=False,
+                output_padding=(0,),
+                groups=64,
+            )
+
+        foo(
+            torch.randn(4, 64, 100, device=GPU_TYPE),
+            torch.randn(64, 1, 3, device=GPU_TYPE),
+        )
+        if not torch.version.hip:
+            self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+
     def test_TritonTemplateCaller_str(self):
         """
         Make sure str(TritonTemplateCaller) does not raise exceptions.

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -119,6 +119,12 @@ class InductorChoices:
         conv_heuristics = self.get_config_heuristics(device_type)
         return conv_heuristics.get_conv_configs()
 
+    def get_depthwise_conv_configs(
+        self, device_type: Optional[str] = "cuda"
+    ) -> list[Any]:
+        heuristics = self.get_config_heuristics(device_type)
+        return heuristics.get_depthwise_conv_configs()
+
     # Flex attention configs
     # TODO(coconutruben): break out flexattention/decode configs into the new retrieval mechanism
     def get_flex_attention_fwd_configs(

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -29,6 +29,7 @@ from ..utils import (
     use_triton_template,
 )
 from ..virtualized import V
+from .mm_common import load_kernel_template
 
 
 if TYPE_CHECKING:
@@ -59,6 +60,29 @@ def conv3d_grid(n, c, d, h, w, meta, *, cdiv):
         meta["GROUPS"],
     )
 
+
+# =============================================================================
+# Depthwise conv1d (groups == in_channels == out_channels)
+# Uses direct element-wise multiply-accumulate instead of implicit GEMM.
+# Channels-last (NLC) layout with 3D tiling: BLOCK_N x BLOCK_L x BLOCK_C.
+# =============================================================================
+
+
+@SymbolicGridFn
+def depthwise_conv1d_grid(n, c, l, meta, *, cdiv):
+    return (
+        cdiv(n, meta["BLOCK_N"]),
+        cdiv(l, meta["BLOCK_L"]),
+        cdiv(c, meta["BLOCK_C"]),
+    )
+
+
+depthwise_conv1d_template = TritonTemplate(
+    name="depthwise_conv1d",
+    grid=depthwise_conv1d_grid,
+    source=load_kernel_template("triton_depthwise_conv"),
+    cache_codegen_enabled_for_template=True,
+)
 
 LOOP_BODY_2D = """
         idx_x_h = i - PADDING_H + idx_y_h * STRIDE_H
@@ -588,6 +612,22 @@ def convolution(
             and groups == 1
         ):
             choices.append(aten_conv1x1_via_mm.bind(args, layout))
+
+        is_depthwise = groups > 1 and in_chan == 1 and out_chan == groups
+        if is_depthwise and ndim == 1:
+            depthwise_configs = V.choices.get_depthwise_conv_configs(device_type)
+            for cfg in depthwise_configs:
+                depthwise_conv1d_template.maybe_append_choice(
+                    choices,
+                    input_nodes=(x, weight),
+                    layout=layout,
+                    KERNEL_SIZE=kernel_shape[0],
+                    CONV_STRIDE=stride[0],
+                    PADDING=padding[0],
+                    num_stages=cfg.num_stages,
+                    num_warps=cfg.num_warps,
+                    **cfg.kwargs,
+                )
 
         conv_configs = V.choices.get_conv_configs(device_type)
 

--- a/torch/_inductor/kernel/templates/triton_depthwise_conv.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_depthwise_conv.py.jinja
@@ -1,0 +1,64 @@
+{{def_kernel("X", "W")}}
+    # Depthwise conv1d – channels-last (NLC) layout
+    # Each group has exactly 1 input channel (groups == in_channels == out_channels)
+    # 3D tiling: BLOCK_N x BLOCK_L x BLOCK_C
+    # Matches the hand-written NLC kernel from depthwise_conv1d_benchmark.py
+
+    BATCH = {{size("X", 0)}}
+    CHANNELS = {{size("X", 1)}}
+    IN_L = {{size("X", 2)}}
+    OUT_L = {{size(None, 2)}}
+
+    stride_xn = {{stride("X", 0)}}
+    stride_xc = {{stride("X", 1)}}
+    stride_xl = {{stride("X", 2)}}
+
+    stride_wc = {{stride("W", 0)}}
+    stride_wk = {{stride("W", 2)}}
+
+    # Grid: (cdiv(BATCH, BLOCK_N), cdiv(OUT_L, BLOCK_L), cdiv(CHANNELS, BLOCK_C))
+    pid_n = tl.program_id(0).to(INDEX_DTYPE)
+    pid_l = tl.program_id(1).to(INDEX_DTYPE)
+    pid_c = tl.program_id(2).to(INDEX_DTYPE)
+
+    n_start = pid_n * BLOCK_N
+    l_start = pid_l * BLOCK_L
+    c_start = pid_c * BLOCK_C
+
+    n_offs = n_start + tl.arange(0, BLOCK_N)
+    l_offs = l_start + tl.arange(0, BLOCK_L)
+    c_offs = c_start + tl.arange(0, BLOCK_C)
+    n_mask = n_offs < BATCH
+    l_mask = l_offs < OUT_L
+    c_mask = c_offs < CHANNELS
+
+    n3 = n_offs[:, None, None]
+    nm3 = n_mask[:, None, None]
+    c3 = c_offs[None, None, :]
+    cm3 = c_mask[None, None, :]
+
+    in_base = n3 * stride_xn + c3 * stride_xc
+
+    acc = tl.zeros((BLOCK_N, BLOCK_L, BLOCK_C), dtype=tl.float32)
+
+    for k in range(KERNEL_SIZE):
+        wk = tl.load(
+            W + c_offs * stride_wc + k * stride_wk,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        l_in = l_offs * CONV_STRIDE - PADDING + k
+        mask_in = (l_in >= 0) & (l_in < IN_L)
+        x_vals = tl.load(
+            X + in_base + l_in[None, :, None] * stride_xl,
+            mask=nm3 & mask_in[None, :, None] & cm3,
+            other=0.0,
+        ).to(tl.float32)
+        acc += x_vals * wk[None, None, :]
+
+    mask = nm3 & l_mask[None, :, None] & cm3
+    idx_n = n_offs[:, None, None]
+    idx_c = c_offs[None, None, :]
+    idx_l = l_offs[None, :, None]
+
+    {{store_output(("idx_n", "idx_c", "idx_l"), "acc", "mask", val_shape=("BLOCK_N", "BLOCK_L", "BLOCK_C"))}}


### PR DESCRIPTION
Summary: Add a depthwise conv1d triton template in Inductor.

Test Plan:
```
Benchmark Results (3072×128×202, k=3, groups=128):

Variant	Time (ms)	Relative	D92997144 Ref
triton_ncl_CF	0.1757	100.0%	0.1757ms ✅
triton_nlc_CL	0.1827	96.2%	0.1825ms ✅
inductor_dw1d_CL	0.1809	97.2%	was 10.3592ms → 57x faster
inductor_dw1d_CF	0.5781	30.4%	was 6.5351ms → 11x faster
cudnn_dw1d_CF	0.1997	88.0%	0.1997ms ✅
cudnn_dw1d_CL	1.0693	16.4%	1.0727ms ✅
```

Differential Revision: D93027389




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo