### PR TITLE
[MPS] Return pivots from `linalg_solve_out_mps_impl`

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -395,34 +395,32 @@ static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-      MPSMatrixDecompositionLU* filter = [[[MPSMatrixDecompositionLU alloc] initWithDevice:device
-                                                                                      rows:aRows
-                                                                                   columns:aCols] autorelease];
+      auto filter = [[[MPSMatrixDecompositionLU alloc] initWithDevice:device rows:aRows columns:aCols] autorelease];
 
-      MPSMatrixDescriptor* sourceMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
-                                                                                    columns:aCols
-                                                                                   matrices:1
-                                                                                   rowBytes:aCols * aElemSize
-                                                                                matrixBytes:aRows * aCols * aElemSize
-                                                                                   dataType:getMPSDataType(A_)];
-      MPSMatrixDescriptor* pivotsMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:1
-                                                                                    columns:numPivots
-                                                                                   matrices:1
-                                                                                   rowBytes:numPivots * sizeof(uint32_t)
-                                                                                matrixBytes:numPivots * sizeof(uint32_t)
-                                                                                   dataType:MPSDataTypeUInt32];
+      auto sourceMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
+                                                                    columns:aCols
+                                                                   matrices:1
+                                                                   rowBytes:aCols * aElemSize
+                                                                matrixBytes:aRows * aCols * aElemSize
+                                                                   dataType:getMPSDataType(A_)];
+      auto pivotsMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:1
+                                                                    columns:numPivots
+                                                                   matrices:1
+                                                                   rowBytes:numPivots * sizeof(uint32_t)
+                                                                matrixBytes:numPivots * sizeof(uint32_t)
+                                                                   dataType:MPSDataTypeUInt32];
 
       for (const auto i : c10::irange(batchSize)) {
         const uint64_t aBatchOffset = i * aRows * aCols;
-        MPSMatrix* sourceMatrix = [[[MPSMatrix alloc] initWithBuffer:aBuffer
-                                                              offset:(A_.storage_offset() + aBatchOffset) * aElemSize
-                                                          descriptor:sourceMatrixDesc] autorelease];
-        MPSMatrix* pivotIndices = [[[MPSMatrix alloc] initWithBuffer:getMTLBufferStorage(pivots_list[i])
-                                                              offset:0
-                                                          descriptor:pivotsMatrixDesc] autorelease];
-        MPSMatrix* solutionMatrix = [[[MPSMatrix alloc] initWithBuffer:aBuffer
-                                                                offset:(A_.storage_offset() + aBatchOffset) * aElemSize
-                                                            descriptor:sourceMatrixDesc] autorelease];
+        auto sourceMatrix = [[[MPSMatrix alloc] initWithBuffer:aBuffer
+                                                        offset:(A_.storage_offset() + aBatchOffset) * aElemSize
+                                                    descriptor:sourceMatrixDesc] autorelease];
+        auto pivotIndices = [[[MPSMatrix alloc] initWithBuffer:getMTLBufferStorage(pivots_list[i])
+                                                        offset:0
+                                                    descriptor:pivotsMatrixDesc] autorelease];
+        auto solutionMatrix = [[[MPSMatrix alloc] initWithBuffer:aBuffer
+                                                          offset:(A_.storage_offset() + aBatchOffset) * aElemSize
+                                                      descriptor:sourceMatrixDesc] autorelease];
         id<MTLBuffer> statusBuffer = getMTLBufferStorage(status_tensors[i]);
         [filter encodeToCommandBuffer:commandBuffer
                          sourceMatrix:sourceMatrix
@@ -490,8 +488,8 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
 
   uint64_t numPivots = std::min(aRows, aCols);
   std::vector<int64_t> pivot_sizes(A_t.sizes().begin(), A_t.sizes().end() - 2);
-  info.fill_(0); // will be set to 1 during kernel if something fails
   resize_output(info, pivot_sizes);
+  info.fill_(0); // will be set by kernel on failure
   pivot_sizes.push_back(numPivots);
   resize_output(pivots, pivot_sizes);
 
@@ -505,13 +503,9 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
 
   uint64_t batchSize = (A_t.dim() > 2) ? A_t.size(0) : 1;
   std::vector<Tensor> status_tensors;
-  std::vector<Tensor> pivots_list;
-
   status_tensors.reserve(batchSize);
-  pivots_list.reserve(batchSize);
   for ([[maybe_unused]] const auto i : c10::irange(batchSize)) {
     status_tensors.push_back(at::zeros(1, kInt, std::nullopt, kMPS, std::nullopt));
-    pivots_list.push_back(at::zeros(numPivots, kInt, std::nullopt, kMPS, std::nullopt));
   }
 
   resize_output(LU, A_t.sizes());
@@ -534,6 +528,7 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
   id<MTLBuffer> luBuffer = getMTLBufferStorage(LU_);
   id<MTLBuffer> bBuffer = getMTLBufferStorage(B_t);
   id<MTLBuffer> resultBuffer = getMTLBufferStorage(result_t);
+  id<MTLBuffer> pivotsBuffer = getMTLBufferStorage(pivots);
 
   MPSStream* mpsStream = getCurrentMPSStream();
   id<MTLDevice> device = MPSDevice::getInstance()->device();
@@ -542,41 +537,37 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
     @autoreleasepool {
       id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
 
-      MPSMatrixDecompositionLU* lu_decomp = [[[MPSMatrixDecompositionLU alloc] initWithDevice:device
-                                                                                         rows:aRows
-                                                                                      columns:aCols] autorelease];
+      auto lu_decomp = [[[MPSMatrixDecompositionLU alloc] initWithDevice:device rows:aRows columns:aCols] autorelease];
 
-      MPSMatrixSolveLU* solver = [[[MPSMatrixSolveLU alloc] initWithDevice:device
-                                                                 transpose:false
-                                                                     order:aRows
-                                                    numberOfRightHandSides:numberOfRightHandSides] autorelease];
+      auto solver = [[[MPSMatrixSolveLU alloc] initWithDevice:device
+                                                    transpose:false
+                                                        order:aRows
+                                       numberOfRightHandSides:numberOfRightHandSides] autorelease];
 
-      MPSMatrixDescriptor* luMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
-                                                                                columns:aCols
-                                                                               matrices:1
-                                                                               rowBytes:aCols * aElemSize
-                                                                            matrixBytes:aRows * aCols * aElemSize
-                                                                               dataType:getMPSDataType(LU_)];
-      MPSMatrixDescriptor* rhsMatrixDesc =
-          [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
-                                                columns:numberOfRightHandSides
-                                               matrices:1
-                                               rowBytes:numberOfRightHandSides * aElemSize
-                                            matrixBytes:aRows * numberOfRightHandSides * aElemSize
-                                               dataType:getMPSDataType(B_t)];
-      MPSMatrixDescriptor* resultMatrixDesc =
-          [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
-                                                columns:numberOfRightHandSides
-                                               matrices:1
-                                               rowBytes:numberOfRightHandSides * aElemSize
-                                            matrixBytes:aRows * numberOfRightHandSides * aElemSize
-                                               dataType:getMPSDataType(result_t)];
-      MPSMatrixDescriptor* pivotsMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:1
-                                                                                    columns:numPivots
-                                                                                   matrices:1
-                                                                                   rowBytes:numPivots * sizeof(uint32_t)
-                                                                                matrixBytes:numPivots * sizeof(uint32_t)
-                                                                                   dataType:MPSDataTypeUInt32];
+      auto luMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
+                                                                columns:aCols
+                                                               matrices:1
+                                                               rowBytes:aCols * aElemSize
+                                                            matrixBytes:aRows * aCols * aElemSize
+                                                               dataType:getMPSDataType(LU_)];
+      auto rhsMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
+                                                                 columns:numberOfRightHandSides
+                                                                matrices:1
+                                                                rowBytes:numberOfRightHandSides * aElemSize
+                                                             matrixBytes:aRows * numberOfRightHandSides * aElemSize
+                                                                dataType:getMPSDataType(B_t)];
+      auto resultMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
+                                                                    columns:numberOfRightHandSides
+                                                                   matrices:1
+                                                                   rowBytes:numberOfRightHandSides * aElemSize
+                                                                matrixBytes:aRows * numberOfRightHandSides * aElemSize
+                                                                   dataType:getMPSDataType(result_t)];
+      auto pivotsMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:1
+                                                                    columns:numPivots
+                                                                   matrices:1
+                                                                   rowBytes:numPivots * sizeof(uint32_t)
+                                                                matrixBytes:numPivots * sizeof(uint32_t)
+                                                                   dataType:MPSDataTypeUInt32];
 
       for (const auto i : c10::irange(batchSize)) {
         const uint64_t batchOffsetA = i * aRows * aCols;
@@ -593,15 +584,14 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
                                                            offset:(result_t.storage_offset() + batchOffsetB) * aElemSize
                                                        descriptor:resultMatrixDesc] autorelease];
 
-        MPSMatrix* mpsPivots = [[[MPSMatrix alloc] initWithBuffer:getMTLBufferStorage(pivots_list[i])
-                                                           offset:0
-                                                       descriptor:pivotsMatrixDesc] autorelease];
-        id<MTLBuffer> statusBuffer = getMTLBufferStorage(status_tensors[i]);
+        auto mpsPivots = [[[MPSMatrix alloc] initWithBuffer:pivotsBuffer
+                                                     offset:(pivots.storage_offset() + i * numPivots) * sizeof(uint32_t)
+                                                 descriptor:pivotsMatrixDesc] autorelease];
         [lu_decomp encodeToCommandBuffer:commandBuffer
                             sourceMatrix:mpsLU
                             resultMatrix:mpsLU
                             pivotIndices:mpsPivots
-                                  status:statusBuffer];
+                                  status:getMTLBufferStorage(status_tensors[i])];
         [solver encodeToCommandBuffer:commandBuffer
                          sourceMatrix:mpsLU
                   rightHandSideMatrix:mpsRHS
@@ -611,12 +601,13 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
     }
   });
 
-  auto stacked_status = A.dim() > 2 ? at::stack(status_tensors) : status_tensors[0];
-  std::vector<int64_t> info_sizes(A.sizes().begin(), A.sizes().end() - 2);
-  info.copy_(stacked_status.view(info_sizes));
+  pivots.add_(1); // MPS is 0-based, PyTorch/LAPACK is 1-based
+
+  auto stacked_status = batchSize > 1 ? at::stack(status_tensors) : status_tensors[0];
+  info.copy_(stacked_status.view(info.sizes()));
 
   if (check_errors) {
-    for (const auto i : c10::irange(status_tensors.size())) {
+    for (const auto i : c10::irange(batchSize)) {
       int status = status_tensors[i].item<int>();
       TORCH_CHECK(status == 0,
                   "solve(): Linear solve failed at the ",

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -926,10 +926,6 @@ if torch.backends.mps.is_available():
                 torch.float16,
                 torch.float32,
             ],  # missing `aten::lu_solve`.
-            "linalg.tensorsolve": [
-                torch.float16,
-                torch.float32,
-            ],  # missing `aten::lu_solve`.
             "aminmax": [torch.float32, torch.float16],
             "special.i1": [torch.float16],  # "i1_backward" not implemented for 'Half'
             "special.i1e": [torch.float16],  # "i1e_backward" not implemented for 'Half'

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -2831,13 +2831,6 @@ op_db: list[OpInfo] = [
                 "test_output_match",
                 device_type="mps",
             ),
-            # Exception: index ????? is out of bounds for dimension 0 with size 6
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_variant_consistency_eager",
-                device_type="mps",
-            ),
             # Exception: Tensor-likes are not close!
             DecorateInfo(
                 unittest.expectedFailure,
@@ -2847,11 +2840,6 @@ op_db: list[OpInfo] = [
             ),
         ],
         skips=(
-            DecorateInfo(
-                unittest.skip("Unsupported on MPS for now"),
-                "TestCommon",
-                "test_numpy_ref_mps",
-            ),
             # Exception: linalg.lu_factor(): MPS only supports floats.
             DecorateInfo(
                 unittest.expectedFailure, "TestCommon", "test_dtypes", device_type="mps"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #175284

I should have been more careful while reviewing https://github.com/pytorch/pytorch/pull/146531 which initialized pivot tensors but never copied them back (nor offset them by 1 as LAPACK/Fortran expects)

Fixes https://github.com/pytorch/pytorch/issues/175192