### PR TITLE
[dynamo] Adding expected failures for Dynamo + metaclass tests

### DIFF
--- a/test/dynamo/test_enum.py
+++ b/test/dynamo/test_enum.py
@@ -484,6 +484,75 @@ class EnumTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, Priority.LOW, Priority.HIGH)
         self.assertEqual(ref, res)
 
+    @unittest.expectedFailure
+    def test_metaclass_custom_call(self):
+        # When a class has a metaclass that overrides __call__, Python invokes
+        # the metaclass's __call__ instead of the default type.__call__
+        # (which does __new__ + __init__). Dynamo currently bypasses the
+        # metaclass __call__ and uses instantiate_user_defined_class_object
+        # (which mimics type.__call__), producing wrong results.
+        class ScalingMeta(type):
+            def __call__(cls, val):
+                obj = cls.__new__(cls)
+                obj.scaled = val * cls.scale_factor
+                return obj
+
+        class Scaled(metaclass=ScalingMeta):
+            scale_factor = 10
+
+            def __init__(self, val):
+                # type.__call__ would call this, but ScalingMeta.__call__
+                # deliberately skips it and sets scaled directly.
+                self.scaled = val
+
+        def fn(x, val):
+            obj = Scaled(val)
+            return x * obj.scaled
+
+        x = torch.tensor([1.0, 2.0])
+        # Python: ScalingMeta.__call__ sets scaled = 3 * 10 = 30
+        ref = fn(x, 3)
+        compiled_fn = torch.compile(fn, backend="eager")
+        res = compiled_fn(x, 3)
+        self.assertEqual(ref, res)
+
+    @unittest.expectedFailure
+    def test_enum_construction_no_extra_init(self):
+        # Real-world instance of the metaclass __call__ issue above.
+        # EnumMeta.__call__ only calls __new__ (value lookup), NOT __init__.
+        # Dynamo's instantiate_user_defined_class_object calls both, so the
+        # extra __init__ call produces wrong results.
+        init_count = [0]
+
+        class MyEnum(enum.Enum):
+            def __new__(cls, val):
+                obj = object.__new__(cls)
+                obj._value_ = val
+                return obj
+
+            def __init__(self, val):
+                init_count[0] += 1
+
+            A = 1
+            B = 2
+
+        init_count[0] = 0
+
+        def fn(x, val):
+            MyEnum(val)
+            return x * (1 + init_count[0])
+
+        x = torch.tensor([1.0, 2.0])
+        # Python: MyEnum(1) is a value lookup via EnumMeta.__call__, which
+        # only calls Enum.__new__ (lookup) — __init__ is NOT called.
+        # So init_count stays 0 and fn returns x * 1.
+        ref = fn(x, 1)
+        init_count[0] = 0
+
+        compiled_fn = torch.compile(fn, backend="eager")
+        res = compiled_fn(x, 1)
+        self.assertEqual(ref, res)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175290
* #175266

I saw that Dynamo was not tracing `__new__` of a subclassed Enum and
wrongly attributed to a Dynamo issue. But that turned out to be correct Enum is
metaclass which calles custom `__new__` at class creation time, and then monkeypatches the subclass `__new__` to `Enum.__new__`, so that custom `__new__` is never called again.


But, then I also realized that EnumMeta, the metaclass, never calls
custom __init__ method. This got me thinking that Dynamo support for
classes that are metaclassed is wrong. Here are two tests for those.

These are marked expectedFailure.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo