### PR TITLE
[stack trace] ignore CrossRefMode in stack trace

### DIFF
--- a/test/higher_order_ops/test_opaque_inspect_tensor.py
+++ b/test/higher_order_ops/test_opaque_inspect_tensor.py
@@ -17,12 +17,7 @@ from torch._higher_order_ops.invoke_leaf_function import invoke_leaf_function
 from torch._higher_order_ops.opaque_inspect_tensor import make_opaque_inspect_tensor_fn
 from torch.autograd import Function
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import (
-    run_tests,
-    skipIfCrossRef,
-    skipIfTorchDynamo,
-    TestCase,
-)
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
@@ -383,7 +378,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @skipIfCrossRef  # crossref changes graph whitespace
     def test_compile_graph_has_opaque_node_in_bw(self):
         cp = make_opaque_inspect_tensor_fn(
             fwd_f=lambda t: None,

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -313,6 +313,7 @@ def uninteresting_files() -> set[str]:
     import torch._subclasses.fake_tensor
     import torch._subclasses.meta_utils
     import torch.export._trace
+    import torch.testing._internal.common_utils
 
     mods = [
         sys.modules[__name__],
@@ -331,6 +332,7 @@ def uninteresting_files() -> set[str]:
         torch._subclasses.fake_tensor,
         torch._logging._internal,
         torch._logging.structured,
+        torch.testing._internal.common_utils,
     ]
     import torch._dynamo.guards
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175298
* #174636
* #174635



as title, skip `CrossRefMode.__torch_function__`  frames in `torch.testing._internal.common_utils` when populating stack traces. 
