### PR TITLE
[ROCM] Refactor BFloat16 implementation for native usage of BF16 to float conversion.

### DIFF
--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -59,6 +59,12 @@ void neg_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
+// Use signum with typed return to speed up conversions from bool
+// and avoid compilation issues
+inline C10_HOST_DEVICE BFloat16 signum(BFloat16 x) {
+  return c10::signum_indicator(x);
+}
+
 void sign_kernel_cuda(TensorIteratorBase& iter){
   if (iter.dtype() == ScalarType::Bool) {
     gpu_kernel(iter, []GPU_LAMBDA(bool a){

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -59,12 +59,6 @@ void neg_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
-// Use signum with typed return to speed up conversions from bool
-// and avoid compilation issues
-inline C10_HOST_DEVICE BFloat16 signum(BFloat16 x) {
-  return c10::signum_indicator(x);
-}
-
 void sign_kernel_cuda(TensorIteratorBase& iter){
   if (iter.dtype() == ScalarType::Bool) {
     gpu_kernel(iter, []GPU_LAMBDA(bool a){

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -33,6 +33,13 @@ struct alignas(2) BFloat16 {
   };
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
+  explicit inline C10_HOST_DEVICE BFloat16(int value) : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(int64_t value) : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(bool value) : x( value ? 0x3F80 : 0x0000 ) {}
+  explicit inline C10_HOST_DEVICE BFloat16(unsigned long value) : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(unsigned int value) : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(double value) : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE operator bool() const { return x != 0; }
 #else
   uint16_t x;
   BFloat16() = default;

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -157,7 +157,7 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 }
 
 #if defined(__HIPCC__)
-inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value) 
+inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value)
   : x__bf16(value) {}
 inline C10_HOST_DEVICE BFloat16::operator __hip_bfloat16() const {
   return x__bf16;

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -155,7 +155,6 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
   return detail::f32_from_bits(x);
 #endif
 }
-#endif
 
 #if defined(__HIPCC__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value)
@@ -170,6 +169,7 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(const __nv_bfloat16& value) {
 inline C10_HOST_DEVICE BFloat16::operator __nv_bfloat16() const {
   return *reinterpret_cast<const __nv_bfloat16*>(&x);
 }
+#endif
 
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
 inline C10_HOST_DEVICE BFloat16::BFloat16(

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -34,9 +34,12 @@ struct alignas(2) BFloat16 {
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
   // Fast conversion constructors 
-  explicit inline C10_HOST_DEVICE BFloat16(double value);
-  explicit inline C10_HOST_DEVICE BFloat16(int value);
-  explicit inline C10_HOST_DEVICE BFloat16(int64_t value);
+  inline C10_HOST_DEVICE BFloat16(double value);
+  explicit inline C10_HOST_DEVICE operator double() const;
+  inline C10_HOST_DEVICE BFloat16(int value);
+  explicit inline C10_HOST_DEVICE operator int() const;
+  inline C10_HOST_DEVICE BFloat16(int64_t value);
+  explicit inline C10_HOST_DEVICE operator int64_t() const;
 #else
   uint16_t x;
   BFloat16() = default;
@@ -151,10 +154,19 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 #if defined(__HIPCC__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(int value)
   : x__bf16(static_cast<__bf16>(value)) {}
+inline C10_HOST_DEVICE BFloat16::operator int() const {
+    return static_cast<int>(x__bf16);
+}
 inline C10_HOST_DEVICE BFloat16::BFloat16(int64_t value)
   : x__bf16(static_cast<__bf16>(value)) {}  
+inline C10_HOST_DEVICE BFloat16::operator int64_t() const {
+    return static_cast<int64_t>(x__bf16);
+}
 inline C10_HOST_DEVICE BFloat16::BFloat16(double value)
   : x__bf16(static_cast<__bf16>(value)) {}
+inline C10_HOST_DEVICE BFloat16::operator double() const {
+    return static_cast<double>(x__bf16);
+}
 #endif
 
 /// Implicit conversions

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -46,6 +46,8 @@ struct alignas(2) BFloat16 {
   explicit inline C10_HOST_DEVICE operator int() const;
   inline C10_HOST_DEVICE BFloat16(int64_t value);
   explicit inline C10_HOST_DEVICE operator int64_t() const;
+
+  inline C10_HOST_DEVICE BFloat16(bool value) : x(value ? 0x3F80 : 0x0000) {  }
 #else
   uint16_t x;
   BFloat16() = default;
@@ -477,6 +479,23 @@ inline C10_HOST_DEVICE bool operator<(BFloat16& lhs, BFloat16& rhs) {
   return lhs.x__bf16 < rhs.x__bf16;
 #else
   return float(lhs) < float(rhs);
+#endif
+}
+
+/// Returns the sign of variable x as BFloat16 -1, 0, 1
+inline C10_HOST_DEVICE BFloat16 signum_indicator(BFloat16 x) {
+#if defined(__HIPCC__)
+  constexpr uint16_t kSignMask = 0x8000;
+  constexpr uint16_t kMagMask = 0x7FFF;
+  constexpr uint16_t kOneBits = 0x3F80;   // 1.0 in bfloat16
+  constexpr uint16_t kNegOneBits = 0xBF80;  // -1.0 in bfloat16
+  uint16_t mag = x.x & kMagMask;
+  bool is_negative = (x.x & kSignMask) != 0;
+  uint16_t result_bits =
+      (mag == 0) ? 0 : (is_negative ? kNegOneBits : kOneBits);
+  return BFloat16(static_cast<unsigned short>(result_bits), BFloat16::from_bits());
+#else
+  return  (BFloat16(0) < x) - (x < BFloat16(0));
 #endif
 }
 

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -33,11 +33,13 @@ struct alignas(2) BFloat16 {
   };
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
-  // Fast conversion constructors 
-  inline C10_HOST_DEVICE BFloat16(__bf16 value) : x__bf16(value) {}
-  inline C10_HOST_DEVICE BFloat16(unsigned long value) : x__bf16(static_cast<__bf16>(value)) {}
-  inline C10_HOST_DEVICE BFloat16(unsigned int value) : x__bf16(static_cast<__bf16>(value)) {}
-  
+  // Fast conversion constructors
+  inline C10_HOST_DEVICE BFloat16(__bf16 value): x__bf16(value) {}
+  inline C10_HOST_DEVICE BFloat16(unsigned long value)
+  : x__bf16(static_cast<__bf16>(value)) {}
+  inline C10_HOST_DEVICE BFloat16(unsigned int value)
+  : x__bf16(static_cast<__bf16>(value)) {}
+
   inline C10_HOST_DEVICE BFloat16(double value);
   explicit inline C10_HOST_DEVICE operator double() const;
   inline C10_HOST_DEVICE BFloat16(int value);
@@ -155,17 +157,17 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 
 #if defined(__HIPCC__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(int value)
-  : x__bf16(static_cast<__bf16>(value)) {}
+: x__bf16(static_cast<__bf16>(value)) {}
 inline C10_HOST_DEVICE BFloat16::operator int() const {
     return static_cast<int>(x__bf16);
 }
 inline C10_HOST_DEVICE BFloat16::BFloat16(int64_t value)
-  : x__bf16(static_cast<__bf16>(value)) {}  
+: x__bf16(static_cast<__bf16>(value)) {}
 inline C10_HOST_DEVICE BFloat16::operator int64_t() const {
     return static_cast<int64_t>(x__bf16);
 }
 inline C10_HOST_DEVICE BFloat16::BFloat16(double value)
-  : x__bf16(static_cast<__bf16>(value)) {}
+: x__bf16(static_cast<__bf16>(value)) {}
 inline C10_HOST_DEVICE BFloat16::operator double() const {
     return static_cast<double>(x__bf16);
 }
@@ -187,7 +189,7 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 
 #if defined(__HIPCC__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value)
-  : x__bf16(value) {}
+: x__bf16(value) {}
 inline C10_HOST_DEVICE BFloat16::operator __hip_bfloat16() const {
   return x__bf16;
 }
@@ -235,7 +237,7 @@ operator+(const BFloat16& a, const BFloat16& b) {
 
 inline C10_HOST_DEVICE BFloat16
 operator-(const BFloat16& a, const BFloat16& b) {
-#if defined(__HIPCC__)  
+#if defined(__HIPCC__)
   return a.x__bf16 - b.x__bf16;
 #else
   return static_cast<float>(a) - static_cast<float>(b);

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -55,6 +55,11 @@ struct alignas(2) BFloat16 {
   explicit inline C10_HOST_DEVICE operator __nv_bfloat16() const;
 #endif
 
+#if defined(__HIPCC__)
+  inline C10_HOST_DEVICE BFloat16(const __bf16& value);
+  explicit inline C10_HOST_DEVICE operator __bf16() const;
+#endif
+
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
   inline C10_HOST_DEVICE BFloat16(const sycl::ext::oneapi::bfloat16& value);
   explicit inline C10_HOST_DEVICE operator sycl::ext::oneapi::bfloat16() const;
@@ -157,6 +162,10 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 }
 
 #if defined(__HIPCC__)
+inline C10_HOST_DEVICE BFloat16(const __bf16& value) : x__bf16(value) {}
+explicit inline C10_HOST_DEVICE operator __bf16() const {
+  return x__bf16;
+}
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value)
   : x__bf16(value) {}
 inline C10_HOST_DEVICE BFloat16::operator __hip_bfloat16() const {
@@ -197,45 +206,81 @@ inline C10_DEVICE BFloat16 __ldg(const BFloat16* ptr) {
 
 inline C10_HOST_DEVICE BFloat16
 operator+(const BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)
+  return a.x__bf16 + b.x__bf16;
+#else
   return static_cast<float>(a) + static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE BFloat16
 operator-(const BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)  
+  return a.x__bf16 - b.x__bf16;
+#else
   return static_cast<float>(a) - static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE BFloat16
 operator*(const BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)
+  return a.x__bf16 * b.x__bf16;
+#else
   return static_cast<float>(a) * static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE BFloat16 operator/(const BFloat16& a, const BFloat16& b)
     __ubsan_ignore_float_divide_by_zero__ {
+#if defined(__HIPCC__)
+  return a.x__bf16 / b.x__bf16;
+#else
   return static_cast<float>(a) / static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE BFloat16 operator-(const BFloat16& a) {
+#if defined(__HIPCC__)
+  return -a.x__bf16;
+#else
   return -static_cast<float>(a);
+#endif
 }
 
 inline C10_HOST_DEVICE BFloat16& operator+=(BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)
+  a.x__bf16 += b.x__bf16;
+#else
   a = a + b;
+#endif
   return a;
 }
 
 inline C10_HOST_DEVICE BFloat16& operator-=(BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)
+  a.x__bf16 -= b.x__bf16;
+#else
   a = a - b;
+#endif
   return a;
 }
 
 inline C10_HOST_DEVICE BFloat16& operator*=(BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)
+  a.x__bf16 *= b.x__bf16;
+#else
   a = a * b;
+#endif
   return a;
 }
 
 inline C10_HOST_DEVICE BFloat16& operator/=(BFloat16& a, const BFloat16& b) {
+#if defined(__HIPCC__)
+  a.x__bf16 /= b.x__bf16;
+#else
   a = a / b;
+#endif
   return a;
 }
 
@@ -398,11 +443,19 @@ inline C10_HOST_DEVICE BFloat16 operator/(int64_t a, BFloat16 b) {
 // Overloading < and > operators, because std::max and std::min use them.
 
 inline C10_HOST_DEVICE bool operator>(BFloat16& lhs, BFloat16& rhs) {
+#if defined(__HIPCC__)
+  return lhs.x__bf16 > rhs.x__bf16;
+#else
   return float(lhs) > float(rhs);
+#endif
 }
 
 inline C10_HOST_DEVICE bool operator<(BFloat16& lhs, BFloat16& rhs) {
+#if defined(__HIPCC__)
+  return lhs.x__bf16 < rhs.x__bf16;
+#else
   return float(lhs) < float(rhs);
+#endif
 }
 
 C10_CLANG_DIAGNOSTIC_POP()

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -34,11 +34,11 @@ struct alignas(2) BFloat16 {
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
   // Fast conversion constructors
-  inline C10_HOST_DEVICE BFloat16(__bf16 value): x__bf16(value) {}
+  inline C10_HOST_DEVICE BFloat16(__bf16 value) : x__bf16(value) {}
   inline C10_HOST_DEVICE BFloat16(unsigned long value)
-  : x__bf16(static_cast<__bf16>(value)) {}
+      : x__bf16(static_cast<__bf16>(value)) {}
   inline C10_HOST_DEVICE BFloat16(unsigned int value)
-  : x__bf16(static_cast<__bf16>(value)) {}
+      : x__bf16(static_cast<__bf16>(value)) {}
 
   inline C10_HOST_DEVICE BFloat16(double value);
   explicit inline C10_HOST_DEVICE operator double() const;
@@ -75,7 +75,7 @@ struct alignas(2) BFloat16 {
 };
 
 inline std::ostream& operator<<(std::ostream& out, const BFloat16& value) {
-  out << (float)value;
+  out << static_cast<float>(value);
   return out;
 }
 
@@ -157,19 +157,19 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 
 #if defined(__HIPCC__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(int value)
-: x__bf16(static_cast<__bf16>(value)) {}
+    : x__bf16(static_cast<__bf16>(value)) {}
 inline C10_HOST_DEVICE BFloat16::operator int() const {
-    return static_cast<int>(x__bf16);
+  return static_cast<int>(x__bf16);
 }
 inline C10_HOST_DEVICE BFloat16::BFloat16(int64_t value)
-: x__bf16(static_cast<__bf16>(value)) {}
+    : x__bf16(static_cast<__bf16>(value)) {}
 inline C10_HOST_DEVICE BFloat16::operator int64_t() const {
-    return static_cast<int64_t>(x__bf16);
+  return static_cast<int64_t>(x__bf16);
 }
 inline C10_HOST_DEVICE BFloat16::BFloat16(double value)
-: x__bf16(static_cast<__bf16>(value)) {}
+    : x__bf16(static_cast<__bf16>(value)) {}
 inline C10_HOST_DEVICE BFloat16::operator double() const {
-    return static_cast<double>(x__bf16);
+  return static_cast<double>(x__bf16);
 }
 #endif
 
@@ -189,7 +189,7 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 
 #if defined(__HIPCC__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value)
-: x__bf16(value) {}
+    : x__bf16(value) {}
 inline C10_HOST_DEVICE BFloat16::operator __hip_bfloat16() const {
   return x__bf16;
 }

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -33,8 +33,6 @@ struct alignas(2) BFloat16 {
   };
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
-  // Fast conversion constructors
-  inline C10_HOST_DEVICE BFloat16(__bf16 value) : x__bf16(value) {}
 #else
   uint16_t x;
   BFloat16() = default;

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -58,7 +58,6 @@ struct alignas(2) BFloat16 {
       unsigned short bits,
       from_bits_t /*unused*/)
       : x(bits) {}
-
   /* implicit */ inline C10_HOST_DEVICE BFloat16(float value);
   inline C10_HOST_DEVICE operator float() const;
 
@@ -66,7 +65,6 @@ struct alignas(2) BFloat16 {
   inline C10_HOST_DEVICE BFloat16(const __nv_bfloat16& value);
   explicit inline C10_HOST_DEVICE operator __nv_bfloat16() const;
 #endif
-
 
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
   inline C10_HOST_DEVICE BFloat16(const sycl::ext::oneapi::bfloat16& value);
@@ -152,7 +150,7 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
       // RNE by default
       x(detail::round_to_nearest_even(value))
 #endif
-{  
+{
 }
 
 #if defined(__HIPCC__)

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -34,6 +34,10 @@ struct alignas(2) BFloat16 {
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
   // Fast conversion constructors 
+  inline C10_HOST_DEVICE BFloat16(__bf16 value) : x__bf16(value) {}
+  inline C10_HOST_DEVICE BFloat16(unsigned long value) : x__bf16(static_cast<__bf16>(value)) {}
+  inline C10_HOST_DEVICE BFloat16(unsigned int value) : x__bf16(static_cast<__bf16>(value)) {}
+  
   inline C10_HOST_DEVICE BFloat16(double value);
   explicit inline C10_HOST_DEVICE operator double() const;
   inline C10_HOST_DEVICE BFloat16(int value);

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -33,13 +33,21 @@ struct alignas(2) BFloat16 {
   };
   // HIP wants __host__ __device__ tag, CUDA does not
   C10_HOST_DEVICE BFloat16() = default;
-  explicit inline C10_HOST_DEVICE BFloat16(int value) : x__bf16(static_cast<__bf16>(value)) {}
-  explicit inline C10_HOST_DEVICE BFloat16(int64_t value) : x__bf16(static_cast<__bf16>(value)) {}
-  explicit inline C10_HOST_DEVICE BFloat16(bool value) : x( value ? 0x3F80 : 0x0000 ) {}
-  explicit inline C10_HOST_DEVICE BFloat16(unsigned long value) : x__bf16(static_cast<__bf16>(value)) {}
-  explicit inline C10_HOST_DEVICE BFloat16(unsigned int value) : x__bf16(static_cast<__bf16>(value)) {}
-  explicit inline C10_HOST_DEVICE BFloat16(double value) : x__bf16(static_cast<__bf16>(value)) {}
-  explicit inline C10_HOST_DEVICE operator bool() const { return x != 0; }
+  explicit inline C10_HOST_DEVICE BFloat16(int value)
+      : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(int64_t value)
+      : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(bool value)
+      : x(value ? 0x3F80 : 0x0000) {}
+  explicit inline C10_HOST_DEVICE BFloat16(unsigned long value)
+      : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(unsigned int value)
+      : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE BFloat16(double value)
+      : x__bf16(static_cast<__bf16>(value)) {}
+  explicit inline C10_HOST_DEVICE operator bool() const {
+    return x != 0;
+  }
 #else
   uint16_t x;
   BFloat16() = default;

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -48,6 +48,7 @@ struct alignas(2) BFloat16 {
   explicit inline C10_HOST_DEVICE operator bool() const {
     return x != 0;
   }
+  explicit inline C10_HOST_DEVICE BFloat16(uint8_t value);
 #else
   uint16_t x;
   BFloat16() = default;
@@ -156,6 +157,11 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(float value)
 #endif
 {
 }
+
+#if defined(__HIPCC__)
+inline C10_HOST_DEVICE BFloat16::BFloat16(uint8_t value)
+    : x(detail::round_to_nearest_even(static_cast<float>(value))) {}
+#endif
 
 /// Implicit conversions
 inline C10_HOST_DEVICE BFloat16::operator float() const {


### PR DESCRIPTION
Refactor the BFloat16 implementation to efficiently leverage the native HIP float‑conversion capabilities. Instead of performing software‑based conversions to 32‑bit float and back for all operations, update the HIP environment to use the native __bf16 type, which provides hardware‑accelerated conversion for both floating‑point and integer types. 

Example:
The current implementation sums two 16‑bit floating‑point values by converting them to 32‑bit floats in software, performing the addition in 32‑bit precision, and then converting the result back to 16‑bit. This introduces extra operations and register memory overhead of 2x32‑bit for converted values (plus another extra space for conversion function variables: float, int and pointer ~ 4x32-bit).
The proposed implementation performs the addition by directly using hardware support for 16‑bit float arithmetic ~ 2x16bit register usage.

Development notes:
1. Usage of __bf16 type is based of its usage in __hip_bfloat16 class from amd_hip_bf16.h included in hip/hip_bf16.h.
2.  BFloat16.h will be  hipified during build: __CUDACC__ -> __HIPCC__, __nv_bfloat16 -> __hip_bfloat16, cuda_bf16.h -> hip/hip_bf16.h. It makes harder to review code as some code changes still rely on hipification, some code changes overrule it.  

Refactor and optimize sign functions for BFloat16 to avoiding conversion from a bool type: 
1. sign_kernel_cuda uses c10::signum(a), which for signed types does return (T(0) < x) - (x < T(0));
2. The compiler with optimization bypasses constructors and produces an unsupported i1 → bf16 conversion that the ROCm 7.1 LLVM backend cannot lower to GPU instructions.
3. Proposed template specialization version of sign functions based on sign bits. This version is more efficient because does not use conversions and float arithmetic operations.

Performance Justification:

Quick check using HIP program test shows performance of c10::BFloat16  vs __hip_bfloat16 about 20% improvement potential. on kernel level:
```
Device: AMD Radeon Graphics (MI350)
c10::BFloat16 on ROCm: + and * use float promotion (see BFloat16.h).
Grid: 4096 x 256 = 1048576 threads, repeat = 80000

Kernel                            time          Gop/s
------------------------------------------------------------
__hip_bfloat16 __hadd           10.076 ms      8325.12 Gop/s
__hip_bfloat16 __hmul           10.099 ms      8306.73 Gop/s
c10::BFloat16 operator+         12.163 ms      6896.67 Gop/s
c10::BFloat16 operator*         12.035 ms      6970.00 Gop/s
------------------------------------------------------------
Each line counts one scalar add or mul in the loop body.
c10 path does extra bf16<->f32 work each iteration.

```
After current changes:
```

Device: AMD Radeon Graphics
c10::BFloat16 on ROCm: + and * use float promotion (see BFloat16.h).
Grid: 4096 x 256 = 1048576 threads, repeat = 80000

Kernel                            time          Gop/s
------------------------------------------------------------
__hip_bfloat16 __hadd           10.090 ms      8313.97 Gop/s
__hip_bfloat16 __hmul           10.062 ms      8336.82 Gop/s
c10::BFloat16 operator+         10.058 ms      8340.29 Gop/s
c10::BFloat16 operator*         10.065 ms      8334.08 Gop/s
------------------------------------------------------------
Each line counts one scalar add or mul in the loop body.
```



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang 