### PR TITLE
fix(elastic): respect USE_LIBUV on Windows so torchrun works without libuv

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -8,6 +8,7 @@
 import binascii
 import logging
 import os
+import sys
 import tempfile
 from base64 import b64decode, b64encode
 from datetime import timedelta
@@ -149,6 +150,8 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
     if read_timeout <= 0:
         raise ValueError("The read timeout must be a positive integer.")
 
+    use_libuv = os.environ.get("USE_LIBUV", "0" if sys.platform == "win32" else "1") == "1"
+
     # In specific cases we attempt to instantiate the store twice. For details
     # see the explanation in the except clause below.
     for is_server in [is_host, False]:
@@ -159,6 +162,7 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
                 is_master=is_server,
                 multi_tenant=True,
                 timeout=timedelta(seconds=read_timeout),
+                use_libuv=use_libuv,
             )
 
             if is_server:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -10,6 +10,7 @@ import logging
 import os
 import pickle
 import socket
+import sys
 import threading
 import time
 import weakref
@@ -1124,11 +1125,13 @@ class DynamicRendezvousHandler(RendezvousHandler):
         )
 
     def _create_tcp_store_server(self, master_addr, master_port) -> dist.TCPStore:
+        use_libuv = os.environ.get("USE_LIBUV", "0" if sys.platform == "win32" else "1") == "1"
         return dist.TCPStore(
             host_name=master_addr,
             port=master_port,
             is_master=True,
             multi_tenant=True,
+            use_libuv=use_libuv,
         )
 
     @property

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -187,12 +187,14 @@ def _create_c10d_store(
 
     if _torchelastic_use_agent_store():
         # We create a new TCPStore for every retry so no need to add prefix for each attempt.
+        use_libuv = os.environ.get("USE_LIBUV", "0" if sys.platform == "win32" else "1") == "1"
         return TCPStore(
             host_name=hostname,
             port=port,
             world_size=world_size,
             is_master=False,
             timeout=timeout,
+            use_libuv=use_libuv,
         )
     else:
         start_daemon = rank == 0


### PR DESCRIPTION
Torchrun is currently unusable on Windows with the official wheels: you always get the "built without libuv support" error because the elastic code always passes use_libuv=True and the Windows build has no libuv.
Official PyTorch Windows wheels are built without libuv. Elastic rendezvous creates TCPStore with use_libuv defaulting to True, causing: RuntimeError: use_libuv was requested but PyTorch was built without libuv support

What this PR does:
- Read USE_LIBUV env in all four TCPStore creation paths (c10d, dynamic, static_tcp, and env rendezvous).
- When unset: use "0" on Windows and "1" elsewhere, matching existing behavior in rendezvous.py.

Fixes [#148283](https://github.com/pytorch/pytorch/issues/148283)