### PR TITLE
Work around eager-mode issues with logical-xor op

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1322,7 +1322,7 @@
 - func: logical_xor.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA: logical_xor_out
+    CPU, CUDA, MTIA: logical_xor_out
     MPS: logical_xor_out_mps
   tags: pointwise
 


### PR DESCRIPTION
Summary: Register an MTIA-specific native function for `logical_xor_out` that always falls back to using the CPU implementation. This works around an issue where the CPU implementation was passed a non-resizable `out` tensor.

Differential Revision: D92035025


