### PR TITLE
[MPS] Ensure pool2d inputs are contiguous in target memory format

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -208,22 +208,26 @@ static void pool2d_template(const Tensor& input,
     });
 
     MPSStream* mpsStream = getCurrentMPSStream();
-    // in case of ChannelsLast we don't perform gather() in placeholder to avoid implicit conversion to NCHW
+    // Make inputs contiguous in the target memory format (no-op when already contiguous)
+    const bool is_channels_last = (memory_format == MemoryFormat::ChannelsLast);
+    const auto& input_cl = input.contiguous(memory_format);
+    const auto& grad_output_cl =
+        is_backward_pass ? grad_output.contiguous(memory_format) : grad_output;
 
     // MPS TODO: Using strided API causes invalid indices to be generated if the original format is NHWC
     //           Output is still correct, but indices are not matching. Disable it for now and use the old
     //           gather path to solve the strides.
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor,
-                                               input,
+                                               input_cl,
                                                inputShape,
-                                               memory_format != MemoryFormat::ChannelsLast,
+                                               !is_channels_last,
                                                MPSDataTypeInvalid,
                                                /*useMPSStridedAPI=*/false);
     Placeholder gradOutputPlaceholder = !is_backward_pass ? Placeholder()
                                                           : Placeholder(cachedGraph->gradOutputTensor,
-                                                                        grad_output,
+                                                                        grad_output_cl,
                                                                         gradOutputShape,
-                                                                        memory_format != MemoryFormat::ChannelsLast,
+                                                                        !is_channels_last,
                                                                         MPSDataTypeInvalid,
                                                                         /*useMPSStridedAPI=*/false);
     Placeholder indicesPlaceholder = has_indices

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1045,11 +1045,11 @@ torch.cuda.synchronize()
                 with self.assertRaisesRegex(RuntimeError, "not implemented"):
                     module(input)
 
-    @expectedFailureMPS  # TODO: fixme
     @onlyNativeDeviceTypes
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfMPS(torch.float, torch.half)
     def test_avg_pool2d_nhwc(self, device, dtype):
         def helper(
             n,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6766,7 +6766,6 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(x.grad, cpu_x.grad)
 
     # Test adaptive avg pool2d - when the input size is a multiple of output size
-    # Not testing for channels last right now
     def test_adaptive_avg_pool2d_simple(self):
         def helper(input_shape, out_shape, channels_last):
             cpu_x = torch.randn(input_shape, device='cpu', dtype=torch.float, requires_grad=True)
@@ -6804,6 +6803,12 @@ class TestMPS(TestCaseMPS):
         helper((2, 2, 2, 16), (16, 16), False)
 
         helper((2, 4, 4), (16, 16), False)
+
+        # channels_last (4D only)
+        helper((2, 2, 4, 4), (2, 2), True)
+        helper((2, 2, 9, 9), (3, 3), True)
+        helper((2, 2, 16, 16), (2, 2), True)
+        helper((2, 2, 4, 4), (8, 8), True)
 
         try:
             helper((2, 2, 3, 3), (7, 7), False)


### PR DESCRIPTION
## Summary

When `pool2d_template` creates Placeholder objects with `gatherTensorData=false` for ChannelsLast inputs, the raw Metal buffer is passed directly to `MPSNDArray`. Non-contiguous tensors (e.g., expanded views from autograd) can have buffers that are too small or laid out incorrectly, causing SIGABRT or wrong results in backward pass.

Ensure `input` and `grad_output` are contiguous in the target memory format before passing to `Placeholder`. Enable channels_last test coverage for` avg_pool2d`.

Attempted fix for #175190

cc @kulinseth @malfet @DenisVieriu97 @jhavukainen @aditvenk