### PR TITLE
chore(dynamo): disallow direct raise Unsupported in torch/_dynamo

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -627,10 +627,13 @@ def unimplemented(
             past_real_stack = from_exc.real_stack
         if isinstance(from_exc, Unsupported):
             msg = f"{from_exc.msg}\n\n*** While handling this graph break, another graph break occurred: ***\n\n{msg}"
+            # noqa: GB_REGISTRY
             raise Unsupported(msg, gb_type, skip_frame, real_stack=past_real_stack)
+        # noqa: GB_REGISTRY
         raise Unsupported(
             msg, gb_type, skip_frame, real_stack=past_real_stack
         ) from from_exc
+    # noqa: GB_REGISTRY
     raise Unsupported(msg, gb_type, skip_frame)
 
 


### PR DESCRIPTION
Solves #170556 
## Summary
- Add a new `GB_REGISTRY` lint check that flags direct `raise Unsupported(...)` usage in `torch/_dynamo`, including `raise exc.Unsupported(...)`.
- Add explicit suppression support via `# noqa: GB_REGISTRY` for infra-only exceptions.

## Tests
Added coverage in `tools/test/test_gb_registry_linter.py` for:
- direct `raise Unsupported(...)` is flagged
- `raise exc.Unsupported(...)` is flagged
- `# noqa: GB_REGISTRY` suppression works
- in `exc.py`, raise inside `unimplemented()` is allowed, but raise in other functions is flagged


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo