### PR TITLE
Fix shared memory and is_shared for non-CPU devices

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -1043,11 +1043,6 @@ if __name__ == "__main__":
         t = torch.randn(5, 5).cuda()
         self.assertTrue(t.is_shared())
 
-    @unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
-    def test_is_shared_xpu(self):
-        t = torch.randn(5, 5).xpu()
-        self.assertTrue(t.is_shared())
-
     @unittest.skipIf(sys.platform != "linux", "Only runs on Linux; requires prctl(2)")
     def test_set_thread_name(self):
         name = "test name"

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -1043,6 +1043,11 @@ if __name__ == "__main__":
         t = torch.randn(5, 5).cuda()
         self.assertTrue(t.is_shared())
 
+    @unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
+    def test_is_shared_xpu(self):
+        t = torch.randn(5, 5).xpu()
+        self.assertTrue(t.is_shared())
+
     @unittest.skipIf(sys.platform != "linux", "Only runs on Linux; requires prctl(2)")
     def test_set_thread_name(self):
         name = "test name"

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1448,10 +1448,11 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         b = torch.randn(5, 4, device=device)
         nt = torch.nested.nested_tensor([a, b], layout=torch.jagged)
 
-        # Guard CUDA tensors
-        if "cuda" in device:
+        # Non-CPU devices don't use POSIX shared memory
+        if device != "cpu":
             result = nt.share_memory_()
             self.assertIs(result, nt)
+            self.assertTrue(nt.is_shared())
             return
 
         result = nt.share_memory_()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -356,6 +356,8 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, r'only available on CPU'):
             s0.share_memory_()
 
+        self.assertFalse(s0.is_shared())
+
         with self.assertRaisesRegex(NotImplementedError, r'Not available'):
             s0.tolist()
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -664,6 +664,20 @@ print(torch.xpu.is_initialized())
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), original.get_device())
 
+    def test_share_memory(self):
+        t = torch.randn(5, 5, device="xpu")
+        self.assertTrue(t.is_shared())
+        result = t.share_memory_()
+        self.assertIs(result, t)
+
+    def test_share_memory_nested(self):
+        a = torch.randn(3, 4, device="xpu")
+        b = torch.randn(5, 4, device="xpu")
+        nt = torch.nested.nested_tensor([a, b], layout=torch.jagged)
+        result = nt.share_memory_()
+        self.assertIs(result, nt)
+        self.assertTrue(nt.is_shared())
+
     def test_out_of_memory(self):
         if self.expandable_segments:
             self.skipTest("Skipping OOM test for expandable segments allocator.")

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -672,6 +672,7 @@ print(torch.xpu.is_initialized())
         t = torch.randn(5, 5, device="xpu")
         result = t.share_memory_()
         self.assertIs(result, t)
+        self.assertTrue(t.is_shared())
 
     def test_share_memory_nested(self):
         a = torch.randn(3, 4, device="xpu")

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -664,9 +664,12 @@ print(torch.xpu.is_initialized())
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), original.get_device())
 
-    def test_share_memory(self):
+    def test_is_shared(self):
         t = torch.randn(5, 5, device="xpu")
         self.assertTrue(t.is_shared())
+
+    def test_share_memory(self):
+        t = torch.randn(5, 5, device="xpu")
         result = t.share_memory_()
         self.assertIs(result, t)
 

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -627,7 +627,7 @@ static PyObject* THPStorage_sharedFd(PyObject* self, PyObject* noargs) {
 
 static PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
   const auto& storage = THPStorage_Unpack(self);
-  if (storage.device_type() == at::kCUDA) {
+  if (storage.device_type() != at::kCPU) {
     Py_RETURN_TRUE;
   }
   if (at::MapAllocator::fromDataPtr(storage.data_ptr()) ||

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -627,7 +627,7 @@ static PyObject* THPStorage_sharedFd(PyObject* self, PyObject* noargs) {
 
 static PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
   const auto& storage = THPStorage_Unpack(self);
-  if (storage.device_type() != at::kCPU) {
+  if (storage.device_type() != at::kCPU && storage.device_type() != at::kMeta) {
     Py_RETURN_TRUE;
   }
   if (at::MapAllocator::fromDataPtr(storage.data_ptr()) ||

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -433,7 +433,7 @@ def jagged_torch_function(func, *args, **kwargs):
     if func.__name__ == "share_memory_":
         nt = args[0]
 
-        if nt.is_cuda:
+        if nt.is_cuda or nt.is_xpu:
             return nt
 
         names, _ = nt.__tensor_flatten__()
@@ -448,7 +448,7 @@ def jagged_torch_function(func, *args, **kwargs):
     if func.__name__ == "is_shared":
         nt = args[0]
 
-        if nt.is_cuda:
+        if nt.is_cuda or nt.is_xpu:
             return False
 
         names, _ = nt.__tensor_flatten__()

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -433,7 +433,7 @@ def jagged_torch_function(func, *args, **kwargs):
     if func.__name__ == "share_memory_":
         nt = args[0]
 
-        if nt.is_cuda or nt.is_xpu:
+        if not nt.is_cpu:
             return nt
 
         names, _ = nt.__tensor_flatten__()
@@ -448,8 +448,8 @@ def jagged_torch_function(func, *args, **kwargs):
     if func.__name__ == "is_shared":
         nt = args[0]
 
-        if nt.is_cuda or nt.is_xpu:
-            return False
+        if not nt.is_cpu:
+            return True
 
         names, _ = nt.__tensor_flatten__()
         if not names:

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -433,7 +433,7 @@ def jagged_torch_function(func, *args, **kwargs):
     if func.__name__ == "share_memory_":
         nt = args[0]
 
-        if not nt.is_cpu:
+        if not nt.is_cpu and not nt.is_meta:
             return nt
 
         names, _ = nt.__tensor_flatten__()
@@ -448,7 +448,7 @@ def jagged_torch_function(func, *args, **kwargs):
     if func.__name__ == "is_shared":
         nt = args[0]
 
-        if not nt.is_cpu:
+        if not nt.is_cpu and not nt.is_meta:
             return True
 
         names, _ = nt.__tensor_flatten__()

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -392,8 +392,12 @@ class _StorageBase:
         """See :meth:`torch.UntypedStorage.share_memory_`"""
         from torch.multiprocessing import get_sharing_strategy
 
-        if self.device.type in ["cuda", torch._C._get_privateuse1_backend_name()]:
-            pass  # CUDA or PrivateUse1 doesn't use POSIX shared memory
+        if self.device.type in [
+            "cuda",
+            "xpu",
+            torch._C._get_privateuse1_backend_name(),
+        ]:
+            pass  # CUDA, XPU, or PrivateUse1 doesn't use POSIX shared memory
         elif get_sharing_strategy() == "file_system":
             self._share_filename_cpu_()
         else:
@@ -406,7 +410,12 @@ class _StorageBase:
         from torch.multiprocessing import get_sharing_strategy
 
         device = torch.device(device)
-        if device.type in ["cuda", torch._C._get_privateuse1_backend_name(), "hpu"]:
+        if device.type in [
+            "cuda",
+            "xpu",
+            torch._C._get_privateuse1_backend_name(),
+            "hpu",
+        ]:
             return cls(size, device=device)
         elif get_sharing_strategy() == "file_system":
             return cls._new_using_filename_cpu(size)

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -392,12 +392,8 @@ class _StorageBase:
         """See :meth:`torch.UntypedStorage.share_memory_`"""
         from torch.multiprocessing import get_sharing_strategy
 
-        if self.device.type in [
-            "cuda",
-            "xpu",
-            torch._C._get_privateuse1_backend_name(),
-        ]:
-            pass  # CUDA, XPU, or PrivateUse1 doesn't use POSIX shared memory
+        if self.device.type != "cpu":
+            pass  # only CPU uses POSIX shared memory
         elif get_sharing_strategy() == "file_system":
             self._share_filename_cpu_()
         else:
@@ -410,12 +406,7 @@ class _StorageBase:
         from torch.multiprocessing import get_sharing_strategy
 
         device = torch.device(device)
-        if device.type in [
-            "cuda",
-            "xpu",
-            torch._C._get_privateuse1_backend_name(),
-            "hpu",
-        ]:
+        if device.type != "cpu":
             return cls(size, device=device)
         elif get_sharing_strategy() == "file_system":
             return cls._new_using_filename_cpu(size)

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -392,7 +392,7 @@ class _StorageBase:
         """See :meth:`torch.UntypedStorage.share_memory_`"""
         from torch.multiprocessing import get_sharing_strategy
 
-        if self.device.type != "cpu":
+        if self.device.type not in ("cpu", "meta"):
             pass  # only CPU uses POSIX shared memory
         elif get_sharing_strategy() == "file_system":
             self._share_filename_cpu_()


### PR DESCRIPTION
 ### Summary                                                                                                                                                                         
Replaces hardcoded device allowlists (`"cuda"`, `"hpu"`, `_get_privateuse1_backend_name()`) with a single `!= cpu` check in `share_memory_()`, `is_shared()`, and `_new_shared()`. POSIX shared memory is a CPU-only concept - all other device backends manage memory through their own runtime and don't need it. Previously, calling `share_memory_()` on an XPU tensor would crash by falling through to `_share_fd_cpu_()` / `_share_filename_cpu_()`.

   ### Behavioral changes

   - **`is_shared()` for CUDA nested tensors now returns `True`** (was `False`).
     This was a pre-existing bug: device memory is inherently shared, and flat CUDA
     tensors already returned `True`. The nested tensor path was inconsistent.
   - **`is_shared()` / `share_memory_()` for all non-CPU, non-meta devices** (XPU, HPU,
     MPS, PrivateUse1, etc.) now follow the same code path that CUDA previously used.
   - **Meta tensors** are excluded from the non-CPU fast path: `is_shared()` returns
     `False` and `share_memory_()` continues to error, since meta tensors have no
     backing memory to share.

   ## Test plan

   - [x] `test_is_shared` — `is_shared()` returns `True` for XPU tensors
   - [x] `test_share_memory` — `share_memory_()` is a no-op that returns self on XPU
   - [x] `test_share_memory_nested` — both `share_memory_()` and `is_shared()` work for XPU nested tensors
   - [x] Updated `test_share_memory` in `test_nestedtensor.py` to validate `is_shared()` for all non-CPU devices
   - [x] Meta storage `is_shared()` returns `False` (test_torch.py)

Fixes: https://github.com/intel/torch-xpu-ops/issues/2879
