### PR TITLE
[XPU] Skip complex mean extremal values test (IEEE-754 behavior difference)

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -427,8 +427,6 @@ class TestReductions(TestCase):
          allowed_dtypes=[torch.float32, torch.complex64])
     def test_ref_extremal_values(self, device, dtype, op: ReductionOpInfo):
         """Compares op against reference for input tensors with extremal values"""
-        if "xpu" in device and dtype is torch.complex64 and op.name == "mean":
-            self.skipTest("accuracy issue with this test, see https://github.com/intel/torch-xpu-ops/issues/2300")
         t = make_tensor((5,), dtype=dtype, device=device, exclude_zero=True)
         extremals = [0, 1, nan, inf, -inf]
         for extremal in extremals:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22534,6 +22534,10 @@ op_db: list[OpInfo] = [
                          dtypes=[torch.float16]),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_extremal_values',
                          device_type='cuda', dtypes=[torch.complex64]),
+            # Skipped on XPU because complex mean with extremal values (Inf/NaN) exhibits backend-dependent
+            # IEEE-754 behavior that differs from the CPU reference.
+            DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_extremal_values',
+                         device_type='xpu', dtypes=[torch.complex64]),
             # Driver issue of XPU, see https://github.com/intel/torch-xpu-ops/issues/2295
             DecorateInfo(
                 unittest.skip('Skipped!'),


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/2300
XPU computes complex mean using element-wise scaling (sum * factor), while CPU uses sum_out(...).div_(n).
Although mathematically equivalent, these paths may produce different results for extremal values (Inf/NaN) due to IEEE-754 behavior.

CPU returns (inf + nanj) in this case, while XPU returns (inf + finite*j), which is mathematically correct but differs from the reference.

This test was skipped on CUDA more than four years ago for similar backend-dependent behavior.