### PR TITLE
[Inductor] Disable layout constraints by default

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2485,6 +2485,7 @@ class TestMaxAutotune(TestCase):
             "max_autotune": True,
             "max_autotune_gemm_backends": "ATEN,TRITON",
             "force_pointwise_cat": True,
+            "max_autotune_defer_layout_freezing": True,
         }
     )
     @parametrize("epilogue", (True, False))

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -551,6 +551,13 @@ cudagraph_unsafe_unbacked_ops: list[str] = []
 # whether template autotuning should allow flexible layouts if possible (e.g. only extern choices)
 max_autotune_allow_flexible_layouts: bool = False
 
+# Whether template autotuning should defer layout freezing until scheduling time for inputs,
+# prioritizing other fusions over choosing the template case. If inputs have a different layout
+# than what was autotuned due to some other fusion, then default to aten.
+max_autotune_defer_layout_freezing: bool = (
+    os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_DEFER_LAYOUT_FREEZING", "0") == "1"
+)
+
 # force cublas and triton to use the same precision; cublas supports TF32 for matmul operations
 # when m, n, k are multiples of 16, 16, 8, whereas triton supports TF32 for matmul operations
 # for any combinations of m, n, k, regardless of their alignment. setting this flag will ensure

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1581,7 +1581,10 @@ class TritonTemplateKernel(TritonKernel):
         node_name = node.get_name()
 
         if isinstance(layout, ir.FlexibleLayout):
-            if not use_aten_gemm_kernels():
+            if (
+                not use_aten_gemm_kernels()
+                or not config.max_autotune_defer_layout_freezing
+            ):
                 # No ExternKernel fallback available, freeze immediately
                 node.data.freeze_layout()
             else:


### PR DESCRIPTION
Differential Revision: D93739259

Layout constraints currently fails an internal regional inductor case. Disabling it by default now, as we know there are performance improvements that are gained with turning it on.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo