### PR TITLE
[MPS] Fix lu_solve for broadcasted bias

### DIFF
--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -921,11 +921,6 @@ if torch.backends.mps.is_available():
             "grid_sampler_3d": None,
             "igamma": None,  # currently not supported for any device
             "igammac": None,  # currently not supported for any device
-            "linalg.solve": [torch.float16, torch.float32],  # missing `aten::lu_solve`.
-            "linalg.solve_ex": [
-                torch.float16,
-                torch.float32,
-            ],  # missing `aten::lu_solve`.
             "aminmax": [torch.float32, torch.float16],
             "special.i1": [torch.float16],  # "i1_backward" not implemented for 'Half'
             "special.i1e": [torch.float16],  # "i1e_backward" not implemented for 'Half'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #175332

Which fixes the broadcasting logic in the backward, i.e. before this change `torch.linalg.solve(torch.randn(2, 2, 5, 5, device='mps', requires_grad=True), torch.randn(2, 2, 5, device='mps', requires_grad=True)).sum().backward()` failed with `linalg.lu_solve: Incompatible shapes of A and B for the equation AX = B (5x5 and 2x5)`

And also gets rid of the warning on the forward path, i.e. before this change calling the same resulted in 
```
UserWarning: An output with one or more elements was resized since it had shape [2, 2, 5, 5], which does not match the required output shape [4, 5, 5]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0).
```