### PR TITLE
Lazy stack trace summary in TracerBase.create_node

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -99,6 +99,7 @@ from torch.fx.experimental.symbolic_shapes import (
     ShapeEnv,
 )
 from torch.fx.graph import _PyTreeInfo
+from torch.fx.node import _LazyStackTrace
 from torch.utils._pytree import TreeSpec
 from torch.utils._sympy.value_ranges import ValueRangeError
 
@@ -1237,7 +1238,10 @@ def _verify_stack_trace(graph_module: torch.fx.GraphModule) -> None:
         for node in graph_module.graph.nodes:
             stack_trace = node.meta.get("stack_trace", None)
             if node.op in ["call_function", "get_attr"]:
-                if not (stack_trace is None or isinstance(stack_trace, str)):
+                if not (
+                    stack_trace is None
+                    or isinstance(stack_trace, (str, _LazyStackTrace))
+                ):
                     raise SpecViolationError(
                         f"Node {node} of type {node.op} has invalid stack_trace metadata, "
                         f"expected a string or None but instead found: {stack_trace}"

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -53,9 +53,9 @@ Target: TypeAlias = Union[Callable[..., Any], str]
 class _LazyStackTrace:
     """Deferred stack trace that avoids expensive symbolization until accessed.
 
-    During tracing, we capture a raw CapturedTraceback (fast C++ address capture)
-    and a filter function, but defer the expensive symbolize_tracebacks() call
-    and string formatting until node.stack_trace is actually read.
+    Stores a raw CapturedTraceback and a filter function, but defers the
+    expensive symbolize_tracebacks() call and string formatting until
+    node.stack_trace is actually read.
     """
 
     __slots__ = ["_captured_tb", "_filter_fn", "_resolved"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175334
* #174654

During tracing, CapturedTraceback.summary() was called eagerly on every
node creation in TracerBase.create_node(). Profiling showed this accounted
for ~10% of total tracing time:
- symbolize_tracebacks (C++ symbol resolution): ~9.87%
- _extract_symbolized_tb (FrameSummary + linecache I/O): ~7.65%

This diff introduces _LazyStackTrace, which stores the raw
CapturedTraceback and defers the expensive symbolization + formatting
until node.stack_trace is actually accessed. Since stack traces are
rarely read during tracing itself, this effectively eliminates the
overhead.

Changes:
- Add _LazyStackTrace class in torch/fx/node.py
- Modify TracerBase.create_node() to store _LazyStackTrace instead of
  eagerly symbolizing
- Update Node.stack_trace property getter to resolve and cache on first
  access
- Update _verify_stack_trace validation to accept _LazyStackTrace

Saves 10s internal mode
<img width="343" height="57" alt="Screenshot 2026-02-19 at 6 33 46 AM" src="https://github.com/user-attachments/assets/46d97f05-da96-4714-804c-931dc2344b50" />
