### PR TITLE
[inductor] Fix shape display for extern/template/nop nodes in graph_diagram SVG

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -91,6 +91,16 @@ def draw_buffers(
                 group = (group[1],)
             else:
                 group = group[1]
+        elif isinstance(group, str):
+            # extern / template / nop nodes store a string like "extern"
+            # as the group instead of a shape tuple.  Extract the real
+            # output shape from the scheduler node's first output buffer.
+            try:
+                snode = node.meta["fusion_meta"].snode
+                size = snode.get_outputs()[0].node.maybe_get_size()
+                group = tuple(size) if size else ()
+            except Exception:
+                group = ()
 
         # gather meta data
         dtype = None


### PR DESCRIPTION
Summary:
Bug: In draw_buffers(), extern/template/nop scheduler nodes store a string like "extern" as their group value. This string was passed directly as the shape argument to TensorMetadata. Since strings are iterable, it got unpacked character-by-character: ('e', 'x', 't', 'e', 'r', 'n').

Fix: When group is a string, extract the actual output shape from the scheduler node's first output buffer via snode.get_outputs()[0].node.maybe_get_size(), which returns the real tensor dimensions like (8, 128).

Differential Revision: D93744704




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo