### PR TITLE
[c10] Fix missing symbol exports for ValueError/NotImplementedError on Windows

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -237,7 +237,9 @@ struct C10_API WarnAlways {
 // Like Error, but we always report the C++ backtrace, instead of only
 // reporting when TORCH_SHOW_CPP_STACKTRACES
 class C10_API ErrorAlwaysShowCppStacktrace : public Error {
+ public:
   using Error::Error;
+  ErrorAlwaysShowCppStacktrace(SourceLocation source_location, std::string msg);
   const char* what_without_backtrace() const noexcept override {
     return what();
   }
@@ -247,13 +249,15 @@ class C10_API ErrorAlwaysShowCppStacktrace : public Error {
 // lazily inside a kernel (See: advanced indexing).  These turn into
 // IndexError when they cross to Python.
 class C10_API IndexError : public Error {
+ public:
   using Error::Error;
+  IndexError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for invalid values.  These turn into
 // ValueError when they cross to Python.
 class C10_API ValueError : public Error {
-public:
+ public:
   using Error::Error;
   ValueError(SourceLocation source_location, std::string msg);
 };
@@ -261,50 +265,64 @@ public:
 // Used in ATen for invalid types.  These turn into
 // TypeError when they cross to Python.
 class C10_API TypeError : public Error {
+ public:
   using Error::Error;
+  TypeError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for functionality that is not implemented.  These turn into
 // NotImplementedError when they cross to Python.
 class C10_API NotImplementedError : public Error {
-  public:
-    using Error::Error;
-    NotImplementedError(SourceLocation source_location, std::string msg);
+ public:
+  using Error::Error;
+  NotImplementedError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for buffer-related errors, e.g. trying to create a DLPack of
 // an unsupported device.  These turn into BufferError when they cross to
 // Python.
 class C10_API BufferError : public Error {
+ public:
   using Error::Error;
+  BufferError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for non finite indices.  These turn into
 // ExitException when they cross to Python.
 class C10_API EnforceFiniteError : public Error {
+ public:
   using Error::Error;
+  EnforceFiniteError(SourceLocation source_location, std::string msg);
 };
 
 // Used in Onnxifi backend lowering.  These turn into
 // ExitException when they cross to Python.
 class C10_API OnnxfiBackendSystemError : public Error {
+ public:
   using Error::Error;
+  OnnxfiBackendSystemError(SourceLocation source_location, std::string msg);
 };
 
 // Used for numerical errors from the linalg module. These
 // turn into LinAlgError when they cross into Python.
 class C10_API LinAlgError : public Error {
+ public:
   using Error::Error;
+  LinAlgError(SourceLocation source_location, std::string msg);
 };
 
 class C10_API OutOfMemoryError : public Error {
+ public:
   using Error::Error;
+  OutOfMemoryError(SourceLocation source_location, std::string msg);
 };
 
 // Used for handling syntactic errors in input arguments.
 // These turn into SyntaxError when the cross into Python.
 class C10_API SyntaxError : public Error {
+ public:
   using Error::Error;
+  SyntaxError(SourceLocation source_location, std::string msg);
 };
 
 // Raised when accelerator API call hits an error.
@@ -323,31 +341,41 @@ class C10_API AcceleratorError : public Error {
 // Base error type for all distributed errors.
 // These turn into DistError when they cross into Python.
 class C10_API DistError : public Error {
+ public:
   using Error::Error;
+  DistError(SourceLocation source_location, std::string msg);
 };
 
 // Used for collective communication library errors from the distributed module.
 // These turn into DistBackendError when they cross into Python.
 class C10_API DistBackendError : public DistError {
+ public:
   using DistError::DistError;
+  DistBackendError(SourceLocation source_location, std::string msg);
 };
 
 // Used for errors originating from the store.
 // These turn into DistStoreError when they cross into Python.
 class C10_API DistStoreError : public DistError {
+ public:
   using DistError::DistError;
+  DistStoreError(SourceLocation source_location, std::string msg);
 };
 
 // Used for errors originating from the TCP/IP stack and not from collective
 // libraries. These turn into DistNetworkError when they cross into Python.
 class C10_API DistNetworkError : public DistError {
+ public:
   using DistError::DistError;
+  DistNetworkError(SourceLocation source_location, std::string msg);
 };
 
 // Raised when a queue is empty and a non-blocking pop is called.
 // Translated to torch.distributed.QueueEmptyError in Python
 class C10_API DistQueueEmptyError : public DistStoreError {
+ public:
   using DistStoreError::DistStoreError;
+  DistQueueEmptyError(SourceLocation source_location, std::string msg);
 };
 
 // A utility function to return an exception std::string by prepending its

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -253,7 +253,9 @@ class C10_API IndexError : public Error {
 // Used in ATen for invalid values.  These turn into
 // ValueError when they cross to Python.
 class C10_API ValueError : public Error {
+public:
   using Error::Error;
+  ValueError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for invalid types.  These turn into
@@ -265,7 +267,9 @@ class C10_API TypeError : public Error {
 // Used in ATen for functionality that is not implemented.  These turn into
 // NotImplementedError when they cross to Python.
 class C10_API NotImplementedError : public Error {
-  using Error::Error;
+  public:
+    using Error::Error;
+    NotImplementedError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for buffer-related errors, e.g. trying to create a DLPack of

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -114,11 +114,63 @@ Error::Error(SourceLocation source_location, std::string msg)
           std::move(msg),
           std::make_shared<PyTorchStyleBacktrace>(source_location)) {}
 
+// Explicit constructor definitions for Error subclasses. Required because
+// clang-cl does not emit dllexport symbols for constructors inherited via
+// `using Base::Base;` (llvm/llvm-project#162640), which causes LNK2019 in
+// any DLL that links against c10 from outside (torch_hip.dll, inline C++
+// extensions, etc.). Each definition just delegates to the base class
+// constructor so behavior is unchanged.
+ErrorAlwaysShowCppStacktrace::ErrorAlwaysShowCppStacktrace(
+    SourceLocation loc,
+    std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+IndexError::IndexError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
 ValueError::ValueError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+TypeError::TypeError(SourceLocation loc, std::string msg)
     : Error(loc, std::move(msg)) {}
 
 NotImplementedError::NotImplementedError(SourceLocation loc, std::string msg)
     : Error(loc, std::move(msg)) {}
+
+BufferError::BufferError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+EnforceFiniteError::EnforceFiniteError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+OnnxfiBackendSystemError::OnnxfiBackendSystemError(
+    SourceLocation loc,
+    std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+LinAlgError::LinAlgError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+OutOfMemoryError::OutOfMemoryError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+SyntaxError::SyntaxError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+DistError::DistError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+DistBackendError::DistBackendError(SourceLocation loc, std::string msg)
+    : DistError(loc, std::move(msg)) {}
+
+DistStoreError::DistStoreError(SourceLocation loc, std::string msg)
+    : DistError(loc, std::move(msg)) {}
+
+DistNetworkError::DistNetworkError(SourceLocation loc, std::string msg)
+    : DistError(loc, std::move(msg)) {}
+
+DistQueueEmptyError::DistQueueEmptyError(SourceLocation loc, std::string msg)
+    : DistStoreError(loc, std::move(msg)) {}
 
 using APIUsageLoggerType = std::function<void(const std::string&)>;
 using APIUsageMetadataLoggerType = std::function<void(

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -515,7 +515,7 @@ MessageLogger::MessageLogger(
   time(&rawtime);
 
 #ifndef _WIN32
-  struct tm raw_timeinfo = {0};
+  struct tm raw_timeinfo = {};
   struct tm* timeinfo = &raw_timeinfo;
   localtime_r(&rawtime, timeinfo);
 #else
@@ -525,7 +525,7 @@ MessageLogger::MessageLogger(
 
 #ifndef _WIN32
   // Get the current nanoseconds since epoch
-  struct timespec ts = {0};
+  struct timespec ts = {};
   clock_gettime(CLOCK_MONOTONIC, &ts);
   long ns = ts.tv_nsec;
 #else
@@ -613,10 +613,8 @@ void setLogLevelFlagFromEnv() {
     return;
   }
 
-  std::transform(
-      level.begin(), level.end(), level.begin(), [](unsigned char c) {
-        return toupper(c);
-      });
+  std::ranges::transform(
+      level, level.begin(), [](unsigned char c) { return toupper(c); });
 
   if (level == "0" || level == "INFO") {
     FLAGS_caffe2_log_level = 0;

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -114,6 +114,12 @@ Error::Error(SourceLocation source_location, std::string msg)
           std::move(msg),
           std::make_shared<PyTorchStyleBacktrace>(source_location)) {}
 
+ValueError::ValueError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
+NotImplementedError::NotImplementedError(SourceLocation loc, std::string msg)
+    : Error(loc, std::move(msg)) {}
+
 using APIUsageLoggerType = std::function<void(const std::string&)>;
 using APIUsageMetadataLoggerType = std::function<void(
     const std::string&,


### PR DESCRIPTION
## Summary

On Windows, when PyTorch is built with `clang-cl`, the constructors of `c10::Error` subclasses declared via `using Error::Error;` (and similar `using Base::Base;` patterns) are not emitted into `c10.dll`'s export table. This is an instance of the upstream clang-cl bug llvm/llvm-project#162640 — clang-cl does not emit `dllexport` symbols for inherited constructors, while MSVC does.

Any DLL or extension that dynamically links against `c10` and constructs one of these errors (directly, or via macros like `TORCH_CHECK_VALUE` / `TORCH_CHECK_NOT_IMPLEMENTED`) fails to link with:

```
error LNK2019: unresolved external symbol
  __declspec(dllimport) public: __cdecl c10::ValueError::ValueError(
      struct c10::SourceLocation,
      class std::basic_string<...>)
```

The two symbols observed today are `c10::ValueError::ValueError` (referenced from `c10::ivalue::Future::ensureIsSubsetOfDevices`) and `c10::NotImplementedError::NotImplementedError` (referenced from `torch::dynamo::autograd::CompiledNodeArgs::collect`), but every other `Error` subclass with inherited constructors is latently broken the same way.

Fixes #181892.

## Fix

Add an explicit `(SourceLocation, std::string)` constructor declaration in `c10/util/Exception.h` and a matching definition in `c10/util/Logging.cpp` for every `Error` subclass that uses the `using Base::Base;` pattern:

- Direct subclasses of `Error`: `ErrorAlwaysShowCppStacktrace`, `IndexError`, `ValueError`, `TypeError`, `NotImplementedError`, `BufferError`, `EnforceFiniteError`, `OnnxfiBackendSystemError`, `LinAlgError`, `OutOfMemoryError`, `SyntaxError`, `DistError`
- `DistError` subclasses: `DistBackendError`, `DistStoreError`, `DistNetworkError`
- `DistStoreError` subclass: `DistQueueEmptyError`

`AcceleratorError` already declares an explicit constructor and is unchanged. Each new constructor just delegates to the base-class constructor, so there is no behavior change on any platform — it simply forces the compiler to emit an exported symbol.

## How to reproduce

On Windows with PyTorch built using clang-cl (e.g. ROCm/HIP via TheRock):

`python test/test_autograd.py TestAutograd.test_multi_grad_all_hooks`

The test JIT-builds an inline C++ extension that links against `c10.lib` / `torch_cpu.lib`. Without this fix the link fails with LNK2019 on the constructors above.

## Test Plan

`python test_autograd.py TestAutograd.test_multi_grad_all_hooks` passes on Windows.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv