### PR TITLE
[inductor][BE] Fix test_triton_kernel_clone_wekdeps test pollution

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -329,6 +329,7 @@ def forward(self, x_1, output_1):
         from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
         from torch._inductor.choices import InductorChoices
         from torch._inductor.compile_fx import compile_fx_inner
+        from torch._inductor.virtualized import V
         from torch.fx.experimental.proxy_tensor import make_fx
 
         TENSOR_SIZE = 30_000_000
@@ -392,7 +393,7 @@ def forward(self, x_1, output_1):
 
         gm = make_fx(f, tracing_mode="fake")(t)
 
-        with inductor_config.patch({"inductor_choices_class": NoFusionChoices}):
+        with V.set_choices_handler(NoFusionChoices()):
             log_stream, ctx = logs_to_string("torch._inductor.codecache", "output_code")
             with ctx():
                 compiled_gm = compile_fx_inner(gm, [t])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175342
* #175341

Summary: The test failed when running test_triton_kernels.py as a whole, but succeeded when running individually.

The test used inductor_config.patch({"inductor_choices_class": NoFusionChoices}) to disable scheduler fusion, but V.choices is lazily initialized and cached on thread-local storage. When running all tests in test_triton_kernels.py, a prior test triggers torch.compile first, the default InductorChoices gets cached, and the config patch has no effect since _choices_default() is never called again.

Fixed by using V.set_choices_handler(NoFusionChoices()) instead.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo