### PR TITLE
[dynamo] Remove IncorrectUsage exception, replace with RuntimeError

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -251,7 +251,7 @@ class DecoratorTests(PytreeRegisteringTestCase):
         self.assertEqual(cnts.frame_count, 3)
 
     def test_incorrect_usage_disallow_in_graph(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "disallow_in_graph is expected"):
 
             @torch._dynamo.disallow_in_graph
             def fn1(x):

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -10,7 +10,7 @@ import torch
 import torch._dynamo.config as config
 import torch._dynamo.testing
 from torch._dynamo.decorators import leaf_function
-from torch._dynamo.exc import IncorrectUsage, Unsupported
+from torch._dynamo.exc import Unsupported
 from torch._dynamo.testing import normalize_gm
 from torch._dynamo.utils import counters
 from torch.testing._internal.common_utils import (
@@ -251,7 +251,7 @@ class DecoratorTests(PytreeRegisteringTestCase):
         self.assertEqual(cnts.frame_count, 3)
 
     def test_incorrect_usage_disallow_in_graph(self):
-        with self.assertRaises(IncorrectUsage):
+        with self.assertRaises(RuntimeError):
 
             @torch._dynamo.disallow_in_graph
             def fn1(x):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -28,7 +28,6 @@ from .eval_frame import (
     RunOnlyContext,
     skip_code,
 )
-from .exc import IncorrectUsage
 from .external_utils import (
     get_nonrecursive_disable_wrapper,
     wrap_dunder_call_ctx_manager,
@@ -674,7 +673,7 @@ def _disallow_in_graph_helper(throw_if_not_allowed: bool) -> Callable[..., Any]:
             != variables.TorchInGraphFunctionVariable
             and trace_rules.lookup(fn) != variables.TorchInGraphFunctionVariable
         ):
-            raise IncorrectUsage(
+            raise RuntimeError(
                 "disallow_in_graph is expected to be used on an already allowed callable (like torch.* ops). "
                 "Allowed callables means callables that TorchDynamo puts as-is in the extracted graph."
             )

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -309,8 +309,6 @@ class UncapturedHigherOrderOpError(TorchDynamoException):
         )
 
 
-class IncorrectUsage(Exception):
-    pass
 
 
 # TODO: I'm a little uncertain about what error classification we should have

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -309,8 +309,6 @@ class UncapturedHigherOrderOpError(TorchDynamoException):
         )
 
 
-
-
 # TODO: I'm a little uncertain about what error classification we should have
 # for this.  This is potentially a user error, but regressions in
 # specialization in PyTorch proper could also trigger this problem


### PR DESCRIPTION
## Summary
Removes the `IncorrectUsage` exception class and replaces its usage with `RuntimeError`.

`IncorrectUsage` was only used in one place — `disallow_in_graph` in `decorators.py` — to signal that the user called `disallow_in_graph` on a callable that wasn't already allowed. This is a straightforward user programming error, so `RuntimeError` is the appropriate replacement.

## Changes
- **`torch/_dynamo/exc.py`**: Removed the `IncorrectUsage` class definition
- **`torch/_dynamo/decorators.py`**: Replaced `raise IncorrectUsage(...)` with `raise RuntimeError(...)`, removed the import
- **`test/dynamo/test_decorators.py`**: Updated test to expect `RuntimeError` instead of `IncorrectUsage`, removed the import

Fixes #167142

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @jansel