### PR TITLE
[BE] Disable OpenMPOptCGSCCPass for generated autograd files

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -826,7 +826,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND NOT USE_IOS AND NOT USE_COREML
   endif()
   get_target_property(TORCH_CPU_SOURCES torch_cpu SOURCES)
   foreach(generated_file IN LISTS GENERATED_CXX_TORCH)
-    set_source_files_properties(${generated_file} PROPERTIES COMPILE_OPTIONS "-Wno-missing-prototypes;-Wno-error=missing-prototypes")
+    set_source_files_properties(${generated_file} PROPERTIES COMPILE_OPTIONS "-Wno-missing-prototypes;-Wno-error=missing-prototypes;-mllvm;-openmp-opt-disable")
   endforeach()
   foreach(source_file IN LISTS TORCH_CPU_SOURCES)
     get_filename_component(source_file "${source_file}" REALPATH)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #175346

On Apple M4 using clang 17, the LLVM OpenMPOptCGSCCPass takes ~220 seconds per generated file (TraceType, ADInplaceOrViewType) despite them containing no OpenMP code. This is a known upstream LLVM issue (llvm/llvm-project#56241) affecting Clang 14+ when compiling large translation units with `-fopenmp`.

Above analysis was done by Claude using insights from https://github.com/pytorch/pytorch/pull/114438  which used `-ftime-report` to identify a similar pathological optimizer pass on generated code.


Fixed by adding `-mllvm -openmp-opt-disable` to GENERATED_CXX_TORCH compile options when clang compiler is used, reducing compile time from ~240s to ~18s per file.



Fixes https://github.com/pytorch/pytorch/issues/163853

Co-authored-by: Claude <noreply@anthropic.com>