### PR TITLE
Disable einops 0.8.2 check on PyTorch

### DIFF
--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -11,6 +11,7 @@ from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    xfailIf,
 )
 
 
@@ -190,7 +191,7 @@ print(normalize_gm(graph.print_readable(print_output=False)))
             else:
                 self.assertIn(einops_method, output)
 
-    @unittest.expectedFailure
+    @xfailIf(einops_version == "0.8.2")
     @parametrize(
         "method",
         ["reduce", "repeat", "pack", "unpack", "einsum", "rearrange"],

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import unittest
+import warnings
 
 import torch
 from torch import nn
@@ -222,6 +223,15 @@ print(normalize_gm(graph.print_readable(print_output=False)))
         else:
             self.fail(method)
         self._run_in_subprocess(flag, method, einops_method, snippet)
+
+    def test_no_warning(self):
+        # checks that this doesn't produce any warnings
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            return einops.rearrange(x, '... -> (...)')
+
+        x = torch.randn(5)
+        self.assertNotWarn(lambda: fn(x))
 
 
 instantiate_parametrized_tests(

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -190,6 +190,7 @@ print(normalize_gm(graph.print_readable(print_output=False)))
             else:
                 self.assertIn(einops_method, output)
 
+    @unittest.expectedFailure
     @parametrize(
         "method",
         ["reduce", "repeat", "pack", "unpack", "einsum", "rearrange"],

--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 import unittest
-import warnings
 
 import torch
 from torch import nn
@@ -228,7 +227,7 @@ print(normalize_gm(graph.print_readable(print_output=False)))
         # checks that this doesn't produce any warnings
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
-            return einops.rearrange(x, '... -> (...)')
+            return einops.rearrange(x, "... -> (...)")
 
         x = torch.randn(5)
         self.assertNotWarn(lambda: fn(x))

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1277,7 +1277,6 @@ def _allow_in_graph_einops() -> None:
     #         # trigger backend registration up front to avoid a later guard failure
     #         # that would otherwise cause a recompilation
     #         einops.rearrange(torch.randn(1), "i -> i")
-
     #     # einops 0.8.2+ don't need explicit allow_in_graph calls
     #     return
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1270,14 +1270,16 @@ def mark_static_address(t: Any, guard: bool = False) -> None:
 def _allow_in_graph_einops() -> None:
     import einops
 
-    if einops.__version__ >= "0.8.2":
-        if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
-            # trigger backend registration up front to avoid a later guard failure
-            # that would otherwise cause a recompilation
-            einops.rearrange(torch.randn(1), "i -> i")
+    # There is a lru_cache logspam issue with einops when allow_in_graph is not
+    # used. Disabling this for now until the lru_cache issue is resolved.
+    # if einops.__version__ >= "0.8.2":
+    #     if hasattr(einops, "einops") and hasattr(einops.einops, "get_backend"):
+    #         # trigger backend registration up front to avoid a later guard failure
+    #         # that would otherwise cause a recompilation
+    #         einops.rearrange(torch.randn(1), "i -> i")
 
-        # einops 0.8.2+ don't need explicit allow_in_graph calls
-        return
+    #     # einops 0.8.2+ don't need explicit allow_in_graph calls
+    #     return
 
     try:
         # requires einops > 0.6.1, torch >= 2.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #175351

Partially revert #173611 and fallback to the previous behavior on einops, which uses `allow_in_graph`.

**Context**

* Dynamo does not trace into `@lru_cache` and warns on any usage.
* einops uses `@lru_cache` as part of `_prepare_transformation_recipe`.
* Every einops op goes through this function.
* Dynamo warns on every einops op trace and this creates a logspam
  problem.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo