### PR TITLE
Enabled R2/S3 dual upload for torch nightly packages

### DIFF
--- a/.circleci/scripts/binary_upload.sh
+++ b/.circleci/scripts/binary_upload.sh
@@ -92,7 +92,7 @@ r2_upload() {
         AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
         AWS_SESSION_TOKEN="" \
         AWS_DEFAULT_REGION="auto" \
-        aws s3 cp --no-progress "${pkg}" "${r2_upload_dir}" \
+        ${AWS_S3_CP} --no-progress "${pkg}" "${r2_upload_dir}" \
           --metadata "checksum-sha256=${shm_id}" \
           --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
       )

--- a/.circleci/scripts/binary_upload.sh
+++ b/.circleci/scripts/binary_upload.sh
@@ -62,17 +62,61 @@ s3_upload() {
   )
 }
 
+R2_UPLOAD=${R2_UPLOAD:-}
+R2_BUCKET="s3://pytorch-downloads"
+R2_ACCOUNT_ID=${R2_ACCOUNT_ID:-}
+R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID:-}
+R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY:-}
+
+r2_upload() {
+  if [[ -z "${R2_ACCOUNT_ID}" || -z "${R2_ACCESS_KEY_ID}" || -z "${R2_SECRET_ACCESS_KEY}" ]]; then
+    echo "WARNING: R2 credentials not configured, skipping R2 upload"
+    return
+  fi
+  local extension
+  local pkg_type
+  extension="$1"
+  pkg_type="$2"
+  r2_root_dir="${R2_BUCKET}/${pkg_type}/${UPLOAD_CHANNEL}"
+  if [[ -z ${UPLOAD_SUBFOLDER:-} ]]; then
+    r2_upload_dir="${r2_root_dir}/"
+  else
+    r2_upload_dir="${r2_root_dir}/${UPLOAD_SUBFOLDER}/"
+  fi
+  (
+    for pkg in ${PKG_DIR}/*.${extension}; do
+      (
+        set -x
+        shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
+        AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+        AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+        AWS_SESSION_TOKEN="" \
+        AWS_DEFAULT_REGION="auto" \
+        aws s3 cp --no-progress "${pkg}" "${r2_upload_dir}" \
+          --metadata "checksum-sha256=${shm_id}" \
+          --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+      )
+    done
+  )
+}
+
 # Install dependencies (should be a no-op if previously installed)
 pip install -q awscli uv
 
 case "${PACKAGE_TYPE}" in
   libtorch)
     s3_upload "zip" "libtorch"
+    if [[ "${R2_UPLOAD}" == "true" ]]; then
+      r2_upload "zip" "libtorch"
+    fi
     BACKUP_DIR="libtorch/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
     ;;
   # wheel can either refer to wheel/manywheel
   *wheel)
     s3_upload "whl" "whl"
+    if [[ "${R2_UPLOAD}" == "true" ]]; then
+      r2_upload "whl" "whl"
+    fi
     BACKUP_DIR="whl/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
     ;;
   *)

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -59,6 +59,7 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-22.04
+    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/nightly') && 'pytorchbot-env' || '' }}
     container:
       image: continuumio/miniconda3:4.12.0
     env:
@@ -133,3 +134,70 @@ jobs:
         run: |
             set -ex
             bash .circleci/scripts/binary_upload.sh
+
+      - name: Check if R2 upload is enabled
+        id: check-r2
+        if: steps.download-artifacts.outcome == 'success'
+        shell: bash
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          R2_UPLOAD="false"
+          if [[ -n "${R2_ACCOUNT_ID}" && -n "${R2_ACCESS_KEY_ID}" && -n "${R2_SECRET_ACCESS_KEY}" ]]; then
+            R2_UPLOAD="true"
+          fi
+          echo "r2_upload=${R2_UPLOAD}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure R2 credentials
+        if: ${{ steps.check-r2.outputs.r2_upload == 'true' && github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' }}
+        shell: bash
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          {
+            echo "AWS_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}"
+            echo "AWS_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}"
+            echo "AWS_SESSION_TOKEN="
+            echo "AWS_DEFAULT_REGION=auto"
+            echo "R2_ACCOUNT_ID=${R2_ACCOUNT_ID}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Upload package to R2
+        if: ${{ steps.check-r2.outputs.r2_upload == 'true' && github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' }}
+        shell: bash
+        env:
+          PKG_DIR: "${{ runner.temp }}/artifacts"
+          UPLOAD_SUBFOLDER: "${{ env.DESIRED_CUDA }}"
+          BUILD_NAME: ${{ inputs.build_name }}
+        run: |
+          set -ex
+          pip install -q awscli
+          UPLOAD_BUCKET="s3://pytorch-downloads"
+          PACKAGE_TYPE="${PACKAGE_TYPE:-wheel}"
+          case "${PACKAGE_TYPE}" in
+            libtorch)
+              PKG_TYPE="libtorch"
+              EXTENSION="zip"
+              ;;
+            *wheel)
+              PKG_TYPE="whl"
+              EXTENSION="whl"
+              ;;
+          esac
+          UPLOAD_DIR="${UPLOAD_BUCKET}/${PKG_TYPE}/nightly"
+          if [[ -n "${UPLOAD_SUBFOLDER}" ]]; then
+            UPLOAD_DIR="${UPLOAD_DIR}/${UPLOAD_SUBFOLDER}"
+          fi
+          if [[ "${BUILD_NAME}" == *-full* ]]; then
+            UPLOAD_DIR="${UPLOAD_DIR}_full"
+          fi
+          for pkg in ${PKG_DIR}/*.${EXTENSION}; do
+            shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
+            aws s3 cp "${pkg}" "${UPLOAD_DIR}/" \
+              --metadata "checksum-sha256=${shm_id}" \
+              --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          done

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -68,7 +68,7 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-22.04
-    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/nightly') && 'pytorchbot-env' || '' }}
+    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/nightly') && 'nightly-wheel-upload' || '' }}
     container:
       image: continuumio/miniconda3:4.12.0
     env:

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -55,6 +55,15 @@ on:
       github-token:
         required: true
         description: Github Token
+      R2_ACCOUNT_ID:
+        required: false
+        description: Cloudflare R2 account ID for nightly uploads
+      R2_ACCESS_KEY_ID:
+        required: false
+        description: Cloudflare R2 access key ID for nightly uploads
+      R2_SECRET_ACCESS_KEY:
+        required: false
+        description: Cloudflare R2 secret access key for nightly uploads
 
 jobs:
   upload:
@@ -131,73 +140,10 @@ jobs:
           PKG_DIR: "${{ runner.temp }}/artifacts"
           UPLOAD_SUBFOLDER: "${{ env.DESIRED_CUDA }}"
           BUILD_NAME: ${{ inputs.build_name }}
+          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/nightly') && 'true' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
             set -ex
             bash .circleci/scripts/binary_upload.sh
-
-      - name: Check if R2 upload is enabled
-        id: check-r2
-        if: steps.download-artifacts.outcome == 'success'
-        shell: bash
-        env:
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        run: |
-          R2_UPLOAD="false"
-          if [[ -n "${R2_ACCOUNT_ID}" && -n "${R2_ACCESS_KEY_ID}" && -n "${R2_SECRET_ACCESS_KEY}" ]]; then
-            R2_UPLOAD="true"
-          fi
-          echo "r2_upload=${R2_UPLOAD}" >> "$GITHUB_OUTPUT"
-
-      - name: Configure R2 credentials
-        if: ${{ steps.check-r2.outputs.r2_upload == 'true' && github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' }}
-        shell: bash
-        env:
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        run: |
-          {
-            echo "AWS_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}"
-            echo "AWS_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}"
-            echo "AWS_SESSION_TOKEN="
-            echo "AWS_DEFAULT_REGION=auto"
-            echo "R2_ACCOUNT_ID=${R2_ACCOUNT_ID}"
-          } >> "${GITHUB_ENV}"
-
-      - name: Upload package to R2
-        if: ${{ steps.check-r2.outputs.r2_upload == 'true' && github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' }}
-        shell: bash
-        env:
-          PKG_DIR: "${{ runner.temp }}/artifacts"
-          UPLOAD_SUBFOLDER: "${{ env.DESIRED_CUDA }}"
-          BUILD_NAME: ${{ inputs.build_name }}
-        run: |
-          set -ex
-          pip install -q awscli
-          UPLOAD_BUCKET="s3://pytorch-downloads"
-          PACKAGE_TYPE="${PACKAGE_TYPE:-wheel}"
-          case "${PACKAGE_TYPE}" in
-            libtorch)
-              PKG_TYPE="libtorch"
-              EXTENSION="zip"
-              ;;
-            *wheel)
-              PKG_TYPE="whl"
-              EXTENSION="whl"
-              ;;
-          esac
-          UPLOAD_DIR="${UPLOAD_BUCKET}/${PKG_TYPE}/nightly"
-          if [[ -n "${UPLOAD_SUBFOLDER}" ]]; then
-            UPLOAD_DIR="${UPLOAD_DIR}/${UPLOAD_SUBFOLDER}"
-          fi
-          if [[ "${BUILD_NAME}" == *-full* ]]; then
-            UPLOAD_DIR="${UPLOAD_DIR}_full"
-          fi
-          for pkg in ${PKG_DIR}/*.${EXTENSION}; do
-            shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
-            aws s3 cp "${pkg}" "${UPLOAD_DIR}/" \
-              --metadata "checksum-sha256=${shm_id}" \
-              --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          done

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -332,6 +332,10 @@ jobs:
           # to nightly or test
           UPLOAD_SUBFOLDER: ""
           PKG_DIR: ${{ runner.temp }}/artifacts
+          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -246,6 +246,10 @@ jobs:
           PACKAGE_TYPE: wheel
           UPLOAD_SUBFOLDER: ${{ env.BUILD_DEVICE }}
           PKG_DIR: ${{ runner.temp }}/artifacts
+          R2_UPLOAD: ${{ ((github.event_name == 'push' && github.event.ref == 'refs/heads/main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'true' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           set -ex


### PR DESCRIPTION
Similar to:
vision: https://github.com/pytorch/vision/pull/9393
audio: https://github.com/pytorch/audio/pull/4179

TLDR. Reason for using dual upload:

[Sippy](https://developers.cloudflare.com/r2/data-migration/sippy/) on demand Cloudflare migration is enabled on our R2 account.
I do see we are running installs from R2 successfully :[ https://github.com/meta-pytorch/torchcomms/actions/runs/21960287284/job/63435607477#step:12:53](https://github.com/meta-pytorch/torchcomms/actions/runs/21960287284/job/63435607477#step:12:53)

Log:
Collecting torch
  Downloading[ https://download-r2.pytorch.org/whl/nightly/cu129/torch-2.11.0.dev20260212%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl.metadata](https://download-r2.pytorch.org/whl/nightly/cu129/torch-2.11.0.dev20260212%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl.metadata) (29 kB)
Collecting filelock (from torch)

However when I naviagate to /whl/nightly/cu129 r2 folder in R2 account I don’t see any torch-2.11 files. Does it mean on every request files are being synced from AWS ? And hence either getting timeouts or 499 or 404 errors. From Sippy documentation once synced, files should be stored on our r2 folder.
Example of a failure: https://github.com/meta-pytorch/torchcomms/actions/runs/21960287284/job/63435607377
