### PR TITLE
Fix device count inconsistency in torch.cuda during lazy initialization

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1108,9 +1108,12 @@ def device_count() -> int:
         return 0
     if _cached_device_count is not None:
         return _cached_device_count
-    # bypass _device_count_nvml() if rocm (not supported)
-    nvml_count = _device_count_amdsmi() if torch.version.hip else _device_count_nvml()
-    r = torch._C._cuda_getDeviceCount() if nvml_count < 0 else nvml_count
+    if _initialized or hasattr(_tls, "is_initializing"):
+        r = torch._C._cuda_getDeviceCount()
+    else:
+        # bypass _device_count_nvml() if rocm (not supported)
+        nvml_count = _device_count_amdsmi() if torch.version.hip else _device_count_nvml()
+        r = torch._C._cuda_getDeviceCount() if nvml_count < 0 else nvml_count
     # NB: Do not cache the device count prior to CUDA initialization, because
     # the number of devices can change due to changes to CUDA_VISIBLE_DEVICES
     # setting prior to CUDA initialization.

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1112,7 +1112,10 @@ def device_count() -> int:
         r = torch._C._cuda_getDeviceCount()
     else:
         # bypass _device_count_nvml() if rocm (not supported)
-        nvml_count = _device_count_amdsmi() if torch.version.hip else _device_count_nvml()
+        if torch.version.hip:
+            nvml_count = _device_count_amdsmi()
+        else:
+            nvml_count = _device_count_nvml()
         r = torch._C._cuda_getDeviceCount() if nvml_count < 0 else nvml_count
     # NB: Do not cache the device count prior to CUDA initialization, because
     # the number of devices can change due to changes to CUDA_VISIBLE_DEVICES


### PR DESCRIPTION
This change prefers the CUDA Runtime's device count (tor`ch._C._cuda_getDeviceCount()`) if initialization has already started or is complete. This ensures that once the environment's usable GPUs are determined by the driver, PyTorch consistently uses that count for capability checks and other initialization tasks.