### PR TITLE
[Pallas] Fix argmax/argmin with keepdim on 3D+ tensors

### DIFF
--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -1092,6 +1092,28 @@ class PallasTestsMixin:
                 self.assertEqual(result, expected)
 
     @skip_if_cuda
+    def test_argmax_keepdim_3d(self):
+        """Test argmax with keepdim=True on 3D tensor.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/174719
+        The Pallas codegen previously produced incorrect reshape when reducing
+        argmax/argmin on a middle dimension of a 3D+ tensor.
+        """
+
+        for dim in [0, 1, 2]:
+
+            def fn(x, d=dim):
+                return x.max(dim=d, keepdim=True)
+
+            compiled = self._compile(fn)
+
+            x = torch.randint(0, 10, (4, 8, 16), device=self.DEVICE)
+            result_vals, result_idx = compiled(x)
+            expected_vals, expected_idx = fn(x)
+            self.assertEqual(result_vals, expected_vals)
+            self.assertEqual(result_idx, expected_idx)
+
+    @skip_if_cuda
     @skip_if_tpu
     def test_softmax_two_pass(self):
         """Test two-pass softmax (max reduction + sum reduction)."""

--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -1107,6 +1107,9 @@ class PallasTestsMixin:
                 result = compiled(x)
                 expected = fn(x)
                 self.assertEqual(result, expected)
+
+    @skip_if_cuda
+    @skip_if_tpu
     def test_softmax_two_pass(self):
         """Test two-pass softmax (max reduction + sum reduction)."""
 

--- a/test/inductor/test_pallas.py
+++ b/test/inductor/test_pallas.py
@@ -1092,29 +1092,21 @@ class PallasTestsMixin:
                 self.assertEqual(result, expected)
 
     @skip_if_cuda
-    def test_argmax_keepdim_3d(self):
-        """Test argmax with keepdim=True on 3D tensor.
+    def test_argmax_argmin_keepdim_3d(self):
+        """Test arg-reductions with keepdim=True on 3D tensor."""
 
-        Regression test for https://github.com/pytorch/pytorch/issues/174719
-        The Pallas codegen previously produced incorrect reshape when reducing
-        argmax/argmin on a middle dimension of a 3D+ tensor.
-        """
+        for reduction_op in (torch.argmax, torch.argmin):
+            for dim in [0, 1, 2]:
 
-        for dim in [0, 1, 2]:
+                def fn(x, op=reduction_op, d=dim):
+                    return op(x, dim=d, keepdim=True)
 
-            def fn(x, d=dim):
-                return x.max(dim=d, keepdim=True)
+                compiled = self._compile(fn)
 
-            compiled = self._compile(fn)
-
-            x = torch.randint(0, 10, (4, 8, 16), device=self.DEVICE)
-            result_vals, result_idx = compiled(x)
-            expected_vals, expected_idx = fn(x)
-            self.assertEqual(result_vals, expected_vals)
-            self.assertEqual(result_idx, expected_idx)
-
-    @skip_if_cuda
-    @skip_if_tpu
+                x = torch.randint(0, 10, (4, 8, 16), device=self.DEVICE)
+                result = compiled(x)
+                expected = fn(x)
+                self.assertEqual(result, expected)
     def test_softmax_two_pass(self):
         """Test two-pass softmax (max reduction + sum reduction)."""
 

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -2505,7 +2505,36 @@ class PallasKernel(SIMDKernel):
                 and reduction_numel
             )
             if is_partial_reduction and n_reduction_dims > 0:
-                reduction_expr = f"pallas_partial_reduce({reduction_op}, {value}, {pointwise_numel}, {reduction_numel})"
+                reduction_axis = None
+                if n_reduction_dims == 1 and self.load_index_exprs:
+                    load_index = next(iter(self.load_index_exprs.values()))
+                    # Sort loop vars by stride (outer to inner) and use the
+                    # reduction var position as axis when disambiguation is needed.
+                    var_strides = []
+                    for var, entry in self.range_tree_nodes.items():
+                        coeff = load_index.coeff(var)
+                        if coeff == 0:
+                            continue
+                        stride = self._safe_int(coeff)
+                        if stride is None:
+                            continue
+                        var_strides.append((var, abs(stride), entry.is_reduction))
+                    var_strides.sort(key=lambda x: -x[1])
+                    # Only disambiguate the axis for the simple 2D case
+                    # (one pointwise dim + one reduction dim). For 3D+ cases,
+                    # pallas_partial_reduce already handles reshaping/layout.
+                    if len(var_strides) == 2 and sum(v[2] for v in var_strides) == 1:
+                        for axis, (_, _, is_reduction) in enumerate(var_strides):
+                            if is_reduction:
+                                reduction_axis = axis
+                                break
+                if reduction_axis is not None:
+                    reduction_expr = (
+                        f"pallas_partial_reduce({reduction_op}, {value}, {pointwise_numel}, "
+                        f"{reduction_numel}, reduction_axis={reduction_axis})"
+                    )
+                else:
+                    reduction_expr = f"pallas_partial_reduce({reduction_op}, {value}, {pointwise_numel}, {reduction_numel})"
             else:
                 # Full reduction to scalar
                 reduction_expr = f"{reduction_op}({value})"

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -257,25 +257,15 @@ def pallas_partial_reduce(
     """
     Helper for partial reductions in Pallas kernels.
 
-    Reduces over contiguous axes whose product matches *red_numel* in the
-    original (un-tiled) tensor, returning the result with keepdims-style
-    shape for proper in-kernel broadcasting.
-
-    When running inside a tiled pallas_call the actual tile shape may differ
-    from ``(pw_numel, red_numel)``, so we reduce directly over the discovered
-    axes instead of reshaping to exact sizes.
+    Reorders axes and reduces, returning result with keepdims-style shape
+    for proper in-kernel broadcasting.
 
     Args:
         reduce_fn: The reduction function to apply (e.g., jnp.sum, jnp.max)
         v: The input array to reduce
-<<<<<<< HEAD
-        pw_numel: The number of pointwise elements (used for axis detection)
-        red_numel: The number of reduction elements (used for axis detection)
-=======
         pw_numel: The number of pointwise elements
         red_numel: The number of reduction elements
         reduction_axis: Optional explicit axis for reduction disambiguation
->>>>>>> 94703ecbb72 (Fix argmax/argmin partial-reduction axis disambiguation)
 
     Returns:
         Reduced array with keepdims-style shape
@@ -298,11 +288,6 @@ def pallas_partial_reduce(
     # when no explicit axis is provided or when the explicit axis would
     # produce an output shape incompatible with pw_numel.
     if red_axes is None:
-<<<<<<< HEAD
-        red_axes = [len(shape) - 1]
-    result = reduce_fn(v, axis=tuple(red_axes), keepdims=True)
-    return result
-=======
         should_search_red_axes = True
     else:
         out_shape = tuple(1 if i in red_axes else s for i, s in enumerate(shape))
@@ -330,7 +315,6 @@ def pallas_partial_reduce(
     reordered = jnp.moveaxis(v, pw_axes, list(range(len(pw_axes))))
     result = reduce_fn(reordered.reshape(pw_numel, red_numel), axis=-1)
     return result.reshape(out_shape)
->>>>>>> 94703ecbb72 (Fix argmax/argmin partial-reduction axis disambiguation)
 
 
 def pallas_gpu_pad_inputs(inputs: list[Any], alignment: int = 128) -> list[Any]:


### PR DESCRIPTION
## Summary
- Fix Pallas backend codegen crash when lowering `argmax`/`argmin` with `keepdim=True` on non-outermost dimensions of 3D+ tensors.
- Disambiguate partial-reduction axis selection for arg-reductions and keep behavior correct for 2D and 3D+ layouts.
- Add/keep coverage in `test/inductor/test_pallas.py` for the affected argmax/argmin keepdim cases.

## Context
This PR supersedes #174726, which became non-reopenable after a rebase/refresh attempt (GitHub returned "Could not open the pull request.").

## Test Plan
- `python test/inductor/test_pallas.py PallasCpuTests.test_argmax_argmin2_cpu_pallas`
- `python test/inductor/test_pallas.py PallasCpuTests.test_argmax_keepdim_3d`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo