### PR TITLE
[pytorch][mtia] Add MTIA to aten uniform_ disptach keys

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9027,7 +9027,7 @@
   tags: nondeterministic_seeded
   variants: method
   dispatch:
-    CPU, CUDA: uniform_
+    CPU, CUDA, MTIA: uniform_
     MPS: uniform_mps_
     Meta: uniform_meta_
   autogen: uniform, uniform.out


### PR DESCRIPTION
Summary:
Currently torch.rand fallbacked to CPU. Since we have supported RNG on MTIA, we should be able to leverage the pytorch native implementation of aten::uniform_ for MTIA. 

So this diff adds MTIA to uniform_ dispatch keys

Test Plan:
WIP

Will need comprehensive testing as this is highly risky

Differential Revision: D93771014


