### PR TITLE
Remove type suppressions in dynamo and utils

### DIFF
--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -70,7 +70,6 @@ class AotAutograd:
         if use_fallback:
             log.debug("Unable to use AOT Autograd because graph has mutation")
             counters["aot_autograd"]["not_ok"] += 1
-            # pyrefly: ignore [bad-return]
             return gm
 
         def wrap_bw_compiler(bw_compiler_fn: Callable[P, R]) -> Callable[..., R]:
@@ -150,7 +149,7 @@ def mem_efficient_fusion_kwargs(use_decomps: bool) -> dict[str, Any]:
     }
 
     if use_decomps:
-        # pyrefly: ignore [bad-typed-dict-key, unsupported-operation]
+        # pyrefly: ignore [bad-typed-dict-key]
         kwargs["decompositions"] = default_decompositions
 
     return kwargs

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -264,7 +264,6 @@ def cudagraphs_inner(
     """This isn't registered as a backend, but is used in some benchmarks"""
     assert isinstance(inputs, (list, tuple))
     if copy_inputs:
-        # pyrefly: ignore [bad-argument-type]
         static_inputs = [torch.zeros_like(x) for x in inputs]
     else:
         static_inputs = list(inputs)

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -79,7 +79,7 @@ def tvm(
     opt_level = options.get("opt_level", 3)
 
     if scheduler == "auto_scheduler":
-        # pyrefly: ignore [import-error, missing-import]
+        # pyrefly: ignore [missing-import]
         from tvm import auto_scheduler
 
         with (
@@ -91,7 +91,7 @@ def tvm(
         ):
             lib = relay.build(mod, target=target, params=params)
     elif scheduler == "meta_schedule":
-        # pyrefly: ignore [import-error, missing-import]
+        # pyrefly: ignore [missing-import]
         from tvm import meta_schedule as ms
 
         with tempfile.TemporaryDirectory() as work_dir:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1113,11 +1113,10 @@ class CaptureOutput:
         runtime_env = self.graph_capture_output.get_runtime_env()
         assert self.backend_input is not None
         backend_id = self.backend_input.backend_id
-        # pyrefly: ignore [bad-assignment, not-callable]
         compiled_fn = compiled_fn or self.backend_input.graph_module
         return runtime_env.forward_callable(
             backend_id,
-            compiled_fn,  # pyrefly: ignore [bad-argument-type]
+            compiled_fn,
             extra_globals=extra_globals,
         )
 
@@ -1137,7 +1136,6 @@ def get_traced_fn(mod: Any) -> tuple[FunctionType, Optional[object]]:
 
         resolved_call = mod.__call__
         if hasattr(resolved_call, "__self__"):
-            # pyrefly: ignore [missing-attribute]
             resolved_call = resolved_call.__func__
 
         # Mirrored from NNModuleVariable.call_function:
@@ -1297,7 +1295,6 @@ def _fullgraph_capture_frame(
             frame.locals,
             frame.builtins,
             frame.closure,
-            # pyrefly: ignore [bad-argument-type]
             compiler_fn=fullgraph_compiler,
             export=_is_export_deprecated_do_not_use,
             export_constraints=constraints,  # type: ignore[arg-type]
@@ -2033,7 +2030,6 @@ class ConvertFrame:
     @property
     def _clone_with_backend(self) -> Callable[[WrapBackendDebug], ConvertFrame]:
         return lambda backend: convert_frame(
-            # pyrefly: ignore [bad-argument-type]
             backend,
             self._hooks,
         )

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -104,7 +104,6 @@ def disable(fn=None, recursive=True, *, reason=None, wrapping=True):  # type: ig
                 nonrecursive_disable_wrapper
             )
             nonrecursive_disable_wrapper._torchdynamo_disable_recursive = False  # type: ignore[attr-defined]
-            # pyrefly: ignore [bad-return]
             return nonrecursive_disable_wrapper
 
         if fn is None:
@@ -631,7 +630,6 @@ def leaf_function(fn: Callable[_P, _R]) -> Callable[_P, _R]:
             )
         # This wrapper call enables @leaf_function to work with make_fx tracing
 
-        # pyrefly: ignore [bad-argument-type]
         return _invoke_leaf_function_python(
             fn,
             # pyrefly: ignore [bad-argument-type]

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -241,7 +241,6 @@ class CudaInterface(DeviceInterface):
     set_device = staticmethod(torch.cuda.set_device)
     device_count = staticmethod(torch.cuda.device_count)
     stream = staticmethod(torch.cuda.stream)  # type: ignore[assignment]
-    # pyrefly: ignore [bad-override]
     current_stream = staticmethod(torch.cuda.current_stream)
     set_stream = staticmethod(torch.cuda.set_stream)  # type: ignore[assignment]
     _set_stream_by_id = staticmethod(torch.cuda._set_stream_by_id)  # type: ignore[assignment]
@@ -338,7 +337,6 @@ class MtiaInterface(DeviceInterface):
     set_device = staticmethod(torch.mtia.set_device)  # type: ignore[assignment]
     device_count = staticmethod(torch.mtia.device_count)
     stream = staticmethod(torch.mtia.stream)  # type: ignore[assignment]
-    # pyrefly: ignore [bad-override]
     current_stream = staticmethod(torch.mtia.current_stream)
     set_stream = staticmethod(torch.mtia.set_stream)  # type: ignore[assignment]
     _set_stream_by_id = staticmethod(torch.mtia._set_stream_by_id)  # type: ignore[assignment]
@@ -421,7 +419,6 @@ class XpuInterface(DeviceInterface):
     set_device = staticmethod(torch.xpu.set_device)
     device_count = staticmethod(torch.xpu.device_count)  # type: ignore[has-type]
     stream = staticmethod(torch.xpu.stream)  # type: ignore[assignment]
-    # pyrefly: ignore [bad-override]
     current_stream = staticmethod(torch.xpu.current_stream)
     set_stream = staticmethod(torch.xpu.set_stream)  # type: ignore[assignment]
     _set_stream_by_id = staticmethod(torch.xpu._set_stream_by_id)  # type: ignore[assignment]

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -234,7 +234,6 @@ def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
     if _stance.stance == "default":
         # force_backend
         if _stance.backend is not None and callback not in (False, None):
-            # pyrefly: ignore [bad-argument-type]
             callback = _create_wrapped_callback(get_compiler_fn(_stance.backend))
 
         return callback
@@ -341,7 +340,6 @@ def _create_delayed_compile_callback(
                 )
             elif stance == "aot_eager_then_compile":
                 aot_eager_fn = get_compiler_fn("aot_eager")
-                # pyrefly: ignore [bad-argument-type]
                 return _create_wrapped_callback(aot_eager_fn)(*args, **kwargs)
 
         dynamism = track_dynamism_across_examples(example_inputs)
@@ -428,7 +426,7 @@ class OptimizedModule(torch.nn.Module):
 
     def __len__(self) -> int:
         # Proxy the len call to the original module
-        # pyrefly: ignore [invalid-argument, unsafe-overlap]
+        # pyrefly: ignore [unsafe-overlap]
         if isinstance(self._orig_mod, Sized):
             return len(self._orig_mod)
         # Mimic python's default behavior for objects without a length
@@ -438,7 +436,6 @@ class OptimizedModule(torch.nn.Module):
         # Do this stuff in constructor to lower overhead slightly
         if isinstance(self.dynamo_ctx, DisableContext):
             # No need to check trace rules
-            # pyrefly: ignore [bad-argument-type]
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
         elif config.wrap_top_frame or (
             isinstance(self._orig_mod.forward, types.MethodType)
@@ -447,7 +444,6 @@ class OptimizedModule(torch.nn.Module):
             # This may be a torch.nn.* instance in trace_rules.py which
             # won't trigger a frame evaluation workaround to add an extra
             # frame we can capture
-            # pyrefly: ignore [bad-argument-type]
             self.forward = self.dynamo_ctx(external_utils.wrap_inline(self._orig_mod))
         else:
             # Invoke hooks outside of dynamo then pickup the inner frame
@@ -1229,7 +1225,6 @@ class DisableContext(_TorchDynamoContext):
             cls_obj.__call__ = self(cls_obj.__call__)
             if issubclass(cls_obj, torch.nn.Module):
                 # NN module variable tracker directly inlines the _call_impl. Disable it.
-                # pyrefly: ignore [missing-attribute]
                 cls_obj._call_impl = self(cls_obj._call_impl)
             return cls_obj
 
@@ -1579,7 +1574,6 @@ def _optimize(
 
     return _optimize_catch_errors(
         convert_frame.convert_frame(
-            # pyrefly: ignore [bad-argument-type]
             backend,
             hooks,
             package=package,
@@ -2463,7 +2457,6 @@ def _optimize_assert(
 
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(
-            # pyrefly: ignore [bad-argument-type]
             backend,
             export=export,
             export_constraints=export_constraints,

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -410,7 +410,7 @@ def get_dynamo_observed_exception(exc_type: type[Exception]) -> type[ObservedExc
         observed_exception_map[exc_type] = type(  # type: ignore[assignment]
             f"Observed{name}Error", (ObservedException,), {}
         )
-    # pyrefly: ignore [bad-index, index-error]
+    # pyrefly: ignore [bad-index]
     return observed_exception_map[exc_type]
 
 
@@ -427,7 +427,7 @@ def raise_observed_exception(
     # CPython here raises an exception. Since there is no python code, we have to manually setup the exception
     # stack and raise the exception.
     exception_vt = SourcelessBuilder.create(tx, exc_type).call_function(
-        tx,  # pyrefly: ignore[bad-argument-type]
+        tx,
         [SourcelessBuilder.create(tx, a) for a in args] if args else [],
         kwargs or {},
     )

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -97,7 +97,6 @@ def wrap_numpy(f: Callable[_P, _R]) -> Callable[_P, _R]:
         args, kwargs = pytree.tree_map_only(
             torch.Tensor, lambda x: x.numpy(), (args, kwargs)
         )
-        # pyrefly: ignore [invalid-param-spec]
         out = f(*args, **kwargs)
         # pyrefly: ignore [missing-attribute]
         return pytree.tree_map_only(np.ndarray, lambda x: torch.as_tensor(x), out)

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -131,10 +131,8 @@ def clean_nn_module_stack_and_source_fn(
                 name, cls = item
                 if isinstance(name, str):
                     clean_name = clean_export_root_string(name)
-                    # pyrefly: ignore[bad-argument-type]
                     cleaned_stack.append((clean_name, cls))
                 else:
-                    # pyrefly: ignore[bad-argument-type]
                     cleaned_stack.append(item)
             else:
                 # pyrefly: ignore [bad-argument-type]
@@ -383,16 +381,16 @@ class DynamoGraphTransformer(torch.fx.Transformer):
             if "dynamo_flat_name_to_original_fqn" in self.module.meta:
                 # pyrefly: ignore [bad-index]
                 result_gm.meta["dynamo_flat_name_to_original_fqn"] = self.module.meta[
-                    # pyrefly: ignore [bad-index, index-error]
-                    # pyrefly: ignore [bad-index, index-error]
+                    # pyrefly: ignore [bad-index]
+                    # pyrefly: ignore [bad-index]
                     "dynamo_flat_name_to_original_fqn"
                 ]
             # pyrefly: ignore [unsupported-operation]
             if "dynamo_compile_id" in self.module.meta:
                 # pyrefly: ignore [bad-index]
                 result_gm.meta["dynamo_compile_id"] = self.module.meta[
-                    # pyrefly: ignore [bad-index, index-error]
-                    # pyrefly: ignore [bad-index, index-error]
+                    # pyrefly: ignore [bad-index]
+                    # pyrefly: ignore [bad-index]
                     "dynamo_compile_id"
                 ]
 

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -382,14 +382,12 @@ class DynamoGraphTransformer(torch.fx.Transformer):
                 # pyrefly: ignore [bad-index]
                 result_gm.meta["dynamo_flat_name_to_original_fqn"] = self.module.meta[
                     # pyrefly: ignore [bad-index]
-                    # pyrefly: ignore [bad-index]
                     "dynamo_flat_name_to_original_fqn"
                 ]
             # pyrefly: ignore [unsupported-operation]
             if "dynamo_compile_id" in self.module.meta:
                 # pyrefly: ignore [bad-index]
                 result_gm.meta["dynamo_compile_id"] = self.module.meta[
-                    # pyrefly: ignore [bad-index]
                     # pyrefly: ignore [bad-index]
                     "dynamo_compile_id"
                 ]

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1823,13 +1823,11 @@ class OutputGraph(OutputGraphCommon):
             for val, count in pass1.uses.items():
                 # If it's already a local source, no need to cache it
                 if count > 1 and not istype(val, (SyntheticLocalSource, LocalSource)):
-                    # pyrefly: ignore [unsupported-operation]
                     tempvars[val] = None
             pass2 = PyCodegen(
                 self.root_tx,
                 root,
                 graph_output_var,
-                # pyrefly: ignore [bad-argument-type]
                 tempvars=tempvars,
                 overridden_sources=overridden_sources,
             )
@@ -2717,7 +2715,7 @@ class OutputGraph(OutputGraphCommon):
             },
         )
 
-        # pyrefly: ignore [unbound-name, bad-return]
+        # pyrefly: ignore [bad-return]
         return compiled_fn
 
     def dedup_pass(self) -> dict[str, torch.fx.GraphModule]:
@@ -3164,7 +3162,6 @@ def check_pt2_compliant_op(
                 hints=[],
             )
 
-        # pyrefly: ignore [unbound-name]
         op = getattr(target, overload)
         if torch.Tag.pt2_compliant_tag in op.tags:
             encountered_compliant_op(op)
@@ -3172,7 +3169,6 @@ def check_pt2_compliant_op(
             encountered_non_compliant_op(
                 op,
                 f"Encountered the torch.ops.OpOverloadPacket {target} "
-                # pyrefly: ignore [unbound-name]
                 f"which resolves to the overload ({overload}) that is "
                 f"not PT2 compliant.",
             )

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -335,7 +335,6 @@ def _get_code_source(code: types.CodeType) -> tuple[str, str]:
     code_source = _find_code_source(toplevel)
     if code_source is None:
         _raise_resolution_error(code, toplevel)
-    # pyrefly: ignore [missing-attribute]
     return toplevel.__qualname__, code_source.strip(".")
 
 
@@ -627,11 +626,9 @@ class CompilePackage:
                             f"Source code changes detected for {code.module} (line {code.firstlineno} - line {code.lastlineno})"
                         )
 
-                # pyrefly: ignore [bad-assignment]
                 self._source_info = dynamo.source_info
 
             main, *codes = dynamo.codes
-            # pyrefly: ignore [bad-assignment]
             self._codes = {self._innermost_fn.__code__: main}
             for code in codes:
                 self._codes[SerializedCode.to_code_object(code.python_code)] = code
@@ -639,7 +636,6 @@ class CompilePackage:
             self._add_function(
                 self._innermost_fn.__code__, self._innermost_fn.__module__
             )
-        # pyrefly: ignore [bad-assignment]
         self._initialized = True
 
     def _add_function(
@@ -783,7 +779,6 @@ class CompilePackage:
             for name in names:
                 module.__dict__.pop(name)
 
-        # pyrefly: ignore [bad-assignment]
         self._installed_globals = {}
 
         _reset_precompile_entries(self._innermost_fn.__code__)

--- a/torch/_dynamo/polyfills/os.py
+++ b/torch/_dynamo/polyfills/os.py
@@ -18,7 +18,6 @@ __all__ = ["fspath"]
 @substitute_in_graph(os.fspath, can_constant_fold_through=True)
 def fspath(path: AnyStr | os.PathLike[AnyStr]) -> AnyStr:
     if isinstance(path, (str, bytes)):
-        # pyrefly: ignore [bad-return]
         return path
 
     path_type = type(path)

--- a/torch/_dynamo/polyfills/pytree.py
+++ b/torch/_dynamo/polyfills/pytree.py
@@ -230,7 +230,6 @@ class PyTreeSpec:
                 or optree.is_namedtuple_class(treespec.type)
                 or optree.is_structseq_class(treespec.type)
             ):
-                # pyrefly: ignore [bad-return]
                 return treespec._unflatten_func(
                     treespec._metadata,
                     children_representations,

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -442,7 +442,6 @@ def generate_custom_triton_kernel(kernel: Any) -> str:
         config_strs = []
         # pyrefly: ignore [missing-attribute]
         for kernel_config in kernel.configs:
-            # pyrefly: ignore [bad-argument-type]
             config_strs.append(f"""triton.Config(
                     {str(kernel_config.kwargs)},
                     num_warps={kernel_config.num_warps},
@@ -565,7 +564,7 @@ if "__compile_source__" in globals():
             return result
 
         fn_globals = getattr(jit_fn.fn, "__globals__", {})
-        src = jit_fn.src  # pyrefly: ignore [missing-attribute]
+        src = jit_fn.src
         full_src = src if src.strip().startswith("def ") else "def " + src
 
         referenced_names: set[str] = set()
@@ -633,9 +632,7 @@ if "__compile_source__" in globals():
             model_str += "ERROR: Repro will not work as intended, "
             model_str += f"User defined triton kernel exception: {e}\n"
 
-    # pyrefly: ignore [unbound-name]
     if len(kernel_side_table.constant_args) > 0:
-        # pyrefly: ignore [unbound-name]
         model_str += f"{kernel_side_table_prefix}.constant_args={kernel_side_table.constant_args}\n"
 
     model_str += NNModuleToString.convert(gm)
@@ -647,10 +644,8 @@ if "__compile_source__" in globals():
     # Extract from graph placeholders and their corresponding arguments
     placeholder_targets = fx_placeholder_targets(gm)
     for placeholder, arg in zip(placeholder_targets, args):
-        # pyrefly: ignore [unbound-name]
         if isinstance(arg, (int, torch.SymInt)):
             writer.symint(placeholder, arg)
-        # pyrefly: ignore [unbound-name]
         elif isinstance(arg, torch.Tensor):
             # TODO: improve these names with FQN
             writer.tensor(placeholder, arg)
@@ -662,7 +657,6 @@ if "__compile_source__" in globals():
         # Extract symbolic variables from the same arguments
 
         if (
-            # pyrefly: ignore [unbound-name]
             isinstance(arg, torch.SymInt)
             # By checking sympy.Symbol, we are excluding any symbolic expressions.
             # TODO: we may need to solve expressions to extract symbol definitions.
@@ -670,12 +664,10 @@ if "__compile_source__" in globals():
             and arg.node.hint is not None
         ):
             used_syms[str(arg.node)] = arg.node.hint
-        # pyrefly: ignore [unbound-name]
         elif isinstance(arg, torch.Tensor):
             # Extract symbolic variables from tensor shapes and strides
             for dim in arg.shape:
                 if (
-                    # pyrefly: ignore [unbound-name]
                     isinstance(dim, torch.SymInt)
                     and isinstance(dim.node.expr, sympy.Symbol)
                     and dim.node.hint is not None
@@ -683,7 +675,6 @@ if "__compile_source__" in globals():
                     used_syms[str(dim.node)] = dim.node.hint
             for stride in arg.stride():
                 if (
-                    # pyrefly: ignore [unbound-name]
                     isinstance(stride, torch.SymInt)
                     and isinstance(stride.node.expr, sympy.Symbol)
                     and stride.node.hint is not None
@@ -692,7 +683,6 @@ if "__compile_source__" in globals():
             # Extract symbols from storage nbytes (can be a symbolic expression)
             storage = arg.untyped_storage()
             nbytes = storage.nbytes()
-            # pyrefly: ignore [unbound-name]
             if isinstance(nbytes, torch.SymInt):
                 expr = nbytes.node.expr
                 shape_env = nbytes.node.shape_env
@@ -1007,7 +997,6 @@ def repro_common(
 
     # Turn mod into a GraphModule the slow way
     # TODO: speed this up
-    # pyrefly: ignore [bad-argument-type]
     mod = make_fx(mod, tracing_mode=options.tracing_mode)(*args)
 
     # pyrefly: ignore [bad-assignment]

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -471,7 +471,6 @@ def repro_minify(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
         compiler_fn,
         compiler_name=options.backend,  # type: ignore[call-arg]
     )
-    # pyrefly: ignore [bad-argument-type]
     opt_mod = torch._dynamo.optimize(dynamo_minifier_backend)(mod)
 
     with torch.amp.autocast("cuda", enabled=options.autocast):
@@ -479,7 +478,6 @@ def repro_minify(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
 
 
 def repro_run(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
-    # pyrefly: ignore [bad-argument-type]
     opt_mod = torch._dynamo.optimize(options.backend)(mod)
 
     if options.accuracy != "":

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1132,7 +1132,6 @@ class BytecodeDispatchTableMeta(type):
             op: getattr(cls, opname, functools.partial(_missing, opname))
             for opname, op in dis.opmap.items()
         }
-        # pyrefly: ignore [missing-attribute]
         cls.dispatch_table = [dispatch_table.get(i) for i in range(2**8)]
 
 
@@ -2698,7 +2697,7 @@ class InstructionTranslatorBase(
                 return True
             elif isinstance(exc_instance, variables.BuiltinVariable) and issubclass(
                 exc_instance.fn,
-                # pyrefly: ignore [invalid-argument, missing-attribute]
+                # pyrefly: ignore [invalid-argument]
                 expected_type.fn,
             ):
                 return True
@@ -2765,16 +2764,12 @@ class InstructionTranslatorBase(
             assert isinstance(null, NullVariable)
 
         if not isinstance(
-            # pyrefly: ignore [unbound-name]
             argsvars,
             BaseListVariable,
-            # pyrefly: ignore [unbound-name]
         ) and argsvars.has_force_unpack_var_sequence(self):
-            # pyrefly: ignore [unbound-name]
             argsvars = TupleVariable(argsvars.force_unpack_var_sequence(self))
 
         # Unpack for cases like fn(**obj) where obj is a map
-        # pyrefly: ignore [unbound-name]
         if isinstance(kwargsvars, UserDefinedObjectVariable):
             kwargsvars = BuiltinVariable.call_custom_dict(self, dict, kwargsvars)  # type: ignore[arg-type]
 
@@ -2793,9 +2788,9 @@ class InstructionTranslatorBase(
             )
 
         # Map to a dictionary of str -> VariableTracker
-        # pyrefly: ignore [bad-assignment, missing-attribute, unbound-name]
+        # pyrefly: ignore [bad-assignment, unbound-name]
         kwargsvars = kwargsvars.keys_as_python_constant()
-        # pyrefly: ignore [bad-argument-type, missing-attribute, unbound-name]
+        # pyrefly: ignore [bad-argument-type, unbound-name]
         self.call_function(fn, argsvars.items, kwargsvars)
 
     @break_graph_if_unsupported(
@@ -3659,17 +3654,14 @@ class InstructionTranslatorBase(
                 "(i.e. `a, b, c = d`).",
                 hints=[*graph_break_hints.USER_ERROR],
             )
-        # pyrefly: ignore [unbound-name]
         if len(val) != inst.argval:
             unimplemented(
                 gb_type="Length mismatch when unpacking object for UNPACK_SEQUENCE",
-                # pyrefly: ignore [unbound-name]
                 context=f"expected length: {inst.argval}, actual: {len(val)}",
                 explanation=f"{seq} unpacked to a list for the UNPACK_SEQUENCE bytecode "
                 "(i.e. `a, b, c = d`) with unexpected length.",
                 hints=[*graph_break_hints.DYNAMO_BUG],
             )
-        # pyrefly: ignore [unbound-name]
         for i in reversed(val):
             self.push(i)
 
@@ -4631,7 +4623,6 @@ class InstructionTranslatorBase(
         return ComprehensionAnalysis(
             end_ip=scan_ip,
             result_var=result_var,
-            # pyrefly: ignore [unbound-name]
             result_on_stack=result_on_stack,
             iterator_vars=iterator_vars,
             walrus_vars=walrus_vars,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -307,13 +307,11 @@ def increment_op_count(cnt: int) -> None:
 def calculate_time_spent() -> dict[str, float]:
     total_by_key = {}
     for phase, timing in cumulative_time_spent_ns.items():
-        # pyrefly: ignore [unsupported-operation]
         total_by_key[phase] = timing / 1e9
 
     total_by_key["total_wall_time"] = total_by_key.get(
         "entire_frame_compile", 0
     ) + total_by_key.get("entire_backward_compile", 0)
-    # pyrefly: ignore [bad-return]
     return total_by_key
 
 
@@ -2442,7 +2440,6 @@ def is_jit_model(
     Union[
         torch.jit._trace.TopLevelTracedModule,
         torch.jit._script.RecursiveScriptModule,
-        # pyrefly: ignore [invalid-param-spec]
         torch.jit.ScriptFunction[Any, Any],
         torch.jit.ScriptModule,
     ]
@@ -2828,16 +2825,13 @@ def get_items_from_dict(obj: dict[K, V]) -> Iterable[tuple[K, Union[V, Any]]]:
     if istype(obj, (dict, OrderedDict)):
         return obj.items()
     elif isinstance(obj, OrderedDict):
-        # pyrefly: ignore [bad-argument-type]
         return [(k, OrderedDict.__getitem__(obj, k)) for k in OrderedDict.keys(obj)]
     else:
-        # pyrefly: ignore [bad-argument-type]
         return [(k, dict.__getitem__(obj, k)) for k in dict.keys(obj)]
 
 
 def nn_module_new(cls: Any) -> Any:
     obj = object_new(cls)
-    # pyrefly: ignore [bad-argument-type]
     torch.nn.Module.__init__(obj)
     return obj
 
@@ -4864,7 +4858,7 @@ class GmWrapper(torch.nn.Module):
         self.unflatten_fn = unflatten_fn
 
     def forward(self, *args: Any) -> Any:
-        # pyrefly: ignore [annotation-mismatch, redefinition]
+        # pyrefly: ignore [redefinition]
         args: list[Any] = list(args)
         return self.gm(*self.unflatten_fn(args))
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -678,7 +678,6 @@ class VariableBuilder:
         items = dict(build_key_value(k, v) for k, v in value.items())
 
         # Create a dict_vt to be used in the mapping proxy variable
-        # pyrefly: ignore[bad-argument-type]
         dict_vt = ConstDictVariable(items, source=None)
         result = MappingProxyVariable(dict_vt, source=self.source)
         return self.tx.output.side_effects.track_mutable(value, result)
@@ -1647,7 +1646,6 @@ class VariableBuilder:
             )
 
             dict_vt = ConstDictVariable(
-                # pyrefly: ignore[bad-argument-type]
                 result,
                 user_cls=(
                     collections.OrderedDict
@@ -3151,7 +3149,7 @@ def _wrap_fx_preexisting_tensor(
             }
             assert "source" in options and options["source"] is not None
             kwargs["source"] = options["source"]
-            # pyrefly: ignore[missing-argument, bad-argument-type]
+            # pyrefly: ignore [missing-argument]
             tensor = wrap_to_fake_tensor_and_record(tensor, tx=tx, **kwargs)
 
         if tensor.device.type != "meta" and (

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1165,7 +1165,6 @@ class BuiltinVariable(VariableTracker):
                             hints=[*graph_break_hints.DYNAMO_BUG],
                             from_exc=exc,
                         )
-                    # pyrefly: ignore [unbound-name]
                     return VariableTracker.build(tx, res)
 
             else:
@@ -1198,7 +1197,6 @@ class BuiltinVariable(VariableTracker):
                                 tx,
                                 args=[VariableTracker.build(tx, a) for a in exc.args],
                             )
-                        # pyrefly: ignore [unbound-name]
                         return VariableTracker.build(tx, res)
                     return None
 
@@ -1702,7 +1700,6 @@ class BuiltinVariable(VariableTracker):
                 except AttributeError:
                     # Graph break
                     return None
-            # pyrefly: ignore [unbound-name]
             elif is_wrapper_or_member_descriptor(str_method):
                 unimplemented(
                     gb_type="Attempted to a str() method implemented in C/C++",
@@ -2441,8 +2438,12 @@ class BuiltinVariable(VariableTracker):
             )
 
         if isinstance(arg, variables.UserDefinedExceptionClassVariable):
+<<<<<<< HEAD
             # pyrefly: ignore [unbound-name]
             return VariableTracker.build(tx, isinstance(arg_type, isinstance_type))
+=======
+            return ConstantVariable.create(isinstance(arg_type, isinstance_type))
+>>>>>>> b06158dc0e4 (Remove unused ignores)
 
         isinstance_type_tuple: tuple[type, ...]
         if isinstance(isinstance_type, type) or callable(
@@ -2474,10 +2475,8 @@ class BuiltinVariable(VariableTracker):
             # through it. This is a limitation of the current implementation.
             # Usually `__subclasscheck__` and `__instancecheck__` can be constant fold through, it
             # might not be a big issue and we trade off it for performance.
-            # pyrefly: ignore [unbound-name]
             val = issubclass(arg_type, isinstance_type_tuple)
         except TypeError:
-            # pyrefly: ignore [unbound-name]
             val = arg_type in isinstance_type_tuple
         return VariableTracker.build(tx, val)
 
@@ -2504,8 +2503,12 @@ class BuiltinVariable(VariableTracker):
 
         # WARNING: This might run arbitrary user code `__subclasscheck__`.
         # See the comment in call_isinstance above.
+<<<<<<< HEAD
         # pyrefly: ignore [unbound-name]
         return VariableTracker.build(tx, issubclass(left_ty_py, right_ty_py))
+=======
+        return variables.ConstantVariable(issubclass(left_ty_py, right_ty_py))
+>>>>>>> b06158dc0e4 (Remove unused ignores)
 
     def call_super(
         self, tx: "InstructionTranslator", a: VariableTracker, b: VariableTracker
@@ -2595,9 +2598,7 @@ class BuiltinVariable(VariableTracker):
                 value = getattr(self.fn, name)
             except AttributeError:
                 raise_observed_exception(AttributeError, tx)
-            # pyrefly: ignore [unbound-name]
             if not callable(value):
-                # pyrefly: ignore [unbound-name]
                 return VariableTracker.build(tx, value, source)
         return variables.GetAttrVariable(self, name, source=source)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2438,12 +2438,8 @@ class BuiltinVariable(VariableTracker):
             )
 
         if isinstance(arg, variables.UserDefinedExceptionClassVariable):
-<<<<<<< HEAD
             # pyrefly: ignore [unbound-name]
             return VariableTracker.build(tx, isinstance(arg_type, isinstance_type))
-=======
-            return ConstantVariable.create(isinstance(arg_type, isinstance_type))
->>>>>>> b06158dc0e4 (Remove unused ignores)
 
         isinstance_type_tuple: tuple[type, ...]
         if isinstance(isinstance_type, type) or callable(
@@ -2503,12 +2499,8 @@ class BuiltinVariable(VariableTracker):
 
         # WARNING: This might run arbitrary user code `__subclasscheck__`.
         # See the comment in call_isinstance above.
-<<<<<<< HEAD
         # pyrefly: ignore [unbound-name]
         return VariableTracker.build(tx, issubclass(left_ty_py, right_ty_py))
-=======
-        return variables.ConstantVariable(issubclass(left_ty_py, right_ty_py))
->>>>>>> b06158dc0e4 (Remove unused ignores)
 
     def call_super(
         self, tx: "InstructionTranslator", a: VariableTracker, b: VariableTracker

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -283,14 +283,12 @@ its type to `common_constant_types`.
 
         if name == "__len__" and not (args or kwargs):
             try:
-                # pyrefly: ignore [bad-argument-type]
                 return ConstantVariable.create(len(self.value))
             except TypeError as e:
                 raise_observed_exception(type(e), tx, args=list(e.args))
         elif name == "__round__" and len(args) == 1 and args[0].is_python_constant():
             try:
                 return ConstantVariable.create(
-                    # pyrefly: ignore [no-matching-overload]
                     round(self.value, args[0].as_python_constant())
                 )
             except Exception as e:
@@ -301,7 +299,6 @@ its type to `common_constant_types`.
             assert not kwargs
             search = args[0].as_python_constant()
             try:
-                # pyrefly: ignore [not-iterable, unsupported-operation]
                 result = search in self.value
                 return ConstantVariable.create(result)
             except TypeError as e:

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1184,9 +1184,7 @@ class SetVariable(ConstDictVariable):
                 # VariableTracker - realize to install guards
                 # pyrefly: ignore [bad-argument-type]
                 realized_items.append(item.realize())
-        # pyrefly: ignore[bad-assignment]
         items = dict.fromkeys(realized_items, SetVariable._default_value())
-        # pyrefly: ignore[bad-argument-type]
         super().__init__(items, **kwargs)
 
     def debug_repr(self) -> str:
@@ -1238,7 +1236,6 @@ class SetVariable(ConstDictVariable):
             raise_observed_exception(
                 type(exc), tx, args=[VariableTracker.build(tx, a) for a in exc.args]
             )
-        # pyrefly: ignore[unbound-name]
         return VariableTracker.build(tx, res)
 
     def call_method(
@@ -1300,9 +1297,7 @@ class SetVariable(ConstDictVariable):
                 raise_observed_exception(
                     KeyError, tx, args=[VariableTracker.build(tx, a) for a in e.args]
                 )
-            # pyrefly: ignore[unbound-name]
             super().call_method(tx, name, [result], kwargs)
-            # pyrefly: ignore[unbound-name]
             return result
         elif name == "isdisjoint":
             if kwargs or len(args) != 1:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2466,7 +2466,6 @@ class CollectionsNamedTupleFunction(UserFunctionVariable):
                     args=[VariableTracker.build(tx, a) for a in exc.args],
                 )
             return variables.UserDefinedClassVariable(
-                # pyrefly: ignore[unbound-name]
                 value,
                 mutation_type=ValueMutationNew(),
             )
@@ -2733,7 +2732,6 @@ class PolyfilledFunctionVariable(VariableTracker):
         options = {}
         if self.source:
             options["source"] = AttrSource(self.source, name)
-        # pyrefly: ignore[bad-specialization]
         polyfilled_method_variable = PolyfilledFunctionVariable(method, **options)
         return polyfilled_method_variable.call_function(tx, args, kwargs)
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1675,7 +1675,6 @@ def speculate_subgraph_with_auto_output_flattening(
             # be actual FX graph outputs.
             # Collect only tensor and symint VTs that should be graph outputs.
             # We walk the output structure and extract proxyable VTs.
-            # pyrefly: ignore [implicit-any]
             graph_output_vt_list = []
 
             def visit(vt: VariableTracker) -> None:

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -158,7 +158,6 @@ class ItertoolsVariable(VariableTracker):
 
             result = []
             try:
-                # pyrefly: ignore [unbound-name]
                 for k, v in itertools.groupby(seq, key=keyfunc):
                     result.append(
                         variables.TupleVariable(

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -257,7 +257,7 @@ class LazyConstantVariable(LazyVariableTracker):
     supported_types = (int, float, bool, str)
 
     @staticmethod
-    def create(  # pyrefly: ignore[bad-override]
+    def create(
         value: Any,
         source: Any,
         **options: Any,

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -381,7 +381,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
 
                 if name == "__setattr__":
                     method(*args_const, **kwargs_const)
-                    return real_obj  # pyrefly: ignore[bad-return]
+                    return real_obj
 
                 constant_val = method(*args_const, **kwargs_const)
 

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -304,7 +304,6 @@ class StreamVariable(StreamContextVariable):
 
         self.proxy = proxy
         self.value = value
-        # pyrefly: ignore [read-only]
         self.device = value.device
 
         self.user_object_index = user_object_index

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -197,7 +197,6 @@ class TensorVariable(VariableTracker):
         super().__init__(**kwargs)
         self.proxy = proxy
         self.dtype = dtype
-        # pyrefly: ignore[read-only]
         self.device = device
         self.layout = layout
         self.ndim = ndim

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -598,7 +598,6 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             )
         elif self.value is torch.nn.attention.sdpa_kernel.__wrapped__:  # type: ignore[attr-defined]
             name_to_arg_map = bind_args_cached(
-                # pyrefly: ignore[bad-argument-type]
                 self.value,
                 tx,
                 self.source,
@@ -1737,17 +1736,14 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 )
 
             # need to guard only on no-arg get_device_module
-            # pyrefly: ignore [unbound-name]
             if device is None:
                 source = CallFunctionNoArgsSource(self.source)
                 install_guard(source.make_guard(GuardBuilder.ID_MATCH))
             # assumes `module` is in the form `torch.xyz`
             new_source = AttrSource(
                 ImportSource("torch"),
-                # pyrefly: ignore [unbound-name]
                 module.__name__.rsplit(".", maxsplit=1)[-1],
             )
-            # pyrefly: ignore [unbound-name]
             return VariableTracker.build(tx, module, new_source)
 
         @register(torch.accelerator.current_stream, torch.cuda.current_stream)
@@ -1863,7 +1859,6 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                             *graph_break_hints.SUPPORTABLE,
                         ],
                     )
-                # pyrefly: ignore[missing-attribute]
                 message_eager = message_vt.get_function()
 
                 message_graph_proxy = tx.output.register_static_attr_and_return_proxy(
@@ -1893,7 +1888,6 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
 
         @register(torch.autograd.grad)
-        # pyrefly: ignore[implicit-any]
         def handle_autograd_grad(self, tx: "InstructionTranslator", *args, **kwargs):
             """
             Handle torch.autograd.grad() calls within compiled regions.
@@ -2874,7 +2868,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             )
 
         # this results in cleaner graphs, but only works for inputs
-        # pyrefly: ignore [missing-attribute]
         if data.source:
             return cls._nn_param_via_prefix_insert(tx, data, requires_grad)
 
@@ -2895,7 +2888,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         if isinstance(
             data,
             TensorWithTFOverrideVariable,
-            # pyrefly: ignore [missing-attribute]
         ) or is_traceable_wrapper_subclass_type(data.class_type):
             unimplemented(
                 gb_type="Attempted to use torch.nn.Parameter constructor with tensor subclass",
@@ -2918,11 +2910,8 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             )
 
         try:
-            # pyrefly: ignore [missing-attribute]
             shape = tuple(data.var_getattr(tx, "shape").as_python_constant())
-            # pyrefly: ignore [missing-attribute]
             dtype = data.var_getattr(tx, "dtype").as_python_constant()
-            # pyrefly: ignore [missing-attribute]
             device = data.var_getattr(tx, "device").as_python_constant()
         except NotImplementedError as e:
             unimplemented(
@@ -2938,12 +2927,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
 
         placeholder = tx.output.synthetic_graph_input(
             new_parameter_placeholder,
-            # pyrefly: ignore [unbound-name]
             (shape, dtype, device, requires_grad),
         )
-        # pyrefly: ignore [missing-attribute]
         if data.requires_grad:
-            # pyrefly: ignore [missing-attribute]
             data = data.call_method(tx, "detach", [], {})
 
         from .builder import wrap_fx_proxy
@@ -2953,7 +2939,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             tx.output.create_proxy(
                 "call_function",
                 tracable_create_parameter,
-                # pyrefly: ignore [missing-attribute]
                 (data.as_proxy(), placeholder.as_proxy()),
                 {},
             ),

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1666,7 +1666,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return variables.UserMethodVariable(
                     getattribute_fn,
                     self,
-                    # pyrefly: ignore[unbound-name]
                     source=new_source,
                 ).call_function(tx, [VariableTracker.build(tx, name)], {})
             except ObservedAttributeError:

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -173,6 +173,7 @@ def device_count() -> int:
 
 def current_device() -> int:
     r"""Return the index of a currently selected device."""
+    # pyrefly: ignore [missing-attribute]
     return torch._C._mtia_getDevice()
 
 
@@ -276,6 +277,7 @@ def set_device(device: Device) -> None:
     """
     device = _get_device_index(device)
     if device >= 0:
+        # pyrefly: ignore [missing-attribute]
         torch._C._mtia_setDevice(device)
 
 
@@ -303,9 +305,11 @@ class device:
         self.prev_idx = -1
 
     def __enter__(self):
+        # pyrefly: ignore [missing-attribute]
         self.prev_idx = torch._C._mtia_maybeExchangeDevice(self.idx)
 
     def __exit__(self, type: Any, value: Any, traceback: Any):
+        # pyrefly: ignore [missing-attribute]
         self.idx = torch._C._mtia_maybeExchangeDevice(self.prev_idx)
         return False
 

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -60,7 +60,6 @@ def _device_constructors():
 # NB: This is directly called from C++ in torch/csrc/Device.cpp
 class DeviceContext(TorchFunctionMode):
     def __init__(self, device) -> None:
-        # pyrefly: ignore [read-only]
         self.device = torch.device(device)
         self.prev_mode: Optional[DeviceContext] = None
 

--- a/torch/utils/_functools.py
+++ b/torch/utils/_functools.py
@@ -36,12 +36,10 @@ def cache_method(
         if not (cache := getattr(self, cache_name, None)):
             cache = {}
             setattr(self, cache_name, cache)
-        # pyrefly: ignore [unbound-name]
         cached_value = cache.get(args, _cache_sentinel)
         if cached_value is not _cache_sentinel:
             return cached_value
         value = f(self, *args, **kwargs)
-        # pyrefly: ignore [unbound-name]
         cache[args] = value
         return value
 

--- a/torch/utils/_ordered_set.py
+++ b/torch/utils/_ordered_set.py
@@ -77,7 +77,6 @@ class OrderedSet(MutableSet[T], Reversible[T]):
     def pop(self) -> T:
         if not self:
             raise KeyError("pop from an empty set")
-        # pyrefly: ignore [bad-return]
         return self._dict.popitem()[0]
 
     def copy(self) -> OrderedSet[T]:

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -200,12 +200,10 @@ class FloorDiv(sympy.Function):
 
     @property
     def base(self) -> sympy.Basic:
-        # pyrefly: ignore [missing-attribute]
         return self.args[0]
 
     @property
     def divisor(self) -> sympy.Basic:
-        # pyrefly: ignore [missing-attribute]
         return self.args[1]
 
     def _sympystr(self, printer: sympy.printing.StrPrinter) -> str:
@@ -305,7 +303,6 @@ class FloorDiv(sympy.Function):
         return None
 
     def _eval_is_nonnegative(self) -> bool | None:
-        # pyrefly: ignore [missing-attribute]
         p, q = self.args[:2]
         if all([p.is_integer, q.is_integer, p.is_nonnegative, q.is_nonnegative]):
             return True
@@ -374,7 +371,6 @@ class ModularIndexing(sympy.Function):
         return None
 
     def _eval_is_nonnegative(self) -> bool | None:
-        # pyrefly: ignore [missing-attribute]
         p, q = self.args[:2]
         return fuzzy_eq(p.is_nonnegative, q.is_nonnegative)  # type: ignore[attr-defined]
 
@@ -470,11 +466,8 @@ class PythonMod(sympy.Function):
         return True if self.args[1].is_negative else None  # type: ignore[attr-defined]
 
     def _ccode(self, printer) -> str:
-        # pyrefly: ignore [missing-attribute]
         p = printer.parenthesize(self.args[0], PRECEDENCE["Atom"] - 0.5)
-        # pyrefly: ignore [missing-attribute]
         q = printer.parenthesize(self.args[1], PRECEDENCE["Atom"] - 0.5)
-        # pyrefly: ignore [missing-attribute]
         abs_q = str(q) if self.args[1].is_positive else f"abs({q})"
         return f"({p} % {q}) < 0 ? {p} % {q} + {abs_q} : {p} % {q}"
 
@@ -557,7 +550,6 @@ class CeilToInt(sympy.Function):
             return sympy.Integer(math.ceil(float(number)))
 
     def _ccode(self, printer) -> str:
-        # pyrefly: ignore [missing-attribute]
         number = printer.parenthesize(self.args[0], self.args[0].precedence - 0.5)
         return f"ceil({number})"
 
@@ -828,7 +820,6 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
             if not cond:
                 return ai.func(*[do(i, a) for i in ai.args], evaluate=False)
             if isinstance(ai, cls):
-                # pyrefly: ignore [missing-attribute]
                 return ai.func(*[do(i, a) for i in ai.args if i != a], evaluate=False)
             return a
 
@@ -1006,7 +997,6 @@ class Max(MinMaxBase, Application):  # type: ignore[misc]
         return fuzzy_or(a.is_nonnegative for a in self.args)  # type: ignore[attr-defined]
 
     def _eval_is_negative(self):  # type:ignore[override]
-        # pyrefly: ignore [missing-attribute]
         return fuzzy_and(a.is_negative for a in self.args)
 
 
@@ -1025,7 +1015,6 @@ class Min(MinMaxBase, Application):  # type: ignore[misc]
         return fuzzy_and(a.is_nonnegative for a in self.args)  # type: ignore[attr-defined]
 
     def _eval_is_negative(self):  # type:ignore[override]
-        # pyrefly: ignore [missing-attribute]
         return fuzzy_or(a.is_negative for a in self.args)
 
 
@@ -1160,9 +1149,7 @@ class IntTrueDiv(sympy.Function):
             return sympy.Float(int(base) / int(divisor))
 
     def _ccode(self, printer) -> str:
-        # pyrefly: ignore [missing-attribute]
         base = printer.parenthesize(self.args[0], PRECEDENCE["Atom"] - 0.5)
-        # pyrefly: ignore [missing-attribute]
         divisor = printer.parenthesize(self.args[1], PRECEDENCE["Atom"] - 0.5)
         return f"((int){base}/(int){divisor})"
 
@@ -1329,16 +1316,13 @@ class Identity(sympy.Function):
     precedence = 10
 
     def __repr__(self) -> str:  # type: ignore[override]
-        # pyrefly: ignore [missing-attribute]
         return f"Identity({self.args[0]})"
 
     def _sympystr(self, printer) -> str:
         """Controls how sympy's StrPrinter prints this"""
-        # pyrefly: ignore [missing-attribute]
         return f"({printer.doprint(self.args[0])})"
 
     def _eval_is_real(self):
-        # pyrefly: ignore [missing-attribute]
         return self.args[0].is_real
 
     def _eval_is_integer(self):
@@ -1348,26 +1332,21 @@ class Identity(sympy.Function):
     def is_number(self):
         # Treat Identity as numeric only when the argument is comparable.
         # This avoids creating numeric non-comparable Identity(I) terms.
-        # pyrefly: ignore [missing-attribute]
         return bool(self.args[0].is_number and self.args[0].is_comparable)
 
     @property
     def is_comparable(self):
         # Delegate comparability to the wrapped argument.
-        # pyrefly: ignore [missing-attribute]
         return bool(self.args[0].is_comparable)
 
     def _eval_expand_identity(self, **hints):
         # Removes the identity op.
-        # pyrefly: ignore [missing-attribute]
         return self.args[0]
 
     def __int__(self) -> int:
-        # pyrefly: ignore [missing-attribute]
         return int(self.args[0])
 
     def __float__(self) -> float:
-        # pyrefly: ignore [missing-attribute]
         return float(self.args[0])
 
 

--- a/torch/utils/_sympy/printers.py
+++ b/torch/utils/_sympy/printers.py
@@ -70,7 +70,6 @@ class ExprPrinter(StrPrinter):
     # NB: this pow by natural, you should never have used builtin sympy.pow
     # for FloatPow, and a symbolic exponent should be PowByNatural.  These
     # means exp is guaranteed to be integer.
-    # pyrefly: ignore [bad-override]
     def _print_Pow(self, expr: sympy.Expr) -> str:
         base, exp = expr.args
         if exp != int(exp):

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -89,14 +89,11 @@ if HAS_TABULATE:
             try:
                 torch._dynamo.reset()
                 compile_counter_with_backend = CompileCounterWithBackend(backend)
-                # pyrefly: ignore [no-matching-overload]
                 opt_model = torch.compile(model, backend=compile_counter_with_backend, mode=mode)
 
                 # Compilation only happens after the first inference
-                # pyrefly: ignore [bad-argument-type]
                 compilation_time = bench_loop(opt_model, sample_input, 1, optimizer, loss_fn)
 
-                # pyrefly: ignore [bad-argument-type]
                 running_time = bench_loop(opt_model, sample_input, num_iters, optimizer, loss_fn)
 
                 if compile_counter_with_backend.frame_count == 0:
@@ -112,7 +109,6 @@ if HAS_TABULATE:
         else:
             opt_model = model
             compilation_time = None
-            # pyrefly: ignore [bad-argument-type]
             running_time = bench_loop(opt_model, sample_input, num_iters, optimizer, loss_fn)
 
         compilation_time = round(compilation_time, 2) if compilation_time else None

--- a/torch/utils/benchmark/utils/sparse_fuzzer.py
+++ b/torch/utils/benchmark/utils/sparse_fuzzer.py
@@ -91,7 +91,6 @@ class FuzzedSparseTensor(FuzzedTensor):
         return x
 
     def _make_tensor(self, params, state):
-        # pyrefly: ignore [missing-attribute]
         size, _, _ = self._get_size_and_steps(params)
         density = params['density']
         nnz = math.ceil(sum(size) * density)
@@ -101,10 +100,8 @@ class FuzzedSparseTensor(FuzzedTensor):
         is_coalesced = params['coalesced']
         sparse_dim = params['sparse_dim'] if self._sparse_dim else len(size)
         sparse_dim = min(sparse_dim, len(size))
-        # pyrefly: ignore [missing-attribute]
         tensor = self.sparse_tensor_constructor(size, self._dtype, sparse_dim, nnz, is_coalesced)
 
-        # pyrefly: ignore [missing-attribute]
         if self._cuda:
             tensor = tensor.cuda()
         sparse_dim = tensor.sparse_dim()
@@ -120,7 +117,6 @@ class FuzzedSparseTensor(FuzzedTensor):
             "sparse_dim": sparse_dim,
             "dense_dim": dense_dim,
             "is_hybrid": is_hybrid,
-            # pyrefly: ignore [missing-attribute]
             "dtype": str(self._dtype),
         }
         return tensor, properties

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -66,7 +66,6 @@ class FunctionCounts:
     def __getitem__(self, item: Any) -> Union[FunctionCount, "FunctionCounts"]:
         data: FunctionCount | tuple[FunctionCount, ...] = self._data[item]
         return (
-            # pyrefly: ignore [bad-return]
             FunctionCounts(cast(tuple[FunctionCount, ...], data), self.inclusive, truncate_rows=False)
             if isinstance(data, tuple) else data
         )
@@ -450,13 +449,11 @@ class GlobalsBridge:
         load_lines = []
         for name, wrapped_value in self._globals.items():
             if wrapped_value.setup is not None:
-                # pyrefly: ignore [bad-argument-type]
                 load_lines.append(textwrap.dedent(wrapped_value.setup))
 
             if wrapped_value.serialization == Serialization.PICKLE:
                 path = os.path.join(self._data_dir, f"{name}.pkl")
                 load_lines.append(
-                    # pyrefly: ignore [bad-argument-type]
                     f"with open({repr(path)}, 'rb') as f:\n    {name} = pickle.load(f)")
                 with open(path, "wb") as f:
                     pickle.dump(wrapped_value.value, f)
@@ -466,13 +463,11 @@ class GlobalsBridge:
                 # TODO: Figure out if we can use torch.serialization.add_safe_globals here
                 # Using weights_only=False after the change in
                 # https://dev-discuss.pytorch.org/t/bc-breaking-change-torch-load-is-being-flipped-to-use-weights-only-true-by-default-in-the-nightlies-after-137602/2573
-                # pyrefly: ignore [bad-argument-type]
                 load_lines.append(f"{name} = torch.load({repr(path)}, weights_only=False)")
                 torch.save(wrapped_value.value, path)
 
             elif wrapped_value.serialization == Serialization.TORCH_JIT:
                 path = os.path.join(self._data_dir, f"{name}.pt")
-                # pyrefly: ignore [bad-argument-type]
                 load_lines.append(f"{name} = torch.jit.load({repr(path)})")
                 with open(path, "wb") as f:
                     torch.jit.save(wrapped_value.value, f)  # type: ignore[no-untyped-call]

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1016,7 +1016,6 @@ def _get_debug_context_and_cb() -> Tuple[Callable[[], Any], Callable[[Checkpoint
             def logging_mode():
                 with LoggingTensorMode(), \
                      capture_logs(True, python_tb=True, script_tb=True, cpp_tb=cpp_tb) as logs_and_tb:
-                    # pyrefly: ignore [bad-assignment]
                     self.logs, self.tbs = logs_and_tb
                     yield logs_and_tb
             return logging_mode()

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -319,7 +319,6 @@ def get_linux_pkg_version(run_lambda, pkg_name):
         },
     }
 
-    # pyrefly: ignore [redundant-cast]
     field_index: int = int(_cast(int, grep_version[pkg_mgr]["field_index"]))
     cmd: str = str(grep_version[pkg_mgr]["command"])
     cmd = cmd.format(pkg_name)

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -284,7 +284,6 @@ class _DataPipeMeta(GenericMeta):
         return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
         # TODO: the statements below are not reachable by design as there is a bug and typing is low priority for now.
-        # pyrefly: ignore [no-access]
         cls.__origin__ = None
         if "type" in namespace:
             return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]

--- a/torch/utils/data/datapipes/dataframe/dataframes.py
+++ b/torch/utils/data/datapipes/dataframe/dataframes.py
@@ -81,7 +81,6 @@ class Capture:
 
     def _ops_str(self):
         res = ""
-        # pyrefly: ignore [not-iterable]
         for op in self.ctx["operations"]:
             if len(res) > 0:
                 res += "\n"
@@ -91,7 +90,6 @@ class Capture:
     def __getstate__(self):
         # TODO(VitalyFedyunin): Currently can't pickle (why?)
         self.ctx["schema_df"] = None
-        # pyrefly: ignore [not-iterable]
         for var in self.ctx["variables"]:
             var.calculated_value = None
         state = {}
@@ -115,13 +113,11 @@ class Capture:
         return CaptureGetItem(self, key, ctx=self.ctx)
 
     def __setitem__(self, key, value) -> None:
-        # pyrefly: ignore [missing-attribute]
         self.ctx["operations"].append(CaptureSetItem(self, key, value, ctx=self.ctx))
 
     def __add__(self, add_val):
         res = CaptureAdd(self, add_val, ctx=self.ctx)
         var = CaptureVariable(res, ctx=self.ctx)
-        # pyrefly: ignore [missing-attribute]
         self.ctx["operations"].append(
             CaptureVariableAssign(variable=var, value=res, ctx=self.ctx)
         )
@@ -130,7 +126,6 @@ class Capture:
     def __sub__(self, add_val):
         res = CaptureSub(self, add_val, ctx=self.ctx)
         var = CaptureVariable(res, ctx=self.ctx)
-        # pyrefly: ignore [missing-attribute]
         self.ctx["operations"].append(
             CaptureVariableAssign(variable=var, value=res, ctx=self.ctx)
         )
@@ -140,19 +135,15 @@ class Capture:
         res = CaptureMul(self, add_val, ctx=self.ctx)
         var = CaptureVariable(res, ctx=self.ctx)
         t = CaptureVariableAssign(variable=var, value=res, ctx=self.ctx)
-        # pyrefly: ignore [missing-attribute]
         self.ctx["operations"].append(t)
         return var
 
     def _is_context_empty(self):
-        # pyrefly: ignore [bad-argument-type]
         return len(self.ctx["operations"]) == 0 and len(self.ctx["variables"]) == 0
 
     def apply_ops_2(self, dataframe) -> None:
         # TODO(VitalyFedyunin): Make this calculation thread safe (as currently it updates pointer)
-        # pyrefly: ignore [unsupported-operation]
         self.ctx["variables"][0].calculated_value = dataframe
-        # pyrefly: ignore [not-iterable]
         for op in self.ctx["operations"]:
             op.execute()
 
@@ -185,7 +176,6 @@ class Capture:
         res = CaptureCall(self, ctx=self.ctx, args=args, kwargs=kwargs)
         var = CaptureVariable(None, ctx=self.ctx)
         t = CaptureVariableAssign(ctx=self.ctx, variable=var, value=res)
-        # pyrefly: ignore [missing-attribute]
         self.ctx["operations"].append(t)
         return var
 
@@ -287,9 +277,7 @@ class CaptureVariable(Capture):
 
     def apply_ops(self, dataframe):
         # TODO(VitalyFedyunin): Make this calculation thread safe (as currently it updates pointer)
-        # pyrefly: ignore [unsupported-operation]
         self.ctx["variables"][0].calculated_value = dataframe
-        # pyrefly: ignore [not-iterable]
         for op in self.ctx["operations"]:
             op.execute()
         return self.calculated_value
@@ -411,7 +399,6 @@ class CaptureDataFrame(CaptureInitial):
 
 class CaptureDataFrameWithDataPipeOps(CaptureDataFrame):
     def as_datapipe(self):
-        # pyrefly: ignore [unsupported-operation]
         return DataFrameTracedOps(self.ctx["variables"][0].source_datapipe, self)
 
     def raw_iterator(self):

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -219,14 +219,12 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
         if group_size is not None and buffer_size is not None:
             if not (0 < group_size <= buffer_size):
                 raise AssertionError("group_size must be > 0 and <= buffer_size")
-            # pyrefly: ignore [bad-assignment]
             self.guaranteed_group_size = group_size
         if guaranteed_group_size is not None:
             if group_size is None or not (0 < guaranteed_group_size <= group_size):
                 raise AssertionError(
                     "guaranteed_group_size must be > 0 and <= group_size and group_size must be set"
                 )
-            # pyrefly: ignore [bad-assignment]
             self.guaranteed_group_size = guaranteed_group_size
         self.drop_remaining = drop_remaining
         self.wrapper_class = DataChunk

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -31,7 +31,6 @@ class FileBaton:
             True if the file could be created, else False.
         """
         try:
-            # pyrefly: ignore [bad-assignment]
             self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL)
             return True
         except FileExistsError:

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -24,7 +24,6 @@ MATH_TRANSPILATIONS = collections.OrderedDict([
     ("std::frexp", ("::frexp")),
 ])
 
-# no-matching-overload
 CUDA_TYPE_NAME_MAP = collections.OrderedDict([
     ("CUresult", "hipError_t"),
     ("cudaError_t", "hipError_t"),
@@ -350,7 +349,6 @@ CUDA_INCLUDE_MAP = collections.OrderedDict([
     ("tensorpipe/tensorpipe_cuda.h", "tensorpipe/tensorpipe_hip.h"),
 ])
 
-# no-matching-overload
 CUDA_IDENTIFIER_MAP = collections.OrderedDict([
     ("__CUDACC__", "__HIPCC__"),
     ("CUDA_ERROR_INVALID_CONTEXT", "hipErrorInvalidContext"),

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -24,7 +24,7 @@ MATH_TRANSPILATIONS = collections.OrderedDict([
     ("std::frexp", ("::frexp")),
 ])
 
-# pyrefly: ignore  # no-matching-overload
+# no-matching-overload
 CUDA_TYPE_NAME_MAP = collections.OrderedDict([
     ("CUresult", "hipError_t"),
     ("cudaError_t", "hipError_t"),
@@ -350,7 +350,7 @@ CUDA_INCLUDE_MAP = collections.OrderedDict([
     ("tensorpipe/tensorpipe_cuda.h", "tensorpipe/tensorpipe_hip.h"),
 ])
 
-# pyrefly: ignore  # no-matching-overload
+# no-matching-overload
 CUDA_IDENTIFIER_MAP = collections.OrderedDict([
     ("__CUDACC__", "__HIPCC__"),
     ("CUDA_ERROR_INVALID_CONTEXT", "hipErrorInvalidContext"),

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -145,7 +145,6 @@ class BackwardHook:
 
                 res = out
 
-            # pyrefly: ignore [bad-assignment]
             self.grad_outputs = None
 
             return self._unpack_none(self.input_tensors_index, res)

--- a/torch/utils/tensorboard/_onnx_graph.py
+++ b/torch/utils/tensorboard/_onnx_graph.py
@@ -23,7 +23,6 @@ def parse(graph):
         print(node.name)
         shapeproto = TensorShapeProto(
             dim=[
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=d.dim_value)
                 for d in node.type.tensor_type.shape.dim
             ]

--- a/torch/utils/tensorboard/_proto_graph.py
+++ b/torch/utils/tensorboard/_proto_graph.py
@@ -6,7 +6,6 @@ from tensorboard.compat.proto.attr_value_pb2 import AttrValue
 from tensorboard.compat.proto.tensor_shape_pb2 import TensorShapeProto
 
 
-# pyrefly: ignore [not-a-type]
 def attr_value_proto(dtype: object, shape: Sequence[int] | None, s: str | None) -> dict[str, AttrValue]:
     """Create a dict of objects matching a NodeDef's attr field.
 
@@ -19,18 +18,15 @@ def attr_value_proto(dtype: object, shape: Sequence[int] | None, s: str | None) 
         attr["attr"] = AttrValue(s=s.encode(encoding="utf_8"))
     if shape is not None:
         shapeproto = tensor_shape_proto(shape)
-        # pyrefly: ignore [missing-attribute]
         attr["_output_shapes"] = AttrValue(list=AttrValue.ListValue(shape=[shapeproto]))
     return attr
 
 
-# pyrefly: ignore [not-a-type]
 def tensor_shape_proto(outputsize: Sequence[int]) -> TensorShapeProto:
     """Create an object matching a tensor_shape field.
 
     Follows https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/tensor_shape.proto .
     """
-    # pyrefly: ignore [missing-attribute]
     return TensorShapeProto(dim=[TensorShapeProto.Dim(size=d) for d in outputsize])
 
 
@@ -42,7 +38,6 @@ def node_proto(
     shape: tuple[int, ...] | None = None,
     outputsize: Sequence[int] | None = None,
     attributes: str = "",
-    # pyrefly: ignore [not-a-type]
 ) -> NodeDef:
     """Create an object matching a NodeDef.
 

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -260,7 +260,6 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
             hps.append(
                 HParamInfo(
                     name=k,
-                    # pyrefly: ignore [missing-attribute]
                     type=DataType.Value("DATA_TYPE_FLOAT64"),
                     domain_discrete=domain_discrete,
                 )
@@ -283,7 +282,6 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
             hps.append(
                 HParamInfo(
                     name=k,
-                    # pyrefly: ignore [missing-attribute]
                     type=DataType.Value("DATA_TYPE_STRING"),
                     domain_discrete=domain_discrete,
                 )
@@ -306,7 +304,6 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
             hps.append(
                 HParamInfo(
                     name=k,
-                    # pyrefly: ignore [missing-attribute]
                     type=DataType.Value("DATA_TYPE_BOOL"),
                     domain_discrete=domain_discrete,
                 )
@@ -316,7 +313,6 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
         if isinstance(v, torch.Tensor):
             v = make_np(v)[0]
             ssi.hparams[k].number_value = v
-            # pyrefly: ignore [missing-attribute]
             hps.append(HParamInfo(name=k, type=DataType.Value("DATA_TYPE_FLOAT64")))
             continue
         raise ValueError(
@@ -325,12 +321,10 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
 
     content = HParamsPluginData(session_start_info=ssi, version=PLUGIN_DATA_VERSION)
     smd = SummaryMetadata(
-        # pyrefly: ignore [missing-attribute]
         plugin_data=SummaryMetadata.PluginData(
             plugin_name=PLUGIN_NAME, content=content.SerializeToString()
         )
     )
-    # pyrefly: ignore [missing-attribute]
     ssi = Summary(value=[Summary.Value(tag=SESSION_START_INFO_TAG, metadata=smd)])
 
     mts = [MetricInfo(name=MetricName(tag=k)) for k in metric_dict]
@@ -339,24 +333,19 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
 
     content = HParamsPluginData(experiment=exp, version=PLUGIN_DATA_VERSION)
     smd = SummaryMetadata(
-        # pyrefly: ignore [missing-attribute]
         plugin_data=SummaryMetadata.PluginData(
             plugin_name=PLUGIN_NAME, content=content.SerializeToString()
         )
     )
-    # pyrefly: ignore [missing-attribute]
     exp = Summary(value=[Summary.Value(tag=EXPERIMENT_TAG, metadata=smd)])
 
-    # pyrefly: ignore [missing-attribute]
     sei = SessionEndInfo(status=Status.Value("STATUS_SUCCESS"))
     content = HParamsPluginData(session_end_info=sei, version=PLUGIN_DATA_VERSION)
     smd = SummaryMetadata(
-        # pyrefly: ignore [missing-attribute]
         plugin_data=SummaryMetadata.PluginData(
             plugin_name=PLUGIN_NAME, content=content.SerializeToString()
         )
     )
-    # pyrefly: ignore [missing-attribute]
     sei = Summary(value=[Summary.Value(tag=SESSION_END_INFO_TAG, metadata=smd)])
 
     return exp, ssi, sei
@@ -390,12 +379,10 @@ def scalar(name, tensor, collections=None, new_style=False, double_precision=Fal
         if double_precision:
             tensor_proto = TensorProto(double_val=[scalar], dtype="DT_DOUBLE")
 
-        # pyrefly: ignore [missing-attribute]
         plugin_data = SummaryMetadata.PluginData(plugin_name="scalars")
         smd = SummaryMetadata(plugin_data=plugin_data)
         return Summary(
             value=[
-                # pyrefly: ignore [missing-attribute]
                 Summary.Value(
                     tag=name,
                     tensor=tensor_proto,
@@ -404,7 +391,6 @@ def scalar(name, tensor, collections=None, new_style=False, double_precision=Fal
             ]
         )
     else:
-        # pyrefly: ignore [missing-attribute]
         return Summary(value=[Summary.Value(tag=name, simple_value=scalar)])
 
 
@@ -432,7 +418,6 @@ def tensor_proto(tag, tensor):
             **{
                 "dtype": dtype,
                 "tensor_shape": TensorShapeProto(
-                    # pyrefly: ignore [missing-attribute]
                     dim=[TensorShapeProto.Dim(size=x) for x in tensor.shape]
                 ),
                 field_name: conversion_fn(tensor),
@@ -441,10 +426,8 @@ def tensor_proto(tag, tensor):
     else:
         raise ValueError(f"{tag} has unsupported tensor dtype {tensor.dtype}")
 
-    # pyrefly: ignore [missing-attribute]
     plugin_data = SummaryMetadata.PluginData(plugin_name="tensor")
     smd = SummaryMetadata(plugin_data=plugin_data)
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, metadata=smd, tensor=tensor_proto)])
 
 
@@ -478,7 +461,6 @@ def histogram_raw(name, min, max, num, sum, sum_squares, bucket_limits, bucket_c
         bucket_limit=bucket_limits,
         bucket=bucket_counts,
     )
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=name, histo=hist)])
 
 
@@ -501,7 +483,6 @@ def histogram(name, values, bins, max_bins=None):
     """
     values = make_np(values)
     hist = make_histogram(values.astype(float), bins, max_bins)
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=name, histo=hist)])
 
 
@@ -595,7 +576,6 @@ def image(tag, tensor, rescale=1, dataformats="NCHW"):
     tensor = tensor.astype(np.float32)
     tensor = (tensor * scale_factor).clip(0, 255).astype(np.uint8)
     image = make_image(tensor, rescale=rescale)
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, image=image)])
 
 
@@ -613,7 +593,6 @@ def image_boxes(
         rois=tensor_boxes,
         labels=labels,
     )
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, image=image)])
 
 
@@ -652,7 +631,6 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
     image.save(output, format="PNG")
     image_string = output.getvalue()
     output.close()
-    # pyrefly: ignore [missing-attribute]
     return Summary.Image(
         height=height,
         width=width,
@@ -669,7 +647,6 @@ def video(tag, tensor, fps=4):
     tensor = tensor.astype(np.float32)
     tensor = (tensor * scale_factor).clip(0, 255).astype(np.uint8)
     video = make_video(tensor, fps)
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, image=video)])
 
 
@@ -707,7 +684,6 @@ def make_video(tensor, fps):
         f.seek(0)
         tensor_string = f.read()
 
-        # pyrefly: ignore [missing-attribute]
         return Summary.Image(
             height=h, width=w, colorspace=c, encoded_image_string=tensor_string
         )
@@ -735,7 +711,6 @@ def audio(tag, tensor, sample_rate=44100):
         wave_write.writeframes(array.data)
     audio_string = fio.getvalue()
     fio.close()
-    # pyrefly: ignore [missing-attribute]
     audio = Summary.Audio(
         sample_rate=sample_rate,
         num_channels=1,
@@ -743,7 +718,6 @@ def audio(tag, tensor, sample_rate=44100):
         encoded_audio_string=audio_string,
         content_type="audio/wav",
     )
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, audio=audio)])
 
 
@@ -758,7 +732,6 @@ def custom_scalars(layout):
                     raise AssertionError("len(tags) != 3")
                 mgcc = layout_pb2.MarginChartContent(
                     series=[
-                        # pyrefly: ignore [missing-attribute]
                         layout_pb2.MarginChartContent.Series(
                             value=tags[0], lower=tags[1], upper=tags[2]
                         )
@@ -772,7 +745,6 @@ def custom_scalars(layout):
         categories.append(layout_pb2.Category(title=k, chart=charts))
 
     layout = layout_pb2.Layout(category=categories)
-    # pyrefly: ignore [missing-attribute]
     plugin_data = SummaryMetadata.PluginData(plugin_name="custom_scalars")
     smd = SummaryMetadata(plugin_data=plugin_data)
     tensor = TensorProto(
@@ -782,14 +754,12 @@ def custom_scalars(layout):
     )
     return Summary(
         value=[
-            # pyrefly: ignore [missing-attribute]
             Summary.Value(tag="custom_scalars__config__", tensor=tensor, metadata=smd)
         ]
     )
 
 
 def text(tag, text):
-    # pyrefly: ignore [missing-attribute]
     plugin_data = SummaryMetadata.PluginData(
         plugin_name="text", content=TextPluginData(version=0).SerializeToString()
     )
@@ -797,11 +767,9 @@ def text(tag, text):
     tensor = TensorProto(
         dtype="DT_STRING",
         string_val=[text.encode(encoding="utf_8")],
-        # pyrefly: ignore [missing-attribute]
         tensor_shape=TensorShapeProto(dim=[TensorShapeProto.Dim(size=1)]),
     )
     return Summary(
-        # pyrefly: ignore [missing-attribute]
         value=[Summary.Value(tag=tag + "/text_summary", metadata=smd, tensor=tensor)]
     )
 
@@ -815,7 +783,6 @@ def pr_curve_raw(
     pr_curve_plugin_data = PrCurvePluginData(
         version=0, num_thresholds=num_thresholds
     ).SerializeToString()
-    # pyrefly: ignore [missing-attribute]
     plugin_data = SummaryMetadata.PluginData(
         plugin_name="pr_curves", content=pr_curve_plugin_data
     )
@@ -825,14 +792,11 @@ def pr_curve_raw(
         float_val=data.reshape(-1).tolist(),
         tensor_shape=TensorShapeProto(
             dim=[
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=data.shape[0]),
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=data.shape[1]),
             ]
         ),
     )
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, metadata=smd, tensor=tensor)])
 
 
@@ -845,7 +809,6 @@ def pr_curve(tag, labels, predictions, num_thresholds=127, weights=None):
     pr_curve_plugin_data = PrCurvePluginData(
         version=0, num_thresholds=num_thresholds
     ).SerializeToString()
-    # pyrefly: ignore [missing-attribute]
     plugin_data = SummaryMetadata.PluginData(
         plugin_name="pr_curves", content=pr_curve_plugin_data
     )
@@ -855,14 +818,11 @@ def pr_curve(tag, labels, predictions, num_thresholds=127, weights=None):
         float_val=data.reshape(-1).tolist(),
         tensor_shape=TensorShapeProto(
             dim=[
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=data.shape[0]),
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=data.shape[1]),
             ]
         ),
     )
-    # pyrefly: ignore [missing-attribute]
     return Summary(value=[Summary.Value(tag=tag, metadata=smd, tensor=tensor)])
 
 
@@ -947,17 +907,13 @@ def _get_tensor_summary(
         float_val=tensor.reshape(-1).tolist(),
         tensor_shape=TensorShapeProto(
             dim=[
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=tensor.shape[0]),
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=tensor.shape[1]),
-                # pyrefly: ignore [missing-attribute]
                 TensorShapeProto.Dim(size=tensor.shape[2]),
             ]
         ),
     )
 
-    # pyrefly: ignore [missing-attribute]
     tensor_summary = Summary.Value(
         tag=metadata.get_instance_name(name, content_type),
         tensor=tensor,
@@ -1005,11 +961,8 @@ def mesh(
 
     summaries = []
     tensors = [
-        # pyrefly: ignore [missing-attribute]
         (vertices, MeshPluginData.VERTEX),
-        # pyrefly: ignore [missing-attribute]
         (faces, MeshPluginData.FACE),
-        # pyrefly: ignore [missing-attribute]
         (colors, MeshPluginData.COLOR),
     ]
     tensors = [tensor for tensor in tensors if tensor[0] is not None]

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -166,7 +166,6 @@ class FileWriter:
         The events will go into a new events file.
         Does nothing if the EventFileWriter was not closed.
         """
-        # pyrefly: ignore [missing-attribute]
         self.event_writer.reopen()
 
 
@@ -255,9 +254,7 @@ class SummaryWriter:
         buckets = []
         neg_buckets = []
         while v < 1e20:
-            # pyrefly: ignore [bad-argument-type]
             buckets.append(v)
-            # pyrefly: ignore [bad-argument-type]
             neg_buckets.append(-v)
             v *= 1.1
         self.default_bins = neg_buckets[::-1] + [0] + buckets
@@ -281,7 +278,6 @@ class SummaryWriter:
                 self.file_writer.add_event(
                     Event(
                         step=most_recent_step,
-                        # pyrefly: ignore [missing-attribute]
                         session_log=SessionLog(status=SessionLog.START),
                     )
                 )

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -467,7 +467,6 @@ def to_html(nodes):
         if n.context is None:
             continue
         s = _listener_template.format(id=str(i + 1), stack=escape(f'{n.label}:\n{n.context}'))
-        # pyrefly: ignore [bad-argument-type]
         listeners.append(s)
     dot = to_dot(nodes)
     return _template.replace('$DOT', repr(dot)).replace('$LISTENERS', '\n'.join(listeners))


### PR DESCRIPTION
After upgrading pyrefly, we can remove error suppressions that are no longer needed. 

This diff cleans them up in two directories. 


`lintrunner -a`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo