### PR TITLE
(Testing) Update pthreadpool to google/pthreadpool 9003ee6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "third_party/NNPACK_deps/pthreadpool"]
     ignore = dirty
     path = third_party/pthreadpool
-    url = https://github.com/Maratyszcza/pthreadpool.git
+    url = git@github.com:google/pthreadpool.git
 [submodule "third_party/NNPACK_deps/FXdiv"]
     ignore = dirty
     path = third_party/FXdiv

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadPThreadPool.cmake
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadPThreadPool.cmake
@@ -10,7 +10,7 @@ project(pthreadpool-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(pthreadpool
-  GIT_REPOSITORY https://github.com/Maratyszcza/pthreadpool.git
+  GIT_REPOSITORY git@github.com:google/pthreadpool.git
   GIT_TAG master
   SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/pthreadpool"
   BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/pthreadpool"


### PR DESCRIPTION
Update pthreadpool to use Google's fork. The original repository is no longer actively maintained and new development is happening in Google's version. It is backwards compatible but introduces new features used by XNNPACK.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01