### PR TITLE
[1/N] Migrate more ops to per-operator headers

### DIFF
--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/jit/passes/batch_mm.h>
 
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
 #include <ATen/core/functional.h>
 #include <ATen/core/symbol.h>
 #include <c10/util/Exception.h>
@@ -11,7 +13,14 @@
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>
 
+#ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/ATen.h>
+#else
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/cat.h>
+#include <ATen/ops/chunk.h>
+#include <ATen/ops/mm.h>
+#endif
 #include <algorithm>
 #include <unordered_map>
 #include <utility>

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -1,3 +1,5 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/onnx/helper.h>
 #include <torch/csrc/onnx/back_compat.h>

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/jit/passes/onnx/peephole.h>
 
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/jit_log.h>

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/jit/passes/shape_analysis.h>
 
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/error_report.h>

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -1,7 +1,9 @@
 #include <torch/csrc/jit/serialization/export.h>
 
-#include <ATen/ATen.h>
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
 #include <ATen/Utils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/core/functional.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175387
* __->__ #175383
* #175382

Guard the ones that do not depend on ATen.h/tensor.h with `TORCH_ASSERT_ONLY_METHOD_OPERATORS`
Goal is to be avoid jit stack recompilation as much as possible when native_functions.yml is modified

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>