### PR TITLE
Fix scratch size for TMA in C++ wrapper

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -6,7 +6,11 @@ from typing import NamedTuple
 
 import torch
 from torch._inductor import config
+from torch._inductor.codegen.common import TritonScratchWorkspace
+from torch._inductor.codegen.cpp_wrapper_gpu import DeferredTritonCallWrapper
+from torch._inductor.codegen.cuda.device_op_overrides import CUDADeviceOpOverrides
 from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import IndentedBuffer
 from torch.testing._internal.common_utils import slowTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, RUN_GPU
 
@@ -76,6 +80,65 @@ class TestGpuWrapper(InductorTestCase):
         with torch.utils._device.DeviceContext(self.device):
             _, code = test_torchinductor.run_and_get_cpp_code(compiled, x, 3)
         self.assertIn("torch.tensor(arg, device='cpu')", code)
+
+    def test_cpp_scratch_scales_with_grid_size_for_tma(self):
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("CUDA-only codegen test")
+
+        scratch_def, scratch_var = CUDADeviceOpOverrides().cpp_scratch(
+            0,
+            TritonScratchWorkspace(
+                size=256, generate_dtype_str=lambda: "at::ScalarType::Byte"
+            ),
+            prefix="global_scratch",
+        )
+        self.assertEqual(scratch_var, "global_scratch_scratch_0")
+        self.assertIn(
+            "static_cast<int64_t>(256) * grid_0 * grid_1 * grid_2", scratch_def[0]
+        )
+
+    def test_triton_wrapper_scales_scratch_with_num_ctas(self):
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("CUDA-only codegen test")
+
+        class FakeWrapper:
+            device = "cuda"
+
+            def __init__(self):
+                self.scratch_spaces = None
+
+            def generate_args_decl(
+                self,
+                prefix,
+                call_args,
+                arg_types,
+                arg_signatures,
+                is_triton_kernel=True,
+                scratch_spaces=None,
+            ):
+                self.scratch_spaces = scratch_spaces
+
+                return ""
+
+        wrapper = FakeWrapper()
+        prefix = IndentedBuffer()
+        params = {
+            "triton_meta": {"signature": {"x": "*fp32"}, "constants": {}},
+            "def_args": ["x"],
+            "call_args": ["x"],
+            "config": {"num_ctas": 8},
+            "num_warps": 4,
+            "shared_mem": 0,
+        }
+
+        DeferredTritonCallWrapper(
+            wrapper_name="wrapper",
+            kernel_name="kernel",
+            kernel_name_to_body={},
+            arg_types=[torch.float32],
+        ).generate_launch_kernel(prefix, wrapper, "kernel_var", params)
+
+        self.assertEqual(wrapper.scratch_spaces, {"global_scratch": 256 * 8})
 
 
 class DynamicShapesGpuWrapperGpuTests(InductorTestCase):

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -129,6 +129,7 @@ class TestGpuWrapper(InductorTestCase):
             "config": {"num_ctas": 8},
             "num_warps": 4,
             "shared_mem": 0,
+            "global_scratch": 256,
         }
 
         DeferredTritonCallWrapper(

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -776,8 +776,9 @@ class DeferredTritonCallWrapper:
         ]
         arg_types = [arg_type_lookup[name] for name in call_args]
         arg_signatures = [triton_meta["signature"][name] for name in call_args]
+        num_ctas = params.get("config", {}).get("num_ctas", 1)
         scratch_spaces = {
-            name: params[name]
+            name: params[name] * num_ctas
             for name in ["global_scratch", "profile_scratch"]
             if params.get(name, None) is not None
         }

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -336,7 +336,10 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         prefix = f"{prefix}_" if prefix else ""
         var_name = f"{prefix}scratch_{idx}"
         if workspace.size > 0:
-            size_array = f"int64_t {var_name}_size[] = {{{workspace.size}}};"
+            size_expr = (
+                f"static_cast<int64_t>({workspace.size}) * grid_0 * grid_1 * grid_2"
+            )
+            size_array = f"int64_t {var_name}_size[] = {{{size_expr}}};"
             stride_array = f"int64_t {var_name}_stride[] = {{1}};"
             device_type = "cached_torch_device_type_cuda"
             device_idx = "device_idx_"


### PR DESCRIPTION
This pull request introduces improvements to the handling of scratch space allocation for CUDA kernels in the Torch Inductor code generation pipeline with cpp wrapper enabled. The main focus is on ensuring that scratch space is correctly scaled based on the number of compute thread arrays (CTAs) and the CUDA grid dimensions, which helps optimize memory usage and kernel execution.

Scratch space allocation improvements:

* In `torch/_inductor/codegen/cpp_wrapper_gpu.py`, the scratch space allocation now multiplies the requested size by the number of CTAs (`num_ctas`), which is retrieved from the kernel configuration parameters. This ensures that each CTA receives the appropriate amount of scratch space.
* In `torch/_inductor/codegen/cuda/device_op_overrides.py`, the scratch space size calculation for CUDA kernels now multiplies the workspace size by the CUDA grid dimensions (`grid_0`, `grid_1`, `grid_2`). This change ensures that the scratch space is properly distributed across all blocks in the grid, improving correctness and efficiency.


Running the following snippet with `CUDA_LAUNCH_BLOCKING=1` would hit `CUDA driver error: an illegal instruction was encountered`.

```python
import torch
import torch._inductor.config as inductor_config

inductor_config.triton.use_tensor_descriptor = True
inductor_config.assume_aligned_inputs = True
inductor_config.cpp_wrapper = True
inductor_config.max_autotune_gemm = False
inductor_config.triton.cudagraphs = False
inductor_config.triton.enable_pdl = False

device = torch.device("cuda")
dtype = torch.bfloat16

# Llama3-8B attention dimensions (smaller dims do not trigger TMA codegen)
hidden_dim = 4096
n_heads = 32
head_dim = hidden_dim // n_heads
seq_len = 512
batch_size = 1


class AttentionBlock(torch.nn.Module):
    """Pre-norm multi-head attention -- the minimal pattern that triggers the bug."""

    def __init__(self):
        super().__init__()
        self.norm = torch.nn.RMSNorm(hidden_dim)
        self.q_proj = torch.nn.Linear(hidden_dim, hidden_dim, bias=False)
        self.k_proj = torch.nn.Linear(hidden_dim, hidden_dim, bias=False)
        self.v_proj = torch.nn.Linear(hidden_dim, hidden_dim, bias=False)
        self.o_proj = torch.nn.Linear(hidden_dim, hidden_dim, bias=False)

    def forward(self, x):
        B, S, D = x.shape
        h = self.norm(x)
        q = self.q_proj(h).view(B, S, n_heads, head_dim).transpose(1, 2)
        k = self.k_proj(h).view(B, S, n_heads, head_dim).transpose(1, 2)
        v = self.v_proj(h).view(B, S, n_heads, head_dim).transpose(1, 2)
        attn_out = torch.nn.functional.scaled_dot_product_attention(
            q, k, v, is_causal=True
        )
        attn_out = attn_out.transpose(1, 2).contiguous().view(B, S, D)
        return x + self.o_proj(attn_out)


def main():
    print(f"PyTorch: {torch.__version__}")
    print(f"GPU: {torch.cuda.get_device_name(0)}")
    print(f"dtype: {dtype}")
    print(f"use_tensor_descriptor: {inductor_config.triton.use_tensor_descriptor}")
    print(f"cpp_wrapper: {inductor_config.cpp_wrapper}")
    print()

    model = AttentionBlock().to(device=device, dtype=dtype)
    compiled = torch.compile(model)

    x = torch.randn(batch_size, seq_len, hidden_dim, device=device, dtype=dtype)
    target = torch.randn_like(x)

    print(
        f"Running compiled attention block: "
        f"batch={batch_size}, seq={seq_len}, dim={hidden_dim}, heads={n_heads}"
    )
    for step in range(3):
        out = compiled(x)
        loss = torch.nn.functional.mse_loss(out, target)
        loss.backward()
        torch.cuda.synchronize()
        print(f"  step {step}: loss={loss.item():.4f}")

    print("\nCompleted without error - failure did NOT reproduce.")


if __name__ == "__main__":
    main()
```

assisted by Opus 4.6.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo