### PR TITLE
[CI] Enable strict mode in vLLM benchmark

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           repository: pytorch/pytorch-integration-testing
           path: pytorch/pytorch-integration-testing
-          ref: strict-check_benchmark_results
+          ref: main
 
       - name: Check if the device is supported
         run: |

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           repository: pytorch/pytorch-integration-testing
           path: pytorch/pytorch-integration-testing
-          ref: main
+          ref: strict-check_benchmark_results
 
       - name: Check if the device is supported
         run: |
@@ -208,7 +208,8 @@ jobs:
 
           # Fail when there is no result or if the metrics are all zero
           python3 pytorch/pytorch-integration-testing/.github/scripts/check_benchmark_results.py \
-            --benchmark-results "${BENCHMARK_RESULTS}"
+            --benchmark-results "${BENCHMARK_RESULTS}" \
+            --strict
 
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0


### PR DESCRIPTION
This is to test and roll out `--strict` validation mode from https://github.com/pytorch/pytorch-integration-testing/pull/150

### Testing

https://github.com/pytorch/pytorch/actions/runs/22214365928