### PR TITLE
[CI] Enable HF cache when updating TorchInductor pinned commits

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -133,6 +133,9 @@
 
 "ci-refresh-hf-cache":
 - .github/ci_commit_pins/vllm.txt
+- .ci/docker/ci_commit_pins/timm.txt
+- .ci/docker/ci_commit_pins/huggingface-requirements.txt
+- .ci/docker/ci_commit_pins/torchbench.txt
 
 "ciflow/inductor-pallas":
 - torch/_inductor/codegen/pallas.py


### PR DESCRIPTION
This will enable HF cache when TorchInductor pinned commits are updated. The cache will be populated accordingly.