### PR TITLE
[dynamo] Replace counter print with log.debug in test tearDown

### DIFF
--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -94,7 +94,7 @@ class TestCase(TorchTestCase):
     def tearDown(self) -> None:
         trace_log.removeHandler(self.handler)
         for k, v in utils.counters.items():
-            print(k, v.most_common())
+            log.debug("%s %s", k, v.most_common())
         reset()
         utils.counters.clear()
         torch._C._autograd._saved_tensors_hooks_enable()


### PR DESCRIPTION
Fixes #135521

The `DynamoTestCase.tearDown()` method prints counter stats to stdout via `print()` on every test teardown. This spams the console when running tests that inherit from the inductor `TestCase` (which extends `DynamoTestCase`), as reported in the issue.

This replaces the `print()` call with `log.debug()`, using the module logger that's already defined in the file. Counter stats are still available when debug logging is enabled, but no longer pollute default stdout.

As suggested by @ezyang and approved by @jansel in https://github.com/pytorch/pytorch/issues/135521#issuecomment-2341122206.

This PR was authored with the assistance of Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo