### PR TITLE
[FSDP] Eliminate redundant allgathers in FSDP nested sharding with AC

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -469,10 +469,12 @@ def _post_forward(
         # recomputed forward
         if handle and handle._training_state == HandleTrainingState.BACKWARD_PRE:
             return output
+        # Only execute for native forward (non-recomputed)   
+        if torch._C._current_graph_task_id() == -1:
+            state._exec_order_data.record_post_forward(handle)
+            if reshard_fn is not None:
+                reshard_fn(state, handle)
 
-        state._exec_order_data.record_post_forward(handle)
-        if reshard_fn is not None:
-            reshard_fn(state, handle)
         # Register pre-backward hooks to unshard the flat parameters for the
         # gradient computation (if needed)
         output = _register_pre_backward_hooks(state, module, output, handle)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -469,7 +469,7 @@ def _post_forward(
         # recomputed forward
         if handle and handle._training_state == HandleTrainingState.BACKWARD_PRE:
             return output
-        # Only execute for native forward (non-recomputed)   
+        # Only execute for native forward (non-recomputed)
         if torch._C._current_graph_task_id() == -1:
             state._exec_order_data.record_post_forward(handle)
             if reshard_fn is not None:


### PR DESCRIPTION
 Eliminate redundant allgathers in FSDP nested sharding with activation checkpointing (AC).

### Background
FSDP nested sharding refers to scenarios where multiple FSDP units exist within a single Transformer layer(e.g., llama-2): 
- The Transformer layer is both an FSDP unit and an AC unit
- The Attention and MLP sub-modules inside each Transformer layer are individual FSDP units
<img width="1617" height="500" alt="f963aa0b7c16fa84026abd9ebc929d3d" src="https://github.com/user-attachments/assets/539848d1-7621-4218-861b-fe9388efccb8" />
With activation checkpointing enabled, the backward recompute phase should theoretically skip resharding. However, the Attention sub-module incorrectly triggers it, leading to two issues: redundant allgathers (Attention params are allgathered twice per Transformer layer) and a broken backward prefetch order.
<img width="1536" height="541" alt="image" src="https://github.com/user-attachments/assets/8313ba3c-6458-4206-aec5-b3a760d7dc42" />

### Checklist Before Starting
 Search for similar PRs. Paste at least one query link here: https://github.com/pytorch/pytorch/pull/164009
### Solution
Add a phase check in the `_post_forward` hook function of FSDP: 

- Check if the current execution is in the backward phase (including recompute stage) via `_current_graph_task_id` 
- Only execute reshard operations and `_exec_order_data.record_post_forward()` when NOT in the backward phase

### Testing Results

Tested on a llama2-7b model (32 layers) with 4×A100 GPUs: 

- End-to-end performance improvement: ≥7%
- Reduced allgather operations: 32 fewer allgather calls during the backward
- No increase in GPU memory peak

Before optimize:
<img width="1361" height="489" alt="image" src="https://github.com/user-attachments/assets/b5094436-595a-4cd0-aee8-b863197d7fb4" />

After optimize:
<img width="1361" height="489" alt="image" src="https://github.com/user-attachments/assets/b4536060-5aaa-441a-a2b4-ac1c14ab18de" />
