### PR TITLE
Remove ir.h from `jit/api/` headers include chain

### DIFF
--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/core/Dict.h>
+#include <ATen/core/enum_type.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/irange.h>
 #include <gmock/gmock.h>

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -1,11 +1,10 @@
 #pragma once
+#include <ATen/core/class_type.h>
 #include <ATen/core/function.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/frontend/name_mangler.h>
 #include <torch/csrc/jit/frontend/source_range.h>
-#include <torch/csrc/jit/ir/ir.h>
-#include <torch/csrc/jit/runtime/graph_executor.h>
 
 #include <torch/csrc/Export.h>
 
@@ -23,6 +22,12 @@
 #include <vector>
 
 namespace torch::jit {
+
+using ::c10::ClassType;
+using ::c10::ClassTypePtr;
+using ::c10::fmap;
+using ::c10::IValue;
+using ::c10::TupleType;
 
 struct Def;
 struct Property;

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/Flags.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
+#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/inliner.h>
 
 #include <torch/csrc/jit/passes/constant_pooling.h>
@@ -74,6 +75,16 @@ c10::intrusive_ptr<c10::ivalue::Future> GraphFunction::runAsync(
     Stack& stack,
     TaskLauncher taskLauncher) {
   return get_executor().runAsync(stack, std::move(taskLauncher));
+}
+
+size_t GraphFunction::num_inputs() const {
+  return graph()->inputs().size();
+}
+
+void GraphFunction::check_single_output() {
+  TORCH_CHECK(
+      graph()->outputs().size() == 1,
+      "Method (but not graphs in general) require a single output. Use None/Tuple for 0 or 2+ outputs");
 }
 
 void GraphFunction::ensure_defined() {

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <ATen/core/function.h>
-#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 
 namespace torch::jit {
+
+using ::c10::FunctionSchema;
 
 struct TORCH_API GraphFunction : public Function {
   GraphFunction(
@@ -58,9 +59,7 @@ struct TORCH_API GraphFunction : public Function {
   // if this isn't yet defined, run its method_creator function
   void ensure_defined() override;
 
-  size_t num_inputs() const override {
-    return graph()->inputs().size();
-  }
+  size_t num_inputs() const override;
 
   Function& setSchema(FunctionSchema schema) override {
     schema_ = std::make_unique<FunctionSchema>(std::move(schema));
@@ -80,11 +79,7 @@ struct TORCH_API GraphFunction : public Function {
     return true;
   }
 
-  void check_single_output() {
-    TORCH_CHECK(
-        graph()->outputs().size() == 1,
-        "Method (but not graphs in general) require a single output. Use None/Tuple for 0 or 2+ outputs");
-  }
+  void check_single_output();
 
   GraphExecutor& get_executor() {
     ensure_defined();

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -3,7 +3,6 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/api/object.h>
 #include <torch/csrc/jit/frontend/source_range.h>
-#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/named_value.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
@@ -34,6 +33,7 @@
 
 namespace torch::jit {
 
+using ::c10::AnyType;
 using ::c10::Argument;
 using ::c10::FunctionSchema;
 using ::c10::QualifiedName;

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/class_type.h>
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
 #include <torch/csrc/jit/api/method.h>
@@ -8,6 +9,8 @@
 #include <utility>
 
 namespace torch::jit {
+
+using ::c10::ClassType;
 
 struct Resolver;
 using ResolverPtr = std::shared_ptr<Resolver>;

--- a/torch/csrc/jit/frontend/versioned_symbols.h
+++ b/torch/csrc/jit/frontend/versioned_symbols.h
@@ -3,6 +3,7 @@
 #include <caffe2/serialize/versions.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/ir.h>
 
 #include <cstdint>
 

--- a/torch/csrc/jit/runtime/argument_spec.cpp
+++ b/torch/csrc/jit/runtime/argument_spec.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/irange.h>
+#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 
 #include <array>

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -18,7 +18,8 @@ namespace torch::jit {
 
 struct Graph;
 
-using ::c10::ArrayRef;
+template <typename T>
+using ArrayRef = at::ArrayRef<T>;
 using ::c10::TensorType;
 using ::c10::TypePtr;
 

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -6,7 +6,6 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/autograd/variable.h>
-#include <torch/csrc/jit/ir/ir.h>
 #include <ostream>
 #include <vector>
 
@@ -16,6 +15,12 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
 #endif
 
 namespace torch::jit {
+
+struct Graph;
+
+using ::c10::ArrayRef;
+using ::c10::TensorType;
+using ::c10::TypePtr;
 
 // GraphExecutor creates specializations of Graphs for different
 // dimensionalitities and types of inputs.

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -59,6 +59,16 @@ C10_DEFINE_bool(
     "Directly reuse the preprocessed graph in the CodeImpl to reduce the memory consumption. This is aggressive memory saving, and please be cautious!")
 
 namespace torch::jit {
+
+ExecutionPlan::ExecutionPlan(
+    std::shared_ptr<Graph> graph,
+    std::string function_name)
+    : code(graph, std::move(function_name)),
+      graph(
+          FLAGS_torch_jit_execution_plan_reuse_code_graph
+              ? code.graph()
+              : std::move(graph)) {}
+
 EnableProfilingGuard::EnableProfilingGuard() {
   auto& executor_mode = getExecutorMode();
   old_executor_mode = executor_mode;

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -13,7 +13,8 @@ TORCH_DECLARE_bool(torch_jit_enable_new_executor);
 TORCH_DECLARE_bool(torch_jit_execution_plan_reuse_code_graph);
 
 namespace torch::jit {
-using ::c10::ArrayRef;
+template <typename T>
+using ArrayRef = at::ArrayRef<T>;
 struct Block;
 struct Value;
 struct GraphExecutorState;

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -3,7 +3,6 @@
 #include <atomic>
 #include <memory>
 
-#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/python/update_graph_executor_opt.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
@@ -14,6 +13,9 @@ TORCH_DECLARE_bool(torch_jit_enable_new_executor);
 TORCH_DECLARE_bool(torch_jit_execution_plan_reuse_code_graph);
 
 namespace torch::jit {
+using ::c10::ArrayRef;
+struct Block;
+struct Value;
 struct GraphExecutorState;
 struct Code;
 
@@ -24,12 +26,7 @@ enum ExecutorExecutionMode {
 
 struct ExecutionPlan {
   ExecutionPlan() = default;
-  ExecutionPlan(std::shared_ptr<Graph> graph, std::string function_name)
-      : code(graph, std::move(function_name)),
-        graph(
-            FLAGS_torch_jit_execution_plan_reuse_code_graph
-                ? code.graph()
-                : std::move(graph)) {}
+  ExecutionPlan(std::shared_ptr<Graph> graph, std::string function_name);
 
   operator bool() const {
     return static_cast<bool>(graph);

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -3,6 +3,8 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/Dict.h>
+#include <ATen/core/class_type.h>
+#include <ATen/core/enum_type.h>
 #include <ATen/quantized/Quantizer.h>
 
 #include <c10/util/irange.h>

--- a/torch/csrc/jit/serialization/pickler_helper.cpp
+++ b/torch/csrc/jit/serialization/pickler_helper.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/jit_type.h>
 
 #include <torch/csrc/jit/api/function_impl.h>
+#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/serialization/pickler_helper.h>
 
 namespace torch::jit {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #175417
* __->__ #175413

To avoid rebuilds when ir.h is modified (whcih is the case every time native_functions.yaml are)
Before this change `touch ../torch/csrc/jit/ir/ir.h; ninja torch_cpu` rebuild 310 files, after 272

- Removing #include ir.h from argument_spec.h, graph_executor.h,
  function_impl.h, compilation_unit.h, and module.h
- Moving inline methods that dereference Graph into .cpp files:
- Adding targeted using-declarations for c10 types that were
  previously imported by ir.h's blanket using block

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>