### PR TITLE
Use non-blocking copy in save_on_cpu pack

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -355,6 +355,14 @@ class save_on_cpu(saved_tensors_hooks):
     Use this context-manager to trade compute for GPU memory usage (e.g.
     when your model doesn't fit in GPU memory during training).
 
+    .. warning::
+
+        When ``pin_memory=True``, the GPU to CPU copy during packing is
+        asynchronous. Accessing saved tensors on CPU (e.g. via
+        ``grad_fn._saved_self``) before the CUDA stream has finished may
+        yield incorrect data. Call :func:`torch.cuda.synchronize` first
+        if you need to read them.
+
     Args:
         pin_memory (bool): If ``True`` tensors will be saved to CPU pinned memory
                            during packing and copied to GPU asynchronously during both

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -357,7 +357,8 @@ class save_on_cpu(saved_tensors_hooks):
 
     Args:
         pin_memory (bool): If ``True`` tensors will be saved to CPU pinned memory
-                           during packing and copied to GPU asynchronously during unpacking.
+                           during packing and copied to GPU asynchronously during both
+                           packing and unpacking.
                            Defaults to ``False``.
                            Also see :ref:`cuda-memory-pinning`.
 
@@ -391,13 +392,14 @@ class save_on_cpu(saved_tensors_hooks):
         def pack_to_cpu(tensor: torch.Tensor) -> tuple[torch.device, torch.Tensor]:
             if not pin_memory:
                 return (tensor.device, tensor.cpu())
+            is_pinnable = device_module.is_available() and not tensor.is_sparse
             packed = torch.empty(
                 tensor.size(),
                 dtype=tensor.dtype,
                 layout=tensor.layout,
-                pin_memory=(device_module.is_available() and not tensor.is_sparse),
+                pin_memory=is_pinnable,
             )
-            packed.copy_(tensor)
+            packed.copy_(tensor, non_blocking=is_pinnable)
             return (tensor.device, packed)
 
         def unpack_from_cpu(packed: tuple[torch.device, torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175425
* __->__ #175421

The GPU→CPU copy in `save_on_cpu`'s pack hook was synchronous even when
`pin_memory=True`. Since the destination is pinned memory, we can use
`non_blocking=True` to avoid blocking cpu on each activation
offload. The unpack (CPU→GPU) path was already non-blocking.

This is safe because the async copy is enqueued on the current CUDA stream
and CUDA's caching allocator won't reuse the source GPU memory until the
copy completes. The destination CPU tensor isn't read until unpack during
backward, well after the copy finishes.

Authored with Claude.