### PR TITLE
[ROCm][CI] Update test_pad_mm

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -531,7 +531,9 @@ class PadMMTest(TestCase):
         ):
             opt_fn = torch.compile(fn, mode="max-autotune")
             ret, code = run_and_get_code(opt_fn, *args)
-        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
+        # xref: https://github.com/pytorch/pytorch/pull/172780
+        if not torch.version.hip:  # autotuning is not guaranteed to run on ROCm
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
 
         code = [c for c in code if "decompose_k" not in c]
         # The mm kernel should use a template (because we set max_autotune_gemm_backends = TRITON).


### PR DESCRIPTION
- The `test/inductor/test_pad_mm.py::PadMMTest::test_original_aten_preserved_pad_mm ` test fails on rocm with
```
AssertionError: Scalars are not equal!
 
 Expected 1 but got 0.
 Absolute difference: 1
 Relative difference: 1.0

```
update the check re autotuning in the same manner as https://github.com/pytorch/pytorch/pull/172780. Tested on AMD Radeon Pro V710.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben