### PR TITLE
Improve error message for CPU-CUDA copy during graph capture

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -445,8 +445,10 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
     TORCH_CHECK(
         host_tensor->is_pinned(),
         "Cannot copy between CPU and CUDA tensors during CUDA graph capture ",
-        "unless the CPU tensor is pinned. Please use tensor.pin_memory() or ",
-        "allocate the tensor with pin_memory=True.");
+        "unless the CPU tensor is pinned and the graph uses ",
+        "capture_error_mode=\"thread_local\". Please use tensor.pin_memory() ",
+        "or allocate the tensor with pin_memory=True, and pass ",
+        "capture_error_mode=\"thread_local\" to torch.cuda.graph().");
   }
 
   void* dst = iter.data_ptr(0);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -445,10 +445,9 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
     TORCH_CHECK(
         host_tensor->is_pinned(),
         "Cannot copy between CPU and CUDA tensors during CUDA graph capture ",
-        "unless the CPU tensor is pinned and the graph uses ",
-        "capture_error_mode=\"thread_local\". Please use tensor.pin_memory() ",
-        "or allocate the tensor with pin_memory=True, and pass ",
-        "capture_error_mode=\"thread_local\" to torch.cuda.graph().");
+        "unless the CPU tensor is pinned. Please use tensor.pin_memory() or ",
+        "allocate the tensor with pin_memory=True. Also make sure ",
+        "capture_error_mode=\"thread_local\" is passed to torch.cuda.graph().");
   }
 
   void* dst = iter.data_ptr(0);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -447,7 +447,8 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
         "Cannot copy between CPU and CUDA tensors during CUDA graph capture ",
         "unless the CPU tensor is pinned. Please use tensor.pin_memory() or ",
         "allocate the tensor with pin_memory=True. Also make sure ",
-        "capture_error_mode=\"thread_local\" is passed to torch.cuda.graph().");
+        "capture_error_mode=\"thread_local\" or \"relaxed\" is passed to ",
+        "torch.cuda.graph().");
   }
 
   void* dst = iter.data_ptr(0);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -447,7 +447,7 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
         "Cannot copy between CPU and CUDA tensors during CUDA graph capture ",
         "unless the CPU tensor is pinned. Please use tensor.pin_memory() or ",
         "allocate the tensor with pin_memory=True. Also make sure ",
-        "capture_error_mode=\"thread_local\" or \"relaxed\" is passed to ",
+        "capture_error_mode=\"thread_local\" is passed to ",
         "torch.cuda.graph().");
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175425
* #175421

The existing error message tells users to pin the CPU tensor, but even
with pinned memory the copy will fail unless the graph was created with
capture_error_mode="thread_local". Update the message to mention both
requirements.

Authored with Claude.