### PR TITLE
[MXFP4] Fix E8M0 blockwise scale size validation for packed FP4 in _scaled_mm

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6638,6 +6638,8 @@ def _check_scaled_mm_sizes(
                 _k = _k * 2
             else:
                 block_size_k = 32
+                if self.dtype == torch.float4_e2m1fn_x2:
+                    _k = _k * 2
 
             block_size_mn = 128
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8918,6 +8918,32 @@ def sample_inputs_scaled_mm(op_info, device, dtype, requires_grad, **kwargs):
     scale_tensor2 = make_scale(scale2, torch.float8_e4m3fn)
     samples.append(SampleInput(mat1, mat2, scale_tensor1, scale_tensor2))
 
+    # Case 4: MXFP4 (float4_e2m1fn_x2) with E8M0 blockwise scaling
+    # Regression test: E8M0 blockwise scale size validation must account for
+    # packed FP4 format where self.size(1) = K/2.
+    # Only supported on MI350 (gfx950).
+    if device == 'cuda' and torch.version.hip:
+        if 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName:
+            mxfp4_M, mxfp4_K, mxfp4_N = 256, 256, 256
+            block_size_k = 32
+            block_size_mn = 128
+            num_k_blocks = math.ceil(mxfp4_K / block_size_k)
+            padded_num_k_blocks = math.ceil(num_k_blocks / 4) * 4
+            scale_a_size = block_size_mn * math.ceil(mxfp4_M / block_size_mn) * padded_num_k_blocks
+            scale_b_size = block_size_mn * math.ceil(mxfp4_N / block_size_mn) * padded_num_k_blocks
+            mat1 = _bfloat16_to_float4_e2m1fn_x2(
+                torch.randn(mxfp4_M, mxfp4_K, device=device, dtype=torch.bfloat16)
+            )
+            mat2 = _bfloat16_to_float4_e2m1fn_x2(
+                torch.randn(mxfp4_N, mxfp4_K, device=device, dtype=torch.bfloat16)
+            ).t()
+            scale_tensor1 = torch.ones(scale_a_size, device=device, dtype=torch.float8_e8m0fnu)
+            scale_tensor2 = torch.ones(scale_b_size, device=device, dtype=torch.float8_e8m0fnu)
+            samples.append(SampleInput(
+                mat1, mat2, scale_tensor1, scale_tensor2,
+                out_dtype=torch.bfloat16,
+            ))
+
     yield from samples
 
 def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
Summary:
The `_check_scaled_mm_sizes` validation for E8M0 blockwise scaling didn't
account for packed FP4 format (`float4_e2m1fn_x2`), where `self.size(1)`
represents K/2 rather than K. This caused valid scale tensors to be rejected
as having incorrect sizes.

The fix adds `_k = _k * 2` in the E8M0 blockwise scaling branch when the
input dtype is `float4_e2m1fn_x2`, matching the existing handling in the
nvfp4 branch and the v2 validation path (`_check_scaled_mm_sizes_v2`).

Also adds a regression test using FakeTensorMode and a Buck target for
test_scaled_matmul_cuda.

Test Plan:
```
[pranavsh@devgpu002.gtn3 ~/fbsource/fbcode]$ HIP_VISIBLE_DEVICES=6 buck test mode/opt-split-dwarf mode/inplace mode/amd-gpu -c fbcode.triton_backend=amd -c fbcode.enable_gpu_sections=true -m rocm70 fbcode//caffe2/test:test_scaled_matmul_cuda
File changed: fbcode//caffe2/test/test_scaled_matmul_cuda.py.tmp.3415371.1771580472414
File changed: fbcode//caffe2/test/test_scaled_matmul_cuda.py
File changed: fbcode//caffe2/test/test_scaled_matmul_cuda.py.tmp.3415371.1771580483856
Buck UI: https://www.internalfb.com/buck2/c15ffb3b-d1be-4d83-a8df-335922fa256a
Test UI: https://www.internalfb.com/intern/testinfra/testrun/14636698941560738
Network: Up: 0B  Down: 18KiB  (reSessionID-08660128-5564-4cb3-bf67-782cd3b24c61)
Analyzing targets. Remaining     0/1747
Executing actions. Remaining     0/28826                                                                                                         0.0s exec time total
Command: test.     Finished 1 local
Time elapsed: 13.4s
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

Differential Revision: D93842181


