### PR TITLE
[inductor] Fix select_one bitcast size mismatch for sub-32-bit dtypes

### DIFF
--- a/test/inductor/test_triton_helpers.py
+++ b/test/inductor/test_triton_helpers.py
@@ -1,18 +1,21 @@
 # Owner(s): ["module: inductor"]
 
-"""Tests for exclusive_scan_decoupled_lookback_64 dtype fix.
+"""Tests for triton_helpers functions.
 
-The fix ensures that `test_target` maintains consistent dtype in the
-`if flag == 2` branch by using `tl.full([], -1, index.dtype)` instead
-of the literal `-1` which would be int32.
-
-This is a compile-time check - Triton validates type consistency across
-all branches during compilation, so the test will fail to compile if
-the dtype mismatch exists.
+Covers:
+- exclusive_scan_decoupled_lookback_64 dtype fix (D89705211): ensures
+  `test_target` maintains consistent dtype by using `tl.full([], -1, index.dtype)`
+  instead of the literal `-1`.
+- select_one bitcast fix for sub-32-bit dtypes (D93872067): ensures the
+  intermediate result from `tl.sum()` is truncated back to the original-width
+  integer type before the final bitcast, preventing size mismatch errors.
 """
 
 import torch
-from torch._inductor.runtime.triton_helpers import exclusive_scan_decoupled_lookback_64
+from torch._inductor.runtime.triton_helpers import (
+    exclusive_scan_decoupled_lookback_64,
+    select_one,
+)
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
 
@@ -43,6 +46,19 @@ if HAS_GPU:
         )
 
         tl.store(result_ptr, exclusive_prefix)
+
+    @triton.jit
+    def test_kernel_select_one(
+        x_ptr,
+        mask_ptr,
+        result_ptr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.arange(0, BLOCK_SIZE)
+        x = tl.load(x_ptr + offsets)
+        mask = tl.load(mask_ptr + offsets)
+        result = select_one(x, mask, dim=0)
+        tl.store(result_ptr, result)
 
 
 class ExclusiveScanDecoupledLookback64Test(TestCase):
@@ -95,6 +111,50 @@ class ExclusiveScanDecoupledLookback64Test(TestCase):
         # Block 1's exclusive prefix = Block 0's inclusive prefix = 10.0
         expected = torch.tensor([10.0], dtype=torch.float64, device=device)
         torch.testing.assert_close(result, expected)
+
+
+class SelectOneTest(TestCase):
+    """Test cases for select_one bitcast fix with sub-32-bit dtypes.
+
+    The fix (D93872067) adds an intermediate .to(idtype) truncation before
+    the final bitcast in select_one. Without this fix, tl.sum() promotes
+    sub-32-bit unsigned integers (e.g. uint16) to int32, and the subsequent
+    bitcast from int32 to a 16-bit dtype fails with a size mismatch error.
+    """
+
+    def _run_select_one(self, dtype: torch.dtype) -> None:
+        device = torch.device(GPU_TYPE)
+        BLOCK_SIZE = 4
+
+        # Create input tensor and a one-hot mask selecting the element at index 2
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=dtype, device=device)
+        mask = torch.tensor([0, 0, 1, 0], dtype=torch.int32, device=device)
+        result = torch.zeros(1, dtype=dtype, device=device)
+
+        test_kernel_select_one[(1,)](x, mask, result, BLOCK_SIZE=BLOCK_SIZE)
+
+        expected = torch.tensor([3.0], dtype=dtype, device=device)
+        torch.testing.assert_close(result, expected)
+
+    @requires_gpu()
+    def test_select_one_bfloat16(self) -> None:
+        """Test select_one with bfloat16 (16-bit) — triggers the bitcast fix."""
+        self._run_select_one(torch.bfloat16)
+
+    @requires_gpu()
+    def test_select_one_float16(self) -> None:
+        """Test select_one with float16 (16-bit) — triggers the bitcast fix."""
+        self._run_select_one(torch.float16)
+
+    @requires_gpu()
+    def test_select_one_float32(self) -> None:
+        """Test select_one with float32 (32-bit) — baseline that always worked."""
+        self._run_select_one(torch.float32)
+
+    @requires_gpu()
+    def test_select_one_float64(self) -> None:
+        """Test select_one with float64 (64-bit) — baseline that always worked."""
+        self._run_select_one(torch.float64)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -679,7 +679,7 @@ def select_one(x, mask, dim, keep_dims=False):
     idtype = tl.core.get_int_dtype(x.dtype.primitive_bitwidth, signed=False)
     ix = x.to(idtype, bitcast=True)
     iy = tl.sum(ix * mask, dim, keep_dims=keep_dims)
-    return iy.to(x.dtype, bitcast=True)
+    return iy.to(idtype).to(x.dtype, bitcast=True)
 
 
 @triton.jit


### PR DESCRIPTION
Summary:
The `select_one` helper in `triton_helpers.py` is used by Inductor's scan
codegen (e.g., cumsum, cumprod) to extract the last element of a partial
scan result. It bitcasts through an integer type of the same width as the
data type. However, `tl.sum()` promotes the result to a wider integer type
(e.g., uint16 → int32), causing the final `iy.to(x.dtype, bitcast=True)`
to fail with "Cannot bitcast data-type of size 32 to data-type of size 16".

Fix by truncating back to the original-width integer type before the final
bitcast. This is safe because the sum is a masked select (only one element
is non-zero), so the value fits in the original width.

Test Plan: Ran cumsum opinfo e2e tests with bf16, int8, int16, uint8 inputs — all pass.

Differential Revision: D93872067




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo