### PR TITLE
Support negative indices in `mark_dynamic`.

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1880,7 +1880,6 @@ from user code:
 
         x = torch.randn(4, 4)
         y = torch.randn(10, 10)
-        torch._dynamo.mark_dynamic(x, 2)
         torch._dynamo.mark_dynamic(y, 1)
 
         def post_munge(s):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9103,6 +9103,31 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         with self.assertRaises(ConstraintViolationError):
             torch.compile(my_dyn_fn, backend="eager")(y)
 
+    def test_mark_dynamic_negative_index(self):
+        counter = CompileCounter()
+
+        def my_dyn_fn(x):
+            return x.cos()
+
+        # mark_dynamic with negative index should work the same as positive
+        y = torch.randn([3, 4])
+        torch._dynamo.mark_dynamic(y, -1)
+        torch.compile(my_dyn_fn, backend=counter)(y)
+
+        z = torch.randn([3, 5])
+        torch._dynamo.mark_dynamic(z, -1)
+        torch.compile(my_dyn_fn, backend=counter)(z)
+
+        # The last dim is dynamic, so changing it shouldn't cause recompilation
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_mark_dynamic_out_of_bounds(self):
+        y = torch.randn([3, 4])
+        with self.assertRaises(IndexError):
+            torch._dynamo.mark_dynamic(y, 2)
+        with self.assertRaises(IndexError):
+            torch._dynamo.mark_dynamic(y, -3)
+
     def test_mark_static(self):
         counter = CompileCounter()
 

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1171,9 +1171,8 @@ class TestInductorDynamic(TestCase):
         def fn(x):
             return x.sum()
 
-        x = torch.rand([31], device=GPU_TYPE)
-
         with V.set_choices_handler(ForcePersistent()):
+            x = torch.rand([31], device=GPU_TYPE)
             torch._dynamo.mark_dynamic(x, 0, min=1, max=62)
             fn_c = torch.compile(fn)
             actual, source_codes = run_and_get_code(fn_c, x)
@@ -1181,7 +1180,8 @@ class TestInductorDynamic(TestCase):
             FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
             torch._dynamo.reset()
 
-            torch._dynamo.mark_dynamic(x, 2, min=1, max=64)
+            x = torch.rand([32], device=GPU_TYPE)
+            torch._dynamo.mark_dynamic(x, 0, min=1, max=64)
             fn_c = torch.compile(fn)
             actual, source_codes = run_and_get_code(fn_c, x)
             self.assertEqual(fn(x), actual)

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1057,6 +1057,18 @@ class _DimRange:
     max: int
 
 
+def _normalize_dim_index(t: torch.Tensor, index: int) -> int:
+    # Mimic c10::maybe_wrap_dim which allows dim=0 for 0-dim (scalar) tensors.
+    ndim = max(t.ndim, 1)
+    if not (-ndim <= index < ndim):
+        raise IndexError(
+            f"Dimension out of range (expected in [{-ndim}, {ndim - 1}], but got {index})"
+        )
+    if index < 0:
+        index += ndim
+    return index
+
+
 @forbid_in_graph
 def mark_unbacked(
     t: Any,
@@ -1101,6 +1113,8 @@ def mark_unbacked(
         assert not is_traceable_wrapper_subclass(t), "not implemented yet"
 
     if isinstance(index, int):
+        index = _normalize_dim_index(t, index)
+
         if strict:
             if not hasattr(t, "_dynamo_strict_unbacked_indices"):
                 t._dynamo_strict_unbacked_indices = set()
@@ -1154,6 +1168,10 @@ def mark_dynamic(
 ) -> None:
     """
     Mark a tensor as having a dynamic dim and set corresponding min and max range for the dim.
+
+    The ``index`` argument follows standard Python indexing conventions: negative values
+    are supported (e.g., -1 for the last dimension) and out-of-range values raise
+    ``IndexError``.
 
     [Note - on the state of mark_dynamic]
 
@@ -1215,9 +1233,10 @@ def mark_dynamic(
             # pyrefly: ignore [implicit-any]
             t._specialize_on = {}
 
+        index = _normalize_dim_index(t, index)
+
         if hint_override:
             t._dynamo_hint_overrides[index] = hint_override
-        # TODO(voz): Should we bounds check?
 
         t._dynamo_dynamic_indices.add(index)
         t._dynamo_dynamic_range.add(_DimRange(index, min, max))  # type: ignore[arg-type]
@@ -1250,8 +1269,8 @@ def maybe_mark_dynamic(t: Any, index: int | list[Any] | tuple[Any]) -> None:
     if isinstance(index, int):
         if not hasattr(t, "_dynamo_weak_dynamic_indices"):
             t._dynamo_weak_dynamic_indices = set()
-        # TODO(voz): Should we bounds check?
 
+        index = _normalize_dim_index(t, index)
         t._dynamo_weak_dynamic_indices.add(index)
         return
 
@@ -1314,7 +1333,7 @@ def mark_static(t: Any, index: int | list[Any] | tuple[Any] | None = None) -> No
     if isinstance(index, int):
         if not hasattr(t, "_dynamo_static_indices"):
             t._dynamo_static_indices = set()  # type: ignore[attr-defined]
-        # TODO(voz): Should we bounds check?
+        index = _normalize_dim_index(t, index)
         t._dynamo_static_indices.add(index)  # type: ignore[attr-defined]
     elif index is None:
         for i in range(t.dim()):


### PR DESCRIPTION
Currently a negative index would silently have no effect, i.e. not be marked dynamic, which was pretty hard to figure out.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @mlazos @Lucaskabela