### PR TITLE
Add timing to GraphPickler.loads method

### DIFF
--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -157,10 +157,13 @@ class GraphPickler(pickle.Pickler):
         """
         Unpickle an object.
         """
-        state = _UnpickleState(fake_mode)
-        with io.BytesIO(data) as stream:
-            unpickler = _GraphUnpickler(stream, state)
-            return unpickler.load()
+        from torch._dynamo.utils import dynamo_timed
+
+        with dynamo_timed("GraphPickler.loads"):
+            state = _UnpickleState(fake_mode)
+            with io.BytesIO(data) as stream:
+                unpickler = _GraphUnpickler(stream, state)
+                return unpickler.load()
 
     @classmethod
     def debug_dumps(


### PR DESCRIPTION
In use cases like [redacted] and vllm, we rely on GraphPickler to serialize FX graph for precompile.

Adding some instrumentation for loading so that it shows up on tlparse.