### PR TITLE
Cleanup impl of TensorBase::const_data_ptr

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -628,11 +628,9 @@ class TORCH_API TensorBase {
     return mutable_data_ptr();
   }
 
-  template <typename T, std::enable_if_t<!std::is_const_v<T>, int> = 0>
+  // Implemented in aten/src/ATen/templates/TensorMethods.cpp
+  template <typename T>
   const T* const_data_ptr() const;
-
-  template <typename T, std::enable_if_t<std::is_const_v<T>, int> = 0>
-  const std::remove_const_t<T>* const_data_ptr() const;
 
   template <typename T>
   T* mutable_data_ptr() const;

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -8,39 +8,39 @@ namespace at {
 namespace {
 
 // Verifies the requested type is the same as the Tensor's type.
-void check_type(const TensorBase& tensor, ScalarType type, std::string_view type_name) {
+void check_type(const TensorBase& tensor, ScalarType type) {
   TORCH_CHECK(
       tensor.scalar_type() == type
       || (isQIntType(tensor.scalar_type())
           && toUnderlying(tensor.scalar_type()) == type),
-      "expected scalar type ", type_name, " but found ", tensor.scalar_type());
+      "expected scalar type ", type, " but found ", tensor.scalar_type());
 }
 
 } // namespace
 
-#define DEFINE_CAST(T, name)                                         \
-   template <>                                                       \
-   TORCH_API const T* TensorBase::const_data_ptr() const {           \
-     check_type(*this, ScalarType::name, #name);                     \
-     return this->unsafeGetTensorImpl()->data_ptr_impl<T>();         \
-   }                                                                 \
-                                                                     \
-   template <>                                                       \
-   TORCH_API const T* TensorBase::const_data_ptr<const T>() const {  \
-     check_type(*this, ScalarType::name, #name);                     \
-     return this->unsafeGetTensorImpl()->data_ptr_impl<std::remove_const_t<T>>(); \
-   }                                                                 \
-                                                                     \
-   template <>                                                       \
-   TORCH_API T* TensorBase::mutable_data_ptr() const {               \
-     check_type(*this, ScalarType::name, #name);                     \
-     return this->unsafeGetTensorImpl()->mutable_data_ptr_impl<T>(); \
-   }                                                                 \
-                                                                     \
-   template <>                                                       \
-   TORCH_API T* TensorBase::data_ptr() const {                       \
-     return mutable_data_ptr<T>();                                   \
-   }                                                                 \
+template <typename T>
+const T* TensorBase::const_data_ptr() const {
+  using NonConstT = std::remove_const_t<T>;
+  check_type(*this, c10::CppTypeToScalarType<NonConstT>());
+  return this->unsafeGetTensorImpl()->data_ptr_impl<NonConstT>();
+}
+
+template <typename T>
+T* TensorBase::mutable_data_ptr() const {
+  check_type(*this, c10::CppTypeToScalarType<T>());
+  return this->unsafeGetTensorImpl()->mutable_data_ptr_impl<T>();
+}
+
+template <typename T>
+T* TensorBase::data_ptr() const {
+  return this->mutable_data_ptr<T>();
+}
+
+#define DEFINE_CAST(T, name)                                                \
+   template TORCH_API const T* TensorBase::const_data_ptr<T>() const;       \
+   template TORCH_API const T* TensorBase::const_data_ptr<const T>() const; \
+   template TORCH_API T* TensorBase::mutable_data_ptr() const;              \
+   template TORCH_API T* TensorBase::data_ptr() const;
 
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_CAST)
  AT_FORALL_QINT_TYPES(DEFINE_CAST)


### PR DESCRIPTION
This commit unifies the implementation of `TensorBase::const_data_ptr` for `T` and `const T`. I also replaced template specialization with explicit template instantiation. This reduces the code generated via macros.