### PR TITLE
[CI][ROCm] Fix theRock nightly builds

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -77,10 +77,15 @@ EOF
   chmod a+x "/opt/cache/bin/$1"
 }
 
-write_sccache_stub cc
-write_sccache_stub c++
-write_sccache_stub gcc
-write_sccache_stub g++
+# Skip all sccache wrapping for theRock nightly: sccache PATH wrappers
+# intercept assembly (.s) compilation and fail because the assembler does not
+# produce the .d dependency file that sccache expects.
+if [ "$ROCM_VERSION" != "nightly" ]; then
+  write_sccache_stub cc
+  write_sccache_stub c++
+  write_sccache_stub gcc
+  write_sccache_stub g++
+fi
 
 # NOTE: See specific ROCM_VERSION case below.
 if [ "x$ROCM_VERSION" = x ]; then

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -41,6 +41,7 @@ ciflow_push_tags:
 - ciflow/rocm-mi300
 - ciflow/rocm-mi355
 - ciflow/rocm-navi31
+- ciflow/rocm-nightly
 - ciflow/s390
 - ciflow/slow
 - ciflow/slow-rocm-mi200

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - nightly  # Trigger when nightly branch is updated
     tags:
-      - ciflow/rocm-mi300/*
+      - ciflow/rocm-nightly/*
   workflow_dispatch:  # Allow manual triggering
 
 concurrency:

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - nightly  # Trigger when nightly branch is updated
+    tags:
+      - ciflow/rocm-mi300/*
   workflow_dispatch:  # Allow manual triggering
 
 concurrency:

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -9,7 +9,7 @@
 #define NCCL_HAS_SYMMEM_SUPPORT
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
 #define NCCL_HAS_SYMMEM_DEVICE_SUPPORT
 #include <nccl_device.h>
 #endif

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -10,8 +10,8 @@
 #endif
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
-#define NCCL_HAS_SYMMEM_DEVICE_SUPPORT
 #if !defined(USE_ROCM)
+#define NCCL_HAS_SYMMEM_DEVICE_SUPPORT
 #include <nccl_device.h>
 #endif
 #endif

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -11,7 +11,9 @@
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
 #define NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+#if !defined(USE_ROCM)
 #include <nccl_device.h>
+#endif
 #endif
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -2,14 +2,14 @@
 
 #if USE_NCCL
 
-#include <nccl.h>
+#include <rccl/rccl.h>
 #include <torch/csrc/cuda/nccl.h>
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
 #define NCCL_HAS_SYMMEM_SUPPORT
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)
 #define NCCL_HAS_SYMMEM_DEVICE_SUPPORT
 #include <nccl_device.h>
 #endif


### PR DESCRIPTION
* Skip sccache wrappers for theRock nightly build (causes AOTriton build-from-source failures)
* Skip nccl_device.h header include for ROCm (causes build failures in theRock nightly builds)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang