### PR TITLE
Copy more dynamo attrs?

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8877,6 +8877,24 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         res = f(torch.tensor([20, 21]))
         self.assertEqual(torch.tensor(True), res)
 
+    def test_mark_dynamic_preserved_by_to(self):
+        counter = CompileCounter()
+
+        def my_dyn_fn(x):
+            return x.cos()
+
+        y = torch.randn([3, 4])
+        torch._dynamo.mark_dynamic(y, 1)
+        y2 = y.to(torch.float64)
+
+        torch.compile(my_dyn_fn, backend=counter)(y2)
+
+        y3 = torch.randn([3, 5], dtype=torch.float64)
+        torch.compile(my_dyn_fn, backend=counter)(y3)
+
+        # The last dim is dynamic (propagated through .to()), so no recompilation
+        self.assertEqual(counter.frame_count, 1)
+
     # Translation validation changes the exception type, don't run with it
     @torch.fx.experimental._config.patch(translation_validation=False)
     def test_mark_dynamic_with_ranges(self):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1081,6 +1081,9 @@ def mark_unbacked(
             All unbacked dimensions with the same shape_id will share the same unbacked symbol. This is useful when multiple tensors
             are known to have the same batch size at runtime. A runtime assertion is added
             to ensure this property at runtime.
+
+    Note: unbacked marking is propagated through ``Tensor.to()`` calls (e.g. dtype or device
+    conversions). Other tensor-returning operations do not propagate unbacked marks.
     """
     if torch.distributed.is_available() and isinstance(
         t, torch.distributed.tensor.DTensor
@@ -1185,6 +1188,9 @@ def mark_dynamic(
     This approach results in one Dynamo trace and two backend compilations. When the input dimension equals 8 or 16
     at runtime, execution will be directed to the specialized compiled region. Performance measurements indicate
     2-8x speedups depending on the specific specialization and model architecture.
+
+    Note: dynamic marking is propagated through ``Tensor.to()`` calls (e.g. dtype or device
+    conversions). Other tensor-returning operations do not propagate dynamic marks.
 
     """
     if is_traceable_wrapper_subclass(t):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2372,11 +2372,14 @@ def copy_dynamo_tensor_attributes(src: torch.Tensor, dst: torch.Tensor) -> None:
     the attribute is removed from dst.
     """
     _copy_dynamo_attr(src, dst, "_dynamo_dynamic_indices")
+    _copy_dynamo_attr(src, dst, "_dynamo_dynamic_range")
     _copy_dynamo_attr(src, dst, "_dynamo_unbacked_indices")
     _copy_dynamo_attr(src, dst, "_dynamo_hint_overrides")
     _copy_dynamo_attr(src, dst, "_dynamo_shape_ids")
     _copy_dynamo_attr(src, dst, "_dynamo_strict_unbacked_indices")
     _copy_dynamo_attr(src, dst, "_dynamo_weak_dynamic_indices")
+    _copy_dynamo_attr(src, dst, "_dynamo_static_indices")
+    _copy_dynamo_attr(src, dst, "_specialize_on")
 
 
 def clone_input(x: torch.Tensor, *, dtype: torch.dtype | None = None) -> torch.Tensor:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -271,6 +271,14 @@ class Tensor(torch._C.TensorBase):
             memo[id(self)] = new_tensor
             return new_tensor
 
+    def to(self, *args, **kwargs):
+        if has_torch_function_unary(self):
+            return handle_torch_function(Tensor.to, (self,), self, *args, **kwargs)
+        result = super().to(*args, **kwargs)
+        if result is not self and self.__dict__:
+            torch._dynamo.utils.copy_dynamo_tensor_attributes(self, result)
+        return result
+
     def __reduce_ex__(self, proto):
         materialize_fake_tensors = (
             torch.serialization._serialization_tls.materialize_fake_tensors

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -273,9 +273,12 @@ class Tensor(torch._C.TensorBase):
 
     def to(self, *args, **kwargs):
         if has_torch_function_unary(self):
-            return handle_torch_function(Tensor.to, (self,), self, *args, **kwargs)
-        result = super().to(*args, **kwargs)
-        if result is not self and self.__dict__:
+            result = handle_torch_function(
+                Tensor.to, (self,), self, *args, **kwargs
+            )
+        else:
+            result = super().to(*args, **kwargs)
+        if result is not self and isinstance(result, Tensor) and self.__dict__:
             torch._dynamo.utils.copy_dynamo_tensor_attributes(self, result)
         return result
 


### PR DESCRIPTION
I noticed that `.to()` loses the dynamo attr from `mark_dynamic`. So I set Claude to fix it, and this is what it came up with. It looks reasaonble? But I'm no PyTorch dev.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98