### PR TITLE
[SymmMem] Do not compile NCCLSymmetricMemory for ROCm

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#if !defined(USE_ROCM)
 #if USE_NCCL
 
 #include <nccl.h>
@@ -18,3 +19,4 @@
 #define NCCL_HAS_ONE_SIDED_API
 #endif
 #endif // USE_NCCL
+#endif // USE_ROCM


### PR DESCRIPTION
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang