### PR TITLE
[dynamo] Avoid graph break on sourceless UserDefinedClassVariable in call_obj_hasattr

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10276,6 +10276,29 @@ def ___make_guard_fn():
         self.assertEqual(fn_out, compiled_out)
         self.assertEqual(fn_out, (True, False, True, False, True, False))
 
+    def test_class_hasattr_sourceless_descriptor(self):
+        """Test that hasattr on sourceless UserDefinedClassVariable does not graph break."""
+        class FlagDescriptor:
+            def __get__(self, instance, owner):
+                if hasattr(owner, "flag"):
+                    return 1
+                return 0
+
+        class WithFlag:
+            flag = True
+            prop = FlagDescriptor()
+
+        class WithoutFlag:
+            prop = FlagDescriptor()
+
+        def fn(x, obj):
+            return x + obj.prop
+
+        compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+        x = torch.randn(3)
+        self.assertEqual(fn(x, WithFlag()), compiled_fn(x, WithFlag()))
+        self.assertEqual(fn(x, WithoutFlag()), compiled_fn(x, WithoutFlag()))
+
     def test_torch_objects_as_keys(self):
         remap = {torch.float16: torch.float32}
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10278,6 +10278,7 @@ def ___make_guard_fn():
 
     def test_class_hasattr_sourceless_descriptor(self):
         """Test that hasattr on sourceless UserDefinedClassVariable does not graph break."""
+
         class FlagDescriptor:
             def __get__(self, instance, owner):
                 if hasattr(owner, "flag"):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1009,8 +1009,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     functools.partial(GuardBuilder.HASATTR, attr=name)
                 )
             )
-            return VariableTracker.build(tx, hasattr(self.value, name))
-        return super().call_obj_hasattr(tx, name)
+        return VariableTracker.build(tx, hasattr(self.value, name))
 
     def const_getattr(self, tx: "InstructionTranslator", name: str) -> Any:
         if name == "__name__":


### PR DESCRIPTION
FIXES #175263 

This fixes graph breaks on sourceless VTs for user defined classes with hasattr. `super().call_obj_hasattr(tx, name)` led to a graph break with `unimplemented`. Since the class value is known no guard should be needed.

I found that no fix is needed for checking if no attribute is set since it is already [handled in the `HASATTR` guard](https://github.com/pytorch/pytorch/blob/f91f262275e12bd6249a2bcd2c3c06e0c78e20ee/torch/_dynamo/guards.py#L1899-L1902).

Example script that graph breaks before this change:
```
import torch
class SupportsScaling:
    """Descriptor that checks if the owner class has a 'scale' attribute."""
    def __get__(self, obj, owner):
        if hasattr(owner, "scale"):
            return owner.scale
        return 1.0

class ScaledLayer:
    scale = 2.0
    multiplier = SupportsScaling()

class UnscaledLayer:
    multiplier = SupportsScaling()

@torch.compile(fullgraph=True)
def apply_layer(x, layer):
    return x * layer.multiplier

x = torch.randn(4)
print(apply_layer(x, ScaledLayer()))    # would graph-break before fix
print(apply_layer(x, UnscaledLayer())) # would graph-break before fix
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo