### PR TITLE
[DTensor] Add _PreparedSingleDimStrategy class

### DIFF
--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -33,6 +33,7 @@ from torch.distributed.tensor._ops.single_dim_strategy import (
     _get_num_tensor_inputs,
     _get_unique_placements,
     _insert_single_dim_replication_strategy,
+    _PreparedSingleDimStrategy,
     _ShardingPlaceholder,
     _SingleDimStrategyInfo,
     register_single_dim_strategy,
@@ -1006,6 +1007,77 @@ class TestExpandPlaceholder(TestCase):
                 op_schema.args_meta,
                 op_schema.kwargs_meta,
             )
+
+    def test_try_propagate_single_dim_strategy(self):
+        """Test _PreparedSingleDimStrategy.try_propagate against mm rules on a 2D mesh."""
+        mesh = DeviceMesh("cpu", mesh=torch.arange(4).reshape(2, 2))
+        M, K, N = 64, 32, 64
+        left_meta, right_meta = _get_mm_metas(M, K, N)
+
+        left_spec = DTensorSpec(mesh, (Replicate(), Replicate()), tensor_meta=left_meta)
+        right_spec = DTensorSpec(
+            mesh, (Replicate(), Replicate()), tensor_meta=right_meta
+        )
+        input_specs = [left_spec, right_spec]
+
+        # Use specs with Shard placements in op_schema so _get_unique_placements
+        # returns Shard types, enabling placeholder expansion.
+        schema_left_spec = DTensorSpec(
+            mesh, (Shard(0), Shard(1)), tensor_meta=left_meta
+        )
+        schema_right_spec = DTensorSpec(
+            mesh, (Shard(0), Shard(1)), tensor_meta=right_meta
+        )
+        op_schema = OpSchema(
+            op=torch.ops.aten.mm.default,
+            args_schema=(
+                OpStrategy([OpSpec(schema_left_spec)]),
+                OpStrategy([OpSpec(schema_right_spec)]),
+            ),
+            kwargs_schema={},
+        )
+
+        output_meta = TensorMeta(torch.Size([M, N]), (N, 1), torch.float32)
+        prepared = _PreparedSingleDimStrategy(
+            mm_single_dim_strategy, op_schema, output_meta
+        )
+
+        cases = [
+            # (input_placements, should_match, expected_output_placements)
+            (
+                ((Replicate(), Replicate()), (Replicate(), Replicate())),
+                True,
+                (Replicate(), Replicate()),
+            ),
+            (
+                ((Shard(0), Shard(0)), (Replicate(), Replicate())),
+                True,
+                (Shard(0), Shard(0)),
+            ),
+            (
+                ((Shard(0), Replicate()), (Replicate(), Shard(1))),
+                True,
+                (Shard(0), Shard(1)),
+            ),
+            # No rule for (S0, S1) on a single dim
+            (
+                ((Shard(0), Shard(1)), (Shard(1), Shard(0))),
+                False,
+                None,
+            ),
+        ]
+        for input_placements, should_match, expected_out in cases:
+            with self.subTest(input_placements=input_placements):
+                result = prepared.try_propagate(mesh, input_placements, input_specs)
+                if should_match:
+                    self.assertIsNotNone(result)
+                    spec = result.strategies[0]
+                    self.assertEqual(spec.output_spec.placements, expected_out)
+                    # Redistribute costs should be zero
+                    for costs in spec.redistribute_cost:
+                        self.assertEqual(costs, [0.0])
+                else:
+                    self.assertIsNone(result)
 
 
 @torch.library.custom_op("mylib::dummy_add", mutates_args=())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Extract the strategy preparation logic (calling strategy fn, expanding
placeholders, building lookup table) into a _PreparedSingleDimStrategy
class. Refactor _expand_single_dim_strategy_to_mesh to use it, removing
duplicated num_outputs computation, placeholder expansion, and
replication strategy insertion. The class accepts _SingleDimStrategyInfo
to carry allow_unbacked_sharding alongside the strategy function.

Also adds _is_sharding module-level utility and _build_output_specs
helper for building output DTensorSpecs from per-mesh-dim placements.

Authored with Claude.