### PR TITLE
Respect property setters in Module __setattr__

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1978,6 +1978,16 @@ class Module:
                     else:
                         d.discard(name)
 
+        # Respect data descriptors (e.g. property setters) defined on the class.
+        # This matches Python's normal attribute-setting behavior and lets users
+        # opt out of registration via a custom setter.
+        attr = inspect.getattr_static(self.__class__, name, None)
+        if attr is not None:
+            set_ = getattr(attr, "__set__", None)
+            if set_ is not None:
+                set_(self, value)
+                return
+
         params = self.__dict__.get("_parameters")
         if isinstance(value, Parameter):
             if params is None:


### PR DESCRIPTION
## Summary
  - Respect data descriptors (e.g., @property setters) during nn.Module
  attribute assignment.
  - This allows custom setters to opt out of parameter registration, matching
  normal Python behavior.

  ## Issue
  Fixes https://github.com/pytorch/pytorch/issues/175372

  ## Testing
  - python test/test_nn.py TestNN.test_property_setter_respected