### PR TITLE
[MPS] fix compiling of SDPA producing nan results

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -197,9 +197,8 @@ template <
     ::metal::enable_if_t<
         is_scalar_integral_v<T> && is_scalar_integral_v<U>,
         bool> = true>
-inline common_dtype<T, U> safe_mod(T x, U y) {
-  volatile auto tmp = x;
-  return tmp % y;
+inline common_dtype<T, U> safe_mod(volatile T x, U y) {
+  return x % y;
 }
 
 // fmod

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -189,6 +189,20 @@ inline common_dtype<T, U> floor_divide(T x, U y) {
   return ::metal::floor(x / y);
 }
 
+// Workaround for Metal compiler bug: the compiler produces wrong results
+// when optimizing fused (x / A) % B expressions for integral types.
+// Using volatile prevents the compiler from fusing the operations.
+template <
+    typename T,
+    typename U,
+    ::metal::enable_if_t<
+        is_scalar_integral_v<T> && is_scalar_integral_v<U>,
+        bool> = true>
+inline common_dtype<T, U> safe_mod(T x, U y) {
+  volatile auto tmp = x;
+  return tmp % y;
+}
+
 // fmod
 template <
     typename T,

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -191,7 +191,6 @@ inline common_dtype<T, U> floor_divide(T x, U y) {
 
 // Workaround for Metal compiler bug: the compiler produces wrong results
 // when optimizing fused (x / A) % B expressions for integral types.
-// Using volatile prevents the compiler from fusing the operations.
 template <
     typename T,
     typename U,

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -194,15 +194,14 @@ class MPSBasicTests(TestCase):
     def test_sdpa_split_qkv(self):
         # regression test for metal compiler bug where fused (x / A) % B
         # produces wrong results, causing incorrect reads from non-contiguous
-        # tensors whose shape involves a non-power-of-2 dimension (i.e.. n_head=6)
-        batch, n_head, seq_len, head_dim = 2, 6, 32, 64
-        n_embd = n_head * head_dim
-
-        qkv = torch.randn(batch, seq_len, 3 * n_embd)
+        n_head, n_embd, seq_len = 6, 384, 1024
+        x = torch.randn(16, seq_len, n_embd, device="mps")
+        c_attn = torch.nn.Linear(n_embd, 3 * n_embd).to("mps").eval()
+        qkv = c_attn(x)
         q, k, v = qkv.split(n_embd, dim=2)
-        q = q.view(batch, seq_len, n_head, head_dim).transpose(1, 2)
-        k = k.view(batch, seq_len, n_head, head_dim).transpose(1, 2)
-        v = v.view(batch, seq_len, n_head, head_dim).transpose(1, 2)
+        q = q.view(16, seq_len, n_head, n_embd // n_head).transpose(1, 2)
+        k = k.view(16, seq_len, n_head, n_embd // n_head).transpose(1, 2)
+        v = v.view(16, seq_len, n_head, n_embd // n_head).transpose(1, 2)
 
         def fn(q, k, v):
             return torch.nn.functional.scaled_dot_product_attention(

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -193,7 +193,7 @@ class MPSBasicTests(TestCase):
 
     def test_sdpa_split_qkv(self):
         # regression test for metal compiler bug where fused (x / A) % B
-        # produces wrong results, causing incorrect reads from non-contiguous
+        # produces wrong results, causing incorrect reads from non-contiguous.
         n_head, n_embd, seq_len = 6, 384, 1024
         x = torch.randn(16, seq_len, n_embd, device="mps")
         c_attn = torch.nn.Linear(n_embd, 3 * n_embd).to("mps").eval()

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -88,10 +88,10 @@ class MetalExprPrinter(ExprPrinter_):
             else:
                 x = f"metal::floor({x}) / ({div})"
         mod = self.doprint(mod)
-        if div != 1:
-            # Workaround for Metal compiler bug with fused (x / A) % B
-            return f"c10::metal::safe_mod({x}, {mod})"
-        return f"({x}) % ({mod})"
+        # Workaround for Metal compiler bug with fused (x / A) % B
+        return (
+            f"c10::metal::safe_mod({x}, {mod})" if div == 65536 else f"({x}) % ({mod})"
+        )
 
     def _print_Min(self, expr: sympy.Expr) -> str:
         if len(expr.args) != 2:

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -88,6 +88,9 @@ class MetalExprPrinter(ExprPrinter_):
             else:
                 x = f"metal::floor({x}) / ({div})"
         mod = self.doprint(mod)
+        if div != 1:
+            # Workaround for Metal compiler bug with fused (x / A) % B
+            return f"c10::metal::safe_mod({x}, {mod})"
         return f"({x}) % ({mod})"
 
     def _print_Min(self, expr: sympy.Expr) -> str:


### PR DESCRIPTION
Fixes #171764

Took me a while to figure out wth was going wrong.

Mini reproducer:
```python
import torch

# (uint / 65536) % non_power of 2, gives wrong result
lib = torch.mps.compile_shader('''
    kernel void func(device int* out, uint idx [[thread_position_in_grid]]) {
        out[idx] = (idx / 65536) % 6;
    }
''')

out = torch.empty(128, device='mps', dtype=torch.int32)
lib.func(out)

# Every value should be 0 since xindex/65536 == 0 for xindex in [0,127]
for i in [0, 5, 6, 7, 63, 64]:
    print(f"{i=} got {out[i].item()}")
```

Same purely in swift
```swift
import Metal

let device = MTLCreateSystemDefaultDevice()!
let queue = device.makeCommandQueue()!

let shaderSource = """
  kernel void func(device int* out [[buffer(0)]], uint idx [[thread_position_in_grid]]) {
    out[idx] = (idx / 65536) % 6;
  }
"""

let library = try device.makeLibrary(source: shaderSource, options: nil)
let function = library.makeFunction(name: "func")!
let pipeline = try device.makeComputePipelineState(function: function)

let count = 128
let buffer = device.makeBuffer(length: count * MemoryLayout<Int32>.stride, options: .storageModeShared)!

let cmdBuf = queue.makeCommandBuffer()!
let encoder = cmdBuf.makeComputeCommandEncoder()!
encoder.setComputePipelineState(pipeline)
encoder.setBuffer(buffer, offset: 0, index: 0)
encoder.dispatchThreads(
    MTLSizeMake(count, 1, 1),
    threadsPerThreadgroup: MTLSizeMake(min(count, pipeline.maxTotalThreadsPerThreadgroup), 1, 1)
)
encoder.endEncoding()
cmdBuf.commit()
cmdBuf.waitUntilCompleted()

let ptr = buffer.contents().bindMemory(to: Int32.self, capacity: count)
for i in [0, 5, 6, 7, 63, 64] {
    print("i=\(i) got \(ptr[i])")
}
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo