### PR TITLE
Fix DefaultsSource pickle serialization for precompile cache

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -22,7 +22,7 @@ from torch._dynamo.bytecode_transformation import transform_code_object
 from torch._dynamo.exc import PackageError
 from torch._dynamo.guards import CheckFunctionManager, CompileId
 from torch._dynamo.package import CompilePackage
-from torch._dynamo.source import LocalSource
+from torch._dynamo.source import DefaultsSource, LocalSource
 from torch._dynamo.symbolic_convert import (
     ExceptionStack,
     InstructionTranslator,
@@ -1886,6 +1886,24 @@ if torch.distributed.is_available() and not IS_MACOS:
             inputs = distribute_tensor(torch.randn(3, 2), mesh, [Replicate()])
             ref, loaded = self._test_serialization("TENSOR_MATCH", m, inputs)
             self._test_check_fn(ref, loaded, {"self": m, "x": inputs}, True)
+
+
+class TestDefaultsSourcePickle(torch._inductor.test_case.TestCase):
+    """Regression tests for DefaultsSource pickle serialization (#174955)."""
+
+    def test_defaults_source_pickle_roundtrip(self):
+        ds = DefaultsSource(LocalSource("y"), True)
+        restored = pickle.loads(pickle.dumps(ds))
+        self.assertEqual(restored, ds)
+        self.assertEqual(restored.field, ds.field)
+        self.assertEqual(restored._name, ds._name)
+
+    def test_defaults_source_pickle_roundtrip_kw(self):
+        ds = DefaultsSource(LocalSource("fn"), "param_name", is_kw=True)
+        restored = pickle.loads(pickle.dumps(ds))
+        self.assertEqual(restored, ds)
+        self.assertTrue(restored.is_kw)
+        self.assertEqual(restored.field, "__kwdefaults__")
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -663,6 +663,11 @@ class DefaultsSource(ChainedSource):
                 self, "_name", f"{{0}}.{_esc_str(self.field)}[{_esc_str(self.idx_key)}]"
             )
 
+    def __reduce__(self) -> tuple:
+        # Only pass init=True fields (base, idx_key, is_kw).
+        # The init=False fields (field, _name) are recomputed in __post_init__.
+        return (self.__class__, (self.base, self.idx_key, self.is_kw))
+
     def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen(self.base)
         codegen.extend_output(codegen.create_load_attrs(self.field))

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -663,7 +663,7 @@ class DefaultsSource(ChainedSource):
                 self, "_name", f"{{0}}.{_esc_str(self.field)}[{_esc_str(self.idx_key)}]"
             )
 
-    def __reduce__(self) -> tuple:
+    def __reduce__(self) -> tuple[type["DefaultsSource"], tuple[Any, ...]]:
         # Only pass init=True fields (base, idx_key, is_kw).
         # The init=False fields (field, _name) are recomputed in __post_init__.
         return (self.__class__, (self.base, self.idx_key, self.is_kw))

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -663,11 +663,6 @@ class DefaultsSource(ChainedSource):
                 self, "_name", f"{{0}}.{_esc_str(self.field)}[{_esc_str(self.idx_key)}]"
             )
 
-    def __reduce__(self) -> tuple[type["DefaultsSource"], tuple[Any, ...]]:
-        # Only pass init=True fields (base, idx_key, is_kw).
-        # The init=False fields (field, _name) are recomputed in __post_init__.
-        return (self.__class__, (self.base, self.idx_key, self.is_kw))
-
     def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen(self.base)
         codegen.extend_output(codegen.create_load_attrs(self.field))

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1150,11 +1150,12 @@ def dataclass_with_cached_hash(
             return self._hash
 
         def __reduce__(self):
-            # Exclude _hash from pickling to ensure deterministic cache keys.
-            # The _hash is a cached value that can be nondeterministically computed
-            # (e.g., based on id() of objects), so it should not affect pickling.
+            # Exclude _hash (cached, possibly nondeterministic) and init=False
+            # fields from pickling. Only init=True fields should be passed to
+            # __init__ during unpickling; init=False fields are recomputed in
+            # __post_init__.
             fields = dataclasses.fields(self)
-            field_values = tuple(getattr(self, f.name) for f in fields)
+            field_values = tuple(getattr(self, f.name) for f in fields if f.init)
             return (self.__class__, field_values)
 
         new_cls.__hash__ = __hash__

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1149,7 +1149,7 @@ def dataclass_with_cached_hash(
                 object.__setattr__(self, "_hash", old_hash(self))
             return self._hash
 
-        def __reduce__(self):
+        def __reduce__(self) -> tuple[type, tuple[Any, ...]]:
             # Exclude _hash (cached, possibly nondeterministic) and init=False
             # fields from pickling. Only init=True fields should be passed to
             # __init__ during unpickling; init=False fields are recomputed in


### PR DESCRIPTION
## Summary

`DefaultsSource` has two `init=False` dataclass fields (`field` and `_name`) that get recomputed in `__post_init__`. The `dataclass_with_cached_hash` decorator defines a generic `__reduce__` that serializes all fields, but `__init__` only accepts the three `init=True` fields. Unpickling blows up:

```
TypeError: DefaultsSource.__init__() takes from 3 to 4 positional arguments but 6 were given
```

This blocks the dynamo precompile cache, which pickles source objects.

The fix is in the decorator itself: filter `__reduce__` to only include `init=True` fields, so the unpickled tuple matches what `__init__` actually expects. The `init=False` fields get recomputed via `__post_init__` as usual. No per-class override needed.

## Reproduction

```python
from torch._dynamo.source import DefaultsSource, LocalSource
import pickle

pickle.loads(pickle.dumps(DefaultsSource(LocalSource("y"), True)))
# TypeError: DefaultsSource.__init__() takes from 3 to 4 positional arguments but 6 were given
```

## Test plan

Two regression tests in `test/dynamo/test_guard_serialization.py`:
- `test_defaults_source_pickle_roundtrip` (positional defaults, `is_kw=False`)
- `test_defaults_source_pickle_roundtrip_kw` (keyword defaults, `is_kw=True`)

Both verify all fields survive the roundtrip, including the derived `init=False` ones.

Fixes #174955

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98