### PR TITLE
[cpu] Fix segfault in embedding_bag with empty offsets

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -883,6 +883,9 @@ void check_arguments(
   checkScalarTypes(
       "embedding_bag", weight_arg, {kHalf, kBFloat16, kFloat, kDouble});
 
+  TORCH_CHECK(
+      indices.numel() == 0 || offsets.size(0) > 0,
+      "embedding_bag: offsets tensor can not be empty if indices tensor is not empty");
   AT_DISPATCH_INDEX_TYPES(offsets.scalar_type(), "_embedding_bag_cpu_impl", [&]() {
     if (offsets.size(0) > 0) {
       index_t offset_0 = offsets.const_data_ptr<index_t>()[0];

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8280,6 +8280,17 @@ def sample_inputs_embedding(op_info, device, dtype, requires_grad, **kwargs):
                           kwargs={'sparse': True, 'scale_grad_by_freq': True,
                                   'padding_idx': 0, 'max_norm': 1.})
 
+def error_inputs_embedding_bag(op_info, device, **kwargs):
+    # test for non-empty indices with empty offsets
+    weight = torch.zeros((1, 10), device=device, dtype=torch.float32)
+    indices = torch.zeros(6, device=device, dtype=torch.int64)
+    offsets = torch.zeros(0, device=device, dtype=torch.int64)
+
+    yield ErrorInput(
+        SampleInput(weight, args=(indices,), kwargs={'offsets': offsets, 'mode': 'sum'}),
+        error_type=RuntimeError,
+        error_regex="offsets tensor can not be empty if indices tensor is not empty"
+    )
 
 def sample_inputs_one_hot(op_info, device, dtype, requires_grad, **kwargs):
     def make_input(shape, *, low, high):
@@ -22212,6 +22223,7 @@ op_db: list[OpInfo] = [
         # backward is not supported for mode `max` and dtype `bfloat16`
         backward_dtypesIfCUDA=floating_types_and(torch.float16),
         sample_inputs_func=sample_inputs_embedding_bag,
+        error_inputs_func=error_inputs_embedding_bag,
         skips=(
             # lambda impl
             DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),


### PR DESCRIPTION
Calling `F.embedding_bag` with a non-empty `indices` tensor but an empty `offsets` tensor results in a segmentation fault. This commit adds a `TORCH_CHECK` in `check_arguments` and it ensures that `offsets` is not empty if `indices` contains elements, gracefully throwing a `RuntimeError` instead of a hard crash.

Fixes #175370

Reproduction code from @SilentTester73
```Python
import torch
import torch.nn.functional as F

weight = torch.zeros(1, 10, dtype=torch.float64)
indices = torch.zeros(6, dtype=torch.int64)
offsets = torch.zeros(0, dtype=torch.int64)  # empty offsets

output = F.embedding_bag(indices, weight, offsets, mode='sum')
````

Results:
```
$ python 175370.py
Segmentation fault (core dumped)
```

And with the fix:
```
((venv-pytorch) ) [root@c10-troch-cpu work]# python 175370.py 
Traceback (most recent call last):
  File "/work/175370.py", line 10, in <module>
    output = F.embedding_bag(indices, weight, offsets, mode='sum')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/pytorch/torch/nn/functional.py", line 2774, in embedding_bag
    ret, _, _, _ = torch.embedding_bag(
                   ^^^^^^^^^^^^^^^^^^^^
RuntimeError: embedding_bag: offsets tensor can not be empty if indices tensor is not empty
```
