### PR TITLE
Fixes #175484: Suppress TF32-disabled warning after explicit matmul p…

### DIFF
--- a/test/inductor/test_tf32_warning.py
+++ b/test/inductor/test_tf32_warning.py
@@ -1,0 +1,58 @@
+# Owner(s): ["module: inductor"]
+import warnings
+from unittest import mock
+
+import torch
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestTF32WarningSuppression(TestCase):
+    def _collect_warnings(self, warn_fn):
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            warn_fn()
+        return records
+
+    def test_warn_tf32_disabled_respects_manual_precision(self):
+        from torch._inductor import compile_fx
+        from torch._inductor.fx_passes import fuse_attention
+
+        for warn_module in (compile_fx, fuse_attention):
+            warn_module._warn_tf32_disabled.cache_clear()
+
+        prev_precision = torch.backends.cuda.matmul.fp32_precision
+        prev_user_flag = torch._float32_matmul_precision_set_by_user
+        try:
+            torch.backends.cuda.matmul.fp32_precision = "highest"
+            with (
+                mock.patch("torch.cuda.is_available", return_value=True),
+                mock.patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            ):
+                with mock.patch(
+                    "torch._float32_matmul_precision_set_by_user", False
+                ):
+                    records = self._collect_warnings(
+                        compile_fx._warn_tf32_disabled
+                    )
+                    self.assertEqual(len(records), 1)
+
+                compile_fx._warn_tf32_disabled.cache_clear()
+                with mock.patch("torch._float32_matmul_precision_set_by_user", True):
+                    records = self._collect_warnings(
+                        compile_fx._warn_tf32_disabled
+                    )
+                    self.assertEqual(len(records), 0)
+
+                fuse_attention._warn_tf32_disabled.cache_clear()
+                with mock.patch("torch._float32_matmul_precision_set_by_user", True):
+                    records = self._collect_warnings(
+                        fuse_attention._warn_tf32_disabled
+                    )
+                    self.assertEqual(len(records), 0)
+        finally:
+            torch.backends.cuda.matmul.fp32_precision = prev_precision
+            torch._float32_matmul_precision_set_by_user = prev_user_flag
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1600,6 +1600,13 @@ def get_deterministic_debug_mode() -> builtins.int:
         return 0
 
 
+_float32_matmul_precision_set_by_user = False
+
+
+def _is_float32_matmul_precision_set_by_user() -> bool:
+    return _float32_matmul_precision_set_by_user
+
+
 def get_float32_matmul_precision() -> str:
     r"""Returns the current value of float32 matrix multiplication precision. Refer to
     :func:`torch.set_float32_matmul_precision` documentation for more details.
@@ -1671,6 +1678,8 @@ def set_float32_matmul_precision(precision: str) -> None:
 
     """
     _C._set_float32_matmul_precision(precision)
+    global _float32_matmul_precision_set_by_user
+    _float32_matmul_precision_set_by_user = True
 
 
 def set_warn_always(b: builtins.bool, /) -> None:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -318,6 +318,7 @@ def _warn_tf32_disabled() -> None:
         torch.cuda.is_available()
         and torch.backends.cuda.matmul.fp32_precision != "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
+        and not torch._is_float32_matmul_precision_set_by_user()
     ):
         warnings.warn(
             "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. "

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -818,6 +818,7 @@ def _warn_tf32_disabled() -> None:
         torch.cuda.is_available()
         and torch.backends.cuda.matmul.fp32_precision != "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
+        and not torch._is_float32_matmul_precision_set_by_user()
     ):
         warnings.warn(
             "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. "


### PR DESCRIPTION
## Summary

Suppress Inductor’s **"TF32 tensor cores available but not enabled"** warning when the user has explicitly set float32 matmul precision (e.g., `torch.set_float32_matmul_precision("highest")`). This prevents repeated warnings in workflows that deliberately opt out of TF32 for correctness, while preserving the warning for the default case.

**Fixes:** #175484 

---

## Problem

Inductor currently warns whenever TF32 is available but disabled, even if the user has explicitly set their desired precision. The warning becomes noise and suggests a change the user does not want.

---

## Solution

Track whether the user has called `set_float32_matmul_precision()` and gate `_warn_tf32_disabled()` on this flag. This keeps the warning for default behavior and suppresses it only when the user made an explicit choice.

---

## Changes

### `torch/__init__.py`
- Add `_float32_matmul_precision_set_by_user` flag.
- Set it to `True` when `torch.set_float32_matmul_precision()` is called.
- Add a private helper `_is_float32_matmul_precision_set_by_user()` for internal use.

### `torch/_inductor/compile_fx.py`
- Suppress `_warn_tf32_disabled()` if the user has set matmul precision.

### `torch/_inductor/fx_passes/fuse_attention.py`
- Suppress `_warn_tf32_disabled()` if the user has set matmul precision.

### `test/inductor/test_tf32_warning.py`
- Add a test verifying the warning fires by default and is suppressed after the user explicitly sets precision.

---

## Testing

```bash
python test/inductor/test_tf32_warning.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo