### PR TITLE
Add failing test documenting SequentialLR resume reproducibility issue

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2681,12 +2681,10 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
-
     # NOTE: Expected-failure tests for known scheduler issues.
     #
     # These tests should be converted to normal regression tests once
     # the underlying behavior is fixed.
-
 
     @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
@@ -2771,6 +2769,7 @@ class TestLRScheduler(TestCase):
         self.assertEqual(loaded_optimizer_lr, loaded_scheduler_lr)
         self.assertEqual(resumed_lrs[0], reference_lrs[resume_step])
         self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
+
 
 instantiate_parametrized_tests(TestLRScheduler)
 

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2681,13 +2681,21 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+
+    # NOTE: Expected-failure tests for known scheduler issues.
+    #
+    # These tests should be converted to normal regression tests once
+    # the underlying behavior is fixed.
+
+
     @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
-        # SequentialLR switches between multiple schedulers at milestone
-        # boundaries. If we save and restore both the optimizer and the
-        # scheduler state partway through training, continuing from that
-        # checkpoint should produce exactly the same LR sequence as if the
-        # training had never been interrupted.
+        # Note: Saving and restoring both the optimizer and SequentialLR
+        # state mid training should reproduce the same LR sequence as a
+        # continuous uninterrupted run.
+        #
+        # This currently fails around scheduler transition boundaries after
+        # restoring from checkpoint state.
 
         base_lr = 0.1
         milestone = 5
@@ -2736,14 +2744,88 @@ class TestLRScheduler(TestCase):
         sched3 = make_scheduler(optim3)
         sched3.load_state_dict(sched_state)
 
-        # Continue stepping and check LR with reference 
-        for i in range(resume_step, total_steps):
+        resumed_lrs = []
+        for _ in range(resume_step, total_steps):
             optim3.step()
             sched3.step()
-            self.assertEqual(
-                sched3.get_last_lr()[0],
-                reference_lrs[i],
+            resumed_lrs.append(sched3.get_last_lr()[0])
+
+        self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
+
+    @expectedFailure
+    def test_sequentiallr_resume_restores_optimizer_lr(self):
+        # Note: This is the mechanism level companion to the behavior level
+        # reproducibility test above.
+        #
+        # The problematic state transition comes from SequentialLR's restore
+        # model:
+        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
+        #    lr back to initial_lr, calls recursive_undo(), and then replays
+        #    _schedulers[0]._initial_step().
+        # 2. At this resume point, that constructor path leaves the optimizer
+        #    lr at 0.05 even though the saved scheduler state corresponds to
+        #    an effective lr of 0.08.
+        # 3. SequentialLR.load_state_dict() restores scheduler fields like
+        #    last_epoch and _last_lr, but it does not re-synchronize the
+        #    optimizer param-group lr with that loaded scheduler state.
+        # 4. LinearLR.get_lr() is recursive: it multiplies the current
+        #    optimizer lr, so the next resumed step advances
+        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
+
+        base_lr = 0.1
+        milestone = 5
+        resume_step = 3
+
+        def make_scheduler(optim):
+            return SequentialLR(
+                optim,
+                [
+                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
+                    ExponentialLR(optim, gamma=0.5),
+                ],
+                milestones=[milestone],
             )
+
+        model = torch.nn.Linear(1, 1)
+        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
+        sched = make_scheduler(optim)
+
+        for _ in range(resume_step):
+            optim.step()
+            sched.step()
+
+        optim_state = optim.state_dict()
+        sched_state = sched.state_dict()
+
+        model2 = torch.nn.Linear(1, 1)
+        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
+        optim2.load_state_dict(optim_state)
+
+        sched2 = make_scheduler(optim2)
+        sched2.load_state_dict(sched_state)
+
+        loaded_optimizer_lr = optim2.param_groups[0]["lr"]
+        loaded_scheduler_lr = sched2.get_last_lr()[0]
+
+        optim2.step()
+        sched2.step()
+        resumed_next_lr = sched2.get_last_lr()[0]
+
+        problems = []
+        if loaded_optimizer_lr != loaded_scheduler_lr:
+            problems.append(
+                "optimizer LR is out of sync with restored scheduler state: "
+                f"optimizer LR = {loaded_optimizer_lr}, "
+                f"scheduler LR = {loaded_scheduler_lr}"
+            )
+
+        if resumed_next_lr != 0.09:
+            problems.append(
+                "first resumed step produced an incorrect LR transition: "
+                f"got {resumed_next_lr}, expected 0.09"
+            )
+
+        self.assertEqual([], problems, "\n".join(problems))
 
 instantiate_parametrized_tests(TestLRScheduler)
 

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2696,6 +2696,21 @@ class TestLRScheduler(TestCase):
         #
         # This currently fails around scheduler transition boundaries after
         # restoring from checkpoint state.
+        #
+        # The problematic state transition comes from SequentialLR's restore
+        # model:
+        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
+        #    lr back to initial_lr, calls recursive_undo(), and then replays
+        #    _schedulers[0]._initial_step().
+        # 2. At this resume point, that constructor path leaves the optimizer
+        #    lr at 0.05 even though the saved scheduler state corresponds to
+        #    an effective lr of 0.08.
+        # 3. SequentialLR.load_state_dict() restores scheduler fields like
+        #    last_epoch and _last_lr, but it does not re-synchronize the
+        #    optimizer param-group lr with that loaded scheduler state.
+        # 4. LinearLR.get_lr() is recursive: it multiplies the current
+        #    optimizer lr, so the next resumed step advances
+        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
 
         base_lr = 0.1
         milestone = 5
@@ -2744,88 +2759,18 @@ class TestLRScheduler(TestCase):
         sched3 = make_scheduler(optim3)
         sched3.load_state_dict(sched_state)
 
+        loaded_optimizer_lr = optim3.param_groups[0]["lr"]
+        loaded_scheduler_lr = sched3.get_last_lr()[0]
+
         resumed_lrs = []
         for _ in range(resume_step, total_steps):
             optim3.step()
             sched3.step()
             resumed_lrs.append(sched3.get_last_lr()[0])
 
+        self.assertEqual(loaded_optimizer_lr, loaded_scheduler_lr)
+        self.assertEqual(resumed_lrs[0], reference_lrs[resume_step])
         self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
-
-    @expectedFailure
-    def test_sequentiallr_resume_restores_optimizer_lr(self):
-        # Note: This is the mechanism level companion to the behavior level
-        # reproducibility test above.
-        #
-        # The problematic state transition comes from SequentialLR's restore
-        # model:
-        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
-        #    lr back to initial_lr, calls recursive_undo(), and then replays
-        #    _schedulers[0]._initial_step().
-        # 2. At this resume point, that constructor path leaves the optimizer
-        #    lr at 0.05 even though the saved scheduler state corresponds to
-        #    an effective lr of 0.08.
-        # 3. SequentialLR.load_state_dict() restores scheduler fields like
-        #    last_epoch and _last_lr, but it does not re-synchronize the
-        #    optimizer param-group lr with that loaded scheduler state.
-        # 4. LinearLR.get_lr() is recursive: it multiplies the current
-        #    optimizer lr, so the next resumed step advances
-        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
-
-        base_lr = 0.1
-        milestone = 5
-        resume_step = 3
-
-        def make_scheduler(optim):
-            return SequentialLR(
-                optim,
-                [
-                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
-                    ExponentialLR(optim, gamma=0.5),
-                ],
-                milestones=[milestone],
-            )
-
-        model = torch.nn.Linear(1, 1)
-        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
-        sched = make_scheduler(optim)
-
-        for _ in range(resume_step):
-            optim.step()
-            sched.step()
-
-        optim_state = optim.state_dict()
-        sched_state = sched.state_dict()
-
-        model2 = torch.nn.Linear(1, 1)
-        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
-        optim2.load_state_dict(optim_state)
-
-        sched2 = make_scheduler(optim2)
-        sched2.load_state_dict(sched_state)
-
-        loaded_optimizer_lr = optim2.param_groups[0]["lr"]
-        loaded_scheduler_lr = sched2.get_last_lr()[0]
-
-        optim2.step()
-        sched2.step()
-        resumed_next_lr = sched2.get_last_lr()[0]
-
-        problems = []
-        if loaded_optimizer_lr != loaded_scheduler_lr:
-            problems.append(
-                "optimizer LR is out of sync with restored scheduler state: "
-                f"optimizer LR = {loaded_optimizer_lr}, "
-                f"scheduler LR = {loaded_scheduler_lr}"
-            )
-
-        if resumed_next_lr != 0.09:
-            problems.append(
-                "first resumed step produced an incorrect LR transition: "
-                f"got {resumed_next_lr}, expected 0.09"
-            )
-
-        self.assertEqual([], problems, "\n".join(problems))
 
 instantiate_parametrized_tests(TestLRScheduler)
 

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -7,6 +7,7 @@ import tempfile
 import types
 import warnings
 from functools import partial
+from unittest import expectedFailure
 
 import torch
 import torch.nn.functional as F
@@ -2680,16 +2681,13 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
-
+    @expectedFailure
     def test_sequentiallr_resume_reproducibility(self):
         # SequentialLR switches between multiple schedulers at milestone
         # boundaries. If we save and restore both the optimizer and the
         # scheduler state partway through training, continuing from that
         # checkpoint should produce exactly the same LR sequence as if the
         # training had never been interrupted.
-        #
-        # This test makes that expectation explicit by comparing a continuous
-        # run against a resumed run starting from an intermediate step.
 
         base_lr = 0.1
         milestone = 5


### PR DESCRIPTION
This PR adds a failing test that highlights an issue with `SequentialLR` when resuming from a checkpoint.

`SequentialLR` switches between multiple schedulers at milestone boundaries. From a user perspective, if we save both the optimizer and scheduler state partway through training and then resume, the learning rate sequence should continue exactly as if the training had never been interrupted.

However, under the current implementation, resuming from an intermediate step can produce a different LR sequence compared to an uninterrupted run. This test makes that expectation explicit by comparing a continuous run against a resumed run starting from the same global step.

This PR is tests only. It does not propose a fix. The goal is simply to document the current behavior and make the reproducibility expectation clear in the test suite. Any future change to `SequentialLR`’s internal state handling or resume semantics can update this test accordingly.

### Related discussion

This test is part of the broader scheduler cleanup work described in:

“RFC: Internal Unification of LRScheduler Semantics for Correct Resuming and Composition” #168044
