### PR TITLE
[nn] Allow eps=0 in batch_norm during eval mode

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2841,7 +2841,9 @@ def batch_norm(
         _verify_batch_size(input.size())
 
     if training and eps <= 0.0:
-        raise ValueError(f"batch_norm eps must be positive during training, but got {eps}")
+        raise ValueError(
+            f"batch_norm eps must be positive during training, but got {eps}"
+        )
     elif eps < 0.0:
         raise ValueError(f"batch_norm eps must be non-negative, but got {eps}")
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2840,8 +2840,10 @@ def batch_norm(
         # pyrefly: ignore [bad-argument-type]
         _verify_batch_size(input.size())
 
-    if eps <= 0.0:
-        raise ValueError(f"batch_norm eps must be positive, but got {eps}")
+    if training and eps <= 0.0:
+        raise ValueError(f"batch_norm eps must be positive during training, but got {eps}")
+    elif eps < 0.0:
+        raise ValueError(f"batch_norm eps must be non-negative, but got {eps}")
 
     return torch.batch_norm(
         input,


### PR DESCRIPTION
## Summary

`torch.nn.functional.batch_norm` currently requires `eps > 0` unconditionally, but in eval mode `running_mean` and `running_var` are frozen and can be constant-folded or pre-adjusted by the user. There are valid use cases where `eps=0` makes sense in eval mode (e.g., when running stats have been deliberately set to avoid division by zero).

This relaxes the check so that:
- **Training mode**: `eps` must be strictly positive (unchanged behavior)
- **Eval mode**: `eps` must be non-negative (`eps=0` is now allowed)
- **Negative `eps`**: always rejected in both modes

cc @mikaylagawarecki (who confirmed this approach sounds reasonable in the issue)

## Test plan

Verified locally with monkeypatching that:
- `eps=0.0, training=False` — works correctly, no error
- `eps=0.0, training=True` — raises `ValueError` with updated message
- `eps=-1.0` — always raises `ValueError` regardless of mode
- `eps=1e-5` — works in both modes (existing behavior preserved)

Fixes #173337