### PR TITLE
[kineto] Generate unique group_trace_id instead of reusing trace_id (#175512)

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -10,6 +10,8 @@
 #include <c10/util/Exception.h>
 #include <c10/util/env.h>
 
+#include <random>
+
 namespace torch {
 
 namespace profiler::impl::kineto {
@@ -269,13 +271,19 @@ bool collectivesProfilerExists() {
 }
 
 #ifdef USE_KINETO
+static uint64_t generate_unique_id() {
+  thread_local std::mt19937_64 gen(std::random_device{}());
+  thread_local std::uniform_int_distribution<uint64_t> dis;
+  return dis(gen);
+}
+
 static const std::string setTraceID(const std::string& trace_id) {
   if (trace_id.empty()) {
     return "";
   }
   std::stringstream configss;
   configss << "REQUEST_TRACE_ID=" << trace_id << '\n';
-  configss << "REQUEST_GROUP_TRACE_ID=" << trace_id << '\n';
+  configss << "REQUEST_GROUP_TRACE_ID=" << generate_unique_id() << '\n';
   return configss.str();
 }
 


### PR DESCRIPTION
Summary:

Previously, `setTraceID()` in `kineto_shim.cpp` set `REQUEST_GROUP_TRACE_ID` to the same value as `REQUEST_TRACE_ID`. This made the group trace id redundant and not useful for distinguishing traces that share the same trace id.

This change generates a unique random `uint64_t` for the group trace id using `std::mt19937_64`, following the same random generation pattern used in `IpcFabricConfigClient.cpp`. The collision probability is negligible (~1 in 37 million at 1M traces).

Test Plan:
Tested in my dev server on a sample training code, the profiler result contains numeric group trace id.
[trace link](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/dynocli/devvm24978.vll0.facebook.com/rank-0.Feb_17_13_18_25.24963.pt.trace.json.gz&bucket=gpu_traces)
{F1985718709}

Differential Revision: D93548844


