### PR TITLE
Implement batching rule for masked_fill_

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -340,6 +340,47 @@ static Tensor binomial_wrapper(const Tensor& count, const Tensor& prob, std::opt
   return at::binomial(count, prob.contiguous(), std::move(gen)); // Bug in PyTorch, prob shouldn't need to be contiguous
 }
 
+static void masked_fill__Tensor_batch_rule(
+    Tensor& self, std::optional<int64_t> self_bdim,
+    const Tensor& mask, std::optional<int64_t> mask_bdim,
+    const Tensor& value, std::optional<int64_t> value_bdim) {
+  if (!self_bdim && (mask_bdim || value_bdim)) {
+    vmapIncompatibleInplaceError("masked_fill_");
+  }
+
+  auto self_logical_rank = rankWithoutBatchDim(self, self_bdim);
+  auto mask_logical_rank = rankWithoutBatchDim(mask, mask_bdim);
+  auto max_logical_rank = std::max(self_logical_rank, mask_logical_rank);
+
+  auto self_ = moveBatchDimToFront(self, self_bdim);
+  auto mask_ = moveBatchDimToFront(mask, mask_bdim);
+
+  self_ = maybePadToLogicalRank(self_, self_bdim, max_logical_rank);
+  mask_ = maybePadToLogicalRank(mask_, mask_bdim, max_logical_rank);
+
+  if (!value_bdim) {
+    self_.masked_fill_(mask_, value);
+    return;
+  }
+
+  TORCH_CHECK(
+    rankWithoutBatchDim(value, value_bdim) == 0,
+    "vmap: masked_fill_(self, mask, value) expects `value` to be a tensor with "
+    "logical rank 0, but got logical rank ",
+    rankWithoutBatchDim(value, value_bdim),
+    ".");
+
+  // when value is batched (0-d --> 1-d after batching)
+  auto value_ = moveBatchDimToFront(value, value_bdim);
+  value_ = maybePadToLogicalRank(value_, value_bdim, max_logical_rank);
+  value_ = value_.to(
+      self_.device(),
+      self_.scalar_type(),
+      /*non_blocking=*/false,
+      /*copy=*/false);
+  self_.copy_(at::where(mask_, value_, self_));
+}
+
 TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
   #define BINARY_RANDOM_POINTWISE(op) \
     m.impl(#op, BINARY_RANDOM_POINTWISE_BATCH_RULE(ATEN_FN(op)));
@@ -509,6 +550,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   VMAP_SUPPORT2(clamp_min_, Tensor, SINGLE_ARG(binary_pointwise_inplace_batch_rule<TensorInplaceT, &Tensor::clamp_min_>));
   VMAP_SUPPORT2(clamp_max_, Tensor, SINGLE_ARG(binary_pointwise_inplace_batch_rule<TensorInplaceT, &Tensor::clamp_max_>));
   VMAP_SUPPORT2(masked_fill_, Scalar, SINGLE_ARG(binary_pointwise_inplace_batch_rule<TensorScalarInplaceT, &Tensor::masked_fill_, const Scalar&>));
+  VMAP_SUPPORT2(masked_fill_, Tensor, masked_fill__Tensor_batch_rule);
   VMAP_SUPPORT(copy_, SINGLE_ARG(binary_pointwise_inplace_batch_rule<CopyT, &Tensor::copy_, bool>));
 
 #define COMPARISON_POINTWISE(op) \

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -373,6 +373,11 @@ static void masked_fill__Tensor_batch_rule(
   // when value is batched (0-d --> 1-d after batching)
   auto value_ = moveBatchDimToFront(value, value_bdim);
   value_ = maybePadToLogicalRank(value_, value_bdim, max_logical_rank);
+  TORCH_CHECK(
+      !(value_.is_complex() && !self_.is_complex()),
+      "value cannot be converted to type ",
+      self_.scalar_type(),
+      " without overflow");
   value_ = value_.to(
       self_.device(),
       self_.scalar_type(),

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -378,6 +378,9 @@ static void masked_fill__Tensor_batch_rule(
       "value cannot be converted to type ",
       self_.scalar_type(),
       " without overflow");
+  TORCH_CHECK(
+      value_.device() == self_.device() || value_.device().is_cpu(),
+      "masked_fill_: Expected inputs to be on same device");
   value_ = value_.to(
       self_.device(),
       self_.scalar_type(),

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -1104,6 +1104,39 @@ std::tuple<Tensor, std::optional<int64_t>> masked_fill_scalar_batch_rule(
   return std::make_tuple(std::move(result), 0);
 }
 
+std::tuple<Tensor, std::optional<int64_t>> masked_fill_tensor_batch_rule(
+    const Tensor & self,
+    std::optional<int64_t> self_bdim,
+    const Tensor & mask,
+    std::optional<int64_t> mask_bdim,
+    const Tensor & value,
+    std::optional<int64_t> value_bdim) {
+  auto self_logical_rank = rankWithoutBatchDim(self, self_bdim);
+  auto mask_logical_rank = rankWithoutBatchDim(mask, mask_bdim);
+  auto max_logical_rank = std::max(self_logical_rank, mask_logical_rank);
+
+  auto self_ = moveBatchDimToFront(self, self_bdim);
+  auto mask_ = moveBatchDimToFront(mask, mask_bdim);
+
+  self_ = maybePadToLogicalRank(self_, self_bdim, max_logical_rank);
+  mask_ = maybePadToLogicalRank(mask_, mask_bdim, max_logical_rank);
+
+  if (!value_bdim) {
+    return std::make_tuple(at::masked_fill(self_, mask_, value), 0);
+  }
+
+  TORCH_CHECK(
+      rankWithoutBatchDim(value, value_bdim) == 0,
+      "vmap: expected masked_fill `value` to be a batched scalar (logical rank 0), "
+      "but got logical rank ",
+      rankWithoutBatchDim(value, value_bdim));
+
+  auto value_ = moveBatchDimToFront(value, value_bdim);
+  value_ = value_.to(self_.device(), self_.scalar_type());
+  value_ = maybePadToLogicalRank(value_, value_bdim, max_logical_rank);
+  return std::make_tuple(at::where(mask_, value_, self_), 0);
+}
+
 std::tuple<Tensor, std::optional<int64_t>> index_fill_batch_rule_helper(
   int64_t batch_size,
   int64_t self_logical_rank,
@@ -1296,6 +1329,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   m.impl("index_copy", index_copy_decomp);
   m.impl("index_select", index_select_decomp);
   VMAP_SUPPORT2(masked_fill, Scalar, masked_fill_scalar_batch_rule);
+  VMAP_SUPPORT2(masked_fill, Tensor, masked_fill_tensor_batch_rule);
   VMAP_SUPPORT2(index_fill_, int_Tensor, index_fill__int_tensor_batch_rule);
   VMAP_SUPPORT2(index_fill_, int_Scalar, index_fill__int_scalar_batch_rule);
   VMAP_SUPPORT2(index_fill, int_Tensor, index_fill_int_tensor_batch_rule);

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -1137,6 +1137,9 @@ std::tuple<Tensor, std::optional<int64_t>> masked_fill_tensor_batch_rule(
       "value cannot be converted to type ",
       self_.scalar_type(),
       " without overflow");
+  TORCH_CHECK(
+      value_.device() == self_.device() || value_.device().is_cpu(),
+      "masked_fill: Expected inputs to be on same device");
   value_ = value_.to(self_.device(), self_.scalar_type());
   value_ = maybePadToLogicalRank(value_, value_bdim, max_logical_rank);
   return std::make_tuple(at::where(mask_, value_, self_), 0);

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -1132,6 +1132,11 @@ std::tuple<Tensor, std::optional<int64_t>> masked_fill_tensor_batch_rule(
       rankWithoutBatchDim(value, value_bdim));
 
   auto value_ = moveBatchDimToFront(value, value_bdim);
+  TORCH_CHECK(
+      !(value_.is_complex() && !self_.is_complex()),
+      "value cannot be converted to type ",
+      self_.scalar_type(),
+      " without overflow");
   value_ = value_.to(self_.device(), self_.scalar_type());
   value_ = maybePadToLogicalRank(value_, value_bdim, max_logical_rank);
   return std::make_tuple(at::where(mask_, value_, self_), 0);

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1365,7 +1365,6 @@ class TestOperators(TestCase):
                     "cdouble"
                 ),  # RuntimeError: required rank 4 tensor to use channels_last format
                 xfail("cumprod"),
-                xfail("masked_fill"),
                 xfail("fill"),
                 skip("masked.mean"),  # ???
                 xfail("masked_scatter"),
@@ -1445,7 +1444,6 @@ class TestOperators(TestCase):
                 ),  # Batching rule not implemented for `narrow.Tensor` (and view op)
                 xfail("special.log_ndtr"),
                 xfail("linalg.householder_product"),
-                xfail("masked_fill"),
                 xfail("masked_scatter"),
                 xfail("masked_select"),
                 xfail("nanquantile"),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1364,7 +1364,6 @@ class TestOperators(TestCase):
                 xfail(
                     "cdouble"
                 ),  # RuntimeError: required rank 4 tensor to use channels_last format
-                xfail("cumprod"),
                 xfail("fill"),
                 skip("masked.mean"),  # ???
                 xfail("masked_scatter"),
@@ -1388,7 +1387,6 @@ class TestOperators(TestCase):
                 xfail("linalg.lu", ""),
                 xfail("nn.functional.dropout3d", ""),
                 xfail("as_strided_scatter", ""),
-                xfail("masked.cumprod", ""),
                 xfail("renorm"),  # hit vmap fallback, which is disabled
                 xfail("native_group_norm"),
             }

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4185,6 +4185,7 @@ class TestVmapOperatorsOpInfo(TestCase):
                     and getattr(op, "variant_test_name", "") == "Tensor"
                     and error_input.error_regex in skip_error_regexes
                 )
+
             # Error inputs check
             if op.error_inputs_func is not None:
                 error_inputs = op.error_inputs(device)

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4173,10 +4173,24 @@ class TestVmapOperatorsOpInfo(TestCase):
         postprocess_fn=None,
     ):
         def test():
+            # some of the inputs suddenly become valid under vmap and won't throw an error
+            # carving these out to preserve the as much of the coverage still
+            def should_skip_error_input(error_input):
+                skip_error_regexes = {
+                    "only supports a 0-dimensional value tensor, but got tensor with 1 dimension",
+                    "value cannot be converted to type .* without overflow",
+                }
+                return (
+                    op.name in {"masked_fill", "masked_fill_"}
+                    and getattr(op, "variant_test_name", "") == "Tensor"
+                    and error_input.error_regex in skip_error_regexes
+                )
             # Error inputs check
             if op.error_inputs_func is not None:
                 error_inputs = op.error_inputs(device)
                 for error_input in error_inputs:
+                    if should_skip_error_input(error_input):
+                        continue
                     sample_input = error_input.sample_input
                     args = (sample_input.input,) + tuple(sample_input.args)
                     kwargs = sample_input.kwargs
@@ -4501,7 +4515,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 # masked index as input which is not supported
                 xfail("index_put", ""),
                 xfail("isin"),
-                xfail("masked_fill"),
                 xfail("masked_scatter"),
                 xfail("masked_select"),
                 xfail("nanquantile"),
@@ -4883,6 +4896,79 @@ class TestVmapOperatorsOpInfo(TestCase):
                 torch.tensor([[0, 1], [2, 3]], device=device),
                 torch.randn(2, device=device),
             )
+
+    def test_masked_fill__Tensor(self, device):
+        def test():
+            B = 2
+            # Both self, mask, and value batched
+            args = (
+                torch.randn(B, 3, device=device),
+                torch.randn(B, 3, device=device) > 0,
+                torch.randn(B, device=device),
+            )
+            self.vmap_inplace_test(Tensor.masked_fill_, args, {}, (0, 0, 0))
+
+            # self and mask batched, value not batched
+            args = (
+                torch.randn(B, 3, device=device),
+                torch.randn(B, 3, device=device) > 0,
+                torch.tensor(1.0, device=device),
+            )
+            self.vmap_inplace_test(Tensor.masked_fill_, args, {}, (0, 0, None))
+
+            # self batched, mask and value not batched
+            args = (
+                torch.randn(B, 3, device=device),
+                torch.randn(3, device=device) > 0,
+                torch.tensor(1.0, device=device),
+            )
+            self.vmap_inplace_test(Tensor.masked_fill_, args, {}, (0, None, None))
+
+            # self not batched (should error)
+            args = (
+                torch.randn(3, device=device),
+                torch.randn(B, 3, device=device) > 0,
+                torch.randn(B, device=device),
+            )
+            self.vmap_inplace_test(Tensor.masked_fill_, args, {}, (None, 0, 0))
+
+        check_vmap_fallback(self, test, Tensor.masked_fill_)
+
+    def test_masked_fill_Tensor_broadcast(self, device):
+        B = 2
+        # self rank > mask rank, both batched
+        self.vmap_outplace_test(
+            torch.masked_fill,
+            (
+                torch.randn(B, 2, 3, device=device),
+                torch.randn(B, 3, device=device) > 0,
+                torch.randn(B, device=device),
+            ),
+            {},
+            (0, 0, 0),
+        )
+        # mask rank > self rank, both batched
+        self.vmap_outplace_test(
+            torch.masked_fill,
+            (
+                torch.randn(B, 3, device=device),
+                torch.randn(B, 2, 3, device=device) > 0,
+                torch.randn(B, device=device),
+            ),
+            {},
+            (0, 0, 0),
+        )
+        # self batched, mask unbatched with different rank
+        self.vmap_outplace_test(
+            torch.masked_fill,
+            (
+                torch.randn(B, 2, 3, device=device),
+                torch.randn(3, device=device) > 0,
+                torch.randn(B, device=device),
+            ),
+            {},
+            (0, None, 0),
+        )
 
     @tf32_on_and_off(0.005)
     def test_conv_double_backward(self, device):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4173,25 +4173,10 @@ class TestVmapOperatorsOpInfo(TestCase):
         postprocess_fn=None,
     ):
         def test():
-            # some of the inputs suddenly become valid under vmap and won't throw an error
-            # carving these out to preserve the as much of the coverage still
-            def should_skip_error_input(error_input):
-                skip_error_regexes = {
-                    "only supports a 0-dimensional value tensor, but got tensor with 1 dimension",
-                    "value cannot be converted to type .* without overflow",
-                }
-                return (
-                    op.name in {"masked_fill", "masked_fill_"}
-                    and getattr(op, "variant_test_name", "") == "Tensor"
-                    and error_input.error_regex in skip_error_regexes
-                )
-
             # Error inputs check
             if op.error_inputs_func is not None:
                 error_inputs = op.error_inputs(device)
                 for error_input in error_inputs:
-                    if should_skip_error_input(error_input):
-                        continue
                     sample_input = error_input.sample_input
                     args = (sample_input.input,) + tuple(sample_input.args)
                     kwargs = sample_input.kwargs


### PR DESCRIPTION
Fixes #148183

# The code builds ✅
```
python -m pip install -e . -v --no-build-isolation
```

# Warn no longer reproduces on Mac ✅
```
import torch

x = torch.randn(3, 4, 5)
mask = torch.randint(0, 2, (3, 4, 5), dtype=torch.bool)
value = torch.tensor([1.0, 2.0, 3.0])

def fn(x, mask, val):
    return x.masked_fill_(mask, val)

result = torch.vmap(fn)(x, mask, value)
```

## Before
```
python3 masked_fill_repro.py 
.../pytorch/masked_fill_repro.py:8: UserWarning: There is a performance drop because we have not yet implemented the batching rule for aten::masked_fill_.Tensor. Please file us an issue on GitHub so that we can prioritize its implementation. (Triggered internally at .../pytorch/aten/src/ATen/functorch/BatchedFallback.cpp:83.)
  return x.masked_fill_(mask, val)
```
## After
```
python3 masked_fill_repro.py 
```

# Linter is ok ✅
```
pytorch % lintrunner f                                                                                                                                                                                                                           ok No lint issues.
```

# Changed test suites ok ✅
```
python test/functorch/test_vmap.py -k "masked_fill"
Ran 7 tests in 0.109s

OK (skipped=1)
```

# Some tests fail - verified fail on main too ✅
```
python ./test/test_torch.py
----------------------------------------------------------------------
Ran 971 tests in 3.808s

FAILED (failures=1, errors=2, skipped=144)
```