### PR TITLE
Fix AttributeError handling in call_getattr to match eager semantics

### DIFF
--- a/test/dynamo/test_exceptions.py
+++ b/test/dynamo/test_exceptions.py
@@ -485,6 +485,33 @@ class ExceptionTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    def test_attribute_error_caught_from_user_getattr(self):
+        """
+        This test specifically covers AttributeError propagation when 
+        overriding the default __getattr__ implementation to ensure 
+        compatibility with hasattr() under torch.compile.
+        """
+        class Obj:
+            def __getattr__(self, name):
+                raise AttributeError("boom")
+
+        obj = Obj()
+
+        def fn(x):
+            try:
+                obj.missing_attr
+            except AttributeError:
+                return torch.sin(x)
+            return torch.cos(x)
+
+        x = torch.randn(4)
+        ref = fn(x)
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x)
+
+        self.assertEqual(ref, res)
+
     def test_stop_iteration(self):
         def zip_longest(*iterables, fillvalue=None):
             # Get the iterators for each iterable

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2671,7 +2671,10 @@ class BuiltinVariable(VariableTracker):
                 pass
 
         if isinstance(obj, variables.NNModuleVariable):
-            return obj.var_getattr(tx, name)
+            try:
+                return obj.var_getattr(tx, name)
+            except AttributeError as e:
+                tx.raise_observed_exception(e)
         elif isinstance(
             obj,
             (
@@ -2726,6 +2729,8 @@ class BuiltinVariable(VariableTracker):
                 # dont fallback on as_python_constant error because this leads
                 # to a failure later on, and leads to a wrong stacktrace
                 raise
+            except AttributeError as e:
+                tx.raise_observed_exception(e)
             except NotImplementedError:
                 return variables.GetAttrVariable(obj, name, source=source)
         elif isinstance(obj, variables.TorchInGraphFunctionVariable):
@@ -2758,6 +2763,8 @@ class BuiltinVariable(VariableTracker):
         else:
             try:
                 return obj.var_getattr(tx, name)
+            except AttributeError as e:
+                tx.raise_observed_exception(e)
             except NotImplementedError:
                 return variables.GetAttrVariable(obj, name, source=source)
 


### PR DESCRIPTION
Fix an issue where torch.compile would crash with
InternalTorchDynamoError when a user AttributeError was raised inside getattr and expected to be caught by a Python except block.

In eager mode, AttributeError raised during attribute access is properly caught by surrounding try/except. However, in compiled mode, the exception was not being observed and instead caused Dynamo to crash.

This change ensures that AttributeError raised from var_getattr() is converted into an observed exception via tx.raise_observed_exception(), allowing Python exception semantics to be preserved under torch.compile.

This makes compiled behavior consistent with eager mode.

### Test Plan
This PR includes a new regression test to verify correct `AttributeError` handling within `torch.compile`.

**1. Regression Test:**
* Added `test_attribute_error_caught_from_user_getattr` to `test/dynamo/test_exceptions.py`.
* **Expected Behavior:** Validates that an `AttributeError` raised from custom `__getattr__` is correctly caught during Dynamo tracing, matching eager mode semantics.
* **Verification:** * **With Fix:** Test passes successfully.
    * **Without Fix:** Test fails, confirming the necessity of the changes in `builtin.py`.

**2. Execution Command:**
`python test/dynamo/test_exceptions.py -v -k test_attribute_error_caught_from_user_getattr`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo