### PR TITLE
[dynamo] Skip guard sanity check when TorchFunctionMode is active

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -778,6 +778,41 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
                         torch.ones(2, 2, 2, 2),
                     )
 
+    def test_guard_sanity_check_skipped_with_torch_function_mode(self):
+        """Test that stateful TorchFunctionMode does not cause guard failures.
+
+        Regression test for #172088.
+        """
+        from torch._dynamo.testing import CompileCounterWithBackend
+
+        class CounterMode(TorchFunctionMode):
+            def __init__(self):
+                self.count = 0
+
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+                self.count += 1
+                return func(*args, **kwargs)
+
+        counter = CompileCounterWithBackend("eager")
+
+        @torch.compile(backend=counter, fullgraph=True)
+        def f(x):
+            return x.sin()
+
+        with CounterMode():
+            x = torch.tensor([1.0])
+            result = f(x)
+            self.assertEqual(counter.frame_count, 1)
+
+            result2 = f(x)
+            self.assertEqual(counter.frame_count, 1)
+
+        expected = torch.sin(torch.tensor([1.0]))
+        self.assertEqual(result, expected)
+        self.assertEqual(result2, expected)
+
     @requires_gpu
     @skipIfXpu(msg="XPU does not support flex attention")
     def test_hop_eager(self):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4176,19 +4176,22 @@ class CheckFunctionManager:
             "pytorch/compiler:guard_nn_modules"
         )
 
-        for guard in sorted_guards:
-            if (
-                not guard_on_nn_modules
-                and guard.is_specialized_nn_module()
-                # Default func args must be guarded on.
-                # TODO: we could make use of 'DefaultsSource' and offer a .guard.is_defaults() API
-                and "__defaults__" not in guard.name
-                and "__kwdefaults__" not in guard.name
-                and (config.skip_nnmodule_hook_guards or "hooks" not in guard.name)
-            ):
-                continue
+        # Disable __torch_function__ dispatch during guard creation to prevent
+        # user code from running when accessing tensor properties.
+        with torch._C.DisableTorchFunction():
+            for guard in sorted_guards:
+                if (
+                    not guard_on_nn_modules
+                    and guard.is_specialized_nn_module()
+                    # Default func args must be guarded on.
+                    # TODO: we could make use of 'DefaultsSource' and offer a .guard.is_defaults() API
+                    and "__defaults__" not in guard.name
+                    and "__kwdefaults__" not in guard.name
+                    and (config.skip_nnmodule_hook_guards or "hooks" not in guard.name)
+                ):
+                    continue
 
-            guard.create(builder)
+                guard.create(builder)
         return builder, guard_manager
 
     def compile_check_fn(


### PR DESCRIPTION
\[dynamo\] TorchFunctionMode with mutable state causes failures during the compile-time guard sanity check because `__torch_function__ `dispatch triggers user code during guard creation, mutating mode state.

During `@torch.compile`, guard creation access tensor properties like `.dtypes, .device, .size()`, etc.

If a TorchFunctionMode is active, those accesses trigger `__torch_function__ `dispatch (running arbitrary user code during compilation).

This mutates state during guard creation, causing the guard sanity check to fail with "Guard failed on the same frame it was created."

Solution: Wrap the guard creation loop in `build_guards()` with `torch._C.DisableTorchFunction()` . This disables` __torch_function__` dispatch so guards on mode state are created correctly.

Comparison LOGS:

```log
===BEFORE FIX===
mode.count before compile: 1
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:4210] [0/0] [__guards] GUARDS:
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] 
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] TREE_GUARD_MANAGER:
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] +- RootGuardManager
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- LAMBDA_GUARD: torch._functorch.aot_autograd.utils.top_saved_tensors_hooks ids == None  # _dynamo/output_graph.py:964 in init_ambient_guards
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- GLOBAL_STATE: ___check_global_state() against {"allow_bf16_reduce":0,"allow_fp16_reduce":0,"allow_tf32":false,"autocast_state":{"cached_enabled":true,"dtype":[15,5,5,15,5,5,15,15,5,5],"enabled":[false,false,false,false,false,false,false,false,false,false]},"default_dtype":6,"deterministic_algorithms":false,"deterministic_algorithms_warn_only":false,"grad_mode":true,"num_threads":80,"torch_function":true,"torch_function_all_disabled":false}
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- TORCH_FUNCTION_MODE_STACK: ___check_torch_function_mode_stack()
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- DEFAULT_DEVICE: utils_device.CURRENT_DEVICE == None                           # _dynamo/output_graph.py:951 in init_ambient_guards
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- GuardManager: source=L['x'], accessed_by=FrameLocalsGuardAccessor(key='x', framelocals_idx=0), type=<class 'torch.Tensor'>, tag_safe=(True, False)
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | +- TENSOR_MATCH: check_tensor(L['x'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[1], stride=[1])  # return x.sin()  # mp/verify_guards_before_after.py:21 in f
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | +- NO_HASATTR: hasattr(L['x'], '_dynamo_dynamic_indices') == False           # return x.sin()  # mp/verify_guards_before_after.py:21 in f
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- GuardManager: source=___get_torch_function_mode_stack_at(0), accessed_by=PythonLambdaGuardAccessor, type=<class '__main__.CounterMode'>, tag_safe=(False, False)
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | +- GuardManager: source=___get_torch_function_mode_stack_at(0).count, accessed_by=GetAttrGuardAccessor(count), type=<class 'int'>, tag_safe=(True, False)
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | | +- EQUALS_MATCH: ___get_torch_function_mode_stack_at(0).count == 5             # self.count += 1  # mp/verify_guards_before_after.py:13 in __torch_function__
V0304 04:28:43.719000 583657 torch/_dynamo/guards.py:3911] [0/0] [__guards] 
FAILED: Guard failed on the same frame it was created. This is a bug - please create an issue.Guard fail reason: 0/0: ___get_torch_function_mode_stack_at(0).count == 5             # self.count += 1  # mp/verify_guards_before_after.py:13 in __torch_function__
User stack trace:
  File "/tmp/verify_guards_before_after.py", line 21, in f
    return x.sin()
  File "/tmp/verify_guards_before_after.py", line 13, in __torch_function__
    self.count += 1
```

```log
=== AFTER FIX ===
mode.count before compile: 1
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:4209] [0/0] [__guards] GUARDS:
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] 
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] TREE_GUARD_MANAGER:
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] +- RootGuardManager
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- LAMBDA_GUARD: torch._functorch.aot_autograd.utils.top_saved_tensors_hooks ids == None  # _dynamo/output_graph.py:964 in init_ambient_guards
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- GLOBAL_STATE: ___check_global_state() against {"allow_bf16_reduce":0,"allow_fp16_reduce":0,"allow_tf32":false,"autocast_state":{"cached_enabled":true,"dtype":[15,5,5,15,5,5,15,15,5,5],"enabled":[false,false,false,false,false,false,false,false,false,false]},"default_dtype":6,"deterministic_algorithms":false,"deterministic_algorithms_warn_only":false,"grad_mode":true,"num_threads":80,"torch_function":true,"torch_function_all_disabled":false}
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- TORCH_FUNCTION_MODE_STACK: ___check_torch_function_mode_stack()
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- DEFAULT_DEVICE: utils_device.CURRENT_DEVICE == None                           # _dynamo/output_graph.py:951 in init_ambient_guards
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- GuardManager: source=L['x'], accessed_by=FrameLocalsGuardAccessor(key='x', framelocals_idx=0), type=<class 'torch.Tensor'>, tag_safe=(True, False)
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | +- TENSOR_MATCH: check_tensor(L['x'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[1], stride=[1])  # return x.sin()  # mp/verify_guards_before_after.py:21 in f
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | +- NO_HASATTR: hasattr(L['x'], '_dynamo_dynamic_indices') == False           # return x.sin()  # mp/verify_guards_before_after.py:21 in f
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | +- GuardManager: source=___get_torch_function_mode_stack_at(0), accessed_by=PythonLambdaGuardAccessor, type=<class '__main__.CounterMode'>, tag_safe=(False, False)
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | +- GuardManager: source=___get_torch_function_mode_stack_at(0).count, accessed_by=GetAttrGuardAccessor(count), type=<class 'int'>, tag_safe=(True, False)
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] | | | +- EQUALS_MATCH: ___get_torch_function_mode_stack_at(0).count == 2             # self.count += 1  # mp/verify_guards_before_after.py:13 in __torch_function__
V0304 04:28:25.352000 582974 torch/_dynamo/guards.py:3911] [0/0] [__guards] 
V0304 04:28:25.375000 582974 torch/_dynamo/guards.py:3947] [0/0] [__guards] Guard eval latency = 30.11 us
mode.count after compile: 2
SUCCESS: result=tensor([0.8415])
```

Guard structure is identical in both cases. The only difference is the capture count value(2 vs 5), because the access of `.dtype/.device/.size()` triggered 3 extra `__torch_function__` which incremented mode.count during guard creation.

fixes: #172088