### PR TITLE
Remove __module__ patching in dtensor experimental API

### DIFF
--- a/torch/distributed/tensor/experimental/__init__.py
+++ b/torch/distributed/tensor/experimental/__init__.py
@@ -1,14 +1,37 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+
 from collections.abc import Iterator
 from contextlib import contextmanager
-
+from functools import wraps
+from typing import ParamSpec, TypeVar
 from torch.distributed.tensor._api import DTensor
-from torch.distributed.tensor.experimental._attention import context_parallel
-from torch.distributed.tensor.experimental._func_map import local_map
-from torch.distributed.tensor.experimental._register_sharding import register_sharding
-
+from torch.distributed.tensor.experimental._attention import (
+    context_parallel as _context_parallel,
+)
+from torch.distributed.tensor.experimental._func_map import local_map as _local_map
+from torch.distributed.tensor.experimental._register_sharding import (
+    register_sharding as _register_sharding,
+)
 
 __all__ = ["context_parallel", "implicit_replication", "local_map", "register_sharding"]
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@wraps(_context_parallel)
+def context_parallel(*args: P.args, **kwargs: P.kwargs) -> R:
+    return _context_parallel(*args, **kwargs)
+
+
+@wraps(_local_map)
+def local_map(*args: P.args, **kwargs: P.kwargs) -> R:
+    return _local_map(*args, **kwargs)
+
+
+@wraps(_register_sharding)
+def register_sharding(*args: P.args, **kwargs: P.kwargs) -> R:
+    return _register_sharding(*args, **kwargs)
 
 
 @contextmanager
@@ -25,10 +48,3 @@ def implicit_replication() -> Iterator[None]:
         yield
     finally:
         DTensor._op_dispatcher._allow_implicit_replication = False
-
-
-# Set namespace for exposed private names
-context_parallel.__module__ = "torch.distributed.tensor.experimental"
-implicit_replication.__module__ = "torch.distributed.tensor.experimental"
-local_map.__module__ = "torch.distributed.tensor.experimental"
-register_sharding.__module__ = "torch.distributed.tensor.experimental"


### PR DESCRIPTION
Fixes #171905
Replace module mutations with wrappers defined in the public namespace, so exported functions naturally have the correct module path.