### PR TITLE
Use correct head dim for XPU SDPA tests

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -778,21 +778,24 @@ class DistMatrixOpsTest(DTensorTestBase):
     def test_scaled_dot_product_attention(self):
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        head_dim = 8
+        if self.device_type == "xpu":
+            head_dim = 64
         # bsz, n_heads, slen, head_dim
         query = torch.rand(
-            (4, 8, 8, 8),
+            (4, 8, 8, head_dim),
             device=self.device_type,
             dtype=torch.bfloat16,
             requires_grad=True,
         )
         key = torch.rand(
-            (4, 8, 8, 8),
+            (4, 8, 8, head_dim),
             device=self.device_type,
             dtype=torch.bfloat16,
             requires_grad=True,
         )
         value = torch.rand(
-            (4, 8, 8, 8),
+            (4, 8, 8, head_dim),
             device=self.device_type,
             dtype=torch.bfloat16,
             requires_grad=True,


### PR DESCRIPTION
This PR fixes failing sdpa tests in `test/distributed/tensor/test_matrix_ops.py`.

The default Flash Attention backend for XPU uses a default alignment size of 64 here:
https://github.com/pytorch/pytorch/blob/b9b2033638527baabef742127e3805fa6b773740/aten/src/ATen/native/transformers/attention.cpp#L763

We use this same alignment in the test in order to match the comm counts and other stats in `test_scaled_dot_product_attention`.

Failing tests in https://github.com/intel/torch-xpu-ops/issues/2569