### PR TITLE
[DTensor] Register DTensorSpec as pytree constant at module level

### DIFF
--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -10,6 +10,7 @@ from torch._export.utils import _maybe_find_pre_dispatch_tf_mode_for_export
 from torch._higher_order_ops.flat_apply import (
     _ConstantFunction,
     flat_apply,
+    is_graphable,
     to_graphable,
 )
 from torch._higher_order_ops.strict_mode import strict_mode
@@ -166,8 +167,26 @@ def _emit_flat_apply_call(
     track_value,
     call_spec_cache_key: str,
 ):
-    # Flatten to graphable form and record the spec on the FX root
-    flat_args, in_spec = to_graphable(graphable_args)
+    # Temporarily register non-graphable hashable types as pytree constants so
+    # tree_flatten absorbs them into the TreeSpec rather than leaving them as
+    # leaves. This is scoped to just this call to avoid polluting global pytree
+    # state which can change dynamo decomposition behavior (see #176128).
+    tmp_registered: list[type] = []
+    for leaf in pytree.tree_leaves(graphable_args):
+        cls = type(leaf)
+        if not is_graphable(leaf) and cls not in pytree.SUPPORTED_NODES:
+            try:
+                pytree.register_constant(cls)
+                tmp_registered.append(cls)
+            except TypeError:
+                pass
+    try:
+        # Flatten to graphable form and record the spec on the FX root
+        flat_args, in_spec = to_graphable(graphable_args)
+    finally:
+        for cls in tmp_registered:
+            pytree._deregister_pytree_node(cls)
+
     qualname = tracer.get_fresh_qualname(spec_name)  # type: ignore[union-attr]
     setattr(tracer.root, qualname, in_spec)  # type: ignore[union-attr]
     spec_proxy = tracer.create_proxy("get_attr", qualname, (), {})

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1134,6 +1134,7 @@ class TreeSpec:
     num_nodes: int = dataclasses.field(init=False)
     num_leaves: int = dataclasses.field(init=False)
     num_children: int = dataclasses.field(init=False)
+    _unflatten_fn: Any = dataclasses.field(init=False, compare=False, hash=False)
 
     def __init__(
         self,
@@ -1155,6 +1156,7 @@ class TreeSpec:
             num_nodes = 1
             num_leaves = 1
             num_children = 0
+            unflatten_fn = None
         else:
             num_nodes = 1
             num_leaves = 0
@@ -1162,9 +1164,13 @@ class TreeSpec:
                 num_nodes += child.num_nodes
                 num_leaves += child.num_leaves
             num_children = len(self._children)
+            # Capture the unflatten function at construction time so the
+            # TreeSpec remains valid even if the type is later deregistered.
+            unflatten_fn = SUPPORTED_NODES[self.type].unflatten_fn
         object.__setattr__(self, "num_nodes", num_nodes)
         object.__setattr__(self, "num_leaves", num_leaves)
         object.__setattr__(self, "num_children", num_children)
+        object.__setattr__(self, "_unflatten_fn", unflatten_fn)
 
     def __repr__(self, indent: int = 0) -> str:
         repr_prefix: str = f"TreeSpec({self.type.__name__}, {self._context}, ["
@@ -1319,7 +1325,13 @@ class TreeSpec:
         if self.is_leaf():
             return leaves[0]
 
-        unflatten_fn = SUPPORTED_NODES[self.type].unflatten_fn
+        # Look up unflatten_fn from the registry when available (dynamo
+        # traces this dict lookup specially).  Fall back to the cached copy
+        # for types that were temporarily registered then deregistered.
+        node_def = SUPPORTED_NODES.get(self.type)
+        unflatten_fn = (
+            node_def.unflatten_fn if node_def is not None else self._unflatten_fn
+        )
 
         # Recursively unflatten the children
         start = 0
@@ -1382,9 +1394,39 @@ class LeafSpec(TreeSpec):
         object.__setattr__(self, "num_nodes", 1)
         object.__setattr__(self, "num_leaves", 1)
         object.__setattr__(self, "num_children", 0)
+        object.__setattr__(self, "_unflatten_fn", None)
 
     def __repr__(self, indent: int = 0) -> str:
         return "*"
+
+
+# Override dataclass-generated __getstate__/__setstate__ (which include all
+# slots) to exclude _unflatten_fn — it holds a function reference that may
+# not be picklable.  Re-resolve it from SUPPORTED_NODES on unpickle.
+def _treespec_getstate(self: TreeSpec) -> dict[str, Any]:
+    return {
+        "type": self.type,
+        "_context": self._context,
+        "_children": self._children,
+        "num_nodes": self.num_nodes,
+        "num_leaves": self.num_leaves,
+        "num_children": self.num_children,
+    }
+
+
+def _treespec_setstate(self: TreeSpec, state: dict[str, Any]) -> None:
+    for k, v in state.items():
+        object.__setattr__(self, k, v)
+    if self.type is None:
+        object.__setattr__(self, "_unflatten_fn", None)
+    else:
+        node_def = SUPPORTED_NODES.get(self.type)
+        unflatten_fn = node_def.unflatten_fn if node_def is not None else None
+        object.__setattr__(self, "_unflatten_fn", unflatten_fn)
+
+
+TreeSpec.__getstate__ = _treespec_getstate  # type: ignore[assignment]
+TreeSpec.__setstate__ = _treespec_setstate  # type: ignore[assignment]
 
 
 # All leaves are equivalent, so represent with a single object to save on


### PR DESCRIPTION
## Summary
Fix `torch.export.export()` failing with `RuntimeError: DTensorSpec not registered as pytree constant` when exporting tensor-parallel models that use DTensor (#175467).

**Commit 1:** During export, temporarily register non-graphable hashable leaf types (e.g. `DTensorSpec`) as pytree constants so `tree_flatten` absorbs them into the TreeSpec rather than leaving them as opaque leaves. Registration is scoped to just the `to_graphable()` call to avoid polluting global pytree state.

**Commit 2:** Cache `unflatten_fn` on `TreeSpec` at construction time so the spec remains valid even after the type is deregistered. The normal `SUPPORTED_NODES` dict lookup is preserved as the primary path (required for dynamo tracing), with the cached function as a fallback for deregistered types. Custom `__getstate__`/`__setstate__` exclude the cached function from pickle.

Fixes #175467