### PR TITLE
[inductor] Fix stride mismatch in K==1 mm/addmm decomposition

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -337,6 +337,13 @@ def addmm(
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
+    if mat1.device.type not in ["cpu", "mps"]:
+        if statically_known_true(mat1.size(-1) == 1):
+            counters["inductor"]["decompose_addmm"] += 1
+            out = mat1 * mat2
+            out = out.as_strided(out.shape, (out.size(1), 1))
+            return alpha * out + beta * self
+
     if self.device.type == "cpu":
         if statically_known_true(mat1.size(0) == 1) and statically_known_true(
             mat2.size(-1) == 1
@@ -374,16 +381,19 @@ def mm(
             input2.shape[1] == 1
         ):
             return (self.unsqueeze(2) * input2.unsqueeze(0)).sum(dim=1)
-    if self.device.type == "cpu":
-        if (
-            statically_known_true(self.size(-1) == 1)
+    # Non-CPU/MPS: always decompose. CPU: only for small tensors.
+    if statically_known_true(self.size(-1) == 1):
+        if self.device.type not in ["cpu", "mps"] or (
+            self.device.type == "cpu"
             and statically_known_true(self.size(0) > 0)
             and statically_known_true(input2.size(0) == 1)
             and (self.dtype == input2.dtype)
             and guard_or_false((torch.numel(self) + torch.numel(input2)) <= 32)
         ):
             counters["inductor"]["decompose_mm"] += 1
-            return self * input2
+            result = self * input2
+            return result.as_strided(result.shape, (result.size(1), 1))
+    if self.device.type == "cpu":
         if statically_known_true(self.size(0) == 1) and statically_known_true(
             input2.size(-1) == 1
         ):


### PR DESCRIPTION
Summary:
The K==1 mm decomposition (`mm((M,1), (1,N))` → `mat1 * mat2`) produced output strides that did not match `mm` strides in certain cases, causing `test_comprehensive_linalg_multi_dot_cuda_float64` to fail with `'stride()' do not match: (1, 1) != (2, 1)`.

The root cause: `mm` always produces contiguous output strides (via `set_output_raw_strided` with empty strides), but broadcast multiply (`mat1 * mat2`) uses TensorIterator, whose dimension reordering is ambiguous when input strides are equal. For example, `randn(2,1).T` has shape `(1,2)` stride `(1,1)` — multiplying with this produces stride `(1,1)` instead of the contiguous `(2,1)`.

This surfaces in the backward pass of `linalg.multi_dot`, which creates K==1 `mm` calls with transposed inputs.

Fix: apply `as_strided` to set contiguous strides on the decomposition result, making it indistinguishable from `mm`. Also fixed the same issue in the pre-existing CPU K==1 decomposition path. Added `test_mm_k1_stride` to verify stride matching across contiguous and transposed input combinations.

Authored with Claude.

Test Plan:
Before fix — `test_comprehensive_linalg_multi_dot_cuda_float64` fails:
```
FAIL: test_comprehensive_linalg_multi_dot_cuda_float64
AssertionError: Tensor-likes are not close!
'stride()' do not match: (1, 1) != (2, 1)
```

After fix — passes:
```
buck2 test fbcode//caffe2/test/inductor:test_torchinductor_opinfo mode/opt -- -r test_comprehensive_linalg_multi_dot
Pass 2 Fail 0 Skip 0
```

mmdecomp tests all pass (28 existing + 1 new `test_mm_k1_stride`):
```
buck2 test fbcode//caffe2/test/inductor:mmdecomp mode/opt
Pass 29 Fail 0 Skip 0
```

Differential Revision: D94097622




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo