### PR TITLE
[BE] Apply pep604 to `torch/_dynamo`

### DIFF
--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -28,7 +28,7 @@ the function call as is in the graph, and only when we Dynamo through the backwa
 compiled autograd do we inline into the function.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
@@ -141,7 +141,7 @@ class TransformGetItemToIndex(TorchFunctionMode):
         func: OpOverload,
         types: tuple[torch._C._TensorMeta, ...],
         args: tuple[object, ...] = (),
-        kwargs: Optional[dict[str, object]] = None,
+        kwargs: dict[str, object] | None = None,
     ) -> object:
         if func is torch.Tensor.__getitem__:
             tensor_to_index = args[0]
@@ -192,7 +192,7 @@ def _assert_meta(
 def inner_trace(
     mode: ProxyTorchDispatchMode,
     *args: Any,
-    bw_state: Optional[BackwardState] = None,
+    bw_state: BackwardState | None = None,
     **kwargs: Any,
 ) -> Any:
     def self_invoke(*args: Any, **dyn_kwargs: Any) -> Any:

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -24,7 +24,7 @@ Key components:
 import functools
 from collections import defaultdict
 from collections.abc import Callable, Sequence
-from typing import Any, Optional
+from typing import Any
 
 import torch
 import torch.fx
@@ -103,7 +103,7 @@ def get_device_node_mapping(
 
 def check_for_mutation_ignore_cuda_graph_managed_tensor(
     aot_model: torch.fx.GraphModule, num_fixed: int
-) -> Optional[str]:
+) -> str | None:
     mutation_indices = find_input_mutations(aot_model.graph) - set(range(num_fixed))
     if not mutation_indices:
         return None
@@ -112,7 +112,7 @@ def check_for_mutation_ignore_cuda_graph_managed_tensor(
     return get_mutation_stack_trace(placeholders, mutation_indices)
 
 
-def check_for_skip(aot_model: torch.fx.GraphModule, num_fixed: int) -> Optional[str]:
+def check_for_skip(aot_model: torch.fx.GraphModule, num_fixed: int) -> str | None:
     if not config.cudagraph_backend_support_input_mutation:
         if mut_skip := check_for_mutation_ignore_cuda_graph_managed_tensor(
             aot_model, num_fixed
@@ -136,7 +136,7 @@ def get_device_index(gm: torch.fx.GraphModule) -> int:
     return device.index
 
 
-def get_stack_traces(gm: torch.fx.GraphModule) -> list[Optional[str]]:
+def get_stack_traces(gm: torch.fx.GraphModule) -> list[str | None]:
     output = output_node(gm)
     assert len(output.args) == 1
     args = output.args[0]

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -28,7 +28,7 @@ import functools
 import logging
 from collections.abc import Callable, Iterable
 from importlib import import_module
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 import torch
 from functorch.compile import min_cut_rematerialization_partition
@@ -312,7 +312,7 @@ def boxed_nop_with_mode(
 def fake_crossref_boxed_nop(
     fx_g: torch.fx.GraphModule,
     example_inputs: list[torch.Tensor],
-    ignore_op_fn: Optional[Callable[[torch._ops.OpOverload], bool]] = None,
+    ignore_op_fn: Callable[[torch._ops.OpOverload], bool] | None = None,
 ) -> Callable[..., Any]:
     from torch.fx.graph import _BoxedCodeGen
 
@@ -352,8 +352,8 @@ def get_nop_func() -> Callable[
 def aot_eager(
     gm: torch.fx.GraphModule,
     fake_tensor_inputs: list[torch.Tensor],
-    fw_compiler: Optional[Callable[..., Any]] = None,
-    bw_compiler: Optional[Callable[..., Any]] = None,
+    fw_compiler: Callable[..., Any] | None = None,
+    bw_compiler: Callable[..., Any] | None = None,
     **kwargs: Any,
 ) -> Callable[..., Any]:
     return aot_autograd(
@@ -545,9 +545,9 @@ class ExplainOutput:
     graph_break_count: int
     break_reasons: list[GraphCompileReason]
     op_count: int
-    ops_per_graph: Optional[list[list["Target"]]] = None
-    out_guards: Optional[list[_guards.Guard]] = None
-    compile_times: Optional[str] = None
+    ops_per_graph: list[list["Target"]] | None = None
+    out_guards: list[_guards.Guard] | None = None
+    compile_times: str | None = None
 
     def __str__(self) -> str:
         output = f"Graph Count: {self.graph_count}\n"
@@ -645,7 +645,7 @@ class ExplainWithBackend:
         print(eb.output())
     """
 
-    def __init__(self, backend: Union[CompilerFn, str]) -> None:
+    def __init__(self, backend: CompilerFn | str) -> None:
         from .registry import lookup_backend
 
         self.backend = lookup_backend(backend)

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -20,7 +20,7 @@ import logging
 import traceback
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from unittest import mock
 
 import torch
@@ -84,7 +84,7 @@ def bucket_has_external_output(bucket: Bucket) -> bool:
 
 def pretty_print_buckets(buckets: list[Bucket], bucket_bytes_cap: int) -> None:
     headers = ("Index", "Size (b)", "Param Names")
-    rows: list[tuple[Optional[int], Optional[int], str]] = []
+    rows: list[tuple[int | None, int | None, str]] = []
     # pyrefly: ignore [implicit-any]
     extended_buckets = []
     for idx, bucket in enumerate(reversed(buckets)):
@@ -433,7 +433,7 @@ class DDPOptimizer:
         self,
         bucket_bytes_cap: int,
         backend_compile_fn: CompilerFn,
-        first_bucket_cap: Optional[int] = None,
+        first_bucket_cap: int | None = None,
     ) -> None:
         if first_bucket_cap is not None:
             self.first_bucket_cap = first_bucket_cap

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -62,7 +62,7 @@ import functools
 import logging
 from collections.abc import Callable, Sequence
 from importlib.metadata import EntryPoint
-from typing import Any, Optional, Protocol, Union
+from typing import Any, Protocol
 
 import torch
 from torch import fx
@@ -77,13 +77,13 @@ class CompiledFn(Protocol):
 
 CompilerFn = Callable[[fx.GraphModule, list[torch.Tensor]], CompiledFn]
 
-_BACKENDS: dict[str, Optional[EntryPoint]] = {}
+_BACKENDS: dict[str, EntryPoint | None] = {}
 _COMPILER_FNS: dict[str, CompilerFn] = {}
 
 
 def register_backend(
-    compiler_fn: Optional[CompilerFn] = None,
-    name: Optional[str] = None,
+    compiler_fn: CompilerFn | None = None,
+    name: str | None = None,
     tags: Sequence[str] = (),
 ) -> Callable[..., Any]:
     """
@@ -116,7 +116,7 @@ register_experimental_backend = functools.partial(
 )
 
 
-def lookup_backend(compiler_fn: Union[str, CompilerFn]) -> CompilerFn:
+def lookup_backend(compiler_fn: str | CompilerFn) -> CompilerFn:
     """Expand backend strings to functions"""
     if isinstance(compiler_fn, str):
         if compiler_fn not in _BACKENDS:

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -29,7 +29,7 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from torch import fx
@@ -47,7 +47,7 @@ def tvm(
     gm: fx.GraphModule,
     example_inputs: list[torch.Tensor],
     *,
-    options: Optional[MappingProxyType[str, Any]] = None,
+    options: MappingProxyType[str, Any] | None = None,
 ) -> Callable[..., Any]:
     if options is None:
         options = MappingProxyType({"scheduler": None, "trials": 20000, "opt_level": 3})

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -17,7 +17,7 @@ import dataclasses
 import dis
 import itertools
 import sys
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -203,8 +203,8 @@ class FixedPointBox:
 
 @dataclasses.dataclass
 class StackSize:
-    low: Union[int, float]
-    high: Union[int, float]
+    low: int | float
+    high: int | float
     fixed_point: FixedPointBox
 
     def zero(self) -> None:
@@ -227,7 +227,7 @@ class StackSize:
             self.fixed_point.value = False
 
 
-def stacksize_analysis(instructions: list["Instruction"]) -> Union[int, float]:
+def stacksize_analysis(instructions: list["Instruction"]) -> int | float:
     assert instructions
     fixed_point = FixedPointBox()
     stack_sizes = {

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -22,7 +22,7 @@ import sys
 import types
 import uuid
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, cast, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, Optional, TYPE_CHECKING
 
 from . import config
 from .bytecode_analysis import (
@@ -72,17 +72,17 @@ class Instruction:
 
     opcode: int
     opname: str
-    arg: Optional[int]
+    arg: int | None
     argval: Any
-    offset: Optional[int] = None
-    starts_line: Optional[int] = None
+    offset: int | None = None
+    starts_line: int | None = None
     is_jump_target: bool = False
 
     positions: Optional["dis.Positions"] = None
     # extra fields to make modification easier:
     target: Optional["Instruction"] = None
-    exn_tab_entry: Optional[InstructionExnTabEntry] = None
-    argrepr: Optional[str] = None
+    exn_tab_entry: InstructionExnTabEntry | None = None
+    argrepr: str | None = None
 
     def __hash__(self) -> int:
         return id(self)
@@ -165,9 +165,9 @@ else:
 def create_instruction(
     name: str,
     *,
-    arg: Optional[int] = None,
-    argval: Optional[Any] = _NotProvided,
-    target: Optional[Instruction] = None,
+    arg: int | None = None,
+    argval: Any | None = _NotProvided,
+    target: Instruction | None = None,
 ) -> Instruction:
     """
     At most one of `arg`, `argval`, and `target` can be not None/_NotProvided.
@@ -255,7 +255,7 @@ def create_rot_n(n: int) -> list[Instruction]:
 
 
 def add_push_null(
-    inst_or_insts: Union[Instruction, list[Instruction]],
+    inst_or_insts: Instruction | list[Instruction],
 ) -> list[Instruction]:
     """
     Appends or prepends a PUSH_NULL instruction to `inst_or_insts`,
@@ -314,7 +314,7 @@ def add_push_null(
 
 
 def add_push_null_call_function_ex(
-    inst_or_insts: Union[Instruction, list[Instruction]],
+    inst_or_insts: Instruction | list[Instruction],
 ) -> list[Instruction]:
     """Like add_push_null, but the low bit of LOAD_ATTR/LOAD_SUPER_ATTR
     is not set, due to an expected CALL_FUNCTION_EX instruction.
@@ -502,7 +502,7 @@ def create_swap(n: int) -> list[Instruction]:
 
 
 def create_binary_slice(
-    start: Optional[int], end: Optional[int], store: bool = False
+    start: int | None, end: int | None, store: bool = False
 ) -> list[Instruction]:
     """
     BINARY_SLICE and STORE_SLICE (if `set` is True) for all Python versions
@@ -830,7 +830,7 @@ def assemble(instructions: list[Instruction], firstlineno: int) -> tuple[bytes, 
 
 def _get_instruction_by_offset(
     offset_to_inst: dict[int, Instruction], offset: int
-) -> Optional[Instruction]:
+) -> Instruction | None:
     """
     Get the instruction located at a given offset, accounting for EXTENDED_ARGs
     """
@@ -1428,7 +1428,7 @@ def get_const_index(code_options: dict[str, Any], val: Any) -> int:
 def fix_vars(
     instructions: list[Instruction],
     code_options: dict[str, Any],
-    varname_from_oparg: Optional[Callable[..., Any]] = None,
+    varname_from_oparg: Callable[..., Any] | None = None,
 ) -> None:
     # compute instruction arg from argval if arg is not provided
     names = {name: idx for idx, name in enumerate(code_options["co_names"])}
@@ -1751,7 +1751,7 @@ def is_generator(code: types.CodeType) -> bool:
 
 def bytecode_from_template(
     fn: Callable[..., Any],
-    varname_map: Optional[Mapping[Any, Any]] = None,
+    varname_map: Mapping[Any, Any] | None = None,
     noreturn: bool = True,
     noprefix: bool = True,
 ) -> list[Instruction]:

--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -1,7 +1,7 @@
 import logging
 import weakref
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from torch._guards import CompileId
 
@@ -101,7 +101,7 @@ class CacheSizeRelevantForFrame:
 
 def _get_weakref_from_f_locals(
     frame: DynamoFrameType, local_name: str
-) -> Optional[weakref.ref[Any]]:
+) -> weakref.ref[Any] | None:
     obj = frame.f_locals.get(local_name, None)
     weak_id = None
     try:

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -17,7 +17,7 @@ import sys
 import types
 from collections import Counter, deque
 from collections.abc import Callable, Iterable
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union
 
 import torch.nn
 from torch.utils._ordered_set import OrderedSet
@@ -76,21 +76,21 @@ class PyCodegen:
     def __init__(
         self,
         tx: "InstructionTranslatorBase",
-        root: Optional[torch.nn.Module] = None,
-        graph_output_var: Optional[str] = None,
-        tempvars: Optional[dict[Union[VariableTracker, Source], Any]] = None,
-        overridden_sources: Optional[dict[Source, Source]] = None,
+        root: torch.nn.Module | None = None,
+        graph_output_var: str | None = None,
+        tempvars: dict[VariableTracker | Source, Any] | None = None,
+        overridden_sources: dict[Source, Source] | None = None,
     ) -> None:
         self.root = root
-        self.top_of_stack: Optional[Union[VariableTracker, Source]] = None
-        self.uses: Counter[Union[VariableTracker, Source]] = collections.Counter()
+        self.top_of_stack: VariableTracker | Source | None = None
+        self.uses: Counter[VariableTracker | Source] = collections.Counter()
         self.graph_outputs: dict[int, GraphOutputEntry] = {}
         self._output: list[Instruction] = []
         # This determines which VariableTracker/Source should be stored as
         # locals, and maps the VariableTracker/Source to the local variable
         # name. Note that it could map to None initially, in which case we'll
         # overwrite it to map to real temporary names via `add_cache`.
-        self.tempvars: dict[Union[VariableTracker, Source], Any] = tempvars or {}
+        self.tempvars: dict[VariableTracker | Source, Any] = tempvars or {}
         self.tx = tx
         self.graph_output_var = graph_output_var
         self.code_options = self.tx.output.code_options
@@ -153,7 +153,7 @@ class PyCodegen:
             self.clear_tos()
 
     def __call__(
-        self, value: Union[VariableTracker, Source, None], allow_cache: bool = True
+        self, value: VariableTracker | Source | None, allow_cache: bool = True
     ) -> None:
         """
         Generate code such that top-of-stack (TOS) is set to value.
@@ -398,12 +398,12 @@ class PyCodegen:
         output.append(self.create_load_const(index))
         output.append(self.create_binary_subscr())
 
-    def add_cache(self, value: Union[VariableTracker, Source]) -> None:
+    def add_cache(self, value: VariableTracker | Source) -> None:
         var = self.new_var()
         self.tempvars[value] = var
         self._output.append(self.create_store(var))
 
-    def foreach(self, items: Iterable[Union[VariableTracker, Source]]) -> None:
+    def foreach(self, items: Iterable[VariableTracker | Source]) -> None:
         for i in items:
             self(i)
 

--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -39,7 +39,7 @@ import dis
 import time
 import traceback
 from collections.abc import Callable, Sequence
-from typing import Any, Optional, TextIO, Union
+from typing import Any, TextIO
 
 import torch
 from torch._dynamo.symbolic_convert import InstructionTranslatorBase
@@ -66,7 +66,7 @@ class ComptimeVar:
     def __init__(self, v: VariableTracker) -> None:
         self.__variable = v
 
-    def as_proxy(self) -> Union[VariableTracker, Sequence[VariableTracker]]:
+    def as_proxy(self) -> VariableTracker | Sequence[VariableTracker]:
         """
         Returns an fx.Proxy (or tuple/list of fx.Proxy) representing
         this variable in the FX graph we are assembling to pass
@@ -86,7 +86,7 @@ class ComptimeVar:
         """
         return self.__variable.is_proxy()
 
-    def as_fake(self) -> Union[FakeTensor, torch.SymInt]:
+    def as_fake(self) -> FakeTensor | torch.SymInt:
         """
         Returns a "fake" value (either a FakeTensor or a SymInt)
         representing the variable in question.  This only works
@@ -98,7 +98,7 @@ class ComptimeVar:
         """
         return self.__variable.as_proxy().node.meta["example_value"]
 
-    def size(self, dim: Optional[int] = None) -> Union[int, torch.SymInt]:
+    def size(self, dim: int | None = None) -> int | torch.SymInt:
         """
         Returns the size of the tensor (if dim is None) or the size
         at the dimension dim.  The returned size may be a SymInt.
@@ -215,7 +215,7 @@ class ComptimeContext:
         )
 
     def print_graph(
-        self, *, verbose: bool = True, file: Optional[TextIO] = None
+        self, *, verbose: bool = True, file: TextIO | None = None
     ) -> None:
         """
         Print the partially constructed FX graph that would be passed
@@ -235,11 +235,11 @@ class ComptimeContext:
             tx = tx.parent  # type: ignore[assignment]
         return tx
 
-    def print(self, val: Any, *, file: Optional[TextIO] = None) -> None:
+    def print(self, val: Any, *, file: TextIO | None = None) -> None:
         print(repr(val), file=file)
 
     def print_disas(
-        self, *, file: Optional[TextIO] = None, stacklevel: int = 0
+        self, *, file: TextIO | None = None, stacklevel: int = 0
     ) -> None:
         """
         Print the current series of opcodes being executed (not including
@@ -256,7 +256,7 @@ class ComptimeContext:
         )
 
     def print_value_stack(
-        self, *, file: Optional[TextIO] = None, stacklevel: int = 0
+        self, *, file: TextIO | None = None, stacklevel: int = 0
     ) -> None:
         """
         Print the current Python value stack.  Note that this is NOT the same
@@ -273,7 +273,7 @@ class ComptimeContext:
             print(f"- {s.debug_repr()}", file=file)
 
     def print_locals(
-        self, *, file: Optional[TextIO] = None, stacklevel: int = 0
+        self, *, file: TextIO | None = None, stacklevel: int = 0
     ) -> None:
         """
         Print all of the locals available in the current context.
@@ -284,7 +284,7 @@ class ComptimeContext:
         for k, v in tx.symbolic_locals.items():
             print(f"{k} = {v.debug_repr()}", file=file)
 
-    def print_bt(self, *, file: Optional[TextIO] = None, stacklevel: int = 0) -> None:
+    def print_bt(self, *, file: TextIO | None = None, stacklevel: int = 0) -> None:
         """
         Print the user code backtrace, starting at the beginning of the
         frame Dynamo started evaluating.  Note that this MAY NOT go all
@@ -303,7 +303,7 @@ class ComptimeContext:
             file=file,
         )
 
-    def print_guards(self, *, file: Optional[TextIO] = None) -> None:
+    def print_guards(self, *, file: TextIO | None = None) -> None:
         """
         Print the currently installed guards for the Dynamo context.
         This does NOT include guards associated with variables that
@@ -328,7 +328,7 @@ class ComptimeContext:
         """
         return self.__tx
 
-    def sleep(self, sec: Union[int, float]) -> None:
+    def sleep(self, sec: int | float) -> None:
         time.sleep(sec)
 
 
@@ -437,7 +437,7 @@ class _Comptime:
         comptime(inner)
 
     @staticmethod
-    def sleep(sec: Union[int, float]) -> None:
+    def sleep(sec: int | float) -> None:
         comptime(lambda ctx: ctx.sleep(ctx.get_local("sec").as_python_constant()))
 
 

--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -214,9 +214,7 @@ class ComptimeContext:
             "expected static but got dynamic (run with TORCH_LOGS=dynamic for more info)"
         )
 
-    def print_graph(
-        self, *, verbose: bool = True, file: TextIO | None = None
-    ) -> None:
+    def print_graph(self, *, verbose: bool = True, file: TextIO | None = None) -> None:
         """
         Print the partially constructed FX graph that would be passed
         to the user compiler after compilation.
@@ -238,9 +236,7 @@ class ComptimeContext:
     def print(self, val: Any, *, file: TextIO | None = None) -> None:
         print(repr(val), file=file)
 
-    def print_disas(
-        self, *, file: TextIO | None = None, stacklevel: int = 0
-    ) -> None:
+    def print_disas(self, *, file: TextIO | None = None, stacklevel: int = 0) -> None:
         """
         Print the current series of opcodes being executed (not including
         parent frames), including where you are in the particular opcode
@@ -272,9 +268,7 @@ class ComptimeContext:
         for s in tx.stack:
             print(f"- {s.debug_repr()}", file=file)
 
-    def print_locals(
-        self, *, file: TextIO | None = None, stacklevel: int = 0
-    ) -> None:
+    def print_locals(self, *, file: TextIO | None = None, stacklevel: int = 0) -> None:
         """
         Print all of the locals available in the current context.
         By default this view is very limited; you can get more information

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -17,7 +17,7 @@ import sysconfig
 import tempfile
 from collections.abc import Callable
 from os.path import abspath, dirname
-from typing import Any, Literal, Optional, TYPE_CHECKING, Union
+from typing import Any, Literal, TYPE_CHECKING
 
 from torch._environment import is_fbcode
 from torch.utils._config_module import Config, get_tristate_env, install_config_module
@@ -31,7 +31,7 @@ from torch.utils._config_module import Config, get_tristate_env, install_config_
 # Design doc: https://docs.google.com/document/d/1ZRfTWKa8eaPq1AxaiHrq4ASTPouzzlPiuquSBEJYwS8/edit#
 # the name of a file to write the logs to
 # [@compile_ignored: debug]
-log_file_name: Optional[str] = None
+log_file_name: str | None = None
 
 # [@compile_ignored: debug] Verbose will print full stack traces on warnings and errors
 verbose = os.environ.get("TORCHDYNAMO_VERBOSE", "0") == "1"
@@ -374,15 +374,7 @@ allow_unspec_int_on_nn_module = False
 # Note that to avoid breaking the existing usage, mode 1 and mode 4 can be
 # specified with a boolean value. True is using ddp_optimizer and False is
 # no optimization.
-optimize_ddp: Union[
-    bool,
-    Literal[
-        "ddp_optimizer",
-        "python_reducer",
-        "python_reducer_without_compiled_forward",
-        "no_optimization",
-    ],
-] = True
+optimize_ddp: bool | Literal["ddp_optimizer", "python_reducer", "python_reducer_without_compiled_forward", "no_optimization"] = True
 
 # By default, Dynamo emits runtime asserts (e.g. torch._check) in the graph.
 # In some cases those asserts could be performance costly
@@ -810,7 +802,7 @@ automatic_dynamic_local_pgo: bool = Config(
 )
 
 # Like above, but using remote cache
-automatic_dynamic_remote_pgo: Optional[bool] = get_tristate_env(
+automatic_dynamic_remote_pgo: bool | None = get_tristate_env(
     "TORCH_DYNAMO_AUTOMATIC_DYNAMIC_REMOTE_PGO"
 )
 
@@ -820,7 +812,7 @@ _unsafe_skip_fsdp_module_guards = (
 )
 
 # Common prefix to append to the id of each compile run to filter out data
-pt2_compile_id_prefix: Optional[str] = os.environ.get("PT2_COMPILE_ID_PREFIX", None)
+pt2_compile_id_prefix: str | None = os.environ.get("PT2_COMPILE_ID_PREFIX", None)
 
 # Run GC at the end of compilation
 run_gc_after_compile = Config(  # type: ignore[var-annotated]
@@ -846,7 +838,7 @@ record_runtime_overhead = True
 enable_aot_compile = False
 
 # HACK: this is for testing custom ops profiling only
-_custom_ops_profile: Optional[Any] = None
+_custom_ops_profile: Any | None = None
 
 # Experimental flag to enable regional compile on invoke_subgraph HOP.
 # For testing only!
@@ -859,7 +851,7 @@ enable_invoke_subgraph_regional_compile: bool = False
 #   don't clear for custom backends (to support standalone_compile, etc.)
 # - True: always clear regardless of backend
 # - False: never clear regardless of backend
-invalidate_compile_context_weakrefs: Optional[bool] = None
+invalidate_compile_context_weakrefs: bool | None = None
 
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -374,7 +374,15 @@ allow_unspec_int_on_nn_module = False
 # Note that to avoid breaking the existing usage, mode 1 and mode 4 can be
 # specified with a boolean value. True is using ddp_optimizer and False is
 # no optimization.
-optimize_ddp: bool | Literal["ddp_optimizer", "python_reducer", "python_reducer_without_compiled_forward", "no_optimization"] = True
+optimize_ddp: (
+    bool
+    | Literal[
+        "ddp_optimizer",
+        "python_reducer",
+        "python_reducer_without_compiled_forward",
+        "no_optimization",
+    ]
+) = True
 
 # By default, Dynamo emits runtime asserts (e.g. torch._check) in the graph.
 # In some cases those asserts could be performance costly

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -50,7 +50,7 @@ import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from types import CellType, CodeType, FunctionType, ModuleType
-from typing import Any, NoReturn, Optional, TypeVar, Union
+from typing import Any, NoReturn, TypeVar
 from typing_extensions import ParamSpec
 from weakref import ReferenceType
 
@@ -173,7 +173,7 @@ from .utils import (
 from .variables.torch_function import torch_function_mode_stack_state_mgr
 
 
-np: Optional[ModuleType]
+np: ModuleType | None
 try:
     import numpy as np
 except ModuleNotFoundError:
@@ -208,7 +208,7 @@ class TODO_UNKNOWN:
 
 
 def _clear_fake_mode_weakrefs(
-    fake_mode: Optional[torch._subclasses.fake_tensor.FakeTensorMode],
+    fake_mode: torch._subclasses.fake_tensor.FakeTensorMode | None,
 ) -> None:
     """Clear WeakIdRef entries from a FakeTensorMode's describer."""
     if fake_mode is None:
@@ -241,12 +241,12 @@ class Tracker:
 input_codes = Tracker()
 output_codes = Tracker()
 
-initial_global_state: Optional[GlobalStateGuard] = None
+initial_global_state: GlobalStateGuard | None = None
 
 
 @functools.wraps(original_forward_from_src)
 def fx_forward_from_src_skip_result(
-    src: str, globals: dict[str, Any], co_fields: Optional[dict[str, str]] = None
+    src: str, globals: dict[str, Any], co_fields: dict[str, str] | None = None
 ) -> FunctionType:
     # we monkey patch FX to prevent infinite loop of trying to convert
     # our generated code
@@ -455,7 +455,7 @@ def has_tensor_in_frame(frame: DynamoFrameType) -> bool:
 def exception_handler(
     e: Exception,
     code: CodeType,
-    frame: Optional[DynamoFrameType] = None,
+    frame: DynamoFrameType | None = None,
     export: bool = False,
 ) -> None:
     record_filename = None
@@ -468,7 +468,7 @@ def exception_handler(
 
 
 FRAME_COUNTER = 0
-FRAME_COMPILE_COUNTER: typing.Counter[Union[int, FrameStateSizeEntry]] = (
+FRAME_COMPILE_COUNTER: typing.Counter[int | FrameStateSizeEntry] = (
     collections.Counter()
 )
 
@@ -556,11 +556,11 @@ def cprofile_wrapper(func: Callable[_P, _T]) -> Callable[_P, _T]:
 
 @dataclass
 class ConvertFrameBox:
-    error_on_graph_break: Optional[bool] = None
+    error_on_graph_break: bool | None = None
 
 
 def get_compile_id(
-    frame_state: dict[str, Union[int, FrameStateSizeEntry]],
+    frame_state: dict[str, int | FrameStateSizeEntry],
 ) -> CompileId:
     global FRAME_COUNTER
     if "_id" not in frame_state:
@@ -612,9 +612,9 @@ class ConvertFrameAssert:
     def __call__(
         self,
         frame: DynamoFrameType,
-        cache_entry: Optional[CacheEntry],
+        cache_entry: CacheEntry | None,
         hooks: Hooks,
-        frame_state: dict[str, Union[int, FrameStateSizeEntry]],
+        frame_state: dict[str, int | FrameStateSizeEntry],
         *,
         skip: int = 0,
     ) -> ConvertFrameReturn:
@@ -763,7 +763,7 @@ def convert_frame_assert(
     one_graph: bool = True,
     export: bool = False,
     export_constraints: Any | None = None,
-    package: Optional[CompilePackage] = None,
+    package: CompilePackage | None = None,
 ) -> ConvertFrameAssert:
     """Fully convert a frame into an FX graph, raising an exception if we fail."""
     return ConvertFrameAssert(
@@ -809,9 +809,9 @@ def trace_frame(
     *,
     export: bool = False,
     export_constraints: Any | None = None,
-    frame_state: Optional[dict[str, Union[int, FrameStateSizeEntry]]] = None,
-    distributed_state: Optional[DistributedState] = None,
-    package: Optional[CompilePackage] = None,
+    frame_state: dict[str, int | FrameStateSizeEntry] | None = None,
+    distributed_state: DistributedState | None = None,
+    package: CompilePackage | None = None,
 ) -> DynamoTracerOutput:
     from torch.fx.experimental.validator import bisect, translation_validation_enabled
 
@@ -889,14 +889,14 @@ class DynamoOutput:
 
     tracer_output: DynamoTracerOutput
     bytecode: types.CodeType
-    last_attempt_start_time: Optional[float]
+    last_attempt_start_time: float | None
 
     def build_guards(
         self,
         code: types.CodeType,
-        hooks: Optional[Hooks] = None,
+        hooks: Hooks | None = None,
         save: bool = False,
-        cache_entry: Optional[CacheEntry] = None,
+        cache_entry: CacheEntry | None = None,
         strict_error: bool = False,
     ) -> CheckFunctionManager:
         output_graph = self.tracer_output.output_graph
@@ -913,8 +913,8 @@ class DynamoOutput:
 
     def graph_capture_output(
         self,
-        argdefs: Optional[tuple[Any, ...]] = None,
-        kwdefaults: Optional[dict[str, Any]] = None,
+        argdefs: tuple[Any, ...] | None = None,
+        kwdefaults: dict[str, Any] | None = None,
     ) -> GraphCaptureOutput:
         output_graph = self.tracer_output.output_graph
         assert output_graph is not None
@@ -959,9 +959,9 @@ class GraphRuntimeEnv:
     bytecode: types.CodeType
     import_sources: dict[str, str]
     used_globals: dict[str, Any]
-    closure: Optional[tuple[Any, ...]]
-    argdefs: Optional[tuple[Any, ...]]
-    kwdefaults: Optional[dict[str, Any]] = None
+    closure: tuple[Any, ...] | None
+    argdefs: tuple[Any, ...] | None
+    kwdefaults: dict[str, Any] | None = None
     external_refs: set[str] = dataclasses.field(default_factory=set)
 
     def forward_callable(
@@ -969,7 +969,7 @@ class GraphRuntimeEnv:
         backend_id: str,
         compiled_fn: Callable[..., Any],
         *,
-        extra_globals: Optional[dict[str, Any]] = None,
+        extra_globals: dict[str, Any] | None = None,
     ) -> Callable[..., Any]:
         import_sources = {
             alias: importlib.import_module(module_name)
@@ -1019,17 +1019,17 @@ class GraphCaptureOutput:
     import_sources: dict[str, str]
     traced_code: list[CodeType]
     bytecode: CodeType
-    closure: Optional[tuple[Any, ...]]
-    argdefs: Optional[tuple[Any, ...]]
-    kwdefaults: Optional[dict[str, Any]]
+    closure: tuple[Any, ...] | None
+    argdefs: tuple[Any, ...] | None
+    kwdefaults: dict[str, Any] | None
     f_globals: dict[str, Any]
 
     def build_guards(
         self,
         code: types.CodeType,
-        hooks: Optional[Hooks] = None,
+        hooks: Hooks | None = None,
         save: bool = False,
-        cache_entry: Optional[CacheEntry] = None,
+        cache_entry: CacheEntry | None = None,
         strict_error: bool = False,
     ) -> CheckFunctionManager:
         return CheckFunctionManager(
@@ -1102,13 +1102,13 @@ class CaptureOutput:
 
     graph_capture_output: GraphCaptureOutput
     # BackendInput can be None when dynamo didn't compile any graph (no tensor op)
-    backend_input: Optional[BackendInput]
+    backend_input: BackendInput | None
 
     def forward_callable(
         self,
         *,
-        compiled_fn: Optional[Callable[..., Any]] = None,
-        extra_globals: Optional[dict[str, Any]] = None,
+        compiled_fn: Callable[..., Any] | None = None,
+        extra_globals: dict[str, Any] | None = None,
     ) -> Callable[..., Any]:
         runtime_env = self.graph_capture_output.get_runtime_env()
         assert self.backend_input is not None
@@ -1121,7 +1121,7 @@ class CaptureOutput:
         )
 
 
-def get_traced_fn(mod: Any) -> tuple[FunctionType, Optional[object]]:
+def get_traced_fn(mod: Any) -> tuple[FunctionType, object | None]:
     """
     Utility function to get the function to trace, and optionally a bound self
     object, from a callable (nn.Module, function, or method).
@@ -1177,7 +1177,7 @@ def _get_signature(fn: Any) -> inspect.Signature:
 def _get_frame(
     mod: Any,
     args: tuple[Any, ...],
-    kwargs: Optional[dict[str, Any]] = None,
+    kwargs: dict[str, Any] | None = None,
 ) -> FrameInfo:
     """
     Create a frame to trace, given a model, args, and optional kwargs.
@@ -1217,9 +1217,9 @@ def _get_frame(
 def fullgraph_capture(
     mod: Any,
     args: tuple[Any, ...],
-    kwargs: Optional[dict[str, Any]] = None,
+    kwargs: dict[str, Any] | None = None,
     *,
-    constraints: Optional[list[Constraint]] = None,
+    constraints: list[Constraint] | None = None,
     _is_export_deprecated_do_not_use: bool = False,
 ) -> CaptureOutput:
     """
@@ -1260,19 +1260,19 @@ class FrameInfo:
     locals: dict[str, object]
     builtins: dict[str, object]
     closure: tuple[CellType]
-    argdefs: Optional[tuple[Any, ...]]
-    kwdefaults: Optional[dict[str, Any]]
+    argdefs: tuple[Any, ...] | None
+    kwdefaults: dict[str, Any] | None
 
 
 def _fullgraph_capture_frame(
     frame: FrameInfo,
     *,
-    constraints: Optional[list[Constraint]] = None,
+    constraints: list[Constraint] | None = None,
     _is_export_deprecated_do_not_use: bool = False,
 ) -> CaptureOutput:
     from torch._guards import TracingContext
 
-    backend_input: Optional[BackendInput] = None
+    backend_input: BackendInput | None = None
 
     def fullgraph_compiler(
         gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
@@ -1354,9 +1354,9 @@ def compile_frame(  # type: ignore[return]
     *,
     export: bool = False,
     export_constraints: Any | None = None,
-    frame_state: Optional[dict[str, Union[int, FrameStateSizeEntry]]] = None,
-    distributed_state: Optional[DistributedState] = None,
-    package: Optional[CompilePackage] = None,
+    frame_state: dict[str, int | FrameStateSizeEntry] | None = None,
+    distributed_state: DistributedState | None = None,
+    package: CompilePackage | None = None,
     # pyrefly: ignore [bad-return]
 ) -> DynamoOutput:
     """
@@ -1462,17 +1462,17 @@ def _compile(
     export: bool,
     export_constraints: Any | None,
     hooks: Hooks,
-    cache_entry: Optional[CacheEntry],
+    cache_entry: CacheEntry | None,
     cache_size: CacheSizeRelevantForFrame,
-    frame: Optional[DynamoFrameType] = None,
-    frame_state: Optional[dict[str, Union[int, FrameStateSizeEntry]]] = None,
+    frame: DynamoFrameType | None = None,
+    frame_state: dict[str, int | FrameStateSizeEntry] | None = None,
     *,
     compile_id: CompileId,
     skip: int = 0,
-    package: Optional[CompilePackage] = None,
+    package: CompilePackage | None = None,
     # Can be used to record things for the caller, both
     # in the case of normal and exception code paths
-    convert_frame_box: Optional[ConvertFrameBox] = None,
+    convert_frame_box: ConvertFrameBox | None = None,
 ) -> ConvertFrameReturn:
     from torch.fx.experimental.validator import (
         BisectValidationException,
@@ -1486,7 +1486,7 @@ def _compile(
     @compile_time_strobelight_meta(phase_name="compile_inner")
     def compile_inner(
         code: CodeType, one_graph: bool, hooks: Hooks
-    ) -> tuple[ConvertFrameReturn, Optional[DynamoTracerOutput]]:
+    ) -> tuple[ConvertFrameReturn, DynamoTracerOutput | None]:
         with contextlib.ExitStack() as stack:
             stack.enter_context(
                 torch._dynamo.callback_handler.install_callbacks(
@@ -1708,7 +1708,7 @@ def _compile(
             distributed_state = None
 
         # Check recompilations
-        recompile_reason: Optional[str] = None
+        recompile_reason: str | None = None
         if is_recompilation(cache_size) and frame:
             reasons = get_and_maybe_log_recompilation_reasons(
                 cache_entry, frame, innermost_fn(compiler_fn)
@@ -1834,11 +1834,11 @@ def _compile(
         # torch/_dynamo/convert_frame.py:780 in <lambda>
         stack_trace = log_dynamo_start(code, skip)
         start_time_ns = time.time_ns()
-        fail_type: Optional[str] = None
-        fail_reason: Optional[str] = None
-        exception_stack_trace: Optional[list[str]] = None
-        fail_user_frame_filename: Optional[str] = None
-        fail_user_frame_lineno: Optional[int] = None
+        fail_type: str | None = None
+        fail_reason: str | None = None
+        exception_stack_trace: list[str] | None = None
+        fail_user_frame_filename: str | None = None
+        fail_user_frame_lineno: int | None = None
         torch._dynamo.utils.ReinplaceCounters.clear()
         guarded_code = None
         tracer_output = None
@@ -2041,7 +2041,7 @@ class ConvertFrame:
         self,
         compiler_fn: CompilerFn,
         hooks: Hooks,
-        package: Optional[CompilePackage] = None,
+        package: CompilePackage | None = None,
     ) -> None:
         self._torchdynamo_orig_backend = compiler_fn
         self._inner_convert = convert_frame_assert(
@@ -2059,9 +2059,9 @@ class ConvertFrame:
     def __call__(
         self,
         frame: DynamoFrameType,
-        cache_entry: Optional[CacheEntry],
+        cache_entry: CacheEntry | None,
         hooks: Hooks,
-        frame_state: dict[str, Union[int, FrameStateSizeEntry]],
+        frame_state: dict[str, int | FrameStateSizeEntry],
         skip: int = 0,
     ) -> ConvertFrameReturn:
         input_codes.add(frame.f_code)
@@ -2177,7 +2177,7 @@ class ConvertFrame:
 def convert_frame(
     compiler_fn: CompilerFn,
     hooks: Hooks,
-    package: Optional[CompilePackage] = None,
+    package: CompilePackage | None = None,
 ) -> ConvertFrame:
     """Try to convert a frame into an FX graph, if error leave frame unmodified"""
     return ConvertFrame(compiler_fn, hooks, package=package)
@@ -2229,9 +2229,9 @@ class ConvertFrameProtocol(typing.Protocol):
     def __call__(
         self,
         frame: DynamoFrameType,
-        cache_entry: Optional[CacheEntry],
+        cache_entry: CacheEntry | None,
         hooks: Hooks,
-        frame_state: dict[str, Union[int, FrameStateSizeEntry]],
+        frame_state: dict[str, int | FrameStateSizeEntry],
         *,
         skip: int = 0,
     ) -> ConvertFrameReturn: ...
@@ -2246,8 +2246,8 @@ class CatchErrorsWrapper:
     def __call__(
         self,
         frame: DynamoFrameType,
-        cache_entry: Optional[CacheEntry],
-        frame_state: dict[str, Union[int, FrameStateSizeEntry]],
+        cache_entry: CacheEntry | None,
+        frame_state: dict[str, int | FrameStateSizeEntry],
     ) -> ConvertFrameReturn:
         assert frame_state is not None
         input_codes.add(frame.f_code)

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -468,9 +468,7 @@ def exception_handler(
 
 
 FRAME_COUNTER = 0
-FRAME_COMPILE_COUNTER: typing.Counter[int | FrameStateSizeEntry] = (
-    collections.Counter()
-)
+FRAME_COMPILE_COUNTER: typing.Counter[int | FrameStateSizeEntry] = collections.Counter()
 
 
 def maybe_cprofile(func: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -34,7 +34,7 @@ import tempfile
 import textwrap
 from collections import Counter
 from importlib import import_module
-from typing import Any, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING, TypeVar
 
 import torch
 import torch._prims_common as utils
@@ -544,14 +544,14 @@ def backend_accuracy_fails(
 
 
 def _stride_or_default(
-    stride: Optional[torch._prims_common.StrideType],
+    stride: torch._prims_common.StrideType | None,
     *,
     shape: torch._prims_common.ShapeType,
 ) -> torch._prims_common.StrideType:
     return stride if stride is not None else utils.make_contiguous_strides_for(shape)
 
 
-def _mk_defaulter(d: T) -> Callable[[Optional[T]], T]:
+def _mk_defaulter(d: T) -> Callable[[T | None], T]:
     return lambda x: x if x is not None else d
 
 
@@ -568,18 +568,18 @@ class NopInputReader:
 
     def storage(
         self,
-        storage_hash: Optional[str],
+        storage_hash: str | None,
         nbytes: int,
         *,
-        device: Optional[torch._prims_common.DeviceLikeType] = None,
-        dtype_hint: Optional[torch.dtype] = None,
+        device: torch._prims_common.DeviceLikeType | None = None,
+        dtype_hint: torch.dtype | None = None,
     ) -> None:
         self.total += 1
 
-    def tensor(self, *args: Any, **kwargs: Any) -> Optional[torch.Tensor]:
+    def tensor(self, *args: Any, **kwargs: Any) -> torch.Tensor | None:
         pass
 
-    def symint(self, *args: Any, **kwargs: Any) -> Optional[int]:
+    def symint(self, *args: Any, **kwargs: Any) -> int | None:
         pass
 
     def const(self, name: str) -> None:
@@ -607,11 +607,11 @@ class InputReader:
 
     def storage(
         self,
-        storage_hash: Optional[str],
+        storage_hash: str | None,
         nbytes: int,
         *,
-        device: Optional[torch._prims_common.DeviceLikeType] = None,
-        dtype_hint: Optional[torch.dtype] = None,
+        device: torch._prims_common.DeviceLikeType | None = None,
+        dtype_hint: torch.dtype | None = None,
     ) -> UntypedStorage:
         if self.pbar is not None:
             self.pbar.update(1)
@@ -638,12 +638,12 @@ class InputReader:
         self,
         storage: UntypedStorage,
         shape: torch._prims_common.ShapeType,
-        stride: Optional[torch._prims_common.StrideType] = None,
+        stride: torch._prims_common.StrideType | None = None,
         *,
-        storage_offset: Optional[int] = None,
-        dtype: Optional[torch.dtype] = None,
-        requires_grad: Optional[bool] = None,
-        is_leaf: Optional[bool] = None,
+        storage_offset: int | None = None,
+        dtype: torch.dtype | None = None,
+        requires_grad: bool | None = None,
+        is_leaf: bool | None = None,
         **metadata: Any,
     ) -> torch.Tensor:
         stride = _stride_or_default(stride, shape=shape)
@@ -691,7 +691,7 @@ class InputReader:
 
 
 class InputWriter:
-    def __init__(self, save_dir: Optional[str], *, stable_hash: bool = False) -> None:
+    def __init__(self, save_dir: str | None, *, stable_hash: bool = False) -> None:
         self._lines: list[str] = []
         # TODO: consider ensuring tensor and storage counters line up?
         self.storage_counter = itertools.count()
@@ -722,8 +722,8 @@ class InputWriter:
         self,
         untyped_storage: UntypedStorage,
         *,
-        device_hint: Optional[torch._prims_common.DeviceLikeType] = None,
-        dtype_hint: Optional[torch.dtype] = None,
+        device_hint: torch._prims_common.DeviceLikeType | None = None,
+        dtype_hint: torch.dtype | None = None,
     ) -> str:
         ws = StorageWeakRef(untyped_storage)
         v = self.seen_storages.get(ws)
@@ -819,8 +819,8 @@ class InputWriter:
 def aot_graph_input_parser(
     func: Callable[[list[Tensor]], list[Tensor]],
     device: str = "cuda",
-    sym_shapes: Optional[dict[str, int]] = None,
-    default_sym_shape: Optional[int] = None,
+    sym_shapes: dict[str, int] | None = None,
+    default_sym_shape: int | None = None,
 ) -> dict[str, Any]:
     """
     Takes in a function which has been printed with print_readable() and constructs kwargs to run it.

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -8,7 +8,7 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, Optional, overload, TYPE_CHECKING, TypeVar, Union
+from typing import Any, overload, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -62,7 +62,7 @@ FuncType = Callable[..., Any]
 F = TypeVar("F", bound=FuncType)
 
 
-def run(fn: Optional[Callable[_P, _R]] = None) -> Any:
+def run(fn: Callable[_P, _R] | None = None) -> Any:
     """Don't do any dynamic compiles, just use prior optimizations"""
     if fn is not None:
         fn = innermost_fn(fn)
@@ -114,7 +114,7 @@ _nonrecursive_disable_wrapper_code = disable(lambda: None, recursive=False).__co
 skip_code(_nonrecursive_disable_wrapper_code)
 
 
-def skip(fn: Optional[Callable[_P, _R]] = None) -> Callable[..., Any]:
+def skip(fn: Callable[_P, _R] | None = None) -> Callable[..., Any]:
     """
     Skip frames associated with the function code, but still process recursively
     invoked frames
@@ -142,7 +142,7 @@ class set_stance(_DecoratorContextManager):
         stance: str = "default",
         *,
         skip_guard_eval_unsafe: bool = False,
-        force_backend: Union[str, Callable[..., Any], None] = None,
+        force_backend: str | Callable[..., Any] | None = None,
     ) -> None:
         if force_backend is not None and stance != "default":
             raise RuntimeError("non-default stance cannot have force_backend set")
@@ -1052,11 +1052,11 @@ class _DimRange:
 @forbid_in_graph
 def mark_unbacked(
     t: Any,
-    index: Union[int, list[Any], tuple[Any]],
-    hint_override: Optional[int] = None,
+    index: int | list[Any] | tuple[Any],
+    hint_override: int | None = None,
     strict: bool = False,
-    specialize_on: Optional[list[Any]] = None,
-    shape_id: Optional[str] = None,
+    specialize_on: list[Any] | None = None,
+    shape_id: str | None = None,
 ) -> None:
     """
     Mark a tensor as having an unbacked dimension. This changes the semantics of operations:
@@ -1137,12 +1137,12 @@ def mark_unbacked(
 @forbid_in_graph
 def mark_dynamic(
     t: Any,
-    index: Union[int, list[Any], tuple[Any]],
+    index: int | list[Any] | tuple[Any],
     *,
-    hint_override: Optional[int] = None,
-    min: Optional[int] = None,
-    max: Optional[int] = None,
-    specialize_on: Optional[list[Any]] = None,
+    hint_override: int | None = None,
+    min: int | None = None,
+    max: int | None = None,
+    specialize_on: list[Any] | None = None,
 ) -> None:
     """
     Mark a tensor as having a dynamic dim and set corresponding min and max range for the dim.
@@ -1229,7 +1229,7 @@ def mark_dynamic(
 
 
 @forbid_in_graph
-def maybe_mark_dynamic(t: Any, index: Union[int, list[Any], tuple[Any]]) -> None:
+def maybe_mark_dynamic(t: Any, index: int | list[Any] | tuple[Any]) -> None:
     """
     Mark a tensor as having a dynamic dim, but don't enforce it (i.e., if this
     dimension ends up getting specialized, don't error).
@@ -1253,7 +1253,7 @@ def maybe_mark_dynamic(t: Any, index: Union[int, list[Any], tuple[Any]]) -> None
 
 
 def mark_static(
-    t: Any, index: Optional[Union[int, list[Any], tuple[Any]]] = None
+    t: Any, index: int | list[Any] | tuple[Any] | None = None
 ) -> None:
     """
     Mark a tensor as having a static dim or mark a nn module class as static.
@@ -1397,9 +1397,9 @@ class DynamoConfigPatchProxy:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         return self.config_patch.__exit__(exc_type, exc_val, exc_tb)
 
@@ -1450,7 +1450,7 @@ def _patch_dynamo_config_check(changes: dict[str, Any]) -> None:
 # Unlike config.patch, we also need to accept tuple as input in order to
 # deal with context manager reconstruction.
 def patch_dynamo_config(
-    arg1: Optional[Union[str, dict[str, Any], tuple[tuple[str, Any], ...]]] = None,
+    arg1: str | dict[str, Any] | tuple[tuple[str, Any], ...] | None = None,
     arg2: Any = None,
     **kwargs: Any,
 ) -> DynamoConfigPatchProxy:
@@ -1485,7 +1485,7 @@ def dont_skip_tracing(fn: None = None) -> DynamoConfigPatchProxy: ...
 def dont_skip_tracing(fn: Callable[_P, _R]) -> Callable[_P, _R]: ...
 
 
-def dont_skip_tracing(fn: Optional[Any] = None) -> Any:
+def dont_skip_tracing(fn: Any | None = None) -> Any:
     """
     Context manager/decorator to trace into functions intentionally marked by developers to be skipped
     when tracing.
@@ -1506,7 +1506,7 @@ def disable_nested_graph_breaks(fn: None = None) -> DynamoConfigPatchProxy: ...
 def disable_nested_graph_breaks(fn: Callable[_P, _R]) -> Callable[_P, _R]: ...
 
 
-def disable_nested_graph_breaks(fn: Optional[Any] = None) -> Any:
+def disable_nested_graph_breaks(fn: Any | None = None) -> Any:
     """
     Context manager/decorator to disable nested graph breaks when tracing
     this function and any nested functions. Used when nested graph breaks
@@ -1530,9 +1530,9 @@ class ErrorOnGraphBreakDecoratorContextManager:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         _set_error_on_graph_break(self.prev_error_on_graph_break)
 
@@ -1560,7 +1560,7 @@ def error_on_graph_break(
 class CudagraphOverrideContextManager:
     """Context manager that overrides cudagraph recording during tracing."""
 
-    def __init__(self, fwd: Optional[bool] = None, bwd: Optional[bool] = None) -> None:
+    def __init__(self, fwd: bool | None = None, bwd: bool | None = None) -> None:
         self.fwd = fwd
         self.bwd = bwd
 
@@ -1571,15 +1571,15 @@ class CudagraphOverrideContextManager:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         pass
 
 
 def override_cudagraphs(
-    fwd: Optional[bool] = None, bwd: Optional[bool] = None
+    fwd: bool | None = None, bwd: bool | None = None
 ) -> CudagraphOverrideContextManager:
     """
     Context manager/decorator to override cudagraph recording for compiled graphs.
@@ -1599,7 +1599,7 @@ def override_cudagraphs(
     return CudagraphOverrideContextManager(fwd=fwd, bwd=bwd)
 
 
-def is_dynamo_disable_recursive(method: Callable[[Any], Any]) -> Optional[bool]:
+def is_dynamo_disable_recursive(method: Callable[[Any], Any]) -> bool | None:
     """
     Check if a method is marked as `dynamo_disable` recursively. It returns:
     - True if disable(recursive=True)

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -384,7 +384,7 @@ def leaf_function(
 
 
 def leaf_function(
-    fn: Optional[Callable[_P, _R]] = None, *, mutates_args: Optional[set[str]] = None
+    fn: Callable[_P, _R] | None = None, *, mutates_args: set[str] | None = None
 ) -> Callable[_P, _R] | Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """
     Decorator to mark a function as a leaf function for :func:`torch.compile`.
@@ -1252,9 +1252,7 @@ def maybe_mark_dynamic(t: Any, index: int | list[Any] | tuple[Any]) -> None:
         maybe_mark_dynamic(t, i)
 
 
-def mark_static(
-    t: Any, index: int | list[Any] | tuple[Any] | None = None
-) -> None:
+def mark_static(t: Any, index: int | list[Any] | tuple[Any] | None = None) -> None:
     """
     Mark a tensor as having a static dim or mark a nn module class as static.
 

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -20,12 +20,12 @@ import time
 from collections import namedtuple
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 import torch
 
 
-get_cuda_stream: Optional[Callable[[int], int]]
+get_cuda_stream: Callable[[int], int] | None
 if torch.cuda._is_compiled():
     from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
 else:
@@ -181,7 +181,7 @@ class DeviceGuard:
     """
 
     def __init__(
-        self, device_interface: type[DeviceInterface], index: Optional[int]
+        self, device_interface: type[DeviceInterface], index: int | None
     ) -> None:
         self.device_interface = device_interface
         self.idx = index
@@ -258,7 +258,7 @@ class CudaInterface(DeviceInterface):
         return torch.cuda.is_available()
 
     @staticmethod
-    def get_compute_capability(device: torch.types.Device = None) -> Union[int, str]:
+    def get_compute_capability(device: torch.types.Device = None) -> int | str:
         if torch.version.hip is None:
             major, min = torch.cuda.get_device_capability(device)
             return major * 10 + min
@@ -289,7 +289,7 @@ class CudaInterface(DeviceInterface):
             raise RuntimeError("triton not built with the 'nvidia' backend")
 
 
-get_mtia_stream: Optional[Callable[[int], int]]
+get_mtia_stream: Callable[[int], int] | None
 if torch.mtia._is_compiled():
     from torch._C import _mtia_getCurrentRawStream as get_mtia_stream
 else:
@@ -371,7 +371,7 @@ class MtiaInterface(DeviceInterface):
             raise RuntimeError("triton not built with the 'mtia' backend")
 
 
-get_xpu_stream: Optional[Callable[[int], int]]
+get_xpu_stream: Callable[[int], int] | None
 if torch.xpu._is_compiled():
     from torch._C import _xpu_getCurrentRawStream as get_xpu_stream
 else:
@@ -566,14 +566,14 @@ _device_initialized = False
 
 
 def register_interface_for_device(
-    device: Union[str, torch.device], device_interface: type[DeviceInterface]
+    device: str | torch.device, device_interface: type[DeviceInterface]
 ) -> None:
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface
 
 
-def get_interface_for_device(device: Union[str, torch.device]) -> type[DeviceInterface]:
+def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:
     if isinstance(device, torch.device):
         device = device.type
     if not _device_initialized:

--- a/torch/_dynamo/distributed.py
+++ b/torch/_dynamo/distributed.py
@@ -14,18 +14,17 @@ is properly initialized, making it safe to import and use this module even in
 non-distributed scenarios.
 """
 
-from typing import Optional
 
 import torch.distributed as dist
 
 from . import config
 
 
-_COMPILE_PG: Optional[dist.ProcessGroup] = None
-_GUARD_PG: Optional[dist.ProcessGroup] = None
+_COMPILE_PG: dist.ProcessGroup | None = None
+_GUARD_PG: dist.ProcessGroup | None = None
 
 
-def get_compile_pg() -> Optional[dist.ProcessGroup]:
+def get_compile_pg() -> dist.ProcessGroup | None:
     if (
         config.enable_compiler_collectives
         and dist.is_available()
@@ -44,7 +43,7 @@ def get_compile_pg() -> Optional[dist.ProcessGroup]:
 
 # NB: Unlike get_compile_pg, this is only called when guard collectives were
 # explicitly requested
-def get_guard_pg() -> Optional[dist.ProcessGroup]:
+def get_guard_pg() -> dist.ProcessGroup | None:
     if dist.is_available() and dist.is_initialized():
         global _GUARD_PG
         if _GUARD_PG is None:

--- a/torch/_dynamo/distributed.py
+++ b/torch/_dynamo/distributed.py
@@ -14,7 +14,6 @@ is properly initialized, making it safe to import and use this module even in
 non-distributed scenarios.
 """
 
-
 import torch.distributed as dist
 
 from . import config

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -43,7 +43,7 @@ from collections.abc import Generator, Sized
 from dataclasses import dataclass
 from enum import Enum
 from os.path import dirname, join
-from typing import Any, NamedTuple, Optional, TYPE_CHECKING, Union
+from typing import Any, NamedTuple, TYPE_CHECKING
 from unittest.mock import patch
 
 import sympy
@@ -172,7 +172,7 @@ else:
 class DynamoStance:
     stance: str = "default"
     skip_guard_eval_unsafe: bool = False
-    backend: Union[str, Callable[..., Any], None] = None
+    backend: str | Callable[..., Any] | None = None
 
 
 _stance = DynamoStance()
@@ -195,7 +195,7 @@ def _set_stance(stance: DynamoStance) -> DynamoStance:
 
 _set_stance._dynamo_forbidden = True  # type: ignore[attr-defined]
 
-_EXAMPLE_INPUTS: Optional[dict[str, list[Any]]] = None
+_EXAMPLE_INPUTS: dict[str, list[Any]] | None = None
 
 
 def get_example_inputs(key: str) -> list[Any]:
@@ -373,7 +373,7 @@ DONT_WRAP_FILES = {
 
 
 def _debug_get_cache_entry_list(
-    code: Union[types.CodeType, Callable[..., Any]],
+    code: types.CodeType | Callable[..., Any],
 ) -> list[CacheEntry]:
     """
     Given a code object or a callable object, retrieve the cache entries
@@ -491,7 +491,7 @@ class OptimizedModule(torch.nn.Module):
 
         self.forward = aot_compile_module(model, inputs, hooks, backend)
 
-    def _save_aot_compiled_module(self, path: Optional[str] = None) -> bytes:
+    def _save_aot_compiled_module(self, path: str | None = None) -> bytes:
         if not config.enable_aot_compile:
             raise RuntimeError(
                 "AOT Compile is not enabled, please set torch._dynamo.config.enable_aot_compile=True"
@@ -739,18 +739,18 @@ class _TorchDynamoContext:
         first_ctx: bool = False,
         *,
         fullgraph: bool = False,
-        error_on_graph_break: Optional[bool] = None,
+        error_on_graph_break: bool | None = None,
         export: bool = False,
-        dynamic: Optional[bool] = None,
-        compiler_config: Optional[Any] = None,
-        package: Optional[CompilePackage] = None,
-        hooks: Optional[Hooks] = None,
+        dynamic: bool | None = None,
+        compiler_config: Any | None = None,
+        package: CompilePackage | None = None,
+        hooks: Hooks | None = None,
     ) -> None:
         super().__init__()
         assert callable(callback) or callback is False or callback is None
         self.callback: DynamoCallback = callback
         self._backend_ctx_ctor = backend_ctx_ctor
-        self.prior: Union[Unset, DynamoCallback] = unset
+        self.prior: Unset | DynamoCallback = unset
         self.first_ctx = first_ctx
         self.fullgraph = fullgraph
         self.error_on_graph_break = error_on_graph_break
@@ -780,7 +780,7 @@ class _TorchDynamoContext:
 
         if backend_ctx_ctor is not contextlib.nullcontext:
             # this case is not common
-            def call_backend_ctx() -> functools.partial[Optional[bool]]:
+            def call_backend_ctx() -> functools.partial[bool | None]:
                 ctx = backend_ctx_ctor()
                 ctx.__enter__()
                 return functools.partial(ctx.__exit__, None, None, None)
@@ -803,10 +803,10 @@ class _TorchDynamoContext:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[types.TracebackType],
-    ) -> Optional[bool]:
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> bool | None:
         assert self.prior is not unset
         set_eval_frame(None)
         set_skip_guard_eval_unsafe(self.prior_skip_guard_eval_unsafe)
@@ -1121,15 +1121,13 @@ class OptimizeContext(_TorchDynamoContext):
         first_ctx: bool = False,
         *,
         fullgraph: bool = False,
-        error_on_graph_break: Optional[bool] = None,
+        error_on_graph_break: bool | None = None,
         export: bool = False,
-        dynamic: Optional[bool] = None,
-        compiler_config: Optional[Any] = None,
-        rebuild_ctx: Optional[
-            Callable[[], Union[OptimizeContext, _NullDecorator]]
-        ] = None,
-        package: Optional[CompilePackage] = None,
-        hooks: Optional[Hooks] = None,
+        dynamic: bool | None = None,
+        compiler_config: Any | None = None,
+        rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
+        package: CompilePackage | None = None,
+        hooks: Hooks | None = None,
     ) -> None:
         def on_enter() -> None:
             install_generation_tagging_init()
@@ -1154,7 +1152,7 @@ class OptimizeContext(_TorchDynamoContext):
             if _dynamic is None:
                 _dynamic = not torch._dynamo.config.assume_static_by_default
 
-            def call_compiled_autograd() -> functools.partial[Optional[bool]]:
+            def call_compiled_autograd() -> functools.partial[bool | None]:
                 assert rebuild_ctx is not None
                 compiler_fn = rebuild_ctx()
                 ctx = torch._dynamo.compiled_autograd._enable(
@@ -1195,7 +1193,7 @@ class RunOnlyContext(_TorchDynamoContext):
 
 
 class DisableContext(_TorchDynamoContext):
-    def __init__(self, msg: Optional[str] = None, wrapping: bool = True) -> None:
+    def __init__(self, msg: str | None = None, wrapping: bool = True) -> None:
         super().__init__(callback=None)
         self.msg = msg
         self.wrapping = wrapping
@@ -1292,12 +1290,12 @@ def _optimize_catch_errors(
         [], contextlib.AbstractContextManager[Any]
     ] = null_context,
     fullgraph: bool = False,
-    error_on_graph_break: Optional[bool] = None,
+    error_on_graph_break: bool | None = None,
     export: bool = False,
-    dynamic: Optional[bool] = None,
-    compiler_config: Optional[Any] = None,
-    rebuild_ctx: Optional[Callable[[], Union[OptimizeContext, _NullDecorator]]] = None,
-    package: Optional[CompilePackage] = None,
+    dynamic: bool | None = None,
+    compiler_config: Any | None = None,
+    rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
+    package: CompilePackage | None = None,
 ) -> OptimizeContext:
     return OptimizeContext(
         convert_frame.catch_errors_wrapper(compile_fn, hooks),
@@ -1315,7 +1313,7 @@ def _optimize_catch_errors(
 
 
 def get_compiler_fn(
-    compiler_fn: Union[str, Callable[..., Any], None],
+    compiler_fn: str | Callable[..., Any] | None,
 ) -> WrapBackendDebug:
     from .repro.after_dynamo import wrap_backend_debug
 
@@ -1344,7 +1342,7 @@ class _NullDecorator(contextlib.nullcontext):  # type: ignore[type-arg]
 # Make dynamo graph to have same input/output spec as user code
 def argument_names(
     f_sig: inspect.Signature,
-    args: Union[list[Any], tuple[Any, ...]],
+    args: list[Any] | tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> list[str]:
     def signature_to_fullargspec(sig: inspect.Signature) -> inspect.FullArgSpec:
@@ -1468,8 +1466,8 @@ def check_for_incompatible_configs() -> None:
     )
 
 
-def optimize(*args: Any, **kwargs: Any) -> Union[OptimizeContext, _NullDecorator]:
-    def rebuild_ctx() -> Union[OptimizeContext, _NullDecorator]:
+def optimize(*args: Any, **kwargs: Any) -> OptimizeContext | _NullDecorator:
+    def rebuild_ctx() -> OptimizeContext | _NullDecorator:
         ca_kwargs_override = config.compiled_autograd_kwargs_override
         if ca_kwargs_override:
             # NOTE: The process of translating other `torch.compile` kwargs to `torch._dynamo.optimize` kwargs
@@ -1484,19 +1482,19 @@ def optimize(*args: Any, **kwargs: Any) -> Union[OptimizeContext, _NullDecorator
 
 
 def _optimize(
-    rebuild_ctx: Callable[[], Union[OptimizeContext, _NullDecorator]],
-    backend: Union[str, Callable[..., Any]] = "inductor",
+    rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator],
+    backend: str | Callable[..., Any] = "inductor",
     *,
     nopython: bool = False,
-    error_on_graph_break: Optional[bool] = None,
-    guard_export_fn: Optional[Callable[[_guards.GuardsSet], None]] = None,
-    guard_fail_fn: Optional[Callable[[GuardFail], None]] = None,
+    error_on_graph_break: bool | None = None,
+    guard_export_fn: Callable[[_guards.GuardsSet], None] | None = None,
+    guard_fail_fn: Callable[[GuardFail], None] | None = None,
     guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
     | None = None,
     disable: bool = False,
-    dynamic: Optional[bool] = None,
-    package: Optional[CompilePackage] = None,
-) -> Union[OptimizeContext, _NullDecorator]:
+    dynamic: bool | None = None,
+    package: CompilePackage | None = None,
+) -> OptimizeContext | _NullDecorator:
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
     backend() to optimize extracted graphs.
@@ -1680,7 +1678,7 @@ class FlattenInputOutputSignature(torch.fx.Transformer):
         matched_output_elements_positions: list[int],
         example_fake_inputs: list[torch.Tensor],
         flat_args_dynamic_dims: list[set[int]],
-        fake_mode: Optional[fake_tensor.FakeTensorMode] = None,
+        fake_mode: fake_tensor.FakeTensorMode | None = None,
     ) -> None:
         super().__init__(m)
 
@@ -1881,12 +1879,12 @@ def check_user_input_output(flat_values: list[Any], error_type: UserErrorType) -
 def rewrite_signature(
     f_sig: inspect.Signature,
     graph: torch.fx.GraphModule,
-    fake_mode: Optional[fake_tensor.FakeTensorMode],
+    fake_mode: fake_tensor.FakeTensorMode | None,
     flat_args: list[Any],
     in_spec: pytree.TreeSpec,
     example_fake_inputs: list[Any],
     graph_captured_input: Iterable[Any],
-    graph_captured_output: Optional[Iterable[Any]],
+    graph_captured_output: Iterable[Any] | None,
     dynamo_traced_result: Any,
     flat_args_dynamic_dims: list[set[int]],
 ) -> torch.fx.GraphModule:
@@ -1919,8 +1917,8 @@ def rewrite_signature(
 
     def produce_matching(
         debug_type: str, sources: Iterable[Any], candidates: Iterable[Any]
-    ) -> list[Optional[int]]:
-        matched_elements_positions: list[Optional[int]] = []
+    ) -> list[int | None]:
+        matched_elements_positions: list[int | None] = []
         dict_of_source_vals = {}
         for i, val in enumerate(sources):
             dict_of_source_vals[id(val)] = i
@@ -1976,18 +1974,16 @@ def export(
     *extra_args: Any,
     aten_graph: bool = False,
     pre_dispatch: bool = False,
-    decomposition_table: Optional[
-        dict[torch._ops.OpOverload, Callable[..., Any]]
-    ] = None,
+    decomposition_table: dict[torch._ops.OpOverload, Callable[..., Any]] | None = None,
     tracing_mode: str = "symbolic",
-    dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
+    dynamic_shapes: dict[str, Any] | tuple[Any] | list[Any] | None = None,
     specialize_float: bool = True,
     assume_static_by_default: bool = False,
     same_signature: bool = True,
     disable_constraint_solver: bool = False,
     prefer_deferred_runtime_asserts_over_guards: bool = False,
     _log_export_usage: bool = True,
-    constraints: Optional[list[Constraint]] = None,
+    constraints: list[Constraint] | None = None,
     **extra_kwargs: Any,
 ) -> Callable[..., ExportResult]:
     """
@@ -2079,7 +2075,7 @@ def export(
         graph = None
         out_guards = None
         graph_captured_input = None
-        graph_captured_result: Optional[tuple[torch.Tensor, ...]] = None
+        graph_captured_result: tuple[torch.Tensor, ...] | None = None
         fake_mode = None
         result_traced = None
 
@@ -2158,7 +2154,7 @@ def export(
                     )
 
                     def fakify_with_ambient(
-                        path: KeyPath, t: Union[torch.Tensor, _IntWrapper, Any]
+                        path: KeyPath, t: torch.Tensor | _IntWrapper | Any
                     ) -> Any:
                         if isinstance(t, torch.Tensor):
                             # pyrefly: ignore [missing-attribute]
@@ -2424,13 +2420,13 @@ def optimize_assert(*args: Any, **kwargs: Any) -> OptimizeContext:
 
 def _optimize_assert(
     rebuild_ctx: Callable[[], OptimizeContext],
-    backend: Union[str, Callable[..., Any], None],
+    backend: str | Callable[..., Any] | None,
     *,
     hooks: Hooks = Hooks(None, None, None),
     export: bool = False,
-    export_constraints: Optional[Any] = None,
-    dynamic: Optional[bool] = None,
-    package: Optional[CompilePackage] = None,
+    export_constraints: Any | None = None,
+    dynamic: bool | None = None,
+    package: CompilePackage | None = None,
 ) -> OptimizeContext:
     """
     Guarantees single-graph capture.

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -35,7 +35,7 @@ from enum import auto, Enum
 from functools import lru_cache
 from pathlib import Path
 from traceback import extract_stack, format_exc, format_list, FrameSummary, StackSummary
-from typing import Any, NoReturn, Optional, TYPE_CHECKING
+from typing import Any, NoReturn, TYPE_CHECKING
 
 import torch._guards
 from torch._utils_internal import get_file_path_2
@@ -80,7 +80,7 @@ class TorchDynamoException(RuntimeError):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._torch_dynamo_tracer_output: Optional[DynamoTracerOutput] = None
+        self._torch_dynamo_tracer_output: DynamoTracerOutput | None = None
         self.frame_exec_strategy: FrameExecStrategy | None = None
 
 
@@ -93,9 +93,9 @@ class ResumePrologueTracingError(TorchDynamoException):
 
 
 class RestartAnalysis(TorchDynamoException):
-    restart_reason: Optional[str]
+    restart_reason: str | None
 
-    def __init__(self, *args: Any, restart_reason: Optional[str] = None) -> None:
+    def __init__(self, *args: Any, restart_reason: str | None = None) -> None:
         self.restart_reason = restart_reason
         super().__init__(*args)
 
@@ -163,7 +163,7 @@ class ResetRequired(TorchDynamoException):
 
 class ShortenTraceback(TorchDynamoException):
     def __init__(
-        self, *args: Any, first_useful_frame: Optional[types.FrameType], **kwargs: Any
+        self, *args: Any, first_useful_frame: types.FrameType | None, **kwargs: Any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.first_useful_frame = first_useful_frame
@@ -183,7 +183,7 @@ class BackendCompilerFailed(ShortenTraceback):
         self,
         backend_fn: Any,
         inner_exception: Exception,
-        first_useful_frame: Optional[types.FrameType],
+        first_useful_frame: types.FrameType | None,
     ) -> None:
         self.backend_name = getattr(backend_fn, "__name__", "?")
         self.inner_exception = inner_exception
@@ -204,7 +204,7 @@ class Unsupported(TorchDynamoException):
         gb_type: str = "",
         skip_frame: bool = False,
         *,
-        case_name: Optional[str] = None,
+        case_name: str | None = None,
         real_stack: StackSummary | None = None,
     ) -> None:
         super().__init__(msg)
@@ -213,7 +213,7 @@ class Unsupported(TorchDynamoException):
         self.real_stack = real_stack
         self.msg = msg
         self.skip_frame = skip_frame
-        self.category: Optional[str] = None
+        self.category: str | None = None
         self.add_to_stats()
         self.gb_type: str | None = gb_type
         self.logged = False
@@ -261,7 +261,7 @@ class UserErrorType(Enum):
 
 class UserError(Unsupported):
     def __init__(
-        self, error_type: UserErrorType, msg: str, case_name: Optional[str] = None
+        self, error_type: UserErrorType, msg: str, case_name: str | None = None
     ) -> None:
         """
         Type of errors that would be valid in Eager, but not supported in TorchDynamo.
@@ -323,7 +323,7 @@ class PackageError(TorchDynamoException):
 class ObservedException(TorchDynamoException):
     # An exception observed during the tracing. This exception is used by Dynamo to handle exceptions.
     def __init__(
-        self, *args: Any, real_stack: Optional[StackSummary] = None, **kwargs: Any
+        self, *args: Any, real_stack: StackSummary | None = None, **kwargs: Any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.real_stack: StackSummary = (
@@ -335,12 +335,12 @@ class ObservedException(TorchDynamoException):
 
 class ObservedUserStopIteration(ObservedException):
     # An UserStopIteration exception observed during the Dynamo tracing (e.g Dynamo tracing __next__)
-    value: Optional[Any]
+    value: Any | None
 
     # Reference `StopIteration_init` in CPython
     # https://github.com/python/cpython/blob/3.11/Objects/exceptions.c#L568-L584
     def __init__(
-        self, *args: Any, real_stack: Optional[StackSummary] = None, **kwargs: Any
+        self, *args: Any, real_stack: StackSummary | None = None, **kwargs: Any
     ) -> None:
         super().__init__("unhandled `raise StopIteration`", real_stack=real_stack)
         if len(args) > 0:
@@ -414,8 +414,8 @@ def raise_observed_exception(
     exc_type: type[Exception],
     tx: InstructionTranslatorBase,
     *,
-    args: Optional[list[Any]] = None,
-    kwargs: Optional[dict[str, Any]] = None,
+    args: list[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
 ) -> NoReturn:
     from .symbolic_convert import ExceptionVals
     from .variables.builder import SourcelessBuilder
@@ -566,7 +566,7 @@ def _load_gb_type_to_gb_id_map() -> dict[str, Any]:
     return mapping
 
 
-def get_gbid_documentation_link(gb_type: str) -> Optional[str]:
+def get_gbid_documentation_link(gb_type: str) -> str | None:
     """
     Retrieves the GBID documentation link for a given graph break type.
 
@@ -709,7 +709,7 @@ def augment_exc_message(exc: Exception, msg: str = "\n", export: bool = False) -
 
 def get_exc_message(
     e: Exception, compile_id: CompileId
-) -> tuple[Optional[str], Optional[int]]:
+) -> tuple[str | None, int | None]:
     filename = None
     lineno = None
     if e.innermost_user_frame_summary is not None:  # type: ignore[attr-defined]
@@ -724,8 +724,8 @@ def get_stack_above_dynamo() -> StackSummary:
 
 
 def get_real_stack(
-    exc: Exception, frame: Optional[DynamoFrameType] = None
-) -> Optional[StackSummary]:
+    exc: Exception, frame: DynamoFrameType | None = None
+) -> StackSummary | None:
     real_stack = getattr(exc, "real_stack", None)
     if real_stack is None:
         return None
@@ -772,7 +772,7 @@ def filter_stack(stack: StackSummary) -> StackSummary:
     return user_stack
 
 
-def remove_resume_prefix(name: str) -> Optional[str]:
+def remove_resume_prefix(name: str) -> str | None:
     from .resume_execution import TORCH_DYNAMO_RESUME_IN_PREFIX
 
     match = re.match(f"{TORCH_DYNAMO_RESUME_IN_PREFIX}_(\\w+)_at_\\d+", name)
@@ -818,8 +818,8 @@ def collapse_resume_frames(stack: StackSummary | list[FrameSummary]) -> StackSum
 def format_error_msg_verbose(
     exc: Exception,
     code: types.CodeType,
-    record_filename: Optional[str] = None,
-    frame: Optional[DynamoFrameType] = None,
+    record_filename: str | None = None,
+    frame: DynamoFrameType | None = None,
 ) -> str:
     msg = (
         f"WON'T CONVERT {code.co_name} {code.co_filename} line {code.co_firstlineno}\n"
@@ -850,7 +850,7 @@ def format_frame_info(code: types.CodeType) -> str:
     )
 
 
-def format_skip_frame_message(code: Optional[types.CodeType], reason: str) -> str:
+def format_skip_frame_message(code: types.CodeType | None, reason: str) -> str:
     if code is not None:
         frame_info = format_frame_info(code)
         return (
@@ -867,8 +867,8 @@ def format_skip_frame_message(code: Optional[types.CodeType], reason: str) -> st
 def format_error_msg(
     exc: Exception,
     code: types.CodeType,
-    record_filename: Optional[str] = None,
-    frame: Optional[DynamoFrameType] = None,
+    record_filename: str | None = None,
+    frame: DynamoFrameType | None = None,
 ) -> str:
     if config.verbose:
         return format_error_msg_verbose(exc, code, record_filename, frame)

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -23,7 +23,7 @@ Key functionality groups:
 import functools
 import warnings
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING, TypeVar, Union
+from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import deprecated, ParamSpec
 
 import torch
@@ -72,7 +72,7 @@ def wrap_inline(fn: Callable[_P, _R]) -> Callable[_P, _R]:
 
 
 def call_hook(
-    hook: Callable[..., Optional[torch.Tensor]], *args: Any, **kwargs: Any
+    hook: Callable[..., torch.Tensor | None], *args: Any, **kwargs: Any
 ) -> torch.Tensor:
     """
     Used by compiled autograd to handle hook returning None.
@@ -128,7 +128,7 @@ def call_backward(
     backward_c_function: torch.autograd.function.BackwardCFunction,
     saved_tensors: list[torch.Tensor],
     *args: Any,
-) -> Union[torch.Tensor, tuple[torch.Tensor, ...]]:
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
     fake = FakeBackwardCFunction(backward_c_function, saved_tensors)
     grads = fake._forward_cls.backward(fake, *args)  # type: ignore[attr-defined]
 
@@ -243,7 +243,7 @@ def wrap_dunder_call_ctx_manager(self: Any, func: Callable[_P, _R]) -> Callable[
 
 # Use only on ints marked dynamic via torch.empty(0, integer)
 # Currently only way to mark ints as dynamic: https://github.com/pytorch/pytorch/issues/129623
-def unwrap_maybe_dynamic_int(x: Union[torch.Tensor, int]) -> int:
+def unwrap_maybe_dynamic_int(x: torch.Tensor | int) -> int:
     if isinstance(x, torch.Tensor):
         # x.size() is expected to be [0, dynamic_int]
         return x.size(1)

--- a/torch/_dynamo/funcname_cache.py
+++ b/torch/_dynamo/funcname_cache.py
@@ -17,7 +17,6 @@ IO errors are handled gracefully by returning empty cache entries.
 """
 
 import tokenize
-from typing import Optional
 
 
 cache: dict[str, dict[int, str]] = {}
@@ -69,7 +68,7 @@ def _add_file(filename: str) -> None:
     cache[filename] = result
 
 
-def get_funcname(filename: str, lineno: int) -> Optional[str]:
+def get_funcname(filename: str, lineno: int) -> str | None:
     if filename not in cache:
         _add_file(filename)
     return cache[filename].get(lineno, None)

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -5,7 +5,7 @@ import traceback
 import types
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Optional, TYPE_CHECKING, TypeVar, Union
+from typing import Any, Optional, TYPE_CHECKING, TypeVar
 
 import sympy
 
@@ -234,8 +234,8 @@ class DynamoGraphTransformer(torch.fx.Transformer):
         flat_args_dynamic_dims: list[set[int]],
         graph_input_order: dict[int, int],
         graph_output_map: dict[int, tuple[str, Any]],
-        fake_mode: Optional[Any] = None,
-        graph_inputs: Optional[dict[int, Any]] = None,
+        fake_mode: Any | None = None,
+        graph_inputs: dict[int, Any] | None = None,
     ) -> None:
         super().__init__(module)
 
@@ -421,7 +421,7 @@ def _suggest_or_raise_constraint_violation(
     graph_capture_output: CaptureOutput,
     args: Any,
     kwargs: Any,
-    dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]],
+    dynamic_shapes: dict[str, Any] | tuple[Any] | list[Any] | None,
 ) -> None:
     constraint_violation_error = None
     try:
@@ -768,7 +768,7 @@ class _DynamoBytecodeCodeGen(torch.fx.graph.CodeGen):
 
 def dynamo_graph_capture_for_export(
     fn: Callable[..., Any],
-    constraints: Optional[list[Constraint]] = None,
+    constraints: list[Constraint] | None = None,
 ) -> Callable[..., Any]:
     if isinstance(fn, torch._ops.OpOverload):
 
@@ -816,8 +816,8 @@ def op_overload_wrapper({", ".join(arg_list)}):
 def _dynamo_graph_capture_for_export(
     mod: Callable[..., Any],
     *,
-    constraints: Optional[list[Constraint]] = None,
-    dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
+    constraints: list[Constraint] | None = None,
+    dynamic_shapes: dict[str, Any] | tuple[Any] | list[Any] | None = None,
 ) -> Callable[..., torch.fx.GraphModule]:
     """
     Improved dynamo graph capture using transformer approach with proper fake tensor handling.
@@ -851,8 +851,8 @@ def _dynamo_graph_capture_for_export(
             module_to_trace = ModuleToTrace(mod, in_spec)
             orig_callable = mod.forward if isinstance(mod, torch.nn.Module) else mod
 
-            constraints: Optional[list[Constraint]] = _constraints
-            dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = (
+            constraints: list[Constraint] | None = _constraints
+            dynamic_shapes: dict[str, Any] | tuple[Any] | list[Any] | None = (
                 _dynamic_shapes
             )
 

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -11,7 +11,6 @@ import logging
 import operator
 from collections import defaultdict, deque
 from collections.abc import Generator, Iterable
-from typing import Optional
 
 import torch
 import torch.fx
@@ -31,7 +30,7 @@ UsageIndex = tuple[int, int]
 
 log = logging.getLogger(__name__)
 
-last_node_to_additional_deps: Optional[dict[Node, OrderedSet[Node]]] = None
+last_node_to_additional_deps: dict[Node, OrderedSet[Node]] | None = None
 
 
 def apply_graph_deduplication(output_graph) -> dict[str, torch.fx.GraphModule]:  # type: ignore[no-untyped-def]

--- a/torch/_dynamo/graph_utils.py
+++ b/torch/_dynamo/graph_utils.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from torch.fx import Graph, map_arg, Node
@@ -79,7 +79,7 @@ def _detect_cycles(
     return "no cycle detected"
 
 
-def _graph_device_type(graph: Optional[Graph]) -> str:
+def _graph_device_type(graph: Graph | None) -> str:
     if graph is None:
         return "cpu"
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -38,7 +38,7 @@ import weakref
 from contextlib import contextmanager
 from copy import deepcopy
 from inspect import currentframe
-from typing import Any, NamedTuple, NoReturn, Optional, TYPE_CHECKING, Union
+from typing import Any, NamedTuple, NoReturn, TYPE_CHECKING
 from typing_extensions import LiteralString, TypeAliasType, TypeVar
 from weakref import ReferenceType
 
@@ -199,7 +199,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-guard_manager_testing_hook_fn: Optional[Callable[[Any, Any, Any], Any]] = None
+guard_manager_testing_hook_fn: Callable[[Any, Any, Any], Any] | None = None
 
 try:
     import numpy as np
@@ -270,21 +270,21 @@ class GuardManagerWrapper:
     the check_nopybind from C++.
     """
 
-    def __init__(self, root: Optional[RootGuardManager] = None) -> None:
+    def __init__(self, root: RootGuardManager | None = None) -> None:
         if root is None:
             self.root = RootGuardManager()
         else:
             self.root = root
 
-        self.diff_guard_root: Optional[RootGuardManager] = None
-        self.closure_vars: Optional[dict[str, Any]] = None
-        self.args: Optional[list[str]] = None
+        self.diff_guard_root: RootGuardManager | None = None
+        self.closure_vars: dict[str, Any] | None = None
+        self.args: list[str] | None = None
         self.code_parts: list[str] = []
-        self.verbose_code_parts: Optional[list[str]] = None
-        self.global_scope: Optional[dict[str, Any]] = None
-        self.guard_fail_fn: Optional[Callable[[GuardFail], None]] = None
-        self.cache_entry: Optional[CacheEntry] = None
-        self.extra_state: Optional[ExtraState] = None
+        self.verbose_code_parts: list[str] | None = None
+        self.global_scope: dict[str, Any] | None = None
+        self.guard_fail_fn: Callable[[GuardFail], None] | None = None
+        self.cache_entry: CacheEntry | None = None
+        self.extra_state: ExtraState | None = None
         self.id_matched_objs: dict[str, ReferenceType[object]] = {}
         self.no_tensor_aliasing_sources: list[str] = []
 
@@ -607,7 +607,7 @@ class GuardManagerWrapper:
         return parts
 
     def get_manager_line(
-        self, guard_manager: GuardManager, accessor_str: Optional[str] = None
+        self, guard_manager: GuardManager, accessor_str: str | None = None
     ) -> str:
         source = guard_manager.get_source()
         t = guard_manager.__class__.__name__
@@ -737,7 +737,7 @@ def uninteresting_files() -> set[str]:
     return {inspect.getfile(m) for m in mods}
 
 
-_CLOSURE_VARS: Optional[dict[str, object]] = None
+_CLOSURE_VARS: dict[str, object] | None = None
 
 
 def _get_closure_vars() -> dict[str, object]:
@@ -778,7 +778,7 @@ def _ast_unparse(node: ast.AST) -> str:
 strip_function_call = torch._C._dynamo.strip_function_call
 
 
-def get_verbose_code_part(code_part: str, guard: Optional[Guard]) -> str:
+def get_verbose_code_part(code_part: str, guard: Guard | None) -> str:
     extra = ""
     if guard is not None:
         if guard.user_stack:
@@ -803,9 +803,9 @@ def get_verbose_code_part(code_part: str, guard: Optional[Guard]) -> str:
 
 
 def get_verbose_code_parts(
-    code_parts: Union[str, list[str]],
-    guard: Optional[Guard],
-    recompile_hint: Optional[str] = None,
+    code_parts: str | list[str],
+    guard: Guard | None,
+    recompile_hint: str | None = None,
 ) -> list[str]:
     if not isinstance(code_parts, list):
         code_parts = [code_parts]
@@ -832,7 +832,7 @@ def get_verbose_code_parts(
     return verbose_code_parts
 
 
-def _get_closure_var_hint(source: Optional[Source]) -> Optional[str]:
+def _get_closure_var_hint(source: Source | None) -> str | None:
     """
     Walk up the source chain to find a CellContentsSource ancestor.
     Returns a hint like 'guard on "varname".attr' or None if not found.
@@ -841,7 +841,7 @@ def _get_closure_var_hint(source: Optional[Source]) -> Optional[str]:
         return None
 
     full_name = source.name
-    current: Optional[Source] = source
+    current: Source | None = source
     while current is not None:
         if isinstance(current, CellContentsSource) and current.freevar_name:
             # Compute the path suffix by comparing names
@@ -854,7 +854,7 @@ def _get_closure_var_hint(source: Optional[Source]) -> Optional[str]:
     return None
 
 
-def convert_int_to_concrete_values(dim: Any) -> Optional[int]:
+def convert_int_to_concrete_values(dim: Any) -> int | None:
     if dim is None:
         return None
     if not is_symbolic(dim):
@@ -864,15 +864,15 @@ def convert_int_to_concrete_values(dim: Any) -> Optional[int]:
         return dim.node.maybe_as_int()
 
 
-def convert_to_concrete_values(size_or_stride: list[Any]) -> list[Optional[int]]:
+def convert_to_concrete_values(size_or_stride: list[Any]) -> list[int | None]:
     return [convert_int_to_concrete_values(dim) for dim in size_or_stride]
 
 
 def get_tensor_guard_code_part(
     value: torch.Tensor,
     name: str,
-    sizes: list[Optional[int]],
-    strides: list[Optional[int]],
+    sizes: list[int | None],
+    strides: list[int | None],
     pytype: type,
     dispatch_keys: DispatchKeySet,
 ) -> str:
@@ -928,14 +928,14 @@ class NNModuleAttrAccessorInfo:
     present_in_generic_dict: bool = False
 
     # Either the actual name or _parameters/_buffers/_modules
-    l1_key: Optional[str] = None
+    l1_key: str | None = None
 
     # Actual parameter/buffer/submodule name
-    l2_key: Optional[str] = None
+    l2_key: str | None = None
 
 
 def getitem_on_dict_manager(
-    source: Union[DictGetItemSource, DictSubclassGetItemSource],
+    source: DictGetItemSource | DictSubclassGetItemSource,
     base_guard_manager: DictGuardManager,
     base_example_value: Any,
     example_value: Any,
@@ -1016,13 +1016,13 @@ class GuardBuilder(GuardBuilderBase):
         f_code: types.CodeType,
         id_ref: Callable[[object, str], int],
         source_ref: Callable[[Source], str],
-        lookup_weakrefs: Callable[[object], Optional[weakref.ref[object]]],
+        lookup_weakrefs: Callable[[object], weakref.ref[object] | None],
         local_scope: dict[str, object],
         global_scope: dict[str, object],
         guard_manager: GuardManagerWrapper,
         check_fn_manager: CheckFunctionManager,
         save_guards: bool = False,
-        runtime_global_scope: Optional[dict[str, object]] = None,
+        runtime_global_scope: dict[str, object] | None = None,
         guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
         | None = None,
     ) -> None:
@@ -1163,7 +1163,7 @@ class GuardBuilder(GuardBuilderBase):
                 )
 
     @staticmethod
-    def _get_generic_dict_manager_example_value(example_value: Any) -> Optional[Any]:
+    def _get_generic_dict_manager_example_value(example_value: Any) -> Any | None:
         # due to a bug in 3.13.0 (introduced by https://github.com/python/cpython/pull/116115,
         # reported in https://github.com/python/cpython/issues/125608,
         # fixed by https://github.com/python/cpython/pull/125611), we cannot take
@@ -1345,9 +1345,7 @@ class GuardBuilder(GuardBuilderBase):
     def get_guard_manager_type(
         self,
         source: Source,
-        example_value: Optional[
-            Union[KeysView[Any], set[Any], frozenset[Any], dict[Any, Any]]
-        ],
+        example_value: KeysView[Any] | set[Any] | frozenset[Any] | dict[Any, Any] | None,
     ) -> GuardManagerType:
         guard_manager_enum = GuardManagerType.GUARD_MANAGER
         if self.requires_key_order_guarding(source):
@@ -1796,7 +1794,7 @@ class GuardBuilder(GuardBuilderBase):
         self,
         code_parts: list[str],
         verbose_code_parts: list[str],
-        closure_vars: Optional[dict[str, object]] = None,
+        closure_vars: dict[str, object] | None = None,
         is_epilogue: bool = True,
     ) -> None:
         if closure_vars is None:
@@ -1832,7 +1830,7 @@ class GuardBuilder(GuardBuilderBase):
     def get(
         self,
         guard_or_source: Guard | Source,
-        closure_vars: Optional[dict[str, Any]] = None,
+        closure_vars: dict[str, Any] | None = None,
     ) -> Any:
         if isinstance(guard_or_source, Source):
             src = guard_or_source
@@ -1848,7 +1846,7 @@ class GuardBuilder(GuardBuilderBase):
     # to call this before generating some code that makes use of 'guard',
     # because without this call, we won't actually bind the variable
     # you reference in the actual guard closure (oops!)
-    def arg_ref(self, guard: Union[str, Guard]) -> str:
+    def arg_ref(self, guard: str | Guard) -> str:
         name: str
         if isinstance(guard, str):
             name = guard
@@ -1942,7 +1940,7 @@ class GuardBuilder(GuardBuilderBase):
         self.already_added_code_parts.add(code)
 
     def NOT_PRESENT_IN_GENERIC_DICT(
-        self, guard: Guard, attr: Optional[Any] = None
+        self, guard: Guard, attr: Any | None = None
     ) -> None:
         assert attr is not None
         ref = self.arg_ref(guard)
@@ -2074,7 +2072,7 @@ class GuardBuilder(GuardBuilderBase):
             get_verbose_code_parts(code, guard), guard.user_stack
         )
 
-    def ID_MATCH(self, guard: Guard, recompile_hint: Optional[str] = None) -> None:
+    def ID_MATCH(self, guard: Guard, recompile_hint: str | None = None) -> None:
         # TODO - Run a CI with the following uncommented to find the remaining places
         # val = self.get(guard)
         # if inspect.isclass(val):
@@ -2084,7 +2082,7 @@ class GuardBuilder(GuardBuilderBase):
         return self.id_match_unchecked(guard, recompile_hint)
 
     def id_match_unchecked(
-        self, guard: Guard, recompile_hint: Optional[str] = None
+        self, guard: Guard, recompile_hint: str | None = None
     ) -> None:
         # ___check_obj_id is same as `id(x) == y`
         if isinstance(guard.originating_source, TypeSource):
@@ -2122,7 +2120,7 @@ class GuardBuilder(GuardBuilderBase):
                 if weak_id is not None:
                     self.id_matched_objs[local_name] = weak_id
 
-    def NOT_NONE_MATCH(self, guard: Guard, value: Optional[Any] = None) -> None:
+    def NOT_NONE_MATCH(self, guard: Guard, value: Any | None = None) -> None:
         ref = self.arg_ref(guard)
         val = self.get(guard)
         assert isinstance(val, torch.Tensor)
@@ -2185,7 +2183,7 @@ class GuardBuilder(GuardBuilderBase):
 
         def hooks_ids_fn(
             hooks: tuple[Callable[[torch.Tensor], Any], Callable[[Any], torch.Tensor]],
-        ) -> Optional[tuple[int, ...]]:
+        ) -> tuple[int, ...] | None:
             if not are_inline_hooks(hooks):
                 return None
 
@@ -2266,7 +2264,7 @@ class GuardBuilder(GuardBuilderBase):
             guard.user_stack,
         )
 
-    def EQUALS_MATCH(self, guard: Guard, recompile_hint: Optional[str] = None) -> None:
+    def EQUALS_MATCH(self, guard: Guard, recompile_hint: str | None = None) -> None:
         ref = self.arg_ref(guard)
         val = self.get(guard)
         if np:
@@ -2710,7 +2708,7 @@ class GuardBuilder(GuardBuilderBase):
                 source_pairs: list[tuple[Source, Source]] = []
                 derived_equalities: list[  # type: ignore[type-arg]
                     # pyrefly: ignore [implicit-any]
-                    tuple[Source, Union[Source, Symbol], Callable]
+                    tuple[Source, Source | Symbol, Callable]
                 ] = []
                 phantom_symbols: dict[str, Symbol] = {}
                 relaxed_sources: set[Source] = set()
@@ -2922,7 +2920,7 @@ class GuardBuilder(GuardBuilderBase):
                 closure_vars={**SYMPY_INTERP, **_get_closure_vars()},
             )
 
-    def TENSOR_MATCH(self, guard: Guard, value: Optional[Any] = None) -> None:
+    def TENSOR_MATCH(self, guard: Guard, value: Any | None = None) -> None:
         if config._unsafe_skip_fsdp_module_guards and guard.is_fsdp_module():
             return
         # For tensors that are part of the Dynamo extracted Fx graph module, an
@@ -3139,8 +3137,8 @@ class GuardBuilder(GuardBuilderBase):
         self,
         guard: Guard,
         code_list: list[str],
-        provided_guarded_object: Optional[Any] = None,
-        provided_func_name: Optional[str] = None,
+        provided_guarded_object: Any | None = None,
+        provided_func_name: str | None = None,
     ) -> None:
         # WARNING: It is important that cur_frame/caller do NOT stay in
         # the current frame, because they will keep things live longer
@@ -3316,7 +3314,7 @@ class DeletedGuardManagerWrapper(GuardManagerWrapper):
 class ShapeCodeParts:
     python_code_parts: _ShapeGuardsHelper
     verbose_code_parts: _ShapeGuardsHelper
-    cpp_code_parts: Optional[_CppShapeGuardsHelper]
+    cpp_code_parts: _CppShapeGuardsHelper | None
     python_fallback: bool
     shape_env_sources: list[Source]
 
@@ -3324,11 +3322,11 @@ class ShapeCodeParts:
 @dataclasses.dataclass
 class GuardsState:
     output_graph: OutputGraphGuardsState
-    shape_code_parts: Optional[ShapeCodeParts]
+    shape_code_parts: ShapeCodeParts | None
 
 
 class _Missing:
-    def __init__(self, reason: Optional[str] = None) -> None:
+    def __init__(self, reason: str | None = None) -> None:
         self._reason = reason
 
     def __repr__(self) -> str:
@@ -3517,7 +3515,7 @@ class GuardsStatePickler(pickle.Pickler):
     # pyrefly: ignore [bad-override]
     def reducer_override(
         self, obj: Any
-    ) -> Union[tuple[Callable[..., Any], tuple[Any, ...]], Any]:
+    ) -> tuple[Callable[..., Any], tuple[Any, ...]] | Any:
         import sympy
 
         if id(obj) in self.empty_values:
@@ -3798,12 +3796,12 @@ class CheckFunctionManager:
         self,
         f_code: types.CodeType,
         output_graph: OutputGraphCommon,
-        cache_entry: Optional[CacheEntry] = None,
-        guard_fail_fn: Optional[Callable[[GuardFail], None]] = None,
+        cache_entry: CacheEntry | None = None,
+        guard_fail_fn: Callable[[GuardFail], None] | None = None,
         guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
         | None = None,
-        shape_code_parts: Optional[ShapeCodeParts] = None,
-        runtime_global_scope: Optional[dict[str, Any]] = None,
+        shape_code_parts: ShapeCodeParts | None = None,
+        runtime_global_scope: dict[str, Any] | None = None,
         save_guards: bool = False,
         strict_error: bool = False,
     ) -> None:
@@ -3813,7 +3811,7 @@ class CheckFunctionManager:
         existing_diff_guard_sources = (
             update_diff_guard_managers_for_existing_cache_entries(cache_entry)
         )
-        self.output_graph: Optional[OutputGraphCommon] = output_graph
+        self.output_graph: OutputGraphCommon | None = output_graph
         assert self.output_graph is not None
 
         # Only used for serialization.
@@ -3828,8 +3826,8 @@ class CheckFunctionManager:
         self.additional_used_local_vars: OrderedSet[str] = OrderedSet()
         self.additional_used_global_vars: OrderedSet[str] = OrderedSet()
         self.runtime_global_scope = runtime_global_scope
-        self.global_state: Optional[torch._C._dynamo.guards.GlobalStateGuard] = None
-        self.torch_function_mode_stack_check_fn: Optional[Callable[[], bool]] = None
+        self.global_state: torch._C._dynamo.guards.GlobalStateGuard | None = None
+        self.torch_function_mode_stack_check_fn: Callable[[], bool] | None = None
 
         if not justknobs_check("pytorch/compiler:guard_nn_modules"):
             log.warning("guard_nn_modules is turned off using justknobs killswitch")
@@ -3957,7 +3955,7 @@ class CheckFunctionManager:
             # account for, we simply increment at the toplevel instead.
             CompileEventLogger.increment_toplevel("guard_latency_us", int(latency))
 
-        self.guards_state: Optional[bytes] = None
+        self.guards_state: bytes | None = None
         if save_guards:
             from torch._dynamo.output_graph import OutputGraphCommon
 
@@ -4196,7 +4194,7 @@ class CheckFunctionManager:
         self,
         builder: GuardBuilder,
         guards_out: list[Guard],
-        guard_fail_fn: Optional[Callable[[GuardFail], None]],
+        guard_fail_fn: Callable[[GuardFail], None] | None,
     ) -> None:
         # see parallel handling of ".0" / "___implicit0" in _eval_frame.c
         largs = builder.argnames
@@ -4218,7 +4216,7 @@ class CheckFunctionManager:
         self.torch_function_mode_stack = None
 
         def add_code_part(
-            code_part: str, guard: Optional[Guard], log_only: bool = False
+            code_part: str, guard: Guard | None, log_only: bool = False
         ) -> None:
             verbose_code_part = get_verbose_code_part(code_part, guard)
             guards_log.debug("%s", verbose_code_part)
@@ -4428,7 +4426,7 @@ class CheckFunctionManager:
             pass  # cannot weakref bool object
         return id(obj)
 
-    def lookup_weakrefs(self, obj: object) -> Optional[weakref.ref[object]]:
+    def lookup_weakrefs(self, obj: object) -> weakref.ref[object] | None:
         """Lookup the _weakrefs created in id_ref function for ID_MATCH'd objects"""
         if id(obj) in self._weakrefs:
             return self._weakrefs[id(obj)]
@@ -4570,9 +4568,9 @@ def format_user_stack_trace(
 def get_guard_fail_reason_helper(
     guard_manager: GuardManagerWrapper,
     f_locals: dict[str, object],
-    compile_id: Optional[CompileId],
+    compile_id: CompileId | None,
     # pyrefly: ignore [implicit-any]
-    backend: Optional[Callable],
+    backend: Callable | None,
 ) -> str:
     """
     Return the reason why `guard_manager` failed.
@@ -4706,7 +4704,7 @@ def get_guard_fail_reason(
 
 
 def get_and_maybe_log_recompilation_reasons(
-    cache_entry: Optional[CacheEntry],
+    cache_entry: CacheEntry | None,
     frame: DynamoFrameType,
     # pyrefly: ignore [implicit-any]
     backend: Callable,
@@ -4775,7 +4773,7 @@ def get_and_maybe_log_recompilation_reasons(
 
 
 def update_diff_guard_managers_for_existing_cache_entries(
-    cache_entry: Optional[CacheEntry],
+    cache_entry: CacheEntry | None,
 ) -> OrderedSet[str]:
     first_cache_entry = cache_entry
 
@@ -4837,7 +4835,7 @@ def unique(seq: Sequence[T]) -> Generator[T, None, None]:
 
 def make_dupe_guard(
     obj_source: Source, dupe_source: Source | None
-) -> Optional[functools.partial[Any]]:
+) -> functools.partial[Any] | None:
     # Note - we may end up in a situation where we invoke something like
     # def fn(x, y)
     # with fn(x, x)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1345,7 +1345,11 @@ class GuardBuilder(GuardBuilderBase):
     def get_guard_manager_type(
         self,
         source: Source,
-        example_value: KeysView[Any] | set[Any] | frozenset[Any] | dict[Any, Any] | None,
+        example_value: KeysView[Any]
+        | set[Any]
+        | frozenset[Any]
+        | dict[Any, Any]
+        | None,
     ) -> GuardManagerType:
         guard_manager_enum = GuardManagerType.GUARD_MANAGER
         if self.requires_key_order_guarding(source):

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -19,7 +19,7 @@ import heapq
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
 from typing_extensions import Self
 
 
@@ -54,7 +54,7 @@ class TopN:
 
 
 OnExitType: TypeAlias = Callable[
-    [int, int, dict[str, Any], Optional[type[BaseException]], Optional[BaseException]],
+    [int, int, dict[str, Any], type[BaseException] | None, BaseException | None],
     None,
 ]
 
@@ -87,8 +87,8 @@ class MetricsContext:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
         _traceback: Any,
     ) -> None:
         """
@@ -218,7 +218,7 @@ class RuntimeMetricsContext:
         self._start_time_ns: int = 0
 
     def increment(
-        self, metric: str, value: int, extra: Optional[dict[str, Any]] = None
+        self, metric: str, value: int, extra: dict[str, Any] | None = None
     ) -> None:
         """
         Increment a metric by a given amount.

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -698,9 +698,7 @@ class OutputGraph(OutputGraphCommon):
         self.tracing_context.traced_code.append(f_code)
         self.tracing_context.cudagraph_annotation = self.cudagraph_annotation
         self.traced_code = self.tracing_context.traced_code
-        self.dynamo_compile_id: CompileId | None = (
-            CompileContext.current_compile_id()
-        )
+        self.dynamo_compile_id: CompileId | None = CompileContext.current_compile_id()
         self.init_ambient_guards()
 
         # Map each tensor id to a list of sources. This is necessary because
@@ -3738,9 +3736,7 @@ class SubgraphTracer(fx.Tracer):
             return proxy
 
     # See NOTE: [Nested SubgraphTracer and free_variable handling] for more details
-    def lift_tracked_freevar_to_input(
-        self, proxy: fx.Proxy
-    ) -> LazyProxy | fx.Proxy:
+    def lift_tracked_freevar_to_input(self, proxy: fx.Proxy) -> LazyProxy | fx.Proxy:
         # You're doing something wrong if we are the root SubgraphTracer because
         # Dynamo adds tensors to graph inputs before creating a proxy for them.
         assert self.parent is not None, (

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -403,7 +403,7 @@ class OutputGraphGuardsState:
     input_source_to_sizes_strides: dict[Source, dict[str, Any]]
     dual_level: int
     functorch_layers: list[torch._functorch.pyfunctorch.FuncTorchInterpreter]
-    current_device: Optional[torch.device]
+    current_device: torch.device | None
     global_state_guard: torch._C._dynamo.guards.GlobalStateGuard
     _guards: torch._guards.GuardsSet
     _aotautograd_guards: list[torch._guards.GuardEnvExpr]
@@ -413,7 +413,7 @@ class OutputGraphGuardsState:
     export: bool = False
     skip_guards_check: bool = False
     export_constraints: bool = False
-    name_of_builtins_dict_key_in_fglobals: Optional[str] = None
+    name_of_builtins_dict_key_in_fglobals: str | None = None
 
     @property
     def shape_env(self) -> ShapeEnv:
@@ -480,12 +480,12 @@ class ExportMetaData:
     # 3) constants
     output_return_type: dict[int, tuple[str, Any]] = dc_field(default_factory=dict)
     # output spec of the traced function
-    out_spec: Union[torch.utils._pytree.TreeSpec, torch.utils._pytree.LeafSpec] = (
+    out_spec: torch.utils._pytree.TreeSpec | torch.utils._pytree.LeafSpec = (
         torch.utils._pytree._LEAF_SPEC
     )
     module_call_spec: dict[
         str,
-        dict[str, Union[torch.utils._pytree.TreeSpec, torch.utils._pytree.LeafSpec]],
+        dict[str, torch.utils._pytree.TreeSpec | torch.utils._pytree.LeafSpec],
     ] = dc_field(default_factory=dict)
 
 
@@ -536,10 +536,10 @@ class OutputGraphCommon(OutputGraphGuardsState):
     def __init__(
         self,
         output_graph_guards_state: OutputGraphGuardsState,
-        import_sources: Optional[dict[str, str]] = None,
-        shape_env: Optional[ShapeEnv] = None,
-        export_metadata: Optional[ExportMetaData] = None,
-        tracked_fakes_id_to_source: Optional[dict[int, list[Source]]] = None,
+        import_sources: dict[str, str] | None = None,
+        shape_env: ShapeEnv | None = None,
+        export_metadata: ExportMetaData | None = None,
+        tracked_fakes_id_to_source: dict[int, list[Source]] | None = None,
     ) -> None:
         super().__init__(
             output_graph_guards_state.local_scope,
@@ -598,7 +598,7 @@ class OutputGraph(OutputGraphCommon):
     def __init__(
         self,
         code_options: dict[str, Any],
-        compiler_fn: Optional[CompilerFn],
+        compiler_fn: CompilerFn | None,
         root_tx: "InstructionTranslatorBase",
         export: bool,
         export_constraints: Sequence[_ConstraintTarget],
@@ -698,7 +698,7 @@ class OutputGraph(OutputGraphCommon):
         self.tracing_context.traced_code.append(f_code)
         self.tracing_context.cudagraph_annotation = self.cudagraph_annotation
         self.traced_code = self.tracing_context.traced_code
-        self.dynamo_compile_id: Optional[CompileId] = (
+        self.dynamo_compile_id: CompileId | None = (
             CompileContext.current_compile_id()
         )
         self.init_ambient_guards()
@@ -712,7 +712,7 @@ class OutputGraph(OutputGraphCommon):
             collections.defaultdict(list)
         )
         # Stores the full fqn of a param or buffer to the relevant source.
-        self.param_name_to_source: Optional[dict[str, Source]] = {}
+        self.param_name_to_source: dict[str, Source] | None = {}
         self.side_effects = SideEffects(self)
         # Cached variable trackers. This makes symbolic analysis of LOAD_GLOBAL
         # and LOAD_ATTR for same python objects free.
@@ -745,11 +745,11 @@ class OutputGraph(OutputGraphCommon):
         self.register_finalizer_fns: list[Callable[[fx.GraphModule], None]] = []
 
         # Not checkpointed
-        self.compiler_fn: Optional[CompilerFn] = compiler_fn
+        self.compiler_fn: CompilerFn | None = compiler_fn
         self.root_tx = root_tx
 
         # Profiler state for tracking function trace timings
-        self.profiler_state: Optional[DynamoProfilerState] = None
+        self.profiler_state: DynamoProfilerState | None = None
 
         self.package = package
         # Given a source, what are the user stacks of all locations that
@@ -819,8 +819,8 @@ class OutputGraph(OutputGraphCommon):
 
         # Use to pass values to backward hooks when using compiled autograd
         self.backward_state: dict[str, VariableTracker] = {}
-        self.backward_state_proxy: Optional[torch.fx.Proxy] = None
-        self.backward_state_var: Optional[str] = None
+        self.backward_state_proxy: torch.fx.Proxy | None = None
+        self.backward_state_var: str | None = None
 
         # pyrefly: ignore [bad-override]
         self.name_of_builtins_dict_key_in_fglobals: str = (
@@ -835,7 +835,7 @@ class OutputGraph(OutputGraphCommon):
         # that are set for the entire duration of the compiled region.
         # This is an invariant today because we graph break on the saved_tensor_hook
         # context manager inside a compiled region
-        self.saved_tensors_hooks_subgraph_names: Optional[list[str]] = (
+        self.saved_tensors_hooks_subgraph_names: list[str] | None = (
             self.maybe_install_saved_tensors_hooks_subgraphs()
         )
 
@@ -990,7 +990,7 @@ class OutputGraph(OutputGraphCommon):
                 )
             )
 
-    def maybe_install_saved_tensors_hooks_subgraphs(self) -> Optional[list[str]]:
+    def maybe_install_saved_tensors_hooks_subgraphs(self) -> list[str] | None:
         if torch._dynamo.compiled_autograd.in_compiled_autograd_region:
             return None
 
@@ -1106,9 +1106,9 @@ class OutputGraph(OutputGraphCommon):
     @contextlib.contextmanager
     def subtracer(
         self,
-        source_target: Optional[Target],
+        source_target: Target | None,
         prior_tracer: Optional["SubgraphTracer"],
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> Generator["SubgraphTracer", None, None]:
         new_scope_ctx = enter_new_scope()
         try:
@@ -1161,7 +1161,7 @@ class OutputGraph(OutputGraphCommon):
         return self.tracing_context.guards_context.aotautograd_guards
 
     def save_global_state(
-        self, out: Optional[dict[str, tuple[Callable[..., Any], bool]]] = None
+        self, out: dict[str, tuple[Callable[..., Any], bool]] | None = None
     ) -> None:
         """
         Saves to out if it is provided. Else saves to the tracing context's global_state.
@@ -1217,9 +1217,9 @@ class OutputGraph(OutputGraphCommon):
     def has_outputs(self) -> bool:
         return len([x for x in self.graph.nodes if x.op == "output"]) > 0
 
-    def get_submodule(self, keys: str) -> Union[torch.nn.Module, Any]:
+    def get_submodule(self, keys: str) -> torch.nn.Module | Any:
         assert keys
-        obj: Union[torch.nn.Module, dict[str, torch.nn.Module]] = self.nn_modules
+        obj: torch.nn.Module | dict[str, torch.nn.Module] = self.nn_modules
         for k in keys.split("."):
             if isinstance(obj, dict):
                 obj = obj[k]
@@ -1286,7 +1286,7 @@ class OutputGraph(OutputGraphCommon):
 
     def register_attr_or_module(
         self,
-        target: Union[torch.nn.Module, torch.Tensor, Any],
+        target: torch.nn.Module | torch.Tensor | Any,
         *names: Any,
         **options: Any,
     ) -> VariableTracker:
@@ -1679,7 +1679,7 @@ class OutputGraph(OutputGraphCommon):
         # first element corresponds to current frame (N)
         all_stack_values = []
         all_stack_locals_metas = []
-        cur_tx: Optional[InstructionTranslatorBase] = tx
+        cur_tx: InstructionTranslatorBase | None = tx
         while cur_tx is not None:
             # this should have been checked by the caller
             assert all(block.can_restore() for block in cur_tx.block_stack)
@@ -2086,7 +2086,7 @@ class OutputGraph(OutputGraphCommon):
         # no need to codegen if reason.graph_break is False (since we won't resume)
         if self.compile_subgraph_reason.graph_break:
             tx_cnt = 0
-            cur_tx: Optional[InstructionTranslatorBase] = tx
+            cur_tx: InstructionTranslatorBase | None = tx
             while cur_tx is not None:
                 # NOTE: we generate cells in the same order as resume_execution.py: sorted freevars + cellvars
                 # Emitting `LOAD_FAST/LOAD_CLOSURE` with names in `co_freevars`
@@ -2199,8 +2199,8 @@ class OutputGraph(OutputGraphCommon):
         self.package.bypass_current_entry()
         self.package = None
 
-    def get_graph_sizes_structured(self) -> dict[str, list[Union[int, str]]]:
-        ret: dict[str, list[Union[int, str]]] = {}
+    def get_graph_sizes_structured(self) -> dict[str, list[int | str]]:
+        ret: dict[str, list[int | str]] = {}
         for node in self.graph.nodes:
             example_value = node.meta.get("example_value", None)
             if isinstance(example_value, torch._subclasses.FakeTensor):
@@ -2832,7 +2832,7 @@ class OutputGraph(OutputGraphCommon):
                 ):
                     self.remove_node(node)
 
-        def placeholder_binds_symbol(node: fx.Node) -> Optional[sympy.Symbol]:
+        def placeholder_binds_symbol(node: fx.Node) -> sympy.Symbol | None:
             arg = node.meta["grapharg"]
             example = arg.example
             if isinstance(example, torch.SymInt) and isinstance(
@@ -2852,7 +2852,7 @@ class OutputGraph(OutputGraphCommon):
         used_symbols: set[sympy.Symbol] = set()
 
         def update_used_symbols(
-            used_symbols: set[sympy.Symbol], fake: Union[torch.SymInt, torch.Tensor]
+            used_symbols: set[sympy.Symbol], fake: torch.SymInt | torch.Tensor
         ) -> None:
             used_symbols |= free_symbols(fake)
 
@@ -3067,15 +3067,15 @@ class OutputGraph(OutputGraphCommon):
 class DynamoTracerOutput:
     error_on_graph_break: bool
     is_tracing_resume_prologue: bool
-    output_graph: Optional[OutputGraph]
+    output_graph: OutputGraph | None
     # output_graph_for_cleanup is set even when there's an error, to allow
     # cleanup of graph nodes to break reference cycles
-    output_graph_for_cleanup: Optional[OutputGraph]
-    closure: Optional[tuple[Any, ...]]
+    output_graph_for_cleanup: OutputGraph | None
+    closure: tuple[Any, ...] | None
     f_globals: dict[str, Any]
 
     def __init__(
-        self, tracer: "InstructionTranslatorBase", error: Optional[Any] = None
+        self, tracer: "InstructionTranslatorBase", error: Any | None = None
     ) -> None:
         self.error_on_graph_break = tracer.error_on_graph_break
         self.is_tracing_resume_prologue = tracer.is_tracing_resume_prologue
@@ -3221,8 +3221,8 @@ class SubgraphTracer(fx.Tracer):
         output_graph: "OutputGraph",
         parent: Optional["SubgraphTracer"] = None,
         is_export: bool = False,
-        source_target: Optional[Target] = None,
-        description: Optional[str] = None,
+        source_target: Target | None = None,
+        description: str | None = None,
     ) -> None:
         super().__init__()
         self.output_graph = weakref.proxy(output_graph)
@@ -3262,7 +3262,7 @@ class SubgraphTracer(fx.Tracer):
         # 2. when we track_produced_symints for intermediate results
         # bound_symbols always map the symbol to the proxy whose
         # tracer is the current tracer that's readily accessible in current tracer's graph.
-        self.bound_symbols: dict[sympy.Symbol, Union[torch.fx.Proxy, LazyProxy]] = {}
+        self.bound_symbols: dict[sympy.Symbol, torch.fx.Proxy | LazyProxy] = {}
 
         # Maps _DynamicScalar object ids to allocated SymInt nodes, for symbol reuse
         self.dynamic_scalar_nodes: dict[int, torch.SymInt] = {}
@@ -3285,9 +3285,9 @@ class SubgraphTracer(fx.Tracer):
         self.debug_level: int = parent.debug_level + 1 if parent is not None else 0
 
         self._cur_code = None
-        self._orig_gm_meta: Optional[list[Any]] = None
-        self._orig_gm_lineno_map: Optional[dict[int, Optional[int]]] = None
-        self._orig_gm_firstlineno: Optional[int] = None
+        self._orig_gm_meta: list[Any] | None = None
+        self._orig_gm_lineno_map: dict[int, int | None] | None = None
+        self._orig_gm_firstlineno: int | None = None
         # Each SubgraphTracer is associated with a source target, which indicates
         # which operator this subgraph is attached to. We compute a source_fn_stack
         # based on the source target. For the root tracer, it's set to [].
@@ -3343,9 +3343,9 @@ class SubgraphTracer(fx.Tracer):
         target: Any,
         args: Any,
         kwargs: Any,
-        name: Optional[str] = None,
-        type_expr: Optional[Any] = None,
-        proxy_factory_fn: Optional[Callable[[fx.Node], fx.Proxy]] = None,
+        name: str | None = None,
+        type_expr: Any | None = None,
+        proxy_factory_fn: Callable[[fx.Node], fx.Proxy] | None = None,
     ) -> fx.Proxy:
         _t0 = time.time_ns()
         try:
@@ -3363,9 +3363,9 @@ class SubgraphTracer(fx.Tracer):
         target: Any,
         args: Any,
         kwargs: Any,
-        name: Optional[str] = None,
-        type_expr: Optional[Any] = None,
-        proxy_factory_fn: Optional[Callable[[fx.Node], fx.Proxy]] = None,
+        name: str | None = None,
+        type_expr: Any | None = None,
+        proxy_factory_fn: Callable[[fx.Node], fx.Proxy] | None = None,
     ) -> fx.Proxy:
         # NOTE: [Nested SubgraphTracer and free_variable handling]
         # --------------------------------------------------------
@@ -3571,8 +3571,8 @@ class SubgraphTracer(fx.Tracer):
         target: Target,
         args: Any = None,
         kwargs: Any = None,
-        name: Optional[str] = None,
-        type_expr: Optional[Any] = None,
+        name: str | None = None,
+        type_expr: Any | None = None,
     ) -> fx.Node:
         check_pt2_compliant_op(self.output_graph, kind, target, args, kwargs)
         if self.parent is not None:
@@ -3619,7 +3619,7 @@ class SubgraphTracer(fx.Tracer):
         type_expr: Any,
         example_value: Any,
         before: bool = False,
-        source: Optional[Source] = None,
+        source: Source | None = None,
     ) -> fx.Proxy:
         if isinstance(example_value, torch.Tensor):
             self._input_versions_at_beginning.append(example_value._version)
@@ -3740,7 +3740,7 @@ class SubgraphTracer(fx.Tracer):
     # See NOTE: [Nested SubgraphTracer and free_variable handling] for more details
     def lift_tracked_freevar_to_input(
         self, proxy: fx.Proxy
-    ) -> Union[LazyProxy, fx.Proxy]:
+    ) -> LazyProxy | fx.Proxy:
         # You're doing something wrong if we are the root SubgraphTracer because
         # Dynamo adds tensors to graph inputs before creating a proxy for them.
         assert self.parent is not None, (
@@ -3816,7 +3816,7 @@ class SubgraphTracer(fx.Tracer):
     # for symbols that're not going to be used, the LazyProxy will be turned into a proxy
     # when it's lifted as input to subgraph.
     def track_produced_symints(
-        self, example_value: Any, e_proxy: Union[LazyProxy, torch.fx.Proxy]
+        self, example_value: Any, e_proxy: LazyProxy | torch.fx.Proxy
     ) -> None:
         # When binding the symbols in an example_value, we bind the symbols
         # to the proxy's associated Tracer instead of current tracer.
@@ -3940,15 +3940,15 @@ class SubgraphTracer(fx.Tracer):
 
     # See Note [Auto lift basic free symbols when create_graph_input]
     def _lift_basic_symbols(
-        self, example_value: Union[torch.SymInt, torch.Tensor], src: Optional[Source]
+        self, example_value: torch.SymInt | torch.Tensor, src: Source | None
     ) -> None:
         # The before arg is for inserting symints in the sizes/strides of a tensor
         # before the tensor. This ordering ensures that when we look at the tensor's
         # symbols, they're already lifted/tracked. E.g. this assumption is used
         # in insert_deferred_runtime_asserts.
         def _lift_symbols_in_symint(
-            s: Union[int, torch.SymInt],
-            source: Optional[Source],
+            s: int | torch.SymInt,
+            source: Source | None,
             before: bool = False,
         ) -> None:
             if not is_symbolic(s):

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -1141,9 +1141,7 @@ class DiskDynamoCache(DiskDynamoStore):
         counters["dynamo_cache"]["dynamo_cache_miss"] += 1
         return None
 
-    def load_and_install_package(
-        self, fn: Callable[..., Any]
-    ) -> CompilePackage | None:
+    def load_and_install_package(self, fn: Callable[..., Any]) -> CompilePackage | None:
         """
         Load directly into a package and install backends
         """

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -78,10 +78,10 @@ class SerializedCode:
     co_firstlineno: int
     co_cellvars: tuple[str, ...]
     co_freevars: tuple[str, ...]
-    co_linetable: Optional[bytes] = None
-    co_qualname: Optional[str] = None
-    co_exceptiontable: Optional[bytes] = None
-    co_lnotab: Optional[str] = None
+    co_linetable: bytes | None = None
+    co_qualname: str | None = None
+    co_exceptiontable: bytes | None = None
+    co_lnotab: str | None = None
 
     @classmethod
     @_code_cache
@@ -214,7 +214,7 @@ class _DynamoCodeCacheEntry:
     guarded_codes: list[_GuardedCodeCacheEntry]
     import_sources: dict[str, str]
     backend_ids: list[_BackendId]
-    code_source: Optional[str]
+    code_source: str | None
     install_to_global: bool
     has_compile_id: bool = False
     bypassed: bool = False
@@ -278,7 +278,7 @@ def _get_code_source(code: types.CodeType) -> tuple[str, str]:
                 break
     seen = set()
 
-    def _find_code_source(obj: Any) -> Optional[str]:
+    def _find_code_source(obj: Any) -> str | None:
         nonlocal toplevel
         nonlocal seen
         if obj in seen:
@@ -348,9 +348,9 @@ class SystemInfo:
 
     python_version: str
     torch_version: str
-    toolkit_version: Optional[str]
-    triton_version: Optional[tuple[int, int]]
-    gpu_name: Optional[str]
+    toolkit_version: str | None
+    triton_version: tuple[int, int] | None
+    gpu_name: str | None
     CHECK_GPUS = ("cuda", "xpu")
 
     @classmethod
@@ -425,8 +425,8 @@ class _DynamoCacheEntry:
     source_info: SourceInfo
     device_type: str
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
-    fn_name: Optional[str] = None
-    fn_first_lineno: Optional[str] = None
+    fn_name: str | None = None
+    fn_first_lineno: str | None = None
 
     @property
     def backend_ids(self) -> set[_BackendId]:
@@ -577,14 +577,14 @@ class CompilePackage:
 
     def __init__(
         self,
-        fn: Optional[Callable[..., Any]],
-        dynamo: Optional[_DynamoCacheEntry] = None,
+        fn: Callable[..., Any] | None,
+        dynamo: _DynamoCacheEntry | None = None,
         ignore_inlined_sources: bool = False,
     ) -> None:
         self._innermost_fn = None
         self._codes: dict[types.CodeType, _DynamoCodeCacheEntry] = {}
 
-        self._current_entry: Optional[_DynamoCodeCacheEntry] = None
+        self._current_entry: _DynamoCodeCacheEntry | None = None
         self._installed_globals: dict[types.ModuleType, list[str]] = {}
         # device_type that model compiled with.
         self._device_type = "cpu"
@@ -605,7 +605,7 @@ class CompilePackage:
     def initialize(
         self,
         fn: Any,
-        dynamo: Optional[_DynamoCacheEntry] = None,
+        dynamo: _DynamoCacheEntry | None = None,
         ignore_inlined_sources: bool = False,
     ) -> None:
         from .eval_frame import innermost_fn
@@ -642,8 +642,8 @@ class CompilePackage:
         self,
         python_code: types.CodeType,
         python_module: str,
-        function_name: Optional[_FunctionId] = None,
-        code_source: Optional[str] = None,
+        function_name: _FunctionId | None = None,
+        code_source: str | None = None,
         install_to_global: bool = False,
     ) -> None:
         if python_code not in self._codes:
@@ -728,7 +728,7 @@ class CompilePackage:
                 continue
             self._source_info.add_code(code)
 
-    def update_device_type(self, graph: Optional[torch.fx.Graph]) -> None:
+    def update_device_type(self, graph: torch.fx.Graph | None) -> None:
         self._device_type = _graph_device_type(graph)
 
     def bypass_current_entry(self) -> None:
@@ -739,7 +739,7 @@ class CompilePackage:
         self,
         python_code: types.CodeType,
         python_module: str,
-        function_name: Optional[str],
+        function_name: str | None,
     ) -> None:
         self._add_function(
             python_code,
@@ -753,7 +753,7 @@ class CompilePackage:
         assert self._current_entry is not None
         self._current_entry.import_sources[alias] = module_name
 
-    def add_backend_id(self, backend_id: str, backend: Optional[Any] = None) -> None:
+    def add_backend_id(self, backend_id: str, backend: Any | None = None) -> None:
         assert self._current_entry is not None
         assert backend_id.startswith("__compiled_fn_")  # sanity check
         backend_id = _BackendId(backend_id)
@@ -1121,7 +1121,7 @@ class DiskDynamoCache(DiskDynamoStore):
         logger.info("Saving CompilePackage for %s", package.source_id)
         super().save_package(package, key)
 
-    def load(self, fn: Callable[..., Any]) -> Optional[PrecompileCacheEntry]:
+    def load(self, fn: Callable[..., Any]) -> PrecompileCacheEntry | None:
         """
         Loads a package from a given path and returns it plus a list of deserialized backends
         """
@@ -1143,7 +1143,7 @@ class DiskDynamoCache(DiskDynamoStore):
 
     def load_and_install_package(
         self, fn: Callable[..., Any]
-    ) -> Optional[CompilePackage]:
+    ) -> CompilePackage | None:
         """
         Load directly into a package and install backends
         """

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -230,10 +230,12 @@ class FrameStateSizeEntry:
     scalar: int | AutoDynamic | AutoUnset = dataclasses.field(default=auto_unset)
     # NB: We don't have cases where we have a known dimensionality but
     # we know NOTHING about the individual sizes
-    size: AutoDynamic | AutoUnset | tuple[int | AutoDynamic, ...] = (
+    size: AutoDynamic | AutoUnset | tuple[int | AutoDynamic, ...] = dataclasses.field(
+        default=auto_unset
+    )
+    stride: AutoDynamic | AutoUnset | tuple[int | AutoDynamic | InferStride, ...] = (
         dataclasses.field(default=auto_unset)
     )
-    stride: AutoDynamic | AutoUnset | tuple[int | AutoDynamic | InferStride, ...] = dataclasses.field(default=auto_unset)
 
     def render(self) -> str:
         # Special cases

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -22,7 +22,7 @@ import pickle
 import re
 import zlib
 from collections import defaultdict
-from typing import Optional, TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar
 from typing_extensions import override, Self
 
 import torch._dynamo.config
@@ -171,8 +171,8 @@ class CodeState:
     )
 
 
-_INIT_CODE_STATE: Optional[defaultdict[CodeId, CodeState]] = None
-_CODE_STATE: Optional[defaultdict[CodeId, CodeState]] = None
+_INIT_CODE_STATE: defaultdict[CodeId, CodeState] | None = None
+_CODE_STATE: defaultdict[CodeId, CodeState] | None = None
 _LOGGED_DYNAMIC_ALLOWLIST: bool = False
 _KNOWN_DYNAMIC_SOURCES: set[str] = set()
 
@@ -227,19 +227,17 @@ auto_dynamic = AutoDynamic.token
 
 @dataclasses.dataclass
 class FrameStateSizeEntry:
-    scalar: Union[int, AutoDynamic, AutoUnset] = dataclasses.field(default=auto_unset)
+    scalar: int | AutoDynamic | AutoUnset = dataclasses.field(default=auto_unset)
     # NB: We don't have cases where we have a known dimensionality but
     # we know NOTHING about the individual sizes
-    size: Union[AutoDynamic, AutoUnset, tuple[Union[int, AutoDynamic], ...]] = (
+    size: AutoDynamic | AutoUnset | tuple[int | AutoDynamic, ...] = (
         dataclasses.field(default=auto_unset)
     )
-    stride: Union[
-        AutoDynamic, AutoUnset, tuple[Union[int, AutoDynamic, InferStride], ...]
-    ] = dataclasses.field(default=auto_unset)
+    stride: AutoDynamic | AutoUnset | tuple[int | AutoDynamic | InferStride, ...] = dataclasses.field(default=auto_unset)
 
     def render(self) -> str:
         # Special cases
-        def render_single(s: Union[int, AutoDynamic, AutoUnset, InferStride]) -> str:
+        def render_single(s: int | AutoDynamic | AutoUnset | InferStride) -> str:
             if s is auto_dynamic:
                 return "?"
             elif s is auto_unset:
@@ -250,7 +248,7 @@ class FrameStateSizeEntry:
             else:
                 return str(s)
 
-        def render_tuple(ss: tuple[Union[int, AutoDynamic, InferStride], ...]) -> str:
+        def render_tuple(ss: tuple[int | AutoDynamic | InferStride, ...]) -> str:
             return "[" + ", ".join(render_single(s) for s in ss) + "]"
 
         # Common cases
@@ -309,7 +307,7 @@ class FrameStateSizeEntry:
         return self.stride[dim] is auto_dynamic
 
     @staticmethod
-    def _munge_symint(xs: tuple[int, ...]) -> tuple[Union[AutoDynamic, int], ...]:
+    def _munge_symint(xs: tuple[int, ...]) -> tuple[AutoDynamic | int, ...]:
         return tuple(auto_dynamic if isinstance(x, torch.SymInt) else x for x in xs)
 
     @classmethod
@@ -335,7 +333,7 @@ class FrameStateSizeEntry:
         )
 
     @staticmethod
-    def _merge_atom(x: _T, y: _T) -> Union[AutoDynamic, _T]:
+    def _merge_atom(x: _T, y: _T) -> AutoDynamic | _T:
         if x is auto_unset:
             return y
         if y is auto_unset:
@@ -347,9 +345,9 @@ class FrameStateSizeEntry:
     @classmethod
     def _merge_atom_tup(
         cls,
-        xs: Union[AutoDynamic, AutoUnset, tuple[_T, ...]],
-        ys: Union[AutoDynamic, AutoUnset, tuple[_T, ...]],
-    ) -> Union[AutoDynamic, AutoUnset, tuple[Union[AutoDynamic, _T], ...]]:
+        xs: AutoDynamic | AutoUnset | tuple[_T, ...],
+        ys: AutoDynamic | AutoUnset | tuple[_T, ...],
+    ) -> AutoDynamic | AutoUnset | tuple[AutoDynamic | _T, ...]:
         if xs is auto_unset:
             return ys
         if ys is auto_unset:
@@ -410,7 +408,7 @@ def update_automatic_dynamic(
                 )
 
         def log_tup(
-            tup_name: str, short_reason: str, long_reason: str, i: Optional[int] = None
+            tup_name: str, short_reason: str, long_reason: str, i: int | None = None
         ) -> None:
             entry_tup = (
                 getattr(entry, tup_name) if i is None else getattr(entry, tup_name)[i]
@@ -532,7 +530,7 @@ def format_cache_key(key: str) -> str:
     return f"{key}:{rank}:{tag}"
 
 
-def get_cache_key() -> Optional[str]:
+def get_cache_key() -> str | None:
     # TODO: info versions of these logs that log only once
     if torch.compiler.config.force_disable_caches:
         warn_once(
@@ -558,7 +556,7 @@ def get_cache_key() -> Optional[str]:
     return None
 
 
-def get_extra_cache_key(sticky_key: str) -> Optional[str]:
+def get_extra_cache_key(sticky_key: str) -> str | None:
     if torch.compiler.config.force_disable_caches:
         warn_once(
             "dynamo_pgo force disabled by torch.compiler.config.force_disable_caches"
@@ -569,7 +567,7 @@ def get_extra_cache_key(sticky_key: str) -> Optional[str]:
 
 
 # This solely controls local PGO
-def code_state_path(cache_key: str) -> Optional[str]:
+def code_state_path(cache_key: str) -> str | None:
     if not torch._dynamo.config.automatic_dynamic_local_pgo:
         log.debug("automatic_dynamic_local_pgo not enabled")
         return None
@@ -603,7 +601,7 @@ def should_use_remote_dynamo_pgo_cache() -> bool:
     )
 
 
-def get_remote_cache() -> Optional[RemoteCache[JsonDataTy]]:
+def get_remote_cache() -> RemoteCache[JsonDataTy] | None:
     from torch._inductor.remote_cache import create_cache
 
     if not should_use_remote_dynamo_pgo_cache():
@@ -738,7 +736,7 @@ def hit(key: str, ty: str) -> defaultdict[CodeId, CodeState]:
     return _CODE_STATE
 
 
-def get_local_code_state(cache_key: str) -> Optional[defaultdict[CodeId, CodeState]]:
+def get_local_code_state(cache_key: str) -> defaultdict[CodeId, CodeState] | None:
     global _CODE_STATE
     path = code_state_path(cache_key)
     if path is not None and os.path.exists(path):
@@ -768,8 +766,8 @@ def get_local_code_state(cache_key: str) -> Optional[defaultdict[CodeId, CodeSta
 def lookup_remote_cache_entry(
     remote_cache: RemoteCache[JsonDataTy],
     cache_key: str,
-    event_name: Optional[str] = None,
-) -> Optional[defaultdict[CodeId, CodeState]]:
+    event_name: str | None = None,
+) -> defaultdict[CodeId, CodeState] | None:
     code_state = None
     try:
         cache_data = remote_cache.get(cache_key)
@@ -802,7 +800,7 @@ def lookup_remote_cache_entry(
     return code_state
 
 
-def get_remote_code_state(cache_key: str) -> Optional[defaultdict[CodeId, CodeState]]:
+def get_remote_code_state(cache_key: str) -> defaultdict[CodeId, CodeState] | None:
     global _CODE_STATE
     remote_cache = get_remote_cache()
     if remote_cache is not None:
@@ -907,7 +905,7 @@ def put_code_state() -> None:
             put_remote_code_state(extra_write_key)
 
 
-def write_local_impl(cache_key: str, pickled_code: bytes) -> Optional[tuple[str, int]]:
+def write_local_impl(cache_key: str, pickled_code: bytes) -> tuple[str, int] | None:
     path = code_state_path(cache_key)
 
     if path is None:

--- a/torch/_dynamo/polyfills/itertools.py
+++ b/torch/_dynamo/polyfills/itertools.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import itertools
 import operator
 from collections.abc import Callable
-from typing import Optional, overload, TYPE_CHECKING, TypeAlias, TypeVar
+from typing import overload, TYPE_CHECKING, TypeAlias, TypeVar
 
 from ..decorators import substitute_in_graph
 
@@ -50,9 +50,9 @@ def chain(*iterables: Iterable[_T]) -> Iterator[_T]:
 @substitute_in_graph(itertools.accumulate, is_embedded_type=True)  # type: ignore[arg-type]
 def accumulate(
     iterable: Iterable[_T],
-    func: Optional[Callable[[_T, _T], _T]] = None,
+    func: Callable[[_T, _T], _T] | None = None,
     *,
-    initial: Optional[_T] = None,
+    initial: _T | None = None,
 ) -> Iterator[_T]:
     # call iter outside of the generator to match cypthon behavior
     iterator = iter(iterable)

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 import torch
 from torch._dynamo.package import (
@@ -134,7 +134,7 @@ class PrecompileContext:
         artifact.edit_contents(edit_fn)
 
     @classmethod
-    def serialize_artifact_by_key(cls, key: str) -> Optional[BackendCacheArtifact[Any]]:
+    def serialize_artifact_by_key(cls, key: str) -> BackendCacheArtifact[Any] | None:
         """
         Return the backend cache artifact with the associated key
         """

--- a/torch/_dynamo/replay_record.py
+++ b/torch/_dynamo/replay_record.py
@@ -17,7 +17,7 @@ import dataclasses
 from dataclasses import field
 from io import BufferedReader, BufferedWriter
 from types import CellType, CodeType, ModuleType
-from typing import Any, IO, Union
+from typing import Any, IO
 from typing_extensions import Self
 
 from torch.utils._import_utils import import_dill
@@ -52,12 +52,12 @@ class ExecutionRecord:
     builtins: dict[str, Any] = field(default_factory=dict)
     code_options: dict[str, Any] = field(default_factory=dict)
 
-    def dump(self, f: Union[IO[str], BufferedWriter]) -> None:
+    def dump(self, f: IO[str] | BufferedWriter) -> None:
         assert dill is not None, "replay_record requires `pip install dill`"
         dill.dump(self, f)
 
     @classmethod
-    def load(cls, f: Union[IO[bytes], BufferedReader]) -> Self:
+    def load(cls, f: IO[bytes] | BufferedReader) -> Self:
         assert dill is not None, "replay_record requires `pip install dill`"
         return dill.load(f)
 

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -33,7 +33,7 @@ import textwrap
 import uuid
 from importlib import import_module
 from tempfile import TemporaryFile
-from typing import Any, IO, Optional, TYPE_CHECKING, Union
+from typing import Any, IO, TYPE_CHECKING
 from typing_extensions import Unpack
 
 import sympy
@@ -213,7 +213,7 @@ def generate_standalone_repro(
     gm: torch.fx.GraphModule,
     args: Sequence[Any],
     *,
-    save_path: Optional[str] = None,
+    save_path: str | None = None,
 ) -> str:
     """
     Generate a self-contained repro script from an FX graph.
@@ -472,7 +472,7 @@ def generate_compiler_repro_string(
     args: Sequence[Any],
     *,
     stable_output: bool = False,
-    save_dir: Optional[str] = None,
+    save_dir: str | None = None,
     stable_hash: bool = False,
     has_distributed_ops: bool = False,
 ) -> str:
@@ -714,11 +714,11 @@ def save_graph_repro(
     compiler_name: str,
     *,
     stable_output: bool = False,
-    save_dir: Optional[str] = None,
+    save_dir: str | None = None,
     command: str = "run",
-    accuracy: Optional[Union[str, bool]] = None,
-    tracing_mode: Optional[str] = None,
-    check_str: Optional[str] = None,
+    accuracy: str | bool | None = None,
+    tracing_mode: str | None = None,
+    check_str: str | None = None,
     stable_hash: bool = False,
 ) -> None:
     if any(
@@ -785,7 +785,7 @@ def dump_compiler_graph_state(
     args: Sequence[Any],
     compiler_name: str,
     *,
-    accuracy: Optional[Union[str, bool]] = None,
+    accuracy: str | bool | None = None,
 ) -> None:
     subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
@@ -830,11 +830,11 @@ def isolate_fails(
     fx_g: torch.fx.GraphModule,
     args: Sequence[Any],
     compiler_name: str,
-    env: Optional[dict[str, Any]] = None,
-    save_dir: Optional[str] = None,
-    accuracy: Optional[Union[bool, str]] = None,
-    tracing_mode: Optional[str] = None,
-    check_str: Optional[str] = None,
+    env: dict[str, Any] | None = None,
+    save_dir: str | None = None,
+    accuracy: bool | str | None = None,
+    tracing_mode: str | None = None,
+    check_str: str | None = None,
 ) -> bool:
     if env is None:
         env = {}
@@ -895,7 +895,7 @@ def isolate_fails(
 
 
 def inductor_fails(
-    fx_g: torch.fx.GraphModule, args: Sequence[Any], check_str: Optional[str] = None
+    fx_g: torch.fx.GraphModule, args: Sequence[Any], check_str: str | None = None
 ) -> bool:
     has_cuda = False
     for arg in args:
@@ -935,7 +935,7 @@ def inductor_fails(
 def inductor_accuracy_fails(
     fx_g: torch.fx.GraphModule,
     args: Sequence[Any],
-    check_str: Optional[str] = None,
+    check_str: str | None = None,
     *,
     require_fp64: bool = False,
     ignore_non_fp: bool = False,
@@ -1105,7 +1105,7 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
         compiled(new_args)  # type: ignore[arg-type]
         assert not new_args
 
-    def compare_tuples(tuple1: tuple[Any], tuple2: tuple[Any]) -> Optional[str]:
+    def compare_tuples(tuple1: tuple[Any], tuple2: tuple[Any]) -> str | None:
         diff_indices = [i for i in range(len(tuple1)) if tuple1[i] != tuple2[i]]
         diff_values = [(tuple1[i], tuple2[i]) for i in diff_indices]
 
@@ -1254,11 +1254,11 @@ def run_repro(
     load_args: Any,
     *,
     command: str = "run",
-    accuracy: Union[bool, str] = "",
-    save_dir: Optional[str] = None,
-    tracing_mode: Optional[str] = None,
-    patch_code: Optional[str] = None,
-    check_str: Optional[str] = None,
+    accuracy: bool | str = "",
+    save_dir: str | None = None,
+    tracing_mode: str | None = None,
+    patch_code: str | None = None,
+    check_str: str | None = None,
     **kwargs: Any,
 ) -> Any:
     for k in kwargs:

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -26,7 +26,7 @@ import sys
 import textwrap
 from collections.abc import Callable, Sequence
 from importlib import import_module
-from typing import Any, Optional, Union
+from typing import Any
 
 import torch
 import torch.fx as fx
@@ -82,7 +82,7 @@ def _accuracy_fails(
 
 class WrapBackendDebug:
     def __init__(
-        self, unconfigured_compiler_fn: CompilerFn, compiler_name: Optional[str]
+        self, unconfigured_compiler_fn: CompilerFn, compiler_name: str | None
     ) -> None:
         functools.wraps(unconfigured_compiler_fn)(self)
         self._torchdynamo_orig_backend = unconfigured_compiler_fn
@@ -159,7 +159,7 @@ class WrapBackendDebug:
 
 
 def wrap_backend_debug(
-    unconfigured_compiler_fn: CompilerFn, compiler_name: Optional[str]
+    unconfigured_compiler_fn: CompilerFn, compiler_name: str | None
 ) -> WrapBackendDebug:
     """
     A minifier decorator that wraps the TorchDynamo produced Fx graph modules.
@@ -180,11 +180,11 @@ def wrap_backend_debug(
 def generate_dynamo_fx_repro_string(
     gm: torch.fx.GraphModule,
     args: Sequence[Any],
-    compiler_name: Optional[str],
+    compiler_name: str | None,
     check_accuracy: bool = False,
     *,
     stable_output: bool = False,
-    save_dir: Optional[str] = None,
+    save_dir: str | None = None,
     command: str = "run",
 ) -> str:
     """
@@ -236,7 +236,7 @@ if __name__ == '__main__':
 def dump_backend_repro_as_file(
     gm: torch.fx.GraphModule,
     args: Sequence[Any],
-    compiler_name: Optional[str],
+    compiler_name: str | None,
     check_accuracy: bool = False,
 ) -> None:
     """
@@ -269,7 +269,7 @@ def dump_backend_repro_as_file(
 def dump_backend_state(
     gm: torch.fx.GraphModule,
     args: Sequence[Any],
-    compiler_name: Optional[str],
+    compiler_name: str | None,
     check_accuracy: bool = False,
 ) -> None:
     """
@@ -290,7 +290,7 @@ def dump_backend_state(
 
 
 def dump_to_minify_after_dynamo(
-    gm: torch.fx.GraphModule, args: Sequence[Any], compiler_name: Optional[str]
+    gm: torch.fx.GraphModule, args: Sequence[Any], compiler_name: str | None
 ) -> None:
     # TODO: factor this out
     subdir = os.path.join(minifier_dir(), "checkpoints")
@@ -315,7 +315,7 @@ def dump_to_minify_after_dynamo(
 
 @register_debug_backend  # type: ignore[arg-type]
 def dynamo_minifier_backend(
-    gm: fx.GraphModule, example_inputs: Sequence[Any], compiler_name: Optional[str]
+    gm: fx.GraphModule, example_inputs: Sequence[Any], compiler_name: str | None
 ) -> fx.GraphModule:
     from functorch.compile import minifier
 
@@ -357,7 +357,7 @@ def dynamo_minifier_backend(
 
 @register_debug_backend  # type: ignore[arg-type]
 def dynamo_accuracy_minifier_backend(
-    gm: fx.GraphModule, example_inputs: Sequence[Any], compiler_name: Optional[str]
+    gm: fx.GraphModule, example_inputs: Sequence[Any], compiler_name: str | None
 ) -> fx.GraphModule:
     from functorch.compile import minifier
 
@@ -516,8 +516,8 @@ def run_repro(
     load_args: Any,
     *,
     command: str = "run",
-    accuracy: Union[bool, str] = "",
-    save_dir: Optional[str] = None,
+    accuracy: bool | str = "",
+    save_dir: str | None = None,
     autocast: bool = False,
     backend: str = "inductor",
     **kwargs: Any,

--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -26,7 +26,7 @@ import sys
 import textwrap
 from collections.abc import Sequence
 from importlib import import_module
-from typing import Any, IO, Optional, Union
+from typing import Any, IO
 
 import torch
 from torch._dynamo.debug_utils import (
@@ -53,7 +53,7 @@ use_buck = inductor_config.is_fbcode()
 
 
 class AOTIMinifierError(Exception):
-    def __init__(self, original_exception: Union[str, Exception]) -> None:
+    def __init__(self, original_exception: str | Exception) -> None:
         additional_message = "This error is caused by a bug in the AOTI minifier, please report a bug to PyTorch"
         full_message = f"{additional_message}: {str(original_exception)}"
         super().__init__(full_message)
@@ -64,7 +64,7 @@ def dump_to_minify(
     exported_program: ExportedProgram,
     compiler_name: str,
     command: str = "minify",
-    options: Optional[dict[str, Any]] = None,
+    options: dict[str, Any] | None = None,
 ) -> None:
     """
     If command is "minify":
@@ -134,15 +134,15 @@ def save_graph_repro_ep(
     fd: IO[Any],
     compiler_name: str,
     *,
-    exported_program: Optional[ExportedProgram] = None,
-    gm: Optional[torch.nn.Module] = None,
-    args: Optional[tuple[Any]] = None,
-    config_patches: Optional[dict[str, str]] = None,
+    exported_program: ExportedProgram | None = None,
+    gm: torch.nn.Module | None = None,
+    args: tuple[Any] | None = None,
+    config_patches: dict[str, str] | None = None,
     stable_output: bool = False,
-    save_dir: Optional[str] = None,
+    save_dir: str | None = None,
     command: str = "run",
-    accuracy: Optional[Union[str, bool]] = None,
-    check_str: Optional[str] = None,
+    accuracy: str | bool | None = None,
+    check_str: str | None = None,
     module_in_comment: bool = False,
     strict: bool = False,
 ) -> None:
@@ -193,8 +193,8 @@ def dump_compiler_graph_state(
     args: Sequence[Any],
     compiler_name: str,
     *,
-    config_patches: Optional[dict[str, str]] = None,
-    accuracy: Optional[Union[str, bool]] = None,
+    config_patches: dict[str, str] | None = None,
+    accuracy: str | bool | None = None,
     strict: bool = False,
 ) -> None:
     subdir = os.path.join(minifier_dir(), "checkpoints")
@@ -235,9 +235,9 @@ def dump_compiler_graph_state(
 def generate_compiler_repro_exported_program(
     exported_program: ExportedProgram,
     *,
-    options: Optional[dict[str, str]] = None,
+    options: dict[str, str] | None = None,
     stable_output: bool = False,
-    save_dir: Optional[str] = None,
+    save_dir: str | None = None,
 ) -> str:
     model_str = textwrap.dedent(
         f"""
@@ -272,7 +272,7 @@ isolate_fails_code_str = None
     return model_str
 
 
-def repro_load_args(load_args: Any, save_dir: Optional[str]) -> tuple[Any]:
+def repro_load_args(load_args: Any, save_dir: str | None) -> tuple[Any]:
     if not hasattr(load_args, "_version"):
         log.warning(
             "load_args does not have a _version attribute, please file a bug to PyTorch "
@@ -311,7 +311,7 @@ def repro_common(
 def repro_get_args(
     options: Any,
     exported_program: ExportedProgram,
-    config_patches: Optional[dict[str, Any]],
+    config_patches: dict[str, Any] | None,
 ) -> tuple[torch.fx.GraphModule, Any, Any]:
     mod, args, kwargs = repro_common(options, exported_program)
     return mod, args, kwargs
@@ -320,7 +320,7 @@ def repro_get_args(
 def repro_run(
     options: Any,
     exported_program: ExportedProgram,
-    config_patches: Optional[dict[str, Any]],
+    config_patches: dict[str, Any] | None,
 ) -> None:
     from torch._inductor import _aoti_compile_and_package_inner
 
@@ -353,7 +353,7 @@ def export_for_aoti_minifier(
     tuple_inputs: tuple[Any],
     strict: bool = False,
     skip_export_error: bool = True,
-) -> Optional[torch.nn.Module]:
+) -> torch.nn.Module | None:
     # Some graphs cannot be used for AOTI/export (illegal graphs), these should be
     # considered as graphs that don't fail in the minifier, so the minifier keeps searching.
     # In these case, we return None. Otherwise, we return the exported graph module.
@@ -391,7 +391,7 @@ def export_for_aoti_minifier(
 def repro_minify(
     options: Any,
     exported_program: ExportedProgram,
-    config_patches: Optional[dict[str, Any]],
+    config_patches: dict[str, Any] | None,
 ) -> None:
     from functorch.compile import minifier
     from torch._inductor import _aoti_compile_and_package_inner
@@ -420,7 +420,7 @@ def repro_minify(
     def module_fails(
         gm: torch.fx.GraphModule,
         flat_example_inputs: list[Any],
-        check_str: Optional[str] = None,
+        check_str: str | None = None,
     ) -> bool:
         # Need to export first so the in_spec and out_spec are populated
         tuple_inputs = tuple(flat_example_inputs)
@@ -474,12 +474,12 @@ def repro_minify(
 def run_repro(
     exported_program: ExportedProgram,
     *,
-    config_patches: Optional[dict[str, str]] = None,
+    config_patches: dict[str, str] | None = None,
     command: str = "run",
-    accuracy: Union[bool, str] = "",
-    save_dir: Optional[str] = None,
-    tracing_mode: Optional[str] = None,
-    check_str: Optional[str] = None,
+    accuracy: bool | str = "",
+    save_dir: str | None = None,
+    tracing_mode: str | None = None,
+    check_str: str | None = None,
     minifier_export_mode: str = "python",
     skip_export_error: bool = True,
     **more_kwargs: Any,

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -19,7 +19,7 @@ import sys
 import types
 from collections.abc import Callable, Iterable
 from contextlib import AbstractContextManager
-from typing import Any, cast, Optional
+from typing import Any, cast
 
 from .bytecode_transformation import (
     add_push_null,
@@ -67,7 +67,7 @@ def _initial_push_null(insts: list[Instruction]) -> None:
 def _bytecode_from_template_with_split(
     template: Callable[..., Any],
     stack_index: int,
-    varname_map: Optional[dict[str, Any]] = None,
+    varname_map: dict[str, Any] | None = None,
 ) -> tuple[list[Instruction], list[Instruction]]:
     template_code = bytecode_from_template(template, varname_map=varname_map)
     template_code.append(create_instruction("POP_TOP"))
@@ -116,7 +116,7 @@ def _try_except_tf_mode_template(dummy: Any, stack_var_name: Any) -> None:
 @dataclasses.dataclass(frozen=True)
 class ReenterWith:
     stack_index: int
-    target_values: Optional[tuple[Any, ...]] = None
+    target_values: tuple[Any, ...] | None = None
 
     def try_except_torch_function_mode(
         self, code_options: dict[str, Any], cleanup: list[Instruction]
@@ -191,7 +191,7 @@ class ReenterWith:
 
     def __call__(
         self, code_options: dict[str, Any], cleanup: list[Instruction]
-    ) -> tuple[list[Instruction], Optional[Instruction]]:
+    ) -> tuple[list[Instruction], Instruction | None]:
         """
         Codegen based off of:
         with ctx(args):

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -30,7 +30,7 @@ import warnings
 import weakref
 from collections.abc import Generator, MutableMapping
 from types import CellType
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn
@@ -115,27 +115,13 @@ class SideEffects:
     def __init__(
         self,
         output_graph: "OutputGraph",
-        id_to_variable: Optional[dict[int, VariableTracker]] = None,
-        store_attr_mutations: Optional[
-            dict[VariableTracker, dict[str, VariableTracker]]
-        ] = None,
+        id_to_variable: dict[int, VariableTracker] | None = None,
+        store_attr_mutations: dict[VariableTracker, dict[str, VariableTracker]] | None = None,
         mutation_user_stacks: dict[VariableTracker, list[traceback.StackSummary]]
         | None = None,
-        keepalive: Optional[list[Any]] = None,
-        save_for_backward: Optional[
-            list[tuple[AutogradFunctionContextVariable, list[VariableTracker]]]
-        ] = None,
-        tensor_hooks: Optional[
-            dict[
-                int,
-                tuple[
-                    "variables.TensorVariable",
-                    VariableTracker,
-                    "variables.RemovableHandleVariable",
-                    str,
-                ],
-            ]
-        ] = None,
+        keepalive: list[Any] | None = None,
+        save_for_backward: list[tuple[AutogradFunctionContextVariable, list[VariableTracker]]] | None = None,
+        tensor_hooks: dict[int, tuple["variables.TensorVariable", VariableTracker, "variables.RemovableHandleVariable", str]] | None = None,
     ) -> None:
         super().__init__()
         self.output_graph_weakref = weakref.ref(output_graph)
@@ -150,7 +136,7 @@ class SideEffects:
         self._has_existing_dict_mutation = False
         # Track Compiled Autograd final callbacks that must be called at the end of Compiled Autograd backward graph.
         # Only applicable if this graph is created from Dynamo tracing in Compiled Autograd.
-        self.ca_final_callbacks_var: Optional[ListVariable] = None
+        self.ca_final_callbacks_var: ListVariable | None = None
 
         # Tracks VariableTracker objects whose mutations can be skipped.
         # For normal mutated variables, Dynamo generates code to replay/reconstruct
@@ -191,7 +177,7 @@ class SideEffects:
             and self.tensor_hooks == other.tensor_hooks
         )
 
-    def diff(self, other: "SideEffects") -> Optional[str]:
+    def diff(self, other: "SideEffects") -> str | None:
         if self.id_to_variable != other.id_to_variable:
             sk_itv = self.id_to_variable.keys()
             ok_itv = other.id_to_variable.keys()
@@ -578,7 +564,7 @@ class SideEffects:
         return variable
 
     def track_cell_existing(
-        self, source: Optional[Source], cell: CellType, contents: VariableTracker
+        self, source: Source | None, cell: CellType, contents: VariableTracker
     ) -> VariableTracker:
         variable = variables.CellVariable(
             # We don't support mutation to cell without source because we need
@@ -657,7 +643,7 @@ class SideEffects:
         # Recursively visit Variables and see if any of them have been mutated.
         init_live_vars = []
         # gather stack/symbolic_locals for all tx's up the chain
-        cur_tx: Optional[InstructionTranslatorBase] = tx
+        cur_tx: InstructionTranslatorBase | None = tx
         while cur_tx is not None:
             init_live_vars.extend([cur_tx.stack, cur_tx.symbolic_locals])
             if cur_tx.parent is not None:

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -116,12 +116,25 @@ class SideEffects:
         self,
         output_graph: "OutputGraph",
         id_to_variable: dict[int, VariableTracker] | None = None,
-        store_attr_mutations: dict[VariableTracker, dict[str, VariableTracker]] | None = None,
+        store_attr_mutations: dict[VariableTracker, dict[str, VariableTracker]]
+        | None = None,
         mutation_user_stacks: dict[VariableTracker, list[traceback.StackSummary]]
         | None = None,
         keepalive: list[Any] | None = None,
-        save_for_backward: list[tuple[AutogradFunctionContextVariable, list[VariableTracker]]] | None = None,
-        tensor_hooks: dict[int, tuple["variables.TensorVariable", VariableTracker, "variables.RemovableHandleVariable", str]] | None = None,
+        save_for_backward: list[
+            tuple[AutogradFunctionContextVariable, list[VariableTracker]]
+        ]
+        | None = None,
+        tensor_hooks: dict[
+            int,
+            tuple[
+                "variables.TensorVariable",
+                VariableTracker,
+                "variables.RemovableHandleVariable",
+                str,
+            ],
+        ]
+        | None = None,
     ) -> None:
         super().__init__()
         self.output_graph_weakref = weakref.ref(output_graph)

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -21,7 +21,7 @@ import dataclasses
 import enum
 import functools
 from collections.abc import Callable
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 from torch import device as device_type
 from torch._guards import (
@@ -118,7 +118,7 @@ def is_constant_source(source: Source) -> bool:
     return False
 
 
-def _get_source_debug_name(source: Optional[Source]) -> str:
+def _get_source_debug_name(source: Source | None) -> str:
     if source is None:
         return "<unknown source>"
     else:
@@ -152,7 +152,7 @@ class LocalSource(Source):
 
     # Whether we know this input is dynamic (based on example_inputs)
     # For non tensors, we simply look at the first index of the tuple
-    dynamism: Optional[frozenset[str]] = None
+    dynamism: frozenset[str] | None = None
 
     # Whether the item at this source is the _content_ of a cell that is
     # dereferenced from the root frame, i.e., it's a part of the `co_cellvars`
@@ -456,7 +456,7 @@ class UnspecializedParamBufferSource(AttrSource):
 # present within the final view shape metadata.
 @dataclass_with_cached_hash(frozen=True)
 class EphemeralSource(Source):
-    desc: Optional[str] = None
+    desc: str | None = None
 
     @property
     def guard_source(self) -> GuardSource:
@@ -503,7 +503,7 @@ class TensorProperty(enum.Enum):
 @dataclass_with_cached_hash(frozen=True)
 class TensorPropertySource(ChainedSource):
     prop: TensorProperty
-    idx: Optional[int] = None  # None for STORAGE_OFFSET
+    idx: int | None = None  # None for STORAGE_OFFSET
 
     def __post_init__(self) -> None:
         assert self.base is not None
@@ -639,7 +639,7 @@ class AttrProxySource(ChainedSource):
 
 @dataclass_with_cached_hash(frozen=True)
 class DefaultsSource(ChainedSource):
-    idx_key: Union[int, str]
+    idx_key: int | str
     is_kw: bool = False
     field: str = dataclasses.field(init=False, repr=False, compare=False)
     _name: str = dataclasses.field(init=False, repr=False, compare=False)
@@ -1155,7 +1155,7 @@ class BackwardStateSource(Source):
 @functools.lru_cache
 def get_local_source_name(
     source: Source, *, only_allow_input: bool = False
-) -> Optional[str]:
+) -> str | None:
     if isinstance(source, ChainedSource):
         return get_local_source_name(source.base, only_allow_input=only_allow_input)
     if not isinstance(source, LocalSource):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -49,11 +49,9 @@ from typing import (
     Any,
     cast,
     NoReturn,
-    Optional,
     TYPE_CHECKING,
     TypeAlias,
     TypeVar,
-    Union,
 )
 from typing_extensions import TypeIs
 
@@ -229,11 +227,7 @@ compare_op_handlers["not in"] = lambda tx, args, _: handle_not(
     tx, [handle_contains(tx, [*reversed(args)], {})], {}
 )
 
-ExceptionVals: TypeAlias = Union[
-    variables.ExceptionVariable,
-    UserDefinedExceptionClassVariable,
-    UserDefinedExceptionObjectVariable,
-]
+ExceptionVals: TypeAlias = variables.ExceptionVariable | UserDefinedExceptionClassVariable | UserDefinedExceptionObjectVariable
 
 
 @functools.cache
@@ -254,8 +248,8 @@ class SpeculationEntry:
     inst: Instruction  # for debugging only
     _failed: bool = False
     # TX error_on_graph_break setting at the time of failure
-    error_on_graph_break: Optional[bool] = None
-    reason: Optional[GraphCompileReason] = None
+    error_on_graph_break: bool | None = None
+    reason: GraphCompileReason | None = None
 
     def fail_and_restart_analysis(self, error_on_graph_break: bool) -> None:
         """
@@ -365,7 +359,7 @@ class LocalState:
 class DistributedState:
     compile_pg: Any
     local_state: LocalState
-    all_states: Optional[list[LocalState]] = None
+    all_states: list[LocalState] | None = None
 
 
 class TensorifyState:
@@ -434,9 +428,7 @@ class BlockStackEntry:
     inst: Instruction
     target: Instruction | None
     stack_index: int
-    with_context: Optional[
-        Union[ContextWrappingVariable, GenericContextWrappingVariable]
-    ] = None
+    with_context: ContextWrappingVariable | GenericContextWrappingVariable | None = None
 
     def can_restore(self) -> bool:
         return self.with_context is not None
@@ -561,7 +553,7 @@ def _get_comprehension_result_patterns() -> dict[str, dict[str, Any]]:
     def fn_consumed() -> int:
         return sum([i for i in range(1)])  # noqa: C416
 
-    def extract_pattern(fn: Callable[..., Any]) -> tuple[list[str], Optional[str]]:
+    def extract_pattern(fn: Callable[..., Any]) -> tuple[list[str], str | None]:
         """Extract (pre_store_ops, post_store_op) from comprehension bytecode."""
         target_line = list(dis.findlinestarts(fn.__code__))[1][1]
         insts: list[str] = []
@@ -614,7 +606,7 @@ class ComprehensionAnalysis:
     """
 
     end_ip: int
-    result_var: Optional[str]
+    result_var: str | None
     result_on_stack: bool
     iterator_vars: list[str]
     walrus_vars: list[str]
@@ -964,7 +956,7 @@ def _reconstruct_block_stack(
     in the compiled bytecode."""
     # Reconstruct the context variable CLASS in the block stack
     all_txes: list[InstructionTranslatorBase] = []
-    cur_tx: Optional[InstructionTranslatorBase] = tx
+    cur_tx: InstructionTranslatorBase | None = tx
     while cur_tx is not None:
         all_txes.append(cur_tx)
         cur_tx = cur_tx.parent
@@ -1161,7 +1153,7 @@ class ExceptionStack:
     #  + POP_EXCEPT := pops TOS from the *exception stack*
 
     _exc_stack: list[ExceptionVals] = dataclasses.field(default_factory=list)
-    _current_exception: Optional[ExceptionVals] = dataclasses.field(default=None)
+    _current_exception: ExceptionVals | None = dataclasses.field(default=None)
 
     def clear_current_exception(self) -> None:
         self._current_exception = None
@@ -1250,32 +1242,32 @@ class InstructionTranslatorBase(
     symbolic_globals: dict[str, VariableTracker]
     symbolic_torch_function_state: SymbolicTorchFunctionState
     symbolic_stream_state: SymbolicStreamState
-    post_prune_cell_and_freevars: Optional[dict[str, VariableTracker]]
+    post_prune_cell_and_freevars: dict[str, VariableTracker] | None
     stack: list[VariableTracker]
-    instruction_pointer: Optional[int]
+    instruction_pointer: int | None
     current_instruction: Instruction
     current_instruction_push: bool
     block_stack: list[BlockStackEntry]
     lineno: int
-    kw_names: Optional[ConstantVariable]
+    kw_names: ConstantVariable | None
     accept_prefix_inst: bool
     prefix_insts: list[Instruction]
     inline_depth: int
     inconsistent_side_effects: bool
-    current_speculation: Optional[SpeculationEntry]
+    current_speculation: SpeculationEntry | None
     dispatch_table: list[Any]
     exn_vt_stack: ExceptionStack
-    exec_recorder: Optional[ExecutionRecorder]
-    strict_checks_fn: Optional[Callable[[VariableTracker], bool]]
-    start_point: Optional[int]
+    exec_recorder: ExecutionRecorder | None
+    strict_checks_fn: Callable[[VariableTracker], bool] | None
+    start_point: int | None
     # Does this function make no inlined function calls?
     has_no_inlined_calls: bool
-    parent: Optional[InstructionTranslatorBase]
+    parent: InstructionTranslatorBase | None
     # Does this tx currently have a child tx tracing?
     # Used to correctly implement should_compile_partial_graph
     is_child_tracer_active: bool
     debug_locals: list[tuple[VariableTracker, list[VariableTracker]]]
-    package: Optional[CompilePackage]
+    package: CompilePackage | None
     latest_bytecode_queue: deque[str]
     # Store the latest bytecode before graph_break() call by user
 
@@ -1308,7 +1300,7 @@ class InstructionTranslatorBase(
         # negatives so that Dynamo does not skip the whole frame.
 
         # If any parent tx has a backedge, then return True
-        cur_tx: Optional[InstructionTranslatorBase] = self
+        cur_tx: InstructionTranslatorBase | None = self
         while cur_tx is not None:
             cur_offset = cur_tx.current_instruction.offset
             assert cur_tx.instruction_pointer is not None
@@ -1395,7 +1387,7 @@ class InstructionTranslatorBase(
         else:
             return InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
 
-    def get_line_of_code_header(self, lineno: Optional[int] = None) -> str:
+    def get_line_of_code_header(self, lineno: int | None = None) -> str:
         if lineno is None:
             lineno = self.lineno
         inline_depth_str = (
@@ -1867,7 +1859,7 @@ class InstructionTranslatorBase(
                     # twice is not an issue (second stop is a no op).
                     self.output.mark_bytecode_tracing_stop()
 
-    def push(self, val: Optional[VariableTracker]) -> None:
+    def push(self, val: VariableTracker | None) -> None:
         assert val is None or isinstance(val, VariableTracker), (
             f"push expects VariableTracker, got {typestr(val)}"
         )
@@ -3158,7 +3150,7 @@ class InstructionTranslatorBase(
         txes: list[InstructionTranslatorBase] = []
         idxes: list[int] = []
         resume_insts: list[Instruction] = []
-        cur_tx: Optional[InstructionTranslatorBase] = self
+        cur_tx: InstructionTranslatorBase | None = self
         idx = 0
         while cur_tx is not None:
             if cur_tx is self:
@@ -4129,7 +4121,7 @@ class InstructionTranslatorBase(
 
     def enter_ctx(
         self,
-        ctx: Union[ContextWrappingVariable, GenericContextWrappingVariable],
+        ctx: ContextWrappingVariable | GenericContextWrappingVariable,
         inst: Instruction,
     ) -> VariableTracker:
         if (
@@ -4444,7 +4436,7 @@ class InstructionTranslatorBase(
         return False
 
     def format_frame_summary(
-        self, additional_stack_frames: Optional[list[Any]] = None
+        self, additional_stack_frames: list[Any] | None = None
     ) -> str:
         if additional_stack_frames is None:
             additional_stack_frames = []
@@ -4475,7 +4467,7 @@ class InstructionTranslatorBase(
         return global_name
 
     @property
-    def fake_mode(self) -> Optional[FakeTensorMode]:
+    def fake_mode(self) -> FakeTensorMode | None:
         return self.output.tracing_context.fake_mode
 
     @contextlib.contextmanager
@@ -4633,7 +4625,7 @@ class InstructionTranslatorBase(
                 post_store_op == pat["post_store_op"] or not pat["post_store_op"]
             )
 
-        result_var: Optional[str] = None
+        result_var: str | None = None
         if matches("stored"):
             result_var = self.instructions[store_fast_ip].argval
             result_on_stack = False
@@ -5043,7 +5035,7 @@ class InstructionTranslatorBase(
         return copied_insts
 
     def _make_frame_loc(
-        self, filename: str, lineno: Optional[int], fallback_lineno: int
+        self, filename: str, lineno: int | None, fallback_lineno: int
     ) -> tuple[str, int]:
         if lineno is None or lineno < 0:
             return (filename, fallback_lineno)
@@ -5055,7 +5047,7 @@ class InstructionTranslatorBase(
         frame_loc_chain_list: list[tuple[str, int]] = []
 
         if config.nested_graph_breaks:
-            current_tx: Optional[InstructionTranslatorBase] = self.parent
+            current_tx: InstructionTranslatorBase | None = self.parent
             while current_tx is not None:
                 parent_frame_loc = self._make_frame_loc(
                     current_tx.f_code.co_filename,
@@ -5208,12 +5200,12 @@ class InstructionTranslatorBase(
         inline_depth: int,
         speculation_log: SpeculationLog,
         exn_vt_stack: ExceptionStack,
-        distributed_state: Optional[DistributedState],
+        distributed_state: DistributedState | None,
         # This determines whether to use the execution recorder.
-        closure: Optional[tuple[types.CellType]] = None,
-        package: Optional[CompilePackage] = None,
+        closure: tuple[types.CellType] | None = None,
+        package: CompilePackage | None = None,
         # Pre-computed indexof for cache reuse
-        indexof: Optional[dict[Instruction, int]] = None,
+        indexof: dict[Instruction, int] | None = None,
     ) -> None:
         super().__init__()
         self.speculation_log = speculation_log
@@ -5310,13 +5302,13 @@ class InstructionTranslatorBase(
         self.inline_depth = inline_depth
         self.inconsistent_side_effects = False
         self._constants_cache: list[
-            Optional[Union[ConstantVariable, SliceVariable]]
+            ConstantVariable | SliceVariable | None
         ] = [None] * len(f_code.co_consts)
 
-        self.is_trace_bytecode_log_enabled: Optional[bool] = (
+        self.is_trace_bytecode_log_enabled: bool | None = (
             trace_bytecode_log.isEnabledFor(logging.DEBUG)
         )
-        self.is_trace_source_log_enabled: Optional[bool] = (
+        self.is_trace_source_log_enabled: bool | None = (
             trace_source_log.isEnabledFor(logging.DEBUG)
         )
         linecache.lazycache(f_code.co_filename, f_globals)
@@ -5343,7 +5335,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         f_locals: dict[str, Any],
         f_globals: dict[str, Any],
         f_builtins: dict[str, Any],
-        closure: Optional[tuple[Any, ...]],
+        closure: tuple[Any, ...] | None,
         torch_function_mode_stack: Any,
         code_options: dict[str, Any],
         compiler_fn: Any,
@@ -5353,8 +5345,8 @@ class InstructionTranslator(InstructionTranslatorBase):
         frame_state: Any,
         speculation_log: SpeculationLog,
         exn_vt_stack: ExceptionStack,
-        distributed_state: Optional[DistributedState],
-        package: Optional[CompilePackage],
+        distributed_state: DistributedState | None,
+        package: CompilePackage | None,
     ) -> None:
         _step_logger()(
             logging.INFO,
@@ -5687,7 +5679,7 @@ def profile_inline_call(
 class InliningInstructionTranslator(InstructionTranslatorBase):
     """Trace and inline a called method"""
 
-    symbolic_result: Optional[VariableTracker]
+    symbolic_result: VariableTracker | None
     # pyrefly: ignore [bad-override]
     parent: InstructionTranslatorBase
 
@@ -6047,7 +6039,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.one_graph = parent.one_graph
 
     @property
-    def fake_mode(self) -> Optional[FakeTensorMode]:
+    def fake_mode(self) -> FakeTensorMode | None:
         return self.parent.fake_mode
 
     def run_ctx_mgr(self) -> Any:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -45,14 +45,7 @@ import traceback
 import types
 import weakref
 from collections import deque
-from typing import (
-    Any,
-    cast,
-    NoReturn,
-    TYPE_CHECKING,
-    TypeAlias,
-    TypeVar,
-)
+from typing import Any, cast, NoReturn, TYPE_CHECKING, TypeAlias, TypeVar
 from typing_extensions import TypeIs
 
 import torch
@@ -227,7 +220,11 @@ compare_op_handlers["not in"] = lambda tx, args, _: handle_not(
     tx, [handle_contains(tx, [*reversed(args)], {})], {}
 )
 
-ExceptionVals: TypeAlias = variables.ExceptionVariable | UserDefinedExceptionClassVariable | UserDefinedExceptionObjectVariable
+ExceptionVals: TypeAlias = (
+    variables.ExceptionVariable
+    | UserDefinedExceptionClassVariable
+    | UserDefinedExceptionObjectVariable
+)
 
 
 @functools.cache
@@ -5301,15 +5298,15 @@ class InstructionTranslatorBase(
 
         self.inline_depth = inline_depth
         self.inconsistent_side_effects = False
-        self._constants_cache: list[
-            ConstantVariable | SliceVariable | None
-        ] = [None] * len(f_code.co_consts)
+        self._constants_cache: list[ConstantVariable | SliceVariable | None] = [
+            None
+        ] * len(f_code.co_consts)
 
         self.is_trace_bytecode_log_enabled: bool | None = (
             trace_bytecode_log.isEnabledFor(logging.DEBUG)
         )
-        self.is_trace_source_log_enabled: bool | None = (
-            trace_source_log.isEnabledFor(logging.DEBUG)
+        self.is_trace_source_log_enabled: bool | None = trace_source_log.isEnabledFor(
+            logging.DEBUG
         )
         linecache.lazycache(f_code.co_filename, f_globals)
 

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -17,7 +17,7 @@ import re
 import sys
 import unittest
 from collections.abc import Callable
-from typing import Any, Union
+from typing import Any
 
 import torch
 import torch.testing
@@ -36,7 +36,7 @@ from . import config, reset, utils
 log = logging.getLogger(__name__)
 
 
-def run_tests(needs: Union[str, tuple[str, ...]] = ()) -> None:
+def run_tests(needs: str | tuple[str, ...] = ()) -> None:
     from torch.testing._internal.common_utils import run_tests
 
     if TEST_WITH_TORCHDYNAMO or TEST_WITH_CROSSREF:
@@ -184,7 +184,7 @@ class CPythonTestCase(TestCase):
     def compile_fn(
         self,
         fn: Callable[..., Any],
-        backend: Union[str, Callable[..., Any]],
+        backend: str | Callable[..., Any],
         nopython: bool,
     ) -> Callable[..., Any]:
         # We want to compile only the test function, excluding any setup code

--- a/torch/_dynamo/test_minifier_common.py
+++ b/torch/_dynamo/test_minifier_common.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 import traceback
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any
 from unittest.mock import patch
 
 import torch
@@ -47,7 +47,7 @@ class MinifierTestResult:
         r = re.sub(r"\n{3,}", "\n\n", r)
         return r.strip()
 
-    def get_exported_program_path(self) -> Optional[str]:
+    def get_exported_program_path(self) -> str | None:
         # Extract the exported program file path from AOTI minifier's repro.py
         # Regular expression pattern to match the file path
         pattern = r'torch\.export\.load\(\s*["\'](.*?)["\']\s*\)'
@@ -109,7 +109,7 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
 """
 
     def _maybe_subprocess_run(
-        self, args: Sequence[Any], *, isolate: bool, cwd: Optional[str] = None
+        self, args: Sequence[Any], *, isolate: bool, cwd: str | None = None
     ) -> subprocess.CompletedProcess[bytes]:
         from torch._inductor.cpp_builder import normalize_path_separator
 
@@ -180,7 +180,7 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
     # minifier launcher script, if `code` outputted it.
     def _run_test_code(
         self, code: str, *, isolate: bool
-    ) -> tuple[subprocess.CompletedProcess[bytes], Union[str, Any]]:
+    ) -> tuple[subprocess.CompletedProcess[bytes], str | Any]:
         proc = self._maybe_subprocess_run(
             ["python3", "-c", code], isolate=isolate, cwd=self.DEBUG_DIR
         )
@@ -201,7 +201,7 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
         isolate: bool,
         *,
         minifier_args: Sequence[Any] = (),
-        repro_after: Optional[str] = None,
+        repro_after: str | None = None,
     ) -> tuple[subprocess.CompletedProcess[bytes], str]:
         self.assertIsNotNone(repro_dir)
         launch_file = _as_posix_path(os.path.join(repro_dir, "minifier_launcher.py"))
@@ -282,11 +282,11 @@ torch._dynamo.config.debug_dir_root = "{_as_posix_path(self.DEBUG_DIR)}"
         self,
         run_code: str,
         repro_after: str,
-        expected_error: Optional[str],
+        expected_error: str | None,
         *,
         isolate: bool,
         minifier_args: Sequence[Any] = (),
-    ) -> Optional[MinifierTestResult]:
+    ) -> MinifierTestResult | None:
         if isolate:
             repro_level = 3
         elif expected_error is None or expected_error == "AccuracyError":

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -24,7 +24,7 @@ import sys
 import types
 import unittest
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, Optional, overload, TypeVar, Union
+from typing import Any, overload, TypeVar
 from typing_extensions import ParamSpec
 from unittest.mock import patch
 
@@ -45,7 +45,7 @@ from .types import ConvertFrameReturn, DynamoFrameType, wrap_guarded_code
 from .utils import CompileCounterInt, same
 
 
-np: Optional[types.ModuleType] = None
+np: types.ModuleType | None = None
 try:
     import numpy as np
 except ModuleNotFoundError:
@@ -60,7 +60,7 @@ log = logging.getLogger(__name__)
 _P = ParamSpec("_P")
 
 
-def clone_me(x: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+def clone_me(x: torch.Tensor | None) -> torch.Tensor | None:
     if x is None:
         return None
     return x.detach().clone().requires_grad_(x.requires_grad)
@@ -151,11 +151,11 @@ def reduce_to_scalar_loss(out: torch.Tensor) -> torch.Tensor: ...
 
 @overload
 def reduce_to_scalar_loss(
-    out: Union[list[Any], tuple[Any, ...], dict[Any, Any]],
+    out: list[Any] | tuple[Any, ...] | dict[Any, Any],
 ) -> float: ...
 
 
-def reduce_to_scalar_loss(out: Any) -> Union[torch.Tensor, float]:
+def reduce_to_scalar_loss(out: Any) -> torch.Tensor | float:
     """Reduce the output of a model to get scalar loss"""
     if isinstance(out, torch.Tensor):
         # Mean does not work on integer tensors
@@ -233,7 +233,7 @@ def debug_insert_nops(
 
 class CompileCounter:
     def __init__(self) -> None:
-        self.frame_count: Union[int, CompileCounterInt] = 0
+        self.frame_count: int | CompileCounterInt = 0
         self.clear()
 
     def __call__(
@@ -255,7 +255,7 @@ class CompileCounter:
 
 class CompileCounterWithBackend:
     def __init__(self, backend: str) -> None:
-        self.frame_count: Union[int, CompileCounterInt] = 0
+        self.frame_count: int | CompileCounterInt = 0
         self.backend = backend
         self.graphs: list[torch.fx.GraphModule] = []
         self.clear()
@@ -388,8 +388,8 @@ def standard_test(
     self: Any,
     fn: Callable[..., Any],
     nargs: int,
-    expected_ops: Optional[int] = None,
-    expected_ops_dynamic: Optional[int] = None,
+    expected_ops: int | None = None,
+    expected_ops_dynamic: int | None = None,
     expected_frame_count: int = 1,
 ) -> None:
     if not config.assume_static_by_default and expected_ops_dynamic is not None:
@@ -440,7 +440,7 @@ def rand_strided(
     size: Sequence[int],
     stride: Sequence[int],
     dtype: torch.dtype = torch.float32,
-    device: Union[str, torch.device] = "cpu",
+    device: str | torch.device = "cpu",
     extra_size: int = 0,
 ) -> torch.Tensor:
     needed_size = extra_size
@@ -490,7 +490,7 @@ def make_test_cls_with_patches(
     cls_prefix: str,
     fn_suffix: str,
     *patches: Any,
-    xfail_prop: Optional[str] = None,
+    xfail_prop: str | None = None,
     decorator: Callable[[Callable[..., Any]], Callable[..., Any]] = lambda x: x,
 ) -> type:
     DummyTestClass = type(f"{cls_prefix}{cls.__name__}", cls.__bases__, {})

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -153,7 +153,9 @@ If you are removing an existing torch level API:
 """
 manual_torch_name_rule_map: dict[
     str,
-    type[TorchInGraphFunctionVariable] | type[SkipFunctionVariable] | type[UserFunctionVariable],
+    type[TorchInGraphFunctionVariable]
+    | type[SkipFunctionVariable]
+    | type[UserFunctionVariable],
 ] = {
     "torch.onnx.is_in_onnx_export": TorchInGraphFunctionVariable,
     "torch.onnx.operators.shape_as_tensor": TorchInGraphFunctionVariable,

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -38,7 +38,7 @@ import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any, cast, Optional, Union
+from typing import Any, cast
 
 import torch
 import torch._inductor.test_operators
@@ -77,7 +77,7 @@ from .variables import (
 from .variables.base import VariableTracker
 
 
-np: Optional[types.ModuleType] = None
+np: types.ModuleType | None = None
 try:
     import numpy as np
 except ModuleNotFoundError:
@@ -153,11 +153,7 @@ If you are removing an existing torch level API:
 """
 manual_torch_name_rule_map: dict[
     str,
-    Union[
-        type[TorchInGraphFunctionVariable],
-        type[SkipFunctionVariable],
-        type[UserFunctionVariable],
-    ],
+    type[TorchInGraphFunctionVariable] | type[SkipFunctionVariable] | type[UserFunctionVariable],
 ] = {
     "torch.onnx.is_in_onnx_export": TorchInGraphFunctionVariable,
     "torch.onnx.operators.shape_as_tensor": TorchInGraphFunctionVariable,
@@ -3097,11 +3093,11 @@ class FunctionIdSet:
     added to the graph and what will cause a graph break.
     """
 
-    function_ids: Optional[set[int]] = None
-    function_names: Optional[dict[int, str]] = None
+    function_ids: set[int] | None = None
+    function_names: dict[int, str] | None = None
 
     def __init__(
-        self, lazy_initializer: Callable[[], Union[dict[int, str], set[int]]]
+        self, lazy_initializer: Callable[[], dict[int, str] | set[int]]
     ) -> None:
         self.lazy_initializer = lazy_initializer
 
@@ -3359,7 +3355,7 @@ def _strip_init_py(s: str) -> str:
     return _as_posix_path(s)
 
 
-def _module_dir(m: types.ModuleType) -> Optional[str]:
+def _module_dir(m: types.ModuleType) -> str | None:
     # Protect against a module not exporting __file__ - this can happen for
     # frozen modules, for example.
     file = getattr(m, "__file__", None)
@@ -3701,10 +3697,10 @@ def add(import_name: str) -> None:
 @dataclasses.dataclass
 class SkipResult:
     skipped: bool
-    reason: Optional[str]
+    reason: str | None
 
 
-def check_file(filename: Optional[str], is_inlined_call: bool = False) -> SkipResult:
+def check_file(filename: str | None, is_inlined_call: bool = False) -> SkipResult:
     """Should skip this file?"""
     if filename is None:
         return SkipResult(True, "filename is None")
@@ -3760,10 +3756,10 @@ def check_file(filename: Optional[str], is_inlined_call: bool = False) -> SkipRe
 
 @dataclasses.dataclass
 class FunctionInfo:
-    py_obj: Optional[object]
-    name: Optional[str]
+    py_obj: object | None
+    name: str | None
     filename: str
-    code: Optional[types.CodeType]
+    code: types.CodeType | None
 
 
 """
@@ -3906,7 +3902,7 @@ def is_torch_inline_allowed(filename: str) -> bool:
 
 
 @functools.cache
-def dynamo_dir() -> Optional[str]:
+def dynamo_dir() -> str | None:
     import torch._dynamo
 
     return _module_dir(torch._dynamo)
@@ -3925,7 +3921,7 @@ Main entry point for looking up the trace rule (the Dynamo variable) for a given
 """
 
 
-def lookup_callable(obj: Callable[..., Any]) -> Optional[type[VariableTracker]]:
+def lookup_callable(obj: Callable[..., Any]) -> type[VariableTracker] | None:
     if not hashable(obj):
         return None
     # Custom allow/disallow in graph takes precedence over the general lookup.
@@ -3946,18 +3942,18 @@ E.g, the lookup result of `torch.sin` is `TorchInGraphFunctionVariable`.
 """
 
 
-def lookup(obj: Any) -> Optional[type[VariableTracker]]:
+def lookup(obj: Any) -> type[VariableTracker] | None:
     return lookup_inner(obj)
 
 
 # also takes config.dont_skip_tracing into account
 def lookup_inner(
     obj: Any,
-    name: Optional[str] = None,
-    filename: Optional[str] = None,
+    name: str | None = None,
+    filename: str | None = None,
     is_direct_call: bool = True,
-    reasons: Union[None, set[str]] = None,
-) -> Optional[type[VariableTracker]]:
+    reasons: None | set[str] = None,
+) -> type[VariableTracker] | None:
     result = _lookup_inner(
         obj,
         name=name,
@@ -3991,11 +3987,11 @@ def lookup_inner(
 
 def _lookup_inner(
     obj: Any,
-    name: Optional[str] = None,
-    filename: Optional[str] = None,
+    name: str | None = None,
+    filename: str | None = None,
     is_direct_call: bool = True,
-    reasons: Optional[set[str]] = None,
-) -> Optional[type[VariableTracker]]:
+    reasons: set[str] | None = None,
+) -> type[VariableTracker] | None:
     # Step 1: lookup obj's tracing rule in `torch_name_rule_map`.
     # The rules defined in `torch_name_rule_map` mainly includes two parts:
     # - Manually defined rules for any functions.

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -14,7 +14,7 @@ ensuring type safety and clear contracts between different components of the sys
 import dataclasses
 import types
 from collections.abc import Callable
-from typing import Any, NamedTuple, Optional, Protocol, Union
+from typing import Any, NamedTuple, Protocol
 
 # CacheEntry has a `guard_manager` field for the guard, and a `code` field for the code object.
 from torch._C._dynamo.eval_frame import (
@@ -55,9 +55,9 @@ class GuardFn(Protocol):
     code_parts: list[str]
     verbose_code_parts: list[str]
     global_scope: dict[str, object]
-    guard_fail_fn: Optional[Callable[[GuardFail], None]]
-    cache_entry: Optional[CacheEntry]
-    extra_state: Optional[ExtraState]
+    guard_fail_fn: Callable[[GuardFail], None] | None
+    cache_entry: CacheEntry | None
+    extra_state: ExtraState | None
 
     # maps locals of user function to bool
     def __call__(self, f_locals: dict[str, object]) -> bool: ...
@@ -82,7 +82,7 @@ class ConvertFrameReturn:
     )
     # also apply frame_exec strategy to future frames with same code
     apply_to_code: bool = True
-    guarded_code: Optional[GuardedCode] = None
+    guarded_code: GuardedCode | None = None
 
 
 def wrap_guarded_code(guarded_code: GuardedCode) -> ConvertFrameReturn:
@@ -96,12 +96,12 @@ class DynamoCallbackFn(Protocol):
     def __call__(
         self,
         frame: DynamoFrameType,
-        cache_entry: Optional[CacheEntry],
+        cache_entry: CacheEntry | None,
         frame_state: FrameState,
     ) -> ConvertFrameReturn: ...
 
 
-DynamoCallback = Union[DynamoCallbackFn, None, bool]
+DynamoCallback = DynamoCallbackFn | None | bool
 
 
 class DynamoGuardHook(Protocol):
@@ -137,4 +137,4 @@ class ProfilerEndHook(Protocol):
 class BytecodeHook(Protocol):
     def __call__(
         self, code: types.CodeType, new_code: types.CodeType
-    ) -> Optional[types.CodeType]: ...
+    ) -> types.CodeType | None: ...

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1209,7 +1209,12 @@ def is_lru_cache_wrapped_function(
     )
 
 
-_FuncTypes: TypeAlias = types.FunctionType | types.BuiltinFunctionType | types.MethodDescriptorType | types.WrapperDescriptorType
+_FuncTypes: TypeAlias = (
+    types.FunctionType
+    | types.BuiltinFunctionType
+    | types.MethodDescriptorType
+    | types.WrapperDescriptorType
+)
 
 
 def is_function_or_wrapper(
@@ -1257,7 +1262,11 @@ cmp_name_to_op_str_mapping = {
 def is_wrapper_or_member_descriptor(
     value: Any,
 ) -> TypeIs[
-    types.GetSetDescriptorType | types.MethodDescriptorType | types.WrapperDescriptorType | types.MemberDescriptorType | types.MethodWrapperType
+    types.GetSetDescriptorType
+    | types.MethodDescriptorType
+    | types.WrapperDescriptorType
+    | types.MemberDescriptorType
+    | types.MethodWrapperType
 ]:
     return isinstance(
         value,
@@ -2273,9 +2282,7 @@ def copy_dynamo_tensor_attributes(src: torch.Tensor, dst: torch.Tensor) -> None:
     _copy_dynamo_attr(src, dst, "_dynamo_weak_dynamic_indices")
 
 
-def clone_input(
-    x: torch.Tensor, *, dtype: torch.dtype | None = None
-) -> torch.Tensor:
+def clone_input(x: torch.Tensor, *, dtype: torch.dtype | None = None) -> torch.Tensor:
     """copy while preserving strides"""
     # TODO: this is questionable
     if is_fake(x):
@@ -2424,7 +2431,10 @@ def preserve_rng_state() -> Generator[None, None, None]:
 def is_jit_model(
     model0: Any,
 ) -> TypeIs[
-    torch.jit._trace.TopLevelTracedModule | torch.jit._script.RecursiveScriptModule | torch.jit.ScriptFunction[Any, Any] | torch.jit.ScriptModule
+    torch.jit._trace.TopLevelTracedModule
+    | torch.jit._script.RecursiveScriptModule
+    | torch.jit.ScriptFunction[Any, Any]
+    | torch.jit.ScriptModule
 ]:
     return isinstance(
         model0,
@@ -3552,9 +3562,7 @@ def get_fake_values_from_nodes(
     return torch.fx.node.map_arg(nodes, visit)
 
 
-def get_concrete_sizes_from_symints(
-    msg: str, fake_mode: FakeTensorMode | None
-) -> str:
+def get_concrete_sizes_from_symints(msg: str, fake_mode: FakeTensorMode | None) -> str:
     """
     Replace symbolic size expressions (like 's0', 's94') in error messages
     with their concrete runtime values for better readability.

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -56,12 +56,10 @@ from typing import (
     Generic,
     Literal,
     NoReturn,
-    Optional,
     overload,
     TypeAlias,
     TypeGuard,
     TypeVar,
-    Union,
 )
 from typing_extensions import ParamSpec, TypeIs
 
@@ -237,8 +235,8 @@ class ReinplaceCounters:
 
 
 def tabulate(
-    rows: Union[list[tuple[str, Any]], list[list[Any]]],
-    headers: Union[tuple[str, ...], list[str]],
+    rows: list[tuple[str, Any]] | list[list[Any]],
+    headers: tuple[str, ...] | list[str],
 ) -> str:
     try:
         import tabulate
@@ -267,7 +265,7 @@ def reset_frame_count() -> None:
     curr_frame = 0
 
 
-_recompile_user_contexts: Optional[list[Callable[[], str]]] = None
+_recompile_user_contexts: list[Callable[[], str]] | None = None
 
 
 def register_hook_for_recompile_user_context(hook: Callable[[], str]) -> None:
@@ -284,7 +282,7 @@ def register_hook_for_recompile_user_context(hook: Callable[[], str]) -> None:
     _recompile_user_contexts.append(hook)
 
 
-def get_hook_for_recompile_user_context() -> Optional[list[Callable[[], str]]]:
+def get_hook_for_recompile_user_context() -> list[Callable[[], str]] | None:
     return _recompile_user_contexts
 
 
@@ -413,7 +411,7 @@ class CompileEventLogger:
     def log_instant_event(
         event_name: str,
         metadata: dict[str, Any],
-        time_ns: Optional[int] = None,
+        time_ns: int | None = None,
         log_level: CompileEventLogLevel = CompileEventLogLevel.CHROMIUM,
     ) -> None:
         if time_ns is None:
@@ -646,7 +644,7 @@ class CompileEventLogger:
 
     @staticmethod
     def instant(
-        event_name: str, metadata: dict[str, Any], time_ns: Optional[int] = None
+        event_name: str, metadata: dict[str, Any], time_ns: int | None = None
     ) -> None:
         """
         Log an instant event to chromium logs with name <event_name> at time <time_ns>. The `args` field in
@@ -712,14 +710,14 @@ def compile_time_record_function(name: str) -> Generator[Any, None, None]:
 def dynamo_timed(
     key: str,
     # TODO(masneral): Deprecate this param.
-    phase_name: Optional[str] = None,
+    phase_name: str | None = None,
     log_pt2_compile_event: bool = False,
-    metadata: Optional[dict[str, object]] = None,
-    dynamo_compile_column_us: Optional[str] = None,
-    compile_id: Optional[CompileId] = None,
-    is_backward: Optional[bool] = None,
+    metadata: dict[str, object] | None = None,
+    dynamo_compile_column_us: str | None = None,
+    compile_id: CompileId | None = None,
+    is_backward: bool | None = None,
     log_waitcounter: bool = False,
-    waitcounter_name_override: Optional[str] = None,
+    waitcounter_name_override: str | None = None,
 ) -> Generator[Any, None, None]:
     """
     dynamo_timed is a context manager
@@ -866,7 +864,7 @@ def compile_times(
 
 def compile_times(  # type: ignore[misc]
     repr: str = "str", aggregate: bool = False
-) -> Union[str, None, tuple[list[str], list[str]]]:
+) -> str | None | tuple[list[str], list[str]]:
     """
     Get metrics about torchdynamo frontend/backend compilation times.
 
@@ -930,7 +928,7 @@ class DuplicateWarningChecker:
     def reset(self) -> None:
         self.set: OrderedDict[Any, Any] = OrderedDict()
 
-    def add(self, key: Union[str, tuple[object, object]]) -> bool:
+    def add(self, key: str | tuple[object, object]) -> bool:
         if key in self.set:
             self.set.move_to_end(key, last=True)
             if not config.verbose:
@@ -1124,11 +1122,11 @@ if sys.version_info >= (3, 12):
 def get_inputs_devices(
     inputs: collections.abc.Sequence[object],
     model: torch.fx.GraphModule,
-) -> list[Optional[torch.device]]:
+) -> list[torch.device | None]:
     all_inputs = pytree.tree_flatten(inputs)[0] + [
         node.meta["val"] for node in list(model.graph.nodes) if "val" in node.meta
     ]
-    devices: list[Optional[torch.device]] = list(
+    devices: list[torch.device | None] = list(
         OrderedSet([i.device for i in all_inputs if hasattr(i, "device")])
     )
     return [
@@ -1211,17 +1209,12 @@ def is_lru_cache_wrapped_function(
     )
 
 
-_FuncTypes: TypeAlias = Union[
-    types.FunctionType,
-    types.BuiltinFunctionType,
-    types.MethodDescriptorType,
-    types.WrapperDescriptorType,
-]
+_FuncTypes: TypeAlias = types.FunctionType | types.BuiltinFunctionType | types.MethodDescriptorType | types.WrapperDescriptorType
 
 
 def is_function_or_wrapper(
     value: Any,
-) -> TypeIs[Union[_FuncTypes, torch._ops.OpOverloadPacket, torch._ops.OpOverload]]:
+) -> TypeIs[_FuncTypes | torch._ops.OpOverloadPacket | torch._ops.OpOverload]:
     return is_function(value) or isinstance(
         value, (torch._ops.OpOverloadPacket, torch._ops.OpOverload)
     )
@@ -1264,13 +1257,7 @@ cmp_name_to_op_str_mapping = {
 def is_wrapper_or_member_descriptor(
     value: Any,
 ) -> TypeIs[
-    Union[
-        types.GetSetDescriptorType,
-        types.MethodDescriptorType,
-        types.WrapperDescriptorType,
-        types.MemberDescriptorType,
-        types.MethodWrapperType,
-    ]
+    types.GetSetDescriptorType | types.MethodDescriptorType | types.WrapperDescriptorType | types.MemberDescriptorType | types.MethodWrapperType
 ]:
     return isinstance(
         value,
@@ -1293,7 +1280,7 @@ def unwrap_if_wrapper(fn: Any) -> Any:
     return unwrap_with_attr_name_if_wrapper(fn)[0]
 
 
-def unwrap_with_attr_name_if_wrapper(fn: Any) -> tuple[Any, Optional[str]]:
+def unwrap_with_attr_name_if_wrapper(fn: Any) -> tuple[Any, str | None]:
     # TODO(anijain2305) - Investigate if we can get rid of this function
     # unpack @torch._dynamo.optimize()(fn) wrapped function
     if is_function(fn) and inspect.getattr_static(fn, "_torchdynamo_inline", False):
@@ -1360,13 +1347,13 @@ def proxy_args_kwargs(args: Any, kwargs: Any) -> tuple[tuple[Any, ...], dict[str
         )
 
 
-def to_int_ms(v: Optional[float]) -> Optional[int]:
+def to_int_ms(v: float | None) -> int | None:
     return None if v is None else int(v * 1000)
 
 
 # float64 timestamp has a quarter microsecond precision in 2024, so while
 # this is suboptimal we shouldn't meaningfully lose precision
-def to_int_us(v: Optional[float]) -> Optional[int]:
+def to_int_us(v: float | None) -> int | None:
     return None if v is None else int(v * 1_000_000)
 
 
@@ -1377,113 +1364,113 @@ LOG_FORMAT_VERSION = 3
 
 @dataclasses.dataclass
 class CompilationMetrics:
-    compile_id: Optional[str] = None
-    frame_key: Optional[str] = None
-    co_name: Optional[str] = None
-    co_filename: Optional[str] = None
-    co_firstlineno: Optional[int] = None
-    cache_size: Optional[int] = None
-    accumulated_cache_size: Optional[int] = None
-    guard_count: Optional[int] = None
-    shape_env_guard_count: Optional[int] = None
-    graph_op_count: Optional[int] = None
-    graph_node_count: Optional[int] = None
-    graph_input_count: Optional[int] = None
-    start_time: Optional[float] = None
-    entire_frame_compile_time_s: Optional[float] = None
-    backend_compile_time_s: Optional[float] = None
-    inductor_compile_time_s: Optional[float] = None
-    code_gen_time_s: Optional[float] = None
-    fail_type: Optional[str] = None
-    fail_reason: Optional[str] = None
-    fail_user_frame_filename: Optional[str] = None
-    fail_user_frame_lineno: Optional[int] = None
-    non_compliant_ops: Optional[set[str]] = None
-    compliant_custom_ops: Optional[set[str]] = None
-    restart_reasons: Optional[set[str]] = None
-    dynamo_time_before_restart_s: Optional[float] = None
-    stack_trace: Optional[list[str]] = None
-    exception_stack_trace: Optional[list[str]] = None
-    graph_node_shapes: Optional[str] = None
+    compile_id: str | None = None
+    frame_key: str | None = None
+    co_name: str | None = None
+    co_filename: str | None = None
+    co_firstlineno: int | None = None
+    cache_size: int | None = None
+    accumulated_cache_size: int | None = None
+    guard_count: int | None = None
+    shape_env_guard_count: int | None = None
+    graph_op_count: int | None = None
+    graph_node_count: int | None = None
+    graph_input_count: int | None = None
+    start_time: float | None = None
+    entire_frame_compile_time_s: float | None = None
+    backend_compile_time_s: float | None = None
+    inductor_compile_time_s: float | None = None
+    code_gen_time_s: float | None = None
+    fail_type: str | None = None
+    fail_reason: str | None = None
+    fail_user_frame_filename: str | None = None
+    fail_user_frame_lineno: int | None = None
+    non_compliant_ops: set[str] | None = None
+    compliant_custom_ops: set[str] | None = None
+    restart_reasons: set[str] | None = None
+    dynamo_time_before_restart_s: float | None = None
+    stack_trace: list[str] | None = None
+    exception_stack_trace: list[str] | None = None
+    graph_node_shapes: str | None = None
     # Sometimes, we will finish analyzing a frame but conclude we don't want
     # to install any guarded code.  True means we actually decided to install
     # a compiled frame
-    has_guarded_code: Optional[bool] = None
-    remote_cache_time_saved_s: Optional[float] = None
-    structured_logging_overhead_s: Optional[float] = None
-    config_suppress_errors: Optional[bool] = None
-    config_inline_inbuilt_nn_modules: Optional[bool] = None
-    specialize_float: Optional[bool] = None
-    dynamo_config: Optional[str] = None
-    compiler_config: Optional[str] = None
-    is_forward: Optional[bool] = None
-    num_triton_bundles: Optional[int] = None
-    remote_fx_graph_cache_get_time_ms: Optional[int] = None
-    remote_fx_graph_cache_put_time_ms: Optional[int] = None
-    start_time_us: Optional[int] = None
-    duration_us: Optional[int] = None
-    dynamo_cumulative_compile_time_us: Optional[int] = None
-    aot_autograd_cumulative_compile_time_us: Optional[int] = None
-    inductor_cumulative_compile_time_us: Optional[int] = None
-    inductor_code_gen_cumulative_compile_time_us: Optional[int] = None
-    triton_compile_time_us: Optional[int] = None
-    runtime_cudagraphify_time_us: Optional[int] = None
-    runtime_triton_autotune_time_us: Optional[int] = None
-    dynamo_compile_time_before_restart_us: Optional[int] = None
-    distributed_ephemeral_timeout_us: Optional[int] = None
-    structured_logging_overhead_us: Optional[int] = None
-    remote_fx_graph_cache_get_time_us: Optional[int] = None
-    remote_fx_graph_cache_put_time_us: Optional[int] = None
-    backward_cumulative_compile_time_us: Optional[int] = None
-    end_time_us: Optional[int] = None
-    pre_grad_pass_time_us: Optional[int] = None
-    post_grad_pass_time_us: Optional[int] = None
-    joint_graph_pass_time_us: Optional[int] = None
+    has_guarded_code: bool | None = None
+    remote_cache_time_saved_s: float | None = None
+    structured_logging_overhead_s: float | None = None
+    config_suppress_errors: bool | None = None
+    config_inline_inbuilt_nn_modules: bool | None = None
+    specialize_float: bool | None = None
+    dynamo_config: str | None = None
+    compiler_config: str | None = None
+    is_forward: bool | None = None
+    num_triton_bundles: int | None = None
+    remote_fx_graph_cache_get_time_ms: int | None = None
+    remote_fx_graph_cache_put_time_ms: int | None = None
+    start_time_us: int | None = None
+    duration_us: int | None = None
+    dynamo_cumulative_compile_time_us: int | None = None
+    aot_autograd_cumulative_compile_time_us: int | None = None
+    inductor_cumulative_compile_time_us: int | None = None
+    inductor_code_gen_cumulative_compile_time_us: int | None = None
+    triton_compile_time_us: int | None = None
+    runtime_cudagraphify_time_us: int | None = None
+    runtime_triton_autotune_time_us: int | None = None
+    dynamo_compile_time_before_restart_us: int | None = None
+    distributed_ephemeral_timeout_us: int | None = None
+    structured_logging_overhead_us: int | None = None
+    remote_fx_graph_cache_get_time_us: int | None = None
+    remote_fx_graph_cache_put_time_us: int | None = None
+    backward_cumulative_compile_time_us: int | None = None
+    end_time_us: int | None = None
+    pre_grad_pass_time_us: int | None = None
+    post_grad_pass_time_us: int | None = None
+    joint_graph_pass_time_us: int | None = None
     log_format_version: int = LOG_FORMAT_VERSION
-    inductor_config: Optional[str] = None
-    remote_cache_version: Optional[int] = None
-    inductor_fx_remote_cache_hit_count: Optional[int] = 0
-    inductor_fx_remote_cache_miss_count: Optional[int] = 0
-    inductor_fx_remote_cache_backend_type: Optional[str] = None
-    inductor_fx_remote_cache_hit_keys: Optional[str] = None
-    inductor_fx_remote_cache_miss_keys: Optional[str] = None
-    inductor_fx_local_cache_hit_count: Optional[int] = 0
-    inductor_fx_local_cache_miss_count: Optional[int] = 0
-    aotautograd_remote_cache_hit_count: Optional[int] = 0
-    aotautograd_remote_cache_miss_count: Optional[int] = 0
-    aotautograd_local_cache_hit_count: Optional[int] = 0
-    aotautograd_local_cache_miss_count: Optional[int] = 0
-    cuda_version: Optional[str] = None
-    triton_version: Optional[str] = None
-    feature_usage: Optional[dict[str, bool]] = None
-    compile_time_autotune_time_us: Optional[int] = None
-    is_runtime: Optional[bool] = False
-    gc_time_us: Optional[int] = None
-    tensorify_float_attempt: Optional[bool] = None
-    tensorify_float_success: Optional[bool] = None
-    tensorify_float_failure: Optional[set[str]] = None
-    guard_latency_us: Optional[float] = None
-    recompile_reason: Optional[str] = None
-    num_graph_breaks: Optional[int] = None
-    triton_kernel_compile_times_us: Optional[str] = None
-    ir_count: Optional[int] = None
-    cudagraph_skip_reason: Optional[str] = None
-    python_version: Optional[str] = None
-    pgo_put_remote_code_state_time_us: Optional[int] = None
-    pgo_get_remote_code_state_time_us: Optional[int] = None
+    inductor_config: str | None = None
+    remote_cache_version: int | None = None
+    inductor_fx_remote_cache_hit_count: int | None = 0
+    inductor_fx_remote_cache_miss_count: int | None = 0
+    inductor_fx_remote_cache_backend_type: str | None = None
+    inductor_fx_remote_cache_hit_keys: str | None = None
+    inductor_fx_remote_cache_miss_keys: str | None = None
+    inductor_fx_local_cache_hit_count: int | None = 0
+    inductor_fx_local_cache_miss_count: int | None = 0
+    aotautograd_remote_cache_hit_count: int | None = 0
+    aotautograd_remote_cache_miss_count: int | None = 0
+    aotautograd_local_cache_hit_count: int | None = 0
+    aotautograd_local_cache_miss_count: int | None = 0
+    cuda_version: str | None = None
+    triton_version: str | None = None
+    feature_usage: dict[str, bool] | None = None
+    compile_time_autotune_time_us: int | None = None
+    is_runtime: bool | None = False
+    gc_time_us: int | None = None
+    tensorify_float_attempt: bool | None = None
+    tensorify_float_success: bool | None = None
+    tensorify_float_failure: set[str] | None = None
+    guard_latency_us: float | None = None
+    recompile_reason: str | None = None
+    num_graph_breaks: int | None = None
+    triton_kernel_compile_times_us: str | None = None
+    ir_count: int | None = None
+    cudagraph_skip_reason: str | None = None
+    python_version: str | None = None
+    pgo_put_remote_code_state_time_us: int | None = None
+    pgo_get_remote_code_state_time_us: int | None = None
     # The number of elements within parameters. This is classically what people
     # think of when they think of parameters in a ML model.
-    param_numel: Optional[int] = None
+    param_numel: int | None = None
     # The number of elements counted by bytes - i.e. a float32 is 4 bytes
     # per element.
-    param_bytes: Optional[int] = None
+    param_bytes: int | None = None
     # The number of parameters counted by fields. This is mostly a proxy for
     # the number of distinct type of params.
-    param_count: Optional[int] = None
-    recompile_user_contexts: Optional[set[str]] = None
-    inline_inbuilt_nn_modules_candidate: Optional[bool] = False
-    pytorch_version: Optional[str] = None
-    inductor_provenance: Optional[set[str]] = None
+    param_count: int | None = None
+    recompile_user_contexts: set[str] | None = None
+    inline_inbuilt_nn_modules_candidate: bool | None = False
+    pytorch_version: str | None = None
+    inductor_provenance: set[str] | None = None
 
     @classmethod
     def create(cls, metrics: dict[str, Any]) -> CompilationMetrics:
@@ -1493,13 +1480,13 @@ class CompilationMetrics:
         we transform some fields to comma-separated strings for scuba logging.
         """
 
-        def us_to_s(metric: Optional[int]) -> Optional[float]:
+        def us_to_s(metric: int | None) -> float | None:
             return metric / 1e6 if metric is not None else None
 
-        def us_to_ms(metric: Optional[int]) -> Optional[int]:
+        def us_to_ms(metric: int | None) -> int | None:
             return metric // 1000 if metric is not None else None
 
-        def collection_to_str(metric: Optional[Any]) -> Optional[str]:
+        def collection_to_str(metric: Any | None) -> str | None:
             def safe_str(item: Any) -> str:
                 try:
                     return str(item)
@@ -1514,7 +1501,7 @@ class CompilationMetrics:
 
             return ",".join(safe_str(item) for item in sorted(metric))
 
-        def collection_to_json_str(metric: Optional[Any]) -> Optional[str]:
+        def collection_to_json_str(metric: Any | None) -> str | None:
             if metric is None:
                 return None
             try:
@@ -1627,7 +1614,7 @@ def add_compilation_metrics_to_chromium(c: CompilationMetrics) -> None:
     )
 
 
-def _get_dynamo_config_for_logging() -> Optional[str]:
+def _get_dynamo_config_for_logging() -> str | None:
     def clean_for_json(d: dict[str, Any]) -> dict[str, Any]:
         blocklist = {
             "TYPE_CHECKING",
@@ -1662,7 +1649,7 @@ def _get_dynamo_config_for_logging() -> Optional[str]:
     return json.dumps(config_dict, sort_keys=True)
 
 
-def _compiler_config_for_logging() -> Optional[str]:
+def _compiler_config_for_logging() -> str | None:
     def clean_for_json(d: dict[str, Any]) -> dict[str, Any]:
         blocklist = {
             "TYPE_CHECKING",
@@ -1686,7 +1673,7 @@ def _compiler_config_for_logging() -> Optional[str]:
     return json.dumps(config_dict, sort_keys=True)
 
 
-def _scrubbed_inductor_config_for_logging() -> Optional[str]:
+def _scrubbed_inductor_config_for_logging() -> str | None:
     """
     Method to parse and scrub uninteresting configs from inductor config
     """
@@ -1738,8 +1725,8 @@ def record_compilation_metrics(
     start_time_ns: int,
     end_time_ns: int,
     metrics: dict[str, Any],
-    exc_type: Optional[type[BaseException]],
-    exc_value: Optional[BaseException],
+    exc_type: type[BaseException] | None,
+    exc_value: BaseException | None,
 ) -> None:
     if torch._inductor.utils.should_use_remote_fx_graph_cache():
         try:
@@ -1853,7 +1840,7 @@ class ChromiumEventLogger:
             self.tls.stack = []
             return self.tls.stack
 
-    def get_outermost_event(self) -> Optional[str]:
+    def get_outermost_event(self) -> str | None:
         """
         Get the outermost event name (i.e. the longest running event)
         or None if the stack is empty.
@@ -1971,7 +1958,7 @@ class ChromiumEventLogger:
         time_ns: int,
         metadata: dict[str, Any],
         log_pt2_compile_event: bool = False,
-        compile_id: Optional[CompileId] = None,
+        compile_id: CompileId | None = None,
     ) -> None:
         """
         Logs the start of a single event.
@@ -2028,7 +2015,7 @@ class ChromiumEventLogger:
         metadata: dict[str, Any],
         start_time_ns: int,
         log_pt2_compile_event: bool,
-        compile_id: Optional[CompileId] = None,
+        compile_id: CompileId | None = None,
     ) -> None:
         """
         Logs the end of a single event. This function should only be
@@ -2106,7 +2093,7 @@ class ChromiumEventLogger:
         event_name: str,
         time_ns: int,
         phase: str,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
         Logs a timed event in chromium format. See log_event_start, log_event_end, etc.
@@ -2134,7 +2121,7 @@ class ChromiumEventLogger:
         self,
         event_name: str,
         time_ns: int,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
         # By default, an instant event isn't logged internally, only to structured logging.
         log_pt2_compile_event: bool = False,
     ) -> None:
@@ -2173,7 +2160,7 @@ class ChromiumEventLogger:
             )
 
 
-CHROMIUM_EVENT_LOG: Optional[ChromiumEventLogger] = None
+CHROMIUM_EVENT_LOG: ChromiumEventLogger | None = None
 
 
 def get_chromium_event_logger() -> ChromiumEventLogger:
@@ -2287,7 +2274,7 @@ def copy_dynamo_tensor_attributes(src: torch.Tensor, dst: torch.Tensor) -> None:
 
 
 def clone_input(
-    x: torch.Tensor, *, dtype: Optional[torch.dtype] = None
+    x: torch.Tensor, *, dtype: torch.dtype | None = None
 ) -> torch.Tensor:
     """copy while preserving strides"""
     # TODO: this is questionable
@@ -2366,7 +2353,7 @@ def clone_input(
 
 @overload
 def clone_inputs(
-    example_inputs: dict[str, Union[T, tuple[T, ...]]],
+    example_inputs: dict[str, T | tuple[T, ...]],
 ) -> dict[str, list[T]]: ...
 
 
@@ -2375,7 +2362,7 @@ def clone_inputs(example_inputs: Sequence[T]) -> list[T]: ...
 
 
 def clone_inputs(example_inputs: Any) -> Any:
-    res: Union[dict[str, Any], list[Any]]
+    res: dict[str, Any] | list[Any]
     if type(example_inputs) is dict:
         res = dict(example_inputs)
         for key, value in res.items():
@@ -2437,12 +2424,7 @@ def preserve_rng_state() -> Generator[None, None, None]:
 def is_jit_model(
     model0: Any,
 ) -> TypeIs[
-    Union[
-        torch.jit._trace.TopLevelTracedModule,
-        torch.jit._script.RecursiveScriptModule,
-        torch.jit.ScriptFunction[Any, Any],
-        torch.jit.ScriptModule,
-    ]
+    torch.jit._trace.TopLevelTracedModule | torch.jit._script.RecursiveScriptModule | torch.jit.ScriptFunction[Any, Any] | torch.jit.ScriptModule
 ]:
     return isinstance(
         model0,
@@ -2473,7 +2455,7 @@ def torchscript(model: Any, example_inputs: Any, verbose: bool = False) -> Any:
     return None
 
 
-def getfile(obj: Any) -> Optional[str]:
+def getfile(obj: Any) -> str | None:
     try:
         return inspect.getfile(obj)
     except (TypeError, OSError):
@@ -2664,7 +2646,7 @@ def common_constants() -> set[int]:
     }
 
 
-def is_torch_sym(value: Any) -> TypeGuard[Union[torch.SymBool, torch.SymInt]]:
+def is_torch_sym(value: Any) -> TypeGuard[torch.SymBool | torch.SymInt]:
     return isinstance(value, (torch.SymBool, torch.SymInt)) and not isinstance(
         value.node, torch.nested._internal.nested_int.NestedIntNode
     )
@@ -2819,7 +2801,7 @@ def builtin_dict_keys(d: dict[K, V]) -> KeysView[K]:
     return dict.keys(d)
 
 
-def get_items_from_dict(obj: dict[K, V]) -> Iterable[tuple[K, Union[V, Any]]]:
+def get_items_from_dict(obj: dict[K, V]) -> Iterable[tuple[K, V | Any]]:
     # Get items without calling the user defined __getitem__ or keys method.
     assert isinstance(obj, dict)
     if istype(obj, (dict, OrderedDict)):
@@ -2983,7 +2965,7 @@ def iter_contains(
         # Match of Tensor means match of FakeTensor
         search = _get_fake_tensor(search)
 
-    found: Optional[VariableTracker] = None
+    found: VariableTracker | None = None
     for x in items:
         if must_check_tensor_id:
             if x.is_tensor():
@@ -3008,7 +2990,7 @@ def iter_contains(
 
 def key_is_id(
     k: Any,
-) -> TypeIs[Union[torch.Tensor, torch.nn.Module, MethodWrapperType]]:
+) -> TypeIs[torch.Tensor | torch.nn.Module | MethodWrapperType]:
     """Returns whether it indexes dictionaries using its id"""
     return isinstance(k, (torch.Tensor, torch.nn.Module, MethodWrapperType))
 
@@ -3571,7 +3553,7 @@ def get_fake_values_from_nodes(
 
 
 def get_concrete_sizes_from_symints(
-    msg: str, fake_mode: Optional[FakeTensorMode]
+    msg: str, fake_mode: FakeTensorMode | None
 ) -> str:
     """
     Replace symbolic size expressions (like 's0', 's94') in error messages
@@ -3846,7 +3828,7 @@ def _get_fake_value_impl(
 _current_node = threading.local()
 
 
-def get_current_node() -> Optional[torch.fx.Node]:
+def get_current_node() -> torch.fx.Node | None:
     return getattr(_current_node, "value", None)
 
 
@@ -4061,7 +4043,7 @@ def class_has_getattribute(cls: type) -> bool:
 
 def get_custom_getattr(
     value: Any, ignore_nn_module_getattr: bool = False
-) -> Optional[Any]:
+) -> Any | None:
     try:
         getattr_fn = inspect.getattr_static(type(value), "__getattr__")
     except AttributeError:
@@ -4089,10 +4071,10 @@ def tensor_static_reason_to_message(reason: TensorStaticReason) -> str:
 
 
 def tensor_always_has_static_shape(
-    tensor: Union[torch.Tensor, Any],
+    tensor: torch.Tensor | Any,
     is_tensor: bool,
     tensor_source: Source,
-) -> tuple[bool, Optional[TensorStaticReason]]:
+) -> tuple[bool, TensorStaticReason | None]:
     """
     Given a tensor, source, and is_tensor flag, determine if a shape should be static.
 
@@ -4433,7 +4415,7 @@ class _Anchors:
     right_start_offset: int
 
 
-def _extract_anchors_from_expr(segment: str) -> Optional[_Anchors]:
+def _extract_anchors_from_expr(segment: str) -> _Anchors | None:
     """
     Given source code `segment` corresponding to a bytecode
     instruction, determine:
@@ -4644,7 +4626,7 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
         num_spaces = len(last_line) - len(last_line.lstrip())
         markers.append(" " * num_spaces + "~" * (end_offset - num_spaces))
 
-    anchors: Optional[_Anchors] = None
+    anchors: _Anchors | None = None
     try:
         anchors = _extract_anchors_from_expr(segment)
     except AssertionError:
@@ -5181,7 +5163,7 @@ def maybe_disable_inference_mode_for_fake_prop() -> Generator[None, None, None]:
         yield
 
 
-def is_node_meta_valid(node: Optional[torch.fx.Node]) -> bool:
+def is_node_meta_valid(node: torch.fx.Node | None) -> bool:
     return node is None or "example_value" in node.meta or "val" in node.meta
 
 
@@ -5216,7 +5198,7 @@ def record_pregraph_bytecode_exit(cm: AbstractContextManager[None]) -> None:
 
 # Returns a set of code objects present traced in the current TracingContext, or None
 # if there is no current TracingContext.
-def get_traced_code() -> Optional[list[CodeType]]:
+def get_traced_code() -> list[CodeType] | None:
     from torch._guards import TracingContext
 
     return TracingContext.get_traced_code()

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -19,7 +19,7 @@ import logging
 from collections.abc import Callable, ItemsView, KeysView, Sequence, ValuesView
 from contextvars import ContextVar
 from enum import Enum
-from typing import Any, NoReturn, Optional, TYPE_CHECKING
+from typing import Any, NoReturn, TYPE_CHECKING
 
 from torch._guards import Guard
 from torch.fx.proxy import Node
@@ -195,7 +195,7 @@ class AttributeMutationNew(AttributeMutation):
     the Python world.
     """
 
-    def __init__(self, cls_source: Optional[Source] = None) -> None:
+    def __init__(self, cls_source: Source | None = None) -> None:
         super().__init__(SourceType.New)
         self.cls_source = cls_source
 
@@ -296,7 +296,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         cls,
         fn: Callable[["VariableTracker"], None],
         value: Any,
-        cache: Optional[dict[int, Any]] = None,
+        cache: dict[int, Any] | None = None,
     ) -> None:
         """
         Walk value and call fn on all the VariableTracker instances
@@ -449,7 +449,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def as_proxy(self) -> Any:
         raise NotImplementedError(str(self))
 
-    def maybe_fx_node(self) -> Optional[Node]:
+    def maybe_fx_node(self) -> Node | None:
         try:
             proxy = self.as_proxy()
             import torch.fx
@@ -821,7 +821,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def build(
         tx: Any,
         value: Any,
-        source: Optional[Source] = None,
+        source: Source | None = None,
         realize: bool = False,
     ) -> Any:
         """Create a new VariableTracker from a value and optional Source"""
@@ -896,8 +896,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def __init__(
         self,
         *,
-        source: Optional[Source] = None,
-        mutation_type: Optional[MutationType] = None,
+        source: Source | None = None,
+        mutation_type: MutationType | None = None,
     ) -> None:
         super().__init__()
         self.source = source

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -37,7 +37,7 @@ import types
 import weakref
 from collections.abc import Callable, MutableMapping
 from types import ModuleType
-from typing import Any, NamedTuple, NoReturn, Optional, overload, TYPE_CHECKING, Union
+from typing import Any, NamedTuple, NoReturn, overload, TYPE_CHECKING, Union
 
 import sympy
 
@@ -2215,14 +2215,14 @@ class VariableBuilder:
     @overload
     def _wrap_lazy_constant(
         self,
-        value: Union[int, float, bool, str],
+        value: int | float | bool | str,
         wrap_fn: None = None,
     ) -> VariableTracker: ...
 
     def _wrap_lazy_constant(
         self,
-        value: Union[int, float, bool, str],
-        wrap_fn: Optional[Callable[[Any], VariableTracker]] = None,
+        value: int | float | bool | str,
+        wrap_fn: Callable[[Any], VariableTracker] | None = None,
     ) -> VariableTracker:
         """Wrap a primitive constant, deferring guard installation if allowed."""
         if not self.allow_lazy_constant:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -32,7 +32,7 @@ import typing
 import unittest
 from collections import defaultdict, OrderedDict
 from collections.abc import Callable, Iterable, KeysView, Sequence
-from typing import Any, cast, Literal, TYPE_CHECKING, Union
+from typing import Any, cast, Literal, TYPE_CHECKING
 
 import torch
 from torch import sym_float, sym_int
@@ -151,7 +151,7 @@ IN_PLACE_DESUGARING_MAP = {
 _HandlerCallback = Callable[
     ["InstructionTranslator", typing.Any, typing.Any], VariableTracker | None
 ]
-_TrackersType = Union[type[VariableTracker], tuple[type[VariableTracker], ...]]
+_TrackersType = type[VariableTracker] | tuple[type[VariableTracker], ...]
 polyfill_fn_mapping = {
     operator.eq: polyfills.cmp_eq,
     operator.ne: polyfills.cmp_ne,

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -9,7 +9,7 @@ maintaining type safety through the compilation process.
 import enum
 import operator
 from collections.abc import Sequence
-from typing import Any, Literal, Optional, overload, TYPE_CHECKING, Union
+from typing import Any, Literal, Optional, overload, TYPE_CHECKING
 from typing_extensions import Never, override
 
 import torch
@@ -396,7 +396,7 @@ class EnumVariable(VariableTracker):
     both standard Enum and IntEnum with proper value tracking and comparison.
     """
 
-    def __init__(self, value: Union[enum.Enum, enum.IntEnum], **kwargs: Any) -> None:
+    def __init__(self, value: enum.Enum | enum.IntEnum, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -417,7 +417,7 @@ class EnumVariable(VariableTracker):
             hints=[*graph_break_hints.USER_ERROR, *graph_break_hints.SUPPORTABLE],
         )
 
-    def as_proxy(self) -> Union[enum.Enum, int]:
+    def as_proxy(self) -> enum.Enum | int:
         if isinstance(self.value, int):
             return int(self.value)  # convert IntEnum to a normal int
         return self.value
@@ -425,7 +425,7 @@ class EnumVariable(VariableTracker):
     def __repr__(self) -> str:
         return f"EnumVariable({type(self.value)})"
 
-    def as_python_constant(self) -> Union[enum.Enum, enum.IntEnum]:
+    def as_python_constant(self) -> enum.Enum | enum.IntEnum:
         return self.value
 
     def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -23,7 +23,7 @@ import logging
 import warnings
 from collections.abc import Callable, Sequence, Sized
 from contextlib import AbstractContextManager, ExitStack
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 import torch._C
 from torch._dynamo import config
@@ -67,7 +67,7 @@ class ContextWrappingVariable(VariableTracker):
     }
 
     def __init__(
-        self, target_values: Any, initial_values: Optional[Any] = None, **kwargs: Any
+        self, target_values: Any, initial_values: Any | None = None, **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
         self.target_values = target_values
@@ -80,7 +80,7 @@ class ContextWrappingVariable(VariableTracker):
         return variables.CONSTANT_VARIABLE_NONE
 
     def set_cleanup_hook(
-        self, tx: "InstructionTranslator", fn: Optional[Callable[..., Any]] = None
+        self, tx: "InstructionTranslator", fn: Callable[..., Any] | None = None
     ) -> None:
         if fn is None:
 
@@ -88,7 +88,7 @@ class ContextWrappingVariable(VariableTracker):
                 if hasattr(self, "_call_func"):
                     self._call_func(tx, self.initial_values)
 
-        self.cleanup_fn: Optional[Callable[..., Any]] = fn
+        self.cleanup_fn: Callable[..., Any] | None = fn
         tx.output.add_cleanup_hook(self.cleanup)
 
     def exit(
@@ -512,8 +512,8 @@ class CatchWarningsCtxManagerVariable(ContextWrappingVariable):
     def __init__(
         self,
         catch_warnings_args: dict[str, VariableTracker],
-        target_values: Optional[Any] = None,
-        initial_values: Optional[Any] = None,
+        target_values: Any | None = None,
+        initial_values: Any | None = None,
         **kwargs: Any,
     ) -> None:
         assert isinstance(catch_warnings_args, dict), catch_warnings_args
@@ -619,7 +619,7 @@ class GradModeVariable(ContextWrappingVariable):
     def __init__(
         self,
         target_values: Any,
-        initial_values: Optional[Sequence[bool]] = None,
+        initial_values: Sequence[bool] | None = None,
         initialized: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -677,7 +677,7 @@ class InferenceModeVariable(ContextWrappingVariable):
     def __init__(
         self,
         target_values: Any,
-        initial_values: Optional[bool] = None,
+        initial_values: bool | None = None,
         **kwargs: Any,
     ) -> None:
         if initial_values is None:
@@ -753,7 +753,7 @@ class CUDADeviceVariable(ContextWrappingVariable):
     def __init__(
         self,
         target_values: Any,
-        initial_values: Optional[Any] = None,
+        initial_values: Any | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -811,7 +811,7 @@ class TorchFunctionDisableVariable(ContextWrappingVariable):
         self,
         tx: "InstructionTranslator",
         target_values: Sized,
-        initial_values: Optional[Sized] = None,
+        initial_values: Sized | None = None,
         only_subclass: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -869,7 +869,7 @@ class DisabledSavedTensorsHooksVariable(ContextWrappingVariable):
 
     @staticmethod
     def create(
-        tx: "InstructionTranslator", target_value: Optional[str], **kwargs: Any
+        tx: "InstructionTranslator", target_value: str | None, **kwargs: Any
     ) -> "DisabledSavedTensorsHooksVariable":
         var = DisabledSavedTensorsHooksVariable(
             target_values=[target_value],
@@ -884,8 +884,8 @@ class DisabledSavedTensorsHooksVariable(ContextWrappingVariable):
 
     def __init__(
         self,
-        target_values: Sequence[Optional[str]],
-        initial_values: Optional[Sequence[Optional[str]]] = None,
+        target_values: Sequence[str | None],
+        initial_values: Sequence[str | None] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -896,7 +896,7 @@ class DisabledSavedTensorsHooksVariable(ContextWrappingVariable):
         return variables.CONSTANT_VARIABLE_NONE
 
     def _call_func(
-        self, tx: "InstructionTranslator", values: Sequence[Optional[str]]
+        self, tx: "InstructionTranslator", values: Sequence[str | None]
     ) -> None:
         assert len(values) == 1
         value = values[0]
@@ -966,7 +966,7 @@ class AutocastModeVariable(ContextWrappingVariable):
     def __init__(
         self,
         target_values: Sequence[Any],
-        initial_values: Optional[Any] = None,
+        initial_values: Any | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -1002,7 +1002,7 @@ class NullContextVariable(ContextWrappingVariable):
     This class represents Python contextlib.nullcontext.
     """
 
-    def __init__(self, target_values: Optional[Any] = None, **kwargs: Any) -> None:
+    def __init__(self, target_values: Any | None = None, **kwargs: Any) -> None:
         super().__init__(target_values=target_values, **kwargs)
 
     def enter(self, tx: "InstructionTranslator") -> VariableTracker:
@@ -1109,7 +1109,7 @@ class ProfilerRecordFunctionContextVariable(ContextWrappingVariable):
     def __init__(
         self,
         target_values: Any = None,
-        initial_values: Optional[Any] = None,
+        initial_values: Any | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -1268,7 +1268,7 @@ class FSDPParamGroupUseTrainingStateVariable(ContextWrappingVariable):
         self,
         param_group_var: Any,
         target_values: Sequence[Any],
-        initial_values: Optional[Sequence[Any]] = None,
+        initial_values: Sequence[Any] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -1569,7 +1569,7 @@ class CudagraphOverrideVariable(ContextWrappingVariable):
 class WithEnterFunctionVariable(VariableTracker):
     def __init__(
         self,
-        ctx: Union[ContextWrappingVariable, GenericContextWrappingVariable],
+        ctx: ContextWrappingVariable | GenericContextWrappingVariable,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -1615,7 +1615,7 @@ class WithExitFunctionVariable(VariableTracker):
 
     def __init__(
         self,
-        ctx: Union[ContextWrappingVariable, GenericContextWrappingVariable],
+        ctx: ContextWrappingVariable | GenericContextWrappingVariable,
         target: Any,
         **kwargs: Any,
     ) -> None:

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1516,7 +1516,7 @@ class ErrorOnGraphBreakVariable(ContextWrappingVariable):
 class CudagraphOverrideVariable(ContextWrappingVariable):
     """represents torch._dynamo.override_cudagraphs"""
 
-    def __init__(self, fwd: Optional[bool], bwd: Optional[bool], **kwargs: Any) -> None:
+    def __init__(self, fwd: bool | None, bwd: bool | None, **kwargs: Any) -> None:
         super().__init__(
             target_values=(fwd, bwd),
             initial_values=None,  # Captured in enter()

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -382,7 +382,7 @@ class ConstDictVariable(VariableTracker):
         )
 
     def is_new_item(
-        self, value: Optional[VariableTracker], other: VariableTracker
+        self, value: VariableTracker | None, other: VariableTracker
     ) -> bool:
         # compare the id of the realized values if both values are not lazy VTs
         if value and value.is_realized() and other.is_realized():
@@ -482,7 +482,7 @@ class ConstDictVariable(VariableTracker):
             )
         return self.items[key]
 
-    def maybe_getitem_const(self, arg: VariableTracker) -> Optional[VariableTracker]:
+    def maybe_getitem_const(self, arg: VariableTracker) -> VariableTracker | None:
         key = ConstDictVariable._HashableTracker(arg)
         if key not in self.items:
             return None
@@ -1041,7 +1041,7 @@ class DefaultDictVariable(ConstDictVariable):
         self,
         items: dict[VariableTracker, VariableTracker],
         user_cls: type,
-        default_factory: Optional[VariableTracker] = None,
+        default_factory: VariableTracker | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(items, user_cls, **kwargs)
@@ -1716,7 +1716,7 @@ class DictViewVariable(VariableTracker):
     This is an "abstract" class. Subclasses will override kv and the items method
     """
 
-    kv: Optional[str] = None
+    kv: str | None = None
 
     def __init__(self, dv_dict: ConstDictVariable, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -241,7 +241,7 @@ def add_call_function(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
     flat_example_value: Any,
-    config: Optional[NestedCompileRegionOptions] = None,
+    config: NestedCompileRegionOptions | None = None,
 ) -> VariableTracker:
     from .builder import wrap_fx_proxy
 
@@ -1454,8 +1454,8 @@ def speculate_subgraph_with_auto_output_flattening(
     *,
     # source_target is the .value of HigherOrderOpVariable and is the
     # target of the proxy that we created for the higherOrderOperator.
-    source_target: Optional[HigherOrderOperator] = None,
-    enable_grad: Optional[bool] = None,
+    source_target: HigherOrderOperator | None = None,
+    enable_grad: bool | None = None,
     # automatic: relies on Dynamo to find the used tensors and lift them as
     # inputs.
     #
@@ -2068,7 +2068,7 @@ def add_hop_context(cls: type[HOP_VT_Alias]) -> type[HOP_VT_Alias]:
 
 class TorchHigherOrderOperatorVariable(VariableTracker):
     # Subclasses should set _HOP_NAME to enable automatic HOP context in error messages
-    _HOP_NAME: Optional[str] = None
+    _HOP_NAME: str | None = None
     # Set to False for HOPs that hard error on graph break (e.g., cond, map, scan); otherwise
     # HOPs will fall back to eager.
     _ALLOW_FALLBACK_TO_EAGER: bool = True

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -16,7 +16,7 @@ handling of iterator operations during code transformation and optimization.
 import itertools
 import sys
 from collections.abc import Callable, Sequence
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 from .. import graph_break_hints, polyfills, variables
 from ..bytecode_transformation import (
@@ -338,8 +338,8 @@ class RepeatIteratorVariable(IteratorVariable):
 class CountIteratorVariable(IteratorVariable):
     def __init__(
         self,
-        item: Union[int, VariableTracker] = 0,
-        step: Union[int, VariableTracker] = 1,
+        item: int | VariableTracker = 0,
+        step: int | VariableTracker = 1,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -428,7 +428,7 @@ class ZipVariable(IteratorVariable):
         args = []
 
         def get_item(
-            it: Union[list[VariableTracker], VariableTracker],
+            it: list[VariableTracker] | VariableTracker,
         ) -> VariableTracker:
             if isinstance(it, list):
                 if old_index >= len(it):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1128,7 +1128,7 @@ class DequeVariable(CommonListMethodsVariable):
     def __init__(
         self,
         items: list[VariableTracker],
-        maxlen: Optional[VariableTracker] = None,
+        maxlen: VariableTracker | None = None,
         **kwargs: Any,
     ) -> None:
         if maxlen is None:
@@ -1351,7 +1351,7 @@ class SizeVariable(TupleVariable):
     def __init__(
         self,
         items: list[VariableTracker],
-        proxy: Optional[torch.fx.Proxy] = None,
+        proxy: torch.fx.Proxy | None = None,
         **kwargs: Any,
     ) -> None:
         self.proxy = proxy
@@ -1525,8 +1525,8 @@ class NamedTupleVariable(UserDefinedTupleVariable):
         items: list[VariableTracker],
         # pyrefly: ignore [implicit-any]
         tuple_cls: type[tuple],
-        dynamic_attributes: Optional[dict[str, VariableTracker]] = None,
-        tuple_vt: Optional[TupleVariable] = None,
+        dynamic_attributes: dict[str, VariableTracker] | None = None,
+        tuple_vt: TupleVariable | None = None,
         **kwargs: Any,
     ) -> None:
         if tuple_vt is None:

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -28,7 +28,7 @@ import re
 import types
 from collections.abc import Iterable, Sequence
 from contextlib import contextmanager, nullcontext
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch.nn
 from torch._guards import Source
@@ -142,7 +142,7 @@ def record_nn_module_stack(
 
 
 def guard_to_detect_forward_monkeypatching(
-    source: Optional[Source], mod: torch.nn.Module
+    source: Source | None, mod: torch.nn.Module
 ) -> None:
     # Users sometimes patch the forward method of a nn module instance to
     # perform optimizations like quantization. Though this is not a good
@@ -304,7 +304,7 @@ class NNModuleVariable(VariableTracker):
         tx: "InstructionTranslator",
         name: str,
         obj_source: Source,
-    ) -> Optional[VariableTracker]:
+    ) -> VariableTracker | None:
         """Check for a __getattr__ and handle it specially if it is implemented"""
         if object_has_getattribute(base):
             unimplemented(
@@ -1244,7 +1244,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
 
     def getattr_helper(
         self, tx: "InstructionTranslator", field: str, name_vt: VariableTracker
-    ) -> Optional[VariableTracker]:
+    ) -> VariableTracker | None:
         dict_vt = self.var_getattr(tx, field)
         if isinstance(dict_vt, variables.ConstDictVariable):
             return dict_vt.maybe_getitem_const(name_vt)

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -23,7 +23,7 @@ optimizer-specific optimizations and safety guarantees.
 import logging
 import weakref
 from collections.abc import Iterable
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch
 from torch._dynamo.variables.tensor import TensorVariable
@@ -94,9 +94,9 @@ class OptimizerVariable(UserDefinedObjectVariable):
     def __init__(
         self,
         value: torch.optim.Optimizer,
-        grad_to_source: Optional[dict[Any, GradSource]] = None,
-        static_tensor_names: Optional[set[str]] = None,
-        tensor_to_source: Optional[dict[torch.Tensor, Source]] = None,
+        grad_to_source: dict[Any, GradSource] | None = None,
+        static_tensor_names: set[str] | None = None,
+        tensor_to_source: dict[torch.Tensor, Source] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(value, **kwargs)

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -22,7 +22,7 @@ import functools
 import inspect
 import types
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -212,7 +212,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
         proxy: Proxy,
         value: Any,
         ctor_args_kwargs: Any = None,
-        source: Optional[Source] = None,
+        source: Source | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(value, **kwargs)

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -229,7 +229,7 @@ class SymbolicStreamState:
     def exit_stream(self) -> None:
         self.cur_stream_stack.pop()
 
-    def cur_stream(self, device: Optional[torch.device] = None) -> "StreamVariable":
+    def cur_stream(self, device: torch.device | None = None) -> "StreamVariable":
         if device is not None:
             for stream in reversed(self.cur_stream_stack):
                 if stream.device == device:
@@ -294,7 +294,7 @@ class StreamVariable(StreamContextVariable):
         self,
         proxy: Proxy,
         value: torch.Stream,
-        user_object_index: Optional[int] = None,
+        user_object_index: int | None = None,
         **kwargs: Any,
     ) -> None:
         # Index into the user object table
@@ -427,7 +427,7 @@ class EventVariable(VariableTracker):
         self,
         proxy: Proxy,
         value: torch.Event,
-        user_object_index: Optional[int],
+        user_object_index: int | None,
         **kwargs: Any,
     ) -> None:
         if proxy is not None and "example_value" in proxy.node.meta:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1140,7 +1140,7 @@ class TensorVariable(VariableTracker):
 
     def _collect_backward_inputs(
         self, vars_iter: Iterable[VariableTracker], error_on_non_leaf: bool = False
-    ) -> Optional[list[VariableTracker]]:
+    ) -> list[VariableTracker] | None:
         """
         Collect unique leaf tensors from vars_iter for backward.
 
@@ -1197,11 +1197,11 @@ class TensorVariable(VariableTracker):
     def method_backward(
         self,
         tx: "InstructionTranslator",
-        gradient: Optional[VariableTracker] = None,
-        retain_graph: Optional[VariableTracker] = None,
-        create_graph: Optional[VariableTracker] = None,
-        inputs: Optional[VariableTracker] = None,
-    ) -> Optional[VariableTracker]:
+        gradient: VariableTracker | None = None,
+        retain_graph: VariableTracker | None = None,
+        create_graph: VariableTracker | None = None,
+        inputs: VariableTracker | None = None,
+    ) -> VariableTracker | None:
         """
         Trace tensor.backward() by rewriting as autograd.grad() + accumulate_grad.
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -33,7 +33,7 @@ import math
 import re
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import nullcontext
-from typing import Any, NoReturn, Optional, TYPE_CHECKING, TypeVar, Union
+from typing import Any, NoReturn, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import TypeIs
 
 import torch._C
@@ -211,7 +211,7 @@ constant_fold_functions = dict.fromkeys(constant_fold_functions)
 
 
 @functools.cache
-def tracing_state_functions() -> dict[Callable[[], Any], Optional[bool]]:
+def tracing_state_functions() -> dict[Callable[[], Any], bool | None]:
     # Defined as a function to avoid circular import like torch.onnx
     return {
         torch.jit.is_scripting: False,
@@ -307,7 +307,7 @@ def _collect_all_grad_fns(tensor: torch.Tensor) -> set[torch.autograd.graph.Node
 
 def _collect_tensors_with_sources(
     var: VariableTracker,
-) -> list[tuple[torch.Tensor, Optional[str]]]:
+) -> list[tuple[torch.Tensor, str | None]]:
     """Extract (fake_tensor, source_name) pairs from a VariableTracker.
 
     Used by handle_autograd_grad to collect tensors from the outputs and inputs
@@ -317,7 +317,7 @@ def _collect_tensors_with_sources(
     from .lists import BaseListVariable
     from .tensor import TensorVariable
 
-    results: list[tuple[torch.Tensor, Optional[str]]] = []
+    results: list[tuple[torch.Tensor, str | None]] = []
     if isinstance(var, TensorVariable):
         fake_tensor = var.as_proxy().node.meta.get("example_value")
         assert isinstance(fake_tensor, torch._subclasses.fake_tensor.FakeTensor)
@@ -1359,7 +1359,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             self,
             tx: "InstructionTranslator",
             expr: VariableTracker,
-            fallback: Optional[VariableTracker] = None,
+            fallback: VariableTracker | None = None,
         ) -> VariableTracker | None:
             fallback_int = fallback.as_python_constant() if fallback else None
             if isinstance(expr, SymNodeVariable):

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -31,7 +31,7 @@ import inspect
 import operator
 from collections.abc import Generator, Iterable, Sequence
 from types import TracebackType
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch._C
 import torch.utils._pytree as pytree
@@ -157,8 +157,8 @@ class TorchFunctionModeVariable(GenericContextWrappingVariable):
 
     def __init__(
         self,
-        value: Optional[TorchFunctionMode],
-        source: Optional[Source] = None,
+        value: TorchFunctionMode | None,
+        source: Source | None = None,
         **kwargs: Any,
     ) -> None:
         if value is not None:
@@ -245,9 +245,9 @@ class TorchFunctionModeStackStateManager:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         set_torch_function_mode_stack(self.stack)
         self.stack = []


### PR DESCRIPTION
Since python>=3.10 is defined in the pyproject.toml, we can enable [pep604](https://peps.python.org/pep-0604/) (in python >=3.10)

Why? 

1) Fewer imports making code simpler
2) Standardization - prior to this change, we could have `Optional` or the  `| None` intermixed in the codebase
3) Future proof for direction of python type system


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @xmfan @aditvenk