### PR TITLE
[torch/mtia] Reduce current_stream overhead by avoiding slow _get_device_index path

### DIFF
--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -186,7 +186,8 @@ def current_stream(device: Device = None) -> Stream:
             by :func:`~torch.mtia.current_device`, if :attr:`device` is ``None``
             (default).
     """
-    return torch._C._mtia_getCurrentStream(_get_device_index(device, optional=True))
+    device_idx = _get_device_index(device, optional=True)
+    return torch._C._mtia_getCurrentStream(device_idx)
 
 
 def default_stream(device: Device = None) -> Stream:


### PR DESCRIPTION
Summary: `Make torch.mtia.current_device()` faster

Test Plan: CI

Differential Revision: D94111510


