### PR TITLE
[cudagraph_trees] Fix tensor_weakrefs/stack_traces assertion in dealloc_current_path_weakrefs

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -5310,6 +5310,41 @@ if HAS_CUDA_AND_TRITON:
             run(10)
             run(25)
 
+        def test_dealloc_handles_tensor_weakrefs_stack_traces_mismatch(self):
+            """Verify dealloc_current_path_weakrefs handles tensor_weakrefs /
+            stack_traces length mismatch without asserting.
+
+            This injects the mismatch directly so the deallocation path is
+            deterministic. The fix replaces the hard assert with a warning and
+            relies on zip(), matching the existing defensive pattern for
+            outputs_weakrefs in the same function.
+            """
+
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x + 1
+
+            inp = torch.rand([4], device="cuda")
+
+            # First call: warmup phase creates and runs a CUDAWarmupNode.
+            torch.compiler.cudagraph_mark_step_begin()
+            foo(inp)
+
+            # Simulate the tensor_weakrefs / stack_traces length divergence.
+            node = self.curr_node()
+            self.assertEqual(len(node.tensor_weakrefs), len(node.stack_traces))
+            node.tensor_weakrefs.append(None)
+
+            # Second call: transitions warmup -> recording, which invokes
+            # try_end_curr_warmup -> dealloc_current_path_weakrefs.
+            # cudagraph_mark_step_begin ensures can_start_new_generation()
+            # returns True so dealloc is actually called.
+            # Without the fix, this would hit:
+            #   assert len(node.tensor_weakrefs) == len(node.stack_traces)
+            # With the fix, zip() safely truncates to the shorter list.
+            torch.compiler.cudagraph_mark_step_begin()
+            foo(inp)
+
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_opaque_value_input_cudagraph(self):
             """Opaque reference-type objects (e.g. DeviceMesh, ProcessGroup)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2687,7 +2687,15 @@ class CUDAGraphTreeManager:
         stor_dealloc_info: dict[int, tuple[str | None, bool]] = {}
         for node in self.current_node._path_from_root:
             assert node.stack_traces is not None
-            assert len(node.tensor_weakrefs) == len(node.stack_traces)
+            # tensor_weakrefs and stack_traces are paired below with zip(),
+            # matching the defensive handling for outputs_weakrefs and
+            # stack_traces.
+            if len(node.tensor_weakrefs) != len(node.stack_traces):
+                log.warning(
+                    "tensor_weakrefs length (%d) != stack_traces length (%d)",
+                    len(node.tensor_weakrefs),
+                    len(node.stack_traces),
+                )
             is_grad_output = (
                 self.id_to_mode[node.wrapped_function.id] == CompilationMode.BACKWARD
             )


### PR DESCRIPTION
In `dealloc_current_path_weakrefs`, `tensor_weakrefs` and `stack_traces` are consumed with `zip(node.tensor_weakrefs, node.stack_traces)`, matching the defensive pattern already used for `outputs_weakrefs` and `stack_traces` later in the same function. The hard assert immediately before the zip prevents that defensive behavior if the lengths ever differ.

This PR replaces the hard assert with a warning and keeps the existing `zip()` behavior.

Scope note: this is a narrow defensive consistency cleanup. It does **not** fix the separate compiled autoregressive decode / DynamicCache overwrite failure tracked in #175557 and #154824. After rechecking the TR126 artifacts and repro attempts, I could not support the earlier claim that TR126 organically reproduced a `tensor_weakrefs` / `stack_traces` mismatch; the reproducible TR126 failure is the `CUDAGraphs` tensor-overwrite RuntimeError.

Test coverage: `test_dealloc_handles_tensor_weakrefs_stack_traces_mismatch` injects a deterministic mismatch on a warmup node and verifies the warmup-to-recording deallocation path no longer asserts.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eellison @BoyuanFeng