### PR TITLE
Fix test_extension_backend race condition

### DIFF
--- a/test/inductor/extension_backends/cpp/extension_codegen_backend.py
+++ b/test/inductor/extension_backends/cpp/extension_codegen_backend.py
@@ -1,4 +1,8 @@
+from typing import Optional
+
+from torch._inductor import ir
 from torch._inductor.codegen import cpp, cpp_wrapper_cpu, wrapper
+from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.scheduler import BaseScheduling
 from torch._inductor.virtualized import V
 
@@ -7,10 +11,43 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    @staticmethod
+    def create(
+        is_subgraph: bool,
+        subgraph_name: Optional[str],
+        parent_wrapper: Optional[PythonWrapperCodegen],
+        partition_signatures: Optional[ir.GraphPartitionSignature] = None,
+    ):
+        return ExtensionWrapperCodegen()
+
+    def _generate_kernel_call_helper(self, kernel_name, call_args, *, device=None, **kwargs):
+        device = device or V.graph.get_current_device_or_throw()
+        if device.type == "extension_device":
+            import torch
+            device = torch.device("cpu")
+        super()._generate_kernel_call_helper(
+            kernel_name, call_args, device=device, **kwargs
+        )
+
 
 class ExtensionCppWrapperCodegen(cpp_wrapper_cpu.CppWrapperCpu):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def create(
+        is_subgraph: bool,
+        subgraph_name: Optional[str],
+        parent_wrapper: Optional[PythonWrapperCodegen],
+        partition_signatures: Optional[ir.GraphPartitionSignature] = None,
+    ):
+        return ExtensionCppWrapperCodegen()
+
+    @staticmethod
+    def get_device_include_path(device: str) -> str:
+        if device == "extension_device":
+            return cpp_wrapper_cpu.CppWrapperCpu.get_device_include_path("cpu")
+        return cpp_wrapper_cpu.CppWrapperCpu.get_device_include_path(device)
 
 
 class ExtensionScheduling(BaseScheduling):

--- a/test/inductor/extension_backends/cpp/extension_codegen_backend.py
+++ b/test/inductor/extension_backends/cpp/extension_codegen_backend.py
@@ -20,10 +20,13 @@ class ExtensionWrapperCodegen(wrapper.PythonWrapperCodegen):
     ):
         return ExtensionWrapperCodegen()
 
-    def _generate_kernel_call_helper(self, kernel_name, call_args, *, device=None, **kwargs):
+    def _generate_kernel_call_helper(
+        self, kernel_name, call_args, *, device=None, **kwargs
+    ):
         device = device or V.graph.get_current_device_or_throw()
         if device.type == "extension_device":
             import torch
+
             device = torch.device("cpu")
         super()._generate_kernel_call_helper(
             kernel_name, call_args, device=device, **kwargs

--- a/test/inductor/extension_backends/cpp/extension_device.cpp
+++ b/test/inductor/extension_backends/cpp/extension_device.cpp
@@ -185,4 +185,7 @@ bool custom_op_called() {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("custom_device", &get_custom_device, "get custom device object");
     m.def("custom_op_called", &custom_op_called, "check if our custom function was called");
+    m.def("is_available", []() { return true; });
+    m.def("device_count", []() { return 1; });
+    m.def("current_device", []() { return 0; });
 }

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -95,7 +95,12 @@ class BaseExtensionBackendTests(TestCase):
         super().tearDown()
         torch._dynamo.reset()
 
-        # return the working directory (see setUp)
+        backend_name = torch._C._get_privateuse1_backend_name()
+        if hasattr(torch, backend_name):
+            delattr(torch, backend_name)
+        if f"torch.{backend_name}" in sys.modules:
+            del sys.modules[f"torch.{backend_name}"]
+
         os.chdir(self.old_working_dir)
 
 

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import os
 import sys
+import tempfile
 import unittest
 
 import torch
@@ -22,8 +23,6 @@ except ImportError:
         ExtensionScheduling,
         ExtensionWrapperCodegen,
     )
-
-from filelock import FileLock, Timeout
 
 import torch._inductor.config as config
 from torch._inductor import cpu_vec_isa, metrics
@@ -55,22 +54,11 @@ TestCase = test_torchinductor.TestCase
 class BaseExtensionBackendTests(TestCase):
     module = None
 
-    # Use a lock file so that only one test can build this extension at a time
-    lock_file = "extension_device.lock"
-    lock = FileLock(lock_file)
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        try:
-            cls.lock.acquire(timeout=600)
-        except Timeout:
-            # This shouldn't happen, still attempt to build the extension anyway
-            pass
-
-        # Build Extension
-        torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
+        cls._build_dir = tempfile.TemporaryDirectory()
         source_file_path = os.path.dirname(os.path.abspath(__file__))
         source_file = os.path.join(
             source_file_path, "extension_backends/cpp/extension_device.cpp"
@@ -82,6 +70,7 @@ class BaseExtensionBackendTests(TestCase):
             ],
             extra_cflags=["-g"],
             verbose=True,
+            build_directory=cls._build_dir.name,
         )
 
     @classmethod
@@ -89,11 +78,7 @@ class BaseExtensionBackendTests(TestCase):
         cls._stack.close()
         super().tearDownClass()
 
-        torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
-
-        cls.lock.release()
-        if os.path.exists(cls.lock_file):
-            os.remove(cls.lock_file)
+        cls._build_dir.cleanup()
 
     def setUp(self):
         torch._dynamo.reset()
@@ -181,4 +166,4 @@ if __name__ == "__main__":
 
     # cpp_extension doesn't work in fbcode right now
     if HAS_CPU and not IS_MACOS and not IS_FBCODE:
-        run_tests(needs="filelock")
+        run_tests()


### PR DESCRIPTION
Fixes #137027

Removing the build tree removes a lock file that we also are trying to
separately remove. Instead, perform each build in its own directory.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo