### PR TITLE
Fix weak dep check if not all indices are used

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8932,6 +8932,30 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.common(fn, (a, idx))
         assertGeneratedKernelCountEqual(self, 2)
 
+    @skip_if_halide
+    def test_index_put_duplicate_indices_no_accumulate(self):
+        # https://github.com/pytorch/pytorch/issues/174074
+        def fn(x):
+            x[[0, 0]] += x[[0, 0]]
+            return x
+
+        # ncols=2048 forces multiple Triton blocks on GPU, exposing the
+        # inter-block race that small tensors mask.
+        x = torch.randn(1, 2048, dtype=torch.float64)
+        self.common(fn, (x,))
+
+    @skip_if_pallas
+    def test_index_put_duplicate_indices_accumulate(self):
+        # accumulate=True is well-defined with duplicate indices.
+        def fn(x):
+            idx = torch.tensor([0, 0], device=x.device)
+            vals = x[[0, 0]] * 2
+            x.index_put_((idx,), vals, accumulate=True)
+            return x
+
+        x = torch.randn(1, 2048, dtype=torch.float64)
+        self.common(fn, (x,))
+
     def test_adding_tensor_offsets(self):
         @torch.compile(fullgraph=True)
         def fn(x):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8933,6 +8933,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         assertGeneratedKernelCountEqual(self, 2)
 
     @skip_if_halide
+    @skip_if_pallas
     def test_index_put_duplicate_indices_no_accumulate(self):
         # https://github.com/pytorch/pytorch/issues/174074
         def fn(x):
@@ -8941,7 +8942,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         # ncols=2048 forces multiple Triton blocks on GPU, exposing the
         # inter-block race that small tensors mask.
-        x = torch.randn(1, 2048, dtype=torch.float64)
+        x = torch.randn(1, 2048, dtype=torch.float32)
         self.common(fn, (x,))
 
     @skip_if_pallas
@@ -8953,7 +8954,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             x.index_put_((idx,), vals, accumulate=True)
             return x
 
-        x = torch.randn(1, 2048, dtype=torch.float64)
+        x = torch.randn(1, 2048, dtype=torch.float32)
         self.common(fn, (x,))
 
     def test_adding_tensor_offsets(self):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6016,6 +6016,14 @@ class Scheduler:
         if free_symbol_is_type(write.index, SymT.TMP):
             return False
 
+        # Non-injective scatter: range vars absent from write index mean
+        # multiple iterations hit the same location. Can't fuse the reader
+        # in or it will see partially-written state between iterations.
+        write_index_vars = write.index.free_symbols
+        for var, size in zip(write.var_names, write.size):
+            if var not in write_index_vars and size != 1:
+                return False
+
         real_name = self.mutation_real_name[weak_dep.mutating_buf]
         relevant_reading_nodes = [node1]
         if isinstance(node1, ForeachKernelSchedulerNode):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6019,10 +6019,8 @@ class Scheduler:
         # Non-injective scatter: range vars absent from write index mean
         # multiple iterations hit the same location. Can't fuse the reader
         # in or it will see partially-written state between iterations.
-        write_index_vars = write.index.free_symbols
-        for var, size in zip(write.var_names, write.size):
-            if var not in write_index_vars and size != 1:
-                return False
+        if not set(write.var_names) <= write.index.free_symbols:
+            return False
 
         real_name = self.mutation_real_name[weak_dep.mutating_buf]
         relevant_reading_nodes = [node1]

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6019,7 +6019,7 @@ class Scheduler:
         # Non-injective scatter: range vars absent from write index mean
         # multiple iterations hit the same location. Can't fuse the reader
         # in or it will see partially-written state between iterations.
-        if not set(write.var_names) <= write.index.free_symbols:
+        if not OrderedSet(write.var_names) <= write.index.free_symbols:
             return False
 
         real_name = self.mutation_real_name[weak_dep.mutating_buf]


### PR DESCRIPTION
Fixes #174074

This can happen also on non-UB paths when accumulate is set, as a
consequence of how we inline the offset in there.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela