### PR TITLE
[Inductor][CUDA][test] Fix test_mm_plus_mm3_dynamic_shapes_gpu_wrapper on CUDA

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -117,6 +117,13 @@ test_failures_gpu_wrapper = {
     ),
 }
 
+# Skip only on CUDA as wrapper dynamic shapes passes on ROCm.
+# Per https://github.com/pytorch/pytorch/pull/172780
+if not torch.version.hip:
+    test_failures_gpu_wrapper["test_mm_plus_mm3_dynamic_shapes"] = (
+        test_torchinductor.TestFailure(("gpu_wrapper",), is_skip=False)
+    )
+
 
 def make_test_case(
     name,

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -78,7 +78,6 @@ def patches(fn):
     return wrapped
 
 
-# @instantiate_parametrized_tests
 class TestSelectAlgorithm(TestCase):
     def setUp(self):
         super().setUp()

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -6,8 +6,6 @@ from collections.abc import Callable
 from typing import Any, Optional, Union
 from unittest.mock import patch
 
-import pytest
-
 import torch
 import torch._dynamo.config as dynamo_config
 import torch._inductor.config as inductor_config
@@ -80,6 +78,7 @@ def patches(fn):
     return wrapped
 
 
+# @instantiate_parametrized_tests
 class TestSelectAlgorithm(TestCase):
     def setUp(self):
         super().setUp()
@@ -293,10 +292,6 @@ class TestSelectAlgorithm(TestCase):
         if not torch.version.hip:  # autotuning is not guaranteed to run on ROCm
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
-    @pytest.mark.xfail(
-        condition=not torch.version.hip,
-        reason="C++ wrapper dynamic shapes fails on CUDA, fixed on ROCm",
-    )
     @patches
     def test_mm_plus_mm3(self):
         @torch.compile


### PR DESCRIPTION
`test_mm_plus_mm3_gpu_wrapper` was marked xfail on CUDA but actually passes, causing XPASS. The expected failure was only in the `test_mm_plus_mm3_dynamic_shapes_gpu_wrapper`.

Removed xfail from `test_mm_plus_mm3` in `test/inductor/test_select_algorithm.py` and added `test_mm_plus_mm3_dynamic_shapes` to `test_failures_gpu_wrapper` list in `test/inductor/test_gpu_cpp_wrapper.py`

Fixes: https://github.com/pytorch/pytorch/issues/175546

CC: @eqy 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo