### PR TITLE
[fix] raise exception from _CoalescingManager when the ops in list are not the same

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4470,7 +4470,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         process_group = c10d.distributed_c10d._get_default_group()
         device = torch.device(f"cuda:{self.rank:d}")
         with self.assertRaisesRegex(
-            ValueError,
+            RuntimeError,
             "Coalescing manager requires all collectives to be the same type",
         ):
             with torch.distributed._coalescing_manager(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2754,9 +2754,9 @@ def _coalescing_manager(
         # - coalesced `reduce_scatter_tensor`
         op0 = op_list[0].op
         if any(op.op is not op0 for op in op_list):
-            raise ValueError(
+            raise RuntimeError(
                 "Coalescing manager requires all collectives to be the same type, "
-                f"but got mixed types: {set(op.op.__name__ for op in op_list)}"
+                f"but got mixed types: {set(op.op.__name__ for op in op_list)}"  # noqa: C401
             )
 
         if op0 is all_reduce:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2753,6 +2753,12 @@ def _coalescing_manager(
         # - coalesced `all_gather_into_tensor`
         # - coalesced `reduce_scatter_tensor`
         op0 = op_list[0].op
+        if any(op.op is not op0 for op in op_list):
+            raise ValueError(
+                "Coalescing manager requires all collectives to be the same type, "
+                f"but got mixed types: {set(op.op.__name__ for op in op_list)}"
+            )
+
         if op0 is all_reduce:
             tensors = [op.tensor for op in op_list]
             all_reduce_opts = AllreduceCoalescedOptions()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175573
* #175379

# Problem
If users put two different types of collective call in the coalescing manager, c10d code ignores
such difference and call the coalesced collective of the first on tensor arguments:
```
with torch.distributed._coalescing_manager(...):
    torch.distributed.all_reduce(...)
    torch.distributed.all_gather_into_tensor(...)
```

We add a sanity check on the identity among all collective ops within the manager so the following `RuntimeError` will be thrown in the above case:
```
Coalescing manager requires all collectives to be the same type, but got mixed types: {'all_reduce', 'all_gather_into_tensor'}
```