### PR TITLE
[re-submit] More size-hinting cleanups (#174580)

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2368,9 +2368,8 @@ class CppKernel(Kernel):
 
     def size_hint(self):
         assert self.call_ranges is not None
-        return V.graph.sizevars.size_hint(
-            sympy_product(self.call_ranges), fallback=8192
-        )
+        expr = sympy_product(self.call_ranges)
+        return V.graph.sizevars.optimization_hint(expr)
 
     def codegen_loops_impl(self, loop_nest, code, worksharing):
         assert isinstance(self, CppKernelProxy)
@@ -3926,7 +3925,7 @@ class TilingSelect:
                     if tiling_indice < 0 or tiling_indice >= len(call_ranges):
                         continue
                     if has_free_symbols(call_ranges):
-                        call_range = V.graph.sizevars.size_hint(
+                        call_range = V.graph.sizevars.optimization_hint(
                             call_ranges[tiling_indice], fallback=0
                         )
                         if call_range < factor_lowp:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2306,7 +2306,8 @@ class TMACompatibilityChecker:
         """
         if self.force:
             strides = [
-                V.graph.sizevars.symbolic_hint(st) for st in block_params.strides
+                V.graph.sizevars.replace_backed_symbols_with_hints(st)
+                for st in block_params.strides
             ]
         else:
             strides = block_params.strides
@@ -5331,7 +5332,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if prefix_is_reduction(prefix) and not self.inside_reduction:
                 continue
 
-            numel_hint = V.graph.sizevars.symbolic_hint(numel)
+            numel_hint = V.graph.sizevars.replace_backed_symbols_with_hints(numel)
             if not isinstance(numel_hint, (int, sympy.Integer)):
                 # This default heuristic hint was picked carefully: it is
                 # large, to ensure that we don't shrink the block size (since

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -727,7 +727,7 @@ class EfficientPeakEstimate:
         )
 
     def _get_size(self, node: BufferLike) -> int:
-        return V.graph.sizevars.size_hint(
+        return V.graph.sizevars.optimization_hint(
             V.graph.get_allocation_storage_size(node), fallback=0
         ) * get_dtype_size(node.get_dtype())
 
@@ -788,7 +788,7 @@ class AllocateLine(MemoryPlanningLine):
         key = buffer_reuse_key(self.node)
         if config.allow_buffer_reuse and key in state:
             free_line = state.pop(key)
-            size = V.graph.sizevars.size_hint(
+            size = V.graph.sizevars.optimization_hint(
                 V.graph.get_allocation_storage_size(self.node), fallback=0
             ) * get_dtype_size(self.node.get_dtype())
             if self.should_reuse_buffer(free_line, size):
@@ -2333,14 +2333,13 @@ class PythonWrapperCodegen(CodeGen):
                         f"torch.cuda.default_generators[{value.device.index}].graphsafe_get_state()",
                     )
                 else:
-                    shape = [
-                        V.graph.sizevars.optimization_hint(x, fallback=42)
-                        for x in value.get_size()
-                    ]
-                    stride = [
-                        V.graph.sizevars.size_hint(x, fallback=42)
-                        for x in value.get_stride()
-                    ]
+                    shape = V.graph.sizevars.optimization_hints(
+                        value.get_size(), fallback=42
+                    )
+                    stride = V.graph.sizevars.optimization_hints(
+                        value.get_stride(), fallback=42
+                    )
+
                     add_fake_input(
                         name,
                         shape,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -468,11 +468,8 @@ def significant_strides_equal(
         if V.graph.sizevars.statically_known_leq(dim, 1):
             continue
 
-        if not V.graph.sizevars.statically_known_equals(
-            s1, s2
-        ) and V.graph.sizevars.symbolic_hint(s1) != V.graph.sizevars.symbolic_hint(s2):
+        if not V.graph.sizevars.guard_or_false(sympy.Eq(s1, s2)):
             return False
-
     return True
 
 
@@ -1319,8 +1316,13 @@ class Reduction(Loops):
         reduction_numel: Expr,
         input_node: Optional[IRNode] = None,
     ) -> tuple[ReductionHint, _IntLike]:
-        reduction_numel_hint = V.graph.sizevars.symbolic_hint(reduction_numel)
-        numel_hint = V.graph.sizevars.symbolic_hint(sympy_product(ranges))
+        # TODO Laith support unbacked!
+        reduction_numel_hint = V.graph.sizevars.replace_backed_symbols_with_hints(
+            reduction_numel
+        )
+        numel_hint = V.graph.sizevars.replace_backed_symbols_with_hints(
+            sympy_product(ranges)
+        )
 
         should_split = reduction_type == "scan" or (
             not V.graph.has_feature(device, BackendFeature.REDUCE_TO_SINGLE_ELEMENT)
@@ -1373,8 +1375,10 @@ class Reduction(Loops):
                         new_reduction_ranges,
                     ) = extract_input_node_reduction_ranges(input_node)
                 if new_ranges is not None and new_reduction_ranges is not None:
-                    extracted_numel_hint = V.graph.sizevars.symbolic_hint(
-                        sympy_product(new_ranges + new_reduction_ranges)
+                    extracted_numel_hint = (
+                        V.graph.sizevars.replace_backed_symbols_with_hints(
+                            sympy_product(new_ranges + new_reduction_ranges)
+                        )
                     )
                     if reduction_numel_hint == extracted_numel_hint:
                         log.debug(

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -122,10 +122,7 @@ class KernelInputs(ABC):
             A tuple of shape tuples with integer hints for each input node
         """
         return tuple(
-            V.graph.sizevars.size_hints(
-                node.get_size(),
-                fallback=torch._inductor.config.unbacked_symint_fallback,
-            )
+            V.graph.sizevars.optimization_hints(node.get_size())
             for node in self._input_nodes
         )
 
@@ -146,10 +143,7 @@ class KernelInputs(ABC):
             A tuple of stride tuples with integer hints for each input node
         """
         return tuple(
-            V.graph.sizevars.size_hints(
-                node.get_stride(),
-                fallback=torch._inductor.config.unbacked_symint_fallback,
-            )
+            V.graph.sizevars.optimization_hints(node.get_stride())
             for node in self._input_nodes
         )
 

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -205,7 +205,7 @@ def compute_size_for_scheduler_buffer(
             )
             return size_alloc
         else:
-            buf_size = V.graph.sizevars.size_hint(
+            buf_size = V.graph.sizevars.optimization_hint(
                 sched_buf.node.get_numel(), fallback=0
             ) * get_dtype_size(sched_buf.node.get_dtype())
             sched_buf_to_size[sched_buf.get_name()] = (

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5199,7 +5199,9 @@ class Scheduler:
             ):
                 candidates.append(
                     (
-                        V.graph.sizevars.size_hint(lhs_dep.get_numel(), fallback=0),
+                        V.graph.sizevars.optimization_hint(
+                            lhs_dep.get_numel(), fallback=0
+                        ),
                         lhs_dep,
                         rhs_dep,
                     )

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -23,7 +23,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.symbol import symbol_is_type, SymT
-from torch.utils._sympy.value_ranges import bound_sympy, IntInfinity, ValueRanges
+from torch.utils._sympy.value_ranges import IntInfinity, ValueRanges
 
 from . import config
 from .runtime.runtime_utils import is_power_of_2
@@ -38,6 +38,25 @@ from .virtualized import V
 
 
 log = logging.getLogger(__name__)
+
+# Symbols created by CppTemplateKernel.slice_nd → parse_expr_with_index_symbols
+# and are internal to C++ GEMM codegen (not tracked by ShapeEnv).
+_GEMM_TEMPLATE_SYMBOL_NAMES = OrderedSet(
+    [
+        "m_start",
+        "m_end",
+        "n_start",
+        "n_end",
+        "k_start",
+        "k_end",
+        "m_size",
+        "n_size",
+        "m_offset",
+        "m_start_unsliced",
+        "m_end_unsliced",
+        "m_size_unsliced",
+    ]
+)
 
 
 def statically_known_true(
@@ -566,14 +585,18 @@ class SizeVarAllocator:
             return sympy_subs(expr, self.inv_precomputed_replacements)  # type: ignore[arg-type]
         return expr
 
-    def symbolic_hint(
+    def replace_backed_symbols_with_hints(
         self,
         expr: Union[Expr, int],
-        # Only flip this flag if you don't plan on guarding/adding runtime
-        # asserts based on this value and promise to only use this value
-        # in a heuristic nature.
-        use_user_provided_hint_override: bool = False,
     ) -> Union[Expr, int]:
+        """
+        Replace all backed symbols in an expression with their concrete hint values.
+
+        This function substitutes backed symbolic variables with their known concrete
+        values from the shape environment, while leaving unbacked symbols (data-dependent
+        values) untouched. Not recommended to be used except as last resort!
+        was added for existing usages compatibility.
+        """
         if isinstance(expr, int):
             return expr
         # Substitute all hints into expr, but leave unbacked symints alone
@@ -581,19 +604,19 @@ class SizeVarAllocator:
         if not isinstance(expr, Expr):
             assert isinstance(expr, int)
             return expr
+
+        expr = self.remove_precomputed_replacements(expr)
+        expr = sympy_subs(expr, self.backed_var_to_val)
+        expr = expr.expand(identity=True)
+
         free_symbols = expr.free_symbols
         if not free_symbols:
             try:
-                return int(expr)  # type: ignore[return-value]
+                return int(expr)
             except TypeError:
                 return expr  # inf/nan/I
 
-        expr = self.remove_precomputed_replacements(expr)
-
-        if use_user_provided_hint_override:
-            expr = sympy_subs(expr, self.var_to_hint_override)
-
-        return sympy_subs(expr, self.backed_var_to_val)
+        return expr
 
     def to_symint_or_int(self, expr: Union[Expr, int]) -> Union[SymInt, int]:
         """Convert a sympy expression to SymInt, or return int as is."""
@@ -623,34 +646,14 @@ class SizeVarAllocator:
         """Convert a sequence of sympy expressions to SymInts, or return ints as is."""
         return [self.to_symint_or_int(e) for e in exprs]
 
-    def size_hint(
-        self,
-        expr: Union[Expr, int],
-        *,
-        fallback: Optional[int] = None,
-    ) -> int:
+    # TODO this will be deprecated.
+    def size_hint(self, expr: Union[Expr, int]) -> int:
         if isinstance(expr, SymInt):
             raise TypeError(
                 "wrong API usage!, use size_hint from torch.fx.experimental.symbolic_shapes or pass sympy expressions instead"
             )
 
-        out = self.symbolic_hint(
-            expr,
-            use_user_provided_hint_override=fallback is not None,
-        )
-        if not isinstance(out, (int, sympy.Integer)) and fallback is not None:
-            # Use the provided heuristic fallback hint
-            unbacked_sym_vrs = {
-                s: self.shape_env.var_to_range.get(s, None) for s in out.free_symbols
-            }
-            if all(vr is not None for vr in unbacked_sym_vrs.values()):
-                hint_vr = bound_sympy(out, unbacked_sym_vrs)  # type: ignore[arg-type]
-                if isinstance(hint_vr.lower, (int, sympy.Integer)):
-                    fallback = max(fallback, int(hint_vr.lower))
-                if isinstance(hint_vr.upper, (int, sympy.Integer)):
-                    fallback = min(fallback, int(hint_vr.upper))
-            return fallback
-
+        out = self.replace_backed_symbols_with_hints(expr)
         try:
             return int(out)
         except Exception:
@@ -685,14 +688,13 @@ class SizeVarAllocator:
         if isinstance(expr, sympy.Expr):
             expr = expr.expand(identity=True)
 
-        # apply replacements
-        expr = self.remove_precomputed_replacements(expr)
-        expr = sympy_subs(expr, self.backed_var_to_val)
+        # Replace backed symbols with their hints, leaving unbacked symbols alone.
+        expr = self.replace_backed_symbols_with_hints(expr)
+
         if has_free_unbacked_symbols(expr):
             raise GuardOnDataDependentSymNode(expr)
 
-        result = self._maybe_realize_expr(expr, nan_fallback=None)
-
+        result = self._maybe_realize_expr(expr, None)
         assert result is not None, expr
         return result
 
@@ -717,7 +719,7 @@ class SizeVarAllocator:
         if isinstance(expr, Expr):
             if expr.has(sympy.I):
                 raise ValueError(
-                    f"optimization_hint received a complex expression: {expr}. "
+                    f"_maybe_realize_expr received a complex expression: {expr}. "
                     "Tensor dimensions cannot be complex numbers."
                 )
             if expr in (int_oo, sympy.oo):
@@ -753,7 +755,6 @@ class SizeVarAllocator:
             fallback = config.unbacked_symint_fallback
         assert fallback is not None
 
-        original = expr
         expr = self.simplify(expr)
         result = self._maybe_realize_expr(expr, fallback)
         if result is not None:
@@ -762,25 +763,34 @@ class SizeVarAllocator:
         if isinstance(expr, sympy.Expr):
             expr = expr.expand(identity=True)
 
-        # remove precomputed_replacements
-        expr = self.remove_precomputed_replacements(expr)
+        original = expr
 
-        # replace all backed symbols with their backed hints,
-        # unbacked with optimizations hints if exists.
-        expr = sympy_subs(expr, self.backed_var_to_val)
-        expr = sympy_subs(expr, self.var_to_hint_override)
+        expr = self.replace_backed_symbols_with_hints(expr)
+
         result = self._maybe_realize_expr(expr, fallback)
         if result is not None:
             return result
 
-        # Assign values to remaining unbacked symbols using a heuristic
-        # tries to maximize consistency with shape environment.
-        assert has_free_unbacked_symbols(expr), expr
+        # replace unbacked with optimizations hints if exists.
+        expr = sympy_subs(expr, self.var_to_hint_override)
 
-        # Make sure to substitute with the factored version
-        # e.g. 10*(s0 + u0) instead of 10*s0 + 10*u0
-        # TODO optimize _sub_unbacked_exprs
-        expr = self._sub_unbacked_exprs(sympy.factor(original))
+        result = self._maybe_realize_expr(expr, fallback)
+        if result is not None:
+            return result
+
+        # If unbacked symbols remain, try to substitute them using heuristics
+        # that maximize consistency with the shape environment.
+        if has_free_unbacked_symbols(expr):
+            # Make sure to substitute with the factored version
+            # e.g. 10*(s0 + u0) instead of 10*s0 + 10*u0
+
+            # Limit sympy.factor() to expressions with <= 200 free symbols,
+            # as factoring polynomials with many variables is expensive.
+            if isinstance(original, sympy.Expr) and len(original.free_symbols) <= 200:
+                expr = self._sub_unbacked_exprs(sympy.factor(original))
+            else:
+                # TODO optimize _sub_unbacked_exprs
+                expr = self._sub_unbacked_exprs(original)
 
         # For multiple expressions that depend on an unbacked symint,
         # we want to compute them consistently for a size hint we have chosen.
@@ -807,7 +817,7 @@ class SizeVarAllocator:
         final_result = self._maybe_realize_expr(final_result, fallback)
         assert final_result is not None, final_result
 
-        return int(final_result)
+        return final_result
 
     def optimization_hints(
         self,
@@ -883,16 +893,8 @@ class SizeVarAllocator:
     def size_hints(
         self,
         exprs: Iterable[Union[Expr, int]],
-        *,
-        fallback: Optional[int] = None,
     ) -> tuple[int, ...]:
-        return tuple(
-            self.size_hint(
-                x,
-                fallback=fallback,
-            )
-            for x in exprs
-        )
+        return tuple(self.size_hint(x) for x in exprs)
 
     def guarding_hints_or_throw(
         self,
@@ -1144,7 +1146,12 @@ class SizeVarAllocator:
             new_expr = expr.subs(replacements)
             if new_expr == expr:
                 break
-            expr = sympy.factor(new_expr)
+            # Skip sympy.factor() for expressions with many free symbols,
+            # as factoring polynomials with many variables is expensive.
+            if len(new_expr.free_symbols) <= 200:
+                expr = sympy.factor(new_expr)
+            else:
+                expr = new_expr
             sub_cnt += 1
         else:
             log.warning("Substitution limit (%d) reached w/ %s", sub_cnt_limit, expr)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1904,8 +1904,12 @@ def can_use_tma(
             sizes_i = V.graph.sizevars.guard_int_seq(sizes)
             strides_i = V.graph.sizevars.guard_int_seq(strides)
         else:
-            sizes_i = [V.graph.sizevars.symbolic_hint(s) for s in sizes]
-            strides_i = [V.graph.sizevars.symbolic_hint(st) for st in strides]
+            sizes_i = [
+                V.graph.sizevars.replace_backed_symbols_with_hints(s) for s in sizes
+            ]
+            strides_i = [
+                V.graph.sizevars.replace_backed_symbols_with_hints(st) for st in strides
+            ]
 
         # Find the single contiguous ("inner") dim
         inner = [
@@ -1942,14 +1946,16 @@ def can_use_tma(
     ) -> bool:
         # Make sure the last dimension is contiguous
         last_stride = strides[-1]
-        last_stride_hint = V.graph.sizevars.symbolic_hint(last_stride)
+        last_stride_hint = V.graph.sizevars.replace_backed_symbols_with_hints(
+            last_stride
+        )
         if not V.graph.sizevars.statically_known_equals(last_stride_hint, 1):
             return False
 
         # Triton's type of index is uint32, so all dimensions must fit in uint32
         MAX_UINT32 = 2**32 - 1
         for size in sizes:
-            size_hint = V.graph.sizevars.symbolic_hint(size)
+            size_hint = V.graph.sizevars.replace_backed_symbols_with_hints(size)
             if V.graph.sizevars.statically_known_gt(size_hint, MAX_UINT32):
                 return False
 


### PR DESCRIPTION
Summary:
Most changes belongs to:

1. all size_hint calls with fallback --> use optimization_hint since we already handle unbacked.
2. remove fallback from size_hint call (note size_hint will deleted eventually soon).
3. calls to symbolic_hint() -> replace_backed_with_hints()

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/1bf7a3e0e554a606f55bd5a3f5f5c9ebbb39674f

Differential Revision: D94130156




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo