### PR TITLE
Remove python constraint on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1703,7 +1703,7 @@ def main() -> None:
     install_requires = [
         "filelock",
         "typing-extensions>=4.10.0",
-        'setuptools<82 ; python_version >= "3.12"',
+        "setuptools<82",
         "sympy>=1.13.3",
         "networkx>=2.5.1",
         "jinja2",


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/173823
Dependency on setuptools was added 8 years ago here: https://github.com/pytorch/pytorch/pull/5207
This issue remained hidden since we run smoke test in conda env. Conda create env installs setuptools by default. This became apparent when testing using uv
