### PR TITLE
[inductor] Fix FakeTensor error in custom op autotuning with SDPA math backend

### DIFF
--- a/test/inductor/test_sdpa_custom_op_autotune.py
+++ b/test/inductor/test_sdpa_custom_op_autotune.py
@@ -1,0 +1,242 @@
+# Owner(s): ["module: inductor"]
+"""
+Tests for custom op autotuning with SDPA decompositions.
+
+Validates that custom ops can be autotuned when decompositions involve:
+- CompositeImplicitAutograd kernels (e.g. ATen SDPA math backend) that create
+  intermediate real tensors during FakeTensorMode tracing
+- Multiple input shapes in a single sweep (fallback choice reuse)
+- triton_op-based kernels (inlining skip)
+"""
+
+import torch
+import torch.nn.functional as F
+from torch._inductor import config
+from torch._inductor.kernel.custom_op import (
+    CustomOpConfig,
+    register_custom_op_autotuning,
+)
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import skipIfXpu
+from torch.testing._internal.inductor_utils import HAS_GPU
+
+
+torch.set_float32_matmul_precision("high")
+
+
+class TestCustomOpAutotuneSDPA(TestCase):
+    """Test custom op autotuning with SDPA decompositions."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        if not HAS_GPU:
+            self.skipTest("GPU not available")
+        self.device = "cuda"
+        self.dtype = torch.bfloat16
+
+    def _run_sdpa_autotune_test(self, op_fn, inputs, expected, test_name):
+        """Run a compiled autotune test and verify numerical correctness."""
+
+        @torch.compile(
+            options={
+                "max_autotune": True,
+                "benchmark_kernel": True,
+            }
+        )
+        def test_model(*args):
+            return op_fn(*args)
+
+        torch._dynamo.reset()
+
+        with config.patch(fx_graph_cache=False):
+            compiled_result = test_model(*inputs)
+
+        self.assertEqual(
+            compiled_result.shape, expected.shape, f"{test_name} shape mismatch"
+        )
+        torch.testing.assert_close(
+            compiled_result,
+            expected,
+            rtol=2e-1,
+            atol=5e-1,
+            msg=f"{test_name} numerical mismatch",
+        )
+
+    @skipIfXpu
+    def test_sdpa_math_backend_decomposition(self):
+        """Test autotuning with ATen SDPA math backend decomposition.
+
+        This is the key regression test for the FakeTensor fix. When flash/cudnn/
+        mem_efficient backends are disabled, ATen SDPA falls back to the math backend
+        (_scaled_dot_product_attention_math), which is a C++ CompositeImplicitAutograd
+        kernel. During make_fx tracing, this kernel creates intermediate real tensors
+        (e.g. scalar_tensor(-inf) for causal masks) that violate FakeTensorMode.
+
+        The fix temporarily patches FakeTensorMode.allow_non_fake_inputs = True
+        during make_fx tracing so these intermediate real tensors are tolerated.
+        """
+        # Disable optimized SDPA backends to force math backend
+        orig_flash = torch.backends.cuda.flash_sdp_enabled()
+        orig_mem = torch.backends.cuda.mem_efficient_sdp_enabled()
+        orig_cudnn = torch.backends.cuda.cudnn_sdp_enabled()
+
+        try:
+            torch.backends.cuda.enable_flash_sdp(False)
+            torch.backends.cuda.enable_mem_efficient_sdp(False)
+            torch.backends.cuda.enable_cudnn_sdp(False)
+
+            test_op_name = f"test_lib::sdpa_math_{id(self)}"
+
+            def decomp_aten_sdpa(
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                is_causal: bool = True,
+            ) -> torch.Tensor:
+                return F.scaled_dot_product_attention(
+                    query, key, value, is_causal=is_causal
+                )
+
+            def decomp_manual_sdpa(
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                is_causal: bool = True,
+            ) -> torch.Tensor:
+                """Manual SDPA implementation using basic ops."""
+                scale = query.shape[-1] ** -0.5
+                attn = torch.matmul(query * scale, key.transpose(-2, -1))
+                if is_causal:
+                    L, S = attn.shape[-2], attn.shape[-1]
+                    mask = torch.ones(L, S, dtype=torch.bool, device=query.device).tril()
+                    attn = attn.masked_fill(~mask, float("-inf"))
+                attn = torch.softmax(attn, dim=-1)
+                return torch.matmul(attn, value)
+
+            @torch.library.custom_op(test_op_name, mutates_args=())
+            def sdpa_op(
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                is_causal: bool = True,
+            ) -> torch.Tensor:
+                return F.scaled_dot_product_attention(
+                    query, key, value, is_causal=is_causal
+                )
+
+            @sdpa_op.register_fake
+            def _(query, key, value, is_causal=True):
+                return torch.empty_like(query)
+
+            register_custom_op_autotuning(
+                sdpa_op,
+                configs=[
+                    CustomOpConfig(decomp_aten_sdpa),
+                    CustomOpConfig(decomp_manual_sdpa),
+                ],
+                name=f"test_sdpa_math_{id(self)}",
+                input_gen_fns={
+                    "query": lambda t: torch.randn_like(t),
+                    "key": lambda t: torch.randn_like(t),
+                    "value": lambda t: torch.randn_like(t),
+                },
+            )
+
+            B, H, L, D = 1, 4, 64, 64
+            query = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
+            key = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
+            value = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
+
+            expected = F.scaled_dot_product_attention(
+                query, key, value, is_causal=True
+            )
+
+            self._run_sdpa_autotune_test(
+                sdpa_op, (query, key, value), expected, "SDPA_math_backend"
+            )
+
+        finally:
+            torch.backends.cuda.enable_flash_sdp(orig_flash)
+            torch.backends.cuda.enable_mem_efficient_sdp(orig_mem)
+            torch.backends.cuda.enable_cudnn_sdp(orig_cudnn)
+            torch._dynamo.reset()
+
+    @skipIfXpu
+    def test_sdpa_multiple_shapes(self):
+        """Test autotuning across multiple shapes.
+
+        Validates the _ReusedExternKernelChoice fix: fallback choice must be added
+        for every shape, not just the first. Previously, when the extern kernel was
+        already registered for shape 1, shape 2 would skip adding the fallback,
+        leading to missing choices.
+        """
+        orig_flash = torch.backends.cuda.flash_sdp_enabled()
+        orig_mem = torch.backends.cuda.mem_efficient_sdp_enabled()
+        orig_cudnn = torch.backends.cuda.cudnn_sdp_enabled()
+
+        try:
+            torch.backends.cuda.enable_flash_sdp(False)
+            torch.backends.cuda.enable_mem_efficient_sdp(False)
+            torch.backends.cuda.enable_cudnn_sdp(False)
+
+            test_op_name = f"test_lib::sdpa_multi_{id(self)}"
+
+            def decomp_sdpa(query, key, value, is_causal=True):
+                return F.scaled_dot_product_attention(
+                    query, key, value, is_causal=is_causal
+                )
+
+            @torch.library.custom_op(test_op_name, mutates_args=())
+            def sdpa_op(
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                is_causal: bool = True,
+            ) -> torch.Tensor:
+                return F.scaled_dot_product_attention(
+                    query, key, value, is_causal=is_causal
+                )
+
+            @sdpa_op.register_fake
+            def _(query, key, value, is_causal=True):
+                return torch.empty_like(query)
+
+            register_custom_op_autotuning(
+                sdpa_op,
+                configs=[CustomOpConfig(decomp_sdpa)],
+                name=f"test_sdpa_multi_{id(self)}",
+                input_gen_fns={
+                    "query": lambda t: torch.randn_like(t),
+                    "key": lambda t: torch.randn_like(t),
+                    "value": lambda t: torch.randn_like(t),
+                },
+            )
+
+            # Test two different shapes
+            shapes = [(1, 4, 32, 64), (2, 4, 64, 64)]
+            for B, H, L, D in shapes:
+                query = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
+                key = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
+                value = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
+
+                expected = F.scaled_dot_product_attention(
+                    query, key, value, is_causal=True
+                )
+
+                self._run_sdpa_autotune_test(
+                    sdpa_op,
+                    (query, key, value),
+                    expected,
+                    f"SDPA_multi_shape_{B}x{H}x{L}x{D}",
+                )
+                torch._dynamo.reset()
+
+        finally:
+            torch.backends.cuda.enable_flash_sdp(orig_flash)
+            torch.backends.cuda.enable_mem_efficient_sdp(orig_mem)
+            torch.backends.cuda.enable_cudnn_sdp(orig_cudnn)
+            torch._dynamo.reset()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_sdpa_custom_op_autotune.py
+++ b/test/inductor/test_sdpa_custom_op_autotune.py
@@ -108,7 +108,9 @@ class TestCustomOpAutotuneSDPA(TestCase):
                 attn = torch.matmul(query * scale, key.transpose(-2, -1))
                 if is_causal:
                     L, S = attn.shape[-2], attn.shape[-1]
-                    mask = torch.ones(L, S, dtype=torch.bool, device=query.device).tril()
+                    mask = torch.ones(
+                        L, S, dtype=torch.bool, device=query.device
+                    ).tril()
                     attn = attn.masked_fill(~mask, float("-inf"))
                 attn = torch.softmax(attn, dim=-1)
                 return torch.matmul(attn, value)
@@ -147,9 +149,7 @@ class TestCustomOpAutotuneSDPA(TestCase):
             key = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
             value = torch.randn(B, H, L, D, device=self.device, dtype=self.dtype)
 
-            expected = F.scaled_dot_product_attention(
-                query, key, value, is_causal=True
-            )
+            expected = F.scaled_dot_product_attention(query, key, value, is_causal=True)
 
             self._run_sdpa_autotune_test(
                 sdpa_op, (query, key, value), expected, "SDPA_math_backend"

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -98,6 +98,24 @@ class RangeImplGroup:
         return self.impl_config.kwargs
 
 
+def _graph_contains_triton_op(gm: torch.fx.GraphModule) -> bool:
+    """Check if graph contains triton_op calls (torch.ops.*.* from @triton_op).
+
+    triton_op doesn't have a registered inductor lowering and falls back to
+    fallback_handler, which causes issues during inlining. When detected,
+    we skip inlining and fall back to using SubgraphBuffer.
+    """
+    for node in gm.graph.nodes:
+        if node.op == "call_function":
+            target = node.target
+            if isinstance(target, torch._ops.OpOverload):
+                op_name = str(target)
+                if "triton" in op_name.lower():
+                    log.debug("Found triton_op in graph: %s", op_name)
+                    return True
+    return False
+
+
 def _detect_collective_ops(choices: list) -> bool:
     """
     Detect if choices contain collective operations.
@@ -408,8 +426,81 @@ def _create_fallback_choice(
         name=f"{name}_fallback_default",
         has_out_variant=False,
         op_overload=default_impl,
-        use_fallback_kernel=True,
+      use_fallback_kernel=True,
     )
+
+
+class _ReusedExternKernelChoice:
+    """A lightweight wrapper to reuse an already-registered extern kernel.
+
+    This mimics the ExternKernelChoice interface but doesn't register a new kernel.
+    Used when the same fallback kernel needs to be added as a choice for different
+    input shapes without triggering duplicate registration errors.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        op_overload: Callable[..., Any],
+    ) -> None:
+        from torch._inductor.select_algorithm import extern_kernels
+
+        self.name = name
+        self.has_out_variant = False
+        self.op_overload = op_overload
+        self.use_fallback_kernel = True
+        self.src_hash = None
+        self.gm = None
+        self.cpp_kernel_name = None
+        self._kernel = getattr(extern_kernels, name)
+
+    def to_callable(self) -> Callable[..., Any]:
+        return self._kernel
+
+    def call_name(self) -> str:
+        return f"extern_kernels.{self.name}"
+
+    def hash_key(self) -> str:
+        """Return hash key for this choice, matching ExternKernelChoice interface."""
+        import inspect
+
+        from torch._inductor.codecache import code_hash
+
+        fn = self.to_callable()
+        parts = [
+            self.name,
+            getattr(fn, "__name__", ""),
+            getattr(fn, "__module__", ""),
+        ]
+        try:
+            parts.append(inspect.getsource(fn))
+        except Exception:
+            pass
+        return code_hash("-".join(parts))
+
+    def bind(
+        self,
+        input_nodes: list[Any],
+        layout: Any,
+        ordered_kwargs_for_cpp_kernel: tuple[Any, ...] = (),
+        **kwargs: Any,
+    ) -> Any:
+        from torch._inductor.select_algorithm import ExternKernelCaller
+
+        self.ordered_kwargs_for_cpp_kernel = ordered_kwargs_for_cpp_kernel
+        return ExternKernelCaller(
+            self, input_nodes, layout, kwargs, has_out_variant=self.has_out_variant
+        )
+
+    def maybe_append_choice(
+        self,
+        choices: list[Any],
+        input_nodes: list[Any],
+        layout: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Append this choice to the choices list."""
+        choices.append(self.bind(input_nodes, layout, **kwargs))
 
 
 def autotune_custom_op(
@@ -486,36 +577,40 @@ def autotune_custom_op(
     )
 
     # Add default implementation as fallback
+    # Note: We must always add the fallback choice for every shape, not just the first.
     if op_overload and hasattr(op_overload, "_op"):
         fallback_name = f"{name}_fallback_default"
         from torch._inductor.select_algorithm import extern_kernels
 
-        # Skip if extern_kernel already registered to avoid duplicate registration error
+        with V.fake_mode:
+            # pyrefly: ignore [no-matching-overload]
+            fake_inputs = [ir_node_to_tensor(inp) for inp in inputs]
+            fallback_kwargs = non_tensor_args[0] if non_tensor_args else {}
+            fake_output = op_overload(*fake_inputs, **fallback_kwargs)
+
+        output_size = tuple(convert_symint_to_expr(s) for s in fake_output.shape)
+        output_stride = tuple(convert_symint_to_expr(s) for s in fake_output.stride())
+
         if not hasattr(extern_kernels, fallback_name):
-            with V.fake_mode:
-                # pyrefly: ignore [no-matching-overload]
-                fake_inputs = [ir_node_to_tensor(inp) for inp in inputs]
-                fallback_kwargs = non_tensor_args[0] if non_tensor_args else {}
-                fake_output = op_overload(*fake_inputs, **fallback_kwargs)
-
-            output_size = tuple(convert_symint_to_expr(s) for s in fake_output.shape)
-            output_stride = tuple(
-                convert_symint_to_expr(s) for s in fake_output.stride()
-            )
-
             fallback_choice = _create_fallback_choice(
                 name, op_overload, fake_output, fallback_kwargs
             )
-            fallback_choice.maybe_append_choice(
-                choices=choices,
-                input_nodes=list(inputs),
-                layout=FixedLayout(
-                    device=fake_output.device,
-                    dtype=fake_output.dtype,
-                    size=output_size,
-                    stride=output_stride,
-                ),
+        else:
+            fallback_choice = _ReusedExternKernelChoice(
+                name=fallback_name,
+                op_overload=op_overload,
             )
+
+        fallback_choice.maybe_append_choice(
+            choices=choices,
+            input_nodes=list(inputs),
+            layout=FixedLayout(
+                device=fake_output.device,
+                dtype=fake_output.dtype,
+                size=output_size,
+                stride=output_stride,
+            ),
+        )
 
     if not choices:
         raise RuntimeError(f"No valid choices generated for {name}")
@@ -545,11 +640,23 @@ def autotune_custom_op(
             )
             return selected_result, winning_choice
 
+        # Skip inlining if graph contains triton_op calls.
+        # triton_op doesn't have a registered inductor lowering, so it falls back
+        # to fallback_handler which causes issues. Use SubgraphBuffer instead.
+        if _graph_contains_triton_op(winning_choice.gm):
+            log.debug(
+                "Skipping inline for triton_op graph: %s (name=%s)",
+                getattr(winning_choice, "name", type(winning_choice).__name__),
+                name,
+            )
+            return selected_result
+
         log.debug(
             "Inlining winning choice: %s (name=%s)",
             getattr(winning_choice, "name", type(winning_choice).__name__),
             name,
         )
+        log.debug("Graph to inline:\n%s", winning_choice.gm.graph)
         from torch._inductor.codegen.subgraph import inline_subgraph_to_ir_nodes
 
         result = inline_subgraph_to_ir_nodes(winning_choice.gm, inputs, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175785
* __->__ #175587

When autotuning custom ops whose decompositions involve CompositeImplicitAutograd
kernels (e.g. ATen SDPA math backend), make_fx tracing fails because these C++
kernels create intermediate real tensors (like scalar_tensor(-inf) for causal masks)
that violate FakeTensorMode.

Root cause: make_fx detects and reuses the existing FakeTensorMode from args via
detect_fake_mode(), but the reused mode has allow_non_fake_inputs=False. The
_allow_non_fake_inputs parameter passed to make_fx is ignored since no new
FakeTensorMode is created.

Fix: Temporarily patch the existing FakeTensorMode.allow_non_fake_inputs=True
before calling make_fx, and restore it afterwards.

Additional changes from D91758533:
- Remove max_autotune_gemm_backends=ATEN restriction to allow Triton backend
- Add _ReusedExternKernelChoice for fallback choice reuse across shapes
- Add _graph_contains_triton_op to skip inlining for triton_op graphs
- Use size_hints instead of deprecated optimization_hints

Test: test/inductor/test_sdpa_custom_op_autotune.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo