### PR TITLE
[not intending to land]Add sharding strategy for aten.linear because export doesn't want linear to be decomposed

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -243,7 +243,8 @@ class OpDispatcher:
                 # When running under inference mode, CompositeImplicitAutograd ops show up in __torch_dispatch__,
                 # so we manually decompose them, here
                 out = op_call.decompose(*args, **kwargs)
-                assert out is not NotImplemented
+                if out is NotImplemented:
+                    raise
                 return out
             else:
                 raise


### PR DESCRIPTION
When `out` is Unimplemented, it's better to `raise` than `assert`. In the case of https://github.com/pytorch/pytorch/issues/175469, raise would give a more informative error than assertion failure: `[Rank 0] Decomposition failed: NotImplementedError: Operator aten.linear.default does not have a sharding strategy registered.` 