### PR TITLE
[CI] Delete `pch` test workflow

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -232,10 +232,6 @@ if [[ "${BUILD_ENVIRONMENT}" == *no-ops* ]]; then
   export USE_PER_OPERATOR_HEADERS=0
 fi
 
-if [[ "${BUILD_ENVIRONMENT}" == *-pch* ]]; then
-    export USE_PRECOMPILED_HEADERS=1
-fi
-
 if [[ "${BUILD_ENVIRONMENT}" != *cuda* ]]; then
   export BUILD_STATIC_RUNTIME_BENCHMARK=ON
 fi

--- a/.ci/pytorch/common-build.sh
+++ b/.ci/pytorch/common-build.sh
@@ -6,12 +6,6 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
     # Save the absolute path in case later we chdir (as occurs in the gpu perf test)
     script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
 
-    if [[ "${BUILD_ENVIRONMENT}" == *-pch* ]]; then
-        # This is really weird, but newer sccache somehow produces broken binary
-        # see https://github.com/pytorch/pytorch/issues/139188
-        sudo mv /opt/cache/bin/sccache-0.2.14a /opt/cache/bin/sccache
-    fi
-
     if which sccache > /dev/null; then
         # Clear SCCACHE_BUCKET and SCCACHE_REGION if they are empty, otherwise
         # sccache will complain about invalid bucket configuration

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -179,23 +179,6 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-jammy-py3_10-gcc11-pch:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11-pch ') }}
-    name: linux-jammy-py3.10-gcc11-pch
-    uses: ./.github/workflows/_linux-build.yml
-    needs:
-      - get-label-type
-      - job-filter
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-py3.10-gcc11-pch
-      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-gcc11
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1 },
-        ]}
-    secrets: inherit
-
   linux-jammy-py3_10-clang18-asan-build:
     if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-clang18-asan ') }}
     name: linux-jammy-py3.10-clang18-asan


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #175592

Support for precompiled headers was added in https://github.com/pytorch/pytorch/pull/62827 well before per-operator headers, but it has never regressed since 2021 (if it as at all used outside of this CI config)

But it's performance benefits are not clear, at least not in CI. I.e. right now typical `linux-jammy-py3.10-gcc11 / build` jobs takes about 30 min to compile, but `linux-jammy-py3.10-gcc11-pch / build` always takes at least 60 min