### PR TITLE
[inductor] Use CUDA toolkit libdevice for Triton pow precision

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -47,6 +47,7 @@ from torch._inductor.compile_worker.tracked_process_pool import (
 )
 from torch._inductor.compile_worker.utils import _async_compile_initializer
 from torch._inductor.runtime.compile_tasks import (
+    _set_triton_libdevice_path,
     _set_triton_ptxas_path,
     _worker_compile_triton,
 )
@@ -478,6 +479,7 @@ class AsyncCompile:
                 try:
                     start_ns = time_ns()
                     _set_triton_ptxas_path()
+                    _set_triton_libdevice_path()
                     kernel = load_kernel()
                     kernel.set_compile_info(compile_id, is_backward)
                     kernel.precompile(

--- a/torch/_inductor/compile_worker/__main__.py
+++ b/torch/_inductor/compile_worker/__main__.py
@@ -16,7 +16,10 @@ from torch._inductor.compile_worker.subproc_pool import (
     SubprocPickler,
 )
 from torch._inductor.compile_worker.utils import _async_compile_initializer
-from torch._inductor.runtime.compile_tasks import _set_triton_ptxas_path
+from torch._inductor.runtime.compile_tasks import (
+    _set_triton_libdevice_path,
+    _set_triton_ptxas_path,
+)
 
 
 _T = TypeVar("_T")
@@ -25,6 +28,7 @@ _T = TypeVar("_T")
 log = logging.getLogger(__name__)
 
 _set_triton_ptxas_path()
+_set_triton_libdevice_path()
 
 try:
     import triton

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -51,12 +51,66 @@ def _set_triton_ptxas_path() -> None:
         warnings.warn(f"{ptxas} exists but is not an executable")
 
 
+@functools.cache
+def _set_triton_libdevice_path() -> None:
+    """
+    Use the CUDA toolkit's libdevice instead of Triton's bundled version.
+    This ensures Triton's libdevice.pow matches CUDA's powf for bitwise precision.
+    """
+    try:
+        from triton import knobs
+    except ImportError:
+        return
+
+    # Check if already set via environment variable or knobs
+    env_path = os.environ.get("TRITON_LIBDEVICE_PATH")
+    if env_path is not None:
+        knobs.nvidia.libdevice_path = env_path
+        return
+
+    if knobs.nvidia.libdevice_path is not None:
+        return
+
+    try:
+        from torch.utils.cpp_extension import CUDA_HOME
+
+        if CUDA_HOME is None:
+            warnings.warn(
+                "CUDA_HOME not set; using Triton's bundled libdevice which may "
+                "cause minor precision differences in pow operations. "
+                "To fix: set TRITON_LIBDEVICE_PATH to your CUDA toolkit's libdevice, "
+                "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/libdevice/libdevice.10.bc",
+                stacklevel=3,
+            )
+            return
+        libdevice = Path(CUDA_HOME) / "nvvm" / "libdevice" / "libdevice.10.bc"
+        if libdevice.is_file():
+            knobs.nvidia.libdevice_path = str(libdevice)
+        else:
+            warnings.warn(
+                f"CUDA libdevice not found at {libdevice}; using Triton's bundled "
+                "libdevice which may cause minor precision differences in pow operations. "
+                "To fix: set TRITON_LIBDEVICE_PATH to your CUDA toolkit's libdevice, "
+                "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/libdevice/libdevice.10.bc",
+                stacklevel=3,
+            )
+    except ImportError:
+        warnings.warn(
+            "torch.utils.cpp_extension not available; using Triton's bundled "
+            "libdevice which may cause minor precision differences in pow operations. "
+            "To fix: set TRITON_LIBDEVICE_PATH to your CUDA toolkit's libdevice, "
+            "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/libdevice/libdevice.10.bc",
+            stacklevel=3,
+        )
+
+
 def _worker_compile_triton(
     load_kernel: Callable[[], CachingAutotuner],
     extra_env: dict[str, str],
     extra_config: dict[str, Any],
 ) -> tuple[CachingAutotuner, int]:
     _set_triton_ptxas_path()
+    _set_triton_libdevice_path()
     os.environ.update(extra_env)
     from torch._inductor import config
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #174911
* #175310
* #175309
* #174912
* #174751
* __->__ #175594
* #174749

Configure Triton to use the CUDA toolkit's libdevice instead of its bundled
version. This ensures Triton's libdevice.pow matches CUDA's powf for bitwise
precision in compiled optimizers.

Triton bundles its own libdevice.10.bc which uses FTZ (flush-to-zero)
instructions (fma.rn.ftz.f32) and different polynomial coefficients than
CUDA's version, causing 1-5 ULP differences in pow results:
  pow(0.9, 3.0):   eager=0x3f3a9fbd  triton=0x3f3a9fbe  (1 ULP)
  pow(0.9, 100.0): eager=0x37ded005  triton=0x37ded000  (5 ULP)

By setting TRITON_LIBDEVICE_PATH to the CUDA toolkit's libdevice, we eliminate
these precision differences without needing inline PTX or ATen fallbacks that
would break kernel fusion.

The path is auto-detected via CUDA_HOME from torch.utils.cpp_extension.
A warning is emitted if the CUDA libdevice cannot be found.

Co-authored-by: Claude <noreply@anthropic.com>