### PR TITLE
[inductor] Cache SDPA constraint results to avoid duplicate buffer copies

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -740,6 +740,13 @@ layout_optimization = (
 
 force_layout_optimization = os.environ.get("TORCHINDUCTOR_FORCE_LAYOUT_OPT", "0") == "1"
 
+# Cache SDPA constraint results keyed by (tensor identity, stride_order) to avoid
+# creating duplicate buffers when the same tensor feeds multiple SDPA positions
+# (e.g., key=value in simplified PMA attention).
+cache_sdpa_constraint = (
+    os.environ.get("TORCHINDUCTOR_CACHE_SDPA_CONSTRAINT", "0") == "1"
+)
+
 
 # Whether to keep the output strides the same as eager after layout optimization.
 keep_output_stride = os.environ.get("TORCHINDUCTOR_KEEP_OUTPUT_STRIDE", "1") == "1"

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -451,6 +451,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.removed_buffers: OrderedSet[str] = OrderedSet()
         self.removed_inplace_buffers: OrderedSet[str] = OrderedSet()
         self.mutated_buffers: OrderedSet[str] = OrderedSet()
+        self.sdpa_constraint_cache: dict[tuple, ir.IRNode] = {}
         self.never_reuse_buffers: OrderedSet[str] = OrderedSet()
         self.inplaced_to_remove: OrderedSet[str] = OrderedSet()
         self.device_ops: DeviceOpOverrides = None  # type: ignore[assignment]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2909,7 +2909,7 @@ def constrain_to_fx_strides(fx_node, *args, **kwargs):
 
 
 def sdpa_constraint(fx_node, *args, **kwargs):
-    # sdpa requires dense last dimension]
+    """Apply stride constraints to SDPA inputs, ensuring dense last dimension."""
 
     def apply_constraint(idx, arg, fx_arg):
         if not isinstance(arg, ir.IRNode):
@@ -2938,6 +2938,31 @@ def sdpa_constraint(fx_node, *args, **kwargs):
             # Check https://github.com/pytorch/pytorch/issues/138772
             stride_order = (3, 1, 2, 0)
 
+        # Cache keyed by (id(arg), arg_name, stride_order) to avoid
+        # duplicate copy_input when the same tensor feeds multiple SDPA
+        # positions (e.g., key=value).  Including arg_name handles
+        # mutation: mark_buffer_mutated() renames the buffer in place,
+        # so a mutated tensor has the same id but a different name,
+        # causing a cache miss.
+        cache_key = None
+        if config.cache_sdpa_constraint:
+            arg_name = arg.maybe_get_name()
+            cache_key = (
+                id(arg),
+                arg_name,
+                tuple(stride_order) if stride_order else None,
+            )
+            if cache_key in V.graph.sdpa_constraint_cache:
+                return V.graph.sdpa_constraint_cache[cache_key]
+
+        result = _apply_constraint_inner(
+            idx, arg, meta_val, meta_stride_expr, stride_order
+        )
+        if cache_key is not None:
+            V.graph.sdpa_constraint_cache[cache_key] = result
+        return result
+
+    def _apply_constraint_inner(idx, arg, meta_val, meta_stride_expr, stride_order):
         if not meta_val.is_cuda:
             return ir.ExternKernel.require_stride_order(arg, stride_order)
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/175833

Summary:
When the same tensor feeds multiple SDPA positions (e.g., key=value in
PMA attention), `sdpa_constraint` previously applied `require_strides` to
the shared TensorBox on the first call, which mutated it in place. On the
second call, `copy_input` detected the already-constrained tensor as needing
a new copy, creating a redundant buffer and GPU memcpy kernel.

This adds a per-invocation cache keyed by `(id(arg), stride_order)` inside
`sdpa_constraint`. When the same tensor appears at multiple positions with
the same layout requirements, the cached result is returned directly,
eliminating the duplicate buffer allocation.

Benchmarked on mtml_ctr_inline_cvr_mbl_feed_model (entity 1037535765,
module merge, batch_size=3024) which has 12 SDPA calls all using the
key=value PMA pattern:
- Baseline: QPS 99,378, latency 30.43ms
- Modified: QPS 102,214, latency 29.59ms
- Delta: +2.85% QPS, -2.8% latency

Authored with Claude.

Test Plan:
```
CUDA_VISIBLE_DEVICES=2 buck2 run mode/dev-nosan -c fbcode.nvcc_arch=a100,h100 -c fbcode.enable_gpu_sections=true fbcode//caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark -- --model-path=/data/users/kevinqfu/models/1037535765/0/input_model.predictor.disagg.gpu.merge --lower-backend="AOT_INDUCTOR" --batch-size=3024 --gpu-trace
```
Baseline: QPS 99,378, latency 30.43ms
Modified: QPS 102,214, latency 29.59ms (+2.85% QPS, -2.8% latency)

automation

Differential Revision: D94149223




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo