### PR TITLE
[inductor] Add compile backend registry and custom device support for AOTI eager

### DIFF
--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -21,6 +21,8 @@
 
 namespace torch::inductor {
 
+AOTIModelContainerRunner::AOTIModelContainerRunner() = default;
+
 AOTIModelContainerRunner::AOTIModelContainerRunner(
     const std::string& model_so_path,
     size_t num_models,
@@ -126,9 +128,13 @@ consider rebuild your model with the latest AOTInductor.");
 }
 
 AOTIModelContainerRunner::~AOTIModelContainerRunner() {
-  AOTIRuntimeError result = delete_func_(container_handle_);
-  TORCH_CHECK(
-      result == AOTI_RUNTIME_SUCCESS, "AOTInductorModelContainerDelete failed");
+  // Custom device implementations don't set delete_func_
+  if (delete_func_ != nullptr) {
+    AOTIRuntimeError result = delete_func_(container_handle_);
+    TORCH_CHECK(
+        result == AOTI_RUNTIME_SUCCESS,
+        "AOTInductorModelContainerDelete failed");
+  }
 }
 
 std::vector<at::Tensor> AOTIModelContainerRunner::run_impl(

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -15,7 +15,6 @@ using TensorConstantMap = std::unordered_map<std::string, at::Tensor*>;
 
 class TORCH_API AOTIModelContainerRunner {
  public:
-  AOTIModelContainerRunner() = delete;
   AOTIModelContainerRunner(const AOTIModelContainerRunner& other) = delete;
   AOTIModelContainerRunner(AOTIModelContainerRunner&& other) = delete;
   AOTIModelContainerRunner& operator=(const AOTIModelContainerRunner& other) =
@@ -67,6 +66,10 @@ class TORCH_API AOTIModelContainerRunner {
       const std::string& cubin_dir,
       const bool run_single_threaded);
 
+  // Default constructor for custom device implementations that don't
+  // use .so files. Derived classes must override run_impl().
+  AOTIModelContainerRunner();
+
   virtual std::vector<at::Tensor> run_impl(
       std::vector<AtenTensorHandle>& input_handles,
       void* stream_handle);
@@ -107,7 +110,7 @@ class TORCH_API AOTIModelContainerRunner {
 
   AOTInductorModelContainerHandle container_handle_ = nullptr;
 
-  AOTIProxyExecutorHandle proxy_executor_handle_;
+  AOTIProxyExecutorHandle proxy_executor_handle_ = nullptr;
 
  private:
   std::unique_ptr<torch::aot_inductor::ProxyExecutor> proxy_executor_;


### PR DESCRIPTION
Summary:
Adds extension points that let out-of-tree device backends plug into the AOTI eager compilation and loading flow without modifying upstream code.

Python (aoti_eager.py): Add AOTICompileBackend dataclass and register_aoti_compile_backend() function. Registered backends get early-return dispatch in load_aoti_eager_cache() and aoti_compile_with_persistent_cache(), leaving the original function bodies untouched.

C++ (model_container_runner.h/.cpp): Add a protected default constructor so custom device subclasses can skip the dlopen-based .so loading path. Make the destructor null-safe for delete_func_ since custom device implementations don't set it. Initialize proxy_executor_handle_ to nullptr by default.

C++ (kernel_holder.cpp): Fix auto -> auto& to avoid copying the runner registry map. Add a defensive TORCH_CHECK in the else branch of load_aoti_model_runner() before indexing into the registry, so unregistered devices get a clear error message.

Test Plan: Upstream CPU/CUDA paths are unchanged and verified by existing CI.

Differential Revision: D92997384




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo