### PR TITLE
Implement narrow_copy derivative

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3210,6 +3210,10 @@
   self: grad.reshape_symint(self.sym_sizes())
   result: auto_linear
 
+- name: narrow_copy(Tensor self, int dim, SymInt start, SymInt length) -> Tensor
+  self: slice_backward_wrapper(grad, self.sym_sizes(), dim, start, start + length, 1)
+  result: auto_linear
+
 # note(crcrpar): `torchgen/api/autograd` logic would unwantedly replace substrings of `self` and `other` of function names.
 - name: _foreach_div.List(Tensor[] self, Tensor[] other) -> Tensor[]
   self: div_tensor_self_backward(grads[i], other[i], self[i].scalar_type())

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -376,6 +376,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     "_neg_view",
     "_reshape_alias",
     "_reshape_copy",
+    "narrow_copy",
     "_linalg_det",
     "lu_solve",
     "linalg_solve_triangular",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18072,9 +18072,8 @@ op_db: list[OpInfo] = [
     OpInfo('narrow_copy',
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16, torch.chalf),
            supports_out=True,
-           supports_forward_ad=False,
-           supports_fwgrad_bwgrad=False,
-           supports_autograd=False,
+           supports_forward_ad=True,
+           supports_fwgrad_bwgrad=True,
            # https://github.com/pytorch/pytorch/issues/86931
            sample_inputs_func=partial(sample_inputs_narrow_narrow_copy, is_narrow=False),
            reference_inputs_func=partial(reference_inputs_narrow_narrow_copy, is_narrow=False),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -931,8 +931,6 @@ if torch.backends.mps.is_available():
             "nextafter": None,
             # derivative for aten::floor_divide is not implemented on CPU
             "floor_divide": [torch.float16, torch.float32],
-            # derivative for aten::narrow_copy is not implemented on CPU
-            "narrow_copy": [torch.float16, torch.float32],
             # derivative for aten::_histogramdd_from_bin_cts is not implemented on CPU
             "histogramdd": [torch.float16, torch.float32],
             # derivative for aten::histogram is not implemented


### PR DESCRIPTION
Fixes #65617

<details><summary>Unit testing ok</summary>
### Test ok ✅
```
 python test/test_torch.py -k "test_narrow_copy_gradient" -v
test_narrow_copy_gradient_cpu (__main__.TestTorchDeviceTypeCPU) ... ok
...
Ran 1 test in 0.022s
OK
```

### Linter ok ✅
```
 lintrunner f 
ok No lint issues.
```

### Existing tests ok ✅
```
pip install -e . -v --no-build-isolation && python test/test_ops.py -k "narrow_copy" -v && python test/test_ops_gradients.py -k "narrow_copy" -v 
```
https://www.diffchecker.com/JIeLTegz/
```
python test/test_mps.py TestConsistencyMPS.test_output_grad_match_narrow_copy_mps_float16 TestConsistencyMPS.test_output_grad_match_narrow_copy_mps_float32
..
----------------------------------------------------------------------
Ran 2 tests in 0.143s

OK
```
</details>