### PR TITLE
[2/N] C++20 template method instantiation adjustements

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -480,20 +480,20 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                 multi_tensor_apply<1>(
                     tensor_lists,
                     LpNormFunctor<scalar_t, NormType::L1, out_t>(),
-                    output_per_tensor.mutable_data_ptr<out_opmath_t>(),
+                    output_per_tensor.template mutable_data_ptr<out_opmath_t>(),
                     max_chunks_per_tensor);
               } else if (p == static_cast<double>(2)) {
                 multi_tensor_apply<1>(
                     tensor_lists,
                     LpNormFunctor<scalar_t, NormType::L2, out_t>(),
-                    output_per_tensor.mutable_data_ptr<out_opmath_t>(),
+                    output_per_tensor.template mutable_data_ptr<out_opmath_t>(),
                     max_chunks_per_tensor);
               } else if constexpr (support_infinity) {
                 if (p == std::numeric_limits<double>::infinity()) {
                   multi_tensor_apply<1>(
                       tensor_lists,
                       LpNormFunctor<scalar_t, NormType::LInf, out_t>(),
-                      output_per_tensor.mutable_data_ptr<out_opmath_t>(),
+                      output_per_tensor.template mutable_data_ptr<out_opmath_t>(),
                       max_chunks_per_tensor);
                 }
               }
@@ -515,13 +515,13 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                 for (const auto j : c10::irange(num_tensors_this_kernel)) {
                   addr_struct.addresses[j] =
                       vec_res[i * MAX_TENSORS_PER_KERNEL + j]
-                          .mutable_data_ptr<out_t>();
+                          .template mutable_data_ptr<out_t>();
                 }
 
                 if (p == static_cast<double>(1)) {
                   lpnorm_cleanup<scalar_t, NormType::L1, out_t, apply_root>
                       <<<num_tensors_this_kernel, 512, 0, stream>>>(
-                          output_per_tensor.const_data_ptr<out_opmath_t>() +
+                          output_per_tensor.template const_data_ptr<out_opmath_t>() +
                               i * MAX_TENSORS_PER_KERNEL *
                                   max_chunks_per_tensor,
                           addr_struct,
@@ -529,7 +529,7 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                 } else if (p == static_cast<double>(2)) {
                   lpnorm_cleanup<scalar_t, NormType::L2, out_t, apply_root>
                       <<<num_tensors_this_kernel, 512, 0, stream>>>(
-                          output_per_tensor.const_data_ptr<out_opmath_t>() +
+                          output_per_tensor.template const_data_ptr<out_opmath_t>() +
                               i * MAX_TENSORS_PER_KERNEL *
                                   max_chunks_per_tensor,
                           addr_struct,
@@ -538,7 +538,7 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                   if (p == std::numeric_limits<double>::infinity()) {
                     lpnorm_cleanup<scalar_t, NormType::LInf, out_t, apply_root>
                         <<<num_tensors_this_kernel, 512, 0, stream>>>(
-                            output_per_tensor.const_data_ptr<out_opmath_t>() +
+                            output_per_tensor.template const_data_ptr<out_opmath_t>() +
                                 i * MAX_TENSORS_PER_KERNEL *
                                     max_chunks_per_tensor,
                             addr_struct,

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -493,7 +493,8 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                   multi_tensor_apply<1>(
                       tensor_lists,
                       LpNormFunctor<scalar_t, NormType::LInf, out_t>(),
-                      output_per_tensor.template mutable_data_ptr<out_opmath_t>(),
+                      output_per_tensor
+                          .template mutable_data_ptr<out_opmath_t>(),
                       max_chunks_per_tensor);
                 }
               }
@@ -521,7 +522,8 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                 if (p == static_cast<double>(1)) {
                   lpnorm_cleanup<scalar_t, NormType::L1, out_t, apply_root>
                       <<<num_tensors_this_kernel, 512, 0, stream>>>(
-                          output_per_tensor.template const_data_ptr<out_opmath_t>() +
+                          output_per_tensor
+                                  .template const_data_ptr<out_opmath_t>() +
                               i * MAX_TENSORS_PER_KERNEL *
                                   max_chunks_per_tensor,
                           addr_struct,
@@ -529,7 +531,8 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                 } else if (p == static_cast<double>(2)) {
                   lpnorm_cleanup<scalar_t, NormType::L2, out_t, apply_root>
                       <<<num_tensors_this_kernel, 512, 0, stream>>>(
-                          output_per_tensor.template const_data_ptr<out_opmath_t>() +
+                          output_per_tensor
+                                  .template const_data_ptr<out_opmath_t>() +
                               i * MAX_TENSORS_PER_KERNEL *
                                   max_chunks_per_tensor,
                           addr_struct,
@@ -538,7 +541,8 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                   if (p == std::numeric_limits<double>::infinity()) {
                     lpnorm_cleanup<scalar_t, NormType::LInf, out_t, apply_root>
                         <<<num_tensors_this_kernel, 512, 0, stream>>>(
-                            output_per_tensor.template const_data_ptr<out_opmath_t>() +
+                            output_per_tensor
+                                    .template const_data_ptr<out_opmath_t>() +
                                 i * MAX_TENSORS_PER_KERNEL *
                                     max_chunks_per_tensor,
                             addr_struct,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #167929
* #175616
* __->__ #175612

Similar to https://github.com/pytorch/pytorch/pull/168132
Non-compliant instantiation were probably introduced by https://github.com/pytorch/pytorch/pull/172685

Fixes a very verbose Windows compilation error that includes 200 `ForeachReduceOp.cu(470): error: type name is not allowed` and 200 `ForeachReduceOp.cu(470): error: expected an expression`
