### PR TITLE
[meta_registrations] Add bmm out variant support

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4587,12 +4587,14 @@ def common_meta_baddbmm_bmm(batch1, batch2, is_bmm, self_baddbmm=None, out_dtype
     return output
 
 
-@register_meta(aten.bmm.default)
+@register_meta([aten.bmm.default, aten.bmm.out])
+@out_wrapper(exact_dtype=True)
 def meta_bmm(self, mat2):
     return common_meta_baddbmm_bmm(self, mat2, True)
 
 
-@register_meta(aten.bmm.dtype)
+@register_meta([aten.bmm.dtype, aten.bmm.dtype_out])
+@out_wrapper(exact_dtype=True)
 def meta_bmm_dtype(self, mat2, out_dtype):
     return common_meta_baddbmm_bmm(self, mat2, True, out_dtype=out_dtype)
 


### PR DESCRIPTION
Summary: Use python-level meta impl for aten.bmm.out. As Claude described when analyzing, "The fundamental issue is that the C++ structured kernel API (MetaBase::set_output_raw_strided) only accepts IntArrayRef (concrete int64_t), so no C++ structured kernel can avoid concretizing SymInts."

Differential Revision: D94181784


