### PR TITLE
Change order of operations when calculating reference value for test_fq_module_per_tensor.

### DIFF
--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -36,14 +36,14 @@ from torch.testing._internal.common_utils import TestCase, skipIfTorchDynamo
 # Note: because scale/zero_point are left as float in the actual kernel, this mimics how fake_quant works for float16/64
 def _fake_quantize_per_tensor_affine_reference(X, scale, zero_point, quant_min, quant_max):
     dtype = X.dtype
-    res = ((torch.clamp(torch.round(X.to(torch.float32) * (1.0 / scale) + zero_point), quant_min, quant_max) - zero_point) * scale)
+    res = ((torch.clamp(torch.round(X.to(torch.float32) * (1.0 / scale)) + zero_point, quant_min, quant_max) - zero_point) * scale)
     return res.to(dtype)
 
 # Reference method for the gradient of the fake quantize operator
 # Note: because scale/zero_point are left as float in the actual kernel, this mimics how fake_quant works for float16/64
 def _fake_quantize_per_tensor_affine_grad_reference(dY, X, scale, zero_point, quant_min, quant_max):
     dtype = X.dtype
-    Xq = torch.round(X.to(torch.float32) * (1.0 / scale) + zero_point)
+    Xq = torch.round(X.to(torch.float32) * (1.0 / scale)) + zero_point
     mask = (Xq >= quant_min) * (Xq <= quant_max)
     res = torch.zeros_like(dY)
     res[mask] = dY[mask]


### PR DESCRIPTION
Performing addition before rounding, in some specific cases, causes precision loss, that changes rounding direction, causing values mismatch.
More specifically:
    if X * 1.0 / scale == 63.500003815... (one ULP above 63.5 in float32)
    then adding zero_point == 63
    produces 126.5 exactly.
    The fractional excess is lost because ULP is larger in this value range.

The kernel calculates this correctly: https://github.com/pytorch/pytorch/blob/aa3b33d02e90a392351b45186a3614ae1ca37ec1/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp#L2702-L2707 First rounding, then adding offset.

This patch changes order of addition and rounding to rounding first to avoid precision loss.