### PR TITLE
dynamo: dynamic_dict API

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2161,6 +2161,96 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 2)
 
+    def test_mark_dynamic_dict_setitem_no_recompile(self):
+        cnts = CompileCounter()
+
+        d = {"obs": torch.randn(3)}
+        torch._dynamo.mark_dynamic_dict(d)
+
+        @torch.compile(backend=cnts)
+        def fn(d):
+            d["loss"] = d["obs"] * 2
+            return d["loss"]
+
+        fn(d)
+        self.assertEqual(cnts.frame_count, 1)
+        # dict now has {"obs", "loss"} — should NOT recompile
+        fn(d)
+        self.assertEqual(cnts.frame_count, 1)
+
+    def test_mark_dynamic_dict_getitem_setitem(self):
+        cnts = CompileCounter()
+
+        d = {"a": torch.randn(3), "b": torch.randn(3)}
+        torch._dynamo.mark_dynamic_dict(d)
+
+        @torch.compile(backend=cnts)
+        def fn(d):
+            d["c"] = d["a"] + d["b"]
+            return d["c"]
+
+        result = fn(d)
+        self.assertEqual(result, d["a"] + d["b"])
+        self.assertEqual(cnts.frame_count, 1)
+        # second call — dict now has extra key "c"
+        result2 = fn(d)
+        self.assertEqual(cnts.frame_count, 1)
+
+    def test_mark_dynamic_dict_iteration_installs_guard(self):
+        # items/keys/values/len on a dynamic dict should work but install
+        # a DICT_KEYS_MATCH guard, so key-set changes trigger recompilation.
+        cnts = CompileCounter()
+
+        d = {"a": torch.randn(3), "b": torch.randn(3)}
+        torch._dynamo.mark_dynamic_dict(d)
+
+        @torch.compile(backend=cnts)
+        def fn(d):
+            return sum(d.values())
+
+        fn(d)
+        self.assertEqual(cnts.frame_count, 1)
+        d["c"] = torch.randn(3)
+        fn(d)
+        # keys changed and values() installed a guard → recompile
+        self.assertEqual(cnts.frame_count, 2)
+
+    def test_mark_dynamic_dict_setitem_then_len(self):
+        # setitem alone should not guard, but len in the same function should.
+        cnts = CompileCounter()
+
+        d = {"obs": torch.randn(3)}
+        torch._dynamo.mark_dynamic_dict(d)
+
+        @torch.compile(backend=cnts)
+        def fn(d):
+            d["loss"] = d["obs"] * 2
+            return len(d)
+
+        result = fn(d)
+        self.assertEqual(cnts.frame_count, 1)
+        # len() installs guard → second call with extra key recompiles
+        result2 = fn(d)
+        self.assertEqual(cnts.frame_count, 2)
+        # third call stabilizes
+        result3 = fn(d)
+        self.assertEqual(cnts.frame_count, 2)
+
+    def test_unmarked_dict_still_guards_on_keys(self):
+        cnts = CompileCounter()
+        d = {"obs": torch.randn(3)}
+
+        @torch.compile(backend=cnts)
+        def fn(d):
+            d["loss"] = d["obs"] * 2
+            return d["loss"]
+
+        fn(d)
+        self.assertEqual(cnts.frame_count, 1)
+        # dict now has {"obs", "loss"} — normal dict SHOULD recompile
+        fn(d)
+        self.assertGreaterEqual(cnts.frame_count, 2)
+
     def test_listcomp(self):
         def fn2(inputs):
             return torch.sum(torch.cat([v + 1 for k, v in inputs.items()], 0))

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -34,6 +34,7 @@ from .decorators import (
     graph_break,
     is_dynamo_disable_recursive,
     mark_dynamic,
+    mark_dynamic_dict,
     mark_static,
     mark_static_address,
     maybe_mark_dynamic,
@@ -93,6 +94,7 @@ __all__ = [
     "list_backends",
     "lookup_backend",
     "mark_dynamic",
+    "mark_dynamic_dict",
     "maybe_mark_dynamic",
     "mark_static",
     "mark_static_address",
@@ -161,6 +163,10 @@ def reset() -> None:
         TensorifyState.clear()
         torch._dynamo.utils.warn_once_cache.clear()
         torch._C._autograd._saved_tensors_hooks_set_tracing(False)
+
+        from .decorators import _dynamic_dict_ids
+
+        _dynamic_dict_ids.clear()
 
         # Reset cudagraph trees unconditionally since they are global state
         # not tied to a specific backend instance

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1061,6 +1061,30 @@ def mark_unbacked(
         mark_unbacked(t, i, shape_id=shape_id)
 
 
+_dynamic_dict_ids: set[int] = set()
+
+
+def is_dynamic_dict(d: dict) -> bool:
+    return id(d) in _dynamic_dict_ids
+
+
+@forbid_in_graph
+def mark_dynamic_dict(d: dict) -> None:
+    """Mark a dict as having a dynamic key set.
+
+    Dynamo will not install ``DICT_KEYS_MATCH`` guards for mutations like
+    ``__setitem__``, so adding keys between ``torch.compile`` calls will
+    not trigger recompilation.
+
+    Operations that depend on the full key set (``items()``, ``keys()``,
+    ``values()``, ``len()``, ``copy()``) still install the guard lazily
+    when used, so they recompile correctly when the key set changes.
+    """
+    if not isinstance(d, dict):
+        raise TypeError(f"expected dict, got {type(d)}")
+    _dynamic_dict_ids.add(id(d))
+
+
 @forbid_in_graph
 def mark_dynamic(
     t: Any,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -195,6 +195,7 @@ from .dicts import (
     ConstDictVariable,
     DefaultDictVariable,
     DictKeySetVariable,
+    DynamicKeysConstDictVariable,
     FrozensetVariable,
     MappingProxyVariable,
     OrderedSetClassVariable,
@@ -876,7 +877,14 @@ class VariableBuilder:
                     source=self.source,
                 )
             else:
-                result = ConstDictVariable(
+                from ..decorators import is_dynamic_dict
+
+                cls = (
+                    DynamicKeysConstDictVariable
+                    if is_dynamic_dict(value)
+                    else ConstDictVariable
+                )
+                result = cls(
                     result,  # type: ignore[arg-type]
                     user_cls=type(value),
                     source=self.source,

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1036,6 +1036,36 @@ class NNModuleHooksDictVariable(ConstDictVariable):
         pass
 
 
+class DynamicKeysConstDictVariable(ConstDictVariable):
+    """Dict variable that skips DICT_KEYS_MATCH guards by default.
+
+    Used for dicts marked with ``torch._dynamo.mark_dynamic_dict()``.
+    ``install_dict_keys_match_guard`` is a no-op so that mutations like
+    ``__setitem__`` do not install a full key-set guard.  Operations that
+    genuinely depend on the full key set (``items``, ``keys``, ``values``,
+    ``__len__``, ``copy``) explicitly install the guard before delegating to
+    the parent, so they still recompile when the key set changes.
+    """
+
+    def install_dict_keys_match_guard(self) -> None:
+        pass
+
+    def _install_dict_keys_match_guard_force(self) -> None:
+        if self.source:
+            install_guard(self.make_guard(GuardBuilder.DICT_KEYS_MATCH))
+
+    def call_method(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if name in ("items", "keys", "values", "__len__", "copy"):
+            self._install_dict_keys_match_guard_force()
+        return super().call_method(tx, name, args, kwargs)
+
+
 class DefaultDictVariable(ConstDictVariable):
     def __init__(
         self,


### PR DESCRIPTION
Adds torch._dynamo.mark_dynamic_dict(d) which prevents Dynamo from installing DICT_KEYS_MATCH guards on mutations like _setitem. This lets libraries such as tensordict add new keys inside torch.compile without triggering recompilation.Operations that depend on the full key set (items(), keys(), values(), len(), copy()) lazily install the guard when used, so they still recompile correctly — no graph breaks anywhere.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98