### PR TITLE
Skip test_scaled_mm for ROCm

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -420,6 +420,10 @@ class DistMatrixOpsTest(DTensorTestBase):
     @with_comms
     @skip_unless_torch_gpu
     @unittest.skipIf(
+        TEST_WITH_ROCM,
+        "NCCL does not support Float8_e4m3fn on ROCm (Unconvertible NCCL type)",
+    )
+    @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,
         "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
     )


### PR DESCRIPTION
## Summary

Skip `DistMatrixOpsTest.test_scaled_mm` when running with ROCm so the test is not run in an environment where it is known to fail, and ROCm CI can pass.

## Why

`test_scaled_mm` tests distributed FP8 `_scaled_mm` with DTensor: it creates `Float8_e4m3fn` tensors and distributes them over the device mesh. Distribution uses NCCL for collective communication.

On ROCm, that code path hits:

```
RuntimeError: Unconvertible NCCL type Float8_e4m3fn
```

In `torch/csrc/cuda/nccl.cpp`, `to_nccl_data_type()` does not handle `Float8_e4m3fn` (and `Float8_e5m2`) when `USE_ROCM` is defined—only the `*fnuz` FP8 variants are mapped there. So the test cannot pass on ROCm until that support is added.

## Change

- Add `@unittest.skipIf(TEST_WITH_ROCM, "NCCL does not support Float8_e4m3fn on ROCm (Unconvertible NCCL type)")` on `test_scaled_mm`.
- No change to behavior on CUDA or other platforms.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang