### PR TITLE
[Dynamo] Fix crash when shadowing dataclass fields with properties

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -4195,6 +4195,8 @@ class SourcelessBuilder:
                 for name in namedtuple_fields(type(value))
             ]
             return NamedTupleVariable(output, tuple_cls=type(value))
+        elif isinstance(value, property) or hasattr(value, "__get__"):
+            return UserDefinedObjectVariable(value)
         elif (
             isinstance(value, torch.SymInt)
             and value.node.expr in tx.output.bound_symbols
@@ -4265,6 +4267,7 @@ class SourcelessBuilder:
         )
         handlers[random.Random] = lambda tx, value: RandomClassVariable()
         handlers[types.ModuleType] = lambda tx, value: PythonModuleVariable(value)
+        handlers[property] = lambda tx, value: UserDefinedObjectVariable(value)
 
         handlers[torch.DispatchKeySet] = lambda tx, value: DispatchKeySetVariable(
             value, mutation_type=ValueMutationNew()


### PR DESCRIPTION
**Description**
Currently, torch.compile (via TorchDynamo) crashes when it encounters a class (like a dataclass) where a field name is shadowed by a @property. This happens because SourcelessBuilder doesn't know how to handle property objects during the reconstruction of the object's __init__ arguments.

This PR adds a handler for property types (and objects with __get__ descriptors) in SourcelessBuilder, allowing them to be wrapped as UserDefinedObjectVariable instead of triggering an unimplemented error.

**Testing**
```import torch
from dataclasses import dataclass
from torch._subclasses.fake_tensor import FakeTensorMode

@dataclass
class Data:
    value: torch.Tensor
    edges: torch.Tensor

    @property
    def edges(self) -> torch.Tensor:
        return torch.randn(3)

@torch.compile(fullgraph=True, backend="eager")
def test_function(x):
    data = Data(value=x, edges=x)
    return data.value

# THE "NO-DATA" TEST
print("Starting reproduction with Fake Tensors...")
try:
    with FakeTensorMode():
        # Create a 'fake' input: shape (3,), on CUDA, but no data
        fake_x = torch.randn(3, device="cuda")

        # This triggers the compiler's tracing logic
        test_function(fake_x)

    print("✅ SUCCESS: Trace completed without a name-shadowing crash.")
except Exception as e:
    print("\n❌ FAILURE: Compiler crashed during tracing!")
    print(f"Error Type: {type(e).__name__}")
    print(f"Details: {e}")
```

**Affected Files**
`torch/_dynamo/variables/builder.py`: Added property to `make_type_handlers` and a general descriptor check in `create()`.

**Closes #174794**

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98