### PR TITLE
[Inductor] Benchmark with layout constrained stride

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -384,6 +384,8 @@ class TensorMeta:
     def from_irnodes(
         cls, irnodes: LayoutOrBuffer | Sequence[LayoutOrBuffer]
     ) -> TensorMeta | list[TensorMeta]:
+        from torch._inductor.select_algorithm import get_strides_with_layout_constraints
+
         if isinstance(irnodes, Sequence):
             result: list[Any] = [cls.from_irnodes(x) for x in irnodes]
             assert all(isinstance(x, TensorMeta) for x in result)
@@ -402,7 +404,9 @@ class TensorMeta:
             device=device,
             dtype=dtype,
             sizes=V.graph.sizevars.optimization_hints(node.get_size()),
-            strides=V.graph.sizevars.optimization_hints(node.get_stride()),
+            strides=V.graph.sizevars.optimization_hints(
+                get_strides_with_layout_constraints(node)
+            ),
             offset=V.graph.sizevars.optimization_hint(node.get_layout().offset),
             name=node.get_name(),
         )

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3797,7 +3797,12 @@ class Scheduler:
         for inp in multi_node.inputs:
             # pyrefly: ignore [missing-attribute]
             inp_name = inp.get_name()
-            if not getattr(inp, "layout", None) or inp_name not in constraints:
+            # View has its own fixed layout that is not constrained
+            if (
+                not getattr(inp, "layout", None)
+                or inp_name not in constraints
+                or isinstance(inp, ir.ReinterpretView)
+            ):
                 continue
 
             layout = inp.layout


### PR DESCRIPTION
Differential Revision: D94160830

Previously there was a CUDA IMA with an edge case in bmm autotuning, as deferred layout constraints did not properly propogate to benchmarking, potentially also causing a difference in timings. Here, we also benchmark with the constrained layouts, in the BMM case padded, to reflect the padded layout that is expected through layout_constraints.

Furthermore, we properly handle `ReinterpretView` buffers, which are just a wrapper node over a regular buffer. Previously, if we had a `ReinterpretView` over a traditional buffer, that buffers layout was used to detect layout conflicts, which will always cause a conflict as the `ReinterpretView`'s layout will always be different than the underlying buffer's layout. Since `ReinterpretView` contains a FixedLayout, we do not need to evaluate constraints for it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo