### PR TITLE
index_select decomposition preserve memory format

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1172,6 +1172,20 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(eager_out, compiled_out)
         self.assertEqual(eager_out.stride(), compiled_out.stride())
 
+    # https://github.com/pytorch/pytorch/issues/174963
+    def test_roll_as_strided_channels_last(self):
+        def fn(x):
+            x = torch.roll(x, shifts=-1, dims=0)
+            return torch.as_strided(x, (5, 10), (4, 1), 0)
+
+        x = torch.arange(100).reshape(2, 5, 2, 5).to(
+            memory_format=torch.channels_last
+        )
+        eager_out = fn(x)
+        compiled_fn = torch.compile(fn, backend="aot_eager_decomp_partition")
+        compiled_out = compiled_fn(x)
+        self.assertEqual(eager_out, compiled_out)
+
     # https://github.com/pytorch/pytorch/issues/109053
     def test_view_dtype_overload(self):
         def f(x):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1178,9 +1178,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             x = torch.roll(x, shifts=-1, dims=0)
             return torch.as_strided(x, (5, 10), (4, 1), 0)
 
-        x = torch.arange(100).reshape(2, 5, 2, 5).to(
-            memory_format=torch.channels_last
-        )
+        x = torch.arange(100).reshape(2, 5, 2, 5).to(memory_format=torch.channels_last)
         eager_out = fn(x)
         compiled_fn = torch.compile(fn, backend="aot_eager_decomp_partition")
         compiled_out = compiled_fn(x)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4359,7 +4359,7 @@ def index_select(x: TensorLike, dim: int, index: TensorLike):
         return torch.empty_like(x).index_copy(0, index, x.expand_as(index))
 
     idx = (slice(None),) * dim + (index,)
-    return x[idx].contiguous()
+    return x[idx].contiguous(memory_format=torch._prims_common.suggest_memory_format(x))
 
 
 @register_decomposition(aten.squeeze.dims)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4359,7 +4359,7 @@ def index_select(x: TensorLike, dim: int, index: TensorLike):
         return torch.empty_like(x).index_copy(0, index, x.expand_as(index))
 
     idx = (slice(None),) * dim + (index,)
-    return x[idx].contiguous(memory_format=torch._prims_common.suggest_memory_format(x))
+    return x[idx].contiguous(memory_format=utils.suggest_memory_format(x))
 
 
 @register_decomposition(aten.squeeze.dims)


### PR DESCRIPTION
Fixes #174963.

The change to index_select decomp. introduced in ff961d2f025b6445509a6e5e4b7d1a448a9e0031 did not preserve memory format. Therefore, when using `torch.roll` as per repro in the issue, it's decomposition used index_select and did not preserve memory format. 

cc. @kshitij12345 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo