### PR TITLE
Clarify default value of eps in RMSNorm documentation

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -357,10 +357,11 @@ class RMSNorm(Module):
 
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension which is expected to be of that specific size.
-        eps: a value added to the denominator for numerical stability. If not specified,
-            uses the machine epsilon of the computation (opmath) type: fp16/bf16 and
-            fp32 inputs use ``torch.finfo(torch.float32).eps``, while fp64 inputs use
-            ``torch.finfo(torch.float64).eps``.
+        eps (float, optional): a value added to the denominator for numerical stability.
+            Default: ``None`` (in which case ``eps`` is determined at runtime based on
+            the computation (opmath) dtype of the input: fp16/bf16 and fp32 inputs use
+            ``torch.finfo(torch.float32).eps``, while fp64 inputs use
+            ``torch.finfo(torch.float64).eps``).
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
 


### PR DESCRIPTION
## Summary
Updates the `RMSNorm` docstring to explicitly clarify that `eps=None` (the default in the signature) means the value is determined at runtime based on the input dtype.

## Changes
- Updated the `eps` parameter description in the `RMSNorm` docstring to show `Default: None` and explain the runtime behavior
- Clarified that fp16/bf16/fp32 inputs use `torch.finfo(torch.float32).eps` and fp64 inputs use `torch.finfo(torch.float64).eps`

Fixes #155527