### PR TITLE
[optim] Fix SGD weight_decay docstring to include Tensor type

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -194,7 +194,7 @@ SGD.__doc__ = (
         lr (float, Tensor, optional): learning rate (default: 1e-3)
         momentum (float, optional): momentum factor (default: 0)
         dampening (float, optional): dampening for momentum (default: 0)
-        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        weight_decay (float, Tensor, optional): weight decay (L2 penalty) (default: 0)
         nesterov (bool, optional): enables Nesterov momentum. Only applicable
             when momentum is non-zero. (default: False)
         {_maximize_doc}


### PR DESCRIPTION
## Summary

`SGD.__init__` accepts `weight_decay: float | Tensor = 0` but the class docstring listed only `float`. This brings it in line with the `lr` parameter directly above it, which already correctly documents `float, Tensor`.

## Test plan

- [ ] No functional change — docstring only.
- [ ] Verified `help(torch.optim.SGD)` shows `weight_decay (float, Tensor, optional)` after the fix.

> PR authored with Claude Code (claude-sonnet-4-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)