### PR TITLE
Add default args support to def_static

### DIFF
--- a/aten/src/ATen/core/custom_class.cpp
+++ b/aten/src/ATen/core/custom_class.cpp
@@ -164,5 +164,25 @@ c10::FunctionSchema class_base::withNewArguments(
   return schema.cloneWithArguments(std::move(new_args));
 }
 
+c10::FunctionSchema class_base::withNewArgumentsStatic(
+    const c10::FunctionSchema& schema,
+    std::initializer_list<arg> default_args) {
+  const auto& old_args = schema.arguments();
+  std::vector<c10::Argument> new_args;
+  new_args.reserve(old_args.size());
+
+  size_t argIdx = 0;
+  for (const auto& default_arg : default_args) {
+    auto& old_arg = old_args[argIdx++];
+    new_args.emplace_back(
+        default_arg.name_,
+        old_arg.type(),
+        old_arg.real_type(),
+        old_arg.N(),
+        default_arg.value_);
+  }
+  return schema.cloneWithArguments(std::move(new_args));
+}
+
 } // namespace detail
 } // namespace torch

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -71,6 +71,12 @@ struct _StaticMethod : torch::CustomClassHolder {
   static int64_t staticMethod(int64_t input) {
     return 2 * input;
   }
+  static int64_t staticMethodWithDefault(int64_t input, std::optional<int64_t> scale) {
+      if (scale)
+          return (*scale) * input;
+      else
+          return 2 * input;
+  }
 };
 
 struct FooGetterSetter : torch::CustomClassHolder {
@@ -469,7 +475,12 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
 
   m.class_<_StaticMethod>("_StaticMethod")
       .def(torch::init<>())
-      .def_static("staticMethod", &_StaticMethod::staticMethod);
+      .def_static("staticMethod", &_StaticMethod::staticMethod)
+      .def_static(
+          "staticMethodWithDefault",
+          &_StaticMethod::staticMethodWithDefault,
+          "",
+          {torch::arg("input"), torch::arg("scale") = torch::arg::none()});
 
   m.class_<DefaultArgs>("_DefaultArgs")
       .def(torch::init<int64_t>(), "", {torch::arg("start") = 3})

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -74,10 +74,7 @@ struct _StaticMethod : torch::CustomClassHolder {
   static int64_t staticMethodWithDefault(
       int64_t input,
       std::optional<int64_t> scale) {
-    if (scale)
-      return (*scale) * input;
-    else
-      return 2 * input;
+    return scale.value_or(2) * input;
   }
 };
 

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -71,11 +71,13 @@ struct _StaticMethod : torch::CustomClassHolder {
   static int64_t staticMethod(int64_t input) {
     return 2 * input;
   }
-  static int64_t staticMethodWithDefault(int64_t input, std::optional<int64_t> scale) {
-      if (scale)
-          return (*scale) * input;
-      else
-          return 2 * input;
+  static int64_t staticMethodWithDefault(
+      int64_t input,
+      std::optional<int64_t> scale) {
+    if (scale)
+      return (*scale) * input;
+    else
+      return 2 * input;
   }
 };
 

--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -436,6 +436,13 @@ class TestTorchbind(JitTestCase):
 
         self.checkScript(fn, (1,))
 
+    def test_staticmethod_default_args(self):
+        def fn(inp: int) -> int:
+            res = torch.classes._TorchScriptTesting._StaticMethod.staticMethodWithDefault(inp)
+            return torch.classes._TorchScriptTesting._StaticMethod.staticMethodWithDefault(res, 4)
+
+        self.checkScript(fn, (1,))
+
     def test_hasattr(self):
         ss = torch.classes._TorchScriptTesting._StackString(["foo", "bar"])
         self.assertFalse(hasattr(ss, "baz"))

--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -438,8 +438,16 @@ class TestTorchbind(JitTestCase):
 
     def test_staticmethod_default_args(self):
         def fn(inp: int) -> int:
-            res = torch.classes._TorchScriptTesting._StaticMethod.staticMethodWithDefault(inp)
-            return torch.classes._TorchScriptTesting._StaticMethod.staticMethodWithDefault(res, 4)
+            res = (
+                torch.classes._TorchScriptTesting._StaticMethod.staticMethodWithDefault(
+                    inp
+                )
+            )
+            return (
+                torch.classes._TorchScriptTesting._StaticMethod.staticMethodWithDefault(
+                    res, 4
+                )
+            )
 
         self.checkScript(fn, (1,))
 

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -167,10 +167,31 @@ class class_ : public ::torch::detail::class_base {
 
   /// Method registration API for static methods.
   template <typename Func>
-  class_& def_static(std::string name, Func func, std::string doc_string = "") {
+  class_& def_static(
+      std::string name,
+      Func func,
+      std::string doc_string = "",
+      std::initializer_list<arg> default_args = {}) {
     auto qualMethodName = qualClassName + "." + name;
     auto schema =
         c10::inferFunctionSchemaSingleReturn<Func>(std::move(name), "");
+
+    // If default values are provided for function arguments, there must be
+    // none (no default values) or default values for all function
+    // arguments. This is because argument names are not extracted by
+    // inferFunctionSchemaSingleReturn, and so there must be a torch::arg
+    // instance in default_args even for arguments that do not have an actual
+    // default value provided.
+    TORCH_CHECK(
+        default_args.size() == 0 ||
+            default_args.size() == schema.arguments().size(),
+        "Default values must be specified for none or all arguments");
+
+    // If there are default args, copy the argument names and default values to
+    // the function schema.
+    if (default_args.size() > 0) {
+        schema = withNewArgumentsStatic(schema, default_args);
+    }
 
     auto wrapped_func =
         [func = std::move(func)](jit::Stack& stack) mutable -> void {

--- a/torch/custom_class_detail.h
+++ b/torch/custom_class_detail.h
@@ -208,7 +208,14 @@ class TORCH_API class_base {
       const std::type_info& intrusivePtrClassTypeid,
       const std::type_info& taggedCapsuleClass);
 
+  // Copies the argument names and default values to the function schema
+  // taking care to preserve the first argument (self)
   static c10::FunctionSchema withNewArguments(
+      const c10::FunctionSchema& schema,
+      std::initializer_list<arg> default_args);
+
+  // Copies the argument names and default values to the function schema
+  static c10::FunctionSchema withNewArgumentsStatic(
       const c10::FunctionSchema& schema,
       std::initializer_list<arg> default_args);
   std::string qualClassName;


### PR DESCRIPTION
Unlike `def(...)`, `def_static(...)` does not support kwargs and/or default values. This PR adds that support for `def_static` and incrementally improves support for custom classes within PyTorch.

In our application, this is needed to support custom types in schemas for operators that we've registered with the dispatch system following the tutorial in https://docs.pytorch.org/tutorials/advanced/custom_classes.html