### PR TITLE
[export] Remove unneeded flag from dynamo_graph_capture_for_export

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1481,9 +1481,7 @@ from user code:
 
             from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 
-            gm = dynamo_graph_capture_for_export(model, restore_state_dict=True)(
-                input_ids_dt
-            )
+            gm = dynamo_graph_capture_for_export(model)(input_ids_dt)
 
             fake_mode = gm.meta["fake_mode"]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #175647
* __->__ #175646

Summary:
This flag doesn't seem to do anything useful, removing to reduce confusion.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo