### PR TITLE
[ROCm] Require rocm_smi package

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1093,7 +1093,7 @@ if(USE_ROCM)
     endif()
 
     # ROCM-SMI needed to support symmetric memory
-    if (USE_DISTRIBUED AND UNIX)
+    if(USE_DISTRIBUTED AND UNIX)
       list(APPEND Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS
         rocm_smi64
       )

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1092,6 +1092,13 @@ if(USE_ROCM)
       endif()
     endif()
 
+    # ROCM-SMI needed to support symmetric memory
+    if (USE_DISTRIBUED AND UNIX)
+      list(APPEND Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS
+        rocm_smi64
+      )
+    endif()
+
     # ---[ Kernel asserts
     # Kernel asserts is disabled for ROCm by default.
     # It can be turned on by turning on the env USE_ROCM_KERNEL_ASSERT to the build system.

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -219,6 +219,7 @@ if(HIP_FOUND)
   if(UNIX)
     find_package_and_print_version(rccl)
     find_package_and_print_version(hsa-runtime64 REQUIRED)
+    find_package_and_print_version(rocm_smi REQUIRED)
   endif()
 
   # Optional components.


### PR DESCRIPTION
Fixes #158725 

This is essentially @AngryLoki  patch:
https://github.com/gentoo/gentoo/blob/8cdbe88fa388ce264d1d70047222fcad190fec3d/sci-ml/caffe2/files/caffe2-2.9.0-rocm-distributed-link.patch

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang