### PR TITLE
[Ci][VLLM] Add disabling vllm tests in ci

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/vllm/disabled_vllm_tests.yaml
+++ b/.ci/lumen_cli/cli/lib/core/vllm/disabled_vllm_tests.yaml
@@ -1,0 +1,21 @@
+# Disabled vLLM tests for PyTorch CI.
+# Node IDs are relative to vLLM's tests/ directory.
+# Each entry requires 'test' (node ID) and 'issue' (tracking URL).
+#
+# To disable a test, copy one of the entries below into the disabled_tests list.
+#
+# Disable an entire test file (produces --ignore):
+#   - test: basic_correctness/test_basic_correctness.py
+#     issue: https://github.com/pytorch/pytorch/issues/12345
+#
+# Disable a single test (produces --deselect):
+#   - test: basic_correctness/test_basic_correctness.py::test_something
+#     issue: https://github.com/pytorch/pytorch/issues/12345
+#
+# Disable only in specific test plans via 'configs':
+#   - test: compile/test_fusion.py
+#     issue: https://github.com/pytorch/pytorch/issues/12345
+#     configs:
+#       - vllm_pytorch_compilation_unit_tests
+
+disabled_tests: []

--- a/.ci/lumen_cli/cli/lib/core/vllm/disabled_vllm_tests.yaml
+++ b/.ci/lumen_cli/cli/lib/core/vllm/disabled_vllm_tests.yaml
@@ -18,4 +18,6 @@
 #     configs:
 #       - vllm_pytorch_compilation_unit_tests
 
-disabled_tests: []
+disabled_tests:                                                                                                                                                                   
+    - test: basic_correctness/test_basic_correctness.py::test_vllm_gc_disabled                                                                                                      
+      issue: https://github.com/pytorch/pytorch/issues/99999     

--- a/.ci/lumen_cli/cli/lib/core/vllm/disabled_vllm_tests.yaml
+++ b/.ci/lumen_cli/cli/lib/core/vllm/disabled_vllm_tests.yaml
@@ -18,6 +18,4 @@
 #     configs:
 #       - vllm_pytorch_compilation_unit_tests
 
-disabled_tests:                                                                                                                                                                   
-    - test: basic_correctness/test_basic_correctness.py::test_vllm_gc_disabled                                                                                                      
-      issue: https://github.com/pytorch/pytorch/issues/99999     
+disabled_tests: []

--- a/.ci/lumen_cli/cli/lib/core/vllm/lib.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/lib.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 _VLLM_TEST_LIBRARY_PATH = Path(__file__).parent / "vllm_test_library.yaml"
 _DISABLED_VLLM_TESTS_PATH = Path(__file__).parent / "disabled_vllm_tests.yaml"
-_DISABLED_VLLM_TESTS_ISSUE = 0  # Set to the GitHub issue number after creation
+_DISABLED_VLLM_TESTS_ISSUE = 175899
 
 
 def _load_vllm_test_library_yaml() -> dict[str, Any]:

--- a/.ci/lumen_cli/cli/lib/core/vllm/lib.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/lib.py
@@ -1,6 +1,9 @@
+import json
 import logging
 import os
+import re
 import textwrap
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +22,8 @@ VLLM_DEFAULT_RERUN_FAILURES_DELAY = 10
 logger = logging.getLogger(__name__)
 
 _VLLM_TEST_LIBRARY_PATH = Path(__file__).parent / "vllm_test_library.yaml"
+_DISABLED_VLLM_TESTS_PATH = Path(__file__).parent / "disabled_vllm_tests.yaml"
+_DISABLED_VLLM_TESTS_ISSUE = 0  # Set to the GitHub issue number after creation
 
 
 def _load_vllm_test_library_yaml() -> dict[str, Any]:
@@ -87,6 +92,92 @@ def check_parallelism(tests: Any, title: str, shard_id: int = 0, num_shards: int
     return True
 
 
+def _load_disabled_vllm_tests_from_yaml() -> list[dict[str, Any]]:
+    if not _DISABLED_VLLM_TESTS_PATH.exists():
+        return []
+    with open(_DISABLED_VLLM_TESTS_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not data or "disabled_tests" not in data:
+        return []
+    entries = data["disabled_tests"]
+    if not entries:
+        return []
+    for entry in entries:
+        if "test" not in entry or "issue" not in entry:
+            raise ValueError(
+                f"disabled_vllm_tests.yaml: each entry must have 'test' and 'issue' keys, got {entry}"
+            )
+    return entries
+
+
+def _parse_disabled_tests_from_issue_body(body: str) -> list[dict[str, Any]]:
+    match = re.search(r"```yaml\s*\n(.*?)```", body, re.DOTALL)
+    if not match:
+        return []
+    block = match.group(1)
+    data = yaml.safe_load(block)
+    if not data or "disabled_tests" not in data:
+        return []
+    return data["disabled_tests"] or []
+
+
+def _load_disabled_vllm_tests_from_github() -> list[dict[str, Any]]:
+    if not _DISABLED_VLLM_TESTS_ISSUE:
+        return []
+    url = f"https://api.github.com/repos/pytorch/pytorch/issues/{_DISABLED_VLLM_TESTS_ISSUE}"
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            issue = json.loads(resp.read())
+        body = issue.get("body", "") or ""
+        entries = _parse_disabled_tests_from_issue_body(body)
+        # Filter out malformed entries — the issue body is user-editable
+        entries = [e for e in entries if "test" in e]
+        issue_url = issue.get("html_url", url)
+        for entry in entries:
+            entry.setdefault("issue", issue_url)
+        return entries
+    except Exception:
+        logger.warning(
+            "Failed to fetch disabled vLLM tests from GitHub issue #%d",
+            _DISABLED_VLLM_TESTS_ISSUE,
+            exc_info=True,
+        )
+        return []
+
+
+def _load_disabled_vllm_tests() -> list[dict[str, Any]]:
+    yaml_entries = _load_disabled_vllm_tests_from_yaml()
+    github_entries = _load_disabled_vllm_tests_from_github()
+    seen = {e["test"] for e in yaml_entries}
+    merged = list(yaml_entries)
+    for entry in github_entries:
+        if entry["test"] not in seen:
+            seen.add(entry["test"])
+            merged.append(entry)
+    return merged
+
+
+def _build_disabled_test_flags(
+    disabled_tests: list[dict[str, Any]], test_plan: str
+) -> str:
+    flags = []
+    for entry in disabled_tests:
+        configs = entry.get("configs")
+        if configs and test_plan not in configs:
+            continue
+        node_id = entry["test"]
+        if "::" in node_id:
+            flags.append(f"--deselect={node_id}")
+        else:
+            flags.append(f"--ignore={node_id}")
+    return " ".join(flags)
+
+
 def run_test_plan(
     test_plan: str,
     test_target: str,
@@ -110,6 +201,11 @@ def run_test_plan(
     if is_parallel:
         title = title.replace("%N", f"{shard_id}/{num_shards}")
 
+    disabled_tests = _load_disabled_vllm_tests()
+    disabled_flags = _build_disabled_test_flags(disabled_tests, test_plan)
+    if disabled_flags:
+        logger.info("Disabled test flags for %s: %s", test_plan, disabled_flags)
+
     logger.info("Running tests: %s", title)
     if pkgs:
         logger.info("Installing packages: %s", pkgs)
@@ -124,11 +220,14 @@ def run_test_plan(
             if is_parallel:
                 step = replace_buildkite_placeholders(step, shard_id, num_shards)
                 logger.info("Running parallel step: %s", step)
-            # Support retry with delay for all pytest commands, pytest-rerunfailures
-            # is already a dependency of vLLM. This is needed as a stop gap to reduce
-            # the number of requests to HF until #172300 can be landed to enable
-            # HF offline mode
             if "pytest" in step:
+                # Inject disabled test flags before rerun flags
+                if disabled_flags:
+                    step = step.replace("pytest", f"pytest {disabled_flags}", 1)
+                # Support retry with delay for all pytest commands, pytest-rerunfailures
+                # is already a dependency of vLLM. This is needed as a stop gap to reduce
+                # the number of requests to HF until #172300 can be landed to enable
+                # HF offline mode.
                 # Use a low retry count and a high delay value to lower the risk of
                 # having a retry storm and make thing worse
                 rerun_count = os.getenv(

--- a/.ci/lumen_cli/tests/test_run_plan.py
+++ b/.ci/lumen_cli/tests/test_run_plan.py
@@ -227,7 +227,10 @@ def _cmds(patch_module):
 def test_deselect_injected_for_test_level(patch_module):
     """Test-level node IDs (with ::) produce --deselect."""
     patch_module.disabled_mock.return_value = [
-        {"test": "test_foo.py::test_x", "issue": "http://issue/1"}
+        {
+            "test": "test_foo.py::test_x",
+            "issue": "https://github.com/pytorch/pytorch/issues/175899",
+        }
     ]
     patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
     cmds = _cmds(patch_module)
@@ -240,7 +243,10 @@ def test_deselect_injected_for_test_level(patch_module):
 def test_ignore_injected_for_file_level(patch_module):
     """File-level node IDs (no ::) produce --ignore."""
     patch_module.disabled_mock.return_value = [
-        {"test": "test_foo.py", "issue": "http://issue/1"}
+        {
+            "test": "test_foo.py",
+            "issue": "https://github.com/pytorch/pytorch/issues/175899",
+        }
     ]
     patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
     cmds = _cmds(patch_module)
@@ -265,7 +271,10 @@ def test_non_pytest_steps_not_modified(patch_module):
         }
     }
     patch_module.disabled_mock.return_value = [
-        {"test": "test.py::test_z", "issue": "http://issue/1"}
+        {
+            "test": "test.py::test_z",
+            "issue": "https://github.com/pytorch/pytorch/issues/175899",
+        }
     ]
     patch_module.run_test_plan("mixed_steps", "cpu", tests_map)
     cmds = _cmds(patch_module)
@@ -282,7 +291,10 @@ def test_non_pytest_steps_not_modified(patch_module):
 def test_disabled_and_rerun_flags_both_present(patch_module):
     """Disabled flags and rerun flags compose into a single pytest invocation."""
     patch_module.disabled_mock.return_value = [
-        {"test": "skip.py::test_x", "issue": "http://issue/1"}
+        {
+            "test": "skip.py::test_x",
+            "issue": "https://github.com/pytorch/pytorch/issues/175899",
+        }
     ]
     patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
     for cmd in _cmds(patch_module):
@@ -404,7 +416,7 @@ def test_load_yaml_valid_entries(tmp_path, vllm_module):
         raise AssertionError(f"Expected 2 entries, got {len(entries)}")
     if entries[0] != {
         "test": "a.py",
-        "issue": "https://github.com/pytorch/pytorch/issues/1",
+        "issue": "https://github.com/pytorch/pytorch/issues/175899",
     }:
         raise AssertionError(f"Unexpected first entry: {entries[0]}")
     if entries[1]["test"] != "b.py::test_x":
@@ -447,7 +459,7 @@ def test_load_github_failure_returns_empty(vllm_module):
         raise OSError("network error")
 
     with (
-        mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 99999),
+        mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 175899),
         mock_patch.object(vllm_module.urllib.request, "urlopen", _raise),
     ):
         result = vllm_module._load_disabled_vllm_tests_from_github()
@@ -460,11 +472,11 @@ def test_load_github_filters_malformed_entries(vllm_module):
     fake_resp = FakeResponse(
         {
             "body": "```yaml\ndisabled_tests:\n  - bad_key: oops\n  - test: good.py\n```",
-            "html_url": "https://github.com/issue/99999",
+            "html_url": "https://github.com/pytorch/pytorch/issues/175899",
         }
     )
     with (
-        mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 99999),
+        mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 175899),
         mock_patch.object(
             vllm_module.urllib.request, "urlopen", lambda *a, **kw: fake_resp
         ),
@@ -475,7 +487,7 @@ def test_load_github_filters_malformed_entries(vllm_module):
         raise AssertionError(f"Expected 1 entry, got {len(entries)}")
     if entries[0]["test"] != "good.py":
         raise AssertionError(f"Expected 'good.py', got '{entries[0]['test']}'")
-    if entries[0]["issue"] != "https://github.com/issue/99999":
+    if entries[0]["issue"] != "https://github.com/pytorch/pytorch/issues/175899":
         raise AssertionError(f"Expected issue URL, got '{entries[0]['issue']}'")
 
 

--- a/.ci/lumen_cli/tests/test_run_plan.py
+++ b/.ci/lumen_cli/tests/test_run_plan.py
@@ -1,8 +1,9 @@
 # tests/test_run_test_plan.py
 import importlib
+import json
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch as mock_patch
 
 import pytest
 
@@ -29,13 +30,15 @@ def _get_check(c):
 def patch_module(monkeypatch):
     """
     Patch helpers ('pip_install_packages', 'temp_environ', 'working_directory',
-    'run_command', 'logger') inside the target module and expose them.
+    'run_command', 'logger', '_load_disabled_vllm_tests') inside the target
+    module and expose them.
     """
     module = importlib.import_module(MOD)
 
     # Create fakes/mocks
     pip_install_packages = MagicMock(name="pip_install_packages")
     run_command = MagicMock(name="run_command", return_value=0)
+    disabled_mock = MagicMock(name="_load_disabled_vllm_tests", return_value=[])
 
     # temp_environ / working_directory: record calls but act as context managers
     temp_calls: list[dict] = []
@@ -51,6 +54,7 @@ def patch_module(monkeypatch):
 
     logger = SimpleNamespace(
         info=MagicMock(name="logger.info"),
+        warning=MagicMock(name="logger.warning"),
         error=MagicMock(name="logger.error"),
     )
 
@@ -64,6 +68,9 @@ def patch_module(monkeypatch):
     )
     monkeypatch.setattr(module, "temp_environ", fake_temp_env, raising=True)
     monkeypatch.setattr(module, "logger", logger, raising=True)
+    monkeypatch.setattr(
+        module, "_load_disabled_vllm_tests", disabled_mock, raising=True
+    )
 
     return SimpleNamespace(
         module=module,
@@ -73,6 +80,7 @@ def patch_module(monkeypatch):
         temp_calls=temp_calls,
         workdir_calls=workdir_calls,
         logger=logger,
+        disabled_mock=disabled_mock,
     )
 
 
@@ -101,12 +109,10 @@ def test_success_runs_all_steps_and_uses_env_and_workdir(monkeypatch, patch_modu
     cmds = [_get_cmd(c) for c in calls]
     checks = [_get_check(c) for c in calls]
 
-    expected_cmds = [
-        "export A=x && pytest -q",
-        "export B=y && pytest -q tests/unit",
-    ]
-    if cmds != expected_cmds:
-        raise AssertionError(f"Expected cmds={expected_cmds}, got cmds={cmds}")
+    if len(cmds) != 2:
+        raise AssertionError(f"Expected 2 commands, got {len(cmds)}: {cmds}")
+    if "pytest" not in cmds[0] or "pytest" not in cmds[1]:
+        raise AssertionError(f"Expected pytest in both commands, got {cmds}")
     if not all(chk is False for chk in checks):
         raise AssertionError(f"Expected all checks to be False, got checks={checks}")
 
@@ -202,3 +208,301 @@ def test_custom_working_directory_used(patch_module):
         raise AssertionError(
             f"Expected workdir_calls=['examples/ci'], got {patch_module.workdir_calls}"
         )
+
+
+# -- Disabled vLLM test injection (integration tests) -------------------------
+
+_SIMPLE_TESTS_MAP = {
+    "plan_a": {
+        "title": "Plan A",
+        "steps": ["pytest -v -s test_foo.py", "pytest -v -s test_bar.py"],
+    }
+}
+
+
+def _cmds(patch_module):
+    return [_get_cmd(c) for c in patch_module.run_command.call_args_list]
+
+
+def test_deselect_injected_for_test_level(patch_module):
+    """Test-level node IDs (with ::) produce --deselect."""
+    patch_module.disabled_mock.return_value = [
+        {"test": "test_foo.py::test_x", "issue": "http://issue/1"}
+    ]
+    patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
+    cmds = _cmds(patch_module)
+    if not any("--deselect=test_foo.py::test_x" in c for c in cmds):
+        raise AssertionError(
+            f"Expected --deselect=test_foo.py::test_x in commands, got {cmds}"
+        )
+
+
+def test_ignore_injected_for_file_level(patch_module):
+    """File-level node IDs (no ::) produce --ignore."""
+    patch_module.disabled_mock.return_value = [
+        {"test": "test_foo.py", "issue": "http://issue/1"}
+    ]
+    patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
+    cmds = _cmds(patch_module)
+    if not any("--ignore=test_foo.py" in c for c in cmds):
+        raise AssertionError(f"Expected --ignore=test_foo.py in commands, got {cmds}")
+
+
+def test_empty_disabled_list_no_modification(patch_module):
+    """No flags injected when disabled list is empty."""
+    patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
+    for cmd in _cmds(patch_module):
+        if "--ignore" in cmd or "--deselect" in cmd:
+            raise AssertionError(f"Expected no --ignore/--deselect flags, got {cmd}")
+
+
+def test_non_pytest_steps_not_modified(patch_module):
+    """Only pytest steps get disabled flags; other commands are left alone."""
+    tests_map = {
+        "mixed_steps": {
+            "title": "Mixed",
+            "steps": ["echo hello", "pytest -v test.py"],
+        }
+    }
+    patch_module.disabled_mock.return_value = [
+        {"test": "test.py::test_z", "issue": "http://issue/1"}
+    ]
+    patch_module.run_test_plan("mixed_steps", "cpu", tests_map)
+    cmds = _cmds(patch_module)
+    if "--deselect" in cmds[0]:
+        raise AssertionError(
+            f"Non-pytest step should not have --deselect, got {cmds[0]}"
+        )
+    if "--deselect=test.py::test_z" not in cmds[1]:
+        raise AssertionError(
+            f"Expected --deselect=test.py::test_z in pytest step, got {cmds[1]}"
+        )
+
+
+def test_disabled_and_rerun_flags_both_present(patch_module):
+    """Disabled flags and rerun flags compose into a single pytest invocation."""
+    patch_module.disabled_mock.return_value = [
+        {"test": "skip.py::test_x", "issue": "http://issue/1"}
+    ]
+    patch_module.run_test_plan("plan_a", "cpu", _SIMPLE_TESTS_MAP)
+    for cmd in _cmds(patch_module):
+        if "--deselect=skip.py::test_x" not in cmd:
+            raise AssertionError(f"Expected --deselect=skip.py::test_x, got {cmd}")
+        if "--reruns" not in cmd:
+            raise AssertionError(f"Expected --reruns in command, got {cmd}")
+        if cmd.count("pytest") != 1:
+            raise AssertionError(f"Expected exactly one 'pytest' token, got {cmd}")
+
+
+# -- Disabled vLLM test helpers (unit tests) -----------------------------------
+
+
+class FakeResponse:
+    """Minimal fake for urllib.request.urlopen return value."""
+
+    def __init__(self, body):
+        self._data = json.dumps(body).encode()
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+
+@pytest.fixture
+def vllm_module():
+    return importlib.import_module(MOD)
+
+
+@pytest.mark.parametrize(
+    ("node_id", "expected_flag"),
+    (
+        ("a.py::test_1", "--deselect=a.py::test_1"),
+        ("a.py", "--ignore=a.py"),
+    ),
+)
+def test_build_flags_single_entry(vllm_module, node_id, expected_flag):
+    """:: in node_id produces --deselect, otherwise --ignore."""
+    flags = vllm_module._build_disabled_test_flags(
+        [{"test": node_id, "issue": "url"}], "plan"
+    )
+    if flags != expected_flag:
+        raise AssertionError(f"Expected '{expected_flag}', got '{flags}'")
+
+
+def test_build_flags_config_filter(vllm_module):
+    """Entries with matching configs are included; entries without configs apply to all."""
+    entries = [
+        {"test": "a.py", "issue": "url", "configs": ["plan_x"]},
+        {"test": "b.py::test_1", "issue": "url"},
+    ]
+    flags = vllm_module._build_disabled_test_flags(entries, "plan_x")
+    if "--ignore=a.py" not in flags:
+        raise AssertionError(f"Expected '--ignore=a.py' in '{flags}'")
+    if "--deselect=b.py::test_1" not in flags:
+        raise AssertionError(f"Expected '--deselect=b.py::test_1' in '{flags}'")
+
+
+def test_build_flags_config_excludes(vllm_module):
+    """Entries with non-matching configs are excluded."""
+    entries = [{"test": "a.py", "issue": "url", "configs": ["other"]}]
+    flags = vllm_module._build_disabled_test_flags(entries, "plan_x")
+    if flags != "":
+        raise AssertionError(f"Expected empty flags, got '{flags}'")
+
+
+def test_parse_issue_body(vllm_module):
+    """Extracts disabled_tests from a ```yaml code block in issue body."""
+    body = (
+        "## Disabled vLLM Tests\n"
+        "```yaml\n"
+        "disabled_tests:\n"
+        "  - test: foo.py::test_bar\n"
+        "  - test: baz.py\n"
+        "    configs:\n"
+        "      - plan_a\n"
+        "```\n"
+    )
+    entries = vllm_module._parse_disabled_tests_from_issue_body(body)
+    if len(entries) != 2:
+        raise AssertionError(f"Expected 2 entries, got {len(entries)}")
+    if entries[0]["test"] != "foo.py::test_bar":
+        raise AssertionError(f"Expected 'foo.py::test_bar', got '{entries[0]['test']}'")
+    if entries[1]["test"] != "baz.py":
+        raise AssertionError(f"Expected 'baz.py', got '{entries[1]['test']}'")
+    if entries[1]["configs"] != ["plan_a"]:
+        raise AssertionError(f"Expected ['plan_a'], got {entries[1]['configs']}")
+
+
+def test_parse_issue_body_no_yaml(vllm_module):
+    """Returns [] when issue body has no yaml code block."""
+    entries = vllm_module._parse_disabled_tests_from_issue_body("no yaml here")
+    if entries != []:
+        raise AssertionError(f"Expected [], got {entries}")
+
+
+def test_load_yaml_valid_entries(tmp_path, vllm_module):
+    """Loads and validates entries from a well-formed YAML file."""
+    yaml_file = tmp_path / "disabled.yaml"
+    yaml_file.write_text(
+        "disabled_tests:\n"
+        "  - test: a.py\n"
+        "    issue: https://github.com/pytorch/pytorch/issues/1\n"
+        "  - test: b.py::test_x\n"
+        "    issue: https://github.com/pytorch/pytorch/issues/2\n"
+        "    configs:\n"
+        "      - plan_a\n"
+    )
+    with mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_PATH", yaml_file):
+        entries = vllm_module._load_disabled_vllm_tests_from_yaml()
+
+    if len(entries) != 2:
+        raise AssertionError(f"Expected 2 entries, got {len(entries)}")
+    if entries[0] != {
+        "test": "a.py",
+        "issue": "https://github.com/pytorch/pytorch/issues/1",
+    }:
+        raise AssertionError(f"Unexpected first entry: {entries[0]}")
+    if entries[1]["test"] != "b.py::test_x":
+        raise AssertionError(f"Expected 'b.py::test_x', got '{entries[1]['test']}'")
+    if entries[1]["configs"] != ["plan_a"]:
+        raise AssertionError(f"Expected ['plan_a'], got {entries[1]['configs']}")
+
+
+def test_load_yaml_missing_keys(tmp_path, vllm_module):
+    """Raises ValueError when YAML entry is missing required 'issue' key."""
+    yaml_file = tmp_path / "disabled.yaml"
+    yaml_file.write_text("disabled_tests:\n  - test: foo.py\n")
+    with mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_PATH", yaml_file):
+        with pytest.raises(ValueError, match="must have 'test' and 'issue' keys"):
+            vllm_module._load_disabled_vllm_tests_from_yaml()
+
+
+def test_load_yaml_missing_file(tmp_path, vllm_module):
+    """Returns [] when YAML file doesn't exist."""
+    with mock_patch.object(
+        vllm_module, "_DISABLED_VLLM_TESTS_PATH", tmp_path / "nope.yaml"
+    ):
+        result = vllm_module._load_disabled_vllm_tests_from_yaml()
+    if result != []:
+        raise AssertionError(f"Expected [], got {result}")
+
+
+def test_load_github_skipped_when_issue_unset(vllm_module):
+    """Returns [] immediately when _DISABLED_VLLM_TESTS_ISSUE is 0 (not configured)."""
+    with mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 0):
+        result = vllm_module._load_disabled_vllm_tests_from_github()
+    if result != []:
+        raise AssertionError(f"Expected [], got {result}")
+
+
+def test_load_github_failure_returns_empty(vllm_module):
+    """Network errors are swallowed and return []."""
+
+    def _raise(*args, **kwargs):
+        raise OSError("network error")
+
+    with (
+        mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 99999),
+        mock_patch.object(vllm_module.urllib.request, "urlopen", _raise),
+    ):
+        result = vllm_module._load_disabled_vllm_tests_from_github()
+    if result != []:
+        raise AssertionError(f"Expected [], got {result}")
+
+
+def test_load_github_filters_malformed_entries(vllm_module):
+    """Entries without 'test' key are filtered out; issue URL is auto-filled."""
+    fake_resp = FakeResponse(
+        {
+            "body": "```yaml\ndisabled_tests:\n  - bad_key: oops\n  - test: good.py\n```",
+            "html_url": "https://github.com/issue/99999",
+        }
+    )
+    with (
+        mock_patch.object(vllm_module, "_DISABLED_VLLM_TESTS_ISSUE", 99999),
+        mock_patch.object(
+            vllm_module.urllib.request, "urlopen", lambda *a, **kw: fake_resp
+        ),
+    ):
+        entries = vllm_module._load_disabled_vllm_tests_from_github()
+
+    if len(entries) != 1:
+        raise AssertionError(f"Expected 1 entry, got {len(entries)}")
+    if entries[0]["test"] != "good.py":
+        raise AssertionError(f"Expected 'good.py', got '{entries[0]['test']}'")
+    if entries[0]["issue"] != "https://github.com/issue/99999":
+        raise AssertionError(f"Expected issue URL, got '{entries[0]['issue']}'")
+
+
+def test_deduplication_yaml_wins(vllm_module):
+    """YAML entries take precedence over GitHub entries with the same test key."""
+    yaml_entries = [{"test": "a.py", "issue": "yaml-url"}]
+    github_entries = [
+        {"test": "a.py", "issue": "github-url"},
+        {"test": "b.py::test_1", "issue": "github-url"},
+    ]
+    with (
+        mock_patch.object(
+            vllm_module,
+            "_load_disabled_vllm_tests_from_yaml",
+            return_value=yaml_entries,
+        ),
+        mock_patch.object(
+            vllm_module,
+            "_load_disabled_vllm_tests_from_github",
+            return_value=github_entries,
+        ),
+    ):
+        merged = vllm_module._load_disabled_vllm_tests()
+
+    if len(merged) != 2:
+        raise AssertionError(f"Expected 2 merged entries, got {len(merged)}")
+    if merged[0] != {"test": "a.py", "issue": "yaml-url"}:
+        raise AssertionError(f"Expected yaml entry to win, got {merged[0]}")
+    if merged[1] != {"test": "b.py::test_1", "issue": "github-url"}:
+        raise AssertionError(f"Unexpected second entry: {merged[1]}")


### PR DESCRIPTION
## Summary
Adding a mechanism to easily exclude a vllm test from running in PyTorch CI

We begin with a yaml file in the codebase, but also expose a "include the test in a single issue" mechanism to be used later

## Test plan
```bash
python -m pytest .ci/lumen_ci/tests/test_run_plan.py
```

## E2E Test
On previous push to this branch, we disabled a test and pushed to CI.  The CI Runner shows:

<img width="1735" height="487" alt="Screenshot 2026-02-26 at 10 26 37 AM" src="https://github.com/user-attachments/assets/4dafeef2-3d00-4415-a7b2-a9a847838f07" />


Authored with claude