### PR TITLE
[flex_attention] Fix BlockMask._adjust to update seq_lengths

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -846,8 +846,10 @@ class BlockMask:
             new_kv_indices,
             new_full_kv_num_blocks,
             new_full_kv_indices,
-            self.BLOCK_SIZE,
-            self.mask_mod,
+            BLOCK_SIZE=self.BLOCK_SIZE,
+            mask_mod=self.mask_mod,
+            seq_lengths=(new_q_len, new_kv_len),
+            compute_q_blocks=self.q_indices is not None,
         )
 
     def numel(self):


### PR DESCRIPTION
What/why:
BlockMask _adjust() rebuilt the mask but didn’t propagate adjusted seq_lengths, so flex_attention could fail validation after shrinking Q/KV lengths.

Change:
Pass seq_lengths=(new_q_len, new_kv_len) when rebuilding; add a regression test.

Test plan:
python -m pytest test/inductor/test_flex_attention.py -k adjust -v

Footer:
Fixes #175533

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo