### PR TITLE
Raise Error if mutation is done on overlapping strided view in compile

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9179,6 +9179,57 @@ class TestAOTAutogradWithDynamo(TestAOTAutograd):
 
         self.assertEqual(out, optout)
 
+    def test_inputs_overlapping_with_mutation_guard_base_as_strided(self):
+        def f(x):
+            x = x.clone()
+            y = x.as_strided((2, 2), (1, 1), 0)
+            y.add_(1.0)
+            return y
+
+        def run(f):
+            base = torch.randn([2, 2, 10])
+            return f(base)
+
+        optf = torch.compile(backend="aot_eager", dynamic=True)(f)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "torch.compile/functionalization does not support in-place mutation on overlapping as_strided views",
+        ):
+            run(optf)
+
+    def test_inputs_overlapping_with_mutation_guard_base_as_strided_autograd(self):
+        def f(x):
+            x = x.clone()
+            y = x.as_strided((2, 2), (1, 1), 0)
+            y.add_(1.0)
+            return y
+
+        def run(f):
+            base = torch.randn([2, 2, 10], requires_grad=True)
+            return f(base)
+
+        optf = torch.compile(backend="aot_eager", dynamic=True)(f)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "torch.compile/functionalization does not support in-place mutation on overlapping as_strided views",
+        ):
+            run(optf)
+
+    def test_inputs_overlapping_with_mutation_guard_base_as_strided_partial(self):
+        def f(x):
+            x = x.clone()
+            y = x.as_strided((3,), (2,), 1)
+            y.add_(1.0)
+            return y
+
+        base = torch.randn(8)
+        optf = torch.compile(backend="aot_eager", dynamic=True)(f)
+        out = f(base.clone())
+        optout = optf(base.clone())
+        self.assertEqual(out, optout)
+
     def test_mutations_in_bw_detached_from_tangent(self):
         class AF(torch.autograd.Function):
             @staticmethod

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -300,6 +300,8 @@ def aot_dispatch_base_graph(
         aot_config=aot_config,
     )
 
+    _check_no_overlapping_as_strided_views_in_graph(fw_module)
+
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
         # We update metadata to consider any assigned buffers as buffer mutations.
         i = len(dict(mod_when_exporting_non_strict.named_parameters()))
@@ -408,6 +410,60 @@ def aot_dispatch_base_graph(
         saved_updated_flat_args_subclasses_desugared_descs,
         maybe_subclass_meta,
     )
+
+
+def _resolve(x: Any) -> Any:
+    if isinstance(x, torch.fx.Node):
+        return x.meta.get("val", x)
+    return x
+
+def _check_no_overlapping_as_strided_views_in_graph(
+    graph: torch.fx.GraphModule,
+) -> None:
+    for node in graph.graph.nodes:
+        if (
+            node.op != "call_function"
+            or node.target != torch.ops.aten.as_strided_scatter.default
+        ):
+            continue
+        base_node = node.args[0]
+        base = base_node.meta.get("val", None) if hasattr(base_node, "meta") else None
+        if not isinstance(base, torch.Tensor):
+            continue
+
+        sizes = node.args[2]
+        strides = node.args[3]
+        if isinstance(sizes, (list, tuple)):
+            sizes = [_resolve(s) for s in sizes]
+        else:
+            continue
+        if isinstance(strides, (list, tuple)):
+            strides = [_resolve(s) for s in strides]
+        else:
+            continue
+
+        storage_offset = (
+            0 if len(node.args) < 5 or node.args[4] is None else _resolve(node.args[4])
+        )
+
+        if any(isinstance(v, torch.SymInt) for v in (*sizes, *strides)):
+            continue
+        if isinstance(storage_offset, torch.SymInt):
+            continue
+
+        view = base.as_strided(sizes, strides, storage_offset).squeeze()
+        if torch._debug_has_internal_overlap(view) != 0:
+            sq_strides = view.stride()
+            sq_sizes = view.shape
+            indices = list(range(len(sq_strides)))
+            indices = [x for _, x in sorted(zip(sq_strides, indices))]
+            for i in range(len(sq_strides)):
+                prev_stride = 1 if i == 0 else sq_strides[indices[i - 1]]
+                prev_size = 1 if i == 0 else sq_sizes[indices[i - 1]]
+                if sq_strides[indices[i]] < prev_stride * prev_size:
+                    raise RuntimeError(
+                        "torch.compile/functionalization does not support in-place mutation on overlapping as_strided views"
+                    )
 
 
 # Has the precondition that there
@@ -519,6 +575,8 @@ def aot_dispatch_autograd_graph(
         updated_joint_inputs_descs,
         aot_config=aot_config,
     )
+
+    _check_no_overlapping_as_strided_views_in_graph(fx_g)
 
     # Redundant with the check above, but worth having in case tracing introduced
     # a fake tensor. Unlikely.


### PR DESCRIPTION
Fixes #174371 

torch.compile does not support mutation on overlapping strides as they result in undefined behavior. We need to raise error rather than silent execution. If the view of as_strided on base tensor has overlap when functionalizing