### PR TITLE
Remove unused `half_t` specialization in `ArrayExponential`

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_thread_apply_logsumexp.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_thread_apply_logsumexp.h
@@ -35,8 +35,6 @@
 
 #pragma once
 
-#include <cuda_fp16.h>
-
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>
 #include <cutlass/epilogue/thread/activation.h>
@@ -72,24 +70,16 @@ struct ArrayExponential {
 
 template <int ElementsPerAccess>
 struct ArrayExponential<half_t, ElementsPerAccess> {
-  CUTLASS_DEVICE
-  Array<half_t, ElementsPerAccess> operator()(
-      Array<half_t, ElementsPerAccess> const& input) const {
-    Array<half_t, ElementsPerAccess> result;
+  static_assert(
+      !std::is_same<half_t, half_t>::value,
+      "ArrayExponential is not implemented for half_t");
+};
 
-    int const kVectorCount = ElementsPerAccess / 2;
-
-    __half2 const* input_ptr =
-        reinterpret_cast<__half2 const*>(input.raw_data());
-    __half2* res_ptr = reinterpret_cast<__half2*>(result.raw_data());
-
-    CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < kVectorCount; ++i) {
-      res_ptr[i] = h2exp(input_ptr[i]);
-    }
-
-    return result;
-  }
+template <int ElementsPerAccess>
+struct ArrayExponential<bfloat16_t, ElementsPerAccess> {
+  static_assert(
+      !std::is_same<bfloat16_t, bfloat16_t>::value,
+      "ArrayExponential is not implemented for bfloat16_t");
 };
 } // namespace detail
 

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_thread_apply_logsumexp.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_thread_apply_logsumexp.h
@@ -68,17 +68,20 @@ struct ArrayExponential {
   }
 };
 
+template <int N>
+struct dependent_false : std::false_type {};
+
 template <int ElementsPerAccess>
 struct ArrayExponential<half_t, ElementsPerAccess> {
   static_assert(
-      !std::is_same<half_t, half_t>::value,
+      dependent_false<ElementsPerAccess>::value,
       "ArrayExponential is not implemented for half_t");
 };
 
 template <int ElementsPerAccess>
 struct ArrayExponential<bfloat16_t, ElementsPerAccess> {
   static_assert(
-      !std::is_same<bfloat16_t, bfloat16_t>::value,
+      dependent_false<ElementsPerAccess>::value,
       "ArrayExponential is not implemented for bfloat16_t");
 };
 } // namespace detail


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #175662

The `half_t` specialization of `ArrayExponential` uses `h2exp` intrinsics that fail to compile with MSVC+CUDA-12.6 using C++200, because it probably too aggressively instantiates templates.
On the other hand this specialization is dead code: `ElementCompute` is always float in all instantiation paths through `ApplyLogSumExp` — so it could be removed or replaced with a static_assert to catch any future attempts to instantiate it. 
Add a matching bfloat16_t guard as well.

Authored with Claude.