### PR TITLE
Fix conditional-uninitialized warnings (round 2) (#175678)

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -3267,7 +3267,7 @@ inline C10_HOST_DEVICE T modified_bessel_i0_forward(T x) {
             +8.04490411014108831608e-01,
     };
 
-    T p;
+    T p = T{0};
     T q = 0.0;
 
     if (std::abs(x) <= T(8.0)) {
@@ -3355,7 +3355,7 @@ inline C10_HOST_DEVICE T modified_bessel_i1_forward(T x) {
             +7.78576235018280120474e-01,
     };
 
-    T p;
+    T p = T{0};
     T q = 0.0;
 
     if (std::abs(x) <= T(8.0)) {
@@ -3440,7 +3440,7 @@ inline C10_HOST_DEVICE T modified_bessel_k0_forward(T x) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
-    T p;
+    T p = T{0};
     T q = 0.0;
 
     if (x <= T(2.0)) {
@@ -3518,7 +3518,7 @@ inline C10_HOST_DEVICE T modified_bessel_k1_forward(T x) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
-    T p;
+    T p = T{0};
     T q = 0.0;
 
     if (x <= T(2.0)) {
@@ -3595,7 +3595,7 @@ inline C10_HOST_DEVICE T scaled_modified_bessel_k0_forward(T x) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
-    T p;
+    T p = T{0};
     T q = 0.0;
 
     if (x <= T(2.0)) {
@@ -3673,7 +3673,7 @@ inline C10_HOST_DEVICE T scaled_modified_bessel_k1_forward(T x) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
-    T p;
+    T p = T{0};
     T q = 0.0;
 
     if (x <= T(2.0)) {

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -618,7 +618,7 @@ static void autogradNotImplementedInplaceOrViewFallbackImpl(
       "input and the first output (the output can be a vector of tensors). Please change the "
       "order of your operator's parameters so that this is the case.");
   const bool is_view = aliased_input_idx.has_value();
-  size_t aliased_input_idx_val;
+  size_t aliased_input_idx_val = 0;
 
   // Save inputs before we redispatch down
   torch::jit::Stack non_tensor_stack;


### PR DESCRIPTION
Summary:

In preparation for promoting conditional-uninitialized to a compiler error at Meta, this diff initializes variables to safe defaults.

Test Plan: builds on D92969284

Reviewed By: nausicaasnow

Differential Revision: D93137190


