### PR TITLE
[DTensor][torch.compile][Bugfix] Simplify unpading to work with vLLM

### DIFF
--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -394,7 +394,11 @@ class Shard(torch._C._distributed.Shard):
             group=(mesh, mesh_dim),
         )
 
-        result = self._maybe_unpad_tensor(result, logical_dim_size, num_chunks)
+        # Narrow to the exact logical dim size. This both removes any
+        # padding added by _maybe_pad_tensor and ensures the correct
+        # symbolic shape under torch.compile (where all_gather produces
+        # n * ceil(s/n) which SymPy cannot simplify back to s).
+        result = result.narrow(self.dim, 0, logical_dim_size)
 
         return result
 


### PR DESCRIPTION
This bug came up in the context of enabling vLLM compile for torchtitan/experiments/rl (see https://github.com/pytorch/torchtitan/pull/2393)

In that code, we would encounter a failure in cuda graph tracing from this shape being propogated through graph capture, resulting in an incorrect graph, like:

```bash
  RuntimeError: a and b must have same reduction dim, but got [1, 4096] X [2048, 1024]                                                                                     
```

To fix this, we can unconditionally narrow.  This is safe because we always want to restore the tensor to`logical_dim_size` which is known inside this function


### Testplan

See attached issue - the symbolic capture is correct after this PR 

