### PR TITLE
[BE][HOPS] Apply PEP 604 type annotations to HOPS

### DIFF
--- a/torch/_higher_order_ops/_invoke_quant.py
+++ b/torch/_higher_order_ops/_invoke_quant.py
@@ -2,7 +2,6 @@
 # need to fix prim_hop_base type annotations first
 
 import dataclasses
-from typing import Optional
 
 import torch
 from torch._higher_order_ops.base_hop import BaseHOP, FunctionWithNoFreeVars
@@ -50,7 +49,7 @@ class InvokeQuant:
     def __call__(
         self,
         *args,
-        scheme: Optional[str] = None,
+        scheme: str | None = None,
         **kwargs,
     ):
         if not torch.compiler.is_compiling():

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -3,7 +3,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, get_args, Optional, Union
+from typing import Any, get_args
 
 import torch
 import torch._library.utils as library_utils
@@ -71,8 +71,8 @@ class ViewInfo(ABC):
 
 @dataclass
 class AsStridedViewInfo(ViewInfo):
-    size: Sequence[Union[int, torch.SymInt]]
-    stride: Sequence[Union[int, torch.SymInt]]
+    size: Sequence[int | torch.SymInt]
+    stride: Sequence[int | torch.SymInt]
     storage_offset: int
 
     def __init__(self, base_index, size, stride, storage_offset):
@@ -92,9 +92,9 @@ class AsStridedViewInfo(ViewInfo):
 
 @dataclass
 class SliceViewInfo(ViewInfo):
-    dim: Union[int, torch.SymInt]
-    start: Union[int, torch.SymInt]
-    end: Union[int, torch.SymInt]
+    dim: int | torch.SymInt
+    start: int | torch.SymInt
+    end: int | torch.SymInt
 
     def __init__(self, base_index, dim, start, end):
         super().__init__(base_index)
@@ -377,7 +377,7 @@ auto_functionalized.fallthrough(DispatchKey.AutogradCPU)
 auto_functionalized.fallthrough(DispatchKey.AutogradCUDA)
 
 
-_MutableOpType = Union[OpOverload, HigherOrderOperator]
+_MutableOpType = OpOverload | HigherOrderOperator
 
 
 class AutoFunctionalizedV2(HigherOrderOperator):
@@ -397,7 +397,7 @@ class AutoFunctionalizedV2(HigherOrderOperator):
         _mutable_op: _MutableOpType,
         **kwargs: Any,
     ) -> tuple[Any, tuple[Tensor, ...]]:
-        _op_to_check: Optional[Union[OpOverload, HopInstance]] = None
+        _op_to_check: OpOverload | HopInstance | None = None
         if isinstance(_mutable_op, HigherOrderOperator):
             _op_to_check = HopInstance(
                 _mutable_op,
@@ -424,7 +424,7 @@ auto_functionalized_v2.fallthrough(DispatchKey.AutogradCUDA)
 
 
 def can_auto_functionalize(
-    op: Union[OperatorBase, HopInstance],
+    op: OperatorBase | HopInstance,
 ) -> bool:
     if isinstance(op, HopInstance):
         # HOPs that implement gen_schema and schema is not functional are auto_functionalizable.
@@ -545,9 +545,7 @@ def do_auto_functionalize(
     # List of the name of args that get mutated (according to the schema)
     mutable_args_names, _ = get_mutable_args(op)
 
-    unwrapped_actual_out: Union[Any, tuple[Any]] = unwrapped_outs[
-        : -len(mutable_args_names)
-    ]
+    unwrapped_actual_out: Any | tuple[Any] = unwrapped_outs[: -len(mutable_args_names)]
     unwrapped_mutable_out = unwrapped_outs[-len(mutable_args_names) :]
 
     if len(op._schema.returns) == 0:
@@ -628,7 +626,7 @@ class FunctionalCallableWithEpilogue:
 
 def do_auto_functionalize_v2(
     mode: "torch._subclasses.functional_tensor.FunctionalTensorMode",
-    op: Union[OpOverload, HopInstance],
+    op: OpOverload | HopInstance,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> Any:
@@ -746,7 +744,7 @@ def do_auto_functionalize_v2(
             **auto_func_kwargs,  # type: ignore[arg-type]
         )
 
-    unwrapped_actual_out: Union[Any, tuple[Any]] = (
+    unwrapped_actual_out: Any | tuple[Any] = (
         unwrapped_outs if len(all_bases) == 0 else unwrapped_outs[: -len(all_bases)]
     )
 
@@ -816,7 +814,7 @@ def do_auto_functionalize_v2(
 @auto_functionalized.py_impl(DispatchKey.CompositeExplicitAutograd)
 def auto_functionalized_dense(
     _mutable_op: OpOverload,
-    _only_clone_these_tensors: Optional[tuple[str, ...]] = None,
+    _only_clone_these_tensors: tuple[str, ...] | None = None,
     **kwargs: Any,
 ) -> tuple[Any, tuple[Tensor, ...]]:
     new_kwargs = dict(**kwargs)
@@ -893,7 +891,7 @@ def auto_functionalized_func(ctx, _mutable_op, **kwargs):
 @auto_functionalized_v2.py_impl(DispatchKey.CompositeExplicitAutograd)
 def auto_functionalized_v2_dense(
     _mutable_op: _MutableOpType,
-    _only_clone_these_bases: Optional[tuple[int, ...]] = None,
+    _only_clone_these_bases: tuple[int, ...] | None = None,
     **kwargs: Any,
 ) -> tuple[Any, tuple[Tensor, ...]]:
     _all_bases: list[Tensor] = kwargs.pop("_all_bases", [])
@@ -906,7 +904,7 @@ def auto_functionalized_v2_dense(
         schema = pytree.tree_unflatten([], kwargs.pop("_op_schema")).schema
 
     if isinstance(_mutable_op, OpOverload):
-        _callable_op: Union[HopInstance, OpOverload] = _mutable_op
+        _callable_op: HopInstance | OpOverload = _mutable_op
     else:
         if not isinstance(schema, HopSchema):
             raise AssertionError(f"Expected HopSchema, got {type(schema)}")

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import warnings
 from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
@@ -94,10 +94,10 @@ cond_op = CondOp()
 
 @exposed_in("torch")
 def cond(
-    pred: Union[bool, int, float, torch.Tensor],
+    pred: bool | int | float | torch.Tensor,
     true_fn: Callable,
     false_fn: Callable,
-    operands: Union[tuple, list] = (),
+    operands: tuple | list = (),
 ) -> Any:
     r"""
     Conditionally applies `true_fn` or `false_fn`.
@@ -452,8 +452,8 @@ def check_tensor_meta_match(
 
 
 def _merge_output(
-    a: Optional[Union[torch.Tensor, int]],
-    b: Optional[Union[torch.Tensor, int]],
+    a: torch.Tensor | int | None,
+    b: torch.Tensor | int | None,
     mode: FakeTensorMode,
 ):
     from torch.fx.experimental.symbolic_shapes import (
@@ -531,9 +531,9 @@ def _merge_output(
         u2 has range [5, 8]
         u3 has range [5, 7]
     """
-    merged_size: list[Union[int, torch.SymInt]] = []
+    merged_size: list[int | torch.SymInt] = []
 
-    def _has_unbacked_symbols(s: Union[int, torch.SymInt]) -> bool:
+    def _has_unbacked_symbols(s: int | torch.SymInt) -> bool:
         if isinstance(s, int):
             return False
         else:
@@ -609,19 +609,19 @@ def _merge_output(
         b_ex_size: torch.Size,
         a_ex_stride: tuple[int, ...],
         b_ex_stride: tuple[int, ...],
-        merged_size: list[Union[int, torch.SymInt]],
-    ) -> list[Union[int, torch.SymInt]]:
+        merged_size: list[int | torch.SymInt],
+    ) -> list[int | torch.SymInt]:
         from torch._inductor.ir import get_stride_order
 
         a_sorted_stride_idx = get_stride_order(a_ex_stride, mode.shape_env)
         b_sorted_stride_idx = get_stride_order(b_ex_stride, mode.shape_env)
 
-        a_stride_li: list[Optional[tuple[Union[int, torch.SymInt], int]]] = [
-            None
-        ] * len(a_ex_stride)
-        b_stride_li: list[Optional[tuple[Union[int, torch.SymInt], int]]] = [
-            None
-        ] * len(b_ex_stride)
+        a_stride_li: list[tuple[int | torch.SymInt, int] | None] = [None] * len(
+            a_ex_stride
+        )
+        b_stride_li: list[tuple[int | torch.SymInt, int] | None] = [None] * len(
+            b_ex_stride
+        )
         for i, idx in enumerate(a_sorted_stride_idx):
             a_stride_li[idx] = (a_ex_stride[i], -i)
         for i, idx in enumerate(b_sorted_stride_idx):
@@ -643,14 +643,14 @@ def _merge_output(
                     f"Consider using contiguous() to make the two branches have the same contiguousness."
                 )
 
-        def _maybe_expr(s: Union[int, torch.SymInt]):
+        def _maybe_expr(s: int | torch.SymInt):
             if isinstance(s, int):
                 return s
             return s.node.expr
 
-        a_stride_expr: dict[Any, Union[int, torch.SymInt]] = {}
-        b_stride_expr: dict[Any, Union[int, torch.SymInt]] = {}
-        merged_strides: list[Union[int, torch.SymInt]] = [None] * len(a_ex_stride)  # type: ignore[list-item]
+        a_stride_expr: dict[Any, int | torch.SymInt] = {}
+        b_stride_expr: dict[Any, int | torch.SymInt] = {}
+        merged_strides: list[int | torch.SymInt] = [None] * len(a_ex_stride)  # type: ignore[list-item]
         for a_pair, b_pair in zip(a_stride_li, b_stride_li):
             if a_pair is None or b_pair is None:
                 raise AssertionError(
@@ -700,7 +700,7 @@ def _merge_output(
             b_stride_expr[_maybe_expr(b_val * b_ex_size[i])] = nxt_merged_stride_expr
         return merged_strides
 
-    merged_stride: list[Union[int, torch.SymInt]] = _bound_stride(
+    merged_stride: list[int | torch.SymInt] = _bound_stride(
         a.size(), b.size(), a.stride(), b.stride(), merged_size
     )
 

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import torch
 import torch.utils._pytree as pytree
@@ -46,7 +46,7 @@ def _get_op_qualname(op: _op_identifier) -> str:
 
 
 def _register_effectful_op(
-    op: _op_identifier, effect: Optional[EffectType]
+    op: _op_identifier, effect: EffectType | None
 ) -> RegistrationHandle:
     qualname = _get_op_qualname(op)
     entry = torch._library.simple_registry.singleton.find(qualname)
@@ -54,7 +54,7 @@ def _register_effectful_op(
     return handle
 
 
-def _get_effect(op: _op_identifier) -> Optional[_EffectType]:
+def _get_effect(op: _op_identifier) -> _EffectType | None:
     qualname = _get_op_qualname(op)
     entry = torch._library.simple_registry.singleton.find(qualname)
     return entry.effect.effect
@@ -220,7 +220,7 @@ def with_effects_functional(
 _EFFECTFUL_HOPS_WITH_SCHEMA = {hop_print, invoke_leaf_function}
 
 
-def _get_schema(op, args, kwargs: Optional[dict] = None) -> torch.FunctionSchema:
+def _get_schema(op, args, kwargs: dict | None = None) -> torch.FunctionSchema:
     if isinstance(op, torch._ops.OpOverload):
         return op._schema
     elif op == call_torchbind:

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
@@ -50,7 +50,7 @@ invoke_subgraph_counter = 0
 # InvokeSubgraphAutogradOp.
 @dataclass
 class OutputMetadata:
-    num_fw_outs: Optional[int] = None
+    num_fw_outs: int | None = None
     indexes_with_symint: set[int] = field(default_factory=set)
     indexes_with_no_grad: set[int] = field(default_factory=set)
 
@@ -61,8 +61,8 @@ class OutputMetadata:
 class NestedCompileRegionOptions:
     # A Callable that takes (gm, example_inputs, decompositions=None, **kwargs) as inputs.
     # Returns AOTCompiledArtifact
-    fw_compiler: Optional[Callable] = None
-    bw_compiler: Optional[Callable] = None
+    fw_compiler: Callable | None = None
+    bw_compiler: Callable | None = None
 
     # Note: [InvokeSubgraphHOP Partitioner]
     # If not None, add "partitioner" to HOP node meta.
@@ -70,11 +70,11 @@ class NestedCompileRegionOptions:
     # If str, the options are "default_partition" and "min_cut_rematerialization_partition".
     # The HOP joint graph will be partitioned using the corresponding functions in
     # torch/_functorch/partitioners.py
-    partitioner: Optional[Callable | str] = None
+    partitioner: Callable | str | None = None
 
     # If it's None, we'll inherit the parent call's decompositions.
     # Otherwise, the nested region will use this decompositions.
-    decompositions: Optional[dict[str, Any]] = None
+    decompositions: dict[str, Any] | None = None
 
 
 def _extract_nested_region_config(fn):
@@ -115,8 +115,8 @@ class InvokeSubgraphHOP(HigherOrderOperator):
     # identifying two invoke_subgraph calls have same subgraph.
     def __call__(
         self,
-        subgraph: Union[GraphModule, FunctionalizeCtxWrapper],
-        identifier: Optional[str],
+        subgraph: GraphModule | FunctionalizeCtxWrapper,
+        identifier: str | None,
         *operands,
     ):
         if identifier is not None and not isinstance(identifier, str):
@@ -174,7 +174,7 @@ invoke_subgraph = InvokeSubgraphHOP()
 
 
 def invoke_subgraph_infer(
-    subgraph: Union[GraphModule, FunctionalizeCtxWrapper],
+    subgraph: GraphModule | FunctionalizeCtxWrapper,
     *operands,
 ):
     """Inference-only entrypoint for invoke_subgraph that auto-generates identifier.
@@ -264,7 +264,7 @@ def invoke_subgraph_placeholder(func, *args, **kwargs):
     return func(*args, **kwargs)
 
 
-def mark_compile_region(fn=None, options: Optional[NestedCompileRegionOptions] = None):
+def mark_compile_region(fn=None, options: NestedCompileRegionOptions | None = None):
     """
     This wrapper instructs torch.compile to compile the wrapped region once and
     reuse the compiled artifact, instead of the usual way of aggressively

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -9,7 +9,7 @@ import contextlib
 import functools
 from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
-from typing import Any, Optional, TypeAlias
+from typing import Any, TypeAlias
 
 import torch
 import torch.utils._pytree as pytree
@@ -49,8 +49,8 @@ def defer_inlining() -> Generator[None, None, None]:
 # Used to unwrap tensors classes like FunctionalTensor and Parameter
 def _new_tensor(
     t: Any,
-    new_shape: Optional[Sequence[int]] = None,
-    new_stride: Optional[Sequence[int]] = None,
+    new_shape: Sequence[int] | None = None,
+    new_stride: Sequence[int] | None = None,
 ) -> Any:
     if isinstance(t, torch.Tensor):
         if type(t) not in (FunctionalTensor, FakeTensor, torch.Tensor):
@@ -113,7 +113,7 @@ def _redistribute(
 
 
 def redistribute_fw_inputs(
-    global_args: Any, all_placements: Any, mesh: Any, _: Optional[int] = None
+    global_args: Any, all_placements: Any, mesh: Any, _: int | None = None
 ) -> GraphArg:
     if len(global_args) != len(all_placements):
         raise AssertionError(
@@ -174,7 +174,7 @@ def redistribute_bw_inputs(
 
 
 def redistribute_bw_outputs(
-    local_outs: Any, all_placements: Any, mesh: Any, _: Optional[int] = None
+    local_outs: Any, all_placements: Any, mesh: Any, _: int | None = None
 ) -> GraphArg:
     if len(local_outs) != len(all_placements):
         raise AssertionError(
@@ -463,7 +463,7 @@ class LocalMapAutogradOp(torch.autograd.Function):
         filtered_grads_idx: set[int],
         *args: Any,
         **kwargs: Any,
-    ) -> tuple[Optional[torch.Tensor], ...]:
+    ) -> tuple[torch.Tensor | None, ...]:
         from torch._functorch._aot_autograd.schemas import MemoryFormatMeta
 
         ctx.bw_gm = bw_gm
@@ -485,7 +485,7 @@ class LocalMapAutogradOp(torch.autograd.Function):
     @staticmethod
     def backward(
         ctx: Any, *_grads: tuple[torch.Tensor]
-    ) -> tuple[Optional[torch.Tensor], ...]:
+    ) -> tuple[torch.Tensor | None, ...]:
         from torch._functorch._aot_autograd.runtime_wrappers import (
             coerce_to_expected_memory_format,
         )

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import functools
 from collections.abc import Callable
-from typing import Union
 from typing_extensions import TypeVarTuple
 
 import torch
@@ -47,7 +46,7 @@ map_impl = MapImpl()
 
 def map(
     f: Callable[[pytree.PyTree, tuple[pytree.PyTree, ...]], pytree.PyTree],
-    xs: Union[pytree.PyTree, torch.Tensor],
+    xs: pytree.PyTree | torch.Tensor,
     *args: TypeVarTuple,
 ):
     r"""

--- a/torch/_higher_order_ops/partitioner.py
+++ b/torch/_higher_order_ops/partitioner.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable
-from typing import Any, Union
+from typing import Any
 
 import torch
 from torch._higher_order_ops.utils import create_bw_fn, materialize_as_graph
@@ -83,8 +83,8 @@ class HopPartitionedGraph:
         bw_grads = bw_phs[-self.n_fw_outputs :]
 
         def _match_size_or_expr(
-            val1: Union[torch.SymInt, torch.Tensor],
-            val2: Union[torch.SymInt, torch.Tensor],
+            val1: torch.SymInt | torch.Tensor,
+            val2: torch.SymInt | torch.Tensor,
         ) -> bool:
             if type(val1) is not type(val2):
                 return False
@@ -312,7 +312,7 @@ class HopJointGraph:
 
 def create_hop_joint_graph(
     fw_fn: Callable,
-    fw_args: tuple[Union[torch.Tensor, torch.SymInt], ...],
+    fw_args: tuple[torch.Tensor | torch.SymInt, ...],
     functionalize: bool,
 ) -> HopJointGraph:
     fw_gm = materialize_as_graph(fw_fn, fw_args, force_enable_grad=True)
@@ -357,7 +357,7 @@ class HopGraphMinCutPartitioner:
     @staticmethod
     def create_partitioned_graph(
         fw_fn: Callable,
-        fw_args: tuple[Union[torch.Tensor, torch.SymInt], ...],
+        fw_args: tuple[torch.Tensor | torch.SymInt, ...],
         *,
         always_recompute_complex_exprs: bool = False,
     ) -> HopPartitionedGraph:

--- a/torch/_higher_order_ops/schema.py
+++ b/torch/_higher_order_ops/schema.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
@@ -32,7 +32,7 @@ class HopArgumentInfoGen:
         example_value: Any,
         *,
         name: str = "",
-        default_value: Optional[Any] = None,
+        default_value: Any | None = None,
         is_mutated: bool = False,
         kw_only: bool = False,
     ) -> HopArgumentInfo:
@@ -104,14 +104,14 @@ class HopSchemaGenerator:
     def __init__(self, hop: torch._ops.HigherOrderOperator):
         self.arg_infos: list[HopArgumentInfo] = []
         self.example_outputs: list[Any] = []
-        self.schema_tree_spec: Optional[pytree.TreeSpec] = None
+        self.schema_tree_spec: pytree.TreeSpec | None = None
         self.hop = hop
 
     def add_arg(
         self,
         name: str,
         example_value: Any,
-        default_value: Optional[Any] = None,
+        default_value: Any | None = None,
         is_mutated: bool = False,
         kw_only: bool = False,
     ) -> None:
@@ -212,7 +212,7 @@ class CFunctionSchemaGen:
         op_name: str,
         inp_argument_info: list[HopArgumentInfo],
         out_argument_info: HopArgumentInfo,
-        schema_tree_spec: Optional[pytree.TreeSpec],
+        schema_tree_spec: pytree.TreeSpec | None,
     ) -> Any:
         args = []
         for i, arg_info in enumerate(inp_argument_info):
@@ -265,7 +265,7 @@ class HopSchema(torch._C.FunctionSchema):
         returns: list[torch._C.Argument],
         is_vararg: bool,
         is_varret: bool,
-        schema_tree_spec: Optional[pytree.TreeSpec],
+        schema_tree_spec: pytree.TreeSpec | None,
     ):
         self.tree_spec = schema_tree_spec
         self.is_vararg = is_vararg

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -2,7 +2,6 @@
 import contextlib
 import functools
 from collections.abc import Callable
-from typing import Union
 
 import torch
 import torch.utils._pytree as pytree
@@ -35,8 +34,8 @@ class WhileLoopOp(HigherOrderOperator):
         self,
         cond_fn: Callable,
         body_fn: Callable,
-        carried_inputs: tuple[Union[torch.Tensor, int, float, bool]],
-        additional_inputs: tuple[Union[torch.Tensor, torch.SymInt, int], ...],
+        carried_inputs: tuple[torch.Tensor | int | float | bool],
+        additional_inputs: tuple[torch.Tensor | torch.SymInt | int, ...],
         /,
     ):
         if not isinstance(carried_inputs, (tuple, list)):
@@ -627,8 +626,8 @@ class WhileLoopStackOutputOp(HigherOrderOperator):
         self,
         cond_fn: Callable,
         body_fn: Callable,
-        carried_inputs: tuple[Union[torch.Tensor, int, float, bool]],
-        additional_inputs: tuple[Union[torch.Tensor, torch.SymInt, int], ...],
+        carried_inputs: tuple[torch.Tensor | int | float | bool],
+        additional_inputs: tuple[torch.Tensor | torch.SymInt | int, ...],
         /,
     ):
         if not isinstance(carried_inputs, (tuple, list)):

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -3,7 +3,7 @@ import inspect
 import itertools
 import logging
 import weakref
-from typing import Any, Optional
+from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
@@ -267,9 +267,9 @@ class WrapWithAutocast(HigherOrderOperator):
     def __call__(
         self,
         device_type: str,
-        dtype: Optional[_dtype],
+        dtype: _dtype | None,
         enabled: bool,
-        cache_enabled: Optional[bool],
+        cache_enabled: bool | None,
         wrapped_func,
         *args,
         **kwargs,


### PR DESCRIPTION
Convert Union[X, Y] to X | Y and Optional[X] to X | None using ruff rules UP007 and UP045 in torch/_higher_order_ops