### PR TITLE
fix DDE for ifr model to unblock pkg release

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -734,7 +734,9 @@ Tensor scaled_dot_product_attention(
   // _batch_norm_impl_index in Normalization.cpp) to make the output depend
   // on all inputs so that backward() produces correctly-shaped zero
   // gradients instead of None.
-  if (query_.sym_numel() == 0 || key.sym_numel() == 0 || value.sym_numel() == 0) {
+  if (TORCH_GUARD_OR_FALSE(query_.sym_numel().sym_eq(0)) ||
+      TORCH_GUARD_OR_FALSE(key.sym_numel().sym_eq(0)) ||
+      TORCH_GUARD_OR_FALSE(value.sym_numel().sym_eq(0))) {
     auto output_shape = query_.sym_sizes().vec();
     output_shape[output_shape.size() - 1] = value.sym_size(-1);
     auto out = at::zeros_symint(output_shape, query_.options());

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1604,6 +1604,59 @@ class TestSDPAFailureModes(NNTestCase):
         self.assertEqual(out.shape, (2, 2, 0, 8))
         self.assertEqual(out, torch.zeros(2, 2, 0, 8, dtype=dtype, device=device))
 
+    @skipIfTorchDynamo("mark_dynamic is not traceable")
+    def test_sdpa_unbacked_no_dde(self, device):
+        """
+        Test that scaled_dot_product_attention with dynamic symbolic dimensions
+        does not raise GuardOnDataDependentSymNode when checking for empty tensors.
+        This tests the TORCH_GUARD_OR_FALSE fix in attention.cpp.
+        Regression test for D94287846.
+        """
+
+        def func(q, k, v):
+            return F.scaled_dot_product_attention(q, k, v)
+
+        dtype = torch.float32
+        q = torch.rand(4, 2, 8, 16, dtype=dtype, device=device)
+        k = torch.rand(4, 2, 8, 16, dtype=dtype, device=device)
+        v = torch.rand(4, 2, 8, 16, dtype=dtype, device=device)
+
+        torch._dynamo.mark_dynamic(q, 0)
+        torch._dynamo.mark_dynamic(k, 0)
+        torch._dynamo.mark_dynamic(v, 0)
+
+        torch._dynamo.reset()
+        compiled_func = torch.compile(func, fullgraph=True, backend="eager")
+        result = compiled_func(q, k, v)
+        expected = func(q, k, v)
+        self.assertEqual(result.shape, expected.shape)
+
+    @skipIfTorchDynamo("mark_dynamic is not traceable")
+    def test_sdpa_empty_unbacked_no_dde(self, device):
+        """
+        Test that scaled_dot_product_attention with zero sequence length and
+        dynamic dimensions does not raise GuardOnDataDependentSymNode.
+        This tests the early return path in attention.cpp with symbolic shapes.
+        Regression test for D94287846.
+        """
+
+        def func(q, k, v):
+            return F.scaled_dot_product_attention(q, k, v)
+
+        dtype = torch.float32
+        q = torch.rand(2, 2, 0, 8, dtype=dtype, device=device)
+        k = torch.rand(2, 2, 0, 8, dtype=dtype, device=device)
+        v = torch.rand(2, 2, 0, 8, dtype=dtype, device=device)
+
+        torch._dynamo.mark_dynamic(q, 2)
+        torch._dynamo.mark_dynamic(k, 2)
+        torch._dynamo.mark_dynamic(v, 2)
+
+        torch._dynamo.reset()
+        compiled_func = torch.compile(func, fullgraph=True, backend="eager")
+        result = compiled_func(q, k, v)
+        self.assertEqual(result.shape, (2, 2, 0, 8))
+
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
     @parametrize("kernel", PLATFORM_SPECIFIC_SDPA)


### PR DESCRIPTION
Follow up after https://github.com/pytorch/pytorch/pull/175063

Summary:
D93540513 triggered a data-dependent exception in the unit test for ifr model.

```
Details: Could not guard on data-dependent expression Eq(448*u5, 0) (unhinted: Eq(448*u5, 0)). (Size-like symbols: u5)
```
The input tensor to scaled_dot_product_attention has a symbolic shape. 
u5 is equal to 0, so it enters the early return logic.

Test Plan:
OSS CI

local lowering passes - P2203884597

Differential Revision: D94287846


