### PR TITLE
Cleanup C++17.h

### DIFF
--- a/aten/src/ATen/core/ATen_pch.h
+++ b/aten/src/ATen/core/ATen_pch.h
@@ -97,7 +97,6 @@
 #include <c10/util/AlignOf.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/BFloat16.h>
-#include <c10/util/C++17.h>
 #include <c10/util/ConstexprCrc.h>
 #include <c10/util/Deprecated.h>
 #include <c10/util/DimVector.h>

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -24,7 +24,6 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/core/WrapDimMinimal.h>
-#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <c10/util/ExclusivelyOwned.h>
 #include <c10/util/ExclusivelyOwnedTensorTraits.h>

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -3,7 +3,6 @@
 #include <ATen/core/boxing/impl/boxing.h>
 #include <ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h>
 
-#include <c10/util/C++17.h>
 #include <type_traits>
 
 namespace c10 {

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -27,7 +27,6 @@
 //
 
 #include <cstdint>
-#include <c10/util/C++17.h>
 #include <c10/util/Load.h>
 #include <c10/util/irange.h>
 #include <ATen/detail/FunctionTraits.h>

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -8,6 +8,7 @@
 #include <ATen/native/cuda/thread_constants.h>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 
+#include <c10/util/C++17.h>
 #include <tuple>
 
 

--- a/c10/util/C++17.cpp
+++ b/c10/util/C++17.cpp
@@ -1,1 +1,0 @@
-#include <c10/util/C++17.h>

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -3,43 +3,15 @@
 #define C10_UTIL_CPP17_H_
 
 #include <c10/macros/Macros.h>
-#include <functional>
-#include <memory>
-#include <type_traits>
+#include <tuple>
 #include <utility>
-
-#if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
-    __GNUC__ < 9
-#error \
-    "You're trying to build PyTorch with a too old version of GCC. We need GCC 9 or later."
-#endif
-
-#if defined(__clang__) && __clang_major__ < 9
-#error \
-    "You're trying to build PyTorch with a too old version of Clang. We need Clang 9 or later."
-#endif
-
-#if (defined(_MSC_VER) && (!defined(_MSVC_LANG) || _MSVC_LANG < 201703L)) || \
-    (!defined(_MSC_VER) && __cplusplus < 201703L)
-#error You need C++17 to compile PyTorch
-#endif
-
-#if defined(_WIN32) && (defined(min) || defined(max))
-#error Macro clash with min and max -- define NOMINMAX when compiling your program on Windows
-#endif
-
-/*
- * This header adds some polyfills with C++17 functionality
- */
 
 namespace c10::guts {
 
 #if defined(__HIP__)
 
-// Implementation from http://en.cppreference.com/w/cpp/utility/apply (but
-// modified)
-// TODO This is an incomplete implementation of std::apply, not working for
-// member functions.
+// std::apply is not available in HIP device code because it lacks
+// __host__ __device__ annotations in the standard library.
 namespace detail {
 template <class F, class Tuple, std::size_t... INDEX>
 C10_HOST_DEVICE constexpr auto apply_impl(

--- a/c10/util/CallOnce.h
+++ b/c10/util/CallOnce.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
 
 #include <atomic>
 #include <functional>

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -6,7 +6,6 @@
 #include <system_error>
 
 #include <ATen/detail/FunctionTraits.h>
-#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
 #include <pybind11/pybind11.h>

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -6,7 +6,6 @@
 #include <ATen/core/class_type.h>
 #include <ATen/core/op_registration/infer_schema.h>
 #include <ATen/core/stack.h>
-#include <c10/util/C++17.h>
 #include <c10/util/Metaprogramming.h>
 #include <c10/util/TypeList.h>
 #include <c10/util/TypeTraits.h>


### PR DESCRIPTION
Since PT was bumped to C++20. We can further clean up C++17.h to keep only the wrapper of std::apply for HIP. Unnecessary inclusions of this header are removed. 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01