### PR TITLE
add --verbose option to commitlist.py script for release notes

### DIFF
--- a/scripts/release_notes/commitlist.py
+++ b/scripts/release_notes/commitlist.py
@@ -4,6 +4,7 @@ import dataclasses
 import os
 import pprint
 import re
+import time
 from collections import defaultdict
 from pathlib import Path
 from typing import List
@@ -34,6 +35,8 @@ Update the existing commitlist to commit bfcb687b9c.
 
 # Increase the allowed size of a CSV field to 1mil bytes for long files changed
 csv.field_size_limit(1000000)
+
+verbose = False
 
 
 @dataclasses.dataclass(frozen=False)
@@ -388,7 +391,13 @@ class CommitList:
 
         log_lines = commits.split("\n")
         hashes, titles = zip(*[log_line.split(" ", 1) for log_line in log_lines])
-        return [CommitList.gen_commit(commit_hash) for commit_hash in hashes]
+        result = []
+        for i, commit_hash in enumerate(hashes):
+            if verbose and (i % 10 == 0):
+                timestamp = time.strftime("%H:%M:%S")
+                print(f"[{timestamp}] Processing {i + 1} out of {len(hashes)} commits")
+            result.append(CommitList.gen_commit(commit_hash))
+        return result
 
     def filter(self, *, category=None, topic=None):
         commits = self.commits
@@ -538,7 +547,11 @@ def main():
         "--export-csv-categories", "--export_csv_categories", action="store_true"
     )
     parser.add_argument("--path", default="results/commitlist.csv")
+    parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
+
+    global verbose
+    verbose = args.verbose
 
     if args.create_new:
         create_new(args.path, args.create_new[0], args.create_new[1])


### PR DESCRIPTION
Summary:

simple progress printing for initial run of `commitlist.py`:

```bash
$ time with-proxy python commitlist.py --create-new v2.10.0
origin/release/2.11 --verbose
...
[18:17:48] Processing 2621 out of 2699 commits
[18:17:53] Processing 2631 out of 2699 commits
[18:17:58] Processing 2641 out of 2699 commits
[18:18:03] Processing 2651 out of 2699 commits
[18:18:08] Processing 2661 out of 2699 commits
[18:18:13] Processing 2671 out of 2699 commits
[18:18:19] Processing 2681 out of 2699 commits
[af5c4ec030d: [RELEASE 2.11] Release only changes (#175091)] Could not
parse PR number, ignoring PR
[18:18:24] Processing 2691 out of 2699 commits
[a2813af6564: [release-only] Remove +ptx from cuda 13.0 builds
(#175567)] Could not parse PR number, ignoring PR
Finished creating new commit list. Results have been saved to
results/commitlist.csv
```

dead simple, no dependencies, no fancy features. This way I can know that the script is chugging along without waiting 30 mins with no input.

Test Plan:

```bash
time with-proxy python commitlist.py --create-new v2.10.0 origin/release/2.11 --verbose
```

Reviewers:

Subscribers:

Tasks:

Tags: