### PR TITLE
fix: stage_backward_weight with multi-output intermediate

### DIFF
--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -186,6 +186,30 @@ class MultiMLP(torch.nn.Module):
         return x
 
 
+class TwoInputOutputOp(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input: torch.Tensor, weight: torch.Tensor):
+        return input, weight
+
+    @staticmethod
+    def backward(ctx, grad_input, grad_weight):
+        return grad_input, grad_weight
+
+
+# Model with multi-output intermediates
+class MultiInterMediateModel(torch.nn.Module):
+    def __init__(self, weight_shape: list[int]):
+        super().__init__()
+        self.shape = weight_shape
+        self.w = torch.nn.Parameter(torch.randn(*weight_shape))
+
+    def forward(self, x):
+        a, b = torch.split(x, self.shape, dim=1)
+        a, w = TwoInputOutputOp.apply(a, self.w)
+        a = torch.matmul(a, w)
+        return a * b
+
+
 # Multi-MLP with kwargs model
 class MultiMLPKwargs(torch.nn.Module):
     def __init__(self, d_hid: int, n_layers: int = 2):

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -241,12 +241,11 @@ def stage_backward_weight(
         for grads_tuple, intermediate in zip(
             param_group["grads"], param_group["intermediates"]
         ):
-            non_none_grads = [g for g in grads_tuple if g is not None]
-            if non_none_grads:
-                summed_grad = sum(non_none_grads)
-                valid_edges.append(GradientEdge(intermediate, 0))
-                # pyrefly: ignore [bad-argument-type]
-                valid_grad_outputs.append(summed_grad)
+            for i, grad in enumerate(grads_tuple):
+                if grad is not None:
+                    valid_edges.append(GradientEdge(intermediate, i))
+                    # pyrefly: ignore [bad-argument-type]
+                    valid_grad_outputs.append(grad)
 
         # Break a reference cycle caused inside stage_backward_input->get_hook->hook
         # The summarized cycle is:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #175705

Based on https://github.com/pytorch/pytorch/pull/170416, copying the PR description:

Fixes [#170227](https://github.com/pytorch/pytorch/issues/170277)

## Summary
This PR fixes a critical bug in `stage_backward_weight` where gradients for multi-output intermediate nodes (e.g., `torch.split`, `torch.chunk`, or custom Functions) were being incorrectly summed and applied solely to the 0-th output index.

## The Fix
The updated logic iterates through the gradient tuple and creates a distinct `GradientEdge` for each output index that received a gradient. This ensures that `grad_out[i]` is correctly routed to `output[i]` of the intermediate node.

```python
# New logic
for i, grad in enumerate(grads_tuple):
    if grad is not None:
        valid_edges.append(GradientEdge(intermediate, i)) # <--- Fix: Correct index
        valid_grad_outputs.append(grad)
```

## Test Plan
Added a new regression test `test_stage_backward_multi_output_intermediate` in `test/distributed/pipelining/test_backward.py`.
- **Verification:** Compares the weight gradients produced by `stage_backward` against a standard local reference execution. Confirms that gradients flowing back from both outputs are correctly computed and assigned.

----

- Add testcase for stage_backward_weight_grad_validation
- Update test_stage_backward_weight_grad_validation
- Fix linter issues