### PR TITLE
Extend OpenReg RNG tests

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rng.py
@@ -91,6 +91,95 @@ class TestRNG(TestCase):
         # Should produce same sequence with same seed
         self.assertEqual(x0.cpu(), x1.cpu())
 
+    def test_torch_manual_seed_seeds_openreg(self):
+        """Test that torch.manual_seed seeds openreg and RNG ops produce
+        deterministic results on device"""
+        torch.manual_seed(42)
+        self.assertEqual(torch.openreg.initial_seed(), 42)
+
+        for name, op in [
+            ("randn", lambda: torch.randn(100, device="openreg")),
+            ("rand", lambda: torch.rand(100, device="openreg")),
+            ("randint", lambda: torch.randint(0, 100, (50,), device="openreg")),
+            ("randperm", lambda: torch.randperm(50, device="openreg")),
+        ]:
+            with self.subTest(op=name):
+                torch.manual_seed(42)
+                x = op()
+                torch.manual_seed(42)
+                y = op()
+                self.assertEqual(x.device.type, "openreg")
+                self.assertEqual(x, y)
+
+    def test_different_seeds_different_results(self):
+        """Test that different seeds produce different results"""
+        torch.manual_seed(42)
+        x1 = torch.randn(100, device="openreg")
+
+        torch.manual_seed(123)
+        x2 = torch.randn(100, device="openreg")
+
+        self.assertNotEqual(x1, x2)
+
+    def test_randn_different_dtypes(self):
+        """Test randn reproducibility across different dtypes"""
+        dtypes = [torch.float32, torch.float64, torch.float16, torch.bfloat16]
+
+        for dtype in dtypes:
+            with self.subTest(dtype=dtype):
+                torch.manual_seed(42)
+                x = torch.randn(100, device="openreg", dtype=dtype)
+
+                torch.manual_seed(42)
+                y = torch.randn(100, device="openreg", dtype=dtype)
+
+                self.assertEqual(x.dtype, dtype)
+                # Compare on CPU; openreg assertEqual does not support float16/bfloat16 comparison
+                self.assertEqual(x.cpu(), y.cpu())
+
+    @unittest.skip("openreg backend does not implement per-device RNG yet")
+    def test_different_seeds_different_devices(self):
+        """Test that different seeds on different devices produce different results"""
+        gen0 = torch.Generator(device="openreg:0")
+        gen1 = torch.Generator(device="openreg:1")
+
+        gen0.manual_seed(42)
+        gen1.manual_seed(123)
+
+        x0 = torch.randn(100, device="openreg:0", generator=gen0)
+        x1 = torch.randn(100, device="openreg:1", generator=gen1)
+
+        self.assertNotEqual(x0.cpu(), x1.cpu())
+
+    @unittest.skip("openreg backend does not implement per-device RNG yet")
+    def test_device_rng_independence(self):
+        """Test that RNG on one device does not affect another device's state"""
+        gen0 = torch.Generator(device="openreg:0")
+        gen1 = torch.Generator(device="openreg:1")
+
+        gen0.manual_seed(42)
+        gen1.manual_seed(42)
+
+        ref = torch.randn(50, device="openreg:1", generator=gen1)
+
+        gen0.manual_seed(42)
+        gen1.manual_seed(42)
+
+        _ = torch.randn(1000, device="openreg:0", generator=gen0)
+
+        y1 = torch.randn(50, device="openreg:1", generator=gen1)
+        self.assertEqual(ref.cpu(), y1.cpu())
+
+    @unittest.skip("openreg backend does not implement per-device RNG yet")
+    def test_manual_seed_all_produces_identical_sequences(self):
+        """Test that manual_seed_all gives the same sequence on every device"""
+        torch.openreg.manual_seed_all(77)
+
+        x0 = torch.randn(50, device="openreg:0")
+        x1 = torch.randn(50, device="openreg:1")
+
+        self.assertEqual(x0.cpu(), x1.cpu())
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Fixes #172322 

**Summary**

Extend RNG test coverage for the OpenReg backend to validate seeded reproducibility across all random ops (randn, rand, randint, randperm), dtype support, and seed independence.

**Changes**

- Add ```test_torch_manual_seed_seeds_openreg```:  Verifies that ```torch.manual_seed``` propagates to the openreg backend and that ```randn```, ```rand```, ```randint```, ```randperm``` produce deterministic results when seeded.
- Add ```test_randn_different_dtypes```: reproducibility across ```float32```, ```float64```, ```float16``` and ```bfloat16```
- Add ```test_different_seeds_different_results```: negative test for seed uniqueness
- Add 3 skipped tests for per-device RNG independence (pending per-device RNG support)