### PR TITLE
Openreg extend test misc coverage

### DIFF
--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -480,56 +480,6 @@ class TestSourceMatcher(JitTestCase):
         input_node_names = {node.name for node in module_partitions[k][0].input_nodes}
         self.assertEqual(input_node_names, {"x"})
 
-    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
-    def test_module_partitioner_linear_relu_linear_nn_module_stack(self):
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear1 = torch.nn.Linear(3, 3)
-                self.linear2 = torch.nn.Linear(3, 3)
-                self.relu = torch.nn.ReLU()
-                self.linear3 = torch.nn.Linear(3, 5)
-
-            def forward(self, x):
-                x = self.linear1(x)
-                x = self.linear2(x)
-                x = self.relu(x)
-                x = self.linear3(x)
-                return x
-
-        inputs = (torch.randn(3, 3),)
-        # strict=False does not populate source_fn_stack, so
-        # get_source_partitions should fall back to nn_module_stack.
-        gm = torch.export.export(M(), inputs, strict=False).module()
-        gm.graph.eliminate_dead_code()
-
-        module_partitions = get_source_partitions(
-            gm.graph, [torch.nn.Linear, torch.nn.ReLU]
-        )
-
-        self.assertEqual(len(module_partitions), 2)
-        self.assertEqual(len(module_partitions[torch.nn.Linear]), 3)
-        self.assertEqual(len(module_partitions[torch.nn.ReLU]), 1)
-
-        self.assertFalse(
-            check_subgraphs_connected(
-                module_partitions[torch.nn.Linear][0],
-                module_partitions[torch.nn.ReLU][0],
-            )
-        )
-        self.assertTrue(
-            check_subgraphs_connected(
-                module_partitions[torch.nn.Linear][1],
-                module_partitions[torch.nn.ReLU][0],
-            )
-        )
-        self.assertFalse(
-            check_subgraphs_connected(
-                module_partitions[torch.nn.Linear][2],
-                module_partitions[torch.nn.ReLU][0],
-            )
-        )
-
 
 instantiate_parametrized_tests(TestSourceMatcher)
 

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -92,26 +92,6 @@ def get_source_partitions(
                 partition = diff_modules.setdefault(node_fqn, [])
                 partition.append(node)
 
-        # Fallback: when source_fn_stack is not populated (e.g. strict=False export),
-        # use nn_module_stack to resolve the originating module type.
-        if (source_fn_st := node.meta.get("source_fn_stack", None)) is None:
-            nn_module_stack = node.meta.get("nn_module_stack", None)
-            if nn_module_stack is not None:
-                # Get the innermost module (last entry in the ordered dict)
-                innermost_fqn, innermost_cls = list(nn_module_stack.values())[-1]
-                for src in wanted_sources:
-                    # nn_module_stack stores class as a qualified string
-                    src_str = (
-                        src.__module__ + "." + src.__qualname__
-                        if isinstance(src, type)
-                        else src
-                    )
-                    if innermost_cls == src_str:
-                        diff_modules = modules.setdefault(src, {})
-                        partition = diff_modules.setdefault(innermost_fqn, [])
-                        partition.append(node)
-                        break
-
         if (source_fn_st := node.meta.get("source_fn_stack", None)) is not None:
             source_fn = source_fn_st[-1]
             if source_fn[1] in wanted_sources:


### PR DESCRIPTION
Fixes 
**Summary**

Extend ```test_misc.py``` coverage for the OpenReg backend to validate dispatch key registration, CPU fallback correctness, and tensor subclass compatibility.

**Changes**

- Add ```test_dispatch_key_registration```: Verifies that all core aten ops, extra ops, custom ops, and autograd ops have the correct ```PrivateUse1``` / ```AutogradPrivateUse1``` dispatch keys registered, and that non-registered ops resolve via the global fallback.
- Add ```test_cpu_fallback_behavior```: Validates that the CPU fallback mechanism produces numerically correct results for global fallback ops (```add, mul```), per-op fallback (```sub.Tensor```), and in-place ops (```add_```), and confirms that blocklisted ops (```abs```) use the native OpenReg implementation instead.
- Add ```test_tensor_subclass_compatibility```: Confirms that ```__torch_function__``` subclasses and ```TorchDispatchMode``` correctly intercept and observe operations on OpenReg tensors without breaking the PrivateUse1 dispatch path.

