### PR TITLE
[WIP][inductor] Refactor AllocatorType to dataclass and migrate isinstance checks

### DIFF
--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -70,7 +70,8 @@ def can_realize_as_comm_buffer(
         return False
 
     layout = data.get_output_spec()
-    if isinstance(layout, ir.CommBufferLayout):
+    assert isinstance(layout, ir.Layout)
+    if layout.allocator.is_symm_mem:
         return True
 
     if isinstance(layout, ir.FixedLayout):
@@ -119,7 +120,10 @@ def _propagate_comm_layout_to_upstream(
         if not upstream_buf.should_allocate():
             continue
         upstream_layout = upstream_buf.get_output_spec()
-        if isinstance(upstream_layout, ir.CommBufferLayout):
+        if (
+            isinstance(upstream_layout, ir.Layout)
+            and upstream_layout.allocator.is_symm_mem
+        ):
             converted_upstream = upstream_buf
             break
         if not isinstance(upstream_layout, (ir.FlexibleLayout, ir.FixedLayout)):
@@ -160,7 +164,8 @@ def realize_as_comm_buffer(
     assert isinstance(buffer, ir.Buffer)
 
     layout = buffer.get_output_spec()
-    if isinstance(layout, ir.CommBufferLayout):
+    assert isinstance(layout, ir.Layout)
+    if layout.allocator.is_symm_mem:
         return
 
     # The buffer may have already been frozen to FixedLayout if it was used

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1530,7 +1530,10 @@ class GraphLowering(torch.fx.Interpreter):
         for r, fx_node in zip(result, fx_node_args):
             if not isinstance(r, (ir.TensorBox, ir.BaseView)):
                 result_correct_strides.append(r)
-            elif isinstance(r.get_output_spec(), ir.CommBufferLayout):
+            elif (
+                isinstance(r.get_output_spec(), ir.Layout)
+                and r.get_output_spec().allocator.is_symm_mem  # pyrefly: ignore[missing-attribute]
+            ):
                 # Active references to persistent comm buffers are not allowed
                 # outside of graphs
                 result_correct_strides.append(ir.ExternKernel.copy_input(r))

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -464,7 +464,10 @@ class SchedulerBuffer:
         if (
             self.node.get_inputs_that_alias_output()
             or self.node.get_mutation_names()
-            or isinstance(self.node.get_output_spec(), ir.CommBufferLayout)
+            or (
+                isinstance(self.node.get_output_spec(), ir.Layout)
+                and self.node.get_output_spec().allocator.is_symm_mem  # pyrefly: ignore[missing-attribute]
+            )
         ):
             V.graph.wrapper_code.codegen_allocation(self.node)
             return
@@ -6752,7 +6755,10 @@ class Scheduler:
                 if (
                     isinstance(node, ir.ExternKernelOut)
                     and node.should_allocate()
-                    and not isinstance(node.get_output_spec(), ir.CommBufferLayout)
+                    and not (
+                        isinstance(node.get_output_spec(), ir.Layout)
+                        and node.get_output_spec().allocator.is_symm_mem  # pyrefly: ignore[missing-attribute]
+                    )
                     and node.get_device()
                     and node.get_device().type == "cuda"  # type: ignore[union-attr]
                 ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Implements Step A and Step B from the Layout allocator refactoring roadmap (#138280).

Step A: Converts AllocatorType from Enum to @dataclass(frozen=True) with proper
fields (kind, group_name, alloc_id). This eliminates the fragile monkey-patching
of group_name onto FixedLayout.

Step B: Replaces all 11 isinstance(layout, CommBufferLayout) checks across 5 files
with layout.allocator.is_symm_mem. This decouples allocator semantics from class
hierarchy.

Differential Revision: [DRAFT]

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo