### PR TITLE
[inductor] Fix test_fxir_backend.test_backward expected kernel count

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -394,7 +394,7 @@ class FxirTestCase(InductorTestCase):
 
         # Expect separate forward and backward graphs.
         (forward_gm, backward_gm) = self._compile_and_check(
-            foo, (x, y), expected_num_triton_kernels=3
+            foo, (x, y), expected_num_triton_kernels=4
         )
 
     def test_custom_compiler(self):


### PR DESCRIPTION
Summary:
D94097622 extended the K==1 mm decomposition to GPU, which changes the backward pass of `test_backward`: `x.T @ grad_z` (a K==1 mm) is now decomposed into an elementwise triton kernel instead of a cuBLAS call, increasing the triton kernel count from 3 to 4.

| Kernel | Before | After |
|--------|--------|-------|
| `triton_poi_fused_add_sigmoid_squeeze_sub_0` | triton | triton |
| `triton_poi_fused_add_binary_cross_entropy_with_logits_squeeze_1` | triton | triton |
| `triton_poi_fused_div_mul_0` | triton | triton |
| `triton_poi_fused_mm_t_unsqueeze_1` | — | triton (new) |
| `gemvx::kernel` (forward matmul) | cuBLAS | cuBLAS |
| `gemmk1_kernel` (backward K==1 mm) | cuBLAS | — |

Test Plan:
```
buck2 test fbcode//caffe2/test/inductor:fxir_backend mode/opt -- -r test_backward
Pass 2 Fail 0 Skip 0
```

Differential Revision: D94331567




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo