### PR TITLE
[inductor] Avoid duplicate computation in cat/pad when inputs have multiple consumers

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5807,9 +5807,10 @@ class ConcatKernel(NopKernel):
                     break
         any_input_is_storage_and_layout = any(is_storage_and_layout(x) for x in inputs)
         fx_node_args = V.graph.current_node.args[0]
-        assert isinstance(fx_node_args, list), type(fx_node_args)
         # If any of the inputs has meta tensor and the meta tensor is in CL format, use CL format for the output
-        if any_input_is_storage_and_layout is False and any(
+        # fx_node_args is a list when called from aten.cat lowering; when ConcatKernel.create()
+        # is called from other contexts (e.g., _pad_as_cat), skip this CL format check.
+        if any_input_is_storage_and_layout is False and isinstance(fx_node_args, list) and any(
             # pyrefly: ignore [missing-attribute]
             "val" in arg.meta
             and (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175727

## Summary

Fixes a performance issue where `torch.cat` and `F.pad` (constant_pad_nd)
generate redundant computation when their inputs have multiple consumers.

**Related issues:**
- vllm-project/vllm#25477 — Fuse mul and pad in MoE models — **fixed by this PR**
- pytorch/pytorch#125075 — Inductor cannot fuse cat with a pointwise — **partially related, NOT fixed by this PR** (requires scheduler-level kernel fusion, see next stack PR)

## Problem

In MoE models (e.g., GPT-OSS in vLLM), a common pattern is:

```python
mul_result = x * scale              # [tokens, 2880]
padded = F.pad(mul_result, [0, 192])  # [tokens, 3072] — pad for expert alignment
mm_result = torch.addmm(bias, mul_result, weight)  # also uses mul_result
```

`mul_result` has two consumers: `pad` and `addmm`.

**Before this change**, Inductor's cat lowering had a `horizontal_fuse_cat`
heuristic that selected `pointwise_cat` whenever all inputs were unrealized
Pointwise ops. `pointwise_cat` inlines the mul computation into the cat/pad
kernel via `tl.where` masking. But since `addmm` also needs `mul_result`,
it must be realized separately — causing `x * scale` to be **computed twice**:

```python
# Before: 3 buffer allocations, mul computed twice
buf0 = empty_strided_cuda((4096, 2880), ...)          # intermediate mul buffer
triton_poi_fused_mul_0.run(x, scale, buf0)             # mul → buf0
extern_kernels.addmm(bias, buf0, weight, out=buf1)     # addmm reads buf0
del buf0
buf2 = empty_strided_cuda((4096, 3072), ...)           # padded buffer
triton_poi_fused_pad_mul_1.run(x, scale, buf2)         # mul recomputed + tl.where
```

The same issue occurs when users write `torch.cat([mul_result, zeros])` directly —
the `horizontal_fuse_cat` heuristic also selects `pointwise_cat`, leading to
duplicate computation.

## Solution

Three targeted changes:

### 1. Fix `horizontal_fuse_cat` heuristic in cat lowering (lowering.py)

Add `any_input_has_multi_consumers()` check: when any input FX node has multiple
users, skip `pointwise_cat` and fall through to `ConcatKernel.create()`.
ConcatKernel pre-allocates the output buffer and uses `NonOwningLayout` to let
the input Pointwise write directly into the output's slice — zero copy, computed once.

### 2. Add `_pad_as_cat` path in constant_pad_nd lowering (lowering.py)

For `F.pad` (constant_pad_nd) with right-pad on a single dimension AND
multi-consumer input, rewrite as `ConcatKernel.create([x, fill_tensor], dim)`.
This lets `F.pad` benefit from ConcatKernel's zero-copy mechanism without
requiring users to manually replace `F.pad` with `torch.cat`.

### 3. Relax assert in ConcatKernel.create() (ir.py)

`ConcatKernel.create()` previously asserted that `V.graph.current_node.args[0]`
is a list (true for aten.cat FX nodes). When called from `_pad_as_cat`, the
current node is constant_pad_nd. Changed the assert to a conditional check
to support this new call site.

## Codegen After Fix

```python
# After: 2 buffer allocations, mul computed once, zero-copy
buf0 = empty_strided_cuda((4096, 3072), (3072, 1), ...)      # padded buffer
buf_mul = reinterpret_tensor(buf0, (4096, 2880), (3072, 1), 0)  # slice (no alloc)
triton_poi_fused_mul_0.run(x, scale, buf_mul)                    # mul → slice of buf0
buf_pad = reinterpret_tensor(buf0, (4096, 192), (3072, 1), 2880) # pad slice
triton_poi_fused_zeros_1.run(buf_pad)                             # fill zeros
extern_kernels.addmm(bias, buf_mul, weight, out=buf1)            # addmm reads same slice
```

- `buf_mul` is a `reinterpret_tensor` (alias) of `buf0`, not a separate allocation
- `addmm` reads from `buf_mul` with stride `[3072, 1]` (cuBLAS handles non-contiguous lda)
- mul is computed once, shared by both pad and addmm

## What This Covers

| Pattern | Before | After |
|---------|--------|-------|
| `torch.cat([pointwise_result, ...])` + other consumer | pointwise_cat, dup compute | ConcatKernel, zero-copy |
| `F.pad(pointwise_result, [0, P])` + other consumer | masked Pointwise, dup compute | ConcatKernel, zero-copy |
| Single-consumer cat/pad | pointwise_cat (optimal) | **unchanged** |

## What This Does NOT Cover (next stack PR)

- **Issue #125075**: cat + pointwise kernel fusion (e.g., `cat(x, zeros)` + `x.to(fp16)` sharing input `x`) — this requires scheduler-level expand_dimension changes to merge kernels with different iteration domains, not lowering-level buffer optimization
- Left-pad or multi-dimension padding — only right-pad on single dim supported
- pad_mm upstream fusion when input has single consumer — already handled by inplace_padding

## Test Plan

Verified with repro script (`repro_pad_vs_cat.py`) on NVIDIA B200:

| Variant | Buffers Before | Buffers After | Correctness |
|---------|---------------|---------------|-------------|
| F.pad + addmm (multi-consumer) | 3 | **2** | PASS |
| torch.cat + addmm (multi-consumer) | 3 | **2** | PASS |
| torch.cat single consumer | 1 | **1 (unchanged)** | PASS |
| F.pad single consumer | 1 | **1 (unchanged)** | PASS |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @shunting314 @eellison @BoyuanFeng